### PR TITLE
feat: lint consumes the one inventory — finish #244

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -972,25 +972,44 @@ class Drawing:
                     view_edge_cache=self._view_edge_cache,
                 )
         if self.part is not None:
-            if self._cyl_cache is None:
-                self._cyl_cache = analyse_cylinders(self.part)
+            # Reuse the single feature inventory from the build (#244) when present,
+            # so lint does not re-detect holes/patterns/turned-steps; fall back to
+            # detecting when there is no analysis (a manually-built Drawing, or lint
+            # called mid-build before _analysis is attached).
+            a = self._analysis
+            holes: list | None
+            patterns: list | None
+            prof_kw: dict
+            if a is not None:
+                cyls = a.cyls
+                holes, patterns, prof_kw = a.holes, a.patterns, {"prof": a.prof}
+            else:
+                if self._cyl_cache is None:
+                    self._cyl_cache = analyse_cylinders(self.part)
+                cyls = self._cyl_cache
+                holes = patterns = None
+                prof_kw = {}
             issues += lint_feature_coverage(
                 self.part,
                 self.items,
-                cyls=self._cyl_cache,
+                cyls=cyls,
                 exclude=self._coverage.dropped_diams,
                 assembly=self.assembly,
+                holes=holes,
             )
             issues += lint_axial_coverage(
                 self.part,
                 self,
                 assembly=self.assembly,
+                **prof_kw,
             )
             issues += lint_location_coverage(
                 self.part,
                 self,
-                cyls=self._cyl_cache,
+                cyls=cyls,
                 assembly=self.assembly,
+                holes=holes,
+                patterns=patterns,
             )
         issues += list(self._build_issues)
         # Attach a ready-to-paste fix snippet where one is computable (#29).

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -32,6 +32,8 @@ from draftwright.recognition import (
     find_turned_steps,
 )
 
+_UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
+
 
 def _dim_vertices(ann) -> list[tuple[float, float]]:
     """A ``Dimension``'s vertices as ``(x, y)`` page points; ``[]`` if they won't
@@ -91,7 +93,7 @@ class CoverageState:
 
 
 def lint_feature_coverage(
-    part, annotations, tol: float = 0.15, cyls=None, exclude=None, assembly=None
+    part, annotations, tol: float = 0.15, cyls=None, exclude=None, assembly=None, holes=None
 ) -> list:
     """Coarse completeness check: report part diameters with no callout (#80).
 
@@ -131,13 +133,16 @@ def lint_feature_coverage(
     count semantics. Location coverage remains out of scope (#93).
     """
     z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
+    if holes is None:
+        holes = find_holes(part, cyls=(z_cyls, cross_cyls))
     # Coverage inventory: the *recognised* dimensionable diameters (bores,
     # cbore/spotface steps, bosses) from feature_diameters — built via
     # find_holes/find_bosses, so slot ends and interrupted recesses (partial
     # cylinders that an angle-only test mistakes for full bores) are excluded.
     # Replaces the raw full_cylinders patch list, which over-reported those as
-    # undimensioned features (helpers #158/#159).
-    inventory = feature_diameters(part, cyls=(z_cyls, cross_cyls))
+    # undimensioned features (helpers #158/#159). *holes* reuses the single
+    # inventory (#244); find_bosses inside feature_diameters is the one residual.
+    inventory = feature_diameters(part, cyls=(z_cyls, cross_cyls), holes=holes)
 
     if assembly is None:
         assembly = len(part.solids()) > 1
@@ -171,7 +176,7 @@ def lint_feature_coverage(
     ]
 
     required: dict[float, int] = {}
-    for h in find_holes(part, cyls=(z_cyls, cross_cyls)):
+    for h in holes:
         for d in (h.diameter, *(s.diameter for s in (h.cbore, h.spotface) if s)):
             key = next((k for k in required if abs(k - d) <= tol), d)
             required[key] = required.get(key, 0) + 1
@@ -192,7 +197,9 @@ def lint_feature_coverage(
     return issues
 
 
-def lint_location_coverage(part, dwg, cyls=None, assembly=None, tol: float = 0.6) -> list:
+def lint_location_coverage(
+    part, dwg, cyls=None, assembly=None, tol: float = 0.6, holes=None, patterns=None
+) -> list:
     """Report holes with no **centre mark** or no **locating dimension**, derived
     from the drawing itself (not a build-time side channel — so it judges any
     producer, the engine or the model pipeline alike). Closes the location-coverage
@@ -212,13 +219,16 @@ def lint_location_coverage(part, dwg, cyls=None, assembly=None, tol: float = 0.6
     Coarse by design (a hole with *no* locating witness at all is the signal); severity
     mirrors :func:`lint_feature_coverage` (``info`` for an assembly, else ``warning``).
     """
-    holes = find_holes(part, cyls=cyls) if cyls is not None else find_holes(part)
+    if holes is None:
+        holes = find_holes(part, cyls=cyls) if cyls is not None else find_holes(part)
     if not holes:
         return []
     if assembly is None:
         assembly = len(part.solids()) > 1
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
-    patterned = {id(h) for pat in find_hole_patterns(holes) for h in pat.holes}
+    if patterns is None:
+        patterns = find_hole_patterns(holes)
+    patterned = {id(h) for pat in patterns for h in pat.holes}
 
     marks: dict[str, list] = {}
     dim_verts: dict[str, list] = {}
@@ -315,7 +325,7 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
     return covered
 
 
-def lint_axial_coverage(part, dwg, assembly=None) -> list:
+def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     """Report a stepped turned part whose axial step lengths are undimensioned.
 
     A turned part can have every diameter called out yet be unmanufacturable: with
@@ -331,8 +341,12 @@ def lint_axial_coverage(part, dwg, assembly=None) -> list:
     (e.g. the chain skipped for want of page room). Only **Y-axis** turning is
     excluded — it is drawn end-on, so no view shows its length. Severity mirrors
     :func:`lint_feature_coverage`: ``info`` for an assembly, else ``warning``.
+    *prof* may be supplied (the single inventory, #244) to skip re-detection;
+    omitted, it is detected here. A sentinel distinguishes "not supplied" from a
+    valid ``prof=None`` (non-turned part).
     """
-    prof = find_turned_steps(part)
+    if prof is _UNSET:
+        prof = find_turned_steps(part)
     if prof is None or prof.axis == "y":
         return []
     if assembly is None:

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -604,7 +604,7 @@ def find_bosses(part, cyls=None) -> list:
     return bosses
 
 
-def feature_diameters(part, cyls=None) -> list:
+def feature_diameters(part, cyls=None, holes=None) -> list:
     """Sorted unique diameters of the *recognised* dimensionable cylindrical
     features on *part*: every hole bore, each hole's counterbore/spotface step,
     and every boss.
@@ -618,11 +618,15 @@ def feature_diameters(part, cyls=None) -> list:
     counterbore/spotface steps are kept. (#158)
 
     Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to share one
-    scan between ``find_holes`` and ``find_bosses``.
+    scan between ``find_holes`` and ``find_bosses``. Pass *holes* — a precomputed
+    ``find_holes`` result — to reuse the single feature inventory instead of
+    re-detecting (ADR 0008 Amendment 5, #244).
     """
     cyls = analyse_cylinders(part) if cyls is None else cyls
+    if holes is None:
+        holes = find_holes(part, cyls=cyls)
     diams: list[float] = []
-    for h in find_holes(part, cyls=cyls):
+    for h in holes:
         diams.append(h.diameter)
         if h.cbore is not None:
             diams.append(h.cbore.diameter)

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -272,3 +272,30 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     assert counts.get("find_hole_patterns") == 1
     assert counts.get("find_slots") == 1
     assert counts.get("find_turned_steps") == 1
+
+
+def test_lint_reuses_the_build_inventory(monkeypatch):
+    """#244 part 2 — linting consumes the one inventory: after a build, dwg.lint()
+    must not re-detect holes / patterns / turned steps (it reuses dwg._analysis)."""
+    from build123d import Box, Cylinder, Pos
+
+    import draftwright.linting.coverage as cov
+    from draftwright import build_drawing
+
+    part = Box(100, 60, 12) - Pos(-30, 0, 0) * Cylinder(4, 30) - Pos(30, 0, 0) * Cylinder(4, 30)
+    dwg = build_drawing(part)
+
+    calls: dict[str, int] = {}
+    for name in ("find_holes", "find_hole_patterns", "find_turned_steps"):
+        orig = getattr(cov, name)
+
+        def wrap(*a, _orig=orig, _n=name, **k):
+            calls[_n] = calls.get(_n, 0) + 1
+            return _orig(*a, **k)
+
+        monkeypatch.setattr(cov, name, wrap)
+
+    dwg.lint()
+    assert calls.get("find_holes", 0) == 0
+    assert calls.get("find_hole_patterns", 0) == 0
+    assert calls.get("find_turned_steps", 0) == 0


### PR DESCRIPTION
Part 2 of the keystone (ADR 0008 Amendment 5). Linting was the **third** independent feature detector (`lint_feature_coverage`/`lint_location_coverage`/`lint_axial_coverage` re-ran `find_holes`/`find_hole_patterns`/`find_turned_steps`/`feature_diameters`). Now it reuses the single build inventory.

## What
- **`Drawing.lint()`**: when `self._analysis` is present, reuse `a.cyls` and pass `a.holes` / `a.patterns` / `a.prof` into the coverage checks. Falls back to detecting when there's no analysis (manually-built drawing, or lint mid-build before `_analysis` is attached).
- The three coverage fns accept the pre-detected sets (`holes=` / `patterns=` / `prof=` sentinel) and skip re-detection; omitted → detect (standalone callers unchanged).
- `feature_diameters(part, cyls, holes=)` reuses the holes inventory. Its internal `find_bosses` is the one residual (bosses aren't on `Analysis` yet — noted).

## Adversarial review (done before merge)
- **Equivalence (decisive):** lint codes are **byte-identical** inventory-path vs detect-path on clean *and* non-clean parts — side-drilled (`feature_not_located` + 3× `off_axis_location_dropped`) and bored shaft.
- **`id()`-identity** for pattern exclusion preserved (`a.patterns = find_hole_patterns(a.holes)` → same objects as iterated).
- **Fallback** path intact, and *improved* — `lint_feature_coverage` now detects holes once, not twice.
- **`a.cyls` ≡ `_cyl_cache`** (same `analyse_cylinders(part)`).

## Verification
After a build, `dwg.lint()` runs `find_holes`/`find_hole_patterns`/`find_turned_steps` **zero** extra times (new counting-spy regression test). Full fast suite **587 passed / 1 skipped**; ruff (0.15.17, CI version) / format / mypy clean.

Finishes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)