### PR TITLE
#138 P1: relocate _text_width to _core

### DIFF
--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -10,7 +10,7 @@
   (#139), `registry.py` (annotation identity, Step 2), `linting.py`
   (`CoverageState` + `lint_feature_coverage` + `_suggest_fix`, Step 3), `repair.py`
   (the lint→repair loop), and `export.py`. **Remaining** (deeply-coupled stage
-  splits, sequenced prerequisite-first): P1 `_text_width`→`_core` (#160), P2
+  splits, sequenced prerequisite-first): P1 `_text_width`→`_core` (#160, done), P2
   `projection.py` (#161), P3 `sheet.py` (#162), P4 `analysis.py` (#163), P5
   `annotations/` (#164), P6 `builder.py` + build-context threading (#165), P7 mypy
   (#166). Build context (`_analysis`, edge cache) is threaded through

--- a/docs/plans/138-module-split-roadmap.md
+++ b/docs/plans/138-module-split-roadmap.md
@@ -32,7 +32,7 @@ no PR introduces an import cycle, riskiest (annotations) last:
 
 | Phase | Issue | Chunk(s) | Size | Depends |
 |---|---|---|---|---|
-| **P1** | #160 | `_text_width` → `_core` | tiny | — |
+| ~~P1~~ | #160 | `_text_width` → `_core` ✅ | tiny | — |
 | **P2** | #161 | `projection.py` (silhouettes, iso) | med | — |
 | **P3** | #162 | `sheet.py` — 3a footprints/estimators, 3b scale/zone/repack | large (2 PRs) | P1 |
 | **P4** | #163 | `analysis.py` (`_analyse`) | med-lg | — |

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -10,13 +10,14 @@ the dimension/format helpers, and the layout constants).  It imports only from
 
 from __future__ import annotations
 
+import functools
 import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
 
-from build123d import BoundBox, Location, Shape
+from build123d import Align, BoundBox, Location, Mode, Shape, Text
 from build123d_drafting.helpers import (
     Dimension,
     TitleBlock,
@@ -24,7 +25,7 @@ from build123d_drafting.helpers import (
     format_drawing_scale,
 )
 
-from draftwright.fonts import PLEX_SANS_CONDENSED
+from draftwright.fonts import PLEX_MONO, PLEX_SANS_CONDENSED
 from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
 
 _log = logging.getLogger(__name__)
@@ -67,6 +68,34 @@ _DIAM_RE = re.compile(r"[øØ⌀]\s*(\d+(?:\.\d+)?)")
 # A single-quoted label lifted from a lint message, e.g. "labels 'A' and 'B' …".
 # Shared by the #29 lint suggestions (linting.py) and the #30 repair loop.
 _QUOTED_RE = re.compile(r"'([^']*)'")
+
+
+@functools.lru_cache(maxsize=512)
+def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> float:
+    """Measured rendered width (page-mm) of *text* at *font_size*.
+
+    Uses build123d's ``Text`` — the same primitive ``Dimension``/``HoleCallout``
+    stroke their labels with — so callout-width estimates use real glyph metrics
+    instead of a character-count fudge (#31).  Pinned to a vendored font **file**
+    (``font_path``), not a system font *name*: name resolution substitutes a
+    different font on Linux, which makes this estimate — and the layout it feeds —
+    platform-variant (#149). The default is the same face the annotations render
+    with, so estimate and render agree.  Cached because the same numeric labels
+    recur across holes and the rasterisation is the costly part.
+    """
+    if not text:
+        return 0.0
+    return (
+        Text(
+            txt=text,
+            font_size=font_size,
+            font_path=font_path,
+            align=(Align.CENTER, Align.CENTER),
+            mode=Mode.PRIVATE,
+        )
+        .bounding_box()
+        .size.X
+    )
 
 
 def _axis_letter(obj) -> str:

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -19,7 +19,6 @@ CLI (registered as ``make-drawing``)::
 from __future__ import annotations
 
 import argparse
-import functools
 import logging
 import math
 import re
@@ -104,6 +103,7 @@ from draftwright._core import (
     _log,
     _Projector,
     _tag_sequence,
+    _text_width,
 )
 from draftwright.annotate import _auto_annotate
 from draftwright.export import (
@@ -324,34 +324,6 @@ def dedup_diams(cyls, tol: float = 0.15) -> list:
         if not merged or abs(d - merged[-1]) > tol:
             merged.append(round(d, 2))
     return merged
-
-
-@functools.lru_cache(maxsize=512)
-def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> float:
-    """Measured rendered width (page-mm) of *text* at *font_size*.
-
-    Uses build123d's ``Text`` — the same primitive ``Dimension``/``HoleCallout``
-    stroke their labels with — so callout-width estimates use real glyph metrics
-    instead of a character-count fudge (#31).  Pinned to a vendored font **file**
-    (``font_path``), not a system font *name*: name resolution substitutes a
-    different font on Linux, which makes this estimate — and the layout it feeds —
-    platform-variant (#149). The default is the same face the annotations render
-    with, so estimate and render agree.  Cached because the same numeric labels
-    recur across holes and the rasterisation is the costly part.
-    """
-    if not text:
-        return 0.0
-    return (
-        Text(
-            txt=text,
-            font_size=font_size,
-            font_path=font_path,
-            align=(Align.CENTER, Align.CENTER),
-            mode=Mode.PRIVATE,
-        )
-        .bounding_box()
-        .size.X
-    )
 
 
 def _build_table(rows, draft, block_cols=None):


### PR DESCRIPTION
Closes #160. Phase 1 (prerequisite) of the #138 module-split roadmap.

Moves the cached `_text_width` measurement from `make_drawing.py` to `_core.py` — the sheet/layout estimators call it 8×, so placing it below `make_drawing` removes the `sheet → make_drawing` cycle P3 would hit. No new import edge (`_core` already uses fonts/build123d).

**Pure move, verified:** golden gate unchanged (no regeneration), ruff check + format + mypy clean, text-width/estimator tests pass. **Adversarial review clean:** body byte-identical, `_core` imports standalone (no cycle), measurements unchanged, lru_cache intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoG24RWpmNApX4cMiucS7v