### PR TITLE
feat: horizontal (X/Y) round body's OD on the profile view (#222)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -468,6 +468,7 @@ class Analysis:
     prof: TurnedProfile | None  # turned step profile (find_turned_steps), detected once
     od_diam: float | None
     is_rotational: bool
+    od_axis: str  # rotation/turning axis of a rotational part ("z" default; "x"/"y" #222)
     step_zs: list[float]
     sv_right: float
     iso_right_limit: float

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -253,6 +253,32 @@ def _analyse(
         math.hypot(od_cyl["axis_xyz"][0] - cx, od_cyl["axis_xyz"][1] - cy) if od_cyl else 0.0
     )
     is_rotational = _is_rotational(x_size, y_size, od_diam, od_axis_offset)
+    od_axis = "z"
+    if not is_rotational:
+        # Fallback: a *horizontal* (X/Y) round body — its OD is a cross-axis cylinder
+        # filling the square envelope perpendicular to that axis (#222). The Z check
+        # above is untouched, so vertical parts classify exactly as before; this only
+        # fires when Z-rotational fails and a cross-axis round body is present.
+        sizes = {"x": x_size, "y": y_size, "z": z_size}
+        ctr = {"x": cx, "y": cy, "z": cz}
+        cross_full = full_cylinders(cross_cyls)
+        for ax in ("x", "y"):
+            ext = [c for c in cross_full if c.get("axis") == ax and c["external"]]
+            # #222 targets a *single-OD* round body. A stepped shaft (multiple distinct
+            # cross diameters) stays on the turned-diameter path, not the OD furniture.
+            if len({round(c["diameter"], 1) for c in ext}) != 1:
+                continue
+            oc = max(ext, key=lambda c: c["diameter"], default=None)
+            if oc is None:
+                continue
+            p0, p1 = (a for a in "xyz" if a != ax)
+            off = math.hypot(
+                oc["axis_xyz"]["xyz".index(p0)] - ctr[p0],
+                oc["axis_xyz"]["xyz".index(p1)] - ctr[p1],
+            )
+            if _is_rotational(sizes[p0], sizes[p1], oc["diameter"], off):
+                od_diam, od_axis_offset, od_axis, is_rotational = oc["diameter"], off, ax, True
+                break
     if z_diams and not is_rotational:
         _log.info("Part classified prismatic; skipping OD/centreline/bore annotations")
 
@@ -406,6 +432,7 @@ def _analyse(
         prof=_turned,
         od_diam=od_diam,
         is_rotational=is_rotational,
+        od_axis=od_axis,
         step_zs=step_zs,
         sv_right=sv_right,
         iso_right_limit=iso_right_limit,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -775,9 +775,13 @@ def render_height_ladder(dwg, model, a) -> int:
             n += 1
 
     # Overall height — placed last so it sits OUTERMOST; suppressed for a Z-turned
-    # part (its IR step-length chain already tiles the full height, ISO 129).
-    z_turned = model.orientation == "z"
-    px = None if z_turned else a.fv_zones.right.allocate(_SLOT_DIM_HEIGHT)
+    # part (its IR step-length chain already tiles the full height, ISO 129) and for
+    # an X/Y rotational body (its Z extent IS the OD, dimensioned by render_rotational
+    # — #222).
+    rot = next((f for f in model.features if f.kind == "rotational"), None)
+    od_is_height = rot is not None and rot.frame.axis in ("x", "y")
+    suppress_height = model.orientation == "z" or od_is_height
+    px = None if suppress_height else a.fv_zones.right.allocate(_SLOT_DIM_HEIGHT)
     if px is not None:
         dwg.add(
             _dim(
@@ -792,7 +796,7 @@ def render_height_ladder(dwg, model, a) -> int:
             view="front",
         )
         n += 1
-    elif not z_turned:
+    elif not suppress_height:
         _log.warning("dim_height skipped: fv_zones.right strip full")
     return n
 
@@ -808,57 +812,117 @@ def render_rotational(dwg, model, a) -> int:
     draft = dwg.draft
     FX, FZ = a.proj.front_x, a.proj.front_z
     SX, SZ = a.proj.side_x, a.proj.side_z
+    PX, PY = a.proj.plan_x, a.proj.plan_y
     n = 0
     od = rot.od
-    dwg.add(
-        _dim(
-            (FX(a.cx - od / 2), FZ(a.bb.max.Z) + 2, 0),
-            (FX(a.cx + od / 2), FZ(a.bb.max.Z) + 2, 0),
-            "above",
-            8,
-            draft,
-            label=f"ø{_fmt(od)}",
-        ),
-        "dim_od",
-        view="front",
-    )
-    n += 1
-    dwg.add(
-        Centerline((FX(a.cx), FZ(a.bb.min.Z) - 5, 0), (FX(a.cx), FZ(a.bb.max.Z) + 5, 0)),
-        "centerline_front",
-        view="front",
-    )
-    dwg.add(
-        Centerline((SX(a.cy), SZ(a.bb.min.Z) - 5, 0), (SX(a.cy), SZ(a.bb.max.Z) + 5, 0)),
-        "centerline_side",
-        view="side",
-    )
+    axis = rot.frame.axis
 
-    # Concentric bore leaders to the left of the front view, centred on the axis.
-    if rot.bores:
-        left_edge = FX(a.bb.min.X)
-        if left_edge - a.margin >= a.DIM_PAD:
-            elbow_x = left_edge - a.DIM_PAD * 0.6
-            nb = len(rot.bores)
-            pitch = max(10.0, draft.font_size * 3.0)
-            for i, d in enumerate(rot.bores):
-                tip_z = FZ(a.cz) + (i - (nb - 1) / 2) * pitch
-                dwg.add(
-                    Leader(
-                        tip=(FX(a.cx - d / 2), tip_z, 0),
-                        elbow=(elbow_x, tip_z, 0),
-                        label=f"ø{_fmt(d)}",
-                        draft=draft,
-                    ),
-                    f"ldr_z{i}",
-                    view="front",
+    if axis == "z":
+        # Vertical turning axis (the common case): OD across the top of the front
+        # (profile) view; axis centrelines vertical on front + side.
+        dwg.add(
+            _dim(
+                (FX(a.cx - od / 2), FZ(a.bb.max.Z) + 2, 0),
+                (FX(a.cx + od / 2), FZ(a.bb.max.Z) + 2, 0),
+                "above",
+                8,
+                draft,
+                label=f"ø{_fmt(od)}",
+            ),
+            "dim_od",
+            view="front",
+        )
+        n += 1
+        dwg.add(
+            Centerline((FX(a.cx), FZ(a.bb.min.Z) - 5, 0), (FX(a.cx), FZ(a.bb.max.Z) + 5, 0)),
+            "centerline_front",
+            view="front",
+        )
+        dwg.add(
+            Centerline((SX(a.cy), SZ(a.bb.min.Z) - 5, 0), (SX(a.cy), SZ(a.bb.max.Z) + 5, 0)),
+            "centerline_side",
+            view="side",
+        )
+
+        # Concentric bore leaders to the left of the front view, centred on the axis.
+        if rot.bores:
+            left_edge = FX(a.bb.min.X)
+            if left_edge - a.margin >= a.DIM_PAD:
+                elbow_x = left_edge - a.DIM_PAD * 0.6
+                nb = len(rot.bores)
+                pitch = max(10.0, draft.font_size * 3.0)
+                for i, d in enumerate(rot.bores):
+                    tip_z = FZ(a.cz) + (i - (nb - 1) / 2) * pitch
+                    dwg.add(
+                        Leader(
+                            tip=(FX(a.cx - d / 2), tip_z, 0),
+                            elbow=(elbow_x, tip_z, 0),
+                            label=f"ø{_fmt(d)}",
+                            draft=draft,
+                        ),
+                        f"ldr_z{i}",
+                        view="front",
+                    )
+                    n += 1
+            else:
+                _log.info(
+                    "Additional diameters %s not annotated (insufficient left margin)",
+                    list(rot.bores),
                 )
-                n += 1
-        else:
-            _log.info(
-                "Additional diameters %s not annotated (insufficient left margin)",
-                list(rot.bores),
-            )
+    elif axis == "x":
+        # Horizontal turning axis along X (#222): the OD is the Z extent — a vertical
+        # ø dim left of the front (profile) view; axis centrelines run horizontally
+        # through z=cz on front and y=cy on plan.
+        dwg.add(
+            _dim(
+                (FX(a.bb.min.X) - 2, FZ(a.cz - od / 2), 0),
+                (FX(a.bb.min.X) - 2, FZ(a.cz + od / 2), 0),
+                "left",
+                8,
+                draft,
+                label=f"ø{_fmt(od)}",
+            ),
+            "dim_od",
+            view="front",
+        )
+        n += 1
+        dwg.add(
+            Centerline((FX(a.bb.min.X) - 5, FZ(a.cz), 0), (FX(a.bb.max.X) + 5, FZ(a.cz), 0)),
+            "centerline_front",
+            view="front",
+        )
+        dwg.add(
+            Centerline((PX(a.bb.min.X) - 5, PY(a.cy), 0), (PX(a.bb.max.X) + 5, PY(a.cy), 0)),
+            "centerline_plan",
+            view="plan",
+        )
+    elif axis == "y":
+        # Horizontal turning axis along Y (#222): the OD is the Z extent — a vertical
+        # ø dim left of the side (profile) view; axis centrelines run horizontally
+        # through z=cz on side and vertically through x=cx on plan.
+        dwg.add(
+            _dim(
+                (SX(a.bb.min.Y) - 2, SZ(a.cz - od / 2), 0),
+                (SX(a.bb.min.Y) - 2, SZ(a.cz + od / 2), 0),
+                "left",
+                8,
+                draft,
+                label=f"ø{_fmt(od)}",
+            ),
+            "dim_od",
+            view="side",
+        )
+        n += 1
+        dwg.add(
+            Centerline((SX(a.bb.min.Y) - 5, SZ(a.cz), 0), (SX(a.bb.max.Y) + 5, SZ(a.cz), 0)),
+            "centerline_side",
+            view="side",
+        )
+        dwg.add(
+            Centerline((PX(a.cx), PY(a.bb.min.Y) - 5, 0), (PX(a.cx), PY(a.bb.max.Y) + 5, 0)),
+            "centerline_plan",
+            view="plan",
+        )
     return n
 
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -148,7 +148,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     # The part model — built once and rendered from for the IR-migrated passes
     # (centre marks, turned diameters/lengths); ADR 0008 convergence / #229.
-    _bores = tuple(_concentric_bore_diams(a)) if a.is_rotational else ()
+    # Concentric bore leaders are a Z-axis construction (bores on the vertical
+    # rotation axis); a horizontal (X/Y) round body gets OD + centrelines only
+    # (#222), so its bore set is empty.
+    _bores = tuple(_concentric_bore_diams(a)) if a.is_rotational and a.od_axis == "z" else ()
     _model = build_part_model(
         a.part,
         holes=a.holes,
@@ -157,7 +160,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         slots=a.slots,
         prof=a.prof,
         step_zs=a.step_zs,
-        rotational=(a.od_diam, _bores) if a.is_rotational else None,
+        rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
         pmi=a.pmi,
     )
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -257,10 +257,10 @@ def build_part_model(
     # Rotational furniture — OD + centrelines + concentric bore leaders (#237). Its
     # presence marks the part rotational; emitted from the classification (od, bores).
     if rotational is not None:
-        od, bores = rotational
+        od, bores, rot_axis = rotational
         c = bbox.center()
         features.append(
-            RotationalFeature(frame=Frame((c.X, c.Y, c.Z), "z"), od=od, bores=tuple(bores))
+            RotationalFeature(frame=Frame((c.X, c.Y, c.Z), rot_axis), od=od, bores=tuple(bores))
         )
 
     # Pre-authored PMI annotations (STEP AP242) — re-homed into the IR as features

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -117,6 +117,15 @@ def _suppression(model: PartModel, feature: Feature, param: DimParameter):
     dim along the turning axis is redundant."""
     if feature.kind != "envelope":
         return False, None
+    # A rotational part's OD already conveys its cross-axis extent(s); the envelope
+    # dim(s) perpendicular to the turning axis would double-dimension it (#222). The
+    # axis-aligned envelope dim (the length) is kept. (The overall *height* dim is the
+    # height-ladder renderer's call — it skips it for an X/Y rotational part likewise.)
+    rot = next((f for f in model.features if f.kind == "rotational"), None)
+    if rot is not None:
+        od_perp = {"x": {"depth"}, "y": {"width"}, "z": {"width", "depth"}}[rot.frame.axis]
+        if param.role in od_perp:
+            return True, f"rotational OD ({rot.frame.axis}-axis) conveys this extent"
     if param.role in ("width", "depth") and _square_footprint(model):
         return True, "square footprint (single overall dim suffices)"
     if param.role == "width" and model.orientation == "x":

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4477,6 +4477,22 @@ class TestTurnedDiameters:
         dwg = build_drawing(Cylinder(15, 40))  # plain Z disc/shaft
         assert not any(n.startswith("m_dia") for n in dwg._named)
 
+    def test_horizontal_round_body_od_on_profile(self):
+        # A horizontal (X-axis) single-OD cylinder shows its OD as a clean profile-view
+        # diameter dim (dim_od) — not an end-on/corner boss leader — with the envelope
+        # dims that duplicate the OD suppressed, so no double-dimensioning (#222).
+        from build123d import Rot
+
+        for rot, axis in ((Rot(0, 90, 0), "x"), (Rot(90, 0, 0), "y")):
+            dwg = build_drawing(rot * Cylinder(25, 40), number="X")
+            assert dwg._analysis.od_axis == axis
+            assert "dim_od" in dwg._named, f"{axis}: OD not on profile"
+            assert not any(n.startswith("m_dia") for n in dwg._named), f"{axis}: end-on leader"
+            # the OD (50) appears once (ø50), not also as a bare envelope "50"
+            labels = [str(o.label) for o in dwg._named.values() if getattr(o, "label", None)]
+            assert "50" not in labels, f"{axis}: OD double-dimensioned as envelope"
+            assert [i for i in dwg.lint() if i.severity != "info"] == []
+
     def test_unfittable_row_skips_without_crashing(self, monkeypatch):
         # When the labels do not fit the row, both solvers return None; the pass
         # must skip gracefully, not crash the whole build on a None unpack.


### PR DESCRIPTION
#237 put a *vertical* (Z) rotational part's OD on the profile view (`dim_od`), but a horizontal round body — a cylinder turned about X or Y — stayed Z-classified, so its OD rendered as an awkward end-on/corner boss leader. This generalizes the rotational furniture to any turning axis (frame-derived), scoped to single-OD round bodies.

## What
- **analysis:** after the *unchanged* Z check, a fallback detects a horizontal round body (a single-distinct-diameter external cross-axis cylinder filling the square envelope perpendicular to that axis) and sets `od_axis` (x/y), threaded to `RotationalFeature`.
- **render_rotational:** Z branch unchanged; X/Y branches place the OD as a vertical ø dim on the profile view (left of front for X, left of side for Y) + rotation-axis centrelines on the two views where the axis is a line.
- **no double-dimensioning:** the planner suppresses the envelope dim(s) perpendicular to the axis (the OD), and `render_height_ladder` skips the overall height for an X/Y rotational body (its Z extent *is* the OD). The axis-aligned length dim is kept.
- **bores/section stay Z-guarded** (concentric-bore leaders are a Z construction; bored X/Y rotational parts are out of scope, unchanged).

Before → after for the X-cyl: `ø50` corner-leader → clean vertical `ø50` profile dim + axis centrelines + `40` length.

## Adversarial review (before merge)
- **Z path untouched:** the fallback runs only `if not is_rotational` (Z failed); `render_rotational`'s z branch is byte-identical. Verified the Z-disc is unchanged (dim_od + dim_height + front/side centrelines).
- **Prismatic misclassification:** the fallback needs an *external cylinder* filling a *square* perpendicular envelope, centered — a box has no such cylinder. Verified box/plate stay `is_rot=False`, normal envelope.
- **Stepped-shaft regression (caught in review):** my first cut re-classified an X-*stepped* shaft (it tripped `TestTurnedDiameters`); added a single-distinct-cross-diameter guard so stepped shafts stay on the turned-diameter path. Verified those tests pass.
- **Double-dimensioning:** the OD's cross extents are suppressed (planner) and the Z-height skipped (height ladder); verified the X-cyl shows `ø50` + `40` only, no bare `50`, lint clean. Test asserts this.
- **Y-axis symmetry:** verified Y-cyl → `ø50` on the side profile + plan/side centrelines + depth(length) kept.

Full fast suite **588 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Regression test (X **and** Y) added. Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)