### PR TITLE
docs: sweep stale comments to current ADR 0008 state (#248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ generation, the lint→repair loop, and the constraint-based layout engine).
 
 ## Architecture
 
-draftwright is a single module (`make_drawing.py`) on top of two libraries:
+draftwright is structured as a **part-drawing compiler** (ADR 0008): feature
+detectors → a `PartModel` IR (`Feature`s exposing `DimParameter`s) → a dimensioning
+planner → renderers, feeding a shared layout/projection/export stack. It builds on
+two libraries:
 
 ```
 draftwright
@@ -126,7 +129,10 @@ draftwright
     └── build123d                   — CAD kernel
 ```
 
-The engine handles view layout (strip/zone model), scale selection, feature recognition
-(holes, bosses, bolt circles), annotation placement, and section view generation.
-Annotation primitives (`Dimension`, `Leader`, `lint_drawing`, etc.) live in
-`build123d-drafting-helpers` and can be used independently.
+It owns feature recognition (`recognition/`) and linting (`linting/`); annotation
+primitives (`Dimension`, `Leader`, etc.) live in `build123d-drafting-helpers` and can
+be used independently. The compiler is converging in production (turned dims/lengths,
+centre marks, envelope, slots are on the IR; holes/sections/PMI are migrating) — see
+[`docs/target-architecture.md`](docs/target-architecture.md) and
+[`docs/adr/`](docs/adr/). The engine handles view layout (strip/zone model), scale
+selection, annotation placement, and section views.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -583,12 +583,16 @@ def render_step_lengths(dwg, model) -> int:
 
 
 def render_into(dwg, model) -> int:
-    """The end-to-end seam: plan *model* and **add** its annotations to *dwg*
-    (which must already have its views, e.g. ``build_drawing(part, auto_dims=False)``).
-    Diameter callouts (holes/patterns/bosses) are placed clear of the views and of
-    each other (ADR-0003 layout); overall envelope dims sit just outside their view.
-    Returns the count added; lint *dwg* to judge correctness. Turned stepped parts
-    remain the engine's domain (out-grow, not reproduce — ADR 0008 Amendment 2)."""
+    """End-to-end demonstration seam: plan *model* and **add** its annotations to
+    *dwg* (which must already have its views, e.g. ``build_drawing(part,
+    auto_dims=False)``). Diameter callouts (holes/patterns/bosses) are placed clear
+    of the views and of each other (ADR-0003 layout); overall envelope dims sit just
+    outside their view. Returns the count added; lint *dwg* to judge correctness.
+
+    **Test-only.** This drives the e2e-slice tests; production uses the per-feature
+    renderers (``render_diameters``/``render_step_lengths``/``render_envelope``/…)
+    wired into the orchestrator. To be retired once the holes epic supersedes its
+    remaining hole-callout capability (#251)."""
     view_boxes = [vb for v in dwg.views if (vb := dwg.view_bounds(v)) is not None]
     placed: list = []
     n = 0

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -1,14 +1,17 @@
-"""The part-drawing compiler IR — prototype (ADR 0008).
+"""The part-drawing compiler IR (ADR 0008).
 
-A vertical slice proving the architecture: a stable intermediate representation
-(`PartModel` of `Feature` objects exposing `DimParameter`s) sitting between the
-feature *detectors* (front-ends adapting the recognition heuristics) and a
-*dimensioning planner* (back-end). The narrow waist that lets new shapes be new
-types, not new branches.
+A stable intermediate representation (`PartModel` of `Feature` objects exposing
+`DimParameter`s) sitting between the feature *detectors* (front-ends adapting the
+recognition heuristics) and a *dimensioning planner* (back-end). The narrow waist
+that lets new shapes be new types, not new branches.
 
-**Prototype status:** not yet wired into `build_drawing`. It builds a model from a
-real solid and plans dimensions, exercised by `tests/test_part_model.py`, to
-de-risk the protocol before any production rewiring (ADR 0008 migration step 1).
+**Status:** wired into `build_drawing` in production (ADR 0008 convergence,
+in progress). `build_part_model` is built once per build from `_analyse`'s single
+feature inventory (Amendment 5) and consumed by the renderers in
+`annotations/from_model.py` (turned step lengths/diameters, centre marks, envelope
+width/depth, slots) and by the lint coverage checks. Remaining engine passes
+(holes, sections, PMI, the prismatic step-ladder) are migrating onto it — see
+`docs/plans/0008-convergence-roadmap.md`.
 
 - :mod:`.ir` — the IR: `DimParameter`, `Datum`, `Frame`, the `Feature` protocol,
   the concrete feature types, and `PartModel`.

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -13,8 +13,9 @@ contract was tightened twice under adversarial review of the counterbore work:
   do not emit spurious duplicates. Genuine redundancy/count of *repeated identical
   features* ("3× ø8") is upstream (pattern detection), not here.
 
-Prototype scope: convention + group view selection. The full ISO/ASME rule set
-grows here as real features demand it.
+Current scope: convention + group view selection. Richer render intents
+(suppression / datum / grouping) are the next planned increment (#250); the full
+ISO/ASME rule set grows here as real features demand it.
 """
 
 from __future__ import annotations

--- a/tests/test_e2e_slice.py
+++ b/tests/test_e2e_slice.py
@@ -6,10 +6,11 @@ pipeline (`build_drawing(auto_dims=False)` gives only the view scaffold), judged
 **correctness** (lint passes, coverage complete, it exports) — *not* by equivalence
 to the engine.
 
-Scope today: hole callouts, **placed clear of the views and of each other** via the
-layout search (no more naive fixed offsets). The remaining gap the slice surfaces is
-overall/envelope + OD dims, which the new path doesn't produce yet — so a part with
-an un-dimensioned OD (e.g. a flange) still lints with `feature_not_dimensioned`.
+Scope: the IR-driven hole callouts + envelope width/depth (`render_into`), **placed
+clear of the views and of each other** via the layout search. The drawing lints
+clean for prismatic plates and simple rotational parts. `render_into` is the
+test-only demonstration path (production uses the per-feature renderers wired into
+the orchestrator); it is retired once the holes epic supersedes it (#251).
 """
 
 import os

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -1,4 +1,4 @@
-"""Prototype tests for the part-drawing compiler IR (ADR 0008).
+"""Tests for the part-drawing compiler IR (ADR 0008).
 
 Proves the architecture's claims on real geometry:
 1. Diverse features (holes + turned steps + bosses), from different detectors,


### PR DESCRIPTION
Foundation finding 5 (umbrella #241). The IR is wired into production for 6 passes, but several comments still described the prototype/out-grow stage — they'd misdirect the next migration. **Docs/comments only, no behaviour change.**

- `model/__init__.py` — "prototype, not yet wired" → wired in production (one inventory, consumed by from_model renderers + lint).
- `annotations/from_model.py` — `render_into` docstring: drop Amendment-2 "out-grow" framing; mark test-only, retired by #251.
- `tests/test_e2e_slice.py` — drop "envelope/OD not produced yet" (they are now).
- `model/planner.py` + `tests/test_part_model.py` — drop "prototype"; render-intents → #250.
- `README.md` — describe the part-drawing compiler structure, not "a single module".

**Review (accuracy):** each updated statement checked against current code — IR wired for 6 passes ✓, `render_into` is test-only ✓, planner-intents tracked as #250 ✓. No stale phrase remains in code/README (verified by grep).

Full fast suite **587 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean.

Closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)