### PR TITLE
feat: hole callouts built from the IR spec, not a second extraction (#238 B1)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -99,23 +99,35 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     }
 
 
+def callout_from_spec(spec, draft, count) -> HoleCallout | None:
+    """Build a `HoleCallout` from a :func:`hole_callout_spec` dict. *count* is passed
+    explicitly (the bare/test path uses the spec's own count; the engine pass uses its
+    view-local hole count) — the single callout builder both the IR and the migrating
+    engine pass share, so the bore/cbore/suffix mapping lives in one place (#238 B1)."""
+    if spec is None:
+        return None
+
+    def f(v):  # the IR carries clean floats (no baked labels); the renderer formats
+        return _fmt(v) if v is not None else None
+
+    return HoleCallout(
+        f(spec["diameter"]),
+        count=count,
+        through=spec["through"],
+        depth=f(spec["depth"]),
+        cbore_dia=f(spec["cbore_dia"]),
+        cbore_depth=f(spec["cbore_depth"]),
+        suffix=spec["suffix"],
+        draft=draft,
+    )
+
+
 def _hole_callout(dwg, group) -> HoleCallout | None:
     """The `HoleCallout` for a hole/pattern group from its planned spec, or ``None``
     if the group is not hole-bearing. The shared callout builder for both the placed
     (`render_into`) and the bare (`render_callouts`) paths."""
     spec = hole_callout_spec(group)
-    if spec is None:
-        return None
-    return HoleCallout(
-        spec["diameter"],
-        count=spec["count"],
-        through=spec["through"],
-        depth=spec["depth"],
-        cbore_dia=spec["cbore_dia"],
-        cbore_depth=spec["cbore_depth"],
-        suffix=spec["suffix"],
-        draft=dwg.draft,
-    )
+    return callout_from_spec(spec, dwg.draft, spec["count"]) if spec is not None else None
 
 
 def _place_leader(dwg, view, tip_model, obstacles, *, label="", callout=None) -> Leader | None:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -12,7 +12,6 @@ import math
 
 from build123d_drafting.helpers import (
     CenterlineCircle,
-    HoleCallout,
     Leader,
 )
 
@@ -29,7 +28,9 @@ from draftwright._core import (
     _log,
 )
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
+from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
 from draftwright.layout import LayoutSolver, Placeable
+from draftwright.model import plan_dimensions
 from draftwright.recognition import (
     BoltCircle,
     HoleSpec,
@@ -421,7 +422,7 @@ def _solve_strip_via_layout(naturals, min_gap, lo, hi, key_prefix):
     return [placed[k] for k in keys]
 
 
-def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=None):
+def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, model, holes_in=None):
     """Leader-attached HoleCallouts, one per distinct hole spec per view (#91).
 
     Identical holes share one callout with an ``n×`` count prefix (#92's
@@ -481,6 +482,17 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=Non
     # one callout PER pattern + one for the leftover unpatterned holes (#92).
     hole_pattern = {h: p for p in found_patterns for h in p.holes}
 
+    # Map each hole location → its IR hole/pattern DimensionGroup so the callout's
+    # bore/cbore/suffix come from the single IR spec (hole_callout_spec), not a
+    # second engine-side extraction (#238 B1). The IR groups holes the same way the
+    # engine does (HoleSpec / find_hole_patterns), so every hole has a group.
+    _loc_to_group: dict = {}
+    for g in plan_dimensions(model):
+        if g.feature_kind not in ("hole", "pattern"):
+            continue
+        for m in getattr(g.feature, "members", ()) or (g.anchor,):
+            _loc_to_group[(round(m[0], 3), round(m[1], 3), round(m[2], 3))] = g
+
     def _subspecs(holes):
         """Split a spec group's holes into ``(subholes, pattern)`` entries — one
         per recognised pattern (its full hole set) plus a trailing ``(rest,
@@ -499,31 +511,18 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=Non
         return out
 
     def _build_callout(holes, pattern):
-        h = holes[0]
-        step = h.cbore or h.spotface
-        if h.cbore and h.spotface:
-            _log.info(
-                "Hole ø%s has both cbore and spotface; spotface not in the callout",
-                _fmt(h.diameter),
-            )
-            step = h.cbore
-        through = h.bottom == "through"
-        if isinstance(pattern, BoltCircle):
-            suffix = f"EQ SP ON ø{_fmt(pattern.diameter)} BC"
-        elif isinstance(pattern, RectGrid):
-            suffix = f"({pattern.rows}×{pattern.cols})"
-        else:
-            suffix = None
-        return HoleCallout(
-            _fmt(h.diameter),
-            count=len(holes) if len(holes) > 1 else None,
-            through=through,
-            depth=None if through else _fmt(h.depth),
-            cbore_dia=_fmt(step.diameter) if step else None,
-            cbore_depth=_fmt(step.depth) if step else None,
-            suffix=suffix,
-            draft=draft,
-        )
+        """The `HoleCallout` for a spec group, built from its IR group's planned spec
+        (bore/cbore/through/suffix) with the engine's view-local hole count. The
+        cbore-precedence and pattern-suffix logic lives once, in `hole_callout_spec`
+        (#238 B1). *pattern* is unused here — the IR group carries the suffix; it
+        stays in the spec tuple for placement + sheet furniture."""
+        key = holes[0].location
+        group = _loc_to_group.get((round(key[0], 3), round(key[1], 3), round(key[2], 3)))
+        if group is None:  # every hole is in build_part_model; guard, don't crash
+            _log.warning("no IR group for hole at %s; callout skipped", _fmt(holes[0].diameter))
+            return None
+        count = len(holes) if len(holes) > 1 else None
+        return callout_from_spec(hole_callout_spec(group), draft, count)
 
     def _rim_tip(centre, elbow, holes):
         """Pull the tip from the hole centre to its circumference."""
@@ -553,7 +552,9 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, found_patterns, holes_in=Non
         specs = []
         for holes in view_groups:
             for subholes, pattern in _subspecs(holes):
-                specs.append((subholes, _build_callout(subholes, pattern), pattern))
+                callout = _build_callout(subholes, pattern)
+                if callout is not None:
+                    specs.append((subholes, callout, pattern))
         # No fixed cap (#36): every spec is attempted; the per-view placement
         # bounds below (front-view shaft rows, plan/side strip Y-solver) are the
         # real limit, and any callout that genuinely doesn't fit surfaces as

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -274,7 +274,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         present = set(map(id, feature_holes))
         feature_patterns = [p for p in a.patterns if all(id(h) in present for h in p.holes)]
     if feature_holes:
-        _annotate_holes(dwg, a, view_of_axis, feature_patterns, holes_in=feature_holes)
+        _annotate_holes(dwg, a, view_of_axis, feature_patterns, _model, holes_in=feature_holes)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
     # through the existing above-view strips. Replaces the engine's _add_location_dims.
     render_locations(dwg, _model, a)


### PR DESCRIPTION
First step of the hole-callout migration (#238 B1, per the [roadmap plan](https://github.com/pzfreo/draftwright/blob/main/docs/plans/0008-convergence-roadmap.md#238-remaining--hole-callout-placement)). The engine's `_annotate_holes` built its `HoleCallout` from a **second copy** of the bore/cbore/suffix/through logic (`_build_callout`); the IR already has it in `hole_callout_spec`. Route the engine through the IR so the callout-content rules live in **one place**.

## What
- **`from_model`**: extract **`callout_from_spec(spec, draft, count)`** — the single `HoleCallout` builder (count passed explicitly: bare/test path uses the spec's count; the engine its view-local count). `_hole_callout` delegates to it.
- **`holes`**: thread the `PartModel` in; map each hole location → its IR hole/pattern `DimensionGroup` (the IR groups the same way the engine does, #257); `_build_callout` is now a thin adapter returning `callout_from_spec(hole_callout_spec(group), …)`. The duplicated cbore-precedence / pattern-suffix / through extraction is **deleted**; the `HoleCallout` import is gone. Placement, `_subspecs`, furniture **unchanged**.

## Key finding (adversarial review)
`HoleCallout` renders a **float** `ø8.0` wider than the `_fmt` **string** `"ø8"` — so passing the IR's clean float values shifted placement and dropped callouts (caught by the hole tests). Fixed at the right layer: the IR stays float-clean (no baked labels — an architecture principle), the **renderer** formats with `_fmt`, matching the engine.

## Verification
- **Visual** on a `4× ø5` + counterbore plate: identical to the engine — `ø8 THRU ⌴ ø14 ↓ 5`, `4× ø5 THRU`, section A–A, score 1.0.
- Count stays view-local (rotational-filtered counts unaffected); each hole maps 1:1 to its IR feature.
- Full fast suite **587 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean.

Next: **B2** — drive the callout loop from the IR groups + delete `_subspecs`/HoleSpec grouping (resolves the furniture/`_cover_pattern` recognition coupling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)