### PR TITLE
docs: reconcile tracking — roadmap + target-architecture with the live board

### DIFF
--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -46,37 +46,38 @@ Every migration PR must:
 The mechanically-tractable migrate-and-delete work is done. **What remains needs
 new IR modelling, not a mechanical loop.**
 
-## Foundation hardening — do FIRST (ADR 0008 Amendment 5, review #241)
+## Foundation hardening — do FIRST (ADR 0008 Amendment 5, umbrella #241)
 
 A mid-migration review (#241) found the foundation must catch up before the last
-epics, because the IR is now load-bearing for 6 production passes. **Ordered:**
+epics, because the IR is now load-bearing for 6 production passes. Each item is a
+discrete sub-issue under #241. **Ordered:**
 
-1. **Unify the feature inventory** — *keystone.* `_analyse` and `build_part_model`
-   both re-detect (turned steps 3× per build; `a.slots` now has no reader). Build
-   the `PartModel` from `_analyse`'s products (or `_analyse` builds+caches it once
-   and threads it) — one inventory, no divergence. Prereq for the epics below.
-2. **Docs/comment sweep** — `model/__init__` still says "prototype, not wired";
-   `test_e2e_slice` + some `from_model` comments carry Amendment-2 framing. Cheap.
-3. **Annotation-ownership accessor** — a registry-backed API for
+1. ✅ **Unify the feature inventory** — *keystone, done* (#244: PR #246 build-time,
+   #247 lint). `_analyse` detects once; `build_part_model` + `Drawing.lint()`
+   consume its products. Residual: bosses still detected independently.
+2. **Docs/comment sweep** (**#248**) — `model/__init__` "prototype, not wired";
+   `target-architecture.md` re #244; `test_e2e_slice`; `from_model` Amendment-2
+   wording; `README`. Cheap; do next.
+3. **Annotation-ownership accessor** (**#249**) — a registry-backed API for
    ownership/iteration/build-issues so production stops reading `dwg._named`/
-   `_anno_view` directly (the new renderers added more reads). No new aliases.
-4. **Planner render-intent increment** — suppression/view/datum/grouping move into
-   the planner output (not layout; Amendment 4). After the inventory is unified.
-5. **Delete `render_into`** — the test-only parallel; superseded in production by
-   `render_envelope`/`render_diameters`; retire once the holes epic (#238) lands.
+   `_anno_view` directly. No new aliases.
+4. **Planner render-intent increment** (**#250**) — suppression/view/datum/grouping
+   move into the planner output (not layout; Amendment 4). Makes #238 cleaner.
+5. **Delete `render_into`** (**#251**) — the test-only parallel; superseded in
+   production by `render_envelope`/`render_diameters`; retire once #238 lands.
 
-## Remaining — feature epics (need IR modelling; AFTER foundation #1–#2)
+## Remaining — feature epics (need IR modelling; AFTER the foundation track)
 
-Ordered by value / readiness. Each needs the modelling in its **Prereq** before the
-migrate-and-delete is even possible.
+Ordered by value / readiness. Each needs the **Prereq** modelling before the
+migrate-and-delete is possible. (Slots, turned diameters/lengths, centre marks, and
+envelope width/depth are already done — see [Done](#done).)
 
-| Engine pass (to delete) | Lives in | Prereq (new IR modelling) | Issue |
+| Issue | Engine pass (to delete) | Prereq (new IR modelling) | Priority |
 |---|---|---|---|
-| **prismatic step-height ladder** + **envelope height** + **OD** (`dim_step_*`, `_detect_step_repeat`, `_legible_steps`, `dim_height`, `dim_od`) — all coupled via the shared `fv_zones.right` ladder / `_right_ladder` cursor | orchestrator inline | a **prismatic-step `Feature`** (detection half-exists in `analyse_face_levels` → `step_zs`); rotational-OD modelling. Migrate the whole right-strip group together (zone-aware), folds in #230 (`N× rise`) + #222 (OD on profile) | NEW |
-| **holes**: callouts + location dims + `n×` grouping + pitch dims + balloons (`_annotate_holes` 1063 lines, `_add_location_dims`) | `holes.py` | **location datums** + **pattern pitch** + **hole-table escalation** in the IR — the largest single piece. Centre marks already done (#235) | #220 (+ NEW for tables/location) |
-| **slots** `_annotate_slots` | `holes.py` | a **slot detector** → `SlotFeature` | #199 → #206 |
-| **sections / detail views** `_add_section_view`, `_add_detail_view` | `sections.py` | planner **section-trigger** modelling (which features need a section) | #207 |
-| **PMI / GD&T** `_annotate_pmi` | `pmi.py` | a **PMI/thread detector** → GD&T `Feature`s | #200 → #208 |
+| **#238** | **holes**: callouts + location dims + `n×` grouping + pitch + balloons (`_annotate_holes` ~1063 lines, `_add_location_dims`) | **location datums** + pattern pitch in the IR; **feed** the existing table/balloon escalation (don't rebuild it, Amend. 4). Centre marks already done (#235) | **highest** — do first; #250 (planner intents) makes it cleaner |
+| **#207** | **sections / detail views** (`_add_section_view`, `_add_detail_view`) | planner **section-trigger** (which features need a section); rendering stays shared infra | medium |
+| **#200 → #208** | **PMI / GD&T** (`_annotate_pmi`) | a **PMI/thread detector** → GD&T `Feature`s | medium |
+| **#237** | **prismatic step-height ladder + envelope height + OD** (`dim_step_*`, `_detect_step_repeat`, `_legible_steps`, `dim_height`, `dim_od`) — coupled via the `fv_zones.right` / `_right_ladder` cursor | a **prismatic-step `Feature`** (`analyse_face_levels` → `step_zs`) + rotational classification/OD. Folds in #230, #222 | **deferred** — lowest frequency, highest complexity, worst ROI |
 
 When these land, the orchestrator's per-feature calls are gone and it reduces to
 `build model → plan → render`.

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -136,23 +136,25 @@ slots. Each was migrate-and-delete; `annotations/turned.py` is gone.
 - **PMI / GD&T placement** — needs a PMI/thread detector emitting GD&T `Feature`s.
   ([#208](https://github.com/pzfreo/draftwright/issues/208))
 
-**Foundation gaps to close before the remaining epics** (review
-[#241](https://github.com/pzfreo/draftwright/issues/241)):
+**Foundation track — close before the feature epics** (umbrella
+[#241](https://github.com/pzfreo/draftwright/issues/241); ADR Amendment 5):
 
-- **One inventory not yet realised** *(keystone,
-  [#244](https://github.com/pzfreo/draftwright/issues/244)).* Feature detection
-  currently runs in **three** places — `_analyse()`, `build_part_model()`, and
-  linting — so some features are detected 3–4× per build, and `a.slots` is now
-  computed with no reader. The `PartModel` must become the single inventory all
-  three consume. This is the prerequisite for #237/#238.
-- **Private `Drawing` state still read across production** (`_named`,
-  `_anno_view`, …) — needs a registry-backed accessor so the state-bus surface
-  stops widening.
-- **The planner is still thin** — suppression / view / datum / grouping decisions
-  largely live in the renderers; they should become explicit planner render-intents
-  (without absorbing layout).
-- **`render_into` is a test-only parallel path** — superseded in production by the
-  per-feature renderers; delete once the holes epic lands.
+- ✅ **One feature inventory** (keystone,
+  [#244](https://github.com/pzfreo/draftwright/issues/244), done via #246/#247).
+  `_analyse` detects once; `build_part_model` and `Drawing.lint()` consume its
+  results — each detector runs once per build, zero extra in lint. *Residual:*
+  bosses are still detected independently in the feature-diameter path.
+- **Docs/comment sweep** ([#248](https://github.com/pzfreo/draftwright/issues/248))
+  — stale `model/__init__` "prototype", `from_model` Amendment-2 wording, etc.
+- **Annotation-ownership accessor**
+  ([#249](https://github.com/pzfreo/draftwright/issues/249)) — stop production
+  reading `dwg._named`/`_anno_view` directly.
+- **Planner render-intents**
+  ([#250](https://github.com/pzfreo/draftwright/issues/250)) — suppression /
+  view / datum / grouping into the planner (not layout).
+- **Delete `render_into`**
+  ([#251](https://github.com/pzfreo/draftwright/issues/251)) — the test-only
+  parallel, once the holes epic supersedes it.
 
 **Inherent (not a migration gap):** recognition is heuristic — a chamfered bore in
 a tapered section will not recognise itself cleanly. The architecture *contains*


### PR DESCRIPTION
Brings every tracking artifact into one consistent story after #244 (closed) and slots (#242).

## Issue board (already applied)
- **#195** rewritten as the master tracker (Done / Foundation track / Feature epics / Satellites / DoD).
- **#241** = foundation umbrella; its 5 findings now discrete sub-issues: #244 ✅, **#248** docs sweep, **#249** accessor, **#250** planner intents, **#251** render_into.
- Closed **#206** (slots done via #242, missed by auto-close).

## Docs (this PR)
- `convergence-roadmap.md`: Foundation track marks #244 done + links #248–#251; feature-epics table de-staled (slots removed, ROI-ordered — #238 first, #237 deferred).
- `target-architecture.md`: Current Gaps — "one inventory not yet realised" → ✅ done (#244, bosses residual noted); foundation items linked to #248–#251.

Now consistent across **epic #195 → #241 (#248–#251) → #238/#207/#208/#237 → satellites**, mirrored in both docs.

The remaining stale **code comments** (`model/__init__`, `from_model`, `README`, `test_e2e_slice`) are the **#248** sweep — a separate PR, so this one stays docs-tracking-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)