### PR TITLE
fix: degraded-pattern callout consistency (#262) + document HoleCallout contract (#261)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -97,11 +97,18 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
     """Build a `HoleCallout` from a :func:`hole_callout_spec` dict. *count* is passed
     explicitly (the bare/test path uses the spec's own count; the engine pass uses its
     view-local hole count) — the single callout builder both the IR and the migrating
-    engine pass share, so the bore/cbore/suffix mapping lives in one place (#238 B1)."""
+    engine pass share, so the bore/cbore/suffix mapping lives in one place (#238 B1).
+
+    **This is the only place draftwright constructs a `HoleCallout`** — and it MUST
+    pass each numeric value as a `_fmt` string, never a raw float: `HoleCallout`
+    renders a float (``ø8.0``) wider than the equivalent string (``ø8``), which
+    shifts placement and can drop callouts (#261). Keep the formatting here; the IR
+    carries clean floats (no baked labels). The robust fix — `HoleCallout` formatting
+    its own numeric inputs — is upstream in build123d-drafting-helpers."""
     if spec is None:
         return None
 
-    def f(v):  # the IR carries clean floats (no baked labels); the renderer formats
+    def f(v):  # see the #261 note above — every value crosses as a formatted string
         return _fmt(v) if v is not None else None
 
     return HoleCallout(

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -488,6 +488,12 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, model, feature_keys):
         spec = hole_callout_spec(g)
         if spec is None:  # not a hole-bearing callout
             continue
+        # A pattern only partially surviving the feature-holes filter (a member is a
+        # concentric bore on a rotational part) is rendered as plain holes — drop its
+        # pattern suffix too, so the callout doesn't claim "EQ SP ON … BC" / "(r×c)"
+        # for a subset with no centre-line/pitch furniture (#262; matches the engine).
+        if g.feature_kind == "pattern" and feat is None:
+            spec = {**spec, "suffix": None}
         dia = spec["diameter"]  # bore diameter (mm), for the leader rim tip
         count = len(locs) if len(locs) > 1 else None
         callout = callout_from_spec(spec, draft, count)


### PR DESCRIPTION
Two callout-area cleanups raised during the holes migration. Two atomic commits.

## #262 — degraded pattern renders as plain holes (fix)
A pattern only partially surviving the feature-holes filter (a member is a concentric bore on a rotational part — e.g. the centre hole of a grid centred on a disc) is gated to "un-patterned" (no centre-line/pitch furniture), but the callout still carried the `EQ SP ON … BC` / `(r×c)` **suffix** — a misleading callout on a subset with no furniture, and a divergence from the engine. Strip the suffix when the pattern is degraded, so the callout matches its rendering.

## #261 — document the HoleCallout formatting contract (doc only)
`callout_from_spec` is the single place draftwright builds a `HoleCallout`, and it must pass `_fmt` strings, never raw floats (`HoleCallout(8.0)` renders wider than `"8"`, shifting placement). Production is already contained; this records *why*. The robust fix — `HoleCallout` formatting its own inputs — is upstream in build123d-drafting-helpers (separate pip package), so it can't land here.

## Adversarial review (before merge)
- **#262 — can it strip a normal pattern's suffix?** No: `feat` is non-`None` only when fully surviving (`len(locs)==len(members)`), so the strip is gated to degraded patterns only; bolt-circle/grid tests pass.
- **#262 — `feat is None` reliable for "degraded"?** A pattern's `g.feature` is always truthy, so `None` ⇔ degraded; the `feature_kind=="pattern"` guard excludes plain holes.
- **#262 — cover/table interaction:** a degraded pattern doesn't `cover_pattern` (feat=None → `_add_furniture` returns early), so its holes are treated as plain — matching the engine; no double-documentation regression.
- **#262 — verified visually:** 3×3 grid centred on a disc → `8× ø5 THRU` (no `(3×3)`), centre bore leadered separately, score 1.0.
- **#261 — claims accurate:** single construction chokepoint (grep; `suggest.py` hits are string templates), float-vs-string width confirmed empirically.

Full fast suite **585 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)