### PR TITLE
feat: renderer seam — DimensionGroup → placed HoleCallout (ADR 0008, #201 start)

### DIFF
--- a/src/draftwright/model/render.py
+++ b/src/draftwright/model/render.py
@@ -1,0 +1,80 @@
+"""render — the renderer seam: DimensionGroup → placed annotations (ADR 0008).
+
+The **first real consumer** of the planner output, validating the IR/planner
+contract end-to-end. A hole/pattern group is read *purely from its planned
+parameters* (+ the feature's `count`) and turned into a placed `HoleCallout`
+leader via the existing projection (`Drawing.at`) and rendering primitives. GD&T
+symbols (⌴/↧) are the helper's geometry, which is exactly why the IR carries
+semantic `role`s, not glyph strings.
+
+This is the planner→layout seam. It does **not** yet replace the engine's hole
+placement — that swap-in, under the migration gate, is #201. Here it proves the
+contract carries what a renderer needs, and surfaces gaps before wiring. Kept out
+of `draftwright.model.__init__` so the pure IR stays free of any helpers import.
+"""
+
+from __future__ import annotations
+
+from build123d_drafting.helpers import HoleCallout, Leader
+
+from draftwright.model.planner import DimensionGroup
+
+
+def _value(group: DimensionGroup, kind: str, role: str) -> float | None:
+    for pd in group.dims:
+        if pd.param.kind == kind and pd.param.role == role:
+            return pd.param.value
+    return None
+
+
+def hole_callout_spec(group: DimensionGroup) -> dict | None:
+    """A hole/pattern group's planned params → `HoleCallout` kwargs (the renderer's
+    reading of the plan). ``None`` if the group is not a hole-bearing callout.
+
+    Everything comes from the plan: the bore/counterbore values from
+    `DimParameter` roles, ``through`` inferred from the absence of a bore-depth
+    param, and ``count`` from the source feature (so a 6-hole bolt circle is one
+    ``6× ø6`` callout)."""
+    if group.feature_kind not in ("hole", "pattern"):
+        return None
+    bore = _value(group, "diameter", "bore")
+    if bore is None:
+        return None
+    depth = _value(group, "depth", "bore")
+    count = getattr(group.feature, "count", 1)
+    return {
+        "diameter": bore,
+        "count": count if count and count > 1 else None,
+        "through": depth is None,
+        "depth": depth,
+        "cbore_dia": _value(group, "diameter", "counterbore"),
+        "cbore_depth": _value(group, "depth", "counterbore"),
+    }
+
+
+def render_callouts(dwg, groups) -> list[Leader]:
+    """Build placed `HoleCallout` leaders for the hole/pattern groups, projecting
+    each group's anchor into its view. Returns the annotations; does not mutate
+    *dwg* (the swap-in that adds them to the drawing is #201)."""
+    out: list[Leader] = []
+    for g in groups:
+        spec = hole_callout_spec(g)
+        if spec is None:
+            continue
+        callout = HoleCallout(
+            spec["diameter"],
+            count=spec["count"],
+            through=spec["through"],
+            depth=spec["depth"],
+            cbore_dia=spec["cbore_dia"],
+            cbore_depth=spec["cbore_depth"],
+            draft=dwg.draft,
+        )
+        tip = dwg.at(g.view, *g.anchor)
+        elbow = (tip[0] + 12.0, tip[1] + 8.0, 0)
+        out.append(
+            Leader(
+                tip=(tip[0], tip[1], 0), elbow=elbow, label="", draft=dwg.draft, callout=callout
+            )
+        )
+    return out

--- a/src/draftwright/model/render.py
+++ b/src/draftwright/model/render.py
@@ -17,45 +17,60 @@ from __future__ import annotations
 
 from build123d_drafting.helpers import HoleCallout, Leader
 
+from draftwright._core import _fmt
 from draftwright.model.planner import DimensionGroup
 
 
-def _value(group: DimensionGroup, kind: str, role: str) -> float | None:
-    for pd in group.dims:
-        if pd.param.kind == kind and pd.param.role == role:
-            return pd.param.value
+def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
+    """First parameter value matching *kind* and any of *roles*, in role order."""
+    for role in roles:
+        for pd in group.dims:
+            if pd.param.kind == kind and pd.param.role == role:
+                return pd.param.value
     return None
 
 
 def hole_callout_spec(group: DimensionGroup) -> dict | None:
-    """A hole/pattern group's planned params → `HoleCallout` kwargs (the renderer's
-    reading of the plan). ``None`` if the group is not a hole-bearing callout.
+    """A hole/pattern group's plan → `HoleCallout` kwargs, mirroring the engine's
+    convention. ``None`` if not a hole-bearing callout.
 
-    Everything comes from the plan: the bore/counterbore values from
-    `DimParameter` roles, ``through`` inferred from the absence of a bore-depth
-    param, and ``count`` from the source feature (so a 6-hole bolt circle is one
-    ``6× ø6`` callout)."""
+    From the plan: bore from `DimParameter` roles; the cbore/spotface *step* with
+    counterbore precedence (``step = cbore or spotface``, as the engine does);
+    ``through`` inferred from the absence of a bore-depth param; ``count`` and the
+    pattern *suffix* (``EQ SP ON ø50 BC`` / ``(3×3)``) from the source feature."""
     if group.feature_kind not in ("hole", "pattern"):
         return None
-    bore = _value(group, "diameter", "bore")
+    bore = _first(group, "diameter", "bore")
     if bore is None:
         return None
-    depth = _value(group, "depth", "bore")
-    count = getattr(group.feature, "count", 1)
+    depth = _first(group, "depth", "bore")
+    feat = group.feature
+    count = getattr(feat, "count", 1)
+    suffix = None
+    pattern = getattr(feat, "pattern", None)
+    bcd = getattr(feat, "bcd", None)
+    rows, cols = getattr(feat, "rows", None), getattr(feat, "cols", None)
+    if pattern == "bolt_circle" and bcd is not None:
+        suffix = f"EQ SP ON ø{_fmt(bcd)} BC"
+    elif pattern == "grid" and rows and cols:
+        suffix = f"({rows}×{cols})"
     return {
         "diameter": bore,
         "count": count if count and count > 1 else None,
         "through": depth is None,
         "depth": depth,
-        "cbore_dia": _value(group, "diameter", "counterbore"),
-        "cbore_depth": _value(group, "depth", "counterbore"),
+        # counterbore precedence, spotface fallback — the engine's mapping
+        "cbore_dia": _first(group, "diameter", "counterbore", "spotface"),
+        "cbore_depth": _first(group, "depth", "counterbore", "spotface"),
+        "suffix": suffix,
     }
 
 
 def render_callouts(dwg, groups) -> list[Leader]:
-    """Build placed `HoleCallout` leaders for the hole/pattern groups, projecting
-    each group's anchor into its view. Returns the annotations; does not mutate
-    *dwg* (the swap-in that adds them to the drawing is #201)."""
+    """Build placed `HoleCallout` leaders for the hole/pattern groups. The leader
+    tips at a real member hole (not the empty pattern centre), projected into the
+    group's view. Returns the annotations; does not mutate *dwg* (the swap-in that
+    adds them is #201)."""
     out: list[Leader] = []
     for g in groups:
         spec = hole_callout_spec(g)
@@ -68,9 +83,14 @@ def render_callouts(dwg, groups) -> list[Leader]:
             depth=spec["depth"],
             cbore_dia=spec["cbore_dia"],
             cbore_depth=spec["cbore_depth"],
+            suffix=spec["suffix"],
             draft=dwg.draft,
         )
-        tip = dwg.at(g.view, *g.anchor)
+        # Point at a member hole for a pattern (the centre has no hole); the hole
+        # itself otherwise.
+        members = getattr(g.feature, "members", ())
+        tip_model = members[0] if members else g.anchor
+        tip = dwg.at(g.view, *tip_model)
         elbow = (tip[0] + 12.0, tip[1] + 8.0, 0)
         out.append(
             Leader(

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -1,0 +1,70 @@
+"""Renderer-seam tests (ADR 0008) — the first real consumer of the planner output.
+
+Validates that the IR/planner contract carries what a renderer needs to build a
+hole callout: the bore/counterbore values, blind-vs-through, and the pattern count
+all reconstruct from the plan, and the seam produces placed callout leaders via the
+real projection + helpers. (Content correctness vs the engine is the gate's job at
+the #201 swap-in; here we prove the seam mechanically and at the spec level.)
+"""
+
+import math
+
+from build123d import Box, Cylinder, Pos
+from build123d_drafting.helpers import Leader
+
+from draftwright import build_drawing
+from draftwright.model import build_part_model, plan_dimensions
+from draftwright.model.render import hole_callout_spec, render_callouts
+
+
+def _groups(part):
+    return plan_dimensions(build_part_model(part))
+
+
+def _hole_or_pattern_spec(part):
+    g = next(g for g in _groups(part) if g.feature_kind in ("hole", "pattern"))
+    return hole_callout_spec(g)
+
+
+class TestCalloutSpec:
+    def test_simple_through_hole(self):
+        part = Box(60, 60, 12) - Pos(0, 0, 0) * Cylinder(4, 30)
+        s = _hole_or_pattern_spec(part)
+        assert s["diameter"] == 8.0 and s["through"] is True
+        assert s["count"] is None and s["cbore_dia"] is None
+
+    def test_blind_hole_carries_depth(self):
+        part = Box(60, 60, 20) - Pos(0, 0, 6) * Cylinder(4, 16)  # blind ø8
+        s = _hole_or_pattern_spec(part)
+        assert s["diameter"] == 8.0 and s["through"] is False and s["depth"] is not None
+
+    def test_counterbored_hole(self):
+        part = Box(60, 60, 16) - Pos(0, 0, 0) * Cylinder(4, 30) - Pos(0, 0, 4) * Cylinder(8, 12)
+        s = _hole_or_pattern_spec(part)
+        assert s["diameter"] == 8.0
+        assert s["cbore_dia"] == 16.0 and s["cbore_depth"] is not None
+
+    def test_bolt_circle_is_one_counted_callout(self):
+        part = Cylinder(40, 8)
+        for i in range(6):
+            a = i * math.pi / 3
+            part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
+        s = _hole_or_pattern_spec(part)
+        assert s["diameter"] == 6.0 and s["count"] == 6  # 6× ø6, not six callouts
+
+
+class TestRender:
+    def test_produces_placed_callout_leaders(self):
+        part = Box(80, 60, 12) - Pos(20, 0, 0) * Cylinder(4, 30) - Pos(-20, 0, 0) * Cylinder(4, 30)
+        dwg = build_drawing(part, number="X")
+        anns = render_callouts(dwg, _groups(part))
+        assert len(anns) == 2 and all(isinstance(a, Leader) for a in anns)  # one per hole, placed
+
+    def test_bolt_circle_renders_one_leader_not_six(self):
+        part = Cylinder(40, 8)
+        for i in range(6):
+            a = i * math.pi / 3
+            part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
+        dwg = build_drawing(part, number="X")
+        anns = render_callouts(dwg, _groups(part))
+        assert len(anns) == 1  # one grouped callout for the whole bolt circle

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -44,13 +44,25 @@ class TestCalloutSpec:
         assert s["diameter"] == 8.0
         assert s["cbore_dia"] == 16.0 and s["cbore_depth"] is not None
 
-    def test_bolt_circle_is_one_counted_callout(self):
+    def test_bolt_circle_is_one_counted_callout_with_bc_suffix(self):
         part = Cylinder(40, 8)
         for i in range(6):
             a = i * math.pi / 3
             part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
         s = _hole_or_pattern_spec(part)
         assert s["diameter"] == 6.0 and s["count"] == 6  # 6× ø6, not six callouts
+        assert s["suffix"] is not None and "BC" in s["suffix"]  # BCD in the suffix
+
+    def test_spotface_maps_to_the_step(self):
+        # The renderer must not drop a spotface (review): step = cbore or spotface.
+        from draftwright.model import Frame, HoleFeature, PartModel
+
+        hole = HoleFeature(
+            Frame((0, 0, 0), "z"), 6.0, depth=None, through=True, spotface=(14.0, 1.0)
+        )
+        g = plan_dimensions(PartModel(bbox=None, orientation=None, features=[hole]))[0]
+        s = hole_callout_spec(g)
+        assert s["cbore_dia"] == 14.0 and s["cbore_depth"] == 1.0
 
 
 class TestRender:
@@ -60,11 +72,17 @@ class TestRender:
         anns = render_callouts(dwg, _groups(part))
         assert len(anns) == 2 and all(isinstance(a, Leader) for a in anns)  # one per hole, placed
 
-    def test_bolt_circle_renders_one_leader_not_six(self):
+    def test_bolt_circle_renders_one_leader_pointing_at_a_member(self):
         part = Cylinder(40, 8)
         for i in range(6):
             a = i * math.pi / 3
             part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
         dwg = build_drawing(part, number="X")
-        anns = render_callouts(dwg, _groups(part))
+        groups = _groups(part)
+        pat = next(g for g in groups if g.feature_kind == "pattern")
+        anns = render_callouts(dwg, groups)
         assert len(anns) == 1  # one grouped callout for the whole bolt circle
+        # the leader tips at a member hole, not the empty pattern centre
+        member_tip = dwg.at(pat.view, *pat.feature.members[0])
+        assert abs(anns[0].tip[0] - member_tip[0]) < 1e-6
+        assert abs(anns[0].tip[1] - member_tip[1]) < 1e-6


### PR DESCRIPTION
Builds the **renderer seam** — the first real consumer of the planner output —
validating the IR/planner contract against a real consumer instead of review
guesswork. Part of #201 (planner in production for holes).

## What
`model/render.py` reads a hole/pattern `DimensionGroup` **purely from its planned
parameters** (+ the feature's `count`) and builds a placed `HoleCallout` leader via
the real projection (`Drawing.at`) and helpers:
- `hole_callout_spec(group)` — the renderer's reading of the plan (bore/counterbore
  values by role, through inferred from absent depth param, count from the feature).
- `render_callouts(dwg, groups)` — placed `HoleCallout` leaders, projected into each
  group's view.

GD&T symbols (⌴/↧) are the helper's geometry — which is exactly why the IR carries
semantic `role`s, not glyph strings. This is the payoff of that contract decision.

## Why this, now
The last 5 review rounds found contract gaps by imagining the renderer's needs. A
real consumer settles them: this proves the plan carries what's needed (bore +
counterbore + blind/through + **pattern count → one `6× ø6` callout, not six**), and
any remaining gap now surfaces against real code, not speculation.

## Scope
- **Does not yet replace** the engine's hole placement — kept out of
  `model.__init__` (pure IR stays helpers-free) and not wired into `build_drawing`.
  The swap-in under the migration gate (turned-bore routing, etc.) is the rest of
  #201.
- Gate unaffected (engine untouched).

## Verification
`tests/test_render_seam.py`: spec-level (through / blind / counterbore / count) +
render (placed leaders; bolt circle → 1 leader). 6 passed; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)