### PR TITLE
feat: derive bare layout constants from text metrics (#31)

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -17,6 +17,7 @@ CLI (registered as ``make-drawing``)::
 """
 
 import argparse
+import functools
 import logging
 import math
 import re
@@ -26,6 +27,7 @@ from types import SimpleNamespace
 from typing import Literal
 
 from build123d import (
+    Align,
     Arrow,
     Box,
     Color,
@@ -40,6 +42,7 @@ from build123d import (
     Mode,
     Pos,
     Shape,
+    Text,
     Vector,
 )
 from build123d_drafting.features import (
@@ -204,6 +207,30 @@ def _fmt(v: float) -> str:
     """Format a float as integer string if whole, otherwise 1 dp."""
     r = round(v)
     return str(r) if abs(v - r) < 1e-6 else f"{v:.1f}"
+
+
+@functools.lru_cache(maxsize=512)
+def _text_width(text: str, font_size: float, font: str = "Arial") -> float:
+    """Measured rendered width (page-mm) of *text* in *font* at *font_size*.
+
+    Uses build123d's ``Text`` — the same primitive ``Dimension``/``HoleCallout``
+    stroke their labels with — so callout-width estimates use real glyph metrics
+    instead of a character-count fudge (#31).  Cached because the same numeric
+    labels recur across holes and the rasterisation is the costly part.
+    """
+    if not text:
+        return 0.0
+    return (
+        Text(
+            txt=text,
+            font_size=font_size,
+            font=font,
+            align=(Align.CENTER, Align.CENTER),
+            mode=Mode.PRIVATE,
+        )
+        .bounding_box()
+        .size.X
+    )
 
 
 _DIAM_RE = re.compile(r"[øØ⌀]\s*(\d+(?:\.\d+)?)")
@@ -519,14 +546,37 @@ def _parse_page(page) -> tuple:
 _STRIP_GAP = 8.0
 _STRIP_SPACING = 4.0
 
+# Horizontal page budget to reserve for the isometric view during scale
+# selection and view placement, as a fraction of bbox_max * scale.  This is a
+# deliberate *under-estimate*, not the true projected size (a cube's iso
+# projection is ~1.63*bbox_max wide): the iso is the last column and is fitted
+# to the actual largest-empty-rect afterwards by _fit_iso_view(), which shrinks
+# it to whatever space is genuinely left.  A true fit test here is circular —
+# the empty rect depends on the very view positions this estimate feeds — so
+# the budget stays a single, named factor rather than a recomputed fit (#31).
+_ISO_WIDTH_BUDGET = 0.7
+
 # Slot sizes for the annotations that allocate from fv/pv/sv strips.
 # Shared between the depth estimators below and the allocate() call-sites in
 # _auto_annotate() so that a slot-size change is automatically reflected in
 # the estimator-driven corridor widths.
-_SLOT_DIM_HEIGHT = 10.0  # fv_zones.right: overall height dimension
-_SLOT_DIM_STEP = 14.0  # fv_zones.right: step-height dimension
-_SLOT_DIM_WIDTH = 8.0  # pv_zones.below: overall width dimension
-_SLOT_DIM_DEPTH = 8.0  # sv_zones.below: overall depth dimension
+#
+# A slot is the perpendicular depth (page-mm) reserved for one Dimension: its
+# dim-line offset from the view edge plus the label, which sits exactly
+# pad_around_text beyond the line (measured: a "right"/"below" Dimension's
+# perpendicular span equals offset + pad_around_text - extension_gap, and
+# pad == extension_gap in the draft preset).  Each slot is therefore derived
+# from text metrics (font_size + pad_around_text), like _MIN_STEP_DIM_MM, so it
+# rescales with _FONT_SIZE instead of being a bare mm guess (#31).
+_PAD = draft_preset(font_size=_FONT_SIZE, decimal_precision=1).pad_around_text
+# Single overall dim: two glyph-heights of line offset + the outboard label pad.
+_SLOT_DIM_WIDTH = 2 * _FONT_SIZE + _PAD  # pv_zones.below: overall width dimension
+_SLOT_DIM_DEPTH = 2 * _FONT_SIZE + _PAD  # sv_zones.below: overall depth dimension
+# The overall height dim leads the right ladder, so it carries an extra pad of
+# clearance from the view above the first step dim's witness.
+_SLOT_DIM_HEIGHT = 2 * _FONT_SIZE + 2 * _PAD  # fv_zones.right: overall height dim
+# Stacked step dims sit deeper so each ladder rung's label clears the rung below.
+_SLOT_DIM_STEP = 4 * _FONT_SIZE + _PAD  # fv_zones.right: step-height dimension
 
 # Smallest projected step height (page-mm) that can still carry a *legible*
 # stacked dimension between its two extension lines.  Derived from what has to
@@ -615,10 +665,13 @@ def _est_bore_callout_width(
                 bc_by_spec[_spec_key(p.holes[0])] = p
 
     h_fs = font_size
+    # gap (inter-token spacing) and sym_w (geometry-symbol cell width) mirror
+    # HoleCallout's own internal layout constants so the estimate matches what
+    # the primitive actually strokes.  Variable text tokens are measured with
+    # real glyph metrics (_text_width) rather than a character-count fudge (#31).
     gap = 0.45 * h_fs
     sym_w = h_fs
     pad = pad_around_text
-    char_w = 0.6 * h_fs  # avg character width
 
     max_w = 0.0
     for spec_key, group in groups.items():
@@ -629,26 +682,26 @@ def _est_bore_callout_width(
 
         token_w: list[float] = []
         if count:
-            token_w.append(len(f"{count}×") * char_w)
+            token_w.append(_text_width(f"{count}×", h_fs))
         token_w.append(sym_w)  # ⌀ symbol
-        token_w.append(len(_fmt(rep.diameter)) * char_w)
+        token_w.append(_text_width(_fmt(rep.diameter), h_fs))
         if through:
-            token_w.append(len("THRU") * char_w)
+            token_w.append(_text_width("THRU", h_fs))
         elif rep.depth:
             token_w.append(sym_w)  # depth symbol
-            token_w.append(len(_fmt(rep.depth)) * char_w)
+            token_w.append(_text_width(_fmt(rep.depth), h_fs))
         if step:
             token_w.append(sym_w)  # counterbore/spotface symbol
             token_w.append(sym_w)  # ⌀
-            token_w.append(len(_fmt(step.diameter)) * char_w)
+            token_w.append(_text_width(_fmt(step.diameter), h_fs))
             if step.depth:
                 token_w.append(sym_w)  # depth symbol
-                token_w.append(len(_fmt(step.depth)) * char_w)
+                token_w.append(_text_width(_fmt(step.depth), h_fs))
 
         # BoltCircle suffix: "EQ SP ON ø{bc_dia} BC"
         bc = bc_by_spec.get(spec_key)
         if bc is not None:
-            token_w.append(len(f"EQ SP ON ø{_fmt(bc.diameter)} BC") * char_w)
+            token_w.append(_text_width(f"EQ SP ON ø{_fmt(bc.diameter)} BC", h_fs))
 
         n = len(token_w)
         w = sum(token_w) + max(n - 1, 0) * gap + pad
@@ -723,7 +776,7 @@ def _fits(
         + gap_fv_sv
         + y_size * scale
         + _DIM_PAD
-        + bbox_max * scale * 0.7
+        + bbox_max * scale * _ISO_WIDTH_BUDGET
         + _DIM_PAD
         + tb_w
         + _MARGIN
@@ -998,7 +1051,7 @@ def _analyse(step_file, title, number, tolerance, drawn_by, out, scale=None, pag
         + x_size * SCALE
         + y_size * SCALE
         + 2 * DIM_PAD
-        + bbox_max * SCALE * 0.7
+        + bbox_max * SCALE * _ISO_WIDTH_BUDGET
     )
     x_offset = max(0.0, (PAGE_W - 2 * margin - TB_W - total_content_w) / 2)
 
@@ -2670,7 +2723,11 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
     """
     draft = dwg.draft
     gap = draft.pad_around_text
-    min_gap = draft.font_size * 2.2
+    # Minimum vertical separation between stacked bore-callout labels: one label
+    # height (font_size) plus pad_around_text clearance above and below, so
+    # adjacent labels never touch.  Derived from text metrics rather than a bare
+    # font-size ratio (#31).
+    min_gap = draft.font_size + 2 * gap
     # Group on the same machining-spec key pattern detection uses (snapped
     # axis vector included): blind holes drilled from opposite faces are
     # different operations and get separate callouts, and a spec group's
@@ -2938,9 +2995,6 @@ def _add_title_block(dwg, a):
         draft=dwg.draft,
     ).locate(Location((a.PAGE_W - a.TB_W - 11, 11, 0)))
     dwg.add(tb, "title_block")
-
-
-_ISO_SHRINK_FACTORS = (0.5, 0.2, 0.1)
 
 
 def _iso_bbox(dwg):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -587,6 +587,54 @@ class TestDepthEstimators:
 
 
 # ---------------------------------------------------------------------------
+# #31: layout constants derived from text metrics
+# ---------------------------------------------------------------------------
+
+
+class TestDerivedLayoutConstants:
+    """Slots / callout widths / iso budget derive from text metrics, not bare mm."""
+
+    def test_slots_derive_from_font_metrics(self):
+        from draftwright.make_drawing import (
+            _FONT_SIZE,
+            _PAD,
+            _SLOT_DIM_DEPTH,
+            _SLOT_DIM_HEIGHT,
+            _SLOT_DIM_STEP,
+            _SLOT_DIM_WIDTH,
+        )
+
+        assert _SLOT_DIM_WIDTH == pytest.approx(2 * _FONT_SIZE + _PAD)
+        assert _SLOT_DIM_DEPTH == pytest.approx(2 * _FONT_SIZE + _PAD)
+        assert _SLOT_DIM_HEIGHT == pytest.approx(2 * _FONT_SIZE + 2 * _PAD)
+        assert _SLOT_DIM_STEP == pytest.approx(4 * _FONT_SIZE + _PAD)
+        # The slots are linear in font metrics — a hypothetical larger font
+        # would yield larger slots — so they are not frozen mm constants.
+        assert (2 * (2 * _FONT_SIZE) + 2 * _PAD) > _SLOT_DIM_HEIGHT
+
+    def test_text_width_returns_real_glyph_metrics(self):
+        from draftwright.make_drawing import _text_width
+
+        assert _text_width("", 3.0) == 0.0
+        # A real measurement is positive and grows with the string.
+        w1 = _text_width("8", 3.0)
+        w3 = _text_width("888", 3.0)
+        assert 0.0 < w1 < w3
+        # Wider glyphs (uppercase) measure wider than the old 0.6*font fudge
+        # would have estimated — the whole point of using real metrics (#31).
+        assert _text_width("THRU", 3.0) > 4 * 0.6 * 3.0
+
+    def test_bore_callout_width_scales_with_font_size(self):
+        from draftwright.make_drawing import _est_bore_callout_width, find_holes
+
+        part = Box(60, 40, 12) - Pos(0, 0, 6) * Cylinder(3, 12)
+        holes = find_holes(part)
+        small = _est_bore_callout_width(holes, font_size=3.0)
+        large = _est_bore_callout_width(holes, font_size=6.0)
+        assert large > small
+
+
+# ---------------------------------------------------------------------------
 # Phase 3 (#118): dynamic FV→SV corridor
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #31.

## What this does

Converts layout constants that had **no derivation at all** — bare mm tuned to the current fixtures — into values computed from text metrics, following the `_MIN_STEP_DIM_MM` pattern. They now rescale with `_FONT_SIZE` / page size instead of silently degrading on novel (API-driven) geometry.

### Derived from first principles

- **Strip slot widths** (`_SLOT_DIM_HEIGHT/STEP/WIDTH/DEPTH`). A slot is the perpendicular depth one `Dimension` occupies: its dim-line offset from the view edge plus the label, which (measured from a real `Dimension` bbox) sits exactly `pad_around_text` beyond the line. Now derived from `font_size` + `pad_around_text`:
  - width = depth = `2*font_size + pad`
  - height = `2*font_size + 2*pad` (leads the right ladder, extra clearance)
  - step = `4*font_size + pad` (stacked rungs sit deeper)

  The derivations evaluate to the existing values (8/8/10/14 mm), so no fixture moves; the existing `TestDepthEstimators` assertions still hold.

- **Bore-callout label widths.** Replaced the `char_w = 0.6 * font_size` character-count fudge with **real measured Arial glyph metrics** via a cached `_text_width()` helper that uses build123d's `Text` — the same primitive the labels are actually stroked with. The old fudge *under-estimated* uppercase-heavy tokens (`THRU`, `EQ SP ON … BC`); measuring fixes that, improving generalisation.

- **Stacked bore-callout separation.** `min_gap = font_size + 2*pad_around_text` (label height plus clearance above/below) instead of the bare `font_size * 2.2` ratio.

- **Removed dead `_ISO_SHRINK_FACTORS`** (the guess-and-shrink ladder). It was unused — `_fit_iso_view()` already does exactly the fit test the issue asks for, scaling the iso against the real `_largest_empty_rect` region.

### Deliberately left (single-sourced + named, not converted)

- **Iso width budget** (`bbox_max * scale * 0.7`). Promoted to a named `_ISO_WIDTH_BUDGET` with a comment. It is a deliberate *under-estimate* used during scale selection; the iso is fitted afterwards by `_fit_iso_view()` against the true largest-empty-rect. A real fit test *here* is circular — the empty rect depends on the very view positions this estimate feeds — so per the issue's pragmatic guidance it stays a single named factor rather than a risky refactor.

- **`gap = 0.45*font_size` / `sym_w = font_size`** in the callout estimator. These intentionally mirror `HoleCallout`'s own internal layout constants (so the estimate matches what the primitive strokes); kept matching with a comment. (Re-typing them is a #12 drift concern, not a #31 no-derivation concern.)

## Tests

- Added `TestDerivedLayoutConstants`: slots derive from font metrics, `_text_width` returns real glyph metrics (and beats the old 0.6 fudge for uppercase), callout width scales with font size.
- `uv run pytest` (fast): **211 passed**.
- `uv run pytest -m slow` (NIST CTC AP203 + AP242, the real generalization check): **10 passed** (~16 min).
- `uv run ruff check`, `ruff format --check`, `mypy src/draftwright/`: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
