### PR TITLE
feat: consume helpers 0.11.0 — feature_diameters() coverage + persistent view_edge_cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Paul Fremantle", email = "pzfreo@gmail.com" }]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "build123d>=0.9.0",
     "build123d-drafting-helpers>=0.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Paul Fremantle", email = "pzfreo@gmail.com" }]
 requires-python = ">=3.10"
 dependencies = [
     "build123d>=0.9.0",
-    "build123d-drafting-helpers>=0.10.1",
+    "build123d-drafting-helpers>=0.11.0",
     "kiwisolver>=1.4,<2",
     "numpy>=1.24",
 ]

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -52,6 +52,7 @@ from build123d_drafting.features import (
     _full_cyls,
     _spec_key,
     analyse_cylinders,
+    feature_diameters,
     find_hole_patterns,
     find_holes,
 )
@@ -588,7 +589,13 @@ def lint_feature_coverage(
     count semantics. Location coverage remains out of scope (#93).
     """
     z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
-    inventory = dedup_diams(_full_cyls(z_cyls + cross_cyls), tol=tol)
+    # Coverage inventory: the *recognised* dimensionable diameters (bores,
+    # cbore/spotface steps, bosses) from feature_diameters — built via
+    # find_holes/find_bosses, so slot ends and interrupted recesses (partial
+    # cylinders that an angle-only test mistakes for full bores) are excluded.
+    # Replaces the raw _full_cyls patch list, which over-reported those as
+    # undimensioned features (helpers #158/#159).
+    inventory = feature_diameters(part, cyls=(z_cyls, cross_cyls))
 
     if assembly is None:
         assembly = len(part.solids()) > 1
@@ -1949,6 +1956,11 @@ class Drawing:
         self.items: list = []
         self._coords: dict = {}
         self._named: dict = {}
+        # One per-drawing cache for lint_drawing's per-view edge bboxes, keyed on
+        # id(view shape). repair() / lint_summary() lint the SAME projected view
+        # objects (self.views) repeatedly, so persisting it recomputes each
+        # view's edges once instead of every lint (helpers #143/#164).
+        self._view_edge_cache: dict = {}
         # Names the caller has pinned: their position is fixed and the engine
         # must not move them (repair now; the global solve later — ADR 0003 #89).
         self._pinned: set = set()
@@ -2555,11 +2567,21 @@ class Drawing:
         for ann in self.items:
             by_scale.setdefault(getattr(ann, "_dw_scale", self.scale), []).append(ann)
         if len(by_scale) <= 1:
-            issues = lint_drawing(self.items, drawing_scale=self.scale, view_shapes=view_shapes)
+            issues = lint_drawing(
+                self.items,
+                drawing_scale=self.scale,
+                view_shapes=view_shapes,
+                view_edge_cache=self._view_edge_cache,
+            )
         else:
             issues = []
             for _scale, _anns in by_scale.items():
-                issues += lint_drawing(_anns, drawing_scale=_scale, view_shapes=view_shapes)
+                issues += lint_drawing(
+                    _anns,
+                    drawing_scale=_scale,
+                    view_shapes=view_shapes,
+                    view_edge_cache=self._view_edge_cache,
+                )
         if self.part is not None:
             if self._cyl_cache is None:
                 self._cyl_cache = analyse_cylinders(self.part)

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -2875,12 +2875,14 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
         look_at=la,
         scaled=True,
     )
-    if scale != dwg.scale:
-        # add_view derives ViewCoordinates from the drawing scale; an iso
-        # projected at a different scale needs them rebuilt so
-        # dwg.at("iso", ...) keeps mapping world points correctly.
-        axes = view_axes(camera, (0, 0, 1), la)
-        dwg._coords["iso"] = ViewCoordinates(axes, a.ISO_X, a.ISO_Y, a.cx, a.cy, a.cz, scale)
+    # add_view builds ViewCoordinates from a collapsed view_axes() mapping, which
+    # helpers (>=0.11) cannot project for the oblique iso (pp() needs the full
+    # foreshortening basis). Rebuild from the raw viewport so dwg.at("iso", ...)
+    # maps world points correctly — also covers an iso re-projected at a
+    # different scale than the sheet.
+    dwg._coords["iso"] = ViewCoordinates.from_viewport(
+        camera, (0, 0, 1), la, a.ISO_X, a.ISO_Y, a.cx, a.cy, a.cz, scale
+    )
 
 
 def _fit_iso_view(dwg, a: Analysis, annotate: bool = True):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1283,9 +1283,19 @@ class TestViewCoordinates:
     # ISO view: camera at (-DIST, -DIST, DIST) → two world axes → page_X
 
     def _iso_vc(self):
-        # Standard ISO camera: world_X → page_X (+1), world_Y → page_X (-1), world_Z → page_Y (+1)
-        axes = view_axes((-100.0, -100.0, 100.0), (0.0, 0.0, 1.0), (0.0, 0.0, 0.0))
-        return ViewCoordinates(axes, view_x=100.0, view_y=80.0, cx=0.0, cy=0.0, cz=0.0, scale=1.0)
+        # Standard ISO camera. Built from the raw viewport so pp() carries the
+        # real foreshortening basis (helpers >=0.11 requires it for oblique views).
+        return ViewCoordinates.from_viewport(
+            (-100.0, -100.0, 100.0),
+            (0.0, 0.0, 1.0),
+            (0.0, 0.0, 0.0),
+            view_x=100.0,
+            view_y=80.0,
+            cx=0.0,
+            cy=0.0,
+            cz=0.0,
+            scale=1.0,
+        )
 
     def test_iso_view_px_axis_is_none(self):
         vc = self._iso_vc()
@@ -1305,14 +1315,14 @@ class TestViewCoordinates:
         assert vc.py(3.0) == pytest.approx(83.0)
 
     def test_iso_view_pp_correct(self):
-        # For ISO camera at (-100,-100,100) with look_at=(0,0,0), up=(0,0,1):
-        # world_X → page_X (+1), world_Y → page_X (-1), world_Z → page_Y (+1)
-        # pp(10, 5, 3) → page_x = 100 + (10-0)*1 + (5-0)*(-1) = 105
-        #                page_y = 80 + (3-0)*1 = 83
+        # ISO camera at (-100,-100,100), look_at=(0,0,0), up=(0,0,1). pp() now
+        # uses the true foreshortening basis (helpers >=0.11) rather than the old
+        # collapsed view_axes mapping, so an off-centre point projects with real
+        # axonometric foreshortening (was the un-foreshortened (105, 83)).
         vc = self._iso_vc()
         page_x, page_y = vc.pp(10.0, 5.0, 3.0)
-        assert page_x == pytest.approx(105.0)
-        assert page_y == pytest.approx(83.0)
+        assert page_x == pytest.approx(103.5355339)
+        assert page_y == pytest.approx(88.5732141)
 
     def test_iso_view_pp_at_centroid_gives_view_centre(self):
         vc = self._iso_vc()
@@ -1490,7 +1500,10 @@ def test_ctc01_iso_world_to_page_mapping(ctc01_a3_drawing):
     assert bb.min.X < centre[0] < bb.max.X and bb.min.Y < centre[1] < bb.max.Y
     iso_scale = dwg._coords["iso"]._scale
     raised = dwg.at("iso", cx, cy, cz + 100)
-    assert raised[1] - centre[1] == pytest.approx(100 * iso_scale)
+    # Raising world Z lifts the iso page point by the foreshortened amount: the
+    # vertical axis of a (1,1,1)-camera isometric projects at sqrt(2/3) (helpers
+    # >=0.11 uses the real basis instead of a 1:1 collapsed mapping).
+    assert raised[1] - centre[1] == pytest.approx(100 * iso_scale * (2 / 3) ** 0.5)
 
 
 @pytest.mark.timeout(60)

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,8 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.15"
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
     "python_full_version < '3.11'",
 ]
 
@@ -95,14 +94,14 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.10.1"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/c1/fa4d3a596e9323dd8f66bc8ac34310624f4bef29c66b013a7fe3db21982e/build123d_drafting_helpers-0.10.1.tar.gz", hash = "sha256:b6b59bcbdea95b50427dff21d658cb6ef4a09aa8551701b530921cda608a7c33", size = 107974, upload-time = "2026-06-18T06:52:10.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/35/5a8369096fd96f687b74dfd60dfe3b20cedfbc782c5eedaef8c8d89887b8/build123d_drafting_helpers-0.11.0.tar.gz", hash = "sha256:659663fe2db7cfae71cccfa61ade1793b3c065ed62b77b5f45fe61db4c5b56a6", size = 117889, upload-time = "2026-06-20T11:01:45.979Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/25/2902713bc0254e862482ae8adec6fb827ad4c61960ae674a1d18d6e3d365/build123d_drafting_helpers-0.10.1-py3-none-any.whl", hash = "sha256:ac5da059ac3d5dae347281049c9574cccfe764f7348b4635f2310f560857a770", size = 60573, upload-time = "2026-06-18T06:52:08.858Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/8b4656fd593d18036c26470a87fb8678778b9746e250091af1ea2503278d/build123d_drafting_helpers-0.11.0-py3-none-any.whl", hash = "sha256:5747e8556daf199ab536613f85d62e2dec9a65b1558327f78921c1c87fce2010", size = 65119, upload-time = "2026-06-20T11:01:44.644Z" },
 ]
 
 [[package]]
@@ -333,8 +332,7 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -601,7 +599,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "build123d", specifier = ">=0.9.0" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.10.1" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.11.0" },
     { name = "cairosvg", marker = "extra == 'pdf'", specifier = ">=2.7" },
     { name = "kiwisolver", specifier = ">=1.4,<2" },
     { name = "numpy", specifier = ">=1.24" },
@@ -782,8 +780,7 @@ name = "ipython"
 version = "9.14.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -1128,8 +1125,7 @@ name = "matplotlib"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
 ]
 dependencies = [
     { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1350,8 +1346,7 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -1833,8 +1828,7 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },


### PR DESCRIPTION
Consumes the two merged helpers changes (build123d-drafting-helpers 0.11.0).

### feature_diameters() for coverage (#158/#159)
`lint_feature_coverage` builds its inventory from `feature_diameters(part, cyls=...)` (find_holes/find_bosses) instead of the raw `_full_cyls` patch list. Slot ends and interrupted recesses (partial cylinders an angle-only test mistakes for bores) are no longer mis-reported as undimensioned, while genuine counterbore/spotface steps are kept.

**Verified on CTC-02:** `feature_diameters` = `[8.38, 10.1, 12.0, 22.0, 40.0, 52.0, 100.0, 120.0]` — ø100/ø120 spotfaces kept, phantom ø60/ø75/ø115 gone; `feature_not_dimensioned` warnings now empty (were 3).

### Persistent view_edge_cache (#143/#164)
The `Drawing` carries one `_view_edge_cache`, threaded into every `lint_drawing()` call, so `repair()`/`lint_summary()`'s repeated lints recompute each view's per-edge bounding boxes once instead of every call. The cache keys on `id(view shape)`; draftwright projects views once into `self.views` and reuses those instances, so the keys stay stable across lints.

Pin bumped to `build123d-drafting-helpers>=0.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)