### PR TITLE
feat: AnnoBox composer — box-model footprint foundation (#112, Step 4a)

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1079,6 +1079,73 @@ def _measure_strips(
     return StripDepths(right=right, left=left, pv_halo=pv_halo)
 
 
+@dataclass(frozen=True)
+class AnnoBox:
+    """A composed annotation band as a page-mm box (#112, ADR 0004 Step 4).
+
+    ``side`` is the view side the band sits on (``"right"``/``"left"`` of the
+    front/plan views, or ``"plan_halo"`` for the balloon standoff ring);
+    ``depth`` is the band's perpendicular extent from the view edge.  A view's
+    footprint is the deepest band per side — see ``_footprint_from_boxes``.
+
+    This is the box-model expression of the scalar corridor reservation that
+    ``_measure_strips`` computes (Step 4a): each band that contributes to a
+    ``StripDepths`` field becomes one ``AnnoBox``.  Today the depths are the
+    same estimates ``_measure_strips`` uses, so the two are interchangeable
+    (byte-identical); later steps replace the estimates with depths measured
+    from the real placement.
+    """
+
+    side: str
+    depth: float
+
+
+def _compose_anno_boxes(
+    holes,
+    patterns,
+    n_steps: int,
+    font_size: float = _FONT_SIZE,
+    arrow_length: float = 2.7,
+    pad_around_text: float = 2.0,
+) -> list[AnnoBox]:
+    """Compose a drawing's annotation bands as ``AnnoBox`` boxes (#112, Step 4a).
+
+    Mirrors ``_measure_strips`` exactly, but emits each contributing band as a
+    box rather than folding them into three scalars up front.
+    ``_footprint_from_boxes`` reduces these back to the identical
+    ``StripDepths``.
+    """
+    boxes = [AnnoBox("right", _est_right_strip_depth(n_steps))]  # FV right dim ladder
+    bore_depth = _est_bore_callout_width(
+        holes, font_size, patterns=patterns, pad_around_text=pad_around_text
+    )
+    if bore_depth > 0:
+        # elbow clearance + leader-to-label gap, as in _measure_strips
+        bore_depth += pad_around_text + arrow_length
+        boxes.append(AnnoBox("right", bore_depth))  # FV/PV right bore callouts
+        boxes.append(AnnoBox("left", bore_depth))  # FV/PV left bore callouts
+    if _will_balloon(holes, patterns):
+        boxes.append(AnnoBox("plan_halo", _est_plan_halo(font_size)))
+    return boxes
+
+
+def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
+    """Reduce composed ``AnnoBox`` bands to per-side corridor depths (Step 4a).
+
+    Each ``StripDepths`` field is the deepest band on its side; ``left`` keeps
+    the ``_DIM_PAD`` floor it has in ``_measure_strips``.
+    """
+
+    def deepest(side: str) -> float:
+        return max((b.depth for b in boxes if b.side == side), default=0.0)
+
+    return StripDepths(
+        right=deepest("right"),
+        left=max(_DIM_PAD, deepest("left")),
+        pv_halo=deepest("plan_halo"),
+    )
+
+
 def _fits(
     x_size,
     y_size,

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1089,9 +1089,10 @@ class AnnoBox:
     footprint is the deepest band per side — see ``_footprint_from_boxes``.
 
     This is the box-model expression of the scalar corridor reservation that
-    ``_measure_strips`` computes (Step 4a): each band that contributes to a
-    ``StripDepths`` field becomes one ``AnnoBox``.  Today the depths are the
-    same estimates ``_measure_strips`` uses, so the two are interchangeable
+    ``_measure_strips`` computes (Step 4a): every band that can drive a
+    ``StripDepths`` field is emitted as an ``AnnoBox``, and the deepest band per
+    side wins (see ``_footprint_from_boxes``).  Today the depths are the same
+    estimates ``_measure_strips`` uses, so the two are interchangeable
     (byte-identical); later steps replace the estimates with depths measured
     from the real placement.
     """

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -715,6 +715,54 @@ class TestDerivedLayoutConstants:
         assert large > small
 
 
+class TestComposeAnnoBoxes:
+    """Step 4a (#112): the AnnoBox composer reduces to the identical StripDepths
+    that _measure_strips computes — the byte-identical box-model foundation that
+    later steps make honest."""
+
+    def _assert_match(self, holes, patterns, n_steps, bb):
+        from draftwright.make_drawing import (
+            _compose_anno_boxes,
+            _footprint_from_boxes,
+            _measure_strips,
+        )
+
+        composed = _footprint_from_boxes(_compose_anno_boxes(holes, patterns, n_steps))
+        scalar = _measure_strips(holes, patterns, n_steps, bb)
+        assert composed == scalar
+
+    def test_matches_for_plain_part(self):
+        from draftwright.make_drawing import find_hole_patterns, find_holes
+
+        part = Box(60, 40, 12)
+        holes = find_holes(part)
+        patterns = find_hole_patterns(holes)
+        bb = part.bounding_box()
+        for n_steps in (0, 1, 3):
+            self._assert_match(holes, patterns, n_steps, bb)
+
+    def test_matches_for_bored_part(self):
+        from draftwright.make_drawing import find_hole_patterns, find_holes
+
+        part = Box(60, 40, 12) - Pos(0, 0, 6) * Cylinder(3, 12)
+        holes = find_holes(part)
+        patterns = find_hole_patterns(holes)
+        bb = part.bounding_box()
+        for n_steps in (0, 2):
+            self._assert_match(holes, patterns, n_steps, bb)
+
+    def test_matches_for_dense_ballooning_part(self):
+        # _dense_plate triggers _will_balloon → exercises the plan_halo band.
+        from draftwright.make_drawing import _will_balloon, find_hole_patterns, find_holes
+
+        part = _dense_plate()
+        holes = find_holes(part)
+        patterns = find_hole_patterns(holes)
+        bb = part.bounding_box()
+        assert _will_balloon(holes, patterns)  # guard: this case must balloon
+        self._assert_match(holes, patterns, 0, bb)
+
+
 # ---------------------------------------------------------------------------
 # Phase 3 (#118): dynamic FV→SV corridor
 # ---------------------------------------------------------------------------

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -762,6 +762,30 @@ class TestComposeAnnoBoxes:
         assert _will_balloon(holes, patterns)  # guard: this case must balloon
         self._assert_match(holes, patterns, 0, bb)
 
+    def test_footprint_reduction_and_left_floor(self):
+        # Direct unit test of the reducer: deepest band per side wins, and the
+        # left keeps its _DIM_PAD floor even when the deepest left band is
+        # shallower — the branch real parts rarely make the deciding one.
+        from draftwright.make_drawing import (
+            _DIM_PAD,
+            AnnoBox,
+            StripDepths,
+            _footprint_from_boxes,
+        )
+
+        fp = _footprint_from_boxes(
+            [
+                AnnoBox("right", 5.0),
+                AnnoBox("right", 30.0),  # deeper right band wins
+                AnnoBox("left", 5.0),  # below the floor → floor wins
+                AnnoBox("plan_halo", 21.0),
+            ]
+        )
+        assert fp == StripDepths(right=30.0, left=_DIM_PAD, pv_halo=21.0)
+
+        # No bands at all → zero depths, but the left floor still applies.
+        assert _footprint_from_boxes([]) == StripDepths(right=0.0, left=_DIM_PAD, pv_halo=0.0)
+
 
 # ---------------------------------------------------------------------------
 # Phase 3 (#118): dynamic FV→SV corridor


### PR DESCRIPTION
## Step 4a of compose-then-pack (ADR 0004, tracked in #112)

Introduces the box-model footprint that the rest of Step 4 makes honest. Purely **additive and byte-identical** — nothing consumes the composer yet.

### What
- **`AnnoBox(side, depth)`** — one composed annotation band as a page-mm box (`side` ∈ `right`/`left`/`plan_halo`; `depth` = perpendicular extent from the view edge).
- **`_compose_anno_boxes(holes, patterns, n_steps, …)`** — emits each band that contributes to a corridor reservation: the FV right dim ladder, the FV/PV bore-callout bands, the plan balloon halo.
- **`_footprint_from_boxes(boxes)`** — reduces the boxes back to per-side `StripDepths`.

### Safety
`_footprint_from_boxes(_compose_anno_boxes(...))` equals `_measure_strips(...)` **by construction** (same primitives, just emitted as boxes then reduced). A contract test (`TestComposeAnnoBoxes`) asserts the equality across plain / bored / dense-ballooning parts. The dense case guards that `_will_balloon` is true so the `plan_halo` band is exercised.

### Sequencing (per #112)
- **4a (this PR)** — box-model foundation, byte-identical.
- **4b** — make the depths honest (measured from the real placement), shadow-validate the divergence against `_measure_strips`.
- **4c** — switch `_layout_geometry`'s reservation to the composed footprint (the behaviour step; golden diffs reviewed).
- **4d** — retire `StripDepths` + the `_est_*` corridor estimators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)