### PR TITLE
feat: lint→repair loop — Drawing.repair() acts on fixable lint (#30)

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1980,12 +1980,23 @@ class Drawing:
         flip is attempted at most once and overlap pushes only move outward, so
         the loop terminates and a clean drawing is returned unchanged.
 
+        A pass that would *net-increase* the issue count (e.g. an overlap push
+        that shoves a label out of frame on a tight sheet) is rolled back and
+        the loop stops, so :meth:`repair` never makes a drawing worse.
+
         Returns ``self`` for chaining.
         """
         flipped: set = set()
         for _ in range(max_iter):
+            before = self.lint()
+            if not before:
+                break
+            snap_annotations = list(self.annotations)
+            snap_named = dict(self._named)
             changed = False
-            for issue in self.lint():
+            for issue in before:
+                if issue.code not in _REPAIRABLE_CODES:
+                    continue
                 if issue.code == "dim_inside_part":
                     labels = _QUOTED_RE.findall(issue.message)
                     key = labels[0] if labels else None
@@ -1997,6 +2008,12 @@ class Drawing:
                 elif issue.code == "annotation_overlap":
                     changed |= self._repair_overlap(issue)
             if not changed:
+                break
+            if len(self.lint()) > len(before):
+                # The repairs net-worsened the sheet — undo this pass and stop.
+                self.annotations[:] = snap_annotations
+                self._named.clear()
+                self._named.update(snap_named)
                 break
         return self
 

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -407,6 +407,27 @@ _SCORE_WARNING_PENALTY = 0.05
 # Quote a label parsed from a lint message safely back into a snippet.
 _QUOTED_RE = re.compile(r"'([^']*)'")
 
+# Lint codes the #30 repair loop can mechanically resolve, and the side flip
+# used to move a dimension that landed on the wrong side of its witness points.
+_REPAIRABLE_CODES = frozenset({"annotation_overlap", "dim_inside_part"})
+_OPPOSITE_SIDE = {"above": "below", "below": "above", "left": "right", "right": "left"}
+
+
+def _dim(p1, p2, side, distance, draft, **kwargs):
+    """Build a :class:`Dimension`, tagged with its placement spec.
+
+    Identical to constructing ``Dimension`` directly, but records ``p1``,
+    ``p2``, ``side``, ``distance`` and the label kwargs on the result as
+    ``_dw_spec`` so the #30 repair loop can re-place the dimension (flip the
+    side, widen the offset) without re-deriving any geometry. Only dimensions
+    built this way are re-placeable by :meth:`Drawing.repair`.
+    """
+    d = Dimension(p1, p2, side, distance, draft, **kwargs)
+    d._dw_spec = SimpleNamespace(
+        p1=p1, p2=p2, side=side, distance=abs(distance), draft=draft, kwargs=kwargs
+    )
+    return d
+
 # Tolerance for matching a lint message's reported diameter (dedup
 # representative at tol 0.15, formatted to 1 dp) back to a raw feature
 # diameter when generating a fix snippet (#29).
@@ -1829,8 +1850,6 @@ class Drawing:
         layout analysis is available (e.g. when ``auto_dims=False`` was not used
         with :func:`build_drawing`).
         """
-        from build123d_drafting.helpers import Dimension
-
         a = self._analysis
         _view_zones = {"front": "fv_zones", "plan": "pv_zones", "side": "sv_zones"}
         strip = None
@@ -1847,7 +1866,7 @@ class Drawing:
                     dist = coord - max(p[ax] for p in (p1, p2))
                 else:
                     dist = min(p[ax] for p in (p1, p2)) - coord
-        return self.add(Dimension(p1, p2, side, max(dist, 4.0), draft, **kwargs), name)
+        return self.add(_dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name)
 
     # -- annotations ----------------------------------------------------------
     def add(self, obj, name=None):
@@ -1895,6 +1914,91 @@ class Drawing:
         annotation the layout had to drop). Surfaced by :meth:`lint` so a
         dropped feature is never silent."""
         self._build_issues.append(LintIssue(severity=severity, code=code, message=message))
+
+    # -- repair ---------------------------------------------------------------
+    def _find_dim(self, label):
+        """Return the re-placeable dimension whose label is *label*, or None.
+
+        Only dimensions built by :func:`_dim` (carrying ``_dw_spec``) qualify;
+        leaders, callouts and hand-built annotations are left untouched.
+        """
+        for o in self.annotations:
+            if getattr(o, "_dw_spec", None) is not None and getattr(o, "label", None) == label:
+                return o
+        return None
+
+    def _replace_dim(self, old, new):
+        """Swap *old* for *new* in :attr:`annotations`, preserving its name and
+        any per-view scale tag (so a re-placed detail-view dim stays at scale)."""
+        if getattr(old, "_dw_scale", None) is not None:
+            new._dw_scale = old._dw_scale
+        self.annotations[self.annotations.index(old)] = new
+        for n, o in self._named.items():
+            if o is old:
+                self._named[n] = new
+
+    def _repair_dim_inside_part(self, issue) -> bool:
+        """Flip a dimension that sits inside the view onto the opposite side."""
+        labels = _QUOTED_RE.findall(issue.message)
+        dim = self._find_dim(labels[0]) if labels else None
+        if dim is None:
+            return False
+        s = dim._dw_spec
+        new_side = _OPPOSITE_SIDE.get(s.side)
+        if new_side is None:
+            return False
+        self._replace_dim(dim, _dim(s.p1, s.p2, new_side, s.distance, s.draft, **s.kwargs))
+        return True
+
+    def _repair_overlap(self, issue) -> bool:
+        """Push the first re-placeable label in an overlap one strip-row further
+        out so the two labels separate. Monotonic, so repeated passes converge."""
+        step = _STRIP_SPACING + _SLOT_DIM_HEIGHT
+        for label in _QUOTED_RE.findall(issue.message):
+            dim = self._find_dim(label)
+            if dim is None:
+                continue
+            s = dim._dw_spec
+            self._replace_dim(
+                dim, _dim(s.p1, s.p2, s.side, s.distance + step, s.draft, **s.kwargs)
+            )
+            return True
+        return False
+
+    def repair(self, max_iter: int = 3):
+        """Close the lint→repair loop: act on violations, don't only report them.
+
+        After the greedy initial placement, re-place the dimensions behind the
+        mechanically-clear violations and re-lint, bounded to *max_iter* passes:
+
+        - ``dim_inside_part`` — the offset is on the wrong side; flip it once.
+        - ``annotation_overlap`` — two labels collide; push one further out.
+
+        Only engine-built dimensions (carrying ``_dw_spec``) are re-placeable;
+        leaders, callouts and standards-judgement issues (e.g.
+        ``missing_principal_dimension``) are left for the caller. Each side
+        flip is attempted at most once and overlap pushes only move outward, so
+        the loop terminates and a clean drawing is returned unchanged.
+
+        Returns ``self`` for chaining.
+        """
+        flipped: set = set()
+        for _ in range(max_iter):
+            changed = False
+            for issue in self.lint():
+                if issue.code == "dim_inside_part":
+                    labels = _QUOTED_RE.findall(issue.message)
+                    key = labels[0] if labels else None
+                    if key in flipped:
+                        continue
+                    if self._repair_dim_inside_part(issue):
+                        flipped.add(key)
+                        changed = True
+                elif issue.code == "annotation_overlap":
+                    changed |= self._repair_overlap(issue)
+            if not changed:
+                break
+        return self
 
     # -- output ---------------------------------------------------------------
     def lint(self):
@@ -2189,7 +2293,7 @@ def _auto_annotate(dwg, a, *, detail_view: bool = False):
     if a.is_rotational:
         od = a.od_diam
         dwg.add(
-            Dimension(
+            _dim(
                 (FX(a.cx - od / 2), FZ(a.bb.max.Z) + 2, 0),
                 (FX(a.cx + od / 2), FZ(a.bb.max.Z) + 2, 0),
                 "above",
@@ -2301,7 +2405,7 @@ def _auto_annotate(dwg, a, *, detail_view: bool = False):
         _px = a.fv_zones.right.allocate(_SLOT_DIM_STEP)
         if _px is not None:
             dwg.add(
-                Dimension(
+                _dim(
                     (_right_ladder, FZ(a.bb.min.Z), 0),
                     (_right_ladder, FZ(first_step_z), 0),
                     "right",
@@ -2343,7 +2447,7 @@ def _auto_annotate(dwg, a, *, detail_view: bool = False):
                 )
                 break
             dwg.add(
-                Dimension(
+                _dim(
                     (_right_ladder, FZ(a.bb.min.Z), 0),
                     (_right_ladder, FZ(z), 0),
                     "right",
@@ -2359,7 +2463,7 @@ def _auto_annotate(dwg, a, *, detail_view: bool = False):
     _px = a.fv_zones.right.allocate(_SLOT_DIM_HEIGHT)
     if _px is not None:
         dwg.add(
-            Dimension(
+            _dim(
                 (_right_ladder, FZ(a.bb.min.Z), 0),
                 (_right_ladder, FZ(a.bb.max.Z), 0),
                 "right",
@@ -2379,7 +2483,7 @@ def _auto_annotate(dwg, a, *, detail_view: bool = False):
         _py = a.pv_zones.below.allocate(_SLOT_DIM_WIDTH)
         if _py is not None:
             dwg.add(
-                Dimension(
+                _dim(
                     (PX(a.bb.min.X), _below_witness, 0),
                     (PX(a.bb.max.X), _below_witness, 0),
                     "below",
@@ -2398,7 +2502,7 @@ def _auto_annotate(dwg, a, *, detail_view: bool = False):
         _pd = a.sv_zones.below.allocate(_SLOT_DIM_DEPTH)
         if _pd is not None:
             dwg.add(
-                Dimension(
+                _dim(
                     (SX(a.bb.min.Y), _below_witness_d, 0),
                     (SX(a.bb.max.Y), _below_witness_d, 0),
                     "below",
@@ -2607,7 +2711,7 @@ def _annotate_pmi(dwg, a, draft) -> None:
             return False
         slot = strip.allocate(_SLOT)
         dwg.add(
-            Dimension(
+            _dim(
                 (p1[0], witness_y, 0),
                 (p2[0], witness_y, 0),
                 "above",
@@ -2628,7 +2732,7 @@ def _annotate_pmi(dwg, a, draft) -> None:
             return False
         slot = strip.allocate(_SLOT)
         dwg.add(
-            Dimension(
+            _dim(
                 (p1[0], witness_y, 0),
                 (p2[0], witness_y, 0),
                 "below",
@@ -2649,7 +2753,7 @@ def _annotate_pmi(dwg, a, draft) -> None:
             return False
         slot = strip.allocate(_SLOT)
         dwg.add(
-            Dimension(
+            _dim(
                 (witness_x, p1[1], 0),
                 (witness_x, p2[1], 0),
                 "right",
@@ -2670,7 +2774,7 @@ def _annotate_pmi(dwg, a, draft) -> None:
             return False
         slot = strip.allocate(_SLOT)
         dwg.add(
-            Dimension(
+            _dim(
                 (witness_x, p1[1], 0),
                 (witness_x, p2[1], 0),
                 "left",
@@ -2936,7 +3040,7 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
             )
             continue
         dwg.add(
-            Dimension(
+            _dim(
                 (PX(datum_x), PY(ry), 0),
                 (PX(rx), PY(ry), 0),
                 "above",
@@ -3010,7 +3114,7 @@ def _add_location_dims(dwg, a, axis_letter, patterns, holes_in=None):
             )
             continue
         dwg.add(
-            Dimension(
+            _dim(
                 (SX(datum_y), SZ(a.bb.max.Z), 0),
                 (SX(ry), SZ(a.bb.max.Z), 0),
                 "above",
@@ -3416,7 +3520,7 @@ def _add_detail_view(dwg, a):
         try:
             p_lo = dwg.at("detail_a", a.bb.max.X, dcy, a.bb.min.Z)
             p_hi = dwg.at("detail_a", a.bb.max.X, dcy, z)
-            _dim = Dimension(
+            det_dim = _dim(
                 (ladder, p_lo[1], 0),
                 (ladder, p_hi[1], 0),
                 "right",
@@ -3426,8 +3530,8 @@ def _add_detail_view(dwg, a):
             )
             # The detail view is drawn at detail_scale, not sheet scale; tag the
             # dim so lint() checks label-vs-measured against the right scale (#42).
-            _dim._dw_scale = detail_scale
-            dwg.add(_dim, f"dim_detail_step_{i}")
+            det_dim._dw_scale = detail_scale
+            dwg.add(det_dim, f"dim_detail_step_{i}")
             ladder += step_pad
         except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
             _log.info("dim_detail_step_%d skipped (%s)", i, exc)
@@ -3436,7 +3540,7 @@ def _add_detail_view(dwg, a):
     try:
         p_lo = dwg.at("detail_a", a.bb.max.X, dcy, a.bb.min.Z)
         p_hi = dwg.at("detail_a", a.bb.max.X, dcy, a.bb.max.Z)
-        _dim = Dimension(
+        det_dim = _dim(
             (ladder, p_lo[1], 0),
             (ladder, p_hi[1], 0),
             "right",
@@ -3444,8 +3548,8 @@ def _add_detail_view(dwg, a):
             dwg.draft,
             label=_fmt(a.z_size),
         )
-        _dim._dw_scale = detail_scale  # detail view scale, for label-vs-measured lint (#42)
-        dwg.add(_dim, "dim_detail_height")
+        det_dim._dw_scale = detail_scale  # detail view scale, for label-vs-measured lint (#42)
+        dwg.add(det_dim, "dim_detail_height")
     except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
         _log.info("dim_detail_height skipped (%s)", exc)
 
@@ -3521,7 +3625,7 @@ def _add_pitch_dim(dwg, a, view, j, pattern, to_page):
         return
     n = len(pattern.holes)
     dwg.add(
-        Dimension(
+        _dim(
             (p1[0], p1[1], 0),
             (p2[0], p2[1], 0),
             side,
@@ -4014,6 +4118,7 @@ def build_drawing(
     auto_dims: bool = True,
     detail_view: bool = False,
     pmi: Literal["off", "report", "annotate"] = "off",
+    repair: bool = True,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -4029,6 +4134,10 @@ def build_drawing(
             page, and title block are still produced; add your own
             annotations before export. (Annotations added by the default can
             also be removed wholesale with :meth:`Drawing.clear_annotations`.)
+        repair: run the bounded lint→repair loop (:meth:`Drawing.repair`) after
+            placement to fix mechanically-clear violations (a dim on the wrong
+            side, two overlapping labels). Default ``True``; a no-op on a clean
+            sheet. Pass ``False`` to inspect the raw greedy placement (#30).
 
     Returns:
         A :class:`Drawing` with the standard front/plan/side/iso views projected
@@ -4094,6 +4203,12 @@ def build_drawing(
     else:
         _fit_iso_view(dwg, a, annotate=False)
         _add_title_block(dwg, a)
+    if repair:
+        # Close the loop on the greedy placement: re-place dims behind any
+        # mechanically-clear violations (overlap, wrong-side) and re-lint (#30).
+        # A no-op on a clean sheet, so default-on costs nothing when there is
+        # nothing to fix.
+        dwg.repair()
     return dwg
 
 

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -428,6 +428,7 @@ def _dim(p1, p2, side, distance, draft, **kwargs):
     )
     return d
 
+
 # Tolerance for matching a lint message's reported diameter (dedup
 # representative at tol 0.15, formatted to 1 dp) back to a raw feature
 # diameter when generating a fix snippet (#29).

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3177,3 +3177,99 @@ class TestLintSuggestions:
         sug = _suggest_fix(issue, dwg)
         assert sug is not None
         assert "count=4" in sug
+
+
+class TestRepair:
+    """#30: bounded lint→repair loop acts on violations instead of only reporting."""
+
+    def test_repair_clears_annotation_overlap(self):
+        # Two dimensions forced onto the same page location → their labels
+        # collide; the repair loop pushes one further out to separate them.
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        d = dwg.draft
+        p1, p2 = (40.0, 20.0, 0.0), (80.0, 20.0, 0.0)
+        dwg.add(_dim(p1, p2, "above", 8, d, label="AA"), "ov1")
+        dwg.add(_dim(p1, p2, "above", 8, d, label="BB"), "ov2")
+        assert [i for i in dwg.lint() if i.code == "annotation_overlap"]
+
+        dwg.repair()
+        assert not [i for i in dwg.lint() if i.code == "annotation_overlap"]
+
+    def test_repair_dim_inside_part_flips_side(self):
+        # dim_inside_part is dormant in the multi-view sheet (lint passes no
+        # part_bbox), so drive the repair directly: a wrong-side dim flips to
+        # the opposite side and keeps its name binding.
+        from build123d_drafting.helpers import LintIssue
+
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        dim = dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="INSIDE"), "x")
+        assert dim._dw_spec.side == "above"
+
+        issue = LintIssue(
+            severity="warning",
+            message="Dim 'INSIDE': annotation bbox overlaps part outline by 40%",
+            code="dim_inside_part",
+        )
+        assert dwg._repair_dim_inside_part(issue) is True
+        new = dwg._named["x"]
+        assert new is not dim
+        assert new._dw_spec.side == "below"
+        assert new in dwg.annotations and dim not in dwg.annotations
+
+    def test_repair_inside_part_attempted_once_no_oscillation(self):
+        # A side flip that does not help must not be re-flipped (oscillation).
+        # The same label is only flipped once across the whole loop.
+        from build123d_drafting.helpers import LintIssue
+
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="OSC"), "x")
+
+        # Monkeypatch lint to always report the same dim_inside_part.
+        issue = LintIssue(
+            severity="warning",
+            message="Dim 'OSC': annotation bbox overlaps part outline by 40%",
+            code="dim_inside_part",
+        )
+        dwg.lint = lambda: [issue]
+        dwg.repair(max_iter=5)
+        # Flipped exactly once → ends on "below", not back to "above".
+        assert dwg._named["x"]._dw_spec.side == "below"
+
+    def test_repair_idempotent_on_clean_drawing(self):
+        # build_drawing already repairs by default, so a second pass is a no-op:
+        # same objects, same order.
+        dwg = build_drawing(Box(60, 40, 20))
+        before = [id(o) for o in dwg.annotations]
+        assert dwg.repair() is dwg
+        assert [id(o) for o in dwg.annotations] == before
+
+    def test_repair_does_not_increase_issue_counts(self):
+        # Acceptance: on the existing fixtures, error+warning counts after the
+        # repair pass are <= the raw greedy placement — no regressions.
+        def ew(dwg):
+            return sum(1 for i in dwg.lint() if i.severity in ("error", "warning"))
+
+        for part in (Box(60, 40, 20), _holed_plate(), _uniform_staircase()):
+            raw = ew(build_drawing(part, repair=False))
+            fixed = ew(build_drawing(part, repair=True))
+            assert fixed <= raw
+
+    def test_build_drawing_repair_flag_is_respected(self):
+        # repair=False leaves the greedy placement untouched; the default repairs.
+        from draftwright.make_drawing import _dim
+
+        # A clean part is identical either way (nothing to repair).
+        a = build_drawing(Box(60, 40, 20), repair=False)
+        b = build_drawing(Box(60, 40, 20), repair=True)
+        assert [getattr(o, "label", None) for o in a.annotations] == [
+            getattr(o, "label", None) for o in b.annotations
+        ]
+        # The factory tags engine dims so repair can re-place them.
+        d = _dim((0, 0, 0), (40, 0, 0), "above", 8, a.draft, label="Z")
+        assert d._dw_spec.side == "above"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3270,9 +3270,7 @@ class TestRepair:
         from draftwright.make_drawing import _dim
 
         dwg = build_drawing(Box(60, 40, 20))
-        orig = dwg.add(
-            _dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="RB"), "x"
-        )
+        orig = dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="RB"), "x")
         overlap = LintIssue(
             severity="warning",
             message="labels 'RB' and 'QQ' overlap",

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3260,6 +3260,39 @@ class TestRepair:
             fixed = ew(build_drawing(part, repair=True))
             assert fixed <= raw
 
+    def test_repair_rolls_back_a_pass_that_makes_things_worse(self):
+        # Guard: if a repair (e.g. an overlap push off a tight sheet) net-raises
+        # the issue count, that pass is undone and the loop stops — repair never
+        # makes a drawing worse. Drive it with a stateful lint stub: one fixable
+        # overlap before, two issues after the push.
+        from build123d_drafting.helpers import LintIssue
+
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        orig = dwg.add(
+            _dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="RB"), "x"
+        )
+        overlap = LintIssue(
+            severity="warning",
+            message="labels 'RB' and 'QQ' overlap",
+            code="annotation_overlap",
+        )
+        worse = LintIssue(
+            severity="warning", message="label 'RB' off sheet", code="label_out_of_frame"
+        )
+        calls = {"n": 0}
+
+        def fake_lint():
+            calls["n"] += 1
+            return [overlap] if calls["n"] == 1 else [overlap, worse]
+
+        dwg.lint = fake_lint
+        dwg.repair(max_iter=3)
+        # The pushed dim was reverted: 'x' is the original object, offset intact.
+        assert dwg._named["x"] is orig
+        assert dwg._named["x"]._dw_spec.distance == 8
+
     def test_build_drawing_repair_flag_is_respected(self):
         # repair=False leaves the greedy placement untouched; the default repairs.
         from draftwright.make_drawing import _dim


### PR DESCRIPTION
Closes #30.

## What

Closes the iteration loop ADR 0002 calls for: draftwright now mechanically resolves the two lint codes that have a deterministic placement fix, instead of only reporting them.

## How

- **`_dim()` factory** wraps `Dimension(...)` and tags the result with a `_dw_spec` (`p1`/`p2`/`side`/`distance`/`draft`/`kwargs`). `Dimension` stores none of its construction params, so this is what makes a dimension re-placeable. All dimension call sites route through the factory.
- **`Drawing.repair(max_iter=3)`** runs a bounded lint→repair loop:
  - `annotation_overlap` → push the offending dim outward by one slot (`_STRIP_SPACING + _SLOT_DIM_HEIGHT`).
  - `dim_inside_part` → flip the dim to the opposite side, tracked once per label to prevent oscillation.
  - Pushes are monotonic and the loop is bounded ⇒ it terminates; a clean sheet is a no-op.
- **`build_drawing(..., repair=True)`** runs the loop after greedy placement; the flag lets callers opt out.

## Notes

- `dim_inside_part` is dormant in multi-view sheets (`Drawing.lint()` doesn't pass `part_bbox`), so its end-to-end coverage drives `_repair_dim_inside_part` via a synthetic `LintIssue`; `annotation_overlap` (always-on) provides the dirty→clean end-to-end path.

## Tests

`TestRepair` (6 tests): overlap clearing, side-flip, no-oscillation, idempotency on clean drawings, no issue-count increase across box/holed-plate/staircase fixtures, and the `build_drawing` flag.

Full fast suite green locally (270 passed, ruff clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)