### PR TITLE
refactor: delete the test-only render_into/render_callouts parallel (#251)

### DIFF
--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -70,8 +70,10 @@ which waits on the holes epic):
 4. ✅ **Planner render-intent increment** (#250, PR #255) — `PlannedDimension` carries
    `suppressed`/`reason` (model-level suppression moved into the planner) + a `datum`
    slot (consumed by #238 location dims).
-5. ⏳ **Delete `render_into`** (**#251**) — the test-only parallel; retire once the
-   holes callout migration supersedes its remaining hole-callout capability.
+5. ✅ **Delete `render_into`** (#251, PR pending) — the test-only parallel
+   (`render_into`/`render_callouts` + their leader helpers) is removed; the seam +
+   e2e-slice tests are repointed at the production renderers. **Foundation track
+   complete.**
 
 ## Remaining — feature epics (need IR modelling; AFTER the foundation track)
 

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -161,9 +161,11 @@ prerequisite for migrating the callouts.
 - ✅ **Planner render-intents**
   ([#250](https://github.com/pzfreo/draftwright/issues/250), PR #255) — model-level
   suppression moved into the planner; `datum` slot added (consumed by #238).
-- ⏳ **Delete `render_into`**
-  ([#251](https://github.com/pzfreo/draftwright/issues/251)) — the test-only
-  parallel, once the holes callout-placement migration supersedes it.
+- ✅ **Delete `render_into`**
+  ([#251](https://github.com/pzfreo/draftwright/issues/251)) — the test-only parallel
+  (`render_into`/`render_callouts` + their leader helpers) is removed; the seam/e2e
+  tests are repointed at the production renderers. The **foundation track is
+  complete.**
 
 **Inherent (not a migration gap):** recognition is heuristic — a chamfered bore in
 a tapered section will not recognise itself cleanly. The architecture *contains*

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -9,8 +9,11 @@ exactly why the IR carries semantic `role`s, not glyph strings.
 This lives in `annotations/` (not `model/`) so the IR package stays pure — it
 imports *down* into `model` + `_core`, and is called by the orchestrator (ADR 0008
 Amendment 3: one path, this is its render stage). Judged by **correctness** (lint),
-not equivalence to the engine. `render_step_lengths` is wired into production;
-`render_into`/`render_callouts` drive the end-to-end slice + seam tests.
+not equivalence to the engine. All renderers here (`render_diameters`/`render_envelope`/
+`render_locations`/`render_centermarks`/`render_step_lengths`/`render_slots`, and the
+shared `hole_callout_spec`/`callout_from_spec` consumed by the holes pass) are wired
+into production — the test-only `render_into`/`render_callouts` parallel was retired
+once the holes epic landed (#251).
 """
 
 from __future__ import annotations
@@ -43,15 +46,6 @@ _ENVELOPE_PLACEMENT = {
     "height": ("front", "right"),  # Z extent
     "depth": ("side", "below"),  # Y extent
 }
-
-# Candidate leader-elbow offsets from the hole, in rings of increasing radius and
-# eight directions — the renderer's local placement search (ADR 0003 layout: keep
-# the callout near its feature but clear of the views and other callouts).
-_ELBOW_OFFSETS = [
-    (r * ux, r * uy)
-    for r in (14.0, 22.0, 34.0, 50.0, 72.0)
-    for ux, uy in ((1, 1), (-1, 1), (1, -1), (-1, -1), (1, 0), (0, 1), (-1, 0), (0, -1))
-]
 
 
 def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
@@ -120,72 +114,6 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
         suffix=spec["suffix"],
         draft=draft,
     )
-
-
-def _hole_callout(dwg, group) -> HoleCallout | None:
-    """The `HoleCallout` for a hole/pattern group from its planned spec, or ``None``
-    if the group is not hole-bearing. The shared callout builder for both the placed
-    (`render_into`) and the bare (`render_callouts`) paths."""
-    spec = hole_callout_spec(group)
-    return callout_from_spec(spec, dwg.draft, spec["count"]) if spec is not None else None
-
-
-def _place_leader(dwg, view, tip_model, obstacles, *, label="", callout=None) -> Leader | None:
-    """A leader (callout or plain ø label) placed clear of *obstacles* by searching
-    outward from the feature (ADR 0003 layout): the first elbow whose label box is
-    on-page and non-colliding wins; the farthest candidate is the fallback. With no
-    obstacles the first on-page ring wins, so a bare call is deterministic."""
-    tx, ty, *_ = dwg.at(view, *tip_model)
-
-    def _on_page(b) -> bool:
-        return bool(
-            b[0] >= _MARGIN
-            and b[1] >= _MARGIN
-            and b[2] <= dwg.page_w - _MARGIN
-            and b[3] <= dwg.page_h - _MARGIN
-        )
-
-    fallback = None
-    for dx, dy in _ELBOW_OFFSETS:
-        leader = Leader(
-            tip=(tx, ty, 0),
-            elbow=(tx + dx, ty + dy, 0),
-            label=label,
-            draft=dwg.draft,
-            callout=callout,
-        )
-        box = _anno_box(leader)
-        if box is None:
-            return leader
-        if _on_page(box) and not _box_hits(box, obstacles):
-            return leader
-        fallback = leader
-    return fallback
-
-
-def _hole_leader(dwg, group, obstacles) -> Leader | None:
-    """A `HoleCallout` leader for a hole/pattern group, placed clear of *obstacles*.
-    Tips at a real member hole (not the empty pattern centre)."""
-    callout = _hole_callout(dwg, group)
-    if callout is None:
-        return None
-    members = getattr(group.feature, "members", ())
-    tip = members[0] if members else group.anchor
-    return _place_leader(dwg, group.view, tip, obstacles, callout=callout)
-
-
-def render_callouts(dwg, groups) -> list[Leader]:
-    """The hole/pattern callout leaders for *groups* (does not mutate *dwg*). The
-    bare path: placed against no obstacles, so deterministic."""
-    return [ldr for g in groups if (ldr := _hole_leader(dwg, g, [])) is not None]
-
-
-def _diameter_leader(dwg, group, obstacles) -> Leader | None:
-    """A plain ø diameter callout for a boss/step group (the external diameter)."""
-    dia = _first(group, "diameter", "boss", "step")
-    if dia is None:
-        return None
-    return _place_leader(dwg, group.view, group.anchor, obstacles, label=f"ø{_fmt(dia)}")
 
 
 def render_slots(dwg, model, a) -> int:
@@ -743,39 +671,3 @@ def render_step_lengths(dwg, model) -> int:
     for name, dim in candidates:
         dwg.add(dim, name, view="front")
     return len(candidates)
-
-
-def render_into(dwg, model) -> int:
-    """End-to-end demonstration seam: plan *model* and **add** its annotations to
-    *dwg* (which must already have its views, e.g. ``build_drawing(part,
-    auto_dims=False)``). Diameter callouts (holes/patterns/bosses) are placed clear
-    of the views and of each other (ADR-0003 layout); overall envelope dims sit just
-    outside their view. Returns the count added; lint *dwg* to judge correctness.
-
-    **Test-only.** This drives the e2e-slice tests; production uses the per-feature
-    renderers (``render_diameters``/``render_step_lengths``/``render_envelope``/…)
-    wired into the orchestrator. To be retired once the holes epic supersedes its
-    remaining hole-callout capability (#251)."""
-    view_boxes = [vb for v in dwg.views if (vb := dwg.view_bounds(v)) is not None]
-    placed: list = []
-    n = 0
-    for g in plan_dimensions(model):
-        if g.feature_kind in ("hole", "pattern"):
-            ann = _hole_leader(dwg, g, view_boxes + placed)
-        elif g.feature_kind in ("boss", "step"):
-            ann = _diameter_leader(dwg, g, view_boxes + placed)
-        elif g.feature_kind == "envelope":
-            for dim, view in _envelope_dims(dwg, g):
-                dwg.add(dim, f"m_env{n}", view=view)
-                n += 1
-            continue
-        else:
-            ann = None
-        if ann is None:
-            continue
-        dwg.add(ann, f"m_callout{n}", view=g.view)
-        n += 1
-        box = _anno_box(ann)
-        if box is not None:
-            placed.append(box)
-    return n

--- a/tests/test_e2e_slice.py
+++ b/tests/test_e2e_slice.py
@@ -1,16 +1,10 @@
-"""End-to-end slice (ADR 0008) — a complete drawing via the new pipeline.
+"""End-to-end slice (ADR 0008) — a complete drawing via the compiler pipeline.
 
-The honest whole-pipeline test the pivot called for: a real part →
-detect → model → plan → render → a Drawing whose annotations come from the **new**
-pipeline (`build_drawing(auto_dims=False)` gives only the view scaffold), judged by
-**correctness** (lint passes, coverage complete, it exports) — *not* by equivalence
-to the engine.
-
-Scope: the IR-driven hole callouts + envelope width/depth (`render_into`), **placed
-clear of the views and of each other** via the layout search. The drawing lints
-clean for prismatic plates and simple rotational parts. `render_into` is the
-test-only demonstration path (production uses the per-feature renderers wired into
-the orchestrator); it is retired once the holes epic supersedes it (#251).
+The honest whole-pipeline test the pivot called for: a real part → detect → model →
+plan → render, judged by **correctness** (lint passes, coverage complete, it exports)
+— not by equivalence to the engine. These now drive the **production** path
+(`build_drawing`), which *is* the IR pipeline (detectors → `PartModel` → planner →
+the `from_model` renderers); the test-only `render_into` parallel was retired in #251.
 """
 
 import os
@@ -18,8 +12,6 @@ import os
 from build123d import Box, Cylinder, Pos
 
 from draftwright import build_drawing
-from draftwright.annotations.from_model import render_into
-from draftwright.model import build_part_model
 
 
 def _plate():
@@ -32,17 +24,15 @@ def _labels(dwg):
 
 def test_prismatic_plate_sized_and_error_free():
     part = _plate()  # 100×60×12 with two ø8 holes
-    dwg = build_drawing(part, number="X", auto_dims=False)  # view scaffold only
-    render_into(dwg, build_part_model(part))
+    dwg = build_drawing(part, number="X")
     s = dwg.lint_summary()
     assert s["passed"]  # no lint ERRORS
     assert s["by_code"].get("feature_not_dimensioned", 0) == 0  # all sizes covered
     assert {"100", "60", "12"} <= set(_labels(dwg))  # overall dims present
-    # The strengthened lint (#218) correctly flags the new pipeline's remaining
-    # completeness gap — no center marks / location dims. #220 closes these; this
-    # assertion documents the gap and flips when it lands.
-    assert s["by_code"].get("feature_no_centermark", 0) == 1  # one aggregated issue
-    assert s["by_code"].get("feature_not_located", 0) == 1
+    # The pipeline now places centre marks + location dims for every hole, so the
+    # completeness gaps the early slice documented are closed.
+    assert s["by_code"].get("feature_no_centermark", 0) == 0
+    assert s["by_code"].get("feature_not_located", 0) == 0
 
 
 def test_flange_od_sized_and_error_free():
@@ -52,15 +42,12 @@ def test_flange_od_sized_and_error_free():
     for i in range(6):
         a = i * math.pi / 3
         part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
-    dwg = build_drawing(part, number="X", auto_dims=False)
-    render_into(dwg, build_part_model(part))
+    dwg = build_drawing(part, number="X")
     s = dwg.lint_summary()
     assert s["passed"]  # no errors
     assert s["by_code"].get("feature_not_dimensioned", 0) == 0  # OD covered
     assert "ø80" in _labels(dwg)  # the OD, not a width×depth box
-    # bolt-circle holes are located by the pattern, so no feature_not_located;
-    # they still lack center marks until #220.
-    assert s["by_code"].get("feature_no_centermark", 0) == 1  # one issue, covers 6 holes
+    assert s["by_code"].get("feature_no_centermark", 0) == 0
     assert s["by_code"].get("feature_not_located", 0) == 0
 
 
@@ -71,9 +58,8 @@ def test_dense_plate_callouts_dont_collide():
     for x in (-40, 40):
         for y in (-20, 20):
             part -= Pos(x, y, 0) * Cylinder(4, 30)
-    dwg = build_drawing(part, number="X", auto_dims=False)
-    n = render_into(dwg, build_part_model(part))
-    assert n >= 4  # at least the four hole callouts (plus overall dims)
+    dwg = build_drawing(part, number="X")
+    assert any(n.startswith("hc_") for n in dwg._named)  # hole callouts placed
     s = dwg.lint_summary()
     assert s["by_code"].get("annotation_overlap", 0) == 0
     assert s["by_code"].get("view_annotation_overlap", 0) == 0
@@ -81,7 +67,6 @@ def test_dense_plate_callouts_dont_collide():
 
 def test_model_pipeline_drawing_exports(tmp_path):
     part = Box(80, 60, 12) - Pos(0, 0, 0) * Cylinder(4, 30)
-    dwg = build_drawing(part, number="X", auto_dims=False)
-    render_into(dwg, build_part_model(part))
+    dwg = build_drawing(part, number="X")
     svg, dxf = dwg.export(str(tmp_path / "slice"))
     assert os.path.getsize(svg) > 0 and os.path.getsize(dxf) > 0  # renders real geometry

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -2,18 +2,16 @@
 
 Validates that the IR/planner contract carries what a renderer needs to build a
 hole callout: the bore/counterbore values, blind-vs-through, and the pattern count
-all reconstruct from the plan, and the seam produces placed callout leaders via the
-real projection + helpers. (Content correctness vs the engine is the gate's job at
-the #201 swap-in; here we prove the seam mechanically and at the spec level.)
+all reconstruct from the plan via `hole_callout_spec`. (Placement of the production
+callouts is covered by the hole-callout tests in `test_make_drawing`; the test-only
+`render_callouts` seam was retired with `render_into` in #251.)
 """
 
 import math
 
 from build123d import Box, Cylinder, Pos
-from build123d_drafting.helpers import Leader
 
-from draftwright import build_drawing
-from draftwright.annotations.from_model import hole_callout_spec, render_callouts
+from draftwright.annotations.from_model import hole_callout_spec
 from draftwright.model import build_part_model, plan_dimensions
 
 
@@ -63,28 +61,3 @@ class TestCalloutSpec:
         g = plan_dimensions(PartModel(bbox=None, orientation=None, features=[hole]))[0]
         s = hole_callout_spec(g)
         assert s["cbore_dia"] == 14.0 and s["cbore_depth"] == 1.0
-
-
-class TestRender:
-    def test_produces_placed_callout_leaders(self):
-        part = Box(80, 60, 12) - Pos(20, 0, 0) * Cylinder(4, 30) - Pos(-20, 0, 0) * Cylinder(4, 30)
-        dwg = build_drawing(part, number="X")
-        anns = render_callouts(dwg, _groups(part))
-        # The two identical holes group into one ``2×`` callout (machining-spec
-        # grouping in the IR), so one placed leader — not one per hole.
-        assert len(anns) == 1 and all(isinstance(a, Leader) for a in anns)
-
-    def test_bolt_circle_renders_one_leader_pointing_at_a_member(self):
-        part = Cylinder(40, 8)
-        for i in range(6):
-            a = i * math.pi / 3
-            part -= Pos(25 * math.cos(a), 25 * math.sin(a), 0) * Cylinder(3, 20)
-        dwg = build_drawing(part, number="X")
-        groups = _groups(part)
-        pat = next(g for g in groups if g.feature_kind == "pattern")
-        anns = render_callouts(dwg, groups)
-        assert len(anns) == 1  # one grouped callout for the whole bolt circle
-        # the leader tips at a member hole, not the empty pattern centre
-        member_tip = dwg.at(pat.view, *pat.feature.members[0])
-        assert abs(anns[0].tip[0] - member_tip[0]) < 1e-6
-        assert abs(anns[0].tip[1] - member_tip[1]) < 1e-6


### PR DESCRIPTION
Foundation finding 4 (umbrella #241), unblocked by #263 (holes fully on the IR). Removes the test-only IR-demo path now that production renders holes/envelope/diameters directly — **no divergent path lingers.**

## What
- **Delete** `render_into`, `render_callouts`, and their leader helpers (`_hole_leader`, `_diameter_leader`, `_hole_callout`, `_place_leader`, `_ELBOW_OFFSETS`) from `from_model`. `hole_callout_spec`/`callout_from_spec`/`_first` stay — production consumes them.
- **`test_render_seam`**: keep `TestCalloutSpec` (the IR spec contract); drop `TestRender` (render_callouts placement) — production placement is covered by the hole-callout tests in `test_make_drawing`.
- **`test_e2e_slice`**: repoint at the production pipeline (`build_drawing`), which *is* the IR pipeline now; the centre-mark / location-dim gaps the early slice documented are **closed**, so those assertions flip to clean.
- **Docs**: foundation track marked complete in target-architecture + roadmap; `from_model` docstring updated.

## Verification
- No production path changed (the deleted functions had no production caller — verified by grep).
- Full fast suite **585 passed / 1 skipped** (−2 = the retired `TestRender`); ruff(0.15.17)/format/mypy clean.

The foundation track (#244 / #248 / #249 / #250 / #251) is now **complete**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)