### PR TITLE
fix: generate_script emits correct draftwright import

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -2500,7 +2500,7 @@ def _write_script(a) -> str:
         f"Run:  uv run python {py_name}\n"
         f'"""\n'
         f"import os as _os\n"
-        f"from build123d_drafting import build_drawing\n"
+        f"from draftwright import build_drawing\n"
         f"\n"
         f"# ── Config (auto-updated by cog) ──────────────────────────────────────────────\n"
     )


### PR DESCRIPTION
## Summary

`generate_script()` emitted `from build123d_drafting import build_drawing` in the
generated script header. `build_drawing` moved to `draftwright` in v0.1.0, so any
script produced by `generate_script()` would fail with `ImportError` when run
against `build123d-drafting-helpers >= 0.9.1`.

One-line fix: change the emitted import to `from draftwright import build_drawing`.

The comment example on the next line (`from build123d_drafting import Leader`)
is correct — `Leader` is an annotation primitive that stays in `build123d_drafting`.

## Test plan

- [ ] Run `generate_script("part.step", out="test_out")` and confirm the generated `.py` contains `from draftwright import build_drawing`
- [ ] Execute the generated script — should import cleanly and produce SVG + DXF

🤖 Generated with [Claude Code](https://claude.com/claude-code)