### PR TITLE
feat: dwg.view_bounds(view) — page bbox of a named view (#28)

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -80,6 +80,7 @@ dwg = build_drawing(part, out="drawings/bracket", title="BRACKET",
 #   dwg.get_annotation(name) → the named annotation object, or None
 #   dwg.draft / dwg.scale / dwg.page_w / dwg.page_h
 #   dwg.at(view, x, y, z)    → page point (px, py, 0) mapped from world coordinates
+#   dwg.view_bounds(view)    → (x_min, y_min, x_max, y_max) page bbox of the view, or None
 
 # Add a dimension/leader the automatic pass missed:
 dwg.add(Leader(tip=dwg.at("front", 10, 0, 5), elbow=(8, 40, 0),

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1775,6 +1775,30 @@ class Drawing:
         px, py = self._coords[view].pp(x, y, z)
         return (px, py, 0.0)
 
+    def view_bounds(self, view):
+        """Return ``(x_min, y_min, x_max, y_max)`` of the projected geometry in
+        *view*, or ``None`` if the view is unknown (#28).
+
+        The box is the tight bounding box of the placed silhouette — visible
+        plus hidden lines — in page coordinates (mm from the sheet origin), the
+        same space :meth:`at` returns. Use it to place free-form notes, leader
+        elbows and the like just outside a view without guessing offsets::
+
+            x0, y0, x1, y1 = dwg.view_bounds("front")
+            dwg.add(Note("SEE NOTE 1", (x1 + 5, (y0 + y1) / 2), dwg.draft))
+        """
+        placed = self.views.get(view)
+        if placed is None:
+            return None
+        vis, hid = placed
+        bb = vis.bounding_box()
+        x0, y0, x1, y1 = bb.min.X, bb.min.Y, bb.max.X, bb.max.Y
+        if hid:
+            hb = hid.bounding_box()
+            x0, y0 = min(x0, hb.min.X), min(y0, hb.min.Y)
+            x1, y1 = max(x1, hb.max.X), max(y1, hb.max.Y)
+        return (x0, y0, x1, y1)
+
     def features(self, view="front"):
         """Return detected geometric features in page coordinates for *view*.
 
@@ -4020,14 +4044,7 @@ def _add_title_block(dwg, a):
 
 def _iso_bbox(dwg):
     """(min_x, min_y, max_x, max_y) of the placed iso view, hidden lines included."""
-    vis, hid = dwg.views["iso"]
-    bb = vis.bounding_box()
-    x0, y0, x1, y1 = bb.min.X, bb.min.Y, bb.max.X, bb.max.Y
-    if hid:
-        hb = hid.bounding_box()
-        x0, y0 = min(x0, hb.min.X), min(y0, hb.min.Y)
-        x1, y1 = max(x1, hb.max.X), max(y1, hb.max.Y)
-    return x0, y0, x1, y1
+    return dwg.view_bounds("iso")
 
 
 def _bbox_within(bb, region, tol: float = 0.5) -> bool:
@@ -4384,6 +4401,7 @@ def _write_script(a) -> str:
         "# dwg.annotations()        → {name: type} of every named annotation\n"
         "# dwg.get_annotation(name) → the named annotation object, or None\n"
         "# dwg.at(view, x, y, z)  → page point (px, py, 0) mapped from world coordinates\n"
+        "# dwg.view_bounds(view)  → (x_min, y_min, x_max, y_max) page bbox of the view, or None\n"
         "# dwg.add(obj, name) / dwg.remove(name)\n"
         "# dwg.add_view(name, shape, camera, up, position)  → section / auxiliary view\n"
         "# Example:\n"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3389,3 +3389,14 @@ class TestViewBounds:
             assert b is not None, v
             x0, y0, x1, y1 = b
             assert x1 > x0 and y1 > y0, v
+
+    def test_view_bounds_includes_hidden_lines(self):
+        # Bounds union the visible and hidden silhouettes. Replace the front
+        # view's hidden compound with one that extends past the visible box and
+        # confirm the right edge moves out to it.
+        dwg = build_drawing(Box(60, 40, 20))
+        vis, _ = dwg.views["front"]
+        _, _, x1, _ = dwg.view_bounds("front")
+        far = Compound(children=[Edge.make_line((x1 + 10, 0, 0), (x1 + 10, 5, 0))])
+        dwg.views["front"] = (vis, far)
+        assert dwg.view_bounds("front")[2] == pytest.approx(x1 + 10)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3355,3 +3355,37 @@ class TestAnnotationsQuery:
         dwg.remove("r")
         assert dwg.get_annotation("r") is None
         assert "r" not in dwg.annotations()
+
+
+class TestViewBounds:
+    """#28: page bounding box of a named view's projected geometry."""
+
+    def test_view_bounds_returns_page_bbox(self):
+        dwg = build_drawing(Box(60, 40, 20))
+        b = dwg.view_bounds("front")
+        assert b is not None and len(b) == 4
+        x0, y0, x1, y1 = b
+        assert x1 > x0 and y1 > y0
+        # Front view (looking along Y) shows X=60 wide, Z=20 tall, at sheet scale.
+        assert (x1 - x0) == pytest.approx(60 * dwg.scale, rel=1e-3)
+        assert (y1 - y0) == pytest.approx(20 * dwg.scale, rel=1e-3)
+
+    def test_view_bounds_contains_projected_centroid(self):
+        # The part centroid (world origin for a centred Box) projects inside.
+        dwg = build_drawing(Box(60, 40, 20))
+        x0, y0, x1, y1 = dwg.view_bounds("front")
+        px, py, _ = dwg.at("front", 0, 0, 0)
+        assert x0 <= px <= x1
+        assert y0 <= py <= y1
+
+    def test_view_bounds_unknown_view_is_none(self):
+        dwg = build_drawing(Box(60, 40, 20))
+        assert dwg.view_bounds("does_not_exist") is None
+
+    def test_view_bounds_for_each_standard_view(self):
+        dwg = build_drawing(Box(60, 40, 20))
+        for v in ("front", "plan", "side", "iso"):
+            b = dwg.view_bounds(v)
+            assert b is not None, v
+            x0, y0, x1, y1 = b
+            assert x1 > x0 and y1 > y0, v


### PR DESCRIPTION
Closes #28.

## What

`dwg.at(view, x, y, z)` maps a world point to a page point, but there was no way to query a view's extent on the page. Scripts placing `Note`s, `Leader` elbows or other free-form annotations outside a view had to guess offsets, leading to labels on top of projection lines or off the sheet edge.

- **`dwg.view_bounds(view)`** → `(x_min, y_min, x_max, y_max)` of the projected geometry (visible + hidden silhouette) in page coordinates — the same mm space `dwg.at` returns — or `None` for an unknown view.

```python
x0, y0, x1, y1 = dwg.view_bounds("front")
dwg.add(Note("SEE NOTE 1", (x1 + 5, (y0 + y1) / 2), dwg.draft))
```

## How

The placed view compounds (`dwg.views[name]`) are already in page space, so this is the bounding box of the visible compound, extended by the hidden compound. A private `_iso_bbox()` already did exactly this for the iso view — it's been refactored to delegate to `view_bounds("iso")` (no behaviour change; all 8 call sites unchanged).

Documented in the generated-script header and `skills/SKILL.md` alongside `dwg.at`.

## Tests

`TestViewBounds` (4 tests): page bbox dims match part×scale for the front view, the projected centroid lies inside, unknown view → `None`, and every standard view (front/plan/side/iso) returns a valid box.

Full fast suite green locally (287 passed), ruff `check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)