### PR TITLE
chore: relocate analyse_face_levels into recognition/ (#191 — obsolete premise)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,11 @@ No lower module imports an upper one.
   helpers). `_features.py` (vendored from `build123d_drafting.features`; the
   hole/boss/cylinder/pattern recognisers — `find_holes`/`find_bosses`/
   `analyse_cylinders`/`feature_diameters`/`find_hole_patterns`/`full_cylinders`
-  + the feature/pattern types) and `slots.py` (the milled-slot recogniser, #135).
-  Bottom of the DAG: depends only on build123d/OCP. Import via the package surface.
+  + the feature/pattern types), `slots.py` (the milled-slot recogniser, #135),
+  `turned.py` (`find_turned_steps` — turned-shaft shoulders, OD-silhouette filtered),
+  and `levels.py` (`analyse_face_levels` — prismatic horizontal face levels; the
+  complement of `turned.py`, dispatched by part class, #191). Bottom of the DAG:
+  depends only on build123d/OCP. Import via the package surface.
 - **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
   cross-platform layout (ADR 0006).
 - **`export.py`** — SVG/DXF/PDF export + post-processing (page-size fix,

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -15,10 +15,6 @@ import math
 
 from build123d import Compound, Shape
 from build123d_drafting.helpers import draft_preset
-from OCP.BRepAdaptor import BRepAdaptor_Surface
-from OCP.BRepGProp import BRepGProp
-from OCP.GeomAbs import GeomAbs_Plane
-from OCP.GProp import GProp_GProps
 from OCP.IFSelect import IFSelect_ReturnStatus
 from OCP.STEPControl import STEPControl_Reader
 
@@ -33,6 +29,7 @@ from draftwright._core import (
 )
 from draftwright.recognition import (
     analyse_cylinders,
+    analyse_face_levels,
     find_bosses,
     find_hole_patterns,
     find_holes,
@@ -115,40 +112,6 @@ def _is_rotational(x_size, y_size, od_diam, od_axis_offset) -> bool:
 
 
 # --- lint scoring (see Drawing.lint_summary) -------------------------------
-
-
-def analyse_face_levels(part, tol: float = 0.5, min_area_frac: float = 0.0) -> list:
-    """Return sorted unique Z-coords of horizontal (normal≈±Z) planar faces.
-
-    Uses tol-bucket deduplication but returns the actual face Z, not the rounded
-    bucket centre, so dimension labels match the true geometry.
-
-    When *min_area_frac* > 0, a Z level is kept only if the total area of its
-    horizontal faces is at least ``min_area_frac × (x_size × y_size)`` (the
-    part's plan footprint). This drops sub-feature faces — e.g. fragments of
-    engraved text/numbers — that are not real steps and would otherwise be
-    dimensioned as phantom shoulders (staircase.step review).
-    """
-    buckets: dict = {}  # bucket key -> representative z
-    areas: dict = {}  # bucket key -> total horizontal-face area
-    for face in part.faces():
-        surf = BRepAdaptor_Surface(face.wrapped)
-        if surf.GetType() == GeomAbs_Plane:
-            ax = surf.Plane().Axis().Direction()
-            if abs(ax.Z()) > 0.99:
-                z = surf.Plane().Location().Z()
-                key = round(z / tol) * tol
-                buckets.setdefault(key, z)
-                if min_area_frac > 0.0:
-                    props = GProp_GProps()
-                    BRepGProp.SurfaceProperties_s(face.wrapped, props)
-                    areas[key] = areas.get(key, 0.0) + props.Mass()
-    if min_area_frac > 0.0:
-        bb = part.bounding_box()
-        footprint = (bb.max.X - bb.min.X) * (bb.max.Y - bb.min.Y)
-        threshold = min_area_frac * footprint
-        return sorted(z for key, z in buckets.items() if areas.get(key, 0.0) >= threshold)
-    return sorted(buckets.values())
 
 
 # ---------------------------------------------------------------------------

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -27,6 +27,7 @@ from draftwright.recognition._features import (
     find_holes,
     full_cylinders,
 )
+from draftwright.recognition.levels import analyse_face_levels
 from draftwright.recognition.slots import Slot, find_slots
 from draftwright.recognition.turned import TurnedProfile, TurnedStep, find_turned_steps
 
@@ -42,6 +43,7 @@ __all__ = [
     "TurnedProfile",
     "TurnedStep",
     "analyse_cylinders",
+    "analyse_face_levels",
     "feature_diameters",
     "find_bosses",
     "find_hole_patterns",

--- a/src/draftwright/recognition/levels.py
+++ b/src/draftwright/recognition/levels.py
@@ -1,0 +1,51 @@
+"""levels — horizontal face-level recognition (ADR 0007).
+
+``analyse_face_levels`` returns the Z-coords of a part's horizontal planar faces —
+the step levels of a *prismatic* part. It is the complement of ``find_turned_steps``
+(turned.py): a box-stepped part has no cylinders, so the OD-silhouette recogniser
+cannot see its steps, while a turned shaft's shoulders are better filtered by the OD
+silhouette than by a raw face scan (#191 — the two are dispatched by part class in
+`analysis`, not duplicates). Bottom of the recognition DAG: depends only on
+build123d/OCP.
+"""
+
+from __future__ import annotations
+
+from OCP.BRepAdaptor import BRepAdaptor_Surface
+from OCP.BRepGProp import BRepGProp
+from OCP.GeomAbs import GeomAbs_Plane
+from OCP.GProp import GProp_GProps
+
+
+def analyse_face_levels(part, tol: float = 0.5, min_area_frac: float = 0.0) -> list:
+    """Return sorted unique Z-coords of horizontal (normal≈±Z) planar faces.
+
+    Uses tol-bucket deduplication but returns the actual face Z, not the rounded
+    bucket centre, so dimension labels match the true geometry.
+
+    When *min_area_frac* > 0, a Z level is kept only if the total area of its
+    horizontal faces is at least ``min_area_frac × (x_size × y_size)`` (the
+    part's plan footprint). This drops sub-feature faces — e.g. fragments of
+    engraved text/numbers — that are not real steps and would otherwise be
+    dimensioned as phantom shoulders (staircase.step review).
+    """
+    buckets: dict = {}  # bucket key -> representative z
+    areas: dict = {}  # bucket key -> total horizontal-face area
+    for face in part.faces():
+        surf = BRepAdaptor_Surface(face.wrapped)
+        if surf.GetType() == GeomAbs_Plane:
+            ax = surf.Plane().Axis().Direction()
+            if abs(ax.Z()) > 0.99:
+                z = surf.Plane().Location().Z()
+                key = round(z / tol) * tol
+                buckets.setdefault(key, z)
+                if min_area_frac > 0.0:
+                    props = GProp_GProps()
+                    BRepGProp.SurfaceProperties_s(face.wrapped, props)
+                    areas[key] = areas.get(key, 0.0) + props.Mass()
+    if min_area_frac > 0.0:
+        bb = part.bounding_box()
+        footprint = (bb.max.X - bb.min.X) * (bb.max.Y - bb.min.Y)
+        threshold = min_area_frac * footprint
+        return sorted(z for key, z in buckets.items() if areas.get(key, 0.0) >= threshold)
+    return sorted(buckets.values())


### PR DESCRIPTION
**#191's premise is obsolete.** It proposed making `find_turned_steps` the single axial-step recogniser and retiring `analyse_face_levels`. But since #244/#237, `step_zs` is dispatched by part class (analysis.py):

- **turned** → `find_turned_steps.shoulders` (OD-silhouette filtered — inherits #191's hoped-for robustness payoff)
- **prismatic** → `analyse_face_levels` (a box-stepped part has **no cylinders**, so `find_turned_steps` returns `None` and cannot see its steps)

They answer different questions for disjoint part classes — not duplicates. `find_turned_steps` genuinely cannot replace `analyse_face_levels`, so "retire it" would break all prismatic step dimensioning.

**The one real residual is architectural:** `analyse_face_levels` is a recognition primitive that lived in `analysis.py` rather than `recognition/` (ADR 0007). This PR moves it to `recognition/levels.py`, next to `find_turned_steps` (`turned.py`), so both axial-step recognisers live together. `analysis.py` re-exports it (used internally + public API), so every existing import path is unchanged.

## Adversarial review
- **Pure relocation, no behaviour change:** the function body is byte-identical (moved, not edited). Verified import identity across all three paths (`draftwright`, `draftwright.analysis`, `draftwright.recognition`) — same object. No output change, so no visual check needed.
- **Import compatibility:** `from draftwright.analysis import analyse_face_levels` still resolves (analysis.py imports it from recognition and uses it internally at the prismatic step_zs branch, so it's a live re-export, not a dangling one — ruff confirms no unused-import).
- **DAG direction:** the move is *downward* (analysis.py → recognition/, the bottom layer) — no cycle; recognition depends only on build123d/OCP.
- **Dead imports:** the 4 OCP imports (`BRepAdaptor_Surface`/`GeomAbs_Plane`/`GProp_GProps`/`BRepGProp`) were used only by the moved function — removed from analysis.py (ruff-verified).

Full fast suite **587 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)