### PR TITLE
feat: adaptive per-view callout cap — place every bore that fits (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Changed
 
+- **Hole callouts are no longer capped at four per view.** Every distinct bore
+  is attempted; the per-view placement bounds (front-view shaft rows, plan/side
+  strip Y-solver) are the real limit, and a callout that genuinely doesn't fit
+  surfaces as `callout_dropped` (a warning, with its diameter, excluded from
+  `feature_not_dimensioned`). Three previously-silent front-view skip paths now
+  surface too. The bore-callout "no room"/"strip full" drops are reclassified
+  from error (`placement_unsatisfiable`) to this warning, since under the
+  adaptive model an unplaceable callout is an incomplete — not invalid —
+  drawing. Completes the adaptive-caps work (#36); NIST CTC parts now place
+  5–9 callouts (vs a capped 4) with no error-severity lint.
 - **Step-height dimensions are no longer capped at three.** The `fv_zones.right`
   corridor is now sized for every legible step (`_est_right_strip_depth` no
   longer caps the count), and a step dim is placed for each legible level. A

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -2292,7 +2292,20 @@ def _annotate_pmi(dwg, a, draft) -> None:
     _log.info("PMI annotate: %d/%d dims placed", emitted, len(usable))
 
 
-_MAX_CALLOUTS_PER_VIEW = 4
+def _record_callout_drop(dwg, view, diam, reason):
+    """Record a hole callout the layout could not place (#36).
+
+    A warning (the drawing is incomplete, not invalid), whose diameter is
+    excluded from ``feature_not_dimensioned`` like the old per-view cap drop —
+    so a callout that genuinely doesn't fit is surfaced once, with a reason,
+    and not double-reported.
+    """
+    dwg._dropped_callout_diams.append(diam)
+    dwg._record_build_issue(
+        "warning",
+        "callout_dropped",
+        f"hole callout ø{_fmt(diam)} dropped from the {view} view ({reason})",
+    )
 
 
 def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
@@ -2925,32 +2938,12 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
         for holes in view_groups:
             pattern = patterns.get(frozenset(holes))
             specs.append((holes, _build_callout(holes, pattern), pattern))
-        if len(specs) > _MAX_CALLOUTS_PER_VIEW:
-            # annotate the largest features; the rest surface via the lint
-            # (their pattern furniture is withheld too — a bare pitch circle
-            # with no callout referencing it explains nothing)
-            specs.sort(key=lambda s: s[0][0].diameter, reverse=True)
-            dropped = specs[_MAX_CALLOUTS_PER_VIEW:]
-            dropped_diams = [s[0][0].diameter for s in dropped]
-            # Remember which diameters were dropped so lint() can suppress the
-            # redundant feature_not_dimensioned for them — callout_dropped names
-            # them and is the more specific signal (no double-report).
-            dwg._dropped_callout_diams.extend(dropped_diams)
-            _log.info(
-                "%d hole specs in %s view; annotating the %d largest "
-                "(the rest surface as callout_dropped)",
-                len(specs),
-                view,
-                _MAX_CALLOUTS_PER_VIEW,
-            )
-            _diams = ", ".join(f"ø{_fmt(d)}" for d in dropped_diams)
-            dwg._record_build_issue(
-                "warning",
-                "callout_dropped",
-                f"{len(dropped)} hole callout(s) dropped from the {view} view "
-                f"(cap of {_MAX_CALLOUTS_PER_VIEW} per view): {_diams}",
-            )
-            specs = specs[:_MAX_CALLOUTS_PER_VIEW]
+        # No fixed cap (#36): every spec is attempted; the per-view placement
+        # bounds below (front-view shaft rows, plan/side strip Y-solver) are the
+        # real limit, and any callout that genuinely doesn't fit surfaces as
+        # callout_dropped. Largest diameters first so the most significant
+        # features win the available room.
+        specs.sort(key=lambda s: s[0][0].diameter, reverse=True)
 
         if view == "front":
             # Below the view, vertical shafts. Rows are assigned right-to-
@@ -2968,6 +2961,7 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     side, x0, x1 = "left", centre[0] - gap - w, centre[0] - gap
                 else:
                     _log.info("Hole callout ø%s skipped (no room)", _fmt(holes[0].diameter))
+                    _record_callout_drop(dwg, view, holes[0].diameter, "no room beside the view")
                     continue
                 # the title block only constrains rows that reach its x-range
                 floor = (tb_top + 4) if x1 > tb_left - 4 else a.margin + 4
@@ -2975,6 +2969,7 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     _log.info(
                         "Hole callout ø%s skipped (front strip full)", _fmt(holes[0].diameter)
                     )
+                    _record_callout_drop(dwg, view, holes[0].diameter, "front strip full")
                     continue
                 if any(
                     ox0 <= centre[0] <= ox1 and row_y > elbow_y for ox0, ox1, row_y in occupied
@@ -2982,6 +2977,9 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     _log.info(
                         "Hole callout ø%s skipped (shaft would cross another callout)",
                         _fmt(holes[0].diameter),
+                    )
+                    _record_callout_drop(
+                        dwg, view, holes[0].diameter, "shaft would cross another callout"
                     )
                     continue
                 elbow = (centre[0], elbow_y)
@@ -3042,12 +3040,7 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
 
             if not can_right and not can_left:
                 _log.info("Hole callout ø%s skipped (no room)", _fmt(holes[0].diameter))
-                dwg._record_build_issue(
-                    "error",
-                    "placement_unsatisfiable",
-                    f"hole callout ø{_fmt(holes[0].diameter)} not placed "
-                    f"(no room beside the {view} view)",
-                )
+                _record_callout_drop(dwg, view, holes[0].diameter, "no room beside the view")
                 continue
 
             if can_right and (not can_left or d_right <= d_left):
@@ -3074,12 +3067,8 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     n_drop,
                     len(right_queue),
                 )
-                dwg._record_build_issue(
-                    "error",
-                    "placement_unsatisfiable",
-                    f"{n_drop} of {len(right_queue)} bore callout(s) dropped "
-                    f"(strip full right of the {view} view)",
-                )
+                for holes, *_ in right_queue[len(right_ys) :]:
+                    _record_callout_drop(dwg, view, holes[0].diameter, "right strip full")
             right_queue = right_queue[: len(right_ys)]
         if left_ys is None and left_queue:
             left_ys = _greedy_strip_ys(
@@ -3092,12 +3081,8 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
                     n_drop,
                     len(left_queue),
                 )
-                dwg._record_build_issue(
-                    "error",
-                    "placement_unsatisfiable",
-                    f"{n_drop} of {len(left_queue)} bore callout(s) dropped "
-                    f"(strip full left of the {view} view)",
-                )
+                for holes, *_ in left_queue[len(left_ys) :]:
+                    _record_callout_drop(dwg, view, holes[0].diameter, "left strip full")
             left_queue = left_queue[: len(left_ys)]
 
         for i, ((holes, callout, pattern, _, rep), elbow_y) in enumerate(

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1688,7 +1688,10 @@ class TestAutoHoleAnnotations:
         assert [i for i in dwg.lint() if i.severity != "info"] == []
 
     @pytest.mark.timeout(60)
-    def test_callout_cap_keeps_the_largest_holes(self):
+    def test_all_distinct_bores_get_callouts(self):
+        # #36: no per-view callout cap — six distinct-diameter holes in a row
+        # all get callouts (previously capped at the four largest), and nothing
+        # is dropped because they fit.
         part = Box(120, 80, 10)
         for i, r in enumerate([1, 1.5, 2, 2.5, 3, 4]):
             part = part - Pos(-50 + i * 20, 0, 0) * Cylinder(r, 10)
@@ -1697,14 +1700,8 @@ class TestAutoHoleAnnotations:
         for name, ann in dwg._named.items():
             if name.startswith("hc_"):
                 covered.update(ann.covers_diameters)
-        assert covered == {4.0, 5.0, 6.0, 8.0}
-        # the dropped specs (ø2, ø3) surface through callout_dropped, which names
-        # them — not double-reported as feature_not_dimensioned (#32 de-dup)
-        issues = dwg.lint()
-        cd = next(i for i in issues if i.code == "callout_dropped")
-        assert "ø2" in cd.message and "ø3" in cd.message
-        flagged = {i.message for i in issues if i.code == "feature_not_dimensioned"}
-        assert flagged == set()
+        assert covered == {2.0, 3.0, 4.0, 5.0, 6.0, 8.0}
+        assert "callout_dropped" not in {i.code for i in dwg.lint()}
 
     @pytest.mark.timeout(60)
     def test_rotational_part_keeps_leader_annotations(self):
@@ -2366,27 +2363,20 @@ class TestLintSummaryAndDrops:
         # callout_dropped is a geometry-aware code, so it lifts that count too.
         assert after["geometry_issues"] == before["geometry_issues"] + 1
 
-    @pytest.mark.timeout(120)
-    def test_callout_cap_overflow_is_surfaced(self):
-        from build123d import Box, Cylinder, Pos
+    def test_dropped_callout_diameter_excluded_from_feature_lint(self):
+        # The de-dup contract: a diameter recorded as a dropped callout is
+        # excluded from feature_not_dimensioned, so a callout the layout could
+        # not place (#36) is surfaced once (as callout_dropped) and not
+        # double-reported.
+        from build123d import Box, Cylinder
 
-        from draftwright import build_drawing
+        from draftwright.make_drawing import lint_feature_coverage
 
-        # Five distinct-diameter through-holes in the plan view exceed the
-        # per-view callout cap (4); the overflow must surface, not vanish.
-        # The smallest (ø4) is the one dropped (largest four are kept).
-        plate = Box(120, 60, 8)
-        for x, r in zip((-48, -24, 0, 24, 48), (2.0, 2.5, 3.0, 3.5, 4.0)):
-            plate -= Pos(x, 0, 0) * Cylinder(r, 8)
-        dwg = build_drawing(plate)
-        issues = dwg.lint()
-        assert "callout_dropped" in {i.code for i in issues}
-        # The dropped diameter is named by callout_dropped...
-        cd = next(i for i in issues if i.code == "callout_dropped")
-        assert "ø4" in cd.message
-        # ...and NOT double-reported as feature_not_dimensioned (de-dup).
-        fnd = [i.message for i in issues if i.code == "feature_not_dimensioned"]
-        assert not any("ø4" in m for m in fnd), fnd
+        part = Box(60, 40, 20) - Cylinder(5, 20)  # one undimensioned ø10 bore
+        base = lint_feature_coverage(part, [])
+        assert any(i.code == "feature_not_dimensioned" for i in base)
+        excluded = lint_feature_coverage(part, [], exclude=[10.0])
+        assert not any(i.code == "feature_not_dimensioned" for i in excluded)
 
     @pytest.mark.timeout(120)
     def test_step_dims_are_adaptive_not_capped(self):
@@ -2518,16 +2508,15 @@ class TestLayoutGeneralisation:
         assert [i for i in dwg.lint() if i.severity == "error"] == []
 
     @pytest.mark.timeout(120)
-    def test_turned_flange_callout_overflow_is_surfaced_not_dropped(self):
-        # A turned part with more distinct bores than the per-view callout cap
-        # must annotate the largest up to the cap and surface the rest via
-        # lint — never silently drop them (the bores[:N] concern in #13).
+    def test_turned_flange_dimensions_all_its_bores(self):
+        # #36: no per-view callout cap — a turned part with five distinct bores
+        # gets a callout for every one (was capped at four largest), more than
+        # the old cap, with nothing dropped because they fit.
         import math
 
         from build123d import Cylinder, Pos
 
         from draftwright import build_drawing
-        from draftwright.make_drawing import _MAX_CALLOUTS_PER_VIEW
 
         flange = Cylinder(radius=45, height=10) - Cylinder(radius=8, height=10)
         for i, r in enumerate((2.0, 2.5, 3.0, 3.5, 4.0)):
@@ -2536,9 +2525,8 @@ class TestLayoutGeneralisation:
         dwg = build_drawing(flange)
 
         n_callouts = len([n for n in dwg._named if n.startswith("hc_")])
-        assert n_callouts <= _MAX_CALLOUTS_PER_VIEW
-        # The overflow is surfaced, not silent.
-        assert "callout_dropped" in {i.code for i in dwg.lint()}
+        assert n_callouts > 4, f"expected adaptive >4 callouts, got {n_callouts}"
+        assert "callout_dropped" not in {i.code for i in dwg.lint()}
 
     @pytest.mark.timeout(120)
     def test_step_height_legibility_threshold(self):


### PR DESCRIPTION
**Closes #36** — the third and final cardinality cap.

## Why
`_MAX_CALLOUTS_PER_VIEW = 4` dropped hole callouts even when the view had room. Empirically, uncapping is clean: the placement bounds (front-view shaft rows, plan/side strip Y-solver) accommodate the callouts and only drop in genuinely crowded cases.

## What
- **Remove the cap.** Every distinct bore spec is attempted (largest-diameter first); the per-view placement bounds are the real limit.
- **New shared `_record_callout_drop` helper.** A callout that doesn't fit surfaces as `callout_dropped` (warning) with its diameter, excluded from `feature_not_dimensioned` via the existing de-dup — surfaced once, with a reason.
- **Surface three previously-silent front-view skips** ("no room" / "front strip full" / "shaft would cross another callout") — #32 only instrumented the plan/side bore drops.
- **Severity reclassification.** The bore "no room"/"strip full" drops move from error (`placement_unsatisfiable`) to `callout_dropped` (warning). Under the adaptive model an unplaceable callout is an *incomplete*, not *invalid*, drawing — consistent with `location_ref_dropped`. `placement_unsatisfiable` (error) now remains only for the step strip-full degenerate case (corridor sized but still no fit).

## Heads-up: this refines a #32 decision
#32 escalated `placement_unsatisfiable` to error on my recommendation. #36 reframes "couldn't fit" as the *normal* overflow outcome, so for the callout/bore paths a warning is the right severity. I've left the step degenerate path as error. Flagging since you weighed in on that escalation.

## Verified
NIST CTC parts place **5–9** callouts (vs a capped 4) and an 8-distinct-bore plate places all 8 — all with **no error-severity lint** (direct probe over all ten fixtures).

## Tests
- The three cap-overflow tests become **adaptive** (all bores get callouts, >4, nothing dropped).
- De-dup kept as a focused `lint_feature_coverage(exclude=…)` unit test (real callout drops are now rare, like `placement_unsatisfiable`).
- Full fast suite: **225 passed, 10 deselected**. `ruff`, `ruff format`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)