### PR TITLE
refactor: move render out of model/ + consolidate duplication (#221)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -36,6 +36,21 @@ _MARGIN = 10.0
 
 _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for clearance
 
+# The orthographic view a feature is dimensioned end-on in — the view normal to its
+# axis. Single source of truth shared by the planner (view choice) and the lint
+# coverage checks (where to look for a feature's dims). Orientation is data.
+_END_ON = {"x": "side", "y": "front", "z": "plan"}
+
+
+def _xyz(loc) -> tuple[float, float, float]:
+    """A build123d ``Vector`` (has ``.X/.Y/.Z``) or an ``(x, y, z)`` sequence → an
+    ``(x, y, z)`` float tuple. Shared by the detectors and the lint coverage checks
+    so the Vector-unpacking idiom lives in one place."""
+    if hasattr(loc, "X"):
+        return (loc.X, loc.Y, loc.Z)
+    x, y, z = loc
+    return (float(x), float(y), float(z))
+
 
 _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built with this
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1,18 +1,16 @@
-"""render — the renderer seam: DimensionGroup → placed annotations (ADR 0008).
+"""from_model — render planner output into placed annotations (ADR 0008).
 
-The **first real consumer** of the planner output, validating the IR/planner
-contract end-to-end. A hole/pattern group is read *purely from its planned
-parameters* (+ the feature's `count`) and turned into a placed `HoleCallout`
-leader via the existing projection (`Drawing.at`) and rendering primitives. GD&T
-symbols (⌴/↧) are the helper's geometry, which is exactly why the IR carries
-semantic `role`s, not glyph strings.
+The renderer back-end of the compiler: a `DimensionGroup` (read *purely from its
+planned parameters* + the feature's metadata) becomes placed `HoleCallout` /
+`Dimension` annotations via the existing projection (`Drawing.at`), layout search,
+and rendering primitives. GD&T symbols (⌴/↧) are the helper's geometry, which is
+exactly why the IR carries semantic `role`s, not glyph strings.
 
-This is the planner→layout seam: `render_into` places each callout clear of the
-views and of other callouts via the ADR-0003 layout search. The pipeline runs
-end-to-end and is judged by **correctness** (lint), per the out-grow strategy
-(ADR 0008 Amendment 2) — it is the path for new/poorly-handled shapes, not a
-reproduce-and-swap of the engine. Kept out of `draftwright.model.__init__` so the
-pure IR stays free of any helpers/annotations import.
+This lives in `annotations/` (not `model/`) so the IR package stays pure — it
+imports *down* into `model` + `_core`, and is called by the orchestrator (ADR 0008
+Amendment 3: one path, this is its render stage). Judged by **correctness** (lint),
+not equivalence to the engine. `render_step_lengths` is wired into production;
+`render_into`/`render_callouts` drive the end-to-end slice + seam tests.
 """
 
 from __future__ import annotations
@@ -85,14 +83,14 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     }
 
 
-def _callout_leader(dwg, group) -> Leader | None:
-    """A placed `HoleCallout` leader for a hole/pattern group, or ``None``. Tips at
-    a real member hole (not the empty pattern centre), projected into the group's
-    view."""
+def _hole_callout(dwg, group) -> HoleCallout | None:
+    """The `HoleCallout` for a hole/pattern group from its planned spec, or ``None``
+    if the group is not hole-bearing. The shared callout builder for both the placed
+    (`render_into`) and the bare (`render_callouts`) paths."""
     spec = hole_callout_spec(group)
     if spec is None:
         return None
-    callout = HoleCallout(
+    return HoleCallout(
         spec["diameter"],
         count=spec["count"],
         through=spec["through"],
@@ -102,22 +100,13 @@ def _callout_leader(dwg, group) -> Leader | None:
         suffix=spec["suffix"],
         draft=dwg.draft,
     )
-    members = getattr(group.feature, "members", ())
-    tip_model = members[0] if members else group.anchor
-    tip = dwg.at(group.view, *tip_model)
-    elbow = (tip[0] + 12.0, tip[1] + 8.0, 0)
-    return Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label="", draft=dwg.draft, callout=callout)
-
-
-def render_callouts(dwg, groups) -> list[Leader]:
-    """The hole/pattern callout leaders for *groups* (does not mutate *dwg*)."""
-    return [ldr for g in groups if (ldr := _callout_leader(dwg, g)) is not None]
 
 
 def _place_leader(dwg, view, tip_model, obstacles, *, label="", callout=None) -> Leader | None:
     """A leader (callout or plain ø label) placed clear of *obstacles* by searching
     outward from the feature (ADR 0003 layout): first non-colliding elbow wins; the
-    farthest candidate is the fallback."""
+    farthest candidate is the fallback. With no obstacles the first ring wins, so a
+    bare call is deterministic."""
     tx, ty, *_ = dwg.at(view, *tip_model)
     fallback = None
     for dx, dy in _ELBOW_OFFSETS:
@@ -138,22 +127,20 @@ def _place_leader(dwg, view, tip_model, obstacles, *, label="", callout=None) ->
 
 
 def _hole_leader(dwg, group, obstacles) -> Leader | None:
-    spec = hole_callout_spec(group)
-    if spec is None:
+    """A `HoleCallout` leader for a hole/pattern group, placed clear of *obstacles*.
+    Tips at a real member hole (not the empty pattern centre)."""
+    callout = _hole_callout(dwg, group)
+    if callout is None:
         return None
-    callout = HoleCallout(
-        spec["diameter"],
-        count=spec["count"],
-        through=spec["through"],
-        depth=spec["depth"],
-        cbore_dia=spec["cbore_dia"],
-        cbore_depth=spec["cbore_depth"],
-        suffix=spec["suffix"],
-        draft=dwg.draft,
-    )
     members = getattr(group.feature, "members", ())
     tip = members[0] if members else group.anchor
     return _place_leader(dwg, group.view, tip, obstacles, callout=callout)
+
+
+def render_callouts(dwg, groups) -> list[Leader]:
+    """The hole/pattern callout leaders for *groups* (does not mutate *dwg*). The
+    bare path: placed against no obstacles, so deterministic."""
+    return [ldr for g in groups if (ldr := _hole_leader(dwg, g, [])) is not None]
 
 
 def _diameter_leader(dwg, group, obstacles) -> Leader | None:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -38,6 +38,7 @@ from draftwright._core import (
     _log,
     _tag_sequence,
 )
+from draftwright.annotations.from_model import render_step_lengths
 from draftwright.annotations.holes import (
     _add_location_dims,
     _annotate_holes,
@@ -50,7 +51,6 @@ from draftwright.annotations.turned import (
     _annotate_turned_diameters,
 )
 from draftwright.model import build_part_model
-from draftwright.model.render import render_step_lengths
 from draftwright.recognition import (
     find_turned_steps,
     full_cylinders,

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -22,7 +22,7 @@ from typing import Literal
 
 from build123d_drafting.helpers import CenterMark, Dimension, TitleBlock
 
-from draftwright._core import _DIAM_RE, _axis_letter, _fmt
+from draftwright._core import _DIAM_RE, _END_ON, _axis_letter, _fmt, _xyz
 from draftwright.linting.issues import LintIssue
 from draftwright.recognition import (
     analyse_cylinders,
@@ -32,16 +32,15 @@ from draftwright.recognition import (
     find_turned_steps,
 )
 
-# A hole/circular feature is dimensioned end-on in the view normal to its axis.
-_END_ON = {"x": "side", "y": "front", "z": "plan"}
 
-
-def _loc_xyz(loc) -> tuple[float, float, float]:
-    """A recogniser hole location (Vector or sequence) → an (x, y, z) tuple."""
-    if hasattr(loc, "X"):
-        return (loc.X, loc.Y, loc.Z)
-    x, y, z = loc
-    return (float(x), float(y), float(z))
+def _dim_vertices(ann) -> list[tuple[float, float]]:
+    """A ``Dimension``'s vertices as ``(x, y)`` page points; ``[]`` if they won't
+    evaluate. The shared, error-tolerant harvest both drawing-derived coverage
+    checks use to read placed dimensions back off the drawing."""
+    try:
+        return [(p.X, p.Y) for p in ann.vertices()]
+    except Exception:  # noqa: BLE001 — a dim whose vertices won't evaluate is skipped
+        return []
 
 
 class CoverageState:
@@ -231,18 +230,14 @@ def lint_location_coverage(part, dwg, cyls=None, assembly=None, tol: float = 0.6
             c = ann.center()
             marks.setdefault(view, []).append((c.X, c.Y))
         elif isinstance(ann, Dimension):
-            try:
-                pts = [(p.X, p.Y) for p in ann.vertices()]
-            except Exception:  # noqa: BLE001 — a dim whose vertices won't evaluate is skipped
-                pts = []
-            dim_verts.setdefault(view, []).extend(pts)
+            dim_verts.setdefault(view, []).extend(_dim_vertices(ann))
 
     bb = part.bounding_box()
     centre = (bb.center().X, bb.center().Y, bb.center().Z)
 
     no_mark = no_loc = 0
     for h in holes:
-        x, y, z = _loc_xyz(h.location)
+        x, y, z = _xyz(h.location)
         axis = _axis_letter(h)
         view = _END_ON.get(axis, "plan")
         px, py, *_ = dwg.at(view, x, y, z)
@@ -304,14 +299,11 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
         return float(px if use_x else py)
 
     shoulder_c = {s: shoulder_coord(s) for s in prof.shoulders}
-    dim_csets: list[set[float]] = []
-    for name, ann in dwg._named.items():
-        if dwg._anno_view.get(name) != "front" or not isinstance(ann, Dimension):
-            continue
-        try:
-            dim_csets.append({(p.X if use_x else p.Y) for p in ann.vertices()})
-        except Exception:  # noqa: BLE001 — a dim whose vertices won't evaluate is skipped
-            pass
+    dim_csets: list[set[float]] = [
+        {(x if use_x else y) for x, y in _dim_vertices(ann)}
+        for name, ann in dwg._named.items()
+        if dwg._anno_view.get(name) == "front" and isinstance(ann, Dimension)
+    ]
     covered = 0
     for step in prof.steps:
         clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -14,7 +14,7 @@ for any part.
 
 from __future__ import annotations
 
-from draftwright._core import _axis_letter
+from draftwright._core import _axis_letter, _xyz
 from draftwright.model.ir import (
     BossFeature,
     EnvelopeFeature,
@@ -23,7 +23,6 @@ from draftwright.model.ir import (
     HoleFeature,
     PartModel,
     PatternFeature,
-    Point,
     StepFeature,
 )
 from draftwright.recognition import (
@@ -35,14 +34,6 @@ from draftwright.recognition import (
     find_holes,
     find_turned_steps,
 )
-
-
-def _pt(loc) -> Point:
-    """A build123d Vector or sequence → an (x, y, z) tuple."""
-    if hasattr(loc, "X"):
-        return (loc.X, loc.Y, loc.Z)
-    x, y, z = loc
-    return (float(x), float(y), float(z))
 
 
 def _member_hole(h, frame: Frame) -> HoleFeature:
@@ -62,9 +53,9 @@ def _pattern_feature(pat, members) -> PatternFeature:
     composing a representative member hole so its counterbore/spotface survive."""
     axis = _axis_letter(members[0])
     n = len(members)
-    locs = tuple(_pt(m.location) for m in members)  # raw arrangement — never discarded
+    locs = tuple(_xyz(m.location) for m in members)  # raw arrangement — never discarded
     if isinstance(pat, BoltCircle):
-        frame = Frame(_pt(pat.center), axis)
+        frame = Frame(_xyz(pat.center), axis)
         return PatternFeature(
             frame,
             "bolt_circle",
@@ -90,7 +81,7 @@ def _pattern_feature(pat, members) -> PatternFeature:
             direction=tuple(pat.direction),
         )
     if isinstance(pat, RectGrid):
-        frame = Frame(_pt(pat.center), axis)
+        frame = Frame(_xyz(pat.center), axis)
         return PatternFeature(
             frame,
             "grid",
@@ -102,7 +93,7 @@ def _pattern_feature(pat, members) -> PatternFeature:
             cols=pat.cols,
             angle=pat.angle,
         )
-    frame = Frame(_pt(members[0].location), axis)  # unknown type — plain count× callout
+    frame = Frame(_xyz(members[0].location), axis)  # unknown type — plain count× callout
     return PatternFeature(frame, "other", n, _member_hole(members[0], frame), members=locs)
 
 
@@ -133,7 +124,7 @@ def build_part_model(part) -> PartModel:
     for h in holes:
         if id(h) in patterned:
             continue
-        features.append(_member_hole(h, Frame(origin=_pt(h.location), axis=_axis_letter(h))))
+        features.append(_member_hole(h, Frame(origin=_xyz(h.location), axis=_axis_letter(h))))
 
     # Turned profile → step segments; else external bosses → diameters.
     prof = find_turned_steps(part)
@@ -162,7 +153,7 @@ def build_part_model(part) -> PartModel:
         for b in bosses:
             features.append(
                 BossFeature(
-                    frame=Frame(origin=_pt(b.location), axis=_axis_letter(b)),
+                    frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
                     diameter=b.diameter,
                 )
             )

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -21,11 +21,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from draftwright._core import _END_ON
 from draftwright.model.ir import DimParameter, Feature, PartModel, Point
-
-# The view a cylinder is seen end-on (as a circle), by its axis — where a
-# diameter callout belongs. Orientation is data: X and Z go through the same rule.
-_END_ON = {"x": "side", "y": "front", "z": "plan"}
 
 # How each (role, kind) is drawn. Defaults keep the table small.
 _CONVENTION = {

--- a/tests/test_e2e_slice.py
+++ b/tests/test_e2e_slice.py
@@ -17,8 +17,8 @@ import os
 from build123d import Box, Cylinder, Pos
 
 from draftwright import build_drawing
+from draftwright.annotations.from_model import render_into
 from draftwright.model import build_part_model
-from draftwright.model.render import render_into
 
 
 def _plate():

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -13,8 +13,8 @@ from build123d import Box, Cylinder, Pos
 from build123d_drafting.helpers import Leader
 
 from draftwright import build_drawing
+from draftwright.annotations.from_model import hole_callout_spec, render_callouts
 from draftwright.model import build_part_model, plan_dimensions
-from draftwright.model.render import hole_callout_spec, render_callouts
 
 
 def _groups(part):


### PR DESCRIPTION
Closes #221. Layering + dedup cleanup before more renderers pile on (ADR 0008 convergence, Amendment 3). **No behaviour change** — output identical across turned/prismatic/holed parts; the value is structural.

## Layering — the IR package is now pure
`model/render.py` → `annotations/from_model.py` (history preserved). `model/{ir,detect,planner}` now import **no** annotations or helpers; the renderer back-end lives in `annotations/`, importing *down* into `model` + `_core`, called by the orchestrator. This removes the model→annotations smell the slice review flagged.

## Duplication collapsed
- **Two leader builders → one path:** a shared `_hole_callout` + the placed `_place_leader`; `render_callouts` now routes through the placed path (no obstacles → deterministic). The fixed-offset `_callout_leader` is deleted.
- **`_END_ON`** (was in `planner` *and* `coverage`) → one home in `_core`.
- **Vector→tuple helper** (`_pt` in `detect` / `_loc_xyz` in `coverage`) → one `_xyz` in `_core`.
- **`_dim_vertices`** — the error-tolerant `Dimension.vertices()` harvest shared by the two drawing-derived coverage checks.

## Out of scope (noted, not a duplication/divergence concern)
A `dwg` accessor to replace `_named`/`_anno_view` reach-through — a Drawing-API change, lower value; left for later.

## Verification
Output identical (turned/prismatic/holed all lint 1.0). Full fast suite **585 passed / 1 skipped**; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)