### PR TITLE
feat: dimension turned-part axial step lengths + scoring (ADR 0007 PR-C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,10 @@ No lower module imports an upper one.
     (incl. side-drilled #133), pitch/grid dims, slots (the largest pass).
   - **`annotations/sections.py`** — section A–A + detail views (ISO 128-44 arrows,
     ISO 128-50 hatching).
-  - **`annotations/turned.py`** — turned-part step-diameter callouts.
+  - **`annotations/turned.py`** — turned-part step-diameter callouts and the
+    axial step-length chain (X-axis turned parts; `find_turned_steps` +
+    `lint_axial_coverage` close the drive-screw gap — diameters dimensioned but
+    shoulders unlocatable).
   - **`annotations/pmi.py`** — the PMI/GD&T annotation pass (distinct from the
     STEP-side extraction in `pmi.py`).
   - **`annotations/_common.py`** — shared placement helpers (`_anno_box`,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -46,8 +46,12 @@ from draftwright.annotations.holes import (
 )
 from draftwright.annotations.pmi import _annotate_pmi
 from draftwright.annotations.sections import _add_detail_view, _add_section_view
-from draftwright.annotations.turned import _annotate_turned_diameters
+from draftwright.annotations.turned import (
+    _annotate_turned_diameters,
+    _annotate_turned_lengths,
+)
 from draftwright.recognition import (
+    find_turned_steps,
     full_cylinders,
 )
 
@@ -362,8 +366,14 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     else:
         _log.warning("dim_height skipped: fv_zones.right strip full")
 
+    # An X-axis turned (stepped-shaft) part gets a full axial step-length chain
+    # below (the step-length pass); that chain already conveys the overall length,
+    # so the envelope width dim would double-dimension it (ISO 129). Suppress it.
+    _turned_prof = find_turned_steps(a.part)
+    _x_turned = _turned_prof is not None and _turned_prof.axis == "x"
+
     # Width (non-round / non-square parts only) — routed through pv_zones.below
-    if abs(a.x_size - a.y_size) > max(a.x_size, a.y_size) * 0.05:
+    if not _x_turned and abs(a.x_size - a.y_size) > max(a.x_size, a.y_size) * 0.05:
         _below_witness = PY(a.bb.min.Y) - 2
         _py = a.pv_zones.below.allocate(_SLOT_DIM_WIDTH)
         if _py is not None:
@@ -415,6 +425,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     # External turned diameters (X-axis turning) the passes above do not cover.
     _annotate_turned_diameters(dwg, a)
+
+    # Axial step lengths for an X-axis turned part — the chain above the front
+    # view that locates every shoulder (the overall width dim was suppressed
+    # above for these parts so the chain does not double-dimension it).
+    _annotate_turned_lengths(dwg, a, _turned_prof)
 
     # Side-drilled (X/Y-axis) hole locations — last, so the envelope and
     # turned-diameter dims claim their strip space first and are never evicted (#133).

--- a/src/draftwright/annotations/turned.py
+++ b/src/draftwright/annotations/turned.py
@@ -224,24 +224,37 @@ def _annotate_turned_lengths(dwg, a: Analysis, prof: TurnedProfile | None) -> No
     page_x = {s: dwg.at("front", s, y_ref, z_top)[0] for s in prof.shoulders}
     witness_y = fy1  # witness lines start at the profile top and rise to the chain
     gap = draft.font_size + 4 * draft.pad_around_text
+    # No room above the profile within the page — skip rather than run the chain
+    # off the top edge (the diameters/lengths then surface via lint as
+    # axial_length_missing). Mirrors the diameter row's room guard.
+    if witness_y + gap + draft.font_size > dwg.page_h - a.margin:
+        _log.info("turned-length chain skipped (no room above the front view)")
+        return
+
+    # Order the steps by their page-x (a front view need not preserve model-X
+    # ordering), so the strip solve and the chain read left to right.
+    steps = sorted(prof.steps, key=lambda s: (page_x[s.lo] + page_x[s.hi]) / 2)
+    labels = [_fmt(s.length) for s in steps]
+    centers = [(page_x[s.lo] + page_x[s.hi]) / 2 for s in steps]
 
     # A chain over closely-spaced steps (the drive-screw's 0.5 mm boss next to a
     # 2 mm disc) crowds its labels. Slide each label along the dim line so the
     # text clears its neighbours: a 1D strip solve (ADR 0003 layer-2, the same
-    # primitive the ø row uses) spreads label centres to ≥ one label-width apart,
-    # symmetric about the profile, then label_offset_x carries each back.
-    labels = [_fmt(s.length) for s in prof.steps]
-    centers = [(page_x[s.lo] + page_x[s.hi]) / 2 for s in prof.steps]
+    # primitive the ø row uses) spreads label centres ≥ one label-width apart
+    # within the page, then label_offset_x carries each back to its step.
     half_w = max(len(label) for label in labels) * draft.font_size * 0.62 / 2
     min_gap = 2 * half_w + 2 * draft.pad_around_text
-    mid = (centers[0] + centers[-1]) / 2
-    span = len(labels) * min_gap
-    solved = (
-        _solve_strip_ys(centers, min_gap, mid - span / 2, mid + span / 2)
-        or _greedy_strip_ys(centers, min_gap, mid - span / 2, mid + span / 2)
-        or centers
+    x_lo, x_hi = a.margin + half_w, dwg.page_w - a.margin - half_w
+    solved = _solve_strip_ys(centers, min_gap, x_lo, x_hi) or _greedy_strip_ys(
+        centers, min_gap, x_lo, x_hi
     )
-    for i, step in enumerate(prof.steps):
+    if solved is None:
+        # The labels do not fit the page width even greedily — skip rather than
+        # place an off-page chain; lint reports axial_length_missing (no coverage
+        # is recorded below).
+        _log.info("turned-length chain skipped (%d labels will not fit the page)", len(labels))
+        return
+    for i, step in enumerate(steps):
         dwg.add(
             _dim(
                 (page_x[step.lo], witness_y, 0),
@@ -255,4 +268,4 @@ def _annotate_turned_lengths(dwg, a: Analysis, prof: TurnedProfile | None) -> No
             f"dim_len{i}",
             view="front",
         )
-    dwg._coverage.cover_axial(len(prof.steps))
+    dwg._coverage.cover_axial(len(steps))

--- a/src/draftwright/annotations/turned.py
+++ b/src/draftwright/annotations/turned.py
@@ -199,19 +199,27 @@ def _turned_diameters_beside(dwg, a: Analysis, todo):
 
 
 def _annotate_turned_lengths(dwg, a: Analysis, prof: TurnedProfile | None) -> None:
-    """Axial step-length chain for an X-axis turned part, above the front view.
+    """Axial step-length chain for an **X-axis** turned part, above the front view.
 
     A turned part can have every diameter called out yet be unmanufacturable: with
     no shoulder located, the step lengths are unknown (the drive-screw gap). This
     places a complete chain — one dimension per step, end to end — so every
     shoulder is located. The chain is complete, so the orchestrator drops the
-    redundant overall length (``dim_width``) for these parts (no double
+    redundant overall width dim (``dim_width``) for these parts (no double
     dimensioning, ISO 129).
 
-    Scoped to X-axis turning (a shaft drawn on its side): the chain runs above the
-    front-view profile, clear of the ø-callout row the diameter pass places below.
-    Z-axis (vertical) shafts are out of scope here, matching
-    :func:`lint_axial_coverage`. Each dim is built with :func:`_dim` so the repair
+    **Only X-axis turning** (a shaft drawn on its side), because the other
+    orientations are already handled:
+
+    - **Z-axis** (a vertical stepped shaft) is dimensioned by the *existing*
+      step-height ordinate ladder in the orchestrator (``dim_step_*`` + the
+      overall ``dim_height``, with its own ``step_dim_dropped`` signal). A chain
+      here would double-dimension it.
+    - **Y-axis** is drawn end-on (concentric circles), so no view shows the
+      length — there is nothing to chain.
+
+    The chain runs above the front-view profile, clear of the ø-callout row the
+    diameter pass places below. Each dim is built with :func:`_dim` so the repair
     loop can re-place it.
     """
     if prof is None or prof.axis != "x":
@@ -225,8 +233,8 @@ def _annotate_turned_lengths(dwg, a: Analysis, prof: TurnedProfile | None) -> No
     witness_y = fy1  # witness lines start at the profile top and rise to the chain
     gap = draft.font_size + 4 * draft.pad_around_text
     # No room above the profile within the page — skip rather than run the chain
-    # off the top edge (the diameters/lengths then surface via lint as
-    # axial_length_missing). Mirrors the diameter row's room guard.
+    # off the top edge (the lengths then surface via lint as axial_length_missing).
+    # Mirrors the diameter row's room guard.
     if witness_y + gap + draft.font_size > dwg.page_h - a.margin:
         _log.info("turned-length chain skipped (no room above the front view)")
         return

--- a/src/draftwright/annotations/turned.py
+++ b/src/draftwright/annotations/turned.py
@@ -15,6 +15,7 @@ from draftwright._core import (
     _DIAM_RE,
     Analysis,
     _axis_letter,
+    _dim,
     _fmt,
     _greedy_strip_ys,
     _log,
@@ -22,6 +23,7 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
 from draftwright.recognition import (
+    TurnedProfile,
     find_bosses,
 )
 
@@ -194,3 +196,63 @@ def _turned_diameters_beside(dwg, a: Analysis, todo):
             continue
         dwg.add(ldr, f"ldr_dz{i}", view="front")
         occupied.append(_anno_box(ldr))
+
+
+def _annotate_turned_lengths(dwg, a: Analysis, prof: TurnedProfile | None) -> None:
+    """Axial step-length chain for an X-axis turned part, above the front view.
+
+    A turned part can have every diameter called out yet be unmanufacturable: with
+    no shoulder located, the step lengths are unknown (the drive-screw gap). This
+    places a complete chain — one dimension per step, end to end — so every
+    shoulder is located. The chain is complete, so the orchestrator drops the
+    redundant overall length (``dim_width``) for these parts (no double
+    dimensioning, ISO 129).
+
+    Scoped to X-axis turning (a shaft drawn on its side): the chain runs above the
+    front-view profile, clear of the ø-callout row the diameter pass places below.
+    Z-axis (vertical) shafts are out of scope here, matching
+    :func:`lint_axial_coverage`. Each dim is built with :func:`_dim` so the repair
+    loop can re-place it.
+    """
+    if prof is None or prof.axis != "x":
+        return
+    draft = dwg.draft
+    _, _, _, fy1 = dwg.view_bounds("front")  # page top of the profile
+    y_ref = a.bb.center().Y
+    z_top = a.bb.max.Z
+    # Page-x of each shoulder, on the top silhouette of the front view.
+    page_x = {s: dwg.at("front", s, y_ref, z_top)[0] for s in prof.shoulders}
+    witness_y = fy1  # witness lines start at the profile top and rise to the chain
+    gap = draft.font_size + 4 * draft.pad_around_text
+
+    # A chain over closely-spaced steps (the drive-screw's 0.5 mm boss next to a
+    # 2 mm disc) crowds its labels. Slide each label along the dim line so the
+    # text clears its neighbours: a 1D strip solve (ADR 0003 layer-2, the same
+    # primitive the ø row uses) spreads label centres to ≥ one label-width apart,
+    # symmetric about the profile, then label_offset_x carries each back.
+    labels = [_fmt(s.length) for s in prof.steps]
+    centers = [(page_x[s.lo] + page_x[s.hi]) / 2 for s in prof.steps]
+    half_w = max(len(label) for label in labels) * draft.font_size * 0.62 / 2
+    min_gap = 2 * half_w + 2 * draft.pad_around_text
+    mid = (centers[0] + centers[-1]) / 2
+    span = len(labels) * min_gap
+    solved = (
+        _solve_strip_ys(centers, min_gap, mid - span / 2, mid + span / 2)
+        or _greedy_strip_ys(centers, min_gap, mid - span / 2, mid + span / 2)
+        or centers
+    )
+    for i, step in enumerate(prof.steps):
+        dwg.add(
+            _dim(
+                (page_x[step.lo], witness_y, 0),
+                (page_x[step.hi], witness_y, 0),
+                "above",
+                gap,
+                draft,
+                label=labels[i],
+                label_offset_x=solved[i] - centers[i],
+            ),
+            f"dim_len{i}",
+            view="front",
+        )
+    dwg._coverage.cover_axial(len(prof.steps))

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -64,6 +64,7 @@ from draftwright.linting import (
     CoverageState,
     LintIssue,
     _suggest_fix,
+    lint_axial_coverage,
     lint_drawing,
     lint_feature_coverage,
 )
@@ -974,6 +975,11 @@ class Drawing:
                 self.items,
                 cyls=self._cyl_cache,
                 exclude=self._coverage.dropped_diams,
+                assembly=self.assembly,
+            )
+            issues += lint_axial_coverage(
+                self.part,
+                self._coverage.axial_covered,
                 assembly=self.assembly,
             )
         issues += list(self._build_issues)

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -16,7 +16,11 @@ Import the public surface from here, not the submodules.
 
 from __future__ import annotations
 
-from draftwright.linting.coverage import CoverageState, lint_feature_coverage
+from draftwright.linting.coverage import (
+    CoverageState,
+    lint_axial_coverage,
+    lint_feature_coverage,
+)
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import lint_drawing
 from draftwright.linting.suggest import _suggest_fix
@@ -25,6 +29,7 @@ __all__ = [
     "CoverageState",
     "LintIssue",
     "_suggest_fix",
+    "lint_axial_coverage",
     "lint_drawing",
     "lint_feature_coverage",
 ]

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -28,6 +28,7 @@ from draftwright.recognition import (
     analyse_cylinders,
     feature_diameters,
     find_holes,
+    find_turned_steps,
 )
 
 
@@ -45,6 +46,10 @@ class CoverageState:
         # redundant feature_not_dimensioned for them. Reset at the top of
         # _auto_annotate so re-annotation does not accumulate.
         self._dropped_callout_diams: list = []
+        # Count of turned-part axial step lengths the step-length pass dimensioned,
+        # so lint_axial_coverage knows how many shoulders are located. Reset with
+        # the dropped diameters at the top of _auto_annotate.
+        self._axial_covered: int = 0
 
     # -- pattern coverage -----------------------------------------------------
 
@@ -65,8 +70,9 @@ class CoverageState:
     # -- dropped diameters ----------------------------------------------------
 
     def reset_dropped(self) -> None:
-        """Clear dropped-diameter tracking (top of _auto_annotate)."""
+        """Clear dropped-diameter and axial tracking (top of _auto_annotate)."""
         self._dropped_callout_diams = []
+        self._axial_covered = 0
 
     def drop_diam(self, diam) -> None:
         """Record a diameter dropped by the per-view callout cap."""
@@ -76,6 +82,17 @@ class CoverageState:
     def dropped_diams(self) -> list:
         """Diameters dropped by the cap (passed to lint_feature_coverage)."""
         return self._dropped_callout_diams
+
+    # -- axial step coverage --------------------------------------------------
+
+    def cover_axial(self, count: int = 1) -> None:
+        """Record that the step-length pass dimensioned *count* axial steps."""
+        self._axial_covered += count
+
+    @property
+    def axial_covered(self) -> int:
+        """Number of turned-part axial steps dimensioned (for lint_axial_coverage)."""
+        return self._axial_covered
 
 
 def lint_feature_coverage(
@@ -178,3 +195,37 @@ def lint_feature_coverage(
                 )
             )
     return issues
+
+
+def lint_axial_coverage(part, covered: int, assembly=None) -> list:
+    """Report a stepped turned part whose axial step lengths are undimensioned.
+
+    A turned part can have every diameter called out yet be unmanufacturable: with
+    no shoulder located, the lengths are unknown (the drive-screw gap). A complete
+    chain dimensions all ``n`` steps; *covered* is how many the step-length pass
+    placed (from :attr:`CoverageState.axial_covered`). A shortfall yields one
+    ``axial_length_missing`` issue.
+
+    Scoped to X-axis turning — the orientation the step-length pass dimensions; a
+    vertical (Z-axis) stepped shaft is out of scope here so lint and placement
+    stay consistent (no perpetually-dirty Z parts). Severity mirrors
+    :func:`lint_feature_coverage`: ``info`` for an assembly, else ``warning``.
+    """
+    prof = find_turned_steps(part)
+    if prof is None or prof.axis != "x":
+        return []
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    n = len(prof.steps)
+    if covered >= n:
+        return []
+    return [
+        LintIssue(
+            severity="info" if assembly else "warning",
+            code="axial_length_missing",
+            message=(
+                f"turned part has {n} axial steps but only {covered} step length(s) "
+                f"dimensioned — shoulders cannot be located"
+            ),
+        )
+    ]

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -206,9 +206,12 @@ def lint_axial_coverage(part, covered: int, assembly=None) -> list:
     placed (from :attr:`CoverageState.axial_covered`). A shortfall yields one
     ``axial_length_missing`` issue.
 
-    Scoped to X-axis turning — the orientation the step-length pass dimensions; a
-    vertical (Z-axis) stepped shaft is out of scope here so lint and placement
-    stay consistent (no perpetually-dirty Z parts). Severity mirrors
+    Scoped to **X-axis** turning (a shaft drawn on its side) — the gap the
+    step-length pass fills. The other orientations are covered elsewhere, so
+    flagging them here would be a false positive: a **Z-axis** (vertical) stepped
+    shaft is dimensioned by the orchestrator's existing step-height ladder
+    (``dim_step_*``, with its own ``step_dim_dropped`` signal), and a **Y-axis**
+    part is drawn end-on (no view shows its length). Severity mirrors
     :func:`lint_feature_coverage`: ``info`` for an assembly, else ``warning``.
     """
     prof = find_turned_steps(part)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4433,6 +4433,22 @@ class TestTurnedLengths:
         dwg = build_drawing(Box(80, 60, 20))
         assert not any(n.startswith("dim_len") for n in dwg._named)
 
+    def test_chain_skips_gracefully_when_no_room(self):
+        # Forced onto a too-small page, the chain must SKIP rather than run off the
+        # page edge (the parity guard the diameter row has). Lint then reports the
+        # gap instead of the engine emitting off-page dims.
+        from build123d import Cylinder, Pos, Rotation
+
+        z = 0.0
+        part = None
+        for i in range(10):
+            seg = Pos(0, 0, z + 1.0) * Cylinder((12 - 0.6 * i) / 2, 2.0)
+            part = seg if part is None else part + seg
+            z += 2.0
+        dwg = build_drawing(Rotation(0, 90, 0) * part, page="90x70", scale=4.0)
+        assert not any(n.startswith("dim_len") for n in dwg._named)  # skipped, not off-page
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) >= 1
+
 
 class TestAxialCoverageLint:
     """lint_axial_coverage — the scoring signal for undimensioned turned steps."""

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4399,6 +4399,63 @@ class TestTurnedDiameters:
         assert not any(n.startswith("ldr_d") for n in dwg._named)
 
 
+class TestTurnedLengths:
+    """Axial step-length chain for X-axis turned parts (the drive-screw gap:
+    every diameter dimensioned, no shoulder locatable)."""
+
+    def test_each_step_length_is_dimensioned(self):
+        dwg = build_drawing(_x_stepped_shaft())  # ø30 l40 then ø16 l30
+        labels = {o.label for n, o in dwg._named.items() if n.startswith("dim_len")}
+        assert labels == {"40", "30"}
+
+    def test_overall_width_suppressed_for_turned_part(self):
+        # The complete chain conveys the overall length, so the envelope width dim
+        # is dropped — no double dimensioning (ISO 129).
+        dwg = build_drawing(_x_stepped_shaft())
+        assert "dim_width" not in dwg._named
+
+    def test_turned_part_lints_clean(self):
+        dwg = build_drawing(_x_stepped_shaft())
+        codes = dwg.lint_summary()["by_code"]
+        assert codes.get("axial_length_missing", 0) == 0
+        assert codes.get("annotation_overlap", 0) == 0
+
+    def test_three_step_shaft_dimensions_all_steps(self):
+        from build123d import Cylinder, Pos, Rotation
+
+        shaft = Rotation(0, 90, 0) * (
+            Cylinder(10, 10) + Pos(0, 0, 10) * Cylinder(7, 10) + Pos(0, 0, 20) * Cylinder(4, 10)
+        )
+        dwg = build_drawing(shaft)
+        assert len([n for n in dwg._named if n.startswith("dim_len")]) == 3
+
+    def test_prismatic_part_has_no_step_lengths(self):
+        dwg = build_drawing(Box(80, 60, 20))
+        assert not any(n.startswith("dim_len") for n in dwg._named)
+
+
+class TestAxialCoverageLint:
+    """lint_axial_coverage — the scoring signal for undimensioned turned steps."""
+
+    def test_flags_uncovered_turned_part(self):
+        from draftwright.linting import lint_axial_coverage
+
+        issues = lint_axial_coverage(_x_stepped_shaft(), covered=0)
+        assert [i.code for i in issues] == ["axial_length_missing"]
+        assert issues[0].severity == "warning"
+
+    def test_clean_when_all_steps_covered(self):
+        from draftwright.linting import lint_axial_coverage
+
+        # _x_stepped_shaft has 2 steps; covering both clears the check.
+        assert lint_axial_coverage(_x_stepped_shaft(), covered=2) == []
+
+    def test_silent_for_non_turned_part(self):
+        from draftwright.linting import lint_axial_coverage
+
+        assert lint_axial_coverage(Box(80, 60, 20), covered=0) == []
+
+
 def _multi_hole_plate():
     """A plate with three spec-groups of Z-holes (two ø10, one ø16)."""
     from build123d import Box, Cylinder, Pos


### PR DESCRIPTION
**The original goal.** The gramel drive screw had every diameter dimensioned but
no shoulder locatable — unmanufacturable — and lint scored it **1.0**, blind to
the omission. This closes that gap, built on the now draftwright-owned recognition
(`find_turned_steps`, #188) and lint (#186).

## Scoring (first, per the brief)

`lint_axial_coverage` flags a stepped turned part whose axial step lengths are
undimensioned → `axial_length_missing` (warning; info for assemblies).
`CoverageState` gains an axial-covered counter the placement pass records.
Scoped to **X-axis turning** so lint and placement stay consistent (no
perpetually-dirty Z parts).

## Placement (option 1, refined)

`_annotate_turned_lengths` places a **complete chain** — one dim per step, end to
end — above the front-view profile, locating every shoulder. The orchestrator
**suppresses the overall width dim** for these parts so the chain doesn't
double-dimension it (ISO 129).

Refined from the literal "(n−1) + overall, drop the longest" because **the
longest step is the thread** — dropping it would omit the most functional
dimension (the whole point for a drive screw). A complete chain dimensions every
step, including the thread, with no omission judgment.

Crowded labels (the drive screw's 0.5 mm boss beside a 2 mm disc) are spread along
the dim line via the layer-2 strip solver (ADR 0003) + `label_offset_x`.

## Result

The drive screw now lints **clean (1.0)** with all five step lengths placed
(3.2, 0.5, 2, 3, 20, sum 28.7). The stepped-shaft fixture: `dim_len` chain
present, `dim_width` suppressed, no `axial_length_missing`, no `annotation_overlap`.

## Verification

Full fast tier **552 passed, 1 skipped**; goldens incl. the slow `ctc01` NIST
part stable (prismatic → unaffected); `ruff`/`format`/`mypy` clean. New tests:
`TestTurnedLengths`, `TestAxialCoverageLint`.

## Scope / follow-ups

- Z-axis (vertical) stepped shafts: lengths out of scope here (lint + placement
  both skip them) — a follow-up, mirroring how the diameter pass handles Z.
- The orchestrator calls `find_turned_steps` once per build for the suppression
  decision; could be cached on `Analysis` later (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)