### PR TITLE
docs: add Contributor License Agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,125 @@
+# draftwright Contributor License Agreement
+
+Thank you for contributing to **draftwright**.
+
+draftwright is released under the GNU Affero General Public License v3.0
+(AGPL-3.0) and is also offered under separate commercial terms by the Project
+Owner. So that contributions can be included in *both* the AGPL release and any
+commercially-licensed release, we ask every contributor to agree to this
+Contributor License Agreement ("Agreement").
+
+This Agreement is for your protection as a contributor as well as the protection
+of the Project Owner and downstream users; it does **not** change your rights to
+use your own Contributions for any other purpose. **You keep the copyright to
+your Contributions** — you are granting a licence, not assigning ownership.
+
+In this Agreement:
+
+- **"Project Owner"** means Paul Fremantle (pzfreo@gmail.com), the copyright
+  holder and maintainer of draftwright.
+- **"You"** / **"Your"** means the individual or legal entity agreeing to this
+  Agreement.
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, that You intentionally submit to
+  the Project Owner for inclusion in, or documentation of, draftwright. "Submit"
+  means any form of communication sent to the Project Owner or its
+  representatives — including but not limited to pull requests, patches, issues,
+  and electronic or written correspondence — but excludes anything You
+  conspicuously mark in writing as "Not a Contribution."
+
+By submitting a Contribution, You accept and agree to the following terms.
+
+## 1. Copyright licence grant
+
+You hereby grant to the Project Owner, and to recipients of software distributed
+by the Project Owner, a perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable copyright licence to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works.
+
+## 2. Right to relicense (dual licensing)
+
+You acknowledge that the Project Owner distributes draftwright under the
+AGPL-3.0 **and** under separate commercial licence terms. Accordingly, the
+licence in Section 1 expressly includes the right for the Project Owner to
+license and sublicense Your Contributions, in source or object form, **under any
+licensing terms** — including the AGPL-3.0, other open-source licences, and
+proprietary/commercial licences — and to do so without any obligation of
+accounting or payment to You. You retain all right, title, and interest in Your
+Contributions and may use them for any other purpose.
+
+## 3. Patent licence grant
+
+You hereby grant to the Project Owner and to recipients of draftwright a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except as stated
+in this section) patent licence to make, have made, use, offer to sell, sell,
+import, and otherwise transfer Your Contributions, where such licence applies
+only to those patent claims licensable by You that are necessarily infringed by
+Your Contribution(s) alone or by combination of Your Contribution(s) with
+draftwright. If any entity institutes patent litigation against You or any other
+entity (including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or draftwright to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licences granted to that
+entity under this Agreement for that Contribution or draftwright shall terminate
+as of the date such litigation is filed.
+
+## 4. You are entitled to grant these rights
+
+You represent that:
+
+1. Each of Your Contributions is Your original creation, or You otherwise have
+   the right to submit it under the terms of this Agreement.
+2. If You are employed or engaged in work to which Your Contributions may be
+   relevant, You have received any necessary permissions from Your employer or
+   client to make the Contributions, **or** Your employer or client has waived
+   such rights for Your Contributions to draftwright, **or** Your employer or
+   client has executed a separate agreement with the Project Owner.
+3. The grant of rights under this Agreement does not violate any grant of rights
+   You have made to third parties.
+
+## 5. Third-party material
+
+Should You wish to submit work that is not Your original creation, You may submit
+it to the Project Owner separately from any Contribution, identifying the
+complete details of its source and of any licence or other restriction
+(including related patents, trademarks, and licence agreements) of which You are
+personally aware, and conspicuously marking the work as
+"Submitted on behalf of a third party: [named here]".
+
+## 6. No obligation
+
+You understand that the decision to include Your Contribution in any project or
+source repository is entirely that of the Project Owner, and this Agreement does
+not guarantee that the Contributions will be included in any product.
+
+## 7. No warranty
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" basis, **without warranties or conditions of any
+kind**, either express or implied, including, without limitation, any warranties
+or conditions of title, non-infringement, merchantability, or fitness for a
+particular purpose.
+
+## 8. Notice
+
+You agree to notify the Project Owner of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect.
+
+---
+
+## How to accept
+
+By submitting a pull request, patch, or other Contribution to draftwright, You
+indicate Your agreement to this Contributor License Agreement for that and all
+future Contributions, unless You state otherwise in writing at the time of
+submission.
+
+If You are contributing on behalf of an organisation that wishes to record its
+agreement explicitly, or if You need an entity-level CLA covering employees,
+contact the Project Owner at pzfreo@gmail.com.
+
+---
+
+*This document is provided for project-governance purposes and is not legal
+advice. If the relicensing terms in Sections 1–3 matter to Your business,
+consider having it reviewed by a lawyer before relying on it.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to draftwright
+
+Thanks for your interest in improving draftwright. Contributions of all kinds —
+bug reports, fixes, features, and documentation — are welcome.
+
+## Contributor License Agreement
+
+draftwright is dual-licensed: it is released under the AGPL-3.0 and also offered
+under separate commercial terms. So that contributions can be included in **both**
+releases, all contributors must agree to the
+[Contributor License Agreement (CLA.md)](CLA.md).
+
+You keep the copyright to your work — the CLA grants a licence, not an
+assignment. **By opening a pull request you indicate your agreement to the CLA**
+for that and all future contributions. Please read it before submitting.
+
+## Development
+
+draftwright uses [`uv`](https://github.com/astral-sh/uv) for environment and
+dependency management.
+
+```
+uv sync                       # install dependencies
+uv run pytest -m smoke        # quick "did I break something obvious" check (~30 s)
+uv run pytest                 # full fast tier
+```
+
+For a full local run, spread it across cores with
+`uv run pytest -n auto --dist loadscope`. See [CLAUDE.md](CLAUDE.md) for the test
+tiers and the architecture overview, and `docs/adr/` for the design decisions
+behind layout, scaling, and annotation placement — please read the relevant ADRs
+before changing those areas.
+
+## Pull requests
+
+- Branch off `main` and open a PR with a clear description of **why**.
+- Keep changes focused; add tests for new behaviour.
+- Make sure the fast test tier passes locally before pushing.
+
+Questions or commercial-licensing enquiries: pzfreo@gmail.com.


### PR DESCRIPTION
## What

- `CLA.md` — a Contributor License Agreement for draftwright.
- `CONTRIBUTING.md` — contributor entry point that links to the CLA and the dev/test workflow.

## Why

draftwright is dual-licensed: AGPL-3.0 plus the commercial licence offered via `pzfreo@gmail.com` (see README / CLAUDE.md). A DCO `Signed-off-by` only certifies provenance — it grants no right to ship a contributor's code under proprietary terms. To keep offering commercial licences, every contributor needs to grant relicensing rights.

## Design

- **License-in, not assignment.** Contributors keep their copyright and grant a broad licence (Harmony/MongoDB-style), which is far less off-putting than a copyright assignment and is sufficient for dual licensing.
- **Section 2 is the load-bearing clause** — the explicit right to relicense under "any licensing terms," including proprietary/commercial.
- **Structure follows the Apache ICLA** (patent grant, original-creation rep, employer-permission rep, third-party material, AS-IS warranty disclaimer), with the relicensing grant grafted on.
- **Acceptance** is click-through-by-PR (lowest friction), stated in both `CLA.md` and `CONTRIBUTING.md`. A CLA bot is the usual upgrade once external contributors appear.

## Not included (deliberate)

- No entity CLA (no corporate contributors yet — left as a "contact me" line).
- No CLA-check automation.
- Not legal review — the doc notes that Sections 1–3 should be lawyer-reviewed if the commercial revenue becomes material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)