### PR TITLE
feat: balloons keying holes to the hole table (#93)

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -31,6 +31,7 @@ from build123d import (
     Align,
     Arrow,
     Box,
+    Circle,
     Color,
     Compound,
     Edge,
@@ -2208,22 +2209,75 @@ class Drawing:
             return None
         return self.add(table.locate(Location((pos[0], pos[1], 0))), name)
 
-    def add_hole_table(self, view="plan", *, prefer="tr", name=None):
+    def _hole_spec_groups(self, view):
+        """Ordered ``(tag, [holes])`` spec-groups of *view*'s holes (tags A, B,
+        …). The shared basis for the hole table's rows and its balloons, so the
+        TAG column and the balloon glyphs line up."""
+        a = self._analysis
+        target = {"plan": "z", "front": "y", "side": "x"}.get(view)
+        if a is None or target is None or view not in self._coords:
+            return []
+
+        def axis_letter(h):
+            return max(zip("xyz", h.axis, strict=True), key=lambda t: abs(t[1]))[0]
+
+        groups: dict = {}
+        for h in a.holes:
+            if axis_letter(h) == target:
+                groups.setdefault(_spec_key(h), []).append(h)
+        glist = list(groups.values())
+        return list(zip(_tag_sequence(len(glist)), glist, strict=True))
+
+    def _add_balloon(self, view, tag, j, hole):
+        """A circled tag (no leader) adjacent to *hole*, keyed to its table row."""
+        cx, cy = self._coords[view].pp(*hole.location)
+        fs = self.draft.font_size
+        r = fs * 1.5  # circle comfortably larger than the glyph
+        off = hole.diameter * self.scale / 2 + r + 1.0
+        bx, by = cx + off * 0.7, cy + off * 0.7
+        loc = Location((bx, by, 0))
+        # The annotation layer fills closed paths, so a circle edge renders as a
+        # disc. A thin annular FACE fills as a ring — i.e. a circle outline.
+        ring_faces = [f.moved(loc) for f in (Circle(r) - Circle(r - 0.35)).faces()]
+        text = Text(
+            txt=tag, font_size=fs, align=(Align.CENTER, Align.CENTER), mode=Mode.PRIVATE
+        ).locate(loc)
+        balloon = Compound(children=[*ring_faces, *text.faces()])
+        # Furniture that legitimately sits on the view geometry — exempt from the
+        # annotation-overlap / centreline lint, as the section arrows do.
+        balloon.is_centerline = True
+        self.add(balloon, f"balloon_{view}_{tag}_{j}")
+
+    def add_hole_table(self, view="plan", *, prefer="tr", name=None, balloons=True):
         """Add a hole table for *view*'s holes, placed in a free corner (#93).
 
         One row per hole spec-group — ``TAG | ⌀ | DEPTH | QTY`` with tags
-        ``A, B, …`` — derived from :meth:`features` and placed via
-        :meth:`add_table`. Returns the table, or ``None`` when *view* has no
+        ``A, B, …`` — placed via :meth:`add_table`. With *balloons* (the
+        default) a circled tag is added at each hole keyed to its row. The table
+        carries ``covers_diameters`` so the coverage lint counts the tabulated
+        holes as dimensioned. Returns the table, or ``None`` when *view* has no
         holes or it will not fit.
         """
-        feats = [f for f in self.features(view) if f.type == "hole"]
-        if not feats:
+        groups = self._hole_spec_groups(view)
+        if not groups:
             return None
         rows = [("TAG", "⌀", "DEPTH", "QTY")]
-        for tag, f in zip(_tag_sequence(len(feats)), feats, strict=True):
-            depth = "THRU" if f.through else (_fmt(f.depth) if f.depth else "")
-            rows.append((tag, f"ø{_fmt(f.diameter)}", depth, str(f.count)))
-        return self.add_table(rows, prefer=prefer, name=name or f"hole_table_{view}")
+        diams = []
+        for tag, holes in groups:
+            h = holes[0]
+            depth = "THRU" if h.bottom == "through" else (_fmt(h.depth) if h.depth else "")
+            rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(len(holes))))
+            diams.append(h.diameter)
+        table = self.add_table(rows, prefer=prefer, name=name or f"hole_table_{view}")
+        if table is None:
+            return None
+        # The table documents these diameters — let lint see that (#93).
+        table.covers_diameters = tuple(diams)
+        if balloons:
+            for tag, holes in groups:
+                for j, h in enumerate(holes):
+                    self._add_balloon(view, tag, j, h)
+        return table
 
     def pin(self, name):
         """Pin a named annotation so the engine never moves it (#89).

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3662,6 +3662,29 @@ class TestHoleTable:
         # header + one row per group; the table is a grid Compound.
         assert tbl.table_size[0] > 0 and tbl.table_size[1] > 0
 
+    def test_a_balloon_per_hole_keyed_to_a_row(self):
+        # 3 physical holes (1 ø16 → A, 2 ø10 → B) get 3 balloons; tags A,B exist.
+        dwg = build_drawing(_multi_hole_plate())
+        dwg.add_hole_table("plan")
+        balloons = [n for n in dwg.annotations() if n.startswith("balloon_plan_")]
+        assert len(balloons) == 3
+        tags = {n.split("_")[2] for n in balloons}
+        assert tags == {"A", "B"}
+
+    def test_balloons_false_suppresses_them(self):
+        dwg = build_drawing(_multi_hole_plate())
+        dwg.add_hole_table("plan", balloons=False)
+        assert not any(n.startswith("balloon_") for n in dwg.annotations())
+
+    def test_table_and_balloons_keep_lint_clean(self):
+        # covers_diameters lets coverage lint count the tabulated holes, and the
+        # balloons are furniture (is_centerline) so they do not trip overlap lint.
+        dwg = build_drawing(_multi_hole_plate())
+        before = {i.code for i in dwg.lint()}
+        dwg.add_hole_table("plan")
+        assert {i.code for i in dwg.lint()} == before
+        assert dwg._named["hole_table_plan"].covers_diameters == (16.0, 10.0)
+
     def test_table_does_not_overlap_views_or_title_block(self):
         dwg = build_drawing(_multi_hole_plate())
         dwg.add_hole_table("plan")


### PR DESCRIPTION
Adds **balloons** — a circled tag (A, B, …) at each physical hole, keyed to its hole-table row. Still behind the explicit `add_hole_table` API (the auto **escalation trigger** is the final PR), so zero behaviour change.

## What
- **`_hole_spec_groups`** — the shared spec-grouping so the table's TAG column and the balloon glyphs line up (every hole → its group's tag).
- **`_add_balloon`** — a circled tag adjacent to each hole. *Rendering note:* the annotation layer fills closed paths (so an edge-circle would draw as a **disc**); the balloon ring is a thin **annular face**, which fills as an **outline**. Marked `is_centerline` so this furniture (which legitimately sits on the view geometry) is exempt from overlap lint, exactly as the section arrows are.
- **`add_hole_table(..., balloons=True)`** default; the table carries **`covers_diameters`** so the coverage lint counts the tabulated holes as dimensioned → lint stays clean.

## Verified visually
Renders as proper balloons (A on the ø16, B on both ø10s) keyed to the table; lint clean.

## Tests
TestHoleTable balloon cases: one balloon per hole keyed to a row, `balloons=False` suppresses, table+balloons keep lint clean. ruff + mypy clean.

## Final #93 PR after this
the **escalation trigger** — when the auto pass would drop callouts (dense sheet), build the table + balloons and remove the individual callouts. Makes it automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)