### PR TITLE
feat(#92): consume helpers 0.12.0 — grouped callouts for sub-clustered hole patterns + RectGrid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "Paul Fremantle", email = "pzfreo@gmail.com" }]
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "build123d>=0.9.0",
-    "build123d-drafting-helpers>=0.11.0",
+    "build123d-drafting-helpers>=0.12.0",
     "kiwisolver>=1.4,<2",
     "numpy>=1.24",
 ]

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -1752,8 +1752,14 @@ def _add_grid_pitch_dims(dwg, a: Analysis, view, j, grid, to_page):
         # perpendicular coordinate, take the far one along u. Picking the global
         # max-projection hole instead lands on the opposite diagonal corner and
         # draws the pitch dim diagonally across the grid (#92).
+        # Tolerance must be below the PERPENDICULAR lattice-line spacing — which
+        # is the *other* axis' pitch, so use the smaller of the two pitches.
+        # (pitch_page * 0.25 fails on a high-aspect grid: for the long axis the
+        # perpendicular lines are only the short pitch apart, and a quarter of
+        # the long pitch can exceed that, merging two lines → diagonal again.)
         lo_across = across(lo)
-        line = [idx for idx in range(len(pts)) if abs(across(idx) - lo_across) < pitch_page * 0.25]
+        line_tol = min(l1, l2) * 0.25
+        line = [idx for idx in range(len(pts)) if abs(across(idx) - lo_across) < line_tol]
         hi = max(line, key=along)
         span = along(hi) - along(lo)
         n = round(span / pitch_page) + 1

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -653,8 +653,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     # pattern dimension, so they must not become table rows or per-hole balloons
     # (#92).  Excluding them is also what keeps a densely-but-regularly drilled
     # part (e.g. NIST CTC-02) off the 61-row escalation (#111).
-    patterned = {h for p in a.patterns for h in p.holes}
-    holes = [h for h in a.holes if _axis_letter(h) == "z" and h not in patterned]
+    holes = [h for h in a.holes if _axis_letter(h) == "z" and h not in dwg._patterned_holes]
     # A chart is warranted only for a *genuinely* dense plan view — a part that
     # merely dropped one too-close location ref keeps its individual dims (the
     # legibility gate already handled it). #93.
@@ -1676,10 +1675,14 @@ def _add_detail_view(dwg, a: Analysis):
 def _add_furniture(dwg, a: Analysis, view, j, pattern, to_page):
     """Pattern sheet furniture, added once its callout is placed (#92)."""
     if pattern is not None:
-        # Remember which bore-callout names belong to a pattern, so a later
-        # hole-table escalation tabulates only the genuinely unpatterned holes
-        # and leaves the grouped pattern callouts standing (#92).
+        # Remember the bore-callout name AND the holes it documents, so a later
+        # hole-table escalation leaves the grouped pattern callout standing and
+        # tabulates only the holes no *placed* pattern callout covers (#92).
+        # Recording here (callout already placed) — not from a.patterns — means a
+        # pattern dropped for lack of room, or filtered off a rotational part,
+        # correctly falls back to the table instead of going undocumented.
         dwg._pattern_callouts.add(f"hc_{view}{j}")
+        dwg._patterned_holes.update(pattern.holes)
     if isinstance(pattern, BoltCircle):
         cx = sum(to_page(h)[0] for h in pattern.holes) / len(pattern.holes)
         cy = sum(to_page(h)[1] for h in pattern.holes) / len(pattern.holes)
@@ -1736,9 +1739,23 @@ def _add_grid_pitch_dims(dwg, a: Analysis, view, j, grid, to_page):
     nominals = (grid.row_pitch, grid.col_pitch)
 
     def _axis_dim(u, pitch_page, sub):
-        order = sorted(range(len(pts)), key=lambda idx: pts[idx][0] * u[0] + pts[idx][1] * u[1])
-        lo, hi = order[0], order[-1]
-        span = (pts[hi][0] - pts[lo][0]) * u[0] + (pts[hi][1] - pts[lo][1]) * u[1]
+        perp = (-u[1], u[0])
+
+        def along(idx):
+            return pts[idx][0] * u[0] + pts[idx][1] * u[1]
+
+        def across(idx):
+            return pts[idx][0] * perp[0] + pts[idx][1] * perp[1]
+
+        lo = min(range(len(pts)), key=along)
+        # Keep the dimension on ONE lattice line: of the holes sharing lo's
+        # perpendicular coordinate, take the far one along u. Picking the global
+        # max-projection hole instead lands on the opposite diagonal corner and
+        # draws the pitch dim diagonally across the grid (#92).
+        lo_across = across(lo)
+        line = [idx for idx in range(len(pts)) if abs(across(idx) - lo_across) < pitch_page * 0.25]
+        hi = max(line, key=along)
+        span = along(hi) - along(lo)
         n = round(span / pitch_page) + 1
         # Label with the recogniser's nominal pitch nearest this axis' page step.
         pitch = min(nominals, key=lambda v: abs(v - pitch_page / a.SCALE))

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -28,6 +28,7 @@ from build123d import (
 from build123d_drafting.features import (
     BoltCircle,
     LinearArray,
+    RectGrid,
     _full_cyls,
     _spec_key,
     find_bosses,
@@ -647,7 +648,13 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     if not any(i.code in ("callout_dropped", "location_ref_dropped") for i in dwg._build_issues):
         return
 
-    holes = [h for h in a.holes if _axis_letter(h) == "z"]  # plan-view holes
+    # Tabulate only the genuinely UNpatterned plan-view holes: holes in a
+    # recognised pattern are documented by their grouped ``n× ⌀`` callout +
+    # pattern dimension, so they must not become table rows or per-hole balloons
+    # (#92).  Excluding them is also what keeps a densely-but-regularly drilled
+    # part (e.g. NIST CTC-02) off the 61-row escalation (#111).
+    patterned = {h for p in a.patterns for h in p.holes}
+    holes = [h for h in a.holes if _axis_letter(h) == "z" and h not in patterned]
     # A chart is warranted only for a *genuinely* dense plan view — a part that
     # merely dropped one too-close location ref keeps its individual dims (the
     # legibility gate already handled it). #93.
@@ -666,7 +673,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     replaced = {
         n: dwg._named[n]
         for n in list(dwg._named)
-        if n.startswith(("hc_plan", "dim_locx", "dim_locy"))
+        if n.startswith(("hc_plan", "dim_locx", "dim_locy")) and n not in dwg._pattern_callouts
     }
     replaced_view = {n: dwg._anno_view.get(n) for n in replaced}
     for n in replaced:
@@ -1668,20 +1675,95 @@ def _add_detail_view(dwg, a: Analysis):
 
 def _add_furniture(dwg, a: Analysis, view, j, pattern, to_page):
     """Pattern sheet furniture, added once its callout is placed (#92)."""
+    if pattern is not None:
+        # Remember which bore-callout names belong to a pattern, so a later
+        # hole-table escalation tabulates only the genuinely unpatterned holes
+        # and leaves the grouped pattern callouts standing (#92).
+        dwg._pattern_callouts.add(f"hc_{view}{j}")
     if isinstance(pattern, BoltCircle):
         cx = sum(to_page(h)[0] for h in pattern.holes) / len(pattern.holes)
         cy = sum(to_page(h)[1] for h in pattern.holes) / len(pattern.holes)
         dwg.add(CenterlineCircle((cx, cy), pattern.diameter * a.SCALE), f"bc_{view}{j}", view=view)
     elif isinstance(pattern, LinearArray):
-        _add_pitch_dim(dwg, a, view, j, pattern, to_page)
+        _place_pitch_dim(
+            dwg,
+            a,
+            view,
+            pattern.holes[0],
+            pattern.holes[-1],
+            len(pattern.holes),
+            pattern.pitch,
+            to_page,
+            f"dim_pitch_{view}{j}",
+        )
+    elif isinstance(pattern, RectGrid):
+        _add_grid_pitch_dims(dwg, a, view, j, pattern, to_page)
 
 
-def _add_pitch_dim(dwg, a: Analysis, view, j, pattern, to_page):
-    """Pitch dimension for a linear hole array: first→last hole centres,
-    labelled ``(n-1)× pitch``, placed just outside the view on the side of
-    the row's outward perpendicular (#92)."""
-    p1 = to_page(pattern.holes[0])
-    p2 = to_page(pattern.holes[-1])
+def _add_grid_pitch_dims(dwg, a: Analysis, view, j, grid, to_page):
+    """Both pitch dimensions of a rectangular grid — one along each lattice axis,
+    each labelled ``(n-1)× pitch`` (#92).  The two axes are recovered as the two
+    shortest near-orthogonal inter-hole page vectors (the recogniser's own
+    basis); this is used only to pick the dimension endpoints and the per-axis
+    count, not to re-recognise the grid (recognition stays upstream)."""
+    pts = [to_page(h) for h in grid.holes]
+    diffs = []
+    for ia in range(len(pts)):
+        for ib in range(len(pts)):
+            if ia == ib:
+                continue
+            dx, dy = pts[ib][0] - pts[ia][0], pts[ib][1] - pts[ia][1]
+            length = math.hypot(dx, dy)
+            if length > 1e-6:
+                diffs.append((length, dx, dy))
+    if not diffs:
+        return
+    diffs.sort()
+    l1, ax, ay = diffs[0]
+    u1 = (ax / l1, ay / l1)
+    basis2 = next(
+        (
+            (length, dx, dy)
+            for length, dx, dy in diffs
+            if abs((dx * u1[0] + dy * u1[1]) / length) < 0.2
+        ),
+        None,
+    )
+    if basis2 is None:
+        return
+    l2, bx, by = basis2
+    u2 = (bx / l2, by / l2)
+    nominals = (grid.row_pitch, grid.col_pitch)
+
+    def _axis_dim(u, pitch_page, sub):
+        order = sorted(range(len(pts)), key=lambda idx: pts[idx][0] * u[0] + pts[idx][1] * u[1])
+        lo, hi = order[0], order[-1]
+        span = (pts[hi][0] - pts[lo][0]) * u[0] + (pts[hi][1] - pts[lo][1]) * u[1]
+        n = round(span / pitch_page) + 1
+        # Label with the recogniser's nominal pitch nearest this axis' page step.
+        pitch = min(nominals, key=lambda v: abs(v - pitch_page / a.SCALE))
+        _place_pitch_dim(
+            dwg,
+            a,
+            view,
+            grid.holes[lo],
+            grid.holes[hi],
+            n,
+            pitch,
+            to_page,
+            f"dim_pitch_{view}{j}_{sub}",
+        )
+
+    _axis_dim(u1, l1, 0)
+    _axis_dim(u2, l2, 1)
+
+
+def _place_pitch_dim(dwg, a: Analysis, view, h1, h2, n, pitch, to_page, name):
+    """Pitch dimension between two hole centres ``h1``→``h2``, labelled
+    ``(n-1)× pitch``, placed just outside the view on the side of the row's
+    outward perpendicular (#92)."""
+    p1 = to_page(h1)
+    p2 = to_page(h2)
     ux, uy = p2[0] - p1[0], p2[1] - p1[1]
     norm = math.hypot(ux, uy)
     if norm < 1e-9:
@@ -1723,7 +1805,7 @@ def _add_pitch_dim(dwg, a: Analysis, view, j, pattern, to_page):
         pref = (-0.3, 1.0) if view == "plan" else (-0.3, -1.0)
         side, reach = max(cands, key=lambda c: c[0][0] * pref[0] + c[0][1] * pref[1])
     # stack further pitch dims in this view on outer tiers
-    prior = sum(1 for name in dwg._named if name.startswith(f"dim_pitch_{view}"))
+    prior = sum(1 for nm in dwg._named if nm.startswith(f"dim_pitch_{view}"))
     offset = reach + 8 + 10 * prior
     # never force-place: skip (and log) when the dim line would leave the page
     ox = mid[0] + side[0] * (offset + 6)
@@ -1731,11 +1813,10 @@ def _add_pitch_dim(dwg, a: Analysis, view, j, pattern, to_page):
     if not (a.margin <= ox <= a.PAGE_W - a.margin and a.margin <= oy <= a.PAGE_H - a.margin):
         _log.info(
             "Pitch dimension for the %s× %s array skipped (no room)",
-            len(pattern.holes),
-            _fmt(pattern.pitch),
+            n,
+            _fmt(pitch),
         )
         return
-    n = len(pattern.holes)
     dwg.add(
         _dim(
             (p1[0], p1[1], 0),
@@ -1743,9 +1824,9 @@ def _add_pitch_dim(dwg, a: Analysis, view, j, pattern, to_page):
             side,
             offset,
             dwg.draft,
-            label=f"{n - 1}× {_fmt(pattern.pitch)}",
+            label=f"{n - 1}× {_fmt(pitch)}",
         ),
-        f"dim_pitch_{view}{j}",
+        name,
         view=view,
     )
 
@@ -1835,10 +1916,29 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=Non
         for h in a.holes
     )
 
-    # A pattern annotates only when it accounts for the whole spec group —
-    # a 7th same-size hole off the circle would make "7× ... EQ SP ON BC"
-    # a lie about six of them.
-    patterns = {frozenset(p.holes): p for p in found_patterns}
+    # v0.12.0 sub-clusters a machining-spec group into >=0 patterns: a filled
+    # lattice -> one RectGrid, a rectangular perimeter -> its edge LinearArray
+    # rows, plus a same-spec second bolt circle, etc.  Each hole belongs to at
+    # most one pattern, so map hole -> pattern and split every spec group into
+    # one callout PER pattern + one for the leftover unpatterned holes (#92).
+    hole_pattern = {h: p for p in found_patterns for h in p.holes}
+
+    def _subspecs(holes):
+        """Split a spec group's holes into ``(subholes, pattern)`` entries — one
+        per recognised pattern (its full hole set) plus a trailing ``(rest,
+        None)`` for any holes no pattern claimed."""
+        by_pat: dict = {}
+        remainder = []
+        for h in holes:
+            p = hole_pattern.get(h)
+            if p is None:
+                remainder.append(h)
+            else:
+                by_pat.setdefault(p, []).append(h)
+        out = [(list(p.holes), p) for p in by_pat]
+        if remainder:
+            out.append((remainder, None))
+        return out
 
     def _build_callout(holes, pattern):
         h = holes[0]
@@ -1850,9 +1950,12 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=Non
             )
             step = h.cbore
         through = h.bottom == "through"
-        suffix = (
-            f"EQ SP ON ø{_fmt(pattern.diameter)} BC" if isinstance(pattern, BoltCircle) else None
-        )
+        if isinstance(pattern, BoltCircle):
+            suffix = f"EQ SP ON ø{_fmt(pattern.diameter)} BC"
+        elif isinstance(pattern, RectGrid):
+            suffix = f"({pattern.rows}×{pattern.cols})"
+        else:
+            suffix = None
         return HoleCallout(
             _fmt(h.diameter),
             count=len(holes) if len(holes) > 1 else None,
@@ -1891,8 +1994,8 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=Non
         to_page = view_of_axis[{"plan": "z", "front": "y", "side": "x"}[view]][1]
         specs = []
         for holes in view_groups:
-            pattern = patterns.get(frozenset(holes))
-            specs.append((holes, _build_callout(holes, pattern), pattern))
+            for subholes, pattern in _subspecs(holes):
+                specs.append((subholes, _build_callout(subholes, pattern), pattern))
         # No fixed cap (#36): every spec is attempted; the per-view placement
         # bounds below (front-view shaft rows, plan/side strip Y-solver) are the
         # real limit, and any callout that genuinely doesn't fit surfaces as

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1532,7 +1532,20 @@ def _annotations_out_of_bounds(dwg, a, tol: float = 1.0) -> bool:
     (#92).  Only view-owned annotations count — those are what a repack can move
     by escalating the sheet."""
     lo, hi_x, hi_y = a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin
-    for _name, _view, bb, _label in _attribute_annotations(dwg, a):
+    for name, o in dwg._named.items():
+        if dwg._anno_view.get(name) not in ("front", "plan", "side"):
+            continue
+        # Match the lint, which tests each item's FULL bounding_box (extension
+        # lines, arrowheads, leader + balloon ring) — not just the label rect —
+        # so a dimension whose extension lines overrun the page is caught too.
+        try:
+            b = o.bounding_box()
+            bb = (b.min.X, b.min.Y, b.max.X, b.max.Y)
+        except Exception:  # noqa: BLE001 — fall back to the label rect, else skip
+            lb = getattr(o, "label_bbox", None)
+            if lb is None:
+                continue
+            bb = lb
         if bb[0] < lo - tol or bb[1] < lo - tol or bb[2] > hi_x + tol or bb[3] > hi_y + tol:
             return True
     return False
@@ -2265,9 +2278,11 @@ class Drawing:
         # iso/section notes) carry no view.
         self._anno_view: dict = {}
         # Names of bore callouts that document a recognised hole pattern (a
-        # grouped ``n× ⌀`` callout). The hole-table escalation keeps these and
-        # tabulates only the unpatterned holes (#92).
+        # grouped ``n× ⌀`` callout), and the holes those placed callouts cover.
+        # The hole-table escalation keeps these callouts and tabulates only the
+        # holes no placed pattern callout documents (#92).
         self._pattern_callouts: set = set()
+        self._patterned_holes: set = set()
         # One per-drawing cache for lint_drawing's per-view edge bboxes, keyed on
         # id(view shape). repair() / lint_summary() lint the SAME projected view
         # objects (self.views) repeatedly, so persisting it recomputes each

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -49,6 +49,7 @@ from build123d import (
 )
 from build123d_drafting.features import (
     BoltCircle,
+    RectGrid,
     _full_cyls,
     _spec_key,
     analyse_cylinders,
@@ -1103,12 +1104,22 @@ def _est_bore_callout_width(
     for h in holes:
         groups.setdefault(_spec_key(h), []).append(h)
 
-    # Map spec_key → BoltCircle so BoltCircle groups get their suffix estimated.
-    bc_by_spec: dict = {}
+    # Map spec_key → the widest pattern-callout suffix, so a spec's grouped
+    # callout reserves room for it. A spec can sub-cluster into several patterns
+    # (#92); the BoltCircle "EQ SP ON ø… BC" is wider than a RectGrid "(r×c)",
+    # so the widest wins (the corridor must hold the longest callout).
+    suffix_by_spec: dict = {}
     if patterns:
         for p in patterns:
             if isinstance(p, BoltCircle):
-                bc_by_spec[_spec_key(p.holes[0])] = p
+                s = f"EQ SP ON ø{_fmt(p.diameter)} BC"
+            elif isinstance(p, RectGrid):
+                s = f"({p.rows}×{p.cols})"
+            else:
+                continue
+            key = _spec_key(p.holes[0])
+            if len(s) > len(suffix_by_spec.get(key, "")):
+                suffix_by_spec[key] = s
 
     h_fs = font_size
     # gap (inter-token spacing) and sym_w (geometry-symbol cell width) mirror
@@ -1144,10 +1155,11 @@ def _est_bore_callout_width(
                 token_w.append(sym_w)  # depth symbol
                 token_w.append(_text_width(_fmt(step.depth), h_fs))
 
-        # BoltCircle suffix: "EQ SP ON ø{bc_dia} BC"
-        bc = bc_by_spec.get(spec_key)
-        if bc is not None:
-            token_w.append(_text_width(f"EQ SP ON ø{_fmt(bc.diameter)} BC", h_fs))
+        # Pattern callout suffix ("EQ SP ON ø… BC" / "(r×c)"), when this spec
+        # group is recognised as a pattern.
+        suffix = suffix_by_spec.get(spec_key)
+        if suffix is not None:
+            token_w.append(_text_width(suffix, h_fs))
 
         n = len(token_w)
         w = sum(token_w) + max(n - 1, 0) * gap + pad
@@ -2237,6 +2249,10 @@ class Drawing:
         # ownership from page coordinates.  Drawing-level marks (title block,
         # iso/section notes) carry no view.
         self._anno_view: dict = {}
+        # Names of bore callouts that document a recognised hole pattern (a
+        # grouped ``n× ⌀`` callout). The hole-table escalation keeps these and
+        # tabulates only the unpatterned holes (#92).
+        self._pattern_callouts: set = set()
         # One per-drawing cache for lint_drawing's per-view edge bboxes, keyed on
         # id(view shape). repair() / lint_summary() lint the SAME projected view
         # objects (self.views) repeatedly, so persisting it recomputes each

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1523,6 +1523,21 @@ def _cross_view_overlaps(dwg, a) -> int:
     return n
 
 
+def _annotations_out_of_bounds(dwg, a, tol: float = 1.0) -> bool:
+    """True when any view-owned annotation's footprint extends past the drawable
+    area — the second repack trigger besides cross-view overlap.  A ballooned
+    plan view can overflow the page top (the balloon ring) without crossing
+    another view, so the page must still escalate; the measure-and-repack pass
+    re-sizes it because the overflowing balloons are part of the plan footprint
+    (#92).  Only view-owned annotations count — those are what a repack can move
+    by escalating the sheet."""
+    lo, hi_x, hi_y = a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin
+    for _name, _view, bb, _label in _attribute_annotations(dwg, a):
+        if bb[0] < lo - tol or bb[1] < lo - tol or bb[2] > hi_x + tol or bb[3] > hi_y + tol:
+            return True
+    return False
+
+
 def _measure_blocks(dwg, a) -> dict:
     """Measure each orthographic view's *actual* annotation footprint from the
     laid-out drawing (#121, ADR 0004 — "lay out, don't predict").
@@ -3412,11 +3427,12 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
     fitness is *do the packed disjoint blocks fit*).
 
     Returns ``(a2, dwg2)`` for the repacked drawing, or ``None`` when pass 1 has
-    no cross-view overlap (the common case — a clean sheet is left exactly as
-    placed, so well-estimated parts stay byte-identical) or when the repack would
-    change nothing (same sheet/scale and no view actually moves).
+    no cross-view overlap AND nothing overflows the drawable (the common case — a
+    clean sheet is left exactly as placed, so well-estimated parts stay
+    byte-identical) or when the repack would change nothing (same sheet/scale and
+    no view actually moves).
     """
-    if _cross_view_overlaps(dwg, a) == 0:
+    if _cross_view_overlaps(dwg, a) == 0 and not _annotations_out_of_bounds(dwg, a):
         return None
     blocks = _measure_blocks(dwg, a)
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1257,6 +1257,76 @@ class TestComposeThenPackRepack:
         assert "tag3" not in dwg._anno_view
 
 
+class TestHolePatternCallouts:
+    """Grouped pattern callouts from the helpers v0.12.0 recognition (RectGrid +
+    sub-clustered LinearArrays): a recognised set collapses to one ``n× ⌀``
+    callout plus its pattern dimensions, never per-hole balloons/table (#92,
+    #111). Coverage lint stays quiet because the grouped callout carries the
+    full diameter count."""
+
+    @staticmethod
+    def _grid_part():
+        # 2 rows × 4 cols of ⌀8 through-holes; 20 mm pitch one way, 25 mm the
+        # other → a single RectGrid(2×4).
+        part = Box(140, 70, 12)
+        for r in range(2):
+            for c in range(4):
+                part -= Pos(-37.5 + c * 25, -10 + r * 20, 0) * Cylinder(4, 12)
+        return part
+
+    @staticmethod
+    def _perimeter_part():
+        # Rectangular perimeter of ⌀6 holes — five along the top and bottom
+        # edges (recognised as two LinearArrays), the rest unpatterned.
+        part = Box(140, 100, 12)
+        pos = set()
+        for x in (-50, -25, 0, 25, 50):
+            pos.add((x, -35))
+            pos.add((x, 35))
+        for y in (-35, 0, 35):
+            pos.add((-50, y))
+            pos.add((50, y))
+        for x, y in pos:
+            part -= Pos(x, y, 0) * Cylinder(3, 12)
+        return part
+
+    @pytest.mark.timeout(120)
+    def test_rect_grid_one_callout_and_two_pitch_dims(self):
+        dwg = build_drawing(self._grid_part())
+        named = dwg._named
+        hc = [n for n in named if n.startswith("hc_")]
+        pitch = [n for n in named if n.startswith("dim_pitch_")]
+        # one grouped callout covering all eight holes — not eight callouts
+        assert len(hc) == 1, f"expected one grouped callout, got {hc}"
+        assert named[hc[0]].covers_count == 8
+        assert named[hc[0]].covers_diameters == (8.0,)
+        # both grid pitch dimensions, labelled (n-1)× pitch
+        assert len(pitch) == 2, f"expected two pitch dims, got {pitch}"
+        assert {named[n].label for n in pitch} == {"1× 20", "3× 25"}
+        # the grouped callout replaces — never coexists with — per-hole furniture
+        assert not [n for n in named if n.startswith("balloon")]
+        assert not [n for n in named if "table" in n]
+
+    @pytest.mark.timeout(120)
+    def test_rect_grid_coverage_lint_quiet(self):
+        codes = {i.code for i in build_drawing(self._grid_part()).lint()}
+        assert "feature_not_dimensioned" not in codes
+        assert "feature_count_mismatch" not in codes
+
+    @pytest.mark.timeout(120)
+    def test_perimeter_rows_dimensioned_not_per_hole(self):
+        dwg = build_drawing(self._perimeter_part())
+        named = dwg._named
+        pitch = [n for n in named if n.startswith("dim_pitch_")]
+        # each recognised edge row (5 holes, pitch 25) gets its own pitch dim
+        assert len(pitch) >= 2, f"expected the edge rows dimensioned, got {pitch}"
+        assert any(named[n].label == "4× 25" for n in pitch)
+        # the rows are not exploded into a per-hole table / balloons
+        assert not [n for n in named if n.startswith("balloon")]
+        assert not [n for n in named if "table" in n]
+        assert "feature_not_dimensioned" not in {i.code for i in dwg.lint()}
+
+
 # ---------------------------------------------------------------------------
 # Integration test — requires build123d + OCP (slow)
 # ---------------------------------------------------------------------------

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1161,6 +1161,25 @@ class TestComposeThenPackRepack:
         )
         assert _cross_view_overlaps(dwg, None) == 0
 
+    # --- out-of-bounds escalation trigger (#92) ---------------------------
+
+    def test_out_of_bounds_trigger(self):
+        # The second repack trigger: a view-owned annotation past the drawable
+        # (e.g. a ballooned plan view overflowing the page top) escalates even
+        # without a cross-view overlap. Untagged overflow is ignored — a repack
+        # can only move view-owned annotations.
+        from types import SimpleNamespace
+
+        from draftwright.make_drawing import _annotations_out_of_bounds
+
+        a = SimpleNamespace(margin=10.0, PAGE_W=200.0, PAGE_H=100.0)
+        inb = self._fake_dwg({"d": self._line((20, 20, 40, 40))}, {"d": "plan"})
+        assert not _annotations_out_of_bounds(inb, a)
+        over = self._fake_dwg({"d": self._line((20, 20, 40, 120))}, {"d": "plan"})
+        assert _annotations_out_of_bounds(over, a)
+        untagged = self._fake_dwg({"d": self._line((20, 20, 40, 120))}, {"d": "iso"})
+        assert not _annotations_out_of_bounds(untagged, a)
+
     # --- disjoint block packing ------------------------------------------
 
     def test_repacked_blocks_are_disjoint(self):
@@ -1303,6 +1322,15 @@ class TestHolePatternCallouts:
         # both grid pitch dimensions, labelled (n-1)× pitch
         assert len(pitch) == 2, f"expected two pitch dims, got {pitch}"
         assert {named[n].label for n in pitch} == {"1× 20", "3× 25"}
+        # each dim runs ALONG one lattice axis — its endpoints share a coordinate
+        # — not diagonally across the grid; and the two are perpendicular.
+        axes = set()
+        for n in pitch:
+            sp = named[n]._dw_spec
+            dx, dy = abs(sp.p1[0] - sp.p2[0]), abs(sp.p1[1] - sp.p2[1])
+            assert dx < 0.5 or dy < 0.5, f"{n} drawn diagonally: p1={sp.p1} p2={sp.p2}"
+            axes.add("vertical" if dx < 0.5 else "horizontal")
+        assert axes == {"vertical", "horizontal"}, f"grid dims not perpendicular: {axes}"
         # the grouped callout replaces — never coexists with — per-hole furniture
         assert not [n for n in named if n.startswith("balloon")]
         assert not [n for n in named if "table" in n]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1336,6 +1336,33 @@ class TestHolePatternCallouts:
         assert not [n for n in named if "table" in n]
 
     @pytest.mark.timeout(120)
+    def test_rect_grid_pitch_dims_not_diagonal_when_rotated(self):
+        # Regression guard for the high-aspect ROTATED grid: each pitch dim must
+        # measure along one lattice edge (endpoint span == label span), not
+        # corner-to-corner. A 2×5 grid (10 × 45 pitch) rotated 25° — the short-
+        # axis dim spans 10 mm; the diagonal bug would make it ~180 mm.
+        ang = math.radians(25)
+        ca, sa = math.cos(ang), math.sin(ang)
+        part = Box(220, 120, 12)
+        for r in range(2):
+            for c in range(5):
+                x, y = (c - 2) * 45, (r - 0.5) * 10
+                part -= Pos(x * ca - y * sa, x * sa + y * ca, 0) * Cylinder(4, 12)
+        dwg = build_drawing(part)
+        scale = dwg._analysis.SCALE
+        pitch = [n for n in dwg._named if n.startswith("dim_pitch_")]
+        assert len(pitch) == 2, f"expected two grid pitch dims, got {pitch}"
+        for n in pitch:
+            dim = dwg._named[n]
+            sp = dim._dw_spec
+            span = math.hypot(sp.p2[0] - sp.p1[0], sp.p2[1] - sp.p1[1]) / scale
+            k, p = dim.label.split("× ")
+            expected = int(k) * float(p)
+            assert abs(span - expected) < 1.0, (
+                f"{n} ({dim.label!r}) endpoint span {span:.1f} ≠ {expected:.1f} — drawn diagonally"
+            )
+
+    @pytest.mark.timeout(120)
     def test_rect_grid_coverage_lint_quiet(self):
         codes = {i.code for i in build_drawing(self._grid_part()).lint()}
         assert "feature_not_dimensioned" not in codes

--- a/uv.lock
+++ b/uv.lock
@@ -94,14 +94,14 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.11.0"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/35/5a8369096fd96f687b74dfd60dfe3b20cedfbc782c5eedaef8c8d89887b8/build123d_drafting_helpers-0.11.0.tar.gz", hash = "sha256:659663fe2db7cfae71cccfa61ade1793b3c065ed62b77b5f45fe61db4c5b56a6", size = 117889, upload-time = "2026-06-20T11:01:45.979Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/d8/a82b2101c46f4554e8af4225e615bba8dac934d3a9c79340ae9da22d862a/build123d_drafting_helpers-0.12.0.tar.gz", hash = "sha256:629b19117021c4cc3380e850a8d93849aa8177ef0b061a66b1cb859671abc153", size = 122101, upload-time = "2026-06-21T03:35:25.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/44/8b4656fd593d18036c26470a87fb8678778b9746e250091af1ea2503278d/build123d_drafting_helpers-0.11.0-py3-none-any.whl", hash = "sha256:5747e8556daf199ab536613f85d62e2dec9a65b1558327f78921c1c87fce2010", size = 65119, upload-time = "2026-06-20T11:01:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/aa/bb310375dbdfcd56b341eb6f23d444da33f87b19edc7e7f6e2901e97a3dd/build123d_drafting_helpers-0.12.0-py3-none-any.whl", hash = "sha256:feebebb80b078b0b5cc31e8ece3f906e8a7a8b551dc7ce32a0ceaf524afc4adf", size = 67530, upload-time = "2026-06-21T03:35:23.949Z" },
 ]
 
 [[package]]
@@ -599,7 +599,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "build123d", specifier = ">=0.9.0" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.11.0" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.12.0" },
     { name = "cairosvg", marker = "extra == 'pdf'", specifier = ">=2.7" },
     { name = "kiwisolver", specifier = ">=1.4,<2" },
     { name = "numpy", specifier = ">=1.24" },


### PR DESCRIPTION
## What

`build123d-drafting-helpers` 0.12.0's `find_hole_patterns` now **sub-clusters** a machining-spec group into multiple patterns — a rectangular perimeter → its edge `LinearArray` rows, a filled lattice → one `RectGrid`, a same-spec second bolt circle, etc. — instead of fitting the whole group as one pattern or returning nothing. This PR makes draftwright consume that, so a regularly-drilled part produces **grouped pattern callouts + pattern dimensions** instead of a per-hole table with a balloon on every hole (#111).

## Changes

- **Dependency** → floor bumped to `>=0.12.0`; `uv.lock` updated.
- **Spec-group dispatch** (`annotate.py`) — map each hole to its (≤1) pattern and split every spec group into **one grouped callout per pattern + one remainder callout** for the unpatterned holes. Replaces the old one-pattern-per-*whole-group* assumption (`patterns.get(frozenset(group))`) that returned `None` for a sub-clustered group and ballooned everything.
- **RectGrid** — callout suffix `(rows×cols)` and **both** pitch dimensions (`(n-1)× pitch`), placed through the existing zone layout (new `_add_grid_pitch_dims`; `_add_pitch_dim` generalised to `_place_pitch_dim`). The two lattice axes are recovered from the holes only to pick dimension endpoints — recognition stays upstream (layer separation).
- **Hole-table collapse** (`_maybe_tabulate_holes`) — tabulate/balloon only the **genuinely unpatterned** plan-view holes; the grouped pattern callouts are preserved (`_pattern_callouts`).
- **Coverage lint** stays quiet for patterned holes (the grouped callout carries the full diameter count); `_est_bore_callout_width` reserves the widest pattern suffix per spec.
- **Page escalation** — broadened the #121 measure-and-repack trigger to also fire when a view-owned annotation overflows the drawable (`_annotations_out_of_bounds`), not only on cross-view overlap. With fewer balloons CTC-02 picked a smaller sheet, and the remaining 22-balloon ring overflowed the page top without crossing another view; the repack now re-sizes/re-centres so it fits.

## Results — NIST CTC-02 (geometry fixture)

- `find_hole_patterns` → **14 patterns (10 LinearArray + 4 BoltCircle), 51/83 holes** (matches the upstream validation).
- The ⌀10.1 perimeter and ⌀8.38 ring collapse to grouped callouts + pitch/bolt-circle furniture.
- Per-hole table shrinks from **61 rows → the ~22-hole unpatterned remainder**; coverage lint clean; fits A1.

## Tests

- `TestHolePatternCallouts` (geometry-level): a `RectGrid` part → one grouped callout + two pitch dims; a perimeter → edge rows dimensioned, not per-hole; coverage lint quiet.
- Full suite (fast + all slow CTC): **394 passed**. ruff + ruff-format + mypy clean.

## Not in scope

- Over-long top-side balloon leaders / tightening the ring to keep CTC-02 on a smaller sheet — separate cosmetic **#125**.
- `label_centerline_overlap` warnings — pre-existing **#119** (blocked on helpers#161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)