### PR TITLE
feat: legibility gate for hole-location dimensions (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@
 
 ### Changed
 
+- **Hole-location dimensions are gated for legibility.** A hole-dense part (e.g.
+  NIST CTC-02, ~38 distinct hole locations) previously stacked every location
+  reference into a tall, busy tower above the views — "fits" is not "legible".
+  Each axis's references are now gated by inter-dimension page spacing
+  (`_legible_locations`, analogous to the step-height gate #41): only locations
+  at least one value-label footprint apart on the page are dimensioned; the rest
+  surface as `location_ref_dropped` (full fidelity belongs in a detail view,
+  #42). Sparse parts are unchanged (#43).
 - **Step heights are dimensioned only where legibly separable.** After the
   adaptive cap (#36), a part with many closely-spaced shoulders (e.g. NIST
   CTC-02 at 1:5) tried to dimension faces only ~1 mm apart on the page. A step

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -2625,8 +2625,11 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
         if not any(abs(r[0] - u[0]) < 0.5 for u in x_refs):
             x_refs.append(r)
     # Legibility gate (#43): drop X refs whose baseline witness lines would be
-    # page-coincident with a kept one — "fits" is not "legible" (cf. #41).
-    _kept_x, _n_x_close = _legible_locations([r[0] for r in x_refs], a.SCALE)
+    # page-coincident with a kept one — "fits" is not "legible" (cf. #41). Gate
+    # only the refs that will actually be drawn: a hole on the datum edge is
+    # skipped below, so it must not anchor a cluster and drop a real neighbour.
+    _x_drawable = {r[0] for r in x_refs if abs(r[0] - datum_x) * a.SCALE >= 1.0}
+    _kept_x, _n_x_close = _legible_locations(_x_drawable, a.SCALE)
     if _n_x_close:
         dwg._record_build_issue(
             "warning",
@@ -2635,7 +2638,7 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
             "(use a detail view)",
         )
     _kept_x_set = set(_kept_x)
-    x_refs = [r for r in x_refs if r[0] in _kept_x_set]
+    x_refs = [r for r in x_refs if r[0] not in _x_drawable or r[0] in _kept_x_set]
     for n, ann in dwg._named.items():
         if n.startswith("dim_pitch_plan") and getattr(ann, "dim_level_y", 0) > plan_top:
             a.pv_zones.above.allocate(10.0)  # consume space used by pitch dim
@@ -2679,8 +2682,11 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
     for rx, ry, dia in refs:
         if not any(abs(ry - u[1]) < 0.5 for u in y_refs):
             y_refs.append((rx, ry, dia))
-    # Legibility gate (#43): drop Y refs page-coincident with a kept one.
-    _kept_y, _n_y_close = _legible_locations([r[1] for r in y_refs], a.SCALE)
+    # Legibility gate (#43): drop Y refs page-coincident with a kept one. Gate
+    # only drawable refs (the placement loop skips datum-edge ones), so the gate
+    # never anchors a cluster on a hole that isn't dimensioned.
+    _y_drawable = {r[1] for r in y_refs if abs(r[1] - datum_y) * a.SCALE >= 1.0}
+    _kept_y, _n_y_close = _legible_locations(_y_drawable, a.SCALE)
     if _n_y_close:
         dwg._record_build_issue(
             "warning",
@@ -2689,7 +2695,7 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
             "(use a detail view)",
         )
     _kept_y_set = set(_kept_y)
-    y_refs = [r for r in y_refs if r[1] in _kept_y_set]
+    y_refs = [r for r in y_refs if r[1] not in _y_drawable or r[1] in _kept_y_set]
     # Y locations: dims above the side view, routed through sv_zones.above.
     # Pre-advance past any pitch dims already placed above side_top.
     for n, ann in dwg._named.items():

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -679,6 +679,39 @@ _MIN_STEP_SEP_MM = _FONT_SIZE + 2 * _PAD
 # faces from engraved text/numbers that are not steps (staircase.step review).
 _STEP_MIN_AREA_FRAC = 0.01
 
+# Minimum page-mm separation between two *consecutive* hole-location dimensions
+# along one axis. Stacked location dims sit on separate tiers, so their value
+# labels never collide (the tier pitch handles that); the legibility limit is the
+# extension lines / arrowheads merging when two holes share almost the same
+# position on that axis. Sized to one arrowhead plus clearance — smaller than the
+# step-spacing gate, which also stacks labels in one column. Holes closer than
+# this read as one, so only the first of such a run is dimensioned and the rest
+# surface via lint (#43): "fits" is not the same as "legible".
+_MIN_LOC_SEP_MM = draft_preset(font_size=_FONT_SIZE, decimal_precision=1).arrow_length + _PAD
+
+
+def _legible_locations(positions, scale):
+    """Axis positions far enough apart on the page to dimension legibly.
+
+    Given world-coordinate *positions* along one axis, keep a position only if it
+    is at least ``_MIN_LOC_SEP_MM`` page-mm from the previously kept one;
+    consecutive holes closer than that produce baseline witness lines that read
+    as a single busy cluster (#43). Returns ``(kept, n_too_close)``: the
+    positions to dimension and the count dropped for spacing (the caller surfaces
+    these via ``location_ref_dropped`` lint; the full-fidelity answer is a detail
+    view, #42). Mirrors :func:`_legible_steps` for hole locations.
+    """
+    kept: list[float] = []
+    n_too_close = 0
+    last = None
+    for p in sorted(positions):
+        if last is not None and (p - last) * scale < _MIN_LOC_SEP_MM:
+            n_too_close += 1
+            continue
+        kept.append(p)
+        last = p
+    return kept, n_too_close
+
 
 def _legible_steps(step_zs, bb_min_z, scale):
     """Step heights worth dimensioning at *scale*, and how many were too close.
@@ -2591,6 +2624,18 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
     for r in refs:
         if not any(abs(r[0] - u[0]) < 0.5 for u in x_refs):
             x_refs.append(r)
+    # Legibility gate (#43): drop X refs whose baseline witness lines would be
+    # page-coincident with a kept one — "fits" is not "legible" (cf. #41).
+    _kept_x, _n_x_close = _legible_locations([r[0] for r in x_refs], a.SCALE)
+    if _n_x_close:
+        dwg._record_build_issue(
+            "warning",
+            "location_ref_dropped",
+            f"{_n_x_close} X location dim(s) too closely spaced to dimension legibly "
+            "(use a detail view)",
+        )
+    _kept_x_set = set(_kept_x)
+    x_refs = [r for r in x_refs if r[0] in _kept_x_set]
     for n, ann in dwg._named.items():
         if n.startswith("dim_pitch_plan") and getattr(ann, "dim_level_y", 0) > plan_top:
             a.pv_zones.above.allocate(10.0)  # consume space used by pitch dim
@@ -2634,6 +2679,17 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
     for rx, ry, dia in refs:
         if not any(abs(ry - u[1]) < 0.5 for u in y_refs):
             y_refs.append((rx, ry, dia))
+    # Legibility gate (#43): drop Y refs page-coincident with a kept one.
+    _kept_y, _n_y_close = _legible_locations([r[1] for r in y_refs], a.SCALE)
+    if _n_y_close:
+        dwg._record_build_issue(
+            "warning",
+            "location_ref_dropped",
+            f"{_n_y_close} Y location dim(s) too closely spaced to dimension legibly "
+            "(use a detail view)",
+        )
+    _kept_y_set = set(_kept_y)
+    y_refs = [r for r in y_refs if r[1] in _kept_y_set]
     # Y locations: dims above the side view, routed through sv_zones.above.
     # Pre-advance past any pitch dims already placed above side_top.
     for n, ann in dwg._named.items():

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2551,6 +2551,55 @@ class TestLintSummaryAndDrops:
         assert n_loc > 4, f"expected adaptive >4 location dims, got {n_loc}"
         assert "location_ref_dropped" not in {i.code for i in dwg.lint()}
 
+    def test_legible_locations_gate_drops_closely_spaced(self):
+        # #43: a location is dimensioned only if it is at least _MIN_LOC_SEP_MM
+        # (page-mm) from the previously kept one; closer ones read as one busy
+        # cluster and are dropped (surfaced via lint).
+        from draftwright.make_drawing import _MIN_LOC_SEP_MM, _legible_locations
+
+        sep = _MIN_LOC_SEP_MM
+        positions = [0.0, 1.0, 2.0, sep + 2.0, sep + 2.5, 2 * sep + 5.0]
+        kept, n_too_close = _legible_locations(positions, scale=1.0)
+        assert kept == [0.0, sep + 2.0, 2 * sep + 5.0]
+        assert n_too_close == 3
+        # At a larger scale the same world spacing reads fine — nothing dropped.
+        kept2, n2 = _legible_locations([0.0, 1.0, 2.0], scale=10.0)
+        assert kept2 == [0.0, 1.0, 2.0]
+        assert n2 == 0
+
+    @pytest.mark.timeout(120)
+    def test_location_tower_trimmed_to_legible_set(self):
+        # #43: many unpatterned holes with near-coincident X/Y positions trim to
+        # a legible set; the rest surface as location_ref_dropped, no error lint.
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        plate = Box(80, 60, 8)
+        pts = [
+            (-30, -20),
+            (-28, 18),
+            (-26, -5),
+            (-10, 22),
+            (-8, -22),
+            (6, 10),
+            (9, -15),
+            (24, 20),
+            (27, -8),
+            (30, 4),
+        ]
+        for x, y in pts:
+            plate -= Pos(x, y, 0) * Cylinder(1.2, 8)
+        dwg = build_drawing(plate)
+        codes = {i.code for i in dwg.lint()}
+        n_locx = len([n for n in dwg._named if n.startswith("dim_locx")])
+        n_locy = len([n for n in dwg._named if n.startswith("dim_locy")])
+        assert "location_ref_dropped" in codes  # closely-spaced refs were trimmed
+        assert not any(i.severity == "error" for i in dwg.lint())
+        # The kept set is strictly fewer than the ten holes per axis.
+        assert 0 < n_locx < 10
+        assert 0 < n_locy < 10
+
     @pytest.mark.timeout(120)
     def test_auto_annotate_clears_stale_build_issues(self):
         # Re-annotating starts build-time lint tracking from a clean slate:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2601,6 +2601,27 @@ class TestLintSummaryAndDrops:
         assert 0 < n_locy < 10
 
     @pytest.mark.timeout(120)
+    def test_location_gate_ignores_datum_edge_hole(self):
+        # #43 follow-up: a hole on the datum edge is never dimensioned (its dim is
+        # ~zero), so the gate must not anchor a cluster on it and drop a real
+        # neighbour. Box centred at origin -> datum corner at (-40, -30).
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        part = Box(80, 60, 20)
+        part -= Pos(-39.3, 0, 0) * Cylinder(0.4, 20)  # ~0.7 mm from datum_x: skipped
+        part -= Pos(-36.5, 0, 0) * Cylinder(1.5, 20)  # ~2.8 mm from the edge hole
+        dwg = build_drawing(part)
+        # The real neighbour is dimensioned...
+        assert any(n.startswith("dim_locx") for n in dwg._named)
+        # ...and the gate did not record a spurious X spacing drop.
+        x_spacing_drops = [
+            i for i in dwg.lint() if i.code == "location_ref_dropped" and "X location" in i.message
+        ]
+        assert x_spacing_drops == []
+
+    @pytest.mark.timeout(120)
     def test_auto_annotate_clears_stale_build_issues(self):
         # Re-annotating starts build-time lint tracking from a clean slate:
         # stale drop records from a prior pass are cleared, not accumulated.


### PR DESCRIPTION
Closes #43. The sequel to #47: now that automatic selection prefers tighter sheets, hole-location dimensions need a legibility gate so dense parts trim gracefully instead of stacking a busy tower.

## Problem
After #36 removed the per-part cap, a hole-dense part (NIST CTC-02, ~38 distinct hole locations) stacks every location reference into a tall tower above the views. #41 tightened the tier pitch but that only lets *more* fit — information-complete but busy. Same class of issue #41 fixed for step heights: "fits" ≠ "legible".

## Fix
A per-axis page-mm spacing gate, `_legible_locations` (mirrors `_legible_steps` from #41):
- along each axis, a hole location is dimensioned only if it is at least one arrowhead-plus-clearance (~4.7 mm) from the previously kept one;
- closer holes' extension lines merge and read as one, so the rest surface via the existing `location_ref_dropped` lint (full fidelity belongs in a detail view, #42).

**Threshold rationale:** stacked location dims sit on *separate tiers*, so their value labels never collide (the tier pitch handles that) — unlike step dims, which stack labels in one column. The real limit is extension-line/arrowhead merging, hence a smaller threshold than the step gate (one arrowhead + clearance, not the full label footprint).

## Acceptance (all met)
- CTC-02's location tower trims to a legibly-spaced set; the rest surface as `location_ref_dropped`; **no error lint**.
- Sparse parts unchanged — verified a 2-hole part with holes 5 mm apart keeps both dims (this caught an early over-aggressive threshold).

## Tests
- `_legible_locations` unit test (kept/dropped, scale-dependent).
- `test_location_tower_trimmed_to_legible_set` — many close unpatterned holes → trimmed set + `location_ref_dropped`, no error lint.
- Existing `test_location_dims_are_adaptive_not_capped` and `test_underside_cbore_triggers_a_section` (lint-clean) still pass.
- Full suite (on top of #47): 236 passed, 10 deselected; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)