### PR TITLE
fix: fuzzy boolean for section cut (#20, CTC-04 abort)

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -71,7 +71,9 @@ from build123d_drafting.helpers import (
     view_axes,
 )
 from OCP.BRepAdaptor import BRepAdaptor_Surface
+from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut
 from OCP.GeomAbs import GeomAbs_Plane
+from OCP.TopTools import TopTools_ListOfShape
 
 _log = logging.getLogger(__name__)
 
@@ -2311,6 +2313,39 @@ def _section_hatch_edges(face, SX, SZ, spacing):
     return result
 
 
+def _fuzzy_cut(body, cutter, fuzzy: float = 1e-3):
+    """Boolean-subtract *cutter* from *body* with a fuzzy tolerance.
+
+    Returns a build123d ``Solid`` (or ``Compound`` of solids), or ``None`` if the
+    boolean fails or yields no solid.
+
+    build123d's plain ``body - cutter`` runs an exact (zero-fuzzy) boolean which
+    raises an *uncatchable* ``Standard_DomainError`` on some cast geometry — the
+    C++ exception escapes to ``libc++abi: terminating`` (SIGABRT) and a
+    surrounding ``try/except`` never sees it, killing the whole drawing (NIST
+    CTC-04 section cut, #20). A small fuzzy value makes ``BRepAlgoAPI_Cut`` robust
+    on the same input. We drive the OCCT op directly (build123d's
+    ``Shape._bool_op`` result-processing aborts on the resulting compound) and
+    keep only the solids, so non-solid boolean artefacts can't crash the
+    downstream hidden-line projection.
+    """
+    args = TopTools_ListOfShape()
+    args.Append(body.wrapped)
+    tools = TopTools_ListOfShape()
+    tools.Append(cutter.wrapped)
+    op = BRepAlgoAPI_Cut()
+    op.SetArguments(args)
+    op.SetTools(tools)
+    op.SetFuzzyValue(fuzzy)
+    op.Build()
+    if not op.IsDone():
+        return None
+    solids = Compound(op.Shape()).solids()
+    if not solids:
+        return None
+    return solids[0] if len(solids) == 1 else Compound(children=list(solids))
+
+
 def _add_section_view(dwg, a, axis_letter, holes=None):
     """Full section A–A when blind or stepped holes hide their structure (#94).
 
@@ -2380,9 +2415,14 @@ def _add_section_view(dwg, a, axis_letter, holes=None):
         return
     body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
     try:
-        keep_behind = body - Pos(a.cx, y_star - big / 2, a.cz) * Box(big, big, big)
+        # Fuzzy boolean: the exact `body - Box(...)` aborts uncatchably
+        # (Standard_DomainError) on some cast geometry — see _fuzzy_cut / #20.
+        keep_behind = _fuzzy_cut(body, Pos(a.cx, y_star - big / 2, a.cz) * Box(big, big, big))
     except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
         _log.warning("Section A–A skipped (cut failed: %s)", exc)
+        return
+    if keep_behind is None:
+        _log.warning("Section A–A skipped (boolean cut produced no solid)")
         return
     camera = (dwg.look_at[0], dwg.look_at[1] - dwg.dist, dwg.look_at[2])
     dwg.add_view("section_aa", keep_behind, camera, (0, 0, 1), (pos_x, a.FV_Y))

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -91,14 +91,15 @@ def test_e2e_from_step_meets_standards(tmp_path):
 
 # ---------------------------------------------------------------------------
 # NIST MBE PMI Combined Test Cases (CTC), public-domain models.
-# All 10 variants ship as fixtures, but CTC-04 (both variants) and CTC-02 AP242
-# currently crash OCCT on import (see issue #20) — a segfault/abort would kill
-# the whole test run, so those are excluded from the build tests below.
+# All 10 variants ship as fixtures. CTC-04 used to abort in the section-view
+# boolean cut; the fuzzy cut (_fuzzy_cut, #20) fixed that, so it now builds.
+# CTC-02 AP242 still segfaults inside OCCT's AP242/PMI STEP read (#20) — a
+# segfault would kill the whole test run, so it stays excluded.
 # ---------------------------------------------------------------------------
 
 FIXTURES = Path(__file__).parent / "fixtures"
-_CTC_AP203_OK = ["01", "02", "03", "05"]  # 04 aborts on import (#20)
-_CTC_AP242_OK = ["01", "03", "05"]  # 02, 04 segfault on import (#20)
+_CTC_AP203_OK = ["01", "02", "03", "04", "05"]  # all build (#20 section-cut fix)
+_CTC_AP242_OK = ["01", "03", "04", "05"]  # 02 segfaults in OCCT STEP+PMI read (#20)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Problem
NIST CTC-04 (both AP203 and AP242) crashed the whole drawing with `Standard_DomainError` → `libc++abi: terminating` (SIGABRT). Root-caused in #20: the section-view half-space cut `body - Box(...)` uses build123d's exact boolean, which trips an OCCT robustness bug on this cast geometry. The C++ abort escapes Python's `try/except`, so it can't be caught.

## Fix
`_fuzzy_cut()` runs `BRepAlgoAPI_Cut` directly with `SetFuzzyValue(1e-3)` (verified robust on CTC-04) and returns only the result solids:
- build123d's `Shape._bool_op` result-processing itself aborts on the resulting compound, so we drive the OCCT op directly;
- keeping solids-only prevents stray boolean artefacts from crashing the downstream HLR projection;
- returns `None` → section skipped gracefully if no solid results.

## Result
- CTC-04 AP203 + AP242 now build with a clean section view (lint-clean); both added to the CTC build tests (`_CTC_AP203_OK` now 01–05, `_CTC_AP242_OK` now 01/03/04/05).
- 9/9 CTC build tests pass locally.

## Out of scope
CTC-02 AP242 still segfaults inside OCCT's AP242/PMI STEP read (#20) — upstream, can't be caught from Python; stays excluded from build tests.