### PR TITLE
#138 P4: extract analysis.py (_analyse + geometry analysis)

### DIFF
--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -11,7 +11,7 @@
   (`CoverageState` + `lint_feature_coverage` + `_suggest_fix`, Step 3), `repair.py`
   (the lint→repair loop), and `export.py`. **Remaining** (deeply-coupled stage
   splits, sequenced prerequisite-first): P1 `_text_width`→`_core` (#160, done), P2
-  `projection.py` (#161), P3 `sheet.py` (#162, done; repack deferred to P6), P4 `analysis.py` (#163), P5
+  `projection.py` (#161), P3 `sheet.py` (#162, done; repack deferred to P6), P4 `analysis.py` (#163, done), P5
   `annotations/` (#164), P6 `builder.py` + build-context threading (#165), P7 mypy
   (#166). Build context (`_analysis`, edge cache) is threaded through
   `builder`/`projection` in P6, **not** parked on `Drawing` as a standalone owner.

--- a/docs/plans/138-module-split-roadmap.md
+++ b/docs/plans/138-module-split-roadmap.md
@@ -35,7 +35,7 @@ no PR introduces an import cycle, riskiest (annotations) last:
 | ~~P1~~ | #160 | `_text_width` → `_core` ✅ | tiny | — |
 | ~~P2~~ | #161 | `projection.py` (silhouettes, iso) ✅ | med | — |
 | ~~P3~~ | #162 | `sheet.py` — compose-then-pack (repack deferred to P6) ✅ | large (2 PRs) | P1 |
-| **P4** | #163 | `analysis.py` (`_analyse`) | med-lg | — |
+| ~~P4~~ | #163 | `analysis.py` (`_analyse`) ✅ | med-lg | — |
 | **P5** | #164 | `annotations/` — sections, turned, pmi, **holes**, **orchestrator** | biggest (~5 PRs) | P1–P4 |
 | **P6** | #165 | `builder.py` + thread the build context | med | P2, P4 |
 | **P7** | #166 | tighten mypy on settled contracts | cleanup | all |
@@ -44,7 +44,7 @@ no PR introduces an import cycle, riskiest (annotations) last:
 ```text
 make_drawing.py   # transitional compat facade / public re-exports
 builder.py        # build_drawing/make_drawing orchestration (P6)
-analysis.py       # _analyse, Analysis construction (P4)
+analysis.py       # _analyse, Analysis construction (DONE)
 sheet.py          # choose_scale, compose-then-pack (DONE; repack→P6)
 projection.py     # view projection, silhouettes, iso fit (DONE)
 registry.py       # annotation identity (DONE)

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -11,19 +11,18 @@ Requires build123d-drafting-helpers for annotation primitives.
 Licensed under the GNU Affero General Public License v3 (AGPL-3.0).
 """
 
+from draftwright.analysis import analyse_face_levels, dedup_diams
 from draftwright.make_drawing import (
     Drawing,
     FeatureInfo,
-    analyse_face_levels,
     build_drawing,
-    choose_scale,
-    dedup_diams,
     fix_svg_page_size,
     generate_script,
     lint_feature_coverage,
     make_drawing,
 )
 from draftwright.pmi import PmiRecord, extract_pmi
+from draftwright.sheet import choose_scale
 
 __all__ = [
     "Drawing",

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -227,6 +227,9 @@ _SLOT_DIM_HEIGHT = 2 * _FONT_SIZE + 2 * _PAD  # fv_zones.right: overall height d
 
 
 _STRIP_SPACING = 4.0  # page-mm between successive annotations in a strip
+_MIN_VIEW_MM = (
+    10.0  # min projected view dimension; below it annotation geometry degenerates (#129)
+)
 
 
 _SLOT_DIM_STEP = 4 * _FONT_SIZE + _PAD  # fv_zones.right: step-height dimension

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -1,0 +1,479 @@
+"""Geometry/feature analysis — build the Analysis namespace from a part (#138 / ADR 0005, P4).
+
+`_analyse` imports the part (STEP or Shape), runs feature detection (holes,
+patterns, cylinders, face levels), classifies it (rotational vs prismatic),
+chooses the sheet (scale/page via `sheet.choose_scale`) and lays out the view
+zones (`sheet._layout_geometry`/`_build_zones`) — returning the `Analysis`
+namespace the rest of the pipeline reads. Sits above `sheet` and below
+`make_drawing` in the DAG.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from build123d import Compound, Shape
+from build123d_drafting.features import (
+    analyse_cylinders,
+    find_hole_patterns,
+    find_holes,
+    full_cylinders,
+)
+from build123d_drafting.helpers import draft_preset
+from OCP.BRepAdaptor import BRepAdaptor_Surface
+from OCP.BRepGProp import BRepGProp
+from OCP.GeomAbs import GeomAbs_Plane
+from OCP.GProp import GProp_GProps
+from OCP.IFSelect import IFSelect_ReturnStatus
+from OCP.STEPControl import STEPControl_Reader
+
+from draftwright._core import (
+    _DIM_PAD,
+    _FONT_SIZE,
+    _MARGIN,
+    _MIN_VIEW_MM,
+    Analysis,
+    _legible_steps,
+    _Projector,
+)
+from draftwright.features import find_slots
+from draftwright.sheet import (
+    _build_zones,
+    _layout_geometry,
+    _measure_strips,
+    choose_scale,
+)
+
+_log = logging.getLogger(__name__)
+
+# Turned-part classification (#81): a rotational part's bounding box is square
+# in XY to within _SQUARENESS_TOL, and its OD (largest full external Z cylinder)
+# fills >= _OD_FILL_MIN of that envelope, axis within _OD_AXIS_TOL of centre.
+_SQUARENESS_TOL = 0.05
+_OD_FILL_MIN = 0.8
+_OD_AXIS_TOL = 0.05
+
+
+def _import_step(path) -> Compound:
+    """Read solid geometry from a STEP file via OCCT's ``STEPControl_Reader``.
+
+    build123d's ``import_step`` uses the XCAF reader (colours, names, PMI), which
+    **segfaults** on some AP242 files carrying semantic PMI — e.g. NIST CTC-02
+    AP242 (#20) — before any Python code can intervene. draftwright needs only
+    the solid geometry (it drops PMI presentation data anyway), so we read the
+    geometry directly. Verified to produce identical shapes (solids, edges, bbox)
+    to ``import_step`` on the files that read in both, minus the unused metadata.
+    """
+    reader = STEPControl_Reader()
+    if reader.ReadFile(str(path)) != IFSelect_ReturnStatus.IFSelect_RetDone:
+        raise ValueError(f"could not read STEP file {path!r}")
+    reader.TransferRoots()
+    return Compound(reader.OneShape())
+
+
+# ---------------------------------------------------------------------------
+# Geometry analysis
+# ---------------------------------------------------------------------------
+
+
+def dedup_diams(cyls, tol: float = 0.15) -> list:
+    """Return sorted-descending deduplicated diameter list from cylinder records."""
+    raw = sorted({c["diameter"] for c in cyls}, reverse=True)
+    merged: list[float] = []
+    for d in raw:
+        if not merged or abs(d - merged[-1]) > tol:
+            merged.append(round(d, 2))
+    return merged
+
+
+def _is_rotational(x_size, y_size, od_diam, od_axis_offset) -> bool:
+    """True for turned parts: an outward-facing Z cylinder, concentric with
+    the bounding box, filling a square envelope.
+
+    ``od_diam`` is the largest full *external* Z-cylinder diameter (``None``
+    when there is none — bores never qualify as an OD) and
+    ``od_axis_offset`` that cylinder's axis distance from the bbox centre.
+    """
+    if od_diam is None:
+        return False
+    envelope = max(x_size, y_size)
+    return (
+        abs(x_size - y_size) <= _SQUARENESS_TOL * envelope
+        and od_diam >= _OD_FILL_MIN * envelope
+        and od_axis_offset <= _OD_AXIS_TOL * envelope
+    )
+
+
+# A hole is "concentric" with a turned part's rotation axis when its drilling
+# axis is the Z (OD) axis and its opening sits on the part centreline.  Such
+# bores are already dimensioned by the ldr_z bore leaders, so they must not
+# also receive a hole callout / location dim (#10).  Off-axis holes (a bolt
+# circle, a cross-hole) fall through to the feature-presence path.
+
+
+# --- lint scoring (see Drawing.lint_summary) -------------------------------
+
+
+def analyse_face_levels(part, tol: float = 0.5, min_area_frac: float = 0.0) -> list:
+    """Return sorted unique Z-coords of horizontal (normal≈±Z) planar faces.
+
+    Uses tol-bucket deduplication but returns the actual face Z, not the rounded
+    bucket centre, so dimension labels match the true geometry.
+
+    When *min_area_frac* > 0, a Z level is kept only if the total area of its
+    horizontal faces is at least ``min_area_frac × (x_size × y_size)`` (the
+    part's plan footprint). This drops sub-feature faces — e.g. fragments of
+    engraved text/numbers — that are not real steps and would otherwise be
+    dimensioned as phantom shoulders (staircase.step review).
+    """
+    buckets: dict = {}  # bucket key -> representative z
+    areas: dict = {}  # bucket key -> total horizontal-face area
+    for face in part.faces():
+        surf = BRepAdaptor_Surface(face.wrapped)
+        if surf.GetType() == GeomAbs_Plane:
+            ax = surf.Plane().Axis().Direction()
+            if abs(ax.Z()) > 0.99:
+                z = surf.Plane().Location().Z()
+                key = round(z / tol) * tol
+                buckets.setdefault(key, z)
+                if min_area_frac > 0.0:
+                    props = GProp_GProps()
+                    BRepGProp.SurfaceProperties_s(face.wrapped, props)
+                    areas[key] = areas.get(key, 0.0) + props.Mass()
+    if min_area_frac > 0.0:
+        bb = part.bounding_box()
+        footprint = (bb.max.X - bb.min.X) * (bb.max.Y - bb.min.Y)
+        threshold = min_area_frac * footprint
+        return sorted(z for key, z in buckets.items() if areas.get(key, 0.0) >= threshold)
+    return sorted(buckets.values())
+
+
+# ---------------------------------------------------------------------------
+# Strip / zone layout model
+# ---------------------------------------------------------------------------
+
+
+# Slot sizes for the annotations that allocate from fv/pv/sv strips.
+# Shared between the depth estimators below and the allocate() call-sites in
+# _auto_annotate() so that a slot-size change is automatically reflected in
+# the estimator-driven corridor widths.
+#
+# A slot is the perpendicular depth (page-mm) reserved for one Dimension: its
+# dim-line offset from the view edge plus the label, which sits exactly
+# pad_around_text beyond the line (measured: a "right"/"below" Dimension's
+# perpendicular span equals offset + pad_around_text - extension_gap, and
+# pad == extension_gap in the draft preset).  Each slot is therefore derived
+# from text metrics (font_size + pad_around_text), like _MIN_STEP_DIM_MM, so it
+# rescales with _FONT_SIZE instead of being a bare mm guess (#31).
+# Single overall dim: two glyph-heights of line offset + the outboard label pad.
+# The overall height dim leads the right ladder, so it carries an extra pad of
+# clearance from the view above the first step dim's witness.
+# Stacked step dims sit deeper so each ladder rung's label clears the rung below.
+
+# A plan view with at least this many holes escalates to a hole chart when it is
+# too dense to dimension every hole individually (#93). Below it, a dropped ref
+# stays a legibility drop rather than tabulating a handful of holes.
+
+# Smallest projected step height (page-mm) that can still carry a *legible*
+# stacked dimension between its two extension lines.  Derived from what has to
+# fit vertically: the label (font height) plus an arrowhead at each end plus
+# the text clearance above and below — not an arbitrary page-mm cutoff (#13).
+# Used as the single gate in BOTH _analyse (n_steps) and _auto_annotate
+# (dim_step placement) so the two can never diverge.
+
+# Minimum page-mm separation between two *consecutive* dimensioned step heights.
+# Shoulders closer than this on the page read as one, so only the first of such
+# a cluster is dimensioned and the rest surface via lint (#41). Sized to the
+# value-label footprint (one glyph height + clearance) — enough to tell two
+# stacked step dims apart, without dropping genuinely-distinct shoulders.
+
+# A horizontal face counts as a real step only if its area is at least this
+# fraction of the part's plan footprint (x_size × y_size). Filters out tiny
+# faces from engraved text/numbers that are not steps (staircase.step review).
+_STEP_MIN_AREA_FRAC = 0.01
+
+# Minimum page-mm separation between two *consecutive* hole-location dimensions
+# along one axis. Stacked location dims sit on separate tiers, so their value
+# labels never collide (the tier pitch handles that); the legibility limit is the
+# extension lines / arrowheads merging when two holes share almost the same
+# position on that axis. Sized to one arrowhead plus clearance — smaller than the
+# step-spacing gate, which also stacks labels in one column. Holes closer than
+# this read as one, so only the first of such a run is dimensioned and the rest
+# surface via lint (#43): "fits" is not the same as "legible".
+
+
+# ---------------------------------------------------------------------------
+# Annotation depth estimators (Phase 2 of #118)
+#
+# These pure functions estimate the strip depth (mm) required for each
+# inter-view boundary BEFORE view positions are fixed.  They are intentionally
+# conservative (may over-estimate slightly).  Used by _analyse() (Phase 3) to
+# set minimum corridor widths, and by _fits() (Phase 3) for consistent sheet
+# selection.
+# ---------------------------------------------------------------------------
+
+
+def _analyse(
+    step_file, title, number, tolerance, drawn_by, out, scale=None, page=None, pmi="off"
+) -> Analysis:
+    """Load STEP or use a build123d Shape, analyse geometry, compute layout.
+
+    Returns an :class:`Analysis`.
+    """
+    if isinstance(step_file, Shape):
+        part = step_file
+        src = "build123d object"
+    else:
+        part = _import_step(step_file)
+        src = str(step_file)
+    # AP242 STEP files carry PMI presentation geometry (annotation-plane
+    # border wires, leader curves) beside the solid; left in, it draws as
+    # phantom rectangles in every view and inflates the bounding box —
+    # corrupting the scale choice and the envelope dimensions. The drawing
+    # is of the solids.
+    solids = part.solids()
+    if solids:
+        body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
+        if body.bounding_box().size != part.bounding_box().size or len(part.edges()) != len(
+            body.edges()
+        ):
+            _log.info(
+                "Dropping non-solid geometry from %s (PMI presentation data)",
+                src,
+            )
+        part = body
+
+    # Semantic PMI extraction (AP242 only; separate read-only pass).
+    pmi_records: list = []
+    if pmi != "off" and not isinstance(step_file, Shape):
+        try:
+            from draftwright.pmi import extract_pmi
+
+            pmi_records = extract_pmi(step_file)
+        except Exception as exc:
+            _log.warning("PMI extraction failed: %s", exc)
+
+    bb = part.bounding_box()
+    x_size = bb.max.X - bb.min.X
+    y_size = bb.max.Y - bb.min.Y
+    z_size = bb.max.Z - bb.min.Z
+    cx = (bb.min.X + bb.max.X) / 2
+    cy = (bb.min.Y + bb.max.Y) / 2
+    cz = (bb.min.Z + bb.max.Z) / 2
+    bbox_max = max(x_size, y_size, z_size)
+
+    _log.info("Loaded %s  bbox: %.2f × %.2f × %.2f mm", src, x_size, y_size, z_size)
+
+    z_cyls, cross_cyls = analyse_cylinders(part)
+    # Partial (fillet) faces are not features: they would pollute the OD,
+    # the bore leaders, and the rotational classification alike (#81)
+    full_z = full_cylinders(z_cyls)
+    z_diams = dedup_diams(full_z)
+    cross_diams = dedup_diams(full_cylinders(cross_cyls))
+
+    _log.info("Z-axis diameters: %s", z_diams)
+    if cross_diams:
+        _log.info("Cross-hole diams: %s", cross_diams)
+
+    od_cyl = max((c for c in full_z if c["external"]), key=lambda c: c["diameter"], default=None)
+    od_diam = None
+    if od_cyl:
+        # Snap to the dedup_diams representative so comparisons against
+        # z_diams entries (bore-leader exclusion, labels) are exact even if
+        # the cylinder records ever carry unrounded OCCT diameters (#86)
+        raw_od = od_cyl["diameter"]
+        od_diam = min(z_diams, key=lambda d: abs(d - raw_od))
+    od_axis_offset = (
+        math.hypot(od_cyl["axis_xyz"][0] - cx, od_cyl["axis_xyz"][1] - cy) if od_cyl else 0.0
+    )
+    is_rotational = _is_rotational(x_size, y_size, od_diam, od_axis_offset)
+    if z_diams and not is_rotational:
+        _log.info("Part classified prismatic; skipping OD/centreline/bore annotations")
+
+    face_zs = analyse_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)
+    step_zs = [z for z in face_zs if z > bb.min.Z + 0.6 and z < bb.max.Z - 0.6]
+
+    # Pass 1 (two-pass layout, #131): measure annotation strip depths before
+    # view positions are fixed.  font_size=3.0 is a fixed page-mm constant so
+    # all annotation sizes are scale-independent — no circularity.
+    # Construct the same draft preset used later in build_drawing() to read
+    # arrow_length and pad_around_text from their authoritative source rather
+    # than re-stating them as magic literals in the estimators.
+    _draft_est = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
+    _arrow_length = _draft_est.arrow_length
+    _pad_around_text = _draft_est.pad_around_text
+    holes = find_holes(part, cyls=(z_cyls, cross_cyls))
+    patterns = find_hole_patterns(holes)
+    slots = find_slots(part)
+
+    # Choose scale/page, iterating so the reserved step corridor matches the
+    # number of steps the legibility gate will actually place (#1) — not the raw
+    # face count. Otherwise a part with many sub-legible faces (e.g. a staircase
+    # with 15 tiny treads) reserves a phantom step ladder that blocks a larger
+    # scale. Seed conservatively (all faces), then re-gate at the chosen scale;
+    # converges in a couple of rounds.
+    n_for_sizing = len(step_zs)
+    strips_i = None
+    for _ in range(3):
+        strips_i = _measure_strips(
+            holes,
+            patterns,
+            n_for_sizing,
+            bb,
+            arrow_length=_arrow_length,
+            pad_around_text=_pad_around_text,
+        )
+        SCALE, PAGE_W, PAGE_H, TB_W = choose_scale(
+            x_size, y_size, z_size, n_steps=n_for_sizing, scale=scale, page=page, strips=strips_i
+        )
+        n_next = len(_legible_steps(step_zs, bb.min.Z, SCALE)[0])
+        if n_next == n_for_sizing:
+            break
+        n_for_sizing = n_next
+    if scale is not None:
+        auto_scale, _, _, _ = choose_scale(
+            x_size, y_size, z_size, n_steps=n_for_sizing, scale=None, page=page, strips=strips_i
+        )
+        if SCALE < auto_scale:
+            min_dim = min(x_size, y_size, z_size)
+            min_view = min_dim * SCALE
+            if min_view < _MIN_VIEW_MM:
+                safe = _MIN_VIEW_MM / min_dim
+                raise ValueError(
+                    f"scale {SCALE!r} projects the smallest part dimension "
+                    f"({min_dim:.0f} mm) to {min_view:.1f} mm — "
+                    f"annotation geometry degenerates below {_MIN_VIEW_MM:.0f} mm "
+                    f"(OCCT Standard_DomainError / SIGABRT). "
+                    f"Use scale ≥ {safe:.3g} or omit --scale for automatic selection."
+                )
+    DIM_PAD = _DIM_PAD
+    margin = _MARGIN
+    # Refine: apply the same legibility gate _auto_annotate uses for dim_step.
+    n_steps = len(_legible_steps(step_zs, bb.min.Z, SCALE)[0])
+    strips = _measure_strips(
+        holes,
+        patterns,
+        n_steps,
+        bb,
+        arrow_length=_arrow_length,
+        pad_around_text=_pad_around_text,
+    )
+    # View positions + iso empty-rectangle, shared with scale selection (_fits)
+    # via _layout_geometry so placement and fit never diverge (#11).  _fit_iso_view
+    # later scales the iso to fill its rectangle.
+    _g = _layout_geometry(x_size, y_size, z_size, SCALE, PAGE_W, PAGE_H, TB_W, strips, n_steps)
+    fv_hw = _g.fv_hw
+    fv_hh = _g.fv_hh
+    pv_hh = _g.pv_hh
+    sv_hw = _g.sv_hw
+    x_offset = _g.x_offset
+    FV_X = _g.FV_X
+    FV_Y = _g.FV_Y
+    PV_X = _g.PV_X
+    PV_Y = _g.PV_Y
+    SV_X = _g.SV_X
+    SV_Y = _g.SV_Y
+    sv_right = _g.sv_right
+    iso_left_limit = _g.iso_left
+    iso_bottom_limit = _g.iso_bottom
+    iso_right_limit = _g.iso_right
+    iso_top_limit = _g.iso_top
+    ISO_X = _g.ISO_X
+    ISO_Y = _g.ISO_Y
+
+    # ------------------------------------------------------------------
+    # Strip / zone construction.
+    # Phase 1: defines regions only — annotation functions still use their
+    # own hard-coded offsets.  Later phases will route each annotation
+    # through strip.allocate().  The iso view's outer limits are conservative
+    # here (PAGE_H - margin / iso_right_limit); _auto_annotate() tightens
+    # them once the iso has been projected.
+    fv_zones, pv_zones, sv_zones = _build_zones(_g, margin, PAGE_H)
+
+    page_label = {297: "A4", 420: "A3", 594: "A2", 841: "A1", 1189: "A0"}.get(
+        int(PAGE_W), f"{PAGE_W:.0f}mm"
+    )
+    _log.info(
+        "Scale %s:1  page %s  FV(%.0f,%.0f) PV(%.0f,%.0f) SV(%.0f,%.0f) ISO(%.0f,%.0f)",
+        SCALE,
+        page_label,
+        FV_X,
+        FV_Y,
+        PV_X,
+        PV_Y,
+        SV_X,
+        SV_Y,
+        ISO_X,
+        ISO_Y,
+    )
+
+    return Analysis(
+        part=part,
+        bb=bb,
+        x_size=x_size,
+        y_size=y_size,
+        z_size=z_size,
+        cx=cx,
+        cy=cy,
+        cz=cz,
+        bbox_max=bbox_max,
+        holes=holes,
+        patterns=patterns,
+        slots=slots,
+        z_diams=z_diams,
+        cross_diams=cross_diams,
+        cyls=(z_cyls, cross_cyls),
+        od_diam=od_diam,
+        is_rotational=is_rotational,
+        step_zs=step_zs,
+        sv_right=sv_right,
+        iso_right_limit=iso_right_limit,
+        SCALE=SCALE,
+        PAGE_W=PAGE_W,
+        PAGE_H=PAGE_H,
+        TB_W=TB_W,
+        DIM_PAD=DIM_PAD,
+        margin=margin,
+        x_offset=x_offset,
+        FV_X=FV_X,
+        FV_Y=FV_Y,
+        PV_X=PV_X,
+        PV_Y=PV_Y,
+        SV_X=SV_X,
+        SV_Y=SV_Y,
+        proj=_Projector(
+            fv_x=FV_X,
+            fv_y=FV_Y,
+            sv_x=SV_X,
+            sv_y=SV_Y,
+            pv_x=PV_X,
+            pv_y=PV_Y,
+            cx=cx,
+            cy=cy,
+            cz=cz,
+            scale=SCALE,
+        ),
+        ISO_X=ISO_X,
+        ISO_Y=ISO_Y,
+        iso_left_limit=iso_left_limit,
+        iso_bottom_limit=iso_bottom_limit,
+        iso_top_limit=iso_top_limit,
+        # View half-extents in page units (convenient for strip arithmetic)
+        fv_hw=fv_hw,
+        fv_hh=fv_hh,
+        pv_hh=pv_hh,
+        sv_hw=sv_hw,
+        # Strip / zone layout model (Phase 1 — regions defined, not yet used)
+        fv_zones=fv_zones,
+        pv_zones=pv_zones,
+        sv_zones=sv_zones,
+        step_file=step_file,
+        title=title,
+        number=number,
+        tolerance=tolerance,
+        drawn_by=drawn_by,
+        out=out,
+        pmi=pmi_records,
+        pmi_mode=pmi,
+    )

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -43,9 +43,6 @@ from build123d import (
 from build123d_drafting.features import (
     HoleSpec,
     analyse_cylinders,
-    find_hole_patterns,
-    find_holes,
-    full_cylinders,
 )
 from build123d_drafting.helpers import (
     Leader,
@@ -57,20 +54,10 @@ from build123d_drafting.helpers import (
     set_page,
     view_axes,
 )
-from OCP.BRepAdaptor import BRepAdaptor_Surface
-from OCP.BRepGProp import BRepGProp
-from OCP.GeomAbs import (
-    GeomAbs_Plane,
-)
-from OCP.GProp import GProp_GProps
-from OCP.IFSelect import IFSelect_ReturnStatus
-from OCP.STEPControl import STEPControl_Reader
 
 from draftwright._core import (
-    _DIM_PAD,
     _FONT_SIZE,
     _LADDER,
-    _MARGIN,
     _PAGE_SIZES,
     _SCALES,
     _STRIP_GAP,
@@ -81,7 +68,6 @@ from draftwright._core import (
     _dim,
     _fmt,
     _iso_bbox,
-    _legible_steps,
     _log,
     _parse_page,
     _Projector,
@@ -89,6 +75,7 @@ from draftwright._core import (
     _tb_width,
     _text_width,
 )
+from draftwright.analysis import _analyse
 from draftwright.annotate import _auto_annotate
 from draftwright.export import (
     _export_shape,
@@ -99,7 +86,6 @@ from draftwright.export import (
     sanitize_svg_arcs,
     set_dxf_metadata,
 )
-from draftwright.features import find_slots
 from draftwright.fonts import PLEX_MONO
 from draftwright.layout import (
     _greedy_strip_1d,
@@ -120,16 +106,13 @@ from draftwright.sheet import (
     _attribute_annotations,
     _build_zones,
     _layout_geometry,
-    _measure_strips,
     _view_geom,
-    choose_scale,
 )
 
 _TB_W = 150.0
 # Minimum acceptable projected view dimension (page-mm).  Below this, annotation
 # geometry (leader wires, centre marks, bore callout elbows) can degenerate and
 # cause OCCT Standard_DomainError / SIGABRT (#129).
-_MIN_VIEW_MM = 10.0
 
 
 # ---------------------------------------------------------------------------
@@ -140,38 +123,6 @@ _MIN_VIEW_MM = 10.0
 # Equidistance tolerance (page-mm) for accepting a sampled silhouette spline as
 # a circle about a known projected axis.  Loose enough to swallow HLR's spline
 # approximation error, tight enough not to round a genuinely off-axis curve.
-def _import_step(path) -> Compound:
-    """Read solid geometry from a STEP file via OCCT's ``STEPControl_Reader``.
-
-    build123d's ``import_step`` uses the XCAF reader (colours, names, PMI), which
-    **segfaults** on some AP242 files carrying semantic PMI — e.g. NIST CTC-02
-    AP242 (#20) — before any Python code can intervene. draftwright needs only
-    the solid geometry (it drops PMI presentation data anyway), so we read the
-    geometry directly. Verified to produce identical shapes (solids, edges, bbox)
-    to ``import_step`` on the files that read in both, minus the unused metadata.
-    """
-    reader = STEPControl_Reader()
-    if reader.ReadFile(str(path)) != IFSelect_ReturnStatus.IFSelect_RetDone:
-        raise ValueError(f"could not read STEP file {path!r}")
-    reader.TransferRoots()
-    return Compound(reader.OneShape())
-
-
-# ---------------------------------------------------------------------------
-# Geometry analysis
-# ---------------------------------------------------------------------------
-
-
-def dedup_diams(cyls, tol: float = 0.15) -> list:
-    """Return sorted-descending deduplicated diameter list from cylinder records."""
-    raw = sorted({c["diameter"] for c in cyls}, reverse=True)
-    merged: list[float] = []
-    for d in raw:
-        if not merged or abs(d - merged[-1]) > tol:
-            merged.append(round(d, 2))
-    return merged
-
-
 def _build_table(rows, draft, block_cols=None):
     """Build a generic data-table annotation at the origin (bottom-left ``(0, 0)``).
 
@@ -235,42 +186,6 @@ def _build_table(rows, draft, block_cols=None):
     return table
 
 
-# Turned-part classification (#81): a rotational part's bounding box is
-# square in XY to within _SQUARENESS_TOL, and its OD — the largest full
-# *external* Z cylinder — fills at least _OD_FILL_MIN of that envelope, with
-# its axis within _OD_AXIS_TOL of the envelope centre. Anything else is
-# prismatic — its Z cylinders are holes or local bosses, not an OD.
-_SQUARENESS_TOL = 0.05
-_OD_FILL_MIN = 0.8
-_OD_AXIS_TOL = 0.05
-
-
-def _is_rotational(x_size, y_size, od_diam, od_axis_offset) -> bool:
-    """True for turned parts: an outward-facing Z cylinder, concentric with
-    the bounding box, filling a square envelope.
-
-    ``od_diam`` is the largest full *external* Z-cylinder diameter (``None``
-    when there is none — bores never qualify as an OD) and
-    ``od_axis_offset`` that cylinder's axis distance from the bbox centre.
-    """
-    if od_diam is None:
-        return False
-    envelope = max(x_size, y_size)
-    return (
-        abs(x_size - y_size) <= _SQUARENESS_TOL * envelope
-        and od_diam >= _OD_FILL_MIN * envelope
-        and od_axis_offset <= _OD_AXIS_TOL * envelope
-    )
-
-
-# A hole is "concentric" with a turned part's rotation axis when its drilling
-# axis is the Z (OD) axis and its opening sits on the part centreline.  Such
-# bores are already dimensioned by the ldr_z bore leaders, so they must not
-# also receive a hole callout / location dim (#10).  Off-axis holes (a bolt
-# circle, a cross-hole) fall through to the feature-presence path.
-
-
-# --- lint scoring (see Drawing.lint_summary) -------------------------------
 # Codes that check standards/geometry correctness rather than pure page
 # layout. Grouped so a caller (and the #30 repair loop) can tell a wrong
 # drawing from a merely tight one.
@@ -293,105 +208,6 @@ _GEOMETRY_AWARE_CODES = frozenset(
 # severity/code counts in the summary are the authoritative output.
 _SCORE_ERROR_PENALTY = 0.2
 _SCORE_WARNING_PENALTY = 0.05
-
-
-def analyse_face_levels(part, tol: float = 0.5, min_area_frac: float = 0.0) -> list:
-    """Return sorted unique Z-coords of horizontal (normal≈±Z) planar faces.
-
-    Uses tol-bucket deduplication but returns the actual face Z, not the rounded
-    bucket centre, so dimension labels match the true geometry.
-
-    When *min_area_frac* > 0, a Z level is kept only if the total area of its
-    horizontal faces is at least ``min_area_frac × (x_size × y_size)`` (the
-    part's plan footprint). This drops sub-feature faces — e.g. fragments of
-    engraved text/numbers — that are not real steps and would otherwise be
-    dimensioned as phantom shoulders (staircase.step review).
-    """
-    buckets: dict = {}  # bucket key -> representative z
-    areas: dict = {}  # bucket key -> total horizontal-face area
-    for face in part.faces():
-        surf = BRepAdaptor_Surface(face.wrapped)
-        if surf.GetType() == GeomAbs_Plane:
-            ax = surf.Plane().Axis().Direction()
-            if abs(ax.Z()) > 0.99:
-                z = surf.Plane().Location().Z()
-                key = round(z / tol) * tol
-                buckets.setdefault(key, z)
-                if min_area_frac > 0.0:
-                    props = GProp_GProps()
-                    BRepGProp.SurfaceProperties_s(face.wrapped, props)
-                    areas[key] = areas.get(key, 0.0) + props.Mass()
-    if min_area_frac > 0.0:
-        bb = part.bounding_box()
-        footprint = (bb.max.X - bb.min.X) * (bb.max.Y - bb.min.Y)
-        threshold = min_area_frac * footprint
-        return sorted(z for key, z in buckets.items() if areas.get(key, 0.0) >= threshold)
-    return sorted(buckets.values())
-
-
-# ---------------------------------------------------------------------------
-# Strip / zone layout model
-# ---------------------------------------------------------------------------
-
-
-# Slot sizes for the annotations that allocate from fv/pv/sv strips.
-# Shared between the depth estimators below and the allocate() call-sites in
-# _auto_annotate() so that a slot-size change is automatically reflected in
-# the estimator-driven corridor widths.
-#
-# A slot is the perpendicular depth (page-mm) reserved for one Dimension: its
-# dim-line offset from the view edge plus the label, which sits exactly
-# pad_around_text beyond the line (measured: a "right"/"below" Dimension's
-# perpendicular span equals offset + pad_around_text - extension_gap, and
-# pad == extension_gap in the draft preset).  Each slot is therefore derived
-# from text metrics (font_size + pad_around_text), like _MIN_STEP_DIM_MM, so it
-# rescales with _FONT_SIZE instead of being a bare mm guess (#31).
-# Single overall dim: two glyph-heights of line offset + the outboard label pad.
-# The overall height dim leads the right ladder, so it carries an extra pad of
-# clearance from the view above the first step dim's witness.
-# Stacked step dims sit deeper so each ladder rung's label clears the rung below.
-
-# A plan view with at least this many holes escalates to a hole chart when it is
-# too dense to dimension every hole individually (#93). Below it, a dropped ref
-# stays a legibility drop rather than tabulating a handful of holes.
-
-# Smallest projected step height (page-mm) that can still carry a *legible*
-# stacked dimension between its two extension lines.  Derived from what has to
-# fit vertically: the label (font height) plus an arrowhead at each end plus
-# the text clearance above and below — not an arbitrary page-mm cutoff (#13).
-# Used as the single gate in BOTH _analyse (n_steps) and _auto_annotate
-# (dim_step placement) so the two can never diverge.
-
-# Minimum page-mm separation between two *consecutive* dimensioned step heights.
-# Shoulders closer than this on the page read as one, so only the first of such
-# a cluster is dimensioned and the rest surface via lint (#41). Sized to the
-# value-label footprint (one glyph height + clearance) — enough to tell two
-# stacked step dims apart, without dropping genuinely-distinct shoulders.
-
-# A horizontal face counts as a real step only if its area is at least this
-# fraction of the part's plan footprint (x_size × y_size). Filters out tiny
-# faces from engraved text/numbers that are not steps (staircase.step review).
-_STEP_MIN_AREA_FRAC = 0.01
-
-# Minimum page-mm separation between two *consecutive* hole-location dimensions
-# along one axis. Stacked location dims sit on separate tiers, so their value
-# labels never collide (the tier pitch handles that); the legibility limit is the
-# extension lines / arrowheads merging when two holes share almost the same
-# position on that axis. Sized to one arrowhead plus clearance — smaller than the
-# step-spacing gate, which also stacks labels in one column. Holes closer than
-# this read as one, so only the first of such a run is dimensioned and the rest
-# surface via lint (#43): "fits" is not the same as "legible".
-
-
-# ---------------------------------------------------------------------------
-# Annotation depth estimators (Phase 2 of #118)
-#
-# These pure functions estimate the strip depth (mm) required for each
-# inter-view boundary BEFORE view positions are fixed.  They are intentionally
-# conservative (may over-estimate slightly).  Used by _analyse() (Phase 3) to
-# set minimum corridor widths, and by _fits() (Phase 3) for consistent sheet
-# selection.
-# ---------------------------------------------------------------------------
 
 
 def _cross_view_overlaps(dwg, a) -> int:
@@ -481,271 +297,6 @@ def _measure_blocks(dwg, a) -> dict:
             left=max(0.0, (cx - hw) - e[0]),
         )
     return blocks
-
-
-def _analyse(
-    step_file, title, number, tolerance, drawn_by, out, scale=None, page=None, pmi="off"
-) -> Analysis:
-    """Load STEP or use a build123d Shape, analyse geometry, compute layout.
-
-    Returns an :class:`Analysis`.
-    """
-    if isinstance(step_file, Shape):
-        part = step_file
-        src = "build123d object"
-    else:
-        part = _import_step(step_file)
-        src = str(step_file)
-    # AP242 STEP files carry PMI presentation geometry (annotation-plane
-    # border wires, leader curves) beside the solid; left in, it draws as
-    # phantom rectangles in every view and inflates the bounding box —
-    # corrupting the scale choice and the envelope dimensions. The drawing
-    # is of the solids.
-    solids = part.solids()
-    if solids:
-        body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
-        if body.bounding_box().size != part.bounding_box().size or len(part.edges()) != len(
-            body.edges()
-        ):
-            _log.info(
-                "Dropping non-solid geometry from %s (PMI presentation data)",
-                src,
-            )
-        part = body
-
-    # Semantic PMI extraction (AP242 only; separate read-only pass).
-    pmi_records: list = []
-    if pmi != "off" and not isinstance(step_file, Shape):
-        try:
-            from draftwright.pmi import extract_pmi
-
-            pmi_records = extract_pmi(step_file)
-        except Exception as exc:
-            _log.warning("PMI extraction failed: %s", exc)
-
-    bb = part.bounding_box()
-    x_size = bb.max.X - bb.min.X
-    y_size = bb.max.Y - bb.min.Y
-    z_size = bb.max.Z - bb.min.Z
-    cx = (bb.min.X + bb.max.X) / 2
-    cy = (bb.min.Y + bb.max.Y) / 2
-    cz = (bb.min.Z + bb.max.Z) / 2
-    bbox_max = max(x_size, y_size, z_size)
-
-    _log.info("Loaded %s  bbox: %.2f × %.2f × %.2f mm", src, x_size, y_size, z_size)
-
-    z_cyls, cross_cyls = analyse_cylinders(part)
-    # Partial (fillet) faces are not features: they would pollute the OD,
-    # the bore leaders, and the rotational classification alike (#81)
-    full_z = full_cylinders(z_cyls)
-    z_diams = dedup_diams(full_z)
-    cross_diams = dedup_diams(full_cylinders(cross_cyls))
-
-    _log.info("Z-axis diameters: %s", z_diams)
-    if cross_diams:
-        _log.info("Cross-hole diams: %s", cross_diams)
-
-    od_cyl = max((c for c in full_z if c["external"]), key=lambda c: c["diameter"], default=None)
-    od_diam = None
-    if od_cyl:
-        # Snap to the dedup_diams representative so comparisons against
-        # z_diams entries (bore-leader exclusion, labels) are exact even if
-        # the cylinder records ever carry unrounded OCCT diameters (#86)
-        raw_od = od_cyl["diameter"]
-        od_diam = min(z_diams, key=lambda d: abs(d - raw_od))
-    od_axis_offset = (
-        math.hypot(od_cyl["axis_xyz"][0] - cx, od_cyl["axis_xyz"][1] - cy) if od_cyl else 0.0
-    )
-    is_rotational = _is_rotational(x_size, y_size, od_diam, od_axis_offset)
-    if z_diams and not is_rotational:
-        _log.info("Part classified prismatic; skipping OD/centreline/bore annotations")
-
-    face_zs = analyse_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)
-    step_zs = [z for z in face_zs if z > bb.min.Z + 0.6 and z < bb.max.Z - 0.6]
-
-    # Pass 1 (two-pass layout, #131): measure annotation strip depths before
-    # view positions are fixed.  font_size=3.0 is a fixed page-mm constant so
-    # all annotation sizes are scale-independent — no circularity.
-    # Construct the same draft preset used later in build_drawing() to read
-    # arrow_length and pad_around_text from their authoritative source rather
-    # than re-stating them as magic literals in the estimators.
-    _draft_est = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
-    _arrow_length = _draft_est.arrow_length
-    _pad_around_text = _draft_est.pad_around_text
-    holes = find_holes(part, cyls=(z_cyls, cross_cyls))
-    patterns = find_hole_patterns(holes)
-    slots = find_slots(part)
-
-    # Choose scale/page, iterating so the reserved step corridor matches the
-    # number of steps the legibility gate will actually place (#1) — not the raw
-    # face count. Otherwise a part with many sub-legible faces (e.g. a staircase
-    # with 15 tiny treads) reserves a phantom step ladder that blocks a larger
-    # scale. Seed conservatively (all faces), then re-gate at the chosen scale;
-    # converges in a couple of rounds.
-    n_for_sizing = len(step_zs)
-    strips_i = None
-    for _ in range(3):
-        strips_i = _measure_strips(
-            holes,
-            patterns,
-            n_for_sizing,
-            bb,
-            arrow_length=_arrow_length,
-            pad_around_text=_pad_around_text,
-        )
-        SCALE, PAGE_W, PAGE_H, TB_W = choose_scale(
-            x_size, y_size, z_size, n_steps=n_for_sizing, scale=scale, page=page, strips=strips_i
-        )
-        n_next = len(_legible_steps(step_zs, bb.min.Z, SCALE)[0])
-        if n_next == n_for_sizing:
-            break
-        n_for_sizing = n_next
-    if scale is not None:
-        auto_scale, _, _, _ = choose_scale(
-            x_size, y_size, z_size, n_steps=n_for_sizing, scale=None, page=page, strips=strips_i
-        )
-        if SCALE < auto_scale:
-            min_dim = min(x_size, y_size, z_size)
-            min_view = min_dim * SCALE
-            if min_view < _MIN_VIEW_MM:
-                safe = _MIN_VIEW_MM / min_dim
-                raise ValueError(
-                    f"scale {SCALE!r} projects the smallest part dimension "
-                    f"({min_dim:.0f} mm) to {min_view:.1f} mm — "
-                    f"annotation geometry degenerates below {_MIN_VIEW_MM:.0f} mm "
-                    f"(OCCT Standard_DomainError / SIGABRT). "
-                    f"Use scale ≥ {safe:.3g} or omit --scale for automatic selection."
-                )
-    DIM_PAD = _DIM_PAD
-    margin = _MARGIN
-    # Refine: apply the same legibility gate _auto_annotate uses for dim_step.
-    n_steps = len(_legible_steps(step_zs, bb.min.Z, SCALE)[0])
-    strips = _measure_strips(
-        holes,
-        patterns,
-        n_steps,
-        bb,
-        arrow_length=_arrow_length,
-        pad_around_text=_pad_around_text,
-    )
-    # View positions + iso empty-rectangle, shared with scale selection (_fits)
-    # via _layout_geometry so placement and fit never diverge (#11).  _fit_iso_view
-    # later scales the iso to fill its rectangle.
-    _g = _layout_geometry(x_size, y_size, z_size, SCALE, PAGE_W, PAGE_H, TB_W, strips, n_steps)
-    fv_hw = _g.fv_hw
-    fv_hh = _g.fv_hh
-    pv_hh = _g.pv_hh
-    sv_hw = _g.sv_hw
-    x_offset = _g.x_offset
-    FV_X = _g.FV_X
-    FV_Y = _g.FV_Y
-    PV_X = _g.PV_X
-    PV_Y = _g.PV_Y
-    SV_X = _g.SV_X
-    SV_Y = _g.SV_Y
-    sv_right = _g.sv_right
-    iso_left_limit = _g.iso_left
-    iso_bottom_limit = _g.iso_bottom
-    iso_right_limit = _g.iso_right
-    iso_top_limit = _g.iso_top
-    ISO_X = _g.ISO_X
-    ISO_Y = _g.ISO_Y
-
-    # ------------------------------------------------------------------
-    # Strip / zone construction.
-    # Phase 1: defines regions only — annotation functions still use their
-    # own hard-coded offsets.  Later phases will route each annotation
-    # through strip.allocate().  The iso view's outer limits are conservative
-    # here (PAGE_H - margin / iso_right_limit); _auto_annotate() tightens
-    # them once the iso has been projected.
-    fv_zones, pv_zones, sv_zones = _build_zones(_g, margin, PAGE_H)
-
-    page_label = {297: "A4", 420: "A3", 594: "A2", 841: "A1", 1189: "A0"}.get(
-        int(PAGE_W), f"{PAGE_W:.0f}mm"
-    )
-    _log.info(
-        "Scale %s:1  page %s  FV(%.0f,%.0f) PV(%.0f,%.0f) SV(%.0f,%.0f) ISO(%.0f,%.0f)",
-        SCALE,
-        page_label,
-        FV_X,
-        FV_Y,
-        PV_X,
-        PV_Y,
-        SV_X,
-        SV_Y,
-        ISO_X,
-        ISO_Y,
-    )
-
-    return Analysis(
-        part=part,
-        bb=bb,
-        x_size=x_size,
-        y_size=y_size,
-        z_size=z_size,
-        cx=cx,
-        cy=cy,
-        cz=cz,
-        bbox_max=bbox_max,
-        holes=holes,
-        patterns=patterns,
-        slots=slots,
-        z_diams=z_diams,
-        cross_diams=cross_diams,
-        cyls=(z_cyls, cross_cyls),
-        od_diam=od_diam,
-        is_rotational=is_rotational,
-        step_zs=step_zs,
-        sv_right=sv_right,
-        iso_right_limit=iso_right_limit,
-        SCALE=SCALE,
-        PAGE_W=PAGE_W,
-        PAGE_H=PAGE_H,
-        TB_W=TB_W,
-        DIM_PAD=DIM_PAD,
-        margin=margin,
-        x_offset=x_offset,
-        FV_X=FV_X,
-        FV_Y=FV_Y,
-        PV_X=PV_X,
-        PV_Y=PV_Y,
-        SV_X=SV_X,
-        SV_Y=SV_Y,
-        proj=_Projector(
-            fv_x=FV_X,
-            fv_y=FV_Y,
-            sv_x=SV_X,
-            sv_y=SV_Y,
-            pv_x=PV_X,
-            pv_y=PV_Y,
-            cx=cx,
-            cy=cy,
-            cz=cz,
-            scale=SCALE,
-        ),
-        ISO_X=ISO_X,
-        ISO_Y=ISO_Y,
-        iso_left_limit=iso_left_limit,
-        iso_bottom_limit=iso_bottom_limit,
-        iso_top_limit=iso_top_limit,
-        # View half-extents in page units (convenient for strip arithmetic)
-        fv_hw=fv_hw,
-        fv_hh=fv_hh,
-        pv_hh=pv_hh,
-        sv_hw=sv_hw,
-        # Strip / zone layout model (Phase 1 — regions defined, not yet used)
-        fv_zones=fv_zones,
-        pv_zones=pv_zones,
-        sv_zones=sv_zones,
-        step_file=step_file,
-        title=title,
-        number=number,
-        tolerance=tolerance,
-        drawn_by=drawn_by,
-        out=out,
-        pmi=pmi_records,
-        pmi_mode=pmi,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8,20 +8,17 @@ from build123d import Box, Compound, Cylinder, Edge, Pos, Rotation, export_step
 from build123d_drafting import HoleCallout, Leader, ViewCoordinates, view_axes
 
 from draftwright import Drawing, build_drawing, make_drawing
+from draftwright._core import _MIN_VIEW_MM
+from draftwright.analysis import _is_rotational, analyse_face_levels, dedup_diams
 from draftwright.features import Slot, find_slots
 from draftwright.make_drawing import (
-    _MIN_VIEW_MM,
     _export_shape,
     _fmt,
-    _is_rotational,
     analyse_cylinders,
-    analyse_face_levels,
-    choose_scale,
-    dedup_diams,
     generate_script,
     lint_feature_coverage,
 )
-from draftwright.sheet import _fits
+from draftwright.sheet import _fits, choose_scale
 
 
 def _state_snapshot(dwg):
@@ -619,7 +616,7 @@ class TestDepthEstimators:
     """Pure-function tests for _est_right_strip_depth / _est_pv_below_depth."""
 
     def test_right_depth_no_steps_equals_dim_pad(self):
-        from draftwright.make_drawing import _DIM_PAD
+        from draftwright._core import _DIM_PAD
         from draftwright.sheet import _est_right_strip_depth
 
         # 0 steps → dim_height only → gap(8) + slot(10) = 18 = _DIM_PAD
@@ -730,7 +727,8 @@ class TestDerivedLayoutConstants:
         assert _text_width("WXYZ", 3.0) > _text_width("iiii", 3.0)
 
     def test_bore_callout_width_scales_with_font_size(self):
-        from draftwright.make_drawing import find_holes
+        from build123d_drafting.features import find_holes
+
         from draftwright.sheet import _est_bore_callout_width
 
         part = Box(60, 40, 12) - Pos(0, 0, 6) * Cylinder(3, 12)
@@ -746,8 +744,8 @@ class TestComposeAnnoBoxes:
     later steps make honest."""
 
     def _assert_match(self, holes, patterns, n_steps, bb, label=""):
-        from draftwright.make_drawing import _FONT_SIZE, _measure_strips, draft_preset
-        from draftwright.sheet import _compose_anno_boxes, _footprint_from_boxes
+        from draftwright.make_drawing import _FONT_SIZE, draft_preset
+        from draftwright.sheet import _compose_anno_boxes, _footprint_from_boxes, _measure_strips
 
         # The composer must reproduce StripDepths exactly for ANY clearance
         # args (#112, Step 4b): the bore-band elbow+gap overhead
@@ -768,7 +766,7 @@ class TestComposeAnnoBoxes:
             assert composed == scalar, (label, n_steps, kw)
 
     def test_matches_for_plain_part(self):
-        from draftwright.make_drawing import find_hole_patterns, find_holes
+        from build123d_drafting.features import find_hole_patterns, find_holes
 
         part = Box(60, 40, 12)
         holes = find_holes(part)
@@ -778,7 +776,7 @@ class TestComposeAnnoBoxes:
             self._assert_match(holes, patterns, n_steps, bb)
 
     def test_matches_for_bored_part(self):
-        from draftwright.make_drawing import find_hole_patterns, find_holes
+        from build123d_drafting.features import find_hole_patterns, find_holes
 
         part = Box(60, 40, 12) - Pos(0, 0, 6) * Cylinder(3, 12)
         holes = find_holes(part)
@@ -789,7 +787,8 @@ class TestComposeAnnoBoxes:
 
     def test_matches_for_dense_ballooning_part(self):
         # _dense_plate triggers _will_balloon → exercises the plan_halo band.
-        from draftwright.make_drawing import find_hole_patterns, find_holes
+        from build123d_drafting.features import find_hole_patterns, find_holes
+
         from draftwright.sheet import _will_balloon
 
         part = _dense_plate()
@@ -803,7 +802,7 @@ class TestComposeAnnoBoxes:
         # Direct unit test of the reducer: deepest band per side wins, and the
         # left keeps its _DIM_PAD floor even when the deepest left band is
         # shallower — the branch real parts rarely make the deciding one.
-        from draftwright.make_drawing import _DIM_PAD
+        from draftwright._core import _DIM_PAD
         from draftwright.sheet import AnnoBox, StripDepths, _footprint_from_boxes
 
         fp = _footprint_from_boxes(
@@ -836,7 +835,7 @@ class TestComposeAnnoBoxesCorpus:
         (plan halo band). The right dim ladder depth is a pure function of the
         n_steps argument (not geometry), so it is swept per part below rather
         than via a dedicated stepped fixture."""
-        from draftwright.make_drawing import find_hole_patterns, find_holes
+        from build123d_drafting.features import find_hole_patterns, find_holes
 
         parts = {
             "plain_block": Box(60, 40, 12),
@@ -928,7 +927,7 @@ class TestDynamicCorridors:
         from build123d import Box
 
         from draftwright import build_drawing
-        from draftwright.make_drawing import _DIM_PAD
+        from draftwright._core import _DIM_PAD
 
         a = build_drawing(Box(60, 40, 20))._analysis
         assert len(a.step_zs) == 0
@@ -941,7 +940,7 @@ class TestDynamicCorridors:
         # With n_steps=3, gap_fv_sv jumps to 72 mm — A3 no longer fits and
         # choose_scale must return A2.  This verifies that the conservative
         # n_steps_ub path in _analyse() ensures the page is never too small.
-        from draftwright.make_drawing import choose_scale
+        from draftwright.sheet import choose_scale
 
         _, page_w_flat, _, _ = choose_scale(5.0, 100.0, 100.0, n_steps=0)
         _, page_w_deep, _, _ = choose_scale(5.0, 100.0, 100.0, n_steps=3)
@@ -988,7 +987,7 @@ class TestTwoPassLayout:
         from build123d_drafting.features import find_holes
 
         from draftwright import build_drawing
-        from draftwright.make_drawing import _DIM_PAD
+        from draftwright._core import _DIM_PAD
         from draftwright.sheet import _est_bore_callout_width
 
         # Four identical cylinders → "4× ⌀16 THRU" callout with a count prefix
@@ -1020,7 +1019,7 @@ class TestTwoPassLayout:
         from build123d import Box
 
         from draftwright import build_drawing
-        from draftwright.make_drawing import _DIM_PAD
+        from draftwright._core import _DIM_PAD
 
         a = build_drawing(Box(60, 40, 20))._analysis
         sv_left = a.SV_X - a.sv_hw
@@ -1223,7 +1222,8 @@ class TestComposeThenPackRepack:
         # sheet the centring slack would absorb the mis-anchoring and the buggy
         # code (FV_X anchored on fv.left) would pass anyway.  With x_offset == 0
         # the bug puts the plan-view left edge at margin - 120 = -110 mm.
-        from draftwright.make_drawing import _MARGIN, ViewBlock, _layout_geometry
+        from draftwright._core import _MARGIN
+        from draftwright.make_drawing import ViewBlock, _layout_geometry
 
         blocks = {
             "front": ViewBlock(10, 10, left=0.0, right=8, top=8, bottom=8),
@@ -3462,7 +3462,7 @@ class TestDetailView:
         assert not any(n.startswith("dim_detail") for n in dwg._named)
 
     def test_crowded_shoulders_get_a_detail_view_when_requested(self):
-        from draftwright.make_drawing import _legible_steps
+        from draftwright._core import _legible_steps
 
         dwg = build_drawing(_crowded_shoulder_part(), detail_view=True)
         a = dwg._analysis


### PR DESCRIPTION
Closes #163. Phase 4 of the #138 module-split.

Moves `_analyse` and its helpers (`_import_step`, `dedup_diams`, `_is_rotational`, `analyse_face_levels`) from `make_drawing.py` into **`analysis.py`** — the stage that imports the part, detects features, classifies rotational-vs-prismatic, and chooses the sheet + view zones, returning the `Analysis` namespace.

`analysis.py` sits **above `sheet`, below make_drawing**: imports `_core`/`sheet`/features/build123d/OCP, never make_drawing — no cycle. make_drawing re-imports `_analyse`; `__init__` now sources `analyse_face_levels`/`dedup_diams` from analysis and `choose_scale` from sheet; `_MIN_VIEW_MM`→`_core`; the rotational tolerances move into analysis. Lint scoring constants stay with `lint_summary`.

**Verified:** golden gate unchanged (no regeneration), ruff+format+mypy clean, full make_drawing/golden/e2e suites pass (361). **Adversarial review clean:** no upward import, no stale defs, rotational/prismatic classify correctly with scale+zones, `lint_summary` scores, `FeatureInfo` `@dataclass` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoG24RWpmNApX4cMiucS7v