### PR TITLE
feat: Typer CLI — completion, rich help, --version (#289)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "build123d-drafting-helpers>=0.13.0",
     "kiwisolver>=1.4,<2",
     "numpy>=1.24",
+    "typer>=0.12",
 ]
 keywords = ["build123d", "cad", "drafting", "engineering-drawing", "technical-drawing", "automation"]
 classifiers = [
@@ -33,7 +34,7 @@ classifiers = [
 pdf = ["cairosvg>=2.7"]
 
 [project.scripts]
-draftwright = "draftwright.make_drawing:_cli"
+draftwright = "draftwright.cli:app"
 
 [project.urls]
 Homepage = "https://github.com/pzfreo/draftwright"

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -9,8 +9,6 @@ stage modules -- never make_drawing -- so the graph stays a DAG.
 
 from __future__ import annotations
 
-import argparse
-import logging
 from dataclasses import replace
 from pathlib import Path
 from typing import Literal
@@ -614,91 +612,16 @@ def generate_script(
 
 
 def _cli():
-    ap = argparse.ArgumentParser(
-        description="Zero-AI STEP -> technical drawing (SVG + DXF, or editable .py script)",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    ap.add_argument("step_file", help="Input STEP file (.step / .stp)")
-    ap.add_argument("--out", default=None, help="Output prefix (default: input stem)")
-    ap.add_argument("--title", default=None, help="Part title for title block")
-    ap.add_argument("--number", default="DWG-001", help="Drawing number")
-    ap.add_argument("--tolerance", default="ISO 2768-m", help="General tolerance")
-    ap.add_argument("--drawn-by", default="", help="Designer name")
-    ap.add_argument(
-        "--scale",
-        type=float,
-        default=None,
-        help="Drawing-scale override, e.g. 5 for 5:1 or 0.5 for 1:2 (default: auto)",
-    )
-    ap.add_argument(
-        "--page",
-        default=None,
-        help="Page-size override: A4..A0 or WIDTHxHEIGHT in mm, e.g. 420x297 (default: auto)",
-    )
-    ap.add_argument(
-        "--script",
-        action="store_true",
-        help="Write an editable .py drawing script instead of SVG+DXF",
-    )
-    ap.add_argument(
-        "--pmi",
-        default="off",
-        choices=["off", "report", "annotate"],
-        help=(
-            "AP242 PMI handling: 'off' (default) - ignore; "
-            "'report' - log extracted PMI without annotating; "
-            "'annotate' - add PMI-derived dimensions to the drawing"
-        ),
-    )
-    ap.add_argument(
-        "--pdf",
-        action="store_true",
-        help="Also write a PDF (requires draftwright[pdf] / cairosvg)",
-    )
-    ap.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Show detailed progress (default: warnings and errors only)",
-    )
-    args = ap.parse_args()
+    """Compat shim: the CLI moved to the Typer app in ``draftwright.cli`` (#289).
 
-    logging.basicConfig(
-        level=logging.INFO if args.verbose else logging.WARNING,
-        format="%(message)s",
-    )
+    Kept so ``python -m draftwright.make_drawing`` and existing
+    ``from draftwright... import _cli`` imports keep working; the engine entry
+    point (``[project.scripts]``) points straight at ``draftwright.cli:app``.
+    Imported lazily so a bare ``import draftwright.builder`` does not pull Typer.
+    """
+    from draftwright.cli import app
 
-    if args.script and (args.scale is not None or args.page is not None):
-        ap.error("--scale/--page only apply to direct output; edit the generated script instead")
-
-    if args.script:
-        py_path = generate_script(
-            step_file=args.step_file,
-            out=args.out,
-            title=args.title,
-            number=args.number,
-            tolerance=args.tolerance,
-            drawn_by=args.drawn_by,
-            pmi=args.pmi,
-        )
-        print(py_path)
-    else:
-        dwg = build_drawing(
-            step_file=args.step_file,
-            out=args.out,
-            title=args.title,
-            number=args.number,
-            tolerance=args.tolerance,
-            drawn_by=args.drawn_by,
-            scale=args.scale,
-            page=args.page,
-            pmi=args.pmi,
-        )
-        svg_path, dxf_path = dwg.export()
-        print(svg_path)
-        print(dxf_path)
-        if args.pdf:
-            print(dwg.export_pdf())
+    app()
 
 
 if __name__ == "__main__":

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -1,0 +1,129 @@
+"""cli — the draftwright command-line interface (Typer, #289).
+
+A thin Typer front-end over the build engine (`builder.build_drawing` /
+`generate_script`): it owns argument parsing, ``--version``, shell completion,
+and rich-formatted help, then calls down into the engine. The engine stays
+headless — no presentation concern leaks below this module, so this is also the
+home the event-stream / TUI work (#276) wraps its sink + renderer around.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+import typer
+
+from draftwright.builder import build_drawing, generate_script
+
+app = typer.Typer(
+    add_completion=True,
+    help="Zero-AI STEP → technical drawing (SVG + DXF, or an editable .py script).",
+)
+
+
+class PmiMode(str, Enum):
+    """AP242 PMI handling mode (mirrors the engine's ``pmi`` argument)."""
+
+    off = "off"
+    report = "report"
+    annotate = "annotate"
+
+
+def _installed_version() -> str:
+    """The installed distribution version (the PyPI version once pip-installed);
+    ``"unknown"`` when running from a source tree with no installed metadata."""
+    try:
+        return _pkg_version("draftwright")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"draftwright {_installed_version()}")
+        raise typer.Exit()
+
+
+@app.command()
+def main(
+    step_file: Path = typer.Argument(..., help="Input STEP file (.step / .stp)"),
+    out: str | None = typer.Option(None, help="Output prefix (default: input stem)"),
+    title: str | None = typer.Option(None, help="Part title for title block"),
+    number: str = typer.Option("DWG-001", help="Drawing number"),
+    tolerance: str = typer.Option("ISO 2768-m", help="General tolerance"),
+    drawn_by: str = typer.Option("", "--drawn-by", help="Designer name"),
+    scale: float | None = typer.Option(
+        None, help="Drawing-scale override, e.g. 5 for 5:1 or 0.5 for 1:2 (default: auto)"
+    ),
+    page: str | None = typer.Option(
+        None, help="Page-size override: A4..A0 or WIDTHxHEIGHT in mm, e.g. 420x297 (default: auto)"
+    ),
+    script: bool = typer.Option(
+        False, "--script", help="Write an editable .py drawing script instead of SVG+DXF"
+    ),
+    pmi: PmiMode = typer.Option(
+        PmiMode.off,
+        help=(
+            "AP242 PMI handling: 'off' ignore; 'report' log extracted PMI without "
+            "annotating; 'annotate' add PMI-derived dimensions to the drawing"
+        ),
+    ),
+    pdf: bool = typer.Option(
+        False, "--pdf", help="Also write a PDF (requires draftwright[pdf] / cairosvg)"
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "-v",
+        "--verbose",
+        help="Show detailed progress (default: warnings and errors only)",
+    ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the installed draftwright version and exit.",
+    ),
+) -> None:
+    """Generate a fully-annotated technical drawing from a STEP file."""
+    logging.basicConfig(level=logging.INFO if verbose else logging.WARNING, format="%(message)s")
+
+    if script and (scale is not None or page is not None):
+        raise typer.BadParameter(
+            "--scale/--page only apply to direct output; edit the generated script instead"
+        )
+
+    step = str(step_file)
+    if script:
+        py_path = generate_script(
+            step_file=step,
+            out=out,
+            title=title,
+            number=number,
+            tolerance=tolerance,
+            drawn_by=drawn_by,
+            pmi=pmi.value,
+        )
+        print(py_path)
+        return
+
+    dwg = build_drawing(
+        step_file=step,
+        out=out,
+        title=title,
+        number=number,
+        tolerance=tolerance,
+        drawn_by=drawn_by,
+        scale=scale,
+        page=page,
+        pmi=pmi.value,
+    )
+    svg_path, dxf_path = dwg.export()
+    print(svg_path)
+    print(dxf_path)
+    if pdf:
+        print(dwg.export_pdf())

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -13,7 +13,6 @@ import logging
 from enum import Enum
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
-from pathlib import Path
 
 import typer
 
@@ -21,7 +20,11 @@ from draftwright.builder import build_drawing, generate_script
 
 app = typer.Typer(
     add_completion=True,
-    help="Zero-AI STEP → technical drawing (SVG + DXF, or an editable .py script).",
+    # Plain tracebacks on an engine error, matching the old argparse CLI — a rich
+    # source-panel traceback buries clean domain errors (e.g. "could not read STEP
+    # file") in developer noise.
+    pretty_exceptions_enable=False,
+    help="Zero-AI STEP -> technical drawing (SVG + DXF, or an editable .py script).",
 )
 
 
@@ -50,7 +53,7 @@ def _version_callback(value: bool) -> None:
 
 @app.command()
 def main(
-    step_file: Path = typer.Argument(..., help="Input STEP file (.step / .stp)"),
+    step_file: str = typer.Argument(..., help="Input STEP file (.step / .stp)"),
     out: str | None = typer.Option(None, help="Output prefix (default: input stem)"),
     title: str | None = typer.Option(None, help="Part title for title block"),
     number: str = typer.Option("DWG-001", help="Drawing number"),
@@ -97,10 +100,9 @@ def main(
             "--scale/--page only apply to direct output; edit the generated script instead"
         )
 
-    step = str(step_file)
     if script:
         py_path = generate_script(
-            step_file=step,
+            step_file=step_file,
             out=out,
             title=title,
             number=number,
@@ -112,7 +114,7 @@ def main(
         return
 
     dwg = build_drawing(
-        step_file=step,
+        step_file=step_file,
         out=out,
         title=title,
         number=number,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1516,9 +1516,24 @@ def test_make_drawing_module_entrypoint_runs_cli_help():
     )
 
     assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    assert "usage:" in result.stdout
+    assert "Usage:" in result.stdout  # Typer/rich help capitalises (was argparse "usage:")
     assert "step_file" in result.stdout
+    # rich degrades its box-drawing to ASCII on a cp1252 stream, so help stays safe.
     assert result.stdout.isascii()
+
+
+def test_cli_version_reports_installed_version():
+    """``--version`` prints the installed distribution version (the PyPI version
+    once pip-installed) and exits cleanly, without needing a STEP file."""
+    from importlib.metadata import version as _pkg_version
+
+    result = subprocess.run(
+        [sys.executable, "-m", "draftwright.make_drawing", "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert result.stdout.strip() == f"draftwright {_pkg_version('draftwright')}"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "anytree"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -265,7 +274,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -335,7 +344,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -580,6 +589,7 @@ dependencies = [
     { name = "kiwisolver" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -604,6 +614,7 @@ requires-dist = [
     { name = "cairosvg", marker = "extra == 'pdf'", specifier = ">=2.7" },
     { name = "kiwisolver", specifier = ">=1.4,<2" },
     { name = "numpy", specifier = ">=1.24" },
+    { name = "typer", specifier = ">=0.12" },
 ]
 provides-extras = ["pdf"]
 
@@ -622,7 +633,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -769,17 +780,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -794,18 +805,18 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -817,7 +828,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1056,6 +1067,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1063,15 +1086,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version < '3.11'" },
+    { name = "fonttools", marker = "python_full_version < '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1139,15 +1162,15 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cycler", marker = "python_full_version >= '3.11'" },
+    { name = "fonttools", marker = "python_full_version >= '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -1208,6 +1231,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1764,6 +1796,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
@@ -1796,7 +1841,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1855,7 +1900,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -1919,6 +1964,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -2072,6 +2126,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/52/18f909fcc652b2a4de75a274aa3de0d567a5d592b13d57e65b76c550bdf1/trianglesolver-1.2.tar.gz", hash = "sha256:4af18aade579d5c0d64389b3e65aeaf06cff26319762ccd859e3268559a76aea", size = 4718, upload-time = "2020-04-10T18:52:31.193Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/8e/43d45cf3e18e3f455e4b5ab333a7c27b8e38c4e535f7346b7148ce08eb65/trianglesolver-1.2-py3-none-any.whl", hash = "sha256:aa0903c3708b4e2b496f06d490cae72c6ff6274b00d1edce420fcfa3b2b76682", size = 5377, upload-time = "2020-04-10T18:52:29.811Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the core of #289: replace the argparse `_cli` with a **Typer** app in a dedicated `src/draftwright/cli.py`. This is the framework foundation the event-stream/TUI work (#276) and the `--format` selector (#288) build on. Typer was chosen in #289 and validated against `estampo/estampo`, which runs the same `typer + click + rich` stack in production.

## What's in

- **New `cli.py`** — a thin Typer front-end over `builder.build_drawing` / `generate_script`. The engine stays headless; no presentation concern leaks below this module (so it's also the home #276 will wrap its sink + renderer around).
- **Shell completion** — `--install-completion` / `--show-completion`, free from Typer (argparse needed a bolt-on). Confirmed present in `--help`.
- **Rich help** — and it **degrades to ASCII box-drawing on a cp1252 stream**, so the existing Windows-safety guard still holds.
- **`--version`** — reports the installed distribution version via `importlib.metadata` (the PyPI version once pip-installed; `unknown` from a bare source tree). Eager, so `draftwright --version` works without a STEP file.

## Scope discipline

- **Framework only.** Every existing flag is ported **1:1** (`--out`, `--title`, `--number`, `--tolerance`, `--drawn-by`, `--scale`, `--page`, `--script`, `--pmi`, `--pdf`, `-v/--verbose`). No behavioural change to the drawing. `--format` (#288) and the TUI (#276) are deliberately **not** here.
- `builder._cli` becomes a **thin shim** to the Typer app, so `python -m draftwright.make_drawing` and existing `from draftwright... import _cli` imports keep working. The `[project.scripts]` entry point now targets `draftwright.cli:app`.
- Removed the now-unused `argparse` / `logging` imports from `builder.py`.
- Kept a single-command app (bare `draftwright foo.step` preserved — **not** a breaking move to `draftwright build …`). The #289 Q2 mixed-model decision is left for when a second command actually arrives.

## Verification

- End-to-end CLI run (SVG + DXF written, paths to stdout, exit 0); `--script`; the `--script`+`--scale` guard (exit 2); `--version`; completion options present.
- `ruff check` + `ruff format` clean; `mypy` clean.
- Entrypoint-help test updated for Typer's capitalised `Usage:` (ASCII guard retained); new `--version` test added.
- **Full fast tier green — 589 passed.**

## Note

`typer` is now a core dependency (it brings `click` + `rich` + `shellingham`). `rich` was already slated to become a base dep by #276/#289, so this isn't net-new weight there.

Closes #289.