### PR TITLE
feat: auto detail view for turned heads with sub-floor steps (#304)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -584,7 +584,7 @@ def render_envelope(dwg, groups, a) -> int:
     return n
 
 
-def render_step_lengths(dwg, groups) -> int:
+def render_step_lengths(dwg, groups, head_band=None) -> int:
     """Unified turned step-length chain (ADR 0008 #223) — one IR-driven path that
     replaces the engine's asymmetric X-chain / Z-ladder. Each `StepFeature`'s length
     span is projected into the front view; the chain runs *along the projected axis*
@@ -594,8 +594,14 @@ def render_step_lengths(dwg, groups) -> int:
 
     The chain is collinear (all segments share one offset line) and tiles end to
     end, so every shoulder is located. Crowded labels are spread along the line by
-    the ADR-0003 strip solve (the primitive the engine's X chain already used)."""
-    segs = []  # (page_lo, page_hi, value), in axis order
+    the ADR-0003 strip solve (the primitive the engine's X chain already used).
+
+    ``head_band`` ``(band_lo, band_hi, _)`` (#304): when an X-turned head is too
+    crowded to dimension in line and gets an enlarged detail view, the steps inside
+    the band are NOT chained here — the main view shows the head as one block dim
+    (located against the shaft), and the detail breaks it down. ``None`` (default)
+    keeps the full chain."""
+    segs = []  # (page_lo, page_hi, value, world_lo, world_hi), in axis order
     for g in groups:
         if g.feature_kind != "step":
             continue
@@ -607,13 +613,37 @@ def render_step_lengths(dwg, groups) -> int:
             continue
         a, b = length.span
         pa, pb = dwg.at("front", *a), dwg.at("front", *b)
-        segs.append((pa, pb, length.value))
+        segs.append((pa, pb, length.value, min(a[0], b[0]), max(a[0], b[0])))
     if not segs:
         return 0
     vb = dwg.view_bounds("front")
     if vb is None:
         return 0
     x0, y0, x1, y1 = vb
+
+    # Detail-view coordination (#304): drop the head steps from the main chain and
+    # replace them with a single head-block dim, so the head is located as a unit
+    # here and broken down in the detail (no double-dimensioning).
+    if head_band is not None:
+        band_lo, band_hi, _ = head_band
+        head = [s for s in segs if band_lo - 1e-6 <= s[3] and s[4] <= band_hi + 1e-6]
+        segs = [s for s in segs if s not in head]
+        if head:
+            hlo, hhi = min(s[3] for s in head), max(s[4] for s in head)
+            ha, hb = dwg.at("front", hlo, 0, 0), dwg.at("front", hhi, 0, 0)
+            block_gap = dwg.draft.font_size + 4 * dwg.draft.pad_around_text
+            block = _dim(
+                (ha[0], y1, 0),
+                (hb[0], y1, 0),
+                "above",
+                block_gap,
+                dwg.draft,
+                label=_fmt(hhi - hlo),
+            )
+            dwg.add(block, "m_steplen_head", view="front")
+            if not segs:
+                return 1
+    segs = [(pa, pb, v) for pa, pb, v, _wlo, _whi in segs]
     draft = dwg.draft
     gap = draft.font_size + 4 * draft.pad_around_text
     # Orientation is data: the projected span direction. Horizontal → X-turned

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -44,7 +44,12 @@ from draftwright.annotations.holes import (
     _annotate_holes,
     _locate_off_axis_holes,
 )
-from draftwright.annotations.sections import _add_detail_view, _add_section_view
+from draftwright.annotations.sections import (
+    _add_detail_view,
+    _add_section_view,
+    _add_turned_detail_view,
+    _turned_head_band,
+)
 from draftwright.model import build_part_model, plan_dimensions, plan_sections
 from draftwright.recognition import (
     full_cylinders,
@@ -237,7 +242,15 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     #    suppressed so the chain does not double-dimension the length.
     render_diameters(dwg, _groups)
     if a.prof is not None:
-        render_step_lengths(dwg, _groups)
+        # A turned head whose shoulders are too close to dimension legibly even
+        # staggered gets an auto enlarged detail view (#304) — the textbook fix for
+        # a fine head + long shaft. The band is computed once: the main chain shows
+        # the head as one block (located against the shaft), the detail breaks it
+        # down. ``None`` when nothing is sub-floor → the full staggered chain.
+        head_band = _turned_head_band(a, dwg.draft.arrow_length)
+        render_step_lengths(dwg, _groups, head_band=head_band)
+        if head_band is not None:
+            _add_turned_detail_view(dwg, a, head_band)
 
     # Side-drilled (X/Y-axis) hole locations — last, so the envelope and
     # turned-diameter dims claim their strip space first and are never evicted (#133).

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -259,6 +259,209 @@ def _add_section_view(dwg, a: Analysis, section):
         dwg.add(hatch, "section_hatch")
 
 
+def _turned_head_band(a: Analysis, arrow_length: float):
+    """The crowded X-band of an X-turned part: the contiguous span covering every
+    step whose length is below the page legibility floor (two arrowheads can't fit
+    between its shoulders at sheet scale), extended by one bracketing shoulder each
+    side for context, padded and clamped to the bbox. Returns ``(band_lo, band_hi,
+    detail_scale)`` or ``None`` when the part is not X-turned or nothing is
+    sub-floor (the staggered main-view chain already handles it). (#304)"""
+    prof = a.prof
+    if prof is None or prof.axis != "x" or len(prof.steps) < 2:
+        return None
+    floor = 2 * arrow_length / a.SCALE  # part-mm: below this, arrowheads collide
+    steps = sorted(prof.steps, key=lambda s: s.lo)
+    sub_idx = [i for i, s in enumerate(steps) if s.length < floor]
+    if not sub_idx:
+        return None
+    # Grow the crowded cluster outward from the sub-floor steps over *contiguous*
+    # near-floor neighbours (length < 2x floor) so the head reads as a unit — but
+    # STOP at a clearly larger step (e.g. the long shaft), or the band would swallow
+    # it and there'd be nothing left to locate the head against.
+    cluster_floor = 2 * floor
+    i0, i1 = min(sub_idx), max(sub_idx)
+    while i0 > 0 and steps[i0 - 1].length < cluster_floor:
+        i0 -= 1
+    while i1 < len(steps) - 1 and steps[i1 + 1].length < cluster_floor:
+        i1 += 1
+    lo, hi = steps[i0].lo, steps[i1].hi
+    pad = 0.08 * (hi - lo) + 1.0
+    band_lo = max(a.bb.min.X, lo - pad)
+    band_hi = min(a.bb.max.X, hi + pad)
+    # Detail scale: smallest standard multiple of sheet scale that separates the
+    # closest in-band shoulder pair to >= _MIN_STEP_SEP_MM (always >= 2x).
+    in_band = [s.length for s in prof.steps if band_lo - pad <= s.lo and s.hi <= band_hi + pad]
+    min_gap = min(in_band) if in_band else min(steps[i].length for i in sub_idx)
+    need = _MIN_STEP_SEP_MM / min_gap if min_gap > 0 else float("inf")
+    detail_scale = a.SCALE * 2
+    for factor in (2, 5, 10):
+        detail_scale = a.SCALE * factor
+        if detail_scale >= need:
+            break
+    return band_lo, band_hi, detail_scale
+
+
+def _add_turned_detail_view(dwg, a: Analysis, band):
+    """Enlarged detail of an X-turned part's crowded head (#304).
+
+    The X-axis sibling of :func:`_add_detail_view`: when the front-view step-length
+    chain has shoulders too close to dimension legibly even staggered, crop the
+    dense X-band, project it front-on at a larger standard scale into the largest
+    free rectangle, mark the region on the front view, and caption it "DETAIL A".
+    Every risky boolean/projection is wrapped and skips-with-log rather than
+    aborting the drawing; returns early (unchanged) when nothing needs detailing.
+    The head's step dimensions are drawn into the detail here."""
+    if band is None:
+        return
+    band_lo, band_hi, detail_scale = band
+
+    # Crop to the X-band (remove x<band_lo and x>band_hi); solids only — a mixed
+    # compound (PMI curves) cannot be cut.
+    solids = a.part.solids()
+    if not solids:
+        _log.info("Turned detail skipped (no solid bodies to crop)")
+        return
+    body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
+    big = 4 * a.bbox_max
+    try:
+        cropped = _fuzzy_cut(body, Pos(band_lo - big / 2, a.cy, a.cz) * Box(big, big, big))
+        if cropped is not None:
+            cropped = _fuzzy_cut(cropped, Pos(band_hi + big / 2, a.cy, a.cz) * Box(big, big, big))
+    except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
+        _log.warning("Turned detail skipped (crop failed: %s)", exc)
+        return
+    if cropped is None:
+        _log.warning("Turned detail skipped (boolean crop produced no solid)")
+        return
+
+    # Placement: largest empty rectangle avoiding every placed view + title block.
+    drawable = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
+    obstacles = []
+    for vis, hid in dwg.views.values():
+        for shp in (vis, hid):
+            if shp is None:
+                continue
+            vb = shp.bounding_box()
+            obstacles.append((vb.min.X, vb.min.Y, vb.max.X, vb.max.Y))
+    obstacles.append(
+        (a.PAGE_W - a.TB_W - _TB_CLEAR, a.margin, a.PAGE_W - _TB_CLEAR, _TB_CLEAR + _TB_H)
+    )
+    rx0, ry0, rx1, ry1 = _largest_empty_rect(drawable, obstacles)
+    rect_w, rect_h = rx1 - rx0, ry1 - ry0
+
+    # Footprint at the chosen scale: band width + a two-tier chain above + caption
+    # below. Shrink the scale to fit if necessary (never below 1.2x — a genuine
+    # enlargement).
+    tier = dwg.draft.font_size + 2 * dwg.draft.pad_around_text
+    chain_h = 2 * tier + a.DIM_PAD
+    band_w = band_hi - band_lo
+    while detail_scale > a.SCALE * 1.2:
+        detail_w = band_w * detail_scale + 2 * a.DIM_PAD
+        detail_h = a.z_size * detail_scale + chain_h + a.DIM_PAD + 8
+        if detail_w <= rect_w and detail_h <= rect_h:
+            break
+        detail_scale -= a.SCALE
+    detail_w = band_w * detail_scale + 2 * a.DIM_PAD
+    detail_h = a.z_size * detail_scale + chain_h + a.DIM_PAD + 8
+    if detail_scale <= a.SCALE * 1.2 or detail_w > rect_w or detail_h > rect_h:
+        _log.info("Turned detail skipped (no room)")
+        return
+
+    DX = (rx0 + rx1) / 2
+    DY = (ry0 + ry1) / 2
+
+    # Project the cropped band front-on (look from −Y, up +Z), at detail_scale
+    # around the band's own centroid, mirroring _add_detail_view.
+    cb = cropped.bounding_box()
+    dcx = (cb.min.X + cb.max.X) / 2
+    dcy = (cb.min.Y + cb.max.Y) / 2
+    dcz = (cb.min.Z + cb.max.Z) / 2
+    la = (dcx * detail_scale, dcy * detail_scale, dcz * detail_scale)
+    dist_d = a.bbox_max * detail_scale + 100
+    camera = (la[0], la[1] - dist_d, la[2])
+    try:
+        band_s = cropped.scale(detail_scale)
+        dwg.add_view("detail_a", band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True)
+    except Exception as exc:  # noqa: BLE001 — projection raises broadly on cast geometry
+        _log.warning("Turned detail skipped (projection failed: %s)", exc)
+        return
+    dwg._coords["detail_a"] = ViewCoordinates(
+        view_axes(camera, (0, 0, 1), la), DX, DY, dcx, dcy, dcz, detail_scale
+    )
+
+    # Marker on the front view: a rectangle around the X-band, captioned 'A'.
+    FX = a.proj.front_x
+    FZ = a.proj.front_z
+    mx0, mx1 = FX(band_lo), FX(band_hi)
+    my0, my1 = FZ(a.bb.min.Z), FZ(a.bb.max.Z)
+    marker = Compound(
+        children=[
+            Edge.make_line(Vector(mx0, my0, 0), Vector(mx1, my0, 0)),
+            Edge.make_line(Vector(mx1, my0, 0), Vector(mx1, my1, 0)),
+            Edge.make_line(Vector(mx1, my1, 0), Vector(mx0, my1, 0)),
+            Edge.make_line(Vector(mx0, my1, 0), Vector(mx0, my0, 0)),
+        ]
+    )
+    marker.is_centerline = True  # furniture, not a dimension — exempt from overlap lint
+    dwg.add(marker, "detail_marker")
+    dwg.add(Note("A", (mx1 + 3, my1 + 2), dwg.draft), "detail_marker_label")
+
+    # Step-length chain in the detail: a staggered horizontal chain above the
+    # detail view (same ISO 129-1 staggering as the main chain), at detail_scale
+    # where the head's shoulders separate. Tag each dim with the detail scale so
+    # label-vs-measured lint compares against the right scale (#42).
+    z_top = a.bb.max.Z
+    head_steps = [s for s in a.prof.steps if band_lo - 1e-6 <= s.lo and s.hi <= band_hi + 1e-6]
+    draft = dwg.draft
+    tier_step = draft.font_size + 2 * draft.pad_around_text
+    cw = [
+        (
+            (dwg.at("detail_a", s.lo, dcy, z_top)[0] + dwg.at("detail_a", s.hi, dcy, z_top)[0])
+            / 2,
+            len(_fmt(s.length)) * draft.font_size * 0.62,
+        )
+        for s in head_steps
+    ]
+
+    def _clear(items):
+        return all(
+            c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
+            for (c1, w1), (c2, w2) in zip(items, items[1:])
+        )
+
+    tiers = [0] * len(head_steps)
+    if not _clear(cw) and _clear(cw[0::2]) and _clear(cw[1::2]):
+        tiers = [i % 2 for i in range(len(head_steps))]
+    det_top = dwg.at("detail_a", band_lo, dcy, z_top)[1]
+    for i, s in enumerate(head_steps):
+        try:
+            p1 = dwg.at("detail_a", s.lo, dcy, z_top)
+            p2 = dwg.at("detail_a", s.hi, dcy, z_top)
+            det_dim = _dim(
+                (p1[0], det_top, 0),
+                (p2[0], det_top, 0),
+                "above",
+                a.DIM_PAD + tiers[i] * tier_step,
+                draft,
+                label=_fmt(s.length),
+            )
+            det_dim._dw_scale = detail_scale
+            dwg.add(det_dim, f"dim_detail_steplen_{i}", view="detail_a")
+        except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
+            _log.info("dim_detail_steplen_%d skipped (%s)", i, exc)
+
+    # Caption below the detail, anchored to the view's real footprint.
+    dvb = dwg.views["detail_a"][0].bounding_box()
+    dwg.add(
+        Note(
+            f"DETAIL A — SCALE {format_drawing_scale(detail_scale)}",
+            ((dvb.min.X + dvb.max.X) / 2, dvb.min.Y - 8),
+            dwg.draft,
+        ),
+        "detail_caption",
+    )
+
+
 def _add_detail_view(dwg, a: Analysis):
     """Enlarged detail of a stepped region whose shoulders the legibility gate
     dropped (#42).

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -38,9 +38,18 @@ _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=No
 
 
 def _dim_vertices(ann) -> list[tuple[float, float]]:
-    """A ``Dimension``'s vertices as ``(x, y)`` page points; ``[]`` if they won't
-    evaluate. The shared, error-tolerant harvest both drawing-derived coverage
-    checks use to read placed dimensions back off the drawing."""
+    """A ``Dimension``'s witness endpoints as ``(x, y)`` page points; ``[]`` if they
+    won't evaluate. The shared, error-tolerant harvest both drawing-derived coverage
+    checks use to read placed dimensions back off the drawing.
+
+    Prefers the recorded ``_dw_spec`` endpoints (the two points the dimension was
+    built from — the shoulder/feature positions) over ``ann.vertices()``: the latter
+    returns *every* geometry vertex, including the text-glyph outline, whose points
+    scatter across the span and can falsely satisfy a shoulder match for a wide dim
+    (e.g. a head-block dim whose centred label sits over interior shoulders, #304)."""
+    spec = getattr(ann, "_dw_spec", None)
+    if spec is not None:
+        return [(spec.p1[0], spec.p1[1]), (spec.p2[0], spec.p2[1])]
     try:
         return [(p.X, p.Y) for p in ann.vertices()]
     except Exception:  # noqa: BLE001 — a dim whose vertices won't evaluate is skipped
@@ -313,43 +322,47 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
     base = [c.X, c.Y, c.Z]
     use_x = prof.axis == "x"  # horizontal chain → match page-x; else vertical → page-y
 
-    def shoulder_coord(s: float) -> float:
+    def shoulder_coord(view: str, s: float) -> float:
         pt = list(base)
         pt[idx] = s
-        px, py, *_ = dwg.at("front", *pt)
+        px, py, *_ = dwg.at(view, *pt)
         return float(px if use_x else py)
 
-    shoulder_c = {s: shoulder_coord(s) for s in prof.shoulders}
-    dims = [
-        (
-            str(getattr(ann, "label", "") or ""),
-            {(x if use_x else y) for x, y in _dim_vertices(ann)},
-        )
-        for _name, ann in dwg.annotations_in_view("front")
-        if isinstance(ann, Dimension)
-    ]
-    # A collapsed uniform-staircase dim ("N× v", #230) spans the whole run with
-    # witnesses only at the extreme shoulders, yet locates *every* shoulder of the
-    # uniform chain — the collapse fires only when all steps are equal. Count it as
-    # full coverage when such a dim spans the shoulder extent.
-    coords = list(shoulder_c.values())
-    cmin, cmax = min(coords), max(coords)
-    for label, cs in dims:
-        if (
-            re.match(r"^\s*\d+\s*×", label)
-            and any(abs(v - cmin) <= tol for v in cs)
-            and any(abs(v - cmax) <= tol for v in cs)
-        ):
-            return len(prof.steps)
-    covered = 0
-    for step in prof.steps:
-        clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]
-        if any(
-            any(abs(v - clo) <= tol for v in cs) and any(abs(v - chi) <= tol for v in cs)
-            for _label, cs in dims
-        ):
-            covered += 1
-    return covered
+    # A crowded X-turned head is dimensioned in the enlarged detail view (#304), not
+    # the front chain — so a shoulder counts as located when matched in EITHER view.
+    views = ["front"] + (["detail_a"] if "detail_a" in dwg.views else [])
+    covered_steps: set[int] = set()
+    for view in views:
+        shoulder_c = {s: shoulder_coord(view, s) for s in prof.shoulders}
+        dims = [
+            (
+                str(getattr(ann, "label", "") or ""),
+                {(x if use_x else y) for x, y in _dim_vertices(ann)},
+            )
+            for _name, ann in dwg.annotations_in_view(view)
+            if isinstance(ann, Dimension)
+        ]
+        # A collapsed uniform-staircase dim ("N× v", #230) spans the whole run with
+        # witnesses only at the extreme shoulders, yet locates *every* shoulder of the
+        # uniform chain — the collapse fires only when all steps are equal. Count it as
+        # full coverage when such a dim spans the shoulder extent.
+        coords = list(shoulder_c.values())
+        cmin, cmax = min(coords), max(coords)
+        for label, cs in dims:
+            if (
+                re.match(r"^\s*\d+\s*×", label)
+                and any(abs(v - cmin) <= tol for v in cs)
+                and any(abs(v - cmax) <= tol for v in cs)
+            ):
+                return len(prof.steps)
+        for i, step in enumerate(prof.steps):
+            clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]
+            if any(
+                any(abs(v - clo) <= tol for v in cs) and any(abs(v - chi) <= tol for v in cs)
+                for _label, cs in dims
+            ):
+                covered_steps.add(i)
+    return len(covered_steps)
 
 
 def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4834,25 +4834,25 @@ class TestTurnedLengths:
         ), "step-length dims overprint — chain crammed instead of skipping"
 
     def test_crowded_chain_staggers_into_two_tiers_at_current_scale(self):
-        # The gramel thumbwheel drive screw (GRM-03): fine steps near the head + one
-        # long shaft. Rather than skip (wasting the empty sheet) or cram, the chain
-        # staggers successive dims between a near and a far tier (ISO 129-1) so every
-        # step length is legible at the drawing's own scale (#293). All segments are
-        # dimensioned, the labels don't overprint each other, and axial coverage is
-        # satisfied — no rescale needed.
+        # A *moderately* crowded chain — steps just ABOVE the arrowhead floor (so no
+        # detail view is triggered), but with labels that would collide on one tier.
+        # Rather than cram, the chain staggers successive dims between a near and a
+        # far tier (ISO 129-1) so every step length is legible at the drawing's own
+        # scale (#293). Scale pinned so the crowding regime is deterministic.
         from build123d import Align, Cylinder, Pos, Rotation
 
         from draftwright.annotations._common import _anno_box
 
         b = Align.MIN
-        specs = [(8, 1.0), (12, 1.0), (8, 1.0), (12, 1.0), (6, 30.0)]
+        specs = [(8, 3.1), (12, 2.9), (8, 3.2), (12, 2.8), (6, 3.0)]  # ~3 mm, > floor
         shaft = None
         z = 0.0
         for d, ln in specs:
             seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
             shaft = seg if shaft is None else shaft + seg
             z += ln
-        dwg = build_drawing(Rotation(0, 90, 0) * shaft)
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft, scale=2.0)
+        assert "detail_a" not in dwg.views  # above floor → no detail, staggered in place
         steps = {n: o for n, o in dwg._named.items() if n.startswith("m_steplen")}
         assert len(steps) == 5  # every segment dimensioned, none dropped
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
@@ -4870,6 +4870,39 @@ class TestTurnedLengths:
             for i in range(len(boxes))
             for j in range(i + 1, len(boxes))
         ), "staggered step-length labels overprint"
+
+    def test_subfloor_head_gets_detail_view(self):
+        # The gramel GRM-03 pattern: a fine head (sub-floor steps) + a long shaft.
+        # The head can't be dimensioned legibly in line at sheet scale, so it gets an
+        # enlarged DETAIL A: the main view locates the head as one block + the shaft,
+        # the detail breaks the head into its individual steps, and axial coverage is
+        # satisfied across the two views (no double-dimensioning). (#304)
+        #
+        # Head steps are 2 mm — sub-floor at the pinned 2:1 (4 mm < 2x arrow), but
+        # legible once the detail enlarges them — so the detail genuinely resolves
+        # them (an ultra-fine head can still out-run the detail's room; that is the
+        # scaler/room limit, #300).
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        b = Align.MIN
+        specs = [(4, 2.0), (6, 2.0), (4, 2.0), (3, 25.0)]
+        shaft = None
+        z = 0.0
+        for d, ln in specs:
+            seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
+            shaft = seg if shaft is None else shaft + seg
+            z += ln
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft, scale=2.0)
+        assert "detail_a" in dwg.views  # crowded head → enlarged detail
+        # Main view: head block + shaft, not the fine head steps.
+        main = {o.label for n, o in dwg._named.items() if n.startswith("m_steplen")}
+        assert "m_steplen_head" in dwg._named
+        assert "25" in main  # the legible shaft stays in the main chain
+        # Detail view carries the head breakdown (the three 2 mm steps).
+        det = [n for n in dwg._named if n.startswith("dim_detail_steplen")]
+        assert len(det) >= 3
+        # Coverage satisfied across both views — no false axial_length_missing.
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
 
 
 class TestStepLadderRecognition:


### PR DESCRIPTION
## What

A turned part with a fine head and a long shaft — the gramel **GRM-03 drive
screw** — can't have its head dimensioned legibly in line at any sensible scale:
the shoulders are physically too close (its 0.5 mm step is 1 mm on the page at
2:1). The textbook fix is an enlarged detail view; this generates one
automatically.

Result for GRM-03: the main front view locates the head as one `8.7` block (with
an **A** marker box) + the `20` shaft, and **DETAIL A — SCALE 4:1** breaks the
head down into `3.2 / 0.5 / 2 / 3`. No cramming, no double-dimensioning.

## How

- **`_turned_head_band`** (`sections.py`): the crowded X-band — the contiguous run
  of steps below the page arrowhead floor, grown over near-floor neighbours but
  **stopping at a clearly larger step** (so it never swallows the shaft) — plus the
  detail scale that separates the closest shoulder pair.
- **`_add_turned_detail_view`** (`sections.py`): the X-axis sibling of the
  prismatic `_add_detail_view` — crop the band, project front-on at the detail
  scale into the largest free rectangle, draw the head's staggered chain there,
  mark the region, caption it. Skips-with-log (never aborts) when there's no room.
- **Coordination** (`render_step_lengths` + orchestrator): the band is computed
  once; the main chain drops the head steps and shows the head as one block dim
  (located against the shaft), the detail breaks it down. `head_band=None` keeps
  the full chain (unchanged default).
- **Axial coverage** (`linting/coverage.py`): credit shoulders located in EITHER
  the front or the detail view, so a detailed head isn't falsely flagged.

## Latent bug fixed (surfaced here)

`_dim_vertices` read **every** geometry vertex — including the text-glyph outline —
so a wide dim whose centred label sat over interior shoulders could *fake* shoulder
coverage. It now reads the recorded `_dw_spec` witness endpoints. (This is why the
no-room fallback now honestly reports `axial_length_missing` instead of silently
passing.)

## Tests

- `test_subfloor_head_gets_detail_view` — sub-floor head → detail placed, main =
  block + shaft, detail breaks it down, coverage satisfied across both views.
- `test_crowded_chain_staggers_into_two_tiers_at_current_scale` — retargeted to a
  *moderately* crowded chain (above floor) so it asserts staggering, not detail.
- Full fast tier: **610 passed**.

## Adversarial review (tried to refute)

- **`_dim_vertices` ripples to ALL coverage (axial + location).** The 91-test
  coverage cohort and the full 610 tier pass — no location-coverage regression;
  dims without `_dw_spec` fall back to `vertices()` unchanged.
- **Detail fails to place → head undimensioned?** Verified honest: the coverage
  fix makes `axial_length_missing` fire (not silent) when the detail can't fit.
- **`detail_a` vs the repack trigger?** `detail_a` isn't an ortho view, so it's
  exempt from `_annotation_view_overlaps` / `_measure_blocks`, and it's placed in
  the largest rect avoiding every view — no cross-view collision.
- **Double-detail?** An x-turned part has empty `step_zs`, so the prismatic
  `_add_detail_view` can't also fire on `detail_a`.
- **Band swallows the shaft?** Fixed: cluster growth stops at a step ≥ 2× floor
  (the long shaft), verified on both GRM-03 and a synthetic `[1,1,1,1,30]`.

## Known limit / follow-ups

The detail is placed into **leftover sheet space**, so an ultra-fine head (GRM-03's
0.5 mm needs ~14:1) can out-run the room and land lower (4:1 — better than in line,
not perfect). Tracked as **#306** (detail-view page escalation). The two bespoke
detailers (prismatic + turned) should fold into one generic
detection→plan→render path — **#307**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)