### PR TITLE
fix: drop phantom zero-diameter turned steps (#279) + stale-comment sweep

### DIFF
--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -150,8 +150,8 @@ def lint_feature_coverage(
     # find_holes/find_bosses, so slot ends and interrupted recesses (partial
     # cylinders that an angle-only test mistakes for full bores) are excluded.
     # Replaces the raw full_cylinders patch list, which over-reported those as
-    # undimensioned features (helpers #158/#159). *holes* reuses the single
-    # inventory (#244); find_bosses inside feature_diameters is the one residual.
+    # undimensioned features (helpers #158/#159). Both *holes* and *bosses* reuse
+    # the single feature inventory (#244/#264) — no detector runs twice here.
     inventory = feature_diameters(part, cyls=(z_cyls, cross_cyls), holes=holes, bosses=bosses)
 
     if assembly is None:

--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -123,10 +123,21 @@ def find_turned_steps(part) -> TurnedProfile | None:
     planes = sorted(shoulders)
     if len(planes) < 3:  # fewer than two steps
         return None
+    # A segment whose midpoint has no external band over it (`local_od` → 0) is a
+    # gap between disconnected bands, not a real step — drop it so it never renders
+    # as a phantom ø0 diameter (#279).
     steps = tuple(
-        TurnedStep(
-            lo=planes[i], hi=planes[i + 1], diameter=2 * local_od((planes[i] + planes[i + 1]) / 2)
-        )
+        s
         for i in range(len(planes) - 1)
+        if (
+            s := TurnedStep(
+                lo=planes[i],
+                hi=planes[i + 1],
+                diameter=2 * local_od((planes[i] + planes[i + 1]) / 2),
+            )
+        ).diameter
+        > 0
     )
+    if len(steps) < 2:  # fewer than two real steps → nothing to dimension axially
+        return None
     return TurnedProfile(axis=axis, steps=steps)

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -61,6 +61,15 @@ class TestBuildPartModel:
         assert any(isinstance(f, BossFeature) for f in model.features)
         assert not any(isinstance(f, StepFeature) for f in model.features)
 
+    def test_no_phantom_zero_diameter_step(self):
+        # A gapped (disconnected) shaft has an axial segment with no OD over it;
+        # find_turned_steps must drop it, not emit a ø0 step (#279).
+        gapped = Cylinder(20, 40) + Pos(0, 0, 40) * Cylinder(13, 30)
+        model = build_part_model(gapped)
+        step_dias = [f.diameter for f in model.features if isinstance(f, StepFeature)]
+        assert step_dias, "expected step features for the stepped shaft"
+        assert all(d > 0 for d in step_dias), f"phantom zero-diameter step: {step_dias}"
+
     def test_bolt_circle_is_one_pattern_not_six_holes(self):
         import math
 


### PR DESCRIPTION
Two review-findings fixes batched (same post-convergence review):

## 1. `ø0` phantom turned step (#279)
`find_turned_steps` built one step per gap between shoulder planes, `diameter = 2 * local_od(midpoint)`. When a segment's midpoint has no external band over it (a gap between disconnected bands), `local_od` returns 0 → the step got `diameter 0` and `render_diameters` drew a spurious `ø0` leader.

**Fix:** drop segments whose midpoint has no OD (a gap, not a step), then re-apply the existing "fewer than two steps → None" guard after filtering.

### Adversarial review
- **Regress real shafts?** No — a connected segment always has a band over its midpoint, so nothing is dropped; flush/overlapping shafts stay `[40, 26]`, the gapped one goes `[40, 0, 26] → [40, 26]`. Only disconnected input (genuinely no material over a segment) is affected.
- **Can the `len < 2` recheck null a real part?** Only if a step was dropped, which needs a zero-OD gap, which needs disconnected input. Real parts: no-op ⇒ no `None` regression. The ≥2-distinct-diameter guard still runs first.
- **Right layer?** The zero originates in `find_turned_steps`; fixing it at the source keeps the bad step out of the IR (vs masking in `render_diameters`).
- Regression test added (`test_no_phantom_zero_diameter_step`).

## 2. Stale comment sweep (review finding)
`linting/coverage.py` claimed `find_bosses inside feature_diameters is the one residual` of the single-inventory work, but bosses were threaded through the one inventory in #264 (the very next line passes `bosses=bosses`). Comment corrected. Comment-only.

Full fast suite **586 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)