### PR TITLE
docs(#138): module-split roadmap + refreshed ADRs + phase issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,14 +89,14 @@ Current ADRs:
   annotation identity/pins/build-issues move to a `registry.py`, coverage state to
   lint, build context (`Analysis`, edge cache) to the pipeline. Stages split into
   `builder`/`analysis`/`sheet`/`projection`/`linting`/`repair`/`export`/`annotations/`;
-  `layout.py` unchanged. **Landed so far:** Step 0 (golden-output harness, gates
-  behaviour-equivalence), Step 1 (#139, public helper APIs), Step 2 (`registry.py`
-  owns annotation identity; `Drawing` delegates, with `_named`/`_anno_view`/
-  `_pinned`/`_build_issues` kept as compat properties), Step 3 (`linting.py`
-  `CoverageState` owns the lint-side coverage signal). **Still ahead:** build
-  context → pipeline, and the sheet/projection/export/annotations splits. The
-  module list above is the *current* tree; the remaining stage modules do not
-  exist yet.
+  `layout.py` unchanged. **Roadmap + per-phase issues:**
+  `docs/plans/138-module-split-roadmap.md`. **Landed** (`make_drawing.py`
+  3,907 → 3,476): golden gate (Step 0), public helper APIs (#139), `registry.py`
+  (Step 2), `linting.py` (`CoverageState` + lint functions, Step 3), `repair.py`,
+  `export.py`. **Still ahead:** P1 `_text_width`→`_core` (#160), P2 `projection.py`
+  (#161), P3 `sheet.py` (#162), P4 `analysis.py` (#163), P5 `annotations/` (#164),
+  P6 `builder.py` + build-context threading (#165), P7 mypy (#166). The module list
+  above is the *current* tree; the remaining stage modules do not exist yet.
 - **0006** — **Accepted** (#149): deterministic cross-platform layout via bundled,
   path-pinned fonts. Layout depends on measured text width; resolving a font *name*
   (`"Arial"`) substitutes a different font on Linux, drifting the whole sheet ~1 mm.

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -194,13 +194,15 @@ Decisions:
    fitness function. If even A0 at the smallest standard scale will not hold the
    packed blocks, **suggest a larger page / smaller scale** rather than cram.
 
-## Module homes (forward note — ADR 0005, proposed)
+## Module homes (forward note — ADR 0005, in progress)
 
 This ADR names its anchors by their *current* location: `_analyse`,
 `StripDepths`, `ViewBlock`, `_repack`, `choose_scale` in `make_drawing.py`, and
 `_auto_annotate` in `annotate.py`. [ADR 0005](0005-pipeline-architecture-and-state-ownership.md)
-(proposed) plans to relocate these — sheet planning/compose-then-pack to
-`sheet.py`, projection/`_assemble` to `projection.py`, annotation sequencing to
-`annotations/orchestrator.py` — **without changing this decision**. When that
-migration lands, refresh the anchor names above. The compose-then-pack model,
-the box-layout footprint, and the monotone `(scale, page)` search are unaffected.
+(Accepted, in progress) relocates these **without changing this decision** —
+sheet planning/compose-then-pack to `sheet.py` (#162), projection/`_assemble` to
+`projection.py` (#161) / `builder.py` (#165), `_analyse` to `analysis.py` (#163),
+annotation sequencing to `annotations/orchestrator.py` (#164). Refresh the anchor
+names above as each phase lands (roadmap: `docs/plans/138-module-split-roadmap.md`).
+The compose-then-pack model, the box-layout footprint, and the monotone
+`(scale, page)` search are unaffected.

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -3,12 +3,18 @@
 - **Status:** Accepted, in progress
 - **Date:** 2026-06-27
 - **Deciders:** Paul Fremantle (pzfreo)
-- **Progress:** Step 0 (golden gate), Step 1 (#139, public helper APIs), Step 2
-  (`registry.py` owns annotation identity; `Drawing` delegates, the four field
-  names kept as compat properties), and Step 3 (`linting.py` `CoverageState` owns
-  the lint-side coverage signal — pattern callouts, patterned holes, dropped
-  callout diameters) landed. Remaining: build context (`Analysis`, edge cache) →
-  pipeline, and the stage-module splits.
+- **Progress:** Execution roadmap with per-phase tracking issues:
+  [`docs/plans/138-module-split-roadmap.md`](../plans/138-module-split-roadmap.md).
+  **Landed** (`make_drawing.py` 3,907 → 3,476): the golden gate (Step 0, made
+  cross-platform-deterministic by the #149 font pinning), public helper APIs
+  (#139), `registry.py` (annotation identity, Step 2), `linting.py`
+  (`CoverageState` + `lint_feature_coverage` + `_suggest_fix`, Step 3), `repair.py`
+  (the lint→repair loop), and `export.py`. **Remaining** (deeply-coupled stage
+  splits, sequenced prerequisite-first): P1 `_text_width`→`_core` (#160), P2
+  `projection.py` (#161), P3 `sheet.py` (#162), P4 `analysis.py` (#163), P5
+  `annotations/` (#164), P6 `builder.py` + build-context threading (#165), P7 mypy
+  (#166). Build context (`_analysis`, edge cache) is threaded through
+  `builder`/`projection` in P6, **not** parked on `Drawing` as a standalone owner.
 
 ## Context
 

--- a/docs/plans/138-module-split-roadmap.md
+++ b/docs/plans/138-module-split-roadmap.md
@@ -1,0 +1,89 @@
+# #138 — Module-split roadmap
+
+Execution roadmap for [ADR 0005](../adr/0005-pipeline-architecture-and-state-ownership.md)
+(compiler-pipeline module boundaries + single-owner build state). Tracking issue:
+**#138**. Each phase below is a GitHub issue; each chunk is one PR.
+
+## Why
+`make_drawing.py` (3,907 lines at the start) and `annotate.py` (2,587) held almost
+everything, and `Drawing` was the implicit state bus between subsystems. ADR 0005
+reshapes the package along the compiler-pipeline stages and gives each build-time
+state concern a single owner. The golden-output gate (`tests/test_golden.py`,
+made cross-platform-deterministic by the #149 font pinning) proves every move is
+behaviour-preserving.
+
+## Status
+
+**Landed** (`make_drawing.py` 3,907 → 3,476):
+
+| Step | What | PR |
+|---|---|---|
+| 0 | Golden-output gate (Step 0) | #147 |
+| — | Deterministic layout (font pinning — makes the gate pin real parts) | #149 |
+| 1 | Public helper APIs (#139) | #152 |
+| 2 | `registry.py` — annotation identity/ownership/pins/build-issues | #152 |
+| 3 | `linting.py` — `CoverageState` + `lint_feature_coverage` + `_suggest_fix` | #155, #158, #159 |
+| — | `repair.py` — deterministic lint→repair loop | #159 |
+| — | `export.py` — SVG/DXF/PDF export + post-processing | #156 |
+| — | Infra: smoke tier, coverage→CI, xdist, slow-tier-post-merge | #154, #157 |
+
+**Remaining** — the deeply-coupled stage modules, sequenced prerequisite-first so
+no PR introduces an import cycle, riskiest (annotations) last:
+
+| Phase | Issue | Chunk(s) | Size | Depends |
+|---|---|---|---|---|
+| **P1** | #160 | `_text_width` → `_core` | tiny | — |
+| **P2** | #161 | `projection.py` (silhouettes, iso) | med | — |
+| **P3** | #162 | `sheet.py` — 3a footprints/estimators, 3b scale/zone/repack | large (2 PRs) | P1 |
+| **P4** | #163 | `analysis.py` (`_analyse`) | med-lg | — |
+| **P5** | #164 | `annotations/` — sections, turned, pmi, **holes**, **orchestrator** | biggest (~5 PRs) | P1–P4 |
+| **P6** | #165 | `builder.py` + thread the build context | med | P2, P4 |
+| **P7** | #166 | tighten mypy on settled contracts | cleanup | all |
+
+## Target module shape (ADR 0005 §1)
+```text
+make_drawing.py   # transitional compat facade / public re-exports
+builder.py        # build_drawing/make_drawing orchestration (P6)
+analysis.py       # _analyse, Analysis construction (P4)
+sheet.py          # choose_scale, compose-then-pack, repack (P3)
+projection.py     # view projection, silhouettes, iso fit (P2)
+registry.py       # annotation identity (DONE)
+linting.py        # lint_feature_coverage, _suggest_fix, CoverageState (DONE)
+repair.py         # deterministic repair loop (DONE)
+export.py         # SVG/DXF/PDF export (DONE)
+fonts.py          # vendored path-pinned fonts (DONE)
+annotations/      # the split annotate.py passes (P5)
+  orchestrator.py envelope.py holes.py turned.py sections.py pmi.py
+layout.py         # solver/placement — UNCHANGED (ADR 0003)
+_core.py          # shared primitives below everything
+```
+
+## Per-PR playbook (proven across the six splits already landed)
+1. Branch off `main`; move **one** cluster.
+2. `make_drawing.py`/`annotate.py` re-import the moved symbols (compat facade) so
+   `from draftwright.make_drawing import …` and public re-exports keep working;
+   redirect test imports to the new home only where deliberate.
+3. **Golden gate must pass against the committed snapshots with no regeneration** —
+   the proof the move changed nothing.
+4. `ruff check` **and** `ruff format --check` **and** `mypy` (all three — `ruff
+   check` alone misses format/type errors), plus the moved area's targeted tests.
+5. Open PR; merge on green. CI: lint + parallel matrix on the PR; slow tier
+   post-merge on `main`.
+
+## Risk notes
+- **Cycles** — if a moved cluster needs a `make_drawing`-local helper, relocate
+  that helper to `_core` first as a mini-prereq (P1 does this for `_text_width`).
+- **Hairiest** — P5 holes (most shared helpers) and the orchestrator (the envelope
+  OD/width/depth/height/step dims are *inline* in `_auto_annotate`, not separate
+  functions, so they must be extracted into `annotations/envelope.py` during the
+  orchestrator split). Give these the most review.
+- **Build context** (`_analysis`, `_view_edge_cache`) is **not** made a standalone
+  owner — that would contradict ADR 0005 §2 ("threaded through `builder`/
+  `projection`, not parked on `Drawing`"). It is resolved in P6.
+
+## Success criteria (every phase)
+- Named symbols live in the new module; compat facade keeps imports working.
+- No import cycle; new module imports only `_core`/below + build123d.
+- Golden gate unchanged (no snapshot regeneration).
+- `ruff check` + `ruff format --check` + `mypy` clean; targeted tests + CI green.
+- `make_drawing.py` / `annotate.py` line count drops; CLAUDE.md + ADR 0005 updated.


### PR DESCRIPTION
Plans the remaining #138 work into trackable phases.

## What's here
- **`docs/plans/138-module-split-roadmap.md`** — execution roadmap for ADR 0005: landed work (make_drawing 3907→3476), the remaining **prerequisite-first phases P1–P7**, target module shape, per-PR playbook, risk notes.
- **ADR 0005** Progress refreshed — lists every landed split + the P1–P7 phases with tracking issues, points at the roadmap. Build context noted as threaded (P6), not a standalone owner.
- **ADR 0004** module-homes note: `proposed` → `in progress` with per-phase issue links.
- **CLAUDE.md** 0005 bullet updated.

## Tracking issues created
P1 #160 · P2 #161 · P3 #162 · P4 #163 · P5 #164 · P6 #165 · P7 #166 — each with clear success criteria (symbols moved + compat facade, no import cycle, **golden gate unchanged**, ruff+format+mypy+CI green).

Docs-only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoG24RWpmNApX4cMiucS7v