### PR TITLE
#138: extract lint (_suggest_fix) + repair into their modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ It sits on top of two Apache 2.0 libraries:
 ## Architecture
 
 The dependency graph is a DAG: the leaf modules `layout.py`, `registry.py`,
-`linting.py`, and `fonts.py` sit below `_core.py`; `_core.py` and the stage module
-`export.py` sit below (`make_drawing.py`, `annotate.py`); and `make_drawing.py` →
-`annotate.py`. No lower module imports an upper one.
+`linting.py`, and `fonts.py` sit below `_core.py`; `_core.py` and the stage modules
+`export.py` / `repair.py` sit below (`make_drawing.py`, `annotate.py`); and
+`make_drawing.py` → `annotate.py`. No lower module imports an upper one.
 
 - **`make_drawing.py`** — orchestration and the public surface:
   - **STEP/Shape import + geometry analysis** (`_analyse`) — builds the `Analysis` namespace
@@ -54,6 +54,10 @@ The dependency graph is a DAG: the leaf modules `layout.py`, `registry.py`,
   shape-export degradation, cairo PDF render). The first **module-split** step of
   #138 (ADR 0005): `Drawing.export()` / `export_pdf()` stay as thin wrappers.
   Sits below `make_drawing.py`, above `_core.py`.
+- **`repair.py`** — the deterministic lint→repair loop (#30 / ADR 0002): the
+  re-place helpers (`_find_dim`/`_replace_dim`/`_repair_*`/`repair_drawing`) take
+  the drawing duck-typed as `dwg`; `Drawing.repair()` stays a thin wrapper.
+  Depends only on `_core`.
 - **`pmi.py`** — PMI (product manufacturing information) extraction from STEP AP242.
 
 ## Architecture decisions — READ `docs/adr/` FIRST

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,10 @@ The dependency graph is a DAG: the leaf modules `layout.py`, `registry.py`,
   delegates here and keeps the render list; `_named`/`_anno_view`/`_pinned`/
   `_build_issues` remain `Drawing` properties during the migration.
 - **`linting.py`** — the lint module (#138 / ADR 0005): `lint_feature_coverage`
-  (the feature-coverage completeness check) and `CoverageState` (the coverage
-  signal it reads — pattern callouts, patterned holes, dropped diameters).
-  Depends only on `_core` + build123d_drafting. (`_suggest_fix` follows with the
-  repair extraction — it shares `_QUOTED_RE` with the repair code.)
+  (feature-coverage completeness check), `_suggest_fix` (#29 fix snippets), and
+  `CoverageState` (the coverage signal — pattern callouts, patterned holes,
+  dropped diameters). Depends only on `_core` + build123d_drafting. `_QUOTED_RE`
+  (a lint-message label regex shared with the repair loop) lives in `_core`.
 - **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
   cross-platform layout (ADR 0006).
 - **`export.py`** — SVG/DXF/PDF export + post-processing (page-size fix,

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -64,6 +64,10 @@ def _tag_sequence(n):
 
 _DIAM_RE = re.compile(r"[øØ⌀]\s*(\d+(?:\.\d+)?)")
 
+# A single-quoted label lifted from a lint message, e.g. "labels 'A' and 'B' …".
+# Shared by the #29 lint suggestions (linting.py) and the #30 repair loop.
+_QUOTED_RE = re.compile(r"'([^']*)'")
+
 
 def _axis_letter(obj) -> str:
     """Letter (``"x"``/``"y"``/``"z"``) of ``obj.axis``'s dominant component.

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -197,6 +197,9 @@ _SLOT_DIM_DEPTH = 2 * _FONT_SIZE + _PAD  # sv_zones.below: overall depth dimensi
 _SLOT_DIM_HEIGHT = 2 * _FONT_SIZE + 2 * _PAD  # fv_zones.right: overall height dim
 
 
+_STRIP_SPACING = 4.0  # page-mm between successive annotations in a strip
+
+
 _SLOT_DIM_STEP = 4 * _FONT_SIZE + _PAD  # fv_zones.right: step-height dimension
 
 

--- a/src/draftwright/linting.py
+++ b/src/draftwright/linting.py
@@ -1,22 +1,24 @@
-"""Lint-side build state (#138 / ADR 0005, Step 3).
+"""The lint module (#138 / ADR 0005).
 
-ADR 0005 §2 assigns the drawing's *coverage signal* a single owner on the lint
-side: which features a placed pattern callout already documents, and which
-diameters the per-view callout cap dropped. `lint_feature_coverage` consumes this
-to avoid double-reporting a hole that a grouped ``n× ⌀`` callout covers (#92) and
-to suppress the redundant ``feature_not_dimensioned`` for capped diameters.
+Holds the lint-side logic and state:
 
-`Drawing` delegates here and keeps `_pattern_callouts` / `_patterned_holes` /
-`_dropped_callout_diams` reachable as properties during the migration (ADR
-0005 §4). This module is the designated home for the lint functions
-(`lint_feature_coverage`, `_suggest_fix`, scoring) that move out of
-`make_drawing.py` in a later step; for now it owns just the state they read.
+- `lint_feature_coverage` — the completeness check that reports part diameters
+  with no callout (#80), avoiding double-reporting a hole a grouped ``n× ⌀``
+  callout covers (#92) and suppressing the redundant ``feature_not_dimensioned``
+  for capped diameters.
+- `_suggest_fix` — the per-issue ready-to-paste fix snippet (#29).
+- `CoverageState` — the coverage signal the passes record and the checks read
+  (pattern callouts, patterned holes, dropped callout diameters). `Drawing`
+  delegates to it and keeps `_pattern_callouts` / `_patterned_holes` /
+  `_dropped_callout_diams` reachable as properties during the migration (§4).
 
 It sits low in the import DAG — it depends only on `_core` (and build123d_drafting),
-never on `make_drawing`/`annotate`.
+never on `make_drawing`/`annotate`. `Drawing.lint()` calls these via re-imports.
 """
 
 from __future__ import annotations
+
+import re
 
 from build123d_drafting.features import (
     analyse_cylinders,
@@ -25,7 +27,7 @@ from build123d_drafting.features import (
 )
 from build123d_drafting.helpers import LintIssue, TitleBlock
 
-from draftwright._core import _DIAM_RE, _fmt
+from draftwright._core import _DIAM_RE, _QUOTED_RE, _fmt
 
 
 class CoverageState:
@@ -175,3 +177,92 @@ def lint_feature_coverage(
                 )
             )
     return issues
+
+
+# Tolerance for matching a lint message's reported diameter (dedup representative
+# at tol 0.15, formatted to 1 dp) back to a raw feature diameter when generating a
+# fix snippet (#29).
+_DIAM_MATCH_TOL = 0.2
+
+
+def _suggest_fix(issue, dwg) -> str | None:
+    """Return a ready-to-paste code snippet that addresses *issue*, or None.
+
+    The snippet is a hint, not necessarily runnable verbatim (``...`` stands in
+    for args the engine cannot infer). It uses the public domain API
+    (:meth:`Drawing.features`, :meth:`Drawing.at`, :meth:`Drawing.place_dim`)
+    so a caller or LLM can paste and fill the gaps trivially (#29).
+    """
+    code = issue.code
+
+    if code == "feature_not_dimensioned":
+        # Message: "cylindrical feature ø8 has no diameter callout on the sheet".
+        m = _DIAM_RE.search(issue.message)
+        if m is None:
+            return None
+        d = float(m.group(1))
+        # The reported diameter is the dedup representative (tol 0.15) formatted
+        # to 1 dp, so match raw feature diameters with that combined slack — a
+        # 1e-6 match would silently miss every non-integer bore.
+        for view in ("plan", "front", "side"):
+            if any(abs(f.diameter - d) < _DIAM_MATCH_TOL for f in dwg.features(view)):
+                tag = _fmt(d).replace(".", "_")
+                return (
+                    f"# ø{_fmt(d)} has no callout. Locate it via features() and add a leader:\n"
+                    f'for f in dwg.features("{view}"):\n'
+                    f"    if abs(f.diameter - {_fmt(d)}) < {_DIAM_MATCH_TOL}:\n"
+                    f"        callout = HoleCallout(f.diameter, count=f.count,\n"
+                    f"                              through=f.through, depth=f.depth, draft=dwg.draft)\n"
+                    f"        elbow = (f.page_pos[0] + 15, f.page_pos[1] + 10, 0)\n"
+                    f'        leader = Leader((*f.page_pos, 0), elbow, "", dwg.draft, callout=callout)\n'
+                    f'        dwg.add(leader, name="hole_{tag}")'
+                )
+        return None
+
+    if code == "feature_count_mismatch":
+        # Message: "4 ø8 features on the part but callouts account for 1".
+        # `need` is the leading count; anchor it so diameter digits never
+        # interfere regardless of message word order.
+        m = _DIAM_RE.search(issue.message)
+        need_m = re.match(r"\s*(\d+)", issue.message)
+        if m is None or need_m is None:
+            return None
+        need = need_m.group(1)
+        return (
+            f"# Only some ø{m.group(1)} holes are counted. Set count={need} on the "
+            f"callout so it covers them all:\n"
+            f"# HoleCallout(..., count={need}, draft=dwg.draft)"
+        )
+
+    if code == "annotation_overlap":
+        # Message: "labels 'A' and 'B' overlap by ...".
+        labels = _QUOTED_RE.findall(issue.message)
+        first = labels[0] if labels else "<dim>"
+        return (
+            f"# Re-add the dimension with place_dim so it auto-stacks in the "
+            f"layout strip instead of overlapping:\n"
+            f'dwg.remove("{first}")  # if it was named\n'
+            f'dwg.place_dim(p1, p2, "below", "plan", dwg.draft, name="{first}")'
+        )
+
+    if code == "dim_inside_part":
+        # Message: "Dim 'X': annotation bbox overlaps part outline by ...".
+        labels = _QUOTED_RE.findall(issue.message)
+        first = labels[0] if labels else "<dim>"
+        return (
+            f"# The dim sits inside the view — its offset is on the wrong side. "
+            f"Re-place it on the opposite side via place_dim (auto-stacks clear "
+            f"of the part):\n"
+            f'dwg.remove("{first}")  # if it was named\n'
+            f'dwg.place_dim(p1, p2, "right", "front", dwg.draft, name="{first}")'
+        )
+
+    if code == "step_dim_dropped":
+        # Steps too closely spaced to dimension at sheet scale (#41/#42).
+        return (
+            "# Re-build with an enlarged detail view so the crowded shoulders are "
+            "dimensionable:\n"
+            "dwg = build_drawing(part, detail_view=True)"
+        )
+
+    return None

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -84,10 +84,10 @@ from OCP.STEPControl import STEPControl_Reader
 from draftwright._core import (
     _FONT_SIZE,
     _MARGIN,
-    _QUOTED_RE,
     _SLOT_DIM_HEIGHT,
     _SLOT_DIM_STEP,
     _SLOT_DIM_WIDTH,
+    _STRIP_SPACING,
     _TABULATE_MIN_HOLES,
     _TB_CLEAR,
     _TB_H,
@@ -124,6 +124,7 @@ from draftwright.layout import (
 )
 from draftwright.linting import CoverageState, _suggest_fix, lint_feature_coverage
 from draftwright.registry import AnnotationRegistry
+from draftwright.repair import repair_drawing
 
 _TB_W = 150.0
 _DIM_PAD = 18.0
@@ -475,10 +476,6 @@ _GEOMETRY_AWARE_CODES = frozenset(
 _SCORE_ERROR_PENALTY = 0.2
 _SCORE_WARNING_PENALTY = 0.05
 
-# Lint codes the #30 repair loop can mechanically resolve, and the side flip
-# used to move a dimension that landed on the wrong side of its witness points.
-_REPAIRABLE_CODES = frozenset({"annotation_overlap", "dim_inside_part"})
-_OPPOSITE_SIDE = {"above": "below", "below": "above", "left": "right", "right": "left"}
 
 
 def analyse_face_levels(part, tol: float = 0.5, min_area_frac: float = 0.0) -> list:
@@ -593,7 +590,6 @@ def _parse_page(page) -> tuple:
 
 
 _STRIP_GAP = 8.0
-_STRIP_SPACING = 4.0
 
 # Horizontal page budget to reserve for the isometric view during scale
 # selection and view placement, as a fraction of bbox_max * scale.  This is a
@@ -2610,113 +2606,28 @@ class Drawing:
         self._registry.drop_issues(codes)
 
     # -- repair ---------------------------------------------------------------
-    def _find_dim(self, label):
-        """Return the re-placeable dimension whose label is *label*, or None.
-
-        Only dimensions built by :func:`_dim` (carrying ``_dw_spec``) qualify;
-        leaders, callouts and hand-built annotations are left untouched. A
-        pinned dimension (#89) is also skipped — a deliberate placement must
-        win over automatic repair.
-        """
-        # Identity-based, matching clear_annotations: "this specific object",
-        # not build123d's geometric Shape equality.
-        pinned_ids = self._registry.pinned_object_ids()
-        for o in self.items:
-            if id(o) in pinned_ids:
-                continue
-            if getattr(o, "_dw_spec", None) is not None and getattr(o, "label", None) == label:
-                return o
-        return None
-
-    def _replace_dim(self, old, new):
-        """Swap *old* for *new* in :attr:`items`, preserving its name and
-        any per-view scale tag (so a re-placed detail-view dim stays at scale)."""
-        if getattr(old, "_dw_scale", None) is not None:
-            new._dw_scale = old._dw_scale
-        self.items[self.items.index(old)] = new
-        for n, o in self._named.items():
-            if o is old:
-                self._named[n] = new
-
-    def _repair_dim_inside_part(self, issue) -> bool:
-        """Flip a dimension that sits inside the view onto the opposite side."""
-        labels = _QUOTED_RE.findall(issue.message)
-        dim = self._find_dim(labels[0]) if labels else None
-        if dim is None:
-            return False
-        s = dim._dw_spec
-        new_side = _OPPOSITE_SIDE.get(s.side)
-        if new_side is None:
-            return False
-        self._replace_dim(dim, _dim(s.p1, s.p2, new_side, s.distance, s.draft, **s.kwargs))
-        return True
-
-    def _repair_overlap(self, issue) -> bool:
-        """Push the first re-placeable label in an overlap one strip-row further
-        out so the two labels separate. Monotonic, so repeated passes converge."""
-        step = _STRIP_SPACING + _SLOT_DIM_HEIGHT
-        for label in _QUOTED_RE.findall(issue.message):
-            dim = self._find_dim(label)
-            if dim is None:
-                continue
-            s = dim._dw_spec
-            self._replace_dim(
-                dim, _dim(s.p1, s.p2, s.side, s.distance + step, s.draft, **s.kwargs)
-            )
-            return True
-        return False
-
     def repair(self, max_iter: int = 3):
-        """Close the lint→repair loop: act on violations, don't only report them.
+        """Close the lint\u2192repair loop: act on violations, don't only report them.
 
         After the greedy initial placement, re-place the dimensions behind the
         mechanically-clear violations and re-lint, bounded to *max_iter* passes:
 
-        - ``dim_inside_part`` — the offset is on the wrong side; flip it once.
-        - ``annotation_overlap`` — two labels collide; push one further out.
+        - ``dim_inside_part`` \u2014 the offset is on the wrong side; flip it once.
+        - ``annotation_overlap`` \u2014 two labels collide; push one further out.
 
         Only engine-built dimensions (carrying ``_dw_spec``) are re-placeable;
         leaders, callouts and standards-judgement issues (e.g.
-        ``missing_principal_dimension``) are left for the caller. Each side
-        flip is attempted at most once and overlap pushes only move outward, so
-        the loop terminates and a clean drawing is returned unchanged.
+        ``missing_principal_dimension``) are left for the caller. Each side flip
+        is attempted at most once and overlap pushes only move outward, so the
+        loop terminates and a clean drawing is returned unchanged.
 
         A pass that would *net-increase* the issue count (e.g. an overlap push
-        that shoves a label out of frame on a tight sheet) is rolled back and
-        the loop stops, so :meth:`repair` never makes a drawing worse.
+        that shoves a label out of frame on a tight sheet) is rolled back and the
+        loop stops, so :meth:`repair` never makes a drawing worse.
 
         Returns ``self`` for chaining.
         """
-        flipped: set = set()
-        for _ in range(max_iter):
-            before = self.lint()
-            if not before:
-                break
-            snap_annotations = list(self.items)
-            snap_named = dict(self._named)
-            changed = False
-            for issue in before:
-                if issue.code not in _REPAIRABLE_CODES:
-                    continue
-                if issue.code == "dim_inside_part":
-                    labels = _QUOTED_RE.findall(issue.message)
-                    key = labels[0] if labels else None
-                    if key in flipped:
-                        continue
-                    if self._repair_dim_inside_part(issue):
-                        flipped.add(key)
-                        changed = True
-                elif issue.code == "annotation_overlap":
-                    changed |= self._repair_overlap(issue)
-            if not changed:
-                break
-            if len(self.lint()) > len(before):
-                # The repairs net-worsened the sheet — undo this pass and stop.
-                self.items[:] = snap_annotations
-                self._named.clear()
-                self._named.update(snap_named)
-                break
-        return self
+        return repair_drawing(self, max_iter)
 
     # -- output ---------------------------------------------------------------
     def lint(self):

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -477,7 +477,6 @@ _SCORE_ERROR_PENALTY = 0.2
 _SCORE_WARNING_PENALTY = 0.05
 
 
-
 def analyse_face_levels(part, tol: float = 0.5, min_area_frac: float = 0.0) -> list:
     """Return sorted unique Z-coords of horizontal (normal≈±Z) planar faces.
 
@@ -2607,13 +2606,13 @@ class Drawing:
 
     # -- repair ---------------------------------------------------------------
     def repair(self, max_iter: int = 3):
-        """Close the lint\u2192repair loop: act on violations, don't only report them.
+        """Close the lint→repair loop: act on violations, don't only report them.
 
         After the greedy initial placement, re-place the dimensions behind the
         mechanically-clear violations and re-lint, bounded to *max_iter* passes:
 
-        - ``dim_inside_part`` \u2014 the offset is on the wrong side; flip it once.
-        - ``annotation_overlap`` \u2014 two labels collide; push one further out.
+        - ``dim_inside_part`` — the offset is on the wrong side; flip it once.
+        - ``annotation_overlap`` — two labels collide; push one further out.
 
         Only engine-built dimensions (carrying ``_dw_spec``) are re-placeable;
         leaders, callouts and standards-judgement issues (e.g.

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -82,9 +82,9 @@ from OCP.IFSelect import IFSelect_ReturnStatus
 from OCP.STEPControl import STEPControl_Reader
 
 from draftwright._core import (
-    _DIAM_RE,
     _FONT_SIZE,
     _MARGIN,
+    _QUOTED_RE,
     _SLOT_DIM_HEIGHT,
     _SLOT_DIM_STEP,
     _SLOT_DIM_WIDTH,
@@ -122,7 +122,7 @@ from draftwright.layout import (
     _solve_strip_1d,
     fit_box,
 )
-from draftwright.linting import CoverageState, lint_feature_coverage
+from draftwright.linting import CoverageState, _suggest_fix, lint_feature_coverage
 from draftwright.registry import AnnotationRegistry
 
 _TB_W = 150.0
@@ -475,102 +475,10 @@ _GEOMETRY_AWARE_CODES = frozenset(
 _SCORE_ERROR_PENALTY = 0.2
 _SCORE_WARNING_PENALTY = 0.05
 
-# Quote a label parsed from a lint message safely back into a snippet.
-_QUOTED_RE = re.compile(r"'([^']*)'")
-
 # Lint codes the #30 repair loop can mechanically resolve, and the side flip
 # used to move a dimension that landed on the wrong side of its witness points.
 _REPAIRABLE_CODES = frozenset({"annotation_overlap", "dim_inside_part"})
 _OPPOSITE_SIDE = {"above": "below", "below": "above", "left": "right", "right": "left"}
-
-
-# Tolerance for matching a lint message's reported diameter (dedup
-# representative at tol 0.15, formatted to 1 dp) back to a raw feature
-# diameter when generating a fix snippet (#29).
-_DIAM_MATCH_TOL = 0.2
-
-
-def _suggest_fix(issue, dwg) -> str | None:
-    """Return a ready-to-paste code snippet that addresses *issue*, or None.
-
-    The snippet is a hint, not necessarily runnable verbatim (``...`` stands in
-    for args the engine cannot infer). It uses the public domain API
-    (:meth:`Drawing.features`, :meth:`Drawing.at`, :meth:`Drawing.place_dim`)
-    so a caller or LLM can paste and fill the gaps trivially (#29).
-    """
-    code = issue.code
-
-    if code == "feature_not_dimensioned":
-        # Message: "cylindrical feature ø8 has no diameter callout on the sheet".
-        m = _DIAM_RE.search(issue.message)
-        if m is None:
-            return None
-        d = float(m.group(1))
-        # The reported diameter is the dedup representative (tol 0.15) formatted
-        # to 1 dp, so match raw feature diameters with that combined slack — a
-        # 1e-6 match would silently miss every non-integer bore.
-        for view in ("plan", "front", "side"):
-            if any(abs(f.diameter - d) < _DIAM_MATCH_TOL for f in dwg.features(view)):
-                tag = _fmt(d).replace(".", "_")
-                return (
-                    f"# ø{_fmt(d)} has no callout. Locate it via features() and add a leader:\n"
-                    f'for f in dwg.features("{view}"):\n'
-                    f"    if abs(f.diameter - {_fmt(d)}) < {_DIAM_MATCH_TOL}:\n"
-                    f"        callout = HoleCallout(f.diameter, count=f.count,\n"
-                    f"                              through=f.through, depth=f.depth, draft=dwg.draft)\n"
-                    f"        elbow = (f.page_pos[0] + 15, f.page_pos[1] + 10, 0)\n"
-                    f'        leader = Leader((*f.page_pos, 0), elbow, "", dwg.draft, callout=callout)\n'
-                    f'        dwg.add(leader, name="hole_{tag}")'
-                )
-        return None
-
-    if code == "feature_count_mismatch":
-        # Message: "4 ø8 features on the part but callouts account for 1".
-        # `need` is the leading count; anchor it so diameter digits never
-        # interfere regardless of message word order.
-        m = _DIAM_RE.search(issue.message)
-        need_m = re.match(r"\s*(\d+)", issue.message)
-        if m is None or need_m is None:
-            return None
-        need = need_m.group(1)
-        return (
-            f"# Only some ø{m.group(1)} holes are counted. Set count={need} on the "
-            f"callout so it covers them all:\n"
-            f"# HoleCallout(..., count={need}, draft=dwg.draft)"
-        )
-
-    if code == "annotation_overlap":
-        # Message: "labels 'A' and 'B' overlap by ...".
-        labels = _QUOTED_RE.findall(issue.message)
-        first = labels[0] if labels else "<dim>"
-        return (
-            f"# Re-add the dimension with place_dim so it auto-stacks in the "
-            f"layout strip instead of overlapping:\n"
-            f'dwg.remove("{first}")  # if it was named\n'
-            f'dwg.place_dim(p1, p2, "below", "plan", dwg.draft, name="{first}")'
-        )
-
-    if code == "dim_inside_part":
-        # Message: "Dim 'X': annotation bbox overlaps part outline by ...".
-        labels = _QUOTED_RE.findall(issue.message)
-        first = labels[0] if labels else "<dim>"
-        return (
-            f"# The dim sits inside the view — its offset is on the wrong side. "
-            f"Re-place it on the opposite side via place_dim (auto-stacks clear "
-            f"of the part):\n"
-            f'dwg.remove("{first}")  # if it was named\n'
-            f'dwg.place_dim(p1, p2, "right", "front", dwg.draft, name="{first}")'
-        )
-
-    if code == "step_dim_dropped":
-        # Steps too closely spaced to dimension at sheet scale (#41/#42).
-        return (
-            "# Re-build with an enlarged detail view so the crowded shoulders are "
-            "dimensionable:\n"
-            "dwg = build_drawing(part, detail_view=True)"
-        )
-
-    return None
 
 
 def analyse_face_levels(part, tol: float = 0.5, min_area_frac: float = 0.0) -> list:

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -1,0 +1,111 @@
+"""The deterministic lint→repair loop (#138 / ADR 0005; #30 / ADR 0002).
+
+After the greedy initial placement, re-place the engine-built dimensions behind
+the mechanically-clear violations (a dim on the wrong side, two overlapping
+labels) and re-lint — bounded and monotonic, so it terminates and never worsens a
+sheet. `Drawing.repair()` is the public wrapper; these helpers take the drawing as
+`dwg` (duck-typed — `lint` / `items` / `_named` / `_registry`), so this module
+imports only `_core`, never `make_drawing` — no cycle.
+"""
+
+from __future__ import annotations
+
+from draftwright._core import _QUOTED_RE, _SLOT_DIM_HEIGHT, _STRIP_SPACING, _dim
+
+# Lint codes the repair loop can mechanically resolve, and the side flip used to
+# move a dimension that landed on the wrong side of its witness points.
+_REPAIRABLE_CODES = frozenset({"annotation_overlap", "dim_inside_part"})
+_OPPOSITE_SIDE = {"above": "below", "below": "above", "left": "right", "right": "left"}
+
+
+def _find_dim(dwg, label):
+    """Return the re-placeable dimension whose label is *label*, or None.
+
+    Only dimensions built by :func:`_dim` (carrying ``_dw_spec``) qualify;
+    leaders, callouts and hand-built annotations are left untouched. A pinned
+    dimension (#89) is also skipped — a deliberate placement must win over
+    automatic repair.
+    """
+    # Identity-based, matching clear_annotations: "this specific object", not
+    # build123d's geometric Shape equality.
+    pinned_ids = dwg._registry.pinned_object_ids()
+    for o in dwg.items:
+        if id(o) in pinned_ids:
+            continue
+        if getattr(o, "_dw_spec", None) is not None and getattr(o, "label", None) == label:
+            return o
+    return None
+
+
+def _replace_dim(dwg, old, new):
+    """Swap *old* for *new* in ``dwg.items``, preserving its name and any per-view
+    scale tag (so a re-placed detail-view dim stays at scale)."""
+    if getattr(old, "_dw_scale", None) is not None:
+        new._dw_scale = old._dw_scale
+    dwg.items[dwg.items.index(old)] = new
+    for n, o in dwg._named.items():
+        if o is old:
+            dwg._named[n] = new
+
+
+def _repair_dim_inside_part(dwg, issue) -> bool:
+    """Flip a dimension that sits inside the view onto the opposite side."""
+    labels = _QUOTED_RE.findall(issue.message)
+    dim = _find_dim(dwg, labels[0]) if labels else None
+    if dim is None:
+        return False
+    s = dim._dw_spec
+    new_side = _OPPOSITE_SIDE.get(s.side)
+    if new_side is None:
+        return False
+    _replace_dim(dwg, dim, _dim(s.p1, s.p2, new_side, s.distance, s.draft, **s.kwargs))
+    return True
+
+
+def _repair_overlap(dwg, issue) -> bool:
+    """Push the first re-placeable label in an overlap one strip-row further out
+    so the two labels separate. Monotonic, so repeated passes converge."""
+    step = _STRIP_SPACING + _SLOT_DIM_HEIGHT
+    for label in _QUOTED_RE.findall(issue.message):
+        dim = _find_dim(dwg, label)
+        if dim is None:
+            continue
+        s = dim._dw_spec
+        _replace_dim(dwg, dim, _dim(s.p1, s.p2, s.side, s.distance + step, s.draft, **s.kwargs))
+        return True
+    return False
+
+
+def repair_drawing(dwg, max_iter: int = 3):
+    """Close the lint→repair loop; see :meth:`Drawing.repair` for the contract.
+    Returns *dwg* for chaining."""
+    flipped: set = set()
+    for _ in range(max_iter):
+        before = dwg.lint()
+        if not before:
+            break
+        snap_annotations = list(dwg.items)
+        snap_named = dict(dwg._named)
+        changed = False
+        for issue in before:
+            if issue.code not in _REPAIRABLE_CODES:
+                continue
+            if issue.code == "dim_inside_part":
+                labels = _QUOTED_RE.findall(issue.message)
+                key = labels[0] if labels else None
+                if key in flipped:
+                    continue
+                if _repair_dim_inside_part(dwg, issue):
+                    flipped.add(key)
+                    changed = True
+            elif issue.code == "annotation_overlap":
+                changed |= _repair_overlap(dwg, issue)
+        if not changed:
+            break
+        if len(dwg.lint()) > len(before):
+            # The repairs net-worsened the sheet — undo this pass and stop.
+            dwg.items[:] = snap_annotations
+            dwg._named.clear()
+            dwg._named.update(snap_named)
+            break
+    return dwg

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4071,6 +4071,7 @@ class TestRepair:
         from build123d_drafting.helpers import LintIssue
 
         from draftwright.make_drawing import _dim
+        from draftwright.repair import _repair_dim_inside_part
 
         dwg = build_drawing(Box(60, 40, 20))
         dim = dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="INSIDE"), "x")
@@ -4081,7 +4082,7 @@ class TestRepair:
             message="Dim 'INSIDE': annotation bbox overlaps part outline by 40%",
             code="dim_inside_part",
         )
-        assert dwg._repair_dim_inside_part(issue) is True
+        assert _repair_dim_inside_part(dwg, issue) is True
         new = dwg._named["x"]
         assert new is not dim
         assert new._dw_spec.side == "below"


### PR DESCRIPTION
Continues the #138 module-split (one PR, atomic commits). **Pure code moves — golden gate unchanged on each.**

## Commit 1 — finish the lint module
`_suggest_fix` (#29 fix snippets) + `_DIAM_MATCH_TOL` move into `linting.py` alongside `lint_feature_coverage`. The shared `_QUOTED_RE` (lint-message label regex, used by both `_suggest_fix` and the repair loop) relocates to `_core` — so `linting.py` and repair both import it from below, no cycle.

## Commit 2 — extract `repair.py`
The deterministic lint→repair helpers (`_find_dim`/`_replace_dim`/`_repair_*`/`repair_drawing`) move out of `Drawing` into `repair.py` as free functions taking `dwg` (duck-typed). `Drawing.repair()` stays a thin wrapper. `_REPAIRABLE_CODES`/`_OPPOSITE_SIDE` → `repair.py`; shared `_STRIP_SPACING` → `_core`.

`make_drawing.py`: **3477** (from ~3907 at session start).

## Verified
Golden gate passes against committed snapshots with no regeneration on both commits; lint/suggestion + `TestRepair` suites pass; ruff clean; no import cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoG24RWpmNApX4cMiucS7v
