### PR TITLE
feat: section A–A trigger via the planner, not a recogniser scan (#207)

### DIFF
--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -84,7 +84,7 @@ envelope width/depth are already done — see [Done](#done).)
 | Issue | Engine pass (to delete) | Prereq (new IR modelling) | Priority |
 |---|---|---|---|
 | **#238** | **holes**: callout *placement* + pitch/balloons (`_annotate_holes`, `_build_callout`/`_subspecs`). *Done:* location dims (`_add_location_dims` deleted, #256); centre marks (#235); IR hole grouping (#257) | callout placement fed from the grouped IR; **feed** the existing strip/balloon/**table** escalation (don't rebuild it, Amend. 4). See [#238 remaining](#238-remaining--hole-callout-placement) | **highest** — partially landed; placement is the hard remainder |
-| **#207** | **sections / detail views** (`_add_section_view`, `_add_detail_view`) | planner **section-trigger** (which features need a section); rendering stays shared infra | medium |
+| ~~**#207**~~ ✅ | **section view** trigger | **done** — `plan_sections(model, feature_keys)` decides the A–A trigger + cut-plane row from the IR; `_add_section_view` is the shared rendering it feeds. Detail view stays user/lint-triggered | done |
 | **#200 → #208** | **PMI / GD&T** (`_annotate_pmi`) | a **PMI/thread detector** → GD&T `Feature`s | medium |
 | **#237** | **prismatic step-height ladder + envelope height + OD** (`dim_step_*`, `_detect_step_repeat`, `_legible_steps`, `dim_height`, `dim_od`) — coupled via the `fv_zones.right` / `_right_ladder` cursor | a **prismatic-step `Feature`** (`analyse_face_levels` → `step_zs`) + rotational classification/OD. Folds in #230, #222 | **deferred** — lowest frequency, highest complexity, worst ROI |
 

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -139,8 +139,10 @@ prerequisite for migrating the callouts.
 - **Prismatic step-height ladder + envelope height + OD** — coupled via the shared
   right-strip cursor; needs a prismatic-step `Feature`.
   ([#237](https://github.com/pzfreo/draftwright/issues/237))
-- **Section / detail views** — the *trigger* needs to move into the planner; the
-  rendering machinery stays shared. ([#207](https://github.com/pzfreo/draftwright/issues/207))
+- ~~**Section views** — trigger into the planner~~ ✅ **done** (#207): `plan_sections`
+  decides the section A–A trigger + cut-plane row from the IR; `_add_section_view`
+  is the shared rendering machinery it feeds. (The detail view stays user/lint-
+  triggered, not feature-driven.) ([#207](https://github.com/pzfreo/draftwright/issues/207))
 - **PMI / GD&T placement** — needs a PMI/thread detector emitting GD&T `Feature`s.
   ([#208](https://github.com/pzfreo/draftwright/issues/208))
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -50,7 +50,7 @@ from draftwright.annotations.holes import (
 )
 from draftwright.annotations.pmi import _annotate_pmi
 from draftwright.annotations.sections import _add_detail_view, _add_section_view
-from draftwright.model import build_part_model
+from draftwright.model import build_part_model, plan_sections
 from draftwright.recognition import (
     full_cylinders,
 )
@@ -273,12 +273,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     feature_holes = a.holes
     if a.is_rotational:
         feature_holes = [h for h in a.holes if not _is_concentric_hole(h, a)]
+    # The surviving feature-hole *positions* (concentric bores excluded on rotational
+    # parts) — the IR gates callouts/furniture/sections on membership in this set, so
+    # no recogniser Hole object crosses into the renderers (Amendment 6, #263/#207).
+    feature_keys = {HoleRef.of(h.location) for h in feature_holes}
     if feature_holes:
-        # _annotate_holes is fed purely by the IR (`_model`) — the only recognition-
-        # derived input is `feature_keys`, the surviving feature-hole *positions*
-        # (concentric bores excluded on rotational parts), not Hole objects. The IR
-        # gates callouts/furniture on membership in this set (Amendment 6, #263).
-        feature_keys = {HoleRef.of(h.location) for h in feature_holes}
         _annotate_holes(dwg, a, view_of_axis, _model, feature_keys)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
     # through the existing above-view strips. Replaces the engine's _add_location_dims.
@@ -396,12 +395,14 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # the planner's decision (#250); the renderer just skips suppressed dims.
     render_envelope(dwg, _model, a)
 
-    # The section view goes last: its room check clears every annotation
-    # already placed right of the side view (callout labels, height/step
-    # dim ladders).  Fires on feature presence, not class (#10); concentric
-    # bores on a turned part are excluded (the ldr_z leaders cover them).
-    if feature_holes:
-        _add_section_view(dwg, a, holes=feature_holes)
+    # The section view goes last: its room check clears every annotation already
+    # placed right of the side view (callout labels, height/step dim ladders). The
+    # *trigger* + cut-plane row are the planner's decision (`plan_sections`, #207);
+    # the renderer just draws the planned section. Concentric bores on a turned part
+    # are excluded via feature_keys (the ldr_z leaders cover them).
+    section = plan_sections(_model, feature_keys)
+    if section is not None:
+        _add_section_view(dwg, a, section)
 
     # Detail view: only when explicitly requested via build_drawing(detail_view=True).
     if detail_view:

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -33,7 +33,6 @@ from draftwright._core import (
     _TB_CLEAR,
     _TB_H,
     Analysis,
-    _axis_letter,
     _dim,
     _fmt,
     _iso_bbox,
@@ -126,31 +125,18 @@ def _fuzzy_cut(body, cutter, fuzzy: float = 1e-3):
     return solids[0] if len(solids) == 1 else Compound(children=list(solids))
 
 
-def _add_section_view(dwg, a: Analysis, holes=None):
-    """Full section A–A when blind or stepped holes hide their structure (#94).
+def _add_section_view(dwg, a: Analysis, section):
+    """Render the planned full section A–A (#94, #207).
 
-    Trigger: any Z-axis hole with a counterbore/spotface or a non-through
-    bottom — its internal profile is hidden-line-only in every standard
-    view. The cut plane passes through the densest row of qualifying hole
-    axes, parallel to the front view; material on the viewer's side is
-    removed so the cut face shows the hole profiles as visible line-work.
-    The section is placed right of the side view when there is room
-    (skipped with a log otherwise), captioned, marked with ISO 128-44
-    cutting-plane arrows and 'A' letters on the plan view, and filled with
-    ISO 128-50 45° hatching on the cut face.
+    The *trigger* + cut-plane row are decided by the planner (`plan_sections` →
+    `SectionPlan`, ADR 0008 Amendment 4); this is the shared rendering machinery it
+    feeds. The cut plane (normal Y at ``section.cut_y``, parallel to the front view)
+    removes material on the viewer's side so the cut face shows the hole profiles as
+    visible line-work. Placed right of the side view when there is room (skipped with
+    a log otherwise), captioned, marked with ISO 128-44 cutting-plane arrows and 'A'
+    letters on the plan view, and filled with ISO 128-50 45° hatching on the cut face.
     """
-    cands = [
-        h
-        for h in (a.holes if holes is None else holes)
-        if _axis_letter(h) == "z" and (h.cbore or h.spotface or h.bottom != "through")
-    ]
-    if not cands:
-        return
-    ys = [h.location[1] for h in cands]
-    y_star = max(
-        {round(y, 1) for y in ys},
-        key=lambda v: (sum(1 for y in ys if abs(y - v) <= 0.5), -abs(v - a.cy)),
-    )
+    y_star = section.cut_y
 
     # room check: same row as the front/side views, to the right — past any
     # side-view callout labels already placed there.

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -36,7 +36,13 @@ from draftwright.model.ir import (
     StepFeature,
     display,
 )
-from draftwright.model.planner import DimensionGroup, PlannedDimension, plan_dimensions
+from draftwright.model.planner import (
+    DimensionGroup,
+    PlannedDimension,
+    SectionPlan,
+    plan_dimensions,
+    plan_sections,
+)
 
 __all__ = [
     "BossFeature",
@@ -54,5 +60,7 @@ __all__ = [
     "StepFeature",
     "build_part_model",
     "display",
+    "SectionPlan",
     "plan_dimensions",
+    "plan_sections",
 ]

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from draftwright._core import _END_ON
+from draftwright._core import _END_ON, HoleRef
 from draftwright.model.ir import Datum, DimParameter, Feature, PartModel, Point
 
 # How each (role, kind) is drawn. Defaults keep the table small.
@@ -201,3 +201,44 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
                 DimensionGroup(feature=feature, view=_group_view(feature), dims=tuple(dims))
             )
     return groups
+
+
+@dataclass(frozen=True)
+class SectionPlan:
+    """A planned full section A–A: the plane is normal to Y at ``cut_y``, parallel to
+    the front view. The *intent* (does the part need a section, and where the plane
+    sits) — the rendering machinery (cut / hatch / cutting-plane arrows) stays shared
+    infrastructure that consumes this (ADR 0008 Amendment 4 / #207)."""
+
+    cut_y: float
+
+
+def plan_sections(model: PartModel, feature_keys: set[HoleRef]) -> SectionPlan | None:
+    """Decide whether a part needs a full section A–A, and where the plane cuts.
+
+    Trigger: any Z-axis hole/pattern whose bore has a counterbore, spotface, or a
+    non-through bottom — its internal profile is hidden-line-only in every standard
+    view. The cut plane passes through the **densest row** of qualifying hole axes
+    (ISO practice), tie-broken toward the part centre. Only holes whose positions are
+    in *feature_keys* count (so a rotational part's concentric bores, dimensioned by
+    the centreline leaders, don't drive a section). ``None`` when no section is
+    warranted."""
+    qual_ys: list[float] = []
+    for f in model.features:
+        if f.kind not in ("hole", "pattern") or f.frame.axis != "z":
+            continue
+        bore = getattr(f, "member", f)  # a pattern's representative HoleFeature, else f
+        cbore, spotface = getattr(bore, "cbore", None), getattr(bore, "spotface", None)
+        if cbore is None and spotface is None and getattr(bore, "through", True):
+            continue
+        for m in getattr(f, "members", ()) or (f.frame.origin,):
+            if HoleRef.of(m) in feature_keys:
+                qual_ys.append(m[1])
+    if not qual_ys:
+        return None
+    cy = model.bbox.center().Y  # type: ignore[attr-defined]  # build123d BoundBox
+    cut_y = max(
+        {round(y, 1) for y in qual_ys},
+        key=lambda v: (sum(1 for y in qual_ys if abs(y - v) <= 0.5), -abs(v - cy)),
+    )
+    return SectionPlan(cut_y=cut_y)


### PR DESCRIPTION
The section-view **trigger** (which features warrant a section, and where the cut plane sits) moves into the IR/planner; the cut/hatch/arrow rendering stays shared infrastructure that consumes it (**ADR 0008 Amendment 4** — "the IR decides *what/where*; the infra decides *how it's drawn*").

## What
- **planner**: `SectionPlan(cut_y)` + **`plan_sections(model, feature_keys)`** — scans the model's Z hole/pattern features whose bore has a counterbore/spotface/blind bottom (gated by `feature_keys`, so a rotational part's concentric bores don't drive a section), returns the densest qualifying row as the cut plane, else `None`.
- **sections**: `_add_section_view(dwg, a, section)` takes the `SectionPlan` — the recogniser-hole scan + `y_star` computation are gone; the cut geometry / room-check / hatch / ISO 128-44 arrows are unchanged.
- **orchestrator**: `section = plan_sections(_model, feature_keys); if section: _add_section_view(...)`. `feature_keys` is computed once for holes + sections.

## Verification
- Behaviour-equivalent: counterbored/blind parts get the section; plain through-hole plates don't; cut row + hatch + arrows match. **Visual confirmed** on a counterbored plate (section A–A with both counterbore profiles hatched).
- Full fast suite **585 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean.

The detail view stays user/lint-triggered (not feature-driven), so #207's feature-trigger scope is the section A–A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)