### PR TITLE
feat: pin/override — manual placement wins over the engine (#89)

### DIFF
--- a/docs/adr/0003-constraint-based-layout.md
+++ b/docs/adr/0003-constraint-based-layout.md
@@ -133,11 +133,11 @@ required mitigations:
 - **Manual override must win.** When a human or AI places something explicitly
   ("put *this* label *here*"), the solver must treat it as a hard **pin** that
   survives every later re-solve and stays local — never re-derive over a
-  deliberate placement. This needs a `locked`/`pinned` preference on `Placeable`
-  **and** a domain-facing verb (e.g. `dwg.pin(name, at=…)`); the existing
-  `dof_axis=None` is the mechanism, but without the verb the global solve could
-  overwrite an intentional tweak. **This is a hard prerequisite for the global
-  2D solve / escalation (#82), not a later nicety.**
+  deliberate placement. _Partly landed (#89):_ `dwg.pin(name)` / `dwg.unpin(name)`
+  are the domain verbs, `Placeable.locked` is the solver-side flag, and
+  `repair()` already refuses to move a pinned annotation. **Still owed by #82:**
+  the global 2D solve must honour `locked` (keep it at `natural`, solve the rest
+  around it). This remains a hard prerequisite for that solve, not a later nicety.
 
 Keep `Placeable`/`LayoutSolver` an implementation detail: callers edit through
 the domain API (`place_dim`, `features`, `annotations`, lint→repair), never by

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -241,6 +241,10 @@ for i in dwg.lint():
 #    labels pushed apart, wrong-side dims flipped). Runs by default inside
 #    build_drawing; call again after manual edits. It never makes a sheet worse.
 dwg.repair()
+
+# Pin a deliberate placement so repair won't move it (the constraint solver will
+# honour it too as it lands — ADR 0003):
+dwg.pin(name)             # name from dwg.annotations(); dwg.unpin(name) to release
 ```
 
 Codes are domain-meaningful (`feature_not_dimensioned`, `feature_count_mismatch`,

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -172,6 +172,10 @@ class Placeable:
             centre), derived from ``size`` plus padding.
         group: alignment-group id; placeables sharing a group will share an
             offset variable once alignment lands (phase 3, #81).
+        locked: when true the solver must keep this at ``natural`` and never
+            move it — a deliberate (human/AI) placement that wins over automatic
+            layout. The global solve (#82) honours this; the Drawing-level pin
+            verb (``dwg.pin`` / #89) is how callers set it.
     """
 
     key: str
@@ -181,6 +185,7 @@ class Placeable:
     natural: float
     min_gap: float
     group: str | None = None
+    locked: bool = False
 
 
 class LayoutSolver:

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1879,6 +1879,9 @@ class Drawing:
         self.items: list = []
         self._coords: dict = {}
         self._named: dict = {}
+        # Names the caller has pinned: their position is fixed and the engine
+        # must not move them (repair now; the global solve later — ADR 0003 #89).
+        self._pinned: set = set()
         self.svg_path: str | None = None
         self.dxf_path: str | None = None
         self._analysis: SimpleNamespace | None = None
@@ -2077,6 +2080,9 @@ class Drawing:
         """
         if name is not None and name in self._named:
             self.items.remove(self._named[name])
+            # A replacement under the same name is a fresh, deliberate object —
+            # it does not inherit the old object's pin (#89).
+            self._pinned.discard(name)
         annotate(obj, name)
         self.items.append(obj)
         if name is not None:
@@ -2089,6 +2095,7 @@ class Drawing:
         if obj is None:
             raise KeyError(f"no annotation named {name!r}")
         self.items.remove(obj)
+        self._pinned.discard(name)  # a removed name carries no pin (#89)
         return obj
 
     def annotations(self) -> dict:
@@ -2104,6 +2111,27 @@ class Drawing:
     def get_annotation(self, name):
         """Return the named annotation object, or ``None`` if no such name (#27)."""
         return self._named.get(name)
+
+    def pin(self, name):
+        """Pin a named annotation so the engine never moves it (#89).
+
+        A deliberate placement — by you or an AI — must win over automatic
+        layout. :meth:`repair` will not re-place a pinned annotation, and the
+        constraint solver (ADR 0003) treats it as fixed. Pinning fixes the
+        *position*, not existence: :meth:`remove` and :meth:`clear_annotations`
+        still apply. Raises ``KeyError`` if *name* is not a known annotation.
+        Returns ``self`` for chaining.
+        """
+        if name not in self._named:
+            raise KeyError(f"no annotation named {name!r}")
+        self._pinned.add(name)
+        return self
+
+    def unpin(self, name):
+        """Release a pin so the engine may move *name* again (#89). Returns
+        ``self``; a no-op if *name* was not pinned."""
+        self._pinned.discard(name)
+        return self
 
     def clear_annotations(self, keep=("title_block",)):
         """Remove all annotations except those named in *keep* (#74).
@@ -2121,6 +2149,7 @@ class Drawing:
         removed = [o for o in self.items if id(o) not in kept_ids]
         self.items = [o for o in self.items if id(o) in kept_ids]
         self._named = kept_named
+        self._pinned &= keep_set  # drop pins for cleared names (#89)
         return removed
 
     def _record_build_issue(self, severity, code, message):
@@ -2134,9 +2163,16 @@ class Drawing:
         """Return the re-placeable dimension whose label is *label*, or None.
 
         Only dimensions built by :func:`_dim` (carrying ``_dw_spec``) qualify;
-        leaders, callouts and hand-built annotations are left untouched.
+        leaders, callouts and hand-built annotations are left untouched. A
+        pinned dimension (#89) is also skipped — a deliberate placement must
+        win over automatic repair.
         """
+        # Identity-based, matching clear_annotations: "this specific object",
+        # not build123d's geometric Shape equality.
+        pinned_ids = {id(self._named[n]) for n in self._pinned if n in self._named}
         for o in self.items:
+            if id(o) in pinned_ids:
+                continue
             if getattr(o, "_dw_spec", None) is not None and getattr(o, "label", None) == label:
                 return o
         return None
@@ -4682,6 +4718,7 @@ def _write_script(a) -> str:
         "# dwg.annotations()        → {name: type} of every named annotation\n"
         "# dwg.get_annotation(name) → the named annotation object, or None\n"
         "# dwg.remove(name) / dwg.add(obj, name)\n"
+        "# dwg.pin(name) / dwg.unpin(name)  → fix a placement so repair never moves it\n"
         "# dwg.lint_summary()       → {passed, score, by_code, issues:[…suggestion]}\n"
         "# dwg.repair()             → auto-fix mechanically-fixable lint (never worsens)\n"
         "# dwg.add_view(name, shape, camera, up, position)  → section / auxiliary view\n"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3403,6 +3403,82 @@ class TestRepair:
         assert d._dw_spec.side == "above"
 
 
+class TestPin:
+    """#89: a pinned annotation is never moved by the engine (repair today)."""
+
+    def _two_overlapping(self):
+        from draftwright.make_drawing import _dim
+
+        dwg = build_drawing(Box(60, 40, 20))
+        p1, p2 = (40.0, 20.0, 0.0), (80.0, 20.0, 0.0)
+        dwg.add(_dim(p1, p2, "above", 8, dwg.draft, label="AA"), "a")
+        dwg.add(_dim(p1, p2, "above", 8, dwg.draft, label="BB"), "b")
+        return dwg
+
+    def test_repair_does_not_move_a_pinned_dim(self):
+        # 'a' is the first re-placeable in the overlap, so repair would push it;
+        # pinned, it stays at distance 8 and 'b' is pushed instead.
+        dwg = self._two_overlapping()
+        dwg.pin("a")
+        dwg.repair()
+        assert dwg._named["a"]._dw_spec.distance == 8  # untouched
+        assert dwg._named["b"]._dw_spec.distance > 8  # moved in its place
+
+    def test_unpin_lets_repair_move_it_again(self):
+        dwg = self._two_overlapping()
+        dwg.pin("a").unpin("a")
+        dwg.repair()
+        # With nothing pinned, the overlap is resolved (one of them moved).
+        assert not [i for i in dwg.lint() if i.code == "annotation_overlap"]
+
+    def test_pin_unknown_name_raises(self):
+        dwg = build_drawing(Box(60, 40, 20))
+        with pytest.raises(KeyError):
+            dwg.pin("does_not_exist")
+
+    def test_pin_and_unpin_are_chainable(self):
+        dwg = self._two_overlapping()
+        assert dwg.pin("a") is dwg
+        assert dwg.unpin("a") is dwg
+
+    def test_placeable_locked_defaults_false(self):
+        from draftwright.layout import Placeable
+
+        p = Placeable("k", ((0, 0),), (4, 2), "y", 0.0, 5.0)
+        assert p.locked is False
+        assert Placeable("k", ((0, 0),), (4, 2), "y", 0.0, 5.0, locked=True).locked is True
+
+    def test_pinning_both_overlap_labels_is_a_noop(self):
+        # Both deliberate → the engine respects both and leaves the overlap.
+        dwg = self._two_overlapping()
+        dwg.pin("a").pin("b")
+        dwg.repair()
+        assert dwg._named["a"]._dw_spec.distance == 8
+        assert dwg._named["b"]._dw_spec.distance == 8
+
+    def test_pinning_a_non_dim_then_repair_does_not_crash(self):
+        # _find_dim builds an id-set over pinned objects of any type; pinning a
+        # Leader (not a re-placeable dim) must not break repair.
+        dwg = self._two_overlapping()
+        dwg.add(Leader((0, 0, 0), (10, 10, 0), "L", dwg.draft), "ldr")
+        dwg.pin("ldr")
+        dwg.repair()  # must not raise
+        assert "ldr" in dwg.annotations()
+
+    def test_removed_then_readded_name_is_not_still_pinned(self):
+        from draftwright.make_drawing import _dim
+
+        dwg = self._two_overlapping()
+        dwg.pin("a")
+        dwg.remove("a")
+        # Re-add a fresh "a" at the same overlapping spot; it must NOT inherit
+        # the old pin, so repair is free to move it.
+        dwg.add(_dim((40.0, 20.0, 0.0), (80.0, 20.0, 0.0), "above", 8, dwg.draft, label="AA"), "a")
+        assert "a" not in dwg._pinned
+        dwg.repair()
+        assert not [i for i in dwg.lint() if i.code == "annotation_overlap"]
+
+
 class TestAnnotationsQuery:
     """#27: introspect existing annotations by name and type."""
 


### PR DESCRIPTION
Closes #89. The ADR 0003 **editability guardrail** — a deliberate (human/AI) placement must not be moved by automatic layout. Scoped to deliver value now and scaffold #82.

## What
- **`dwg.pin(name)` / `dwg.unpin(name)`** — domain verbs. `pin` validates the name exists, is chainable; fixes *position*, not existence.
- **`repair()` refuses to move a pinned annotation** — at the single `_find_dim` gateway both repair paths use, via `id()`-based membership (the only thing that moves annotations today is `repair()`).
- **`Placeable.locked`** — scaffolding for the global solve (#82; honoured there, no consumer yet).

## Review fixes (adversarial review found these)
- **Stale-pin bug:** `_pinned` is now pruned on `remove()`, `clear_annotations()`, and `add()`-replace, so a removed/re-added name never silently stays pinned.
- **`id()`-based membership** in `_find_dim` (not build123d's geometric `Shape.__eq__`).

## Tests — `TestPin` (8)
repair skips a pinned dim (pushes the other), unpin restores, unknown name raises, chainable, `locked` default, **both-pinned no-op**, **non-dim pin + repair no crash**, **stale-pin reuse not re-pinned**.

Full fast suite green locally (328 passed), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)