### PR TITLE
refactor: registry-backed annotation accessor; stop external _named reads (#249)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -29,7 +29,7 @@ def _occupied_boxes(dwg):
     hatch.  Bare centrelines/leaders are excluded — those legitimately cross a
     dimension and lint does not flag them."""
     boxes = []
-    for name, o in dwg._named.items():
+    for name, o in dwg.iter_annotations():
         if getattr(o, "label_bbox", None) is None and name != "section_hatch":
             continue
         bb = _anno_box(o)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -305,7 +305,7 @@ def _mentioned_diameters(dwg) -> set[float]:
     """Diameters already called out on the drawing (ø-labels + ``covers_diameters``)
     — so a diameter another annotation already documents is not repeated."""
     diams: set[float] = set()
-    for ann in dwg._named.values():
+    for _, ann in dwg.iter_annotations():
         if isinstance(ann, TitleBlock):
             continue
         for m in _DIAM_RE.finditer(getattr(ann, "label", None) or ""):

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -155,7 +155,7 @@ def _add_location_dims(dwg, a: Analysis, patterns, holes_in=None):
         )
     _kept_x_set = set(_kept_x)
     x_refs = [r for r in x_refs if r[0] not in _x_drawable or r[0] in _kept_x_set]
-    for n, ann in dwg._named.items():
+    for n, ann in dwg.iter_annotations():
         if n.startswith("dim_pitch_plan") and getattr(ann, "dim_level_y", 0) > plan_top:
             a.pv_zones.above.allocate(10.0)  # consume space used by pitch dim
     for i, (rx, ry, _) in enumerate(sorted(x_refs, key=lambda r: abs(r[0] - datum_x))):
@@ -212,7 +212,7 @@ def _add_location_dims(dwg, a: Analysis, patterns, holes_in=None):
     y_refs = [r for r in y_refs if r[1] not in _y_drawable or r[1] in _kept_y_set]
     # Y locations: dims above the side view, routed through sv_zones.above.
     # Pre-advance past any pitch dims already placed above side_top.
-    for n, ann in dwg._named.items():
+    for n, ann in dwg.iter_annotations():
         if n.startswith("dim_pitch_side") and getattr(ann, "dim_level_y", 0) > side_top:
             a.sv_zones.above.allocate(10.0)  # consume space used by pitch dim
     # Tighten outer_limit if any witness line approaches the iso view boundary.
@@ -542,7 +542,7 @@ def _place_pitch_dim(dwg, a: Analysis, view, h1, h2, n, pitch, to_page, name):
         pref = (-0.3, 1.0) if view == "plan" else (-0.3, -1.0)
         side, reach = max(cands, key=lambda c: c[0][0] * pref[0] + c[0][1] * pref[1])
     # stack further pitch dims in this view on outer tiers
-    prior = sum(1 for nm in dwg._named if nm.startswith(f"dim_pitch_{view}"))
+    prior = sum(1 for nm, _ in dwg.iter_annotations() if nm.startswith(f"dim_pitch_{view}"))
     offset = reach + 8 + 10 * prior
     # never force-place: skip (and log) when the dim line would leave the page
     ox = mid[0] + side[0] * (offset + 6)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -523,11 +523,11 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     # their space for the table and shrinks the obstacle set fit_box scans (the
     # dense parts have dozens), which is the dominant cost on heavy sheets (#93).
     replaced = {
-        n: dwg._named[n]
-        for n in list(dwg._named)
+        n: o
+        for n, o in list(dwg.iter_annotations())
         if n.startswith(("hc_plan", "dim_locx", "dim_locy")) and not dwg._is_pattern_callout(n)
     }
-    replaced_view = {n: dwg._anno_view.get(n) for n in replaced}
+    replaced_view = {n: dwg.view_of(n) for n in replaced}
     for n in replaced:
         dwg.remove(n)
 

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -163,7 +163,7 @@ def _add_section_view(dwg, a: Analysis, holes=None):
     if side_hid:
         side_right = max(side_right, side_hid.bounding_box().max.X)
     left_edge = side_right + 10
-    for name, ann in dwg._named.items():
+    for name, ann in dwg.iter_annotations():
         # past side-view callout labels and the height/step dim ladder
         if name.startswith(("hc_side", "dim_height", "dim_step")) and getattr(
             ann, "label_bbox", None
@@ -219,7 +219,7 @@ def _add_section_view(dwg, a: Analysis, holes=None):
     # the line and its letters must clear pattern centrelines that sweep
     # past the part outline (a corner-hole bolt circle is always wider)
     ext_x0, ext_x1 = PX(a.bb.min.X), PX(a.bb.max.X)
-    for name, ann in dwg._named.items():
+    for name, ann in dwg.iter_annotations():
         if name.startswith("bc_plan"):
             cb = ann.bounding_box()
             if cb.min.Y - 3 < y_page < cb.max.Y + 3:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -101,8 +101,8 @@ def _annotations_out_of_bounds(dwg, a, tol: float = 1.0) -> bool:
     (#92).  Only view-owned annotations count — those are what a repack can move
     by escalating the sheet."""
     lo, hi_x, hi_y = a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin
-    for name, o in dwg._named.items():
-        if dwg._anno_view.get(name) not in ("front", "plan", "side"):
+    for name, o in dwg.iter_annotations():
+        if dwg.view_of(name) not in ("front", "plan", "side"):
             continue
         # Match the lint, which tests each item's FULL bounding_box (extension
         # lines, arrowheads, leader + balloon ring) — not just the label rect —

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -591,6 +591,27 @@ class Drawing:
         """
         return self._registry.annotations()
 
+    def iter_annotations(self):
+        """Iterate ``(name, annotation object)`` for every named annotation.
+
+        The encapsulated read path for production code (lint, sheet, sections,
+        renderers): use this instead of reaching into ``dwg._named`` directly so the
+        registry stays the single owner of annotation identity (#241).
+        """
+        return self._registry.iter_named()
+
+    def view_of(self, name):
+        """The owning orthographic view for *name* ("front"/"plan"/"side"), or
+        ``None`` — instead of reading ``dwg._anno_view`` directly (#241)."""
+        return self._registry.view_of(name)
+
+    def annotations_in_view(self, view):
+        """Yield ``(name, annotation object)`` for the named annotations owned by
+        *view* — the common filter-by-view read (#241)."""
+        return (
+            (n, o) for n, o in self._registry.iter_named() if self._registry.view_of(n) == view
+        )
+
     def get_annotation(self, name):
         """Return the named annotation object, or ``None`` if no such name (#27)."""
         return self._registry.named(name)

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -232,8 +232,8 @@ def lint_location_coverage(
 
     marks: dict[str, list] = {}
     dim_verts: dict[str, list] = {}
-    for name, ann in dwg._named.items():
-        view = dwg._anno_view.get(name)
+    for name, ann in dwg.iter_annotations():
+        view = dwg.view_of(name)
         if view is None:
             continue
         if isinstance(ann, CenterMark):
@@ -311,8 +311,8 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
     shoulder_c = {s: shoulder_coord(s) for s in prof.shoulders}
     dim_csets: list[set[float]] = [
         {(x if use_x else y) for x, y in _dim_vertices(ann)}
-        for name, ann in dwg._named.items()
-        if dwg._anno_view.get(name) == "front" and isinstance(ann, Dimension)
+        for _name, ann in dwg.annotations_in_view("front")
+        if isinstance(ann, Dimension)
     ]
     covered = 0
     for step in prof.steps:

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -55,6 +55,27 @@ class AnnotationRegistry:
         """The owning view for *name* ("front"/"plan"/"side"), or ``None``."""
         return self._anno_view.get(name)
 
+    def iter_named(self):
+        """Iterate ``(name, annotation object)`` for every named annotation — the
+        encapsulated read path (callers no longer touch ``_named`` directly, #241)."""
+        return self._named.items()
+
+    def replace_object(self, old, new) -> None:
+        """Swap annotation object *old* for *new* wherever it is named, keeping the
+        name → view binding (the repair loop's re-placement; #241)."""
+        for name, obj in self._named.items():
+            if obj is old:
+                self._named[name] = new
+
+    def snapshot(self) -> dict:
+        """An opaque snapshot of the name → object map, for restore() (repair undo)."""
+        return dict(self._named)
+
+    def restore(self, snap: dict) -> None:
+        """Restore a :meth:`snapshot` (repair undo of a net-worsening pass)."""
+        self._named.clear()
+        self._named.update(snap)
+
     def add(self, obj, name, view):
         """Register *obj* under *name* and record its owning *view*.
 

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -4,7 +4,7 @@ After the greedy initial placement, re-place the engine-built dimensions behind
 the mechanically-clear violations (a dim on the wrong side, two overlapping
 labels) and re-lint — bounded and monotonic, so it terminates and never worsens a
 sheet. `Drawing.repair()` is the public wrapper; these helpers take the drawing as
-`dwg` (duck-typed — `lint` / `items` / `_named` / `_registry`), so this module
+`dwg` (duck-typed — `lint` / `items` / `_registry`), so this module
 imports only `_core`, never `make_drawing` — no cycle.
 """
 
@@ -43,9 +43,7 @@ def _replace_dim(dwg, old, new):
     if getattr(old, "_dw_scale", None) is not None:
         new._dw_scale = old._dw_scale
     dwg.items[dwg.items.index(old)] = new
-    for n, o in dwg._named.items():
-        if o is old:
-            dwg._named[n] = new
+    dwg._registry.replace_object(old, new)
 
 
 def _repair_dim_inside_part(dwg, issue) -> bool:
@@ -85,7 +83,7 @@ def repair_drawing(dwg, max_iter: int = 3):
         if not before:
             break
         snap_annotations = list(dwg.items)
-        snap_named = dict(dwg._named)
+        snap_named = dwg._registry.snapshot()
         changed = False
         for issue in before:
             if issue.code not in _REPAIRABLE_CODES:
@@ -105,7 +103,6 @@ def repair_drawing(dwg, max_iter: int = 3):
         if len(dwg.lint()) > len(before):
             # The repairs net-worsened the sheet — undo this pass and stop.
             dwg.items[:] = snap_annotations
-            dwg._named.clear()
-            dwg._named.update(snap_named)
+            dwg._registry.restore(snap_named)
             break
     return dwg

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -537,7 +537,7 @@ def _anno_bbox(o):
 
 def _attribute_annotations(dwg, a):
     """Yield ``(name, view, bbox, is_label)`` for every annotation OWNED by an
-    orthographic view, per the view recorded at creation (``dwg._anno_view``).
+    orthographic view, per the view recorded at creation (``dwg.view_of``).
 
     Ownership is authoritative — the annotation pass that drew it knew which view
     it belonged to and tagged it (#121) — so a front-view step dimension sitting
@@ -547,8 +547,8 @@ def _attribute_annotations(dwg, a):
     is true when the annotation carries a text ``label_bbox`` (a dimension value
     or balloon tag) rather than bare geometry (a centreline/leader line).
     """
-    for name, o in dwg._named.items():
-        view = dwg._anno_view.get(name)
+    for name, o in dwg.iter_annotations():
+        view = dwg.view_of(name)
         if view not in ("front", "plan", "side"):
             continue
         label = getattr(o, "label_bbox", None)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1125,7 +1125,15 @@ class TestComposeThenPackRepack:
     def _fake_dwg(self, named, views):
         from types import SimpleNamespace
 
-        return SimpleNamespace(_named=named, _anno_view=views)
+        # Mirror Drawing's annotation read surface (#249) so stage helpers that now
+        # call dwg.iter_annotations()/view_of() work against the fake.
+        return SimpleNamespace(
+            _named=named,
+            _anno_view=views,
+            iter_annotations=lambda: named.items(),
+            view_of=lambda n: views.get(n),
+            annotations_in_view=lambda v: ((n, o) for n, o in named.items() if views.get(n) == v),
+        )
 
     def test_overlap_counts_label_vs_label_across_views(self):
         from draftwright.builder import _cross_view_overlaps


### PR DESCRIPTION
Foundation finding 3 (umbrella #241). Production read `Drawing`'s private `_named`/`_anno_view` across 9 modules; the new renderers widened it. This encapsulates annotation ownership behind the registry. **Behaviour-unchanged refactor.**

## API (as approved)
- **`AnnotationRegistry`**: `iter_named()`, `replace_object(old, new)`, `snapshot()`/`restore()`.
- **`Drawing`**: `iter_annotations()`, `view_of(name)`, `annotations_in_view(view)` — delegating.

## Migration
- Read sites (coverage, sheet, sections, `_common`, `from_model`, holes, builder, orchestrator) → the accessors.
- `repair`'s mutations (replace + snapshot/restore of the re-placement loop) → the registry mutation API.
- **No production code touches `dwg._named`/`_anno_view` now** (verified by grep).

## Adversarial review (before merge)
- Read accessors return the same `.items()` view; no caller mutates mid-loop (orchestrator materializes with `list(...)`). `replace_object`/`snapshot`/`restore` are identical to the old inline ops.
- **Finding (caught by the suite):** the duck-typed stage-helper contract changed (`_named` → accessors), so the `SimpleNamespace` test fakes (`_fake_dwg`) broke; updated to mirror the accessor surface.
- `annotations_in_view` used in the axial harvest (not dead code).
- Behaviour: lint score/by_code identical across part types (all 1.0).

Full fast suite **587 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Closes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)