### PR TITLE
docs: ADRs 0001 & 0002 — editing model + iteration loop

### DIFF
--- a/docs/adr/0001-deterministic-generation-over-editable-dsl.md
+++ b/docs/adr/0001-deterministic-generation-over-editable-dsl.md
@@ -1,0 +1,104 @@
+# ADR 0001 — Deterministic generation and domain-semantic editing over a bespoke editable-code DSL
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+draftwright was originally conceived to *generate code*: a build123d +
+`build123d-drafting` script that, when run, produces a fully-annotated technical
+drawing. The premise was that emitting code (rather than only SVG/DXF) would make
+the result easy for humans **and AIs** to edit.
+
+In practice two things became clear:
+
+1. **The generated "code" is not what the premise assumed.** `generate_script`
+   emits a thin wrapper around the engine — `dwg = build_drawing(STEP_FILE, …)`
+   plus a "customise here" surface (`dwg.add` / `dwg.remove` / `dwg.at` /
+   `dwg.add_view`) — not fully-expanded primitive calls that spell out every view
+   and dimension.
+
+2. **The deeper problem is fluency, not verbosity.** The drawing *domain* —
+   orthographic views, ISO/ASME dimensioning, section views, title blocks — is
+   well represented in public material; humans and AIs reason about it readily.
+   What is unfamiliar is draftwright's *DSL for expressing a drawing*: the
+   `Drawing` object, the strip/zone layout model, `dwg.at`, `_legible_steps`, and
+   so on. There is essentially **no public corpus of "technical-drawing-as-code,"**
+   so a model cannot be pretrained-fluent in this API; it must relearn it from
+   context on every call. This is the root cause of the observed gap where
+   API-driven (one-shot) output underperforms interactive sessions: in a session a
+   fluent operator reasons in the domain and merely *drives* the tool; via the API
+   the model is asked to *author an unfamiliar DSL* from scratch.
+
+There is also **no dominant public "drawing-as-code" library to adopt** in place
+of our own convention (FreeCAD TechDraw and similar are not meaningfully present
+in training data), so "ride a familiar convention" is not an available option.
+The closest universally-understood targets are SVG (fluent, but semantics-free —
+a dimension is just lines + text) and the build123d **solid** model (genuinely
+fluent, but it describes the part, not the drawing).
+
+## Decision
+
+Treat **deterministic correctness as the primary interface**, and make any
+necessary editing happen in a vocabulary the editor already speaks. Concretely:
+
+1. **The best convention is no convention.** Invest in making the engine "get it
+   right the first time" — scale/page selection, legibility gates, placement —
+   so that in the common case nobody needs to touch draftwright code at all. Each
+   such improvement makes the unfamiliar DSL *unnecessary* rather than better
+   documented.
+
+2. **Expose editing in domain terms, not layout-engine terms.** Where a caller
+   must adjust the drawing, the API surface should be the **domain** vocabulary a
+   model already knows (features such as holes/bores/sections; intent such as
+   "dimension this bore's depth"), not the internal strip/zone machinery. The
+   roadmap's "Cluster B" primitives (`dwg.features()`, `place_dim()`,
+   `annotations()`, lint `suggestion`s, the lint→repair loop) are reframed as a
+   **domain-semantic layer**, not a layout layer.
+
+3. **De-emphasise bespoke editable-code generation.** `generate_script` remains a
+   convenience for reproducible builds, but it is **not** the strategic path to
+   AI/human editability and should not accrue investment aimed at that goal. Full
+   literal-primitive expansion (every view and dimension as code with computed
+   page coordinates) is explicitly **rejected**: it converts a black box into a
+   brittle transcript of dead coordinates that is harder, not easier, to edit
+   safely (move one view and nothing follows; an editor has no constraints to
+   reason with).
+
+4. **Use familiar vocabularies for the cases they fit.** When a part needs to
+   change, prefer editing the **build123d solid** (a familiar API) and
+   re-drafting. Reserve raw **SVG** editing for last-mile visual nudges, not
+   semantic changes.
+
+## Consequences
+
+**Positive**
+- Effort concentrates on the highest-leverage gap (deterministic quality + a
+  machine-readable lint/repair loop), which is permanent and free per run.
+- The public API we ask callers/AIs to learn shrinks to domain concepts they
+  already understand, reducing the in-context learning burden per call.
+- Avoids over-investing in a code-generation path whose value proposition is
+  undermined by the lack of API fluency.
+
+**Negative / costs**
+- The "edit the generated code directly" story is intentionally weakened; users
+  expecting fully-expanded primitive scripts will not get them.
+- A domain-semantic API is more design work than dumping primitive calls, and it
+  must be kept genuinely domain-shaped (resisting leakage of strip/zone concepts).
+- Deterministic correctness has a long tail; "no convention needed" is an
+  asymptote, and there will always be parts that need manual intervention.
+
+**Neutral / follow-ups**
+- Revisit if a widely-known technical-drawing-as-code convention emerges in
+  public training corpora — adopting it could change the calculus.
+- The lint score/`lint_summary()` is the contract the repair loop and any
+  external editor consume; keep it stable and domain-meaningful.
+
+## Related
+
+- `docs/plans/right-first-time-roadmap.md` — the deterministic-core + Cluster B
+  work that this ADR motivates and reframes.
+- Issues #26 (`features()`), #25 (`place_dim()`), #27 (`annotations()`),
+  #29 (lint suggestions), #30 (lint→repair loop) — the domain-semantic /
+  self-correction layer.

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -1,0 +1,103 @@
+# ADR 0002 — Iterate via lint critique and domain-semantic repair, not by editing generated code
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+ADR 0001 establishes *what* draftwright optimises for: deterministic correctness
+plus a domain-semantic edit surface, rather than a bespoke editable-code DSL.
+This ADR records *how* a caller — human or, especially, an AI via the API — gets
+from the automatic first output to a correct drawing.
+
+The motivating observation (the one that opened this line of work): draftwright
+produces good results when driven *interactively* — render → eyeball → read the
+issues → adjust → re-render — but a one-shot API call underperforms. The
+difference is not model quality; it is that the interactive operator gets
+**laps** (a critique after each attempt) and reasons in the *domain*, whereas a
+one-shot caller gets neither a critique nor a vocabulary it is fluent in.
+
+So the design question is: what replaces the human's "eyeball → adjust" lap for a
+non-interactive caller, without requiring that caller to be fluent in
+draftwright's internals?
+
+## Decision
+
+Adopt an explicit **build → critique → domain-fix** loop as the supported
+refinement model, with the lint system as the machine-readable critic.
+
+1. **`build` — automatic first pass.** `build_drawing(...)` applies all
+   deterministic intelligence and returns both the drawing *and* a critique
+   (`lint_summary()`): `passed`, a coarse `score`, severity counts, and per-issue
+   records with domain-meaningful codes (`feature_not_dimensioned`,
+   `callout_dropped`, `location_ref_dropped`, …). Because of ADR 0001's
+   deterministic investment, the common case ends here — no iteration needed.
+
+2. **`critique` — lint is the machine version of the eyeball lap.** When issues
+   remain, they are surfaced two ways:
+   - **Machine channel (primary for an AI):** `lint_summary()` codes name exactly
+     what is wrong, in domain terms.
+   - **Visual channel:** things lint cannot know (e.g. "the section should cut the
+     other row") come from a human, or from an AI reading the **SVG** (a format
+     models are genuinely fluent in).
+
+3. **`domain-fix` — repair in domain vocabulary, never the layout DSL.** Each fix
+   is expressed as domain intent — `dimension(feature=…)`, `section("A",
+   through=…)` — not strip/zone/`dwg.at` mechanics. Then re-build and re-critique;
+   loop until `passed` (or the score plateaus).
+
+4. **Make the loop cheap to close.** Two mechanisms reduce the fix step to near
+   review-only:
+   - **Per-issue `suggestion` (#29):** each lint issue carries a computed,
+     ready-to-apply domain-API call, so the caller reviews/applies rather than
+     invents.
+   - **lint→repair loop (#30):** computable suggestions are auto-applied; only
+     genuinely judgement-bearing issues reach the human/AI.
+
+The loop is the API-side equivalent of the interactive laps: the engine gives the
+first lap free, lint gives the critique, and the domain API + repair loop give the
+same iterate-and-fix laps — with no fluency in draftwright internals required.
+
+## Consequences
+
+**Positive**
+- A non-interactive caller gets the scaffolding an interactive operator has;
+  this directly addresses the "API less impressive than interactive" gap.
+- The critique contract (`lint_summary()`) is small, stable, and domain-shaped —
+  a good integration point for external tools and agents.
+- Cleanly separates concerns: deterministic quality shrinks step-1→step-2
+  traffic; the loop handles the residue.
+
+**Negative / costs**
+- The loop is only as good as the critic: lint must keep growing toward
+  "flags everything a competent reviewer would," including *never-attempted*
+  coverage gaps, not just drops. Blind spots become silent failures.
+- The `score` is a heuristic; callers should gate on severity/code **counts**,
+  treating the scalar as secondary.
+- Requires building the domain-semantic API, suggestions, and repair loop
+  (roadmap Cluster B / #25–#30) — the loop is aspirational until they exist.
+
+**Neutral / follow-ups**
+- Visual-channel issues remain outside lint by definition; SVG round-trip or a
+  vision-capable reviewer is the path for those, not more lint codes.
+- Keep lint codes domain-meaningful (not layout-internal) so suggestions and the
+  repair loop stay expressible in the domain API.
+
+## Current state vs target
+
+- **Exists:** the engine, `lint()` / `lint_summary()` (the critique), and the
+  deterministic gains that minimise iteration.
+- **Roadmap (mostly unbuilt):** the domain-semantic edit API (#25–28), per-issue
+  suggestions (#29), and the lint→repair loop (#30). Until these land, the
+  "domain-fix" step falls back to the DSL — the path ADR 0001 deprecates — so
+  building this layer is the work that makes the loop real.
+
+## Related
+
+- [ADR 0001](0001-deterministic-generation-over-editable-dsl.md) — the *what*
+  this ADR's *how* depends on.
+- `docs/plans/right-first-time-roadmap.md` — Cluster A (self-correction) and
+  Cluster B (domain primitives) are the build-out of this loop.
+- Issues #25, #26, #27, #28 (domain API), #29 (suggestions), #30 (repair loop),
+  #32 (`lint_summary`, done).


### PR DESCRIPTION
First two ADRs (new `docs/adr/` directory), capturing the architecture decisions from today's discussion on how humans/AIs should drive draftwright.

### ADR 0001 — Deterministic generation over a bespoke editable-code DSL
**Decision:** optimise for deterministic correctness + a domain-semantic edit API, not generating bespoke editable code.
**Why:** the drawing *domain* (views, ISO/ASME dims, sections, title blocks) is familiar to humans and AIs; draftwright's *DSL* (`Drawing`, strips/zones, `dwg.at`) is in no public corpus, so models can't be fluent in it — "the best convention is no convention." Reframes roadmap Cluster B as a *domain* layer; rejects full literal-primitive script expansion.

### ADR 0002 — Iterate via lint critique and domain-semantic repair
**Decision:** the supported refinement model is **build → critique → domain-fix**: `lint_summary()` is the machine version of the interactive "eyeball → adjust" lap; fixes are expressed as domain intent (`dimension(feature=…)`, `section("A", through=…)`), never the layout DSL; per-issue suggestions (#29) + the lint→repair loop (#30) close the loop cheaply.
**Why:** gives a one-shot API caller the same iterate-and-fix laps an interactive operator gets — the gap that opened this work.

Both are honest about current state vs target: the engine + `lint_summary()` exist; the domain API, suggestions, and repair loop (#25–#30) are the build-out that makes the loop real.

Docs-only; own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)