### PR TITLE
feat: unify Z step recognition on find_turned_steps (ADR 0008 step 1)

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -1,6 +1,6 @@
 # ADR 0008 — Unified feature model and a dimensioning planner
 
-- **Status:** Proposed
+- **Status:** Accepted (migration in progress — step 1 landed: #191)
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -36,6 +36,7 @@ from draftwright.recognition import (
     find_hole_patterns,
     find_holes,
     find_slots,
+    find_turned_steps,
     full_cylinders,
 )
 from draftwright.sheet import (
@@ -291,8 +292,20 @@ def _analyse(
     if z_diams and not is_rotational:
         _log.info("Part classified prismatic; skipping OD/centreline/bore annotations")
 
-    face_zs = analyse_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)
-    step_zs = [z for z in face_zs if z > bb.min.Z + 0.6 and z < bb.max.Z - 0.6]
+    # Step Z-levels feed both the step-height ladder and the page-sizing step
+    # count. For a vertical (Z-axis) turned part, take them from the unified
+    # turned-step model (ADR 0008 step 1): it filters shoulders by the OD
+    # silhouette, so an internal feature face — a blind bore's flat floor — is
+    # never read as a phantom OD shoulder (the area-only filter in
+    # analyse_face_levels admitted it). Prismatic and other parts keep the
+    # general face-level scan, which find_turned_steps cannot replace (no
+    # cylinders → no profile).
+    _turned = find_turned_steps(part)
+    if _turned is not None and _turned.axis == "z":
+        step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
+    else:
+        face_zs = analyse_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)
+        step_zs = [z for z in face_zs if z > bb.min.Z + 0.6 and z < bb.max.Z - 0.6]
 
     # Pass 1 (two-pass layout, #131): measure annotation strip depths before
     # view positions are fixed.  font_size=3.0 is a fixed page-mm constant so

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4450,6 +4450,29 @@ class TestTurnedLengths:
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) >= 1
 
 
+class TestStepLadderRecognition:
+    """ADR 0008 step 1: the Z step-height ladder draws its step levels from the
+    unified turned-step model, which filters by the OD silhouette."""
+
+    def test_blind_bore_floor_is_not_a_phantom_shoulder(self):
+        from build123d import Cylinder, Pos
+
+        # Two OD steps (one real interior shoulder at z=15) + a blind axial bore
+        # whose flat floor sits at z=30. The floor must NOT be dimensioned as a
+        # step height — that was the area-filter phantom the model removes.
+        shaft = Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)
+        part = shaft - Pos(0, 0, 45) * Cylinder(5, 30)
+        dwg = build_drawing(part, number="D-1")
+        labels = [o.label for n, o in dwg._named.items() if n.startswith("dim_step")]
+        assert labels == ["30"]  # the real shoulder only; no '45' bore-floor phantom
+
+    def test_plain_z_stepped_shaft_still_laddered(self):
+        from build123d import Cylinder, Pos
+
+        dwg = build_drawing(Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30), number="D-1")
+        assert [o.label for n, o in dwg._named.items() if n.startswith("dim_step")] == ["30"]
+
+
 class TestAxialCoverageLint:
     """lint_axial_coverage — the scoring signal for undimensioned turned steps."""
 


### PR DESCRIPTION
First strangler step of **ADR 0008** (#192). Also flips ADR 0008 to **Accepted**.

## What

The Z step-height ladder (`dim_step_*`) and the page-sizing step count both read
`step_zs`. For a **vertical (Z-axis) turned part**, derive `step_zs` from the
unified `find_turned_steps` model instead of `analyse_face_levels`. Prismatic and
other parts keep `analyse_face_levels` (find_turned_steps returns `None` without
cylinders) — the more general primitive stays where it's more general (per the
#191 review).

## The bug it fixes

A blind axial bore's flat **floor** was admitted by `analyse_face_levels`'
area-only filter as a **phantom OD shoulder** and dimensioned as a step height.
The model's OD-silhouette filter excludes it:

```
bored Z shaft:  dim_step ['30', '45']  →  ['30']     # '45' was the bore floor
```

Z/prismatic/X cases all unaffected (verified). New regression tests:
`TestStepLadderRecognition`.

## Why this is step 1, not a standalone dedup

Doing #191 in isolation would add a fourth orientation special-case. Routing the
single `step_zs` feed through the model moves **both** consumers (ladder + sizing)
onto it at once, which is the ADR-0008 direction: one recognizer, orientation as
data.

## Verification

Fast tier **551 passed, 1 skipped**; ruff/format/mypy clean. The CTC slow tier is
unaffected by construction (prismatic parts use the unchanged path) and runs
post-merge per CI policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)