### PR TITLE
feat: dwg.annotations() + get_annotation() query API (#27)

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -75,7 +75,9 @@ dwg = build_drawing(part, out="drawings/bracket", title="BRACKET",
 
 # Available on dwg:
 #   dwg.views        {"front","plan","side","iso"} → (visible, hidden) compounds
-#   dwg.annotations  mutable list of annotation objects
+#   dwg.items        mutable list of annotation objects
+#   dwg.annotations()        → {name: type} of every named annotation
+#   dwg.get_annotation(name) → the named annotation object, or None
 #   dwg.draft / dwg.scale / dwg.page_w / dwg.page_h
 #   dwg.at(view, x, y, z)    → page point (px, py, 0) mapped from world coordinates
 

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1676,7 +1676,7 @@ class Drawing:
         dist: orthographic camera distance in scaled space.
         centroid: unscaled centroid ``(x, y, z)``.
         views: ``{name: (visible_compound, hidden_compound_or_None)}``.
-        annotations: ordered list of annotation objects (mutable).
+        items: ordered list of annotation objects (mutable).
         part: the source solid, when known — enables the feature-coverage lint.
 
     The constructor also accepts ``cyls``, a precomputed
@@ -1711,7 +1711,7 @@ class Drawing:
         self.centroid = centroid
         self.out = out
         self.views: dict = {}
-        self.annotations: list = []
+        self.items: list = []
         self._coords: dict = {}
         self._named: dict = {}
         self.svg_path: str | None = None
@@ -1874,12 +1874,12 @@ class Drawing:
         """Register an annotation so lint and export include it; returns ``obj``.
 
         Re-using an existing ``name`` replaces the previously added object (it is
-        dropped from :attr:`annotations`), so a name always maps to one object.
+        dropped from :attr:`items`), so a name always maps to one object.
         """
         if name is not None and name in self._named:
-            self.annotations.remove(self._named[name])
+            self.items.remove(self._named[name])
         annotate(obj, name)
-        self.annotations.append(obj)
+        self.items.append(obj)
         if name is not None:
             self._named[name] = obj
         return obj
@@ -1889,8 +1889,22 @@ class Drawing:
         obj = self._named.pop(name, None)
         if obj is None:
             raise KeyError(f"no annotation named {name!r}")
-        self.annotations.remove(obj)
+        self.items.remove(obj)
         return obj
+
+    def annotations(self) -> dict:
+        """Return ``{name: type_name}`` for every *named* annotation (#27).
+
+        Lets a script introspect what is already on the drawing before adding
+        more — e.g. ``if "dim_width" not in dwg.annotations()`` — so it can do
+        incremental edits without risking a silent name-collision replace.
+        Unnamed annotations are omitted; iterate :attr:`items` for those.
+        """
+        return {name: type(obj).__name__ for name, obj in self._named.items()}
+
+    def get_annotation(self, name):
+        """Return the named annotation object, or ``None`` if no such name (#27)."""
+        return self._named.get(name)
 
     def clear_annotations(self, keep=("title_block",)):
         """Remove all annotations except those named in *keep* (#74).
@@ -1905,8 +1919,8 @@ class Drawing:
         keep_set = set(keep)
         kept_named = {n: o for n, o in self._named.items() if n in keep_set}
         kept_ids = {id(o) for o in kept_named.values()}
-        removed = [o for o in self.annotations if id(o) not in kept_ids]
-        self.annotations = [o for o in self.annotations if id(o) in kept_ids]
+        removed = [o for o in self.items if id(o) not in kept_ids]
+        self.items = [o for o in self.items if id(o) in kept_ids]
         self._named = kept_named
         return removed
 
@@ -1923,17 +1937,17 @@ class Drawing:
         Only dimensions built by :func:`_dim` (carrying ``_dw_spec``) qualify;
         leaders, callouts and hand-built annotations are left untouched.
         """
-        for o in self.annotations:
+        for o in self.items:
             if getattr(o, "_dw_spec", None) is not None and getattr(o, "label", None) == label:
                 return o
         return None
 
     def _replace_dim(self, old, new):
-        """Swap *old* for *new* in :attr:`annotations`, preserving its name and
+        """Swap *old* for *new* in :attr:`items`, preserving its name and
         any per-view scale tag (so a re-placed detail-view dim stays at scale)."""
         if getattr(old, "_dw_scale", None) is not None:
             new._dw_scale = old._dw_scale
-        self.annotations[self.annotations.index(old)] = new
+        self.items[self.items.index(old)] = new
         for n, o in self._named.items():
             if o is old:
                 self._named[n] = new
@@ -1992,7 +2006,7 @@ class Drawing:
             before = self.lint()
             if not before:
                 break
-            snap_annotations = list(self.annotations)
+            snap_annotations = list(self.items)
             snap_named = dict(self._named)
             changed = False
             for issue in before:
@@ -2012,7 +2026,7 @@ class Drawing:
                 break
             if len(self.lint()) > len(before):
                 # The repairs net-worsened the sheet — undo this pass and stop.
-                self.annotations[:] = snap_annotations
+                self.items[:] = snap_annotations
                 self._named.clear()
                 self._named.update(snap_named)
                 break
@@ -2032,12 +2046,10 @@ class Drawing:
         # scale group with its own drawing_scale so label-vs-measured is correct
         # per view. The common single-scale case is byte-identical to before.
         by_scale: dict = {}
-        for ann in self.annotations:
+        for ann in self.items:
             by_scale.setdefault(getattr(ann, "_dw_scale", self.scale), []).append(ann)
         if len(by_scale) <= 1:
-            issues = lint_drawing(
-                self.annotations, drawing_scale=self.scale, view_shapes=view_shapes
-            )
+            issues = lint_drawing(self.items, drawing_scale=self.scale, view_shapes=view_shapes)
         else:
             issues = []
             for _scale, _anns in by_scale.items():
@@ -2047,7 +2059,7 @@ class Drawing:
                 self._cyl_cache = analyse_cylinders(self.part)
             issues += lint_feature_coverage(
                 self.part,
-                self.annotations,
+                self.items,
                 cyls=self._cyl_cache,
                 exclude=self._dropped_callout_diams,
             )
@@ -2181,7 +2193,7 @@ class Drawing:
             _export_shape(exporter, vis, "part", f"view {name!r}")
             if hid:
                 _export_shape(exporter, hid, "hidden", f"view {name!r}")
-        for ann in self.annotations:
+        for ann in self.items:
             label = getattr(ann, "label", "") or type(ann).__name__
             _export_shape(exporter, ann, "dims", f"annotation {label!r}")
 
@@ -4368,7 +4380,9 @@ def _write_script(a) -> str:
         "\n"
         "# ── Customise here — runs BEFORE export, so edits land in the output ───────────\n"
         "# dwg.views        'front' 'plan' 'side' 'iso'  → (visible, hidden) compounds\n"
-        "# dwg.annotations  mutable list of annotation objects\n"
+        "# dwg.items        mutable list of annotation objects\n"
+        "# dwg.annotations()        → {name: type} of every named annotation\n"
+        "# dwg.get_annotation(name) → the named annotation object, or None\n"
         "# dwg.at(view, x, y, z)  → page point (px, py, 0) mapped from world coordinates\n"
         "# dwg.add(obj, name) / dwg.remove(name)\n"
         "# dwg.add_view(name, shape, camera, up, position)  → section / auxiliary view\n"

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -44,8 +44,8 @@ def _assert_meets_standards(dwg, svg_path, dxf_path):
 
     # Structure: four standard views, a title block, at least one dimension.
     assert set(dwg.views) >= {"front", "plan", "side", "iso"}
-    assert any(isinstance(a, TitleBlock) for a in dwg.annotations), "no title block"
-    assert len(dwg.annotations) >= 2, "expected dimensions + title block"
+    assert any(isinstance(a, TitleBlock) for a in dwg.items), "no title block"
+    assert len(dwg.items) >= 2, "expected dimensions + title block"
 
     # Lint: no error-severity issues (warnings tolerated).
     errors = [i for i in dwg.lint() if i.severity == "error"]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1236,7 +1236,7 @@ def test_build_drawing_returns_populated_drawing(tmp_path):
     dwg = build_drawing(Box(30, 20, 10), out=str(tmp_path / "b"), title="B", number="DWG-1")
     assert isinstance(dwg, Drawing)
     assert set(dwg.views) == {"front", "plan", "side", "iso"}
-    assert dwg.annotations, "expected automatic annotations"
+    assert dwg.items, "expected automatic annotations"
     # build_drawing must not write any files — that is export()'s job.
     assert not (tmp_path / "b.svg").exists()
     assert not (tmp_path / "b.dxf").exists()
@@ -1264,18 +1264,18 @@ def test_build_drawing_auto_dims_false():
     # #74 — views, scale, page, and title block only; no turned-part dims.
     dwg = build_drawing(Cylinder(15, 40), auto_dims=False)
     assert set(dwg.views) == {"front", "plan", "side", "iso"}
-    assert [a for a in dwg.annotations] == [dwg._named["title_block"]]
+    assert [a for a in dwg.items] == [dwg._named["title_block"]]
 
 
 @pytest.mark.timeout(60)
 def test_clear_annotations_keeps_title_block():
     # #74 — wholesale removal without knowing the auto-name scheme.
     dwg = build_drawing(Cylinder(15, 40))  # cylinder → od dim, centerlines, …
-    assert len(dwg.annotations) > 1
+    assert len(dwg.items) > 1
     removed = dwg.clear_annotations()
     assert removed
-    assert all(a not in dwg.annotations for a in removed)
-    assert len(dwg.annotations) == 1
+    assert all(a not in dwg.items for a in removed)
+    assert len(dwg.items) == 1
     assert "title_block" in dwg._named and len(dwg._named) == 1
 
 
@@ -1288,8 +1288,8 @@ def test_clear_annotations_keep_custom_and_unnamed_removed():
     dwg.add(Leader(tip=dwg.at("front", 0, 0, 0), elbow=(6, 6, 0), label="U", draft=dwg.draft))
     dwg.clear_annotations(keep=("title_block", "ldr_k"))
     assert set(dwg._named) == {"title_block", "ldr_k"}
-    assert keep_me in dwg.annotations
-    assert len(dwg.annotations) == 2  # unnamed leader removed too
+    assert keep_me in dwg.items
+    assert len(dwg.items) == 2  # unnamed leader removed too
 
 
 @pytest.fixture(scope="module")
@@ -1305,7 +1305,7 @@ def test_ctc01_iso_uses_upper_right_zone(ctc01_a3_drawing):
     from draftwright.make_drawing import _iso_bbox
 
     dwg = ctc01_a3_drawing
-    labels = [getattr(a, "label", "") for a in dwg.annotations]
+    labels = [getattr(a, "label", "") for a in dwg.items]
     assert "ISO VIEW (NTS)" not in labels  # iso now fits at sheet scale — no NTS
     x0, y0, x1, y1 = _iso_bbox(dwg)
     assert (
@@ -1414,13 +1414,13 @@ def test_tall_part_iso_in_largest_free_zone():
 @pytest.mark.timeout(60)
 def test_drawing_add_and_remove():
     dwg = build_drawing(Box(30, 20, 10))
-    n0 = len(dwg.annotations)
+    n0 = len(dwg.items)
     ldr = Leader(tip=dwg.at("front", 0, 0, 0), elbow=(5, 5, 0), label="X", draft=dwg.draft)
     dwg.add(ldr, "ldr_test")
-    assert len(dwg.annotations) == n0 + 1
+    assert len(dwg.items) == n0 + 1
     removed = dwg.remove("ldr_test")
     assert removed is ldr
-    assert len(dwg.annotations) == n0
+    assert len(dwg.items) == n0
     with pytest.raises(KeyError):
         dwg.remove("does_not_exist")
 
@@ -1428,13 +1428,13 @@ def test_drawing_add_and_remove():
 @pytest.mark.timeout(60)
 def test_drawing_add_replaces_reused_name():
     dwg = build_drawing(Box(30, 20, 10))
-    n0 = len(dwg.annotations)
+    n0 = len(dwg.items)
     first = Leader(tip=dwg.at("front", 0, 0, 0), elbow=(5, 5, 0), label="A", draft=dwg.draft)
     second = Leader(tip=dwg.at("front", 0, 0, 0), elbow=(6, 6, 0), label="B", draft=dwg.draft)
     dwg.add(first, "ldr")
     dwg.add(second, "ldr")  # same name → replaces, no orphan left behind
-    assert len(dwg.annotations) == n0 + 1
-    assert first not in dwg.annotations
+    assert len(dwg.items) == n0 + 1
+    assert first not in dwg.items
     assert dwg.remove("ldr") is second
 
 
@@ -3218,7 +3218,7 @@ class TestRepair:
         new = dwg._named["x"]
         assert new is not dim
         assert new._dw_spec.side == "below"
-        assert new in dwg.annotations and dim not in dwg.annotations
+        assert new in dwg.items and dim not in dwg.items
 
     def test_repair_inside_part_attempted_once_no_oscillation(self):
         # A side flip that does not help must not be re-flipped (oscillation).
@@ -3245,9 +3245,9 @@ class TestRepair:
         # build_drawing already repairs by default, so a second pass is a no-op:
         # same objects, same order.
         dwg = build_drawing(Box(60, 40, 20))
-        before = [id(o) for o in dwg.annotations]
+        before = [id(o) for o in dwg.items]
         assert dwg.repair() is dwg
-        assert [id(o) for o in dwg.annotations] == before
+        assert [id(o) for o in dwg.items] == before
 
     def test_repair_does_not_increase_issue_counts(self):
         # Acceptance: on the existing fixtures, error+warning counts after the
@@ -3298,9 +3298,60 @@ class TestRepair:
         # A clean part is identical either way (nothing to repair).
         a = build_drawing(Box(60, 40, 20), repair=False)
         b = build_drawing(Box(60, 40, 20), repair=True)
-        assert [getattr(o, "label", None) for o in a.annotations] == [
-            getattr(o, "label", None) for o in b.annotations
+        assert [getattr(o, "label", None) for o in a.items] == [
+            getattr(o, "label", None) for o in b.items
         ]
         # The factory tags engine dims so repair can re-place them.
         d = _dim((0, 0, 0), (40, 0, 0), "above", 8, a.draft, label="Z")
         assert d._dw_spec.side == "above"
+
+
+class TestAnnotationsQuery:
+    """#27: introspect existing annotations by name and type."""
+
+    def test_annotations_maps_name_to_type(self):
+        dwg = build_drawing(Box(60, 40, 20))
+        anns = dwg.annotations()
+        # A dict keyed by the names actually registered, valued by class name.
+        assert isinstance(anns, dict)
+        assert anns  # a box drawing has named annotations
+        assert all(isinstance(k, str) and isinstance(v, str) for k, v in anns.items())
+        # Every key resolves, and its reported type matches the live object.
+        for name, type_name in anns.items():
+            assert type(dwg._named[name]).__name__ == type_name
+
+    def test_annotations_omits_unnamed(self):
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        before = dict(dwg.annotations())
+        dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="U"))  # no name
+        # Unnamed annotation lands in items but not in the name→type map.
+        assert dwg.annotations() == before
+        assert len(dwg.items) == len(before) + 1
+
+    def test_annotations_reflects_add_and_membership(self):
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        assert "q_dim" not in dwg.annotations()
+        dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="Q"), "q_dim")
+        assert dwg.annotations()["q_dim"] == "Dimension"
+
+    def test_get_annotation_returns_object_or_none(self):
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        obj = dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="G"), "g")
+        assert dwg.get_annotation("g") is obj
+        assert dwg.get_annotation("does_not_exist") is None
+
+    def test_get_annotation_follows_remove(self):
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="R"), "r")
+        assert dwg.get_annotation("r") is not None
+        dwg.remove("r")
+        assert dwg.get_annotation("r") is None
+        assert "r" not in dwg.annotations()


### PR DESCRIPTION
Closes #27.

## What

Lets a script introspect what annotations are already on the drawing before adding more — so AI-generated scripts can do incremental edits ("add a hole callout if one isn't already there") without risking a silent name-collision replace.

- **`dwg.annotations()`** → `{name: type_name}` for every *named* annotation (the issue's exact spec). Unnamed annotations are omitted; iterate `dwg.items` for those.
- **`dwg.get_annotation(name)`** → the named annotation object, or `None`.

## ⚠️ Breaking change

The ordered list of annotation objects is renamed from **`dwg.annotations`** (now a method) to **`dwg.items`** — still a public, mutable list. `dwg.annotations()` as specced in the issue collides with the old list attribute, so the list got the rename. Pre-1.0 with no external users (per maintainer), so this was the right time to take the cleaner name rather than spell the method awkwardly.

Updated: all internal call sites, the generated-script header comment, `skills/SKILL.md`, and tests (`test_make_drawing.py` + `test_e2e_standards.py`).

## Tests

`TestAnnotationsQuery` (5 tests): name→type mapping, unnamed omitted, reflects add + membership, `get_annotation` object/None, and follows `remove`.

Full fast suite green locally (283 passed), ruff `check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)