### PR TITLE
fix: place_dim labels real-world length at non-1:1 scale

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -2174,6 +2174,13 @@ class Drawing:
                     dist = coord - max(p[ax] for p in (p1, p2))
                 else:
                     dist = min(p[ax] for p in (p1, p2)) - coord
+        # p1/p2 are page coordinates; Dimension labels the raw page distance when
+        # no label is given, which is scale-too-big at non-1:1 scales. Supply the
+        # real-world length (page distance ÷ drawing scale) unless the caller set
+        # an explicit label.
+        if "label" not in kwargs:
+            page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
+            kwargs["label"] = _fmt(page_len / self.scale)
         return self.add(_dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name)
 
     # -- annotations ----------------------------------------------------------

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3184,6 +3184,29 @@ class TestPlaceDim:
         result = dwg.place_dim((0, 0, 0), (80, 0, 0), "below", "plan", d, slot=8.0)
         assert isinstance(result, Dimension)
 
+    def test_place_dim_labels_real_world_length_at_non_unity_scale(self):
+        # place_dim receives page-coordinate points; at 1:2 the page span is 2× the
+        # world size. The auto label must read the real-world length, not the page
+        # distance, or it disagrees with the geometry (and trips label_vs_measured).
+        from build123d_drafting.helpers import lint_drawing
+
+        dwg = build_drawing(Box(80, 60, 20), scale=2.0)
+        assert dwg.scale == 2.0
+        p1 = dwg.at("plan", -40, 0, 0)
+        p2 = dwg.at("plan", 40, 0, 0)
+        d = dwg.place_dim(p1, p2, "below", "plan", dwg.draft, name="w")
+        assert d.label == "80"
+        assert [
+            i for i in lint_drawing([d], drawing_scale=dwg.scale) if i.code == "label_vs_measured"
+        ] == []
+
+    def test_place_dim_explicit_label_wins_over_scale_autolabel(self):
+        dwg = build_drawing(Box(80, 60, 20), scale=2.0)
+        p1 = dwg.at("plan", -40, 0, 0)
+        p2 = dwg.at("plan", 40, 0, 0)
+        d = dwg.place_dim(p1, p2, "below", "plan", dwg.draft, label="CUSTOM")
+        assert d.label == "CUSTOM"
+
 
 # ---------------------------------------------------------------------------
 # Issue #29: lint findings carry a suggested-fix code snippet


### PR DESCRIPTION
## Bug

`dwg.place_dim()` mislabels dimensions on any drawing not at 1:1.

It takes **page-coordinate** points (via `dwg.at()`). When the caller doesn't pass an explicit `label`, `Dimension` (build123d-drafting-helpers) labels the **raw page distance** between the points — it has no `scale` parameter. At sheet scale 1:N the page span is N× the real size, so the label is N× too large and `label_vs_measured` fires.

The auto-dimensions never hit this because they always pass `label=_fmt(a.x_size)` (the real world size). `place_dim` passed page points but no label.

### Repro (before this PR)

```python
dwg = build_drawing(Box(80, 60, 20), scale=2.0)   # 1:2 sheet
p1, p2 = dwg.at("plan", -40, 0, 0), dwg.at("plan", 40, 0, 0)
d = dwg.place_dim(p1, p2, "below", "plan", dwg.draft)
d.label                      # "160"  ← wrong; the part is 80 mm wide
# lint_drawing([d], drawing_scale=2.0) → label_vs_measured
```

## Fix

`place_dim` is a `Drawing` method, so it has `self.scale`. Derive the label from `page_distance / self.scale` when the caller omits one:

```python
if "label" not in kwargs:
    page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
    kwargs["label"] = _fmt(page_len / self.scale)
```

Explicit `label=` still wins; identity at 1:1 (no change to existing drawings).

## Tests

Added two cases to `TestPlaceDim`:
- `test_place_dim_labels_real_world_length_at_non_unity_scale` — at 1:2, label is `"80"` and no `label_vs_measured`.
- `test_place_dim_explicit_label_wins_over_scale_autolabel` — explicit label respected.

Full `tests/test_make_drawing.py`: **307 passed**.

## Context

Surfaced while wiring maquetto's AI drawing loop, whose system prompt tells the model to add dimensions via `place_dim(dwg.at(world…), …)` — so every AI-added dim on a scaled-down (larger) part was mislabelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)