### PR TITLE
feat: dimension external turned diameters on X-axis turned parts (#77) + ADR 0003

### DIFF
--- a/docs/adr/0003-constraint-based-layout.md
+++ b/docs/adr/0003-constraint-based-layout.md
@@ -1,0 +1,153 @@
+# ADR 0003 — Constraint-based layout: one solver for every placeable
+
+- **Status:** Proposed
+- **Date:** 2026-06-18
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+draftwright places many kinds of annotation on a sheet — linear/diameter
+dimensions, leaders, hole callouts, centrelines, GD&T frames (#61/#62), and
+soon tables (hole tables, BOM, revision blocks). Placement decides *where* each
+label, witness line, and leader shaft goes so the result is legible: nothing
+overlaps, leaders stay short and uncrossed, dimensions sit at standard offsets,
+and a too-busy sheet degrades gracefully rather than producing a tangle.
+
+Today that work is spread across **four mechanisms that do not compose**:
+
+1. **Strip/zone allocation** — `Strip.allocate(slot)` over `fv_zones` etc. The
+   principled space-budget; used by step/height dim ladders.
+2. **Manual pitch stacking** — bore leaders (and, initially, the #77 turned-
+   diameter leaders) compute positions by hand and bypass the allocator.
+3. **Cassowary (kiwisolver)** — `_solve_strip_ys` solves bore-callout placement
+   along one strip as a 1D constraint problem. The right tool, used in one place.
+4. **Post-hoc repair** (#30, ADR 0002) — `Drawing.repair()` nudges *dimensions*
+   to clear overlaps after the fact, but **cannot move leaders** and has no
+   model of leader length or crossing.
+
+The costs are concrete: leaders are second-class (nothing deconflicts them); a
+new annotation type means inventing placement from scratch; stacked-dimension
+"nesting" is hand-rolled where a constraint would say it directly; and "it fit"
+is decided greedily, so a dense sheet silently produces long or colliding
+leaders instead of escalating.
+
+We already pay for a Cassowary solver and have proven it works (mechanism 3).
+The question this ADR settles: **what is the single layout model that every
+placeable uses, so dimensions, leaders, callouts, tables, and GD&T all place
+well together?**
+
+## Decision
+
+Adopt a **two-layer, constraint-based layout architecture**. Every placeable
+implements one protocol; placement is one assignment pass feeding one global
+Cassowary solve.
+
+The load-bearing insight: **Cassowary is linear, and non-overlap is not**
+("A clears B" is a disjunction — left *or* right *or* above *or* below). So a
+single solve cannot do layout alone. Layout is two layers:
+
+1. **Assignment (combinatorial).** The discrete choices: which zone/side a label
+   takes, which view annotates a feature, the order within a stack, and whether
+   N features become N callouts or one *table*. Seeded heuristically from anchor
+   position (today's strip model, generalised). Fixing these choices turns each
+   non-overlap into a *linear* separation constraint.
+
+2. **Placement (continuous, Cassowary).** Given the assignment, solve **all**
+   continuous positions as one global linear system with priorities:
+   - *required*: boxes within page; no overlap with views / title block / one
+     another (separation direction fixed by layer 1); minimum standoff.
+   - *strong/medium/weak*: pull each box to its natural offset; **align** a group
+     by a shared offset variable (stacked-dim nesting becomes one equality);
+     minimise leader length as `|Δx| + |Δy|` (linear).
+
+### The unifying abstraction: `Placeable`
+
+Every dimension, leader, callout, table, and GD&T frame exposes:
+
+- **anchors** — fixed geometric points it must connect to (dimension: 2 witness
+  points; leader/callout: 1 tip; table: 0; note: 0–1).
+- **box** — its label/footprint bbox; size from text metrics, position from
+  solver variables.
+- **dof** — what the solver may move: a dimension slides along its offset axis
+  (plus text along the dim line); a leader's elbow+label move with the tip
+  pinned; a table is 2-DOF or corner-pinned.
+- **connectors** — witness/leader lines linking anchor→box that should not cross
+  other boxes.
+- **preferences** — natural offset, pull-toward-anchor, alignment-group id.
+
+Once everything is a `Placeable`, **leaders cease to be second-class** — they are
+solved by the same system as dimensions, which is the specific gap today.
+
+### The solve pipeline (this subsumes the repair loop)
+
+1. **Assign** each placeable to a zone/side (heuristic seed from anchors).
+2. **Build** one Cassowary system from the constraints above.
+3. **Solve** once; priorities resolve contention.
+4. **Validate** → on residual overlap/crossing, add a separating constraint and
+   re-solve (lazy / branch-and-bound). This is the principled replacement for
+   #30's nudge-and-hope — *and it works for leaders*.
+5. **Escalate** when unsatisfiable (below).
+
+### The escalation ladder (systematises today's drop-lint)
+
+When a fidelity level is infeasible, follow a defined ladder rather than ad-hoc
+drops: zone A → zone B → **tabulate** (callouts → hole table) → **detail view**
+→ **reduce scale**. Today's `callout_dropped` / `step_dim_dropped` /
+`location_ref_dropped` are the scattered manual version; "unsatisfiable" becomes
+a real solver outcome that drives the ladder, and a genuine drop is still
+surfaced as lint.
+
+## Consequences
+
+**Positive**
+- One placement model for every annotation type; a new type (GD&T, tables) drops
+  in as a `Placeable` with **no new layout code** — the main payoff.
+- Leaders become first-class: deconflicted, length-minimised, escalated.
+- Stacked-dimension alignment and nesting become constraints, deleting bespoke
+  "outermost" ordering logic.
+- Repair (ADR 0002) generalises from "nudge dims" to "add a constraint and
+  re-solve," covering leaders and tables for free.
+- Tests improve: "assert constraint satisfied" beats brittle bbox assertions.
+
+**Negative / costs**
+- The combinatorial assignment layer is irreducible — this is **not** "one magic
+  solve." Over-selling Cassowary would mislead; the win is *structure*.
+- Global solves can move distant elements surprisingly; "pin near anchor" plus
+  priorities mitigate but need tuning.
+- **Determinism is mandatory** — stable variable ordering, or drawings and tests
+  stop being reproducible. Cassowary is deterministic given stable input order.
+- Multi-PR effort; risk of a half-migrated engine running two models at once.
+
+**Neutral / follow-ups**
+- Performance: hundreds of variables is comfortable for Cassowary; watch the
+  largest sheets.
+- Euclidean leader length is non-linear; Manhattan is the supported approximation.
+
+## Migration — incremental, subsumes existing behaviour
+
+1. Define `Placeable` + a `LayoutSolver` wrapping Cassowary; generalise
+   `_solve_strip_ys` into the axis-neutral 1D primitive it already is.
+2. **Prove on one mechanism** — the #77 turned-diameter leaders place via the
+   shared 1D solver, not manual pitch (this PR; the bridge to the protocol).
+3. Port hole callouts (already Cassowary) → bore leaders → dimension ladders.
+4. Retire manual pitch-stacking and fold the post-hoc repair loop into
+   validate-and-resolve as passes move in.
+5. Tables and GD&T arrive as new `Placeable`s.
+
+## Current state vs target
+
+- **Exists:** the strip/zone allocator, `_solve_strip_ys` (a working 1D
+  Cassowary placement), and `Drawing.repair()` (dim-only post-hoc fix).
+- **Target:** the `Placeable` protocol, a global `LayoutSolver`, the escalation
+  ladder, and all passes migrated onto them. Until then the engine runs the four
+  mechanisms side by side; each migration step removes one.
+
+## Related
+
+- [ADR 0001](0001-deterministic-generation-over-editable-dsl.md) — deterministic
+  generation; layout quality is a pillar of that determinism.
+- [ADR 0002](0002-iterate-via-lint-critique-and-domain-repair.md) — the repair
+  loop this ADR generalises from "nudge dims" to "constrain and re-solve."
+- Issue #77 (external turned diameters — the first `Placeable`); the phased
+  layout issues (protocol/solver → port callouts → port dims → tables/GD&T);
+  #61/#62 (GD&T — beneficiaries of the unified placement).

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -54,6 +54,7 @@ from build123d_drafting.features import (
     _full_cyls,
     _spec_key,
     analyse_cylinders,
+    find_bosses,
     find_hole_patterns,
     find_holes,
 )
@@ -2446,6 +2447,108 @@ def _export_shape(exporter, shape, layer, ctx):
         )
 
 
+def _mentioned_diams(annotations):
+    """Diameters already called out by an annotation — from ø-labels and from
+    structured ``covers_diameters`` metadata (e.g. ``HoleCallout``). Mirrors the
+    coverage :func:`lint_feature_coverage` checks, so a diameter in this set will
+    not lint as ``feature_not_dimensioned``."""
+    diams: set = set()
+    for ann in annotations:
+        if isinstance(ann, TitleBlock):
+            continue
+        for m in _DIAM_RE.finditer(getattr(ann, "label", None) or ""):
+            diams.add(float(m.group(1)))
+        for v in getattr(ann, "covers_diameters", ()):
+            diams.add(float(v))
+    return diams
+
+
+def _annotate_turned_diameters(dwg, a):
+    """Leader ø-callouts for external turned diameters whose axis lies along X (#77).
+
+    draftwright dimensions holes and, for a Z-rotational part, the OD; the
+    external stepped diameters of a turned part lying along X — a peg body, a
+    stepped shaft drawn on its side — are otherwise undimensioned and surface
+    only as ``feature_not_dimensioned``. This pass places one ø leader per
+    distinct external diameter, the thread/worm patches collapsed by
+    :func:`find_bosses` into a single boss, below the front-view profile.
+    Diameters another annotation already covers are skipped.
+
+    Scope (MVP): X-axis turning only. Z-rotational parts keep their existing
+    OD/bore path untouched; Y-axis turning, gear/thread module notes, and
+    axial-length dims are out of scope.
+    """
+    draft = dwg.draft
+    try:
+        bosses = find_bosses(a.part)
+    except Exception as exc:  # noqa: BLE001 — recognition may fail on odd geometry
+        _log.info("turned-diameter annotation skipped (%s)", exc)
+        return
+
+    def _axis_letter(vec):
+        return max(zip("xyz", vec, strict=True), key=lambda t: abs(t[1]))[0]
+
+    x_bosses = [b for b in bosses if _axis_letter(b.axis) == "x"]
+    if not x_bosses:
+        return
+
+    mentioned = _mentioned_diams(dwg.items)
+    # One representative boss per distinct external diameter (tallest wins),
+    # skipping any diameter another annotation already covers.
+    by_diam: dict = {}
+    for b in x_bosses:
+        key = next((k for k in by_diam if abs(k - b.diameter) <= 0.15), b.diameter)
+        if key not in by_diam or b.height > by_diam[key].height:
+            by_diam[key] = b
+    todo = [b for d, b in by_diam.items() if not any(abs(d - m) <= 0.15 for m in mentioned)]
+    if not todo:
+        return
+
+    # Each callout's label sits in a row below the front view, pulled toward the
+    # page-x of its feature; a shared 1D Cassowary solve spreads any that would
+    # overlap. This is ADR 0003's layer-2 primitive (_solve_strip_ys reused on
+    # the x axis) standing in for the manual pitch stacking the other leaders
+    # still use — the first pass to place on the constraint solver (#77).
+    fx0, fy0, fx1, _ = dwg.view_bounds("front")  # page bbox of the profile (#28)
+    # Drop the row clear of anything already placed below the profile (hole
+    # callouts, envelope dims). This is a coarse single-pass guard against the
+    # cross-pass overlap a global solve would handle exactly (ADR 0003 / #80):
+    # it deconflicts the whole row vertically, not per-label.
+    obstacle_bottom = fy0
+    for o in dwg.items:
+        try:
+            ob = o.bounding_box()
+        except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+            continue
+        if ob.min.Y < fy0 and ob.max.X > fx0 and ob.min.X < fx1:
+            obstacle_bottom = min(obstacle_bottom, ob.min.Y)
+    label_y = obstacle_bottom - (draft.font_size + 4 * draft.pad_around_text)
+    specs = []  # (tip_page, label) ordered by feature x
+    for b in todo:
+        mid_x = b.location[0] - b.axis[0] * (b.height / 2)
+        tip = dwg.at("front", mid_x, b.location[1], b.location[2] - b.diameter / 2)
+        specs.append((tip, f"ø{_fmt(b.diameter)}"))
+    specs.sort(key=lambda s: s[0][0])
+
+    half_w = max(len(label) for _, label in specs) * draft.font_size * 0.62 / 2
+    min_gap = 2 * half_w + 2 * draft.pad_around_text
+    naturals = [tip[0] for tip, _ in specs]
+    x_lo, x_hi = fx0 + half_w, fx1 - half_w
+    label_xs = _solve_strip_ys(naturals, min_gap, x_lo, x_hi) or _greedy_strip_ys(
+        naturals, min_gap, x_lo, x_hi
+    )
+    for i, ((tip, label), lx) in enumerate(zip(specs, label_xs, strict=True)):
+        dwg.add(
+            Leader(
+                tip=(tip[0], tip[1], 0),
+                elbow=(lx, label_y, 0),
+                label=label,
+                draft=draft,
+            ),
+            f"ldr_d{i}",
+        )
+
+
 def _auto_annotate(dwg, a, *, detail_view: bool = False):
     """Add the standard automatic dimensions, centrelines, and title block."""
     draft = dwg.draft
@@ -2746,6 +2849,9 @@ def _auto_annotate(dwg, a, *, detail_view: bool = False):
     # Detail view: only when explicitly requested via build_drawing(detail_view=True).
     if detail_view:
         _add_detail_view(dwg, a)
+
+    # External turned diameters (X-axis turning) the passes above do not cover.
+    _annotate_turned_diameters(dwg, a)
 
     # Phase 7 — strip footprint debug logging + post-placement overflow check.
     # Overflow can only occur when outer_limit was tightened after allocations

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -2523,6 +2523,13 @@ def _annotate_turned_diameters(dwg, a):
         if ob.min.Y < fy0 and ob.max.X > fx0 and ob.min.X < fx1:
             obstacle_bottom = min(obstacle_bottom, ob.min.Y)
     label_y = obstacle_bottom - (draft.font_size + 4 * draft.pad_around_text)
+    # No room below the profile within the page — skip rather than run the row
+    # off the sheet. The diameters then surface as feature_not_dimensioned; the
+    # escalation ladder (#82) will tabulate instead of dropping.
+    if label_y < a.margin + draft.font_size:
+        _log.info("turned-diameter callouts skipped (no room below the front view)")
+        return
+
     specs = []  # (tip_page, label) ordered by feature x
     for b in todo:
         mid_x = b.location[0] - b.axis[0] * (b.height / 2)
@@ -2537,6 +2544,11 @@ def _annotate_turned_diameters(dwg, a):
     label_xs = _solve_strip_ys(naturals, min_gap, x_lo, x_hi) or _greedy_strip_ys(
         naturals, min_gap, x_lo, x_hi
     )
+    if label_xs is None:
+        # The labels do not fit the row even greedily; skip rather than crash on
+        # a None unpack. They surface as feature_not_dimensioned (#82 tabulates).
+        _log.info("turned-diameter callouts skipped (%d will not fit the row)", len(specs))
+        return
     for i, ((tip, label), lx) in enumerate(zip(specs, label_xs, strict=True)):
         dwg.add(
             Leader(

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3512,3 +3512,14 @@ class TestTurnedDiameters:
         # a no-op (no X-axis bosses), so no ldr_d callouts appear.
         dwg = build_drawing(Cylinder(15, 40))  # plain Z disc/shaft
         assert not any(n.startswith("ldr_d") for n in dwg._named)
+
+    def test_unfittable_row_skips_without_crashing(self, monkeypatch):
+        # When the labels do not fit the row, both solvers return None; the pass
+        # must skip gracefully, not crash the whole build on a None unpack.
+        import sys
+
+        m = sys.modules["draftwright.make_drawing"]  # __init__ shadows the submodule
+        monkeypatch.setattr(m, "_solve_strip_ys", lambda *a, **k: None)
+        monkeypatch.setattr(m, "_greedy_strip_ys", lambda *a, **k: None)
+        dwg = build_drawing(_x_stepped_shaft())  # must not raise
+        assert not any(n.startswith("ldr_d") for n in dwg._named)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4,7 +4,7 @@ import math
 from pathlib import Path
 
 import pytest
-from build123d import Box, Compound, Cylinder, Edge, Pos, export_step
+from build123d import Box, Compound, Cylinder, Edge, Pos, Rotation, export_step
 from build123d_drafting import HoleCallout, Leader, ViewCoordinates, view_axes
 
 from draftwright import Drawing, build_drawing, make_drawing
@@ -3471,3 +3471,44 @@ class TestViewBounds:
         far = Compound(children=[Edge.make_line((x1 + 10, 0, 0), (x1 + 10, 5, 0))])
         dwg.views["front"] = (vis, far)
         assert dwg.view_bounds("front")[2] == pytest.approx(x1 + 10)
+
+
+def _x_stepped_shaft():
+    """A turned shaft lying along X: ø30 (len 40) then ø16 (len 30).
+
+    Built about Z then rotated so the turning axis is X — the orientation that
+    is *not* flagged rotational (the OD logic is Z-centric), exercising #77.
+    """
+    return Rotation(0, 90, 0) * (Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(8, 30))
+
+
+class TestTurnedDiameters:
+    """#77: external turned diameters (X-axis turning) get ø leader callouts."""
+
+    def test_each_external_diameter_gets_a_callout(self):
+        dwg = build_drawing(_x_stepped_shaft())
+        labels = {o.label for n, o in dwg._named.items() if n.startswith("ldr_d")}
+        assert "ø30" in labels
+        assert "ø16" in labels
+
+    def test_no_feature_not_dimensioned_left(self):
+        # The whole point: the external diameters no longer lint as uncovered.
+        dwg = build_drawing(_x_stepped_shaft())
+        codes = dwg.lint_summary()["by_code"]
+        assert codes.get("feature_not_dimensioned", 0) == 0
+
+    def test_callouts_are_leaders_on_the_constraint_solver(self):
+        # Placed via _solve_strip_ys (ADR 0003 layer-2), so two distinct
+        # diameters never share an x and never collide: label xs are min_gap
+        # apart and inside the front view's page bounds.
+        dwg = build_drawing(_x_stepped_shaft())
+        leaders = [o for n, o in dwg._named.items() if n.startswith("ldr_d")]
+        assert len(leaders) >= 2
+        xs = sorted(ldr.elbow[0] for ldr in leaders)
+        assert all(b - a > 1.0 for a, b in zip(xs, xs[1:]))  # spread, not stacked
+
+    def test_z_rotational_part_is_untouched(self):
+        # A Z-axis turned part keeps its existing OD/bore path: the new pass is
+        # a no-op (no X-axis bosses), so no ldr_d callouts appear.
+        dwg = build_drawing(Cylinder(15, 40))  # plain Z disc/shaft
+        assert not any(n.startswith("ldr_d") for n in dwg._named)


### PR DESCRIPTION
Closes #77.

## What

On a turned part lying along **X** (a peg body, a stepped shaft drawn on its side), draftwright dimensioned holes and — for Z-rotational parts — the OD, but the **external stepped diameters were left undimensioned** and surfaced only as `feature_not_dimensioned`. This adds `_annotate_turned_diameters`:

- one **ø leader per distinct external diameter**, the worm/thread patches collapsed by `find_bosses` into a single boss;
- placed in a **row below the front profile**, each label pulled toward its feature;
- diameters another annotation already covers (the OD, a bore) are skipped.

### Evidence (the motivating part)
On a guitar peg head (`gib-tuners-mk2/sent/fixedv2/peg_head_rh.step`): before, 4 diameters (ø7, ø4.8, ø4.5, ø2.1) were undimensioned; after, all are called out and `feature_not_dimensioned` clears.

## Architecture — first pass on the constraint solver (ADR 0003)

This PR also lands **ADR 0003 (constraint-based layout)**, which records the target: a two-layer engine (combinatorial assignment + one global Cassowary solve) where every dim/leader/callout/table/GD&T frame is a `Placeable`, replacing today's four uncoordinated placement mechanisms. Phased rollout: #79–#83.

Per that ADR, this pass places via the **shared Cassowary primitive** (`_solve_strip_ys`, reused on the x axis) instead of manual pitch stacking — the first pass to do so. A **coarse single-pass guard** drops the row clear of annotations already below the profile; full cross-pass deconfliction is the global solve (#80). The guard is explicitly a bridge, not the destination.

## Scope (deliberately small blast radius)

- **X-axis turning only.** Z-rotational parts keep their existing OD/bore path untouched, so existing turned fixtures are a no-op → zero regression risk.
- Out of scope: Y-axis turning, gear/thread *module* notes, axial-length dims (and non-cylindrical features — that's #84).

## Tests

`TestTurnedDiameters` (4): each external ø gets a callout; `feature_not_dimensioned` cleared; labels are solver-spread (never collide); Z-rotational part untouched. Dogfoods `view_bounds` (#28).

Full fast suite green locally (295 passed), ruff `check` + `format --check` clean.

## Follow-ups filed
- #79–#83 — the ADR 0003 layout phases
- #84 — completeness lint blind to non-cylindrical revolved features (the deeper gap behind the "8.5 cap" question)

🤖 Generated with [Claude Code](https://claude.com/claude-code)