### PR TITLE
fix: skip an illegibly-dense step-length chain instead of cramming (#293)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -640,6 +640,11 @@ def render_step_lengths(dwg, groups) -> int:
         candidates = [("m_steplen_typ", dim)]
     else:
         offsets = [0.0] * len(segs)
+        # Legibility guard (#293): a too-dense chain must SKIP, not overprint. Placing
+        # an unreadable wall of overlapping dims is worse than none — lint then reports
+        # axial_length_missing, and the user resolves it with a larger scale or a detail
+        # view. The room guard's sibling, for crowding rather than page overflow.
+        gap_min = draft.font_size + 2 * draft.pad_around_text
         if horizontal:
             centers = [(pa[0] + pb[0]) / 2 for pa, pb, _ in segs]
             half_w = max(len(_fmt(v)) for *_, v in segs) * draft.font_size * 0.62 / 2
@@ -647,8 +652,19 @@ def render_step_lengths(dwg, groups) -> int:
             solved = _solve_strip_ys(
                 centers, min_gap, x0 + half_w, x1 - half_w
             ) or _greedy_strip_ys(centers, min_gap, x0 + half_w, x1 - half_w)
+            placed = sorted(solved) if solved else sorted(centers)
+            if any(b - a < min_gap - 0.01 for a, b in zip(placed, placed[1:])):
+                _log.info("step-length chain skipped: %d labels too dense to space", len(segs))
+                return 0
             if solved:
                 offsets = [s - c for s, c in zip(solved, centers)]
+        else:
+            # Z-turned chain places plain dims at the shoulders (no along-line spread is
+            # available vertically), so its legibility is the raw shoulder spacing.
+            shoulder_ys = sorted({c for pa, pb, _ in segs for c in (pa[1], pb[1])})
+            if any(b - a < gap_min for a, b in zip(shoulder_ys, shoulder_ys[1:])):
+                _log.info("step-length chain skipped: shoulders too close to dimension")
+                return 0
 
         candidates = []
         for i, (pa, pb, value) in enumerate(segs):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4591,6 +4591,35 @@ class TestTurnedLengths:
         assert not any(n.startswith("m_steplen") for n in dwg._named)  # skipped, not off-page
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) >= 1
 
+    def test_dense_chain_skips_instead_of_cramming(self):
+        # A genuinely dense turned shaft (many fine non-uniform steps) whose labels
+        # cannot be spaced legibly must SKIP the chain, not overprint a wall of
+        # overlapping dims (#293). Any placed step-length dims must not overlap.
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        from draftwright.annotations._common import _anno_box
+
+        b = Align.MIN
+        shaft = None
+        z = 0.0
+        for i in range(16):
+            d = 20 if i % 2 == 0 else 16  # alternating ø → truly stepped, fine pitch
+            ln = 3.0 + (i % 3) * 0.4  # non-uniform (no N× collapse)
+            seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
+            shaft = seg if shaft is None else shaft + seg
+            z += ln
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft)
+        boxes = [_anno_box(o) for n, o in dwg._named.items() if n.startswith("m_steplen")]
+
+        def overlap(a, c):
+            return a and c and not (a[2] <= c[0] or a[0] >= c[2] or a[3] <= c[1] or a[1] >= c[3])
+
+        assert not any(
+            overlap(boxes[i], boxes[j])
+            for i in range(len(boxes))
+            for j in range(i + 1, len(boxes))
+        ), "step-length dims overprint — chain crammed instead of skipping"
+
 
 class TestStepLadderRecognition:
     """ADR 0008 step 1: the Z step-height ladder draws its step levels from the


### PR DESCRIPTION
The identification fix (#294) stopped the gramel case being mis-read as turned, but you asked the right follow-up: **the cramming itself wasn't fixed.** When labels can't be spaced, `render_step_lengths` fell back to a greedy pack that **overlapped** them (horizontal), and the Z-turned chain had no spacing guard at all — so a *genuinely* dense shaft still rendered an unreadable wall (verified: 16 steps → 8 overlaps, 24 → 30, score 0.0).

This adds a legibility guard — the room guard's sibling for crowding: if labels can't be spaced ≥ `min_gap` along the chain, **skip it** and let lint report `axial_length_missing`. An overlapping wall looks like data but isn't; none + a lint flag is better, and the user resolves it with a larger scale or a detail view.

## Adversarial review
- **Over-skip real parts?** No — verified a realistic 4-step monotonic shaft still places all dims (score 1.0); the uniform-run collapse (#230) is unaffected; **73 turned/step tests pass**. The guard only triggers when the spread result genuinely has a sub-`min_gap` pair (horizontal) or shoulders below a label height (vertical).
- **Why all-or-nothing, not partial?** Matches the existing page-bounds room guard's precedent; a partial chain on a tiled connected chain is messier and a separate enhancement. The lint signal is the same either way.
- **Both axes:** horizontal uses the actual spread result (so a feasible spread places; an infeasible greedy-cram skips); vertical (no along-line spread available) uses raw shoulder spacing.
- **Double-report?** No new build issue — returns 0 and lets lint's `axial_length_missing` report it, exactly as the room guard does.
- Regression test asserts a dense 16-step shaft's dims never overlap.

Full fast suite **591 passed / 1 skipped**; ruff(0.15.17)/format/mypy clean. Closes #293 (cram half; identification half was #294).

🤖 Generated with [Claude Code](https://claude.com/claude-code)