### PR TITLE
ci: bump pyproject.toml to next .dev0 version after each release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,3 +51,31 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  bump-dev-version:
+    needs: publish-pypi
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - name: Bump to next dev version
+        run: |
+          tag=${{ github.event.release.tag_name }}
+          version=${tag#v}
+          IFS='.' read -r major minor patch <<< "$version"
+          next="${major}.${minor}.$((patch + 1)).dev0"
+          uv version "$next"
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to $(uv version --short) after ${{ github.event.release.tag_name }} release"
+          git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
 
@@ -12,11 +14,18 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-      - name: Sync version with release tag
+      - name: Set TestPyPI dev version
+        if: github.event_name == 'push'
         run: |
-          tag=${{ github.event.release.tag_name }}
-          version=${tag#v}
-          uv version "$version"
+          current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          base="${current%.dev*}"
+          uv version "${base}.dev${{ github.run_number }}"
+      - name: Strip dev suffix for real release
+        if: github.event_name == 'release'
+        run: |
+          current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          base="${current%.dev*}"
+          uv version "$base"
       - run: uv build
       - uses: actions/upload-artifact@v7
         with:
@@ -25,6 +34,7 @@ jobs:
 
   publish-testpypi:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -39,8 +49,8 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
-    needs: publish-testpypi
-    if: ${{ !github.event.release.prerelease }}
+    needs: build
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -52,9 +62,9 @@ jobs:
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
 
-  bump-dev-version:
+  bump-version:
     needs: publish-pypi
-    if: ${{ !github.event.release.prerelease }}
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -65,17 +75,17 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-      - name: Bump to next dev version
+      - name: Bump patch version with .dev0 suffix
         run: |
-          tag=${{ github.event.release.tag_name }}
-          version=${tag#v}
-          IFS='.' read -r major minor patch <<< "$version"
-          next="${major}.${minor}.$((patch + 1)).dev0"
-          uv version "$next"
-      - name: Commit version bump
+          current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          base="${current%.dev*}"
+          IFS='.' read -r major minor patch <<< "$base"
+          uv version "${major}.${minor}.$((patch + 1)).dev0"
+      - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git commit -m "chore: bump version to $(uv version --short) after ${{ github.event.release.tag_name }} release"
+          new_version=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          git add pyproject.toml uv.lock
+          git commit -m "chore: bump version to ${new_version} after release"
           git push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.1.0"
+version = "0.1.1.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Adds a `bump-dev-version` job to `publish.yml` that runs after a successful non-prerelease PyPI publish
- Computes the next patch version (e.g. `0.1.0` → `0.1.1.dev0`) using `uv version`
- Commits and pushes the updated `pyproject.toml` back to `main`

## Test plan
- [ ] Verify the workflow YAML is valid (CI lint will catch syntax errors)
- [ ] After the next real release, confirm `pyproject.toml` on `main` is bumped to `x.y.(z+1).dev0`