### PR TITLE
docs: ADR 0008 convergence complete — one path (#208 done)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ It owns feature recognition (`recognition/`) and linting (`linting/`); annotatio
 primitives (`Dimension`, `Leader`, etc.) live in `build123d-drafting-helpers` and can
 be used independently. The compiler is largely converged in production — turned
 dims/lengths, centre marks, envelope, slots, holes (callouts/locations/grouping),
-and the section A–A trigger are all on the IR; PMI/GD&T (#208) and the prismatic
-step-ladder (#237) are the remaining feature epics. See
+the section A–A trigger, the prismatic step-ladder + rotational furniture, and PMI/GD&T
+are all on the IR — the migration is complete (one path; the orchestrator is
+build → plan → render). See
 [`docs/target-architecture.md`](docs/target-architecture.md) and
 [`docs/adr/`](docs/adr/). The engine handles view layout (strip/zone model), scale
 selection, annotation placement, and section rendering.

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -1,14 +1,17 @@
 # ADR 0008 — The part-drawing compiler: a Feature/DimParameter IR and a dimensioning planner
 
-- **Status:** Accepted — architecture stands; **migration is a correctness-judged
-  strangler that converges on ONE feature→dimension path** (Amendment 3), which
-  *feeds* the engine's shared layout/table/section/projection/export infrastructure
-  rather than reabsorbing it (Amendment 4), **through an IR-typed interface — no
-  recognition objects cross the boundary** (Amendment 6). Not reproduce-and-swap
-  (Amendment 2), not two permanent paths — incremental migration where each step
-  deletes the per-feature engine pass it replaces. The equivalence golden gate is
-  retired. **One path implies one feature inventory** (Amendment 5): `_analyse` and
-  the IR must not re-detect independently — keystone of the remaining migration (#241).
+- **Status:** Accepted — **migration complete; one path** (2026-06-30). The
+  correctness-judged strangler converged on ONE feature→dimension path (Amendment 3),
+  which *feeds* the engine's shared layout/table/section/projection/export
+  infrastructure rather than reabsorbing it (Amendment 4), **through an IR-typed
+  interface — no recognition objects cross the boundary** (Amendment 6). Not
+  reproduce-and-swap (Amendment 2), not two permanent paths — each step deleted the
+  per-feature engine pass it replaced. **One path, one feature inventory**
+  (Amendment 5): `_analyse` detects once and the IR consumes its products. Every
+  feature pass — holes, sections, turned dims/lengths, slots, centre marks, envelope,
+  the prismatic step-ladder + rotational OD/bore furniture (#237), and PMI (#208) — is
+  now on the IR; the orchestrator is `build model → plan → render`. The equivalence
+  golden gate is retired. (Deferred *enhancements*, not migrations: #230, #222, #279.)
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Supersedes the original 0008** ("unified feature model") with a concrete

--- a/docs/plans/0008-convergence-roadmap.md
+++ b/docs/plans/0008-convergence-roadmap.md
@@ -61,10 +61,11 @@ Every migration PR must:
 - **Bosses detected once** — threaded through the one inventory; `find_bosses` runs
   once per build, closing the #244 residual (#264, PR #272).
 
-**The ADR-0008 convergence is nearly complete.** The holes pass, sections, turned
-parts, slots, centre marks, envelope, the prismatic step-ladder + height + rotational
-OD/bore furniture (#237), and the foundation track are all on the IR. **The only
-remaining feature epic is PMI/GD&T (#208)**, which needs a new PMI/thread detector.
+**The ADR-0008 convergence is COMPLETE (2026-06-30).** Every feature pass — holes,
+sections, turned dims/lengths, slots, centre marks, envelope, the prismatic step-ladder
++ height + rotational OD/bore furniture (#237), and PMI/GD&T (#208) — is on the IR, and
+the foundation track is done. The orchestrator is `build model → plan → render` + the
+shared section/table passes; no per-feature engine pass remains.
 
 ## Foundation hardening — ✅ complete (ADR 0008 Amendment 5, umbrella #241)
 
@@ -98,7 +99,7 @@ envelope width/depth are already done — see [Done](#done).)
 |---|---|---|---|
 | ~~**#238**~~ ✅ | **holes** — callouts + location dims + grouping + pitch/furniture + cover/table | **done** — fully on the IR (location dims #256, grouping #257, callout spec #259, callout loop #260, IR-typed interface #263). `_annotate_holes` is placement-only, fed by the IR | done |
 | ~~**#207**~~ ✅ | **section view** trigger | **done** — `plan_sections(model, feature_keys)` decides the A–A trigger + cut-plane row from the IR; `_add_section_view` is the shared rendering it feeds. Detail view stays user/lint-triggered | done |
-| **#200 → #208** | **PMI / GD&T** (`_annotate_pmi`) | a **PMI/thread detector** → GD&T `Feature`s | medium |
+| ~~**#200 → #208**~~ ✅ | **PMI / GD&T** (`_annotate_pmi`) | **done** (PR #282) — `PmiFeature` + `render_pmi`; `extract_pmi`'s records re-homed into the IR; `_annotate_pmi`/`annotations/pmi.py` deleted. PMI is pre-authored so it bypasses the planner (empty `parameters()`), rendered directly like slots | done |
 | ~~**#237**~~ ✅ | **prismatic step-ladder + height + OD/centreline/bore** | **done** (PR #280) — `StepLevelFeature` + `RotationalFeature` + `render_height_ladder`/`render_rotational`; the inline `_right_ladder` block is deleted. #230 (turned `N×`-rise) + #222 (OD on profile) remain as deferred *enhancements*; #279 (phantom ø0) filed |
 
 When these land, the orchestrator's per-feature calls are gone and it reduces to
@@ -153,8 +154,9 @@ not "rebuild the infra."
   - ✅ done: holes, sections (trigger), turned, slots, centre marks, envelope,
     diameters, location dims, the prismatic step-ladder + height + OD/bore (#237);
     foundation track; IR-typed interface. The orchestrator's inline OD/step-ladder is gone.
-  - 🔲 remaining: PMI/GD&T (#208).
+  - ✅ done: **all feature passes** — holes, sections, turned, slots, centre marks,
+    envelope, the step-ladder + OD/bore (#237), PMI (#208). Nothing remains.
 - **Shared infrastructure intact** (fed by the IR, per Amendment 4) — not rewritten.
 - ✅ No `render_into` test-only parallel; no engine/IR duplication in the migrated passes.
 - Full standards + geometry suites green; X/Z parity tests per feature.
-- ADR 0008 status → "migration complete; one path" (after #208).
+- ✅ ADR 0008 status → **"migration complete; one path"** (2026-06-30, after #208).

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -133,12 +133,15 @@ hatch / arrow rendering stays shared infrastructure it feeds. `annotations/turne
 and the `render_into` test-only parallel are gone. The prismatic step-height ladder,
 overall height, and the rotational OD/centreline/bore furniture are on the IR too
 (`StepLevelFeature`/`RotationalFeature` + `render_height_ladder`/`render_rotational`,
-#237) — the orchestrator's inline `_right_ladder` block is deleted.
+#237) — the orchestrator's inline `_right_ladder` block is deleted. Finally, **PMI/GD&T**
+is on the IR (`PmiFeature` + `render_pmi`, #208): `extract_pmi`'s AP242 records are
+re-homed as features and rendered directly (PMI is pre-authored, so it bypasses the
+planner — empty `parameters()`); `_annotate_pmi`/`annotations/pmi.py` are deleted.
 
-**Still produced by the legacy engine passes (not yet migrated):**
-
-- **PMI / GD&T placement** — needs a PMI/thread detector emitting GD&T `Feature`s.
-  ([#208](https://github.com/pzfreo/draftwright/issues/208)) — the last feature epic.
+**Migration complete (2026-06-30).** Every feature pass is on the IR; no engine
+feature pass remains. The orchestrator is `build model → plan → render` + the shared
+section/table/PMI rendering it feeds. Remaining open items are *enhancements*, not
+migrations: #230 (turned `N×`-rise), #222 (OD on the profile view), #279 (phantom ø0).
 
 **Foundation track — ✅ complete** (umbrella
 [#241](https://github.com/pzfreo/draftwright/issues/241); ADR Amendment 5):


### PR DESCRIPTION
With PMI (#208) migrated, every feature pass is on the IR and the orchestrator is build → plan → render. Updates ADR 0008 status to **"migration complete; one path"**, marks the roadmap #208 row + definition-of-done ✅, and refreshes target-architecture + README. Remaining open items are enhancements (#230, #222) + a pre-existing bug (#279), not migrations. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)