### PR TITLE
feat(#135): recognise and dimension enclosed milled slots

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -362,6 +362,7 @@ class Analysis:
     bbox_max: float
     holes: list
     patterns: list
+    slots: list
     z_diams: list[float]
     cross_diams: list[float]
     cyls: tuple[list, list]

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -638,6 +638,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     if feature_holes:
         _locate_off_axis_holes(dwg, a, holes_in=feature_holes)
 
+    # Non-cylindrical machined features: slots / reduced across-flats sections
+    # (#135). Runs after every hole/diameter pass so it claims strip space last.
+    _annotate_slots(dwg, a)
+
     # Phase 7 — strip footprint debug logging + post-placement overflow check.
     # Overflow can only occur when outer_limit was tightened after allocations
     # were already committed (e.g. iso-x tightening or iso-y cap guard).
@@ -1484,6 +1488,127 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None):
             for strip, view, p_lo, p_hi, edge in order
         ):
             _drop("Z", order[0][1])
+
+
+def _annotate_slots(dwg, a: Analysis):
+    """Dimension milled slots / reduced across-flats sections (#135).
+
+    Each recognised slot (``features.find_slots``) is dimensioned in the
+    orthographic view whose two in-plane axes are the slot's ``width_axis`` and
+    ``long_axis``: the *width* (the defining size) across ``width_axis``, its
+    *length* along ``long_axis``, and one *position* dim from the part datum.
+    Width measured along the view's vertical axis is placed in the right strip
+    (falling back to left), along the horizontal axis in the above strip
+    (falling back to below); length/position take the orthogonal strips.
+
+    Runs after the envelope, turned-diameter and hole passes, so it claims strip
+    space last and never evicts a primary dimension.  A dim with no clear room
+    is dropped and recorded at info severity under ``slot_dim_dropped`` — the
+    sheet stays correct (place-what-fits, as #133/#144); the gap is a
+    completeness shortfall, not a drawing defect.
+    """
+    if not a.slots:
+        return
+    draft = dwg.draft
+    occupied = _occupied_boxes(dwg)
+    tier = draft.font_size + 2 * draft.pad_around_text
+
+    # (view name, zones, horizontal axis + projector, vertical axis + projector)
+    views = {
+        frozenset("xy"): ("plan", a.pv_zones, "x", a.proj.plan_x, "y", a.proj.plan_y),
+        frozenset("xz"): ("front", a.fv_zones, "x", a.proj.front_x, "z", a.proj.front_z),
+        frozenset("yz"): ("side", a.sv_zones, "y", a.proj.side_x, "z", a.proj.side_z),
+    }
+
+    def _bb(axis, hi):
+        return getattr(a.bb.max if hi else a.bb.min, axis.upper())
+
+    def _drop(kind, view):
+        dwg._record_build_issue(
+            "info",
+            "slot_dim_dropped",
+            f"slot {kind} dim not placed (no room beside the {view} view)",
+        )
+
+    for i, s in enumerate(a.slots):
+        # width_axis and long_axis are always two distinct orthographic axes
+        # (find_slots derives long_axis from the axes other than width_axis), so
+        # the pair always selects exactly one view.
+        view = views[frozenset((s.width_axis, s.long_axis))]
+        name, zones, h_axis, h_proj, v_axis, v_proj = view
+
+        def _place(
+            meas_axis,
+            p_lo,
+            p_hi,
+            label,
+            kind,
+            anchor="center",
+            vw=view,
+            zn=zones,
+            ha=h_axis,
+            hp=h_proj,
+            va=v_axis,
+            vp=v_proj,
+            idx=i,
+        ):
+            # Snap the dimension's geometric span to its *displayed* value so the
+            # drawn length matches the (1-dp) label exactly — otherwise a true
+            # 4.75 mm feature, labelled "4.8", trips the label-vs-measured lint.
+            # ``center`` snaps symmetrically (a size dim); ``lo`` keeps p_lo fixed
+            # (a position dim anchored on the datum).
+            disp = float(_fmt(label))
+            sgn = 1.0 if p_hi >= p_lo else -1.0
+            if anchor == "center":
+                mid = (p_lo + p_hi) / 2
+                p_lo, p_hi = mid - sgn * disp / 2, mid + sgn * disp / 2
+            else:
+                p_hi = p_lo + sgn * disp
+            # Horizontal measurement (along the view's h-axis) stacks above the
+            # view; vertical (along the v-axis) stacks to the right. Fall back to
+            # the opposite strip before giving up.
+            if meas_axis == ha:
+                meas_proj, perp_axis, perp_proj = hp, va, vp
+                cands = (("above", zn.above, True), ("below", zn.below, False))
+            else:
+                meas_proj, perp_axis, perp_proj = vp, ha, hp
+                cands = (("right", zn.right, True), ("left", zn.left, False))
+            for side, strip, hi in cands:
+                coord = strip.allocate(tier) if strip is not None else None
+                if coord is None:
+                    continue
+                witness = perp_proj(_bb(perp_axis, hi))
+                if side in ("above", "below"):
+                    e_lo = (meas_proj(p_lo), witness, 0)
+                    e_hi = (meas_proj(p_hi), witness, 0)
+                else:
+                    e_lo = (witness, meas_proj(p_lo), 0)
+                    e_hi = (witness, meas_proj(p_hi), 0)
+                dim = _dim(e_lo, e_hi, side, abs(coord - witness), draft, label=_fmt(label))
+                if _box_hits(_anno_box(dim), occupied):
+                    continue
+                dwg.add(dim, f"slot{idx}_{kind}", view=vw[0])
+                occupied.append(_anno_box(dim))
+                return True
+            return False
+
+        # Width — the defining size, always attempted.
+        half = s.width / 2
+        if not _place(s.width_axis, s.w_center - half, s.w_center + half, s.width, "width"):
+            _drop("width", name)
+
+        # Length along the slot's long axis (find_slots already excludes full-span
+        # open features, so the length is always a real, sub-envelope measurement).
+        if not _place(s.long_axis, s.lo, s.hi, s.length, "length"):
+            _drop("length", name)
+
+        # Position: from the part datum (min on the long axis, the same datum the
+        # hole-location dims use) to the slot's near edge — its lo, the edge
+        # closer to that datum. Skipped when the slot abuts the datum.
+        datum = _bb(s.long_axis, False)
+        if (s.lo - datum) * a.SCALE >= 1.0:
+            if not _place(s.long_axis, datum, s.lo, s.lo - datum, "pos", anchor="lo"):
+                _drop("position", name)
 
 
 def _section_hatch_edges(face, SX, SZ, spacing):

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -1510,7 +1510,14 @@ def _annotate_slots(dwg, a: Analysis):
     if not a.slots:
         return
     draft = dwg.draft
-    occupied = _occupied_boxes(dwg)
+    # Two occupancy sets with different collision tests (#146 re-review):
+    #  - ``external`` (callouts, envelope dims, hatch) is tested against the
+    #    candidate's FULL geometry, so a slot dim's witness/arrow line may not
+    #    cross another feature's label even though the label boxes clear;
+    #  - ``placed`` (this pass's own slot dims) is tested label-box to label-box,
+    #    so sibling dims may still stack in a shared strip corridor.
+    external = _occupied_boxes(dwg)
+    placed: list = []
     tier = draft.font_size + 2 * draft.pad_around_text
 
     # (view name, zones, horizontal axis + projector, vertical axis + projector)
@@ -1523,11 +1530,11 @@ def _annotate_slots(dwg, a: Analysis):
     def _bb(axis, hi):
         return getattr(a.bb.max if hi else a.bb.min, axis.upper())
 
-    def _drop(kind, view):
+    def _drop(kind, idx, view):
         dwg._record_build_issue(
             "info",
             "slot_dim_dropped",
-            f"slot {kind} dim not placed (no room beside the {view} view)",
+            f"slot{idx} {kind} dim not placed (no room beside the {view} view)",
         )
 
     for i, s in enumerate(a.slots):
@@ -1595,11 +1602,13 @@ def _annotate_slots(dwg, a: Analysis):
                     e_lo = (witness, meas_proj(p_lo), 0)
                     e_hi = (witness, meas_proj(p_hi), 0)
                 dim = _dim(e_lo, e_hi, side, abs(coord - witness), draft, label=_fmt(label))
-                if _box_hits(_anno_box(dim), occupied):
+                gbb = dim.bounding_box()
+                full = (gbb.min.X, gbb.min.Y, gbb.max.X, gbb.max.Y)
+                if _box_hits(full, external) or _box_hits(_anno_box(dim), placed):
                     continue
                 strip.allocate(tier)
                 dwg.add(dim, f"slot{idx}_{kind}", view=vw[0])
-                occupied.append(_anno_box(dim))
+                placed.append(_anno_box(dim))
                 return True
             return False
 
@@ -1609,7 +1618,7 @@ def _annotate_slots(dwg, a: Analysis):
         if not _place(
             s.width_axis, s.w_center - half, s.w_center + half, s.lo, s.hi, s.width, "width"
         ):
-            _drop("width", name)
+            _drop("width", i, name)
 
         # Length along the slot's long axis (find_slots excludes full-span open
         # features, so length is always a real, sub-envelope measurement); its
@@ -1617,7 +1626,7 @@ def _annotate_slots(dwg, a: Analysis):
         if not _place(
             s.long_axis, s.lo, s.hi, s.w_center - half, s.w_center + half, s.length, "length"
         ):
-            _drop("length", name)
+            _drop("length", i, name)
 
         # Position: from the part datum (min on the long axis, the same datum the
         # hole-location dims use) to the slot's near edge — its lo, the edge
@@ -1634,7 +1643,7 @@ def _annotate_slots(dwg, a: Analysis):
                 "pos",
                 anchor="lo",
             ):
-                _drop("position", name)
+                _drop("position", i, name)
 
 
 def _section_hatch_edges(face, SX, SZ, spacing):

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -1535,12 +1535,14 @@ def _annotate_slots(dwg, a: Analysis):
         # (find_slots derives long_axis from the axes other than width_axis), so
         # the pair always selects exactly one view.
         view = views[frozenset((s.width_axis, s.long_axis))]
-        name, zones, h_axis, h_proj, v_axis, v_proj = view
+        name, zones, h_axis, h_proj, _v_axis, v_proj = view
 
         def _place(
             meas_axis,
             p_lo,
             p_hi,
+            perp_lo,
+            perp_hi,
             label,
             kind,
             anchor="center",
@@ -1548,7 +1550,6 @@ def _annotate_slots(dwg, a: Analysis):
             zn=zones,
             ha=h_axis,
             hp=h_proj,
-            va=v_axis,
             vp=v_proj,
             idx=i,
         ):
@@ -1568,16 +1569,25 @@ def _annotate_slots(dwg, a: Analysis):
             # view; vertical (along the v-axis) stacks to the right. Fall back to
             # the opposite strip before giving up.
             if meas_axis == ha:
-                meas_proj, perp_axis, perp_proj = hp, va, vp
+                meas_proj, perp_proj = hp, vp
                 cands = (("above", zn.above, True), ("below", zn.below, False))
             else:
-                meas_proj, perp_axis, perp_proj = vp, ha, hp
+                meas_proj, perp_proj = vp, hp
                 cands = (("right", zn.right, True), ("left", zn.left, False))
             for side, strip, hi in cands:
-                coord = strip.allocate(tier) if strip is not None else None
+                if strip is None:
+                    continue
+                # Peek, don't allocate yet: a candidate rejected for collision
+                # below must not consume the tier (which would starve later slots
+                # and inflate the drop count).
+                coord = strip.peek(tier)
                 if coord is None:
                     continue
-                witness = perp_proj(_bb(perp_axis, hi))
+                # Witness the dimension off the slot's OWN edge (its extent on the
+                # perpendicular axis), not the part envelope — otherwise a slot's
+                # size dim is drawn across at the far edge of the part and reads
+                # as an envelope dimension (#146 review).
+                witness = perp_proj(perp_hi if hi else perp_lo)
                 if side in ("above", "below"):
                     e_lo = (meas_proj(p_lo), witness, 0)
                     e_hi = (meas_proj(p_hi), witness, 0)
@@ -1587,19 +1597,26 @@ def _annotate_slots(dwg, a: Analysis):
                 dim = _dim(e_lo, e_hi, side, abs(coord - witness), draft, label=_fmt(label))
                 if _box_hits(_anno_box(dim), occupied):
                     continue
+                strip.allocate(tier)
                 dwg.add(dim, f"slot{idx}_{kind}", view=vw[0])
                 occupied.append(_anno_box(dim))
                 return True
             return False
 
-        # Width — the defining size, always attempted.
+        # Width — the defining size, measured across width_axis; its witness
+        # rides the slot's long-axis extent.
         half = s.width / 2
-        if not _place(s.width_axis, s.w_center - half, s.w_center + half, s.width, "width"):
+        if not _place(
+            s.width_axis, s.w_center - half, s.w_center + half, s.lo, s.hi, s.width, "width"
+        ):
             _drop("width", name)
 
-        # Length along the slot's long axis (find_slots already excludes full-span
-        # open features, so the length is always a real, sub-envelope measurement).
-        if not _place(s.long_axis, s.lo, s.hi, s.length, "length"):
+        # Length along the slot's long axis (find_slots excludes full-span open
+        # features, so length is always a real, sub-envelope measurement); its
+        # witness rides the slot's width extent.
+        if not _place(
+            s.long_axis, s.lo, s.hi, s.w_center - half, s.w_center + half, s.length, "length"
+        ):
             _drop("length", name)
 
         # Position: from the part datum (min on the long axis, the same datum the
@@ -1607,7 +1624,16 @@ def _annotate_slots(dwg, a: Analysis):
         # closer to that datum. Skipped when the slot abuts the datum.
         datum = _bb(s.long_axis, False)
         if (s.lo - datum) * a.SCALE >= 1.0:
-            if not _place(s.long_axis, datum, s.lo, s.lo - datum, "pos", anchor="lo"):
+            if not _place(
+                s.long_axis,
+                datum,
+                s.lo,
+                s.w_center - half,
+                s.w_center + half,
+                s.lo - datum,
+                "pos",
+                anchor="lo",
+            ):
                 _drop("position", name)
 
 

--- a/src/draftwright/features.py
+++ b/src/draftwright/features.py
@@ -1,18 +1,28 @@
 """Recognition of non-cylindrical machined features (#135).
 
-Draftwright-local **prototype**.  It recognises milled *slots* / reduced
-across-flats sections — the class of feature the cylinder-based pipeline
-(``analyse_cylinders``/``find_holes`` in ``build123d_drafting.features``) is
-blind to.  Once the recognition predicate stabilises this is intended to be
-upstreamed into ``build123d-drafting-helpers`` beside the hole/boss recognisers;
-it deliberately mirrors their OCC face-scan idioms so the lift is mechanical.
+Draftwright-local **prototype**.  It recognises milled *slots* — the class of
+feature the cylinder-based pipeline (``analyse_cylinders``/``find_holes`` in
+``build123d_drafting.features``) is blind to.  Once the recognition predicate
+stabilises this is intended to be upstreamed into ``build123d-drafting-helpers``
+beside the hole/boss recognisers; it deliberately mirrors their OCC face-scan
+idioms so the lift is mechanical.
 
-The defining signature of a cut-in slot is a pair of **opposed parallel walls
-that face each other**: two axis-aligned planar faces with anti-parallel
-outward normals where each normal points *towards* the other face.  The part's
-own outer faces are also parallel and anti-parallel, but their outward normals
-point *away* from each other, so the facing test excludes them cleanly without
-any bounding-box / "is this an outer face" heuristic.
+Scope (deliberately narrow — see #148): only **enclosed through-slots with
+straight, rectangular walls** are recognised.  The recogniser proves a candidate
+is a slot rather than some other facing-wall feature with three predicates a
+naive "opposed facing walls" test gets wrong:
+
+1. **Facing walls** — two axis-aligned planar faces with anti-parallel outward
+   normals each pointing *towards* the other.  The part's own outer faces face
+   *away*, so this excludes them without any "is this an outer face" heuristic.
+2. **Rectangular walls** — both walls are bounded by straight (LINE) edges only.
+   A turned groove / circlip recess has *annular* walls (CIRCLE edges); this
+   rejects them (otherwise a stepped shaft's groove reads as a slot).
+3. **Through, not blind** — no planar floor caps the cut.  A blind pocket (or
+   the floored gap between two bosses) has a floor face spanning the footprint;
+   a through-slot does not.  This is what separates a slot from a pocket — a
+   distinction that is partly definitional for low-aspect features, which is why
+   blind slots and pockets are deferred to a follow-up recogniser (#148).
 """
 
 from __future__ import annotations
@@ -20,6 +30,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+from build123d import GeomType
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.GeomAbs import GeomAbs_Plane
 from OCP.TopAbs import TopAbs_Orientation
@@ -31,6 +42,11 @@ _AXIS_ALIGNED_TOL = 1e-3
 # Two slot candidates are the same physical feature when their region centres
 # coincide to within this (mm); the narrower wins (the true across-flats width).
 _MERGE_TOL = 0.5
+# A planar face counts as a slot *floor* (capping the slot, so it is blind not
+# through) when its centre on the depth axis is within this of a slot end and it
+# covers at least _FLOOR_COVER_FRAC of the slot footprint on each in-plane axis.
+_FLOOR_TOL = 0.3
+_FLOOR_COVER_FRAC = 0.5
 
 
 @dataclass(frozen=True)
@@ -102,9 +118,19 @@ def _dominant_axis(nrm):
     return None
 
 
-def _planar_walls(part):
-    """Axis-aligned planar faces as (normal, axis, bbox) tuples."""
-    walls = []
+@dataclass(frozen=True)
+class _Face:
+    """An axis-aligned planar face reduced to the data the recogniser needs."""
+
+    normal: tuple
+    axis: str
+    bb: object
+    rect: bool  # bounded by straight (LINE) edges only
+
+
+def _planar_faces(part):
+    """All axis-aligned planar faces as :class:`_Face` records (computed once)."""
+    faces = []
     for face in part.faces():
         nrm = _outward_normal(face)
         if nrm is None:
@@ -112,8 +138,9 @@ def _planar_walls(part):
         axis = _dominant_axis(nrm)
         if axis is None:
             continue
-        walls.append((nrm, axis, face.bounding_box()))
-    return walls
+        rect = all(e.geom_type == GeomType.LINE for e in face.edges())
+        faces.append(_Face(nrm, axis, face.bounding_box(), rect))
+    return faces
 
 
 def _center(bb, k):
@@ -128,79 +155,130 @@ def _overlap_len(bb_a, bb_b, axis):
     return hi - lo
 
 
-def find_slots(part) -> list[Slot]:
-    """Recognise milled slots / reduced across-flats sections in *part*.
+def _candidate(fa, fb, part_ext):
+    """Build a :class:`Slot` from two facing rectangular walls, or None if the
+    pair is not a slot (not facing, not overlapping, wider than long, or
+    spanning the full part).  Geometry only — the through/blind test is applied
+    by the caller, which needs the whole face set."""
+    axis = fa.axis
+    k = _AXES[axis]
+    bb_a, bb_b = fa.bb, fb.bb
+    # Anti-parallel outward normals.
+    if fa.normal[k] * fb.normal[k] >= 0:
+        return None
+    c_a, c_b = _center(bb_a, k), _center(bb_b, k)
+    # Facing each other: A's outward normal points towards B.  Outer faces of
+    # the stock fail this (their normals point apart).
+    if (c_b - c_a) * fa.normal[k] <= 0:
+        return None
+    # The walls must genuinely overlap in both perpendicular axes, otherwise
+    # they are unrelated faces that merely happen to be parallel and facing.
+    others = [a for a in "xyz" if a != axis]
+    ov = [_overlap_len(bb_a, bb_b, a) for a in others]
+    if min(ov) <= 0:
+        return None
+    width = abs(c_b - c_a)
+    # The longer shared extent is the slot length; the shorter is depth.  When
+    # the two are near-equal (a near-square slot) the choice is ambiguous, so
+    # break the tie towards the part's longer axis — a slot on a bar runs along
+    # the bar.
+    (ax0, ov0), (ax1, ov1) = sorted(zip(others, ov), key=lambda t: t[1], reverse=True)
+    if (ov0 - ov1) <= _LENGTH_TIE_FRAC * ov0 and part_ext[ax1] > part_ext[ax0]:
+        (long_axis, length), depth_axis = (ax1, ov1), ax0
+    else:
+        (long_axis, length), depth_axis = (ax0, ov0), ax1
+    # A slot is elongated: its width (the wall separation) is not its largest
+    # dimension.  A wider-than-long pair is a step/pocket or a sliver of two
+    # incidental parallel faces.
+    if width > length:
+        return None
+    # Reject open / full-span features along the length (see _SLOT_MAX_SPAN_FRAC).
+    if length >= _SLOT_MAX_SPAN_FRAC * part_ext[long_axis]:
+        return None
+    lc = "XYZ"[_AXES[long_axis]]
+    lo = max(getattr(bb_a.min, lc), getattr(bb_b.min, lc))
+    hi = min(getattr(bb_a.max, lc), getattr(bb_b.max, lc))
+    dc = "XYZ"[_AXES[depth_axis]]
+    d_lo = max(getattr(bb_a.min, dc), getattr(bb_b.min, dc))
+    d_hi = min(getattr(bb_a.max, dc), getattr(bb_b.max, dc))
+    return Slot(
+        width_axis=axis,
+        long_axis=long_axis,
+        width=round(width, 2),
+        length=round(hi - lo, 2),
+        w_center=round((c_a + c_b) / 2, 2),
+        lo=round(lo, 2),
+        hi=round(hi, 2),
+        d_lo=round(d_lo, 2),
+        d_hi=round(d_hi, 2),
+    )
 
-    Returns a list of :class:`Slot`, one per physical feature (co-located
-    candidate pairs are merged, keeping the narrower width).
+
+def _has_floor(faces, s: Slot) -> bool:
+    """True when a planar floor caps the slot — i.e. it is blind, not through.
+
+    A floor is a planar face perpendicular to the depth axis that sits at one of
+    the slot's depth ends, covers most of its width x length footprint, and whose
+    outward normal points *into* the slot (material lies beyond it).  That last
+    test is what distinguishes a real floor from the part's own outer face: when
+    a through-slot exits the stock, its depth end coincides with an outer face,
+    but that face's normal points *out* of the part — the slot passes through it,
+    it does not cap it.
     """
-    walls = _planar_walls(part)
+    da = s.depth_axis
+    dk = _AXES[da]
+    foot = {
+        s.width_axis: (s.w_center - s.width / 2, s.w_center + s.width / 2),
+        s.long_axis: (s.lo, s.hi),
+    }
+    for f in faces:
+        if f.axis != da:
+            continue
+        ctr = _center(f.bb, dk)
+        # A floor at the low end faces +depth (toward the slot); at the high end,
+        # -depth. The part's outer face at the same level faces the other way.
+        if abs(ctr - s.d_lo) <= _FLOOR_TOL and f.normal[dk] > 0:
+            pass
+        elif abs(ctr - s.d_hi) <= _FLOOR_TOL and f.normal[dk] < 0:
+            pass
+        else:
+            continue
+        if all(
+            min(getattr(f.bb.max, "XYZ"[_AXES[ax]]), hi)
+            - max(getattr(f.bb.min, "XYZ"[_AXES[ax]]), lo)
+            >= _FLOOR_COVER_FRAC * (hi - lo)
+            for ax, (lo, hi) in foot.items()
+        ):
+            return True
+    return False
+
+
+def find_slots(part) -> list[Slot]:
+    """Recognise enclosed through-slots with rectangular walls in *part*.
+
+    Returns a list of :class:`Slot`, one per physical feature, in a
+    deterministic order (co-located candidate pairs are merged, keeping the
+    narrower width).  See the module docstring for the recognition predicate and
+    its (deliberately narrow) scope.
+    """
+    faces = _planar_faces(part)
     pbb = part.bounding_box()
     part_ext = {a: getattr(pbb.size, "XYZ"[_AXES[a]]) for a in "xyz"}
+    # Only straight-walled faces can be slot walls; bucket them by axis so the
+    # O(n^2) pairing runs within each axis instead of across all planar faces.
+    by_axis: dict[str, list[_Face]] = {}
+    for f in faces:
+        if f.rect:
+            by_axis.setdefault(f.axis, []).append(f)
     candidates: list[Slot] = []
-    for i in range(len(walls)):
-        n_a, axis, bb_a = walls[i]
-        k = _AXES[axis]
-        for j in range(i + 1, len(walls)):
-            n_b, axis_b, bb_b = walls[j]
-            if axis_b != axis:
-                continue
-            # Anti-parallel outward normals.
-            if n_a[k] * n_b[k] >= 0:
-                continue
-            c_a, c_b = _center(bb_a, k), _center(bb_b, k)
-            # Facing each other: A's outward normal points towards B.  Outer
-            # faces of the stock fail this (their normals point apart).
-            if (c_b - c_a) * n_a[k] <= 0:
-                continue
-            # The walls must genuinely overlap in both perpendicular axes,
-            # otherwise they are unrelated faces that merely happen to be
-            # parallel and facing.
-            others = [a for a in "xyz" if a != axis]
-            ov = [_overlap_len(bb_a, bb_b, a) for a in others]
-            if min(ov) <= 0:
-                continue
-            width = abs(c_b - c_a)
-            # The longer shared extent is the slot length; the shorter is depth.
-            # When the two are near-equal (a near-square slot, e.g. a channel cut
-            # straight through a shaft) the choice is ambiguous, so break the tie
-            # towards the part's longer axis — the manufacturing "length" of a
-            # slot on a bar runs along the bar.
-            (ax0, ov0), (ax1, ov1) = sorted(zip(others, ov), key=lambda t: t[1], reverse=True)
-            if (ov0 - ov1) <= _LENGTH_TIE_FRAC * ov0 and part_ext[ax1] > part_ext[ax0]:
-                (long_axis, length), (depth_axis, _) = (ax1, ov1), (ax0, ov0)
-            else:
-                (long_axis, length), (depth_axis, _) = (ax0, ov0), (ax1, ov1)
-            # A slot is elongated: its width (the wall separation) is not its
-            # largest dimension.  Pairs wider than they are long are not slots
-            # but wide steps / pockets, or — when the overlap is a sliver —
-            # incidental parallel faces (e.g. two part faces that merely happen
-            # to face each other). Both are filtered here, before merging.
-            if width > length:
-                continue
-            # Reject open / full-span features (an enclosed slot is shorter than
-            # the part along its length — see _SLOT_MAX_SPAN_FRAC).
-            if length >= _SLOT_MAX_SPAN_FRAC * part_ext[long_axis]:
-                continue
-            lc = "XYZ"[_AXES[long_axis]]
-            lo = max(getattr(bb_a.min, lc), getattr(bb_b.min, lc))
-            hi = min(getattr(bb_a.max, lc), getattr(bb_b.max, lc))
-            dc = "XYZ"[_AXES[depth_axis]]
-            d_lo = max(getattr(bb_a.min, dc), getattr(bb_b.min, dc))
-            d_hi = min(getattr(bb_a.max, dc), getattr(bb_b.max, dc))
-            candidates.append(
-                Slot(
-                    width_axis=axis,
-                    long_axis=long_axis,
-                    width=round(width, 2),
-                    length=round(hi - lo, 2),
-                    w_center=round((c_a + c_b) / 2, 2),
-                    lo=round(lo, 2),
-                    hi=round(hi, 2),
-                    d_lo=round(d_lo, 2),
-                    d_hi=round(d_hi, 2),
-                )
-            )
+    for walls in by_axis.values():
+        for i in range(len(walls)):
+            for j in range(i + 1, len(walls)):
+                s = _candidate(walls[i], walls[j], part_ext)
+                # Keep only through-slots: a blind pocket (or the floored gap
+                # between bosses) is capped by a floor and is out of scope (#148).
+                if s is not None and not _has_floor(faces, s):
+                    candidates.append(s)
     return _merge(candidates)
 
 
@@ -218,9 +296,13 @@ def _merge(candidates: list[Slot]) -> list[Slot]:
     """A rectangular slot is bounded by two orthogonal opposed-wall pairs (the
     width walls and the length end-caps), so the same feature is detected twice
     — once per pair.  Collapse candidates that occupy the same region, keeping
-    the one with the smallest width (the true across-flats)."""
+    the one with the smallest width (the true across-flats).
+
+    Sorted by ``(width, region_centre)`` so the output order — and therefore the
+    ``slot{i}`` annotation names downstream — is determined by geometry alone,
+    not by OCC face-iteration order (which is not stable across kernels)."""
     kept: list[Slot] = []
-    for s in sorted(candidates, key=lambda c: c.width):
+    for s in sorted(candidates, key=lambda c: (c.width, _region_center(c))):
         cs = _region_center(s)
         if any(math.dist(cs, _region_center(k)) <= _MERGE_TOL for k in kept):
             continue

--- a/src/draftwright/features.py
+++ b/src/draftwright/features.py
@@ -251,6 +251,10 @@ def _has_floor(faces, s: Slot) -> bool:
                 c = "XYZ"[_AXES[ax]]
                 ov = min(getattr(f.bb.max, c), hi) - max(getattr(f.bb.min, c), lo)
                 area *= max(ov, 0.0)
+            # Sum (not union): the coplanar floor faces of a valid solid tile the
+            # floor without overlapping, so this is exact for them.  Overlapping
+            # coplanar faces would double-count, but those only arise from a
+            # Compound of interpenetrating solids — degenerate input.
             covered += area
         if covered >= _FLOOR_COVER_FRAC * foot_area:
             return True

--- a/src/draftwright/features.py
+++ b/src/draftwright/features.py
@@ -217,13 +217,17 @@ def _candidate(fa, fb, part_ext):
 def _has_floor(faces, s: Slot) -> bool:
     """True when a planar floor caps the slot — i.e. it is blind, not through.
 
-    A floor is a planar face perpendicular to the depth axis that sits at one of
-    the slot's depth ends, covers most of its width x length footprint, and whose
-    outward normal points *into* the slot (material lies beyond it).  That last
-    test is what distinguishes a real floor from the part's own outer face: when
-    a through-slot exits the stock, its depth end coincides with an outer face,
-    but that face's normal points *out* of the part — the slot passes through it,
-    it does not cap it.
+    A floor is one or more planar faces perpendicular to the depth axis sitting
+    at one of the slot's depth ends, whose outward normals point *into* the slot
+    (material lies beyond them) and which together cover most of its width x
+    length footprint.  The into-the-slot normal test is what distinguishes a real
+    floor from the part's own outer face: a through-slot's depth end coincides
+    with an outer face, but that face's normal points *out* of the part — the
+    slot passes through it, it does not cap it.
+
+    Coverage is *aggregated* over all qualifying faces at a depth end (not tested
+    per face), so a floor split into pieces by a rib or divider — a webbed or
+    twin-cavity blind pocket — is still recognised as a floor (#146 re-review).
     """
     da = s.depth_axis
     dk = _AXES[da]
@@ -231,24 +235,24 @@ def _has_floor(faces, s: Slot) -> bool:
         s.width_axis: (s.w_center - s.width / 2, s.w_center + s.width / 2),
         s.long_axis: (s.lo, s.hi),
     }
-    for f in faces:
-        if f.axis != da:
-            continue
-        ctr = _center(f.bb, dk)
-        # A floor at the low end faces +depth (toward the slot); at the high end,
-        # -depth. The part's outer face at the same level faces the other way.
-        if abs(ctr - s.d_lo) <= _FLOOR_TOL and f.normal[dk] > 0:
-            pass
-        elif abs(ctr - s.d_hi) <= _FLOOR_TOL and f.normal[dk] < 0:
-            pass
-        else:
-            continue
-        if all(
-            min(getattr(f.bb.max, "XYZ"[_AXES[ax]]), hi)
-            - max(getattr(f.bb.min, "XYZ"[_AXES[ax]]), lo)
-            >= _FLOOR_COVER_FRAC * (hi - lo)
-            for ax, (lo, hi) in foot.items()
-        ):
+    foot_area = math.prod(hi - lo for lo, hi in foot.values())
+    # A floor at the low end faces +depth (toward the slot interior); at the high
+    # end, -depth.  The part's own outer face at the same level faces the other
+    # way and is excluded.
+    for end, want in ((s.d_lo, 1.0), (s.d_hi, -1.0)):
+        covered = 0.0
+        for f in faces:
+            if f.axis != da or abs(_center(f.bb, dk) - end) > _FLOOR_TOL:
+                continue
+            if f.normal[dk] * want <= 0:
+                continue
+            area = 1.0
+            for ax, (lo, hi) in foot.items():
+                c = "XYZ"[_AXES[ax]]
+                ov = min(getattr(f.bb.max, c), hi) - max(getattr(f.bb.min, c), lo)
+                area *= max(ov, 0.0)
+            covered += area
+        if covered >= _FLOOR_COVER_FRAC * foot_area:
             return True
     return False
 

--- a/src/draftwright/features.py
+++ b/src/draftwright/features.py
@@ -1,0 +1,228 @@
+"""Recognition of non-cylindrical machined features (#135).
+
+Draftwright-local **prototype**.  It recognises milled *slots* / reduced
+across-flats sections — the class of feature the cylinder-based pipeline
+(``analyse_cylinders``/``find_holes`` in ``build123d_drafting.features``) is
+blind to.  Once the recognition predicate stabilises this is intended to be
+upstreamed into ``build123d-drafting-helpers`` beside the hole/boss recognisers;
+it deliberately mirrors their OCC face-scan idioms so the lift is mechanical.
+
+The defining signature of a cut-in slot is a pair of **opposed parallel walls
+that face each other**: two axis-aligned planar faces with anti-parallel
+outward normals where each normal points *towards* the other face.  The part's
+own outer faces are also parallel and anti-parallel, but their outward normals
+point *away* from each other, so the facing test excludes them cleanly without
+any bounding-box / "is this an outer face" heuristic.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from OCP.BRepAdaptor import BRepAdaptor_Surface
+from OCP.GeomAbs import GeomAbs_Plane
+from OCP.TopAbs import TopAbs_Orientation
+
+_AXES = {"x": 0, "y": 1, "z": 2}
+# A normal counts as axis-aligned when its dominant component is within this of
+# unit length — machined slot walls are square to the stock, so this is tight.
+_AXIS_ALIGNED_TOL = 1e-3
+# Two slot candidates are the same physical feature when their region centres
+# coincide to within this (mm); the narrower wins (the true across-flats width).
+_MERGE_TOL = 0.5
+
+
+@dataclass(frozen=True)
+class Slot:
+    """A milled slot / reduced across-flats section.
+
+    A slot is bounded by two opposed parallel walls facing each other.  The
+    wall separation is the *width* (the defining size); the extent the walls
+    share along the part's longer in-plane axis is the *length*.
+
+    width_axis: axis across the slot (the walls' normal axis), 'x'/'y'/'z'.
+    long_axis:  axis the slot runs along (largest shared wall extent).
+    width:      wall-to-wall separation — the defining size dim.
+    length:     slot extent along ``long_axis``.
+    w_center:   ``width_axis`` coordinate of the slot centreline.
+    lo, hi:     ``long_axis`` coordinates of the slot ends (lo < hi).
+    d_lo, d_hi: extent on the third (depth) axis.
+    """
+
+    width_axis: str
+    long_axis: str
+    width: float
+    length: float
+    w_center: float
+    lo: float
+    hi: float
+    d_lo: float
+    d_hi: float
+
+    @property
+    def depth_axis(self) -> str:
+        return next(a for a in "xyz" if a not in (self.width_axis, self.long_axis))
+
+
+# When the two non-width slot extents are within this fraction of each other the
+# slot is near-square in that plane and "which is the length" is ambiguous; the
+# tie is then broken towards the part's longer bounding-box axis.
+_LENGTH_TIE_FRAC = 0.05
+# A slot is *enclosed* — bounded by material at its ends.  A facing-wall pair
+# spanning (almost) the whole part along its length is an OPEN feature instead:
+# the concave corner of an L, a U-channel face, or a through step, where the two
+# walls run flush to the part boundary rather than being capped. Those are not
+# slots, so a pair this long is rejected (this is the open-vs-enclosed cut the
+# recogniser is deliberately conservative about — a partial-span open corner
+# would still slip through, and belongs to a future step/pocket recogniser).
+_SLOT_MAX_SPAN_FRAC = 0.9
+
+
+def _outward_normal(face):
+    """Unit outward normal of a planar face as an (x, y, z) tuple, or None when
+    the face is not planar.  Material-side convention matches helpers'
+    ``analyse_cylinders``: FORWARD orientation agreeing with the plane frame's
+    handedness means the stored normal already points out of the solid."""
+    surf = BRepAdaptor_Surface(face.wrapped)
+    if surf.GetType() != GeomAbs_Plane:
+        return None
+    pl = surf.Plane()
+    n = pl.Axis().Direction()
+    fwd = face.wrapped.Orientation() == TopAbs_Orientation.TopAbs_FORWARD
+    sign = 1.0 if (fwd == pl.Position().Direct()) else -1.0
+    return (sign * n.X(), sign * n.Y(), sign * n.Z())
+
+
+def _dominant_axis(nrm):
+    """Return the axis letter when ``nrm`` is axis-aligned, else None."""
+    for axis, k in _AXES.items():
+        if abs(abs(nrm[k]) - 1.0) <= _AXIS_ALIGNED_TOL:
+            return axis
+    return None
+
+
+def _planar_walls(part):
+    """Axis-aligned planar faces as (normal, axis, bbox) tuples."""
+    walls = []
+    for face in part.faces():
+        nrm = _outward_normal(face)
+        if nrm is None:
+            continue
+        axis = _dominant_axis(nrm)
+        if axis is None:
+            continue
+        walls.append((nrm, axis, face.bounding_box()))
+    return walls
+
+
+def _center(bb, k):
+    return (getattr(bb.min, "XYZ"[k]) + getattr(bb.max, "XYZ"[k])) / 2
+
+
+def _overlap_len(bb_a, bb_b, axis):
+    """Length of the overlap of two bboxes along ``axis`` (0 if disjoint)."""
+    c = "XYZ"[_AXES[axis]]
+    lo = max(getattr(bb_a.min, c), getattr(bb_b.min, c))
+    hi = min(getattr(bb_a.max, c), getattr(bb_b.max, c))
+    return hi - lo
+
+
+def find_slots(part) -> list[Slot]:
+    """Recognise milled slots / reduced across-flats sections in *part*.
+
+    Returns a list of :class:`Slot`, one per physical feature (co-located
+    candidate pairs are merged, keeping the narrower width).
+    """
+    walls = _planar_walls(part)
+    pbb = part.bounding_box()
+    part_ext = {a: getattr(pbb.size, "XYZ"[_AXES[a]]) for a in "xyz"}
+    candidates: list[Slot] = []
+    for i in range(len(walls)):
+        n_a, axis, bb_a = walls[i]
+        k = _AXES[axis]
+        for j in range(i + 1, len(walls)):
+            n_b, axis_b, bb_b = walls[j]
+            if axis_b != axis:
+                continue
+            # Anti-parallel outward normals.
+            if n_a[k] * n_b[k] >= 0:
+                continue
+            c_a, c_b = _center(bb_a, k), _center(bb_b, k)
+            # Facing each other: A's outward normal points towards B.  Outer
+            # faces of the stock fail this (their normals point apart).
+            if (c_b - c_a) * n_a[k] <= 0:
+                continue
+            # The walls must genuinely overlap in both perpendicular axes,
+            # otherwise they are unrelated faces that merely happen to be
+            # parallel and facing.
+            others = [a for a in "xyz" if a != axis]
+            ov = [_overlap_len(bb_a, bb_b, a) for a in others]
+            if min(ov) <= 0:
+                continue
+            width = abs(c_b - c_a)
+            # The longer shared extent is the slot length; the shorter is depth.
+            # When the two are near-equal (a near-square slot, e.g. a channel cut
+            # straight through a shaft) the choice is ambiguous, so break the tie
+            # towards the part's longer axis — the manufacturing "length" of a
+            # slot on a bar runs along the bar.
+            (ax0, ov0), (ax1, ov1) = sorted(zip(others, ov), key=lambda t: t[1], reverse=True)
+            if (ov0 - ov1) <= _LENGTH_TIE_FRAC * ov0 and part_ext[ax1] > part_ext[ax0]:
+                (long_axis, length), (depth_axis, _) = (ax1, ov1), (ax0, ov0)
+            else:
+                (long_axis, length), (depth_axis, _) = (ax0, ov0), (ax1, ov1)
+            # A slot is elongated: its width (the wall separation) is not its
+            # largest dimension.  Pairs wider than they are long are not slots
+            # but wide steps / pockets, or — when the overlap is a sliver —
+            # incidental parallel faces (e.g. two part faces that merely happen
+            # to face each other). Both are filtered here, before merging.
+            if width > length:
+                continue
+            # Reject open / full-span features (an enclosed slot is shorter than
+            # the part along its length — see _SLOT_MAX_SPAN_FRAC).
+            if length >= _SLOT_MAX_SPAN_FRAC * part_ext[long_axis]:
+                continue
+            lc = "XYZ"[_AXES[long_axis]]
+            lo = max(getattr(bb_a.min, lc), getattr(bb_b.min, lc))
+            hi = min(getattr(bb_a.max, lc), getattr(bb_b.max, lc))
+            dc = "XYZ"[_AXES[depth_axis]]
+            d_lo = max(getattr(bb_a.min, dc), getattr(bb_b.min, dc))
+            d_hi = min(getattr(bb_a.max, dc), getattr(bb_b.max, dc))
+            candidates.append(
+                Slot(
+                    width_axis=axis,
+                    long_axis=long_axis,
+                    width=round(width, 2),
+                    length=round(hi - lo, 2),
+                    w_center=round((c_a + c_b) / 2, 2),
+                    lo=round(lo, 2),
+                    hi=round(hi, 2),
+                    d_lo=round(d_lo, 2),
+                    d_hi=round(d_hi, 2),
+                )
+            )
+    return _merge(candidates)
+
+
+def _region_center(s: Slot):
+    """The slot's mid-point in part coordinates (axis-ordered)."""
+    c = {
+        s.width_axis: s.w_center,
+        s.long_axis: (s.lo + s.hi) / 2,
+        s.depth_axis: (s.d_lo + s.d_hi) / 2,
+    }
+    return (c["x"], c["y"], c["z"])
+
+
+def _merge(candidates: list[Slot]) -> list[Slot]:
+    """A rectangular slot is bounded by two orthogonal opposed-wall pairs (the
+    width walls and the length end-caps), so the same feature is detected twice
+    — once per pair.  Collapse candidates that occupy the same region, keeping
+    the one with the smallest width (the true across-flats)."""
+    kept: list[Slot] = []
+    for s in sorted(candidates, key=lambda c: c.width):
+        cs = _region_center(s)
+        if any(math.dist(cs, _region_center(k)) <= _MERGE_TOL for k in kept):
+            continue
+        kept.append(s)
+    return kept

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -109,6 +109,7 @@ from draftwright._core import (
     _tag_sequence,
 )
 from draftwright.annotate import _auto_annotate
+from draftwright.features import find_slots
 from draftwright.layout import (
     _greedy_strip_1d,
     _solve_strip_1d,
@@ -2014,6 +2015,7 @@ def _analyse(
     _pad_around_text = _draft_est.pad_around_text
     holes = find_holes(part, cyls=(z_cyls, cross_cyls))
     patterns = find_hole_patterns(holes)
+    slots = find_slots(part)
 
     # Choose scale/page, iterating so the reserved step corridor matches the
     # number of steps the legibility gate will actually place (#1) — not the raw
@@ -2128,6 +2130,7 @@ def _analyse(
         bbox_max=bbox_max,
         holes=holes,
         patterns=patterns,
+        slots=slots,
         z_diams=z_diams,
         cross_diams=cross_diams,
         cyls=(z_cyls, cross_cyls),

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8,6 +8,7 @@ from build123d import Box, Compound, Cylinder, Edge, Pos, Rotation, export_step
 from build123d_drafting import HoleCallout, Leader, ViewCoordinates, view_axes
 
 from draftwright import Drawing, build_drawing, make_drawing
+from draftwright.features import Slot, find_slots
 from draftwright.make_drawing import (
     _MIN_VIEW_MM,
     _export_shape,
@@ -3641,6 +3642,95 @@ class TestFeatures:
             out="",
         )
         assert dwg.features("plan") == []
+
+
+class TestFindSlots:
+    """#135: recognition of milled slots / reduced across-flats sections.
+
+    find_slots() is a pure-geometry pass (no projection) so these are fast.
+    """
+
+    def test_through_slot_recognised(self):
+        # A 20-long, 8-wide channel milled into the top of a 60×30×12 bar.
+        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        slots = find_slots(part)
+        assert len(slots) == 1
+        s = slots[0]
+        assert s.width_axis == "y"
+        assert s.long_axis == "x"
+        assert s.width == 8.0
+        assert s.length == 20.0
+        assert (s.lo, s.hi) == (-10.0, 10.0)
+
+    def test_plain_box_has_no_slots(self):
+        # The stock's own outer faces are parallel and anti-parallel but face
+        # AWAY from each other — the facing test must exclude them.
+        assert find_slots(Box(40, 20, 10)) == []
+
+    def test_single_flat_is_not_a_slot(self):
+        # One machined flat has no opposing wall, so it is not a slot.
+        part = Box(40, 20, 10) - Pos(0, 12, 0) * Box(40, 10, 10)
+        assert find_slots(part) == []
+
+    def test_full_span_open_channel_is_not_a_slot(self):
+        # A channel that runs the WHOLE length of the part is an open feature
+        # (a U-channel / the open concave corner of an L), not an enclosed slot —
+        # its walls run flush to the part boundary instead of being capped.
+        part = Box(20, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        assert find_slots(part) == []
+
+    def test_rectangular_slot_reported_once(self):
+        # A blind rectangular pocket is bounded by two orthogonal opposed-wall
+        # pairs; the merge must collapse them to a single Slot (the narrower
+        # width), not report the same feature twice.
+        part = Box(60, 40, 12) - Pos(0, 0, 4) * Box(10, 24, 8)
+        slots = find_slots(part)
+        assert len(slots) == 1
+        assert slots[0].width == 10.0  # the narrower of the two opposed pairs
+
+    def test_near_square_slot_runs_along_the_bar(self):
+        # A slot cut into the top with x-extent ≈ z-depth: the length is assigned
+        # to the part's longer axis (a slot on a bar runs along the bar), not
+        # whichever OCC extent is fractionally larger.
+        part = Box(80, 20, 10) - Pos(0, 0, 3) * Box(6, 4, 8)
+        (s,) = find_slots(part)
+        assert s.width_axis == "y"
+        assert s.width == 4.0
+        assert s.long_axis == "x"  # not z, despite z-depth ≈ x-extent locally
+
+    def test_slot_is_frozen_dataclass(self):
+        s = find_slots(Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8))[0]
+        assert isinstance(s, Slot)
+        with pytest.raises(Exception):
+            s.width = 1.0  # frozen
+
+
+class TestSlotDimensioning:
+    """#135: slots carry width / length / position dims, place-what-fits."""
+
+    @pytest.mark.timeout(60)
+    def test_slot_gets_width_length_and_position(self):
+        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        dwg = build_drawing(part)
+        labels = {n: dwg._named[n].label for n in dwg._named if n.startswith("slot")}
+        assert labels.get("slot0_width") == "8"
+        assert labels.get("slot0_length") == "20"
+        assert "slot0_pos" in labels
+
+    @pytest.mark.timeout(60)
+    def test_slot_sheet_is_lint_clean(self):
+        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        dwg = build_drawing(part)
+        assert [i for i in dwg.lint() if i.severity != "info"] == []
+
+    @pytest.mark.timeout(60)
+    def test_non_round_width_label_matches_geometry(self):
+        # A true 4.75 mm slot labels as "4.8"; the dim geometry must be snapped
+        # to the displayed value or the label-vs-measured lint trips (#135).
+        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 4.75, 8)
+        dwg = build_drawing(part)
+        assert dwg._named["slot0_width"].label == "4.8"
+        assert [i for i in dwg.lint() if i.code == "label_vs_measured"] == []
 
 
 class TestPlaceDim:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3704,11 +3704,7 @@ class TestFindSlots:
     def test_gap_between_bosses_is_not_a_slot(self):
         # The floored channel between two raised bosses has facing rectangular
         # walls but is not a cut slot — the floor (the base plate) rejects it.
-        part = (
-            Box(80, 40, 6)
-            + Pos(-15, 0, 9) * Box(10, 40, 12)
-            + Pos(15, 0, 9) * Box(10, 40, 12)
-        )
+        part = Box(80, 40, 6) + Pos(-15, 0, 9) * Box(10, 40, 12) + Pos(15, 0, 9) * Box(10, 40, 12)
         assert find_slots(part) == []
 
     def test_full_span_through_slot_is_not_a_slot(self):
@@ -3745,11 +3741,7 @@ class TestFindSlots:
     def test_output_order_is_deterministic(self):
         # Two equal-width through-slots must be ordered by geometry (not OCC face
         # order), so the slot{i} annotation names are stable.
-        part = (
-            Box(120, 40, 12)
-            - Pos(-30, 0, 0) * Box(8, 20, 20)
-            - Pos(30, 0, 0) * Box(8, 20, 20)
-        )
+        part = Box(120, 40, 12) - Pos(-30, 0, 0) * Box(8, 20, 20) - Pos(30, 0, 0) * Box(8, 20, 20)
         runs = [[(s.width, s.lo, s.hi) for s in find_slots(part)] for _ in range(3)]
         assert runs[0] == runs[1] == runs[2]
         assert len(runs[0]) == 2

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3645,14 +3645,15 @@ class TestFeatures:
 
 
 class TestFindSlots:
-    """#135: recognition of milled slots / reduced across-flats sections.
+    """#135: recognition of enclosed through-slots with rectangular walls.
 
     find_slots() is a pure-geometry pass (no projection) so these are fast.
+    Scope is deliberately narrow (#148): only through-slots with straight walls.
     """
 
     def test_through_slot_recognised(self):
-        # A 20-long, 8-wide channel milled into the top of a 60×30×12 bar.
-        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        # A 20-long, 8-wide channel milled THROUGH a 60×30×12 bar.
+        part = Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20)
         slots = find_slots(part)
         assert len(slots) == 1
         s = slots[0]
@@ -3672,37 +3673,78 @@ class TestFindSlots:
         part = Box(40, 20, 10) - Pos(0, 12, 0) * Box(40, 10, 10)
         assert find_slots(part) == []
 
-    def test_full_span_open_channel_is_not_a_slot(self):
-        # A channel that runs the WHOLE length of the part is an open feature
-        # (a U-channel / the open concave corner of an L), not an enclosed slot —
-        # its walls run flush to the part boundary instead of being capped.
-        part = Box(20, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+    def test_blind_slot_is_not_a_slot(self):
+        # A blind slot (cut partway, leaving a floor) is out of scope (#148):
+        # the floor test rejects it. Same geometry as the through case but the
+        # cutter does not break through the bottom.
+        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        assert find_slots(part) == []
+
+    def test_blind_pocket_is_not_a_slot(self):
+        # A rectangular pocket has the same facing rectangular walls as a slot
+        # but is capped by a floor — the through/blind test must reject it.
+        part = Box(100, 60, 10) - Pos(0, 0, 2) * Box(40, 25, 6)
+        assert find_slots(part) == []
+
+    def test_turned_groove_is_not_a_slot(self):
+        # A circumferential groove on a shaft has ANNULAR (circle-bounded) walls;
+        # the rectangular-wall test must reject it (otherwise a stepped shaft's
+        # circlip groove reads as a slot — the #146 review false positive).
+        part = Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(7, 4))
+        assert find_slots(part) == []
+
+    def test_gap_between_bosses_is_not_a_slot(self):
+        # The floored channel between two raised bosses has facing rectangular
+        # walls but is not a cut slot — the floor (the base plate) rejects it.
+        part = (
+            Box(80, 40, 6)
+            + Pos(-15, 0, 9) * Box(10, 40, 12)
+            + Pos(15, 0, 9) * Box(10, 40, 12)
+        )
+        assert find_slots(part) == []
+
+    def test_full_span_through_slot_is_not_a_slot(self):
+        # A through-channel that runs the WHOLE length of the part is an open
+        # feature (a U-channel), not an enclosed slot — rejected by the span cap.
+        part = Box(20, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20)
         assert find_slots(part) == []
 
     def test_rectangular_slot_reported_once(self):
-        # A blind rectangular pocket is bounded by two orthogonal opposed-wall
+        # A through rectangular slot is bounded by two orthogonal opposed-wall
         # pairs; the merge must collapse them to a single Slot (the narrower
         # width), not report the same feature twice.
-        part = Box(60, 40, 12) - Pos(0, 0, 4) * Box(10, 24, 8)
+        part = Box(60, 40, 12) - Pos(0, 0, 0) * Box(10, 24, 20)
         slots = find_slots(part)
         assert len(slots) == 1
         assert slots[0].width == 10.0  # the narrower of the two opposed pairs
 
     def test_near_square_slot_runs_along_the_bar(self):
-        # A slot cut into the top with x-extent ≈ z-depth: the length is assigned
-        # to the part's longer axis (a slot on a bar runs along the bar), not
-        # whichever OCC extent is fractionally larger.
-        part = Box(80, 20, 10) - Pos(0, 0, 3) * Box(6, 4, 8)
+        # A through slot whose x-extent ≈ z-extent: the length is assigned to the
+        # part's longer axis (a slot on a bar runs along the bar), not whichever
+        # OCC extent is fractionally larger.
+        part = Box(80, 20, 6) - Pos(0, 0, 0) * Box(6, 4, 8)
         (s,) = find_slots(part)
         assert s.width_axis == "y"
         assert s.width == 4.0
-        assert s.long_axis == "x"  # not z, despite z-depth ≈ x-extent locally
+        assert s.long_axis == "x"  # not z, despite z-extent ≈ x-extent locally
 
     def test_slot_is_frozen_dataclass(self):
-        s = find_slots(Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8))[0]
+        s = find_slots(Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20))[0]
         assert isinstance(s, Slot)
         with pytest.raises(Exception):
             s.width = 1.0  # frozen
+
+    def test_output_order_is_deterministic(self):
+        # Two equal-width through-slots must be ordered by geometry (not OCC face
+        # order), so the slot{i} annotation names are stable.
+        part = (
+            Box(120, 40, 12)
+            - Pos(-30, 0, 0) * Box(8, 20, 20)
+            - Pos(30, 0, 0) * Box(8, 20, 20)
+        )
+        runs = [[(s.width, s.lo, s.hi) for s in find_slots(part)] for _ in range(3)]
+        assert runs[0] == runs[1] == runs[2]
+        assert len(runs[0]) == 2
 
 
 class TestSlotDimensioning:
@@ -3710,16 +3752,18 @@ class TestSlotDimensioning:
 
     @pytest.mark.timeout(60)
     def test_slot_gets_width_length_and_position(self):
-        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        # Through slot at x∈[-10,10] in a 60-long bar (datum x=-30): position to
+        # the near (lo) edge is -10-(-30) = 20.
+        part = Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20)
         dwg = build_drawing(part)
         labels = {n: dwg._named[n].label for n in dwg._named if n.startswith("slot")}
         assert labels.get("slot0_width") == "8"
         assert labels.get("slot0_length") == "20"
-        assert "slot0_pos" in labels
+        assert labels.get("slot0_pos") == "20"
 
     @pytest.mark.timeout(60)
     def test_slot_sheet_is_lint_clean(self):
-        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 8, 8)
+        part = Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20)
         dwg = build_drawing(part)
         assert [i for i in dwg.lint() if i.severity != "info"] == []
 
@@ -3727,7 +3771,7 @@ class TestSlotDimensioning:
     def test_non_round_width_label_matches_geometry(self):
         # A true 4.75 mm slot labels as "4.8"; the dim geometry must be snapped
         # to the displayed value or the label-vs-measured lint trips (#135).
-        part = Box(60, 30, 12) - Pos(0, 0, 2) * Box(20, 4.75, 8)
+        part = Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 4.75, 20)
         dwg = build_drawing(part)
         assert dwg._named["slot0_width"].label == "4.8"
         assert [i for i in dwg.lint() if i.code == "label_vs_measured"] == []

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3686,6 +3686,14 @@ class TestFindSlots:
         part = Box(100, 60, 10) - Pos(0, 0, 2) * Box(40, 25, 6)
         assert find_slots(part) == []
 
+    def test_split_floor_pocket_is_not_a_slot(self):
+        # A blind pocket whose floor is divided into two coplanar faces by a rib
+        # (a webbed / twin-cavity pocket): neither floor half covers 50% of the
+        # footprint alone, so the floor test must AGGREGATE coverage across both
+        # — otherwise the pocket reads as a phantom through-slot (#146 re-review).
+        part = (Box(40, 40, 20) - Pos(0, 0, 10) * Box(10, 30, 8)) + Pos(0, 0, 7) * Box(10, 2, 2)
+        assert find_slots(part) == []
+
     def test_turned_groove_is_not_a_slot(self):
         # A circumferential groove on a shaft has ANNULAR (circle-bounded) walls;
         # the rectangular-wall test must reject it (otherwise a stepped shaft's
@@ -3775,6 +3783,32 @@ class TestSlotDimensioning:
         dwg = build_drawing(part)
         assert dwg._named["slot0_width"].label == "4.8"
         assert [i for i in dwg.lint() if i.code == "label_vs_measured"] == []
+
+    @pytest.mark.timeout(60)
+    def test_slot_dims_do_not_overprint_hole_callouts(self):
+        # A slot dim's witness/arrow geometry must not cross a hole callout label.
+        # The collision gate tests the dim's FULL geometry (not just its label
+        # box) against external annotations, which lint is blind to (#146 review).
+        part = Box(140, 60, 16) - Pos(0, 0, 0) * Box(10, 40, 24)
+        for x, y in [(-45, 20), (45, 20), (-45, -20), (45, -20)]:
+            part = part - Pos(x, y, 0) * Cylinder(4, 16)
+        dwg = build_drawing(part)
+
+        def overlaps(a, b):
+            return min(a[2], b[2]) > max(a[0], b[0]) and min(a[3], b[3]) > max(a[1], b[1])
+
+        external = [
+            o.label_bbox
+            for n, o in dwg._named.items()
+            if not n.startswith("slot") and getattr(o, "label_bbox", None) is not None
+        ]
+        assert external  # the holes produced callouts
+        for n, o in dwg._named.items():
+            if not n.startswith("slot"):
+                continue
+            g = o.bounding_box()
+            full = (g.min.X, g.min.Y, g.max.X, g.max.Y)
+            assert not any(overlaps(full, e) for e in external), f"{n} overprints a callout"
 
 
 class TestPlaceDim:


### PR DESCRIPTION
## What
Closes the next manufacturability gap after holes (#93/#133) and diameters (#77/#131): draftwright now recognises and dimensions milled **slots**. The gramel **shaft's blade slot** is now fully dimensioned (width 4.8 × length 6.4, at 24.6), lint-clean.

## Scope — deliberately narrow (follow-up #148)
An adversarial review caught that a naive "opposed facing walls" test over-recognises (pockets, turned grooves, boss-gaps). This PR narrows to the provably-correct subset: **enclosed through-slots with straight rectangular walls**. Broadening (blind slots, pockets, flats, grooves, cross-slots) is tracked in #148.

## How
**features.py (new)** `find_slots`: facing walls + rectangular walls (rejects annular grooves) + through/no-floor (rejects blind pockets & boss-gaps; the floor test checks the cap normal points into the slot). Plus width≤length, span cap, merge, deterministic ordering.
**annotate.py** `_annotate_slots`: width+length+position in the slot's natural view, place-what-fits; witnesses off the slot's own edges (not the envelope), snaps geometry to the displayed value, peeks the strip before allocating.

## Verification
Full suite green; 17 slot tests incl. adversarial negatives (blind slot, pocket, turned groove, boss-gap, full-span — all rejected) + determinism + label pins. Eval corpus: only the gramel blade slot recognised; every prior false positive rejected; no new lint warnings. Rendered & eyeballed gramel_shaft + a centred slot.

## Known limits (→ #148)
`+` cross → 4 arm-slots; blind/pocket/flat/groove deferred; centred-slot width dim offset to strip. score.py metric is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)