### PR TITLE
feat: hole patterns → PatternFeature (ADR 0008 Phase 2, #198)

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -60,13 +60,15 @@ class Feature(Protocol):              # hole, step, boss, slot, chamfer, gear, �
 @dataclass(frozen=True)
 class DimParameter:                   # the universal currency of dimensioning
     kind: Literal["diameter","length","depth","radius","angle","location","thread"]
+    role: str                         # semantic origin: bore/counterbore/step/boss/od/…
     value: float
-    label: str                        # rendered text, e.g. "ø8", "20", "M3"
     span: tuple[Point, Point] | None  # model-space extent, for placement
     refs: tuple[str, ...] = ()        # datum ids it is measured from
 ```
 
 A `PartModel` holds the oriented part, the `Feature` list, and the `Datum` set.
+**`DimParameter` carries a semantic `role`, not a rendered label** — see the
+amendment below; formatting and GD&T symbols are a renderer concern.
 
 ### 2. Why this survives arbitrary new shapes — Open/Closed by construction
 
@@ -88,6 +90,9 @@ chain vs ordinate, datum selection, redundancy/duplication avoidance, view choic
 **uniformly**. "A turned part's step lengths", "a hole's depth", "a slot's width"
 are all `DimParameter`s flowing through one planner. This is the logic currently
 reimplemented per-pass; centralising it is where the back-end stops rotting.
+
+The planner emits one **`DimensionGroup` per feature** (carrying the source
+feature + a single view), not a flat dimension list — see the amendment below.
 
 ### 4. The layout layer is untouched
 
@@ -115,6 +120,38 @@ and X/Z parity as standing criteria):
 5. **Generalise planner rules only after ~3 feature types** have stressed the
    `DimParameter` set — don't build a speculative rule engine (that is just
    framework-shaped spaghetti).
+
+## Amendment (2026-06-28) — contract refined by the prototype + reviews (#211, #212)
+
+Building the prototype and reviewing it (counterbore, then patterns) hardened the
+waist. The decisions, now in `src/draftwright/model/`:
+
+1. **`DimParameter` carries a semantic `role`, never a rendered label.** The pinned
+   font has no GD&T glyphs (`⌴`/`⌵`/`↧`), and the engine draws those as *geometry*,
+   not text — so baking a label into the IR is both wrong and font-fragile.
+   Formatting is a renderer concern; `display()` gives font-safe debug text. `role`
+   (bore / counterbore / step / boss / od / …) is what the planner reasons on.
+2. **The planner emits `DimensionGroup`s, not a flat list.** One group per feature,
+   carrying the **source feature** + a **single view** + its planned dims. This is
+   what lets a *compound* callout (a hole's bore + counterbore + depth) render as
+   one callout, lets a `PatternFeature` keep its `count`/`pattern` metadata across
+   the waist, and keeps the plan Open/Closed (a renderer reads whatever feature
+   metadata it needs without the plan growing a field per feature type).
+3. **Redundancy is feature-aware, never value-blind.** The planner does not
+   collapse two parameters merely because they share a value (a counterbore ø16
+   and a boss ø16; a 10×10 pocket's two 10 mm lengths both survive). Count of
+   *repeated identical features* (`6× ø8`) is upstream — a `PatternFeature`, not a
+   planner dedup.
+4. **View + anchor are group-level and axis-derived.** A group's view comes from
+   the feature's axis by one rule for all axes (a diameter callout end-on:
+   `z→plan`, `x→side`, `y→front`; a turned step's length+OD on the lengthwise
+   `front`) — orientation is data, so X and Z are symmetric. The anchor is the
+   feature's frame origin.
+
+Still open (tracked, gate-protected, for the wiring phases): the view/routing must
+become *model-aware* for turned concentric bores (front bore-leader + section, not
+the generic end-on rule — #201) and for a rotational OD on a single-OD turned part
+(profile view, not end-on — #205).
 
 ## Consequences
 

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -27,6 +27,7 @@ from draftwright.model.ir import (
     Frame,
     HoleFeature,
     PartModel,
+    PatternFeature,
     StepFeature,
     display,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "Frame",
     "HoleFeature",
     "PartModel",
+    "PatternFeature",
     "PlannedDimension",
     "StepFeature",
     "build_part_model",

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -44,42 +44,43 @@ def _pt(loc) -> Point:
     return (float(x), float(y), float(z))
 
 
+def _member_hole(h, frame: Frame) -> HoleFeature:
+    """A recogniser hole → an IR `HoleFeature` (bore + counterbore/spotface)."""
+    return HoleFeature(
+        frame=frame,
+        diameter=h.diameter,
+        depth=h.depth,
+        through=(h.bottom == "through"),
+        cbore=(h.cbore.diameter, h.cbore.depth) if h.cbore else None,
+        spotface=(h.spotface.diameter, h.spotface.depth) if h.spotface else None,
+    )
+
+
 def _pattern_feature(pat, members) -> PatternFeature:
-    """Map a recognised pattern + its member holes to a `PatternFeature`."""
+    """Map a recognised pattern + its member holes to a `PatternFeature`,
+    composing a representative member hole so its counterbore/spotface survive."""
     axis = _axis_letter(members[0])
-    dia = members[0].diameter
     n = len(members)
     if isinstance(pat, BoltCircle):
+        frame = Frame(_pt(pat.center), axis)
         return PatternFeature(
-            frame=Frame(_pt(pat.center), axis),
-            pattern="bolt_circle",
-            count=n,
-            hole_diameter=dia,
-            bcd=pat.diameter,
+            frame, "bolt_circle", n, _member_hole(members[0], frame), bcd=pat.diameter
         )
     if isinstance(pat, LinearArray):
-        cx = sum(m.location[0] for m in members) / n
-        cy = sum(m.location[1] for m in members) / n
-        cz = sum(m.location[2] for m in members) / n
-        return PatternFeature(
-            frame=Frame((cx, cy, cz), axis),
-            pattern="linear",
-            count=n,
-            hole_diameter=dia,
-            pitch=pat.pitch,
+        c = (
+            sum(m.location[0] for m in members) / n,
+            sum(m.location[1] for m in members) / n,
+            sum(m.location[2] for m in members) / n,
         )
+        frame = Frame(c, axis)
+        return PatternFeature(frame, "linear", n, _member_hole(members[0], frame), pitch=pat.pitch)
     if isinstance(pat, RectGrid):
+        frame = Frame(_pt(pat.center), axis)
         return PatternFeature(
-            frame=Frame(_pt(pat.center), axis),
-            pattern="grid",
-            count=pat.rows * pat.cols,
-            hole_diameter=dia,
-            grid=(pat.row_pitch, pat.col_pitch),
+            frame, "grid", n, _member_hole(members[0], frame), grid=(pat.row_pitch, pat.col_pitch)
         )
-    # Unknown pattern type — represent it as a plain count× callout.
-    return PatternFeature(
-        frame=Frame(_pt(members[0].location), axis), pattern="other", count=n, hole_diameter=dia
-    )
+    frame = Frame(_pt(members[0].location), axis)  # unknown type — plain count× callout
+    return PatternFeature(frame, "other", n, _member_hole(members[0], frame))
 
 
 def _distinct_by_diameter(bosses, tol: float = 0.15):
@@ -109,16 +110,7 @@ def build_part_model(part) -> PartModel:
     for h in holes:
         if id(h) in patterned:
             continue
-        features.append(
-            HoleFeature(
-                frame=Frame(origin=_pt(h.location), axis=_axis_letter(h)),
-                diameter=h.diameter,
-                depth=h.depth,
-                through=(h.bottom == "through"),
-                cbore=(h.cbore.diameter, h.cbore.depth) if h.cbore else None,
-                spotface=(h.spotface.diameter, h.spotface.depth) if h.spotface else None,
-            )
-        )
+        features.append(_member_hole(h, Frame(origin=_pt(h.location), axis=_axis_letter(h))))
 
     # Turned profile → step segments; else external bosses → diameters.
     prof = find_turned_steps(part)

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -61,10 +61,16 @@ def _pattern_feature(pat, members) -> PatternFeature:
     composing a representative member hole so its counterbore/spotface survive."""
     axis = _axis_letter(members[0])
     n = len(members)
+    locs = tuple(_pt(m.location) for m in members)  # raw arrangement — never discarded
     if isinstance(pat, BoltCircle):
         frame = Frame(_pt(pat.center), axis)
         return PatternFeature(
-            frame, "bolt_circle", n, _member_hole(members[0], frame), bcd=pat.diameter
+            frame,
+            "bolt_circle",
+            n,
+            _member_hole(members[0], frame),
+            members=locs,
+            bcd=pat.diameter,
         )
     if isinstance(pat, LinearArray):
         c = (
@@ -73,14 +79,30 @@ def _pattern_feature(pat, members) -> PatternFeature:
             sum(m.location[2] for m in members) / n,
         )
         frame = Frame(c, axis)
-        return PatternFeature(frame, "linear", n, _member_hole(members[0], frame), pitch=pat.pitch)
+        return PatternFeature(
+            frame,
+            "linear",
+            n,
+            _member_hole(members[0], frame),
+            members=locs,
+            pitch=pat.pitch,
+            direction=tuple(pat.direction),
+        )
     if isinstance(pat, RectGrid):
         frame = Frame(_pt(pat.center), axis)
         return PatternFeature(
-            frame, "grid", n, _member_hole(members[0], frame), grid=(pat.row_pitch, pat.col_pitch)
+            frame,
+            "grid",
+            n,
+            _member_hole(members[0], frame),
+            members=locs,
+            grid=(pat.row_pitch, pat.col_pitch),
+            rows=pat.rows,
+            cols=pat.cols,
+            angle=pat.angle,
         )
     frame = Frame(_pt(members[0].location), axis)  # unknown type — plain count× callout
-    return PatternFeature(frame, "other", n, _member_hole(members[0], frame))
+    return PatternFeature(frame, "other", n, _member_hole(members[0], frame), members=locs)
 
 
 def _distinct_by_diameter(bosses, tol: float = 0.15):

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -21,10 +21,19 @@ from draftwright.model.ir import (
     Frame,
     HoleFeature,
     PartModel,
+    PatternFeature,
     Point,
     StepFeature,
 )
-from draftwright.recognition import find_bosses, find_holes, find_turned_steps
+from draftwright.recognition import (
+    BoltCircle,
+    LinearArray,
+    RectGrid,
+    find_bosses,
+    find_hole_patterns,
+    find_holes,
+    find_turned_steps,
+)
 
 
 def _pt(loc) -> Point:
@@ -33,6 +42,44 @@ def _pt(loc) -> Point:
         return (loc.X, loc.Y, loc.Z)
     x, y, z = loc
     return (float(x), float(y), float(z))
+
+
+def _pattern_feature(pat, members) -> PatternFeature:
+    """Map a recognised pattern + its member holes to a `PatternFeature`."""
+    axis = _axis_letter(members[0])
+    dia = members[0].diameter
+    n = len(members)
+    if isinstance(pat, BoltCircle):
+        return PatternFeature(
+            frame=Frame(_pt(pat.center), axis),
+            pattern="bolt_circle",
+            count=n,
+            hole_diameter=dia,
+            bcd=pat.diameter,
+        )
+    if isinstance(pat, LinearArray):
+        cx = sum(m.location[0] for m in members) / n
+        cy = sum(m.location[1] for m in members) / n
+        cz = sum(m.location[2] for m in members) / n
+        return PatternFeature(
+            frame=Frame((cx, cy, cz), axis),
+            pattern="linear",
+            count=n,
+            hole_diameter=dia,
+            pitch=pat.pitch,
+        )
+    if isinstance(pat, RectGrid):
+        return PatternFeature(
+            frame=Frame(_pt(pat.center), axis),
+            pattern="grid",
+            count=pat.rows * pat.cols,
+            hole_diameter=dia,
+            grid=(pat.row_pitch, pat.col_pitch),
+        )
+    # Unknown pattern type — represent it as a plain count× callout.
+    return PatternFeature(
+        frame=Frame(_pt(members[0].location), axis), pattern="other", count=n, hole_diameter=dia
+    )
 
 
 def _distinct_by_diameter(bosses, tol: float = 0.15):
@@ -49,8 +96,19 @@ def build_part_model(part) -> PartModel:
     bbox = part.bounding_box()
     features: list[Feature] = []
 
-    # Holes — any orientation; counterbore/spotface steps come along as params.
-    for h in find_holes(part):
+    # Holes and hole patterns. A recognised pattern becomes one PatternFeature
+    # (count× member-diameter + pattern dims); its member holes are NOT also
+    # emitted individually — the grouped-callout rule the engine uses.
+    holes = find_holes(part)
+    patterns = find_hole_patterns(holes)
+    patterned: set[int] = set()
+    for pat in patterns:
+        members = list(pat.holes)
+        patterned.update(id(h) for h in members)
+        features.append(_pattern_feature(pat, members))
+    for h in holes:
+        if id(h) in patterned:
+            continue
         features.append(
             HoleFeature(
                 frame=Frame(origin=_pt(h.location), axis=_axis_letter(h)),

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -147,22 +147,24 @@ class StepFeature:
 
 @dataclass(frozen=True)
 class PatternFeature:
-    """A recognised hole pattern (bolt circle / linear array / rect grid). It owns
-    the pattern-defining dimensions (BCD / pitch / grid pitches) and the shared
-    member-hole diameter as one ``count``× callout; the member holes are NOT also
-    emitted individually (mirrors the engine's grouped ``n× ø`` callout)."""
+    """A recognised hole pattern (bolt circle / linear array / rect grid) =
+    ``count`` × a `member` hole arranged by the pattern. It composes the member
+    `HoleFeature` (so the member's bore + counterbore/spotface/depth all come
+    along — a counterbored bolt circle keeps its counterbore) and adds the
+    pattern-defining dims (BCD / pitch / grid pitches). The member holes are NOT
+    emitted individually (the engine's grouped ``n× ø`` callout)."""
 
     frame: Frame
     pattern: str  # "bolt_circle" | "linear" | "grid"
     count: int
-    hole_diameter: float
+    member: HoleFeature
     bcd: float | None = None  # bolt-circle diameter
     pitch: float | None = None  # linear pitch
     grid: tuple[float, float] | None = None  # (row_pitch, col_pitch)
     kind: ClassVar[str] = "pattern"
 
     def parameters(self) -> list[DimParameter]:
-        ps = [DimParameter("diameter", "pattern_hole", self.hole_diameter)]
+        ps = list(self.member.parameters())  # bore (+ counterbore / spotface / depth)
         if self.bcd is not None:
             ps.append(DimParameter("diameter", "bolt_circle", self.bcd))
         if self.pitch is not None:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -146,6 +146,38 @@ class StepFeature:
 
 
 @dataclass(frozen=True)
+class PatternFeature:
+    """A recognised hole pattern (bolt circle / linear array / rect grid). It owns
+    the pattern-defining dimensions (BCD / pitch / grid pitches) and the shared
+    member-hole diameter as one ``count``× callout; the member holes are NOT also
+    emitted individually (mirrors the engine's grouped ``n× ø`` callout)."""
+
+    frame: Frame
+    pattern: str  # "bolt_circle" | "linear" | "grid"
+    count: int
+    hole_diameter: float
+    bcd: float | None = None  # bolt-circle diameter
+    pitch: float | None = None  # linear pitch
+    grid: tuple[float, float] | None = None  # (row_pitch, col_pitch)
+    kind: ClassVar[str] = "pattern"
+
+    def parameters(self) -> list[DimParameter]:
+        ps = [DimParameter("diameter", "pattern_hole", self.hole_diameter)]
+        if self.bcd is not None:
+            ps.append(DimParameter("diameter", "bolt_circle", self.bcd))
+        if self.pitch is not None:
+            ps.append(DimParameter("length", "pitch", self.pitch))
+        if self.grid is not None:
+            rp, cp = self.grid
+            ps.append(DimParameter("length", "grid_pitch", rp))
+            ps.append(DimParameter("length", "grid_pitch", cp))
+        return ps
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
 class BossFeature:
     """An external cylindrical boss/OD on a non-turned part — its diameter."""
 

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -158,9 +158,14 @@ class PatternFeature:
     pattern: str  # "bolt_circle" | "linear" | "grid"
     count: int
     member: HoleFeature
+    members: tuple[Point, ...] = ()  # ordered member-hole centres (raw arrangement)
     bcd: float | None = None  # bolt-circle diameter
     pitch: float | None = None  # linear pitch
+    direction: tuple[float, float, float] | None = None  # linear array axis
     grid: tuple[float, float] | None = None  # (row_pitch, col_pitch)
+    rows: int | None = None
+    cols: int | None = None
+    angle: float | None = None  # grid lattice rotation (degrees)
     kind: ClassVar[str] = "pattern"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -49,13 +49,25 @@ class PlannedDimension:
 
 @dataclass(frozen=True)
 class DimensionGroup:
-    """A feature's planned dimensions, kept together with the feature's anchor and a
-    single view so a compound callout renders as one callout in one place."""
+    """A feature's planned dimensions, kept together with the source feature and a
+    single view so a compound callout renders as one callout in one place.
 
-    feature_kind: str
+    Carrying the source `feature` (rather than copying selected fields) keeps the
+    plan Open/Closed: a grouped renderer reads whatever metadata it needs —
+    `count`/`pattern` for a pattern, a thread spec later — without the plan
+    contract growing a field per feature type."""
+
+    feature: Feature
     view: str  # one view for the whole group
-    anchor: Point  # the feature's location (Feature.frame.origin)
     dims: tuple[PlannedDimension, ...]
+
+    @property
+    def feature_kind(self) -> str:
+        return self.feature.kind
+
+    @property
+    def anchor(self) -> Point:
+        return self.feature.frame.origin
 
 
 def _group_view(feature: Feature) -> str:
@@ -81,11 +93,6 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
         ]
         if dims:
             groups.append(
-                DimensionGroup(
-                    feature_kind=feature.kind,
-                    view=_group_view(feature),
-                    anchor=feature.frame.origin,
-                    dims=tuple(dims),
-                )
+                DimensionGroup(feature=feature, view=_group_view(feature), dims=tuple(dims))
             )
     return groups

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -38,6 +38,9 @@ _CONVENTION = {
     ("spotface", "diameter"): "leader",
     ("spotface", "depth"): "leader",
     ("boss", "diameter"): "leader",
+    ("bolt_circle", "diameter"): "leader",  # BCD (a pitch-circle diameter)
+    ("pitch", "length"): "pitch",  # linear-array pitch — distinct from a plain linear dim
+    ("grid_pitch", "length"): "pitch",
 }
 
 

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -19,6 +19,7 @@ from draftwright.model import (
     Frame,
     HoleFeature,
     PartModel,
+    PatternFeature,
     StepFeature,
     build_part_model,
     display,
@@ -59,6 +60,37 @@ class TestBuildPartModel:
         assert model.orientation is None
         assert any(isinstance(f, BossFeature) for f in model.features)
         assert not any(isinstance(f, StepFeature) for f in model.features)
+
+    def test_bolt_circle_is_one_pattern_not_six_holes(self):
+        import math
+
+        part = Cylinder(40, 8)
+        for i in range(6):
+            a = i * math.pi / 3
+            part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
+        model = build_part_model(part)
+        pats = [f for f in model.features if isinstance(f, PatternFeature)]
+        assert len(pats) == 1
+        p = pats[0]
+        assert p.pattern == "bolt_circle" and p.count == 6
+        assert p.hole_diameter == 6.0 and p.bcd == 50.0
+        # the 6 member holes are NOT also emitted individually
+        assert not any(isinstance(f, HoleFeature) for f in model.features)
+
+    def test_linear_array_carries_pitch(self):
+        part = Box(100, 20, 10)
+        for x in (-30, -10, 10, 30):
+            part -= Pos(x, 0, 0) * Cylinder(3, 20)
+        pats = [f for f in build_part_model(part).features if isinstance(f, PatternFeature)]
+        assert pats and pats[0].pattern == "linear" and pats[0].pitch == 20.0
+
+    def test_rect_grid_carries_pitches(self):
+        part = Box(80, 80, 10)
+        for x in (-20, 0, 20):
+            for y in (-20, 0, 20):
+                part -= Pos(x, y, 0) * Cylinder(3, 20)
+        pats = [f for f in build_part_model(part).features if isinstance(f, PatternFeature)]
+        assert pats and pats[0].pattern == "grid" and pats[0].grid == (20.0, 20.0)
 
 
 class TestPlanner:

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -95,20 +95,28 @@ class TestBuildPartModel:
         assert params[("diameter", "counterbore")] == 12.0  # counterbore kept
         assert params[("diameter", "bolt_circle")] == 50.0  # BCD
 
-    def test_linear_array_carries_pitch(self):
+    def test_linear_array_carries_pitch_and_arrangement(self):
         part = Box(100, 20, 10)
         for x in (-30, -10, 10, 30):
             part -= Pos(x, 0, 0) * Cylinder(3, 20)
         pats = [f for f in build_part_model(part).features if isinstance(f, PatternFeature)]
-        assert pats and pats[0].pattern == "linear" and pats[0].pitch == 20.0
+        assert pats
+        p = pats[0]
+        assert p.pattern == "linear" and p.pitch == 20.0
+        # arrangement geometry the renderer needs is NOT discarded:
+        assert p.direction is not None and len(p.members) == 4
 
-    def test_rect_grid_carries_pitches(self):
+    def test_rect_grid_carries_pitches_and_lattice(self):
         part = Box(80, 80, 10)
         for x in (-20, 0, 20):
             for y in (-20, 0, 20):
                 part -= Pos(x, y, 0) * Cylinder(3, 20)
         pats = [f for f in build_part_model(part).features if isinstance(f, PatternFeature)]
-        assert pats and pats[0].pattern == "grid" and pats[0].grid == (20.0, 20.0)
+        assert pats
+        p = pats[0]
+        assert p.pattern == "grid" and p.grid == (20.0, 20.0)
+        # rows/cols/angle + member locations survive (the gratuitous-loss the review found):
+        assert p.rows == 3 and p.cols == 3 and p.angle is not None and len(p.members) == 9
 
 
 class TestPlanner:

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -188,6 +188,21 @@ class TestPlanner:
         assert hole_view(z_hole) == "plan"  # Z hole seen end-on in plan
         assert hole_view(x_hole) == "side"  # X hole seen end-on in side — not 'plan'
 
+    def test_pattern_count_survives_the_planner(self):
+        # The planned group must still expose the feature metadata (count, pattern)
+        # so a renderer can emit "6× ø6", not just ø6 + ø50 (the narrow-waist gap
+        # the review found). The plan carries the source feature.
+        import math
+
+        part = Box(100, 100, 10)
+        for i in range(6):
+            a = i * math.pi / 3
+            part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
+        g = next(g for g in plan_dimensions(build_part_model(part)) if g.feature_kind == "pattern")
+        assert g.feature.count == 6
+        assert g.feature.pattern == "bolt_circle"
+        assert g.feature.bcd == 50.0
+
     def test_labels_are_font_safe(self):
         # display() must not emit GD&T glyphs the pinned font lacks (⌴/⌵/↧).
         for sym in ("⌴", "⌵", "↧"):

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -73,9 +73,27 @@ class TestBuildPartModel:
         assert len(pats) == 1
         p = pats[0]
         assert p.pattern == "bolt_circle" and p.count == 6
-        assert p.hole_diameter == 6.0 and p.bcd == 50.0
+        assert p.member.diameter == 6.0 and p.bcd == 50.0
         # the 6 member holes are NOT also emitted individually
         assert not any(isinstance(f, HoleFeature) for f in model.features)
+
+    def test_counterbored_pattern_keeps_its_counterbore(self):
+        # A counterbored bolt circle must NOT lose the counterbore (the adversarial
+        # review found PatternFeature dropping it). Composing the member HoleFeature
+        # carries bore + counterbore through to the pattern's parameters.
+        import math
+
+        part = Cylinder(40, 12)
+        for i in range(6):
+            a = i * math.pi / 3
+            cx, cy = 25 * math.cos(a), 25 * math.sin(a)
+            part -= Pos(cx, cy, 0) * Cylinder(3, 30)  # ø6 bore
+            part -= Pos(cx, cy, 4) * Cylinder(6, 12)  # ø12 counterbore
+        pat = next(f for f in build_part_model(part).features if isinstance(f, PatternFeature))
+        params = {(dp.kind, dp.role): dp.value for dp in pat.parameters()}
+        assert params[("diameter", "bore")] == 6.0  # the n× bore
+        assert params[("diameter", "counterbore")] == 12.0  # counterbore kept
+        assert params[("diameter", "bolt_circle")] == 50.0  # BCD
 
     def test_linear_array_carries_pitch(self):
         part = Box(100, 20, 10)


### PR DESCRIPTION
Closes #198. Phase 2 of the ADR-0008 migration (#195).

Adapts `find_hole_patterns` into a **`PatternFeature`** in the IR. A recognised
pattern (bolt circle / linear array / rect grid) becomes **one** feature carrying:
- the pattern-defining dims — **BCD** (bolt circle), **pitch** (linear), **row+col
  pitch** (grid);
- the shared member-hole diameter as a `count×` callout.

`build_part_model` now detects patterns first and emits individual `HoleFeature`s
**only for holes in no pattern** — the grouped-callout rule the engine uses, so a
6-hole bolt circle is one `n× ø` callout, not six (and not double-counted).

## Scope / verification
- **Parallel model only** — `build_drawing` untouched; migration gate unchanged
  (**18 passed**).
- New tests: bolt circle (1 pattern, count 6, BCD 50, members not double-emitted),
  linear pitch, rect-grid pitches. Prototype suite **13 passed**; ruff/format/mypy
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)