### PR TITLE
refactor: pin the title block as a first-class block (#112)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -423,7 +423,7 @@ def _add_title_block(dwg, a: Analysis):
         legal_owner="",
         width=a.TB_W,
         draft=dwg.draft,
-    ).locate(Location((a.PAGE_W - a.TB_W - 11, 11, 0)))
+    ).locate(Location((a.PAGE_W - a.TB_W - _TB_CLEAR, _TB_CLEAR, 0)))
     dwg.add(tb, "title_block")
 
 

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -89,6 +89,7 @@ from draftwright._core import (
     _SLOT_DIM_STEP,
     _SLOT_DIM_WIDTH,
     _TABULATE_MIN_HOLES,
+    _TB_CLEAR,
     _TB_H,
     Analysis,
     Strip,
@@ -1261,6 +1262,15 @@ class ViewBlock:
     left: float = 0.0
 
 
+def _padded_box(cx, cy, hw, hh, pad=_DIM_PAD):
+    """A view's geometry box centred at (cx, cy), inflated by `pad` mm clearance.
+
+    Used to build the obstacles the iso is placed around (the iso is the one
+    *placed* block; the views and title block are the fixed blocks it dodges).
+    """
+    return (cx - hw - pad, cy - hh - pad, cx + hw + pad, cy + hh + pad)
+
+
 def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips, n_steps=0):
     """Compute the 4-view layout geometry for a part at a given scale/page.
 
@@ -1344,26 +1354,19 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     )
 
     drawable = (margin, margin, page_w - margin, page_h - margin)
+
+    # Title block: a PINNED block.  Its lower-left corner sits _TB_CLEAR in from
+    # the right page edge and _TB_CLEAR up from the bottom, _TB_H tall — the same
+    # pin the renderer uses in _add_title_block.  Everything else is laid out to
+    # work around it.  (#112, ADR 0004.)
+    tb_right = page_w - _TB_CLEAR
+    title_block = (tb_right - tb_w, _TB_CLEAR, tb_right, _TB_CLEAR + _TB_H)
+
     obstacles = [
-        (
-            FV_X - fv_hw - DIM_PAD,
-            FV_Y - fv_hh - DIM_PAD,
-            FV_X + fv_hw + DIM_PAD,
-            FV_Y + fv_hh + DIM_PAD,
-        ),
-        (
-            PV_X - fv_hw - DIM_PAD,
-            PV_Y - pv_hh - DIM_PAD,
-            PV_X + fv_hw + DIM_PAD,
-            PV_Y + pv_hh + DIM_PAD,
-        ),
-        (
-            SV_X - sv_hw - DIM_PAD,
-            SV_Y - fv_hh - DIM_PAD,
-            SV_X + sv_hw + DIM_PAD,
-            SV_Y + fv_hh + DIM_PAD,
-        ),
-        (page_w - tb_w - 11 - DIM_PAD, margin, page_w - 11 + DIM_PAD, 11 + _TB_H + DIM_PAD),
+        _padded_box(FV_X, FV_Y, fv_hw, fv_hh),
+        _padded_box(PV_X, PV_Y, fv_hw, pv_hh),
+        _padded_box(SV_X, SV_Y, sv_hw, fv_hh),
+        (title_block[0] - DIM_PAD, margin, title_block[2] + DIM_PAD, title_block[3] + DIM_PAD),
     ]
     iso_left, iso_bottom, iso_right, iso_top = _largest_empty_rect(drawable, obstacles)
     # _largest_empty_rect falls back to the full drawable when the obstacles

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1261,14 +1261,27 @@ class ViewBlock:
     bottom: float = 0.0
     left: float = 0.0
 
+    def footprint(self, cx, cy):
+        """Outer box of this block placed at centre (cx, cy): the geometry box
+        inflated by the per-side bands.  This is what the layout packs and what
+        other blocks are placed around — the padding lives on the block, not on
+        the caller building the obstacle."""
+        return (
+            cx - self.hw - self.left,
+            cy - self.hh - self.bottom,
+            cx + self.hw + self.right,
+            cy + self.hh + self.top,
+        )
+
 
 def _padded_box(cx, cy, hw, hh, pad=_DIM_PAD):
-    """A view's geometry box centred at (cx, cy), inflated by `pad` mm clearance.
+    """Footprint of a fixed block at (cx, cy) with a uniform `pad` clearance band.
 
-    Used to build the obstacles the iso is placed around (the iso is the one
-    *placed* block; the views and title block are the fixed blocks it dodges).
+    The clearance is expressed as the block's own bands (see
+    ``ViewBlock.footprint``) — the obstacle the iso is placed around is the
+    block's footprint, not an ad-hoc inflation done by the caller.
     """
-    return (cx - hw - pad, cy - hh - pad, cx + hw + pad, cy + hh + pad)
+    return ViewBlock(hw, hh, pad, pad, pad, pad).footprint(cx, cy)
 
 
 def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips, n_steps=0):
@@ -1357,16 +1370,27 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
 
     # Title block: a PINNED block.  Its lower-left corner sits _TB_CLEAR in from
     # the right page edge and _TB_CLEAR up from the bottom, _TB_H tall — the same
-    # pin the renderer uses in _add_title_block.  Everything else is laid out to
-    # work around it.  (#112, ADR 0004.)
-    tb_right = page_w - _TB_CLEAR
-    title_block = (tb_right - tb_w, _TB_CLEAR, tb_right, _TB_CLEAR + _TB_H)
+    # pin the renderer uses in _add_title_block.  Its clearance is the block's
+    # own bands: DIM_PAD on the three free sides, and only down to the page
+    # margin below (it abuts the bottom sheet edge).  Everything else is laid
+    # out to work around its footprint.  (#112, ADR 0004.)
+    title_block = ViewBlock(
+        tb_w / 2,
+        _TB_H / 2,
+        top=DIM_PAD,
+        right=DIM_PAD,
+        bottom=_TB_CLEAR - margin,
+        left=DIM_PAD,
+    )
+    tb_cx, tb_cy = page_w - _TB_CLEAR - tb_w / 2, _TB_CLEAR + _TB_H / 2
 
+    # The iso is the one *placed* block: it takes the largest gap the fixed
+    # blocks' footprints leave.
     obstacles = [
         _padded_box(FV_X, FV_Y, fv_hw, fv_hh),
         _padded_box(PV_X, PV_Y, fv_hw, pv_hh),
         _padded_box(SV_X, SV_Y, sv_hw, fv_hh),
-        (title_block[0] - DIM_PAD, margin, title_block[2] + DIM_PAD, title_block[3] + DIM_PAD),
+        title_block.footprint(tb_cx, tb_cy),
     ]
     iso_left, iso_bottom, iso_right, iso_top = _largest_empty_rect(drawable, obstacles)
     # _largest_empty_rect falls back to the full drawable when the obstacles


### PR DESCRIPTION
## What

Formalises the **title block as a pinned block** (per @pzfreo's framing: *"just pin the title block and everything else works around it"*). The title block's position is fixed by convention — bottom-right, `_TB_CLEAR` in from the page edge — so it is **not placed** by the layout; the views and iso are solved **around** it.

## Why

The pin offset (`11` mm = `_MARGIN + 1`) was hardcoded as a raw `11` in two places that must agree:
- `_core._add_title_block` — the renderer's `.locate()`
- `_layout_geometry` — the iso-avoidance obstacle

`_core` already named this value `_TB_CLEAR`; both now derive from that **single constant**, so the rendered title block and the obstacle the iso dodges can't drift apart.

Also:
- DRY'd the three view obstacle boxes through a `_padded_box()` helper.
- Named the iso as the one **placed** block (it dodges the fixed view/title-block obstacles).

## Safety

**Byte-identical** — `_TB_CLEAR == 11.0`, so no drawing moves. Full fast suite: **358 passed**. Slow CTC e2e unaffected (geometry positions unchanged).

## Context

Part of ADR 0004 (compose-then-pack): a small step toward every placeable being a block — pinned blocks (title block) + placed blocks (views, iso). Sits alongside ADR 0003's `locked`/pin idea.

### Noted, not fixed (would not be byte-identical)
`make_drawing.py:1343`'s `sv_right_wall` computes the title-block left edge as `page_w - tb_w - margin` (margin = 10), 1 mm off from the real pin (`_TB_CLEAR` = 11). Aligning it shifts side-view dims by 1 mm — deferred to a future non-byte-identical pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)