### PR TITLE
feat: hole table primitive placed via place_box (#93 PR-2)

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -429,8 +429,7 @@ def _build_hole_table(rows, draft):
     row_h = fs + 2 * pad
     ncol = len(rows[0])
     col_w = [
-        max(max(_text_width(str(r[c]), fs) for r in rows) + 2 * pad, fs * 2.5)
-        for c in range(ncol)
+        max(max(_text_width(str(r[c]), fs) for r in rows) + 2 * pad, fs * 2.5) for c in range(ncol)
     ]
     xs = [0.0]
     for w in col_w:

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -415,14 +415,15 @@ def _tag_sequence(n):
     return tags
 
 
-def _build_hole_table(rows, draft):
-    """Build a hole-table annotation at the origin (bottom-left at ``(0, 0)``).
+def _build_table(rows, draft):
+    """Build a generic data-table annotation at the origin (bottom-left ``(0, 0)``).
 
     *rows* is a list of equal-length string tuples; ``rows[0]`` is the header,
     drawn at the top. Returns a :class:`Compound` of grid rules + cell text,
     carrying ``.table_size = (w, h)`` so it can be positioned via
     :func:`fit_box`. Column widths are sized to their content via real glyph
-    metrics (:func:`_text_width`).
+    metrics (:func:`_text_width`). Generic — the hole table, and gear/BOM/
+    revision tables, all build through here.
     """
     fs = draft.font_size
     pad = draft.pad_around_text
@@ -2172,26 +2173,21 @@ class Drawing:
         """Return the named annotation object, or ``None`` if no such name (#27)."""
         return self._named.get(name)
 
-    def add_hole_table(self, view="plan", *, prefer="tr", name=None):
-        """Add a hole table for *view*'s holes, placed in a free corner (#93).
+    def add_table(self, rows, *, prefer="tr", name="table"):
+        """Add a generic data table, placed in a free corner (#93).
 
-        One row per hole spec-group — ``TAG | ⌀ | DEPTH | QTY`` with tags
-        ``A, B, …`` — built from :meth:`features` and positioned by
-        :func:`fit_box` clear of the views, title block, and existing
-        annotations. *prefer* is the page corner to sit nearest. Returns the
-        table annotation, or ``None`` when *view* has no holes or it will not
-        fit (recorded as ``hole_table_dropped`` lint).
+        *rows* is a list of equal-length string tuples (``rows[0]`` is the
+        header). The table is positioned by :func:`fit_box` clear of the views,
+        title block, and existing annotations; *prefer* is the page corner to sit
+        nearest. Returns the table annotation, or ``None`` if it has no rows or
+        will not fit (recorded as ``table_dropped`` lint). Gear-data, BOM, and
+        revision tables all go through here; :meth:`add_hole_table` is the
+        hole-specific convenience built on it.
         """
-        feats = [f for f in self.features(view) if f.type == "hole"]
-        if not feats:
+        if not rows:
             return None
-        rows = [("TAG", "⌀", "DEPTH", "QTY")]
-        for tag, f in zip(_tag_sequence(len(feats)), feats, strict=True):
-            depth = "THRU" if f.through else (_fmt(f.depth) if f.depth else "")
-            rows.append((tag, f"ø{_fmt(f.diameter)}", depth, str(f.count)))
-        table = _build_hole_table(rows, self.draft)
+        table = _build_table(rows, self.draft)
         w, h = table.table_size
-
         a = self._analysis
         margin = a.margin if a is not None else 10.0
         pw = a.PAGE_W if a is not None else self.page_w
@@ -2204,14 +2200,30 @@ class Drawing:
             except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
                 continue
             obstacles.append((bb.min.X, bb.min.Y, bb.max.X, bb.max.Y))
-
         pos = fit_box((w, h), region, obstacles, prefer)
         if pos is None:
             self._record_build_issue(
-                "warning", "hole_table_dropped", f"hole table for {view!r} did not fit the sheet"
+                "warning", "table_dropped", f"table {name!r} did not fit the sheet"
             )
             return None
-        return self.add(table.locate(Location((pos[0], pos[1], 0))), name or f"hole_table_{view}")
+        return self.add(table.locate(Location((pos[0], pos[1], 0))), name)
+
+    def add_hole_table(self, view="plan", *, prefer="tr", name=None):
+        """Add a hole table for *view*'s holes, placed in a free corner (#93).
+
+        One row per hole spec-group — ``TAG | ⌀ | DEPTH | QTY`` with tags
+        ``A, B, …`` — derived from :meth:`features` and placed via
+        :meth:`add_table`. Returns the table, or ``None`` when *view* has no
+        holes or it will not fit.
+        """
+        feats = [f for f in self.features(view) if f.type == "hole"]
+        if not feats:
+            return None
+        rows = [("TAG", "⌀", "DEPTH", "QTY")]
+        for tag, f in zip(_tag_sequence(len(feats)), feats, strict=True):
+            depth = "THRU" if f.through else (_fmt(f.depth) if f.depth else "")
+            rows.append((tag, f"ø{_fmt(f.diameter)}", depth, str(f.count)))
+        return self.add_table(rows, prefer=prefer, name=name or f"hole_table_{view}")
 
     def pin(self, name):
         """Pin a named annotation so the engine never moves it (#89).

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -97,6 +97,7 @@ from draftwright.layout import (
     Placeable,
     _greedy_strip_1d,
     _solve_strip_1d,
+    fit_box,
 )
 
 _log = logging.getLogger(__name__)
@@ -398,6 +399,66 @@ def _text_width(text: str, font_size: float, font: str = "Arial") -> float:
         .bounding_box()
         .size.X
     )
+
+
+def _tag_sequence(n):
+    """``A, B, …, Z, AA, AB, …`` — deterministic hole-table tags for *n* rows."""
+    tags = []
+    for i in range(n):
+        s, k = "", i
+        while True:
+            s = chr(ord("A") + k % 26) + s
+            k = k // 26 - 1
+            if k < 0:
+                break
+        tags.append(s)
+    return tags
+
+
+def _build_hole_table(rows, draft):
+    """Build a hole-table annotation at the origin (bottom-left at ``(0, 0)``).
+
+    *rows* is a list of equal-length string tuples; ``rows[0]`` is the header,
+    drawn at the top. Returns a :class:`Compound` of grid rules + cell text,
+    carrying ``.table_size = (w, h)`` so it can be positioned via
+    :func:`fit_box`. Column widths are sized to their content via real glyph
+    metrics (:func:`_text_width`).
+    """
+    fs = draft.font_size
+    pad = draft.pad_around_text
+    row_h = fs + 2 * pad
+    ncol = len(rows[0])
+    col_w = [
+        max(max(_text_width(str(r[c]), fs) for r in rows) + 2 * pad, fs * 2.5)
+        for c in range(ncol)
+    ]
+    xs = [0.0]
+    for w in col_w:
+        xs.append(xs[-1] + w)
+    total_w = xs[-1]
+    total_h = row_h * len(rows)
+    ys = [i * row_h for i in range(len(rows) + 1)]
+    children = []
+    for x in xs:
+        children.append(Edge.make_line(Vector(x, 0, 0), Vector(x, total_h, 0)))
+    for y in ys:
+        children.append(Edge.make_line(Vector(0, y, 0), Vector(total_w, y, 0)))
+    for ri, row in enumerate(rows):  # rows[0] (header) sits at the top
+        cy = total_h - (ri + 0.5) * row_h
+        for ci, cell in enumerate(row):
+            if not str(cell):
+                continue
+            cx = (xs[ci] + xs[ci + 1]) / 2
+            text = Text(
+                txt=str(cell),
+                font_size=fs,
+                align=(Align.CENTER, Align.CENTER),
+                mode=Mode.PRIVATE,
+            ).locate(Location((cx, cy, 0)))
+            children.extend(text.faces())
+    table = Compound(children=children)
+    table.table_size = (total_w, total_h)
+    return table
 
 
 _DIAM_RE = re.compile(r"[øØ⌀]\s*(\d+(?:\.\d+)?)")
@@ -2111,6 +2172,47 @@ class Drawing:
     def get_annotation(self, name):
         """Return the named annotation object, or ``None`` if no such name (#27)."""
         return self._named.get(name)
+
+    def add_hole_table(self, view="plan", *, prefer="tr", name=None):
+        """Add a hole table for *view*'s holes, placed in a free corner (#93).
+
+        One row per hole spec-group — ``TAG | ⌀ | DEPTH | QTY`` with tags
+        ``A, B, …`` — built from :meth:`features` and positioned by
+        :func:`fit_box` clear of the views, title block, and existing
+        annotations. *prefer* is the page corner to sit nearest. Returns the
+        table annotation, or ``None`` when *view* has no holes or it will not
+        fit (recorded as ``hole_table_dropped`` lint).
+        """
+        feats = [f for f in self.features(view) if f.type == "hole"]
+        if not feats:
+            return None
+        rows = [("TAG", "⌀", "DEPTH", "QTY")]
+        for tag, f in zip(_tag_sequence(len(feats)), feats, strict=True):
+            depth = "THRU" if f.through else (_fmt(f.depth) if f.depth else "")
+            rows.append((tag, f"ø{_fmt(f.diameter)}", depth, str(f.count)))
+        table = _build_hole_table(rows, self.draft)
+        w, h = table.table_size
+
+        a = self._analysis
+        margin = a.margin if a is not None else 10.0
+        pw = a.PAGE_W if a is not None else self.page_w
+        ph = a.PAGE_H if a is not None else self.page_h
+        region = (margin, margin, pw - margin, ph - margin)
+        obstacles = [b for v in self.views if (b := self.view_bounds(v)) is not None]
+        for o in self.items:
+            try:
+                bb = o.bounding_box()
+            except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+                continue
+            obstacles.append((bb.min.X, bb.min.Y, bb.max.X, bb.max.Y))
+
+        pos = fit_box((w, h), region, obstacles, prefer)
+        if pos is None:
+            self._record_build_issue(
+                "warning", "hole_table_dropped", f"hole table for {view!r} did not fit the sheet"
+            )
+            return None
+        return self.add(table.locate(Location((pos[0], pos[1], 0))), name or f"hole_table_{view}")
 
     def pin(self, name):
         """Pin a named annotation so the engine never moves it (#89).

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3694,3 +3694,26 @@ class TestHoleTable:
         assert seq[25] == "Z"
         assert seq[26] == "AA"
         assert seq[27] == "AB"
+        # The base-26 rollover boundary and uniqueness.
+        full = _tag_sequence(703)
+        assert full[701] == "ZZ"
+        assert full[702] == "AAA"
+        assert len(set(full)) == 703  # bijective — no dup or skip
+
+    def test_table_keeps_lint_clean(self, tmp_path):
+        # The label-less table must not trip annotation_overlap / view-overlap
+        # lint, and the mixed Edge+Text Compound must export cleanly.
+        dwg = build_drawing(_multi_hole_plate())
+        before = {i.code for i in dwg.lint()}
+        dwg.add_hole_table("plan")
+        after = {i.code for i in dwg.lint()}
+        assert after == before  # no new lint codes from the table
+        svg, dxf = dwg.export(str(tmp_path / "t"))
+        assert Path(svg).stat().st_size > 0 and Path(dxf).stat().st_size > 0
+
+    def test_table_geometry_is_deterministic(self):
+        from draftwright.make_drawing import _build_hole_table
+
+        rows = [("TAG", "⌀", "QTY"), ("A", "ø10", "2")]
+        a = build_drawing(Box(60, 40, 20)).draft
+        assert _build_hole_table(rows, a).table_size == _build_hole_table(rows, a).table_size

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3684,7 +3684,7 @@ class TestHoleTable:
         monkeypatch.setattr(m, "fit_box", lambda *a, **k: None)
         dwg = build_drawing(_multi_hole_plate())
         assert dwg.add_hole_table("plan") is None
-        assert "hole_table_dropped" in {i.code for i in dwg.lint()}
+        assert "table_dropped" in {i.code for i in dwg.lint()}
 
     def test_tag_sequence_rolls_over_past_z(self):
         from draftwright.make_drawing import _tag_sequence
@@ -3712,8 +3712,19 @@ class TestHoleTable:
         assert Path(svg).stat().st_size > 0 and Path(dxf).stat().st_size > 0
 
     def test_table_geometry_is_deterministic(self):
-        from draftwright.make_drawing import _build_hole_table
+        from draftwright.make_drawing import _build_table
 
         rows = [("TAG", "⌀", "QTY"), ("A", "ø10", "2")]
         a = build_drawing(Box(60, 40, 20)).draft
-        assert _build_hole_table(rows, a).table_size == _build_hole_table(rows, a).table_size
+        assert _build_table(rows, a).table_size == _build_table(rows, a).table_size
+
+    def test_generic_add_table_places_arbitrary_rows(self):
+        # The builder is generic: a gear/BOM-style param table places like a
+        # hole table, clear of the views and title block.
+        dwg = build_drawing(_multi_hole_plate())
+        rows = [("PARAMETER", "VALUE"), ("MODULE", "0.5"), ("RATIO", "13:1")]
+        tbl = dwg.add_table(rows, name="gear_data")
+        assert tbl is not None and "gear_data" in dwg.annotations()
+        tb = self._bbox(tbl)
+        for v in dwg.views:
+            assert self._area(tb, dwg.view_bounds(v)) == 0.0, v

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3625,3 +3625,72 @@ class TestTurnedDiameters:
         monkeypatch.setattr(m, "_greedy_strip_ys", lambda *a, **k: None)
         dwg = build_drawing(_x_stepped_shaft())  # must not raise
         assert not any(n.startswith("ldr_d") for n in dwg._named)
+
+
+def _multi_hole_plate():
+    """A plate with three spec-groups of Z-holes (two ø10, one ø16)."""
+    from build123d import Box, Cylinder, Pos
+
+    return (
+        Box(120, 80, 20)
+        - Pos(40, 25, 0) * Cylinder(5, 30)
+        - Pos(-40, 25, 0) * Cylinder(5, 30)
+        - Pos(0, -25, 0) * Cylinder(8, 30)
+    )
+
+
+class TestHoleTable:
+    """#93: hole table placed in a free corner via place_box."""
+
+    @staticmethod
+    def _area(a, b):
+        ox = max(0.0, min(a[2], b[2]) - max(a[0], b[0]))
+        oy = max(0.0, min(a[3], b[3]) - max(a[1], b[1]))
+        return ox * oy
+
+    def _bbox(self, obj):
+        bb = obj.bounding_box()
+        return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+
+    def test_table_has_a_row_per_spec_group(self):
+        dwg = build_drawing(_multi_hole_plate())
+        n_groups = len([f for f in dwg.features("plan") if f.type == "hole"])
+        assert n_groups == 2  # ø10 (×2) and ø16
+        tbl = dwg.add_hole_table("plan")
+        assert tbl is not None
+        assert "hole_table_plan" in dwg.annotations()
+        # header + one row per group; the table is a grid Compound.
+        assert tbl.table_size[0] > 0 and tbl.table_size[1] > 0
+
+    def test_table_does_not_overlap_views_or_title_block(self):
+        dwg = build_drawing(_multi_hole_plate())
+        dwg.add_hole_table("plan")
+        tb = self._bbox(dwg._named["hole_table_plan"])
+        for v in dwg.views:
+            assert self._area(tb, dwg.view_bounds(v)) == 0.0, v
+        assert self._area(tb, self._bbox(dwg._named["title_block"])) == 0.0
+
+    def test_no_holes_in_view_returns_none(self):
+        from build123d import Box
+
+        dwg = build_drawing(Box(60, 40, 20))
+        assert dwg.add_hole_table("plan") is None
+        assert "hole_table_plan" not in dwg.annotations()
+
+    def test_table_dropped_when_it_will_not_fit(self, monkeypatch):
+        import sys
+
+        m = sys.modules["draftwright.make_drawing"]
+        monkeypatch.setattr(m, "fit_box", lambda *a, **k: None)
+        dwg = build_drawing(_multi_hole_plate())
+        assert dwg.add_hole_table("plan") is None
+        assert "hole_table_dropped" in {i.code for i in dwg.lint()}
+
+    def test_tag_sequence_rolls_over_past_z(self):
+        from draftwright.make_drawing import _tag_sequence
+
+        seq = _tag_sequence(28)
+        assert seq[:3] == ["A", "B", "C"]
+        assert seq[25] == "Z"
+        assert seq[26] == "AA"
+        assert seq[27] == "AB"


### PR DESCRIPTION
Second increment of #93. Adds the **hole-chart annotation** and an explicit API to place it (consuming `place_box` from PR-1). The escalation trigger that auto-invokes it is the next/final PR — so this is **zero behaviour change** (nothing in the auto path calls it).

## What
- **`_build_hole_table`** — a grid `Compound` (rule lines + cell text) at the origin, columns **TAG | ⌀ | DEPTH | QTY**, column widths sized to content via real glyph metrics.
- **`_tag_sequence`** — deterministic `A, B, …, Z, AA, …` tags.
- **`Drawing.add_hole_table(view, prefer=, name=)`** — builds the table from `features()` hole groups, positions it with `fit_box` clear of views/title-block/annotations; records `hole_table_dropped` if it won't fit.

## Verified
Renders as a proper hole chart placed in the free corner (zero overlap with any view or the title block — checked by area). 

## Tests — `TestHoleTable` (5)
row-per-spec-group, no overlap with views/title-block, no-holes→`None`, dropped-when-it-won't-fit, tag rollover past Z. Full fast suite green (342 passed); ruff + mypy clean.

## Next (final #93 PR)
adjacent **balloons** keying each hole to its row + the **escalation trigger** (dense sheet → auto-table replacing dropped callouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)