### PR TITLE
docs: ADR 0008 Amendment 4 — the IR/infrastructure boundary

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -1,10 +1,11 @@
 # ADR 0008 — The part-drawing compiler: a Feature/DimParameter IR and a dimensioning planner
 
 - **Status:** Accepted — architecture stands; **migration is a correctness-judged
-  strangler that converges on ONE path** (Amendment 3, superseding Amendment 2's
-  divergence implication). Not reproduce-and-swap (Amendment 2), not two permanent
-  paths — incremental migration where each step deletes the engine pass it replaces.
-  The equivalence golden gate is retired.
+  strangler that converges on ONE feature→dimension path** (Amendment 3), which
+  *feeds* the engine's shared layout/table/section/projection/export infrastructure
+  rather than reabsorbing it (Amendment 4). Not reproduce-and-swap (Amendment 2),
+  not two permanent paths — incremental migration where each step deletes the
+  per-feature engine pass it replaces. The equivalence golden gate is retired.
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Supersedes the original 0008** ("unified feature model") with a concrete
@@ -249,6 +250,37 @@ Net effect vs the two rejected approaches: not a big-bang equivalence swap
 incremental, correctness-judged convergence that ends with one architecture and the
 engine's per-feature passes deleted. Tracked in
 [`docs/plans/0008-convergence-roadmap.md`](../plans/0008-convergence-roadmap.md).
+
+## Amendment 4 (2026-06-29) — the IR/infrastructure boundary
+
+"One path" (Amendment 3) is about the **feature→dimension-intent** path, not a
+rewrite of the drawing engine's *shared infrastructure*. Reviewing the remaining
+migrations showed several were mis-scoped as "model X in the IR" when X is actually
+shared infra the IR should **feed**, not absorb. Draw the line explicitly:
+
+- **Belongs in the IR path (migrate + delete the per-feature code):** feature
+  *recognition* (detectors → `Feature`s) and *what to dimension* (`DimParameter`s,
+  the planner's convention rules, the render intent — which callout/dim, which
+  view, which datum).
+- **Stays as shared infrastructure (the IR feeds it; do NOT reabsorb or rewrite):**
+  the zone-strip layout allocators (ADR 0003), the hole-table / balloon escalation
+  (`add_table`/`add_hole_table`/`_maybe_tabulate_holes`), the section/detail-view
+  *rendering* machinery, projection (`Drawing.at`), and export. These are
+  feature-agnostic services. A migrated renderer *calls* them (e.g. the zone-aware
+  `render_envelope` allocates from `fv/pv/sv` strips); it does not replace them.
+
+Consequences for scope:
+- **Definition of done** is "the per-feature *recognition + placement* passes
+  (`annotations/{holes,sections,pmi}`, inline envelope/OD/step-ladder) are deleted
+  and the orchestrator is `build model → plan → render`" — **with the shared
+  layout/table/section/projection/export infrastructure intact.**
+- A feature that needs a *section* contributes a **trigger** to the planner; the
+  existing section machinery renders it. A dense hole field contributes its **hole
+  set**; the existing escalation tabulates it. The IR decides *what/where*; the
+  infra decides *how it is drawn*.
+
+This shrinks the holes (#238) and sections (#207) epics from "rebuild the
+infrastructure" to "model the feature intent and feed the existing services."
 
 ## Consequences
 

--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -67,11 +67,29 @@ When these land, the orchestrator's per-feature calls are gone and it reduces to
   the scaffold then so no divergent path lingers. (`render_callouts`/`render_into`
   currently drive only the seam + e2e-slice tests.)
 
+## The IR / infrastructure boundary (ADR 0008 Amendment 4)
+
+Migrate the **feature→dimension-intent** logic only. The **shared infrastructure**
+stays — the IR *feeds* it, never reabsorbs it:
+
+- **IR path (migrate + delete):** detectors, `Feature`s/`DimParameter`s, planner
+  convention rules, render intent (which callout/dim, which view, which datum).
+- **Shared infra (keep; the renderer calls it):** zone-strip allocators, the
+  hole-table/balloon escalation (`add_table`/`_maybe_tabulate_holes`), section/detail
+  *rendering*, projection (`Drawing.at`), export.
+
+So a section is *triggered* by the planner but *drawn* by the existing section
+machinery; a dense hole field is *modelled* as a hole set but *tabulated* by the
+existing escalation. This is why #238/#207 are "model the intent + feed the infra,"
+not "rebuild the infra."
+
 ## Definition of done (the whole ADR)
 
-- `annotations/{holes,turned,sections,pmi}` per-feature passes deleted; the inline
-  envelope/OD/centre-mark/step-ladder code gone from the orchestrator.
-- One path: detectors → IR → planner → render-intents → shared layout/export.
+- The per-feature **recognition + placement** passes deleted —
+  `annotations/{holes,sections,pmi}` and the inline envelope/OD/step-ladder code in
+  the orchestrator; orchestrator reduced to `build model → plan → render`.
+- **Shared layout/table/section/projection/export infrastructure intact** (fed by
+  the IR, per Amendment 4) — not rewritten.
 - No `render_into` test-only parallel; no engine/IR duplication.
 - Full standards + geometry suites green; X/Z parity tests per feature.
 - ADR 0008 status → "migration complete; one path".


### PR DESCRIPTION
Clarifies "one path" (Amendment 3): it's the **feature→dimension-intent** path, which **feeds** the engine's shared infrastructure (zone allocators, hole-table/balloon escalation, section rendering, projection, export) — it does **not** reabsorb or rewrite it.

Reviewing the remaining epics showed several were mis-scoped as "model X in the IR" when X is shared infra (`_maybe_tabulate_holes` is already separable; section *rendering* is shared; zones are shared). Amendment 4 draws the line explicitly and updates the Definition of Done: the shared infra stays intact; only the per-feature recognition+placement passes are deleted. This shrinks #238 (holes) and #207 (sections) from "rebuild infra" to "model intent + feed services."

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)