### PR TITLE
refactor: restore typed IR boundary (isinstance) + delete dead envelope code (#275)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import math
 
-from build123d_drafting.helpers import CenterMark, Dimension, HoleCallout, Leader, TitleBlock
+from build123d_drafting.helpers import CenterMark, HoleCallout, Leader, TitleBlock
 
 from draftwright._core import (
     _CONCENTRIC_TOL_MM,
@@ -38,14 +38,8 @@ from draftwright._core import (
     _solve_strip_ys,
 )
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
+from draftwright.model.ir import HoleFeature, PatternFeature
 from draftwright.model.planner import DimensionGroup, plan_dimensions, plan_locations
-
-# Which view + side an overall (envelope) dimension lands on, by its role.
-_ENVELOPE_PLACEMENT = {
-    "width": ("plan", "below"),  # X extent
-    "height": ("front", "right"),  # Z extent
-    "depth": ("side", "below"),  # Y extent
-}
 
 
 def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
@@ -65,22 +59,20 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     counterbore precedence (``step = cbore or spotface``, as the engine does);
     ``through`` inferred from the absence of a bore-depth param; ``count`` and the
     pattern *suffix* (``EQ SP ON ø50 BC`` / ``(3×3)``) from the source feature."""
-    if group.feature_kind not in ("hole", "pattern"):
+    feat = group.feature
+    if not isinstance(feat, HoleFeature | PatternFeature):
         return None
     bore = _first(group, "diameter", "bore")
     if bore is None:
         return None
     depth = _first(group, "depth", "bore")
-    feat = group.feature
-    count = getattr(feat, "count", 1)
+    count = feat.count
     suffix = None
-    pattern = getattr(feat, "pattern", None)
-    bcd = getattr(feat, "bcd", None)
-    rows, cols = getattr(feat, "rows", None), getattr(feat, "cols", None)
-    if pattern == "bolt_circle" and bcd is not None:
-        suffix = f"EQ SP ON ø{_fmt(bcd)} BC"
-    elif pattern == "grid" and rows and cols:
-        suffix = f"({rows}×{cols})"
+    if isinstance(feat, PatternFeature):
+        if feat.pattern == "bolt_circle" and feat.bcd is not None:
+            suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
+        elif feat.pattern == "grid" and feat.rows and feat.cols:
+            suffix = f"({feat.rows}×{feat.cols})"
     return {
         "diameter": bore,
         "count": count if count and count > 1 else None,
@@ -391,12 +383,13 @@ def render_centermarks(dwg, model) -> int:
     of the engine's inline centre-mark loop. Returns the count placed."""
     n = 0
     for g in plan_dimensions(model):
-        if g.feature_kind not in ("hole", "pattern"):
+        feat = g.feature
+        if not isinstance(feat, HoleFeature | PatternFeature):
             continue
         dia = _first(g, "diameter", "bore") or 0.0
         size = max(2.5, dia * dwg.scale + 2.0)
-        view = _END_ON.get(g.feature.frame.axis, "plan")
-        members = getattr(g.feature, "members", ()) or [g.anchor]
+        view = _END_ON.get(feat.frame.axis, "plan")
+        members = feat.members or (g.anchor,)
         for loc in members:
             px, py, *_ = dwg.at(view, *loc)
             dwg.add(CenterMark((px, py, 0), size, dwg.draft), f"m_cm{n}", view=view)
@@ -586,23 +579,6 @@ def render_envelope(dwg, model, a) -> int:
             )
             n += 1
     return n
-
-
-def _envelope_dims(dwg, group) -> list[tuple[Dimension, str]]:
-    """Overall (width/height/depth) linear dims, each placed just outside its view."""
-    out: list[tuple[Dimension, str]] = []
-    for pd in group.dims:
-        place = _ENVELOPE_PLACEMENT.get(pd.param.role)
-        if place is None or pd.param.span is None:
-            continue
-        view, side = place
-        a, b = pd.param.span
-        p1, p2 = dwg.at(view, *a), dwg.at(view, *b)
-        dim = _dim(
-            (p1[0], p1[1], 0), (p2[0], p2[1], 0), side, 9.0, dwg.draft, label=_fmt(pd.param.value)
-        )
-        out.append((dim, view))
-    return out
 
 
 def render_step_lengths(dwg, model) -> int:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -32,6 +32,7 @@ from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxe
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
 from draftwright.layout import LayoutSolver, Placeable
 from draftwright.model import plan_dimensions
+from draftwright.model.ir import HoleFeature, PatternFeature
 
 
 def _legible_locations(positions, scale):
@@ -204,7 +205,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None):
             _drop("Z", order[0][1])
 
 
-def _add_furniture(dwg, a: Analysis, view, j, feat, to_page):
+def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_page):
     """Pattern sheet furniture, added once its callout is placed (#92). Driven by the
     IR `PatternFeature` *feat* (members / bcd / pitch / grid), not a recogniser
     `Pattern` — ADR 0008 Amendment 6."""
@@ -216,10 +217,12 @@ def _add_furniture(dwg, a: Analysis, view, j, feat, to_page):
     # tabulates only the holes no *placed* pattern callout covers (#92).
     dwg._cover_pattern(f"hc_{view}{j}", [HoleRef.of(m) for m in members])
     if feat.pattern == "bolt_circle":
+        assert feat.bcd is not None  # a bolt circle always carries its BCD
         cx = sum(to_page(m)[0] for m in members) / len(members)
         cy = sum(to_page(m)[1] for m in members) / len(members)
         dwg.add(CenterlineCircle((cx, cy), feat.bcd * a.SCALE), f"bc_{view}{j}", view=view)
     elif feat.pattern == "linear":
+        assert feat.pitch is not None  # a linear array always carries its pitch
         _place_pitch_dim(
             dwg,
             a,
@@ -232,6 +235,7 @@ def _add_furniture(dwg, a: Analysis, view, j, feat, to_page):
             f"dim_pitch_{view}{j}",
         )
     elif feat.pattern == "grid":
+        assert feat.grid is not None  # a grid always carries its (row, col) pitch
         _add_grid_pitch_dims(dwg, a, view, j, members, feat.grid, to_page)
 
 
@@ -473,18 +477,18 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, model, feature_keys):
     # members are dimensioned; no recogniser Hole/Pattern object is used.
     by_view: dict = {}
     for g in plan_dimensions(model):
-        if g.feature_kind not in ("hole", "pattern"):
+        feat = g.feature
+        if not isinstance(feat, HoleFeature | PatternFeature):
             continue
-        members = getattr(g.feature, "members", ()) or (g.anchor,)
+        members = feat.members or (g.anchor,)
         # surviving member *locations* (IR geometry — no recogniser Hole, Amendment 6)
         locs = [m for m in members if HoleRef.of(m) in feature_keys]
         if not locs:  # all members filtered out (e.g. concentric bore, rotational)
             continue
         # A pattern earns its sheet furniture (centre-line / pitch dims) only if ALL
         # its members survived the feature-holes filter — the engine's feature_patterns
-        # gate. Otherwise the surviving members are placed as plain holes. The callout
-        # itself always comes from the IR group (so a grouped suffix is preserved).
-        feat = g.feature if g.feature_kind == "pattern" and len(locs) == len(members) else None
+        # gate. Otherwise the surviving members are placed as plain holes.
+        pat = feat if isinstance(feat, PatternFeature) and len(locs) == len(members) else None
         spec = hole_callout_spec(g)
         if spec is None:  # not a hole-bearing callout
             continue
@@ -492,15 +496,15 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, model, feature_keys):
         # concentric bore on a rotational part) is rendered as plain holes — drop its
         # pattern suffix too, so the callout doesn't claim "EQ SP ON … BC" / "(r×c)"
         # for a subset with no centre-line/pitch furniture (#262; matches the engine).
-        if g.feature_kind == "pattern" and feat is None:
+        if isinstance(feat, PatternFeature) and pat is None:
             spec = {**spec, "suffix": None}
         dia = spec["diameter"]  # bore diameter (mm), for the leader rim tip
         count = len(locs) if len(locs) > 1 else None
         callout = callout_from_spec(spec, draft, count)
         if callout is None:
             continue
-        view = view_of_axis[g.feature.frame.axis][0]
-        by_view.setdefault(view, []).append((locs, dia, callout, feat))
+        view = view_of_axis[feat.frame.axis][0]
+        by_view.setdefault(view, []).append((locs, dia, callout, pat))
 
     def _rim_tip(centre, elbow, dia):
         """Pull the tip from the hole centre to its circumference (bore *dia* mm)."""

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -23,7 +23,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from draftwright._core import _END_ON, HoleRef
-from draftwright.model.ir import Datum, DimParameter, Feature, PartModel, Point
+from draftwright.model.ir import (
+    Datum,
+    DimParameter,
+    Feature,
+    HoleFeature,
+    PartModel,
+    PatternFeature,
+    Point,
+)
 
 # How each (role, kind) is drawn. Defaults keep the table small.
 _CONVENTION = {
@@ -145,16 +153,15 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
     for f in model.features:
         if f.frame.axis != "z":
             continue
-        if f.kind == "hole":
+        if isinstance(f, HoleFeature):
             # un-patterned holes — a HoleFeature may group identical holes
-            for m in getattr(f, "members", ()) or (f.frame.origin,):
+            for m in f.members or (f.frame.origin,):
                 refs.append((m, "location"))
-        elif f.kind == "pattern":
-            members = getattr(f, "members", ())
-            if getattr(f, "pattern", None) == "bolt_circle":
+        elif isinstance(f, PatternFeature):
+            if f.pattern == "bolt_circle":
                 refs.append((f.frame.origin, "location_pattern"))
-            elif members:
-                near = min(members, key=lambda m: (m[0] - dx) ** 2 + (m[1] - dy) ** 2)
+            elif f.members:
+                near = min(f.members, key=lambda m: (m[0] - dx) ** 2 + (m[1] - dy) ** 2)
                 refs.append((near, "location_pattern"))
     unique: list[tuple[Point, str]] = []
     for r, role in refs:
@@ -225,13 +232,12 @@ def plan_sections(model: PartModel, feature_keys: set[HoleRef]) -> SectionPlan |
     warranted."""
     qual_ys: list[float] = []
     for f in model.features:
-        if f.kind not in ("hole", "pattern") or f.frame.axis != "z":
+        if not isinstance(f, HoleFeature | PatternFeature) or f.frame.axis != "z":
             continue
-        bore = getattr(f, "member", f)  # a pattern's representative HoleFeature, else f
-        cbore, spotface = getattr(bore, "cbore", None), getattr(bore, "spotface", None)
-        if cbore is None and spotface is None and getattr(bore, "through", True):
+        bore = f.member if isinstance(f, PatternFeature) else f  # the bore-carrying HoleFeature
+        if bore.cbore is None and bore.spotface is None and bore.through:
             continue
-        for m in getattr(f, "members", ()) or (f.frame.origin,):
+        for m in f.members or (f.frame.origin,):
             if HoleRef.of(m) in feature_keys:
                 qual_ys.append(m[1])
     if not qual_ys:


### PR DESCRIPTION
Addresses #275 findings **#1** (highest priority) and **#2**.

## #1 — typed-IR erosion (the important one)
The planner/renderers branched on `f.kind` then reached subtype fields via `getattr(f, "members", ())` / `getattr(feat, "pattern", None)` / `getattr(bore, "cbore", None)` … — invisible to mypy, **undercutting ADR 0008 Amendment 6** ("enforced by the type system, not a written rule"). Replaced with `isinstance` narrowing on the concrete `HoleFeature`/`PatternFeature` subtypes so mypy checks every access:
- `planner`: `plan_locations`, `plan_sections`
- `from_model`: `hole_callout_spec`, `render_centermarks`
- `holes`: the by_view loop; plus `_add_furniture(feat: PatternFeature | None)` is now typed, with invariant asserts (`bolt_circle⇒bcd`, `linear⇒pitch`, `grid⇒grid`).

**No `getattr`-on-IR-feature remains** in the migrated modules (grep-verified).

## #2 — dead code
`_envelope_dims` + `_ENVELOPE_PLACEMENT` were orphaned by the `render_into` retirement (#251) — no caller. Deleted (~17 lines; the `Dimension` import drops out with them).

## Adversarial review (before merge)
- **Branch equivalence:** `isinstance(f, HoleFeature)` ⇔ `f.kind == "hole"` (kind is a per-class `ClassVar`; no two features share a kind), and `f.members` ⇔ `getattr(f, "members", ())` (the field's default is `()`). So the refactor is behaviour-identical — confirmed on flange BC, 3×3 grid, cbore→section, turned shaft, plate (all unchanged, 1.0).
- **`plan_sections` `bore` narrowing:** after the `HoleFeature | PatternFeature` guard, `bore = f.member if PatternFeature else f` is a `HoleFeature` → `.cbore/.spotface/.through` typed; same logic as the old getattr.
- **`_add_furniture` asserts** document real `build_part_model` invariants; they held before (the code already used `feat.bcd` etc.), so they can't newly fire — suite green confirms.
- **Dead-code delete** can't affect any path (no caller; grep src+tests); full suite green.
- **The gain is provable:** mypy passes *without* the getattr escape hatches — if any subtype lacked a field I access, it would now error.

Full fast suite **585 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. #3 (plan-once) and #4 (#237) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)