### PR TITLE
feat: converge hole centre marks onto the IR (#220 part 1)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -15,9 +15,17 @@ not equivalence to the engine. `render_step_lengths` is wired into production;
 
 from __future__ import annotations
 
-from build123d_drafting.helpers import Dimension, HoleCallout, Leader, TitleBlock
+from build123d_drafting.helpers import CenterMark, Dimension, HoleCallout, Leader, TitleBlock
 
-from draftwright._core import _DIAM_RE, _MARGIN, _dim, _fmt, _greedy_strip_ys, _solve_strip_ys
+from draftwright._core import (
+    _DIAM_RE,
+    _END_ON,
+    _MARGIN,
+    _dim,
+    _fmt,
+    _greedy_strip_ys,
+    _solve_strip_ys,
+)
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
 from draftwright.model.planner import DimensionGroup, plan_dimensions
 
@@ -149,6 +157,25 @@ def _diameter_leader(dwg, group, obstacles) -> Leader | None:
     if dia is None:
         return None
     return _place_leader(dwg, group.view, group.anchor, obstacles, label=f"ø{_fmt(dia)}")
+
+
+def render_centermarks(dwg, model) -> int:
+    """A centre mark on every hole (plain holes + each pattern member), in the view
+    normal to the hole's axis (`_END_ON`), sized by its diameter — the IR migration
+    of the engine's inline centre-mark loop. Returns the count placed."""
+    n = 0
+    for g in plan_dimensions(model):
+        if g.feature_kind not in ("hole", "pattern"):
+            continue
+        dia = _first(g, "diameter", "bore") or 0.0
+        size = max(2.5, dia * dwg.scale + 2.0)
+        view = _END_ON.get(g.feature.frame.axis, "plan")
+        members = getattr(g.feature, "members", ()) or [g.anchor]
+        for loc in members:
+            px, py, *_ = dwg.at(view, *loc)
+            dwg.add(CenterMark((px, py, 0), size, dwg.draft), f"m_cm{n}", view=view)
+            n += 1
+    return n
 
 
 def _mentioned_diameters(dwg) -> set[float]:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -17,7 +17,6 @@ import math
 
 from build123d_drafting.helpers import (
     Centerline,
-    CenterMark,
     Leader,
 )
 
@@ -38,7 +37,11 @@ from draftwright._core import (
     _log,
     _tag_sequence,
 )
-from draftwright.annotations.from_model import render_diameters, render_step_lengths
+from draftwright.annotations.from_model import (
+    render_centermarks,
+    render_diameters,
+    render_step_lengths,
+)
 from draftwright.annotations.holes import (
     _add_location_dims,
     _annotate_holes,
@@ -248,11 +251,12 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         "x": ("side", lambda h: (SX(h.location[1]), SZ(h.location[2]))),
     }
 
-    # Centre marks for every hole (all part classes)
-    for i, h in enumerate(a.holes):
-        view, to_page = view_of_axis[_axis_letter(h)]
-        size = max(2.5, h.diameter * a.SCALE + 2.0)
-        dwg.add(CenterMark(to_page(h), size, draft), f"cm_{view}{i}", view=view)
+    # The part model — built once and rendered from for the IR-migrated passes
+    # (centre marks, turned diameters/lengths); ADR 0008 convergence / #229.
+    _model = build_part_model(a.part)
+
+    # Centre marks for every hole (all part classes) — IR renderer.
+    render_centermarks(dwg, _model)
 
     # Hole callouts, location dims, and the section view fire on *feature
     # presence*, independent of the turned/prismatic class (#10): the
@@ -444,7 +448,6 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     #    (#223). Replaces the old X-only chain + the Z step-height ladder (skipped
     #    above for turned parts); the envelope dim along the turning axis was
     #    suppressed so the chain does not double-dimension the length.
-    _model = build_part_model(a.part)
     render_diameters(dwg, _model)
     if _turned_prof is not None:
         render_step_lengths(dwg, _model)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2404,7 +2404,7 @@ class TestAutoHoleAnnotations:
 
     @pytest.mark.timeout(120)
     def test_every_hole_gets_a_centre_mark(self, plate_drawing):
-        cm = [n for n in plate_drawing._named if n.startswith("cm_")]
+        cm = [n for n in plate_drawing._named if n.startswith("m_cm")]
         assert len(cm) == 7  # 6 z-holes in plan + 1 x-hole in side
         assert all(plate_drawing._named[n].is_centerline for n in cm)
 
@@ -2483,7 +2483,7 @@ class TestAutoHoleAnnotations:
         assert "ldr_z0" in dwg._named
         assert not any(n.startswith("hc_") for n in dwg._named)
         # the central bore still gets a centre mark in the plan view
-        assert any(n.startswith("cm_plan") for n in dwg._named)
+        assert any(n.startswith("m_cm") and dwg._anno_view.get(n) == "plan" for n in dwg._named)
 
     @pytest.mark.timeout(60)
     def test_plan_bore_leaders_elbow_outside_view(self):


### PR DESCRIPTION
First sub-migration of the holes pass (ADR 0008 convergence): **centre marks**, migrate-and-delete.

- **`from_model.render_centermarks`** — a centre mark on every hole (plain holes + each pattern member), in the view normal to the hole's axis (`_END_ON`), sized by diameter. The IR migration of the orchestrator's inline `cm_` loop.
- The orchestrator now **builds the `PartModel` once** near the top and renders centre marks from it (reusing it for turned diameters/lengths — the duplicate build in the turned section is removed). The inline centre-mark loop is **deleted**; the unused `CenterMark` import dropped.

## Verification
Counts/views preserved: 7-hole fixture → 7 marks (6 in plan); bolt circle → 4; concentric bore → 1; all `is_centerline`; lint clean. Tests repointed to `m_cm` names (+ view via `_anno_view`). Full fast suite **585 passed / 1 skipped**; ruff/format/mypy clean.

Part of #220 (holes convergence — callouts + location dims follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)