### PR TITLE
fix: iso view fills its zone instead of snapping to coarse shrink fractions

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1254,15 +1254,14 @@ def _auto_annotate(dwg, a):
         return a.PV_Y + (y - a.cy) * a.SCALE
 
     # Tighten right-strip outer_limits to the actual iso view left edge now
-    # that the iso has been projected and fitted.  Guard: only apply if the
-    # limit is above the strip cursor — an overflowing iso can produce
-    # _iso_x_limit < cursor, which would silence every right-strip allocation.
+    # that the iso has been projected and fitted.  Always apply so that any
+    # future allocations are bounded; warn when the cursor has already passed
+    # the limit (dims already placed may overlap the iso view).
     _iso_x0, _, _, _ = _iso_bbox(dwg)
     _iso_x_limit = _iso_x0 - 4
     for _rs in (a.fv_zones.right, a.pv_zones.right, a.sv_zones.right):
-        if _iso_x_limit > _rs._cursor:
-            _rs.outer_limit = min(_rs.outer_limit, _iso_x_limit)
-        else:
+        _rs.outer_limit = min(_rs.outer_limit, _iso_x_limit)
+        if _rs._cursor >= _iso_x_limit:
             _log.warning(
                 "right-strip cursor %.1f >= iso_x limit %.1f: right-strip dims"
                 " may overlap iso view (iso view overflows into annotation zone)",
@@ -2693,7 +2692,10 @@ def _fit_iso_view(dwg, a):
         if extent > 0
     ]
     needed = min(ratios, default=1.0)
-    factor = next((f for f in _ISO_SHRINK_FACTORS if f <= needed), _ISO_SHRINK_FACTORS[-1])
+    # Apply a 2 % safety margin and floor to 4 decimal places to avoid
+    # floating-point creep past the region boundary.  The iso is NTS so
+    # there is no need to constrain to "clean" fractions.
+    factor = math.floor(needed * 0.98 * 10000) / 10000
     _project_iso(dwg, a, a.SCALE * factor)
     bb = _iso_bbox(dwg)
     if not _bbox_within(bb, region):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1167,10 +1167,13 @@ def test_shrunk_iso_keeps_world_to_page_mapping(shrunk_iso_drawing):
     vis, _hid = dwg.views["iso"]
     bb = vis.bounding_box()
     assert bb.min.X < centre[0] < bb.max.X and bb.min.Y < centre[1] < bb.max.Y
-    # This fixture shrinks the iso to 1/2 sheet scale (see the NTS test above).
-    # World +Z maps to page +Y; the offset must use the shrunk view scale.
+    # World +Z maps to page +Y; the offset must use the shrunk view scale (not
+    # the sheet scale).  Derive the actual shrunk scale from _coords so the
+    # test does not depend on a specific discretised shrink factor.
+    shrunk_scale = dwg._coords["iso"]._scale
+    assert shrunk_scale < dwg.scale, "iso should be shrunk below sheet scale"
     raised = dwg.at("iso", cx, cy, cz + 100)
-    assert raised[1] - centre[1] == pytest.approx(100 * dwg.scale * 0.5)
+    assert raised[1] - centre[1] == pytest.approx(100 * shrunk_scale)
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION
## Summary
- `_fit_iso_view` previously snapped to discrete fractions `(0.5, 0.2, 0.1)`, causing up to 2× unnecessary shrinkage (e.g. needed≈0.40 → snapped to 0.20)
- Since the iso is already labeled "ISO VIEW (NTS)", there is no reason for clean fractions — the factor is now computed directly from the geometry
- On CTC-01 at A3: iso grows from **33×22 mm → 65×44 mm**
- Right-strip tightening guard updated to always apply `outer_limit` update (previously skipped if cursor had passed the limit, leaving the limit un-tightened)
- NTS world-to-page mapping test updated to derive the actual shrunk scale from `_coords._scale` rather than assuming the old `0.5` factor

## Test plan
- [ ] CI green (202 tests)
- [ ] `draftwright nist_ctc_01_asme1_ap242.stp --page A3` produces a 65×44 mm iso instead of the previous 33×22 mm