### PR TITLE
feat: unify the feature inventory at build time — one detection (#244 part 1)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -16,6 +16,10 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from draftwright.recognition import TurnedProfile
 
 from build123d import Align, BoundBox, Location, Mode, Shape, Text
 from build123d_drafting.helpers import (
@@ -420,6 +424,7 @@ class Analysis:
     z_diams: list[float]
     cross_diams: list[float]
     cyls: tuple[list, list]
+    prof: TurnedProfile | None  # turned step profile (find_turned_steps), detected once
     od_diam: float | None
     is_rotational: bool
     step_zs: list[float]

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -437,6 +437,7 @@ def _analyse(
         z_diams=z_diams,
         cross_diams=cross_diams,
         cyls=(z_cyls, cross_cyls),
+        prof=_turned,
         od_diam=od_diam,
         is_rotational=is_rotational,
         step_zs=step_zs,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -51,7 +51,6 @@ from draftwright.annotations.pmi import _annotate_pmi
 from draftwright.annotations.sections import _add_detail_view, _add_section_view
 from draftwright.model import build_part_model
 from draftwright.recognition import (
-    find_turned_steps,
     full_cylinders,
 )
 
@@ -252,7 +251,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     # The part model — built once and rendered from for the IR-migrated passes
     # (centre marks, turned diameters/lengths); ADR 0008 convergence / #229.
-    _model = build_part_model(a.part)
+    _model = build_part_model(
+        a.part, holes=a.holes, patterns=a.patterns, slots=a.slots, prof=a.prof
+    )
 
     # Centre marks for every hole (all part classes) — IR renderer.
     render_centermarks(dwg, _model)
@@ -288,7 +289,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # this engine ladder is skipped for turned parts.
     #   If the steps form a uniform staircase (#45) place a single representative
     #   dim labelled "N× rise"; otherwise the per-step ladder (legibility-gated, #41).
-    _turned_prof = find_turned_steps(a.part)
+    _turned_prof = a.prof  # detected once in _analyse (one inventory, #244)
     _step_rep = (
         None
         if _turned_prof is not None

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -108,16 +108,27 @@ def _distinct_by_diameter(bosses, tol: float = 0.15):
     return list(out.values())
 
 
-def build_part_model(part) -> PartModel:
-    """Run the detectors and assemble the :class:`PartModel` IR for *part*."""
+_UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
+
+
+def build_part_model(part, *, holes=None, patterns=None, slots=None, prof=_UNSET) -> PartModel:
+    """Run the detectors and assemble the :class:`PartModel` IR for *part*.
+
+    The detected feature sets may be **supplied** by the caller (from `_analyse`,
+    which already ran them) so detection happens **once per build** — the single
+    feature inventory (ADR 0008 Amendment 5, #244). Omitted sets are detected here,
+    so a standalone ``build_part_model(part)`` still works. ``prof`` uses a sentinel
+    because ``None`` is a valid value (a non-turned part)."""
     bbox = part.bounding_box()
     features: list[Feature] = []
 
     # Holes and hole patterns. A recognised pattern becomes one PatternFeature
     # (count× member-diameter + pattern dims); its member holes are NOT also
     # emitted individually — the grouped-callout rule the engine uses.
-    holes = find_holes(part)
-    patterns = find_hole_patterns(holes)
+    if holes is None:
+        holes = find_holes(part)
+    if patterns is None:
+        patterns = find_hole_patterns(holes)
     patterned: set[int] = set()
     for pat in patterns:
         members = list(pat.holes)
@@ -129,7 +140,9 @@ def build_part_model(part) -> PartModel:
         features.append(_member_hole(h, Frame(origin=_xyz(h.location), axis=_axis_letter(h))))
 
     # Milled slots / reduced across-flats sections (detected for any part).
-    for sl in find_slots(part):
+    if slots is None:
+        slots = find_slots(part)
+    for sl in slots:
         idx = "xyz".index(sl.long_axis)
         origin = [bbox.center().X, bbox.center().Y, bbox.center().Z]
         origin[idx] = (sl.lo + sl.hi) / 2
@@ -147,7 +160,8 @@ def build_part_model(part) -> PartModel:
         )
 
     # Turned profile → step segments; else external bosses → diameters.
-    prof = find_turned_steps(part)
+    if prof is _UNSET:
+        prof = find_turned_steps(part)
     orientation = prof.axis if prof is not None else None
     if prof is not None:
         idx = "xyz".index(prof.axis)

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -243,3 +243,32 @@ class TestOpenClosed:
         groups = plan_dimensions(model)  # planner never heard of keyways
         assert isinstance(groups[0], DimensionGroup) and groups[0].feature_kind == "keyway"
         assert sorted(pd.param.value for pd in _all_dims(groups)) == [4.0, 20.0]
+
+
+def test_feature_detection_runs_once_per_build(monkeypatch):
+    """ADR 0008 Amendment 5 / #244 — one feature inventory: _analyse detects, and
+    build_part_model consumes those results, so each find_* runs ONCE per build
+    (was: holes/patterns/slots 2×, turned steps 3×)."""
+    from build123d import Cylinder, Pos, Rotation
+
+    from draftwright import build_drawing
+    import draftwright.analysis as anmod
+    import draftwright.model.detect as dmod
+
+    counts: dict[str, int] = {}
+    for name in ("find_holes", "find_hole_patterns", "find_slots", "find_turned_steps"):
+        for mod in (anmod, dmod):
+            orig = getattr(mod, name)
+
+            def wrap(*a, _orig=orig, _n=name, **k):
+                counts[_n] = counts.get(_n, 0) + 1
+                return _orig(*a, **k)
+
+            monkeypatch.setattr(mod, name, wrap)
+
+    # A turned X shaft exercises holes/patterns/slots + the turned profile.
+    build_drawing(Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)))
+    assert counts.get("find_holes") == 1
+    assert counts.get("find_hole_patterns") == 1
+    assert counts.get("find_slots") == 1
+    assert counts.get("find_turned_steps") == 1

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -251,9 +251,9 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     (was: holes/patterns/slots 2×, turned steps 3×)."""
     from build123d import Cylinder, Pos, Rotation
 
-    from draftwright import build_drawing
     import draftwright.analysis as anmod
     import draftwright.model.detect as dmod
+    from draftwright import build_drawing
 
     counts: dict[str, int] = {}
     for name in ("find_holes", "find_hole_patterns", "find_slots", "find_turned_steps"):


### PR DESCRIPTION
**Keystone of the ADR 0008 convergence** (Amendment 5). `_analyse()` already detects holes/patterns/slots/turned-profile, but `build_part_model` and the orchestrator were re-detecting the same features — **turned steps ran 3× per build**, holes/patterns/slots 2×.

## What
- `Analysis` gains a **`prof`** field (the `find_turned_steps` profile, detected once in `_analyse` — it was already computed there for `step_zs`).
- `build_part_model(part, *, holes/patterns/slots/prof)` consumes the caller's already-detected sets; omitted ones still detect (standalone calls work). A sentinel distinguishes "prof not supplied" from a valid `prof=None` (non-turned part).
- The orchestrator passes `a.holes/a.patterns/a.slots/a.prof` in, and uses `a.prof` for its turned gate/suppression — dropping its own `find_turned_steps` call + import.

## Result
`find_holes` / `find_hole_patterns` / `find_slots` / `find_turned_steps` each run **once per build** — asserted by a new counting-spy regression test. Behaviour unchanged (plate/turned/flange/slotted/box all lint 1.0). Full fast suite **586 passed / 1 skipped**; ruff/format/mypy clean.

## Scope
This is the **build-time** half. Linting (`coverage.py`) still re-detects independently — folding it onto the same inventory (it needs the model threaded onto `Drawing`) is the follow-up to finish #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)