### PR TITLE
fix: stagger crowded turned step-length chains (ISO 129-1) instead of skipping (#293)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -646,6 +646,15 @@ def render_step_lengths(dwg, groups) -> int:
         # view. The room guard's sibling, for crowding rather than page overflow.
         gap_min = draft.font_size + 2 * draft.pad_around_text
         if horizontal:
+            # Arrowhead legibility: a segment carries an inward-pointing arrowhead at
+            # each end, so a segment narrower than 2× arrow_length overprints them no
+            # matter how the labels are spread along the line (#293 — the gramel drive
+            # screw's 0.5 mm step). Spreading labels can't fix overlapping dimension-line
+            # arrows, so the raw segment width gates the horizontal chain just as the
+            # shoulder spacing gates the vertical chain below.
+            if any(abs(pb[0] - pa[0]) < 2 * draft.arrow_length for pa, pb, _ in segs):
+                _log.info("step-length chain skipped: a segment is too short to dimension")
+                return 0
             centers = [(pa[0] + pb[0]) / 2 for pa, pb, _ in segs]
             half_w = max(len(_fmt(v)) for *_, v in segs) * draft.font_size * 0.62 / 2
             min_gap = 2 * half_w + 2 * draft.pad_around_text

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -639,34 +639,32 @@ def render_step_lengths(dwg, groups) -> int:
             dim = _dim((x1, min(ys), 0), (x1, max(ys), 0), "right", gap, draft, label=label)
         candidates = [("m_steplen_typ", dim)]
     else:
-        offsets = [0.0] * len(segs)
-        # Legibility guard (#293): a too-dense chain must SKIP, not overprint. Placing
-        # an unreadable wall of overlapping dims is worse than none — lint then reports
-        # axial_length_missing, and the user resolves it with a larger scale or a detail
-        # view. The room guard's sibling, for crowding rather than page overflow.
         gap_min = draft.font_size + 2 * draft.pad_around_text
+        tier_step = draft.font_size + 2 * draft.pad_around_text
+        tiers = [0] * len(segs)
         if horizontal:
-            # Arrowhead legibility: a segment carries an inward-pointing arrowhead at
-            # each end, so a segment narrower than 2× arrow_length overprints them no
-            # matter how the labels are spread along the line (#293 — the gramel drive
-            # screw's 0.5 mm step). Spreading labels can't fix overlapping dimension-line
-            # arrows, so the raw segment width gates the horizontal chain just as the
-            # shoulder spacing gates the vertical chain below.
-            if any(abs(pb[0] - pa[0]) < 2 * draft.arrow_length for pa, pb, _ in segs):
-                _log.info("step-length chain skipped: a segment is too short to dimension")
+            # ISO 129-1 staggering, applied only as a response to crowding: keep the
+            # whole chain on one tier when the labels already clear; alternate them
+            # between a near and a far tier only when they would collide; skip when even
+            # two tiers can't separate them (then lint reports the gap, #293). build123d
+            # flips a narrow segment's arrowheads outside the extension lines for us.
+            cw = [
+                ((pa[0] + pb[0]) / 2, len(_fmt(v)) * draft.font_size * 0.62) for pa, pb, v in segs
+            ]
+
+            def _clear(items):  # (center, width) pairs in x order — labels don't overlap
+                return all(
+                    c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
+                    for (c1, w1), (c2, w2) in zip(items, items[1:])
+                )
+
+            if _clear(cw):
+                pass  # one tier suffices — no needless zig-zag for a roomy chain
+            elif _clear(cw[0::2]) and _clear(cw[1::2]):
+                tiers = [i % 2 for i in range(len(segs))]  # alternate to make room
+            else:
+                _log.info("step-length chain skipped: too dense even when staggered")
                 return 0
-            centers = [(pa[0] + pb[0]) / 2 for pa, pb, _ in segs]
-            half_w = max(len(_fmt(v)) for *_, v in segs) * draft.font_size * 0.62 / 2
-            min_gap = 2 * half_w + 2 * draft.pad_around_text
-            solved = _solve_strip_ys(
-                centers, min_gap, x0 + half_w, x1 - half_w
-            ) or _greedy_strip_ys(centers, min_gap, x0 + half_w, x1 - half_w)
-            placed = sorted(solved) if solved else sorted(centers)
-            if any(b - a < min_gap - 0.01 for a, b in zip(placed, placed[1:])):
-                _log.info("step-length chain skipped: %d labels too dense to space", len(segs))
-                return 0
-            if solved:
-                offsets = [s - c for s, c in zip(solved, centers)]
         else:
             # Z-turned chain places plain dims at the shoulders (no along-line spread is
             # available vertically), so its legibility is the raw shoulder spacing.
@@ -677,13 +675,15 @@ def render_step_lengths(dwg, groups) -> int:
 
         candidates = []
         for i, (pa, pb, value) in enumerate(segs):
-            if horizontal:  # X-turned: chain above the view, witnesses rise from the top
+            if horizontal:  # X-turned: chain above the view (staggered only if crowded)
                 p1, p2, side = (pa[0], y1, 0), (pb[0], y1, 0), "above"
-                kw = {"label": _fmt(value), "label_offset_x": offsets[i]}
+                dist = gap + tiers[i] * tier_step
             else:  # Z-turned: chain right of the view, witnesses from the right edge
                 p1, p2, side = (x1, pa[1], 0), (x1, pb[1], 0), "right"
-                kw = {"label": _fmt(value)}
-            candidates.append((f"m_steplen{i}", _dim(p1, p2, side, gap, draft, **kw)))
+                dist = gap
+            candidates.append(
+                (f"m_steplen{i}", _dim(p1, p2, side, dist, draft, label=_fmt(value)))
+            )
 
     # Room guard (the engine's contract): if any dim would fall off the drawable
     # page, place NONE and let lint report axial_length_missing — never run the

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -90,6 +90,31 @@ def _cross_view_overlaps(dwg, a) -> int:
     return n
 
 
+def _annotation_view_overlaps(dwg, a) -> int:
+    """Count view-owned annotation *labels* whose box overlaps a **different**
+    view's geometry box — a dimension that has grown into a neighbouring view's
+    line-work (the staggered step chain bumping the plan view above the front
+    view). A third repack trigger besides cross-annotation overlap and page
+    overflow: the measured blocks already capture the annotation's real depth, so
+    a repack lifts the neighbouring view clear into the headroom (#293). Bare
+    extension/leader lines crossing a view are normal drafting and don't count —
+    only a text label landing on another view's geometry does.
+    """
+    geom = _view_geom(a)
+    boxes = {v: (cx - hw, cy - hh, cx + hw, cy + hh) for v, (cx, cy, hw, hh) in geom.items()}
+    n = 0
+    for _name, v, bb, label in _attribute_annotations(dwg, a):
+        if not label:
+            continue
+        for ov, gb in boxes.items():
+            if ov == v:
+                continue
+            if min(bb[2], gb[2]) > max(bb[0], gb[0]) and min(bb[3], gb[3]) > max(bb[1], gb[1]):
+                n += 1
+                break
+    return n
+
+
 def _annotations_out_of_bounds(dwg, a, tol: float = 1.0) -> bool:
     """True when any view-owned annotation's footprint extends past the drawable
     area — the second repack trigger besides cross-view overlap.  A ballooned
@@ -257,7 +282,11 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
     byte-identical) or when the repack would change nothing (same sheet/scale and
     no view actually moves).
     """
-    if _cross_view_overlaps(dwg, a) == 0 and not _annotations_out_of_bounds(dwg, a):
+    if (
+        _cross_view_overlaps(dwg, a) == 0
+        and _annotation_view_overlaps(dwg, a) == 0
+        and not _annotations_out_of_bounds(dwg, a)
+    ):
         return None
     blocks = _measure_blocks(dwg, a)
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1185,6 +1185,36 @@ class TestComposeThenPackRepack:
         )
         assert _cross_view_overlaps(dwg, None) == 0
 
+    # --- annotation-over-view-linework trigger (#293) ---------------------
+
+    def test_annotation_view_overlap_counts_label_over_other_view(self):
+        # The third repack trigger: a view-owned LABEL grown into a *different*
+        # view's geometry box (the staggered step chain bumping the plan view).
+        # A bare line over another view is normal drafting; a label in its OWN
+        # view is fine. Only a label over another view's box counts.
+        from types import SimpleNamespace
+
+        from draftwright.builder import _annotation_view_overlaps
+
+        a = SimpleNamespace(
+            FV_X=0.0,
+            FV_Y=0.0,
+            fv_hw=10.0,
+            fv_hh=10.0,
+            PV_X=0.0,
+            PV_Y=40.0,
+            pv_hh=10.0,
+            SV_X=40.0,
+            SV_Y=0.0,
+            sv_hw=10.0,
+        )  # plan box spans x[-10,10] y[30,50]
+        over = self._fake_dwg({"d": self._label((-5, 32, 5, 42))}, {"d": "front"})
+        assert _annotation_view_overlaps(over, a) == 1  # front label inside plan box
+        bare = self._fake_dwg({"d": self._line((-5, 32, 5, 42))}, {"d": "front"})
+        assert _annotation_view_overlaps(bare, a) == 0  # bare line — normal drafting
+        own = self._fake_dwg({"d": self._label((-5, -5, 5, 5))}, {"d": "front"})
+        assert _annotation_view_overlaps(own, a) == 0  # inside its own view
+
     # --- out-of-bounds escalation trigger (#92) ---------------------------
 
     def test_out_of_bounds_trigger(self):
@@ -1299,6 +1329,88 @@ class TestComposeThenPackRepack:
         dwg.add(_leader("D"), "tag3", view="side")
         dwg.clear_annotations()  # keeps title_block only
         assert "tag3" not in dwg._anno_view
+
+
+class TestLayoutCleanlinessInvariant:
+    """End-to-end invariant (#293): for a spread of representative part shapes the
+    *finished* drawing must place its views and annotations without layout
+    collisions — the OUTCOME, not just the trigger mechanics the unit tests above
+    cover. This is the check that would have caught the GRM-03 staggered chain
+    bumping the plan view: the trigger unit tests were green while a real part
+    rendered with overlapping annotations. A regression here means the layout
+    engine (estimate → measure-and-repack) let a real collision through."""
+
+    # Genuine layout defects — NOT view_annotation_inside_extents, the soft info
+    # code for a callout legitimately sitting inside a large face.
+    _DEFECTS = {
+        "view_annotation_overlap",
+        "view_overlap",
+        "view_out_of_bounds",
+        "annotation_out_of_bounds",
+        "annotation_overlap",
+    }
+
+    @staticmethod
+    def _x_simple():
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        b = Align.MIN
+        s = Cylinder(8, 20, align=(Align.CENTER, Align.CENTER, b)) + Pos(0, 0, 20) * Cylinder(
+            5, 20, align=(Align.CENTER, Align.CENTER, b)
+        )
+        return Rotation(0, 90, 0) * s  # roomy X-turned chain → one tier, no zig-zag
+
+    @staticmethod
+    def _x_crowded():
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        b = Align.MIN  # GRM-03 shape: fine head steps + long shaft → stagger + view lift
+        s = None
+        z = 0.0
+        for d, ln in [(8, 1.0), (12, 1.0), (8, 1.0), (12, 1.0), (6, 30.0)]:
+            seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
+            s = seg if s is None else s + seg
+            z += ln
+        return Rotation(0, 90, 0) * s
+
+    @staticmethod
+    def _z_stepped():
+        from build123d import Cylinder, Pos
+
+        return Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)  # Z-turned ladder
+
+    @staticmethod
+    def _prism_holes():
+        part = Box(80, 60, 20)  # a row of holes → location dims above the plan view
+        for x in (-30, -10, 10, 30):
+            part -= Pos(x, 20, 0) * Cylinder(3, 30)
+        return part
+
+    @staticmethod
+    def _bolt_circle():
+        import math
+
+        part = Box(60, 60, 15)  # 6-hole bolt circle → ballooned plan-view halo
+        for i in range(6):
+            a = i * math.pi / 3
+            part -= Pos(20 * math.cos(a), 20 * math.sin(a), 0) * Cylinder(2.5, 30)
+        return part
+
+    @staticmethod
+    def _counterbored():
+        part = Box(60, 40, 20)  # counterbore → full section A-A
+        part -= Cylinder(4, 30)
+        part -= Pos(0, 0, 2) * Cylinder(7, 20)
+        return part
+
+    @pytest.mark.parametrize(
+        "factory",
+        ["_x_simple", "_x_crowded", "_z_stepped", "_prism_holes", "_bolt_circle", "_counterbored"],
+    )
+    def test_finished_sheet_has_no_layout_collisions(self, factory):
+        dwg = build_drawing(getattr(self, factory)())
+        hits = sorted({i.code for i in dwg.lint()} & self._DEFECTS)
+        assert not hits, f"{factory}: layout defects in finished drawing: {hits}"
 
 
 class TestHolePatternCallouts:
@@ -4721,13 +4833,16 @@ class TestTurnedLengths:
             for j in range(i + 1, len(boxes))
         ), "step-length dims overprint — chain crammed instead of skipping"
 
-    def test_short_segment_arrows_cram_skips_even_when_labels_fit(self):
+    def test_crowded_chain_staggers_into_two_tiers_at_current_scale(self):
         # The gramel thumbwheel drive screw (GRM-03): fine steps near the head + one
-        # long shaft. The strip solver CAN spread the labels into the shaft's empty
-        # space (so the label-overlap guard passes), but the head segments are
-        # narrower than two arrowheads, so the dimension-line arrows overprint at the
-        # shoulders regardless. The raw segment width must gate the chain too (#293).
+        # long shaft. Rather than skip (wasting the empty sheet) or cram, the chain
+        # staggers successive dims between a near and a far tier (ISO 129-1) so every
+        # step length is legible at the drawing's own scale (#293). All segments are
+        # dimensioned, the labels don't overprint each other, and axial coverage is
+        # satisfied — no rescale needed.
         from build123d import Align, Cylinder, Pos, Rotation
+
+        from draftwright.annotations._common import _anno_box
 
         b = Align.MIN
         specs = [(8, 1.0), (12, 1.0), (8, 1.0), (12, 1.0), (6, 30.0)]
@@ -4738,8 +4853,23 @@ class TestTurnedLengths:
             shaft = seg if shaft is None else shaft + seg
             z += ln
         dwg = build_drawing(Rotation(0, 90, 0) * shaft)
-        assert not any(n.startswith("m_steplen") for n in dwg._named)  # skipped, not crammed
-        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) >= 1
+        steps = {n: o for n, o in dwg._named.items() if n.startswith("m_steplen")}
+        assert len(steps) == 5  # every segment dimensioned, none dropped
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
+        # Two tiers: the dims sit at (at least) two distinct offset rows.
+        boxes = [_anno_box(o) for o in steps.values()]
+        rows = {round((bb[1] + bb[3]) / 2, 1) for bb in boxes if bb}
+        assert len(rows) >= 2, "chain did not stagger into multiple tiers"
+
+        # Labels don't overprint each other.
+        def overlap(a, c):
+            return a and c and not (a[2] <= c[0] or a[0] >= c[2] or a[3] <= c[1] or a[1] >= c[3])
+
+        assert not any(
+            overlap(boxes[i], boxes[j])
+            for i in range(len(boxes))
+            for j in range(i + 1, len(boxes))
+        ), "staggered step-length labels overprint"
 
 
 class TestStepLadderRecognition:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4721,6 +4721,26 @@ class TestTurnedLengths:
             for j in range(i + 1, len(boxes))
         ), "step-length dims overprint — chain crammed instead of skipping"
 
+    def test_short_segment_arrows_cram_skips_even_when_labels_fit(self):
+        # The gramel thumbwheel drive screw (GRM-03): fine steps near the head + one
+        # long shaft. The strip solver CAN spread the labels into the shaft's empty
+        # space (so the label-overlap guard passes), but the head segments are
+        # narrower than two arrowheads, so the dimension-line arrows overprint at the
+        # shoulders regardless. The raw segment width must gate the chain too (#293).
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        b = Align.MIN
+        specs = [(8, 1.0), (12, 1.0), (8, 1.0), (12, 1.0), (6, 30.0)]
+        shaft = None
+        z = 0.0
+        for d, ln in specs:
+            seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
+            shaft = seg if shaft is None else shaft + seg
+            z += ln
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft)
+        assert not any(n.startswith("m_steplen") for n in dwg._named)  # skipped, not crammed
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) >= 1
+
 
 class TestStepLadderRecognition:
     """ADR 0008 step 1: the Z step-height ladder draws its step levels from the


### PR DESCRIPTION
## What

The gramel **GRM-03 thumbwheel drive screw** rendered a crammed, illegible
step-length chain on the front view. This makes the chain legible **at the
drawing's own scale** (no rescale) by staggering it across two tiers, and lifts
the neighbouring view to make room.

(Supersedes this branch's first commit, which merely *skipped* a too-dense chain
— that wasted the empty sheet and dropped all axial dims. Net diff is the
staggering approach below.)

## Root cause

The horizontal step-length chain only skipped/crammed because it placed every dim
on **one tier**. The strip solver could spread the *labels* along the view, but
the **dimension-line arrowheads** stayed at the real shoulders and overprinted.

## Fix

1. **ISO 129-1 staggering (`render_step_lengths`)** — when one tier's labels would
   collide, alternate successive dims between a near and a far tier so every step
   length stays legible. A roomy chain stays on one tier (no needless zig-zag);
   skip only when even two tiers can't separate the labels.
2. **New repack trigger `_annotation_view_overlaps` (`builder.py`)** — the taller
   staggered chain can grow into the plan view above the front view. The
   measure-and-repack already captures the real footprint, but its triggers only
   saw annotation-vs-annotation overlap and page overflow — never an annotation
   growing into a neighbouring view's *line-work*. This third trigger lifts the
   plan view into the headroom so the chain gets its room.

## Tests

- **`TestLayoutCleanlinessInvariant`** — end-to-end check that the *finished*
  drawing has no layout-collision lint across six part archetypes. This is the
  outcome test that was missing: the prior repack tests checked the *mechanism*
  (`_cross_view_overlaps`, disjoint packing), not the *result* — which is why this
  class of bug slipped through.
- unit test for the new `_annotation_view_overlaps` trigger.
- crowded-chain test rewritten to assert staggering + legibility, not skip.

Full fast tier: **609 passed**.

## Adversarial review (tried to refute)

- **Does it stagger unnecessarily?** No — fixed: a roomy chain (`_clear(cw)` true)
  stays single-tier; verified a simple 2-step shaft renders on one row.
- **Does the new trigger fire spuriously?** Full `make_drawing` (387 → 395) and the
  full fast tier (609) show zero regressions; a trivial bbox clip resolves to a
  cheap no-op repack. (Sharp edge tracked: #303 — add an overlap-area threshold.)
- **Convergence?** One repack pass suffices because the chain depth is
  scale/corridor-independent. (General single-pass limit tracked: #302.)

## Known limit (out of scope)

A **sub-floor head** — a shoulder gap below ~2× arrow_length on the page (GRM-03's
0.5 mm step is 1 mm at 2:1, 6× too tight) — **cannot** be made clean by any
in-line technique. The textbook fix is an enlarged detail view, filed as **#304**.
Also surfaced on this part: **#298** (ø6 band hidden under ø10), **#300** (scaler
under-fill), **#305** (bore callout overlaps the view centerline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)