### PR TITLE
feat: vendor the lint engine into draftwright (ADR 0007 PR-B)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -28,11 +28,8 @@ from build123d import (
 )
 from build123d_drafting.helpers import (
     Leader,
-    LintIssue,
     ViewCoordinates,
     annotate,
-    lint_drawing,
-    set_page,
     view_axes,
 )
 
@@ -62,7 +59,13 @@ from draftwright.layout import (
     _solve_strip_1d,
     fit_box,
 )
-from draftwright.linting import CoverageState, _suggest_fix, lint_feature_coverage
+from draftwright.linting import (
+    CoverageState,
+    LintIssue,
+    _suggest_fix,
+    lint_drawing,
+    lint_feature_coverage,
+)
 from draftwright.projection import (
     _exactify_silhouettes,
     _raw_view_projector,
@@ -932,7 +935,10 @@ class Drawing:
         When :attr:`part` is set, also runs :func:`lint_feature_coverage`.
         Build-time drops recorded via :meth:`_record_build_issue` are included.
         """
-        set_page(self.page_w, self.page_h, margin=10)
+        # Drawable area (page minus the 10 mm margin), passed explicitly to
+        # lint_drawing for bounds checks — draftwright owns linting now and no
+        # longer relies on the helpers set_page module-global (ADR 0007).
+        page_bbox = (10, 10, self.page_w - 10, self.page_h - 10)
         view_shapes = [vis for vis, _ in self.views.values()]
         # Most annotations are at sheet scale, but a non-sheet-scale view (the
         # enlarged detail view, #42) tags its dims with `_dw_scale`. Lint each
@@ -944,6 +950,7 @@ class Drawing:
         if len(by_scale) <= 1:
             issues = lint_drawing(
                 self.items,
+                page_bbox=page_bbox,
                 drawing_scale=self.scale,
                 view_shapes=view_shapes,
                 view_edge_cache=self._view_edge_cache,
@@ -953,6 +960,7 @@ class Drawing:
             for _scale, _anns in by_scale.items():
                 issues += lint_drawing(
                     _anns,
+                    page_bbox=page_bbox,
                     drawing_scale=_scale,
                     view_shapes=view_shapes,
                     view_edge_cache=self._view_edge_cache,

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -1,0 +1,30 @@
+"""Linting for draftwright drawings (ADR 0007).
+
+draftwright owns linting; ``build123d-drafting-helpers`` is the rendering
+library. This package is the single home for it:
+
+- :mod:`.issues` — ``LintIssue``, the structured lint result.
+- :mod:`.structural` — ``lint_drawing``: duck-typed structural checks on a
+  composed annotation list (overlap, page bounds, label-vs-measured). Vendored
+  from ``build123d_drafting.helpers``; upstream copy frozen and deprecated.
+- :mod:`.coverage` — ``lint_feature_coverage`` + ``CoverageState``: the
+  feature-coverage completeness check and the signal the passes record.
+- :mod:`.suggest` — ``_suggest_fix``: ready-to-paste fix snippets (#29).
+
+Import the public surface from here, not the submodules.
+"""
+
+from __future__ import annotations
+
+from draftwright.linting.coverage import CoverageState, lint_feature_coverage
+from draftwright.linting.issues import LintIssue
+from draftwright.linting.structural import lint_drawing
+from draftwright.linting.suggest import _suggest_fix
+
+__all__ = [
+    "CoverageState",
+    "LintIssue",
+    "_suggest_fix",
+    "lint_drawing",
+    "lint_feature_coverage",
+]

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -1,28 +1,29 @@
-"""The lint module (#138 / ADR 0005).
+"""coverage — feature-coverage completeness check and its state (#138 / ADR 0005).
 
-Holds the lint-side logic and state:
+Part of the :mod:`draftwright.linting` package (ADR 0007):
 
 - `lint_feature_coverage` — the completeness check that reports part diameters
   with no callout (#80), avoiding double-reporting a hole a grouped ``n× ⌀``
   callout covers (#92) and suppressing the redundant ``feature_not_dimensioned``
   for capped diameters.
-- `_suggest_fix` — the per-issue ready-to-paste fix snippet (#29).
 - `CoverageState` — the coverage signal the passes record and the checks read
   (pattern callouts, patterned holes, dropped callout diameters). `Drawing`
   delegates to it and keeps `_pattern_callouts` / `_patterned_holes` /
   `_dropped_callout_diams` reachable as properties during the migration (§4).
 
-It sits low in the import DAG — it depends only on `_core` (and build123d_drafting),
-never on `make_drawing`/`annotate`. `Drawing.lint()` calls these via re-imports.
+(`_suggest_fix` now lives in :mod:`.suggest`; `lint_drawing` in
+:mod:`.structural`.) Depends only on `_core` + recognition + the rendering
+``TitleBlock``; never on `make_drawing`/`annotate`.
 """
 
 from __future__ import annotations
 
-import re
+from typing import Literal
 
-from build123d_drafting.helpers import LintIssue, TitleBlock
+from build123d_drafting.helpers import TitleBlock
 
-from draftwright._core import _DIAM_RE, _QUOTED_RE, _fmt
+from draftwright._core import _DIAM_RE, _fmt
+from draftwright.linting.issues import LintIssue
 from draftwright.recognition import (
     analyse_cylinders,
     feature_diameters,
@@ -128,7 +129,7 @@ def lint_feature_coverage(
 
     if assembly is None:
         assembly = len(part.solids()) > 1
-    coverage_severity = "info" if assembly else "warning"
+    coverage_severity: Literal["info", "warning"] = "info" if assembly else "warning"
 
     mentioned: set[float] = set()
     text_mentioned: set[float] = set()
@@ -177,92 +178,3 @@ def lint_feature_coverage(
                 )
             )
     return issues
-
-
-# Tolerance for matching a lint message's reported diameter (dedup representative
-# at tol 0.15, formatted to 1 dp) back to a raw feature diameter when generating a
-# fix snippet (#29).
-_DIAM_MATCH_TOL = 0.2
-
-
-def _suggest_fix(issue, dwg) -> str | None:
-    """Return a ready-to-paste code snippet that addresses *issue*, or None.
-
-    The snippet is a hint, not necessarily runnable verbatim (``...`` stands in
-    for args the engine cannot infer). It uses the public domain API
-    (:meth:`Drawing.features`, :meth:`Drawing.at`, :meth:`Drawing.place_dim`)
-    so a caller or LLM can paste and fill the gaps trivially (#29).
-    """
-    code = issue.code
-
-    if code == "feature_not_dimensioned":
-        # Message: "cylindrical feature ø8 has no diameter callout on the sheet".
-        m = _DIAM_RE.search(issue.message)
-        if m is None:
-            return None
-        d = float(m.group(1))
-        # The reported diameter is the dedup representative (tol 0.15) formatted
-        # to 1 dp, so match raw feature diameters with that combined slack — a
-        # 1e-6 match would silently miss every non-integer bore.
-        for view in ("plan", "front", "side"):
-            if any(abs(f.diameter - d) < _DIAM_MATCH_TOL for f in dwg.features(view)):
-                tag = _fmt(d).replace(".", "_")
-                return (
-                    f"# ø{_fmt(d)} has no callout. Locate it via features() and add a leader:\n"
-                    f'for f in dwg.features("{view}"):\n'
-                    f"    if abs(f.diameter - {_fmt(d)}) < {_DIAM_MATCH_TOL}:\n"
-                    f"        callout = HoleCallout(f.diameter, count=f.count,\n"
-                    f"                              through=f.through, depth=f.depth, draft=dwg.draft)\n"
-                    f"        elbow = (f.page_pos[0] + 15, f.page_pos[1] + 10, 0)\n"
-                    f'        leader = Leader((*f.page_pos, 0), elbow, "", dwg.draft, callout=callout)\n'
-                    f'        dwg.add(leader, name="hole_{tag}")'
-                )
-        return None
-
-    if code == "feature_count_mismatch":
-        # Message: "4 ø8 features on the part but callouts account for 1".
-        # `need` is the leading count; anchor it so diameter digits never
-        # interfere regardless of message word order.
-        m = _DIAM_RE.search(issue.message)
-        need_m = re.match(r"\s*(\d+)", issue.message)
-        if m is None or need_m is None:
-            return None
-        need = need_m.group(1)
-        return (
-            f"# Only some ø{m.group(1)} holes are counted. Set count={need} on the "
-            f"callout so it covers them all:\n"
-            f"# HoleCallout(..., count={need}, draft=dwg.draft)"
-        )
-
-    if code == "annotation_overlap":
-        # Message: "labels 'A' and 'B' overlap by ...".
-        labels = _QUOTED_RE.findall(issue.message)
-        first = labels[0] if labels else "<dim>"
-        return (
-            f"# Re-add the dimension with place_dim so it auto-stacks in the "
-            f"layout strip instead of overlapping:\n"
-            f'dwg.remove("{first}")  # if it was named\n'
-            f'dwg.place_dim(p1, p2, "below", "plan", dwg.draft, name="{first}")'
-        )
-
-    if code == "dim_inside_part":
-        # Message: "Dim 'X': annotation bbox overlaps part outline by ...".
-        labels = _QUOTED_RE.findall(issue.message)
-        first = labels[0] if labels else "<dim>"
-        return (
-            f"# The dim sits inside the view — its offset is on the wrong side. "
-            f"Re-place it on the opposite side via place_dim (auto-stacks clear "
-            f"of the part):\n"
-            f'dwg.remove("{first}")  # if it was named\n'
-            f'dwg.place_dim(p1, p2, "right", "front", dwg.draft, name="{first}")'
-        )
-
-    if code == "step_dim_dropped":
-        # Steps too closely spaced to dimension at sheet scale (#41/#42).
-        return (
-            "# Re-build with an enlarged detail view so the crowded shoulders are "
-            "dimensionable:\n"
-            "dwg = build_drawing(part, detail_view=True)"
-        )
-
-    return None

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -1,0 +1,21 @@
+"""LintIssue — the structured lint result (ADR 0007).
+
+Vendored from ``build123d_drafting.helpers`` (which keeps its own copy for its
+standalone validators). draftwright owns linting; this is its ``LintIssue``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class LintIssue:
+    severity: Literal["error", "warning", "info"]
+    message: str
+    location: tuple[float, float] | None = None
+    code: str = ""  # stable machine-readable check id, e.g. "label_vs_measured"
+    # A ready-to-paste fix snippet, attached by Drawing.lint() via _suggest_fix
+    # (#29); None when no concrete repair can be inferred.
+    suggestion: str | None = None

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -1,0 +1,635 @@
+"""structural — duck-typed structural lint of a composed annotation list.
+
+Vendored from ``build123d_drafting.helpers`` (ADR 0007: draftwright owns
+linting; helpers is the rendering library). ``lint_drawing`` dispatches by
+attribute presence, not type, so it needs no import of the drawing-object
+classes. Page bounds are passed explicitly by the caller (``page_bbox``); the
+``set_page`` module-global fallback is kept inert here (``_DRAWING_PAGE = None``)
+since draftwright threads the page extent directly (see ``Drawing.lint``).
+"""
+
+from __future__ import annotations
+
+import re
+
+from build123d import GeomType
+
+from draftwright.linting.issues import LintIssue
+
+# Inert: draftwright always passes page_bbox explicitly (the set_page global
+# coupling is severed, ADR 0007). Kept so the vendored body is a faithful copy.
+_DRAWING_PAGE = None
+
+
+def _seg_intersects_rect(p, q, rect) -> bool:
+    """True if segment p→q intersects the (min_x, min_y, max_x, max_y) rect.
+
+    Thin wrapper over :func:`_seg_hits_box` (the same Liang–Barsky clip) with no
+    padding, kept for call-site readability.
+    """
+    return bool(_seg_hits_box(p, q, rect, pad=0.0))
+
+
+def _centerline_extent(cl_item):
+    """Return (min_x, min_y, max_x, max_y) for a centreline.
+
+    Prefers the zero-width ``.segments`` (the true centreline) so a thin-faced
+    centreline still reads as a zero-width vertical/horizontal line; falls back
+    to the rendered ``.bounding_box()`` (which is line_width wide).
+    """
+    segs = getattr(cl_item, "segments", None)
+    if segs:
+        xs = [p[0] for s in segs for p in s]
+        ys = [p[1] for s in segs for p in s]
+        return (min(xs), min(ys), max(xs), max(ys))
+    bb = cl_item.bounding_box()
+    return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+
+
+def _item_label(item) -> str:
+    """The label lint should use for *item*: its ``.label``, or the explicit
+    string attached via :func:`annotate` (``_annotate_label``) when it has none
+    — e.g. a vanilla build123d ``ExtensionLine`` that does not retain its
+    constructor label."""
+    return getattr(item, "label", "") or getattr(item, "_annotate_label", "") or ""
+
+
+def _label_value(label: str) -> float | None:
+    """The dimensional value a dimension/callout label asserts, or ``None``.
+
+    Handles the three label shapes lint compares against measured geometry::
+
+        "12.5", "⌀8.5", "7.5 ±0.1"   -> the leading number   (12.5 / 8.5 / 7.5)
+        "4× 20"                       -> a pitch span          (4·20 = 80)
+        "4× ⌀8.5", "4× ⌀8.5 THRU"     -> a counted diameter    (8.5, not 4·8.5)
+
+    The diameter/radius prefix on the repeated value is the discriminator: a
+    bare ``N× v`` is a span of N pitches, but ``N× ⌀d`` counts d-diameter
+    features, so the value is ``d`` itself.
+    """
+    body = label.split("±")[0].split("+")[0]
+    nums = re.findall(r"\d+\.?\d*", body.lstrip("ø⌀Rr"))
+    if not nums:
+        return None
+    rep = re.match(r"\s*(\d+)\s*[×x]\s*([ø⌀Rr]?)\s*(\d+\.?\d*)", label)
+    try:
+        if rep:
+            count, prefix, value = rep.group(1), rep.group(2), rep.group(3)
+            return float(value) if prefix else int(count) * float(value)
+        return float(nums[0])
+    except ValueError:
+        return None
+
+
+def lint_drawing(
+    items,
+    part_bbox=None,
+    page_bbox=None,
+    drawing_scale: float = 1.0,
+    view_shapes: list | None = None,
+    view_edge_cache: dict | None = None,
+) -> list[LintIssue]:
+    """Structural checks on a composed annotation list, duck-typed.
+
+    Dispatch is by attribute presence, not type:
+
+    - leader-like  (``.elbow is not None``): elbow-through-label check.
+    - dimension-like (``.measured_length is not None``): label-vs-measured and
+      dim-inside-part checks.
+    - centerline-like (``.is_centerline``): pairwise overlap against dims.
+
+    Page-bounds checking is performed when *page_bbox* is provided as a
+    ``(min_x, min_y, max_x, max_y)`` tuple, or when ``set_page()`` has been
+    called and stored a module-level page context.  Any annotation whose full
+    bounding box extends past the drawable area (page minus margin) is flagged
+    as ``annotation_out_of_bounds`` (severity ``"error"``).  This includes a
+    :class:`TitleBlock` passed as an item: its bounding box grows when a long
+    string (e.g. a verbose subtitle) overflows the frame, so include the title
+    block in *items* to catch text that spills past the page edge.
+
+    Args:
+        items: annotation objects exposing the relevant attrs (or SimpleNamespace
+            stand-ins).
+        part_bbox: optional BoundBox of the projected part outline.
+        page_bbox: optional ``(min_x, min_y, max_x, max_y)`` drawable area.
+            If ``None``, falls back to the module-level context set by
+            ``set_page()``.  When neither is set, page-bounds are not checked.
+        drawing_scale: the N:1 factor the geometry was scaled by before
+            projecting (e.g. ``5.0`` for a 7.5 mm feature drawn at 5:1). The
+            label-vs-measured check divides each measured path length by this
+            before comparing to the label value, so labels carry the *real*
+            dimension while the geometry is drawn enlarged. Defaults to ``1.0``
+            (no scaling). See :func:`format_drawing_scale` to render the
+            matching "5:1" indicator in the title block.
+        view_shapes: optional list of build123d shapes representing projected
+            view outlines.  When provided, annotations are checked against the
+            view's actual projected edges (``view_annotation_overlap``,
+            warning); an annotation inside the view's bounding box but over a
+            blank region — a legitimate convention for callouts on large
+            faces — is only an info-level ``view_annotation_inside_extents``
+            notice.  View bounding boxes are also checked for overlap with
+            each other (``view_overlap``, warning) and, when page bounds are
+            known, against the drawable area (``view_out_of_bounds``, error).
+            Annotations whose line-work must touch the view are not
+            false-flagged: centrelines and datum targets are exempt, and
+            annotations exposing a ``label_bbox`` (dimensions, leaders, datum
+            features, surface-finish marks) are tested by the label-text
+            extents only — witness lines, leader shafts, datum triangles, and
+            finish marks may enter the view freely.  Shapes whose bounding box
+            cannot be computed are silently skipped.
+        view_edge_cache: optional dict, persisted by the caller across repeated
+            ``lint_drawing`` calls on the *same* views, that memoises each view
+            shape's per-edge bounding boxes — the dominant cost when a drawing
+            is linted many times (e.g. a build→critique→fix loop) (#143). Pass
+            the same dict to successive lints; discard it when the view shapes
+            change. Omit it (the default) for a fresh per-call cache, which
+            behaves exactly as before.
+
+    Returns:
+        list[LintIssue].
+
+    Raises:
+        ValueError: if ``drawing_scale`` is not positive (matches
+            :func:`format_drawing_scale` / :class:`TitleBlock`).
+    """
+    if drawing_scale <= 0:
+        raise ValueError(f"drawing_scale must be positive, got {drawing_scale}")
+
+    issues: list[LintIssue] = []
+
+    # Resolve page bounds: explicit arg beats module-level context.
+    if page_bbox is None and _DRAWING_PAGE is not None:
+        p = _DRAWING_PAGE
+        page_bbox = (p["min_x"], p["min_y"], p["max_x"], p["max_y"])
+
+    for item in items:
+        if getattr(item, "elbow", None) is not None:
+            _lint_leader(item, issues)
+        elif getattr(item, "measured_length", None) is not None:
+            _lint_dim(item, part_bbox, issues, drawing_scale)
+
+    # Pairwise label-overlap check. The compare-box for a label-less item is an
+    # *optimal* bounding_box() — expensive, and previously recomputed for both
+    # items of every pair (O(n²): ~200 s on an 83-hole part). Compute each
+    # item's box exactly once up front and index into it instead (#161); the
+    # result is identical. Centre lines are compared via _centerline_extent, not
+    # this box, so they don't need one.
+    def _label_box(item):
+        lb = getattr(item, "label_bbox", None)
+        if lb is not None:
+            return lb
+        bb = item.bounding_box()
+        return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+
+    boxes: list = []
+    for item in items:
+        if getattr(item, "is_centerline", False):
+            boxes.append(None)
+            continue
+        try:
+            boxes.append(_label_box(item))
+        except Exception:
+            boxes.append(None)
+
+    for i, item_a in enumerate(items):
+        for j in range(i + 1, len(items)):
+            item_b = items[j]
+            try:
+                is_cl_a = getattr(item_a, "is_centerline", False)
+                is_cl_b = getattr(item_b, "is_centerline", False)
+
+                if is_cl_a and is_cl_b:
+                    continue
+
+                if is_cl_a or is_cl_b:
+                    dim_item = item_b if is_cl_a else item_a
+                    cl_item = item_a if is_cl_a else item_b
+                    _lint_centerline_dim_overlap(dim_item, cl_item, issues)
+                    continue
+
+                # Compare label text extents, NOT full bounding boxes.
+                # Full bbox includes witness lines which legitimately overlap for
+                # stacked dims (every inner bbox is a subset of the outer one).
+                # label_bbox is the keep-clear region around the value text — the
+                # thing that actually matters to a reader.
+                la_box = boxes[i]
+                lb_box = boxes[j]
+                if la_box is None or lb_box is None:
+                    continue
+                ox = max(0.0, min(la_box[2], lb_box[2]) - max(la_box[0], lb_box[0]))
+                oy = max(0.0, min(la_box[3], lb_box[3]) - max(la_box[1], lb_box[1]))
+                if ox > 0.5 and oy > 0.5:
+                    la = getattr(item_a, "label", "?")
+                    lb = getattr(item_b, "label", "?")
+                    issues.append(
+                        LintIssue(
+                            severity="warning",
+                            message=(
+                                f"labels '{la}' and '{lb}' overlap by "
+                                f"{ox:.1f}×{oy:.1f} mm — use label_offset_x or "
+                                f"increase dim offset to separate them"
+                            ),
+                            code="annotation_overlap",
+                        )
+                    )
+            except Exception:
+                pass
+
+    # Page-bounds check — annotations must stay within the drawable area.
+    if page_bbox is not None:
+        for item in items:
+            try:
+                bb = item.bounding_box()
+                for detail in _overshoots((bb.min.X, bb.min.Y, bb.max.X, bb.max.Y), page_bbox):
+                    lbl = _item_label(item) or "?"
+                    issues.append(
+                        LintIssue(
+                            severity="error",
+                            message=(
+                                f"annotation '{lbl}' extends past drawable area "
+                                f"({detail}) — increase margin or reduce offset"
+                            ),
+                            code="annotation_out_of_bounds",
+                        )
+                    )
+            except Exception:
+                pass
+
+    if view_shapes is not None:
+        _lint_view_shapes(
+            view_shapes, items, issues, page_bbox=page_bbox, edge_cache=view_edge_cache
+        )
+
+    # Principal envelope completeness check: verify each bbox extent appears
+    # as a dimension label.  Only runs when part_bbox is supplied.
+    if part_bbox is not None:
+        covered: set[float] = set()
+        for item in items:
+            if getattr(item, "measured_length", None) is not None:
+                val = _label_value(_item_label(item))
+                if val is not None:
+                    covered.add(val)
+
+        def _check_extent(axis: str, page_extent: float) -> None:
+            world_ext = page_extent / drawing_scale
+            tol = max(0.5, world_ext * 0.001)
+            if not any(abs(v - world_ext) <= tol for v in covered):
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        message=(
+                            f"no dimension found for {axis} extent ({world_ext:.4g} mm)"
+                            " — add dim_width, dim_depth, or equivalent"
+                        ),
+                        code="missing_principal_dimension",
+                    )
+                )
+
+        x_ext = part_bbox.max.X - part_bbox.min.X
+        y_ext = part_bbox.max.Y - part_bbox.min.Y
+        x_approx_y = max(x_ext, y_ext) > 1e-6 and abs(x_ext - y_ext) / max(x_ext, y_ext) < 0.05
+        _check_extent("X", x_ext)
+        if not x_approx_y:
+            _check_extent("Y", y_ext)
+        if hasattr(part_bbox.min, "Z") and hasattr(part_bbox.max, "Z"):
+            _check_extent("Z", part_bbox.max.Z - part_bbox.min.Z)
+
+    return issues
+
+
+def _bbox2d(shape):
+    """Return (minx, miny, maxx, maxy) for a build123d shape, or None on failure."""
+    try:
+        bb = shape.bounding_box()
+        return bb.min.X, bb.min.Y, bb.max.X, bb.max.Y
+    except Exception:
+        return None
+
+
+def _bboxes_overlap_2d(a, b) -> bool:
+    """True if two (minx, miny, maxx, maxy) rectangles overlap in XY."""
+    ax0, ay0, ax1, ay1 = a
+    bx0, by0, bx1, by1 = b
+    return bool(ax0 < bx1 and ax1 > bx0 and ay0 < by1 and ay1 > by0)
+
+
+def _overshoots(bb, bounds) -> list[str]:
+    """Sides where (min_x, min_y, max_x, max_y) *bb* spills past *bounds*, as text."""
+    bx0, by0, bx1, by1 = bounds
+    out = []
+    if bb[0] < bx0:
+        out.append(f"left by {bx0 - bb[0]:.1f} mm")
+    if bb[2] > bx1:
+        out.append(f"right by {bb[2] - bx1:.1f} mm")
+    if bb[1] < by0:
+        out.append(f"below by {by0 - bb[1]:.1f} mm")
+    if bb[3] > by1:
+        out.append(f"above by {bb[3] - by1:.1f} mm")
+    return out
+
+
+def _edges_intersect_rect(edge_entries, rect) -> bool:
+    """True if any ``(edge, bbox2d)`` of *edge_entries* passes through the
+    (min_x, min_y, max_x, max_y) rect.
+
+    Straight edges use exact Liang–Barsky clipping; curved edges are sampled
+    at roughly 1 mm spacing. An edge whose geometry cannot be analysed counts
+    as a hit, so a real overlap is never silently missed.
+    """
+    for e, eb in edge_entries:
+        try:
+            if eb is None:
+                return True  # unanalysable edge — count as a hit
+            if not _bboxes_overlap_2d(eb, rect):
+                continue
+            if e.geom_type == GeomType.LINE:
+                s, t = e.start_point(), e.end_point()
+                if _seg_intersects_rect((s.X, s.Y), (t.X, t.Y), rect):
+                    return True
+                continue
+            n = min(200, max(8, int(e.length) + 1))
+            for i in range(n + 1):
+                p = e.position_at(i / n)
+                if rect[0] <= p.X <= rect[2] and rect[1] <= p.Y <= rect[3]:
+                    return True
+        except Exception:
+            return True
+    return False
+
+
+def _view_edge_entries(vs, cache):
+    """Per-edge ``(edge, bbox2d)`` list for view shape *vs*, memoised in *cache*.
+
+    Building this list is the dominant lint cost (one optimal bounding box per
+    projected edge); a caller-persisted *cache* lets repeated lints of the same
+    views reuse it (#143). The shape is stored alongside its entries and checked
+    by identity, so a reused cache can't return a stale list after ``id()``
+    reuse. ``None`` marks a view whose edges can't be analysed (treated as a
+    hit), matching the un-cached behaviour."""
+    key = id(vs)
+    hit = cache.get(key)
+    if hit is not None and hit[0] is vs:
+        return hit[1]
+    try:
+        entries: list | None = [(e, _bbox2d(e)) for e in vs.edges()]
+    except Exception:
+        entries = None
+    cache[key] = (vs, entries)
+    return entries
+
+
+def _lint_view_shapes(view_shapes, ann_items, issues, page_bbox=None, edge_cache=None) -> None:
+    """Check views against annotations (#159/#76), each other (#160), and the page (#75)."""
+    # Build named bbox list; use the shape's id as fallback name.
+    named_views = []
+    view_shape_ids = set()
+    for vs in view_shapes:
+        bb = _bbox2d(vs)
+        if bb is None:
+            continue
+        name = getattr(vs, "label", None) or getattr(vs, "name", None) or f"view@{id(vs)}"
+        named_views.append((name, bb, vs))
+        view_shape_ids.add(id(vs))
+
+    # #159 — view shape vs annotation overlaps. Line-work (witness lines,
+    # leader shafts, centrelines) legitimately enters the view, so test the
+    # label-text bbox where the annotation exposes one and skip centrelines
+    # entirely; only annotations without a label bbox fall back to their full
+    # bounding box. Within the view bbox, only a label that crosses the view's
+    # actual projected edges is a warning (#76) — on a large part the bbox is
+    # mostly blank face, where placing callouts is a legitimate convention —
+    # so a label over a blank region is reported as an info-level notice.
+    cache = {} if edge_cache is None else edge_cache
+    for vname, vbb, vs in named_views:
+        vx0, vy0, vx1, vy1 = vbb
+        for ann in ann_items:
+            if id(ann) in view_shape_ids:
+                continue
+            if getattr(ann, "is_centerline", False):
+                continue  # a centreline must cross the feature it marks
+            if getattr(ann, "is_datum_target", False):
+                continue  # a datum target sits on the part face by definition
+            if getattr(ann, "is_section_hatch", False):
+                continue  # hatching is intentionally inside the section view
+            try:
+                label_box = getattr(ann, "label_bbox", None)
+                ab = label_box if label_box is not None else _bbox2d(ann)
+                if ab is None:
+                    continue
+                if not _bboxes_overlap_2d(vbb, ab):
+                    continue
+                albl = (
+                    getattr(ann, "label", None) or getattr(ann, "name", None) or type(ann).__name__
+                )
+                what = "label of annotation" if label_box is not None else "annotation"
+                edges = _view_edge_entries(vs, cache)
+                if edges is None or _edges_intersect_rect(edges, ab):
+                    issues.append(
+                        LintIssue(
+                            severity="warning",
+                            message=(
+                                f"view '{vname}' line-work overlaps {what} '{albl}' "
+                                f"— increase view spacing or move the annotation"
+                            ),
+                            code="view_annotation_overlap",
+                        )
+                    )
+                else:
+                    issues.append(
+                        LintIssue(
+                            severity="info",
+                            message=(
+                                f"{what} '{albl}' lies inside view '{vname}' extents "
+                                f"[x={vx0:.1f}–{vx1:.1f}, y={vy0:.1f}–{vy1:.1f}] over a "
+                                f"blank region — legitimate for callouts on large faces"
+                            ),
+                            code="view_annotation_inside_extents",
+                        )
+                    )
+            except Exception:
+                pass
+
+    # #160 — view shape vs view shape bounding box overlaps
+    for i, (aname, abb, _) in enumerate(named_views):
+        ax0, ay0, ax1, ay1 = abb
+        for bname, bbb, _ in named_views[i + 1 :]:
+            bx0, by0, bx1, by1 = bbb
+            if _bboxes_overlap_2d(abb, bbb):
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        message=(
+                            f"view '{aname}' bbox "
+                            f"[x={ax0:.1f}–{ax1:.1f}, y={ay0:.1f}–{ay1:.1f}] "
+                            f"overlaps view '{bname}' "
+                            f"[x={bx0:.1f}–{bx1:.1f}, y={by0:.1f}–{by1:.1f}] "
+                            f"— increase spacing between views"
+                        ),
+                        code="view_overlap",
+                    )
+                )
+
+    # #75 — views must stay within the drawable area.
+    if page_bbox is not None:
+        for vname, vbb, _ in named_views:
+            for detail in _overshoots(vbb, page_bbox):
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        message=(
+                            f"view '{vname}' extends past drawable area ({detail}) "
+                            f"— reduce the view scale or move the view"
+                        ),
+                        code="view_out_of_bounds",
+                    )
+                )
+
+
+def _lint_centerline_dim_overlap(dim_item, cl_item, issues) -> None:
+    """Flag label-vs-centerline overlap for a (dim, centerline) pair."""
+    try:
+        cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl_item)
+
+        label_bbox = getattr(dim_item, "label_bbox", None)
+        if label_bbox is not None:
+            lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
+        else:
+            db = dim_item.bounding_box()
+            lmin_x, lmin_y = db.min.X, db.min.Y
+            lmax_x, lmax_y = db.max.X, db.max.Y
+
+        cl_w = cl_max_x - cl_min_x
+        cl_h = cl_max_y - cl_min_y
+
+        if cl_w < 0.1:
+            cl_x = (cl_min_x + cl_max_x) / 2.0
+            ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
+        else:
+            ox = max(0.0, min(lmax_x, cl_max_x) - max(lmin_x, cl_min_x))
+
+        if cl_h < 0.1:
+            cl_y = (cl_min_y + cl_max_y) / 2.0
+            oy = min(cl_y - lmin_y, lmax_y - cl_y) if lmin_y < cl_y < lmax_y else 0.0
+        else:
+            oy = max(0.0, min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y))
+
+        if ox > 0.5 and oy > 0.5:
+            dim_label = getattr(dim_item, "label", "?")
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    message=(
+                        f"label '{dim_label}' overlaps centerline by "
+                        f"{ox:.1f}×{oy:.1f} mm — use label_offset_x to shift "
+                        f"or increase dim offset to clear the centerline"
+                    ),
+                    code="label_centerline_overlap",
+                )
+            )
+    except Exception:
+        pass
+
+
+def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0) -> None:
+    label = _item_label(item)
+    measured = getattr(item, "measured_length", None)
+
+    label_val = _label_value(label)
+    if label_val is not None and measured is not None:
+        # When drawing_scale != 1.0 the geometry was scaled up before projecting
+        # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured
+        # path length is the *scaled* length; the label carries the *real* value.
+        # Divide measured by the scale factor before comparing so a 37.5 mm
+        # measured segment with label "7.5" at 5:1 is accepted, not flagged.
+        # drawing_scale is guaranteed positive by lint_drawing()'s validation.
+        effective_measured = measured / drawing_scale
+        if effective_measured > 1e-6:
+            ratio = abs(label_val - effective_measured) / effective_measured
+            if ratio > 0.005:
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        message=(
+                            f"Dim '{label}': label value {label_val:.3f} differs from "
+                            f"measured path length {measured:.3f}"
+                            + (
+                                f" (÷{drawing_scale} = {effective_measured:.3f})"
+                                if drawing_scale != 1.0
+                                else ""
+                            )
+                            + f" by {ratio * 100:.1f}% "
+                            f"— possible axis swap or wrong endpoint"
+                        ),
+                        code="label_vs_measured",
+                    )
+                )
+
+    if part_bbox is not None:
+        try:
+            db = item.bounding_box()
+        except Exception:
+            return
+        ox = max(0.0, min(db.max.X, part_bbox.max.X) - max(db.min.X, part_bbox.min.X))
+        oy = max(0.0, min(db.max.Y, part_bbox.max.Y) - max(db.min.Y, part_bbox.min.Y))
+        overlap = ox * oy
+        dim_area = max((db.max.X - db.min.X) * (db.max.Y - db.min.Y), 1e-9)
+        if overlap / dim_area > 0.10:
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    message=(
+                        f"Dim '{label}': annotation bbox overlaps part outline by "
+                        f"{overlap / dim_area * 100:.0f}% — offset sign may place it inside the view"
+                    ),
+                    code="dim_inside_part",
+                )
+            )
+
+
+def _lint_leader(item, issues) -> None:
+    try:
+        box = getattr(item, "label_bbox", None)
+        if box is not None:
+            minx, miny, maxx, maxy = box
+        else:
+            tb = item.bounding_box()
+            minx, miny, maxx, maxy = tb.min.X, tb.min.Y, tb.max.X, tb.max.Y
+        ex, ey = item.elbow
+        if minx <= ex <= maxx and miny <= ey <= maxy:
+            issues.append(
+                LintIssue(
+                    severity="error",
+                    message=(
+                        f"Leader '{getattr(item, 'label', '?')}': elbow point "
+                        f"({ex:.2f}, {ey:.2f}) is inside the label bbox — leader "
+                        f"line passes through the text"
+                    ),
+                    location=item.elbow,
+                    code="leader_line_through_text",
+                )
+            )
+    except Exception:
+        pass
+
+
+def _seg_hits_box(p, q, box, pad=0.2):
+    """Liang–Barsky: does segment p->q intersect the padded AABB box?"""
+    minx, miny, maxx, maxy = box[0] - pad, box[1] - pad, box[2] + pad, box[3] + pad
+    x0, y0 = p
+    dx, dy = q[0] - x0, q[1] - y0
+    t0, t1 = 0.0, 1.0
+    for pp, qq in ((-dx, x0 - minx), (dx, maxx - x0), (-dy, y0 - miny), (dy, maxy - y0)):
+        if abs(pp) < 1e-12:
+            if qq < 0:
+                return False
+        else:
+            r = qq / pp
+            if pp < 0:
+                if r > t1:
+                    return False
+                t0 = max(t0, r)
+            else:
+                if r < t0:
+                    return False
+                t1 = min(t1, r)
+    return t0 <= t1

--- a/src/draftwright/linting/suggest.py
+++ b/src/draftwright/linting/suggest.py
@@ -1,0 +1,100 @@
+"""suggest — ready-to-paste fix snippets for lint issues (#29).
+
+Split out of the coverage module (ADR 0007). Maps a :class:`LintIssue` to a
+hint a caller or LLM can paste and fill in via the public domain API.
+"""
+
+from __future__ import annotations
+
+import re
+
+from draftwright._core import _DIAM_RE, _QUOTED_RE, _fmt
+from draftwright.linting.issues import LintIssue  # noqa: F401 — re-exported for callers
+
+# Tolerance for matching a lint message's reported diameter (dedup representative
+# at tol 0.15, formatted to 1 dp) back to a raw feature diameter when generating a
+# fix snippet (#29).
+_DIAM_MATCH_TOL = 0.2
+
+
+def _suggest_fix(issue, dwg) -> str | None:
+    """Return a ready-to-paste code snippet that addresses *issue*, or None.
+
+    The snippet is a hint, not necessarily runnable verbatim (``...`` stands in
+    for args the engine cannot infer). It uses the public domain API
+    (:meth:`Drawing.features`, :meth:`Drawing.at`, :meth:`Drawing.place_dim`)
+    so a caller or LLM can paste and fill the gaps trivially (#29).
+    """
+    code = issue.code
+
+    if code == "feature_not_dimensioned":
+        # Message: "cylindrical feature ø8 has no diameter callout on the sheet".
+        m = _DIAM_RE.search(issue.message)
+        if m is None:
+            return None
+        d = float(m.group(1))
+        # The reported diameter is the dedup representative (tol 0.15) formatted
+        # to 1 dp, so match raw feature diameters with that combined slack — a
+        # 1e-6 match would silently miss every non-integer bore.
+        for view in ("plan", "front", "side"):
+            if any(abs(f.diameter - d) < _DIAM_MATCH_TOL for f in dwg.features(view)):
+                tag = _fmt(d).replace(".", "_")
+                return (
+                    f"# ø{_fmt(d)} has no callout. Locate it via features() and add a leader:\n"
+                    f'for f in dwg.features("{view}"):\n'
+                    f"    if abs(f.diameter - {_fmt(d)}) < {_DIAM_MATCH_TOL}:\n"
+                    f"        callout = HoleCallout(f.diameter, count=f.count,\n"
+                    f"                              through=f.through, depth=f.depth, draft=dwg.draft)\n"
+                    f"        elbow = (f.page_pos[0] + 15, f.page_pos[1] + 10, 0)\n"
+                    f'        leader = Leader((*f.page_pos, 0), elbow, "", dwg.draft, callout=callout)\n'
+                    f'        dwg.add(leader, name="hole_{tag}")'
+                )
+        return None
+
+    if code == "feature_count_mismatch":
+        # Message: "4 ø8 features on the part but callouts account for 1".
+        # `need` is the leading count; anchor it so diameter digits never
+        # interfere regardless of message word order.
+        m = _DIAM_RE.search(issue.message)
+        need_m = re.match(r"\s*(\d+)", issue.message)
+        if m is None or need_m is None:
+            return None
+        need = need_m.group(1)
+        return (
+            f"# Only some ø{m.group(1)} holes are counted. Set count={need} on the "
+            f"callout so it covers them all:\n"
+            f"# HoleCallout(..., count={need}, draft=dwg.draft)"
+        )
+
+    if code == "annotation_overlap":
+        # Message: "labels 'A' and 'B' overlap by ...".
+        labels = _QUOTED_RE.findall(issue.message)
+        first = labels[0] if labels else "<dim>"
+        return (
+            f"# Re-add the dimension with place_dim so it auto-stacks in the "
+            f"layout strip instead of overlapping:\n"
+            f'dwg.remove("{first}")  # if it was named\n'
+            f'dwg.place_dim(p1, p2, "below", "plan", dwg.draft, name="{first}")'
+        )
+
+    if code == "dim_inside_part":
+        # Message: "Dim 'X': annotation bbox overlaps part outline by ...".
+        labels = _QUOTED_RE.findall(issue.message)
+        first = labels[0] if labels else "<dim>"
+        return (
+            f"# The dim sits inside the view — its offset is on the wrong side. "
+            f"Re-place it on the opposite side via place_dim (auto-stacks clear "
+            f"of the part):\n"
+            f'dwg.remove("{first}")  # if it was named\n'
+            f'dwg.place_dim(p1, p2, "right", "front", dwg.draft, name="{first}")'
+        )
+
+    if code == "step_dim_dropped":
+        # Steps too closely spaced to dimension at sheet scale (#41/#42).
+        return (
+            "# Re-build with an enlarged detail view so the crowded shoulders are "
+            "dimensionable:\n"
+            "dwg = build_drawing(part, detail_view=True)"
+        )
+
+    return None

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -1,0 +1,419 @@
+"""Tests for draftwright.linting.lint_drawing — the duck-typed structural lint.
+
+Vendored from build123d_drafting's test_helpers.py (ADR 0007): the TestLintDrawing
+/ TestLintIssueCode / TestAnnotationOverlapLabelBbox / TestLintViewShapes classes.
+Page bounds are passed explicitly via page_bbox (draftwright severed the set_page
+module-global, ADR 0007); the one set_page/clear_page-based test is adapted to the
+omit-page-bbox default, which is the equivalent "no page context" state.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box, Circle, Draft, Location, Pos
+from build123d_drafting import (
+    Centerline,
+    DatumFeature,
+    DatumTarget,
+    Dimension,
+    Leader,
+    Note,
+    SurfaceFinish,
+    annotate,
+    find_interferences,
+    place_dims,
+)
+
+from draftwright.linting import lint_drawing
+
+
+@pytest.fixture
+def draft():
+    return Draft(font_size=2.5, decimal_precision=1)
+
+
+class TestLintDrawing:
+    def test_empty_list_returns_no_issues(self):
+        assert lint_drawing([]) == []
+
+    def test_label_value_matches_length_no_issue(self, draft):
+        d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        issues = [
+            i for i in lint_drawing([d]) if "axis swap" in i.message or "differs from" in i.message
+        ]
+        assert issues == []
+
+    def test_label_value_diverges_from_length(self, draft):
+        d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="35")
+        issues = lint_drawing([d])
+        assert any("35" in i.message or "differs from" in i.message for i in issues)
+        assert any(i.severity == "warning" for i in issues)
+
+    def test_dim_overlapping_part_flagged(self, draft):
+        d = Dimension((-5, 0, 0), (5, 0, 0), "above", 1, draft, label="10")
+
+        class FakeBBox:
+            class _pt:
+                pass
+
+            min = _pt()
+            min.X = -20
+            min.Y = -20
+            max = _pt()
+            max.X = 20
+            max.Y = 20
+
+        issues = lint_drawing([d], part_bbox=FakeBBox())
+        assert any("overlap" in i.message.lower() for i in issues)
+
+    def test_leader_elbow_outside_text_no_issue(self, draft):
+        ld = Leader((0, 0, 0), (20, 10, 0), "label", draft)
+        assert [i for i in lint_drawing([ld]) if "Leader" in i.message] == []
+
+    def test_mixed_items_checked(self, draft):
+        d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        ld = Leader((50, 0, 0), (70, 10, 0), "Ra 1.6", draft)
+        assert lint_drawing([d, ld]) == []
+
+    def test_overlapping_dims_flagged(self, draft):
+        a = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        b = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        assert any("overlap" in i.message.lower() for i in lint_drawing([a, b]))
+
+    def test_stacked_dims_not_flagged(self, draft):
+        inner = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        outer = Dimension((-10, 0, 0), (10, 0, 0), "above", 18, draft, label="20")
+        assert [i for i in lint_drawing([inner, outer]) if "overlap" in i.message.lower()] == []
+
+    def test_labelless_items_overlap_via_memoized_box(self):
+        # #161: label-less items are compared via bounding_box(), now computed
+        # once per item instead of once per pair. Overlap detection is unchanged.
+
+        def _item(x0, y0, x1, y1, label):
+            bb = SimpleNamespace(min=SimpleNamespace(X=x0, Y=y0), max=SimpleNamespace(X=x1, Y=y1))
+            return SimpleNamespace(label_bbox=None, label=label, bounding_box=lambda b=bb: b)
+
+        a = _item(0, 0, 10, 10, "A")
+        b = _item(5, 5, 15, 15, "B")  # overlaps A
+        c = _item(100, 100, 110, 110, "C")  # clear of both
+        overlaps = [i for i in lint_drawing([a, b, c]) if i.code == "annotation_overlap"]
+        assert len(overlaps) == 1
+        assert "'A'" in overlaps[0].message and "'B'" in overlaps[0].message
+
+    def test_duck_typed_namespace_dim(self, draft):
+        # lint must work on a lightweight SimpleNamespace stand-in (the MCP uses these)
+
+        ns = SimpleNamespace(label="999", measured_length=20.0, label_bbox=None)
+        codes = {i.code for i in lint_drawing([ns])}
+        assert "label_vs_measured" in codes
+
+    def test_annotate_label_is_read_when_item_has_no_label(self):
+        # #146: annotate(label=...) attaches a label that lint_drawing() reads
+        # when the object carries none (e.g. a vanilla build123d ExtensionLine).
+
+        ns = SimpleNamespace(measured_length=20.0, label_bbox=None)
+        # with no label attached, lint has nothing to compare and stays silent
+        assert "label_vs_measured" not in {i.code for i in lint_drawing([ns])}
+        # annotate() attaches the label the docstring promises lint will read
+        annotate(ns, "width", label="999")
+        assert "label_vs_measured" in {i.code for i in lint_drawing([ns])}
+
+
+class TestLintIssueCode:
+    def test_find_interferences_sets_codes(self, draft):
+        dims = place_dims(
+            [
+                ((-18, -10, 0), (18, -10, 0), "below", "36"),
+                ((-18, -10, 0), (0, -10, 0), "below", "18"),
+            ],
+            draft,
+            base_distance=5,
+        )
+        codes = {i.code for i in find_interferences(dims)}
+        assert "line_pierces_label" in codes
+        assert "redundant_lines" in codes
+        assert "" not in codes
+
+    def test_lint_drawing_sets_codes(self, draft):
+        d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="999")
+        codes = {i.code for i in lint_drawing([d])}
+        assert "label_vs_measured" in codes
+
+
+class TestAnnotationOverlapLabelBbox:
+    """Regression: annotation_overlap must compare label text boxes, not full
+    bboxes. Full bboxes include witness lines that legitimately overlap for
+    stacked dimensions — that was always a false positive. Issue #149."""
+
+    def test_stacked_dims_from_same_anchor_no_false_positive(self, draft):
+        # Four stacked height dims from the same left anchor — all witness lines
+        # share the same X and their full bboxes nest inside each other. Only
+        # the label text regions should be compared; they don't overlap.
+        dims = place_dims(
+            [
+                ((0, 0, 0), (0, 15, 0), "left", "15"),
+                ((0, 0, 0), (0, 30, 0), "left", "30"),
+                ((0, 0, 0), (0, 45, 0), "left", "45"),
+                ((0, 0, 0), (0, 60, 0), "left", "60"),
+            ],
+            draft,
+            base_distance=8,
+        )
+        overlaps = [i for i in lint_drawing(dims) if i.code == "annotation_overlap"]
+        assert overlaps == [], "stacked dims should not produce annotation_overlap — " + "; ".join(
+            i.message for i in overlaps
+        )
+
+    def test_truly_overlapping_labels_still_flagged(self, draft):
+        # Two dims placed at the same offset with the same span → labels land
+        # on top of each other → should still be flagged.
+        d1 = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        d2 = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        overlaps = [i for i in lint_drawing([d1, d2]) if i.code == "annotation_overlap"]
+        assert overlaps, "identical dims with overlapping labels should fire annotation_overlap"
+
+
+class TestLintViewShapes:
+    """Tests for view_shapes parameter — #159 (view vs annotation) and #160 (view vs view)."""
+
+    def _make_box_shape(self, x, y, w, h):
+        """Return a build123d Box located at (x+w/2, y+h/2) — stands in for a projected view."""
+
+        return Pos(x + w / 2, y + h / 2, 0) * Box(w, h, 0.01)
+
+    # --- no view_shapes: existing behaviour unchanged ---
+
+    def test_no_view_shapes_no_new_codes(self, draft):
+        d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        codes = {i.code for i in lint_drawing([d])}
+        assert "view_annotation_overlap" not in codes
+        assert "view_overlap" not in codes
+
+    # --- #159: view vs annotation ---
+
+    def test_view_overlapping_annotation_flagged(self, draft):
+        # View at x=0–40, y=0–30; dim label straddles the view's right outline
+        view = self._make_box_shape(0, 0, 40, 30)
+        d = Dimension((35, 10, 0), (45, 10, 0), "above", 4, draft, label="10")
+        codes = {i.code for i in lint_drawing([d], view_shapes=[view])}
+        assert "view_annotation_overlap" in codes
+
+    def test_view_not_overlapping_annotation_not_flagged(self, draft):
+        # View at x=0–40, y=0–30; dim far away at x=100
+        view = self._make_box_shape(0, 0, 40, 30)
+        d = Dimension((100, 10, 0), (120, 10, 0), "above", 4, draft, label="20")
+        codes = {i.code for i in lint_drawing([d], view_shapes=[view])}
+        assert "view_annotation_overlap" not in codes
+
+    def test_view_annotation_overlap_severity_warning(self, draft):
+        view = self._make_box_shape(0, 0, 40, 30)
+        d = Dimension((35, 10, 0), (45, 10, 0), "above", 4, draft, label="10")
+        issues = [
+            i for i in lint_drawing([d], view_shapes=[view]) if i.code == "view_annotation_overlap"
+        ]
+        assert issues and issues[0].severity == "warning"
+
+    # --- #76: label over a blank region inside the view bbox is only a notice ---
+
+    # --- #143: persisted per-edge bbox cache across repeated lints ---
+
+    def test_view_edge_cache_gives_same_result(self, draft):
+        view = self._make_box_shape(0, 0, 40, 30)
+        d = Dimension((35, 10, 0), (45, 10, 0), "above", 4, draft, label="10")
+        without = {i.code for i in lint_drawing([d], view_shapes=[view])}
+        with_cache = {i.code for i in lint_drawing([d], view_shapes=[view], view_edge_cache={})}
+        assert without == with_cache
+        assert "view_annotation_overlap" in with_cache
+
+    def test_view_edge_cache_reused_not_rebuilt(self, draft):
+        view = self._make_box_shape(0, 0, 40, 30)
+        d = Dimension((35, 10, 0), (45, 10, 0), "above", 4, draft, label="10")
+        cache: dict = {}
+        lint_drawing([d], view_shapes=[view], view_edge_cache=cache)
+        assert cache  # populated with the view's per-edge entries
+        key = next(iter(cache))
+        first = cache[key]
+        # second lint of the same view must reuse the cached entry object, not
+        # rebuild it (rebuilding would reassign cache[key] to a new tuple)
+        lint_drawing([d], view_shapes=[view], view_edge_cache=cache)
+        assert cache[key] is first
+
+    def test_label_over_blank_interior_is_info_not_warning(self, draft):
+        # The view bbox is mostly blank face here; a label deliberately placed
+        # over an empty region (hole-callout convention on big parts) must not
+        # warn — it gets an info-level notice instead.
+        view = self._make_box_shape(0, 0, 40, 30)
+        d = Dimension((5, 10, 0), (15, 10, 0), "above", 4, draft, label="10")
+        issues = lint_drawing([d], view_shapes=[view])
+        codes = {i.code for i in issues}
+        assert "view_annotation_overlap" not in codes
+        notices = [i for i in issues if i.code == "view_annotation_inside_extents"]
+        assert notices and notices[0].severity == "info"
+
+    def test_label_crossing_curved_edge_flagged(self, draft):
+        # Curved edges are sampled, not bbox-tested — a label on the rim of a
+        # circular outline fires, one at the blank centre does not.
+
+        view = Pos(20, 15, 0) * Circle(10)
+        on_rim = Note("X", (10.5, 15), draft)
+        codes = {i.code for i in lint_drawing([on_rim], view_shapes=[view])}
+        assert "view_annotation_overlap" in codes
+
+    def test_label_inside_curved_outline_is_info(self, draft):
+
+        view = Pos(20, 15, 0) * Circle(10)
+        centre = Note("X", (20, 15), draft)
+        issues = lint_drawing([centre], view_shapes=[view])
+        assert not any(i.code == "view_annotation_overlap" for i in issues)
+        assert any(i.code == "view_annotation_inside_extents" for i in issues)
+
+    # --- #65: line-work that legitimately touches the view must not fire ---
+
+    def test_centerline_crossing_view_not_flagged(self):
+        # A centreline must cross the feature it marks — never a finding.
+        view = self._make_box_shape(0, 0, 40, 30)
+        cl = Centerline((20, -5, 0), (20, 35, 0))
+        codes = {i.code for i in lint_drawing([cl], view_shapes=[view])}
+        assert "view_annotation_overlap" not in codes
+
+    def test_dim_witness_lines_into_view_not_flagged(self, draft):
+        # Witness lines run from the feature (inside the view) out to the dim
+        # line; full bbox overlaps the view but the label sits outside it.
+        view = self._make_box_shape(0, 0, 40, 30)
+        d = Dimension((5, 25, 0), (15, 25, 0), "above", 10, draft, label="10")
+        codes = {i.code for i in lint_drawing([d], view_shapes=[view])}
+        assert "view_annotation_overlap" not in codes
+
+    def test_leader_tip_in_view_label_outside_not_flagged(self, draft):
+        # Leader tips touch the part outline by definition.
+        view = self._make_box_shape(0, 0, 40, 30)
+        ld = Leader(tip=(20, 15, 0), elbow=(50, 15, 0), label="ø4", draft=draft)
+        codes = {i.code for i in lint_drawing([ld], view_shapes=[view])}
+        assert "view_annotation_overlap" not in codes
+
+    def test_leader_label_on_view_outline_still_flagged(self, draft):
+        # The real failure mode — label text sitting on the part's line-work —
+        # must still fire (#76: only edge crossings warn, not blank regions).
+        view = self._make_box_shape(0, 0, 40, 30)
+        ld = Leader(tip=(20, 15, 0), elbow=(36, 15, 0), label="ø4", draft=draft)
+        codes = {i.code for i in lint_drawing([ld], view_shapes=[view])}
+        assert "view_annotation_overlap" in codes
+
+    def test_datum_triangle_in_view_not_flagged(self, draft):
+        # #69 — the datum triangle attaches to a part edge by design; only the
+        # letter frame matters. Tip on the view's top edge, frame above it.
+
+        view = self._make_box_shape(0, 0, 40, 30)
+        df = DatumFeature("A", draft).moved(Location((20, 27, 0)))
+        codes = {i.code for i in lint_drawing([df], view_shapes=[view])}
+        assert "view_annotation_overlap" not in codes
+
+    def test_datum_letter_frame_on_view_outline_still_flagged(self, draft):
+
+        view = self._make_box_shape(0, 0, 40, 30)
+        df = DatumFeature("A", draft).moved(Location((40, 15, 0)))  # frame straddles x=40
+        codes = {i.code for i in lint_drawing([df], view_shapes=[view])}
+        assert "view_annotation_overlap" in codes
+
+    def test_surface_finish_mark_in_view_not_flagged(self, draft):
+        # #69 — the check-mark sits on the surface line; the Ra text is
+        # outside the view here, so nothing should fire.
+        view = self._make_box_shape(0, 0, 40, 30)
+        sf = SurfaceFinish("Ra 1.6", (38, 15), draft=draft)
+        codes = {i.code for i in lint_drawing([sf], view_shapes=[view])}
+        assert "view_annotation_overlap" not in codes
+
+    def test_surface_finish_text_on_view_outline_still_flagged(self, draft):
+        view = self._make_box_shape(0, 0, 40, 30)
+        sf = SurfaceFinish("Ra 1.6", (35, 15), draft=draft)  # Ra text straddles x=40
+        codes = {i.code for i in lint_drawing([sf], view_shapes=[view])}
+        assert "view_annotation_overlap" in codes
+
+    def test_datum_target_in_view_not_flagged(self, draft):
+        # #71 — a datum target sits on the part face by definition (ISO 5459);
+        # fully inside the view is its only correct placement.
+
+        view = self._make_box_shape(0, 0, 40, 30)
+        dt = DatumTarget("A1", draft=draft).moved(Location((20, 15, 0)))
+        codes = {i.code for i in lint_drawing([dt], view_shapes=[view])}
+        assert "view_annotation_overlap" not in codes
+
+    def test_datum_target_exemption_does_not_leak_to_page_bounds(self, draft):
+        # The exemption is view-overlap only — a datum target off the page
+        # must still fire annotation_out_of_bounds.
+
+        dt = DatumTarget("A1", draft=draft).moved(Location((-50, -50, 0)))
+        issues = lint_drawing([dt], page_bbox=(0, 0, 100, 100))
+        assert any(i.code == "annotation_out_of_bounds" for i in issues)
+
+    # --- #160: view vs view ---
+
+    def test_overlapping_views_flagged(self):
+        v1 = self._make_box_shape(0, 0, 60, 40)
+        v2 = self._make_box_shape(50, 0, 60, 40)  # overlaps v1 by 10mm in X
+        codes = {i.code for i in lint_drawing([], view_shapes=[v1, v2])}
+        assert "view_overlap" in codes
+
+    def test_non_overlapping_views_not_flagged(self):
+        v1 = self._make_box_shape(0, 0, 60, 40)
+        v2 = self._make_box_shape(70, 0, 60, 40)  # 10mm gap
+        codes = {i.code for i in lint_drawing([], view_shapes=[v1, v2])}
+        assert "view_overlap" not in codes
+
+    def test_view_overlap_severity_warning(self):
+        v1 = self._make_box_shape(0, 0, 60, 40)
+        v2 = self._make_box_shape(50, 0, 60, 40)
+        issues = [i for i in lint_drawing([], view_shapes=[v1, v2]) if i.code == "view_overlap"]
+        assert issues and issues[0].severity == "warning"
+
+    def test_three_views_only_adjacent_pairs_flagged(self):
+        # v1 overlaps v2; v2 overlaps v3; v1 and v3 do not overlap each other
+        v1 = self._make_box_shape(0, 0, 60, 40)
+        v2 = self._make_box_shape(50, 0, 60, 40)  # overlaps v1
+        v3 = self._make_box_shape(100, 0, 60, 40)  # overlaps v2, clear of v1
+        issues = [
+            i for i in lint_drawing([], view_shapes=[v1, v2, v3]) if i.code == "view_overlap"
+        ]
+        assert len(issues) == 2
+
+    def test_empty_view_shapes_list_no_error(self, draft):
+        d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        issues = lint_drawing([d], view_shapes=[])
+        assert not any(i.code in ("view_overlap", "view_annotation_overlap") for i in issues)
+
+    def test_invalid_view_shape_skipped_gracefully(self, draft):
+        # A non-shape object with no bounding_box should be silently skipped
+
+        bad = SimpleNamespace()  # no bounding_box attribute
+        d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+        issues = lint_drawing([d], view_shapes=[bad])  # must not raise
+        assert not any(i.code == "view_annotation_overlap" for i in issues)
+
+    def test_same_shape_in_items_and_view_shapes_no_self_overlap(self):
+        # A shape passed in both lists must not generate a spurious self-overlap warning
+        view = self._make_box_shape(0, 0, 40, 30)
+        issues = lint_drawing([view], view_shapes=[view])
+        assert not any(i.code == "view_annotation_overlap" for i in issues)
+
+    # --- #75: view vs drawable area ---
+
+    def test_view_past_page_edge_is_error(self):
+        view = self._make_box_shape(80, 10, 40, 30)  # spans x=80–120 on a 100-wide page
+        issues = [
+            i
+            for i in lint_drawing([], page_bbox=(0, 0, 100, 100), view_shapes=[view])
+            if i.code == "view_out_of_bounds"
+        ]
+        assert issues and issues[0].severity == "error"
+        assert "right by 20.0 mm" in issues[0].message
+
+    def test_view_inside_page_not_flagged(self):
+        view = self._make_box_shape(10, 10, 40, 30)
+        codes = {i.code for i in lint_drawing([], page_bbox=(0, 0, 100, 100), view_shapes=[view])}
+        assert "view_out_of_bounds" not in codes
+
+    def test_view_bounds_not_checked_without_page(self):
+        # no page context (omit page_bbox) → views cannot be bounds-checked
+        view = self._make_box_shape(80, 10, 40, 30)
+        codes = {i.code for i in lint_drawing([], view_shapes=[view])}
+        assert "view_out_of_bounds" not in codes

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3900,7 +3900,7 @@ class TestPlaceDim:
         # place_dim receives page-coordinate points; at 1:2 the page span is 2× the
         # world size. The auto label must read the real-world length, not the page
         # distance, or it disagrees with the geometry (and trips label_vs_measured).
-        from build123d_drafting.helpers import lint_drawing
+        from draftwright.linting import lint_drawing
 
         dwg = build_drawing(Box(80, 60, 20), scale=2.0)
         assert dwg.scale == 2.0
@@ -3983,9 +3983,7 @@ class TestLintSuggestions:
 
     def test_annotation_overlap_suggestion_uses_place_dim(self):
         # Synthetic issue — exercise the _suggest_fix branch directly.
-        from build123d_drafting.helpers import LintIssue
-
-        from draftwright.linting import _suggest_fix
+        from draftwright.linting import LintIssue, _suggest_fix
 
         dwg = build_drawing(Box(60, 40, 20))
         issue = LintIssue(
@@ -3999,9 +3997,7 @@ class TestLintSuggestions:
         assert "dim_width" in sug
 
     def test_dim_inside_part_suggestion_uses_place_dim(self):
-        from build123d_drafting.helpers import LintIssue
-
-        from draftwright.linting import _suggest_fix
+        from draftwright.linting import LintIssue, _suggest_fix
 
         dwg = build_drawing(Box(60, 40, 20))
         issue = LintIssue(
@@ -4015,9 +4011,7 @@ class TestLintSuggestions:
         assert "dim_height" in sug
 
     def test_unknown_code_has_no_suggestion(self):
-        from build123d_drafting.helpers import LintIssue
-
-        from draftwright.linting import _suggest_fix
+        from draftwright.linting import LintIssue, _suggest_fix
 
         dwg = build_drawing(Box(60, 40, 20))
         issue = LintIssue(severity="info", message="something", code="some_unhandled_code")
@@ -4039,9 +4033,7 @@ class TestLintSuggestions:
     def test_feature_count_mismatch_suggestion_sets_count(self):
         # The leading number is `need`; diameter digits (even fractional) must
         # not interfere with the parse.
-        from build123d_drafting.helpers import LintIssue
-
-        from draftwright.linting import _suggest_fix
+        from draftwright.linting import LintIssue, _suggest_fix
 
         dwg = build_drawing(Box(60, 40, 20))
         issue = LintIssue(
@@ -4076,9 +4068,8 @@ class TestRepair:
         # dim_inside_part is dormant in the multi-view sheet (lint passes no
         # part_bbox), so drive the repair directly: a wrong-side dim flips to
         # the opposite side and keeps its name binding.
-        from build123d_drafting.helpers import LintIssue
-
         from draftwright._core import _dim
+        from draftwright.linting import LintIssue
         from draftwright.repair import _repair_dim_inside_part
 
         dwg = build_drawing(Box(60, 40, 20))
@@ -4099,9 +4090,8 @@ class TestRepair:
     def test_repair_inside_part_attempted_once_no_oscillation(self):
         # A side flip that does not help must not be re-flipped (oscillation).
         # The same label is only flipped once across the whole loop.
-        from build123d_drafting.helpers import LintIssue
-
         from draftwright._core import _dim
+        from draftwright.linting import LintIssue
 
         dwg = build_drawing(Box(60, 40, 20))
         dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="OSC"), "x")
@@ -4141,9 +4131,8 @@ class TestRepair:
         # the issue count, that pass is undone and the loop stops — repair never
         # makes a drawing worse. Drive it with a stateful lint stub: one fixable
         # overlap before, two issues after the push.
-        from build123d_drafting.helpers import LintIssue
-
         from draftwright._core import _dim
+        from draftwright.linting import LintIssue
 
         dwg = build_drawing(Box(60, 40, 20))
         orig = dwg.add(_dim((0, 0, 0), (40, 0, 0), "above", 8, dwg.draft, label="RB"), "x")


### PR DESCRIPTION
Second migration step of **ADR 0007**: draftwright owns linting;
`build123d-drafting-helpers` becomes the rendering library.

## What

Vendor the structural lint engine (`lint_drawing` + `LintIssue`) out of helpers
into a **`linting/`** package, alongside the existing coverage lint.

- **`linting/structural.py`** — `lint_drawing` + its 14-function private closure
  (computed via AST so nothing's missed). Fully **duck-typed** — no import of the
  drawing-object classes, confirmed by the closure analysis.
- **`linting/issues.py`** — draftwright's own `LintIssue` (helpers keeps its copy
  for its standalone validators). Gains a `suggestion` field, which `lint()`
  already set dynamically (mypy now checks it since the type is local).
- **`linting/coverage.py`** — the former `linting.py` (`CoverageState` +
  `lint_feature_coverage`).
- **`linting/suggest.py`** — `_suggest_fix`, split out of coverage.
- **`linting/__init__.py`** — the public surface; consumers import from here.

## The one real coupling, severed

`set_page` stored the page extent in a **module global** that `lint_drawing` read
for bounds checks. `Drawing.lint()` now passes `page_bbox` explicitly (page minus
the 10 mm margin — identical to what `set_page` computed), so draftwright no
longer depends on the helpers global. The fallback is kept inert
(`_DRAWING_PAGE = None`) so the vendored body stays a faithful copy. Net
decoupling.

## Scope decisions

- **`find_overlaps`/`find_interferences` NOT vendored** — draftwright never used
  them; they stay in helpers (resolves the ADR's open question).
- Vendored the four lint test classes from helpers' `test_helpers.py` into
  `tests/test_lint_structural.py`; the single `clear_page` test is adapted to the
  `page_bbox` contract (omitting it is the equivalent "no page context"). The
  existing `test_linting.py` (CoverageState) is unchanged.

## Verification

Full fast tier **535 passed, 1 skipped** (+44 vendored lint tests); the lint
engine is also exercised by nearly every test via `Drawing.lint()`. `ruff check`,
`ruff format --check`, `mypy src/draftwright/` all clean.

## Not in scope

- helpers-side deprecation warnings (separate repo — ADR 0007 PR-D).
- The turned-part step-length feature (ADR 0007 PR-C) — the original goal, now
  fully unblocked: recognition **and** lint are owned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)