### PR TITLE
fix: address adversarial review of the lint vendoring (ADR 0007)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -34,6 +34,7 @@ from build123d_drafting.helpers import (
 )
 
 from draftwright._core import (
+    _MARGIN,
     _STRIP_GAP,
     _STRIP_SPACING,
     Analysis,
@@ -935,10 +936,10 @@ class Drawing:
         When :attr:`part` is set, also runs :func:`lint_feature_coverage`.
         Build-time drops recorded via :meth:`_record_build_issue` are included.
         """
-        # Drawable area (page minus the 10 mm margin), passed explicitly to
+        # Drawable area (page minus the standard margin), passed explicitly to
         # lint_drawing for bounds checks — draftwright owns linting now and no
         # longer relies on the helpers set_page module-global (ADR 0007).
-        page_bbox = (10, 10, self.page_w - 10, self.page_h - 10)
+        page_bbox = (_MARGIN, _MARGIN, self.page_w - _MARGIN, self.page_h - _MARGIN)
         view_shapes = [vis for vis, _ in self.views.values()]
         # Most annotations are at sheet scale, but a non-sheet-scale view (the
         # enlarged detail view, #42) tags its dims with `_dw_scale`. Lint each

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2606,7 +2606,9 @@ class TestHolePatternAnnotations:
     @pytest.mark.timeout(60)
     def test_repetition_label_passes_measured_check(self):
         from build123d import Draft
-        from build123d_drafting import Dimension, lint_drawing
+        from build123d_drafting import Dimension
+
+        from draftwright.linting import lint_drawing
 
         d = Draft(font_size=2.5)
         dim = Dimension((0, 0, 0), (80, 0, 0), "above", 8, d, label="4× 20")


### PR DESCRIPTION
Post-merge adversarial review of **PR-B** (#186, lint vendoring) turned up two
issues. The review otherwise confirmed the vendoring is sound.

## Fixes

1. **Test exercised the wrong `lint_drawing`.** `test_repetition_label_passes_measured_check`
   imported `lint_drawing` from `build123d_drafting` (package root, no `.helpers`),
   which the earlier import switch missed — so it still tested the **upstream** lint,
   not the vendored one. Now imports from `draftwright.linting`.
2. **Magic number.** `Drawing.lint()` hardcoded `10` for the page margin in
   `page_bbox`; `_core` already defines `_MARGIN = 10.0`. Use the constant
   (numerically identical, no behaviour change).

## Review findings (no action needed — recorded for the trail)

- **Behavioural equivalence:** vendored `lint_drawing` produces identical issues
  to upstream across normal / overlap / out-of-bounds cases.
- **Source diff:** 13/16 vendored functions byte-identical; the 3 changes are the
  intentional `LintIssue.suggestion` field and two `bool()` wraps that are no-ops
  on already-boolean expressions.
- **Severed global is safe:** `_DRAWING_PAGE` is read *only* by `lint_drawing` in
  helpers — nothing else (export/render) depends on it.
- **`LintIssue.suggestion`:** all constructions use keywords (no positional shift),
  nothing compares it by equality/hash, serialization unchanged.
- **End-to-end:** goldens incl. the slow `ctc01` NIST part are stable.

## Verification

Corrected test passes against the vendored module; build+lint clean; `ruff`,
`ruff format --check`, `mypy` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)