### PR TITLE
feat: rewrite ADR 0008 as the part-drawing compiler + prototype the IR

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -1,153 +1,150 @@
-# ADR 0008 — Unified feature model and a dimensioning planner
+# ADR 0008 — The part-drawing compiler: a Feature/DimParameter IR and a dimensioning planner
 
-- **Status:** Accepted (migration in progress — step 1 landed: #191)
+- **Status:** Accepted (migration in progress — step 1 landed; prototype landed)
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
+- **Supersedes the original 0008** ("unified feature model") with a concrete
+  architecture. Step 1 (unify Z step recognition, #191/#193) stands.
 
 ## Context
 
-draftwright recognises a part's features and then dimensions them. Both halves
-grew by accretion — one issue at a time — and the shape now shows it.
+draftwright recognises a part's features and dimensions them. Both halves grew by
+accretion, and the failure vector is now clear: **N recognisers × M dimensioning
+passes, directly coupled, with orientation encoded as code branches.** Every new
+shape (keyway, taper, groove, gear, knurl, T-slot, chamfered-counterbored bore…)
+tempts another recogniser + another placement pass + another `is_rotational` /
+`axis == "x"` gate. That is quadratic coupling growth — the ball of mud.
 
-**Recognition is fragmented across overlapping scanners.** Each rescans
-`part.faces()` (or the cylinder set) with its *own* tolerances and filters:
+Concrete symptoms already seen: the `analyse_face_levels` vs `find_turned_steps`
+duplication (#191); a phantom bore-floor shoulder from two recognisers filtering
+differently; "dimension a turned part's steps" implemented three times by
+orientation; and the realisation (the `find_bosses` review) that recognisers are
+*plural and complementary*, not a thing to collapse into one function.
 
-- `analyse_cylinders` — cylinder bands (radius, axial span, `external`).
-- `find_bosses` — external cylinders → bosses (diameter, *chamfer-shortened*
-  height).
-- `find_holes` — bores / counterbores / spotfaces.
-- `analyse_face_levels` — transverse Z-face levels (area-filtered) → `step_zs`.
-- `find_turned_steps` — axis-general step segments (cylinder bands + transverse
-  faces, OD-silhouette-filtered).
-- `find_slots` — milled slots.
-
-**Dimensioning is fragmented across orientation-gated passes.** "Dimension a
-turned part's steps" is implemented *three times*, each for a different
-orientation and convention, gated by `is_rotational` / `axis == "x"` /
-`axis == "z"`:
-
-- step **diameters**: X gets a row below the front view (#77), Z a column to the
-  left (#131);
-- step **heights**: a Z-only ordinate ladder (`dim_step_*`);
-- step **lengths**: an X-only chain (`dim_len_*`, ADR 0007 PR-C).
-
-These are not independent designs; they are strata. The recurring problems are
-all symptoms of one missing abstraction:
-
-- **Duplicate recognition** (the `analyse_face_levels` vs `find_turned_steps`
-  overlap, issue #191).
-- **Inconsistent filtering → silent bugs.** A blind bore's flat floor is excluded
-  by `find_turned_steps`' OD-silhouette filter but admitted as a *phantom OD
-  shoulder* by `analyse_face_levels`' area filter (verified: a bored Z shaft gets
-  a spurious step-height dim at the bore floor; lint is silent).
-- **Orientation as branches, not data.** Each new orientation (the "what about
-  Y/Z?" question) means another gated pass, not a parameter — so coverage and
-  quality differ by axis.
-
-Asked "would you design it this way from scratch?", the answer is no. This ADR
-records the design we *would* choose and how to migrate to it without a rewrite.
+The original 0008 ("one model, retire `find_bosses`") had the right instinct but
+named the wrong abstraction. The thing that actually stops the growth is a
+**stable intermediate representation** between recognition and dimensioning — the
+compiler/LLVM hourglass: many front-ends → one narrow IR → many back-ends.
 
 ## Decision
 
-Split recognition and dimensioning into two layers, each with one job, and make
-**orientation a property of the model, not a branch in the code**.
+Build draftwright as a **part-drawing compiler** with four layers and a stable IR
+at the waist. Orientation and feature *kind* become **data in the IR**, never
+branches in the back-end.
 
-### 1. One feature-recognition pass → a single part model
+```
+  Geometry-query layer        faces/edges/cylinders/axes/silhouettes, computed once
+        │
+  Feature detectors (plug-in) find_holes, find_bosses, find_turned_steps, find_slots…
+        │   each adapts its heuristics to emit typed Feature objects; none rescans
+        ▼
+  ┌────────────────────────┐
+  │  PART MODEL  (the IR)   │  oriented part + Feature set + Datums  ← the narrow waist
+  └────────────────────────┘
+        │
+  Dimensioning planner        consumes the IR; applies ISO/ASME convention rules
+        │   asks each Feature for its DimParameters + references
+        ▼
+  Layout / render             EXISTING (ADR 0003 Placeable + solver, 0004 pack, helpers)
+```
 
-A single pass classifies the part's orientation **once** and produces a
-structured, view-independent model built on **one** low-level scan with **one**
-consistent set of tolerances and filters:
+### 1. Two small protocols are the waist (this is the load-bearing decision)
 
-- Turned part: a `Profile` — an ordered list of `Segment(length, diameter,
-  external)` along the turning axis — plus concentric bores and off-axis features
-  (holes, slots, patterns).
-- Prismatic part: envelope + step levels + faces + holes.
+```python
+class Feature(Protocol):              # hole, step, boss, slot, chamfer, gear, …
+    kind: str
+    frame: Frame                      # position + orientation in part space
+    def parameters(self) -> list[DimParameter]: ...   # what a drawing MUST show
+    def references(self) -> list[Datum]: ...           # datums it measures from/provides
 
-The OD-silhouette / internal-vs-external test is applied **once, here**, so an
-internal feature face (a bore floor) is never a shoulder *anywhere* downstream,
-by construction. No later stage rescans the solid; they read the model.
+@dataclass(frozen=True)
+class DimParameter:                   # the universal currency of dimensioning
+    kind: Literal["diameter","length","depth","radius","angle","location","thread"]
+    value: float
+    label: str                        # rendered text, e.g. "ø8", "20", "M3"
+    span: tuple[Point, Point] | None  # model-space extent, for placement
+    refs: tuple[str, ...] = ()        # datum ids it is measured from
+```
 
-### 2. One dimensioning planner → a plan
+A `PartModel` holds the oriented part, the `Feature` list, and the `Datum` set.
 
-A planner consumes the model + the chosen views and applies ISO rules to decide
-*what* to dimension, *which convention* (chain / ordinate / leader), and *where*.
-The orientation-specific behaviour that is three passes today becomes **one rule
-parameterised by the model**: "a turned part: dimension its segment lengths and
-diameters on whichever view shows it lengthwise; use ordinate when the chain is
-crowded." X / Y / Z stop being special cases — Y falls out naturally (no view
-shows the length → nothing to plan).
+### 2. Why this survives arbitrary new shapes — Open/Closed by construction
 
-### 3. Migrate by strangler, not rewrite
+- A new shape = **a new `Feature` subtype + a detector that emits it**, exposing
+  `DimParameter`s of *existing kinds*. **Zero changes** to the planner, the layout,
+  or any other feature. The 30th feature type costs the same as the 3rd.
+- **Orientation is data, not branches.** `frame` carries it; the planner reasons
+  geometrically, so X/Y/Z/turned/prismatic are inputs, not `if`s. The
+  orientation-gate proliferation cannot recur.
+- **Recognisers are front-ends.** `find_bosses` (diameters/bosses) and
+  `find_turned_steps` (axial profile) are complementary detectors emitting into the
+  IR — exactly as the #191 review concluded. The duplicate-recogniser problem
+  cannot recur because dimensioning consumes the IR, not the recognisers.
 
-A clean target is **not** a licence to rewrite working code (the same trap as
-preferring the design one would write over the code that works). Instead:
+### 3. The planner is one rule set over DimParameters
 
-1. **Introduce the model** as a new single recogniser (likely generalising
-   `find_turned_steps` into the `Profile`, and `analyse_face_levels` into the
-   prismatic branch — keeping the *more general* primitive where it is more
-   general, per the #191 review).
-2. **Migrate consumers one at a time** onto the model: the step ladder, the step
-   chain, the diameter row/column, then page sizing — each its own releasable PR,
-   verified against the existing tests.
-3. **Retire the redundant recognisers** (`find_bosses` for steps,
-   `analyse_face_levels` for steps, `find_turned_steps` as a standalone) as their
-   last consumer moves.
-4. The dimensioning planner emerges **last**, once the passes already read a
-   common model — it is then a refactor of placement, not a rewrite of
-   recognition.
+For each feature, for each `DimParameter`, the planner applies convention rules —
+chain vs ordinate, datum selection, redundancy/duplication avoidance, view choice —
+**uniformly**. "A turned part's step lengths", "a hole's depth", "a slot's width"
+are all `DimParameter`s flowing through one planner. This is the logic currently
+reimplemented per-pass; centralising it is where the back-end stops rotting.
 
-### 4. #191 is the first step of this, not a standalone dedup
+### 4. The layout layer is untouched
 
-Doing #191 in isolation (route the ladder through `find_turned_steps`) just adds a
-*fourth* orientation special-case — more of the same disease. Re-scope it as
-"introduce the `Profile` model and move the step ladder + step chain onto it",
-the first migration step above. The phantom-bore bug is fixed for free once
-filtering is centralised in the model.
+The planner emits placement *intents*; the existing `Placeable`/solver (ADR 0003)
++ compose-then-pack (0004) + helpers primitives place them. No change there.
+
+## Migration — strangler, anchored on the protocol (no rewrite)
+
+1. **Define the waist** (`DimParameter`, `Feature`, `Datum`, `PartModel`) and
+   **prototype** a vertical slice: build the model from a real part via adapted
+   detectors and run a minimal planner, proving diverse features (holes + steps +
+   bosses) flow through one pipeline. *(Landed — see `src/draftwright/model/` and
+   `tests/test_part_model.py`; not yet wired into `build_drawing`.)*
+2. **Adapt, don't rewrite, the heuristics.** Wrap `find_holes`/`find_bosses`/
+   `find_turned_steps`/`find_slots` so they emit `Feature` objects; their B-rep
+   logic stays.
+3. **Introduce the planner in production** for one feature end-to-end (holes — the
+   most mature), proving it carries real placement through the existing layout.
+4. **Move features onto the planner one PR at a time**, retiring each
+   orientation-gated pass as its feature lands.
+5. **Generalise planner rules only after ~3 feature types** have stressed the
+   `DimParameter` set — don't build a speculative rule engine (that is just
+   framework-shaped spaghetti).
 
 ## Consequences
 
-- **One source of truth** for features, computed once, consistently filtered —
-  the duplicate-recogniser and inconsistent-filter bug classes disappear.
-- **Orientation coverage becomes uniform.** Adding an orientation or a feature is
-  data in the model + a planner rule, not a new gated pass.
-- **The phantom-bore shoulder is fixed structurally**, not patched per-pass.
-- **Incremental, low-risk path.** Each migration PR is small and test-gated; the
-  engine keeps working throughout. No big-bang.
-- **Cost is real.** This is weeks of incremental work, not hours. Each step is
-  gated by the geometry-level + `test_e2e_standards` suites and targeted
-  behavioural tests. If a particular step is risky (the sizing-path migration is
-  the obvious one), stand up a **scoped, disposable** golden gate for that step
-  alone and delete it afterwards — draftwright keeps no standing general golden
-  gate by design (ADR 0005 §3), since a permanent one freezes improvement. Worth
-  it only because turned/stepped dimensioning is an active growth area; if it were
-  a one-off, the accreted code would be left alone.
+- New shapes are **new types, never new branches** — the property the product
+  needs to absorb complex shape requirements over time.
+- One source of truth (the IR), one dimensioning rule set; the duplicate-recogniser
+  and orientation-gate bug classes are designed out.
+- Incremental and low-risk: each step ships value; the engine keeps working; the
+  prototype de-risks the protocol before any production rewiring.
 
 ## Risks
 
-- **Sizing path is load-bearing.** `analyse_face_levels` → `step_zs` drives page
-  and scale selection. Migrating it risks layout shifts; do it late, with spot
-  checks, after the placement consumers are already on the model.
-- **Scope creep into a rewrite.** Mitigation: each step must be a small,
-  independently-revertable PR with a clear before/after; if a step balloons,
-  stop and re-plan rather than pressing on.
-- **Model over-design.** The `Profile` should capture only what current passes
-  need (segments, diameters, bores, off-axis features); resist speculative
-  generality (ADR-less features). Grow it as consumers demand.
+- **Recognition stays heuristic.** A chamfered bore in a tapered section will not
+  recognise itself cleanly. The architecture *contains* that mess inside detectors
+  behind the IR; it does not eliminate it. That is the realistic goal.
+- **Over-abstraction.** Resist a speculative planner rule engine or a maximal
+  `DimParameter` taxonomy before real features demand them. Grow the IR from
+  consumers, not from imagination.
+- **The sizing path is load-bearing** (`step_zs` → scale/page). Migrate it late;
+  if a step is genuinely risky, stand up a *scoped, disposable* golden gate for
+  that step only and delete it — draftwright keeps no standing general gate by
+  design (ADR 0005 §3), since a permanent one freezes improvement.
 
 ## Impact on other ADRs
 
-- **0003** (constraint layout) — unchanged; the planner still emits boxes the
-  layout solver places.
-- **0004** (compose-then-pack) — unchanged; the planner feeds the same blocks.
-- **0005** (pipeline modules) — extended: this carries the compiler-pipeline
-  separation into the recognition/dimensioning stages 0005 left as a single
-  `analysis`/`annotations` lump. Import direction (DAG) is preserved.
-- **0007** (draftwright owns recognition) — built on: the model lives in the
-  now-owned `recognition/`, the planner alongside `annotations/`.
+- **0003 / 0004** — unchanged; the planner feeds the existing layout/pack.
+- **0005** — extended: this carries the compiler-pipeline separation into the
+  recognition/dimensioning stages 0005 left as an `analysis`/`annotations` lump.
+- **0007** — built on: the IR and detectors live in the now-owned `recognition/`;
+  the planner alongside `annotations/`.
 
 ## Related
 
-- Issue #191 (the recogniser-duplication trigger; re-scoped as step 1 here).
-- The drive-screw thread (ADR 0007 PR-C): the X step-length chain that, added as
-  yet another orientation-gated pass, made the accretion obvious.
-- ADR 0005 (compiler-pipeline module boundaries and single-owner state).
+- Issue #191 (step 1 — unify Z step recognition; landed #193).
+- The drive-screw thread (ADR 0007 PR-C) that made the accretion obvious.
+- Prototype: `src/draftwright/model/` (`ir`, `detect`, `planner`),
+  `tests/test_part_model.py`.

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -96,6 +96,10 @@ The planner emits placement *intents*; the existing `Placeable`/solver (ADR 0003
 
 ## Migration — strangler, anchored on the protocol (no rewrite)
 
+Full execution plan (all detectors + drawing components, with a scoped golden gate
+and X/Z parity as standing criteria):
+[`docs/plans/0008-compiler-migration-roadmap.md`](../plans/0008-compiler-migration-roadmap.md).
+
 1. **Define the waist** (`DimParameter`, `Feature`, `Datum`, `PartModel`) and
    **prototype** a vertical slice: build the model from a real part via adapted
    detectors and run a minimal planner, proving diverse features (holes + steps +

--- a/docs/plans/0008-compiler-migration-roadmap.md
+++ b/docs/plans/0008-compiler-migration-roadmap.md
@@ -1,0 +1,115 @@
+# ADR 0008 migration roadmap — rewrite detectors + drawing components onto the IR
+
+Execution plan for ADR 0008 (the part-drawing compiler). Moves **every** detector
+and **every** drawing component onto the `Feature`/`DimParameter` IR + planner,
+behind a **scoped, disposable golden gate**, with **X/Z parity** as a standing
+acceptance criterion at every step.
+
+Strangler discipline: the engine keeps working throughout; each phase is one (or a
+few) releasable PRs; old code is retired only as its replacement lands.
+
+## Standing acceptance criteria (apply to every phase)
+
+1. **Golden gate green** — the migration gate (Phase 0) shows no *unreviewed*
+   change to the semantic dimension set for the whole corpus. Intentional changes
+   regenerate the snapshot with a rationale in the PR (the ADR-0004 discipline).
+2. **X/Z parity** — every feature, detector, and planner rule is exercised on both
+   an X-oriented and a Z-oriented instance, and they produce the *same* dimension
+   set (same values + conventions, orientation-appropriate placement). No code path
+   may be gated to one axis. Parity is asserted by a dedicated test per migrated
+   component, not left implicit.
+3. **Orientation is data** — no new `is_rotational` / `axis == "x"` / `axis == "z"`
+   branch enters the back-end. Orientation lives in `Feature.frame`; the planner
+   chooses conventions by geometric rule.
+4. Existing suites (geometry-level + `test_e2e_standards`) stay green; `ruff` /
+   `format` / `mypy` clean.
+
+## Phase 0 — the scoped migration golden gate (do first)
+
+A purpose-built characterisation gate, **deleted in Phase 6**.
+
+- **Corpus** (`tests/_migration_gate/corpus.py`): a representative part per feature
+  scenario, **each present as both an X-turned and a Z-turned variant** where
+  orientation applies — plain stepped shaft, bored stepped shaft, chamfered shaft,
+  turned-and-drilled flange, prismatic plate with holes, bolt-circle pattern,
+  slotted part, counterbored/spotfaced part. The X+Z pairing is what makes the gate
+  *enforce* parity, not just hope for it.
+- **Digest**: the **semantic dimension set** of the produced drawing, not bytes —
+  for each part, the sorted set of `(feature_kind, param_kind, value, convention,
+  target_view)` plus placed-annotation labels. Robust to layout jitter, sensitive
+  to real coverage/convention changes. (No font-metric or absolute-position data —
+  the ADR-0005 §3 portability lesson.)
+- **Diff tool**: `UPDATE_MIGRATION_GATE=1` regenerates; otherwise a mismatch fails
+  with a readable per-part diff. The snapshot is taken **now**, off the current
+  engine, as the equivalence baseline.
+- **Lifecycle**: lives only for the migration. Phase 6 deletes
+  `tests/_migration_gate/` entirely — no standing general gate remains (ADR 0005
+  §3 / the golden-gate principle).
+
+## Inventory to migrate
+
+**Detectors → `Feature` emitters** (front-ends; heuristics unchanged, output
+normalised into the IR):
+
+| Detector | Emits | X/Z note |
+|---|---|---|
+| `find_holes` (+ cbore/spotface) | `HoleFeature` | axis from `frame`; already orientation-agnostic |
+| `find_turned_steps` | `StepFeature` | returns the axis; X+Z already symmetric in the recogniser |
+| `find_bosses` | `BossFeature` | external ODs on non-turned parts (both axes) |
+| `find_hole_patterns` | `PatternFeature` (bolt-circle / linear / grid) | — |
+| `find_slots` | `SlotFeature` | — |
+| `pmi` (STEP AP242) | `ThreadFeature` / GD&T features | — |
+
+**Drawing components → planner rules** (back-end; one rule set over
+`DimParameter`s):
+
+| Component (today) | Becomes |
+|---|---|
+| envelope dims (width/height/depth/OD), inline in orchestrator | planner rule over the part's bounding `DimParameter`s |
+| turned **diameters** (X row-below / Z column-left) | one planner rule, view+side chosen by `frame` |
+| turned **step lengths** (X chain / Z ordinate ladder) | one planner rule: chain or ordinate by *crowding*, **for both axes** |
+| hole callouts + location dims | planner rules over `HoleFeature` params + datums |
+| section / detail views | planner-triggered from features needing them |
+| PMI / GD&T pass | planner rules over PMI features |
+| title block / centrelines / balloons / hole tables | planner-emitted furniture |
+
+## Phases
+
+- **Phase 1 — IR foundation.** *(Landed, prototype #194.)* Lock `DimParameter` /
+  `Feature` / `PartModel` / `plan_dimensions`.
+- **Phase 2 — detectors emit Features.** Migrate each detector into
+  `build_part_model`, building the full model in parallel with the live engine.
+  Gate: the model captures everything the current recognisers find, X and Z. No
+  engine behaviour change yet.
+- **Phase 3 — planner in production: holes first.** Route hole callouts + location
+  dims through `plan_dimensions` → existing layout. Holes are the most mature and
+  naturally axis-agnostic, so this proves the planner→layout seam under the gate
+  with parity for free. Retire the hole placement in `annotations/holes.py`.
+- **Phase 4 — turned components (the X/Z crux).** Move **diameters** and **step
+  lengths** onto the planner, handling X and Z **symmetrically**: the planner picks
+  row/column and chain/ordinate by `frame` + crowding rules, not by separate
+  passes. This is where today's asymmetry is fixed — a Z shaft can get a length
+  chain and an X shaft an ordinate ladder when the rule says so. Retire
+  `_annotate_turned_diameters`, `_annotate_turned_lengths`, and the `dim_step_`
+  ladder; `step_zs`/`analyse_face_levels` for steps goes too. Parity test: the
+  X-variant and Z-variant of every turned corpus part produce equal dimension sets.
+- **Phase 5 — remaining components.** Envelope dims, slots, patterns, section/detail
+  triggers, PMI, furniture onto the planner. Retire each inline pass as it lands.
+- **Phase 6 — retire scaffolding.** Delete the orchestrator's inline passes, the
+  now-unused recogniser entry points superseded by detectors, and **the migration
+  golden gate**. Update ADR 0008 status to "migration complete"; the engine is now
+  detectors → IR → planner → layout, with no standing gate.
+
+## Risks & mitigations
+
+- **The sizing path** (`step_zs` → scale/page) is load-bearing; migrate it within
+  Phase 4 behind the gate, last among the turned components.
+- **Intentional output changes** (fixing the X/Z asymmetry will *add* dims the old
+  engine lacked, e.g. a Z length chain) are expected — the gate is a *diff-and-
+  review* tool, not a freeze. Each such change is reviewed and the snapshot
+  regenerated with rationale.
+- **Recognition stays heuristic** — contained in detectors behind the IR, not
+  cleaned. Detector PRs in Phase 2 may surface latent recogniser bugs (as Phase 1
+  did with the phantom bore floor); fix them at the detector, once.
+- **Scope creep into a rewrite** — each phase is independently revertable; if a
+  phase balloons, stop and re-plan rather than press on.

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -1,0 +1,46 @@
+"""The part-drawing compiler IR — prototype (ADR 0008).
+
+A vertical slice proving the architecture: a stable intermediate representation
+(`PartModel` of `Feature` objects exposing `DimParameter`s) sitting between the
+feature *detectors* (front-ends adapting the recognition heuristics) and a
+*dimensioning planner* (back-end). The narrow waist that lets new shapes be new
+types, not new branches.
+
+**Prototype status:** not yet wired into `build_drawing`. It builds a model from a
+real solid and plans dimensions, exercised by `tests/test_part_model.py`, to
+de-risk the protocol before any production rewiring (ADR 0008 migration step 1).
+
+- :mod:`.ir` — the IR: `DimParameter`, `Datum`, `Frame`, the `Feature` protocol,
+  the concrete feature types, and `PartModel`.
+- :mod:`.detect` — `build_part_model`: run the detectors, collect features.
+- :mod:`.planner` — `plan_dimensions`: convention rules over `DimParameter`s.
+"""
+
+from __future__ import annotations
+
+from draftwright.model.detect import build_part_model
+from draftwright.model.ir import (
+    BossFeature,
+    Datum,
+    DimParameter,
+    Feature,
+    Frame,
+    HoleFeature,
+    PartModel,
+    StepFeature,
+)
+from draftwright.model.planner import PlannedDimension, plan_dimensions
+
+__all__ = [
+    "BossFeature",
+    "Datum",
+    "DimParameter",
+    "Feature",
+    "Frame",
+    "HoleFeature",
+    "PartModel",
+    "PlannedDimension",
+    "StepFeature",
+    "build_part_model",
+    "plan_dimensions",
+]

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -1,0 +1,94 @@
+"""detect — build the part-model IR by running the feature detectors (ADR 0008).
+
+The front-end of the compiler. Each detector is an existing recognition heuristic
+(:func:`find_holes`, :func:`find_turned_steps`, :func:`find_bosses`) adapted to
+*emit* IR `Feature` objects — their B-rep logic is unchanged; only their output
+shape is normalised into the waist. New shapes plug in here as new detectors
+emitting new `Feature` types.
+
+Turned profile and bosses are complementary, not competing (the #191 review): a
+turned part is described by its `StepFeature`s (length + OD per segment); a
+non-turned part's external diameters come from `BossFeature`s. Holes are detected
+for any part.
+"""
+
+from __future__ import annotations
+
+from draftwright._core import _axis_letter
+from draftwright.model.ir import (
+    BossFeature,
+    Feature,
+    Frame,
+    HoleFeature,
+    PartModel,
+    Point,
+    StepFeature,
+)
+from draftwright.recognition import find_bosses, find_holes, find_turned_steps
+
+
+def _pt(loc) -> Point:
+    """A build123d Vector or sequence → an (x, y, z) tuple."""
+    if hasattr(loc, "X"):
+        return (loc.X, loc.Y, loc.Z)
+    x, y, z = loc
+    return (float(x), float(y), float(z))
+
+
+def _distinct_by_diameter(bosses, tol: float = 0.15):
+    """One representative boss per distinct external diameter."""
+    out: dict[float, object] = {}
+    for b in bosses:
+        key = next((k for k in out if abs(k - b.diameter) <= tol), b.diameter)
+        out.setdefault(key, b)
+    return list(out.values())
+
+
+def build_part_model(part) -> PartModel:
+    """Run the detectors and assemble the :class:`PartModel` IR for *part*."""
+    bbox = part.bounding_box()
+    features: list[Feature] = []
+
+    # Holes — any orientation.
+    for h in find_holes(part):
+        features.append(
+            HoleFeature(
+                frame=Frame(origin=_pt(h.location), axis=_axis_letter(h)),
+                diameter=h.diameter,
+                depth=h.depth,
+                through=(h.bottom == "through"),
+            )
+        )
+
+    # Turned profile → step segments; else external bosses → diameters.
+    prof = find_turned_steps(part)
+    orientation = prof.axis if prof is not None else None
+    if prof is not None:
+        idx = "xyz".index(prof.axis)
+        c = bbox.center()
+        base = [c.X, c.Y, c.Z]
+        for s in prof.steps:
+            lo = list(base)
+            hi = list(base)
+            lo[idx] = s.lo
+            hi[idx] = s.hi
+            mid = list(base)
+            mid[idx] = (s.lo + s.hi) / 2
+            features.append(
+                StepFeature(
+                    frame=Frame(origin=(mid[0], mid[1], mid[2]), axis=prof.axis),
+                    length=s.length,
+                    diameter=s.diameter,
+                    span=((lo[0], lo[1], lo[2]), (hi[0], hi[1], hi[2])),
+                )
+            )
+    else:
+        for b in _distinct_by_diameter(find_bosses(part)):
+            features.append(
+                BossFeature(
+                    frame=Frame(origin=_pt(b.location), axis=_axis_letter(b)),
+                    diameter=b.diameter,
+                )
+            )
+
+    return PartModel(bbox=bbox, orientation=orientation, features=features)

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1,0 +1,147 @@
+"""ir — the part-drawing compiler's intermediate representation (ADR 0008).
+
+The narrow waist between recognition and dimensioning. Two protocols carry the
+weight:
+
+- `DimParameter` — the universal currency of dimensioning: a single measurable
+  quantity (a diameter, a length, a depth, …) with the value, the rendered label,
+  the model-space extent it spans, and the datums it is measured from. Every
+  feature, of every kind, describes itself as a list of these.
+- `Feature` — anything dimensionable (a hole, a turned step, a boss, later a slot
+  / chamfer / gear …). It exposes its `parameters()` and `references()`. **Adding
+  a new shape is adding a new `Feature` type** — no change to the planner, the
+  layout, or any other feature (Open/Closed).
+
+`PartModel` is the whole-part IR the planner consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar, Literal, Protocol, runtime_checkable
+
+Point = tuple[float, float, float]
+ParamKind = Literal["diameter", "length", "depth", "radius", "angle", "location", "thread"]
+
+
+@dataclass(frozen=True)
+class Frame:
+    """A feature's location and dominant orientation in part space.
+
+    ``axis`` is the dominant axis letter (``"x"``/``"y"``/``"z"``) — enough for the
+    prototype; it generalises to a full direction vector when a feature needs it.
+    """
+
+    origin: Point
+    axis: str
+
+
+@dataclass(frozen=True)
+class Datum:
+    """A reference the planner measures from (a face/axis/point). Minimal here."""
+
+    id: str
+    kind: Literal["plane", "axis", "point"]
+    at: Point
+
+
+@dataclass(frozen=True)
+class DimParameter:
+    """One measurable quantity a drawing must show for a feature."""
+
+    kind: ParamKind
+    value: float
+    label: str
+    span: tuple[Point, Point] | None = None
+    refs: tuple[str, ...] = ()
+
+
+@runtime_checkable
+class Feature(Protocol):
+    """Anything dimensionable. Implementations are plain (frozen) dataclasses, so
+    ``kind`` is a class variable and ``frame`` is read-only."""
+
+    kind: ClassVar[str]
+
+    @property
+    def frame(self) -> Frame: ...
+
+    def parameters(self) -> list[DimParameter]: ...
+
+    def references(self) -> list[Datum]: ...
+
+
+@dataclass(frozen=True)
+class HoleFeature:
+    """A drilled hole — bore diameter, depth (blind), and location from datums."""
+
+    frame: Frame
+    diameter: float
+    depth: float | None
+    through: bool
+    count: int = 1
+    kind: ClassVar[str] = "hole"
+
+    def parameters(self) -> list[DimParameter]:
+        n = f"{self.count}× " if self.count > 1 else ""
+        ps = [DimParameter("diameter", self.diameter, f"{n}ø{_fmt(self.diameter)}")]
+        if not self.through and self.depth is not None:
+            ps.append(DimParameter("depth", self.depth, f"↧{_fmt(self.depth)}"))
+        ps.append(
+            DimParameter("location", 0.0, "loc", span=(self.frame.origin, self.frame.origin))
+        )
+        return ps
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
+class StepFeature:
+    """One axial segment of a turned profile — its length and its OD."""
+
+    frame: Frame
+    length: float
+    diameter: float
+    span: tuple[Point, Point]
+    kind: ClassVar[str] = "step"
+
+    def parameters(self) -> list[DimParameter]:
+        return [
+            DimParameter("length", self.length, _fmt(self.length), span=self.span),
+            DimParameter("diameter", self.diameter, f"ø{_fmt(self.diameter)}"),
+        ]
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
+class BossFeature:
+    """An external cylindrical boss/OD on a non-turned part — its diameter."""
+
+    frame: Frame
+    diameter: float
+    kind: ClassVar[str] = "boss"
+
+    def parameters(self) -> list[DimParameter]:
+        return [DimParameter("diameter", self.diameter, f"ø{_fmt(self.diameter)}")]
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass
+class PartModel:
+    """The whole-part IR: the oriented part plus its features and datums."""
+
+    bbox: object  # build123d BoundBox
+    orientation: str | None  # turning axis if rotational, else None
+    features: list[Feature] = field(default_factory=list)
+    datums: list[Datum] = field(default_factory=list)
+
+
+def _fmt(v: float) -> str:
+    """Local number formatter (mirrors `_core._fmt`; kept local so the prototype
+    has no upward import). Integers render without a trailing ``.0``."""
+    return f"{v:.0f}" if abs(v - round(v)) < 1e-6 else f"{v:.1f}"

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -1,0 +1,71 @@
+"""planner — the dimensioning back-end over the IR (ADR 0008).
+
+One rule set over `DimParameter`s, regardless of which feature produced them.
+"A turned part's step lengths", "a hole's depth", "a slot's width" all arrive as
+`DimParameter`s and are planned uniformly: a *convention* (how to dimension it) and
+a *view* (where) are chosen by rule, and redundant measurements are dropped. This
+is the logic currently reimplemented per-pass; here it is centralised so a new
+feature inherits placement for free.
+
+Prototype scope: enough rules to prove the protocol (convention + view selection,
+diameter de-duplication). The full ISO/ASME rule set — datum selection, ordinate
+vs chain by crowding, GD&T — grows here as real features demand it, not before.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from draftwright.model.ir import DimParameter, PartModel
+
+# How each (feature kind, parameter kind) is drawn. Defaults keep the table small.
+_CONVENTION = {
+    ("step", "length"): "chain",  # shoulder-to-shoulder run
+    ("step", "diameter"): "leader",
+    ("hole", "diameter"): "leader",
+    ("hole", "depth"): "leader",  # part of the hole callout
+    ("boss", "diameter"): "leader",
+}
+
+
+@dataclass(frozen=True)
+class PlannedDimension:
+    """A `DimParameter` with the convention and view the planner chose for it."""
+
+    param: DimParameter
+    feature_kind: str
+    convention: str  # "chain" | "ordinate" | "leader" | "linear"
+    view: str  # "front" | "plan" | "side" (placement intent)
+
+
+def _view(orientation: str | None, param_kind: str) -> str:
+    """The view that shows this parameter. For a turned part the lengthwise view is
+    the front view (the axis lies in the X–Z plane); holes default to the plan."""
+    if param_kind in ("length", "diameter"):
+        return "front"
+    return "plan"
+
+
+def plan_dimensions(model: PartModel) -> list[PlannedDimension]:
+    """Plan one dimension per `DimParameter`, applying convention/view rules and
+    dropping redundant diameters (the same OD measured by two features)."""
+    planned: list[PlannedDimension] = []
+    seen_diam: set[float] = set()
+    for feature in model.features:
+        for p in feature.parameters():
+            if p.kind == "location":
+                continue  # datum-relative location: out of prototype scope
+            if p.kind == "diameter":
+                key = round(p.value, 2)
+                if key in seen_diam:
+                    continue  # redundancy avoidance (ISO 129)
+                seen_diam.add(key)
+            planned.append(
+                PlannedDimension(
+                    param=p,
+                    feature_kind=feature.kind,
+                    convention=_CONVENTION.get((feature.kind, p.kind), "linear"),
+                    view=_view(model.orientation, p.kind),
+                )
+            )
+    return planned

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -1,0 +1,99 @@
+"""Prototype tests for the part-drawing compiler IR (ADR 0008).
+
+Proves the architecture's two claims on real geometry:
+1. Diverse features (holes + turned steps + bosses), from different detectors,
+   flow through ONE planner uniformly.
+2. A brand-new `Feature` type is dimensioned with ZERO changes to the planner —
+   the Open/Closed property the design exists for.
+"""
+
+from dataclasses import dataclass
+
+from build123d import Box, Cylinder, Pos
+
+from draftwright.model import (
+    BossFeature,
+    DimParameter,
+    Frame,
+    HoleFeature,
+    PartModel,
+    StepFeature,
+    build_part_model,
+    plan_dimensions,
+)
+
+
+def _z_stepped_bored():
+    """Vertical stepped shaft (ø30 then ø16) with a blind ø8 axial bore."""
+    shaft = Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)
+    return shaft - Pos(0, 0, 45) * Cylinder(4, 20)
+
+
+class TestBuildPartModel:
+    def test_turned_part_yields_steps_and_holes(self):
+        model = build_part_model(_z_stepped_bored())
+        assert model.orientation == "z"
+        kinds = sorted({f.kind for f in model.features})
+        assert "step" in kinds and "hole" in kinds
+        assert any(isinstance(f, StepFeature) for f in model.features)
+        assert any(isinstance(f, HoleFeature) for f in model.features)
+
+    def test_prismatic_part_yields_bosses_not_steps(self):
+        # A plate with one cylindrical boss — not a turned part.
+        model = build_part_model(Box(80, 60, 10) + Pos(0, 0, 10) * Cylinder(10, 8))
+        assert model.orientation is None
+        assert any(isinstance(f, BossFeature) for f in model.features)
+        assert not any(isinstance(f, StepFeature) for f in model.features)
+
+
+class TestPlanner:
+    def test_diverse_features_flow_through_one_planner(self):
+        plan = plan_dimensions(build_part_model(_z_stepped_bored()))
+        by_kind = {}
+        for pd in plan:
+            by_kind.setdefault(pd.param.kind, []).append(pd)
+        # step lengths planned as a chain; diameters as leaders
+        assert by_kind["length"] and all(pd.convention == "chain" for pd in by_kind["length"])
+        assert by_kind["diameter"] and all(pd.convention == "leader" for pd in by_kind["diameter"])
+        # the two OD steps (ø30, ø16) and the ø8 bore all appear, de-duplicated
+        diams = sorted(pd.param.value for pd in by_kind["diameter"])
+        assert diams == [8.0, 16.0, 30.0]
+
+    def test_redundant_diameters_are_dropped(self):
+        # Two features reporting the same diameter → one planned dimension.
+        feats = [
+            BossFeature(frame=Frame((0, 0, 0), "z"), diameter=12.0),
+            BossFeature(frame=Frame((50, 0, 0), "z"), diameter=12.0),
+        ]
+        plan = plan_dimensions(PartModel(bbox=None, orientation=None, features=feats))
+        assert [pd.param.value for pd in plan] == [12.0]
+
+
+class TestOpenClosed:
+    """The load-bearing claim: a new shape is a new Feature type, not a new branch."""
+
+    def test_new_feature_type_needs_no_planner_change(self):
+        @dataclass(frozen=True)
+        class KeywayFeature:
+            frame: Frame
+            width: float
+            length: float
+            kind = "keyway"
+
+            def parameters(self):
+                return [
+                    DimParameter("length", self.length, f"{self.length:.0f}"),
+                    DimParameter("length", self.width, f"{self.width:.0f}"),
+                ]
+
+            def references(self):
+                return []
+
+        model = PartModel(
+            bbox=None,
+            orientation=None,
+            features=[KeywayFeature(Frame((0, 0, 0), "x"), width=4.0, length=20.0)],
+        )
+        plan = plan_dimensions(model)  # planner is unchanged; it never heard of keyways
+        assert sorted(pd.param.value for pd in plan) == [4.0, 20.0]
+        assert all(pd.feature_kind == "keyway" for pd in plan)


### PR DESCRIPTION
Reframes the architecture and proves it with a working, tested prototype — the
response to "are we moving toward a clean, scalable model that survives complex
shapes without becoming spaghetti?"

## ADR 0008 rewritten

From "one unified model" (right instinct, too weak — the `find_bosses` review
showed recognisers are plural/complementary) to the **part-drawing compiler**: a
hourglass with a stable IR at the waist.

```
detectors (front-ends) → PART MODEL IR → dimensioning planner → existing layout
```

Two small protocols carry the weight:
- **`DimParameter`** — the universal currency of dimensioning (a diameter / length
  / depth / … with value, label, model-space span, datum refs).
- **`Feature`** — anything dimensionable; exposes `parameters()` + `references()`.

**Why it scales:** a new shape = a new `Feature` type + a detector, exposing
existing `DimParameter` kinds → **zero changes** to the planner, the layout, or any
other feature. Orientation becomes `frame` data, not `is_rotational`/`axis==`
branches — so the quadratic "recogniser × pass × orientation" coupling that
produces spaghetti cannot recur.

## Prototype (`src/draftwright/model/`, not yet wired into `build_drawing`)

- **`ir.py`** — `DimParameter`, `Feature` protocol, `HoleFeature`/`StepFeature`/
  `BossFeature`, `PartModel`.
- **`detect.py`** — `build_part_model`: adapts `find_holes`/`find_turned_steps`/
  `find_bosses` into `Feature` emitters (heuristics unchanged; complementary
  detectors per the #191 finding).
- **`planner.py`** — `plan_dimensions`: one rule set over `DimParameter`s
  (convention + view selection, diameter de-dup).

## Proof (`tests/test_part_model.py`)

1. Diverse features (holes + steps + bosses) from different detectors flow through
   **one** planner — e.g. a turned+bored shaft yields hole ⌀+depth, step lengths
   (chain), step diameters (leader) from one model.
2. **A brand-new `KeywayFeature` defined inside the test is dimensioned with zero
   planner changes** — the Open/Closed property the design exists for.

## Scope / honesty

Strangler step 1 of the rewritten ADR: this is the **proven spine alongside** the
working engine, not a rewrite of it. Migration (adapt detectors → introduce the
planner in production for holes first → move features one PR at a time) follows.
Recognition stays heuristic — the IR *contains* that mess, it doesn't eliminate
it. `ruff`/`format`/`mypy` clean; smoke 48 passed; additive (engine untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)