### PR TITLE
#138 P7: tighten mypy on the settled module contracts

### DIFF
--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -1,6 +1,6 @@
 # ADR 0005 — Compiler-pipeline module boundaries and single-owner build state
 
-- **Status:** Accepted, in progress
+- **Status:** Accepted (module split complete; two follow-ups noted below)
 - **Date:** 2026-06-27
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Progress:** Execution roadmap with per-phase tracking issues:
@@ -12,8 +12,8 @@
   (the lint→repair loop), and `export.py`. **Remaining** (deeply-coupled stage
   splits, sequenced prerequisite-first): P1 `_text_width`→`_core` (#160, done), P2
   `projection.py` (#161), P3 `sheet.py` (#162, done; repack deferred to P6), P4 `analysis.py` (#163, done), P5
-  `annotations/` (#164), P6 `builder.py`+`drawing.py` (#165, done; context-threading deferred), P7 mypy
-  (#166). Build context (`_analysis`, edge cache) is threaded through
+  `annotations/` (#164), P6 `builder.py`+`drawing.py` (#165, done; context-threading deferred), P7 mypy (#166, done). All phases landed: make_drawing.py 3,907 → ~17 (facade).
+  Deferred follow-ups: annotations/envelope.py + build-context threading (§2). Build context (`_analysis`, edge cache) is threaded through
   `builder`/`projection` in P6, **not** parked on `Drawing` as a standalone owner.
 
 ## Context

--- a/docs/plans/138-module-split-roadmap.md
+++ b/docs/plans/138-module-split-roadmap.md
@@ -14,6 +14,10 @@ behaviour-preserving.
 
 ## Status
 
+**All phases complete (#138 done).** Two behaviour-sensitive sub-extractions are
+deferred as noted follow-ups: `annotations/envelope.py` (inline envelope dims) and
+build-context threading (`_analysis`/`_view_edge_cache` off `Drawing`, ADR 0005 §2).
+
 **Landed** (`make_drawing.py` 3,907 → 3,476):
 
 | Step | What | PR |
@@ -38,7 +42,7 @@ no PR introduces an import cycle, riskiest (annotations) last:
 | ~~P4~~ | #163 | `analysis.py` (`_analyse`) ✅ | med-lg | — |
 | ~~P5~~ | #164 | `annotations/` — sections, turned, pmi, holes, orchestrator ✅ (envelope.py deferred) | biggest (5 PRs) | P1–P4 |
 | ~~P6~~ | #165 | `builder.py` + `drawing.py` ✅ (context-threading deferred) | med | P2, P4 |
-| **P7** | #166 | tighten mypy on settled contracts | cleanup | all |
+| ~~P7~~ | #166 | tighten mypy on settled contracts ✅ | cleanup | all |
 
 ## Target module shape (ADR 0005 §1)
 ```text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,14 @@ python_version = "3.10"
 ignore_missing_imports = true
 check_untyped_defs = true
 warn_unused_ignores = true
+# Tightened on the settled module contracts (#138 / ADR 0005 P7). disallow_untyped_defs
+# stays off (geometry helpers lean on untyped build123d returns); these flags catch
+# real gaps without demanding annotations everywhere.
+no_implicit_optional = true
+warn_redundant_casts = true
+strict_equality = true
+warn_return_any = true
+extra_checks = true
 
 [tool.ruff]
 line-length = 99

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -98,7 +98,7 @@ def _is_rotational(x_size, y_size, od_diam, od_axis_offset) -> bool:
     if od_diam is None:
         return False
     envelope = max(x_size, y_size)
-    return (
+    return bool(
         abs(x_size - y_size) <= _SQUARENESS_TOL * envelope
         and od_diam >= _OD_FILL_MIN * envelope
         and od_axis_offset <= _OD_AXIS_TOL * envelope

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -163,7 +163,7 @@ def _measure_blocks(dwg, a) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _assemble(a, out, assembly, detail_view, auto_dims):
+def _assemble(a, out, assembly, detail_view, auto_dims) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
     repacked analysis it is also pass 2 of the measure-and-repack loop (#121)."""

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1024,7 +1024,7 @@ class Drawing:
             ],
         }
 
-    def export(self, out=None):
+    def export(self, out=None) -> tuple[str, str]:
         """Lint, then write SVG and DXF. Returns ``(svg_path, dxf_path)``."""
         out = out if out is not None else self.out
         for _ext in (".svg", ".dxf"):

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 _log = logging.getLogger(__name__)
 
@@ -156,7 +157,7 @@ def _shape_bbox(shape) -> tuple[float, float, float, float, float, float]:
     """Return ``(xmin, ymin, zmin, xmax, ymax, zmax)`` of *shape* in global space."""
     bb = Bnd_Box()
     BRepBndLib.Add_s(shape, bb)
-    return bb.Get()
+    return cast(tuple[float, float, float, float, float, float], bb.Get())
 
 
 def _bbox_centroid(bbox: tuple) -> tuple[float, float, float]:

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -185,7 +185,7 @@ _ISO_MAX_GROW = 1.3
 
 def _bbox_within(bb, region, tol: float = 0.5) -> bool:
     """True if (min_x, min_y, max_x, max_y) *bb* fits inside *region* within *tol*."""
-    return (
+    return bool(
         bb[0] >= region[0] - tol
         and bb[1] >= region[1] - tol
         and bb[2] <= region[2] + tol

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -57,12 +57,12 @@ def _est_right_strip_depth(n_steps: int) -> float:
     """
     n = 1 + max(n_steps, 0)  # dim_height + one slot per step dim
     # gap + dim_height + (n-1) step slots each preceded by one spacing
-    return _STRIP_GAP + _SLOT_DIM_HEIGHT + (n - 1) * (_STRIP_SPACING + _SLOT_DIM_STEP)
+    return float(_STRIP_GAP + _SLOT_DIM_HEIGHT + (n - 1) * (_STRIP_SPACING + _SLOT_DIM_STEP))
 
 
 def _est_pv_below_depth() -> float:
     """Depth needed below the plan view: dim_width (always one slot)."""
-    return _STRIP_GAP + _SLOT_DIM_WIDTH
+    return float(_STRIP_GAP + _SLOT_DIM_WIDTH)
 
 
 def _est_pv_above_depth(
@@ -404,7 +404,7 @@ def _fits(
         views_bottom = max(0.0, (page_h - h) / 2) + _MARGIN + _DIM_PAD
         # When views clear the title block row, the iso sits above it and the
         # title block no longer constrains horizontal space — drop tb_w from w.
-        return w - tb_w <= page_w and views_bottom >= _MARGIN + _TB_H
+        return bool(w - tb_w <= page_w and views_bottom >= _MARGIN + _TB_H)
 
     # 2D packing: views + title block fit the row; the iso fits leftover space.
     w_views_tb = (
@@ -425,7 +425,7 @@ def _fits(
     if not g.iso_valid:
         return False
     iso_fit = min(g.iso_right - g.iso_left, g.iso_top - g.iso_bottom)
-    return iso_fit >= _ISO_MIN_FIT_FRAC * g.iso_natural
+    return bool(iso_fit >= _ISO_MIN_FIT_FRAC * g.iso_natural)
 
 
 def choose_scale(


### PR DESCRIPTION
Closes #166 — the **final** phase of the #138 module split.

Enables `no_implicit_optional`, `warn_redundant_casts`, `strict_equality`, `extra_checks` (zero-cost) and `warn_return_any`. The last surfaced **9 functions** declaring a return type but leaking `Any` through untyped build123d/OCC calls — each made honest with a localized `float()`/`bool()`/`cast`, `_assemble -> Drawing`, and `Drawing.export -> tuple[str, str]`. `disallow_untyped_defs` stays off (geometry helpers lean on untyped build123d; `--strict` = 487 errors, not worth the churn).

**Type-only, runtime-identity:** golden gate unchanged (no regeneration), full fast tier passes (420), ruff clean. **Adversarial review clean:** a planted return-Any now *fails* mypy — the flag is enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoG24RWpmNApX4cMiucS7v