### PR TITLE
[codex] fix make_drawing module entrypoint

### DIFF
--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -15,3 +15,6 @@ from draftwright.builder import (  # noqa: F401
 from draftwright.drawing import Drawing, FeatureInfo  # noqa: F401
 from draftwright.export import fix_svg_page_size  # noqa: F401
 from draftwright.linting import lint_feature_coverage  # noqa: F401
+
+if __name__ == "__main__":
+    _cli()

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1,6 +1,8 @@
 """Tests for draftwright.make_drawing."""
 
 import math
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -1483,6 +1485,20 @@ def test_generate_script_rejects_build123d_object():
     box = Box(10, 10, 10)
     with pytest.raises(TypeError, match="STEP file path"):
         generate_script(box)
+
+
+@pytest.mark.smoke
+def test_make_drawing_module_entrypoint_runs_cli_help():
+    """The compat facade remains executable as ``python -m draftwright.make_drawing``."""
+    result = subprocess.run(
+        [sys.executable, "-m", "draftwright.make_drawing", "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "usage:" in result.stdout
+    assert "step_file" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Restores the `python -m draftwright.make_drawing` entrypoint after the refactor turned `make_drawing.py` into a compat facade.

## Root Cause

The facade continued to re-export `_cli`, but the old `if __name__ == "__main__": _cli()` guard was dropped. As a result, direct module execution exited successfully without invoking argparse or generating output.

## Changes

- Re-added the module main guard in `src/draftwright/make_drawing.py`.
- Added a smoke regression test that runs `python -m draftwright.make_drawing --help` and asserts CLI help is emitted.

## Validation

- `uv run pytest tests/test_make_drawing.py::test_make_drawing_module_entrypoint_runs_cli_help`
- `uv run ruff check`
- `uv run mypy src`
- `uv run pytest -m smoke`