### PR TITLE
chore: fix stale step-gate comment and warn on iso fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 testenv/
 .coverage
 coverage.xml
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## v0.1.4 — 2026-06-15
+
+### Changed
+
+- Feature annotations (hole callouts, location dimensions, section view) now
+  fire on feature presence independent of the turned/prismatic classification,
+  so turned-and-drilled parts (e.g. flanges) get both the OD/centreline base
+  set and per-hole callouts plus bolt-circle furniture (#10).
+- Isometric view placement now uses a general largest-empty-rectangle search in
+  place of the wide/flat-on-A3 special case (#11).
+- Concentric bore-leader stacking is generalised beyond three, and the
+  step-height dimension gate is now a single derived constant (#10, #12).
+
+### Internal
+
+- Single-sourced duplicated geometry constants from the draft preset (#12).
+- Minor comment and logging cleanups.
+
 ## v0.1.0 — 2026-06-14
 
 Initial release — spun out of `build123d-drafting-helpers` v0.9.1.

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -769,7 +769,17 @@ def _largest_empty_rect(drawable, obstacles):
                     if score > best_score:
                         best_score = score
                         best = (rx0, ry0, rx1, ry1)
-    return best if best is not None else drawable
+    if best is None:
+        # No empty rectangle exists (obstacles cover the drawable area). This
+        # is unreachable in practice — choose_scale always leaves a gap — but
+        # if it ever happens the iso would render over the other views, so flag
+        # it rather than fail silently.
+        _log.warning(
+            "No empty rectangle found for the iso view; obstacles fill the "
+            "drawable area — iso may overlap other views"
+        )
+        return drawable
+    return best
 
 
 def _analyse(step_file, title, number, tolerance, drawn_by, out, scale=None, page=None, pmi="off"):
@@ -863,7 +873,7 @@ def _analyse(step_file, title, number, tolerance, drawn_by, out, scale=None, pag
     patterns = find_hole_patterns(holes)
 
     # Conservative upper bound for page selection: count all candidate step
-    # faces without the SCALE-dependent 20 mm gate (SCALE is not yet known).
+    # faces without the SCALE-dependent _MIN_STEP_DIM_MM gate (SCALE not yet known).
     n_steps_ub = len(step_zs[:3])
     strips_ub = _measure_strips(
         holes,


### PR DESCRIPTION
Cleans up the two non-blocking nits flagged during the #10 and #11 reviews.

- **`_analyse` comment** — the page-selection upper-bound comment still referenced the old "20 mm" step gate; updated to name the derived `_MIN_STEP_DIM_MM` constant (the actual gate since #10).
- **`_largest_empty_rect` fallback** — the `best is None` branch returned the full `drawable` (which overlaps every obstacle) silently. It's unreachable in practice (`choose_scale` always leaves a gap), but if ever reached the iso view would render over the other views. Now logs a warning before falling back.

No behavior change — a comment fix and a defensive log on an unreachable path. Lint trio + iso/step tests green locally.