### PR TITLE
feat(#121): ownership-based compose-then-pack layout with page escalation

### DIFF
--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -938,7 +938,9 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                     tip = (PX(cx_f), PY(cy_f) + half_pg, 0)
                     slot = a.pv_zones.above.allocate(_SLOT)
                     if slot is not None:
-                        dwg.add(Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d, view="plan")
+                        dwg.add(
+                            Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d, view="plan"
+                        )
                         placed = True
                     else:
                         slot = a.pv_zones.below.allocate(_SLOT)
@@ -961,7 +963,9 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                     tip = (SX(cy_f), SZ(cz_f) + half_pg, 0)
                     slot = a.sv_zones.above.allocate(_SLOT)
                     if slot is not None:
-                        dwg.add(Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d, view="side")
+                        dwg.add(
+                            Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d, view="side"
+                        )
                         placed = True
                     else:
                         slot = a.sv_zones.below.allocate(_SLOT)
@@ -1667,9 +1671,7 @@ def _add_furniture(dwg, a: Analysis, view, j, pattern, to_page):
     if isinstance(pattern, BoltCircle):
         cx = sum(to_page(h)[0] for h in pattern.holes) / len(pattern.holes)
         cy = sum(to_page(h)[1] for h in pattern.holes) / len(pattern.holes)
-        dwg.add(
-            CenterlineCircle((cx, cy), pattern.diameter * a.SCALE), f"bc_{view}{j}", view=view
-        )
+        dwg.add(CenterlineCircle((cx, cy), pattern.diameter * a.SCALE), f"bc_{view}{j}", view=view)
     elif isinstance(pattern, LinearArray):
         _add_pitch_dim(dwg, a, view, j, pattern, to_page)
 

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -272,6 +272,7 @@ def _annotate_turned_diameters(dwg, a: Analysis):
                 draft=draft,
             ),
             f"ldr_d{i}",
+            view="front",
         )
 
 
@@ -342,6 +343,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                 label=f"ø{_fmt(od)}",
             ),
             "dim_od",
+            view="front",
         )
         # Centreline through the rotation axis — front and side views
         dwg.add(
@@ -350,6 +352,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                 (FX(a.cx), FZ(a.bb.max.Z) + 5, 0),
             ),
             "centerline_front",
+            view="front",
         )
         dwg.add(
             Centerline(
@@ -357,6 +360,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                 (SX(a.cy), SZ(a.bb.max.Z) + 5, 0),
             ),
             "centerline_side",
+            view="side",
         )
 
     # Z-axis bore leaders to the left of the front view — these assume bores
@@ -387,6 +391,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                         draft=draft,
                     ),
                     f"ldr_z{i}",
+                    view="front",
                 )
         else:
             _log.info("Additional diameters %s not annotated (insufficient left margin)", bores)
@@ -403,7 +408,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     for i, h in enumerate(a.holes):
         view, to_page = view_of_axis[_axis_letter(h)]
         size = max(2.5, h.diameter * a.SCALE + 2.0)
-        dwg.add(CenterMark(to_page(h), size, draft), f"cm_{view}{i}")
+        dwg.add(CenterMark(to_page(h), size, draft), f"cm_{view}{i}", view=view)
 
     # Hole callouts, location dims, and the section view fire on *feature
     # presence*, independent of the turned/prismatic class (#10): the
@@ -449,6 +454,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                     label=f"{n_rep}× {_fmt(rise_mm)}",
                 ),
                 "dim_step_typ",
+                view="front",
             )
             _right_ladder = _px
         else:
@@ -491,6 +497,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                     label=_fmt(z - a.bb.min.Z),
                 ),
                 f"dim_step_{col}",
+                view="front",
             )
             _right_ladder = _px
 
@@ -507,6 +514,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                 label=_fmt(a.z_size),
             ),
             "dim_height",
+            view="front",
         )
         _right_ladder = _px
     else:
@@ -527,6 +535,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                     label=_fmt(a.x_size),
                 ),
                 "dim_width",
+                view="plan",
             )
         else:
             _log.warning("dim_width skipped: pv_zones.below strip full")
@@ -546,6 +555,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
                     label=_fmt(a.y_size),
                 ),
                 "dim_depth",
+                view="side",
             )
         else:
             _log.warning("dim_depth skipped: sv_zones.below strip full")
@@ -658,6 +668,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
         for n in list(dwg._named)
         if n.startswith(("hc_plan", "dim_locx", "dim_locy"))
     }
+    replaced_view = {n: dwg._anno_view.get(n) for n in replaced}
     for n in replaced:
         dwg.remove(n)
 
@@ -674,7 +685,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
         # Even wrapped it will not fit — restore the callouts/dims and keep the
         # drop lint, so the sheet is never left with neither.
         for n, obj in replaced.items():
-            dwg.add(obj, n)
+            dwg.add(obj, n, view=replaced_view.get(n))
         dwg._record_build_issue("warning", "table_dropped", "hole table did not fit the sheet")
         return
     # One entry per hole (with repeats) so the coverage *count* check sees that
@@ -800,7 +811,7 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
             return None
         return p1, p2, avg_t
 
-    def _try_above(p1, p2, strip, label, name):
+    def _try_above(p1, p2, strip, label, name, view):
         """Place a horizontal dimension line ABOVE the witness points."""
         if strip is None:
             return False
@@ -818,10 +829,11 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 label=label,
             ),
             name,
+            view=view,
         )
         return True
 
-    def _try_below(p1, p2, strip, label, name):
+    def _try_below(p1, p2, strip, label, name, view):
         """Place a horizontal dimension line BELOW the witness points."""
         if strip is None:
             return False
@@ -839,10 +851,11 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 label=label,
             ),
             name,
+            view=view,
         )
         return True
 
-    def _try_right(p1, p2, strip, label, name):
+    def _try_right(p1, p2, strip, label, name, view):
         """Place a vertical dimension line to the RIGHT of the witness points."""
         if strip is None:
             return False
@@ -860,10 +873,11 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 label=label,
             ),
             name,
+            view=view,
         )
         return True
 
-    def _try_left(p1, p2, strip, label, name):
+    def _try_left(p1, p2, strip, label, name, view):
         """Place a vertical dimension line to the LEFT of the witness points."""
         if strip is None:
             return False
@@ -881,6 +895,7 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 label=label,
             ),
             name,
+            view=view,
         )
         return True
         return False
@@ -916,20 +931,22 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 if half_pg >= 4.0:
                     p1 = (PX(cx_f - half), PY(cy_f), 0)
                     p2 = (PX(cx_f + half), PY(cy_f), 0)
-                    placed = _try_above(p1, p2, a.pv_zones.above, label, name_d) or _try_below(
-                        p1, p2, a.pv_zones.below, label, name_d
-                    )
+                    placed = _try_above(
+                        p1, p2, a.pv_zones.above, label, name_d, "plan"
+                    ) or _try_below(p1, p2, a.pv_zones.below, label, name_d, "plan")
                 else:
                     tip = (PX(cx_f), PY(cy_f) + half_pg, 0)
                     slot = a.pv_zones.above.allocate(_SLOT)
                     if slot is not None:
-                        dwg.add(Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d)
+                        dwg.add(Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d, view="plan")
                         placed = True
                     else:
                         slot = a.pv_zones.below.allocate(_SLOT)
                         if slot is not None:
                             tip = (PX(cx_f), PY(cy_f) - half_pg, 0)
-                            dwg.add(Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d)
+                            dwg.add(
+                                Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d, view="plan"
+                            )
                             placed = True
 
             elif bore_axis == "X":
@@ -937,20 +954,22 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 if half_pg >= 4.0:
                     p1 = (SX(cy_f - half), SZ(cz_f), 0)
                     p2 = (SX(cy_f + half), SZ(cz_f), 0)
-                    placed = _try_above(p1, p2, a.sv_zones.above, label, name_d) or _try_below(
-                        p1, p2, a.sv_zones.below, label, name_d
-                    )
+                    placed = _try_above(
+                        p1, p2, a.sv_zones.above, label, name_d, "side"
+                    ) or _try_below(p1, p2, a.sv_zones.below, label, name_d, "side")
                 else:
                     tip = (SX(cy_f), SZ(cz_f) + half_pg, 0)
                     slot = a.sv_zones.above.allocate(_SLOT)
                     if slot is not None:
-                        dwg.add(Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d)
+                        dwg.add(Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d, view="side")
                         placed = True
                     else:
                         slot = a.sv_zones.below.allocate(_SLOT)
                         if slot is not None:
                             tip = (SX(cy_f), SZ(cz_f) - half_pg, 0)
-                            dwg.add(Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d)
+                            dwg.add(
+                                Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d, view="side"
+                            )
                             placed = True
 
             elif bore_axis == "Y":
@@ -958,16 +977,16 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 if half_pg >= 4.0:
                     p1 = (FX(cx_f - half), FZ(cz_f), 0)
                     p2 = (FX(cx_f + half), FZ(cz_f), 0)
-                    placed = _try_above(p1, p2, a.fv_zones.above, label, name_d) or _try_below(
-                        p1, p2, a.fv_zones.below, label, name_d
-                    )
+                    placed = _try_above(
+                        p1, p2, a.fv_zones.above, label, name_d, "front"
+                    ) or _try_below(p1, p2, a.fv_zones.below, label, name_d, "front")
                 else:
                     # Narrow bore: leader from bore bottom into the below strip.
                     tip = (FX(cx_f), FZ(cz_f) - half_pg, 0)
                     slot = a.fv_zones.below.allocate(_SLOT)
                     if slot is not None:
                         elbow = (FX(cx_f), slot, 0)
-                        dwg.add(Leader(tip, elbow, label, draft), name_d)
+                        dwg.add(Leader(tip, elbow, label, draft), name_d, view="front")
                         placed = True
                     else:
                         # Fall back: leader upward into the above strip.
@@ -975,7 +994,7 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                         if slot is not None:
                             tip = (FX(cx_f), FZ(cz_f) + half_pg, 0)
                             elbow = (FX(cx_f), slot, 0)
-                            dwg.add(Leader(tip, elbow, label, draft), name_d)
+                            dwg.add(Leader(tip, elbow, label, draft), name_d, view="front")
                             placed = True
 
         elif ax == "X":
@@ -985,9 +1004,9 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 continue
             p1, p2, avg_pz = wp
             if avg_pz >= a.FV_Y:
-                placed = _try_above(p1, p2, a.fv_zones.above, label, name_x)
+                placed = _try_above(p1, p2, a.fv_zones.above, label, name_x, "front")
             if not placed:
-                placed = _try_below(p1, p2, a.fv_zones.below, label, name_x)
+                placed = _try_below(p1, p2, a.fv_zones.below, label, name_x, "front")
 
         elif ax == "Z":
             wp = _witness_from_bbox(rec, "front")
@@ -996,9 +1015,9 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
                 continue
             p1, p2, avg_px = wp
             if avg_px >= a.FV_X:
-                placed = _try_right(p1, p2, a.fv_zones.right, label, name_z)
+                placed = _try_right(p1, p2, a.fv_zones.right, label, name_z, "front")
             if not placed:
-                placed = _try_left(p1, p2, a.fv_zones.left, label, name_z)
+                placed = _try_left(p1, p2, a.fv_zones.left, label, name_z, "front")
 
         elif ax == "Y":
             # Try side view (Y maps to SX horizontal).
@@ -1006,15 +1025,15 @@ def _annotate_pmi(dwg, a: Analysis, draft) -> None:
             if wp is not None:
                 p1, p2, avg_sz = wp
                 if avg_sz >= a.SV_Y:
-                    placed = _try_above(p1, p2, a.sv_zones.above, label, name_y)
+                    placed = _try_above(p1, p2, a.sv_zones.above, label, name_y, "side")
                 if not placed:
-                    placed = _try_below(p1, p2, a.sv_zones.below, label, name_y)
+                    placed = _try_below(p1, p2, a.sv_zones.below, label, name_y, "side")
             # Fall back: plan view (Y maps to PY vertical).
             if not placed:
                 wp = _witness_from_bbox(rec, "plan")
                 if wp is not None:
                     p1, p2, _ = wp
-                    placed = _try_below(p1, p2, a.pv_zones.below, label, name_y)
+                    placed = _try_below(p1, p2, a.pv_zones.below, label, name_y, "plan")
 
         if placed:
             emitted += 1
@@ -1144,6 +1163,7 @@ def _add_location_dims(dwg, a: Analysis, patterns, holes_in=None):
                 label=_fmt(rx - datum_x),
             ),
             f"dim_locx{i}",
+            view="plan",
         )
 
     # Y locations: the side view maps world Y horizontally, and the strip
@@ -1215,6 +1235,7 @@ def _add_location_dims(dwg, a: Analysis, patterns, holes_in=None):
                 label=_fmt(ry - datum_y),
             ),
             f"dim_locy{i}",
+            view="side",
         )
 
 
@@ -1646,7 +1667,9 @@ def _add_furniture(dwg, a: Analysis, view, j, pattern, to_page):
     if isinstance(pattern, BoltCircle):
         cx = sum(to_page(h)[0] for h in pattern.holes) / len(pattern.holes)
         cy = sum(to_page(h)[1] for h in pattern.holes) / len(pattern.holes)
-        dwg.add(CenterlineCircle((cx, cy), pattern.diameter * a.SCALE), f"bc_{view}{j}")
+        dwg.add(
+            CenterlineCircle((cx, cy), pattern.diameter * a.SCALE), f"bc_{view}{j}", view=view
+        )
     elif isinstance(pattern, LinearArray):
         _add_pitch_dim(dwg, a, view, j, pattern, to_page)
 
@@ -1721,6 +1744,7 @@ def _add_pitch_dim(dwg, a: Analysis, view, j, pattern, to_page):
             label=f"{n - 1}× {_fmt(pattern.pitch)}",
         ),
         f"dim_pitch_{view}{j}",
+        view=view,
     )
 
 
@@ -1858,6 +1882,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=Non
                 callout=callout,
             ),
             f"hc_{view}{i}",
+            view=view,
         )
 
     for view, view_groups in by_view.items():

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -23,7 +23,7 @@ import functools
 import logging
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Literal
@@ -1441,6 +1441,74 @@ def choose_scale(
 # ---------------------------------------------------------------------------
 
 
+def _view_geom(a) -> dict:
+    """The three orthographic geometry boxes as ``{view: (cx, cy, hw, hh)}``."""
+    return {
+        "front": (a.FV_X, a.FV_Y, a.fv_hw, a.fv_hh),
+        "plan": (a.PV_X, a.PV_Y, a.fv_hw, a.pv_hh),
+        "side": (a.SV_X, a.SV_Y, a.sv_hw, a.fv_hh),
+    }
+
+
+def _anno_bbox(o):
+    """Page-space bbox of an annotation: its text ``label_bbox`` if it has one,
+    else its geometric bounding box; ``None`` if neither resolves."""
+    lb = getattr(o, "label_bbox", None)
+    if lb is not None:
+        return lb
+    try:
+        b = o.bounding_box()
+        return (b.min.X, b.min.Y, b.max.X, b.max.Y)
+    except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+        return None
+
+
+def _attribute_annotations(dwg, a):
+    """Yield ``(name, view, bbox, is_label)`` for every annotation OWNED by an
+    orthographic view, per the view recorded at creation (``dwg._anno_view``).
+
+    Ownership is authoritative — the annotation pass that drew it knew which view
+    it belonged to and tagged it (#121) — so a front-view step dimension sitting
+    in the front↔plan gap is the *front* view's, never recovered (and mis-bucketed)
+    from page coordinates.  Annotations with no recorded ortho view (title block,
+    iso/section/detail furniture) belong to no block and are skipped.  ``is_label``
+    is true when the annotation carries a text ``label_bbox`` (a dimension value
+    or balloon tag) rather than bare geometry (a centreline/leader line).
+    """
+    for name, o in dwg._named.items():
+        view = dwg._anno_view.get(name)
+        if view not in ("front", "plan", "side"):
+            continue
+        label = getattr(o, "label_bbox", None)
+        bb = label if label is not None else _anno_bbox(o)
+        if bb is None:
+            continue
+        yield name, view, bb, label is not None
+
+
+def _cross_view_overlaps(dwg, a) -> int:
+    """Count pairs of annotations attributed to *different* views whose boxes
+    overlap — the #121 failure (a plan-view balloon over a front-view dimension).
+
+    This is the repack trigger: a clean sheet (no cross-view overlap) is left
+    exactly as pass 1 placed it, so well-estimated parts stay byte-identical;
+    only a sheet with a real collision is re-packed (ADR 0004).
+    """
+    items = list(_attribute_annotations(dwg, a))
+    n = 0
+    for i in range(len(items)):
+        _, vi, bi, li = items[i]
+        for j in range(i + 1, len(items)):
+            _, vj, bj, lj = items[j]
+            # Only a collision involving a text label matters — two bare lines
+            # (extension/leader) crossing between views is normal drafting.
+            if vi == vj or not (li or lj):
+                continue
+            if min(bi[2], bj[2]) > max(bi[0], bj[0]) and min(bi[3], bj[3]) > max(bi[1], bj[1]):
+                n += 1
+    return n
+
+
 def _measure_blocks(dwg, a) -> dict:
     """Measure each orthographic view's *actual* annotation footprint from the
     laid-out drawing (#121, ADR 0004 — "lay out, don't predict").
@@ -1452,31 +1520,9 @@ def _measure_blocks(dwg, a) -> dict:
     annotations reach past the geometry edge there. Returns ``{view_name:
     ViewBlock}`` whose bands the packer can place disjoint, no ``_est_*`` needed.
     """
-    geom = {
-        "front": (a.FV_X, a.FV_Y, a.fv_hw, a.fv_hh),
-        "plan": (a.PV_X, a.PV_Y, a.fv_hw, a.pv_hh),
-        "side": (a.SV_X, a.SV_Y, a.sv_hw, a.fv_hh),
-    }
-
-    def box(o):
-        lb = getattr(o, "label_bbox", None)
-        if lb is not None:
-            return lb
-        try:
-            b = o.bounding_box()
-            return (b.min.X, b.min.Y, b.max.X, b.max.Y)
-        except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
-            return None
-
+    geom = _view_geom(a)
     ext: dict = {v: None for v in geom}
-    for name, o in dwg._named.items():
-        if name == "title_block":
-            continue
-        bb = box(o)
-        if bb is None:
-            continue
-        bcx, bcy = (bb[0] + bb[2]) / 2, (bb[1] + bb[3]) / 2
-        v = min(geom, key=lambda k: (bcx - geom[k][0]) ** 2 + (bcy - geom[k][1]) ** 2)
+    for _name, v, bb, _label in _attribute_annotations(dwg, a):
         e = ext[v]
         ext[v] = bb if e is None else (
             min(e[0], bb[0]), min(e[1], bb[1]), max(e[2], bb[2]), max(e[3], bb[3])
@@ -1584,27 +1630,42 @@ def _layout_geometry(
     # the headroom above PV, and reserving more would needlessly grow the layout
     # (and can starve the section view of its leftover space).
     pv_top = (max(DIM_PAD, strip_top) + halo) if halo > 0 else DIM_PAD
+    # Estimated blocks (always built): the scale-derived geometry half-extents
+    # plus the heuristic per-side corridor depths.
+    est_fv = ViewBlock(
+        fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
+    )
+    est_pv = ViewBlock(
+        fv_hw,
+        pv_hh,
+        top=pv_top,
+        right=gap_fv_sv,
+        bottom=max(pv_below, halo),  # band below PV holds the width dim + a balloon row
+        left=gap_left,
+    )
+    est_sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
     if blocks is not None:
         # Measure-and-repack pass (#121, ADR 0004): pack the *measured* per-view
-        # footprints disjoint, not the estimated scalar corridors. Bands carry the
-        # geometry half-extents too, so use them as the source of truth.
-        fv, pv, sv = blocks["front"], blocks["plan"], blocks["side"]
-        fv_hw, fv_hh = fv.hw, fv.hh
-        pv_hh = pv.hh
-        sv_hw = sv.hw
+        # footprints disjoint.  Floor each measured band at the estimate — the
+        # repack may only GROW a corridor to fit annotations the estimate
+        # under-sized (the documented FV-top vs PV-balloon overlap), never shrink
+        # below the clearance the estimate guarantees.  The geometry half-extents
+        # stay scale-derived (the estimate), not the measured block.
+        def _merge(est, meas):
+            return ViewBlock(
+                est.hw,
+                est.hh,
+                top=max(est.top, meas.top),
+                right=max(est.right, meas.right),
+                bottom=max(est.bottom, meas.bottom),
+                left=max(est.left, meas.left),
+            )
+
+        fv = _merge(est_fv, blocks["front"])
+        pv = _merge(est_pv, blocks["plan"])
+        sv = _merge(est_sv, blocks["side"])
     else:
-        fv = ViewBlock(
-            fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
-        )
-        pv = ViewBlock(
-            fv_hw,
-            pv_hh,
-            top=pv_top,
-            right=gap_fv_sv,
-            bottom=max(pv_below, halo),  # band below PV holds the width dim + a balloon row
-            left=gap_left,
-        )
-        sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
+        fv, pv, sv = est_fv, est_pv, est_sv
     # Per-side corridor depths from the (possibly measured) blocks. The front and
     # plan views stack vertically (same X, different Y) so they SHARE the left and
     # right corridors — the deeper of the two facing bands. The side view ABUTS
@@ -1691,6 +1752,33 @@ def _layout_geometry(
         for o in obstacles
     )
 
+    # Does the packed disjoint layout actually fit the sheet? — the fitness the
+    # (scale, page) search optimises (#121, ADR 0004).  The union of the three
+    # view *footprints* (geometry + bands) must sit inside the drawable area; the
+    # orthographic views must clear the title block (stay left of its column
+    # unless their bottom is above it); and the iso must have a real gap.  This is
+    # what tells the repack to escalate to a larger sheet when the measured
+    # footprints no longer fit the estimate's page.
+    _view_boxes = [
+        fv.footprint(FV_X, FV_Y),
+        pv.footprint(PV_X, PV_Y),
+        sv.footprint(SV_X, SV_Y),
+    ]
+    cx0 = min(b[0] for b in _view_boxes)
+    cy0 = min(b[1] for b in _view_boxes)
+    cx1 = max(b[2] for b in _view_boxes)
+    cy1 = max(b[3] for b in _view_boxes)
+    _tol = 0.5
+    _clears_tb = cy0 >= (_TB_CLEAR + _TB_H)
+    _right_limit = (page_w - margin) if _clears_tb else (page_w - tb_w - margin)
+    fits = (
+        iso_valid
+        and cy0 >= margin - _tol
+        and cy1 <= page_h - margin + _tol
+        and cx0 >= margin - _tol
+        and cx1 <= _right_limit + _tol
+    )
+
     return SimpleNamespace(
         x_offset=x_offset,
         fv_hw=fv_hw,
@@ -1713,7 +1801,66 @@ def _layout_geometry(
         ISO_Y=(iso_bottom + iso_top) / 2,
         iso_valid=iso_valid,
         iso_natural=bbox_max * scale * _ISO_WIDTH_BUDGET,
+        fits=fits,
     )
+
+
+def _build_zones(g, margin, page_h):
+    """Construct the FV/PV/SV annotation :class:`ViewZones` from a placement
+    namespace *g* (the return of :func:`_layout_geometry`).
+
+    Factored out of :func:`_analyse` so the measure-and-repack pass (#121) can
+    rebuild the zones from the repacked geometry with the same arithmetic — the
+    zones must track the moved view centres, not the pass-1 placement.
+    """
+    FV_X, FV_Y, fv_hw, fv_hh = g.FV_X, g.FV_Y, g.fv_hw, g.fv_hh
+    PV_X, PV_Y, pv_hh = g.PV_X, g.PV_Y, g.pv_hh
+    SV_X, SV_Y, sv_hw = g.SV_X, g.SV_Y, g.sv_hw
+
+    fv_right_edge = FV_X + fv_hw
+    fv_left_edge = FV_X - fv_hw
+    fv_top_edge = FV_Y + fv_hh
+    fv_bottom_edge = FV_Y - fv_hh
+    pv_right_edge = PV_X + fv_hw  # plan has the same X half-width as front
+    pv_left_edge = PV_X - fv_hw
+    pv_top_edge = PV_Y + pv_hh
+    pv_bottom_edge = PV_Y - pv_hh  # = fv_top_edge + DIM_PAD
+    sv_top_edge = SV_Y + fv_hh  # side view has the same Z height as front
+    # Outer limit for fv/pv right strips: must not enter the side view.
+    sv_left_edge = SV_X - sv_hw  # = fv_right_edge + gap_fv_sv
+
+    fv_zones = ViewZones(
+        right=Strip(fv_right_edge, sv_left_edge, direction=1),
+        left=Strip(fv_left_edge, margin, direction=-1),
+        # Stop the front-view 'above' strip short of pv_bottom_edge by the
+        # slack the pv_below slot leaves in the gap, derived (not re-typed) so
+        # it tracks _DIM_PAD and the slot constants.
+        above=Strip(fv_top_edge, pv_bottom_edge - (_DIM_PAD - _est_pv_below_depth()), direction=1),
+        below=Strip(fv_bottom_edge, margin, direction=-1),
+    )
+    pv_zones = ViewZones(
+        # Outer limit = sv_left_edge (not iso_right_limit) so bore callouts in
+        # the plan view are bounded by the same hard wall as the FV right strip,
+        # preventing labels from crossing dim_locy extension lines in the side
+        # view.  gap_fv_sv is sized by _measure_strips to accommodate the widest
+        # callout, so well-estimated labels will always fit within this bound.
+        right=Strip(pv_right_edge, sv_left_edge, direction=1),
+        left=Strip(pv_left_edge, margin, direction=-1),
+        above=Strip(pv_top_edge, page_h - margin, direction=1),
+        # gap_fv_pv = _DIM_PAD; pv_below needs _est_pv_below_depth() mm,
+        # leaving (_DIM_PAD - _est_pv_below_depth()) mm slack (assert above).
+        below=Strip(pv_bottom_edge, fv_top_edge, direction=-1),
+    )
+    sv_bottom_edge = SV_Y - fv_hh  # same as fv_bottom_edge; side and front share Z height
+    sv_zones = ViewZones(
+        # sv_right already includes DIM_PAD; anchor here so the strip never
+        # places annotations inside that gap
+        right=Strip(g.sv_right, g.sv_right_wall, direction=1),
+        left=None,  # immediately abuts the front view's right edge
+        above=Strip(sv_top_edge, page_h - margin, direction=1),
+        below=Strip(sv_bottom_edge, margin, direction=-1),
+    )
+    return fv_zones, pv_zones, sv_zones
 
 
 def _analyse(
@@ -1876,7 +2023,6 @@ def _analyse(
     SV_X = _g.SV_X
     SV_Y = _g.SV_Y
     sv_right = _g.sv_right
-    sv_right_wall = _g.sv_right_wall
     iso_left_limit = _g.iso_left
     iso_bottom_limit = _g.iso_bottom
     iso_right_limit = _g.iso_right
@@ -1891,49 +2037,7 @@ def _analyse(
     # through strip.allocate().  The iso view's outer limits are conservative
     # here (PAGE_H - margin / iso_right_limit); _auto_annotate() tightens
     # them once the iso has been projected.
-    fv_right_edge = FV_X + fv_hw
-    fv_left_edge = FV_X - fv_hw
-    fv_top_edge = FV_Y + fv_hh
-    fv_bottom_edge = FV_Y - fv_hh
-    pv_right_edge = PV_X + fv_hw  # plan has the same X half-width as front
-    pv_left_edge = PV_X - fv_hw
-    pv_top_edge = PV_Y + pv_hh
-    pv_bottom_edge = PV_Y - pv_hh  # = fv_top_edge + DIM_PAD
-    sv_top_edge = SV_Y + fv_hh  # side view has the same Z height as front
-    # Outer limit for fv/pv right strips: must not enter the side view.
-    sv_left_edge = SV_X - sv_hw  # = fv_right_edge + gap_fv_sv
-
-    fv_zones = ViewZones(
-        right=Strip(fv_right_edge, sv_left_edge, direction=1),
-        left=Strip(fv_left_edge, margin, direction=-1),
-        # Stop the front-view 'above' strip short of pv_bottom_edge by the
-        # slack the pv_below slot leaves in the gap, derived (not re-typed) so
-        # it tracks _DIM_PAD and the slot constants.
-        above=Strip(fv_top_edge, pv_bottom_edge - (_DIM_PAD - _est_pv_below_depth()), direction=1),
-        below=Strip(fv_bottom_edge, margin, direction=-1),
-    )
-    pv_zones = ViewZones(
-        # Outer limit = sv_left_edge (not iso_right_limit) so bore callouts in
-        # the plan view are bounded by the same hard wall as the FV right strip,
-        # preventing labels from crossing dim_locy extension lines in the side
-        # view.  gap_fv_sv is sized by _measure_strips to accommodate the widest
-        # callout, so well-estimated labels will always fit within this bound.
-        right=Strip(pv_right_edge, sv_left_edge, direction=1),
-        left=Strip(pv_left_edge, margin, direction=-1),
-        above=Strip(pv_top_edge, PAGE_H - margin, direction=1),
-        # gap_fv_pv = _DIM_PAD; pv_below needs _est_pv_below_depth() mm,
-        # leaving (_DIM_PAD - _est_pv_below_depth()) mm slack (assert above).
-        below=Strip(pv_bottom_edge, fv_top_edge, direction=-1),
-    )
-    sv_bottom_edge = SV_Y - fv_hh  # same as fv_bottom_edge; side and front share Z height
-    sv_zones = ViewZones(
-        # sv_right already includes DIM_PAD; anchor here so the strip never
-        # places annotations inside that gap
-        right=Strip(sv_right, sv_right_wall, direction=1),
-        left=None,  # immediately abuts the front view's right edge
-        above=Strip(sv_top_edge, PAGE_H - margin, direction=1),
-        below=Strip(sv_bottom_edge, margin, direction=-1),
-    )
+    fv_zones, pv_zones, sv_zones = _build_zones(_g, margin, PAGE_H)
 
     page_label = {297: "A4", 420: "A3", 594: "A2", 841: "A1", 1189: "A0"}.get(
         int(PAGE_W), f"{PAGE_W:.0f}mm"
@@ -2106,6 +2210,13 @@ class Drawing:
         self.items: list = []
         self._coords: dict = {}
         self._named: dict = {}
+        # Owning view per named annotation ("front"/"plan"/"side"), captured at
+        # creation by the annotation passes (#121).  This is the authoritative
+        # source for composing each view's footprint rectangle — the view and the
+        # annotations it owns are one block — so the layout never has to recover
+        # ownership from page coordinates.  Drawing-level marks (title block,
+        # iso/section notes) carry no view.
+        self._anno_view: dict = {}
         # One per-drawing cache for lint_drawing's per-view edge bboxes, keyed on
         # id(view shape). repair() / lint_summary() lint the SAME projected view
         # objects (self.views) repeatedly, so persisting it recomputes each
@@ -2308,11 +2419,17 @@ class Drawing:
         return self.add(_dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name)
 
     # -- annotations ----------------------------------------------------------
-    def add(self, obj, name=None):
+    def add(self, obj, name=None, view=None):
         """Register an annotation so lint and export include it; returns ``obj``.
 
         Re-using an existing ``name`` replaces the previously added object (it is
         dropped from :attr:`items`), so a name always maps to one object.
+
+        ``view`` records which orthographic view ("front"/"plan"/"side") owns
+        this annotation, so the layout can compose each view with its own
+        annotations as a single footprint block (#121).  Pass ``None`` for
+        drawing-level marks (title block, iso/section notes) that belong to no
+        single view.
         """
         if name is not None and name in self._named:
             self.items.remove(self._named[name])
@@ -2323,6 +2440,8 @@ class Drawing:
         self.items.append(obj)
         if name is not None:
             self._named[name] = obj
+            if view is not None:
+                self._anno_view[name] = view
         return obj
 
     def remove(self, name):
@@ -2332,6 +2451,7 @@ class Drawing:
             raise KeyError(f"no annotation named {name!r}")
         self.items.remove(obj)
         self._pinned.discard(name)  # a removed name carries no pin (#89)
+        self._anno_view.pop(name, None)
         return obj
 
     def annotations(self) -> dict:
@@ -2526,7 +2646,7 @@ class Drawing:
         # Furniture that legitimately sits on the view geometry — exempt from the
         # annotation-overlap / centreline lint, as the section arrows do.
         balloon.is_centerline = True
-        self.add(balloon, f"balloon_{view}_{tag}_{j}")
+        self.add(balloon, f"balloon_{view}_{tag}_{j}", view=view)
 
     def _add_balloon(self, view, tag, j, hole):
         """Single-balloon convenience over :meth:`_add_balloons` (#111)."""
@@ -3125,6 +3245,170 @@ def _fit_iso_view(dwg, a: Analysis, annotate: bool = True):
     _log.info("Iso view scaled to %g× sheet scale%s", factor, " (NTS)" if annotate else "")
 
 
+# A view centre must move by more than this (mm) for the measure-and-repack
+# pass to re-assemble.  Below it, the estimate already matched the measured
+# footprint and pass 1 stands (the common, non-ballooned case).
+_REPACK_TOL = 0.75
+
+
+def _assemble(a, out, assembly, detail_view, auto_dims):
+    """Project the 4 views for analysis *a*, run the automatic annotation
+    passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
+    repacked analysis it is also pass 2 of the measure-and-repack loop (#121)."""
+    cxs, cys, czs = a.cx * a.SCALE, a.cy * a.SCALE, a.cz * a.SCALE
+    dist = a.bbox_max * a.SCALE + 100
+
+    dwg = Drawing(
+        scale=a.SCALE,
+        page_w=a.PAGE_W,
+        page_h=a.PAGE_H,
+        tb_w=a.TB_W,
+        draft=draft_preset(font_size=_FONT_SIZE, decimal_precision=1),
+        look_at=(cxs, cys, czs),
+        dist=dist,
+        centroid=(a.cx, a.cy, a.cz),
+        out=out,
+        part=a.part,
+        cyls=a.cyls,
+        assembly=assembly,
+    )
+    dwg._analysis = a  # expose analysis namespace for testing and future strip access
+
+    part_s = a.part.scale(a.SCALE)
+    dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)
+    dwg.add_view("plan", part_s, (cxs, cys, czs + dist), (0, 1, 0), (a.PV_X, a.PV_Y), scaled=True)
+    dwg.add_view("side", part_s, (cxs + dist, cys, czs), (0, 0, 1), (a.SV_X, a.SV_Y), scaled=True)
+    _project_iso(dwg, a, a.SCALE, shape_s=part_s)
+
+    if auto_dims:
+        # Snapshot outer_limits before _auto_annotate tightens them against the
+        # initial (possibly overflowing) iso.  After _fit_iso_view rescales the
+        # iso we restore all three right strips to min(original, final_iso_x_limit)
+        # so each strip reflects actual final geometry, not the transient state.
+        _fv_ol = a.fv_zones.right.outer_limit
+        _pv_ol = a.pv_zones.right.outer_limit
+        _sv_ol = a.sv_zones.right.outer_limit
+        _auto_annotate(dwg, a, detail_view=detail_view)
+        _fit_iso_view(dwg, a)
+        _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
+        _final_iso_x_lim = _ix0 - 4
+        a.fv_zones.right.outer_limit = min(_fv_ol, _final_iso_x_lim)
+        a.pv_zones.right.outer_limit = min(_pv_ol, _final_iso_x_lim)
+        # Only re-cap the SV right strip when the iso shares its y-range (see the
+        # matching guard in _auto_annotate); otherwise restore its full width.
+        if (a.SV_Y - a.fv_hh) < _iy1 and _iy0 < (a.SV_Y + a.fv_hh):
+            a.sv_zones.right.outer_limit = min(_sv_ol, _final_iso_x_lim)
+        else:
+            a.sv_zones.right.outer_limit = _sv_ol
+    else:
+        _fit_iso_view(dwg, a, annotate=False)
+        _add_title_block(dwg, a)
+    return dwg
+
+
+def _repack_candidates(a, scale, page):
+    """The (scale, page_w, page_h, tb_w) candidates the repack may choose from,
+    mirroring :func:`choose_scale`: a user-fixed scale and/or page is honoured;
+    otherwise the auto ladder (smallest legible sheet first) is searched."""
+    if scale is not None and page is not None:
+        pw, ph, tb = _parse_page(page)
+        return [(float(scale), pw, ph, tb)]
+    if page is not None:
+        pw, ph, tb = _parse_page(page)
+        return [(s, pw, ph, tb) for s in _SCALES]
+    if scale is not None:
+        return [(float(scale), pw, ph, _tb_width(pw)) for pw, ph in _PAGE_SIZES.values()]
+    return list(_LADDER)
+
+
+def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
+    """Measure the laid-out drawing's *real* per-view annotation footprints and,
+    when a view collides across views, pack the blocks disjoint — escalating the
+    sheet/scale until the packed layout fits — then re-assemble (#121, ADR 0004 —
+    "lay out, don't predict"; the (scale, page) choice is the outer search whose
+    fitness is *do the packed disjoint blocks fit*).
+
+    Returns ``(a2, dwg2)`` for the repacked drawing, or ``None`` when pass 1 has
+    no cross-view overlap (the common case — a clean sheet is left exactly as
+    placed, so well-estimated parts stay byte-identical) or when the repack would
+    change nothing (same sheet/scale and no view actually moves).
+    """
+    if _cross_view_overlaps(dwg, a) == 0:
+        return None
+    blocks = _measure_blocks(dwg, a)
+
+    def _geom(cand):
+        s, pw, ph, tb = cand
+        return _layout_geometry(
+            a.x_size, a.y_size, a.z_size, s, pw, ph, tb, None, 0, blocks=blocks
+        )
+
+    candidates = _repack_candidates(a, scale, page)
+    chosen, g = next(((c, gg) for c in candidates if (gg := _geom(c)).fits), (None, None))
+    if chosen is None:
+        # Nothing fits — keep the largest candidate and let lint report the
+        # overflow (mirrors choose_scale's fallback rather than crashing).
+        chosen = candidates[-1]
+        g = _geom(chosen)
+        _log.warning(
+            "measure-repack: no standard sheet fits the measured layout; using %s", chosen
+        )
+    s, pw, ph, tb = chosen
+    moved = max(
+        abs(g.FV_X - a.FV_X),
+        abs(g.FV_Y - a.FV_Y),
+        abs(g.PV_X - a.PV_X),
+        abs(g.PV_Y - a.PV_Y),
+        abs(g.SV_X - a.SV_X),
+        abs(g.SV_Y - a.SV_Y),
+    )
+    if s == a.SCALE and pw == a.PAGE_W and ph == a.PAGE_H and moved < _REPACK_TOL:
+        return None
+    fv_zones, pv_zones, sv_zones = _build_zones(g, a.margin, ph)
+    a2 = replace(
+        a,
+        SCALE=s,
+        PAGE_W=pw,
+        PAGE_H=ph,
+        TB_W=tb,
+        x_offset=g.x_offset,
+        FV_X=g.FV_X,
+        FV_Y=g.FV_Y,
+        PV_X=g.PV_X,
+        PV_Y=g.PV_Y,
+        SV_X=g.SV_X,
+        SV_Y=g.SV_Y,
+        fv_hw=g.fv_hw,
+        fv_hh=g.fv_hh,
+        pv_hh=g.pv_hh,
+        sv_hw=g.sv_hw,
+        sv_right=g.sv_right,
+        iso_right_limit=g.iso_right,
+        ISO_X=g.ISO_X,
+        ISO_Y=g.ISO_Y,
+        iso_left_limit=g.iso_left,
+        iso_bottom_limit=g.iso_bottom,
+        iso_top_limit=g.iso_top,
+        proj=_Projector(
+            fv_x=g.FV_X,
+            fv_y=g.FV_Y,
+            sv_x=g.SV_X,
+            sv_y=g.SV_Y,
+            pv_x=g.PV_X,
+            pv_y=g.PV_Y,
+            cx=a.cx,
+            cy=a.cy,
+            cz=a.cz,
+            scale=s,
+        ),
+        fv_zones=fv_zones,
+        pv_zones=pv_zones,
+        sv_zones=sv_zones,
+    )
+    dwg2 = _assemble(a2, out, assembly, detail_view, auto_dims=True)
+    return a2, dwg2
+
+
 def build_drawing(
     step_file: str | Path | Shape,
     out: str | None = None,
@@ -3180,55 +3464,15 @@ def build_drawing(
         step_file, title, number, tolerance, drawn_by, out, scale=scale, page=page, pmi=pmi
     )
 
-    cxs, cys, czs = a.cx * a.SCALE, a.cy * a.SCALE, a.cz * a.SCALE
-    look_at = (cxs, cys, czs)
-    dist = a.bbox_max * a.SCALE + 100
-
-    dwg = Drawing(
-        scale=a.SCALE,
-        page_w=a.PAGE_W,
-        page_h=a.PAGE_H,
-        tb_w=a.TB_W,
-        draft=draft_preset(font_size=_FONT_SIZE, decimal_precision=1),
-        look_at=look_at,
-        dist=dist,
-        centroid=(a.cx, a.cy, a.cz),
-        out=out,
-        part=a.part,
-        cyls=a.cyls,
-        assembly=assembly,
-    )
-    dwg._analysis = a  # expose analysis namespace for testing and future strip access
-
-    part_s = a.part.scale(a.SCALE)
-    dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)
-    dwg.add_view("plan", part_s, (cxs, cys, czs + dist), (0, 1, 0), (a.PV_X, a.PV_Y), scaled=True)
-    dwg.add_view("side", part_s, (cxs + dist, cys, czs), (0, 0, 1), (a.SV_X, a.SV_Y), scaled=True)
-    _project_iso(dwg, a, a.SCALE, shape_s=part_s)
-
+    # Pass 1: place + annotate from the estimated layout, then measure the real
+    # per-view footprints and re-pack the blocks disjoint if a view actually
+    # moves (#121, ADR 0004 — "lay out, don't predict").  Non-ballooned parts
+    # measure ≈ estimate, so they skip pass 2 and stand byte-identical.
+    dwg = _assemble(a, out, assembly, detail_view, auto_dims)
     if auto_dims:
-        # Snapshot outer_limits before _auto_annotate tightens them against the
-        # initial (possibly overflowing) iso.  After _fit_iso_view rescales the
-        # iso we restore all three right strips to min(original, final_iso_x_limit)
-        # so each strip reflects actual final geometry, not the transient state.
-        _fv_ol = a.fv_zones.right.outer_limit
-        _pv_ol = a.pv_zones.right.outer_limit
-        _sv_ol = a.sv_zones.right.outer_limit
-        _auto_annotate(dwg, a, detail_view=detail_view)
-        _fit_iso_view(dwg, a)
-        _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
-        _final_iso_x_lim = _ix0 - 4
-        a.fv_zones.right.outer_limit = min(_fv_ol, _final_iso_x_lim)
-        a.pv_zones.right.outer_limit = min(_pv_ol, _final_iso_x_lim)
-        # Only re-cap the SV right strip when the iso shares its y-range (see the
-        # matching guard in _auto_annotate); otherwise restore its full width.
-        if (a.SV_Y - a.fv_hh) < _iy1 and _iy0 < (a.SV_Y + a.fv_hh):
-            a.sv_zones.right.outer_limit = min(_sv_ol, _final_iso_x_lim)
-        else:
-            a.sv_zones.right.outer_limit = _sv_ol
-    else:
-        _fit_iso_view(dwg, a, annotate=False)
-        _add_title_block(dwg, a)
+        repacked = _repack(a, dwg, out, assembly, detail_view, scale=scale, page=page)
+        if repacked is not None:
+            a, dwg = repacked
     if repair:
         # Close the loop on the greedy placement: re-place dims behind any
         # mechanically-clear violations (overlap, wrong-side) and re-lint (#30).

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1005,6 +1005,38 @@ def _est_pv_below_depth() -> float:
     return _STRIP_GAP + _SLOT_DIM_WIDTH
 
 
+def _est_pv_above_depth(
+    holes, patterns, font_size: float = _FONT_SIZE, pad_around_text: float = 2.0
+) -> float:
+    """Estimate the depth above the plan view consumed by X-location dims, which
+    tier one per distinct datum-X reference (#36) — so the layout can reserve it
+    (and a balloon row beyond) *before* placing views, instead of letting the
+    tiers spill into headroom (#121).
+
+    WIP estimate standing in for ADR 0004's "lay out, don't predict": a
+    conservative upper bound (one spare tier for the pitch dim / rounding), which
+    the packer absorbs by scale rather than under-reserving and overlapping.
+    Scale-independent (tier height is fixed page-mm).
+    """
+    z_refs_x: list[float] = []
+    patterned = {h for p in patterns for h in p.holes}
+    for p in patterns:
+        if _axis_letter(p.holes[0]) != "z":
+            continue
+        z_refs_x.append(
+            p.center[0] if isinstance(p, BoltCircle) else p.holes[0].location[0]
+        )
+    z_refs_x += [h.location[0] for h in holes if _axis_letter(h) == "z" and h not in patterned]
+    distinct: list[float] = []
+    for x in sorted(z_refs_x):
+        if not distinct or abs(x - distinct[-1]) > 0.5:
+            distinct.append(x)
+    if not distinct:
+        return 0.0
+    tier = font_size + 2 * pad_around_text
+    return (len(distinct) + 1) * tier  # +1 tier: pitch dim / rounding headroom
+
+
 def _est_plan_halo(font_size: float = _FONT_SIZE) -> float:
     """Per-side standoff band (page-mm) reserved around the plan view when its
     holes will be ballooned, so the leadered balloon ring sits in clear space
@@ -1135,6 +1167,7 @@ class StripDepths:
 
     right: float  # horizontal corridor right of FV/PV → gap_fv_sv
     left: float  # horizontal corridor left of FV/PV
+    top: float = 0.0  # band above PV for tiered X-location dims (#121)
     pv_halo: float = 0.0  # balloon standoff band reserved around the plan view (#111)
 
 
@@ -1163,8 +1196,9 @@ def _measure_strips(
         bore_depth += pad_around_text + arrow_length
     right = max(_est_right_strip_depth(n_steps), bore_depth)
     left = max(_DIM_PAD, bore_depth)
+    top = _est_pv_above_depth(holes, patterns, font_size, pad_around_text)
     pv_halo = _est_plan_halo(font_size) if _will_balloon(holes, patterns) else 0.0
-    return StripDepths(right=right, left=left, pv_halo=pv_halo)
+    return StripDepths(right=right, left=left, top=top, pv_halo=pv_halo)
 
 
 @dataclass(frozen=True)
@@ -1269,7 +1303,10 @@ def _fits(
     halo = strips.pv_halo if strips else 0.0
     gap_fv_sv = max(_DIM_PAD, strips.right if strips else _est_right_strip_depth(n_steps), halo)
     gap_left = max(_DIM_PAD, strips.left if strips else _DIM_PAD, halo)
-    h = _MARGIN + _DIM_PAD + y_size * scale + _DIM_PAD + z_size * scale + _DIM_PAD + _MARGIN
+    # PV top band must hold the tiered X-location dims + a balloon row beyond them
+    # (#121) — mirror _layout_geometry's pv.top so scale/page is sized for it.
+    pv_top = max(_DIM_PAD, strips.top if strips else 0.0) + halo
+    h = _MARGIN + pv_top + y_size * scale + _DIM_PAD + z_size * scale + _DIM_PAD + _MARGIN
     if h > page_h:
         return False
 
@@ -1470,16 +1507,21 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     # ring the part below it, not just left/right/top (#111/#112 Phase 2).  All
     # bands reduce to today's arithmetic when halo = 0 (byte-identical).
     halo = strips.pv_halo if strips else 0.0
+    strip_top = strips.top if strips else 0.0
     gap_fv_sv = max(DIM_PAD, strips.right if strips else _est_right_strip_depth(n_steps), halo)
     gap_left = max(DIM_PAD, strips.left if strips else DIM_PAD, halo)
     pv_below = _est_pv_below_depth()
+    # Top band above PV: the tiered X-location dims (strip_top) PLUS a balloon row
+    # beyond them, not max(DIM_PAD, halo) — the dims were only fitting by spilling
+    # into headroom, so the ring placed beyond them overran the page (#121).
+    pv_top = max(DIM_PAD, strip_top) + halo
     fv = ViewBlock(
         fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
     )
     pv = ViewBlock(
         fv_hw,
         pv_hh,
-        top=DIM_PAD,
+        top=pv_top,
         right=gap_fv_sv,
         bottom=max(pv_below, halo),  # band below PV holds the width dim + a balloon row
         left=gap_left,

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1023,9 +1023,7 @@ def _est_pv_above_depth(
     for p in patterns:
         if _axis_letter(p.holes[0]) != "z":
             continue
-        z_refs_x.append(
-            p.center[0] if isinstance(p, BoltCircle) else p.holes[0].location[0]
-        )
+        z_refs_x.append(p.center[0] if isinstance(p, BoltCircle) else p.holes[0].location[0])
     z_refs_x += [h.location[0] for h in holes if _axis_letter(h) == "z" and h not in patterned]
     distinct: list[float] = []
     for x in sorted(z_refs_x):
@@ -1528,8 +1526,10 @@ def _measure_blocks(dwg, a) -> dict:
     ext: dict = {v: None for v in geom}
     for _name, v, bb, _label in _attribute_annotations(dwg, a):
         e = ext[v]
-        ext[v] = bb if e is None else (
-            min(e[0], bb[0]), min(e[1], bb[1]), max(e[2], bb[2]), max(e[3], bb[3])
+        ext[v] = (
+            bb
+            if e is None
+            else (min(e[0], bb[0]), min(e[1], bb[1]), max(e[2], bb[2]), max(e[3], bb[3]))
         )
 
     blocks: dict = {}
@@ -2607,20 +2607,48 @@ class Drawing:
         # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
         # offset by its side's dim depth so the ring sits clear of the dims.
         self._place_band(
-            view, bands["left"], "y", pl - left_dim - standoff - r,
-            margin + r, ph - margin - r, gap, fs, r,
+            view,
+            bands["left"],
+            "y",
+            pl - left_dim - standoff - r,
+            margin + r,
+            ph - margin - r,
+            gap,
+            fs,
+            r,
         )
         self._place_band(
-            view, bands["right"], "y", pr + right_dim + standoff + r,
-            margin + r, ph - margin - r, gap, fs, r,
+            view,
+            bands["right"],
+            "y",
+            pr + right_dim + standoff + r,
+            margin + r,
+            ph - margin - r,
+            gap,
+            fs,
+            r,
         )
         self._place_band(
-            view, bands["top"], "x", pt + top_dim + standoff + r,
-            pl - standoff, sv_left - r, gap, fs, r,
+            view,
+            bands["top"],
+            "x",
+            pt + top_dim + standoff + r,
+            pl - standoff,
+            sv_left - r,
+            gap,
+            fs,
+            r,
         )
         self._place_band(
-            view, bands["bottom"], "x", bottom_line,
-            pl - standoff, sv_left - r, gap, fs, r,
+            view,
+            bands["bottom"],
+            "x",
+            bottom_line,
+            pl - standoff,
+            sv_left - r,
+            gap,
+            fs,
+            r,
         )
 
     def _place_band(self, view, members, axis, line, lo, hi, gap, fs, r):
@@ -3383,8 +3411,8 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
         )
 
     candidates = _repack_candidates(a, scale, page)
-    chosen, g = next(((c, gg) for c in candidates if (gg := _geom(c)).fits), (None, None))
-    if chosen is None:
+    fit = next(((c, gg) for c in candidates if (gg := _geom(c)).fits), None)
+    if fit is None:
         # Nothing fits — keep the largest candidate and let lint report the
         # overflow (mirrors choose_scale's fallback rather than crashing).
         chosen = candidates[-1]
@@ -3392,6 +3420,8 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
         _log.warning(
             "measure-repack: no standard sheet fits the measured layout; using %s", chosen
         )
+    else:
+        chosen, g = fit
     s, pw, ph, tb = chosen
     moved = max(
         abs(g.FV_X - a.FV_X),

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1541,7 +1541,9 @@ def _padded_box(cx, cy, hw, hh, pad=_DIM_PAD):
     return ViewBlock(hw, hh, pad, pad, pad, pad).footprint(cx, cy)
 
 
-def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips, n_steps=0):
+def _layout_geometry(
+    x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips, n_steps=0, blocks=None
+):
     """Compute the 4-view layout geometry for a part at a given scale/page.
 
     Single source of truth shared by scale selection (:func:`_fits`) and view
@@ -1582,18 +1584,35 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     # the headroom above PV, and reserving more would needlessly grow the layout
     # (and can starve the section view of its leftover space).
     pv_top = (max(DIM_PAD, strip_top) + halo) if halo > 0 else DIM_PAD
-    fv = ViewBlock(
-        fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
-    )
-    pv = ViewBlock(
-        fv_hw,
-        pv_hh,
-        top=pv_top,
-        right=gap_fv_sv,
-        bottom=max(pv_below, halo),  # band below PV holds the width dim + a balloon row
-        left=gap_left,
-    )
-    sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
+    if blocks is not None:
+        # Measure-and-repack pass (#121, ADR 0004): pack the *measured* per-view
+        # footprints disjoint, not the estimated scalar corridors. Bands carry the
+        # geometry half-extents too, so use them as the source of truth.
+        fv, pv, sv = blocks["front"], blocks["plan"], blocks["side"]
+        fv_hw, fv_hh = fv.hw, fv.hh
+        pv_hh = pv.hh
+        sv_hw = sv.hw
+    else:
+        fv = ViewBlock(
+            fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
+        )
+        pv = ViewBlock(
+            fv_hw,
+            pv_hh,
+            top=pv_top,
+            right=gap_fv_sv,
+            bottom=max(pv_below, halo),  # band below PV holds the width dim + a balloon row
+            left=gap_left,
+        )
+        sv = ViewBlock(sv_hw, fv_hh, right=DIM_PAD)
+    # Per-side corridor depths from the (possibly measured) blocks. The front and
+    # plan views stack vertically (same X, different Y) so they SHARE the left and
+    # right corridors — the deeper of the two facing bands. The side view ABUTS
+    # the column, so its gap is that column band PLUS its own facing band (sum) —
+    # disjoint by construction (#121). Byte-identical for the estimator path,
+    # where fv/pv bands are equal and sv.left == 0.
+    col_left = max(fv.left, pv.left)
+    col_right = max(fv.right, pv.right)
 
     # Bottom balloon band: rather than pushing the front view down (which would
     # cascade into the iso/table and the scale choice), LIFT the plan view up
@@ -1603,16 +1622,19 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     # exactly as when halo = 0), while PV is positioned with the full ballooned
     # gap, leaving it max(0, halo - pv_below) higher.  Byte-identical when
     # halo = 0.  (#112, ADR 0004.)
-    base_gap = fv.top + pv_below
+    # FV↔PV vertical gap = fv.top + pv.bottom (abutting → sum). The estimator path
+    # keeps its lift trick (centre on the base gap, place PV on the full gap);
+    # the measured path uses the real gap directly.
+    base_gap = (fv.top + pv.bottom) if blocks is not None else (fv.top + pv_below)
     total_h = 2 * margin + fv.bottom + 2 * fv.hh + base_gap + 2 * pv.hh + pv.top
     y_offset = max(0.0, (page_h - total_h) / 2)
 
     total_content_w = (
-        gap_left
-        + gap_fv_sv
+        col_left
+        + col_right
         + x_size * scale
         + y_size * scale
-        + 2 * DIM_PAD
+        + max(2 * DIM_PAD, sv.right + DIM_PAD)
         + bbox_max * scale * _ISO_WIDTH_BUDGET
     )
     x_offset = max(0.0, (page_w - 2 * margin - tb_w - total_content_w) / 2)
@@ -1624,7 +1646,10 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     # the base gap — so the plan view sits pv_lift higher: lifted into the
     # headroom, front view anchored.
     PV_Y = FV_Y + fv.hh + (fv.top + pv.bottom) + pv.hh
-    SV_X = FV_X + fv.hw + max(fv.right, sv.left) + sv.hw
+    # SV abuts the FV/PV column: gap = column right band + SV's own left band
+    # (disjoint sum). Byte-identical to the old max(fv.right, sv.left) on the
+    # estimator path (fv.right == pv.right == col_right, sv.left == 0).
+    SV_X = FV_X + fv.hw + col_right + sv.left + sv.hw
     SV_Y = FV_Y
     sv_right = SV_X + sv.hw + sv.right
     sv_right_wall = (

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1441,6 +1441,64 @@ def choose_scale(
 # ---------------------------------------------------------------------------
 
 
+def _measure_blocks(dwg, a) -> dict:
+    """Measure each orthographic view's *actual* annotation footprint from the
+    laid-out drawing (#121, ADR 0004 — "lay out, don't predict").
+
+    Each view's four band depths are how far its annotations extend beyond its
+    geometry box, **measured** from what the annotation passes produced — not
+    estimated. Every annotation is attributed to the nearest view (by its
+    label/box centre), and the band depth on a side is the furthest that view's
+    annotations reach past the geometry edge there. Returns ``{view_name:
+    ViewBlock}`` whose bands the packer can place disjoint, no ``_est_*`` needed.
+    """
+    geom = {
+        "front": (a.FV_X, a.FV_Y, a.fv_hw, a.fv_hh),
+        "plan": (a.PV_X, a.PV_Y, a.fv_hw, a.pv_hh),
+        "side": (a.SV_X, a.SV_Y, a.sv_hw, a.fv_hh),
+    }
+
+    def box(o):
+        lb = getattr(o, "label_bbox", None)
+        if lb is not None:
+            return lb
+        try:
+            b = o.bounding_box()
+            return (b.min.X, b.min.Y, b.max.X, b.max.Y)
+        except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+            return None
+
+    ext: dict = {v: None for v in geom}
+    for name, o in dwg._named.items():
+        if name == "title_block":
+            continue
+        bb = box(o)
+        if bb is None:
+            continue
+        bcx, bcy = (bb[0] + bb[2]) / 2, (bb[1] + bb[3]) / 2
+        v = min(geom, key=lambda k: (bcx - geom[k][0]) ** 2 + (bcy - geom[k][1]) ** 2)
+        e = ext[v]
+        ext[v] = bb if e is None else (
+            min(e[0], bb[0]), min(e[1], bb[1]), max(e[2], bb[2]), max(e[3], bb[3])
+        )
+
+    blocks: dict = {}
+    for v, (cx, cy, hw, hh) in geom.items():
+        e = ext[v]
+        if e is None:
+            blocks[v] = ViewBlock(hw, hh)
+            continue
+        blocks[v] = ViewBlock(
+            hw,
+            hh,
+            top=max(0.0, e[3] - (cy + hh)),
+            right=max(0.0, e[2] - (cx + hw)),
+            bottom=max(0.0, (cy - hh) - e[1]),
+            left=max(0.0, (cx - hw) - e[0]),
+        )
+    return blocks
+
+
 @dataclass(frozen=True)
 class ViewBlock:
     """A view's composite footprint (#112): its geometry half-extents plus the

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1459,7 +1459,11 @@ def _anno_bbox(o):
     try:
         b = o.bounding_box()
         return (b.min.X, b.min.Y, b.max.X, b.max.Y)
-    except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+    except Exception as exc:  # noqa: BLE001 — not every annotation bbox-es cleanly
+        # Fails open: an un-bbox-able annotation drops out of the overlap count and
+        # the measured footprint. Surface it so a silently-missed repack trigger is
+        # debuggable rather than invisible (#121).
+        _log.debug("annotation %r has no resolvable bbox: %s", type(o).__name__, exc)
         return None
 
 
@@ -1700,7 +1704,12 @@ def _layout_geometry(
     )
     x_offset = max(0.0, (page_w - 2 * margin - tb_w - total_content_w) / 2)
 
-    FV_X = margin + x_offset + fv.left + fv.hw
+    # Anchor the FV/PV column on the SHARED left corridor (col_left), not fv.left
+    # alone: when the measured plan-view left band is the deeper of the two, the
+    # column must clear it or PV slides left of the centred region — and off the
+    # margin (#121). Byte-identical on the estimator path (col_left == fv.left),
+    # and symmetric with SV_X's use of col_right below.
+    FV_X = margin + x_offset + col_left + fv.hw
     FV_Y = y_offset + margin + fv.bottom + fv.hh
     PV_X = FV_X
     # PV uses the full (ballooned) front↔plan gap while FV/SV were centred with
@@ -1736,13 +1745,24 @@ def _layout_geometry(
     tb_cx, tb_cy = page_w - _TB_CLEAR - tb_w / 2, _TB_CLEAR + _TB_H / 2
 
     # The iso is the one *placed* block: it takes the largest gap the fixed
-    # blocks' footprints leave.
-    obstacles = [
-        _padded_box(FV_X, FV_Y, fv_hw, fv_hh),
-        _padded_box(PV_X, PV_Y, fv_hw, pv_hh),
-        _padded_box(SV_X, SV_Y, sv_hw, fv_hh),
-        title_block.footprint(tb_cx, tb_cy),
-    ]
+    # blocks' footprints leave.  On the repack path use the MEASURED footprints
+    # (bands may exceed DIM_PAD), so the iso stays clear of real annotations
+    # rather than just the estimate's padded box (#121); the estimator path keeps
+    # the DIM_PAD-padded boxes for byte-identity.
+    if blocks is not None:
+        obstacles = [
+            fv.footprint(FV_X, FV_Y),
+            pv.footprint(PV_X, PV_Y),
+            sv.footprint(SV_X, SV_Y),
+            title_block.footprint(tb_cx, tb_cy),
+        ]
+    else:
+        obstacles = [
+            _padded_box(FV_X, FV_Y, fv_hw, fv_hh),
+            _padded_box(PV_X, PV_Y, fv_hw, pv_hh),
+            _padded_box(SV_X, SV_Y, sv_hw, fv_hh),
+            title_block.footprint(tb_cx, tb_cy),
+        ]
     iso_left, iso_bottom, iso_right, iso_top = _largest_empty_rect(drawable, obstacles)
     # _largest_empty_rect falls back to the full drawable when the obstacles
     # leave no genuine gap; detect that (rect overlaps an obstacle) so callers
@@ -2440,8 +2460,13 @@ class Drawing:
         self.items.append(obj)
         if name is not None:
             self._named[name] = obj
+            # A replacement is a fresh object (see the pin discard above): set the
+            # new owner, or clear a stale tag when re-added view-less, so the
+            # ownership map never lags _named (#121).
             if view is not None:
                 self._anno_view[name] = view
+            else:
+                self._anno_view.pop(name, None)
         return obj
 
     def remove(self, name):
@@ -2722,6 +2747,7 @@ class Drawing:
         self.items = [o for o in self.items if id(o) in kept_ids]
         self._named = kept_named
         self._pinned &= keep_set  # drop pins for cleared names (#89)
+        self._anno_view = {n: v for n, v in self._anno_view.items() if n in keep_set}
         return removed
 
     def _record_build_issue(self, severity, code, message):
@@ -3318,7 +3344,20 @@ def _repack_candidates(a, scale, page):
         return [(s, pw, ph, tb) for s in _SCALES]
     if scale is not None:
         return [(float(scale), pw, ph, _tb_width(pw)) for pw, ph in _PAGE_SIZES.values()]
-    return list(_LADDER)
+    # Auto ladder, but floored at pass 1's chosen sheet: the measured blocks are
+    # never smaller than the estimate that pass 1 already rejected the earlier
+    # rungs against, and the repack's .fits is more permissive than choose_scale's
+    # row model — so without this floor the repack could pick a *smaller* sheet
+    # than pass 1 and make things worse (#121). Start the search at pass 1's rung.
+    start = next(
+        (
+            i
+            for i, (s, pw, ph, _tb) in enumerate(_LADDER)
+            if s == a.SCALE and pw == a.PAGE_W and ph == a.PAGE_H
+        ),
+        0,
+    )
+    return list(_LADDER[start:])
 
 
 def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1307,9 +1307,11 @@ def _fits(
     halo = strips.pv_halo if strips else 0.0
     gap_fv_sv = max(_DIM_PAD, strips.right if strips else _est_right_strip_depth(n_steps), halo)
     gap_left = max(_DIM_PAD, strips.left if strips else _DIM_PAD, halo)
-    # PV top band must hold the tiered X-location dims + a balloon row beyond them
-    # (#121) — mirror _layout_geometry's pv.top so scale/page is sized for it.
-    pv_top = max(_DIM_PAD, strips.top if strips else 0.0) + halo
+    # PV top band: when ballooned, hold the tiered X-location dims + a balloon row
+    # beyond them (#121); otherwise the historic DIM_PAD (tiers spill into
+    # headroom). Mirror _layout_geometry's pv.top so scale/page is sized for it.
+    strip_top = strips.top if strips else 0.0
+    pv_top = (max(_DIM_PAD, strip_top) + halo) if halo > 0 else _DIM_PAD
     h = _MARGIN + pv_top + y_size * scale + _DIM_PAD + z_size * scale + _DIM_PAD + _MARGIN
     if h > page_h:
         return False
@@ -1515,10 +1517,13 @@ def _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips
     gap_fv_sv = max(DIM_PAD, strips.right if strips else _est_right_strip_depth(n_steps), halo)
     gap_left = max(DIM_PAD, strips.left if strips else DIM_PAD, halo)
     pv_below = _est_pv_below_depth()
-    # Top band above PV: the tiered X-location dims (strip_top) PLUS a balloon row
-    # beyond them, not max(DIM_PAD, halo) — the dims were only fitting by spilling
-    # into headroom, so the ring placed beyond them overran the page (#121).
-    pv_top = max(DIM_PAD, strip_top) + halo
+    # Top band above PV. When the plan view is ballooned, the ring sits beyond the
+    # tiered X-location dims, so reserve their real depth (strip_top) PLUS a
+    # balloon row — otherwise the ring overruns the page (#121). When NOT
+    # ballooned, keep the historic DIM_PAD: the dim tiers spill harmlessly into
+    # the headroom above PV, and reserving more would needlessly grow the layout
+    # (and can starve the section view of its leftover space).
+    pv_top = (max(DIM_PAD, strip_top) + halo) if halo > 0 else DIM_PAD
     fv = ViewBlock(
         fv_hw, fv_hh, top=DIM_PAD - pv_below, right=gap_fv_sv, bottom=DIM_PAD, left=gap_left
     )

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1247,6 +1247,9 @@ def _compose_anno_boxes(
         bore_depth += pad_around_text + arrow_length
         boxes.append(AnnoBox("right", bore_depth))  # FV/PV right bore callouts
         boxes.append(AnnoBox("left", bore_depth))  # FV/PV left bore callouts
+    above = _est_pv_above_depth(holes, patterns, font_size, pad_around_text)
+    if above > 0:
+        boxes.append(AnnoBox("above", above))  # tiered X-location dims above PV (#121)
     if _will_balloon(holes, patterns):
         boxes.append(AnnoBox("plan_halo", _est_plan_halo(font_size)))
     return boxes
@@ -1265,6 +1268,7 @@ def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
     return StripDepths(
         right=deepest("right"),
         left=max(_DIM_PAD, deepest("left")),
+        top=deepest("above"),
         pv_halo=deepest("plan_halo"),
     )
 

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -2293,13 +2293,27 @@ class Drawing:
         sv_left = a.SV_X - a.sv_hw
         margin, ph = a.margin, a.PAGE_H
 
-        # A bottom band (below PV, beside the overall-width dim) is usable only
-        # when the layout actually lifted the plan view — i.e. widened the FV↔PV
-        # gap beyond the base DIM_PAD (#112, ADR 0004).  Without the lift the gap
-        # is full of the width dimension and a balloon row would collide with it;
-        # bottom-edge holes then fall back to the nearest side/top band.
-        bottom_line = pb - standoff - r
-        has_bottom = pb - (a.FV_Y + a.fv_hh) > _DIM_PAD + 2
+        # Stack the balloon ring *beyond* the dimensions already placed around the
+        # plan view, not on top of them (#121). Each side's dim corridor depth is
+        # the zone strip's used extent (pitch/location dims tier above, the width
+        # dim sits below), measured now that the dims are placed — so the ring
+        # clears them instead of overlapping (the old bands sat at standoff + r,
+        # right where the dims are).
+        # NOTE (WIP): this pushes the ring out cleanly for moderate parts but on a
+        # dense sheet (CTC-02) the top band overruns the page margin — the layout
+        # reservation must grow to match (the real #121 sizing step). Kept here as
+        # the placement half of Stage 1; do not ship without the sizing change.
+        za = a.pv_zones
+        top_dim = za.above.depth_used if za and za.above else 0.0
+        bot_dim = za.below.depth_used if za and za.below else 0.0
+        left_dim = za.left.depth_used if za and za.left else 0.0
+        right_dim = za.right.depth_used if za and za.right else 0.0
+
+        # A bottom band (below PV, beyond the overall-width dim) is usable only
+        # when the FV↔PV gap has room for the width dim *and* a balloon row;
+        # otherwise bottom-edge holes fall back to the nearest side/top band.
+        bottom_line = pb - bot_dim - standoff - r
+        has_bottom = pb - (a.FV_Y + a.fv_hh) > bot_dim + standoff + 2 * r
 
         # Assign each hole to the nearest reserved band.
         bands: dict = {"left": [], "right": [], "top": [], "bottom": []}
@@ -2311,18 +2325,23 @@ class Drawing:
             bands[min(choices, key=lambda s: choices[s])].append((tag, j, hole, cx, cy))
 
         # left/right balloons vary in Y at a fixed X just outside the part; top
-        # and bottom balloons vary in X at a fixed Y just beyond it.
+        # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
+        # offset by its side's dim depth so the ring sits clear of the dims.
         self._place_band(
-            view, bands["left"], "y", pl - standoff - r, margin + r, ph - margin - r, gap, fs, r
+            view, bands["left"], "y", pl - left_dim - standoff - r,
+            margin + r, ph - margin - r, gap, fs, r,
         )
         self._place_band(
-            view, bands["right"], "y", pr + standoff + r, margin + r, ph - margin - r, gap, fs, r
+            view, bands["right"], "y", pr + right_dim + standoff + r,
+            margin + r, ph - margin - r, gap, fs, r,
         )
         self._place_band(
-            view, bands["top"], "x", pt + standoff + r, pl - standoff, sv_left - r, gap, fs, r
+            view, bands["top"], "x", pt + top_dim + standoff + r,
+            pl - standoff, sv_left - r, gap, fs, r,
         )
         self._place_band(
-            view, bands["bottom"], "x", bottom_line, pl - standoff, sv_left - r, gap, fs, r
+            view, bands["bottom"], "x", bottom_line,
+            pl - standoff, sv_left - r, gap, fs, r,
         )
 
     def _place_band(self, view, members, axis, line, lo, hi, gap, fs, r):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1181,6 +1181,11 @@ class TestComposeThenPackRepack:
         # The MAJOR fix: when the plan view's measured left band is the deeper of
         # the two, the FV/PV column must clear it (col_left), or PV slides off the
         # left margin.  front.left tiny, plan.left huge.
+        #
+        # The page is sized so the content FILLS it (x_offset == 0): on a wide
+        # sheet the centring slack would absorb the mis-anchoring and the buggy
+        # code (FV_X anchored on fv.left) would pass anyway.  With x_offset == 0
+        # the bug puts the plan-view left edge at margin - 120 = -110 mm.
         from draftwright.make_drawing import _MARGIN, ViewBlock, _layout_geometry
 
         blocks = {
@@ -1188,7 +1193,11 @@ class TestComposeThenPackRepack:
             "plan": ViewBlock(10, 10, left=120.0, right=8, top=8, bottom=8),
             "side": ViewBlock(10, 10, left=0.0, right=8, top=8, bottom=8),
         }
-        g = _layout_geometry(20, 20, 20, 1.0, 841.0, 594.0, 150.0, None, blocks=blocks)
+        g = _layout_geometry(20, 20, 20, 1.0, 380.0, 300.0, 150.0, None, blocks=blocks)
+        # Precondition: no centring slack, or the test cannot catch the bug.
+        assert g.x_offset == pytest.approx(0.0, abs=0.01), (
+            f"test needs x_offset==0 to be meaningful, got {g.x_offset:.1f}"
+        )
         pv_left_footprint_edge = g.PV_X - g.fv_hw - 120.0
         assert pv_left_footprint_edge >= _MARGIN - 0.5, (
             f"plan-view left footprint edge {pv_left_footprint_edge:.1f} slid past "

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1079,6 +1079,175 @@ class TestTwoPassLayout:
         assert "dim_width" in dwg._named, "dim_width must not be skipped"
 
 
+class TestComposeThenPackRepack:
+    """Ownership-based compose-then-pack + measure-and-repack (#121, ADR 0004):
+    the cross-view collision detector, the disjoint block packing, the candidate
+    floor, and the annotation-ownership map lifecycle.  Pure/fast — no OCP."""
+
+    # --- cross-view collision detector -----------------------------------
+
+    @staticmethod
+    def _label(bb):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(label_bbox=bb)
+
+    @staticmethod
+    def _line(bb):
+        # Bare geometry: no label_bbox attribute, bbox via bounding_box().
+        from types import SimpleNamespace
+
+        class _Bare:
+            def bounding_box(self):
+                return SimpleNamespace(
+                    min=SimpleNamespace(X=bb[0], Y=bb[1]),
+                    max=SimpleNamespace(X=bb[2], Y=bb[3]),
+                )
+
+        return _Bare()
+
+    def _fake_dwg(self, named, views):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(_named=named, _anno_view=views)
+
+    def test_overlap_counts_label_vs_label_across_views(self):
+        from draftwright.make_drawing import _cross_view_overlaps
+
+        dwg = self._fake_dwg(
+            {"a": self._label((0, 0, 10, 10)), "b": self._label((5, 5, 15, 15))},
+            {"a": "front", "b": "plan"},
+        )
+        assert _cross_view_overlaps(dwg, None) == 1
+
+    def test_overlap_counts_label_vs_line_across_views(self):
+        # The literal #121 case: a plan balloon (bare geometry) over a front-view
+        # dimension (label) — counted because at least one side is a label.
+        from draftwright.make_drawing import _cross_view_overlaps
+
+        dwg = self._fake_dwg(
+            {"dim": self._label((0, 0, 10, 10)), "balloon": self._line((5, 5, 15, 15))},
+            {"dim": "front", "balloon": "plan"},
+        )
+        assert _cross_view_overlaps(dwg, None) == 1
+
+    def test_overlap_ignores_same_view(self):
+        from draftwright.make_drawing import _cross_view_overlaps
+
+        dwg = self._fake_dwg(
+            {"a": self._label((0, 0, 10, 10)), "b": self._label((5, 5, 15, 15))},
+            {"a": "front", "b": "front"},
+        )
+        assert _cross_view_overlaps(dwg, None) == 0
+
+    def test_overlap_ignores_line_vs_line(self):
+        # Two bare lines crossing between views is normal drafting, not a clash.
+        from draftwright.make_drawing import _cross_view_overlaps
+
+        dwg = self._fake_dwg(
+            {"a": self._line((0, 0, 10, 10)), "b": self._line((5, 5, 15, 15))},
+            {"a": "front", "b": "side"},
+        )
+        assert _cross_view_overlaps(dwg, None) == 0
+
+    def test_overlap_ignores_untagged_furniture(self):
+        # An annotation with no ortho-view tag (iso/section/detail/title) is
+        # invisible to the detector, even when it overlaps a tagged one.
+        from draftwright.make_drawing import _cross_view_overlaps
+
+        dwg = self._fake_dwg(
+            {"dim": self._label((0, 0, 10, 10)), "note": self._label((5, 5, 15, 15))},
+            {"dim": "front", "note": "iso"},
+        )
+        assert _cross_view_overlaps(dwg, None) == 0
+
+    # --- disjoint block packing ------------------------------------------
+
+    def test_repacked_blocks_are_disjoint(self):
+        from draftwright.make_drawing import ViewBlock, _layout_geometry
+
+        blocks = {
+            "front": ViewBlock(10, 10, top=12, right=12, bottom=12, left=12),
+            "plan": ViewBlock(10, 10, top=12, right=12, bottom=12, left=12),
+            "side": ViewBlock(10, 10, top=12, right=12, bottom=12, left=12),
+        }
+        g = _layout_geometry(20, 20, 20, 1.0, 841.0, 594.0, 150.0, None, blocks=blocks)
+        # FV and PV share X and stack vertically — PV's bottom must clear FV's top.
+        assert (g.PV_Y - g.pv_hh) > (g.FV_Y + g.fv_hh)
+        # SV abuts the column to the right — its left edge must clear FV's right.
+        assert (g.SV_X - g.sv_hw) > (g.FV_X + g.fv_hw)
+
+    def test_left_corridor_uses_shared_band_not_front_only(self):
+        # The MAJOR fix: when the plan view's measured left band is the deeper of
+        # the two, the FV/PV column must clear it (col_left), or PV slides off the
+        # left margin.  front.left tiny, plan.left huge.
+        from draftwright.make_drawing import _MARGIN, ViewBlock, _layout_geometry
+
+        blocks = {
+            "front": ViewBlock(10, 10, left=0.0, right=8, top=8, bottom=8),
+            "plan": ViewBlock(10, 10, left=120.0, right=8, top=8, bottom=8),
+            "side": ViewBlock(10, 10, left=0.0, right=8, top=8, bottom=8),
+        }
+        g = _layout_geometry(20, 20, 20, 1.0, 841.0, 594.0, 150.0, None, blocks=blocks)
+        pv_left_footprint_edge = g.PV_X - g.fv_hw - 120.0
+        assert pv_left_footprint_edge >= _MARGIN - 0.5, (
+            f"plan-view left footprint edge {pv_left_footprint_edge:.1f} slid past "
+            f"the {_MARGIN} mm margin — column anchored on front.left, not col_left"
+        )
+
+    # --- candidate ladder floor ------------------------------------------
+
+    def test_repack_candidates_floored_at_pass1_sheet(self):
+        from types import SimpleNamespace
+
+        from draftwright.make_drawing import _repack_candidates
+
+        a = SimpleNamespace(SCALE=0.2, PAGE_W=594.0, PAGE_H=420.0)
+        cands = _repack_candidates(a, None, None)
+        # Search starts at pass 1's own rung (A2 1:5) ...
+        assert cands[0] == (0.2, 594.0, 420.0, 150.0)
+        # ... never offers a smaller sheet pass 1 already rejected ...
+        assert (10.0, 297.0, 210.0, 120.0) not in cands
+        # ... but a larger reduction (A0 1:5) stays reachable.
+        assert (0.2, 1189.0, 841.0, 150.0) in cands
+
+    def test_repack_candidates_honour_fixed_scale_and_page(self):
+        from types import SimpleNamespace
+
+        from draftwright.make_drawing import _repack_candidates
+
+        a = SimpleNamespace(SCALE=1.0, PAGE_W=297.0, PAGE_H=210.0)
+        cands = _repack_candidates(a, 2.0, "A3")
+        assert len(cands) == 1 and cands[0][0] == 2.0
+
+    # --- ownership-map lifecycle -----------------------------------------
+
+    @pytest.mark.timeout(60)
+    def test_anno_view_lifecycle(self):
+        # add(view=) records; re-add view-less clears the stale tag; remove pops;
+        # clear_annotations prunes — the map never lags _named (#121).
+        dwg = build_drawing(Box(30, 20, 10))
+
+        def _leader(label):
+            return Leader(
+                tip=dwg.at("front", 0, 0, 0), elbow=(5, 5, 0), label=label, draft=dwg.draft
+            )
+
+        dwg.add(_leader("A"), "tag", view="front")
+        assert dwg._anno_view["tag"] == "front"
+
+        dwg.add(_leader("B"), "tag")  # replacement, view-less → clears stale tag
+        assert "tag" not in dwg._anno_view
+
+        dwg.add(_leader("C"), "tag2", view="plan")
+        dwg.remove("tag2")
+        assert "tag2" not in dwg._anno_view
+
+        dwg.add(_leader("D"), "tag3", view="side")
+        dwg.clear_annotations()  # keeps title_block only
+        assert "tag3" not in dwg._anno_view
+
+
 # ---------------------------------------------------------------------------
 # Integration test — requires build123d + OCP (slow)
 # ---------------------------------------------------------------------------

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3889,8 +3889,10 @@ def _multi_hole_plate():
 
 
 def _dense_plate():
-    """A small plate crowded with 24 Z-holes — too dense to dimension each, so
-    the location dims overflow and the engine escalates to a hole chart (#93)."""
+    """A small plate crowded with 24 Z-holes in 5 diameter groups. Dense enough
+    to stress the layout, but on the auto-sized sheet (#121) its location dims +
+    grouped spec-callouts fit, so it group-and-types rather than escalating to a
+    hole chart (#93)."""
     import itertools
 
     from build123d import Box, Cylinder, Pos
@@ -4018,20 +4020,26 @@ class TestHoleTable:
 class TestEscalation:
     """#93: a too-dense plan view auto-escalates to a hole chart + balloons."""
 
-    def test_dense_part_auto_tabulates(self):
+    def test_dense_part_groups_and_types(self):
+        # Sized honestly for its real annotation footprint (#121, ADR 0004), the
+        # sheet grows so the X-location dims + grouped spec-callouts fit — so this
+        # moderately-dense plate no longer escalates to a per-hole table + balloon
+        # ring (the worse representation for a dense varying-diameter field). It
+        # group-and-types instead: spec-group callouts (5× ⌀…) + location dims,
+        # lint clean. The table/balloon escalation path remains for parts too
+        # dense to fit even that — covered by the CTC-02 slow-tier test.
         dwg = build_drawing(_dense_plate())
-        # The escalation fired: a table, a balloon per hole, and the individual
-        # plan callouts + location dims are gone.
-        assert "hole_table_plan" in dwg.annotations()
-        assert len([n for n in dwg.annotations() if n.startswith("balloon_")]) == 24
-        assert not any(
-            n.startswith(("hc_plan", "dim_locx", "dim_locy")) for n in dwg.annotations()
-        )
+        ann = dwg.annotations()
+        assert "hole_table_plan" not in ann
+        assert not any(n.startswith("balloon_") for n in ann)
+        assert sum(1 for n in ann if n.startswith("hc_plan")) >= 1  # spec-group callouts
+        assert any(n.startswith("dim_locx") for n in ann)  # location dims placed, not dropped
+        assert [i for i in dwg.lint() if i.severity in ("warning", "error")] == []
 
     def test_escalation_clears_density_lint(self):
-        # No callout_dropped / location_ref_dropped warnings survive once the
-        # holes are tabulated, and the count check is satisfied (covers_diameters
-        # lists every instance).
+        # No callout_dropped / location_ref_dropped / count-mismatch warnings
+        # survive once the dense plate is dimensioned — whether by group-and-type
+        # (now, on the auto-sized sheet) or by the table escalation it used to need.
         dwg = build_drawing(_dense_plate())
         warns = {i.code for i in dwg.lint() if i.severity in ("warning", "error")}
         assert "callout_dropped" not in warns


### PR DESCRIPTION
Closes #121.

## Problem

On dense ballooned parts (NIST **CTC-02**, 83 holes), plan-view balloon labels collided with front-view dimensions. The old layout ran in the wrong order — it *estimated* annotation margins, placed bare views, then patched. At the front↔plan gap the estimate was wrong and the patch couldn't recover, so labels and dimensions overlapped.

## Approach (ADR 0004 compose-then-pack)

Each view now **owns its annotations**, captured at creation, and the owned footprints are packed disjoint. Concretely:

1. **Ownership at creation** — `dwg.add(obj, name, view=...)` records the owning view in `dwg._anno_view`. Every ortho-owned annotation in `annotate.py` (dims, leaders, callouts, balloons, PMI, bore leaders, hole-table) is tagged with its view. This replaces the old *geometric* nearest-center/nearest-edge attribution, which bucketed gap annotations into the wrong view and so couldn't see the overlap.
2. **Measure, don't predict** — `_measure_blocks` builds a per-view footprint (geometry box + measured top/right/bottom/left annotation bands) from the *rendered* annotations.
3. **Pack disjoint** — `_layout_geometry` stacks FV/PV vertically and abuts SV, flooring each measured band at the estimate (`_merge` = per-band max) so repack only ever *grows*, and exposes a `.fits` predicate (footprints within drawable, clear of the title block, ISO valid).
4. **Escalate when needed** — if `_cross_view_overlaps` (label-vs-anything collisions across different views) is non-zero, `_repack` re-measures and walks the page/scale ladder to the first candidate that `.fits`. CTC-02 escalates A1→A0.

Clean / non-ballooned parts have zero cross-view overlap → repack is skipped → output is unchanged.

## Results (CTC-02)

- cross-view overlaps **10 → 0**
- `annotation_out_of_bounds` (error-severity) **9 → 0** (via A1→A0 escalation)

## Tests

- Full fast suite: **371 passed**.
- Full slow CTC corpus (all 10 NIST fixtures, AP203 + AP242): **10 passed** — both CTC-02 variants now meet standards with no error-severity lint.

## Not in scope

- `label_centerline_overlap` (dimension labels crossing centerlines, 27 on CTC-02) — separate, pre-existing, tracked in #119 (blocked on helpers#161).
- Over-long top-side balloon leaders on CTC-02 — cosmetic, filed as #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)