### PR TITLE
docs: handover doc + roadmap/CLAUDE.md refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,31 @@ It sits on top of two Apache 2.0 libraries:
 
 One module: `make_drawing.py`. It contains:
 
-- **Layout engine** — strip/zone model that places views and reserves space for annotations
-- **Scale selection** (`choose_scale`) — ISO/ASME standard scales
+- **Layout engine** — strip/zone model that places views and reserves space for annotations.
+  `_layout_geometry` is the single source of truth for view positions + the iso
+  largest-empty-rectangle, shared by `_fits` (scale selection) and `_analyse` (placement).
+- **Scale selection** (`choose_scale`) — ISO/ASME standard scales via a **page-major** `_LADDER`
+  (smallest sheet first, largest scale on it). A fixed `--page`/`--scale` packs the iso into 2D
+  free space (`pack_iso_2d`) so a part fills the requested sheet.
+- **Legibility gates** — `_legible_steps` (#41) and `_legible_locations` (#43): only dimension
+  features far enough apart on the page to read; the rest surface via lint ("fits" ≠ "legible").
 - **Feature orchestration** — calls `find_holes`, `analyse_cylinders` from `build123d_drafting.features`
 - **Annotation placement** — calls helpers from `build123d_drafting.helpers`
-- **Section view generation** (`_add_section_view`) — ISO 128-44 arrows, ISO 128-50 hatching
-- **`Drawing` class** — composable result object with `.lint()`, `.add()`, `.export_*`
+- **Section view** (`_add_section_view`) — ISO 128-44 arrows, ISO 128-50 hatching
+- **Detail view** (`_add_detail_view`, #42) — enlarged view of a crowded step cluster the gate
+  dropped; non-sheet scale, so its dims carry `_dw_scale` and `lint()` partitions by scale.
+- **`Drawing` class** — composable result with `.lint()`, `.lint_summary()` (machine-readable
+  critique), `.add()`, `.at(view,x,y,z)`, `.add_view()`, `.export()`
 - **CLI** (`draftwright` command) — STEP → SVG+DXF or editable .py script
+
+## Design direction (read the ADRs)
+
+`docs/adr/` records the architecture decisions. In short: optimise for **deterministic
+correctness** ("the best convention is no convention") plus a **domain-semantic edit API**,
+*not* bespoke editable-code generation — the drawing domain is familiar to humans/AIs but
+draftwright's DSL (strips/zones/`dwg.at`) is in no public corpus. The supported refine loop is
+**build → critique (`lint_summary()`) → domain-fix → re-critique**. See
+`docs/plans/right-first-time-roadmap.md` for the work and `docs/HANDOVER.md` for current state.
 
 ## Dependencies
 
@@ -31,10 +49,24 @@ One module: `make_drawing.py`. It contains:
 - `build123d>=0.9.0` (Apache 2.0)
 - `kiwisolver>=1.4,<2` — Cassowary constraint solver for bore-callout Y-placement
 
-## Testing
+## Development
 
-`uv run pytest`. Tests are geometry-level — edge counts, bbox placement, face counts,
-lint clean checks. Target is 100% passing.
+- **Python 3.12** — OCP/vtk do not support 3.13/3.14. If the default interpreter is newer,
+  create the venv explicitly: `uv venv --python 3.12` (and run via `uv run --python 3.12`).
+- **Tests:** `uv run pytest`. Geometry-level — edge counts, bbox placement, face counts, lint
+  clean. Target 100% passing. Heavy NIST CTC end-to-end builds are marked `slow` and deselected
+  from the default run; run targeted + the fast tier locally and let CI own the slow tier.
+- **Lint/format:** `uv run ruff check src/ tests/` and `uv run ruff format src/ tests/` — keep clean.
+- **Visual changes** (views, dims, scale): render to PNG and eyeball — `dwg.export(prefix)` writes
+  `prefix.svg`/`.dxf`; `rsvg-convert -b white in.svg -o out.png`. `lint_summary()` is the
+  machine check; a render is still the only way to judge layout quality.
+
+## Release
+
+Cutting **vX.Y.Z**: finalise `CHANGELOG.md` (Unreleased → the version) via a PR, then publish a
+GitHub **release** with tag `vX.Y.Z`. `.github/workflows/publish.yml` then strips `.dev0`,
+publishes to PyPI, and auto-commits the next `…dev0` bump. A push to `main` publishes a dev build
+to TestPyPI. Current released line: **v0.1.8** (dev `0.1.9.dev0`).
 
 ## License
 

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,0 +1,82 @@
+# Handover — current state of work
+
+_Snapshot for a Claude/dev picking this up on another machine. Last updated 2026-06-16._
+
+## Orientation (read these first)
+
+1. `CLAUDE.md` — what the project is, architecture, dev/release workflow.
+2. `docs/adr/0001-*.md` and `docs/adr/0002-*.md` — the **design direction** (deterministic
+   correctness + a domain-semantic edit API; the build→critique→domain-fix loop).
+3. `docs/plans/right-first-time-roadmap.md` — the work plan and sequencing.
+4. The whole engine is one module: `src/draftwright/make_drawing.py`; tests in
+   `tests/test_make_drawing.py`; NIST CTC fixtures in `tests/fixtures/`.
+
+## Where things stand
+
+- **Released:** **v0.1.8** on PyPI. `pyproject.toml` is at `0.1.9.dev0` (next dev line).
+- **Merged in the recent arc:** #41 (step legibility gate + tier pitch), #46 (staircase fixes),
+  #47 (page-aware scale selection: page-major ladder + 2D iso packing on fixed page/scale + iso
+  growth cap), #43/#49 (hole-location legibility gate), #42/#52 (enlarged detail view MVP),
+  plus #48/#50 (roadmap + changelog).
+- **Open PR:** **#51** — ADRs 0001 & 0002 (docs only, awaiting merge).
+- **Open issues (the roadmap's remaining work):**
+  - Cluster B (domain-semantic API): #26 `features()`, #25 `place_dim()`, #27 `annotations()`,
+    #28 `view_bounds()`.
+  - Self-correction: #29 lint `suggestion` snippets, #30 lint→repair loop.
+  - Drawing quality: #45 representative / "TYP" dimensioning for repeated features.
+
+## Recommended next steps
+
+Per ADR 0002 and the roadmap, the highest-leverage work is the **domain-semantic layer** that
+makes the build→critique→domain-fix loop real:
+
+1. **#26 `features()` + #25 `place_dim()`** — the domain vocabulary + a strip-aware dimension
+   primitive. Standalone API wins and prerequisites for the repair loop. Frame these in **domain
+   terms** (holes/bores/sections/dimensions), never strip/zone internals (ADR 0001).
+2. **#29 suggestions** — each lint issue carries a ready domain-API call.
+3. **#30 lint→repair loop** — auto-apply computable suggestions; surface the rest.
+4. **#45 TYP dimensioning** — opportunistic; reduces clutter for repeated features.
+
+## Known follow-ups / tech debt (not yet all filed)
+
+- **Detail-view legibility on reduction-scale parts** (#42 MVP): on a part already reduced
+  (e.g. CTC-02 at 0.2 → detail at 0.4) the detail is small/dense. Consider a minimum legible
+  detail size, or giving the detail its own sheet. **Not yet filed — worth an issue.**
+- **`step_dim_dropped` is redundant when a detail view now resolves it** — the warning is still
+  truthful (the main view did drop them) but the resolution exists; consider noting "shown in
+  detail A" or downgrading to info. Affects `lint_summary()` (the critique contract).
+- **Detail marker reuses `is_centerline=True`** to dodge the overlap lint; a dedicated furniture
+  flag would be cleaner (needs a `build123d-drafting-helpers` change).
+- **lint is only per-view-scale aware via the `_dw_scale` tag** added for the detail view;
+  the helper `_lint_dim` still assumes one `drawing_scale`. Fine today (detail is the only
+  non-sheet-scale view with dims) but revisit if more such views appear.
+
+## Conventions & gotchas
+
+- **Python 3.12 only** — OCP/vtk break on 3.13/3.14. `uv venv --python 3.12` if needed.
+- **Import shadowing:** `draftwright/__init__` exposes the `make_drawing` *function*, which
+  shadows the submodule — `import draftwright.make_drawing as m; m.SomeName` fails. Import names
+  directly (`from draftwright.make_drawing import _fits`) or use
+  `sys.modules['draftwright.make_drawing']`.
+- **Branch/PR discipline (from the user's global rules):** never commit to `main`; one feature
+  branch + PR per change; **stop after opening a PR** and wait for explicit "merge"; never
+  auto-merge. Commits end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`; PR
+  bodies end with the Claude Code generated-with line.
+- **Testing tiers:** run targeted + the fast suite locally; CI owns the slow NIST CTC tier
+  (3 OS × 3 Python + a slow job). Full fast suite ≈ 5 min, ~239 passing.
+- **Worktree agents** that need to run tests must create a 3.12 venv in the worktree.
+- **Verifying a change quickly:**
+  ```python
+  from draftwright import build_drawing
+  from draftwright.make_drawing import _import_step
+  d = build_drawing(_import_step("tests/fixtures/nist_ctc_02_asme1_ap203.stp"))
+  print(d.lint_summary()["by_code"])      # machine critique
+  d.export("/tmp/check")                    # then rsvg-convert to PNG and look
+  ```
+
+## The core loop the project is building toward (ADR 0002)
+
+`build_drawing()` → render + `lint_summary()` → (apply **domain** fixes ⇄ re-lint) → done.
+The deterministic engine gives the first lap; lint is the machine critic; the domain API +
+repair loop (#25–#30) give an AI the same iterate-and-fix laps a human gets interactively —
+without anyone needing fluency in draftwright's internal DSL.

--- a/docs/plans/right-first-time-roadmap.md
+++ b/docs/plans/right-first-time-roadmap.md
@@ -1,7 +1,12 @@
 # "Right first time" roadmap — hardening the deterministic core
 
-_Status: living plan. Last updated 2026-06-16 alongside PR #47 (page-aware scale
-selection). Tracks the work toward "API-driven output as good as interactive."_
+_Status: living plan. Last updated 2026-06-16 after #42 (detail view) and the
+ADRs. Tracks the work toward "API-driven output as good as interactive."_
+
+> **Direction is now formalised in `docs/adr/`** (ADR 0001 — deterministic
+> generation over a bespoke editable-code DSL; ADR 0002 — the build→critique→
+> domain-fix loop). Cluster B below is the **domain-semantic** layer those ADRs
+> call for. See `docs/HANDOVER.md` for the current state snapshot.
 
 ## Why this exists
 
@@ -35,8 +40,8 @@ worse on novel input.
 - #28 — `dwg.view_bounds(view)` — page bbox of a projected view
 
 **Cluster C — default drawing quality** (the staircase / NIST CTC-02 review)
-- #43 — location-dimension count/legibility gate (the "tall-tower" fix)
-- #42 — enlarged detail view for fine / closely-spaced features
+- ~~#43 — location-dimension count/legibility gate~~ ✅ done
+- ~~#42 — enlarged detail view for fine / closely-spaced features~~ ✅ done (MVP)
 - #45 — representative / "TYP" dimensioning for repeated features
 
 ## How they depend on each other
@@ -58,19 +63,20 @@ worse on novel input.
 
 ## Recommended sequence
 
+Cluster C (deterministic drawing quality) is essentially done (#41/#43/#42/#46/#47);
+the focus now shifts to the **domain-semantic layer** (ADR 0002's build→critique→
+domain-fix loop):
+
 ```
-#43            location-dim legibility gate   ← do next (sequel to #47)
+#26, #25       domain API: features() + place_dim()   ← do next (frame in DOMAIN terms)
    ↓
-#42            detail view for fine features   (home for what #43 + step gate drop)
+#29            lint suggestions — each issue carries a ready domain-API call
    ↓
-#26, #25       primitives (features, place_dim) — also standalone API wins
-   ↓
-#29            lint suggestions, building on #32's issue dict
-   ↓
-#30            repair loop, consuming features + place_dim + suggestions
+#30            repair loop — auto-apply computable suggestions, surface the rest
 ```
-#45 slots in opportunistically alongside #42 (both reduce annotation clutter).
-#27 / #28 slot in wherever an API caller needs them.
+#45 (TYP dimensioning) slots in opportunistically. #27 / #28 land wherever an API
+caller needs them. Keep #26/#25's surface in **domain vocabulary**
+(holes/bores/sections/dimensions), never strip/zone internals (ADR 0001).
 
 ## Done
 
@@ -88,7 +94,7 @@ worse on novel input.
   turned/hybrid parts (flange OD + bolt circle), multi-bore parts, and the
   step-legibility boundary.
 
-### Default drawing quality (Cluster C in progress)
+### Default drawing quality (Cluster C — done bar #45)
 - **#36 — adaptive cardinality caps**. Removed the hard 4 callouts / 4 location
   refs / 3 step-dims caps; the engine now places as many as the available
   strip/corridor space allows, surfacing genuine drops via lint.
@@ -98,11 +104,24 @@ worse on novel input.
 - **Staircase review fixes** (PR #46). Phantom step corridor no longer blocks a
   larger scale; engraved-text faces no longer dimensioned as phantom steps
   (`min_area_frac` filter); overall-height dim nests outside the step dims.
-- **Page-aware scale selection** (PR #47, in review). A specified page enlarges
+- **Page-aware scale selection** (#47, released v0.1.8). A specified page enlarges
   to the best fitting scale (iso packed into 2D empty space, e.g. staircase 2:1
   on A3); automatic selection now minimises sheet size (page-major ladder, e.g.
   20×15×10 → 2:1 on A4 not 5:1 on A3); iso growth capped at 1.3× sheet scale.
   Shared `_layout_geometry` so fit and placement can't diverge.
+- **Location-dimension legibility gate** (#43, released v0.1.8). `_legible_locations`
+  drops hole-location refs whose witness lines would be page-coincident, per axis;
+  the rest surface via `location_ref_dropped`. The sequel to #47's tighter sheets.
+- **Enlarged detail view** (#42 MVP, #52). When the step gate drops a crowded
+  shoulder cluster, auto-generate one enlarged detail view that recovers the
+  dropped dims (`_add_detail_view`); non-sheet scale, so `lint()` partitions dims
+  by `_dw_scale`. Follow-ups: legibility on already-reduced parts; redundant
+  `step_dim_dropped`; the `is_centerline` marker exemption (see `docs/HANDOVER.md`).
+
+### Architecture decisions
+- **ADR 0001 / 0002** (`docs/adr/`, PR #51). Deterministic generation + a
+  domain-semantic edit API over a bespoke editable-code DSL; the
+  build→critique→domain-fix loop as the supported refinement model.
 
 ### Earlier groundwork
 - #10 turned+drilled classification; #11 free-rectangle iso placement; #12


### PR DESCRIPTION
Hands the current state of work over so a Claude/dev on another machine can pick up cleanly.

### New: `docs/HANDOVER.md`
A state snapshot — orientation (which docs to read), what's released (v0.1.8 → 0.1.9.dev0), the merged arc, open PR #51, recommended next steps (the domain-semantic layer #26/#25 → #29 → #30), known follow-ups/tech-debt, and conventions/gotchas (Python 3.12 only; the `draftwright.make_drawing` import-shadowing quirk; branch/PR discipline; test tiers; quick-verify snippet).

### `docs/plans/right-first-time-roadmap.md`
Cluster C done bar #45; re-sequenced onto ADR 0002's domain-semantic loop; records #42/#43/#47 and the ADRs; points at HANDOVER.md.

### `CLAUDE.md`
Architecture now lists the detail view, legibility gates, `_layout_geometry`, page-major ladder, and `lint_summary()`; adds a **Design direction** section pointing at the ADRs; adds **Development** (Python 3.12 requirement, ruff, test tiers, render-to-eyeball) and **Release** (GitHub-release → `publish.yml`) sections.

Docs-only; own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)