### PR TITLE
feat: lint_summary() + surface silent annotation drops (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
   under a dedicated code (`callout_dropped`, `location_ref_dropped`,
   `step_dim_dropped`, `placement_unsatisfiable`), so a short drawing always
   carries a machine-readable reason (#32).
+- `placement_unsatisfiable` (the engine could not place an annotation it wanted
+  to, as opposed to a deliberate cap) is **error** severity, so it fails the
+  `lint_summary()` `passed` gate; the deliberate-cap drops stay warnings (#32).
+- A callout dropped by the per-view cap is no longer double-reported: the
+  dropped diameters are named in the `callout_dropped` message and excluded from
+  `feature_not_dimensioned` (#32).
+- `_auto_annotate` is idempotent for build-time lint records — re-annotating a
+  drawing no longer accumulates duplicate drop reports (#32).
 
 ## v0.1.6 — 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Added
+
+- `Drawing.lint_summary()` — a JSON-friendly aggregate of `lint()` for
+  non-interactive callers (scripts, or an LLM via the API): severity counts,
+  per-code counts, a `geometry_issues` tally (standards/geometry checks vs pure
+  layout), a `passed` flag, a coarse 0–1 `score`, and the full issue list. Gives
+  a single signal to gate and optimise on without rendering the SVG (#32).
+
+### Fixed
+
+- Annotations the layout had to drop (hole callouts past the per-view cap,
+  location references past the per-part cap, bore callouts with no room or an
+  unsatisfiable strip) are no longer silent: each is recorded during the build
+  and surfaced by `lint()` under a dedicated code (`callout_dropped`,
+  `location_ref_dropped`, `placement_unsatisfiable`), so a short drawing always
+  carries a machine-readable reason (#32).
+
 ## v0.1.6 — 2026-06-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
 ### Fixed
 
 - Annotations the layout had to drop (hole callouts past the per-view cap,
-  location references past the per-part cap, bore callouts with no room or an
-  unsatisfiable strip) are no longer silent: each is recorded during the build
-  and surfaced by `lint()` under a dedicated code (`callout_dropped`,
-  `location_ref_dropped`, `placement_unsatisfiable`), so a short drawing always
+  location references past the per-part cap, step-height dimensions past the
+  first three, bore callouts with no room or an unsatisfiable strip) are no
+  longer silent: each is recorded during the build and surfaced by `lint()`
+  under a dedicated code (`callout_dropped`, `location_ref_dropped`,
+  `step_dim_dropped`, `placement_unsatisfiable`), so a short drawing always
   carries a machine-readable reason (#32).
 
 ## v0.1.6 — 2026-06-15

--- a/docs/plans/right-first-time-roadmap.md
+++ b/docs/plans/right-first-time-roadmap.md
@@ -1,0 +1,95 @@
+# "Right first time" roadmap — hardening the deterministic core
+
+_Status: living plan. Last updated alongside PR #33 (#32)._
+
+## Why this exists
+
+draftwright gets good results when driven interactively (Claude Code): render →
+eyeball → read lint → adjust → re-render. The same engine driven one-shot via an
+API underwhelms — not because of the model, but because the API call doesn't get
+those laps. The fix is two-pronged and both prongs meet at `lint()`:
+
+1. **Push the deterministic boundary outward** so fewer decisions need an LLM at
+   all (the engine self-corrects).
+2. **Give a non-interactive caller the same scaffolding a human has** — the lint
+   critic as a machine-readable signal, plus the primitives to act on it.
+
+Treat "the API gives less impressive results" as a signal pointing at *engine
+gaps*, not a prompt-quality problem. Every gap closed in Python is permanent and
+free per run; every gap left to the API is paid for, non-deterministic, and
+worse on novel input.
+
+## The two clusters of open issues
+
+The open issues are the same goal approached from two ends, meeting at lint:
+
+**Cluster A — make the engine self-correcting**
+- #31 — derive bare layout constants (remove the generalization tax)
+- #32 — lint score + surface silent annotation drops  ← **in progress (PR #33)**
+- #30 — lint→repair loop (act on violations, don't just report)
+- #13 — tests that pin the *general* behaviour (the verification layer)
+
+**Cluster B — primitives so a script/LLM can fix things**
+- #26 — `dwg.features(view)` — expose the geometry analysis
+- #25 — `Drawing.place_dim()` — layout-strip-aware stacking dimension
+- #29 — lint findings carry a `suggestion` code snippet
+- #27 — `dwg.annotations()` — query placed annotations
+- #28 — `dwg.view_bounds(view)` — page bbox of a projected view
+
+## How they depend on each other
+
+- **#32 is the foundation.** It turns lint into structured output (`lint_summary()`)
+  and makes every layout failure a machine-readable lint code instead of a log
+  line. Everything downstream consumes this.
+- **#29 extends #32 directly** — a `suggestion` field is just another key on the
+  issue dict `lint_summary()` already emits. A computable suggestion *is* a
+  repair recipe, so #29 is the bridge from #32 (surface) to #30 (auto-apply).
+- **#26 and #25 are prerequisites for #30**, not just neighbours:
+  - repairing `feature_not_dimensioned` / `callout_dropped` needs the feature
+    geometry back → `dwg.features()` (#26)
+  - repairing `annotation_overlap` needs strip re-stacking → `place_dim` (#25)
+  Both also stand alone as API wins, so they are low-regret to land early.
+- **#13 verifies #31 and #32 together** — its "4+ bores: all annotated or
+  overflow surfaced via lint" assertion is only expressible because of #32's drop
+  codes; its cap/threshold cases are exactly what #31 must derive. Land #13's
+  tests *with* #31 so the overfitting #31 removes can't creep back.
+
+## Recommended sequence
+
+```
+#31 + #13      constants + the tests that pin general behaviour
+   ↓
+#26, #25       primitives (features, place_dim) — also standalone API wins
+   ↓
+#29            lint suggestions, building on #32's issue dict
+   ↓
+#30            repair loop, consuming features + place_dim + suggestions
+```
+#27 / #28 slot in opportunistically wherever an API caller needs them.
+
+## Done / in progress
+
+### #32 — lint score + surface silent drops (PR #33)
+- `Drawing.lint_summary()` — JSON-friendly aggregate of `lint()`: `passed`,
+  coarse 0–1 `score`, severity counts, `by_code`, `geometry_issues`, full issue
+  list. One signal to gate/optimise on without rendering.
+- `Drawing._record_build_issue()` records build-time drops; `lint()` surfaces them.
+- New drop codes: `callout_dropped` (per-view cap), `location_ref_dropped`
+  (per-part cap), `placement_unsatisfiable` (no room / strip full),
+  `step_dim_dropped` (step_zs[:3] cap). No layout change — only surfacing.
+- Score weights (`_SCORE_ERROR_PENALTY`, `_SCORE_WARNING_PENALTY`) and the
+  geometry-aware code set (`_GEOMETRY_AWARE_CODES`) are single-sourced module
+  constants, consistent with #31's intent.
+
+## Notes / gaps to keep in mind
+
+- The lint *score* is itself a heuristic with tunable weights. It's named and
+  single-sourced, but the severity/code counts are the authoritative output —
+  callers should prefer counts over the scalar where it matters.
+- Full location-dimension *coverage* lint (flagging under-located parts that were
+  never even attempted) is still out of scope — #32 surfaces the *drops*, not the
+  never-attempted gaps. Candidate follow-up under #13/#30.
+- `_MAX_CALLOUTS_PER_VIEW=4`, `_MAX_LOCATION_REFS=4`, `step_zs[:3]` remain
+  uncalibrated caps — surfaced now (#32), to be *derived* under #31.
+- Naming drift: #29's examples say `LintFinding`; the class is `LintIssue`. Fix
+  when #29 is implemented.

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -297,8 +297,13 @@ def _concentric_bore_diams(a) -> list:
     return [d for d in a.z_diams if d != a.od_diam and any(abs(d - c) <= 0.15 for c in concentric)]
 
 
-def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None) -> list:
+def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None, exclude=None) -> list:
     """Coarse completeness check: report part diameters with no callout (#80).
+
+    ``exclude`` is an optional iterable of diameters already accounted for by a
+    more specific build-time lint (e.g. the per-view callout cap's
+    ``callout_dropped``); these are skipped here so a dropped callout is not
+    double-reported as ``feature_not_dimensioned``.
 
     Builds a feature inventory from *part*'s hole/boss diameters (cylinder
     patches spanning at least ~half a turn around their axis in total, so
@@ -339,6 +344,7 @@ def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None) -> li
             mentioned.add(float(v))
             provided[float(v)] = provided.get(float(v), 0) + count
 
+    exclude = exclude or ()
     issues = [
         LintIssue(
             severity="warning",
@@ -347,6 +353,7 @@ def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None) -> li
         )
         for d in inventory
         if not any(abs(d - v) <= tol for v in mentioned)
+        and not any(abs(d - e) <= tol for e in exclude)
     ]
 
     required: dict[float, int] = {}
@@ -1318,8 +1325,12 @@ class Drawing:
         self._analysis: SimpleNamespace | None = None
         # Lint issues found while building (e.g. annotations the layout had to
         # drop). Recorded here so :meth:`lint` can surface them — a dropped
-        # feature must never be silent.
+        # feature must never be silent. Diameters dropped by the per-view
+        # callout cap are tracked separately so :meth:`lint` can suppress the
+        # redundant feature_not_dimensioned for them. Both are reset at the
+        # top of :func:`_auto_annotate` so re-annotation does not accumulate.
         self._build_issues: list = []
+        self._dropped_callout_diams: list = []
 
     # -- views ----------------------------------------------------------------
     def add_view(self, name, shape, camera, up, position, *, look_at=None, scaled=False):
@@ -1430,7 +1441,12 @@ class Drawing:
         if self.part is not None:
             if self._cyl_cache is None:
                 self._cyl_cache = analyse_cylinders(self.part)
-            issues += lint_feature_coverage(self.part, self.annotations, cyls=self._cyl_cache)
+            issues += lint_feature_coverage(
+                self.part,
+                self.annotations,
+                cyls=self._cyl_cache,
+                exclude=self._dropped_callout_diams,
+            )
         issues += list(self._build_issues)
         return issues
 
@@ -1616,6 +1632,10 @@ def _export_shape(exporter, shape, layer, ctx):
 def _auto_annotate(dwg, a):
     """Add the standard automatic dimensions, centrelines, and title block."""
     draft = dwg.draft
+    # Idempotent: clear build-time lint state so a second annotation pass does
+    # not accumulate duplicate drop records.
+    dwg._build_issues = []
+    dwg._dropped_callout_diams = []
 
     def FX(x):
         return a.FV_X + (x - a.cx) * a.SCALE
@@ -1816,7 +1836,7 @@ def _auto_annotate(dwg, a):
         if _px is None:
             _log.warning("dim_step_%d skipped: fv_zones.right strip full", col)
             dwg._record_build_issue(
-                "warning",
+                "error",
                 "placement_unsatisfiable",
                 f"{len(_step_zs) - col} step-height dimension(s) dropped "
                 "(front-view right strip full)",
@@ -2925,19 +2945,25 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
             # (their pattern furniture is withheld too — a bare pitch circle
             # with no callout referencing it explains nothing)
             specs.sort(key=lambda s: s[0][0].diameter, reverse=True)
-            n_drop = len(specs) - _MAX_CALLOUTS_PER_VIEW
+            dropped = specs[_MAX_CALLOUTS_PER_VIEW:]
+            dropped_diams = [s[0][0].diameter for s in dropped]
+            # Remember which diameters were dropped so lint() can suppress the
+            # redundant feature_not_dimensioned for them — callout_dropped names
+            # them and is the more specific signal (no double-report).
+            dwg._dropped_callout_diams.extend(dropped_diams)
             _log.info(
                 "%d hole specs in %s view; annotating the %d largest "
-                "(the rest surface as feature_not_dimensioned)",
+                "(the rest surface as callout_dropped)",
                 len(specs),
                 view,
                 _MAX_CALLOUTS_PER_VIEW,
             )
+            _diams = ", ".join(f"ø{_fmt(d)}" for d in dropped_diams)
             dwg._record_build_issue(
                 "warning",
                 "callout_dropped",
-                f"{n_drop} hole callout(s) dropped from the {view} view "
-                f"(cap of {_MAX_CALLOUTS_PER_VIEW} per view)",
+                f"{len(dropped)} hole callout(s) dropped from the {view} view "
+                f"(cap of {_MAX_CALLOUTS_PER_VIEW} per view): {_diams}",
             )
             specs = specs[:_MAX_CALLOUTS_PER_VIEW]
 
@@ -3032,7 +3058,7 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
             if not can_right and not can_left:
                 _log.info("Hole callout ø%s skipped (no room)", _fmt(holes[0].diameter))
                 dwg._record_build_issue(
-                    "warning",
+                    "error",
                     "placement_unsatisfiable",
                     f"hole callout ø{_fmt(holes[0].diameter)} not placed "
                     f"(no room beside the {view} view)",
@@ -3064,7 +3090,7 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     len(right_queue),
                 )
                 dwg._record_build_issue(
-                    "warning",
+                    "error",
                     "placement_unsatisfiable",
                     f"{n_drop} of {len(right_queue)} bore callout(s) dropped "
                     f"(strip full right of the {view} view)",
@@ -3082,7 +3108,7 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     len(left_queue),
                 )
                 dwg._record_build_issue(
-                    "warning",
+                    "error",
                     "placement_unsatisfiable",
                     f"{n_drop} of {len(left_queue)} bore callout(s) dropped "
                     f"(strip full left of the {view} view)",

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -371,6 +371,30 @@ def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None) -> li
     return issues
 
 
+# --- lint scoring (see Drawing.lint_summary) -------------------------------
+# Codes that check standards/geometry correctness rather than pure page
+# layout. Grouped so a caller (and the #30 repair loop) can tell a wrong
+# drawing from a merely tight one.
+_GEOMETRY_AWARE_CODES = frozenset(
+    {
+        "feature_not_dimensioned",
+        "feature_count_mismatch",
+        "missing_principal_dimension",
+        "label_vs_measured",
+        "dim_inside_part",
+        "callout_dropped",
+        "location_ref_dropped",
+        "placement_unsatisfiable",
+    }
+)
+
+# Coarse 0–1 quality heuristic: a clean sheet scores 1.0; each issue subtracts
+# a flat per-severity penalty (clamped at 0). A convenience signal only — the
+# severity/code counts in the summary are the authoritative output.
+_SCORE_ERROR_PENALTY = 0.2
+_SCORE_WARNING_PENALTY = 0.05
+
+
 def analyse_face_levels(part, tol: float = 0.5) -> list:
     """Return sorted unique Z-coords of horizontal (normal≈±Z) planar faces.
 
@@ -1291,6 +1315,10 @@ class Drawing:
         self.svg_path: str | None = None
         self.dxf_path: str | None = None
         self._analysis: SimpleNamespace | None = None
+        # Lint issues found while building (e.g. annotations the layout had to
+        # drop). Recorded here so :meth:`lint` can surface them — a dropped
+        # feature must never be silent.
+        self._build_issues: list = []
 
     # -- views ----------------------------------------------------------------
     def add_view(self, name, shape, camera, up, position, *, look_at=None, scaled=False):
@@ -1382,11 +1410,18 @@ class Drawing:
         self._named = kept_named
         return removed
 
+    def _record_build_issue(self, severity, code, message):
+        """Record a lint issue discovered during construction (e.g. an
+        annotation the layout had to drop). Surfaced by :meth:`lint` so a
+        dropped feature is never silent."""
+        self._build_issues.append(LintIssue(severity=severity, code=code, message=message))
+
     # -- output ---------------------------------------------------------------
     def lint(self):
         """Lint all annotations against all views; returns the list of issues.
 
         When :attr:`part` is set, also runs :func:`lint_feature_coverage`.
+        Build-time drops recorded via :meth:`_record_build_issue` are included.
         """
         set_page(self.page_w, self.page_h, margin=10)
         view_shapes = [vis for vis, _ in self.views.values()]
@@ -1395,7 +1430,52 @@ class Drawing:
             if self._cyl_cache is None:
                 self._cyl_cache = analyse_cylinders(self.part)
             issues += lint_feature_coverage(self.part, self.annotations, cyls=self._cyl_cache)
+        issues += list(self._build_issues)
         return issues
+
+    def lint_summary(self) -> dict:
+        """Aggregate :meth:`lint` into a JSON-friendly quality summary.
+
+        Gives a non-interactive caller (a script, or an LLM via the API) a
+        single signal to gate and optimise on without rendering the SVG:
+
+        - ``passed`` — no error-severity issues;
+        - ``score`` — coarse 0–1 quality heuristic (see ``_SCORE_*``);
+        - ``errors`` / ``warnings`` / ``infos`` — counts by severity;
+        - ``by_code`` — per-check counts;
+        - ``geometry_issues`` — count of standards/geometry-correctness issues
+          as opposed to pure layout (see ``_GEOMETRY_AWARE_CODES``);
+        - ``issues`` — the full list, each as a plain dict.
+        """
+        issues = self.lint()
+        errors = sum(1 for i in issues if i.severity == "error")
+        warnings = sum(1 for i in issues if i.severity == "warning")
+        infos = sum(1 for i in issues if i.severity == "info")
+        by_code: dict[str, int] = {}
+        for i in issues:
+            by_code[i.code] = by_code.get(i.code, 0) + 1
+        score = max(
+            0.0,
+            1.0 - errors * _SCORE_ERROR_PENALTY - warnings * _SCORE_WARNING_PENALTY,
+        )
+        return {
+            "passed": errors == 0,
+            "score": score,
+            "errors": errors,
+            "warnings": warnings,
+            "infos": infos,
+            "by_code": by_code,
+            "geometry_issues": sum(1 for i in issues if i.code in _GEOMETRY_AWARE_CODES),
+            "issues": [
+                {
+                    "severity": i.severity,
+                    "code": i.code,
+                    "message": i.message,
+                    "location": i.location,
+                }
+                for i in issues
+            ],
+        }
 
     def export(self, out=None):
         """Lint, then write SVG and DXF. Returns ``(svg_path, dxf_path)``."""
@@ -2233,10 +2313,17 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
         return
     if len(refs) > _MAX_LOCATION_REFS:
         refs.sort(key=lambda r: r[2], reverse=True)
+        n_drop = len(refs) - _MAX_LOCATION_REFS
         _log.info(
             "%d location references; dimensioning the %d largest",
             len(refs),
             _MAX_LOCATION_REFS,
+        )
+        dwg._record_build_issue(
+            "warning",
+            "location_ref_dropped",
+            f"{n_drop} hole location reference(s) not dimensioned "
+            f"(cap of {_MAX_LOCATION_REFS} per part)",
         )
         refs = refs[:_MAX_LOCATION_REFS]
 
@@ -2819,12 +2906,19 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
             # (their pattern furniture is withheld too — a bare pitch circle
             # with no callout referencing it explains nothing)
             specs.sort(key=lambda s: s[0][0].diameter, reverse=True)
+            n_drop = len(specs) - _MAX_CALLOUTS_PER_VIEW
             _log.info(
                 "%d hole specs in %s view; annotating the %d largest "
                 "(the rest surface as feature_not_dimensioned)",
                 len(specs),
                 view,
                 _MAX_CALLOUTS_PER_VIEW,
+            )
+            dwg._record_build_issue(
+                "warning",
+                "callout_dropped",
+                f"{n_drop} hole callout(s) dropped from the {view} view "
+                f"(cap of {_MAX_CALLOUTS_PER_VIEW} per view)",
             )
             specs = specs[:_MAX_CALLOUTS_PER_VIEW]
 
@@ -2918,6 +3012,12 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
 
             if not can_right and not can_left:
                 _log.info("Hole callout ø%s skipped (no room)", _fmt(holes[0].diameter))
+                dwg._record_build_issue(
+                    "warning",
+                    "placement_unsatisfiable",
+                    f"hole callout ø{_fmt(holes[0].diameter)} not placed "
+                    f"(no room beside the {view} view)",
+                )
                 continue
 
             if can_right and (not can_left or d_right <= d_left):
@@ -2944,6 +3044,12 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     n_drop,
                     len(right_queue),
                 )
+                dwg._record_build_issue(
+                    "warning",
+                    "placement_unsatisfiable",
+                    f"{n_drop} of {len(right_queue)} bore callout(s) dropped "
+                    f"(strip full right of the {view} view)",
+                )
             right_queue = right_queue[: len(right_ys)]
         if left_ys is None and left_queue:
             left_ys = _greedy_strip_ys(
@@ -2955,6 +3061,12 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     "plan/side left strip: %d of %d bore callouts skipped (strip full)",
                     n_drop,
                     len(left_queue),
+                )
+                dwg._record_build_issue(
+                    "warning",
+                    "placement_unsatisfiable",
+                    f"{n_drop} of {len(left_queue)} bore callout(s) dropped "
+                    f"(strip full left of the {view} view)",
                 )
             left_queue = left_queue[: len(left_ys)]
 

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -384,6 +384,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "dim_inside_part",
         "callout_dropped",
         "location_ref_dropped",
+        "step_dim_dropped",
         "placement_unsatisfiable",
     }
 )
@@ -1795,13 +1796,31 @@ def _auto_annotate(dwg, a):
 
     # Step heights — only where the step is tall enough to fit a label;
     # each step witnesses from the previous dim's line (_right_ladder) so
-    # extension lines are adjacent rather than coincident
-    for col, z in enumerate(
-        [z for z in a.step_zs[:3] if (z - a.bb.min.Z) * a.SCALE >= _MIN_STEP_DIM_MM]
-    ):
+    # extension lines are adjacent rather than coincident. Only the first
+    # three steps are dimensioned; any further dimensionable steps surface
+    # via lint rather than being silently dropped.
+    def _step_legible(z):
+        return (z - a.bb.min.Z) * a.SCALE >= _MIN_STEP_DIM_MM
+
+    _step_zs = [z for z in a.step_zs[:3] if _step_legible(z)]
+    _n_over_cap = sum(1 for z in a.step_zs if _step_legible(z)) - len(_step_zs)
+    if _n_over_cap > 0:
+        dwg._record_build_issue(
+            "warning",
+            "step_dim_dropped",
+            f"{_n_over_cap} step-height dimension(s) not placed "
+            "(only the first three steps are dimensioned)",
+        )
+    for col, z in enumerate(_step_zs):
         _px = a.fv_zones.right.allocate(_SLOT_DIM_STEP)
         if _px is None:
             _log.warning("dim_step_%d skipped: fv_zones.right strip full", col)
+            dwg._record_build_issue(
+                "warning",
+                "placement_unsatisfiable",
+                f"{len(_step_zs) - col} step-height dimension(s) dropped "
+                "(front-view right strip full)",
+            )
             break
         dwg.add(
             Dimension(

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2368,3 +2368,18 @@ class TestLintSummaryAndDrops:
             plate -= Pos(x, 0, 0) * Cylinder(r, 8)
         dwg = build_drawing(plate)
         assert "callout_dropped" in {i.code for i in dwg.lint()}
+
+    @pytest.mark.timeout(120)
+    def test_step_dim_cap_overflow_is_surfaced(self):
+        from build123d import Box, Pos
+
+        from draftwright import build_drawing
+
+        # Five stacked ledges → five step heights; only the first three are
+        # dimensioned (step_zs[:3]), so the rest must surface, not vanish.
+        tower = Box(120, 120, 15)
+        for i in range(1, 6):
+            side = 120 - i * 18
+            tower += Pos(0, 0, i * 15) * Box(side, side, 15)
+        dwg = build_drawing(tower)
+        assert "step_dim_dropped" in {i.code for i in dwg.lint()}

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1691,9 +1691,13 @@ class TestAutoHoleAnnotations:
             if name.startswith("hc_"):
                 covered.update(ann.covers_diameters)
         assert covered == {4.0, 5.0, 6.0, 8.0}
-        # the dropped specs surface through the coverage lint by design
-        flagged = {i.message for i in dwg.lint() if i.code == "feature_not_dimensioned"}
-        assert len(flagged) == 2
+        # the dropped specs (ø2, ø3) surface through callout_dropped, which names
+        # them — not double-reported as feature_not_dimensioned (#32 de-dup)
+        issues = dwg.lint()
+        cd = next(i for i in issues if i.code == "callout_dropped")
+        assert "ø2" in cd.message and "ø3" in cd.message
+        flagged = {i.message for i in issues if i.code == "feature_not_dimensioned"}
+        assert flagged == set()
 
     @pytest.mark.timeout(60)
     def test_rotational_part_keeps_leader_annotations(self):
@@ -2363,11 +2367,19 @@ class TestLintSummaryAndDrops:
 
         # Five distinct-diameter through-holes in the plan view exceed the
         # per-view callout cap (4); the overflow must surface, not vanish.
+        # The smallest (ø4) is the one dropped (largest four are kept).
         plate = Box(120, 60, 8)
         for x, r in zip((-48, -24, 0, 24, 48), (2.0, 2.5, 3.0, 3.5, 4.0)):
             plate -= Pos(x, 0, 0) * Cylinder(r, 8)
         dwg = build_drawing(plate)
-        assert "callout_dropped" in {i.code for i in dwg.lint()}
+        issues = dwg.lint()
+        assert "callout_dropped" in {i.code for i in issues}
+        # The dropped diameter is named by callout_dropped...
+        cd = next(i for i in issues if i.code == "callout_dropped")
+        assert "ø4" in cd.message
+        # ...and NOT double-reported as feature_not_dimensioned (de-dup).
+        fnd = [i.message for i in issues if i.code == "feature_not_dimensioned"]
+        assert not any("ø4" in m for m in fnd), fnd
 
     @pytest.mark.timeout(120)
     def test_step_dim_cap_overflow_is_surfaced(self):
@@ -2383,3 +2395,53 @@ class TestLintSummaryAndDrops:
             tower += Pos(0, 0, i * 15) * Box(side, side, 15)
         dwg = build_drawing(tower)
         assert "step_dim_dropped" in {i.code for i in dwg.lint()}
+
+    @pytest.mark.timeout(120)
+    def test_location_ref_cap_overflow_is_surfaced(self):
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        # A 5×3 grid of identical holes gives many location references; the
+        # per-part cap (_MAX_LOCATION_REFS=4) means the rest must surface.
+        plate = Box(120, 120, 8)
+        for x in (-40, -20, 0, 20, 40):
+            for y in (-40, 0, 40):
+                plate -= Pos(x, y, 0) * Cylinder(2.5, 8)
+        dwg = build_drawing(plate)
+        assert "location_ref_dropped" in {i.code for i in dwg.lint()}
+
+    @pytest.mark.timeout(120)
+    def test_auto_annotate_resets_build_issues(self):
+        # Re-running annotation must not accumulate duplicate drop records.
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+        from draftwright.make_drawing import _auto_annotate
+
+        plate = Box(120, 120, 8)
+        for x in (-40, -20, 0, 20, 40):
+            for y in (-40, 0, 40):
+                plate -= Pos(x, y, 0) * Cylinder(2.5, 8)
+        dwg = build_drawing(plate)
+        n_issues = len(dwg._build_issues)
+        n_diams = len(dwg._dropped_callout_diams)
+        assert n_issues > 0
+        _auto_annotate(dwg, dwg._analysis)  # second pass
+        assert len(dwg._build_issues) == n_issues
+        assert len(dwg._dropped_callout_diams) == n_diams
+
+    def test_placement_unsatisfiable_is_error_severity(self):
+        # placement_unsatisfiable (engine could not place a wanted annotation)
+        # is error-severity, so it fails the `passed` gate.
+        from build123d import Box
+
+        from draftwright import build_drawing
+
+        dwg = build_drawing(Box(60, 40, 30))
+        assert dwg.lint_summary()["passed"] is True
+        dwg._record_build_issue("error", "placement_unsatisfiable", "synthetic")
+        s = dwg.lint_summary()
+        assert s["passed"] is False
+        assert s["errors"] >= 1
+        assert s["by_code"]["placement_unsatisfiable"] == 1

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2302,3 +2302,69 @@ class TestSanitizeSvgArcs:
         n = sanitize_svg_arcs(f)
         assert n == 0
         assert "A 5.0 5.0 0 0 1 20 20" in Path(f).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Lint summary + surfacing of build-time annotation drops (#32)
+# ---------------------------------------------------------------------------
+
+
+class TestLintSummaryAndDrops:
+    def test_summary_shape_is_consistent_with_lint(self):
+        from build123d import Box, Cylinder
+
+        from draftwright import build_drawing
+
+        dwg = build_drawing(Box(80, 60, 20) - Cylinder(5, 20))
+        issues = dwg.lint()
+        s = dwg.lint_summary()
+
+        assert set(s) == {
+            "passed",
+            "score",
+            "errors",
+            "warnings",
+            "infos",
+            "by_code",
+            "geometry_issues",
+            "issues",
+        }
+        assert s["errors"] + s["warnings"] + s["infos"] == len(issues)
+        assert s["passed"] is (s["errors"] == 0)
+        assert 0.0 <= s["score"] <= 1.0
+        assert sum(s["by_code"].values()) == len(issues)
+        assert len(s["issues"]) == len(issues)
+        # A single-hole plate doesn't overflow the per-view callout cap.
+        assert "callout_dropped" not in s["by_code"]
+
+    def test_recorded_build_issue_surfaces_and_counts(self):
+        from build123d import Box
+
+        from draftwright import build_drawing
+
+        dwg = build_drawing(Box(60, 40, 30))
+        before = dwg.lint_summary()
+        dwg._record_build_issue("warning", "callout_dropped", "synthetic drop")
+
+        codes = {i.code for i in dwg.lint()}
+        assert "callout_dropped" in codes
+
+        after = dwg.lint_summary()
+        assert after["warnings"] == before["warnings"] + 1
+        assert after["by_code"]["callout_dropped"] == 1
+        # callout_dropped is a geometry-aware code, so it lifts that count too.
+        assert after["geometry_issues"] == before["geometry_issues"] + 1
+
+    @pytest.mark.timeout(120)
+    def test_callout_cap_overflow_is_surfaced(self):
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        # Five distinct-diameter through-holes in the plan view exceed the
+        # per-view callout cap (4); the overflow must surface, not vanish.
+        plate = Box(120, 60, 8)
+        for x, r in zip((-48, -24, 0, 24, 48), (2.0, 2.5, 3.0, 3.5, 4.0)):
+            plate -= Pos(x, 0, 0) * Cylinder(r, 8)
+        dwg = build_drawing(plate)
+        assert "callout_dropped" in {i.code for i in dwg.lint()}


### PR DESCRIPTION
Closes #32.

## Why
`lint()` was a read-only critic, and several layout failures dropped annotations with only a `_log` line. A non-interactive caller — a script, or an LLM via the API — had no machine-readable signal that a drawing came out short or incomplete. This is the "give the API the same scaffolding you have" half of getting drawings right first time.

## What

**1. `Drawing.lint_summary()` — a single signal to gate/optimise on without rendering.**
Returns a JSON-friendly dict:
- `passed` (no error-severity issues), `score` (coarse 0–1 heuristic)
- `errors` / `warnings` / `infos` counts
- `by_code` per-check counts
- `geometry_issues` — count of standards/geometry-correctness issues vs pure layout
- `issues` — the full list as plain dicts

**2. No more silent drops.** Every place the layout drops an annotation now records a lint issue during the build, surfaced by `lint()` under a dedicated code:
- `callout_dropped` — hole callouts past `_MAX_CALLOUTS_PER_VIEW`
- `location_ref_dropped` — location refs past `_MAX_LOCATION_REFS`
- `placement_unsatisfiable` — bore callout with no room / strip full

Recorded via `Drawing._record_build_issue` into `self._build_issues`; `lint()` appends them so repeated calls stay consistent.

Score weights (`_SCORE_ERROR_PENALTY`, `_SCORE_WARNING_PENALTY`) and the geometry-aware code set (`_GEOMETRY_AWARE_CODES`) are single-sourced module constants, not magic numbers at the use site.

## Scope notes
- Full location-dimension *coverage* lint (flagging under-located parts that were never even attempted) is left as follow-up — this PR surfaces the *drops*, which is the silent-failure half. Mentioned as suggested direction in #32.
- The per-view callout cap already surfaced indirectly as `feature_not_dimensioned`; `callout_dropped` is additional signal that distinguishes an engine limitation (a candidate for the #30 repair loop) from a missing input.

## Tests
- `TestLintSummaryAndDrops`: summary shape/consistency with `lint()`; a recorded build issue surfaces and lifts the right counts (incl. `geometry_issues`); a 5-distinct-diameter plate overflows the per-view cap and surfaces `callout_dropped` end-to-end.
- Full fast suite: **214 passed, 10 deselected** (slow CTC builds). `ruff check`, `ruff format --check`, `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)