### PR TITLE
feat: compose-then-pack view blocks + four-side balloon ring (#112)

### DIFF
--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -1,0 +1,160 @@
+# ADR 0004 — Compose-then-pack: views as blocks carrying their annotation footprint
+
+- **Status:** Proposed
+- **Date:** 2026-06-19
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+draftwright lays out a sheet in two stages today: `_analyse` places the
+orthographic views using *heuristic* space reservations (strip depths, gap
+maxes, the balloon halo), then `_auto_annotate` adds the dimensions, callouts,
+balloons, **and the hole table** into whatever space is left.
+
+This ordering — **views first, annotations second** — is the root cause of a
+recurring class of failures (surfaced while making dense hole patterns legible,
+#111/#112):
+
+- The hole table is dropped into a free corner *after* layout and never enters
+  scale/page selection, so reserving any balloon space starves it
+  (`table_dropped`).
+- Balloons can only be reserved on three sides of the plan view; the fourth (the
+  bottom) abuts the front view, and pushing the front view down to make room
+  cascades into the table and the scale choice.
+- `_will_balloon` must *predict* whether a view escalates *before* the views are
+  placed — but reserving the predicted space changes the layout enough that the
+  part may no longer escalate. The prediction is self-defeating on borderline
+  parts.
+- `lint()` measures real geometry bounding boxes at O(n²); a balloon-heavy
+  drawing (NIST CTC-02, ~60 balloons) sits at the CI timeout.
+
+Each symptom is a patch on the same flaw: annotations are second-class citizens
+placed post-hoc, competing for scraps. ADR 0003 settles how *annotations within
+a view* are placed (the `Placeable`/Cassowary inner layout). This ADR settles
+the layer around it: **how a view and its full annotation set are composed into
+one placeable block, and how those blocks are packed onto the page and scaled.**
+
+## Decision
+
+Adopt **compose-then-pack**. Each view becomes a *block* whose footprint
+includes its geometry **and all of its annotations** (dimensions, callouts,
+balloons) **and its furniture** (the hole table, the iso). The sheet is laid out
+by composing the blocks first and packing the complete blocks second.
+
+Two rules make it work and keep it maintainable:
+
+1. **Lay out, don't predict.** A block's footprint is the *actual* laid-out
+   extent of its annotations, not an a-priori guess. Escalation ("N callouts or
+   one table") is decided by whether the per-instance layout fits, not by
+   `_will_balloon`. The prediction problem disappears.
+2. **Layout reasons about boxes; geometry is built last.** Annotations are laid
+   out as lightweight page-mm **rectangles** in view-local coordinates; the
+   packer measures the footprint from those boxes; the real OCC geometry is
+   built only once, at the block's resolved page position.
+
+### The footprint is a box layout, not measured geometry
+
+Three footprint representations were considered:
+
+- **Scalar per-side bands** (today's `StripDepths` / `pv_halo`) — fast but lossy;
+  it cannot say "balloons here, table there," which is exactly what forced the
+  prediction and the cramming.
+- **Measured OCC geometry** — a single source of truth, but *slow* (the O(n²)
+  `lint()` perf wall we already hit in CI) and it forces annotations to be built
+  before placement, then translated.
+- **A box layout (chosen)** — annotations laid out as plain page-mm rectangles.
+  The block's footprint *is* that box layout; the same layout drives both the
+  reservation and the final render positions (single source of truth, no drift);
+  it is rectangle math (fast) and decoupled from OCC (testable in isolation).
+
+The deciding factor is evidence, not theory: we have already hit the
+measured-geometry performance wall in production. The box layout's one real risk
+— box-vs-geometry drift — is controlled by making the box the **contract** the
+renderer must fill at the resolved position.
+
+### Scaling and the scale/page search
+
+A drawing mixes two coordinate regimes that behave oppositely under scale:
+
+- **View geometry scales** with the scale factor (a 70 mm part at 2:1 is a
+  140 mm box on the page).
+- **Annotations are page-mm — scale-independent** (a 3 mm dimension label, a
+  9 mm balloon, the hole-table text are constant at any scale).
+
+So a block's footprint is `(scaled geometry box) + (fixed-size annotation
+boxes)`. Most of it is scale-invariant. The one scale-coupled input is *which*
+annotations exist — legibility/escalation, `world_separation × scale` vs a fixed
+page-mm minimum. So composition is a function of scale: `compose(view, scale)`.
+
+This turns the current tangled fixed-point iteration (measure strips → choose
+scale → re-measure, ×3) into a clean **monotone search over `(scale, page)`
+candidates**:
+
+```text
+for (scale, page) in ladder:                 # largest scale first
+    blocks = [compose(view, scale) for v]    # decide annotations + lay out boxes
+    packed = pack(blocks, page)              # fixed projection topology + free-rect placement
+    if packed fits: return (scale, page), packed
+```
+
+At a *given* scale the footprint is deterministic, so there is no circular
+scale↔footprint loop to iterate — `compose(scale)` fixes the legibility and
+escalation choices for that scale. The scattered estimators (`_est_*_depth`,
+table size, halo) collapse into one composer per view.
+
+### Relationship to ADR 0003 and the deferred 2D solve
+
+- ADR 0003 governs the **inner** layout (placing a view's own annotations in its
+  zones via the `Placeable`/Cassowary system). This ADR governs the **outer**
+  layout (composing view+annotation blocks and packing them on the page). A
+  block's footprint is produced by running the ADR-0003 inner layout in
+  view-local space.
+- The **page-level packing stays fixed-topology** (plan above front sharing X;
+  side beside front sharing Y; iso and table in free rectangles via
+  `place_box` / `fit_box`). It is **not** the full global 2D solve deferred in
+  #94, which we keep deferred — most "2D freedom" is forbidden by projection
+  alignment, and a global non-overlap solve is disjunctive/NP-hard and
+  non-deterministic. Fixed-topology + composed footprints + local free-rect
+  placement is the right amount of structure.
+
+### Roadmap (incremental; each step mergeable, byte-identical for unaffected drawings)
+
+1. **Done** — `ViewBlock` data model + block-driven view placement
+   (byte-identical foundation).
+2. **Hole table as a composed block** — footprint computed up front, packed
+   alongside the iso, participating in scale/page selection.
+3. **Balloon ring as part of the plan block's footprint** — all four sides; the
+   packer makes room (lift the plan view, grow the page, or reduce scale — its
+   choice, not hand-coded).
+4. **Generalise** — each view's dims/callouts become its block footprint; retire
+   the scalar strip-depth heuristics.
+5. **Retire `_will_balloon`** — escalation decided from the composed fit.
+
+The standing acceptance test at every step is the **dense-ballooning hard case**
+(NIST CTC-02); the golden/geometry suite is the contract that unaffected
+drawings do not move.
+
+## Consequences
+
+**Positive**
+- The recurring failures dissolve by construction: no post-hoc table cramming,
+  no self-defeating prediction, no balloon-vs-table competition. The bottom band
+  is just "the plan block's bottom footprint," and the packer places it.
+- The page-level "front view down or plan view up?" decision moves *into the
+  packer* — we stop hand-writing `PV_Y = FV_Y + …`.
+- Performance recovers: layout is rectangle math; OCC geometry is built once at
+  the end, not measured during the search.
+- The scattered estimators and the 3× measure/choose iteration collapse into one
+  `compose(view, scale)` + one scale/page search — fewer mechanisms, more
+  testable.
+
+**Negative / costs**
+- A box model must be maintained for every annotation type (its page-mm size),
+  and the renderer must honour the reserved box. Drift is the failure mode to
+  guard against in tests.
+- Multi-PR migration with a real risk of a half-composed engine running two
+  models at once; mitigated by the byte-identical-per-step discipline and the
+  golden suite.
+- `compose(view, scale)` must run the *real* legibility/escalation logic (not
+  estimate) to be correct — this is where the substance moves, and it must stay
+  fast (box math) to preserve the performance win.

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1276,19 +1276,41 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     margin = _MARGIN
     DIM_PAD = _DIM_PAD
     bbox_max = max(x_size, y_size, z_size)
-    # When the plan view will be ballooned, reserve a standoff band (pv_halo) on
-    # its left and right corridors so the balloon ring has clear space off the
-    # part and no leader crosses a neighbouring view (#111).
-    halo = strips.pv_halo if strips else 0.0
-    gap_fv_sv = max(DIM_PAD, strips.right if strips else _est_right_strip_depth(n_steps), halo)
-    gap_left = max(DIM_PAD, strips.left if strips else DIM_PAD, halo)
-
     fv_hw = x_size * scale / 2
     fv_hh = z_size * scale / 2
     pv_hh = y_size * scale / 2
     sv_hw = y_size * scale / 2
 
-    total_h = 2 * margin + 3 * DIM_PAD + z_size * scale + y_size * scale
+    # Compose each view as a block: geometry half-extents + reserved annotation
+    # bands per side (#112).  The front and plan views form a vertical column
+    # sharing the left/right corridors (max of the two); the side view shares
+    # the FV↔SV corridor; the front↔plan gap is the abutting pair
+    # (fv.top + pv.bottom).  When the plan view is ballooned (halo > 0) its halo
+    # becomes explicit per-side bands so the ballooned plan view is placed as a
+    # unit — including a BOTTOM band that pushes the front view down so balloons
+    # ring the part below it, not just left/right/top (#111/#112 Phase 2).  All
+    # bands reduce to today's arithmetic when halo = 0 (byte-identical).
+    halo = strips.pv_halo if strips else 0.0
+    gap_fv_sv = max(DIM_PAD, strips.right if strips else _est_right_strip_depth(n_steps), halo)
+    gap_left = max(DIM_PAD, strips.left if strips else DIM_PAD, halo)
+    pv_below = _est_pv_below_depth()
+    fv = ViewBlock(
+        fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
+    )
+    pv = ViewBlock(
+        fv_hw,
+        pv_hh,
+        top=DIM_PAD,
+        right=gap_fv_sv,
+        bottom=pv_below,
+        left=gap_left,
+    )
+    sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
+
+    # Vertical stack: bottom margin + FV block + abutting FV↔PV gap + PV block +
+    # PV top band + top margin.  Reduces to 2·margin + 3·DIM_PAD + z·s + y·s when
+    # halo = 0.
+    total_h = 2 * margin + fv.bottom + 2 * fv.hh + (fv.top + pv.bottom) + 2 * pv.hh + pv.top
     y_offset = max(0.0, (page_h - total_h) / 2)
 
     total_content_w = (
@@ -1300,19 +1322,6 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
         + bbox_max * scale * _ISO_WIDTH_BUDGET
     )
     x_offset = max(0.0, (page_w - 2 * margin - tb_w - total_content_w) / 2)
-
-    # Compose each view as a block (geometry half-extents + reserved annotation
-    # bands per side) and place the blocks (#112).  The bands reproduce today's
-    # corridor arithmetic exactly (gap→band map in #112): the front and plan
-    # views form a vertical column sharing the left/right corridors; the side
-    # view sits to the right sharing the FV↔SV corridor; the front↔plan gap is
-    # the one abutting pair (fv.top + pv.bottom = DIM_PAD).
-    pv_below = _est_pv_below_depth()
-    fv = ViewBlock(
-        fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
-    )
-    pv = ViewBlock(fv_hw, pv_hh, top=DIM_PAD, right=gap_fv_sv, bottom=pv_below, left=gap_left)
-    sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
 
     FV_X = margin + x_offset + fv.left + fv.hw
     FV_Y = y_offset + margin + fv.bottom + fv.hh
@@ -2087,7 +2096,9 @@ class Drawing:
         sv_left = a.SV_X - a.sv_hw
         margin, ph = a.margin, a.PAGE_H
 
-        # Assign each hole to the nearest reserved band (bottom excluded).
+        # Assign each hole to the nearest reserved band (bottom excluded — the
+        # front view abuts the plan view there; a bottom balloon band needs the
+        # hole table packed as a block too, see #112).
         bands: dict = {"left": [], "right": [], "top": []}
         for tag, j, hole in specs:
             cx, cy = pp(*hole.location)

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1241,6 +1241,26 @@ def choose_scale(
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class ViewBlock:
+    """A view's composite footprint (#112): its geometry half-extents plus the
+    reserved annotation-band depth on each side (page-mm).
+
+    The block's outer box is the geometry box inflated by its bands; the layout
+    packs these blocks rather than padding bare views with scalar corridors.
+    Two blocks that *abut* are separated by ``bandA + bandB``; two that *share*
+    a corridor (a band against a common wall or neighbour) by ``max(bandA,
+    bandB)`` — see the gap→band map in #112.
+    """
+
+    hw: float  # geometry half-width
+    hh: float  # geometry half-height
+    top: float = 0.0
+    right: float = 0.0
+    bottom: float = 0.0
+    left: float = 0.0
+
+
 def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips, n_steps=0):
     """Compute the 4-view layout geometry for a part at a given scale/page.
 
@@ -1281,13 +1301,26 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     )
     x_offset = max(0.0, (page_w - 2 * margin - tb_w - total_content_w) / 2)
 
-    FV_X = margin + x_offset + gap_left + fv_hw
-    FV_Y = y_offset + margin + DIM_PAD + fv_hh
+    # Compose each view as a block (geometry half-extents + reserved annotation
+    # bands per side) and place the blocks (#112).  The bands reproduce today's
+    # corridor arithmetic exactly (gap→band map in #112): the front and plan
+    # views form a vertical column sharing the left/right corridors; the side
+    # view sits to the right sharing the FV↔SV corridor; the front↔plan gap is
+    # the one abutting pair (fv.top + pv.bottom = DIM_PAD).
+    pv_below = _est_pv_below_depth()
+    fv = ViewBlock(
+        fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
+    )
+    pv = ViewBlock(fv_hw, pv_hh, top=DIM_PAD, right=gap_fv_sv, bottom=pv_below, left=gap_left)
+    sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
+
+    FV_X = margin + x_offset + fv.left + fv.hw
+    FV_Y = y_offset + margin + fv.bottom + fv.hh
     PV_X = FV_X
-    PV_Y = FV_Y + fv_hh + DIM_PAD + pv_hh
-    SV_X = FV_X + fv_hw + gap_fv_sv + sv_hw
+    PV_Y = FV_Y + fv.hh + (fv.top + pv.bottom) + pv.hh
+    SV_X = FV_X + fv.hw + max(fv.right, sv.left) + sv.hw
     SV_Y = FV_Y
-    sv_right = SV_X + sv_hw + DIM_PAD
+    sv_right = SV_X + sv.hw + sv.right
     sv_right_wall = (
         (page_w - margin) if (PV_Y - pv_hh) > (margin + _TB_H) else (page_w - tb_w - margin)
     )

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1302,15 +1302,21 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
         pv_hh,
         top=DIM_PAD,
         right=gap_fv_sv,
-        bottom=pv_below,
+        bottom=max(pv_below, halo),  # band below PV holds the width dim + a balloon row
         left=gap_left,
     )
     sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
 
-    # Vertical stack: bottom margin + FV block + abutting FV↔PV gap + PV block +
-    # PV top band + top margin.  Reduces to 2·margin + 3·DIM_PAD + z·s + y·s when
-    # halo = 0.
-    total_h = 2 * margin + fv.bottom + 2 * fv.hh + (fv.top + pv.bottom) + 2 * pv.hh + pv.top
+    # Bottom balloon band: rather than pushing the front view down (which would
+    # cascade into the iso/table and the scale choice), LIFT the plan view up
+    # into the empty top headroom above it — the front/side views, iso and title
+    # block stay anchored, so the table is undisturbed.  The lift is implicit:
+    # the vertical stack is centred with the BASE front↔plan gap (so FV/SV centre
+    # exactly as when halo = 0), while PV is positioned with the full ballooned
+    # gap, leaving it max(0, halo - pv_below) higher.  Byte-identical when
+    # halo = 0.  (#112, ADR 0004.)
+    base_gap = fv.top + pv_below
+    total_h = 2 * margin + fv.bottom + 2 * fv.hh + base_gap + 2 * pv.hh + pv.top
     y_offset = max(0.0, (page_h - total_h) / 2)
 
     total_content_w = (
@@ -1326,6 +1332,9 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     FV_X = margin + x_offset + fv.left + fv.hw
     FV_Y = y_offset + margin + fv.bottom + fv.hh
     PV_X = FV_X
+    # PV uses the full (ballooned) front↔plan gap while FV/SV were centred with
+    # the base gap — so the plan view sits pv_lift higher: lifted into the
+    # headroom, front view anchored.
     PV_Y = FV_Y + fv.hh + (fv.top + pv.bottom) + pv.hh
     SV_X = FV_X + fv.hw + max(fv.right, sv.left) + sv.hw
     SV_Y = FV_Y
@@ -2088,25 +2097,33 @@ class Drawing:
         fs = self.draft.font_size
         r = fs * 1.5  # circle comfortably larger than the glyph
         standoff = _STRIP_GAP
-        gap = 2 * r + _STRIP_SPACING  # min centre-to-centre between balloons
+        gap = 2 * r + 2 * _STRIP_SPACING  # min centre-to-centre: balloon + padding both sides
 
         # Plan-view page edges; the reserved bands sit just outside them.
         pl, pr = a.PV_X - a.fv_hw, a.PV_X + a.fv_hw
-        pt = a.PV_Y + a.pv_hh
+        pt, pb = a.PV_Y + a.pv_hh, a.PV_Y - a.pv_hh
         sv_left = a.SV_X - a.sv_hw
         margin, ph = a.margin, a.PAGE_H
 
-        # Assign each hole to the nearest reserved band (bottom excluded — the
-        # front view abuts the plan view there; a bottom balloon band needs the
-        # hole table packed as a block too, see #112).
-        bands: dict = {"left": [], "right": [], "top": []}
+        # A bottom band (below PV, beside the overall-width dim) is usable only
+        # when the layout actually lifted the plan view — i.e. widened the FV↔PV
+        # gap beyond the base DIM_PAD (#112, ADR 0004).  Without the lift the gap
+        # is full of the width dimension and a balloon row would collide with it;
+        # bottom-edge holes then fall back to the nearest side/top band.
+        bottom_line = pb - standoff - r
+        has_bottom = pb - (a.FV_Y + a.fv_hh) > _DIM_PAD + 2
+
+        # Assign each hole to the nearest reserved band.
+        bands: dict = {"left": [], "right": [], "top": [], "bottom": []}
         for tag, j, hole in specs:
             cx, cy = pp(*hole.location)
             choices = {"left": cx - pl, "right": pr - cx, "top": pt - cy}
+            if has_bottom:
+                choices["bottom"] = cy - pb
             bands[min(choices, key=lambda s: choices[s])].append((tag, j, hole, cx, cy))
 
         # left/right balloons vary in Y at a fixed X just outside the part; top
-        # balloons vary in X at a fixed Y just above it.
+        # and bottom balloons vary in X at a fixed Y just beyond it.
         self._place_band(
             view, bands["left"], "y", pl - standoff - r, margin + r, ph - margin - r, gap, fs, r
         )
@@ -2115,6 +2132,9 @@ class Drawing:
         )
         self._place_band(
             view, bands["top"], "x", pt + standoff + r, pl - standoff, sv_left - r, gap, fs, r
+        )
+        self._place_band(
+            view, bands["bottom"], "x", bottom_line, pl - standoff, sv_left - r, gap, fs, r
         )
 
     def _place_band(self, view, members, axis, line, lo, hi, gap, fs, r):


### PR DESCRIPTION
First substantive slice of the compose-then-pack layout (#112), architecture recorded in **ADR 0004**.

### What's in here
1. **`ViewBlock` foundation (byte-identical).** `_layout_geometry` composes front/plan/side as blocks and derives the view centres + vertical extent from them. No view moves.
2. **ADR 0004 — compose-then-pack view blocks.** Views-first/annotations-second is the root flaw; the fix is each view a block carrying its full annotation footprint; the footprint is a lightweight page-mm **box layout** (not measured geometry — the perf wall); scale is an input to composition; page packing stays fixed-topology (not the deferred #94 global solve). NIST CTC-02 is the standing acceptance test.
3. **Four-side balloon ring via plan-view lift.** Balloons ring all four sides of the plan view, including the **bottom** — by lifting the plan view into the empty top-margin headroom (front/side/iso/title block stay anchored, table never starved), not by pushing the front view down. No table-as-block, no scale change.

### Validation
- Full non-slow suite **358 passed**; ruff/mypy clean.
- Dense-plate: four sides ringed, 24 balloons, A4, hole table intact, lint clean.
- CTC-02 (irregular worst case): rings all four sides, far more organised; still drops some balloons on overflow + residual leader-vs-dim *warnings* — the case build123d-drafting-helpers#144 removes by not ballooning at all.

### Roadmap (ADR 0004) still ahead
- Iso + title block as first-class blocks.
- Dimensions as composed boxes (retire scalar StripDepths).
- Retire _will_balloon.