### PR TITLE
feat: find_turned_steps — axial step recognition for turned parts

### DIFF
--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -28,6 +28,7 @@ from draftwright.recognition._features import (
     full_cylinders,
 )
 from draftwright.recognition.slots import Slot, find_slots
+from draftwright.recognition.turned import TurnedProfile, TurnedStep, find_turned_steps
 
 __all__ = [
     "BoltCircle",
@@ -38,11 +39,14 @@ __all__ = [
     "LinearArray",
     "RectGrid",
     "Slot",
+    "TurnedProfile",
+    "TurnedStep",
     "analyse_cylinders",
     "feature_diameters",
     "find_bosses",
     "find_hole_patterns",
     "find_holes",
     "find_slots",
+    "find_turned_steps",
     "full_cylinders",
 ]

--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -1,0 +1,132 @@
+"""turned — step/shoulder recognition for turned (rotational) parts.
+
+``find_turned_steps`` extracts the axial steps of a stepped shaft — the
+contiguous segments between shoulders — so the engine can dimension each step
+*length* (the drive-screw gap: every diameter dimensioned, but no shoulder
+locatable). It is draftwright's recognition (ADR 0007), built on the owned
+``analyse_cylinders`` primitive.
+
+Why not ``find_bosses``: a boss's ``.height`` is its *cylindrical-face* length,
+shortened by the chamfers at each shoulder, so boss spans neither tile the axis
+nor sum to the overall length — wrong for axial dims. ``analyse_cylinders``
+instead gives each cylinder's true axial span (``s_lo``/``s_hi``) and an
+``external`` flag.
+
+Algorithm:
+
+1. Take the **external** cylinders on the dominant turning axis (≥2 distinct
+   diameters, else the part is not a stepped turned part → ``None``). Internal
+   bores are excluded by the ``external`` flag, so a bored shaft is handled and
+   a blind bore's flat bottom never reads as a shoulder.
+2. The shoulders/end faces are the part's transverse planar faces (normal along
+   the axis). Keep a face only when its outer radius **reaches the local OD
+   silhouette** (the max external-band radius spanning that axial position,
+   within a chamfer allowance). This separates true shoulders/ends — which reach
+   the OD — from internal feature faces (a bore bottom sits well inside the OD).
+   The allowance tolerates the chamfers that shrink a real shoulder face below
+   the nominal OD.
+3. Sorted shoulder positions delimit the steps; each step carries the local OD.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+
+from draftwright.recognition._features import analyse_cylinders
+
+# A face's axial position counts as on a band edge / its normal counts as
+# axis-aligned within these tolerances (mm / unit-vector component).
+_AXIS_NORMAL_TOL = 0.05
+# Pad a band's [s_lo, s_hi] when asking "what is the OD here", so a shoulder face
+# sitting exactly at a (chamfer-shortened) band edge still sees that band's OD.
+_OD_SPAN_PAD = 0.7
+# A transverse face is a shoulder/end when its outer radius is within this of the
+# local OD. Constant + proportional terms cover both a fixed edge-break and a
+# chamfer that scales with the feature — enough to keep a chamfered shoulder, far
+# less than the gap between an internal bore radius and the OD.
+_CHAMFER_ALLOWANCE_ABS = 0.5
+_CHAMFER_ALLOWANCE_FRAC = 0.12
+
+
+@dataclass(frozen=True)
+class TurnedStep:
+    """One axial segment of a stepped shaft, between two shoulders (or ends)."""
+
+    lo: float
+    hi: float
+    diameter: float  # the external OD over this segment
+
+    @property
+    def length(self) -> float:
+        return self.hi - self.lo
+
+
+@dataclass(frozen=True)
+class TurnedProfile:
+    """The axial step breakdown of a turned part along its turning ``axis``."""
+
+    axis: str  # "x" / "y" / "z"
+    steps: tuple[TurnedStep, ...]
+
+    @property
+    def shoulders(self) -> tuple[float, ...]:
+        """Sorted axial positions of the shoulders and the two end faces."""
+        if not self.steps:
+            return ()
+        return (*(s.lo for s in self.steps), self.steps[-1].hi)
+
+
+def find_turned_steps(part) -> TurnedProfile | None:
+    """Recognise the axial steps of a stepped turned ``part``, or ``None``.
+
+    Returns ``None`` for a non-turned part, a plain (single-diameter) cylinder,
+    or anything with fewer than two steps — nothing to dimension axially.
+    """
+    z_cyls, cross_cyls = analyse_cylinders(part)
+    ext = [c for c in (*z_cyls, *cross_cyls) if c.get("external")]
+    if not ext:
+        return None
+    axis, _ = Counter(c["axis"] for c in ext).most_common(1)[0]
+    bands = [c for c in ext if c["axis"] == axis]
+    if len({round(c["diameter"], 2) for c in bands}) < 2:
+        return None  # one OD → not a stepped turned part
+    idx = "xyz".index(axis)
+
+    def local_od(pos: float) -> float:
+        radii = [
+            c["diameter"] / 2
+            for c in bands
+            if c["s_lo"] - _OD_SPAN_PAD <= pos <= c["s_hi"] + _OD_SPAN_PAD
+        ]
+        return max(radii) if radii else 0.0
+
+    shoulders: set[float] = set()
+    for face in part.faces():
+        try:
+            nrm = face.normal_at(face.center())
+        except Exception:  # noqa: BLE001 — a face whose normal won't evaluate isn't a shoulder
+            continue
+        nv = (nrm.X, nrm.Y, nrm.Z)
+        if abs(abs(nv[idx]) - 1) > _AXIS_NORMAL_TOL or any(
+            abs(nv[j]) > _AXIS_NORMAL_TOL for j in range(3) if j != idx
+        ):
+            continue  # not transverse to the axis
+        bb = face.bounding_box()
+        pos = (face.center().X, face.center().Y, face.center().Z)[idx]
+        spans = ((bb.min.X, bb.max.X), (bb.min.Y, bb.max.Y), (bb.min.Z, bb.max.Z))
+        outer = max(max(abs(spans[j][0]), abs(spans[j][1])) for j in range(3) if j != idx)
+        od = local_od(pos)
+        if outer >= od - (_CHAMFER_ALLOWANCE_ABS + _CHAMFER_ALLOWANCE_FRAC * od):
+            shoulders.add(round(pos, 3))
+
+    planes = sorted(shoulders)
+    if len(planes) < 3:  # fewer than two steps
+        return None
+    steps = tuple(
+        TurnedStep(
+            lo=planes[i], hi=planes[i + 1], diameter=2 * local_od((planes[i] + planes[i + 1]) / 2)
+        )
+        for i in range(len(planes) - 1)
+    )
+    return TurnedProfile(axis=axis, steps=steps)

--- a/tests/test_turned_steps.py
+++ b/tests/test_turned_steps.py
@@ -1,0 +1,87 @@
+"""Tests for find_turned_steps — axial step recognition for turned parts (ADR 0007).
+
+Geometry-level: build stepped shafts with build123d and assert the recognised
+step lengths, ignoring the OCC face-iteration order. Fixtures lie along X (the
+orientation that is not flagged Z-rotational), mirroring _x_stepped_shaft.
+"""
+
+import pytest
+from build123d import Box, Cylinder, GeomType, Pos, Rotation
+
+from draftwright.recognition import TurnedProfile, find_turned_steps
+
+
+def _shaft_x(*sections):
+    """A shaft along X from a list of (diameter, length) sections, stacked +Z
+    then rotated so the turning axis is X."""
+    z = 0.0
+    solid = None
+    for dia, length in sections:
+        seg = Pos(0, 0, z + length / 2) * Cylinder(dia / 2, length)
+        solid = seg if solid is None else solid + seg
+        z += length
+    return Rotation(0, 90, 0) * solid
+
+
+def _lengths(profile: TurnedProfile):
+    return sorted(round(s.length, 2) for s in profile.steps)
+
+
+class TestFindTurnedSteps:
+    def test_two_step_shaft(self):
+        prof = find_turned_steps(_shaft_x((30, 40), (16, 30)))
+        assert prof is not None
+        assert prof.axis == "x"
+        assert _lengths(prof) == [30.0, 40.0]
+
+    def test_three_step_shaft(self):
+        prof = find_turned_steps(_shaft_x((20, 10), (14, 10), (8, 10)))
+        assert prof is not None
+        assert _lengths(prof) == [10.0, 10.0, 10.0]
+
+    def test_steps_tile_the_axis_and_sum_to_overall(self):
+        prof = find_turned_steps(_shaft_x((30, 40), (16, 30)))
+        # contiguous: each step's hi is the next step's lo
+        for a, b in zip(prof.steps, prof.steps[1:]):
+            assert a.hi == pytest.approx(b.lo)
+        assert sum(s.length for s in prof.steps) == pytest.approx(70.0)
+
+    def test_axial_bore_is_ignored(self):
+        # A through-bore down the centre must not add a step or shift shoulders.
+        shaft = _shaft_x((30, 40), (16, 30)) - Rotation(0, 90, 0) * Cylinder(4, 200)
+        prof = find_turned_steps(shaft)
+        assert prof is not None
+        assert _lengths(prof) == [30.0, 40.0]
+
+    def test_chamfered_shoulders_keep_true_lengths(self):
+        # Chamfer the shoulder edges; the step lengths must stay shoulder-to-
+        # shoulder (the chamfer shortens the cylindrical face, not the step).
+        shaft = _shaft_x((30, 40), (16, 30))
+        edges = [e for e in shaft.edges() if e.geom_type == GeomType.CIRCLE]
+        try:
+            shaft = shaft.chamfer(0.8, None, edges)
+        except Exception:
+            pytest.skip("chamfer not constructible on this fixture")
+        prof = find_turned_steps(shaft)
+        assert prof is not None
+        assert _lengths(prof) == [30.0, 40.0]
+
+    def test_diameter_per_step(self):
+        prof = find_turned_steps(_shaft_x((30, 40), (16, 30)))
+        by_len = {round(s.length): round(s.diameter) for s in prof.steps}
+        assert by_len == {40: 30, 30: 16}
+
+    def test_shoulders_property(self):
+        prof = find_turned_steps(_shaft_x((30, 40), (16, 30)))
+        sh = prof.shoulders
+        assert len(sh) == 3
+        assert list(sh) == sorted(sh)  # sorted shoulder positions
+        # consecutive shoulders delimit the steps
+        diffs = sorted(round(b - a, 2) for a, b in zip(sh, sh[1:]))
+        assert diffs == [30.0, 40.0]
+
+    def test_plain_cylinder_is_none(self):
+        assert find_turned_steps(Cylinder(15, 40)) is None
+
+    def test_prismatic_box_is_none(self):
+        assert find_turned_steps(Box(40, 40, 10)) is None


### PR DESCRIPTION
Foundation for the original drive-screw fix (every diameter dimensioned, no
shoulder locatable). Adds `find_turned_steps` to the draftwright-owned recognition
package (ADR 0007). **No drawing behaviour change** — this is the recognition
primitive; scoring + the step-length annotation pass build on it next.

## Why not `find_bosses`

A boss's `.height` is its *cylindrical-face* length, shortened by the shoulder
chamfers — so boss spans neither tile the axis nor sum to the overall length, and
chaining them gives wrong, inconsistent step lengths. `analyse_cylinders` instead
exposes each cylinder's true axial span (`s_lo`/`s_hi`) and an `external` flag.

## Algorithm

1. External cylinders on the dominant turning axis give the OD bands (≥2 distinct
   diameters or it's not a stepped turned part → `None`). Internal bores are
   excluded by the `external` flag — a bored shaft works, and a blind bore's flat
   bottom never reads as a shoulder.
2. Transverse planar faces are kept as shoulders/ends only when their outer radius
   **reaches the local OD silhouette** (within a chamfer allowance). This is the
   key discriminator: true shoulders/ends reach the OD; an internal feature face
   (bore bottom) sits well inside it. The allowance tolerates chamfers that shrink
   a real shoulder face below the nominal OD.
3. Sorted shoulders delimit the steps; each step carries its OD.

## Verification

Against the real gramel drive-screw STEP it extracts the exact section breakdown
`[3.2, 0.5, 2.0, 3.0, 20.0]` (sum 28.7). New `tests/test_turned_steps.py` (9
tests, build123d fixtures — no external files): two/three-step shafts, axis-tiling
+ sum-to-overall, **axial bore ignored**, **chamfered shoulders keep true
lengths**, per-step diameter, and `None` for a plain cylinder / prismatic box.
Recognition + new tests: 79 passed; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)