### PR TITLE
fix: angle a coaxial bore callout off the round view's centre axis (#305)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -514,6 +514,37 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
             return centre
         return (centre[0] + dx / norm * r, centre[1] + dy / norm * r)
 
+    def _coaxial_lift(centre, ny, view_cx, view_cy, y_min, y_max):
+        """Leader row for a hole, lifted clear of the round view's centre axis when
+        the hole is a *coaxial bore* (#305); *ny* unchanged otherwise.
+
+        A bore on the turning axis is led out along the view's horizontal centre
+        axis, so the centre mark / centreline runs straight through the "⌀… ↓…"
+        callout text. Detect that one bore — a rotational part, hole at the view
+        centre — and lift its row a clearance off the axis (an angled leader to a
+        central feature is standard practice), toward the roomier side. Off-axis
+        holes and every prismatic-part hole are untouched (front-view round parts
+        place coaxial bores as vertical shafts below the view, not along an axis,
+        so they can't hit this and are exempt by construction).
+
+        Tactical: the principled fix is to not draw the crossing line at all — a
+        centred bore is located by the axis, so its linear location dims are
+        redundant (#309) — or to make this a layout-solver separation constraint
+        (ADR 0003). This nudge becomes dead code once either lands."""
+        tol = draft.font_size  # "hole at the view centre" tolerance (page mm)
+        if not (
+            a.is_rotational and abs(centre[0] - view_cx) < tol and abs(centre[1] - view_cy) < tol
+        ):
+            return ny
+        # Lift the row a full text height + padding clear of the axis: enough for
+        # the text box (half a font tall) to sit wholly off the centre line with a
+        # pad of margin, giving a legible leader angle rather than a near-flat one.
+        lift = draft.font_size + 3 * draft.pad_around_text
+        # Toward the roomier half-view (geometric, not occupancy-aware — safe here
+        # because the round view of a coaxial bore is otherwise near-empty).
+        up = (y_max - view_cy) >= (view_cy - y_min)
+        return min(view_cy + lift, y_max) if up else max(view_cy - lift, y_min)
+
     def _add(view, i, tip, elbow, side, callout):
         dwg.add(
             Leader(
@@ -598,6 +629,12 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
         else:
             y_min, y_max = a.SV_Y - a.fv_hh, a.SV_Y + a.fv_hh
 
+        # Round view's horizontal centre axis — a coaxial bore led out along it has
+        # its callout text crossed by the centre mark / centreline (#305); see
+        # _coaxial_lift.
+        view_cx = a.PV_X if view == "plan" else a.SV_X
+        view_cy = a.PV_Y if view == "plan" else a.SV_Y
+
         # --- Pass 1: boundary assignment ---
         right_queue = []  # (locs, dia, callout, feat, natural_y, rep)
         left_queue = []
@@ -632,9 +669,11 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                 continue
 
             if can_right and (not can_left or d_right <= d_left):
-                right_queue.append((locs, dia, callout, feat, centre_r[1], rep_r))
+                ny = _coaxial_lift(centre_r, centre_r[1], view_cx, view_cy, y_min, y_max)
+                right_queue.append((locs, dia, callout, feat, ny, rep_r))
             else:
-                left_queue.append((locs, dia, callout, feat, centre_l[1], rep_l))
+                ny = _coaxial_lift(centre_l, centre_l[1], view_cx, view_cy, y_min, y_max)
+                left_queue.append((locs, dia, callout, feat, ny, rep_l))
 
         # Sort each queue by natural Y so leaders don't cross.
         right_queue.sort(key=lambda s: s[4])

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3738,6 +3738,68 @@ class TestLayoutGeneralisation:
         assert n_callouts > 4, f"expected adaptive >4 callouts, got {n_callouts}"
         assert "callout_dropped" not in {i.code for i in dwg.lint()}
 
+    def test_coaxial_bore_callout_clears_centre_axis(self):
+        # #305: a coaxial axial bore on the round (end) view must be leadered OFF
+        # the view's horizontal centre axis. Led out along it, the centre mark and
+        # the bore's own location-dim extension line run straight through the
+        # "⌀… ↓…" callout text (a drafting defect). Assert no horizontal line
+        # crosses the callout text box.
+        from build123d import BuildPart, Cylinder, Hole, Rotation
+
+        from draftwright import build_drawing
+
+        with BuildPart() as p:
+            Cylinder(radius=6, height=20)
+            Hole(0.8, depth=8)  # coaxial axial bore: ⌀1.6, depth 8
+        dwg = build_drawing(Rotation(0, 90, 0) * p.part, scale=2.0)  # axis along X
+
+        hc = [(n, o) for n, o in dwg._named.items() if n.startswith("hc_side")]
+        assert hc, "expected a bore callout on the round (side) view"
+        name, leader = hc[0]
+        tx0, ty0, tx1, ty1 = leader.label_bbox
+
+        crossings = []
+        for n, o in dwg._named.items():
+            if n == name:
+                continue  # the callout's own shelf ends before its text
+            try:
+                edges = list(o.edges())
+            except Exception:
+                continue
+            for e in edges:
+                vs = e.vertices()
+                if len(vs) != 2:
+                    continue
+                (x0, y0), (x1, y1) = (vs[0].X, vs[0].Y), (vs[1].X, vs[1].Y)
+                if abs(y0 - y1) < 0.05 and abs(x0 - x1) > 1.0:  # a horizontal line
+                    ym = (y0 + y1) / 2
+                    xa, xb = min(x0, x1), max(x0, x1)
+                    if ty0 + 0.3 < ym < ty1 - 0.3 and xb > tx0 + 0.3 and xa < tx1 - 0.3:
+                        crossings.append((n, round(ym, 2)))
+        assert not crossings, f"line(s) cross the bore callout text: {crossings}"
+
+    def test_prismatic_central_hole_callout_not_lifted(self):
+        # Scope-lock for #305: the coaxial-bore lift is gated to rotational parts.
+        # A *prismatic* part's central hole stays on the plan-view centre row —
+        # lifting it (the over-broad first cut of this fix) regressed the section /
+        # cbore layouts, because only the rotational round view carries the crossing
+        # centre axis. Without the is_rotational gate this callout jumps a
+        # font-height off the axis; assert it does not.
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        part = Box(80, 60, 20) - Cylinder(4, 20) - Pos(10, 5, -7) * Cylinder(6, 6)
+        dwg = build_drawing(part)
+        assert not dwg._analysis.is_rotational
+        plan_mids = [
+            (o.label_bbox[1] + o.label_bbox[3]) / 2
+            for n, o in dwg._named.items()
+            if n.startswith("hc_plan") and getattr(o, "label_bbox", None)
+        ]
+        assert plan_mids, "expected plan-view hole callouts"
+        assert min(abs(m - dwg._analysis.PV_Y) for m in plan_mids) < dwg.draft.font_size
+
     @pytest.mark.timeout(120)
     def test_step_height_legibility_threshold(self):
         # The step-height dimension gate is the legibility constant


### PR DESCRIPTION
Closes #305.

On the round (end) view of a turned part, a coaxial axial-bore `HoleCallout` (`⌀1.6 ↓16`) was leadered **horizontally along the view's centre axis**, so a line ran straight through the callout text — a drafting defect.

**Before / after** (the GRM-03-style drive screw):

| before | after |
|---|---|
| leader horizontal, line through `⌀1.6 ↓16` | angled leader, text in clean space |

## Root cause (corrected the issue's hypothesis)
Not the view centerline — this round view has **none**. The crossing line is the **location dimension's extension line** (`dim_loc_side_z600`) running along the bore's centre row, where the callout also sits.

## Fix
`_coaxial_lift` (in the plan/side hole placement) detects a **coaxial bore** — a rotational part with the hole at the view centre in *both* axes — and lifts only its leader row a clearance off the axis, toward the roomier half. An angled leader to a central feature is standard practice. Off-axis holes and **every prismatic-part hole are untouched**.

## Scoped after adversarial review
The first cut keyed on row-proximity (~9mm band) and **regressed 2 prismatic-part tests** (`test_underside_cbore_triggers_a_section`, `test_section_clears_the_step_dim_ladder`) by lifting plan-view central holes of `Box` parts. Tightened to `is_rotational` + coaxial, and separated the detection tolerance from the lift distance (they were one conflated constant). A reviewer pass independently reached the same gate and confirmed the front view is exempt by construction.

## Tests
- `test_coaxial_bore_callout_clears_centre_axis` — no horizontal line crosses the bore callout text (fails without the fix).
- `test_prismatic_central_hole_callout_not_lifted` — locks the narrow scope (would fail under the over-broad first cut).
- Full fast tier: **611 passed**; ruff + format + mypy clean.

## Follow-up
The principled fix is to not draw the redundant dim at all — a centred bore is located by the axis. Filed as **#309**; this nudge becomes dead code once that (or an ADR-0003 layout constraint) lands. The docstring says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
