### PR TITLE
feat: vendor feature recognition into draftwright (ADR 0007 PR-A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,16 +10,18 @@ produces a fully-annotated multi-view technical drawing (orthographic views, dim
 section A–A, ISO hatching, title block) ready for DXF/SVG export.
 
 It sits on top of two Apache 2.0 libraries:
-- `build123d-drafting-helpers` — annotation primitives (`Dimension`, `Leader`, `HoleCallout`, …)
+- `build123d-drafting-helpers` — annotation primitives (`Dimension`, `Leader`, `HoleCallout`, …).
+  The *rendering* library; draftwright owns feature recognition and linting (ADR 0007).
 - `build123d` — the underlying CAD kernel
 
 ## Architecture
 
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
-top: leaf modules (`layout.py`, `registry.py`, `linting.py`, `fonts.py`) → `_core.py`
-→ stage modules (`export.py`, `repair.py`, `projection.py`, `sheet.py`, `analysis.py`,
-`drawing.py`, the `annotations/` subpackage) → `builder.py` → the `make_drawing.py` /
-`annotate.py` compat facades. No lower module imports an upper one.
+top: leaf modules (`layout.py`, `registry.py`, `linting.py`, `fonts.py`, the
+`recognition/` subpackage) → `_core.py` → stage modules (`export.py`, `repair.py`,
+`projection.py`, `sheet.py`, `analysis.py`, `drawing.py`, the `annotations/`
+subpackage) → `builder.py` → the `make_drawing.py` / `annotate.py` compat facades.
+No lower module imports an upper one.
 
 - **`make_drawing.py`** — thin compat facade (~17 lines) re-exporting the public
   surface (`Drawing`, `build_drawing`, `make_drawing`, `generate_script`, `_cli`,
@@ -69,6 +71,12 @@ top: leaf modules (`layout.py`, `registry.py`, `linting.py`, `fonts.py`) → `_c
   `CoverageState` (the coverage signal — pattern callouts, patterned holes,
   dropped diameters). Depends only on `_core` + build123d_drafting. `_QUOTED_RE`
   (a lint-message label regex shared with the repair loop) lives in `_core`.
+- **`recognition/`** — feature recognition (ADR 0007: draftwright owns it, not
+  helpers). `_features.py` (vendored from `build123d_drafting.features`; the
+  hole/boss/cylinder/pattern recognisers — `find_holes`/`find_bosses`/
+  `analyse_cylinders`/`feature_diameters`/`find_hole_patterns`/`full_cylinders`
+  + the feature/pattern types) and `slots.py` (the milled-slot recogniser, #135).
+  Bottom of the DAG: depends only on build123d/OCP. Import via the package surface.
 - **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
   cross-platform layout (ADR 0006).
 - **`export.py`** — SVG/DXF/PDF export + post-processing (page-size fix,

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -14,12 +14,6 @@ import logging
 import math
 
 from build123d import Compound, Shape
-from build123d_drafting.features import (
-    analyse_cylinders,
-    find_hole_patterns,
-    find_holes,
-    full_cylinders,
-)
 from build123d_drafting.helpers import draft_preset
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.BRepGProp import BRepGProp
@@ -37,7 +31,13 @@ from draftwright._core import (
     _legible_steps,
     _Projector,
 )
-from draftwright.features import find_slots
+from draftwright.recognition import (
+    analyse_cylinders,
+    find_hole_patterns,
+    find_holes,
+    find_slots,
+    full_cylinders,
+)
 from draftwright.sheet import (
     _build_zones,
     _layout_geometry,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -10,12 +10,6 @@ from __future__ import annotations
 
 import math
 
-from build123d_drafting.features import (
-    BoltCircle,
-    HoleSpec,
-    LinearArray,
-    RectGrid,
-)
 from build123d_drafting.helpers import (
     CenterlineCircle,
     HoleCallout,
@@ -36,6 +30,12 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
 from draftwright.layout import LayoutSolver, Placeable
+from draftwright.recognition import (
+    BoltCircle,
+    HoleSpec,
+    LinearArray,
+    RectGrid,
+)
 
 
 def _legible_locations(positions, scale):

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -15,9 +15,6 @@ from __future__ import annotations
 
 import math
 
-from build123d_drafting.features import (
-    full_cylinders,
-)
 from build123d_drafting.helpers import (
     Centerline,
     CenterMark,
@@ -50,6 +47,9 @@ from draftwright.annotations.holes import (
 from draftwright.annotations.pmi import _annotate_pmi
 from draftwright.annotations.sections import _add_detail_view, _add_section_view
 from draftwright.annotations.turned import _annotate_turned_diameters
+from draftwright.recognition import (
+    full_cylinders,
+)
 
 
 def _wrap_rows(header, data, ncols):

--- a/src/draftwright/annotations/turned.py
+++ b/src/draftwright/annotations/turned.py
@@ -6,9 +6,6 @@ front view (`_annotate_turned_diameters` + helpers). Below annotate in the DAG.
 
 from __future__ import annotations
 
-from build123d_drafting.features import (
-    find_bosses,
-)
 from build123d_drafting.helpers import (
     Leader,
     TitleBlock,
@@ -24,6 +21,9 @@ from draftwright._core import (
     _solve_strip_ys,
 )
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
+from draftwright.recognition import (
+    find_bosses,
+)
 
 
 def _mentioned_diams(annotations):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -26,10 +26,6 @@ from build123d import (
     Text,
     Vector,
 )
-from build123d_drafting.features import (
-    HoleSpec,
-    analyse_cylinders,
-)
 from build123d_drafting.helpers import (
     Leader,
     LintIssue,
@@ -70,6 +66,10 @@ from draftwright.linting import CoverageState, _suggest_fix, lint_feature_covera
 from draftwright.projection import (
     _exactify_silhouettes,
     _raw_view_projector,
+)
+from draftwright.recognition import (
+    HoleSpec,
+    analyse_cylinders,
 )
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing

--- a/src/draftwright/features.py
+++ b/src/draftwright/features.py
@@ -1,0 +1,23 @@
+"""Compatibility facade — feature recognition moved to :mod:`draftwright.recognition`.
+
+ADR 0007 consolidated all feature recognition under
+:mod:`draftwright.recognition`; the slot recogniser that lived here is now
+:mod:`draftwright.recognition.slots`. This shim re-exports it from the old path
+so existing ``from draftwright.features import find_slots`` / ``Slot`` imports
+keep working. Import from :mod:`draftwright.recognition` instead.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from draftwright.recognition import Slot, find_slots
+
+warnings.warn(
+    "draftwright.features is deprecated; import find_slots/Slot from "
+    "draftwright.recognition instead (ADR 0007).",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = ["Slot", "find_slots"]

--- a/src/draftwright/linting.py
+++ b/src/draftwright/linting.py
@@ -20,14 +20,14 @@ from __future__ import annotations
 
 import re
 
-from build123d_drafting.features import (
+from build123d_drafting.helpers import LintIssue, TitleBlock
+
+from draftwright._core import _DIAM_RE, _QUOTED_RE, _fmt
+from draftwright.recognition import (
     analyse_cylinders,
     feature_diameters,
     find_holes,
 )
-from build123d_drafting.helpers import LintIssue, TitleBlock
-
-from draftwright._core import _DIAM_RE, _QUOTED_RE, _fmt
 
 
 class CoverageState:

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -1,0 +1,48 @@
+"""Feature recognition for build123d solids (ADR 0007).
+
+draftwright owns feature recognition; ``build123d-drafting-helpers`` is the
+rendering library. This package is the single home for it:
+
+- :mod:`._features` — vendored hole/boss/cylinder/pattern recognisers (was
+  ``build123d_drafting.features``; upstream copy frozen and deprecated).
+- :mod:`.slots` — the draftwright-local milled-slot recogniser (#135).
+
+Import the public surface from here, not the submodules.
+"""
+
+from __future__ import annotations
+
+from draftwright.recognition._features import (
+    BoltCircle,
+    BossFeature,
+    CounterBore,
+    HoleFeature,
+    HoleSpec,
+    LinearArray,
+    RectGrid,
+    analyse_cylinders,
+    feature_diameters,
+    find_bosses,
+    find_hole_patterns,
+    find_holes,
+    full_cylinders,
+)
+from draftwright.recognition.slots import Slot, find_slots
+
+__all__ = [
+    "BoltCircle",
+    "BossFeature",
+    "CounterBore",
+    "HoleFeature",
+    "HoleSpec",
+    "LinearArray",
+    "RectGrid",
+    "Slot",
+    "analyse_cylinders",
+    "feature_diameters",
+    "find_bosses",
+    "find_hole_patterns",
+    "find_holes",
+    "find_slots",
+    "full_cylinders",
+]

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -1,0 +1,1034 @@
+"""features — geometric feature recognition for build123d parts (#87).
+
+Vendored from ``build123d_drafting.features`` (ADR 0007): draftwright owns
+feature recognition, helpers becomes the rendering library. This is the
+source of truth from here on — the upstream copy is frozen and deprecated.
+Imported via the package surface, :mod:`draftwright.recognition`.
+
+Recognises drilled-hole and boss features from a solid's cylindrical faces:
+
+    from draftwright.recognition import find_holes, find_bosses
+    holes = find_holes(part)    # list[HoleFeature]
+    bosses = find_bosses(part)  # list[BossFeature]
+
+A *hole* is a contiguous coaxial stack of internal full cylinders — the
+drilled bore plus optional counterbore and spotface steps — with its bottom
+classified by probing the adjacent face (``through`` / ``flat`` /
+``drill_point`` / ``unknown``).  A *boss* is an external full cylinder.
+Cylinder patches spanning half a turn or less (fillets, rounds, slot end
+caps) are never features, but a bore split by a slot or keyway still counts,
+and a bore interrupted by a crossing hole is recombined into one feature.
+
+Known approximations: a hole opening onto a slanted or curved surface is
+located at the axial extreme of its lip, and its depth includes the lip
+overhang; counterbores on the far side of a through hole's bore are not
+reported.
+
+This module also hosts the low-level cylinder analysis that
+``make_drawing`` builds on (``analyse_cylinders``, ``full_cylinders``).
+"""
+
+import math
+from dataclasses import dataclass
+
+from OCP.BRepAdaptor import BRepAdaptor_Surface
+from OCP.GeomAbs import (
+    GeomAbs_Cone,
+    GeomAbs_Cylinder,
+    GeomAbs_Plane,
+    GeomAbs_Sphere,
+    GeomAbs_Torus,
+)
+from OCP.TopAbs import TopAbs_Orientation
+
+# Cylinder patches around one axis spanning half a turn or less in total are
+# not holes or bosses: quarter-turn patches are edge blends (fillets/rounds)
+# and exactly-half-turn patches are the end caps of milled slots. Real bores
+# keep more than half a turn even when a slot or keyway splits them.
+_FULL_CYL_MIN_EXTENT = math.pi * 1.05
+
+# Coaxial segments whose axial ranges meet within this gap belong to the same
+# stack (a counterbore shoulder is an exact-touch); larger gaps are distinct
+# features unless bridged by a shoulder chamfer/fillet or a crossing void
+# (see _merge_stacks).
+_STACK_GAP_TOL = 0.1
+
+# A counterbore-like step shallower than this fraction of its diameter is a
+# spotface (a facing cut, e.g. ø60×5), deeper is a counterbore (e.g. ø18×6).
+_SPOTFACE_MAX_RATIO = 0.2
+
+
+def analyse_cylinders(part):
+    """Return (z_cyls, cross_cyls) from OCP cylindrical face analysis.
+
+    Each entry is a dict with keys: diameter, axis (dominant axis letter),
+    u_extent (the face's angular span in radians — partial spans are fillets),
+    axis_xyz (a point on the cylinder axis), external (True when the face
+    is outward-facing — a boss/OD; False for a bore), dir_xyz (unit axis
+    direction with its dominant component positive), s_lo/s_hi (the patch's
+    axial extent as coordinates along dir_xyz), solid_idx (index of the owning
+    solid, keeping coaxial bores in different bodies distinct — see #68), and
+    face (the source face).
+    z_cyls: cylinders whose axis is approximately Z.
+    cross_cyls: cylinders whose axis is approximately X or Y.
+    """
+    z_cyls: list[dict] = []
+    cross_cyls: list[dict] = []
+    # Attribute each face to its owning solid so coaxial bores in *different*
+    # bodies of a multi-solid assembly are not grouped into one hole — which
+    # would measure a depth across the gap between the bodies (#68). A single
+    # solid yields one group, i.e. the historical single-body behaviour.
+    solids = part.solids()
+    faces_by_solid = (
+        [(i, f) for i, s in enumerate(solids) for f in s.faces()]
+        if solids
+        else [(0, f) for f in part.faces()]
+    )
+    for solid_idx, face in faces_by_solid:
+        surf = BRepAdaptor_Surface(face.wrapped)
+        if surf.GetType() != GeomAbs_Cylinder:
+            continue
+        cyl = surf.Cylinder()
+        r = cyl.Radius()
+        d = cyl.Axis().Direction()
+        ap = cyl.Axis().Location()
+        comps = [("x", abs(d.X())), ("y", abs(d.Y())), ("z", abs(d.Z()))]
+        ax = max(comps, key=lambda t: t[1])[0]
+        # Canonical direction (dominant component positive) so coaxial faces
+        # report comparable axial coordinates whichever way their frame points
+        sign = 1.0 if {"x": d.X(), "y": d.Y(), "z": d.Z()}[ax] > 0 else -1.0
+        dir_xyz = (sign * d.X(), sign * d.Y(), sign * d.Z())
+        v0, v1 = surf.FirstVParameter(), surf.LastVParameter()
+        # s(P) = P·dir for P = ap + v*d  →  s = ap·dir + sign*v
+        s_ap = ap.X() * dir_xyz[0] + ap.Y() * dir_xyz[1] + ap.Z() * dir_xyz[2]
+        s0, s1 = s_ap + sign * v0, s_ap + sign * v1
+        rec = dict(
+            diameter=round(r * 2, 2),
+            axis=ax,
+            solid_idx=solid_idx,
+            u_extent=surf.LastUParameter() - surf.FirstUParameter(),
+            axis_xyz=(ap.X(), ap.Y(), ap.Z()),
+            dir_xyz=dir_xyz,
+            s_lo=min(s0, s1),
+            s_hi=max(s0, s1),
+            face=face,
+            # Outward material (boss/OD) vs bore: a right-handed cylinder's
+            # natural normal points away from the axis, so FORWARD means
+            # external — but mirroring makes the frame left-handed and flips
+            # both, so compare against the frame handedness
+            external=(face.wrapped.Orientation() == TopAbs_Orientation.TopAbs_FORWARD)
+            == cyl.Position().Direct(),
+        )
+        (z_cyls if ax == "z" else cross_cyls).append(rec)
+    return z_cyls, cross_cyls
+
+
+def _line_key(c):
+    """Coaxial-stack key: the owning solid plus the axis letter and the axis
+    point projected onto the plane perpendicular to the axis direction (so it is
+    position-independent along the axis, and exact for slanted axes too). The
+    solid component keeps coaxial bores in different bodies of an assembly from
+    grouping into one hole (#68)."""
+    px, py, pz = c["axis_xyz"]
+    dx, dy, dz = c["dir_xyz"]
+    t = px * dx + py * dy + pz * dz
+    return (
+        c.get("solid_idx", 0),
+        c["axis"],
+        round(px - t * dx, 3),
+        round(py - t * dy, 3),
+        round(pz - t * dz, 3),
+    )
+
+
+def _cyl_group_key(c):
+    """Cylinder patches of one hole/boss share an axis line and a diameter."""
+    return (*_line_key(c), round(c["diameter"], 2))
+
+
+def _merge_runs(items, key_fn):
+    """Group *items* by *key_fn*, then split each group into runs of
+    contiguous axial ranges (gap > _STACK_GAP_TOL starts a new run)."""
+    by_key: dict = {}
+    for item in items:
+        by_key.setdefault(key_fn(item), []).append(item)
+    runs = []
+    for group in by_key.values():
+        group.sort(key=lambda c: c["s_lo"])
+        run, hi = [group[0]], group[0]["s_hi"]
+        for c in group[1:]:
+            if c["s_lo"] <= hi + _STACK_GAP_TOL:
+                run.append(c)
+                hi = max(hi, c["s_hi"])
+            else:
+                runs.append(run)
+                run, hi = [c], c["s_hi"]
+        runs.append(run)
+    return runs
+
+
+def full_cylinders(cyls):
+    """The feature-relevant ("full") cylinder records within *cyls*.
+
+    *cyls* is one of the two record lists returned by :func:`analyse_cylinders`
+    (the z-axis list or the cross-axis list); the records are the dicts that
+    function produces. The result keeps only the records that belong to a hole
+    or boss: patches around one axis must total more than half a turn within
+    one contiguous axial range, so fillet faces and slot end caps are excluded
+    (even coaxial caps at different heights) but a bore split by a slot or
+    keyway still counts.
+
+    This is the patch-level filter shared with ``make_drawing``. For the
+    higher-level inventory of dimensionable diameters use
+    :func:`feature_diameters`, which is built from the recognised
+    :func:`find_holes` / :func:`find_bosses` features instead. Public and
+    stable for downstream consumers (e.g. ``draftwright``).
+    """
+    keep = []
+    for run in _merge_runs(cyls, _cyl_group_key):
+        if sum(c["u_extent"] for c in run) >= _FULL_CYL_MIN_EXTENT:
+            keep.extend(run)
+    return keep
+
+
+# Internal alias retained for the in-module call sites.
+_full_cyls = full_cylinders
+
+
+# ---------------------------------------------------------------------------
+# Hole / boss recognition
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CounterBore:
+    """A counterbore or spotface step of a hole: its diameter and axial depth."""
+
+    diameter: float
+    depth: float
+
+
+@dataclass(frozen=True)
+class HoleFeature:
+    """A drilled hole: the bore plus optional counterbore/spotface steps.
+
+    ``axis`` is the drilling direction (unit vector pointing from the opening
+    into the hole) and ``location`` the axis point at the opening surface.
+    ``diameter``/``depth`` describe the bore itself — the narrowest segment of
+    the stack — with ``depth`` measured from the top of the bore to the hole's
+    deep end (a bottom relief groove counts, a drill point's cone does not).
+    ``bottom`` is ``"through"``, ``"flat"``, ``"drill_point"``, or
+    ``"unknown"`` when the adjacent geometry matches none of those.
+    """
+
+    axis: tuple
+    location: tuple
+    diameter: float
+    depth: float
+    bottom: str
+    cbore: CounterBore | None = None
+    spotface: CounterBore | None = None
+
+
+@dataclass(frozen=True)
+class BossFeature:
+    """An external cylindrical boss (including a turned part's OD).
+
+    ``axis`` points from the base toward the free end, ``location`` is the
+    axis point at the free end, and ``height`` the axial extent.
+    """
+
+    axis: tuple
+    location: tuple
+    diameter: float
+    height: float
+
+
+def _unit(v):
+    """Normalise negative zeros out of a direction tuple."""
+    return tuple(0.0 if c == 0 else c for c in v)
+
+
+def _segments(cyls):
+    """Collapse cylinder patches into segments: one per (axis line, diameter,
+    contiguous axial range). Keyway-split patches of one bore merge; coaxial
+    same-diameter holes from opposite faces stay separate."""
+    return [
+        dict(
+            run[0],
+            s_lo=min(p["s_lo"] for p in run),
+            s_hi=max(p["s_hi"] for p in run),
+            faces=[p["face"] for p in run],
+        )
+        for run in _merge_runs(cyls, _cyl_group_key)
+    ]
+
+
+def _axis_point(seg, s):
+    """The 3D point on *seg*'s axis at axial coordinate *s*."""
+    ax, ay, az = seg["axis_xyz"]
+    dx, dy, dz = seg["dir_xyz"]
+    s_ap = ax * dx + ay * dy + az * dz
+    t = s - s_ap
+    return (ax + t * dx, ay + t * dy, az + t * dz)
+
+
+def _end_partners(seg, s_end, edge_faces, cache=None):
+    """The faces beyond one axial end of *seg*: partners of edges that lie at
+    that end. An opening edge on a slanted or curved surface dips away from
+    the end plane (by the lip sagitta), so edges match within a margin — but
+    stay well clear of the segment's other end.
+
+    *cache* (optional) memoises the result per ``(seg, s_end)`` within one
+    ``find_holes``/``find_bosses`` call — the same end is classified several
+    times (``_merge_stacks`` plus the main loop), and each scan walks every
+    face's edges. The seg is stored in the cached value so an ``is`` check
+    rejects (and pins against) any ``id`` reuse."""
+    if cache is not None:
+        key = ("ep", id(seg), round(s_end, 9))
+        hit = cache.get(key)
+        if hit is not None and hit[0] is seg:
+            return hit[1]
+    dx, dy, dz = seg["dir_xyz"]
+    margin = max(_STACK_GAP_TOL, min(0.45 * (seg["s_hi"] - seg["s_lo"]), 0.5 * seg["diameter"]))
+    partners = []
+    for face in seg["faces"]:
+        for edge in face.edges():
+            pts = [edge.center()] + [v.center() for v in edge.vertices()]
+            if not all(abs(p.X * dx + p.Y * dy + p.Z * dz - s_end) <= margin for p in pts):
+                continue
+            for partner in edge_faces.get(edge, ()):
+                if not any(partner.is_same(f) for f in seg["faces"]):
+                    partners.append(partner)
+    if cache is not None:
+        cache[key] = (seg, partners)
+    return partners
+
+
+def _classify_end(seg, s_end, hi_end, edge_faces, cache=None):
+    """Cached wrapper over :func:`_classify_end_uncached` (see *cache* there)."""
+    if cache is None:
+        return _classify_end_uncached(seg, s_end, hi_end, edge_faces)
+    key = ("ce", id(seg), round(s_end, 9), hi_end)
+    hit = cache.get(key)
+    if hit is not None and hit[0] is seg:
+        return hit[1]
+    result = _classify_end_uncached(seg, s_end, hi_end, edge_faces, cache)
+    cache[key] = (seg, result)
+    return result
+
+
+def _classify_end_uncached(seg, s_end, hi_end, edge_faces, cache=None):
+    """Classify one axial end of a cylinder segment from the face beyond it.
+
+    Returns ``"open"`` (the bore exits, or the boss's free end), ``"flat"``
+    (closed by a plane facing back into the segment, or a boss's base),
+    ``"drill_point"`` (a bore closed by a cone), or ``"unknown"``.
+
+    Planes, cones, and tori are decisive; a curved wall (cylinder/sphere) is
+    a weak signal — an exit for a bore, a base for a boss — that only counts
+    when no decisive partner is present (a crossing port near a flat bottom
+    must not outvote the bottom).
+
+    An adjacent cone is read through the segment's internal/external context
+    and its apex direction: for a bore, apex outward closes it (drill point)
+    while apex inward widens it (an entry chamfer or countersink — open);
+    for a boss the senses flip (apex outward is a chamfered free end, apex
+    inward a base draft).  Tori follow the corner they round: one curling
+    inward (major radius below the segment's) is a closed corner — a blind
+    bore's bottom or a boss's base — and one flaring outward is an opening
+    lip or a free end.
+    """
+    dx, dy, dz = seg["dir_xyz"]
+    e_sign = 1.0 if hi_end else -1.0
+    weak = None
+    for partner in _end_partners(seg, s_end, edge_faces, cache):
+        surf = BRepAdaptor_Surface(partner.wrapped)
+        kind = surf.GetType()
+        if kind == GeomAbs_Cone:
+            cone = surf.Cone()
+            apex = cone.Apex()
+            apex_s = apex.X() * dx + apex.Y() * dy + apex.Z() * dz
+            outward = (apex_s - s_end) * e_sign > 0
+            if not seg["external"]:
+                if outward:
+                    # A deburr chamfer on a flat floor's rim is also an
+                    # apex-outward cone — closed either way, but it has the
+                    # floor plane right next to it where a true drill point
+                    # has nothing beyond its apex.
+                    for e2 in partner.edges():
+                        for n in edge_faces.get(e2, ()):
+                            if n.is_same(partner) or any(n.is_same(f) for f in seg["faces"]):
+                                continue
+                            n_surf = BRepAdaptor_Surface(n.wrapped)
+                            if n_surf.GetType() != GeomAbs_Plane:
+                                continue
+                            nv = n.normal_at(n.center())
+                            if abs(nv.X * dx + nv.Y * dy + nv.Z * dz) > 0.9:
+                                return "flat"
+                    return "drill_point"
+                return "open"
+            return "open" if outward else "flat"
+        if kind == GeomAbs_Torus:
+            curls_in = surf.Torus().MajorRadius() < seg["diameter"] / 2
+            if not seg["external"]:
+                return "flat" if curls_in else "open"
+            return "open" if curls_in else "flat"
+        if kind == GeomAbs_Plane:
+            n = partner.normal_at(partner.center())
+            dot = (n.X * dx + n.Y * dy + n.Z * dz) * e_sign
+            if dot < -0.5:
+                return "flat"
+            if dot > 0.5:
+                return "open"
+        elif kind == GeomAbs_Sphere:
+            # Convex (material inside the sphere): the bore exits through a
+            # spherical surface. Concave (a ball-nose cavity): a closed
+            # bottom — reported as "flat" (no rounded-bottom category).
+            convex = (
+                partner.wrapped.Orientation() == TopAbs_Orientation.TopAbs_FORWARD
+            ) == surf.Sphere().Position().Direct()
+            if not seg["external"]:
+                weak = "open" if convex else "flat"
+            else:
+                weak = "flat" if convex else "open"
+        elif kind == GeomAbs_Cylinder:
+            weak = "open" if not seg["external"] else "flat"
+    return weak or "unknown"
+
+
+def _edge_face_map(part):
+    """Map every edge of *part* to the faces that share it."""
+    edge_faces: dict = {}
+    for f in part.faces():
+        for e in f.edges():
+            edge_faces.setdefault(e, []).append(f)
+    return edge_faces
+
+
+def _shared_transition(a, b, edge_faces, cache=None):
+    """True when a cone or torus face spans the gap between segment *a*'s
+    high end and segment *b*'s low end — the shoulder chamfer or fillet that
+    makes the two segments steps of one hole. The transition face touches
+    one segment directly and may reach the other through the shoulder ring
+    plane, so one adjacency hop is followed. Solid material between two
+    unrelated coaxial features has no such connecting face."""
+    a_partners = _end_partners(a, a["s_hi"], edge_faces, cache)
+    b_partners = _end_partners(b, b["s_lo"], edge_faces, cache)
+    for own, other in ((a_partners, b_partners), (b_partners, a_partners)):
+        for t in own:
+            if BRepAdaptor_Surface(t.wrapped).GetType() not in (GeomAbs_Cone, GeomAbs_Torus):
+                continue
+            if any(t.is_same(o) for o in other):
+                return True
+            neighbours = [f for e in t.edges() for f in edge_faces.get(e, ())]
+            if any(n.is_same(o) for n in neighbours for o in other):
+                return True
+    return False
+
+
+def _merge_stacks(stacks, edge_faces, cache=None):
+    """Recombine coaxial stacks that are one hole:
+
+    - same bore diameter on both sides of a crossing void, neither facing
+      end closed (a flat bottom or drill point means genuinely separate
+      holes, e.g. blind holes drilled from opposite faces);
+    - different diameters whose gap is bridged by a shoulder chamfer or
+      fillet face (the steps of a counterbored hole with a deburred
+      shoulder).
+    """
+    by_line: dict = {}
+    for stack in stacks:
+        by_line.setdefault(_line_key(stack[0]), []).append(stack)
+    merged = []
+    for line_stacks in by_line.values():
+        line_stacks.sort(key=lambda st: min(s["s_lo"] for s in st))
+        cur = line_stacks[0]
+        for nxt in line_stacks[1:]:
+            a = max(cur, key=lambda s: s["s_hi"])
+            b = min(nxt, key=lambda s: s["s_lo"])
+            closed = ("flat", "drill_point")
+            if (
+                abs(a["diameter"] - b["diameter"]) < 0.01
+                and _classify_end(a, a["s_hi"], True, edge_faces, cache) not in closed
+                and _classify_end(b, b["s_lo"], False, edge_faces, cache) not in closed
+            ):
+                joined = dict(a, s_hi=b["s_hi"], faces=a["faces"] + b["faces"])
+                cur = [s for s in cur if s is not a] + [joined] + [s for s in nxt if s is not b]
+            elif b["s_lo"] - a["s_hi"] <= _STACK_GAP_TOL + abs(
+                a["diameter"] - b["diameter"]
+            ) and _shared_transition(a, b, edge_faces, cache):
+                cur = cur + nxt
+            else:
+                merged.append(cur)
+                cur = nxt
+        merged.append(cur)
+    return merged
+
+
+def find_holes(part, cyls=None) -> list:
+    """Recognise drilled holes on *part* (see :class:`HoleFeature`).
+
+    Coaxial internal cylinders are grouped into stacks — drill + optional
+    counterbore + optional spotface become one hole, and a bore interrupted
+    by a crossing hole is recombined.  The bottom is classified by probing
+    the face adjacent to the deep end.  Countersinks are not recognised as
+    steps (the cone is treated as an opening); steps on the far side of the
+    bore (e.g. a second counterbore from the back face) are not reported.
+
+    Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to avoid
+    re-scanning the solid (mirrors ``lint_feature_coverage``'s parameter).
+    """
+    z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
+    internal = [c for c in _full_cyls(z_cyls) + _full_cyls(cross_cyls) if not c["external"]]
+    if not internal:
+        return []
+    edge_faces = _edge_face_map(part)
+    # one end-classification cache for the whole call: the same (seg, end) is
+    # classified by _merge_stacks and again in the loop below, each scan walking
+    # every face's edges (#150).
+    cache: dict = {}
+    stacks = _merge_stacks(_merge_runs(_segments(internal), _line_key), edge_faces, cache)
+
+    holes = []
+    for stack in stacks:
+        d = stack[0]["dir_xyz"]
+        lo_seg = min(stack, key=lambda s: s["s_lo"])
+        hi_seg = max(stack, key=lambda s: s["s_hi"])
+        lo_state = _classify_end(lo_seg, lo_seg["s_lo"], False, edge_faces, cache)
+        hi_state = _classify_end(hi_seg, hi_seg["s_hi"], True, edge_faces, cache)
+
+        # The opening is the open end; with both ends open (a through hole)
+        # prefer the wider segment's end (counterbores sit at the opening),
+        # falling back to the high-coordinate end (drilled from the top).
+        if lo_state == "open" and hi_state != "open":
+            from_hi = False
+        elif hi_state == "open" and lo_state != "open":
+            from_hi = True
+        else:
+            from_hi = hi_seg["diameter"] >= lo_seg["diameter"]
+        opening_seg, opening_s = (hi_seg, hi_seg["s_hi"]) if from_hi else (lo_seg, lo_seg["s_lo"])
+        bottom_state = lo_state if from_hi else hi_state
+        bottom = {"open": "through"}.get(bottom_state, bottom_state)
+
+        # Order segments from the opening inward; the bore is the narrowest
+        # (not the farthest — a through hole counterbored from both sides has
+        # a step beyond the bore) and only steps on the opening side count.
+        ordered = sorted(stack, key=lambda s: s["s_hi"], reverse=from_hi)
+        bore_i = min(range(len(ordered)), key=lambda i: ordered[i]["diameter"])
+        bore = ordered[bore_i]
+
+        # Steps narrow monotonically from the opening to the bore; a wider
+        # segment between same-diameter lands is a groove (e.g. an O-ring
+        # gland inside a counterbore), not a step. Lands of one step span
+        # their groove.
+        spans: dict = {}
+        step_order = []
+        min_d = math.inf
+        for step in ordered[:bore_i]:
+            if step["diameter"] > min_d + 0.01:
+                continue
+            min_d = step["diameter"]
+            key = round(step["diameter"], 2)
+            if key not in spans:
+                spans[key] = [step["s_lo"], step["s_hi"]]
+                step_order.append(key)
+            else:
+                spans[key][0] = min(spans[key][0], step["s_lo"])
+                spans[key][1] = max(spans[key][1], step["s_hi"])
+        cbore = spotface = None
+        for key in step_order:
+            lo, hi = spans[key]
+            spec = CounterBore(key, round(hi - lo, 2))
+            if spec.depth < _SPOTFACE_MAX_RATIO * spec.diameter:
+                spotface = spotface or spec
+            else:
+                cbore = cbore or spec
+
+        # The bore's depth runs from its top to the hole's deep end: bore
+        # lands span a mid-bore groove, and a blind hole's depth includes a
+        # bottom relief groove — but not a through hole's far-side steps.
+        bore_segs = [s for s in stack if abs(s["diameter"] - bore["diameter"]) < 0.01]
+        deep_segs = bore_segs if bottom == "through" else stack
+        if from_hi:
+            depth = max(s["s_hi"] for s in bore_segs) - min(s["s_lo"] for s in deep_segs)
+        else:
+            depth = max(s["s_hi"] for s in deep_segs) - min(s["s_lo"] for s in bore_segs)
+        holes.append(
+            HoleFeature(
+                axis=_unit(tuple(-c for c in d) if from_hi else d),
+                location=_axis_point(opening_seg, opening_s),
+                diameter=bore["diameter"],
+                depth=round(depth, 2),
+                bottom=bottom,
+                cbore=cbore,
+                spotface=spotface,
+            )
+        )
+    return holes
+
+
+def find_bosses(part, cyls=None) -> list:
+    """Recognise external cylindrical bosses on *part* (one
+    :class:`BossFeature` per coaxial external cylinder segment, including a
+    turned part's OD — callers wanting only local bosses can filter on
+    diameter against the part envelope).
+
+    Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to avoid
+    re-scanning the solid (mirrors ``find_holes``'s parameter, so a caller
+    computing both holes and bosses can share one analysis).
+    """
+    z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
+    external = [c for c in _full_cyls(z_cyls) + _full_cyls(cross_cyls) if c["external"]]
+    if not external:
+        return []
+    edge_faces = _edge_face_map(part)
+    cache: dict = {}
+
+    bosses = []
+    for seg in _segments(external):
+        d = seg["dir_xyz"]
+        lo_state = _classify_end(seg, seg["s_lo"], False, edge_faces, cache)
+        hi_state = _classify_end(seg, seg["s_hi"], True, edge_faces, cache)
+        # The free end is the open one (its cap faces away from the segment);
+        # default to the high end when both or neither are open.
+        from_hi = not (lo_state == "open" and hi_state != "open")
+        bosses.append(
+            BossFeature(
+                axis=_unit(d if from_hi else tuple(-c for c in d)),
+                location=_axis_point(seg, seg["s_hi"] if from_hi else seg["s_lo"]),
+                diameter=seg["diameter"],
+                height=round(seg["s_hi"] - seg["s_lo"], 2),
+            )
+        )
+    return bosses
+
+
+def feature_diameters(part, cyls=None) -> list:
+    """Sorted unique diameters of the *recognised* dimensionable cylindrical
+    features on *part*: every hole bore, each hole's counterbore/spotface step,
+    and every boss.
+
+    This is the inventory to use for coverage checks ("is each dimensionable
+    diameter called out?"). It is deliberately built from
+    :func:`find_holes` / :func:`find_bosses`, not the raw :func:`full_cylinders`
+    patch list, so partial cylinders that never become a real feature — slot ends and
+    interrupted recesses (an exact half-cylinder pair sums to a full turn and
+    fools an angle-only test, but is not a bore) — are excluded, while genuine
+    counterbore/spotface steps are kept. (#158)
+
+    Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to share one
+    scan between ``find_holes`` and ``find_bosses``.
+    """
+    cyls = analyse_cylinders(part) if cyls is None else cyls
+    diams: list[float] = []
+    for h in find_holes(part, cyls=cyls):
+        diams.append(h.diameter)
+        if h.cbore is not None:
+            diams.append(h.cbore.diameter)
+        if h.spotface is not None:
+            diams.append(h.spotface.diameter)
+    for b in find_bosses(part, cyls=cyls):
+        diams.append(b.diameter)
+    return sorted(set(diams))
+
+
+# ---------------------------------------------------------------------------
+# Hole patterns — bolt circles, linear arrays, and rectangular grids
+# (#92; sub-clustering and grids #126/#144)
+# ---------------------------------------------------------------------------
+
+# A pattern's holes must share a radius (bolt circle) or pitch (linear array)
+# to within this fraction of the nominal, plus a small absolute floor.
+_PATTERN_REL_TOL = 0.02
+_PATTERN_ABS_TOL = 0.1
+# Bolt-circle angular spacing must be even to within this fraction of 2π/n.
+# Tight on purpose: at 15% a 100×80 rectangle reads as an equally spaced
+# bolt circle; real patterns (even from noisy STEP) are within a fraction
+# of a degree.
+_BC_SPACING_TOL = 0.04
+
+
+@dataclass(frozen=True)
+class BoltCircle:
+    """≥3 identical holes equally spaced on a circle.
+
+    ``center`` is the world point at the holes' opening plane, ``diameter``
+    the bolt-circle diameter (BCD), ``holes`` the member features.
+    """
+
+    holes: tuple
+    center: tuple
+    diameter: float
+
+
+@dataclass(frozen=True)
+class LinearArray:
+    """≥3 identical holes collinear at constant pitch.
+
+    ``direction`` is the unit vector from the first hole toward the last
+    (members are ordered along it).
+    """
+
+    holes: tuple
+    pitch: float
+    direction: tuple
+
+
+@dataclass(frozen=True)
+class RectGrid:
+    """A fully-populated rectangular grid of identical holes (an N×M lattice).
+
+    ``rows``×``cols`` holes sit on a regular rectangular lattice with
+    ``row_pitch`` spacing along the first lattice axis and ``col_pitch`` along
+    the second; every lattice position is occupied (``rows * cols == len(holes)``).
+    ``angle`` is the first axis's orientation in degrees within the holes'
+    opening plane, normalised to ``[0, 90)``. ``center`` is the world point at
+    the grid centroid (opening plane).
+
+    A rectangular *ring* / perimeter (holes only around the edge, interior
+    empty) is not a grid — it is reported as its constituent edge
+    :class:`LinearArray` rows instead.
+    """
+
+    holes: tuple
+    rows: int
+    cols: int
+    row_pitch: float
+    col_pitch: float
+    angle: float
+    center: tuple
+
+
+def _pattern_tol(nominal: float) -> float:
+    return _PATTERN_REL_TOL * nominal + _PATTERN_ABS_TOL
+
+
+@dataclass(frozen=True)
+class HoleSpec:
+    """The machining spec shared by holes that are the *same drilled feature*.
+
+    Two holes drilled with the same tool, in the same direction, with the same
+    counterbore/spotface stack have equal :class:`HoleSpec` values (a through
+    drill is the same spec whatever wall it pierces). Because the dataclass is
+    frozen it hashes and compares by value, so it is a stable dict/set key for
+    grouping holes — pattern detection and callout grouping agree when they key
+    on the same :class:`HoleSpec`.
+
+    Build one with :meth:`from_hole`; do not construct the fields by hand (the
+    normalisation in :meth:`from_hole` is part of the contract). ``axis`` is the
+    drilling direction snapped to 6 dp (boolean ops leave ~1e-16 noise on the
+    components, and exact float keys would split a pattern silently). ``depth``
+    is ``None`` for a through hole — its depth is irrelevant to the spec —
+    otherwise the bore depth. Public and stable for downstream consumers (e.g.
+    ``draftwright``).
+    """
+
+    axis: tuple
+    diameter: float
+    depth: float | None
+    bottom: str
+    cbore: CounterBore | None
+    spotface: CounterBore | None
+
+    @classmethod
+    def from_hole(cls, hole: HoleFeature) -> "HoleSpec":
+        """The :class:`HoleSpec` for *hole* (a :class:`HoleFeature`)."""
+        depth = None if hole.bottom == "through" else hole.depth
+        axis = tuple(0.0 if abs(c) < 1e-6 else round(c, 6) for c in hole.axis)
+        return cls(axis, hole.diameter, depth, hole.bottom, hole.cbore, hole.spotface)
+
+
+def _spec_key(h):
+    return HoleSpec.from_hole(h)
+
+
+def _plane_uv(axis):
+    """Two unit vectors spanning the plane perpendicular to *axis*."""
+    ax, ay, az = axis
+    ref = (0.0, 0.0, 1.0) if abs(az) < 0.9 else (1.0, 0.0, 0.0)
+    ux = ay * ref[2] - az * ref[1]
+    uy = az * ref[0] - ax * ref[2]
+    uz = ax * ref[1] - ay * ref[0]
+    n = math.hypot(ux, uy, uz)
+    u = (ux / n, uy / n, uz / n)
+    v = (
+        ay * u[2] - az * u[1],
+        az * u[0] - ax * u[2],
+        ax * u[1] - ay * u[0],
+    )
+    return u, v
+
+
+def _as_bolt_circle(holes, pts):
+    """BoltCircle when *pts* (2D) are equally spaced on a common circle."""
+    n = len(pts)
+    cx = sum(p[0] for p in pts) / n
+    cy = sum(p[1] for p in pts) / n
+    radii = [math.hypot(p[0] - cx, p[1] - cy) for p in pts]
+    r = sum(radii) / n
+    if r < _PATTERN_ABS_TOL or max(abs(ri - r) for ri in radii) > _pattern_tol(r):
+        return None
+    angles = sorted(math.atan2(p[1] - cy, p[0] - cx) for p in pts)
+    gaps = [angles[i + 1] - angles[i] for i in range(n - 1)]
+    gaps.append(2 * math.pi - (angles[-1] - angles[0]))
+    even = 2 * math.pi / n
+    if max(abs(g - even) for g in gaps) > _BC_SPACING_TOL * even:
+        return None
+    center = tuple(sum(c) / n for c in zip(*(h.location for h in holes), strict=True))
+    return BoltCircle(holes=tuple(holes), center=center, diameter=round(2 * r, 2))
+
+
+def _as_linear_array(holes, pts):
+    """LinearArray when *pts* (2D) are collinear at constant pitch."""
+    n = len(pts)
+    # endpoints are the farthest-apart pair: robust for any orientation. A
+    # lexicographic (x, y) sort would pick the wrong ends for a near-axis row
+    # whose coordinates carry the sub-micron noise real STEP geometry always
+    # has — an interior point sorts first, halving the span and pitch and
+    # rejecting a perfectly good array.
+    i0, i1 = max(
+        ((i, j) for i in range(n) for j in range(i + 1, n)),
+        key=lambda ij: math.dist(pts[ij[0]], pts[ij[1]]),
+    )
+    first, last = pts[i0], pts[i1]
+    dx, dy = last[0] - first[0], last[1] - first[1]
+    span = math.hypot(dx, dy)
+    if span < _PATTERN_ABS_TOL:
+        return None
+    ux, uy = dx / span, dy / span
+    # collinearity: every point within tolerance of the first→last line —
+    # scaled to the pitch, not the span (a long row must not absorb holes
+    # millimetres off-line)
+    line_tol = _pattern_tol(span / (n - 1))
+    if any(abs((p[0] - first[0]) * -uy + (p[1] - first[1]) * ux) > line_tol for p in pts):
+        return None
+    # project each point onto the first→last axis once (used both for the pitch
+    # check, sorted, and to order the members below)
+    proj = [(p[0] - first[0]) * ux + (p[1] - first[1]) * uy for p in pts]
+    ts = sorted(proj)
+    pitches = [ts[i + 1] - ts[i] for i in range(n - 1)]
+    pitch = span / (n - 1)
+    if max(abs(p - pitch) for p in pitches) > _pattern_tol(pitch):
+        return None
+    # order members along the array, in world coordinates
+    ordered = sorted(zip(proj, holes, strict=True), key=lambda t: t[0])
+    w0 = ordered[0][1].location
+    w1 = ordered[-1][1].location
+    d = tuple(b - a for a, b in zip(w0, w1, strict=True))
+    norm = math.hypot(d[0], d[1], d[2])
+    return LinearArray(
+        holes=tuple(h for _, h in ordered),
+        pitch=round(pitch, 2),
+        direction=_unit(tuple(c / norm for c in d)),
+    )
+
+
+def _circumcircle(p0, p1, p2):
+    """Centre and radius ``(cx, cy, r)`` of the circle through three 2D points,
+    or ``None`` when they are collinear (so a collinear triple can never seed a
+    bolt circle — collinearity must win, per :func:`find_hole_patterns`)."""
+    ax, ay = p0
+    bx, by = p1
+    cx, cy = p2
+    d = 2 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
+    if abs(d) < 1e-9:
+        return None
+    a2, b2, c2 = ax * ax + ay * ay, bx * bx + by * by, cx * cx + cy * cy
+    ux = (a2 * (by - cy) + b2 * (cy - ay) + c2 * (ay - by)) / d
+    uy = (a2 * (cx - bx) + b2 * (ax - cx) + c2 * (bx - ax)) / d
+    return ux, uy, math.hypot(ax - ux, ay - uy)
+
+
+def _bolt_circle_candidates(members, pts):
+    """All bolt circles within a spec group: every triple seeds a candidate
+    circle, the group's points lying on it are gathered, and the set is kept
+    only if :func:`_as_bolt_circle` confirms it is fully, evenly populated.
+    Returns ``(BoltCircle, frozenset(member indices))`` candidates."""
+    n = len(pts)
+    out, seen = [], set()
+    for i in range(n):
+        for j in range(i + 1, n):
+            for k in range(j + 1, n):
+                circ = _circumcircle(pts[i], pts[j], pts[k])
+                if circ is None:
+                    continue
+                cx, cy, r = circ
+                if r < _PATTERN_ABS_TOL:
+                    continue
+                key = (round(cx, 2), round(cy, 2), round(r, 2))
+                if key in seen:
+                    continue
+                seen.add(key)
+                tol = _pattern_tol(r)
+                idx = [
+                    m
+                    for m in range(n)
+                    if abs(math.hypot(pts[m][0] - cx, pts[m][1] - cy) - r) <= tol
+                ]
+                if len(idx) < 3:
+                    continue
+                pat = _as_bolt_circle([members[m] for m in idx], [pts[m] for m in idx])
+                if pat is not None:
+                    out.append((pat, frozenset(idx)))
+    return out
+
+
+def _linear_array_candidates(members, pts):
+    """All linear arrays within a spec group: every pair seeds a line, the
+    group's collinear points are gathered and sorted, and each maximal
+    constant-pitch run of ≥3 becomes a candidate. Returns
+    ``(LinearArray, frozenset(member indices))`` candidates."""
+    n = len(pts)
+    out, seen = [], set()
+    for i in range(n):
+        for j in range(i + 1, n):
+            dx, dy = pts[j][0] - pts[i][0], pts[j][1] - pts[i][1]
+            span = math.hypot(dx, dy)
+            if span < _PATTERN_ABS_TOL:
+                continue
+            ux, uy = dx / span, dy / span
+            tol = _pattern_tol(span)
+            online = [
+                m
+                for m in range(n)
+                if abs(-(pts[m][1] - pts[i][1]) * ux + (pts[m][0] - pts[i][0]) * uy) <= tol
+            ]
+            order = sorted(
+                online,
+                key=lambda m: (pts[m][0] - pts[i][0]) * ux + (pts[m][1] - pts[i][1]) * uy,
+            )
+            ts = [(pts[m][0] - pts[i][0]) * ux + (pts[m][1] - pts[i][1]) * uy for m in order]
+            # split the sorted collinear points into maximal constant-pitch runs
+            a = 0
+            while a < len(order) - 2:
+                pitch = ts[a + 1] - ts[a]
+                b = a + 1
+                while b + 1 < len(order) and abs((ts[b + 1] - ts[b]) - pitch) <= _pattern_tol(
+                    pitch
+                ):
+                    b += 1
+                run = order[a : b + 1]
+                run_key = frozenset(run)
+                if len(run) >= 3 and run_key not in seen:
+                    seen.add(run_key)
+                    pat = _as_linear_array([members[m] for m in run], [pts[m] for m in run])
+                    if pat is not None:
+                        out.append((pat, run_key))
+                a = b  # a broken pitch starts the next run at the break point
+    return out
+
+
+def _rect_grid(members, pts):
+    """A :class:`RectGrid` when the whole spec group fills a regular N×M
+    rectangular lattice, else ``None``. The two shortest near-orthogonal
+    pairwise vectors define the lattice basis; every point must land on an
+    integer cell and every cell must be occupied (no holes, no extras). 2×2 is
+    excluded — four lattice corners are a rectangle, not a grid."""
+    n = len(pts)
+    if n < 6:
+        return None
+    diffs = []
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            dx, dy = pts[j][0] - pts[i][0], pts[j][1] - pts[i][1]
+            length = math.hypot(dx, dy)
+            if length > _PATTERN_ABS_TOL:
+                diffs.append((length, dx, dy))
+    if not diffs:
+        return None
+    diffs.sort()
+    l1, b1x, b1y = diffs[0]
+    u1 = (b1x / l1, b1y / l1)
+    basis2 = next(
+        (
+            (length, dx, dy)
+            for length, dx, dy in diffs
+            if abs((dx * u1[0] + dy * u1[1]) / length) < 0.2
+        ),
+        None,
+    )
+    if basis2 is None:
+        return None
+    l2, b2x, b2y = basis2
+    u2 = (b2x / l2, b2y / l2)
+    a0 = min(p[0] * u1[0] + p[1] * u1[1] for p in pts)
+    b0 = min(p[0] * u2[0] + p[1] * u2[1] for p in pts)
+    cells = []
+    for p in pts:
+        da = p[0] * u1[0] + p[1] * u1[1] - a0
+        db = p[0] * u2[0] + p[1] * u2[1] - b0
+        ci, cj = round(da / l1), round(db / l2)
+        if abs(da - ci * l1) > _pattern_tol(l1) or abs(db - cj * l2) > _pattern_tol(l2):
+            return None
+        cells.append((ci, cj))
+    if len(set(cells)) != n:
+        return None
+    rows = max(c[0] for c in cells) + 1
+    cols = max(c[1] for c in cells) + 1
+    if rows < 2 or cols < 2 or max(rows, cols) < 3 or rows * cols != n:
+        return None
+    center = tuple(sum(c) / n for c in zip(*(h.location for h in members), strict=True))
+    return RectGrid(
+        holes=tuple(members),
+        rows=rows,
+        cols=cols,
+        row_pitch=round(l1, 2),
+        col_pitch=round(l2, 2),
+        angle=round(math.degrees(math.atan2(u1[1], u1[0])) % 90.0, 2),
+        center=center,
+    )
+
+
+def find_hole_patterns(holes) -> list:
+    """Recognise :class:`BoltCircle`, :class:`LinearArray`, and
+    :class:`RectGrid` patterns among *holes* (``HoleFeature`` records, e.g.
+    from :func:`find_holes`).
+
+    Holes are grouped by machining spec and drilling axis, then each group is
+    *sub-clustered* — a single spec can contribute several patterns (two
+    separate bolt circles, the rows of a rectangular perimeter, a grid). All
+    candidate sub-patterns are enumerated and allocated greedily largest-first,
+    so each hole belongs to at most one pattern and the richest interpretation
+    wins. A filled N×M lattice becomes one :class:`RectGrid`; a rectangular
+    ring or perimeter is reported as its edge :class:`LinearArray` rows.
+
+    Collinearity is tested ahead of concyclicity (any three points are
+    concyclic, so a 3-hole "bolt circle" must really be an equilateral
+    triangle); unpatterned holes are simply absent from the result.
+    """
+    groups: dict = {}
+    for h in holes:
+        groups.setdefault(_spec_key(h), []).append(h)
+
+    patterns = []
+    for spec, members in groups.items():
+        if len(members) < 3:
+            continue
+        u, v = _plane_uv(spec.axis)
+        pts = [
+            (
+                sum(a * b for a, b in zip(h.location, u, strict=True)),
+                sum(a * b for a, b in zip(h.location, v, strict=True)),
+            )
+            for h in members
+        ]
+        candidates: list = []
+        grid = _rect_grid(members, pts)
+        if grid is not None:
+            candidates.append((grid, frozenset(range(len(members)))))
+        candidates += _bolt_circle_candidates(members, pts)
+        candidates += _linear_array_candidates(members, pts)
+        # allocate largest-first; a hole used by one pattern is off the table
+        # for the rest (stable sort keeps grids ahead of circles ahead of rows
+        # at equal size)
+        candidates.sort(key=lambda c: -len(c[1]))
+        used: set = set()
+        for pattern, idx in candidates:
+            if idx & used:
+                continue
+            patterns.append(pattern)
+            used |= idx
+    return patterns

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -1,11 +1,10 @@
 """Recognition of non-cylindrical machined features (#135).
 
-Draftwright-local **prototype**.  It recognises milled *slots* — the class of
-feature the cylinder-based pipeline (``analyse_cylinders``/``find_holes`` in
-``build123d_drafting.features``) is blind to.  Once the recognition predicate
-stabilises this is intended to be upstreamed into ``build123d-drafting-helpers``
-beside the hole/boss recognisers; it deliberately mirrors their OCC face-scan
-idioms so the lift is mechanical.
+It recognises milled *slots* — the class of feature the cylinder-based pipeline
+(``analyse_cylinders``/``find_holes`` in :mod:`._features`) is blind to.  It
+sits beside the hole/boss recognisers in :mod:`draftwright.recognition`, the
+single home for feature recognition (ADR 0007 — recognition lives in
+draftwright, not upstream); it mirrors their OCC face-scan idioms.
 
 Scope (deliberately narrow — see #148): only **enclosed through-slots with
 straight, rectangular walls** are recognised.  The recogniser proves a candidate

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -16,8 +16,6 @@ import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 
-from build123d_drafting.features import BoltCircle, HoleSpec, RectGrid
-
 from draftwright._core import (
     _DIM_PAD,
     _FONT_SIZE,
@@ -44,6 +42,7 @@ from draftwright._core import (
     _tb_width,
     _text_width,
 )
+from draftwright.recognition import BoltCircle, HoleSpec, RectGrid
 
 _log = logging.getLogger(__name__)
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -15,8 +15,8 @@ from draftwright._core import _MIN_VIEW_MM, _fmt
 from draftwright.analysis import _is_rotational, analyse_face_levels, dedup_diams
 from draftwright.drawing import analyse_cylinders
 from draftwright.export import _export_shape
-from draftwright.features import Slot, find_slots
 from draftwright.make_drawing import generate_script, lint_feature_coverage
+from draftwright.recognition import Slot, find_slots
 from draftwright.sheet import _fits, choose_scale
 
 
@@ -726,8 +726,7 @@ class TestDerivedLayoutConstants:
         assert _text_width("WXYZ", 3.0) > _text_width("iiii", 3.0)
 
     def test_bore_callout_width_scales_with_font_size(self):
-        from build123d_drafting.features import find_holes
-
+        from draftwright.recognition import find_holes
         from draftwright.sheet import _est_bore_callout_width
 
         part = Box(60, 40, 12) - Pos(0, 0, 6) * Cylinder(3, 12)
@@ -765,7 +764,7 @@ class TestComposeAnnoBoxes:
             assert composed == scalar, (label, n_steps, kw)
 
     def test_matches_for_plain_part(self):
-        from build123d_drafting.features import find_hole_patterns, find_holes
+        from draftwright.recognition import find_hole_patterns, find_holes
 
         part = Box(60, 40, 12)
         holes = find_holes(part)
@@ -775,7 +774,7 @@ class TestComposeAnnoBoxes:
             self._assert_match(holes, patterns, n_steps, bb)
 
     def test_matches_for_bored_part(self):
-        from build123d_drafting.features import find_hole_patterns, find_holes
+        from draftwright.recognition import find_hole_patterns, find_holes
 
         part = Box(60, 40, 12) - Pos(0, 0, 6) * Cylinder(3, 12)
         holes = find_holes(part)
@@ -786,8 +785,7 @@ class TestComposeAnnoBoxes:
 
     def test_matches_for_dense_ballooning_part(self):
         # _dense_plate triggers _will_balloon → exercises the plan_halo band.
-        from build123d_drafting.features import find_hole_patterns, find_holes
-
+        from draftwright.recognition import find_hole_patterns, find_holes
         from draftwright.sheet import _will_balloon
 
         part = _dense_plate()
@@ -834,7 +832,7 @@ class TestComposeAnnoBoxesCorpus:
         (plan halo band). The right dim ladder depth is a pure function of the
         n_steps argument (not geometry), so it is swept per part below rather
         than via a dedicated stepped fixture."""
-        from build123d_drafting.features import find_hole_patterns, find_holes
+        from draftwright.recognition import find_hole_patterns, find_holes
 
         parts = {
             "plain_block": Box(60, 40, 12),
@@ -983,10 +981,10 @@ class TestTwoPassLayout:
         # "4× ⌀15.9 THRU") that need more than _DIM_PAD right of the plan view.
         # The two-pass layout must size gap_fv_sv >= bore callout depth.
         from build123d import Box, Cylinder, Pos
-        from build123d_drafting.features import find_holes
 
         from draftwright import build_drawing
         from draftwright._core import _DIM_PAD
+        from draftwright.recognition import find_holes
         from draftwright.sheet import _est_bore_callout_width
 
         # Four identical cylinders → "4× ⌀16 THRU" callout with a count prefix
@@ -1053,8 +1051,8 @@ class TestTwoPassLayout:
         # BoltCircle callouts carry "EQ SP ON ø… BC" suffix (~34 mm wide).
         # _est_bore_callout_width must include it when patterns are provided.
         from build123d import Box, Cylinder, Pos
-        from build123d_drafting.features import find_hole_patterns, find_holes
 
+        from draftwright.recognition import find_hole_patterns, find_holes
         from draftwright.sheet import _est_bore_callout_width
 
         # Six ⌀8 holes at equal 60° spacing on R=35 → BoltCircle pattern

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -1,0 +1,847 @@
+"""Tests for draftwright.recognition (vendored from build123d_drafting.features) (find_holes / find_bosses, #87)."""
+
+import math
+
+import pytest
+from build123d import (
+    Align,
+    Axis,
+    Box,
+    Circle,
+    Compound,
+    Cone,
+    Cylinder,
+    GeomType,
+    Plane,
+    Pos,
+    Rectangle,
+    Sphere,
+    chamfer,
+    extrude,
+    fillet,
+    mirror,
+)
+
+from draftwright.recognition import (
+    BossFeature,
+    CounterBore,
+    HoleFeature,
+    HoleSpec,
+    analyse_cylinders,
+    feature_diameters,
+    find_bosses,
+    find_holes,
+    full_cylinders,
+)
+
+
+def _drill_tool(radius, depth, top_z):
+    """A drill-shaped cut tool: cylinder of *depth* plus a 118° point."""
+    tip = radius / math.tan(math.radians(59))
+    bottom = top_z - depth
+    return Pos(0, 0, top_z - depth / 2) * Cylinder(radius, depth) + Pos(
+        0, 0, bottom - tip / 2
+    ) * Cone(0, radius, tip)
+
+
+class TestFindHoles:
+    @pytest.mark.timeout(60)
+    def test_plain_through_hole(self):
+        holes = find_holes(Box(60, 60, 20) - Cylinder(5, 20))
+        assert holes == [
+            HoleFeature(
+                axis=(0.0, 0.0, -1.0),
+                location=(0.0, 0.0, 10.0),
+                diameter=10.0,
+                depth=20.0,
+                bottom="through",
+            )
+        ]
+
+    @pytest.mark.timeout(60)
+    def test_blind_flat_hole(self):
+        part = Box(60, 60, 20) - Pos(0, 0, 10 - 6) * Cylinder(5, 12)
+        (hole,) = find_holes(part)
+        assert hole.bottom == "flat"
+        assert hole.depth == pytest.approx(12.0)
+        assert hole.location == pytest.approx((0.0, 0.0, 10.0))
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+
+    @pytest.mark.timeout(60)
+    def test_drill_point_hole(self):
+        part = Box(60, 60, 20) - _drill_tool(5, 12, top_z=10)
+        (hole,) = find_holes(part)
+        assert hole.bottom == "drill_point"
+        # depth is the full-diameter extent; the cone tip is not included
+        assert hole.depth == pytest.approx(12.0)
+
+    @pytest.mark.timeout(60)
+    def test_counterbored_through_hole(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20) - Pos(0, 0, 10 - 3) * Cylinder(9, 6)
+        (hole,) = find_holes(part)
+        assert hole.diameter == pytest.approx(10.0)
+        assert hole.bottom == "through"
+        assert hole.cbore == CounterBore(diameter=18.0, depth=6.0)
+        assert hole.spotface is None
+        # depth is the bore segment's own extent, below the counterbore
+        assert hole.depth == pytest.approx(14.0)
+
+    @pytest.mark.timeout(60)
+    def test_spotface_cbore_drill_stack(self):
+        # The mcp#264 example: spotface ø60×5, cbore ø18×6, drill ø10.1×15
+        block = Box(100, 100, 40)  # top at z=20
+        part = (
+            block
+            - Pos(0, 0, 20 - 2.5) * Cylinder(30, 5)
+            - Pos(0, 0, 20 - 5 - 3) * Cylinder(9, 6)
+            - Pos(0, 0, 20 - 11 - 7.5) * Cylinder(5.05, 15)
+        )
+        (hole,) = find_holes(part)
+        assert hole.diameter == pytest.approx(10.1)
+        assert hole.depth == pytest.approx(15.0)
+        assert hole.bottom == "flat"
+        assert hole.cbore == CounterBore(diameter=18.0, depth=6.0)
+        assert hole.spotface == CounterBore(diameter=60.0, depth=5.0)
+        assert hole.location == pytest.approx((0.0, 0.0, 20.0))
+
+    @pytest.mark.timeout(60)
+    def test_cross_axis_hole(self):
+        part = Box(60, 60, 20) - Cylinder(4, 60, rotation=(0, 90, 0))
+        (hole,) = find_holes(part)
+        assert hole.diameter == pytest.approx(8.0)
+        assert hole.bottom == "through"
+        assert abs(hole.axis[0]) == pytest.approx(1.0)
+        assert hole.axis[1] == pytest.approx(0.0, abs=1e-9)
+        assert hole.axis[2] == pytest.approx(0.0, abs=1e-9)
+
+    @pytest.mark.timeout(60)
+    def test_opposed_coaxial_blind_holes_stay_separate(self):
+        part = (
+            Box(60, 60, 40)
+            - Pos(0, 0, 20 - 5) * Cylinder(5, 10)
+            - Pos(0, 0, -20 + 5) * Cylinder(5, 10)
+        )
+        holes = sorted(find_holes(part), key=lambda h: h.location[2])
+        assert len(holes) == 2
+        assert holes[0].location[2] == pytest.approx(-20.0)
+        assert holes[0].axis == pytest.approx((0.0, 0.0, 1.0))
+        assert holes[1].location[2] == pytest.approx(20.0)
+        assert holes[1].axis == pytest.approx((0.0, 0.0, -1.0))
+        assert all(h.bottom == "flat" and h.depth == pytest.approx(10.0) for h in holes)
+
+    @pytest.mark.timeout(60)
+    def test_keyway_split_bore_is_one_hole(self):
+        # Two opposed keyway notches split the bore wall into two arc patches
+        # (a single solid). The angular patches must still recombine into one
+        # ⌀10 hole. (The earlier full-width slot bisected the block into two
+        # separate solids — two half-bores, not a keyed hole; coaxial bores in
+        # *different* solids are now kept apart, see test_features for #68.)
+        part = (
+            Box(60, 40, 10)
+            - Cylinder(5, 12)
+            - Pos(0, 5, 0) * Box(2, 4, 12)
+            - Pos(0, -5, 0) * Box(2, 4, 12)
+        )
+        assert len(part.solids()) == 1
+        (hole,) = find_holes(part)
+        assert hole.diameter == pytest.approx(10.0)
+        assert hole.bottom == "through"
+
+    @pytest.mark.timeout(60)
+    def test_coaxial_bores_in_separate_solids_are_distinct_holes(self):
+        # #68: two collinear bores in different bodies of an assembly must not
+        # merge into one hole — that measured a depth across the gap between the
+        # bodies (e.g. ⌀9.8 ↓111.4 where each bore is only 12 deep). Here a thin
+        # plate's through-bore abuts a block's blind bore on the same axis.
+        plate = Pos(-1, 0, 0) * (Box(2, 40, 12) - Cylinder(4.9, 40, rotation=(0, 90, 0)))
+        block = Pos(60.5, 0, 0) * (
+            Box(119, 40, 12) - Pos(-59.5, 0, 0) * Cylinder(4.9, 24, rotation=(0, 90, 0))
+        )
+        whole = Compound(children=[plate, block])
+        holes = find_holes(whole)
+        # The plate's through-bore (≈2 deep) and the block's blind bore (12 deep)
+        # stay separate; no hole spans the inter-body gap.
+        assert len(holes) == 2
+        depths = sorted(h.depth for h in holes)
+        assert depths == pytest.approx([2.0, 12.0])
+        assert {h.bottom for h in holes} == {"through", "flat"}
+
+    @pytest.mark.timeout(60)
+    def test_corner_fillets_are_not_holes(self):
+        part = fillet(Box(60, 60, 20).edges().filter_by(Axis.Z), 8)
+        assert find_holes(part) == []
+        assert find_bosses(part) == []
+
+    @pytest.mark.timeout(60)
+    def test_mirrored_part_keeps_classification(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20) - Pos(0, 0, 10 - 3) * Cylinder(9, 6)
+        (hole,) = find_holes(mirror(part, about=Plane.XZ))
+        assert hole.bottom == "through"
+        assert hole.cbore == CounterBore(diameter=18.0, depth=6.0)
+
+    @pytest.mark.timeout(60)
+    def test_plain_box_has_no_features(self):
+        assert find_holes(Box(20, 20, 20)) == []
+        assert find_bosses(Box(20, 20, 20)) == []
+
+    @pytest.mark.timeout(60)
+    def test_chamfered_opening_stays_through(self):
+        # An entry chamfer is a cone at the opening — it must not read as a
+        # drill point and flip the hole's axis/location to the bottom face.
+        part = Box(60, 60, 20) - Cylinder(5, 20)
+        part = chamfer(part.edges().filter_by(GeomType.CIRCLE).sort_by(Axis.Z)[-1], 1.0)
+        (hole,) = find_holes(part)
+        assert hole.bottom == "through"
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+        assert hole.location[2] == pytest.approx(9.0)  # bore lip, below the chamfer
+
+    @pytest.mark.timeout(60)
+    def test_countersunk_opening_stays_through(self):
+        part = Box(60, 60, 20) - Cylinder(2.5, 20) - Pos(0, 0, 7.5) * Cone(2.5, 5, 5)
+        (hole,) = find_holes(part)
+        assert hole.bottom == "through"
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+        assert hole.diameter == pytest.approx(5.0)
+
+    @pytest.mark.timeout(60)
+    def test_double_counterbored_through_hole_keeps_the_bore(self):
+        # Counterbored from both faces: the bore is the narrowest segment,
+        # not the farthest from the opening; the far-side step is not a cbore.
+        part = (
+            Box(60, 60, 20)
+            - Cylinder(5, 20)
+            - Pos(0, 0, 7) * Cylinder(9, 6)
+            - Pos(0, 0, -7) * Cylinder(9, 6)
+        )
+        (hole,) = find_holes(part)
+        assert hole.diameter == pytest.approx(10.0)
+        assert hole.depth == pytest.approx(8.0)
+        assert hole.bottom == "through"
+        assert hole.cbore == CounterBore(diameter=18.0, depth=6.0)
+
+    @pytest.mark.timeout(60)
+    def test_rounded_end_slot_is_not_holes(self):
+        # Slot end caps span exactly half a turn — below the feature threshold
+        slot = Box(20, 10, 20) + Pos(10, 0, 0) * Cylinder(5, 20) + Pos(-10, 0, 0) * Cylinder(5, 20)
+        assert find_holes(Box(60, 60, 20) - slot) == []
+
+    @pytest.mark.timeout(60)
+    def test_bore_interrupted_by_crossing_hole_is_one_hole(self):
+        # A ø6 cross-drilling severed by the larger ø10 vertical bore must
+        # recombine into one through hole, not two short 'unknown' stubs.
+        part = Box(60, 60, 40) - Cylinder(5, 40) - Cylinder(3, 60, rotation=(0, 90, 0))
+        holes = sorted(find_holes(part), key=lambda h: h.diameter)
+        assert len(holes) == 2
+        assert holes[0].diameter == pytest.approx(6.0)
+        assert holes[0].depth == pytest.approx(60.0)
+        assert holes[0].bottom == "through"
+        assert holes[1].diameter == pytest.approx(10.0)
+        assert holes[1].depth == pytest.approx(40.0)
+
+    @pytest.mark.timeout(60)
+    def test_radial_hole_through_solid_shaft(self):
+        # The hole exits through curved OD faces — still classified through
+        part = Cylinder(15, 60, rotation=(0, 90, 0)) - Cylinder(3, 40)
+        (hole,) = find_holes(part)
+        assert hole.bottom == "through"
+        assert hole.depth == pytest.approx(30.0, abs=0.1)
+
+    @pytest.mark.timeout(60)
+    def test_closely_spaced_parallel_holes_stay_separate(self):
+        # 0.08 mm apart (PCB scale) — position bucketing must not merge them
+        part = (
+            Box(20, 20, 5)
+            - Pos(2.46, 0, 0) * Cylinder(0.15, 5)
+            - Pos(2.54, 0, 0) * Cylinder(0.15, 5)
+        )
+        assert len(find_holes(part)) == 2
+
+    @pytest.mark.timeout(60)
+    def test_slanted_counterbored_hole_groups_as_one(self):
+        # The stack key projects axis points perpendicular to the axis, so a
+        # 45° hole's faces share a line key (depth/location at slanted lips
+        # are documented approximations — only grouping is asserted here).
+        s = math.sin(math.radians(45))
+        pl = Plane(origin=(0, 0, 0), z_dir=(s, 0, math.cos(math.radians(45))))
+        part = Box(60, 60, 20) - (pl * Cylinder(5, 80)) - (pl.offset(8) * Cylinder(9, 30))
+        (hole,) = find_holes(part)
+        assert hole.diameter == pytest.approx(10.0)
+        assert hole.cbore is not None
+        assert hole.cbore.diameter == pytest.approx(18.0)
+
+    @pytest.mark.timeout(60)
+    def test_chamfered_counterbore_shoulder_stays_one_hole(self):
+        # A deburr chamfer on the cbore shoulder creates an axial gap between
+        # the cbore and bore segments — the stack must bridge it, not split
+        # into a phantom ø18 blind hole plus a cbore-less bore.
+        part = Box(60, 60, 20) - Cylinder(5, 20) - Pos(0, 0, 7) * Cylinder(9, 6)
+        edge = [
+            e
+            for e in part.edges().filter_by(GeomType.CIRCLE)
+            if abs(e.center().Z - 4) < 0.01 and abs(e.radius - 5) < 0.01
+        ]
+        (hole,) = find_holes(chamfer(edge, 1.0))
+        assert hole.diameter == pytest.approx(10.0)
+        assert hole.bottom == "through"
+        assert hole.cbore == CounterBore(diameter=18.0, depth=6.0)
+        assert hole.location[2] == pytest.approx(10.0)
+
+    @pytest.mark.timeout(60)
+    def test_filleted_counterbore_shoulder_stays_one_hole(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20) - Pos(0, 0, 7) * Cylinder(9, 6)
+        edge = [
+            e
+            for e in part.edges().filter_by(GeomType.CIRCLE)
+            if abs(e.center().Z - 4) < 0.01 and abs(e.radius - 5) < 0.01
+        ]
+        (hole,) = find_holes(fillet(edge, 1.0))
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+        assert hole.bottom == "through"
+        assert hole.cbore == CounterBore(diameter=18.0, depth=6.0)
+
+    @pytest.mark.timeout(60)
+    def test_filleted_blind_bottom_is_flat(self):
+        # The bottom-corner fillet ring is a torus curling inward — closed
+        part = Box(60, 60, 20) - Pos(0, 0, 4) * Cylinder(5, 12)
+        edge = [e for e in part.edges().filter_by(GeomType.CIRCLE) if abs(e.center().Z + 2) < 0.01]
+        (hole,) = find_holes(fillet(edge, 1.5))
+        assert hole.bottom == "flat"
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+
+    @pytest.mark.timeout(60)
+    def test_filleted_opening_lip_stays_through(self):
+        # The lip fillet is a torus flaring outward — an opening
+        part = Box(60, 60, 20) - Cylinder(5, 20)
+        edge = [
+            e for e in part.edges().filter_by(GeomType.CIRCLE) if abs(e.center().Z - 10) < 0.01
+        ]
+        (hole,) = find_holes(fillet(edge, 1.0))
+        assert hole.bottom == "through"
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+
+    @pytest.mark.timeout(60)
+    def test_oring_groove_does_not_shorten_a_through_bore(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20) - Cylinder(6, 3)
+        (hole,) = find_holes(part)
+        assert hole.diameter == pytest.approx(10.0)
+        assert hole.depth == pytest.approx(20.0)
+        assert hole.bottom == "through"
+
+    @pytest.mark.timeout(60)
+    def test_coaxial_slot_caps_are_not_holes(self):
+        # Two parallel open slots whose rounded ends share an axis, cut from
+        # opposite faces: each cap spans π, and their spans must not be
+        # summed across disjoint axial ranges into a phantom full circle.
+        slot_2d = Rectangle(8, 30, align=(Align.CENTER, Align.MIN)) + Circle(4)
+        slot = extrude(Plane.XY * slot_2d, 10)
+        part = Box(60, 60, 30) - Pos(0, 0, 5) * slot - Pos(0, 0, -15) * slot
+        assert find_holes(part) == []
+
+    @pytest.mark.timeout(60)
+    def test_coaxial_features_behind_a_wall_stay_separate(self):
+        # ø20 blind from the top, ø10 blind from the bottom, 5 mm of solid
+        # between — must be two blind features, never one "through" hole.
+        part = (
+            Box(60, 60, 40) - Pos(0, 0, 12.5) * Cylinder(10, 15) - Pos(0, 0, -10) * Cylinder(5, 20)
+        )
+        holes = sorted(find_holes(part), key=lambda h: h.diameter)
+        assert len(holes) == 2
+        assert all(h.bottom == "flat" for h in holes)
+        assert holes[0].diameter == pytest.approx(10.0)
+        assert holes[1].diameter == pytest.approx(20.0)
+
+    @pytest.mark.timeout(60)
+    def test_groove_inside_counterbore_keeps_the_cbore(self):
+        # An O-ring gland splitting the cbore into lands must not demote the
+        # cbore to a shallow spotface or surface the groove as a step.
+        part = (
+            Box(60, 60, 20)
+            - Cylinder(5, 20)
+            - Pos(0, 0, 7) * Cylinder(9, 6)
+            - Pos(0, 0, 7) * Cylinder(10, 2)
+        )
+        (hole,) = find_holes(part)
+        assert hole.cbore == CounterBore(diameter=18.0, depth=6.0)
+        assert hole.spotface is None
+
+    @pytest.mark.timeout(60)
+    def test_crossing_port_near_flat_bottom_stays_flat(self):
+        # The port's curved wall is a weak signal; the flat bottom plane at
+        # the same end must win regardless of face iteration order.
+        part = (
+            Box(60, 60, 40) - Pos(0, 0, 9) * Cylinder(5, 22) - Cylinder(2, 60, rotation=(0, 90, 0))
+        )
+        (hole,) = (h for h in find_holes(part) if h.diameter == pytest.approx(10.0))
+        assert hole.bottom == "flat"
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+
+    @pytest.mark.timeout(60)
+    def test_drill_point_clipped_by_crossing_hole_stays_drill_point(self):
+        part = (
+            Box(60, 60, 40)
+            - _drill_tool(4, 15, top_z=20)
+            - Pos(0, 0, 4) * Cylinder(2.5, 60, rotation=(0, 90, 0))
+        )
+        (hole,) = (h for h in find_holes(part) if h.diameter == pytest.approx(8.0))
+        assert hole.bottom == "drill_point"
+
+    @pytest.mark.timeout(60)
+    def test_hole_through_a_sphere_is_through(self):
+        (hole,) = find_holes(Sphere(20) - Cylinder(4, 50))
+        assert hole.bottom == "through"
+
+    @pytest.mark.timeout(60)
+    def test_ball_nose_bottom_is_closed(self):
+        # A concave spherical cap closes the bore; and two opposed ball-
+        # bottom holes must not merge across the solid wall between them.
+        part = Box(60, 60, 40) - Pos(0, 0, 8) * Cylinder(5, 24) - Pos(0, 0, -4) * Sphere(5)
+        (hole,) = find_holes(part)
+        assert hole.bottom == "flat"
+        assert hole.axis == pytest.approx((0.0, 0.0, -1.0))
+        opposed = (
+            Box(60, 60, 40)
+            - Pos(0, 0, 11) * Cylinder(5, 18)
+            - Pos(0, 0, 2) * Sphere(5)
+            - Pos(0, 0, -11) * Cylinder(5, 18)
+            - Pos(0, 0, -2) * Sphere(5)
+        )
+        assert len(find_holes(opposed)) == 2
+
+    @pytest.mark.timeout(60)
+    def test_chamfered_flat_floor_is_not_a_drill_point(self):
+        # A deburr chamfer on the floor rim is an apex-outward cone like a
+        # drill point, but it never reaches the axis — the bottom is flat.
+        part = Box(60, 60, 40) - Pos(0, 0, 17.5) * Cylinder(15, 5)
+        edge = [
+            e for e in part.edges().filter_by(GeomType.CIRCLE) if abs(e.center().Z - 15) < 0.01
+        ]
+        (hole,) = find_holes(chamfer(edge, 1.0))
+        assert hole.bottom == "flat"
+
+    @pytest.mark.timeout(60)
+    def test_bottom_relief_groove_extends_depth(self):
+        # A thread-relief groove at the bottom of a blind bore: depth runs to
+        # the true bottom, not to the last bore land above the groove.
+        part = (
+            Box(60, 60, 40)
+            - Pos(0, 0, 12.5) * Cylinder(4.25, 15)
+            - Pos(0, 0, 6) * Cylinder(5.0, 2)
+        )
+        edge = [
+            e for e in part.edges().filter_by(GeomType.CIRCLE) if abs(e.center().Z - 20) < 0.01
+        ]
+        (hole,) = find_holes(chamfer(edge, 1.0))
+        assert hole.diameter == pytest.approx(8.5)
+        assert hole.depth == pytest.approx(14.0)
+        assert hole.bottom == "flat"
+
+    @pytest.mark.timeout(60)
+    def test_turned_part_bore_is_through(self):
+        (hole,) = find_holes(Cylinder(30, 40) - Cylinder(10, 40))
+        assert hole.diameter == pytest.approx(20.0)
+        assert hole.depth == pytest.approx(40.0)
+        assert hole.bottom == "through"
+
+
+class TestFindBosses:
+    @pytest.mark.timeout(60)
+    def test_boss_on_plate(self):
+        part = Box(60, 60, 10) + Pos(0, 0, 5 + 4) * Cylinder(12, 8)
+        assert find_bosses(part) == [
+            BossFeature(
+                axis=(0.0, 0.0, 1.0),
+                location=(0.0, 0.0, 13.0),
+                diameter=24.0,
+                height=8.0,
+            )
+        ]
+
+    @pytest.mark.timeout(60)
+    def test_chamfered_free_end_keeps_orientation(self):
+        # A chamfer on the boss's free end is a cone — it must not flip the
+        # documented base→free-end axis/location contract.
+        part = Box(60, 60, 10) + Pos(0, 0, -9) * Cylinder(12, 8)
+        part = chamfer(part.edges().filter_by(GeomType.CIRCLE).sort_by(Axis.Z)[0], 1.0)
+        (boss,) = find_bosses(part)
+        assert boss.axis == pytest.approx((0.0, 0.0, -1.0))
+        assert boss.location[2] == pytest.approx(-12.0)  # free end, above the chamfer
+
+    @pytest.mark.timeout(60)
+    def test_filleted_free_end_keeps_orientation(self):
+        part = Box(60, 60, 10) + Pos(0, 0, 9) * Cylinder(12, 8)
+        edge = [
+            e for e in part.edges().filter_by(GeomType.CIRCLE) if abs(e.center().Z - 13) < 0.01
+        ]
+        (boss,) = find_bosses(fillet(edge, 1.0))
+        assert boss.axis == pytest.approx((0.0, 0.0, 1.0))
+        assert boss.location[2] == pytest.approx(12.0)  # free end, below the fillet
+
+    @pytest.mark.timeout(60)
+    def test_radial_boss_on_a_pipe_points_outward(self):
+        # The base sits on a curved wall (weak 'flat' signal); the boss on
+        # the negative-X side must still point away from the pipe.
+        pipe = Cylinder(20, 60) - Cylinder(15, 60)
+        part = pipe + Pos(-24, 0, 0) * Cylinder(5, 12, rotation=(0, 90, 0))
+        (boss,) = (b for b in find_bosses(part) if b.diameter == pytest.approx(10.0))
+        assert boss.axis[0] == pytest.approx(-1.0)
+        assert boss.location[0] == pytest.approx(-30.0)
+
+    @pytest.mark.timeout(60)
+    def test_turned_part_od_is_a_boss(self):
+        (boss,) = find_bosses(Cylinder(30, 40) - Cylinder(10, 40))
+        assert boss.diameter == pytest.approx(60.0)
+        assert boss.height == pytest.approx(40.0)
+
+    @pytest.mark.timeout(60)
+    def test_bore_is_not_a_boss(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20)
+        assert find_bosses(part) == []
+        assert len(find_holes(part)) == 1
+
+    @pytest.mark.timeout(60)
+    def test_precomputed_cyls_matches_self_scan(self):
+        # Passing a precomputed analyse_cylinders() result must give the same
+        # bosses as letting find_bosses scan the solid itself (#149).
+        part = Box(60, 60, 10) + Pos(0, 0, 9) * Cylinder(12, 8)
+        cyls = analyse_cylinders(part)
+        assert find_bosses(part, cyls=cyls) == find_bosses(part)
+
+
+class TestFindHolePatterns:
+    @staticmethod
+    def _bc_plate(n=6, r=30, hole_r=4, phase=15.0):
+        part = Box(100, 100, 12)
+        for i in range(n):
+            ang = math.radians(360 / n * i + phase)
+            part = part - Pos(r * math.cos(ang), r * math.sin(ang), 0) * Cylinder(hole_r, 12)
+        return part
+
+    @pytest.mark.timeout(60)
+    def test_six_hole_bolt_circle(self):
+        from draftwright.recognition import BoltCircle, find_hole_patterns
+
+        (pat,) = find_hole_patterns(find_holes(self._bc_plate()))
+        assert isinstance(pat, BoltCircle)
+        assert pat.diameter == pytest.approx(60.0)
+        assert len(pat.holes) == 6
+        assert pat.center[0] == pytest.approx(0.0, abs=0.01)
+        assert pat.center[1] == pytest.approx(0.0, abs=0.01)
+
+    @pytest.mark.timeout(60)
+    def test_three_equally_spaced_holes_are_a_bolt_circle(self):
+        from draftwright.recognition import BoltCircle, find_hole_patterns
+
+        (pat,) = find_hole_patterns(find_holes(self._bc_plate(n=3, r=25)))
+        assert isinstance(pat, BoltCircle)
+        assert pat.diameter == pytest.approx(50.0)
+
+    @pytest.mark.timeout(60)
+    def test_linear_array(self):
+        from draftwright.recognition import LinearArray, find_hole_patterns
+
+        part = Box(120, 40, 10)
+        for i in range(5):
+            part = part - Pos(-40 + i * 20, 0, 0) * Cylinder(3, 10)
+        (pat,) = find_hole_patterns(find_holes(part))
+        assert isinstance(pat, LinearArray)
+        assert pat.pitch == pytest.approx(20.0)
+        assert len(pat.holes) == 5
+        assert abs(pat.direction[0]) == pytest.approx(1.0)
+
+    @pytest.mark.timeout(60)
+    def test_three_collinear_holes_are_an_array_not_a_circle(self):
+        # any three points are concyclic — collinearity must win
+        from draftwright.recognition import LinearArray, find_hole_patterns
+
+        part = (
+            Box(100, 40, 10)
+            - Pos(-20, 0, 0) * Cylinder(3, 10)
+            - Cylinder(3, 10)
+            - Pos(20, 0, 0) * Cylinder(3, 10)
+        )
+        (pat,) = find_hole_patterns(find_holes(part))
+        assert isinstance(pat, LinearArray)
+
+    @pytest.mark.timeout(60)
+    def test_scattered_holes_are_no_pattern(self):
+        from draftwright.recognition import find_hole_patterns
+
+        part = (
+            Box(100, 100, 10)
+            - Pos(10, 5, 0) * Cylinder(3, 10)
+            - Pos(-30, 22, 0) * Cylinder(3, 10)
+            - Pos(17, -38, 0) * Cylinder(3, 10)
+            - Pos(-5, -11, 0) * Cylinder(3, 10)
+        )
+        assert find_hole_patterns(find_holes(part)) == []
+
+    @pytest.mark.timeout(60)
+    def test_uneven_spacing_is_not_a_bolt_circle(self):
+        from draftwright.recognition import find_hole_patterns
+
+        part = Box(100, 100, 10)
+        for deg in (0, 60, 100, 240):
+            ang = math.radians(deg)
+            part = part - Pos(30 * math.cos(ang), 30 * math.sin(ang), 0) * Cylinder(4, 10)
+        assert find_hole_patterns(find_holes(part)) == []
+
+    @pytest.mark.timeout(60)
+    def test_mixed_diameters_do_not_pattern(self):
+        from draftwright.recognition import find_hole_patterns
+
+        part = Box(100, 100, 10)
+        for i, r in zip(range(4), (3, 3, 4, 3), strict=True):
+            ang = math.radians(90 * i)
+            part = part - Pos(30 * math.cos(ang), 30 * math.sin(ang), 0) * Cylinder(r, 10)
+        assert find_hole_patterns(find_holes(part)) == []
+
+    @pytest.mark.timeout(60)
+    def test_rectangle_corners_are_not_a_bolt_circle(self):
+        # 100×80 rectangle corners are equidistant from the centre but not
+        # equally spaced (77.3°/102.7°) — must not read as EQ SP ON BC.
+        from draftwright.recognition import find_hole_patterns
+
+        part = Box(140, 120, 10)
+        for sx in (-50, 50):
+            for sy in (-40, 40):
+                part = part - Pos(sx, sy, 0) * Cylinder(3, 10)
+        assert find_hole_patterns(find_holes(part)) == []
+
+    @pytest.mark.timeout(60)
+    def test_axis_epsilon_noise_does_not_split_a_pattern(self):
+        # Mixed construction history leaves ~1e-16 components on cross-axis
+        # hole axes; the spec key snaps them so the pattern still groups.
+        from build123d import Circle, extrude
+
+        from draftwright.recognition import LinearArray, find_hole_patterns
+
+        part = Box(20, 90, 30)
+        part = part - Pos(0, -30, 0) * Cylinder(4, 20, rotation=(0, 90, 0))
+        part = part - extrude(Plane.YZ * Circle(4), 10, both=True)
+        part = part - Pos(0, 30, 0) * Cylinder(4, 20, rotation=(0, 90, 0))
+        (pat,) = find_hole_patterns(find_holes(part))
+        assert isinstance(pat, LinearArray)
+        assert len(pat.holes) == 3
+
+    @pytest.mark.timeout(60)
+    def test_radius_jitter_beyond_tolerance_rejected(self):
+        from draftwright.recognition import find_hole_patterns
+
+        part = Box(100, 100, 10)
+        for i, r in zip(range(5), (30, 30, 30, 32, 30), strict=True):
+            ang = math.radians(72 * i)
+            part = part - Pos(r * math.cos(ang), r * math.sin(ang), 0) * Cylinder(4, 10)
+        assert find_hole_patterns(find_holes(part)) == []
+
+    @staticmethod
+    def _circle(part, n, r, cx, hole_r=3, phase=0.0):
+        for i in range(n):
+            ang = math.radians(360 / n * i + phase)
+            part = part - Pos(cx + r * math.cos(ang), r * math.sin(ang), 0) * Cylinder(hole_r, 12)
+        return part
+
+    @staticmethod
+    def _grid_plate(nx, ny, px, py, hole_r=3):
+        part = Box(px * (nx + 1), py * (ny + 1), 10)
+        for i in range(nx):
+            for j in range(ny):
+                x = (i - (nx - 1) / 2) * px
+                y = (j - (ny - 1) / 2) * py
+                part = part - Pos(x, y, 0) * Cylinder(hole_r, 10)
+        return part
+
+    @pytest.mark.timeout(120)
+    def test_two_same_spec_bolt_circles_yield_two_patterns(self):
+        # A single drill spec used on two distinct bolt circles must produce
+        # two BoltCircles, not zero (the whole spec group is no longer fitted
+        # as one circle). #144
+        from draftwright.recognition import BoltCircle, find_hole_patterns
+
+        part = Box(160, 80, 12)
+        part = self._circle(part, 6, 20, cx=-40)
+        part = self._circle(part, 6, 15, cx=40)
+        pats = find_hole_patterns(find_holes(part))
+        assert len(pats) == 2
+        assert all(isinstance(p, BoltCircle) for p in pats)
+        assert sorted(round(p.diameter) for p in pats) == [30, 40]
+
+    @pytest.mark.timeout(120)
+    def test_rectangular_ring_decomposes_into_linear_arrays(self):
+        # A rectangular perimeter / ring (interior empty) is reported as its
+        # edge rows, not returned as zero patterns. #144
+        from draftwright.recognition import LinearArray, find_hole_patterns
+
+        part = Box(80, 60, 10)
+        for x in (-24, 0, 24):
+            for y in (-16, 0, 16):
+                if x == 0 and y == 0:
+                    continue  # ring: centre empty
+                part = part - Pos(x, y, 0) * Cylinder(3, 10)
+        pats = find_hole_patterns(find_holes(part))
+        assert pats, "rectangular ring must be recognised, not 0 patterns"
+        assert all(isinstance(p, LinearArray) for p in pats)
+        covered = {h.location for p in pats for h in p.holes}
+        assert len(covered) >= 6
+
+    @pytest.mark.timeout(120)
+    def test_uniform_grid_is_a_rect_grid(self):
+        from draftwright.recognition import RectGrid, find_hole_patterns
+
+        for nx, ny in ((3, 2), (4, 3), (4, 2)):
+            part = self._grid_plate(nx, ny, px=20, py=30)
+            pats = find_hole_patterns(find_holes(part))
+            assert len(pats) == 1, f"{nx}x{ny} grid should be one pattern"
+            (grid,) = pats
+            assert isinstance(grid, RectGrid)
+            assert sorted((grid.rows, grid.cols)) == sorted((nx, ny))
+            assert {round(grid.row_pitch), round(grid.col_pitch)} == {20, 30}
+            assert len(grid.holes) == nx * ny
+
+    @pytest.mark.timeout(60)
+    def test_near_axis_array_with_float_noise_is_found(self):
+        # A near-axis-aligned row whose coordinates carry sub-micron
+        # perpendicular noise (as real STEP geometry does) must still be a
+        # LinearArray: endpoints are the farthest-apart pair, not a
+        # lexicographic sort that a tiny jitter can reorder (mis-measuring the
+        # span and pitch).
+        from draftwright.recognition import HoleFeature, LinearArray, find_hole_patterns
+
+        holes = [
+            HoleFeature(
+                axis=(0.0, 0.0, -1.0),
+                location=(x, 1e-4 * ((i % 2) * 2 - 1), 0.0),
+                diameter=5.0,
+                depth=10.0,
+                bottom="through",
+            )
+            for i, x in enumerate((0.0, 10.0, 20.0, 30.0))
+        ]
+        (pat,) = find_hole_patterns(holes)
+        assert isinstance(pat, LinearArray)
+        assert len(pat.holes) == 4
+        assert pat.pitch == pytest.approx(10.0, abs=0.05)
+
+    @pytest.mark.timeout(120)
+    def test_square_grid_pitches_equal(self):
+        from draftwright.recognition import RectGrid, find_hole_patterns
+
+        part = self._grid_plate(3, 3, px=25, py=25)
+        (grid,) = find_hole_patterns(find_holes(part))
+        assert isinstance(grid, RectGrid)
+        assert grid.rows == 3 and grid.cols == 3
+        assert grid.row_pitch == pytest.approx(25, abs=0.1)
+        assert grid.col_pitch == pytest.approx(25, abs=0.1)
+
+
+class TestEdgeFaceMap:
+    @pytest.mark.timeout(60)
+    def test_shared_edges_map_to_multiple_faces(self):
+        # The bottom-classification chain depends on a topologically-shared edge
+        # hashing/comparing equal across the faces meeting at it. A solid box has
+        # edges shared by two faces; if Edge hashing ever regressed, each edge
+        # would map to a single face and this would fail. (#150)
+        from draftwright.recognition._features import _edge_face_map
+
+        counts = [len(faces) for faces in _edge_face_map(Box(10, 10, 10)).values()]
+        assert counts and max(counts) >= 2
+
+
+class TestFeatureDiameters:
+    # #158: the dimensionable-bore inventory must be the *recognised* features
+    # (bores + cbore/spotface steps + bosses), not raw cylinder patches, so
+    # slot ends / interrupted recesses are excluded while real steps are kept.
+    @pytest.mark.timeout(60)
+    def test_counterbored_hole_lists_bore_and_step(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20) - Pos(0, 0, 10 - 3) * Cylinder(9, 6)
+        assert feature_diameters(part) == [10.0, 18.0]
+
+    @pytest.mark.timeout(60)
+    def test_spotface_stack_lists_all_three_diameters(self):
+        block = Box(100, 100, 40)
+        part = (
+            block
+            - Pos(0, 0, 20 - 2.5) * Cylinder(30, 5)
+            - Pos(0, 0, 20 - 5 - 3) * Cylinder(9, 6)
+            - Pos(0, 0, 20 - 11 - 7.5) * Cylinder(5.05, 15)
+        )
+        assert feature_diameters(part) == [10.1, 18.0, 60.0]
+
+    @pytest.mark.timeout(60)
+    def test_boss_diameter_included(self):
+        part = Box(60, 60, 10) + Pos(0, 0, 9) * Cylinder(12, 8)
+        assert feature_diameters(part) == [24.0]
+
+    @pytest.mark.timeout(60)
+    def test_obround_slot_is_excluded(self):
+        # a milled slot's semicircular ends are partial cylinders, not bores
+        tool = Cylinder(6, 30) + Pos(30, 0, 0) * Cylinder(6, 30) + Pos(15, 0, 0) * Box(30, 12, 30)
+        part = Box(80, 40, 30) - Pos(-15, 0, 0) * tool
+        assert feature_diameters(part) == []
+
+    @pytest.mark.timeout(60)
+    def test_slot_alongside_hole_lists_only_the_hole(self):
+        slot = Cylinder(6, 30) + Pos(20, 0, 0) * Cylinder(6, 30) + Pos(10, 0, 0) * Box(20, 12, 30)
+        part = (Box(120, 60, 30) - Cylinder(5, 30)) - Pos(40, 0, 0) * slot
+        assert feature_diameters(part) == [10.0]
+
+    @pytest.mark.timeout(60)
+    def test_cyls_argument_matches_self_scan(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20) - Pos(0, 0, 10 - 3) * Cylinder(9, 6)
+        assert feature_diameters(part, cyls=analyse_cylinders(part)) == feature_diameters(part)
+
+
+class TestFullCylinders:
+    @pytest.mark.timeout(60)
+    def test_keeps_a_bore_drops_corner_fillets(self):
+        # A box with rounded vertical edges and a central bore: the bore's
+        # cylinder records survive, the fillet faces do not.
+        part = fillet((Box(60, 60, 20) - Cylinder(5, 20)).edges().filter_by(Axis.Z), radius=4)
+        z_cyls, _ = analyse_cylinders(part)
+        full = full_cylinders(z_cyls)
+        # Exactly the bore is full; its diameter is 10.
+        assert full
+        assert all(c["diameter"] == pytest.approx(10.0) for c in full)
+        assert len(full) < len(z_cyls)
+
+    @pytest.mark.timeout(60)
+    def test_empty_input_returns_empty(self):
+        assert full_cylinders([]) == []
+
+
+class TestHoleSpec:
+    @pytest.mark.timeout(60)
+    def test_identical_holes_share_one_spec(self):
+        part = (
+            Box(120, 60, 20) - Pos(-30, 0, 0) * Cylinder(5, 20) - Pos(30, 0, 0) * Cylinder(5, 20)
+        )
+        a, b = find_holes(part)
+        sa, sb = HoleSpec.from_hole(a), HoleSpec.from_hole(b)
+        assert sa == sb
+        assert hash(sa) == hash(sb)
+        assert len({sa, sb}) == 1
+
+    @pytest.mark.timeout(60)
+    def test_different_diameter_is_a_different_spec(self):
+        part = (
+            Box(120, 60, 20) - Pos(-30, 0, 0) * Cylinder(5, 20) - Pos(30, 0, 0) * Cylinder(7, 20)
+        )
+        a, b = find_holes(part)
+        assert HoleSpec.from_hole(a) != HoleSpec.from_hole(b)
+
+    @pytest.mark.timeout(60)
+    def test_through_hole_depth_is_normalised_to_none(self):
+        part = Box(60, 60, 20) - Cylinder(5, 20)
+        (h,) = find_holes(part)
+        assert h.bottom == "through"
+        assert HoleSpec.from_hole(h).depth is None
+
+    @pytest.mark.timeout(60)
+    def test_usable_as_dict_key_for_grouping(self):
+        part = (
+            Box(120, 60, 20) - Pos(-30, 0, 0) * Cylinder(5, 20) - Pos(30, 0, 0) * Cylinder(5, 20)
+        )
+        groups: dict = {}
+        for h in find_holes(part):
+            groups.setdefault(HoleSpec.from_hole(h), []).append(h)
+        assert len(groups) == 1
+        assert len(next(iter(groups.values()))) == 2


### PR DESCRIPTION
First migration step of **ADR 0007**: draftwright owns feature recognition;
`build123d-drafting-helpers` becomes the rendering library.

## What

Vendor `build123d_drafting.features` into a new **`recognition/`** subpackage and
switch every consumer to it. Deprecate-and-vendor (strangler fig): the upstream
copy stays in place — it'll be frozen/deprecated in a separate helpers release
(ADR 0007 PR-D) — and this becomes the source of truth.

- **`recognition/_features.py`** — 1:1 vendored copy (provenance note in the
  docstring) of the hole/boss/cylinder/pattern recognisers
  (`find_holes`/`find_bosses`/`analyse_cylinders`/`feature_diameters`/
  `find_hole_patterns`/`full_cylinders` + the feature/pattern types).
- **`recognition/slots.py`** — the existing draftwright-local slot recogniser
  (#135), `git mv`d in so `recognition/` is the single recognition home. Its
  docstring's "upstream this someday" note is reversed (ADR 0007).
- **`recognition/__init__.py`** — the public surface; all 8 consumers import here.
- **`tests/test_recognition.py`** — helpers' `test_features.py`, vendored with
  imports rewired to the package, so recognition is iterable here in isolation.
- **CLAUDE.md** — DAG + dependency framing updated per ADR 0007.

## Why

Recognition is *reasoning*, not *rendering*. Keeping it upstream fixed its
semantics by the wrong owner (e.g. `find_bosses`' chamfer-shortened length, wrong
for axial dims) and forced a cross-repo release for every tweak. This unblocks
PR-C (turned-part step lengths) to iterate recognition in one repo.

## Verification

Pure move, no logic change. Full fast tier **491 passed, 1 skipped**; the
vendored recognition tests **70 passed**; `ruff check`, `ruff format --check`,
and `mypy src/draftwright/` all clean.

## Not in scope

- helpers-side deprecation warnings (separate repo — ADR 0007 PR-D).
- Vendoring the lint engine (ADR 0007 PR-B).
- The turned-part step-length feature (ADR 0007 PR-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)