### PR TITLE
fix: direct STEP geometry read to avoid AP242/PMI import segfault (#20)

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -41,7 +41,6 @@ from build123d import (
     Pos,
     Shape,
     Vector,
-    import_step,
 )
 from build123d_drafting.features import (
     BoltCircle,
@@ -73,6 +72,8 @@ from build123d_drafting.helpers import (
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut
 from OCP.GeomAbs import GeomAbs_Plane
+from OCP.IFSelect import IFSelect_ReturnStatus
+from OCP.STEPControl import STEPControl_Reader
 from OCP.TopTools import TopTools_ListOfShape
 
 _log = logging.getLogger(__name__)
@@ -165,6 +166,23 @@ def sanitize_svg_arcs(svg_path: str) -> int:
     if n:
         Path(svg_path).write_text(fixed, encoding="utf-8")
     return n
+
+
+def _import_step(path) -> Compound:
+    """Read solid geometry from a STEP file via OCCT's ``STEPControl_Reader``.
+
+    build123d's ``import_step`` uses the XCAF reader (colours, names, PMI), which
+    **segfaults** on some AP242 files carrying semantic PMI — e.g. NIST CTC-02
+    AP242 (#20) — before any Python code can intervene. draftwright needs only
+    the solid geometry (it drops PMI presentation data anyway), so we read the
+    geometry directly. Verified to produce identical shapes (solids, edges, bbox)
+    to ``import_step`` on the files that read in both, minus the unused metadata.
+    """
+    reader = STEPControl_Reader()
+    if reader.ReadFile(str(path)) != IFSelect_ReturnStatus.IFSelect_RetDone:
+        raise ValueError(f"could not read STEP file {path!r}")
+    reader.TransferRoots()
+    return Compound(reader.OneShape())
 
 
 # ---------------------------------------------------------------------------
@@ -840,7 +858,7 @@ def _analyse(step_file, title, number, tolerance, drawn_by, out, scale=None, pag
         part = step_file
         src = "build123d object"
     else:
-        part = import_step(step_file)
+        part = _import_step(step_file)
         src = str(step_file)
     # AP242 STEP files carry PMI presentation geometry (annotation-plane
     # border wires, leader curves) beside the solid; left in, it draws as

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -91,15 +91,15 @@ def test_e2e_from_step_meets_standards(tmp_path):
 
 # ---------------------------------------------------------------------------
 # NIST MBE PMI Combined Test Cases (CTC), public-domain models.
-# All 10 variants ship as fixtures. CTC-04 used to abort in the section-view
-# boolean cut; the fuzzy cut (_fuzzy_cut, #20) fixed that, so it now builds.
-# CTC-02 AP242 still segfaults inside OCCT's AP242/PMI STEP read (#20) — a
-# segfault would kill the whole test run, so it stays excluded.
+# All 10 variants ship as fixtures and now build. Two #20 fixes got them there:
+# the fuzzy section cut (_fuzzy_cut) unblocked CTC-04, and the direct
+# STEPControl_Reader importer (_import_step) avoids the XCAF/PMI segfault that
+# build123d's import_step hit on CTC-02 AP242.
 # ---------------------------------------------------------------------------
 
 FIXTURES = Path(__file__).parent / "fixtures"
-_CTC_AP203_OK = ["01", "02", "03", "04", "05"]  # all build (#20 section-cut fix)
-_CTC_AP242_OK = ["01", "03", "04", "05"]  # 02 segfaults in OCCT STEP+PMI read (#20)
+_CTC_AP203_OK = ["01", "02", "03", "04", "05"]
+_CTC_AP242_OK = ["01", "02", "03", "04", "05"]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Problem
NIST CTC-02 **AP242** segfaulted inside `import_step` (SIGSEGV) before any draftwright code — the last crashing fixture from #20. Root-caused: build123d's `import_step` uses the **XCAF reader** (colours/names/semantic PMI), and the AP242 PMI content crashes that read. The raw geometry read (`STEPControl_Reader`) handles the same file fine.

## Fix
`_import_step()` reads solid geometry directly via `STEPControl_Reader` instead of the XCAF path. draftwright only needs geometry (it drops PMI presentation data anyway). Verified **identical** shapes (solids, edges, bbox) vs `import_step` on files that read in both paths — just without the unused colour/name metadata.

## Result
- CTC-02 AP242 now builds (views, lint-clean); it joins the CTC build tests.
- **All ten** CTC fixtures (01–05 × AP203/AP242) now build.
- Full suite: **221 passed** locally (incl. all 10 CTC builds).

Together with #22 (fuzzy section cut), this **closes #20**.