### PR TITLE
refactor: plan dimensions once and thread the groups (#275 #3)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -39,7 +39,7 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
 from draftwright.model.ir import HoleFeature, PatternFeature
-from draftwright.model.planner import DimensionGroup, plan_dimensions, plan_locations
+from draftwright.model.planner import DimensionGroup, plan_locations
 
 
 def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
@@ -377,12 +377,12 @@ def render_locations(dwg, model, a) -> int:
     return n
 
 
-def render_centermarks(dwg, model) -> int:
+def render_centermarks(dwg, groups) -> int:
     """A centre mark on every hole (plain holes + each pattern member), in the view
     normal to the hole's axis (`_END_ON`), sized by its diameter — the IR migration
     of the engine's inline centre-mark loop. Returns the count placed."""
     n = 0
-    for g in plan_dimensions(model):
+    for g in groups:
         feat = g.feature
         if not isinstance(feat, HoleFeature | PatternFeature):
             continue
@@ -494,7 +494,7 @@ def _diameter_column_left(dwg, items) -> int:
     return placed
 
 
-def render_diameters(dwg, model, tol: float = 0.15) -> int:
+def render_diameters(dwg, groups, tol: float = 0.15) -> int:
     """ø leaders for a turned part's external step/boss diameters, from the IR —
     one distinct callout per diameter, in a tidy row below the front view
     (X-turning) or a column to its left (Z-turning). Orientation is the feature
@@ -504,7 +504,7 @@ def render_diameters(dwg, model, tol: float = 0.15) -> int:
     seen: set[tuple[str, float]] = set()
     rows: list = []  # X-turned (anchor, dia)
     cols: list = []  # Z-turned (anchor, dia)
-    for g in plan_dimensions(model):
+    for g in groups:
         if g.feature_kind not in ("step", "boss"):
             continue
         dia = next((pd.param.value for pd in g.dims if pd.param.kind == "diameter"), None)
@@ -527,14 +527,14 @@ def _env_pd(group, role):
     return next((pd for pd in group.dims if pd.param.role == role), None)
 
 
-def render_envelope(dwg, model, a) -> int:
+def render_envelope(dwg, groups, a) -> int:
     """Overall width (plan, below) + depth (side, below) envelope dims via the IR,
     placed through the engine's below-strip zone allocators (the zone-aware render
     stage — so a migrated dim still coordinates with the un-migrated passes sharing
     those strips). The **planner** decides suppression (square footprint / X-turned;
     #250); this renderer just skips suppressed dims and places the rest. Returns the
     count placed."""
-    env = next((g for g in plan_dimensions(model) if g.feature_kind == "envelope"), None)
+    env = next((g for g in groups if g.feature_kind == "envelope"), None)
     if env is None:
         return 0
     n = 0
@@ -581,7 +581,7 @@ def render_envelope(dwg, model, a) -> int:
     return n
 
 
-def render_step_lengths(dwg, model) -> int:
+def render_step_lengths(dwg, groups) -> int:
     """Unified turned step-length chain (ADR 0008 #223) — one IR-driven path that
     replaces the engine's asymmetric X-chain / Z-ladder. Each `StepFeature`'s length
     span is projected into the front view; the chain runs *along the projected axis*
@@ -593,7 +593,7 @@ def render_step_lengths(dwg, model) -> int:
     end, so every shoulder is located. Crowded labels are spread along the line by
     the ADR-0003 strip solve (the primitive the engine's X chain already used)."""
     segs = []  # (page_lo, page_hi, value), in axis order
-    for g in plan_dimensions(model):
+    for g in groups:
         if g.feature_kind != "step":
             continue
         length = next(

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -31,7 +31,6 @@ from draftwright._core import (
 from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
 from draftwright.layout import LayoutSolver, Placeable
-from draftwright.model import plan_dimensions
 from draftwright.model.ir import HoleFeature, PatternFeature
 
 
@@ -422,7 +421,7 @@ def _solve_strip_via_layout(naturals, min_gap, lo, hi, key_prefix):
     return [placed[k] for k in keys]
 
 
-def _annotate_holes(dwg, a: Analysis, view_of_axis, model, feature_keys):
+def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
     """Leader-attached HoleCallouts, one per distinct hole spec per view (#91).
 
     Identical holes share one callout with an ``n×`` count prefix (#92's
@@ -459,14 +458,15 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, model, feature_keys):
     # When present, its extension lines overhang the plan view boundary by
     # ~arrow_length, so plan-view elbow must sit that far outside to clear them.
     # Room-check failures may still skip the section, but the offset is harmless.
-    def _bore(f):  # the bore-carrying HoleFeature (a pattern's representative member)
-        return f.member if f.kind == "pattern" else f
+    def _needs_section(feat: HoleFeature | PatternFeature) -> bool:
+        bore = feat.member if isinstance(feat, PatternFeature) else feat
+        return bore.cbore is not None or bore.spotface is not None or not bore.through
 
     will_have_section_line = any(
-        f.frame.axis == "z"
-        and (_bore(f).cbore is not None or _bore(f).spotface is not None or not _bore(f).through)
-        for f in model.features
-        if f.kind in ("hole", "pattern")
+        isinstance(g.feature, HoleFeature | PatternFeature)
+        and g.feature.frame.axis == "z"
+        and _needs_section(g.feature)
+        for g in groups
     )
 
     # The IR is the single grouping + geometry authority (#238 B2/B3, Amendment 6):
@@ -476,7 +476,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, model, feature_keys):
     # surviving feature-hole positions, supplied by the orchestrator) gates which
     # members are dimensioned; no recogniser Hole/Pattern object is used.
     by_view: dict = {}
-    for g in plan_dimensions(model):
+    for g in groups:
         feat = g.feature
         if not isinstance(feat, HoleFeature | PatternFeature):
             continue

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -50,7 +50,7 @@ from draftwright.annotations.holes import (
 )
 from draftwright.annotations.pmi import _annotate_pmi
 from draftwright.annotations.sections import _add_detail_view, _add_section_view
-from draftwright.model import build_part_model, plan_sections
+from draftwright.model import build_part_model, plan_dimensions, plan_sections
 from draftwright.recognition import (
     full_cylinders,
 )
@@ -257,9 +257,12 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     _model = build_part_model(
         a.part, holes=a.holes, patterns=a.patterns, bosses=a.bosses, slots=a.slots, prof=a.prof
     )
+    # Plan the dimensions ONCE and thread the groups to every renderer that reads them
+    # (was recomputed per renderer, #275). One rule set over DimParameters, literally.
+    _groups = plan_dimensions(_model)
 
     # Centre marks for every hole (all part classes) — IR renderer.
-    render_centermarks(dwg, _model)
+    render_centermarks(dwg, _groups)
 
     # Hole callouts, location dims, and the section view fire on *feature
     # presence*, independent of the turned/prismatic class (#10): the
@@ -278,7 +281,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # no recogniser Hole object crosses into the renderers (Amendment 6, #263/#207).
     feature_keys = {HoleRef.of(h.location) for h in feature_holes}
     if feature_holes:
-        _annotate_holes(dwg, a, view_of_axis, _model, feature_keys)
+        _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
     # through the existing above-view strips. Replaces the engine's _add_location_dims.
     render_locations(dwg, _model, a)
@@ -393,7 +396,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # placed through the same below-strip zone allocators the engine used (zone-aware
     # render stage, ADR 0008). Suppression (square footprint / X-turned width) is now
     # the planner's decision (#250); the renderer just skips suppressed dims.
-    render_envelope(dwg, _model, a)
+    render_envelope(dwg, _groups, a)
 
     # The section view goes last: its room check clears every annotation already
     # placed right of the side view (callout labels, height/step dim ladders). The
@@ -416,9 +419,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     #    (#223). Replaces the old X-only chain + the Z step-height ladder (skipped
     #    above for turned parts); the envelope dim along the turning axis was
     #    suppressed so the chain does not double-dimension the length.
-    render_diameters(dwg, _model)
+    render_diameters(dwg, _groups)
     if _turned_prof is not None:
-        render_step_lengths(dwg, _model)
+        render_step_lengths(dwg, _groups)
 
     # Side-drilled (X/Y-axis) hole locations — last, so the envelope and
     # turned-diameter dims claim their strip space first and are never evicted (#133).


### PR DESCRIPTION
Addresses #275 finding **#3**. `plan_dimensions(model)` was recomputed in every renderer that reads it (~5× per drawing). Compute it **once** in the orchestrator and thread the `groups` down.

## What
- **orchestrator**: `_groups = plan_dimensions(_model)` once; passed to the five consumers (`render_centermarks`/`render_diameters`/`render_envelope`/`render_step_lengths`/`_annotate_holes`). `render_slots`/`render_locations` keep `_model` (they read `model.features` / `plan_locations`).
- **from_model**: the four renderers take `groups` and iterate directly; `plan_dimensions` import dropped.
- **holes**: `_annotate_holes(…, groups, …)`; `will_have_section_line` now derived from `groups` (typed `isinstance` over `g.feature`) rather than `model.features` (which iterated `Any`) — so it's threaded *and* type-checked.

## Adversarial review (before merge)
- **Equivalence:** `plan_dimensions` is pure over the (already-detected) features, so computing it once and reusing yields the identical `DimensionGroup` list every consumer was building itself — no ordering/content change. Instrumented: **1 call/build** (was ~5); flange / plate / turned all score 1.0.
- **Did any consumer need `model` for more than the plan?** Checked: the four from_model renderers used `model` *only* for `plan_dimensions`; `_annotate_holes` also read `model.features` for `will_have_section_line`, but those are exactly the hole/pattern groups — re-derived from `groups`, equivalently (and now type-checked).
- **Right consumers kept `model`:** `render_slots` (`model.features`) and `render_locations` (`plan_locations(model)`) are untouched — verified they don't use `plan_dimensions`.
- Full fast suite **585 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean.

#275 #4 (orchestrator → build/plan/render) remains = the deferred #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)