### PR TITLE
docs: ADR 0008 Amendment 5 + roadmap — one inventory & foundation hardening (#241)

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -6,6 +6,8 @@
   rather than reabsorbing it (Amendment 4). Not reproduce-and-swap (Amendment 2),
   not two permanent paths — incremental migration where each step deletes the
   per-feature engine pass it replaces. The equivalence golden gate is retired.
+  **One path implies one feature inventory** (Amendment 5): `_analyse` and the IR
+  must not re-detect independently — keystone of the remaining migration (#241).
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Supersedes the original 0008** ("unified feature model") with a concrete
@@ -281,6 +283,45 @@ Consequences for scope:
 
 This shrinks the holes (#238) and sections (#207) epics from "rebuild the
 infrastructure" to "model the feature intent and feed the existing services."
+
+## Amendment 5 (2026-06-29) — ONE feature inventory; foundation hardening (#241)
+
+A mid-migration review (#241) surfaced that "one path" (Amendment 3) needs a
+companion invariant: **one feature inventory.** As production passes migrate onto
+the IR, the engine's `_analyse()` and the IR's `build_part_model()` were left
+*both* running feature detection — `find_holes`/`find_turned_steps`/`find_bosses`/
+`find_slots` are now run by `_analyse`, by `build_part_model`, *and* (for turned
+steps) by the orchestrator — detecting some features 3×. That is a performance
+cost and, worse, a **divergence risk**: two inventories that can disagree while
+both are live. With the engine slot/diameter/length passes now deleted, parts of
+`_analyse`'s feature set (`a.slots`) have no remaining reader — pure duplication.
+
+**Invariant:** there is **one** feature inventory per build. `_analyse()` and
+`build_part_model()` must not independently re-detect; the IR is built *from*
+`_analyse`'s products (or `_analyse` builds and caches the `PartModel` once and
+threads it). This is the **keystone** of the remaining migration — the unmigrated
+epics (#237, #238) will consume the model, so the model must be the single source
+first.
+
+The review also named three foundation smells to hold the line on as migration
+continues (tracked in #241):
+
+- **No new private-`Drawing`-state reads.** `_named`/`_anno_view`/`_pinned`/
+  `_build_issues`/`_pattern_callouts`/… remain as ADR-0005 migration aliases;
+  production code (incl. the new renderers) should reach annotation
+  ownership/iteration/build-issues through a small **registry-backed accessor**,
+  not the raw aliases. Don't widen the state-bus surface.
+- **The planner grows render *intents*, not layout.** Suppression reason,
+  preferred view, semantic datum/reference, and feature grouping belong in the
+  planner's output; *how* it is drawn stays in layout/render infra (Amendment 4).
+  This is the next planner-contract increment (after the inventory is unified).
+- **Docs/comments track the live state.** The architecture is moving fast; stale
+  "prototype / not yet wired" / Amendment-2 framing must be swept after each
+  convergence PR so it does not misdirect the next one.
+
+Order: **unify the inventory first** (keystone), then the docs sweep, the accessor
+boundary, the planner-intent increment, and finally delete the `render_into`
+test-only parallel once the holes epic supersedes it.
 
 ## Consequences
 

--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -40,11 +40,32 @@ Every migration PR must:
 - **Envelope width/depth** — inline blocks *deleted*; the **first zone-aware** IR
   renderer (`render_envelope`, places through the engine's below-strips so it
   coordinates with un-migrated passes) (PR #236).
+- **Slots** — `SlotFeature` + `render_slots`; engine `_annotate_slots` *deleted*;
+  a genuinely new feature type end-to-end (PR #242).
 
 The mechanically-tractable migrate-and-delete work is done. **What remains needs
-new IR modelling, not a mechanical loop** — each is a design epic (below).
+new IR modelling, not a mechanical loop.**
 
-## Remaining — design epics (need IR modelling, not loop iterations)
+## Foundation hardening — do FIRST (ADR 0008 Amendment 5, review #241)
+
+A mid-migration review (#241) found the foundation must catch up before the last
+epics, because the IR is now load-bearing for 6 production passes. **Ordered:**
+
+1. **Unify the feature inventory** — *keystone.* `_analyse` and `build_part_model`
+   both re-detect (turned steps 3× per build; `a.slots` now has no reader). Build
+   the `PartModel` from `_analyse`'s products (or `_analyse` builds+caches it once
+   and threads it) — one inventory, no divergence. Prereq for the epics below.
+2. **Docs/comment sweep** — `model/__init__` still says "prototype, not wired";
+   `test_e2e_slice` + some `from_model` comments carry Amendment-2 framing. Cheap.
+3. **Annotation-ownership accessor** — a registry-backed API for
+   ownership/iteration/build-issues so production stops reading `dwg._named`/
+   `_anno_view` directly (the new renderers added more reads). No new aliases.
+4. **Planner render-intent increment** — suppression/view/datum/grouping move into
+   the planner output (not layout; Amendment 4). After the inventory is unified.
+5. **Delete `render_into`** — the test-only parallel; superseded in production by
+   `render_envelope`/`render_diameters`; retire once the holes epic (#238) lands.
+
+## Remaining — feature epics (need IR modelling; AFTER foundation #1–#2)
 
 Ordered by value / readiness. Each needs the modelling in its **Prereq** before the
 migrate-and-delete is even possible.


### PR DESCRIPTION
Captures the mid-migration review #241 into the ADR + roadmap before acting on it.

## Amendment 5 — one feature inventory (keystone)
"One path" (Amendment 3) needs a companion invariant: **one feature inventory**. `_analyse()` and `build_part_model()` currently both re-detect (turned steps **3×** per build; `a.slots` now has no reader after the engine slot pass was deleted). The IR must be built *from* `_analyse`'s products (or `_analyse` builds+caches the `PartModel` once and threads it). This is the **keystone** — the remaining epics (#237/#238) consume the model, so it must be the single inventory first.

Plus the foundation guardrails #241 named: no new private-`Drawing`-state reads (registry accessor), planner grows render *intents* not layout (Amendment 4), docs track live state.

## Roadmap
- Records slots (PR #242) done.
- Adds a **Foundation-hardening** section, ordered keystone-first: unify inventory → docs sweep → accessor → planner intents → delete `render_into` — **before** the remaining feature epics.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)