### PR TITLE
[codex] Fix README drawing export example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ make_drawing(part, out="drawing", title="My Part", number="DWG-001")
 # Composable: get a Drawing object to inspect or extend
 dwg = build_drawing(part, title="My Part")
 issues = dwg.lint()          # list[LintIssue]
-dwg.export_svg("drawing.svg")
-dwg.export_dxf("drawing.dxf")
+svg_path, dxf_path = dwg.export("drawing")
 ```
 
 ### From a STEP file


### PR DESCRIPTION
## Summary
- Replace nonexistent `Drawing.export_svg()` / `Drawing.export_dxf()` calls in the README with the actual `Drawing.export()` API.

## Why
The composable usage example currently fails if copied because `Drawing` exposes `export()` for SVG/DXF output, not separate export methods.

Closes #137.

## Validation
- `git diff --check`
- `rg -n "export_svg|export_dxf|dwg\.export\(" README.md src tests`
- Existing full pytest run from this session: `386 passed, 1 skipped, 11 deselected`