### PR TITLE
feat: derive axial coverage from the drawing, not CoverageState — #219

### DIFF
--- a/src/draftwright/annotations/turned.py
+++ b/src/draftwright/annotations/turned.py
@@ -276,4 +276,3 @@ def _annotate_turned_lengths(dwg, a: Analysis, prof: TurnedProfile | None) -> No
             f"dim_len{i}",
             view="front",
         )
-    dwg._coverage.cover_axial(len(steps))

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -982,7 +982,7 @@ class Drawing:
             )
             issues += lint_axial_coverage(
                 self.part,
-                self._coverage.axial_covered,
+                self,
                 assembly=self.assembly,
             )
             issues += lint_location_coverage(

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -168,6 +168,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "feature_count_mismatch",
         "feature_not_located",
         "feature_no_centermark",
+        "axial_length_missing",
         "missing_principal_dimension",
         "label_vs_measured",
         "dim_inside_part",

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -58,10 +58,6 @@ class CoverageState:
         # redundant feature_not_dimensioned for them. Reset at the top of
         # _auto_annotate so re-annotation does not accumulate.
         self._dropped_callout_diams: list = []
-        # Count of turned-part axial step lengths the step-length pass dimensioned,
-        # so lint_axial_coverage knows how many shoulders are located. Reset with
-        # the dropped diameters at the top of _auto_annotate.
-        self._axial_covered: int = 0
 
     # -- pattern coverage -----------------------------------------------------
 
@@ -82,9 +78,8 @@ class CoverageState:
     # -- dropped diameters ----------------------------------------------------
 
     def reset_dropped(self) -> None:
-        """Clear dropped-diameter and axial tracking (top of _auto_annotate)."""
+        """Clear dropped-diameter tracking (top of _auto_annotate)."""
         self._dropped_callout_diams = []
-        self._axial_covered = 0
 
     def drop_diam(self, diam) -> None:
         """Record a diameter dropped by the per-view callout cap."""
@@ -94,17 +89,6 @@ class CoverageState:
     def dropped_diams(self) -> list:
         """Diameters dropped by the cap (passed to lint_feature_coverage)."""
         return self._dropped_callout_diams
-
-    # -- axial step coverage --------------------------------------------------
-
-    def cover_axial(self, count: int = 1) -> None:
-        """Record that the step-length pass dimensioned *count* axial steps."""
-        self._axial_covered += count
-
-    @property
-    def axial_covered(self) -> int:
-        """Number of turned-part axial steps dimensioned (for lint_axial_coverage)."""
-        return self._axial_covered
 
 
 def lint_feature_coverage(
@@ -297,14 +281,43 @@ def lint_location_coverage(part, dwg, cyls=None, assembly=None, tol: float = 0.6
     return issues
 
 
-def lint_axial_coverage(part, covered: int, assembly=None) -> list:
+def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
+    """How many of an X-turned part's step lengths are dimensioned **in the
+    drawing** — a step counts as covered when some front-view ``Dimension`` has
+    witnesses at both of its shoulders' page-x positions. Drawing-derived, so it
+    judges any producer (not the engine's :class:`CoverageState` side channel)."""
+    bb = part.bounding_box()
+    y_ref, z_top = bb.center().Y, bb.max.Z
+    shoulder_x = {s: dwg.at("front", s, y_ref, z_top)[0] for s in prof.shoulders}
+    dim_xsets: list[set[float]] = []
+    for name, ann in dwg._named.items():
+        if dwg._anno_view.get(name) != "front" or not isinstance(ann, Dimension):
+            continue
+        try:
+            dim_xsets.append({p.X for p in ann.vertices()})
+        except Exception:  # noqa: BLE001 — a dim whose vertices won't evaluate is skipped
+            pass
+    covered = 0
+    for step in prof.steps:
+        xlo, xhi = shoulder_x[step.lo], shoulder_x[step.hi]
+        if any(
+            any(abs(x - xlo) <= tol for x in xs) and any(abs(x - xhi) <= tol for x in xs)
+            for xs in dim_xsets
+        ):
+            covered += 1
+    return covered
+
+
+def lint_axial_coverage(part, dwg, assembly=None) -> list:
     """Report a stepped turned part whose axial step lengths are undimensioned.
 
     A turned part can have every diameter called out yet be unmanufacturable: with
     no shoulder located, the lengths are unknown (the drive-screw gap). A complete
-    chain dimensions all ``n`` steps; *covered* is how many the step-length pass
-    placed (from :attr:`CoverageState.axial_covered`). A shortfall yields one
-    ``axial_length_missing`` issue.
+    chain dimensions all ``n`` steps; coverage is counted **from the drawing**
+    (:func:`_axial_covered_from_drawing`), not a build-time side channel — so it
+    judges any producer. A shortfall yields one ``axial_length_missing`` issue.
+
+    *dwg* is the drawing, duck-typed (needs ``at``/``_named``/``_anno_view``).
 
     Scoped to **X-axis** turning (a shaft drawn on its side) — the gap the
     step-length pass fills. The other orientations are covered elsewhere, so
@@ -320,6 +333,7 @@ def lint_axial_coverage(part, covered: int, assembly=None) -> list:
     if assembly is None:
         assembly = len(part.solids()) > 1
     n = len(prof.steps)
+    covered = _axial_covered_from_drawing(part, dwg, prof)
     if covered >= n:
         return []
     return [

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4560,6 +4560,22 @@ class TestAxialCoverageLint:
         dwg = build_drawing(part, number="D-1", auto_dims=False)
         assert lint_axial_coverage(part, dwg) == []
 
+    def test_coverage_survives_repair_and_is_idempotent(self):
+        # Drawing-derived coverage must stay clean after the repair loop re-places
+        # dims (witnesses stay anchored to geometry) and across repeated lint()s.
+        part = _x_stepped_shaft()
+        dwg = build_drawing(part, number="D-1")  # repair on
+        first = [i.code for i in dwg.lint() if i.code == "axial_length_missing"]
+        again = [i.code for i in dwg.lint() if i.code == "axial_length_missing"]
+        assert first == [] and again == []
+
+    def test_axial_length_missing_is_geometry_aware(self):
+        # It is a completeness/standards code, so lint_summary must count it under
+        # geometry_issues, not as layout (#226 review follow-through).
+        from draftwright.drawing import _GEOMETRY_AWARE_CODES
+
+        assert "axial_length_missing" in _GEOMETRY_AWARE_CODES
+
 
 def _multi_hole_plate():
     """A plate with three spec-groups of Z-holes (two ø10, one ø16)."""

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4531,25 +4531,34 @@ class TestStepLadderRecognition:
 
 
 class TestAxialCoverageLint:
-    """lint_axial_coverage — the scoring signal for undimensioned turned steps."""
+    """lint_axial_coverage — the scoring signal for undimensioned turned steps,
+    now counted from the drawing (not the CoverageState side channel, #219)."""
 
     def test_flags_uncovered_turned_part(self):
         from draftwright.linting import lint_axial_coverage
 
-        issues = lint_axial_coverage(_x_stepped_shaft(), covered=0)
+        # A bare scaffold (views, no step-length dims) → all steps uncovered.
+        part = _x_stepped_shaft()
+        dwg = build_drawing(part, number="D-1", auto_dims=False)
+        issues = lint_axial_coverage(part, dwg)
         assert [i.code for i in issues] == ["axial_length_missing"]
         assert issues[0].severity == "warning"
 
     def test_clean_when_all_steps_covered(self):
         from draftwright.linting import lint_axial_coverage
 
-        # _x_stepped_shaft has 2 steps; covering both clears the check.
-        assert lint_axial_coverage(_x_stepped_shaft(), covered=2) == []
+        # The engine places the full step-length chain → drawing-derived coverage
+        # finds every step located.
+        part = _x_stepped_shaft()
+        dwg = build_drawing(part, number="D-1")
+        assert lint_axial_coverage(part, dwg) == []
 
     def test_silent_for_non_turned_part(self):
         from draftwright.linting import lint_axial_coverage
 
-        assert lint_axial_coverage(Box(80, 60, 20), covered=0) == []
+        part = Box(80, 60, 20)
+        dwg = build_drawing(part, number="D-1", auto_dims=False)
+        assert lint_axial_coverage(part, dwg) == []
 
 
 def _multi_hole_plate():


### PR DESCRIPTION
Closes #219. Companion to #218: lint should judge a drawing by its **output**, not a build-time side channel set only by the engine's passes.

## Problem
`lint_axial_coverage` read `CoverageState.axial_covered` — a counter the engine's step-length pass increments via `cover_axial`. A stepped shaft drawn through the **model pipeline** therefore *always* tripped `axial_length_missing`, no matter what it actually dimensioned, because nothing called `cover_axial`.

## Fix
`lint_axial_coverage(part, dwg)` now counts dimensioned step lengths **from the drawing**: `_axial_covered_from_drawing` marks a step covered when a front-view `Dimension` has witness vertices at both of its shoulders' page-x positions (same drawing-derived technique as #218's location check). It judges any producer.

Removed the now-dead axial side channel — `CoverageState.cover_axial` / `axial_covered`, and the `cover_axial` call in `annotations/turned.py`.

## Scope (what stays, and why)
`CoverageState` remains for two **genuinely engine-internal** signals that have *no drawing trace* to derive from, and which don't block the model pipeline:
- `dropped_diams` — per-view-cap suppression for `feature_not_dimensioned` (a *dropped* callout leaves no annotation, so it can't be read back from geometry);
- pattern coverage (`cover_pattern` …) — hole-table escalation coordination, not a lint judgment.

The axial channel was the only one producing false lint for the new pipeline.

## Verification
Drawing-derived count matches the old side channel exactly on engine output (2/2, 3/3 on stepped / three-step X shafts). The 3 axial tests now build real drawings (bare scaffold → flagged; engine chain → clean) instead of synthetic counts. Full fast suite **581 passed / 1 skipped**; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)