### PR TITLE
refactor: detect bosses once — close the one-inventory residual (#264)

### DIFF
--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -61,8 +61,8 @@ discrete sub-issue under #241. **The foundation track is complete** (except #251
 which waits on the holes epic):
 
 1. ✅ **Unify the feature inventory** — *keystone* (#244: PR #246 build-time, #247
-   lint). `_analyse` detects once; `build_part_model` + `Drawing.lint()` consume its
-   products. Residual: bosses still detected independently.
+   lint; bosses threaded in #264). `_analyse` detects holes/patterns/bosses/turned-
+   steps once; `build_part_model` + `Drawing.lint()` consume its products.
 2. ✅ **Docs/comment sweep** (#248, PR #253).
 3. ✅ **Annotation-ownership accessor** (#249, PR #254) — registry-backed
    `iter_annotations`/`view_of`/`annotations_in_view` + `replace_object`/`snapshot`/

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -150,10 +150,10 @@ prerequisite for migrating the callouts.
 [#241](https://github.com/pzfreo/draftwright/issues/241); ADR Amendment 5):
 
 - ✅ **One feature inventory** (keystone,
-  [#244](https://github.com/pzfreo/draftwright/issues/244), done via #246/#247).
-  `_analyse` detects once; `build_part_model` and `Drawing.lint()` consume its
-  results — each detector runs once per build, zero extra in lint. *Residual:*
-  bosses are still detected independently in the feature-diameter path.
+  [#244](https://github.com/pzfreo/draftwright/issues/244), done via #246/#247;
+  bosses threaded too in #264). `_analyse` detects holes/patterns/bosses/turned-steps
+  **once**; `build_part_model` and `Drawing.lint()` consume its results — each
+  detector runs once per build, zero extra in lint.
 - ✅ **Docs/comment sweep** ([#248](https://github.com/pzfreo/draftwright/issues/248),
   PR #253).
 - ✅ **Annotation-ownership accessor**

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -460,6 +460,7 @@ class Analysis:
     bbox_max: float
     holes: list
     patterns: list
+    bosses: list  # external bosses (find_bosses), detected once — the one inventory (#244)
     slots: list
     z_diams: list[float]
     cross_diams: list[float]

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -33,6 +33,7 @@ from draftwright._core import (
 )
 from draftwright.recognition import (
     analyse_cylinders,
+    find_bosses,
     find_hole_patterns,
     find_holes,
     find_slots,
@@ -318,6 +319,7 @@ def _analyse(
     _pad_around_text = _draft_est.pad_around_text
     holes = find_holes(part, cyls=(z_cyls, cross_cyls))
     patterns = find_hole_patterns(holes)
+    bosses = find_bosses(part, cyls=(z_cyls, cross_cyls))  # detect once — the one inventory (#264)
     slots = find_slots(part)
 
     # Choose scale/page, iterating so the reserved step corridor matches the
@@ -433,6 +435,7 @@ def _analyse(
         bbox_max=bbox_max,
         holes=holes,
         patterns=patterns,
+        bosses=bosses,
         slots=slots,
         z_diams=z_diams,
         cross_diams=cross_diams,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -255,7 +255,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # The part model — built once and rendered from for the IR-migrated passes
     # (centre marks, turned diameters/lengths); ADR 0008 convergence / #229.
     _model = build_part_model(
-        a.part, holes=a.holes, patterns=a.patterns, slots=a.slots, prof=a.prof
+        a.part, holes=a.holes, patterns=a.patterns, bosses=a.bosses, slots=a.slots, prof=a.prof
     )
 
     # Centre marks for every hole (all part classes) — IR renderer.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1000,15 +1000,17 @@ class Drawing:
             a = self._analysis
             holes: list | None
             patterns: list | None
+            bosses: list | None
             prof_kw: dict
             if a is not None:
                 cyls = a.cyls
-                holes, patterns, prof_kw = a.holes, a.patterns, {"prof": a.prof}
+                holes, patterns, bosses = a.holes, a.patterns, a.bosses
+                prof_kw = {"prof": a.prof}
             else:
                 if self._cyl_cache is None:
                     self._cyl_cache = analyse_cylinders(self.part)
                 cyls = self._cyl_cache
-                holes = patterns = None
+                holes = patterns = bosses = None
                 prof_kw = {}
             issues += lint_feature_coverage(
                 self.part,
@@ -1017,6 +1019,7 @@ class Drawing:
                 exclude=self._coverage.dropped_diams,
                 assembly=self.assembly,
                 holes=holes,
+                bosses=bosses,
             )
             issues += lint_axial_coverage(
                 self.part,

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -96,7 +96,14 @@ class CoverageState:
 
 
 def lint_feature_coverage(
-    part, annotations, tol: float = 0.15, cyls=None, exclude=None, assembly=None, holes=None
+    part,
+    annotations,
+    tol: float = 0.15,
+    cyls=None,
+    exclude=None,
+    assembly=None,
+    holes=None,
+    bosses=None,
 ) -> list:
     """Coarse completeness check: report part diameters with no callout (#80).
 
@@ -145,7 +152,7 @@ def lint_feature_coverage(
     # Replaces the raw full_cylinders patch list, which over-reported those as
     # undimensioned features (helpers #158/#159). *holes* reuses the single
     # inventory (#244); find_bosses inside feature_diameters is the one residual.
-    inventory = feature_diameters(part, cyls=(z_cyls, cross_cyls), holes=holes)
+    inventory = feature_diameters(part, cyls=(z_cyls, cross_cyls), holes=holes, bosses=bosses)
 
     if assembly is None:
         assembly = len(part.solids()) > 1

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -117,7 +117,9 @@ def _distinct_by_diameter(bosses, tol: float = 0.15):
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
 
 
-def build_part_model(part, *, holes=None, patterns=None, slots=None, prof=_UNSET) -> PartModel:
+def build_part_model(
+    part, *, holes=None, patterns=None, bosses=None, slots=None, prof=_UNSET
+) -> PartModel:
     """Run the detectors and assemble the :class:`PartModel` IR for *part*.
 
     The detected feature sets may be **supplied** by the caller (from `_analyse`,
@@ -198,8 +200,9 @@ def build_part_model(part, *, holes=None, patterns=None, slots=None, prof=_UNSET
                 )
             )
     else:
-        bosses = _distinct_by_diameter(find_bosses(part))
-        for b in bosses:
+        raw_bosses = find_bosses(part) if bosses is None else bosses
+        bosses_d = _distinct_by_diameter(raw_bosses)
+        for b in bosses_d:
             features.append(
                 BossFeature(
                     frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
@@ -209,7 +212,7 @@ def build_part_model(part, *, holes=None, patterns=None, slots=None, prof=_UNSET
         # Overall envelope dims for a *prismatic* part — not a round single-OD body
         # (a boss whose diameter fills the footprint is the body, dimensioned by its
         # OD, not a box).
-        if not _is_round(bbox, bosses):
+        if not _is_round(bbox, bosses_d):
             c = bbox.center()
             features.append(
                 EnvelopeFeature(

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -604,7 +604,7 @@ def find_bosses(part, cyls=None) -> list:
     return bosses
 
 
-def feature_diameters(part, cyls=None, holes=None) -> list:
+def feature_diameters(part, cyls=None, holes=None, bosses=None) -> list:
     """Sorted unique diameters of the *recognised* dimensionable cylindrical
     features on *part*: every hole bore, each hole's counterbore/spotface step,
     and every boss.
@@ -632,7 +632,7 @@ def feature_diameters(part, cyls=None, holes=None) -> list:
             diams.append(h.cbore.diameter)
         if h.spotface is not None:
             diams.append(h.spotface.diameter)
-    for b in find_bosses(part, cyls=cyls):
+    for b in find_bosses(part, cyls=cyls) if bosses is None else bosses:
         diams.append(b.diameter)
     return sorted(set(diams))
 


### PR DESCRIPTION
The last #244 (one-inventory, Amendment 5) gap: bosses were detected **independently** in `feature_diameters` (lint) *and* `build_part_model` — the latter via `find_bosses(part)` with **no `cyls`**, re-scanning every cylinder. Thread bosses through the single inventory, exactly as holes/patterns were in #246/#247.

## What
- `_analyse` detects `bosses = find_bosses(part, cyls=...)` **once** → `Analysis.bosses`.
- `build_part_model` + `feature_diameters` take a `bosses=` param (detect-if-`None` fallback keeps standalone calls working).
- `Drawing.lint` passes `a.bosses` → `lint_feature_coverage` → `feature_diameters`; the orchestrator passes `a.bosses` → `build_part_model`.

## Result
`find_bosses` runs **once per build** (instrumented: was 2+, one re-scanning cylinders). Behaviour-equivalent — the boss set is identical (`cyls` is just the shared scan). Boss + feature-coverage tests pass; full fast suite **585 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean.

The one-inventory keystone (#244) is now **complete — no residual**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)