### PR TITLE
feat: converge envelope width/depth onto a zone-aware IR renderer (ADR 0008)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -21,6 +21,8 @@ from draftwright._core import (
     _DIAM_RE,
     _END_ON,
     _MARGIN,
+    _SLOT_DIM_DEPTH,
+    _SLOT_DIM_WIDTH,
     _dim,
     _fmt,
     _greedy_strip_ys,
@@ -301,6 +303,70 @@ def render_diameters(dwg, model, tol: float = 0.15) -> int:
         elif axis == "z":
             cols.append((g.anchor, dia))
     return _diameter_row_below(dwg, rows) + _diameter_column_left(dwg, cols)
+
+
+def _env_param(group, role):
+    """The EnvelopeFeature DimParameter with the given role (width/depth/height)."""
+    return next((pd.param for pd in group.dims if pd.param.role == role), None)
+
+
+def render_envelope(dwg, model, a, *, suppress_width: bool = False) -> int:
+    """Overall width (plan, below) + depth (side, below) envelope dims via the IR,
+    placed through the engine's below-strip zone allocators (the zone-aware render
+    stage — so a migrated dim still coordinates with the un-migrated passes sharing
+    those strips). Sources values/spans from `EnvelopeFeature`. Skips a square
+    footprint (a single dim suffices) and, when *suppress_width*, the width (an
+    X-turned part's step chain already conveys the length, ISO 129). Returns the
+    count placed."""
+    env = next((g for g in plan_dimensions(model) if g.feature_kind == "envelope"), None)
+    if env is None:
+        return 0
+    width, depth = _env_param(env, "width"), _env_param(env, "depth")
+    if width is None or depth is None:
+        return 0
+    # Square footprint: width ≈ depth → one dim suffices (the engine's gate).
+    if abs(width.value - depth.value) <= max(width.value, depth.value) * 0.05:
+        return 0
+    n = 0
+    if not suppress_width and width.span is not None:
+        (x0, y0, z0), (x1, _, _) = width.span
+        p1, p2 = dwg.at("plan", x0, y0, z0), dwg.at("plan", x1, y0, z0)
+        witness = p1[1] - 2
+        py = a.pv_zones.below.allocate(_SLOT_DIM_WIDTH)
+        if py is not None:
+            dwg.add(
+                _dim(
+                    (p1[0], witness, 0),
+                    (p2[0], witness, 0),
+                    "below",
+                    witness - py,
+                    dwg.draft,
+                    label=_fmt(width.value),
+                ),
+                "m_env_width",
+                view="plan",
+            )
+            n += 1
+    if depth.span is not None:
+        (x0, y0, z0), (_, y1, _) = depth.span
+        p1, p2 = dwg.at("side", x0, y0, z0), dwg.at("side", x0, y1, z0)
+        witness = p1[1] - 2
+        pd = a.sv_zones.below.allocate(_SLOT_DIM_DEPTH)
+        if pd is not None:
+            dwg.add(
+                _dim(
+                    (p1[0], witness, 0),
+                    (p2[0], witness, 0),
+                    "below",
+                    witness - pd,
+                    dwg.draft,
+                    label=_fmt(depth.value),
+                ),
+                "m_env_depth",
+                view="side",
+            )
+            n += 1
+    return n
 
 
 def _envelope_dims(dwg, group) -> list[tuple[Dimension, str]]:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -22,10 +22,8 @@ from build123d_drafting.helpers import (
 
 from draftwright._core import (
     _CONCENTRIC_TOL_MM,
-    _SLOT_DIM_DEPTH,
     _SLOT_DIM_HEIGHT,
     _SLOT_DIM_STEP,
-    _SLOT_DIM_WIDTH,
     _TABULATE_MIN_HOLES,
     Analysis,
     _add_title_block,
@@ -40,6 +38,7 @@ from draftwright._core import (
 from draftwright.annotations.from_model import (
     render_centermarks,
     render_diameters,
+    render_envelope,
     render_step_lengths,
 )
 from draftwright.annotations.holes import (
@@ -389,45 +388,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Suppress it. (_turned_prof was computed at the step-height section above.)
     _x_turned = _turned_prof is not None and _turned_prof.axis == "x"
 
-    # Width (non-round / non-square parts only) — routed through pv_zones.below
-    if not _x_turned and abs(a.x_size - a.y_size) > max(a.x_size, a.y_size) * 0.05:
-        _below_witness = PY(a.bb.min.Y) - 2
-        _py = a.pv_zones.below.allocate(_SLOT_DIM_WIDTH)
-        if _py is not None:
-            dwg.add(
-                _dim(
-                    (PX(a.bb.min.X), _below_witness, 0),
-                    (PX(a.bb.max.X), _below_witness, 0),
-                    "below",
-                    _below_witness - _py,
-                    draft,
-                    label=_fmt(a.x_size),
-                ),
-                "dim_width",
-                view="plan",
-            )
-        else:
-            _log.warning("dim_width skipped: pv_zones.below strip full")
-
-    # Depth (Y envelope) — same guard as dim_width; routed through sv_zones.below
-    if abs(a.x_size - a.y_size) > max(a.x_size, a.y_size) * 0.05:
-        _below_witness_d = SZ(a.bb.min.Z) - 2
-        _pd = a.sv_zones.below.allocate(_SLOT_DIM_DEPTH)
-        if _pd is not None:
-            dwg.add(
-                _dim(
-                    (SX(a.bb.min.Y), _below_witness_d, 0),
-                    (SX(a.bb.max.Y), _below_witness_d, 0),
-                    "below",
-                    _below_witness_d - _pd,
-                    draft,
-                    label=_fmt(a.y_size),
-                ),
-                "dim_depth",
-                view="side",
-            )
-        else:
-            _log.warning("dim_depth skipped: sv_zones.below strip full")
+    # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
+    # placed through the same below-strip zone allocators the engine used (zone-aware
+    # render stage, ADR 0008). Width is suppressed for an X-turned part (its step
+    # chain conveys the length); a square footprint gets neither (one dim suffices).
+    render_envelope(dwg, _model, a, suppress_width=_x_turned)
 
     # The section view goes last: its room check clears every annotation
     # already placed right of the side view (callout labels, height/step

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -419,12 +419,13 @@ class TestStripZones:
 
         from draftwright import build_drawing
 
-        # non-square part → x_size != y_size → dim_width should appear
+        # non-square part → width != depth → the width dim should appear (IR
+        # renderer m_env_width, still routed through pv_zones.below).
         part = Box(80, 40, 20)
         dwg = build_drawing(part)
         a = dwg._analysis
-        assert "dim_width" in dwg._named
-        ann = dwg._named["dim_width"]
+        assert "m_env_width" in dwg._named
+        ann = dwg._named["m_env_width"]
         assert ann.label == "80"
         assert a.pv_zones.below.depth_used > 0
 
@@ -586,13 +587,14 @@ class TestStripZones:
 
         from draftwright import build_drawing
 
-        # 80×40×20 box: x_size=80, y_size=40 — differ by > 5%, so dim_depth fires
+        # 80×40×20 box: width=80, depth=40 — differ by > 5%, so the depth dim fires
+        # (IR renderer m_env_depth, still routed through sv_zones.below).
         part = Box(80, 40, 20)
         dwg = build_drawing(part)
         a = dwg._analysis
-        assert "dim_depth" in dwg._named, "expected dim_depth for part with x_size != y_size"
-        ann = dwg._named["dim_depth"]
-        assert ann.label == "40", f"dim_depth label should be y_size=40, got {ann.label!r}"
+        assert "m_env_depth" in dwg._named, "expected m_env_depth for part with width != depth"
+        ann = dwg._named["m_env_depth"]
+        assert ann.label == "40", f"depth label should be y_size=40, got {ann.label!r}"
         assert a.sv_zones.below.depth_used > 0
 
     def test_dim_depth_absent_for_square_plan(self):
@@ -603,7 +605,7 @@ class TestStripZones:
 
         part = Box(60, 60, 20)  # square plan: x_size == y_size
         dwg = build_drawing(part)
-        assert "dim_depth" not in dwg._named, "dim_depth should be skipped for square plan"
+        assert "m_env_depth" not in dwg._named, "depth dim should be skipped for square plan"
 
 
 # ---------------------------------------------------------------------------
@@ -1090,7 +1092,7 @@ class TestTwoPassLayout:
         assert available > needed, (
             f"pv_zones.below available {available:.1f} mm must exceed needed {needed:.1f} mm"
         )
-        assert "dim_width" in dwg._named, "dim_width must not be skipped"
+        assert "m_env_width" in dwg._named, "width dim must not be skipped"
 
 
 class TestComposeThenPackRepack:
@@ -4478,7 +4480,7 @@ class TestTurnedLengths:
         # The complete chain conveys the overall length, so the envelope width dim
         # is dropped — no double dimensioning (ISO 129).
         dwg = build_drawing(_x_stepped_shaft())
-        assert "dim_width" not in dwg._named
+        assert "m_env_width" not in dwg._named
 
     def test_turned_part_lints_clean(self):
         dwg = build_drawing(_x_stepped_shaft())


### PR DESCRIPTION
The **first zone-aware IR migration** — acting on the layout-integration decision (ADR 0008 Amendment 3): IR renderers place through the engine's zone allocators so a migrated dim coordinates with the un-migrated passes sharing those strips (no collisions → one-at-a-time migration stays safe).

## What
- **`from_model.render_envelope`** — overall **width** (plan, below) + **depth** (side, below) from `EnvelopeFeature`, allocating through the same `pv_zones.below` / `sv_zones.below` strips the engine used. Preserves the engine's gates (square footprint → skip; X-turned → suppress width, the step chain conveys length).
- **Deletes** the inline width/depth blocks in the orchestrator (+ their now-unused slot-constant imports). Height (right-strip ladder) and OD remain inline — a later step.
- Reuses the build-once `_model` (#229).

## Verification
- **Visual:** prismatic plate width `100` / depth `60` identical to the engine (below plan / below side); full drawing tidy + complete.
- **Behaviour change:** turned parts no longer get redundant envelope width/depth box dims (their extents are the diameter/length, already covered by ø/OD/chain) — lint clean, arguably tidier.
- Full fast suite **585 passed / 1 skipped**; ruff/format/mypy clean; 5 tests repointed to `m_env_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)