### PR TITLE
feat: cover/table escalation matches by HoleRef, not Hole identity (#263 B3.1)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -56,6 +56,23 @@ def _xyz(loc) -> tuple[float, float, float]:
     return (float(x), float(y), float(z))
 
 
+@dataclass(frozen=True)
+class HoleRef:
+    """A position-keyed reference to a hole — the IR-typed value the cover / hole-table
+    bookkeeping matches on, so the shared escalation never needs a recogniser ``Hole``
+    object (ADR 0008 Amendment 6). Built from any location via :meth:`of` (rounded, so
+    two references at the same position compare equal)."""
+
+    x: float
+    y: float
+    z: float
+
+    @classmethod
+    def of(cls, loc) -> HoleRef:
+        x, y, z = _xyz(loc)
+        return cls(round(x, 3), round(y, 3), round(z, 3))
+
+
 _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built with this
 
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -20,6 +20,7 @@ from draftwright._core import (
     _TB_CLEAR,
     _TB_H,
     Analysis,
+    HoleRef,
     _axis_letter,
     _dim,
     _fmt,
@@ -216,8 +217,9 @@ def _add_furniture(dwg, a: Analysis, view, j, pattern, to_page):
         # tabulates only the holes no *placed* pattern callout covers (#92).
         # Recording here (callout already placed) — not from a.patterns — means a
         # pattern dropped for lack of room, or filtered off a rotational part,
-        # correctly falls back to the table instead of going undocumented.
-        dwg._cover_pattern(f"hc_{view}{j}", pattern.holes)
+        # correctly falls back to the table instead of going undocumented. Cover is
+        # keyed by position (HoleRef), not the recogniser Hole (Amendment 6).
+        dwg._cover_pattern(f"hc_{view}{j}", [HoleRef.of(h.location) for h in pattern.holes])
     if isinstance(pattern, BoltCircle):
         cx = sum(to_page(h)[0] for h in pattern.holes) / len(pattern.holes)
         cy = sum(to_page(h)[1] for h in pattern.holes) / len(pattern.holes)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -26,6 +26,7 @@ from draftwright._core import (
     _SLOT_DIM_STEP,
     _TABULATE_MIN_HOLES,
     Analysis,
+    HoleRef,
     _add_title_block,
     _axis_letter,
     _dim,
@@ -502,7 +503,11 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     # pattern dimension, so they must not become table rows or per-hole balloons
     # (#92).  Excluding them is also what keeps a densely-but-regularly drilled
     # part (e.g. NIST CTC-02) off the 61-row escalation (#111).
-    holes = [h for h in a.holes if _axis_letter(h) == "z" and not dwg._is_hole_patterned(h)]
+    holes = [
+        h
+        for h in a.holes
+        if _axis_letter(h) == "z" and not dwg._is_hole_patterned(HoleRef.of(h.location))
+    ]
     # A chart is warranted only for a *genuinely* dense plan view — a part that
     # merely dropped one too-close location ref keeps its individual dims (the
     # legibility gate already handled it). #93.

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -18,11 +18,12 @@ Part of the :mod:`draftwright.linting` package (ADR 0007):
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Literal
 
 from build123d_drafting.helpers import CenterMark, Dimension, TitleBlock
 
-from draftwright._core import _DIAM_RE, _END_ON, _axis_letter, _fmt, _xyz
+from draftwright._core import _DIAM_RE, _END_ON, HoleRef, _axis_letter, _fmt, _xyz
 from draftwright.linting.issues import LintIssue
 from draftwright.recognition import (
     analyse_cylinders,
@@ -62,19 +63,21 @@ class CoverageState:
 
     # -- pattern coverage -----------------------------------------------------
 
-    def cover_pattern(self, callout_name, holes) -> None:
-        """Record that placed *callout_name* documents *holes* (a grouped
-        pattern callout) — so neither becomes a table row or per-hole balloon."""
+    def cover_pattern(self, callout_name, refs: Iterable[HoleRef]) -> None:
+        """Record that placed *callout_name* documents the holes at *refs* (a grouped
+        pattern callout) — so neither becomes a table row or per-hole balloon. *refs*
+        are :class:`HoleRef` position keys, not recogniser ``Hole`` objects, so the
+        shared escalation stays IR-typed (ADR 0008 Amendment 6)."""
         self._pattern_callouts.add(callout_name)
-        self._patterned_holes.update(holes)
+        self._patterned_holes.update(refs)
 
     def is_pattern_callout(self, name) -> bool:
         """Is *name* a placed pattern (grouped ``n× ⌀``) callout?"""
         return name in self._pattern_callouts
 
-    def is_hole_patterned(self, hole) -> bool:
-        """Is *hole* already documented by a placed pattern callout?"""
-        return hole in self._patterned_holes
+    def is_hole_patterned(self, ref: HoleRef) -> bool:
+        """Is the hole at *ref* already documented by a placed pattern callout?"""
+        return ref in self._patterned_holes
 
     # -- dropped diameters ----------------------------------------------------
 

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -3,27 +3,31 @@
 
 import pytest
 
+from draftwright._core import HoleRef
 from draftwright.linting import CoverageState
 
 # Pure unit tests — no OCC builds — so they join the build-light `smoke` set (#153).
 pytestmark = pytest.mark.smoke
 
+_H1, _H2, _H3 = (HoleRef.of((1, 0, 0)), HoleRef.of((2, 0, 0)), HoleRef.of((3, 0, 0)))
+_H9 = HoleRef.of((9, 0, 0))
+
 
 def test_cover_pattern_records_callout_and_holes():
     c = CoverageState()
-    c.cover_pattern("hc_plan0", ["h1", "h2", "h3"])
+    c.cover_pattern("hc_plan0", [_H1, _H2, _H3])
     assert c.is_pattern_callout("hc_plan0")
     assert not c.is_pattern_callout("hc_plan1")
-    assert c.is_hole_patterned("h2")
-    assert not c.is_hole_patterned("h9")
+    assert c.is_hole_patterned(_H2)
+    assert not c.is_hole_patterned(_H9)
 
 
 def test_cover_pattern_accumulates_across_calls():
     c = CoverageState()
-    c.cover_pattern("a", ["h1"])
-    c.cover_pattern("b", ["h2", "h3"])
+    c.cover_pattern("a", [_H1])
+    c.cover_pattern("b", [_H2, _H3])
     assert c.is_pattern_callout("a") and c.is_pattern_callout("b")
-    assert all(c.is_hole_patterned(h) for h in ("h1", "h2", "h3"))
+    assert all(c.is_hole_patterned(h) for h in (_H1, _H2, _H3))
 
 
 def test_dropped_diams_append_read_reset():


### PR DESCRIPTION
First step of the IR-typed interface (ADR 0008 **Amendment 6** / #263). The hole-table/balloon escalation recorded coverage by recogniser `Hole` identity (`_patterned_holes` held `Hole` objects), so the renderer had to hand it recognition objects — leaving them load-bearing past the IR.

## What
- Add a frozen **`HoleRef`** (position key) to `_core`.
- `CoverageState.cover_pattern(refs: Iterable[HoleRef])` / `is_hole_patterned(ref: HoleRef)` are **typed to it** — a recogniser `Hole` can no longer be passed (mypy enforces Amendment 6 at this boundary).
- `_add_furniture` records `HoleRef.of(h.location)`; the table membership test keys the same way. **No recognition object crosses the cover boundary.**
- `test_linting.py` updated to use `HoleRef`.

## Verification
- Behaviour-equivalent: holes have unique positions, so position-keying ≡ identity-keying. Explicit `add_hole_table` → `covers_diameters=(6,16,10)`, balloons A/B/C key to the right rows (visual confirmed); the table/coverage tests pass.
- Full fast suite **587 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean.

## Scope (the B3 path)
This fixes the cover **matching** boundary. The table still iterates `a.holes` to build rows (recognition in, still) — removed in **B3.4** when `a.holes`/`found_patterns` drop from the hole path. Next: **B3.2** (furniture from `PatternFeature`), **B3.3** (placement on IR geometry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)