### PR TITLE
fix: locate every side-drilled hole, not just the first (#225)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -118,25 +118,24 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None):
         )
 
     def _place(strip, view, p_lo, p_hi, dist, label, name, side):
-        # The strip cursor only tracks dims it allocated; the right strips are
-        # SHARED with hole callouts (``hc_side``) and the section hatch, which
-        # use other placers and are invisible to the cursor (#133). So a clean
-        # allocation is necessary but not sufficient — verify the candidate's box
-        # does not collide with an already-placed occupant before committing.
-        # Returns True on success, False if there was no room/a collision (the
-        # caller decides whether to fall back to another strip or drop).
-        coord = strip.allocate(tier) if strip is not None else None
-        if coord is None:
+        # The strip cursor only tracks dims it allocated; the right/below strips are
+        # SHARED with hole callouts (``hc_*``) and the section hatch, which use other
+        # placers and are invisible to the cursor (#133). So a clean allocation is
+        # necessary but not sufficient — verify the candidate's box does not collide
+        # with an already-placed occupant before committing. On a collision, advance
+        # to the next tier and retry rather than giving up: a hole's own callout often
+        # sits in this strip, and a tier past it would fit — a single collision must
+        # not drop the dim (#225). The strip cursor naturally bounds the retry (it
+        # returns None once exhausted). Returns True on success, False if no tier fits.
+        if strip is None:
             return False
-        dim = _dim(p_lo, p_hi, side, dist(coord), draft, label=_fmt(label))
-        if _box_hits(_anno_box(dim), occupied):
-            # The allocated tier is consumed even though we reject it here; that
-            # only pushes later same-strip dims one tier outward (which then drop
-            # cleanly if they overflow), so it is a benign waste, not a bug.
-            return False
-        dwg.add(dim, name, view=view)
-        occupied.append(_anno_box(dim))
-        return True
+        while (coord := strip.allocate(tier)) is not None:
+            dim = _dim(p_lo, p_hi, side, dist(coord), draft, label=_fmt(label))
+            if not _box_hits(_anno_box(dim), occupied):
+                dwg.add(dim, name, view=view)
+                occupied.append(_anno_box(dim))
+                return True
+        return False
 
     def _below(strip, view, p_lo, p_hi, witness, label, axis):
         if not _place(

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2067,6 +2067,25 @@ class TestPrismaticClassification:
         assert [i for i in dwg.lint() if i.severity != "info"] == []
 
     @pytest.mark.timeout(60)
+    def test_locates_every_side_drilled_hole_not_just_the_first(self):
+        # Two side-drilled (Y-axis) holes at distinct x: each must get its own
+        # in-plane (X) location dim. The first hole's own front-view callout sits
+        # in the below strip, so the location dim collided and was DROPPED after a
+        # single tier — only the first hole ended up located (#225). _place now
+        # retries the next tier past the callout, so both are located.
+        from build123d import Rot
+
+        part = (
+            Box(80, 40, 30)
+            - Pos(-20, 0, 5) * Rot(90, 0, 0) * Cylinder(2.5, 50)
+            - Pos(25, 0, -5) * Rot(90, 0, 0) * Cylinder(4, 50)
+        )
+        dwg = build_drawing(part)
+        xlocs = {n for n in dwg._named if n.startswith("dim_loc_front_x")}
+        assert len(xlocs) == 2, f"both side-drilled holes must be located, got {xlocs}"
+        assert [i for i in dwg.lint() if i.severity != "info"] == []
+
+    @pytest.mark.timeout(60)
     def test_corner_fillets_do_not_make_a_plate_rotational(self):
         # Big quarter-cylinder corner fillets on a square plate must not be
         # mistaken for an OD.
@@ -2464,12 +2483,9 @@ class TestAutoHoleAnnotations:
         )
         dwg = build_drawing(part)
         assert len([n for n in dwg._named if n.startswith("hc_front")]) == 2
-        # This test is about callout placement. The engine under-locates the second
-        # side-drilled hole (a real gap, tracked in #225); filter that one warning.
-        issues = [
-            i for i in dwg.lint() if i.severity != "info" and i.code != "feature_not_located"
-        ]
-        assert issues == []
+        # Both side-drilled holes are now located (#225 fixed), so the sheet is
+        # fully lint-clean — no filtered feature_not_located warning.
+        assert [i for i in dwg.lint() if i.severity != "info"] == []
 
     @pytest.mark.timeout(60)
     def test_all_distinct_bores_get_callouts(self):


### PR DESCRIPTION
A side-drilled (X/Y-axis) hole's location dim shares the view's below/right strip with the hole's **own callout** (`hc_front`/`hc_side`). `_place` allocated a single tier and, if that tier's box collided with the callout, **gave up and dropped the dim** — so on a part with two side-drilled holes only the *first* was located; the second's (x,z) position was undimensioned (surfaced by the location-coverage lint, #218).

**Fix:** `_place` advances to the next tier and retries on a collision instead of dropping. The callout is one tier in the way; a tier past it fits. The strip cursor bounds the retry (returns `None` once exhausted), and every candidate is still box-checked, so nothing overprints.

## Adversarial review (before merge)
- **Confirmed root cause empirically:** traced `_box_hits` on the repro — hole2's X-dim label box `(61.7,40.9,64.9,43.1)` collided with `hc_front1` (the hole's own ø8 callout), and `_place` returned False ⇒ drop. Not strip exhaustion.
- **Does the retry overprint?** No — each candidate tier is `_box_hits`-checked against `occupied` before commit; only a collision-free tier is placed. The retry just stops giving up early.
- **Unbounded loop?** No — `strip.allocate` returns `None` once the strip is exhausted, terminating the `while`. Worst case it consumes the strip (same as the old "tier consumed on reject" path, now used productively).
- **Regression surface:** the retry only *places* dims that previously dropped, never moves/removes existing ones — full suite **586 passed / 1 skipped** confirms. New placements are collision-free by construction.
- **Scope honesty:** Z-height dims still drop under genuine right-strip exhaustion (iso view / callout / section contention) — info severity, place-what-fits, a separate layout-capacity matter, not this bug. Verified a less-contended part gets full X+Z for both holes.
- Regression test added; the previously-**filtered** `feature_not_located` warning on the two-hole part is now gone, so that test asserts full lint cleanliness.

ruff(0.15.17)/format/mypy clean. Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)