### PR TITLE
fix: prismatic part with incidental cylinders mis-detected as turned (#293)

### DIFF
--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -47,6 +47,12 @@ _OD_SPAN_PAD = 0.7
 # less than the gap between an internal bore radius and the OD.
 _CHAMFER_ALLOWANCE_ABS = 0.5
 _CHAMFER_ALLOWANCE_FRAC = 0.12
+# A genuine turned body is round about its axis: the perpendicular cross-section is
+# roughly square and the OD silhouette fills it (#293). Looser than the rotational
+# classifier's gate (chamfers/features perturb the bbox), but firmly rejects an
+# incidental cylinder on a prismatic part (a tiny OD in a large oblong bbox).
+_SQUARENESS_TOL = 0.15
+_OD_FILL_MIN = 0.6
 
 
 @dataclass(frozen=True)
@@ -92,6 +98,22 @@ def find_turned_steps(part) -> TurnedProfile | None:
     if len({round(c["diameter"], 2) for c in bands}) < 2:
         return None  # one OD → not a stepped turned part
     idx = "xyz".index(axis)
+
+    # A genuine turned shaft is a body of revolution about *axis*: its OD silhouette
+    # (largest external band) fills a roughly-square cross-section perpendicular to the
+    # axis. Reject incidental small cylinders on a prismatic part — e.g. a case shell's
+    # side screw-holes — whose unrelated feature faces would otherwise be read as a
+    # spurious multi-step profile (#293).
+    pbb = part.bounding_box()
+    perp = [s for i, s in enumerate((pbb.size.X, pbb.size.Y, pbb.size.Z)) if i != idx]
+    cross = max(perp)
+    max_od = max(c["diameter"] for c in bands)
+    if (
+        cross <= 0
+        or max_od < _OD_FILL_MIN * cross
+        or abs(perp[0] - perp[1]) > _SQUARENESS_TOL * cross
+    ):
+        return None
 
     def local_od(pos: float) -> float:
         radii = [

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -70,6 +70,22 @@ class TestBuildPartModel:
         assert step_dias, "expected step features for the stepped shaft"
         assert all(d > 0 for d in step_dias), f"phantom zero-diameter step: {step_dias}"
 
+    def test_prismatic_with_incidental_cylinders_is_not_turned(self):
+        # A prismatic part with small incidental cross-axis cylinders (e.g. a case
+        # shell's side screw-holes) — two distinct external diameters in a large
+        # oblong bbox — must NOT be read as a stepped turned shaft, or unrelated
+        # feature faces become a spurious multi-step chain (#293).
+        from build123d import Rot
+
+        part = (
+            Box(120, 80, 14)
+            + Pos(-30, 0, 9) * Rot(0, 90, 0) * Cylinder(3, 130)
+            + Pos(30, 0, 9) * Rot(0, 90, 0) * Cylinder(4, 130)
+        )
+        model = build_part_model(part)
+        assert model.orientation is None  # prismatic, not turned
+        assert not any(isinstance(f, StepFeature) for f in model.features)
+
     def test_bolt_circle_is_one_pattern_not_six_holes(self):
         import math
 


### PR DESCRIPTION
A user's clamshell case shell (`gramel_case_shell.step`, bbox 109×143×15.6) rendered as a **mess** — `find_turned_steps` classified it as an X-turned **30-step shaft** (single ø6.2 "OD", many zero-length / 0.3 mm degenerate steps), and `render_step_lengths` crammed 30 dims into one overlapping row (lint score 0.0).

The ø6.2 cylinders are incidental side features, nowhere near filling the 143×15.6 cross-section — the part is **not a body of revolution** about X. This gates `find_turned_steps`: the largest external band must fill a roughly-square cross-section perpendicular to the axis.

## Before → after
The case now renders cleanly as **prismatic** — envelope dims, `4× ⌀6.2 ↧3.1` callout, section A–A — score **1.0**, instead of 30 overlapping step dims.

## Adversarial review
- **Does the gate reject real shafts?** No — a turned shaft's largest step *defines* the bbox cross extent, so `max_od ≈ cross` (fill ≈ 1.0 ≥ 0.6) and the cross-section is round (square within 15%). Verified: 82 turned/step tests pass; a 2-step X shaft still detected.
- **Threshold safety:** thresholds are *looser* than the rotational classifier (0.6/0.15 vs 0.8/0.05) to tolerate chamfers/features on genuine shafts, yet the gramel OD fills only 0.04 of its cross and is wildly non-square — rejected by a wide margin.
- **Why not fix render_step_lengths instead?** The misdetection is the root cause (the part isn't turned); gating at the source also removes the spurious step features from the IR, not just their rendering. A legibility cap on genuinely dense shafts is a separate (rarer) concern.
- **Regression test** reproduces the signature (prismatic plate + two incidental cross rods of distinct ø) and asserts it's not turned.

Full fast suite **590 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)