### PR TITLE
feat: adaptive step-height dimensions — remove the cap of 3 (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Changed
 
+- **Step-height dimensions are no longer capped at three.** The `fv_zones.right`
+  corridor is now sized for every legible step (`_est_right_strip_depth` no
+  longer caps the count), and a step dim is placed for each legible level. A
+  part with several shoulders gets them all dimensioned instead of an arbitrary
+  three; the strip allocator remains the real bound (an unplaceable step
+  surfaces as `placement_unsatisfiable`). Verified the NIST CTC parts (8–16
+  step faces each) build with no error-severity lint. Second step of the
+  adaptive-caps work (#36); the per-view callout cap follows. The
+  `step_dim_dropped` lint code is removed (the cap that produced it is gone).
 - Hole **location dimensions are no longer capped at four** per part: they are
   placed nearest-datum-first (baseline practice) until the above-view tier
   strips fill, so a part with room gets all its holes located instead of an

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -391,7 +391,6 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "dim_inside_part",
         "callout_dropped",
         "location_ref_dropped",
-        "step_dim_dropped",
         "placement_unsatisfiable",
     }
 )
@@ -636,12 +635,11 @@ _MIN_STEP_DIM_MM = (
 def _est_right_strip_depth(n_steps: int) -> float:
     """Depth needed to the right of the front view.
 
-    Always includes dim_height (1 slot).  Up to *n_steps* dim_step slots
-    (capped at 3) follow if any step levels are present.  Returns the minimum
-    corridor width (from view edge to outer_limit) that makes all those
-    allocations succeed.
+    Always includes dim_height (1 slot).  *n_steps* dim_step slots follow if
+    any step levels are present.  Returns the minimum corridor width (from view
+    edge to outer_limit) that makes all those allocations succeed.
     """
-    n = 1 + min(max(n_steps, 0), 3)  # dim_height + up to 3 step dims
+    n = 1 + max(n_steps, 0)  # dim_height + one slot per step dim
     # gap + dim_height + (n-1) step slots each preceded by one spacing
     return _STRIP_GAP + _SLOT_DIM_HEIGHT + (n - 1) * (_STRIP_SPACING + _SLOT_DIM_STEP)
 
@@ -1026,7 +1024,7 @@ def _analyse(step_file, title, number, tolerance, drawn_by, out, scale=None, pag
 
     # Conservative upper bound for page selection: count all candidate step
     # faces without the SCALE-dependent _MIN_STEP_DIM_MM gate (SCALE not yet known).
-    n_steps_ub = len(step_zs[:3])
+    n_steps_ub = len(step_zs)
     strips_ub = _measure_strips(
         holes,
         patterns,
@@ -1057,7 +1055,7 @@ def _analyse(step_file, title, number, tolerance, drawn_by, out, scale=None, pag
     DIM_PAD = _DIM_PAD
     margin = _MARGIN
     # Refine: apply the same legibility gate _auto_annotate uses for dim_step.
-    n_steps = len([z for z in step_zs[:3] if (z - bb.min.Z) * SCALE >= _MIN_STEP_DIM_MM])
+    n_steps = len([z for z in step_zs if (z - bb.min.Z) * SCALE >= _MIN_STEP_DIM_MM])
     strips = _measure_strips(
         holes,
         patterns,
@@ -1816,21 +1814,14 @@ def _auto_annotate(dwg, a):
 
     # Step heights — only where the step is tall enough to fit a label;
     # each step witnesses from the previous dim's line (_right_ladder) so
-    # extension lines are adjacent rather than coincident. Only the first
-    # three steps are dimensioned; any further dimensionable steps surface
-    # via lint rather than being silently dropped.
+    # extension lines are adjacent rather than coincident. No fixed cap: the
+    # fv_zones.right corridor is sized for every legible step (#36), and the
+    # strip allocator is the real bound — a step that doesn't fit surfaces via
+    # lint rather than being silently dropped.
     def _step_legible(z):
         return (z - a.bb.min.Z) * a.SCALE >= _MIN_STEP_DIM_MM
 
-    _step_zs = [z for z in a.step_zs[:3] if _step_legible(z)]
-    _n_over_cap = sum(1 for z in a.step_zs if _step_legible(z)) - len(_step_zs)
-    if _n_over_cap > 0:
-        dwg._record_build_issue(
-            "warning",
-            "step_dim_dropped",
-            f"{_n_over_cap} step-height dimension(s) not placed "
-            "(only the first three steps are dimensioned)",
-        )
+    _step_zs = [z for z in a.step_zs if _step_legible(z)]
     for col, z in enumerate(_step_zs):
         _px = a.fv_zones.right.allocate(_SLOT_DIM_STEP)
         if _px is None:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -533,11 +533,18 @@ class TestDepthEstimators:
         # dim_height (10) + 3×dim_step (14 each) + 3×spacing (4 each) = 8+10+4+14+4+14+4+14 = 72
         assert _est_right_strip_depth(3) == pytest.approx(72.0, abs=0.01)
 
-    def test_right_depth_capped_at_three_steps(self):
-        from draftwright.make_drawing import _est_right_strip_depth
+    def test_right_depth_grows_per_step_uncapped(self):
+        from draftwright.make_drawing import (
+            _SLOT_DIM_STEP,
+            _STRIP_SPACING,
+            _est_right_strip_depth,
+        )
 
-        # n_steps is capped at 3 in the estimator
-        assert _est_right_strip_depth(3) == _est_right_strip_depth(10)
+        # #36: no cap — each further step adds one slot + one spacing.
+        assert _est_right_strip_depth(10) > _est_right_strip_depth(3)
+        assert _est_right_strip_depth(10) - _est_right_strip_depth(3) == pytest.approx(
+            7 * (_STRIP_SPACING + _SLOT_DIM_STEP), abs=0.01
+        )
 
     def test_right_depth_increases_with_steps(self):
         from draftwright.make_drawing import _est_right_strip_depth
@@ -2382,19 +2389,22 @@ class TestLintSummaryAndDrops:
         assert not any("ø4" in m for m in fnd), fnd
 
     @pytest.mark.timeout(120)
-    def test_step_dim_cap_overflow_is_surfaced(self):
+    def test_step_dims_are_adaptive_not_capped(self):
+        # #36: no fixed 3-step cap. Five stacked ledges → a step dim for each
+        # legible ledge (well over the old cap of three), corridor sized to fit
+        # them all, no error-severity lint.
         from build123d import Box, Pos
 
         from draftwright import build_drawing
 
-        # Five stacked ledges → five step heights; only the first three are
-        # dimensioned (step_zs[:3]), so the rest must surface, not vanish.
         tower = Box(120, 120, 15)
         for i in range(1, 6):
             side = 120 - i * 18
             tower += Pos(0, 0, i * 15) * Box(side, side, 15)
         dwg = build_drawing(tower)
-        assert "step_dim_dropped" in {i.code for i in dwg.lint()}
+        n_steps = len([n for n in dwg._named if n.startswith("dim_step")])
+        assert n_steps > 3, f"expected adaptive >3 step dims, got {n_steps}"
+        assert [i for i in dwg.lint() if i.severity == "error"] == []
 
     @pytest.mark.timeout(120)
     def test_location_dims_are_adaptive_not_capped(self):


### PR DESCRIPTION
Second step of #36 (adaptive cardinality caps). #36 stays open for the per-view callout cap.

## Why
Step heights were capped at three, enforced in **two** places: `step_zs[:3]` at placement *and* `min(n_steps, 3)` inside `_est_right_strip_depth` (corridor sizing). A part with several legible shoulders lost all but three step heights even with room on the sheet.

Unlike location dims, this cap is **entangled with corridor sizing** (`n_steps → _measure_strips → gap_fv_sv`), so it needed both halves changed together — and empirical verification that uncapping doesn't blow up the layout on multi-level parts.

## What
- `_est_right_strip_depth` grows one slot per step (no `min(…,3)`); `n_steps` in `_analyse` counts **all** legible steps, so the `fv_zones.right` corridor is sized to fit them and `choose_scale` accounts for it.
- The placement loop places **every** legible step; the strip allocator stays the real bound (an unplaceable step surfaces as `placement_unsatisfiable`, never force-placed).
- Removed the now-unreachable `step_dim_dropped` lint code (the cap that produced it is gone).

## Empirical safety check (the risk was layout blow-up)
The CTC parts have **8–16 step faces** each, so I tested before committing. All ten build with **no error-severity lint** and **no page blow-up** (still A1/A2), now placing **7–12** step dims instead of a capped 3. The corridor growth is absorbed.

## Tests
- Replaced the cap-overflow test with an **adaptive** one: a five-ledge tower → **>3** step dims, no error lint.
- Replaced the estimator's `capped_at_three_steps` test with `grows_per_step_uncapped`.
- Full fast suite: **225 passed, 10 deselected**. `ruff`, `ruff format`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)