### PR TITLE
[codex] fix Windows module CLI smoke

### DIFF
--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -11,18 +11,40 @@ Requires build123d-drafting-helpers for annotation primitives.
 Licensed under the GNU Affero General Public License v3 (AGPL-3.0).
 """
 
+import sys as _sys
+import types as _types
+
 from draftwright.analysis import analyse_face_levels, dedup_diams
-from draftwright.make_drawing import (
-    Drawing,
-    FeatureInfo,
+from draftwright.builder import (
     build_drawing,
-    fix_svg_page_size,
     generate_script,
-    lint_feature_coverage,
     make_drawing,
 )
+from draftwright.drawing import Drawing, FeatureInfo
+from draftwright.export import fix_svg_page_size
+from draftwright.linting import lint_feature_coverage
 from draftwright.pmi import PmiRecord, extract_pmi
 from draftwright.sheet import choose_scale
+
+_make_drawing_function = make_drawing
+
+
+class _DraftwrightModule(_types.ModuleType):
+    def __getattribute__(self, name):
+        if name == "make_drawing":
+            namespace = _types.ModuleType.__getattribute__(self, "__dict__")
+            value = namespace.get(name)
+            if (
+                isinstance(value, _types.ModuleType)
+                and value.__name__ == "draftwright.make_drawing"
+            ):
+                public = namespace["_make_drawing_function"]
+                _types.ModuleType.__setattr__(self, name, public)
+                return public
+        return _types.ModuleType.__getattribute__(self, name)
+
+
+_sys.modules[__name__].__class__ = _DraftwrightModule
 
 __all__ = [
     "Drawing",

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -615,7 +615,7 @@ def generate_script(
 
 def _cli():
     ap = argparse.ArgumentParser(
-        description="Zero-AI STEP → technical drawing (SVG + DXF, or editable .py script)",
+        description="Zero-AI STEP -> technical drawing (SVG + DXF, or editable .py script)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     ap.add_argument("step_file", help="Input STEP file (.step / .stp)")
@@ -645,9 +645,9 @@ def _cli():
         default="off",
         choices=["off", "report", "annotate"],
         help=(
-            "AP242 PMI handling: 'off' (default) — ignore; "
-            "'report' — log extracted PMI without annotating; "
-            "'annotate' — add PMI-derived dimensions to the drawing"
+            "AP242 PMI handling: 'off' (default) - ignore; "
+            "'report' - log extracted PMI without annotating; "
+            "'annotate' - add PMI-derived dimensions to the drawing"
         ),
     )
     ap.add_argument(

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1,6 +1,7 @@
 """Tests for draftwright.make_drawing."""
 
 import math
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -1490,15 +1491,26 @@ def test_generate_script_rejects_build123d_object():
 @pytest.mark.smoke
 def test_make_drawing_module_entrypoint_runs_cli_help():
     """The compat facade remains executable as ``python -m draftwright.make_drawing``."""
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252"
     result = subprocess.run(
-        [sys.executable, "-m", "draftwright.make_drawing", "--help"],
-        check=True,
+        [
+            sys.executable,
+            "-W",
+            "error::RuntimeWarning",
+            "-m",
+            "draftwright.make_drawing",
+            "--help",
+        ],
         capture_output=True,
+        env=env,
         text=True,
     )
 
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     assert "usage:" in result.stdout
     assert "step_file" in result.stdout
+    assert result.stdout.isascii()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep the package root from preloading the make_drawing facade during module execution
- make argparse help text ASCII-safe for Windows redirected stdout encodings
- harden the module-entry smoke test with cp1252 stdio and RuntimeWarning-as-error

## Root cause
PR #181 restored `python -m draftwright.make_drawing`, but the smoke test failed on Windows because argparse help included a Unicode arrow that could not be encoded by Windows redirected stdout. The module path also emitted a `runpy` RuntimeWarning because `draftwright.__init__` imported the same facade module before `-m` executed it.

## Validation
- `PYTHONIOENCODING=cp1252 uv run python -W error::RuntimeWarning -m draftwright.make_drawing --help`
- `uv run pytest tests/test_make_drawing.py::test_make_drawing_module_entrypoint_runs_cli_help`
- `uv run ruff check`
- `uv run mypy src`
- `uv run pytest -m smoke`
- `uv run pytest tests/ -n auto --dist loadscope --cov=src/draftwright --cov-report=term-missing --cov-report=xml`