### PR TITLE
feat: planner render-intents — suppression + datum plumbing (#250)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -426,31 +426,25 @@ def render_diameters(dwg, model, tol: float = 0.15) -> int:
     return _diameter_row_below(dwg, rows) + _diameter_column_left(dwg, cols)
 
 
-def _env_param(group, role):
-    """The EnvelopeFeature DimParameter with the given role (width/depth/height)."""
-    return next((pd.param for pd in group.dims if pd.param.role == role), None)
+def _env_pd(group, role):
+    """The PlannedDimension for an envelope role (width/depth/height), or None."""
+    return next((pd for pd in group.dims if pd.param.role == role), None)
 
 
-def render_envelope(dwg, model, a, *, suppress_width: bool = False) -> int:
+def render_envelope(dwg, model, a) -> int:
     """Overall width (plan, below) + depth (side, below) envelope dims via the IR,
     placed through the engine's below-strip zone allocators (the zone-aware render
     stage — so a migrated dim still coordinates with the un-migrated passes sharing
-    those strips). Sources values/spans from `EnvelopeFeature`. Skips a square
-    footprint (a single dim suffices) and, when *suppress_width*, the width (an
-    X-turned part's step chain already conveys the length, ISO 129). Returns the
+    those strips). The **planner** decides suppression (square footprint / X-turned;
+    #250); this renderer just skips suppressed dims and places the rest. Returns the
     count placed."""
     env = next((g for g in plan_dimensions(model) if g.feature_kind == "envelope"), None)
     if env is None:
         return 0
-    width, depth = _env_param(env, "width"), _env_param(env, "depth")
-    if width is None or depth is None:
-        return 0
-    # Square footprint: width ≈ depth → one dim suffices (the engine's gate).
-    if abs(width.value - depth.value) <= max(width.value, depth.value) * 0.05:
-        return 0
     n = 0
-    if not suppress_width and width.span is not None:
-        (x0, y0, z0), (x1, _, _) = width.span
+    width = _env_pd(env, "width")
+    if width is not None and not width.suppressed and width.param.span is not None:
+        (x0, y0, z0), (x1, _, _) = width.param.span
         p1, p2 = dwg.at("plan", x0, y0, z0), dwg.at("plan", x1, y0, z0)
         witness = p1[1] - 2
         py = a.pv_zones.below.allocate(_SLOT_DIM_WIDTH)
@@ -462,14 +456,15 @@ def render_envelope(dwg, model, a, *, suppress_width: bool = False) -> int:
                     "below",
                     witness - py,
                     dwg.draft,
-                    label=_fmt(width.value),
+                    label=_fmt(width.param.value),
                 ),
                 "m_env_width",
                 view="plan",
             )
             n += 1
-    if depth.span is not None:
-        (x0, y0, z0), (_, y1, _) = depth.span
+    depth = _env_pd(env, "depth")
+    if depth is not None and not depth.suppressed and depth.param.span is not None:
+        (x0, y0, z0), (_, y1, _) = depth.param.span
         p1, p2 = dwg.at("side", x0, y0, z0), dwg.at("side", x0, y1, z0)
         witness = p1[1] - 2
         pd = a.sv_zones.below.allocate(_SLOT_DIM_DEPTH)
@@ -481,7 +476,7 @@ def render_envelope(dwg, model, a, *, suppress_width: bool = False) -> int:
                     "below",
                     witness - pd,
                     dwg.draft,
-                    label=_fmt(depth.value),
+                    label=_fmt(depth.param.value),
                 ),
                 "m_env_depth",
                 view="side",

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -383,17 +383,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     elif not _z_turned:
         _log.warning("dim_height skipped: fv_zones.right strip full")
 
-    # An X-axis turned (stepped-shaft) part gets a full axial step-length chain
-    # below (the IR step-length pass); that chain already conveys the overall
-    # length, so the envelope width dim would double-dimension it (ISO 129).
-    # Suppress it. (_turned_prof was computed at the step-height section above.)
-    _x_turned = _turned_prof is not None and _turned_prof.axis == "x"
-
     # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
     # placed through the same below-strip zone allocators the engine used (zone-aware
-    # render stage, ADR 0008). Width is suppressed for an X-turned part (its step
-    # chain conveys the length); a square footprint gets neither (one dim suffices).
-    render_envelope(dwg, _model, a, suppress_width=_x_turned)
+    # render stage, ADR 0008). Suppression (square footprint / X-turned width) is now
+    # the planner's decision (#250); the renderer just skips suppressed dims.
+    render_envelope(dwg, _model, a)
 
     # The section view goes last: its room check clears every annotation
     # already placed right of the side view (callout labels, height/step

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from draftwright._core import _END_ON
-from draftwright.model.ir import DimParameter, Feature, PartModel, Point
+from draftwright.model.ir import Datum, DimParameter, Feature, PartModel, Point
 
 # How each (role, kind) is drawn. Defaults keep the table small.
 _CONVENTION = {
@@ -44,8 +44,20 @@ _CONVENTION = {
 
 @dataclass(frozen=True)
 class PlannedDimension:
+    """A parameter plus its render *intent* — the planner's decision about how/whether
+    it is drawn, leaving the layout (zones/sides/coordinates) to the renderer
+    (ADR 0008 Amendment 4). `suppressed`/`reason` carry *model-level* suppression
+    (the planner sees the model, not the drawing-in-progress, so render-state
+    suppression like "diameter already mentioned" stays in the renderer). `datum` is
+    the reference a positional dim measures from, resolved from `param.refs` against
+    `model.datums` — reserved for the location-dimension work (#238); ``None`` until
+    a feature emits datum-referenced params."""
+
     param: DimParameter
-    convention: str  # "chain" | "ordinate" | "leader" | "linear"
+    convention: str  # "chain" | "ordinate" | "leader" | "linear" | "pitch"
+    suppressed: bool = False
+    reason: str | None = None
+    datum: Datum | None = None
 
 
 @dataclass(frozen=True)
@@ -82,16 +94,59 @@ def _group_view(feature: Feature) -> str:
     return _END_ON.get(feature.frame.axis, "plan")
 
 
+def _square_footprint(model: PartModel) -> bool:
+    """In-plane width ≈ depth (within 5%) — a single overall dim suffices."""
+    size = model.bbox.size  # type: ignore[attr-defined]  # build123d BoundBox
+    w, d = float(size.X), float(size.Y)
+    return abs(w - d) <= max(w, d) * 0.05
+
+
+def _suppression(model: PartModel, feature: Feature, param: DimParameter):
+    """Model-level suppression intent → ``(suppressed, reason)``. Decisions the
+    planner can make from the model alone (ISO 129 no-double-dimensioning):
+    a square footprint needs one overall dim, not width+depth; a turned part's
+    step-length chain already conveys the length (X) / height (Z), so the envelope
+    dim along the turning axis is redundant."""
+    if feature.kind != "envelope":
+        return False, None
+    if param.role in ("width", "depth") and _square_footprint(model):
+        return True, "square footprint (single overall dim suffices)"
+    if param.role == "width" and model.orientation == "x":
+        return True, "X-turned (step-length chain conveys the length)"
+    if param.role == "height" and model.orientation == "z":
+        return True, "Z-turned (step-length chain conveys the height)"
+    return False, None
+
+
+def _datum_for(model: PartModel, param: DimParameter) -> Datum | None:
+    """The datum a positional param measures from — resolved from ``param.refs``
+    against ``model.datums``. ``None`` until a feature emits datum-referenced
+    params (the location-dimension work, #238)."""
+    if not param.refs:
+        return None
+    return next((d for d in model.datums if d.id in param.refs), None)
+
+
 def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
-    view + planned dims). No cross- or within-feature value de-duplication."""
+    view + planned dims, each carrying its render intent — convention, model-level
+    suppression, datum). No cross- or within-feature value de-duplication."""
     groups: list[DimensionGroup] = []
     for feature in model.features:
-        dims = [
-            PlannedDimension(param=p, convention=_CONVENTION.get((p.role, p.kind), "linear"))
-            for p in feature.parameters()
-            if p.kind != "location"
-        ]
+        dims = []
+        for p in feature.parameters():
+            if p.kind == "location":
+                continue
+            suppressed, reason = _suppression(model, feature, p)
+            dims.append(
+                PlannedDimension(
+                    param=p,
+                    convention=_CONVENTION.get((p.role, p.kind), "linear"),
+                    suppressed=suppressed,
+                    reason=reason,
+                    datum=_datum_for(model, p),
+                )
+            )
         if dims:
             groups.append(
                 DimensionGroup(feature=feature, view=_group_view(feature), dims=tuple(dims))


### PR DESCRIPTION
Foundation finding 2 (umbrella #241). The planner grows explicit render **intent** so renderers stop owning dimensioning policy. Per **Amendment 4**: intent in the planner, layout in the renderer.

## What
- **`PlannedDimension`** gains `suppressed` / `reason` / `datum`.
- The planner applies **model-level suppression**: square footprint → suppress width+depth; X-turned → suppress width; Z-turned → suppress height — each with a reason.
- **`datum`** resolved from `param.refs` against `model.datums` — `None` today; the reserved slot **#238** will populate (the full increment chosen).
- `render_envelope` drops `suppress_width` + the inline square gate; it just skips planner-suppressed dims; the orchestrator drops `_x_turned`.

## Boundary kept (Amendment 4)
Render-**state** suppression ("already mentioned") and placement/zones stay in the renderer.

## Adversarial review (before merge)
- Suppression equivalence: old gate used `width.value`/`depth.value` = `bbox.size.X`/`Y` exactly → planner identical. Verified (square → `m_env=[]`; non-square → both shown).
- `datum` always `None` now (`refs=()`, `datums=[]`) → zero behaviour impact.
- New fields defaulted → only the planner constructs `PlannedDimension`.

Behaviour-unchanged (all parts 1.0). Full fast suite **587 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Closes #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)