### PR TITLE
feat: port hole-callout placement onto LayoutSolver (#80)

### DIFF
--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -153,7 +153,9 @@ class LayoutSolver:
         self._keys.add(placeable.key)
         self._placeables.append(placeable)
 
-    def solve_strip(self, *, lo: float, hi: float, axis: Axis) -> dict | None:
+    def solve_strip(
+        self, *, lo: float, hi: float, axis: Axis, greedy_fallback: bool = True
+    ) -> dict | None:
         """Place every registered placeable with ``dof_axis == axis`` along that
         axis, as one 1D Cassowary solve within ``[lo, hi]``.
 
@@ -162,6 +164,13 @@ class LayoutSolver:
         ordered by ``(natural, key)`` so the result is deterministic regardless
         of registration order; a single ``min_gap`` (the largest any member
         requires) separates neighbours.
+
+        When the exact Cassowary solve is infeasible and *greedy_fallback* is
+        true (the default), a greedy packing is tried before giving up. A caller
+        that does its own overflow handling (e.g. dropping a prefix and recording
+        it) passes ``greedy_fallback=False`` to get the exact-or-``None`` contract
+        of the bare 1D primitive, so its drop logic fires exactly when the solve
+        is full.
         """
         members = sorted(
             (p for p in self._placeables if p.dof_axis == axis),
@@ -172,7 +181,7 @@ class LayoutSolver:
         gap = max(p.min_gap for p in members)
         naturals = [p.natural for p in members]
         positions = _solve_strip_1d(naturals, gap, lo, hi)
-        if positions is None:
+        if positions is None and greedy_fallback:
             positions = _greedy_strip_1d(naturals, gap, lo, hi)
         if positions is None:
             return None

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -92,7 +92,12 @@ from OCP.IFSelect import IFSelect_ReturnStatus
 from OCP.STEPControl import STEPControl_Reader
 from OCP.TopTools import TopTools_ListOfShape
 
-from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
+from draftwright.layout import (
+    LayoutSolver,
+    Placeable,
+    _greedy_strip_1d,
+    _solve_strip_1d,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -3985,6 +3990,38 @@ _greedy_strip_ys = _greedy_strip_1d
 _solve_strip_ys = _solve_strip_1d
 
 
+def _solve_strip_via_layout(naturals, min_gap, lo, hi, key_prefix):
+    """Place a pre-sorted, uniform-gap 1D stack through the shared LayoutSolver
+    (ADR 0003 phase 2, #80), returning positions in input order, or ``None`` if
+    the stack does not fit.
+
+    *naturals* must be ascending (the caller sorts the queue), so the solver's
+    ``(natural, key)`` ordering — with the zero-padded keys built here — is the
+    identity, and the result is byte-identical to the bare ``_solve_strip_1d``
+    this replaces. The label width is irrelevant to a vertical stack, so each
+    placeable carries the uniform ``min_gap`` as its height.
+    """
+    solver = LayoutSolver()
+    keys = [f"{key_prefix}{j:04d}" for j in range(len(naturals))]
+    for key, nat in zip(keys, naturals, strict=True):
+        solver.register(
+            Placeable(
+                key=key,
+                anchors=((0.0, nat),),
+                size=(0.0, min_gap),
+                dof_axis="y",
+                natural=nat,
+                min_gap=min_gap,
+            )
+        )
+    # greedy_fallback=False so this returns exactly what the bare primitive did:
+    # None when the strip is full, leaving the caller's prefix-drop to fire (#80).
+    placed = solver.solve_strip(lo=lo, hi=hi, axis="y", greedy_fallback=False)
+    if placed is None:
+        return None
+    return [placed[k] for k in keys]
+
+
 def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=None):
     """Leader-attached HoleCallouts, one per distinct hole spec per view (#91).
 
@@ -4208,9 +4245,13 @@ def _annotate_holes(dwg, a, view_of_axis, axis_letter, found_patterns, holes_in=
         right_queue.sort(key=lambda s: s[3])
         left_queue.sort(key=lambda s: s[3])
 
-        # --- Pass 2: Y placement ---
-        right_ys = _solve_strip_ys([s[3] for s in right_queue], min_gap, y_min, y_max)
-        left_ys = _solve_strip_ys([s[3] for s in left_queue], min_gap, y_min, y_max)
+        # --- Pass 2: Y placement (through the LayoutSolver, #80) ---
+        right_ys = _solve_strip_via_layout(
+            [s[3] for s in right_queue], min_gap, y_min, y_max, "hc_r"
+        )
+        left_ys = _solve_strip_via_layout(
+            [s[3] for s in left_queue], min_gap, y_min, y_max, "hc_l"
+        )
 
         if right_ys is None and right_queue:
             right_ys = _greedy_strip_ys(

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -126,9 +126,9 @@ class TestLayoutSolver:
         assert out == {"a": 0, "b": 5}
 
 
-def test_layout_is_not_wired_into_the_default_drawing_path():
-    # Phase 1 is scaffolding: no annotation pass constructs a Placeable yet.
+def test_layout_engine_is_wired_into_the_drawing_path():
+    # Phase 2 (#80): hole-callout placement now flows through the LayoutSolver.
     src = (L.__file__).replace("layout.py", "make_drawing.py")
     text = open(src).read()
-    assert "Placeable(" not in text
-    assert "LayoutSolver(" not in text
+    assert "Placeable(" in text
+    assert "LayoutSolver(" in text

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1886,6 +1886,32 @@ class TestAutoHoleAnnotations:
 
         assert _solve_strip_ys([], min_gap=8.0, lo=0.0, hi=100.0) == []
 
+    @pytest.mark.timeout(60)
+    def test_solve_strip_via_layout_is_byte_identical_to_primitive(self):
+        # #80: the hole-callout Y-stack now routes through the LayoutSolver. The
+        # adapter must return exactly what the bare primitive did — including for
+        # tied natural Ys, where the solver's (natural, key) order must reduce to
+        # the input order via the zero-padded keys.
+        from draftwright.make_drawing import _solve_strip_via_layout, _solve_strip_ys
+
+        # (naturals, gap, lo, hi)
+        cases = [
+            ([10.0, 12.0, 14.0, 16.0], 8.0, 0.0, 100.0),  # distinct, feasible
+            ([5.0, 5.0, 5.0], 8.0, 0.0, 100.0),  # all tied
+            ([0.0, 0.0, 20.0, 20.0], 8.0, 0.0, 100.0),  # paired ties
+            ([], 8.0, 0.0, 10.0),  # empty
+            ([0.0, 0.0, 0.0], 8.0, 0.0, 10.0),  # infeasible, greedy also overflows
+            # Knife-edge: exact solve reports infeasible at (n-1)*gap == hi-lo, but
+            # a non-prefix greedy packing would just fit. The adapter must still
+            # return None here (matching the primitive), or the caller's drop is
+            # silently skipped (#80 review).
+            ([4.52, 5.29, 16.07, 22.13], 4.73, 8.44, 22.63),
+        ]
+        for naturals, gap, lo, hi in cases:
+            adapter = _solve_strip_via_layout(naturals, gap, lo, hi, "k")
+            primitive = _solve_strip_ys(naturals, gap, lo, hi)
+            assert adapter == primitive, naturals
+
 
 class TestHolePatternAnnotations:
     """Bolt-circle and linear-array sheet furniture + count-aware lint (#92)."""


### PR DESCRIPTION
Closes #80. ADR 0003 **phase 2** — the first real annotation pass to place through the constraint engine.

## What — byte-identical refactor

Hole-callout plan/side **Pass-2** Y-placement now flows through `LayoutSolver` via a thin `_solve_strip_via_layout` adapter: one `Placeable(dof_axis="y", natural=hole-centre Y, min_gap=font+2·pad)` per callout, with zero-padded keys so the solver's `(natural, key)` ordering reduces to the pre-sorted queue order. The view/side **assignment layer** and the `prefix=True` drop fallback are **untouched** → output is byte-identical.

Scoped to hole callouts only; bore leaders are #87 (a real behaviour change).

## Review fix included (was a BLOCKING equivalence break)

An adversarial review found that `LayoutSolver.solve_strip` internally rescued an infeasible solve with greedy packing, so at a float knife-edge (`(n-1)·gap == hi−lo`) the adapter would *place* callouts the old code *dropped* — silently inverting the `callout_dropped` drop semantics. Fix: `solve_strip` gained `greedy_fallback` (default `True`, preserving #79); the adapter passes **`greedy_fallback=False`** for the exact-or-`None` contract of the bare primitive, so the caller's prefix-drop fires identically.

## Tests
- `test_solve_strip_via_layout_is_byte_identical_to_primitive` — distinct / tied / empty / infeasible / **knife-edge** inputs all match the bare primitive.
- The 43 existing hole-callout tests pass unchanged (the byte-identical proof).
- The phase-1 "not wired in" guard inverted to assert the engine **is** wired in.

Full fast suite green locally (313 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)