### PR TITLE
#138 Step 3: extract CoverageState to linting.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,10 @@ It sits on top of two Apache 2.0 libraries:
 
 ## Architecture
 
-The dependency graph is a DAG: the leaf modules `layout.py`, `registry.py`, and
-`fonts.py` sit below `_core.py` → (`make_drawing.py`, `annotate.py`), and
-`make_drawing.py` → `annotate.py`. No lower module imports an upper one.
+The dependency graph is a DAG: the leaf modules `layout.py`, `registry.py`,
+`linting.py`, and `fonts.py` sit below `_core.py` → (`make_drawing.py`,
+`annotate.py`), and `make_drawing.py` → `annotate.py`. No lower module imports an
+upper one.
 
 - **`make_drawing.py`** — orchestration and the public surface:
   - **STEP/Shape import + geometry analysis** (`_analyse`) — builds the `Analysis` namespace
@@ -41,6 +42,10 @@ The dependency graph is a DAG: the leaf modules `layout.py`, `registry.py`, and
   identity/ownership/pins/build-issues (#138 / ADR 0005, Step 2). `Drawing`
   delegates here and keeps the render list; `_named`/`_anno_view`/`_pinned`/
   `_build_issues` remain `Drawing` properties during the migration.
+- **`linting.py`** — `CoverageState`: the single owner of the lint-side coverage
+  signal (pattern callouts, patterned holes, dropped callout diameters; #138 /
+  ADR 0005, Step 3). The designated future home for `lint_feature_coverage` /
+  `_suggest_fix`; for now it owns just the state they read.
 - **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
   cross-platform layout (ADR 0006).
 - **`pmi.py`** — PMI (product manufacturing information) extraction from STEP AP242.
@@ -77,10 +82,11 @@ Current ADRs:
   `layout.py` unchanged. **Landed so far:** Step 0 (golden-output harness, gates
   behaviour-equivalence), Step 1 (#139, public helper APIs), Step 2 (`registry.py`
   owns annotation identity; `Drawing` delegates, with `_named`/`_anno_view`/
-  `_pinned`/`_build_issues` kept as compat properties). **Still ahead:** coverage
-  state → lint, build context → pipeline, the sheet/projection/export/annotations
-  splits. The module list above is the *current* tree; the remaining stage modules
-  do not exist yet.
+  `_pinned`/`_build_issues` kept as compat properties), Step 3 (`linting.py`
+  `CoverageState` owns the lint-side coverage signal). **Still ahead:** build
+  context → pipeline, and the sheet/projection/export/annotations splits. The
+  module list above is the *current* tree; the remaining stage modules do not
+  exist yet.
 - **0006** — **Accepted** (#149): deterministic cross-platform layout via bundled,
   path-pinned fonts. Layout depends on measured text width; resolving a font *name*
   (`"Arial"`) substitutes a different font on Linux, drifting the whole sheet ~1 mm.

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -3,10 +3,12 @@
 - **Status:** Accepted, in progress
 - **Date:** 2026-06-27
 - **Deciders:** Paul Fremantle (pzfreo)
-- **Progress:** Step 0 (golden gate) and Step 1 (#139, public helper APIs) landed;
-  Step 2 (`registry.py` owns annotation identity; `Drawing` delegates, the four
-  field names kept as compat properties) in progress. Remaining: coverage state →
-  lint, build context → pipeline, and the stage-module splits.
+- **Progress:** Step 0 (golden gate), Step 1 (#139, public helper APIs), Step 2
+  (`registry.py` owns annotation identity; `Drawing` delegates, the four field
+  names kept as compat properties), and Step 3 (`linting.py` `CoverageState` owns
+  the lint-side coverage signal — pattern callouts, patterned holes, dropped
+  callout diameters) landed. Remaining: build context (`Analysis`, edge cache) →
+  pipeline, and the stage-module splits.
 
 ## Context
 

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -341,7 +341,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Idempotent: clear build-time lint state so a second annotation pass does
     # not accumulate duplicate drop records.
     dwg._reset_build_issues()
-    dwg._dropped_callout_diams = []
+    dwg._reset_dropped_callout_diams()
 
     FX = a.proj.front_x
     FZ = a.proj.front_z
@@ -720,7 +720,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     # pattern dimension, so they must not become table rows or per-hole balloons
     # (#92).  Excluding them is also what keeps a densely-but-regularly drilled
     # part (e.g. NIST CTC-02) off the 61-row escalation (#111).
-    holes = [h for h in a.holes if _axis_letter(h) == "z" and h not in dwg._patterned_holes]
+    holes = [h for h in a.holes if _axis_letter(h) == "z" and not dwg._is_hole_patterned(h)]
     # A chart is warranted only for a *genuinely* dense plan view — a part that
     # merely dropped one too-close location ref keeps its individual dims (the
     # legibility gate already handled it). #93.
@@ -739,7 +739,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     replaced = {
         n: dwg._named[n]
         for n in list(dwg._named)
-        if n.startswith(("hc_plan", "dim_locx", "dim_locy")) and n not in dwg._pattern_callouts
+        if n.startswith(("hc_plan", "dim_locx", "dim_locy")) and not dwg._is_pattern_callout(n)
     }
     replaced_view = {n: dwg._anno_view.get(n) for n in replaced}
     for n in replaced:
@@ -1127,7 +1127,7 @@ def _record_callout_drop(dwg, view, diam, reason):
     so a callout that genuinely doesn't fit is surfaced once, with a reason,
     and not double-reported.
     """
-    dwg._dropped_callout_diams.append(diam)
+    dwg._drop_callout_diam(diam)
     dwg._record_build_issue(
         "warning",
         "callout_dropped",
@@ -2076,8 +2076,7 @@ def _add_furniture(dwg, a: Analysis, view, j, pattern, to_page):
         # Recording here (callout already placed) — not from a.patterns — means a
         # pattern dropped for lack of room, or filtered off a rotational part,
         # correctly falls back to the table instead of going undocumented.
-        dwg._pattern_callouts.add(f"hc_{view}{j}")
-        dwg._patterned_holes.update(pattern.holes)
+        dwg._cover_pattern(f"hc_{view}{j}", pattern.holes)
     if isinstance(pattern, BoltCircle):
         cx = sum(to_page(h)[0] for h in pattern.holes) / len(pattern.holes)
         cy = sum(to_page(h)[1] for h in pattern.holes) / len(pattern.holes)

--- a/src/draftwright/linting.py
+++ b/src/draftwright/linting.py
@@ -1,0 +1,65 @@
+"""Lint-side build state (#138 / ADR 0005, Step 3).
+
+ADR 0005 §2 assigns the drawing's *coverage signal* a single owner on the lint
+side: which features a placed pattern callout already documents, and which
+diameters the per-view callout cap dropped. `lint_feature_coverage` consumes this
+to avoid double-reporting a hole that a grouped ``n× ⌀`` callout covers (#92) and
+to suppress the redundant ``feature_not_dimensioned`` for capped diameters.
+
+`Drawing` delegates here and keeps `_pattern_callouts` / `_patterned_holes` /
+`_dropped_callout_diams` reachable as properties during the migration (ADR
+0005 §4). This module is the designated home for the lint functions
+(`lint_feature_coverage`, `_suggest_fix`, scoring) that move out of
+`make_drawing.py` in a later step; for now it owns just the state they read.
+
+It sits at the bottom of the import DAG — it depends on nothing in draftwright.
+"""
+
+from __future__ import annotations
+
+
+class CoverageState:
+    """What the annotation passes covered or dropped, for lint to read."""
+
+    def __init__(self) -> None:
+        # Names of bore callouts that document a recognised hole pattern (a
+        # grouped ``n× ⌀`` callout), and the holes those placed callouts cover.
+        # The hole-table escalation keeps these callouts and tabulates only the
+        # holes no placed pattern callout documents (#92).
+        self._pattern_callouts: set = set()
+        self._patterned_holes: set = set()
+        # Diameters dropped by the per-view callout cap, so lint can suppress the
+        # redundant feature_not_dimensioned for them. Reset at the top of
+        # _auto_annotate so re-annotation does not accumulate.
+        self._dropped_callout_diams: list = []
+
+    # -- pattern coverage -----------------------------------------------------
+
+    def cover_pattern(self, callout_name, holes) -> None:
+        """Record that placed *callout_name* documents *holes* (a grouped
+        pattern callout) — so neither becomes a table row or per-hole balloon."""
+        self._pattern_callouts.add(callout_name)
+        self._patterned_holes.update(holes)
+
+    def is_pattern_callout(self, name) -> bool:
+        """Is *name* a placed pattern (grouped ``n× ⌀``) callout?"""
+        return name in self._pattern_callouts
+
+    def is_hole_patterned(self, hole) -> bool:
+        """Is *hole* already documented by a placed pattern callout?"""
+        return hole in self._patterned_holes
+
+    # -- dropped diameters ----------------------------------------------------
+
+    def reset_dropped(self) -> None:
+        """Clear dropped-diameter tracking (top of _auto_annotate)."""
+        self._dropped_callout_diams = []
+
+    def drop_diam(self, diam) -> None:
+        """Record a diameter dropped by the per-view callout cap."""
+        self._dropped_callout_diams.append(diam)
+
+    @property
+    def dropped_diams(self) -> list:
+        """Diameters dropped by the cap (passed to lint_feature_coverage)."""
+        return self._dropped_callout_diams

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -116,6 +116,7 @@ from draftwright.layout import (
     _solve_strip_1d,
     fit_box,
 )
+from draftwright.linting import CoverageState
 from draftwright.registry import AnnotationRegistry
 
 _TB_W = 150.0
@@ -2284,12 +2285,11 @@ class Drawing:
         # / `_build_issues` remain reachable as properties (below) so tests and
         # helpers that read through them keep working during the migration.
         self._registry = AnnotationRegistry()
-        # Names of bore callouts that document a recognised hole pattern (a
-        # grouped ``n× ⌀`` callout), and the holes those placed callouts cover.
-        # The hole-table escalation keeps these callouts and tabulates only the
-        # holes no placed pattern callout documents (#92).
-        self._pattern_callouts: set = set()
-        self._patterned_holes: set = set()
+        # Lint-side coverage signal (pattern callouts, patterned holes, dropped
+        # callout diameters) lives in its own owner (#138 / ADR 0005, Step 3).
+        # _pattern_callouts / _patterned_holes / _dropped_callout_diams remain
+        # reachable as properties below.
+        self._coverage = CoverageState()
         # One per-drawing cache for lint_drawing's per-view edge bboxes, keyed on
         # id(view shape). repair() / lint_summary() lint the SAME projected view
         # objects (self.views) repeatedly, so persisting it recomputes each
@@ -2298,10 +2298,6 @@ class Drawing:
         self.svg_path: str | None = None
         self.dxf_path: str | None = None
         self._analysis: Analysis | None = None
-        # Diameters dropped by the per-view callout cap, tracked so :meth:`lint`
-        # can suppress the redundant feature_not_dimensioned for them. Reset at
-        # the top of :func:`_auto_annotate` so re-annotation does not accumulate.
-        self._dropped_callout_diams: list = []
 
     # -- annotation registry (compat accessors, ADR 0005 §4) ------------------
     # The registry owns these four; they are exposed as their live containers so
@@ -2338,6 +2334,55 @@ class Drawing:
     @_build_issues.setter
     def _build_issues(self, value) -> None:
         self._registry._build_issues = value
+
+    # -- coverage state (compat accessors, ADR 0005 §4) -----------------------
+    # The CoverageState owner holds these three; exposed as their live containers
+    # so code reading dwg._pattern_callouts / _patterned_holes /
+    # _dropped_callout_diams keeps working until those sites are redirected.
+    @property
+    def _pattern_callouts(self) -> set:
+        return self._coverage._pattern_callouts
+
+    @_pattern_callouts.setter
+    def _pattern_callouts(self, value) -> None:
+        self._coverage._pattern_callouts = value
+
+    @property
+    def _patterned_holes(self) -> set:
+        return self._coverage._patterned_holes
+
+    @_patterned_holes.setter
+    def _patterned_holes(self, value) -> None:
+        self._coverage._patterned_holes = value
+
+    @property
+    def _dropped_callout_diams(self) -> list:
+        return self._coverage._dropped_callout_diams
+
+    @_dropped_callout_diams.setter
+    def _dropped_callout_diams(self, value) -> None:
+        self._coverage._dropped_callout_diams = value
+
+    # -- coverage state operations (used by the annotation passes) ------------
+    def _cover_pattern(self, callout_name, holes):
+        """Record that placed *callout_name* documents *holes* (#92)."""
+        self._coverage.cover_pattern(callout_name, holes)
+
+    def _is_pattern_callout(self, name) -> bool:
+        """Is *name* a placed pattern (grouped ``n× ⌀``) callout?"""
+        return self._coverage.is_pattern_callout(name)
+
+    def _is_hole_patterned(self, hole) -> bool:
+        """Is *hole* already documented by a placed pattern callout?"""
+        return self._coverage.is_hole_patterned(hole)
+
+    def _reset_dropped_callout_diams(self):
+        """Clear dropped-diameter tracking (top of :func:`_auto_annotate`)."""
+        self._coverage.reset_dropped()
+
+    def _drop_callout_diam(self, diam):
+        """Record a diameter dropped by the per-view callout cap."""
+        self._coverage.drop_diam(diam)
 
     # -- views ----------------------------------------------------------------
     def add_view(self, name, shape, camera, up, position, *, look_at=None, scaled=False):
@@ -3029,7 +3074,7 @@ class Drawing:
                 self.part,
                 self.items,
                 cyls=self._cyl_cache,
-                exclude=self._dropped_callout_diams,
+                exclude=self._coverage.dropped_diams,
                 assembly=self.assembly,
             )
         issues += list(self._build_issues)

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -1,0 +1,36 @@
+"""Unit tests for CoverageState — the lint-side coverage-signal owner
+(#138 / ADR 0005, Step 3)."""
+
+import pytest
+
+from draftwright.linting import CoverageState
+
+# Pure unit tests — no OCC builds — so they join the build-light `smoke` set (#153).
+pytestmark = pytest.mark.smoke
+
+
+def test_cover_pattern_records_callout_and_holes():
+    c = CoverageState()
+    c.cover_pattern("hc_plan0", ["h1", "h2", "h3"])
+    assert c.is_pattern_callout("hc_plan0")
+    assert not c.is_pattern_callout("hc_plan1")
+    assert c.is_hole_patterned("h2")
+    assert not c.is_hole_patterned("h9")
+
+
+def test_cover_pattern_accumulates_across_calls():
+    c = CoverageState()
+    c.cover_pattern("a", ["h1"])
+    c.cover_pattern("b", ["h2", "h3"])
+    assert c.is_pattern_callout("a") and c.is_pattern_callout("b")
+    assert all(c.is_hole_patterned(h) for h in ("h1", "h2", "h3"))
+
+
+def test_dropped_diams_append_read_reset():
+    c = CoverageState()
+    assert c.dropped_diams == []
+    c.drop_diam(8.0)
+    c.drop_diam(5.0)
+    assert c.dropped_diams == [8.0, 5.0]
+    c.reset_dropped()
+    assert c.dropped_diams == []


### PR DESCRIPTION
Step 3 of the #138 refactor (ADR 0005 §2). Gives the **lint-side coverage signal** its own owner, the way Step 2 did for annotation identity. **Pure move — no output change.**

## What moved
New `linting.py` holds **`CoverageState`** — the pattern callouts a placed grouped `n× ⌀` callout documents, the holes those cover, and the diameters the per-view callout cap dropped. `lint_feature_coverage` reads this to avoid double-reporting a covered hole (#92) and to suppress the redundant `feature_not_dimensioned` for capped diameters. `linting.py` is the **designated home** for the lint functions (`lint_feature_coverage`, `_suggest_fix`) that move out of `make_drawing.py` in a later step; for now it owns just the state they read.

## Pure move — verified
- `Drawing` delegates via `_cover_pattern` / `_is_pattern_callout` / `_is_hole_patterned` / `_reset_dropped_callout_diams` / `_drop_callout_diam`; the annotation passes call those — **no raw `_pattern_callouts` / `_patterned_holes` / `_dropped_callout_diams` access remains in `annotate.py`**.
- The three field names stay reachable as `Drawing` properties (live containers, with setters) for the one test reading `_dropped_callout_diams` (ADR 0005 §4).
- **Golden gate passes against the committed snapshots with no regeneration** — the proof nothing changed — and the coverage-path tests (patterns / table escalation / dropped diams) pass. `CoverageState` has focused unit tests (joined to `smoke`).

## Adversarial check
A real 15-hole grid build populates the owner through the converted path (1 pattern callout, 15 patterned holes), the compat property returns that live container, and lint excludes the covered holes — so the owner is **exercised, not bypassed**. The only `_pattern_callouts` mentions left in `make_drawing.py` are comments + the compat-setter decorators.

## State of #138
✅ Step 0 (golden gate) · Step 1 (#139 helper APIs) · Step 2 (registry) · **Step 3 (this)**. Remaining: build context (`Analysis`, edge cache) → pipeline, then the sheet/projection/export/annotations module splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoG24RWpmNApX4cMiucS7v
