### PR TITLE
Speed up dev: parallelise tests (xdist) + slow tier post-merge (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,28 @@ jobs:
 
       - name: Run tests
         # Fast tier only — the `slow` marker (heavy CTC fixture builds) is
-        # deselected by default via addopts. The slow tier runs once in the
+        # deselected by default via addopts. The slow tier runs post-merge in the
         # `test-slow` job below.
+        # `-n auto --dist loadscope`: run across all cores (#153). The suite is
+        # build-bound and parallel-safe; loadscope keeps a class/module on one
+        # worker so test ordering and the module-scoped golden fixture hold.
         # No --timeout here: it would override the 300 s set in
         # [tool.pytest.ini_options]. The heaviest test (full specimen-sheet SVG
         # export) can exceed 120 s on the slower macOS runners.
         # Coverage runs in CI; it is kept out of the default addopts so local
         # runs stay lean (see pyproject [tool.pytest.ini_options]).
-        run: uv run pytest tests/ -v --cov=src/draftwright --cov-report=term-missing --cov-report=xml
+        run: uv run pytest tests/ -n auto --dist loadscope --cov=src/draftwright --cov-report=term-missing --cov-report=xml
 
   test-slow:
     # Heavy end-to-end CTC fixture builds (minutes each); run once, not across
     # the full OS/Python matrix.
+    #
+    # POST-MERGE ONLY — runs on push to main, not on pull_request, so it no
+    # longer gates PR merge (#153). Rationale: since #149 pinned the fonts,
+    # generated layout is deterministic, so the cross-platform CTC golden check
+    # rarely catches anything a PR's fast-tier golden digests miss. It stays as a
+    # safety net on main; a regression here is caught right after merge.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -71,4 +81,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
       - name: Run slow tests
-        run: uv run pytest tests/ -v -m slow
+        run: uv run pytest tests/ -m slow -n auto --dist loadscope

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,13 +108,17 @@ checks. Target is 100% passing. Tiers (#153):
 
 - **`uv run pytest -m smoke`** (~30 s) — curated build-light subset for a quick
   local "did I break something obvious" check.
-- **`uv run pytest`** — full fast tier (`-m 'not slow'`, ~8 min; nearly every test
-  does a real OCC build). Prefer **targeted** selections (`-k`, node ids) locally.
-- **`-m slow`** (~19 min, CTC fixture builds) — CI-only.
+- **`uv run pytest`** — full fast tier (`-m 'not slow'`; nearly every test does a
+  real OCC build). Prefer **targeted** selections (`-k`, node ids) locally; for a
+  full local run add **`-n auto --dist loadscope`** (pytest-xdist) to spread it
+  across cores (~471 s → ~200 s on 8 cores, #153).
+- **`-m slow`** (CTC fixture builds) — CI-only.
 
 Coverage is kept out of the default addopts (it adds ~13% locally); the CI
 workflow passes the `--cov` flags. CI runs the full fast tier (3×3 OS/Python
-matrix) plus the slow tier on every PR.
+matrix, parallelised with `-n auto`) on every PR; the **slow tier runs post-merge
+on `main`**, not as a PR gate (#153) — a regression there is caught right after
+merge rather than blocking every PR for ~19 min.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,5 +101,6 @@ dev = [
     "pytest>=8",
     "pytest-cov>=5",
     "pytest-timeout>=2",
+    "pytest-xdist>=3",
     "ruff>=0.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -593,6 +593,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -612,6 +613,7 @@ dev = [
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-timeout", specifier = ">=2" },
+    { name = "pytest-xdist", specifier = ">=3" },
     { name = "ruff", specifier = ">=0.4" },
 ]
 
@@ -625,6 +627,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1725,6 +1736,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cuts the per-PR cycle time, which compounds across the remaining #138 refactor PRs. Two changes:

## 1. Parallelise the test suite (`pytest-xdist`)
The suite is **build-bound** (~408 tests, each a real OCC build) and ran **serially**. CI now runs `-n auto --dist loadscope`.
- **Measured:** full fast tier ~471 s → **~201 s (2.3× on 8 cores)**, still **420 passed**. GitHub's 4-core runners get a smaller but solid factor.
- **`loadscope`, not `load`:** keeps a class/module on one worker, preserving test ordering and the module-scoped golden fixture. Deliberately avoiding plain `load`'s extra parallelism — order-dependency flakiness would cost more velocity than the speed buys. Reliability first.
- Coverage combines correctly across workers (verified).

## 2. Slow tier (CTC builds) → post-merge only
`test-slow` now runs **on push to `main`, not on `pull_request`** (`if: github.event_name == 'push'`), so it **no longer blocks PR merge for ~19 min**.
- **Rationale:** since #149 pinned the fonts, generated layout is deterministic, so the cross-platform CTC golden check rarely catches anything a PR's fast-tier golden digests miss. It stays a safety net on `main` — a regression is caught right after merge.

**Net:** PR merge latency drops from ~19 min (slow-tier gate) to the parallelised fast tier (~a few minutes).

## Local
`uv run pytest -n auto --dist loadscope` for a fast full run; `-m smoke` (~30 s) stays the quick loop. CLAUDE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoG24RWpmNApX4cMiucS7v
