### PR TITLE
docs: ADR 0008 Amendment 3 — converge on one path + convergence roadmap

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -1,8 +1,10 @@
 # ADR 0008 — The part-drawing compiler: a Feature/DimParameter IR and a dimensioning planner
 
-- **Status:** Accepted — architecture stands; **migration strategy pivoted**
-  (Amendment 2): out-grow the engine, don't reproduce-and-swap it. The equivalence
-  golden gate is retired.
+- **Status:** Accepted — architecture stands; **migration is a correctness-judged
+  strangler that converges on ONE path** (Amendment 3, superseding Amendment 2's
+  divergence implication). Not reproduce-and-swap (Amendment 2), not two permanent
+  paths — incremental migration where each step deletes the engine pass it replaces.
+  The equivalence golden gate is retired.
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Supersedes the original 0008** ("unified feature model") with a concrete
@@ -103,8 +105,12 @@ The planner emits placement *intents*; the existing `Placeable`/solver (ADR 0003
 
 ## Migration — strangler, anchored on the protocol (no rewrite)
 
-Full execution plan (all detectors + drawing components, with a scoped golden gate
-and X/Z parity as standing criteria):
+> **Plan of record: [`docs/plans/0008-convergence-roadmap.md`](../plans/0008-convergence-roadmap.md)**
+> (Amendment 3). The original scoped-golden-gate roadmap is retired; the section
+> below records the initial thinking.
+
+Initial execution sketch (all detectors + drawing components, originally with a
+scoped golden gate and X/Z parity as standing criteria):
 [`docs/plans/0008-compiler-migration-roadmap.md`](../plans/0008-compiler-migration-roadmap.md).
 
 1. **Define the waist** (`DimParameter`, `Feature`, `Datum`, `PartModel`) and
@@ -197,6 +203,52 @@ a byte-equivalence golden gate) was wrong, and building it exposed why:
 The earlier roadmap (`docs/plans/0008-compiler-migration-roadmap.md`) and the
 reproduce-and-swap framing of issues #197–#209 are superseded by this; the epic
 (#195) is re-scoped to value-first deployment.
+
+## Amendment 3 (2026-06-29) — converge on ONE path (corrects Amendment 2)
+
+Amendment 2 fixed the *reproduce-and-swap* mistake but, read literally ("the engine
+keeps its responsibilities and is migrated only opportunistically"), it implied a
+**second, permanent failure mode: two divergent paths** — the accreted per-feature
+engine passes *and* a parallel IR pipeline doing overlapping work, drifting apart
+forever. That betrays the entire point of ADR 0008, which is **one consistent
+architecture** replacing the N×M coupled mess. Two permanent paths are worse than
+either pure option.
+
+The destination is, and always was, **a single path**:
+
+```
+detectors → IR (PartModel) → planner → render-intents → [shared layout / projection / export]
+```
+
+The per-feature annotation passes (`annotations/{holes,turned,sections,pmi,slots}`,
+the inline envelope/OD/centre-mark/step-ladder code in the orchestrator) **all
+migrate onto this path and are deleted.** The orchestrator's end state is
+`build model → plan → render` — no per-feature pile. The shared layout/projection/
+export stack is *not* rewritten (ADR 0008 always fed the existing layout); what
+disappears is the duplicated feature→dimensioning logic.
+
+**Migration is a strangler, governed by three rules:**
+
+1. **Convergence, not divergence — each migration DELETES the engine pass it
+   replaces.** This is the load-bearing discipline. Adding an IR renderer while
+   leaving the engine equivalent in place (as `render_into` currently sits, used
+   only in tests) is the divergence smell and is *not* a completed migration. A
+   step is done only when the old code is gone. #231 (turned step lengths) is the
+   template: it deleted `_annotate_turned_lengths` and bypassed the Z ladder.
+2. **Judged by correctness, not equivalence** (kept from Amendment 2). The new path
+   is held to lint-clean + ISO/ASME-compliant + coverage-complete (now a real bar,
+   since lint is drawing-derived — #218/#219), *not* byte-identity with the engine.
+   The output may be *better* (the Z step chain is). No standing equivalence gate.
+3. **Ordered worst-handled-first.** Migrate where the IR adds the most value and
+   de-risks fastest (the engine's asymmetric/awkward features) before the
+   already-clean ones — but *all* of it migrates; "pain-point ordering" is sequence,
+   never a licence to leave a feature on the engine permanently.
+
+Net effect vs the two rejected approaches: not a big-bang equivalence swap
+(Amendment 1), not two forever-paths (a literal reading of Amendment 2) — an
+incremental, correctness-judged convergence that ends with one architecture and the
+engine's per-feature passes deleted. Tracked in
+[`docs/plans/0008-convergence-roadmap.md`](../plans/0008-convergence-roadmap.md).
 
 ## Consequences
 

--- a/docs/plans/0008-compiler-migration-roadmap.md
+++ b/docs/plans/0008-compiler-migration-roadmap.md
@@ -8,7 +8,8 @@
 > the path for new/poorly-handled shapes, judged by *correctness* not equivalence;
 > the engine is migrated only opportunistically. The scoped golden gate (Phase 0)
 > is retired. Kept for history; do not execute the phases below as written.
-> **Live plan: epic #195** (out-grow Done / Now / Next / Backlog).
+> **Live plan: [`0008-convergence-roadmap.md`](0008-convergence-roadmap.md)** (one
+> path, strangler migration, each step deletes the engine pass) + epic #195.
 
 Execution plan for ADR 0008 (the part-drawing compiler). Moves **every** detector
 and **every** drawing component onto the `Feature`/`DimParameter` IR + planner,

--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -1,0 +1,69 @@
+# ADR 0008 convergence roadmap — one path, strangler migration
+
+The plan of record for ADR 0008 (see Amendment 3). Supersedes the
+reproduce-and-swap roadmap (`0008-compiler-migration-roadmap.md`, retired).
+
+**Goal:** one feature→dimensioning path —
+`detectors → IR → planner → render-intents → [shared layout/projection/export]` —
+with the per-feature engine passes **deleted**. The orchestrator ends as
+`build model → plan → render`.
+
+## The discipline (non-negotiable)
+
+Every migration PR must:
+
+1. **Delete the engine pass it replaces** (or the migration is not done — adding a
+   parallel IR renderer is the divergence smell). Convergence is measured by engine
+   code *removed*, not IR code added.
+2. **Be judged by correctness, not equivalence** — lint-clean (drawing-derived,
+   #218/#219) + ISO/ASME + coverage-complete + visual sanity. Output may differ
+   from / improve on the engine. No standing equivalence gate.
+3. **Hold X/Z (and view) parity by construction** — orientation is data
+   (`Feature.frame` / projected span direction), never an axis branch in the
+   back-end. Asserted per migrated feature.
+4. Keep `ruff`/`format`/`mypy` and the full fast suite green.
+
+## Done
+
+- IR + planner + detectors + renderer seam + lint-as-correctness-judge
+  (#194, #211, #212, #213, #218, #219).
+- **Turned step lengths** — engine X-chain + Z-ladder *deleted*, replaced by one
+  IR chain (orientation = projected span direction). The template (#223 / #231).
+
+## The convergence backlog (engine passes still to migrate + delete)
+
+Ordered worst-handled-first (most value / de-risk first). Each row is one (or a
+few) migrate-and-delete PRs.
+
+| # | Engine pass (to delete) | Lives in | Migrates to | Notes |
+|---|---|---|---|---|
+| 1 | turned **diameters** `_annotate_turned_diameters` | `turned.py` | `StepFeature`/`BossFeature` diameter render | pairs naturally with the step-length chain already migrated |
+| 2 | **holes**: callouts + centre marks + location dims + `n×` grouping (`_annotate_holes`, `_add_location_dims`, inline `cm_`) | `holes.py`, orchestrator | `HoleFeature`/`PatternFeature` + planner location rule + render (folds in #220) | the largest pass; needs datum/location modelling in the IR. **Migrate-and-delete, not the `render_into` parallel.** |
+| 3 | **envelope** dims (`dim_width`/`dim_height`/`dim_depth`) + **OD** (`dim_od`) | orchestrator inline | `EnvelopeFeature` (exists) + planner/render | partly prototyped in `render_into`; wire to production and delete the inline code. Fixes #222 (rotational OD on profile). |
+| 4 | **prismatic step-height ladder** (`dim_step_*`, `_detect_step_repeat`, `_legible_steps`) | orchestrator inline | a prismatic step `Feature` + planner rule | the last turned/stepped remnant; reunifies with the step chain. Folds in #230 (`N× rise`). |
+| 5 | **slots** `_annotate_slots` | `holes.py` | `SlotFeature` + planner/render | needs the slot detector (#199) → render (#206). |
+| 6 | **sections / detail views** `_add_section_view`, `_add_detail_view` | `sections.py` | planner-triggered from features needing them | #207; the planner decides when a feature needs a section. |
+| 7 | **PMI / GD&T** `_annotate_pmi` | `pmi.py` | thread/GD&T `Feature`s + planner/render | needs the PMI detector (#200) → placement (#208). |
+
+When rows 1–7 land, the orchestrator's per-feature calls are gone and it reduces to
+`build model → plan → render`.
+
+## Cross-cutting (do alongside, not after)
+
+- **#221** — move `render` out of `model/` + consolidate the duplication that
+  accreted (the two leader paths, `_END_ON`, `_pt`/`_loc_xyz`, drawing-introspection
+  helpers). Do early — before more renderers pile on.
+- **#229** — build the `PartModel` once per drawing and thread it (the orchestrator
+  currently rebuilds it); kills per-pass recompute as more passes consume the IR.
+- **Retire `render_into`'s test-only parallel** — its hole/envelope/OD capability is
+  superseded by rows 2–3 *in production*; once those land, delete the scaffold so no
+  divergent path lingers.
+
+## Definition of done (the whole ADR)
+
+- `annotations/{holes,turned,sections,pmi}` per-feature passes deleted; the inline
+  envelope/OD/centre-mark/step-ladder code gone from the orchestrator.
+- One path: detectors → IR → planner → render-intents → shared layout/export.
+- No `render_into` test-only parallel; no engine/IR duplication.
+- Full standards + geometry suites green; X/Z parity tests per feature.
+- ADR 0008 status → "migration complete; one path".


### PR DESCRIPTION
Corrects the direction after the divergence concern: ADR 0008's point is **one consistent architecture**, and Amendment 2 (read literally) implied two permanent paths.

## Amendment 3 — converge on ONE path
Destination, made explicit:
```
detectors → IR → planner → render-intents → [shared layout / projection / export]
```
The per-feature engine passes (`annotations/{holes,turned,sections,pmi}` + inline envelope/OD/centre-mark/step-ladder) **migrate onto this path and are deleted**. The orchestrator ends as `build model → plan → render`. The shared layout/projection/export stack is *not* rewritten.

## The load-bearing discipline
Migration is a correctness-judged **strangler**; every PR **deletes the engine pass it replaces**. Adding an IR renderer while leaving the engine equivalent in place (as `render_into` currently sits — test-only) is the **divergence smell**, not a completed migration. #231 (turned step lengths) is the template: it deleted `_annotate_turned_lengths` and bypassed the Z ladder.

Kept from Amendment 2: judged by **correctness, not equivalence** (no standing gate; output may improve on the engine). New: convergence is mandatory — "pain-point ordering" is sequence, never a licence to leave a feature on the engine forever.

## Also
- New plan of record: `docs/plans/0008-convergence-roadmap.md` (the 7 engine passes to migrate+delete, ordered worst-handled-first; cross-cutting #221/#229; definition of done).
- Retires the reproduce-and-swap roadmap pointer; re-scopes epic #195.
- Names the current divergence to retire: `render_into`'s test-only hole/envelope/OD parallel must land in production (deleting engine equivalents), not linger.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)