### PR TITLE
feat: assembly-aware feature-coverage lint (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Feature-coverage lint is assembly-aware.** A general-arrangement drawing of
+  a multi-solid part deliberately omits each part's bores (they belong on detail
+  sheets), so `feature_not_dimensioned` / `feature_count_mismatch` are now
+  emitted at `info` rather than `warning` when the part is multi-solid — out of
+  the warning count and quality score, but still queryable. Auto-detected;
+  override with `build_drawing(..., assembly=True/False)` or
+  `lint_feature_coverage(..., assembly=...)` (#69).
+
+### Fixed
+
+- **Exact circles recovered for revolution silhouettes.** `project_to_viewport`'s
+  HLR returns the on-axis silhouette of a turned feature (or a concentric
+  gear-tooth-tip arc) as an approximating spline, not a true circle — splines in
+  the DXF where CAM expects `CIRCLE`/`ARC`, and fitted rather than exact radii.
+  `add_view` now refits any silhouette whose samples are equidistant from a
+  recognised revolution axis back to an exact circle/arc (#67).
+- **Blind-hole depth no longer measured across solid boundaries.** On a
+  multi-solid assembly, coaxial bores in different bodies were merged into one
+  hole, reporting a depth spanning the inter-body gap (the ⌀9.8 ↓111.4 symptom).
+  Fixed upstream in `build123d-drafting-helpers` 0.10.1; the dependency pin is
+  bumped to `>=0.10.1` to pick it up (#68).
+
 ## v0.1.9 — 2026-06-16
 
 ### Added

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -456,13 +456,24 @@ def _concentric_bore_diams(a) -> list:
     return [d for d in a.z_diams if d != a.od_diam and any(abs(d - c) <= 0.15 for c in concentric)]
 
 
-def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None, exclude=None) -> list:
+def lint_feature_coverage(
+    part, annotations, tol: float = 0.15, cyls=None, exclude=None, assembly=None
+) -> list:
     """Coarse completeness check: report part diameters with no callout (#80).
 
     ``exclude`` is an optional iterable of diameters already accounted for by a
     more specific build-time lint (e.g. the per-view callout cap's
     ``callout_dropped``); these are skipped here so a dropped callout is not
     double-reported as ``feature_not_dimensioned``.
+
+    ``assembly`` controls severity for a general-arrangement drawing of a
+    multi-body part. A GA deliberately omits each part's bores (they belong on
+    detail sheets), so demanding a callout for every cylinder is noise. When
+    ``assembly`` is ``True`` the coverage codes (``feature_not_dimensioned`` /
+    ``feature_count_mismatch``) are emitted at ``info`` severity instead of
+    ``warning`` — kept queryable but out of the warning count and quality score.
+    ``None`` (the default) auto-detects: a multi-solid ``part`` is treated as an
+    assembly. Pass ``False`` to force strict single-part severity (#69).
 
     Builds a feature inventory from *part*'s hole/boss diameters (cylinder
     patches spanning at least ~half a turn around their axis in total, so
@@ -488,6 +499,10 @@ def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None, exclu
     z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     inventory = dedup_diams(_full_cyls(z_cyls + cross_cyls), tol=tol)
 
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    coverage_severity = "info" if assembly else "warning"
+
     mentioned: set[float] = set()
     text_mentioned: set[float] = set()
     provided: dict[float, int] = {}
@@ -506,7 +521,7 @@ def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None, exclu
     exclude = exclude or ()
     issues = [
         LintIssue(
-            severity="warning",
+            severity=coverage_severity,
             code="feature_not_dimensioned",
             message=f"cylindrical feature ø{_fmt(d)} has no diameter callout on the sheet",
         )
@@ -527,7 +542,7 @@ def lint_feature_coverage(part, annotations, tol: float = 0.15, cyls=None, exclu
         if 0 < have < need:
             issues.append(
                 LintIssue(
-                    severity="warning",
+                    severity=coverage_severity,
                     code="feature_count_mismatch",
                     message=(
                         f"{need} ø{_fmt(d)} features on the part but callouts account for {have}"
@@ -1835,6 +1850,9 @@ class Drawing:
         views: ``{name: (visible_compound, hidden_compound_or_None)}``.
         items: ordered list of annotation objects (mutable).
         part: the source solid, when known — enables the feature-coverage lint.
+        assembly: feature-coverage severity control — ``None`` auto-detects a
+            multi-solid part as an assembly (per-part bores at ``info``),
+            ``True``/``False`` forces it (#69).
 
     The constructor also accepts ``cyls``, a precomputed
     ``analyse_cylinders(part)`` result (cached privately; computed lazily on
@@ -1855,10 +1873,14 @@ class Drawing:
         out,
         part=None,
         cyls=None,
+        assembly=None,
     ):
         self.scale = scale
         self.part = part
         self._cyl_cache = cyls
+        # None → the coverage lint auto-detects a multi-solid part as an
+        # assembly; True/False forces assembly/strict severity (#69).
+        self.assembly = assembly
         self.page_w = page_w
         self.page_h = page_h
         self.tb_w = tb_w
@@ -2253,6 +2275,7 @@ class Drawing:
                 self.items,
                 cyls=self._cyl_cache,
                 exclude=self._dropped_callout_diams,
+                assembly=self.assembly,
             )
         issues += list(self._build_issues)
         # Attach a ready-to-paste fix snippet where one is computable (#29).
@@ -4333,6 +4356,7 @@ def build_drawing(
     detail_view: bool = False,
     pmi: Literal["off", "report", "annotate"] = "off",
     repair: bool = True,
+    assembly: bool | None = None,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -4352,6 +4376,11 @@ def build_drawing(
             placement to fix mechanically-clear violations (a dim on the wrong
             side, two overlapping labels). Default ``True``; a no-op on a clean
             sheet. Pass ``False`` to inspect the raw greedy placement (#30).
+        assembly: severity of the feature-coverage lint for a general-arrangement
+            drawing. ``None`` (default) auto-detects — a multi-solid part is an
+            assembly, whose per-part bores are reported at ``info`` rather than
+            ``warning`` (a GA omits them by design). Force with ``True``/``False``
+            (#69).
 
     Returns:
         A :class:`Drawing` with the standard front/plan/side/iso views projected
@@ -4385,6 +4414,7 @@ def build_drawing(
         out=out,
         part=a.part,
         cyls=a.cyls,
+        assembly=assembly,
     )
     dwg._analysis = a  # expose analysis namespace for testing and future strip access
 
@@ -4443,6 +4473,7 @@ def make_drawing(
     auto_dims: bool = True,
     detail_view: bool = False,
     pmi: Literal["off", "report", "annotate"] = "off",
+    assembly: bool | None = None,
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -4483,6 +4514,7 @@ def make_drawing(
         auto_dims=auto_dims,
         detail_view=detail_view,
         pmi=pmi,
+        assembly=assembly,
     ).export()
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1659,6 +1659,51 @@ class TestLintFeatureCoverage:
         assert any("ø10" in i.message for i in issues)
 
     @pytest.mark.timeout(60)
+    def test_single_part_feature_warns(self):
+        # A lone part keeps strict severity: an undimensioned bore is a warning.
+        part = Box(40, 40, 12) - Cylinder(4, 12)
+        issues = lint_feature_coverage(part, [])
+        fnd = [i for i in issues if i.code == "feature_not_dimensioned"]
+        assert fnd and all(i.severity == "warning" for i in fnd)
+
+    @pytest.mark.timeout(60)
+    def test_multisolid_assembly_downgrades_to_info(self):
+        # A general-arrangement (multi-solid) drawing omits each part's bores by
+        # design, so feature_not_dimensioned drops to info — out of the warning
+        # count but still queryable (#69).
+        a = Pos(0, 0, 0) * (Box(20, 20, 12) - Cylinder(3, 12))
+        b = Pos(40, 0, 0) * (Box(20, 20, 12) - Cylinder(2.5, 12))
+        asm = Compound(children=[a, b])
+        assert len(asm.solids()) == 2
+        issues = lint_feature_coverage(asm, [])
+        fnd = [i for i in issues if i.code == "feature_not_dimensioned"]
+        assert fnd and all(i.severity == "info" for i in fnd)
+
+    @pytest.mark.timeout(60)
+    def test_assembly_override_forces_strict(self):
+        # assembly=False forces strict severity even on a multi-solid part.
+        a = Pos(0, 0, 0) * (Box(20, 20, 12) - Cylinder(3, 12))
+        b = Pos(40, 0, 0) * (Box(20, 20, 12) - Cylinder(2.5, 12))
+        asm = Compound(children=[a, b])
+        issues = lint_feature_coverage(asm, [], assembly=False)
+        fnd = [i for i in issues if i.code == "feature_not_dimensioned"]
+        assert fnd and all(i.severity == "warning" for i in fnd)
+
+    @pytest.mark.timeout(120)
+    def test_build_drawing_assembly_keeps_warnings_clean(self):
+        # End to end: a GA's uncovered bores land as infos, not warnings, so the
+        # warning count and quality score are not polluted; assembly=False
+        # restores the strict warnings.
+        a = Pos(0, 0, 0) * (Box(20, 20, 12) - Cylinder(3, 12))
+        b = Pos(40, 0, 0) * (Box(20, 20, 12) - Cylinder(2.5, 12))
+        asm = Compound(children=[a, b])
+        auto = build_drawing(asm, page="A4", auto_dims=False).lint_summary()
+        strict = build_drawing(asm, page="A4", auto_dims=False, assembly=False).lint_summary()
+        assert auto["by_code"].get("feature_not_dimensioned", 0) > 0
+        assert auto["warnings"] == 0 and auto["infos"] > 0
+        assert strict["warnings"] > 0 and strict["infos"] == 0
+
+    @pytest.mark.timeout(60)
     def test_hole_callout_accepts_string_diameter(self):
         from build123d_drafting import HoleCallout
 


### PR DESCRIPTION
## Problem

`lint_feature_coverage` raises `feature_not_dimensioned` for every cylindrical feature lacking a callout. On a **single part** that's right; on a **multi-solid general-arrangement drawing** it's mostly noise — a GA deliberately omits each part's bores (they belong on detail sheets), and the warnings drown out the genuinely actionable lint. Closes #69.

## Fix

`feature_not_dimensioned` and `feature_count_mismatch` are emitted at **`info`** rather than **`warning`** when the part is an assembly:
- **Out of the warning count and the quality score** (info carries no score penalty), but **still queryable** in `lint()` / `lint_summary()` — no data loss.
- **Auto-detected**: a multi-solid part (`len(part.solids()) > 1`) is an assembly.
- **Override**: `build_drawing(..., assembly=True/False)`, `make_drawing(..., assembly=...)`, or `lint_feature_coverage(..., assembly=...)`. A single-solid part is unchanged (strict `warning`).

This is option 1 from the issue (multi-solid → downgrade) combined with option 3 (caller override). Option 2 (per-view circle visibility) was rejected: it can't live in the standalone `lint_feature_coverage(part, annotations)` and risks silently dropping a genuine "needs a section view" warning on a single part.

## Verification

End to end on a 2-block multi-solid compound with undimensioned bores (`auto_dims=False`):
- auto (assembly): `warnings=0, infos=2` — noise off the warning count
- `assembly=False`: `warnings=2, infos=0` — strict restored

## Tests

Four new in `TestLintFeatureCoverage`: single-part warns; multi-solid downgrades to info; `assembly=False` forces strict; end-to-end `build_drawing` keeps warnings clean while features stay in `by_code`. Fast tier green (295 passed).

Also backfills the CHANGELOG `Unreleased` section for #67 and #68 (merged without changelog entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)