### PR TITLE
feat: IR groups identical holes by machining spec (#238 callout prerequisite)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -120,10 +120,19 @@ def _hole_callout(dwg, group) -> HoleCallout | None:
 
 def _place_leader(dwg, view, tip_model, obstacles, *, label="", callout=None) -> Leader | None:
     """A leader (callout or plain ø label) placed clear of *obstacles* by searching
-    outward from the feature (ADR 0003 layout): first non-colliding elbow wins; the
-    farthest candidate is the fallback. With no obstacles the first ring wins, so a
-    bare call is deterministic."""
+    outward from the feature (ADR 0003 layout): the first elbow whose label box is
+    on-page and non-colliding wins; the farthest candidate is the fallback. With no
+    obstacles the first on-page ring wins, so a bare call is deterministic."""
     tx, ty, *_ = dwg.at(view, *tip_model)
+
+    def _on_page(b) -> bool:
+        return bool(
+            b[0] >= _MARGIN
+            and b[1] >= _MARGIN
+            and b[2] <= dwg.page_w - _MARGIN
+            and b[3] <= dwg.page_h - _MARGIN
+        )
+
     fallback = None
     for dx, dy in _ELBOW_OFFSETS:
         leader = Leader(
@@ -136,7 +145,7 @@ def _place_leader(dwg, view, tip_model, obstacles, *, label="", callout=None) ->
         box = _anno_box(leader)
         if box is None:
             return leader
-        if not _box_hits(box, obstacles):
+        if _on_page(box) and not _box_hits(box, obstacles):
             return leader
         fallback = leader
     return fallback

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -29,6 +29,7 @@ from draftwright.model.ir import (
 )
 from draftwright.recognition import (
     BoltCircle,
+    HoleSpec,
     LinearArray,
     RectGrid,
     find_bosses,
@@ -39,13 +40,17 @@ from draftwright.recognition import (
 )
 
 
-def _member_hole(h, frame: Frame) -> HoleFeature:
-    """A recogniser hole → an IR `HoleFeature` (bore + counterbore/spotface)."""
+def _member_hole(h, frame: Frame, members: tuple = (), count: int = 1) -> HoleFeature:
+    """A recogniser hole → an IR `HoleFeature` (bore + counterbore/spotface). When
+    *h* represents a machining-spec group of identical holes, *members* are their
+    locations and *count* their number."""
     return HoleFeature(
         frame=frame,
         diameter=h.diameter,
         depth=h.depth,
         through=(h.bottom == "through"),
+        count=count,
+        members=members,
         cbore=(h.cbore.diameter, h.cbore.depth) if h.cbore else None,
         spotface=(h.spotface.diameter, h.spotface.depth) if h.spotface else None,
     )
@@ -135,10 +140,19 @@ def build_part_model(part, *, holes=None, patterns=None, slots=None, prof=_UNSET
         members = list(pat.holes)
         patterned.update(id(h) for h in members)
         features.append(_pattern_feature(pat, members))
+    # Un-patterned holes: group by machining spec so identical holes share one
+    # count× callout (the engine's grouped-callout rule); HoleSpec keys on the
+    # snapped axis too, so opposite-face drillings stay distinct.
+    spec_groups: dict = {}
     for h in holes:
         if id(h) in patterned:
             continue
-        features.append(_member_hole(h, Frame(origin=_xyz(h.location), axis=_axis_letter(h))))
+        spec_groups.setdefault(HoleSpec.from_hole(h), []).append(h)
+    for grp in spec_groups.values():
+        rep = grp[0]
+        frame = Frame(origin=_xyz(rep.location), axis=_axis_letter(rep))
+        mem_locs = tuple(_xyz(h.location) for h in grp)
+        features.append(_member_hole(rep, frame, members=mem_locs, count=len(grp)))
 
     # Milled slots / reduced across-flats sections (detected for any part).
     if slots is None:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -102,6 +102,11 @@ class HoleFeature:
     depth: float | None
     through: bool
     count: int = 1
+    # Member locations when identical holes are grouped by machining spec into one
+    # ``count×`` callout (the engine's grouped-callout rule). Empty for a singleton
+    # (the one hole sits at ``frame.origin``). Consumers iterate ``members or
+    # (frame.origin,)`` so a centre mark / location dim lands on every hole.
+    members: tuple[Point, ...] = ()
     cbore: tuple[float, float] | None = None
     spotface: tuple[float, float] | None = None
     kind: ClassVar[str] = "hole"

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -146,7 +146,9 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
         if f.frame.axis != "z":
             continue
         if f.kind == "hole":
-            refs.append((f.frame.origin, "location"))  # un-patterned holes only
+            # un-patterned holes — a HoleFeature may group identical holes
+            for m in getattr(f, "members", ()) or (f.frame.origin,):
+                refs.append((m, "location"))
         elif f.kind == "pattern":
             members = getattr(f, "members", ())
             if getattr(f, "pattern", None) == "bolt_circle":

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -70,7 +70,9 @@ class TestRender:
         part = Box(80, 60, 12) - Pos(20, 0, 0) * Cylinder(4, 30) - Pos(-20, 0, 0) * Cylinder(4, 30)
         dwg = build_drawing(part, number="X")
         anns = render_callouts(dwg, _groups(part))
-        assert len(anns) == 2 and all(isinstance(a, Leader) for a in anns)  # one per hole, placed
+        # The two identical holes group into one ``2×`` callout (machining-spec
+        # grouping in the IR), so one placed leader — not one per hole.
+        assert len(anns) == 1 and all(isinstance(a, Leader) for a in anns)
 
     def test_bolt_circle_renders_one_leader_pointing_at_a_member(self):
         part = Cylinder(40, 8)


### PR DESCRIPTION
The hole-callout migration (#238) needs the IR to group identical holes the way the engine does. Today `build_part_model` emits **one `HoleFeature` per un-patterned hole**, so driving callouts from it would shatter `4× ø8` into four callouts. This closes that gap — a foundation step, not yet the engine deletion.

## What
- `HoleFeature` gains **`members`** (member locations) alongside `count`.
- `build_part_model` groups un-patterned holes by **`HoleSpec`** (the engine's grouped-callout key, incl. snapped axis → opposite-face drillings stay distinct) into one `HoleFeature` with `count` + `members`.
- `plan_locations` iterates members (a grouped feature still locates every hole). `render_centermarks` already iterates `members or (origin,)` — no change. Lint counts raw `find_holes` — unaffected.

## Test-only ripple
`render_into`/`render_callouts` now group too (correct direction); the seam test expects one grouped `2×` leader. The wider grouped callout exposed a real gap in `_place_leader` (no page-bounds check → 0.9 mm OOB) — added an on-page guard. Both are the test-only path (not in the orchestrator); **production callouts are still engine-placed**, so production output is unchanged.

## Adversarial review
- Grouping key = the engine's `HoleSpec` exactly → same groups.
- Production behaviour-equivalent: corner-plate centre marks=4, location dims=4, score 1.0; IR now yields `2×` / mixed groups correctly.
- `_place_leader` guard verified test-only (callers: `render_into`/`render_callouts`, absent from the orchestrator); full suite green confirms no production churn.

Full fast suite **587 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Next: callout placement migration + `_build_callout`/`_subspecs` deletion (#238).

🤖 Generated with [Claude Code](https://claude.com/claude-code)