### PR TITLE
chore: align release process config with build123d-drafting-helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.scripts]
@@ -32,13 +35,36 @@ draftwright = "draftwright.make_drawing:_cli"
 Homepage = "https://github.com/pzfreo/draftwright"
 Repository = "https://github.com/pzfreo/draftwright"
 Issues = "https://github.com/pzfreo/draftwright/issues"
+Changelog = "https://github.com/pzfreo/draftwright/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/draftwright"]
 
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/draftwright",
+    "tests",
+    "skills",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "pyproject.toml",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--tb=short --cov=src/draftwright --cov-report=term-missing"
+timeout = 300
+addopts = "--tb=short --cov=src/draftwright --cov-report=term-missing --cov-report=xml"
+
+[tool.coverage.run]
+source = ["src/draftwright"]
+omit = ["src/draftwright/__init__.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
## Summary

- Python 3.10/3.11/3.12 classifiers added to `pyproject.toml`
- `Changelog` URL added to `[project.urls]`
- `[tool.hatch.build.targets.sdist]` added so source distributions include `tests/`, `skills/`, and docs alongside the package
- `timeout = 300` added to pytest ini (same as helpers — e2e drawing tests can take >120 s on slow macOS runners)
- `--cov-report=xml` added for CI coverage reporting
- `[tool.coverage.run]` and `[tool.coverage.report]` sections added

`publish.yml` and `ci.yml` were already matching the helpers pattern — no changes needed.

## One manual step required after merge

Set up the **PyPI trusted publisher** before creating the first release:
1. Go to https://pypi.org/manage/account/publishing/ → "Add a new pending publisher"
2. PyPI project name: `draftwright`
3. Owner: `pzfreo`
4. Repository: `draftwright`
5. Workflow filename: `publish.yml`
6. Environment: `pypi`

Then in GitHub repo settings → Environments → create a `pypi` environment (no protection rules needed for a personal project).

## Release workflow (same as helpers)

1. Update `CHANGELOG.md` — move `## Unreleased` items to `## vX.Y.Z — YYYY-MM-DD`
2. Commit: `release: vX.Y.Z — <one-line summary>`
3. `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."` → triggers `publish.yml` → PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)