### PR TITLE
feat: layout-solver placement for model-pipeline callouts (ADR 0008)

### DIFF
--- a/src/draftwright/model/render.py
+++ b/src/draftwright/model/render.py
@@ -7,10 +7,12 @@ leader via the existing projection (`Drawing.at`) and rendering primitives. GD&T
 symbols (⌴/↧) are the helper's geometry, which is exactly why the IR carries
 semantic `role`s, not glyph strings.
 
-This is the planner→layout seam. It does **not** yet replace the engine's hole
-placement — that swap-in, under the migration gate, is #201. Here it proves the
-contract carries what a renderer needs, and surfaces gaps before wiring. Kept out
-of `draftwright.model.__init__` so the pure IR stays free of any helpers import.
+This is the planner→layout seam: `render_into` places each callout clear of the
+views and of other callouts via the ADR-0003 layout search. The pipeline runs
+end-to-end and is judged by **correctness** (lint), per the out-grow strategy
+(ADR 0008 Amendment 2) — it is the path for new/poorly-handled shapes, not a
+reproduce-and-swap of the engine. Kept out of `draftwright.model.__init__` so the
+pure IR stays free of any helpers/annotations import.
 """
 
 from __future__ import annotations
@@ -18,7 +20,17 @@ from __future__ import annotations
 from build123d_drafting.helpers import HoleCallout, Leader
 
 from draftwright._core import _fmt
+from draftwright.annotations._common import _anno_box, _box_hits
 from draftwright.model.planner import DimensionGroup, plan_dimensions
+
+# Candidate leader-elbow offsets from the hole, in rings of increasing radius and
+# eight directions — the renderer's local placement search (ADR 0003 layout: keep
+# the callout near its feature but clear of the views and other callouts).
+_ELBOW_OFFSETS = [
+    (r * ux, r * uy)
+    for r in (14.0, 22.0, 34.0, 50.0, 72.0)
+    for ux, uy in ((1, 1), (-1, 1), (1, -1), (-1, -1), (1, 0), (0, 1), (-1, 0), (0, -1))
+]
 
 
 def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
@@ -95,15 +107,61 @@ def render_callouts(dwg, groups) -> list[Leader]:
     return [ldr for g in groups if (ldr := _callout_leader(dwg, g)) is not None]
 
 
+def _placed_callout_leader(dwg, group, obstacles) -> Leader | None:
+    """A `HoleCallout` leader placed clear of *obstacles* by searching outward from
+    the hole (ADR 0003 layout): the first elbow whose leader box hits nothing wins;
+    the farthest candidate is the fallback."""
+    spec = hole_callout_spec(group)
+    if spec is None:
+        return None
+    callout = HoleCallout(
+        spec["diameter"],
+        count=spec["count"],
+        through=spec["through"],
+        depth=spec["depth"],
+        cbore_dia=spec["cbore_dia"],
+        cbore_depth=spec["cbore_depth"],
+        suffix=spec["suffix"],
+        draft=dwg.draft,
+    )
+    members = getattr(group.feature, "members", ())
+    tip_model = members[0] if members else group.anchor
+    tx, ty, *_ = dwg.at(group.view, *tip_model)
+    fallback = None
+    for dx, dy in _ELBOW_OFFSETS:
+        leader = Leader(
+            tip=(tx, ty, 0),
+            elbow=(tx + dx, ty + dy, 0),
+            label="",
+            draft=dwg.draft,
+            callout=callout,
+        )
+        box = _anno_box(leader)
+        if box is None:
+            return leader  # can't measure → accept
+        if not _box_hits(box, obstacles):
+            return leader
+        fallback = leader
+    return fallback
+
+
 def render_into(dwg, model) -> int:
     """The end-to-end seam: plan *model* and **add** its annotations to *dwg*
     (which must already have its views, e.g. ``build_drawing(part, auto_dims=False)``).
-    Returns the count added. Hole/pattern callouts today; other feature kinds are
-    added as the framework out-grows the engine. Lint *dwg* to judge correctness."""
+    Each callout is placed clear of the views and of callouts already added (the
+    layout solver, not fixed offsets). Returns the count added. Hole/pattern
+    callouts today; other feature kinds follow as the framework out-grows the
+    engine. Lint *dwg* to judge correctness."""
+    view_boxes = [vb for v in dwg.views if (vb := dwg.view_bounds(v)) is not None]
+    placed: list = []
     n = 0
     for g in plan_dimensions(model):
-        leader = _callout_leader(dwg, g)
-        if leader is not None:
-            dwg.add(leader, f"m_callout{n}", view=g.view)
-            n += 1
+        leader = _placed_callout_leader(dwg, g, view_boxes + placed)
+        if leader is None:
+            continue
+        dwg.add(leader, f"m_callout{n}", view=g.view)
+        n += 1
+        box = _anno_box(leader)
+        if box is not None:
+            placed.append(box)
     return n

--- a/tests/test_e2e_slice.py
+++ b/tests/test_e2e_slice.py
@@ -6,11 +6,10 @@ pipeline (`build_drawing(auto_dims=False)` gives only the view scaffold), judged
 **correctness** (lint passes, coverage complete, it exports) — *not* by equivalence
 to the engine.
 
-Scope today: hole callouts. The slice deliberately surfaces what's still missing —
-overall/envelope dims (not yet produced) and layout integration (callouts placed at
-naive offsets, so a `view_annotation_overlap` *warning* can appear; that's the next
-work — route placement through the ADR-0003 solver). Those are warnings/info, not
-errors: the drawing is correct, not yet polished.
+Scope today: hole callouts, **placed clear of the views and of each other** via the
+layout search (no more naive fixed offsets). The remaining gap the slice surfaces is
+overall/envelope + OD dims, which the new path doesn't produce yet — so a part with
+an un-dimensioned OD (e.g. a flange) still lints with `feature_not_dimensioned`.
 """
 
 import os
@@ -26,14 +25,28 @@ def _plate():
     return Box(100, 60, 12) - Pos(-30, 0, 0) * Cylinder(4, 30) - Pos(30, 0, 0) * Cylinder(4, 30)
 
 
-def test_complete_drawing_via_model_pipeline():
+def test_complete_drawing_via_model_pipeline_is_lint_clean():
     part = _plate()
     dwg = build_drawing(part, number="X", auto_dims=False)  # view scaffold only
     n = render_into(dwg, build_part_model(part))
     assert n == 2  # both holes called out by the new pipeline
     s = dwg.lint_summary()
-    assert s["passed"]  # no lint ERRORS — the correctness bar (layout is warning-only)
-    assert s["by_code"].get("feature_not_dimensioned", 0) == 0  # coverage complete
+    assert s["passed"] and s["score"] == 1.0  # fully clean — callouts cleared the views
+    assert s["by_code"] == {}  # no overlap, no missing coverage
+
+
+def test_dense_plate_callouts_dont_collide():
+    # Four holes: collision-aware placement keeps the callouts clear of the views
+    # and each other (the layout-solver integration, not fixed offsets).
+    part = Box(120, 80, 12)
+    for x in (-40, 40):
+        for y in (-20, 20):
+            part -= Pos(x, y, 0) * Cylinder(4, 30)
+    dwg = build_drawing(part, number="X", auto_dims=False)
+    assert render_into(dwg, build_part_model(part)) == 4
+    s = dwg.lint_summary()
+    assert s["by_code"].get("annotation_overlap", 0) == 0
+    assert s["by_code"].get("view_annotation_overlap", 0) == 0
 
 
 def test_model_pipeline_drawing_exports(tmp_path):


### PR DESCRIPTION
The next gap the end-to-end slice (#215) surfaced: callouts were placed at naive
fixed offsets and overlapped the view (`view_annotation_overlap` warning).

## What
`render_into` now places each hole/pattern callout **clear of the views and of
already-placed callouts**, searching outward from the hole (ADR-0003 layout) for the
first elbow whose leader box hits nothing (`_box_hits` against the view bboxes +
prior callouts), with the farthest candidate as fallback.

## Judged by correctness (no gate)
- **Plate (2 holes):** now lints **fully clean — score 1.0, `by_code={}`** (was 0.95
  with `view_annotation_overlap`).
- **Dense plate (4 holes):** collision-free — no `annotation_overlap` /
  `view_annotation_overlap`.

The remaining slice gap is the **un-dimensioned OD/envelope** on rotational parts
(a flange still lints `feature_not_dimensioned`) — that's the next out-grow feature,
not a placement issue.

## Verification
`test_e2e_slice`: plate lint-clean (1.0), dense plate no overlaps; seam tests green.
ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)