### PR TITLE
feat: per-pair gaps in the 1D strip primitive (#81, ADR 0003 phase 3a)

### DIFF
--- a/docs/adr/0003-constraint-based-layout.md
+++ b/docs/adr/0003-constraint-based-layout.md
@@ -118,6 +118,33 @@ surfaced as lint.
   stop being reproducible. Cassowary is deterministic given stable input order.
 - Multi-PR effort; risk of a half-migrated engine running two models at once.
 
+**Editability — the constraint this engine must not break (ADR 0001/0002)**
+
+draftwright's whole point is that humans and AI tweak in *domain vocabulary*
+and never touch placement mechanics; the solver lives strictly *below* that
+line and must keep it. Two specific risks a global solve introduces, and the
+required mitigations:
+
+- **Edit locality.** Adding or nudging one annotation must not silently shift
+  unrelated ones. A from-scratch global re-solve violates the human expectation
+  of a local change. Mitigation: incremental / warm-started re-solve that
+  perturbs minimally, plus the "pin near anchor" priority. An edit's blast
+  radius is part of the editability contract, not just an aesthetic.
+- **Manual override must win.** When a human or AI places something explicitly
+  ("put *this* label *here*"), the solver must treat it as a hard **pin** that
+  survives every later re-solve and stays local — never re-derive over a
+  deliberate placement. This needs a `locked`/`pinned` preference on `Placeable`
+  **and** a domain-facing verb (e.g. `dwg.pin(name, at=…)`); the existing
+  `dof_axis=None` is the mechanism, but without the verb the global solve could
+  overwrite an intentional tweak. **This is a hard prerequisite for the global
+  2D solve / escalation (#82), not a later nicety.**
+
+Keep `Placeable`/`LayoutSolver` an implementation detail: callers edit through
+the domain API (`place_dim`, `features`, `annotations`, lint→repair), never by
+constructing placeables. As long as that holds, the engine *improves*
+editability for AI (state intent, get a correct deconflicted placement) rather
+than eroding it.
+
 **Neutral / follow-ups**
 - Performance: hundreds of variables is comfortable for Cassowary; watch the
   largest sheets.

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -98,7 +98,7 @@ def _greedy_strip_1d_var(naturals, gaps, lo, hi, *, prefix=False):
     ``len(gaps) == max(len(naturals) - 1, 0)``. Otherwise identical to
     :func:`_greedy_strip_1d` (its uniform special case is ``gaps = [g]*(n-1)``).
     """
-    result = []
+    result: list = []
     for i, nat in enumerate(naturals):
         floor = lo if i == 0 else result[-1] + gaps[i - 1]
         v = max(floor, nat)

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -91,6 +91,61 @@ def _solve_strip_1d(naturals, min_gap, lo, hi):
         return None
 
 
+def _greedy_strip_1d_var(naturals, gaps, lo, hi, *, prefix=False):
+    """Greedy 1D placement with **per-pair** gaps (ADR 0003 phase 3a, #81).
+
+    ``gaps[i]`` is the minimum ``naturals[i+1] - naturals[i]`` separation;
+    ``len(gaps) == max(len(naturals) - 1, 0)``. Otherwise identical to
+    :func:`_greedy_strip_1d` (its uniform special case is ``gaps = [g]*(n-1)``).
+    """
+    result = []
+    for i, nat in enumerate(naturals):
+        floor = lo if i == 0 else result[-1] + gaps[i - 1]
+        v = max(floor, nat)
+        if v > hi:
+            if prefix:
+                break
+            return None
+        result.append(v)
+    return result
+
+
+def _solve_strip_1d_var(naturals, gaps, lo, hi):
+    """Cassowary 1D placement with **per-pair** gaps (ADR 0003 phase 3a, #81).
+
+    Like :func:`_solve_strip_1d`, but the required separation between adjacent
+    items is ``gaps[i]`` rather than one uniform value — the capability the
+    ``Placeable.size`` field exists for, used when heterogeneous items (e.g. a
+    deep step-dim slot next to a shallow height slot) share one strip.
+    ``len(gaps)`` must be ``max(len(naturals) - 1, 0)``.
+    """
+    if not naturals:
+        return []
+    n = len(naturals)
+    if sum(gaps) > hi - lo:
+        return None  # provably infeasible
+
+    try:
+        import kiwisolver as ki
+    except ImportError:
+        return _greedy_strip_1d_var(naturals, gaps, lo, hi)
+
+    solver = ki.Solver()
+    vs = [ki.Variable(f"v{i}") for i in range(n)]
+    try:
+        for v in vs:
+            solver.addConstraint((v >= lo) | "required")
+            solver.addConstraint((v <= hi) | "required")
+        for i in range(n - 1):
+            solver.addConstraint((vs[i + 1] - vs[i] >= gaps[i]) | "required")
+        for v, nat in zip(vs, naturals, strict=True):
+            solver.addConstraint((v == nat) | "strong")
+        solver.updateVariables()
+        return [v.value() for v in vs]
+    except ki.UnsatisfiableConstraint:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Placeable protocol + solver
 # ---------------------------------------------------------------------------
@@ -178,11 +233,22 @@ class LayoutSolver:
         )
         if not members:
             return {}
-        gap = max(p.min_gap for p in members)
         naturals = [p.natural for p in members]
-        positions = _solve_strip_1d(naturals, gap, lo, hi)
-        if positions is None and greedy_fallback:
-            positions = _greedy_strip_1d(naturals, gap, lo, hi)
+        min_gaps = [p.min_gap for p in members]
+        if len(set(min_gaps)) <= 1:
+            # Uniform (or single) members — the scalar primitive, byte-identical
+            # to the pre-#81 path (preserves its exact (n-1)*gap arithmetic).
+            gap = max(min_gaps)
+            positions = _solve_strip_1d(naturals, gap, lo, hi)
+            if positions is None and greedy_fallback:
+                positions = _greedy_strip_1d(naturals, gap, lo, hi)
+        else:
+            # Heterogeneous members — per-pair gaps so a larger member's
+            # clearance doesn't over-separate every pair (#81).
+            gaps = [max(min_gaps[i], min_gaps[i + 1]) for i in range(len(members) - 1)]
+            positions = _solve_strip_1d_var(naturals, gaps, lo, hi)
+            if positions is None and greedy_fallback:
+                positions = _greedy_strip_1d_var(naturals, gaps, lo, hi)
         if positions is None:
             return None
         return {p.key: pos for p, pos in zip(members, positions, strict=True)}

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -11,7 +11,9 @@ from draftwright.layout import (
     LayoutSolver,
     Placeable,
     _greedy_strip_1d,
+    _greedy_strip_1d_var,
     _solve_strip_1d,
+    _solve_strip_1d_var,
 )
 
 
@@ -58,6 +60,37 @@ class TestGreedyStrip1d:
         assert out == [0, 8]
 
 
+class TestPerPairGaps:
+    """#81: per-pair gaps in the 1D primitive (heterogeneous slot depths)."""
+
+    def test_var_honours_each_pair_gap(self):
+        # All naturals at 0; gaps [4, 10] → packs to 0, 4, 14.
+        out = _solve_strip_1d_var([0.0, 0.0, 0.0], [4.0, 10.0], 0.0, 100.0)
+        assert out is not None
+        assert out[1] - out[0] >= 4.0 - 1e-9
+        assert out[2] - out[1] >= 10.0 - 1e-9
+
+    def test_var_matches_scalar_for_uniform_gaps(self):
+        # The uniform special case must reproduce the scalar primitive exactly.
+        naturals = [1.0, 1.0, 1.0, 1.0]
+        var = _solve_strip_1d_var(naturals, [3.0, 3.0, 3.0], 0.0, 100.0)
+        scalar = _solve_strip_1d(naturals, 3.0, 0.0, 100.0)
+        assert var == scalar
+
+    def test_var_infeasible_when_gaps_exceed_span(self):
+        # sum(gaps) = 14 > span 10 → None.
+        assert _solve_strip_1d_var([0.0, 0.0, 0.0], [4.0, 10.0], 0.0, 10.0) is None
+
+    def test_var_empty_and_single(self):
+        assert _solve_strip_1d_var([], [], 0.0, 10.0) == []
+        assert _solve_strip_1d_var([5.0], [], 0.0, 10.0) == [5.0]
+
+    def test_greedy_var_prefix_drops_overflow(self):
+        # gaps [4, 4]; span 6 fits only the first two → prefix stops before #3.
+        out = _greedy_strip_1d_var([0.0, 0.0, 0.0], [4.0, 4.0], 0.0, 6.0, prefix=True)
+        assert out == [0.0, 4.0]
+
+
 class TestLayoutSolver:
     def _leader(self, key, natural, gap=5.0, axis="x"):
         return Placeable(
@@ -78,6 +111,31 @@ class TestLayoutSolver:
         assert set(out) == {"a", "b", "c"}
         xs = [out["a"], out["b"], out["c"]]
         assert xs[1] - xs[0] >= 5 - 1e-9 and xs[2] - xs[1] >= 5 - 1e-9
+
+    def test_solve_strip_uses_per_pair_gaps_for_heterogeneous_members(self):
+        # Members with different min_gaps share a strip: each pair is separated
+        # by the larger of its two neighbours' gaps, not one global max (#81).
+        s = LayoutSolver()
+        s.register(self._leader("a", 0, gap=4))
+        s.register(self._leader("b", 0, gap=4))
+        s.register(self._leader("c", 0, gap=12))
+        out = s.solve_strip(lo=0, hi=100, axis="x")
+        xs = [out["a"], out["b"], out["c"]]
+        assert xs[1] - xs[0] == pytest.approx(4)  # max(4,4)
+        assert xs[2] - xs[1] == pytest.approx(12)  # max(4,12), not a global 12 on both
+
+    def test_uniform_members_take_the_scalar_path(self, monkeypatch):
+        # Byte-identical contract: uniform members must NOT touch the _var
+        # primitive's sum(gaps) arithmetic. Make _var explode and confirm a
+        # uniform solve still succeeds — proving it routed to the scalar path.
+        def _boom(*a, **k):
+            raise AssertionError("uniform members must use the scalar path")
+
+        monkeypatch.setattr(L, "_solve_strip_1d_var", _boom)
+        s = LayoutSolver()
+        s.register(self._leader("a", 0, gap=5))
+        s.register(self._leader("b", 10, gap=5))
+        assert set(s.solve_strip(lo=-50, hi=50, axis="x")) == {"a", "b"}
 
     def test_solve_strip_ignores_other_axis_and_pinned(self):
         s = LayoutSolver()


### PR DESCRIPTION
Closes #81 (re-scoped to phase 3a). Adds the heterogeneous-spacing capability the layout engine needs, without touching any drawing output.

## What
- New **`_solve_strip_1d_var` / `_greedy_strip_1d_var`** take explicit **per-pair gaps** (`gaps[i]` = min `v[i+1]-v[i]`) — the capability the `Placeable.size` field exists for. The scalar `_solve_strip_1d` / `_greedy_strip_1d` are **left untouched**.
- **`LayoutSolver.solve_strip`** routes **uniform** members to the scalar path (byte-identical — #80's hole-callout port is unaffected) and **heterogeneous** members to the `_var` path with `gaps[i] = max(adjacent min_gaps)`.
- Amends **ADR 0003** with an **Editability** consequences section (edit-locality + manual-override-must-win/pin), tracked as a hard blocker on the #82 global solve via **#89**.

## Why this shape (design review)
The original #81 — "port the right-side dim ladder via alignment constraints" — was a **no-go**: the ladder is placed by `Strip.allocate` with heterogeneous slots and is *deliberately nested at increasing offsets* (alignment would collapse it). Porting it would be churn with output risk and no user gain. So #81 became this primitive (real, reusable), the byte-identical **location-dim** port is **#90**, and the right-ladder re-port is deferred to **#82** (a deliberate, golden-tested change that will need these per-pair gaps).

## Tests (pure unit, no goldens move)
`TestPerPairGaps` (per-pair honouring, uniform==scalar, `sum(gaps)` infeasibility, empty/single, greedy prefix-drop) + a heterogeneous `solve_strip` test + a **routing-contract** test pinning that uniform members never touch the `_var` path (protects the byte-identical guarantee). #80's byte-identical test still passes.

Full fast suite green locally (319 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)