### PR TITLE
docs: ADR 0008 Amendment 6 — IR-typed interface across the IR→infra boundary

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -352,6 +352,17 @@ The shared *services* still stay shared (Amendment 4 stands — we do not reabso
 the layout solver, projector, exporter). This amendment only fixes **what type of
 data** the renderer hands them.
 
+**Enforcement — by the type system, not a written rule.** The boundary is enforced
+by **IR-typed signatures** (mypy): a shared service accepts IR types only, so a
+recognition object simply *cannot be passed* — the norm becomes a compile-time
+guarantee. Where the data is structured and identity-bearing, use a **small frozen
+value type** (e.g. a `HoleRef`/feature key for the cover/table bookkeeping), not a
+raw `Hole`. Do **not** invent a single universal "render-item" dataclass spanning the
+whole boundary: the sub-channels are genuinely different services (allocate a float,
+project a point, place a primitive, record coverage) — type each at its own
+signature. Grow a shared emit-type only if the renderers later converge and a real
+consumer demands it (the ADR's anti-over-abstraction rule, below).
+
 **Standing norm:** a migration **may not add new recognition-object coupling across
 the boundary.** Where it exists today (the holes/table path) it is **debt on a
 defined path to removal (#263)** — not an acceptable steady state. Per the project

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -3,11 +3,12 @@
 - **Status:** Accepted — architecture stands; **migration is a correctness-judged
   strangler that converges on ONE feature→dimension path** (Amendment 3), which
   *feeds* the engine's shared layout/table/section/projection/export infrastructure
-  rather than reabsorbing it (Amendment 4). Not reproduce-and-swap (Amendment 2),
-  not two permanent paths — incremental migration where each step deletes the
-  per-feature engine pass it replaces. The equivalence golden gate is retired.
-  **One path implies one feature inventory** (Amendment 5): `_analyse` and the IR
-  must not re-detect independently — keystone of the remaining migration (#241).
+  rather than reabsorbing it (Amendment 4), **through an IR-typed interface — no
+  recognition objects cross the boundary** (Amendment 6). Not reproduce-and-swap
+  (Amendment 2), not two permanent paths — incremental migration where each step
+  deletes the per-feature engine pass it replaces. The equivalence golden gate is
+  retired. **One path implies one feature inventory** (Amendment 5): `_analyse` and
+  the IR must not re-detect independently — keystone of the remaining migration (#241).
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Supersedes the original 0008** ("unified feature model") with a concrete
@@ -322,6 +323,40 @@ continues (tracked in #241):
 Order: **unify the inventory first** (keystone), then the docs sweep, the accessor
 boundary, the planner-intent increment, and finally delete the `render_into`
 test-only parallel once the holes epic supersedes it.
+
+## Amendment 6 (2026-06-29) — the IR→infra interface is IR-typed
+
+Amendment 4 drew the *boundary* (the IR decides *what/where*; the shared infra
+decides *how it is drawn*) but did not specify the **interface** across it. The
+holes migration exposed the gap: the shared hole-table / balloon escalation
+(`cover_pattern` / `_maybe_tabulate_holes`) matches on the recogniser's `Hole`
+objects, so the IR-driven callout loop (#260) has to map IR groups **back** to
+recognition `Hole`/`Pattern` objects (`loc_to_hole` / `pat_by_key`) to feed it.
+That leaves recognition objects **load-bearing downstream of the IR** — which
+contradicts the whole point: the IR is supposed to be the *single representation*
+after detection.
+
+**Decision.** The data that crosses the IR→infrastructure boundary is **IR-typed** —
+model-space locations, `DimParameter`s, feature kinds, and stable feature/datum
+keys — **not recognition objects.** Concretely:
+
+- The hole-table / cover bookkeeping matches by **location key**, not `Hole`
+  identity, so the escalation no longer needs `Hole` objects.
+- Placement consumes member **locations** + the feature **diameter**, not `Hole`s.
+- Sheet furniture (bolt-circle centre-line, pitch dims) reads the **`PatternFeature`**
+  (members / bcd / pitch / rows / cols), not the recognition `Pattern`.
+- End state: `a.holes` / `found_patterns` are **not threaded into the render layer**;
+  detection feeds the IR, and only the IR flows downstream.
+
+The shared *services* still stay shared (Amendment 4 stands — we do not reabsorb
+the layout solver, projector, exporter). This amendment only fixes **what type of
+data** the renderer hands them.
+
+**Standing norm:** a migration **may not add new recognition-object coupling across
+the boundary.** Where it exists today (the holes/table path) it is **debt on a
+defined path to removal (#263)** — not an acceptable steady state. Per the project
+stance at this stage: *do it right or not at all — incrementally, no accumulated
+debt.*
 
 ## Consequences
 

--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -107,27 +107,33 @@ in the convergence. Reading `_annotate_holes` surfaced *why* it is not a swap:
   `a.holes` for the table. `PatternFeature` already carries `members`/`bcd`/`pitch`/
   `rows`/`cols`; the open question is hole **identity** for the table match.
 
-### Proposed approach (decomposed, each its own PR)
+### Approach (decomposed, each its own PR)
 
-- **B1 — callout spec from the IR (dedup, low risk).** In `_annotate_holes`, build the
-  `HoleCallout` from the IR's `hole_callout_spec` instead of `_build_callout`. The IR
-  now groups identically (#257), so each engine spec-group maps 1:1 to its IR
-  hole/pattern feature by representative location + diameter (thread `_model` in).
-  **Delete `_build_callout`.** Grouping, placement, furniture unchanged. Removes the
-  spec duplication (engine vs IR) with no placement risk.
-- **B2 — drive the callout loop from the IR (the real migration).** Replace the engine
-  `HoleSpec` grouping + `_subspecs` with iteration over the IR hole/pattern groups;
-  the placement loop consumes `(members, callout, pattern)` sourced from features.
-  Resolve the furniture/`_cover_pattern` recognition-`Pattern` dependency — either map
-  IR `PatternFeature` → recognition `Pattern` (1:1 from the same `find_hole_patterns`)
-  or carry a hole-identity ref on the feature. **Delete `_subspecs` + the HoleSpec
-  grouping.**
-- **B3 — pitch/grid intent to the IR (optional follow-on).** `PatternFeature` already
-  has `pitch`/`grid`; move the *which-pitch-dim* decision into the planner, keep
-  `_place_pitch_dim`/`_add_grid_pitch_dims` as the (shared) placement.
+- ✅ **B1 — callout spec from the IR** (PR #259). The `HoleCallout` is built from the
+  IR's `hole_callout_spec` via a shared `callout_from_spec`; the duplicated engine-side
+  extraction (`_build_callout`) is gone. (Found+fixed: `HoleCallout` renders a float
+  wider than the `_fmt` string — #261; the IR stays float-clean, the renderer formats.)
+- ✅ **B2 — drive the callout loop from the IR** (PR #260). The IR is the single
+  grouping authority; the engine's `HoleSpec` grouping + `_subspecs` are deleted.
+  `_annotate_holes` iterates the IR groups, mapping back to recognition `Hole`/`Pattern`
+  objects to feed the (still shared) placement + furniture + table machinery.
+- **B3 — IR-typed interface (Amendment 6, #263): retire the recognition-object
+  mapping.** B2's `loc_to_hole` / `pat_by_key` mapping is a **scaffold, not the steady
+  state** — recognition objects must not stay load-bearing downstream of the IR.
+  Sequence (each a PR, behaviour-equivalent, dense-part visual gate):
+  1. **Cover-by-location** — `CoverageState.cover_pattern`/`is_pattern_covered` match by
+     location key, not `Hole` identity, so `_maybe_tabulate_holes` no longer needs
+     `Hole` objects. *(Riskiest — the table-escalation matching.)*
+  2. **Furniture from `PatternFeature`** — `_add_furniture` reads the IR feature
+     (members/bcd/pitch/rows/cols); the *which-pitch-dim* intent moves to the planner,
+     `_place_pitch_dim`/`_add_grid_pitch_dims` stay as the shared placement.
+  3. **Placement on IR geometry** — `to_page` over member locations, `_rim_tip` from the
+     feature diameter; drop `loc_to_hole`.
+  4. **Remove `a.holes`/`found_patterns`** from `_annotate_holes` — only the IR flows in.
 
-After B2, `_annotate_holes` is reduced to **placement only** (shared infra) fed by the
-IR; the recognition→spec logic is gone, and **#251** (delete `render_into`) unblocks.
+After B3, `_annotate_holes` is fed **purely by the IR** (Amendment 6 satisfied);
+recognition objects stop at detection, and **#251** (delete `render_into`) unblocks.
+Per the project stance: *do it right or not at all* — B3 is on the path, not optional.
 
 ### Verification bar (this migration specifically)
 

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -108,7 +108,9 @@ verification — detection happens once, three consumers read it.
   (`Feature.frame`), never code paths.
 - **Correctness, not equivalence** — judged by lint/standards, not byte-identity.
 - **The IR feeds shared infrastructure; it doesn't reabsorb it** (Amendment 4) —
-  layout, tables, sections, projection, export stay shared.
+  layout, tables, sections, projection, export stay shared — **through an IR-typed
+  interface: no recognition objects cross the boundary** (Amendment 6). The IR is
+  the single representation downstream of detection.
 - **One feature inventory per build** (Amendment 5) — detect once.
 - **Deterministic generation — no model in the pipeline** (ADR 0001).
 - **Lint is the single correctness judge** (no standing golden gate).


### PR DESCRIPTION
In response to "do it right or not at all — no accumulated debt." Amendment 4 drew the IR↔infra *boundary* but never specified the *interface*; the holes migration (#260) revealed the shared table/balloon escalation consumes recognition `Hole`/`Pattern` **objects**, so B2 maps IR→recognition to feed it — leaving recognition objects load-bearing downstream of the IR.

## Amendment 6 (new)
The data crossing **IR → shared infrastructure is IR-typed** (locations, `DimParameter`s, feature/datum keys), **not recognition objects**. The shared *services* still stay shared (Amendment 4 holds) — this only fixes *what type of data* the renderer hands them. **Standing norm:** no migration may add new recognition-object coupling across the boundary; the existing holes/table coupling is **debt on a defined path (#263)**, not a steady state.

## Changes (docs only)
- **ADR** — add Amendment 6; thread it into the status summary.
- **target-architecture** — the Amendment-4 load-bearing principle now names the IR-typed interface ("IR is the single representation downstream of detection").
- **roadmap** — #238 B1/B2 marked ✅; **B3 reframed** as the IR-typed-interface path: cover-by-location → furniture-from-`PatternFeature` → placement-on-IR-geometry → drop `a.holes`/`found_patterns`. On the path, not optional.
- **#263** reclassified optional → in-scope (the B3 sequence).

No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)