### PR TITLE
feat: unified detail-view pipeline — detect → request → generic render (#307)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -382,6 +382,52 @@ def _largest_empty_rect(drawable, obstacles):
     return best
 
 
+@dataclass
+class DetailRequest:
+    """A renderer's request for an enlarged detail of a region it could not draw
+    legibly at sheet scale (#307). Renderers append these to ``dwg._detail_requests``
+    instead of building bespoke detail views; ``_resolve_details`` resolves them all
+    through one generic detailer (crop → project → place → caption → marker), then
+    calls ``redraw`` to draw the feature's own dims inside the placed detail view.
+
+    The single ``detect → request → generic render`` path that folds the prismatic
+    step detail (#42) and the turned-head detail (#304) into one, mirroring the
+    section pipeline (``plan_sections``/``SectionPlan``).
+
+    Fields:
+        axis:         part axis the band spans / is cropped along ("x"/"y"/"z").
+        lo, hi:       band bounds along ``axis`` (world mm).
+        scale_needed: detail world→page scale that makes the region legible.
+        redraw:       ``redraw(dwg, view_name, detail_scale)`` — draws the detail's
+                      dimensions in the placed detail view's coordinate system, and
+                      any on-success furniture on the main views (e.g. a head-block
+                      dim). Called only when the detail actually places.
+        fallback:     ``fallback(dwg)`` — draws the dims inline on the main view when
+                      the detail can NOT place (transactional: coverage is never
+                      silently lost). ``None`` if there is nothing to fall back to.
+        pad_right:    page-mm band reserved right of the detail view for its dims
+                      (a vertical ladder); reserved in the fit + placement.
+        pad_top:      page-mm band reserved above the detail view (a horizontal
+                      chain); reserved in the fit + placement.
+        pads:         optional ``pads(detail_scale) -> (pad_right, pad_top)`` for a
+                      footprint that depends on the chosen scale (the prismatic
+                      ladder reserves one rung per *legible-at-that-scale* step, so it
+                      shrinks with the scale during the fit). Overrides the constants.
+        kind:         short label for logging.
+    """
+
+    axis: str
+    lo: float
+    hi: float
+    scale_needed: float
+    redraw: object
+    fallback: object = None
+    pad_right: float = 0.0
+    pad_top: float = 0.0
+    pads: object = None
+    kind: str = "detail"
+
+
 @dataclass(frozen=True)
 class _Projector:
     """Model → page coordinate projection for the orthographic views.

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -398,21 +398,19 @@ class DetailRequest:
         axis:         part axis the band spans / is cropped along ("x"/"y"/"z").
         lo, hi:       band bounds along ``axis`` (world mm).
         scale_needed: detail world→page scale that makes the region legible.
-        redraw:       ``redraw(dwg, view_name, detail_scale)`` — draws the detail's
-                      dimensions in the placed detail view's coordinate system, and
-                      any on-success furniture on the main views (e.g. a head-block
-                      dim). Called only when the detail actually places.
-        fallback:     ``fallback(dwg)`` — draws the dims inline on the main view when
-                      the detail can NOT place (transactional: coverage is never
-                      silently lost). ``None`` if there is nothing to fall back to.
-        pad_right:    page-mm band reserved right of the detail view for its dims
-                      (a vertical ladder); reserved in the fit + placement.
+        redraw:       ``redraw(dwg, view_name, detail_scale) -> int`` — draws the
+                      detail's dimensions in the placed detail view's coordinate system
+                      and returns the count placed (0 → the detailer rolls the view
+                      back rather than leave an empty box). Called once the detail is
+                      placed; the main view always carries the located head/block
+                      inline regardless, so a placement failure loses no coverage (lint
+                      reports the un-located interior instead).
         pad_top:      page-mm band reserved above the detail view (a horizontal
                       chain); reserved in the fit + placement.
         pads:         optional ``pads(detail_scale) -> (pad_right, pad_top)`` for a
                       footprint that depends on the chosen scale (the prismatic
                       ladder reserves one rung per *legible-at-that-scale* step, so it
-                      shrinks with the scale during the fit). Overrides the constants.
+                      shrinks with the scale during the fit). Overrides ``pad_top``.
         kind:         short label for logging.
     """
 
@@ -421,8 +419,6 @@ class DetailRequest:
     hi: float
     scale_needed: float
     redraw: object
-    fallback: object = None
-    pad_right: float = 0.0
     pad_top: float = 0.0
     pads: object = None
     kind: str = "detail"

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import functools
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
@@ -418,9 +419,9 @@ class DetailRequest:
     lo: float
     hi: float
     scale_needed: float
-    redraw: object
+    redraw: Callable[..., int]
     pad_top: float = 0.0
-    pads: object = None
+    pads: Callable[[float], tuple[float, float]] | None = None
     kind: str = "detail"
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -586,7 +586,7 @@ def render_envelope(dwg, groups, a) -> int:
     return n
 
 
-def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None) -> int:
+def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True) -> int:
     """Place a turned step-length chain in *view* from *segs* — each ``(pa, pb,
     value)`` already projected to *view*'s page coords, in axis order. Orientation is
     data (the projected span direction): horizontal → chain above the view, vertical
@@ -594,7 +594,10 @@ def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None) -> int:
     per-segment chain, staggered into a near/far tier only when crowded (ISO 129-1,
     #293); skipped if even two tiers can't separate the labels, or if any dim would
     fall off the page. ``detail_scale`` tags the dims for label-vs-measured lint when
-    drawing inside a scaled detail view. Returns the count placed."""
+    drawing inside a scaled detail view. ``allow_collapse=False`` disables the ``N× v``
+    collapse — used when the chain mixes a synthetic head-*block* with real steps, where
+    a uniform-staircase representative would be a false claim of N equal steps (#307
+    review). Returns the count placed."""
     if not segs:
         return 0
     vb = dwg.view_bounds(view)
@@ -606,7 +609,7 @@ def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None) -> int:
     horizontal = abs(segs[0][1][0] - segs[0][0][0]) >= abs(segs[0][1][1] - segs[0][0][1])
     vals = [v for *_, v in segs]
     mean_v = sum(vals) / len(vals)
-    if len(segs) >= 3 and (max(vals) - min(vals)) <= 0.10 * mean_v:
+    if allow_collapse and len(segs) >= 3 and (max(vals) - min(vals)) <= 0.10 * mean_v:
         label = f"{len(segs)}× {_fmt(mean_v)}"
         xs = [p[0] for pa, pb, _ in segs for p in (pa, pb)]
         ys = [p[1] for pa, pb, _ in segs for p in (pa, pb)]
@@ -743,7 +746,9 @@ def render_step_lengths(dwg, groups) -> int:
             head = {i for run in heads for i in run}
             main = [fsegs[i] for i in range(len(fsegs)) if i not in head] + blocks
             main.sort(key=lambda s: s[0][0])
-            return _draw_step_chain(dwg, "front", main, "m_steplen")
+            # The chain now mixes head-block(s) with real steps — never collapse it to a
+            # uniform "N× v" representative (a block is not a repeated step, #307 review).
+            return _draw_step_chain(dwg, "front", main, "m_steplen", allow_collapse=False)
 
     return _draw_step_chain(dwg, "front", fsegs, "m_steplen")
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -27,10 +27,12 @@ from draftwright._core import (
     _DIAM_RE,
     _END_ON,
     _MARGIN,
+    _MIN_STEP_SEP_MM,
     _SLOT_DIM_DEPTH,
     _SLOT_DIM_HEIGHT,
     _SLOT_DIM_STEP,
     _SLOT_DIM_WIDTH,
+    DetailRequest,
     _dim,
     _fmt,
     _greedy_strip_ys,
@@ -584,49 +586,24 @@ def render_envelope(dwg, groups, a) -> int:
     return n
 
 
-def render_step_lengths(dwg, groups) -> int:
-    """Unified turned step-length chain (ADR 0008 #223) — one IR-driven path that
-    replaces the engine's asymmetric X-chain / Z-ladder. Each `StepFeature`'s length
-    span is projected into the front view; the chain runs *along the projected axis*
-    just outside the view — **horizontal** for an X-turned part, **vertical** for a
-    Z-turned part. Orientation is the projected span direction, not a branch, so X
-    and Z get the same complete chain. Returns the number of step dims placed.
-
-    The chain is collinear (all segments share one offset line) and tiles end to
-    end, so every shoulder is located. Crowded labels are spread along the line by
-    the ADR-0003 strip solve (the primitive the engine's X chain already used)."""
-    segs = []  # (page_lo, page_hi, value), in axis order
-    for g in groups:
-        if g.feature_kind != "step":
-            continue
-        length = next(
-            (pd.param for pd in g.dims if pd.param.kind == "length" and pd.param.span is not None),
-            None,
-        )
-        if length is None or length.span is None:
-            continue
-        a, b = length.span
-        pa, pb = dwg.at("front", *a), dwg.at("front", *b)
-        segs.append((pa, pb, length.value))
+def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None) -> int:
+    """Place a turned step-length chain in *view* from *segs* — each ``(pa, pb,
+    value)`` already projected to *view*'s page coords, in axis order. Orientation is
+    data (the projected span direction): horizontal → chain above the view, vertical
+    → chain to the right. A uniform run collapses to one ``N× v`` dim (#230); else a
+    per-segment chain, staggered into a near/far tier only when crowded (ISO 129-1,
+    #293); skipped if even two tiers can't separate the labels, or if any dim would
+    fall off the page. ``detail_scale`` tags the dims for label-vs-measured lint when
+    drawing inside a scaled detail view. Returns the count placed."""
     if not segs:
         return 0
-    vb = dwg.view_bounds("front")
+    vb = dwg.view_bounds(view)
     if vb is None:
         return 0
     x0, y0, x1, y1 = vb
     draft = dwg.draft
     gap = draft.font_size + 4 * draft.pad_around_text
-    # Orientation is data: the projected span direction. Horizontal → X-turned
-    # (chain above the view); vertical → Z-turned (chain left of the view).
     horizontal = abs(segs[0][1][0] - segs[0][0][0]) >= abs(segs[0][1][1] - segs[0][0][1])
-
-    # Spread crowded labels along a horizontal chain (ADR-0003 strip solve), then
-    # carry each label back to its segment via label_offset_x (the only along-line
-    # offset the Dimension primitive supports). A vertical chain places plain dims.
-    # Uniform staircase → one representative "N× length" dim spanning the whole run
-    # (#230), instead of N identical segment dims. Mirrors the prismatic ladder's
-    # _detect_step_repeat: ≥3 segments, all within 10% of the mean (so a 2-step part
-    # or a mixed chain still dimensions each segment).
     vals = [v for *_, v in segs]
     mean_v = sum(vals) / len(vals)
     if len(segs) >= 3 and (max(vals) - min(vals)) <= 0.10 * mean_v:
@@ -637,17 +614,11 @@ def render_step_lengths(dwg, groups) -> int:
             dim = _dim((min(xs), y1, 0), (max(xs), y1, 0), "above", gap, draft, label=label)
         else:
             dim = _dim((x1, min(ys), 0), (x1, max(ys), 0), "right", gap, draft, label=label)
-        candidates = [("m_steplen_typ", dim)]
+        candidates = [(f"{name_prefix}_typ", dim)]
     else:
-        gap_min = draft.font_size + 2 * draft.pad_around_text
         tier_step = draft.font_size + 2 * draft.pad_around_text
         tiers = [0] * len(segs)
         if horizontal:
-            # ISO 129-1 staggering, applied only as a response to crowding: keep the
-            # whole chain on one tier when the labels already clear; alternate them
-            # between a near and a far tier only when they would collide; skip when even
-            # two tiers can't separate them (then lint reports the gap, #293). build123d
-            # flips a narrow segment's arrowheads outside the extension lines for us.
             cw = [
                 ((pa[0] + pb[0]) / 2, len(_fmt(v)) * draft.font_size * 0.62) for pa, pb, v in segs
             ]
@@ -666,28 +637,24 @@ def render_step_lengths(dwg, groups) -> int:
                 _log.info("step-length chain skipped: too dense even when staggered")
                 return 0
         else:
-            # Z-turned chain places plain dims at the shoulders (no along-line spread is
-            # available vertically), so its legibility is the raw shoulder spacing.
             shoulder_ys = sorted({c for pa, pb, _ in segs for c in (pa[1], pb[1])})
-            if any(b - a < gap_min for a, b in zip(shoulder_ys, shoulder_ys[1:])):
+            if any(b - a < tier_step for a, b in zip(shoulder_ys, shoulder_ys[1:])):
                 _log.info("step-length chain skipped: shoulders too close to dimension")
                 return 0
 
         candidates = []
         for i, (pa, pb, value) in enumerate(segs):
-            if horizontal:  # X-turned: chain above the view (staggered only if crowded)
+            if horizontal:
                 p1, p2, side = (pa[0], y1, 0), (pb[0], y1, 0), "above"
                 dist = gap + tiers[i] * tier_step
-            else:  # Z-turned: chain right of the view, witnesses from the right edge
+            else:
                 p1, p2, side = (x1, pa[1], 0), (x1, pb[1], 0), "right"
                 dist = gap
             candidates.append(
-                (f"m_steplen{i}", _dim(p1, p2, side, dist, draft, label=_fmt(value)))
+                (f"{name_prefix}{i}", _dim(p1, p2, side, dist, draft, label=_fmt(value)))
             )
 
-    # Room guard (the engine's contract): if any dim would fall off the drawable
-    # page, place NONE and let lint report axial_length_missing — never run the
-    # chain off the page edge.
+    # Room guard: if any dim would fall off the drawable page, place NONE.
     page = (_MARGIN, _MARGIN, dwg.page_w - _MARGIN, dwg.page_h - _MARGIN)
     for _, dim in candidates:
         box = _anno_box(dim)
@@ -696,8 +663,85 @@ def render_step_lengths(dwg, groups) -> int:
         ):
             return 0
     for name, dim in candidates:
-        dwg.add(dim, name, view="front")
+        if detail_scale is not None:
+            dim._dw_scale = detail_scale
+        dwg.add(dim, name, view=view)
     return len(candidates)
+
+
+def render_step_lengths(dwg, groups) -> int:
+    """Unified turned step-length chain (ADR 0008 #223): each `StepFeature`'s length
+    span projects into the front view and joins the chain that tiles the turning axis
+    so every shoulder is located. X-turned → horizontal chain above the view;
+    Z-turned → vertical chain to the right.
+
+    A crowded **X-turned head** — a contiguous run of steps too short to dimension
+    legibly even staggered (shoulders below the page arrowhead floor) — is not crammed
+    in line: the main view locates that run as one *block* dim and an enlarged
+    `DetailRequest` (#304/#307) is queued to break it down. If the detail later can't
+    place, the block still locates the head extent and lint reports the un-located
+    interior shoulders — never worse than the prior skip. Returns the count placed on
+    the front view."""
+    rows = []  # (a_world, b_world, value) in axis order
+    for g in groups:
+        if g.feature_kind != "step":
+            continue
+        length = next(
+            (pd.param for pd in g.dims if pd.param.kind == "length" and pd.param.span is not None),
+            None,
+        )
+        if length is None or length.span is None:
+            continue
+        rows.append((length.span[0], length.span[1], length.value))
+    if not rows:
+        return 0
+    draft = dwg.draft
+    fsegs = [(dwg.at("front", *a), dwg.at("front", *b), v) for a, b, v in rows]
+    horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
+
+    # X-turned crowded-head detour (#307): split off each contiguous run of sub-floor
+    # steps (segment narrower than two arrowheads on the page), locate it as a block,
+    # and queue an enlarged detail. The legible steps + blocks stay as the main chain.
+    if horizontal:
+        floor_pg = 2 * draft.arrow_length
+        sub = [i for i, (pa, pb, _) in enumerate(fsegs) if abs(pb[0] - pa[0]) < floor_pg]
+        if sub:
+            runs: list[list[int]] = [[sub[0]]]
+            for j in sub[1:]:
+                (runs[-1].append(j) if j == runs[-1][-1] + 1 else runs.append([j]))
+            blocks = []
+            for run in runs:
+                ra = [rows[i] for i in run]
+                hlo = min(min(a[0], b[0]) for a, b, _ in ra)
+                hhi = max(max(a[0], b[0]) for a, b, _ in ra)
+                minlen = min(v for *_, v in ra)
+                scale_needed = (
+                    dwg.scale * _MIN_STEP_SEP_MM / minlen if minlen > 0 else float("inf")
+                )
+                blocks.append((dwg.at("front", hlo, 0, 0), dwg.at("front", hhi, 0, 0), hhi - hlo))
+
+                def _redraw(dwg, view, detail_scale, _hw=ra):
+                    hsegs = [(dwg.at(view, *a), dwg.at(view, *b), v) for a, b, v in _hw]
+                    _draw_step_chain(dwg, view, hsegs, "dim_detail_steplen", detail_scale)
+
+                dwg._detail_requests.append(
+                    DetailRequest(
+                        axis="x",
+                        lo=hlo,
+                        hi=hhi,
+                        scale_needed=scale_needed,
+                        redraw=_redraw,
+                        pad_top=2 * (draft.font_size + 2 * draft.pad_around_text)
+                        + draft.arrow_length,
+                        kind="turned-head",
+                    )
+                )
+            head = {i for run in runs for i in run}
+            main = [fsegs[i] for i in range(len(fsegs)) if i not in head] + blocks
+            main.sort(key=lambda s: s[0][0])
+            return _draw_step_chain(dwg, "front", main, "m_steplen")
+
+    return _draw_step_chain(dwg, "front", fsegs, "m_steplen")
 
 
 def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -699,30 +699,34 @@ def render_step_lengths(dwg, groups) -> int:
     fsegs = [(dwg.at("front", *a), dwg.at("front", *b), v) for a, b, v in rows]
     horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
 
-    # X-turned crowded-head detour (#307): split off each contiguous run of sub-floor
-    # steps (segment narrower than two arrowheads on the page), locate it as a block,
-    # and queue an enlarged detail. The legible steps + blocks stay as the main chain.
+    # X-turned crowded-head detour (#307): split off each contiguous *run of ≥2*
+    # sub-floor steps (segment narrower than two arrowheads on the page), locate it as
+    # a block, and queue an enlarged detail. A single isolated thin step is left in the
+    # main chain — a one-step block would just be that step at its sub-floor width
+    # (#307 review). The legible steps + blocks stay as the main chain.
     if horizontal:
         floor_pg = 2 * draft.arrow_length
         sub = [i for i, (pa, pb, _) in enumerate(fsegs) if abs(pb[0] - pa[0]) < floor_pg]
-        if sub:
-            runs: list[list[int]] = [[sub[0]]]
-            for j in sub[1:]:
-                (runs[-1].append(j) if j == runs[-1][-1] + 1 else runs.append([j]))
+        runs: list[list[int]] = []
+        for j in sub:
+            (runs[-1].append(j) if runs and j == runs[-1][-1] + 1 else runs.append([j]))
+        heads = [run for run in runs if len(run) >= 2]
+        if heads:
             blocks = []
-            for run in runs:
+            for run in heads:
                 ra = [rows[i] for i in run]
                 hlo = min(min(a[0], b[0]) for a, b, _ in ra)
                 hhi = max(max(a[0], b[0]) for a, b, _ in ra)
                 minlen = min(v for *_, v in ra)
-                scale_needed = (
-                    dwg.scale * _MIN_STEP_SEP_MM / minlen if minlen > 0 else float("inf")
-                )
+                # World→page scale for the detail (no sheet factor — detail_scale is an
+                # absolute world→page scale). (#307 review)
+                scale_needed = _MIN_STEP_SEP_MM / minlen if minlen > 0 else float("inf")
                 blocks.append((dwg.at("front", hlo, 0, 0), dwg.at("front", hhi, 0, 0), hhi - hlo))
 
                 def _redraw(dwg, view, detail_scale, _hw=ra):
+                    # View-scoped name prefix so two detail views never collide (#307 review).
                     hsegs = [(dwg.at(view, *a), dwg.at(view, *b), v) for a, b, v in _hw]
-                    _draw_step_chain(dwg, view, hsegs, "dim_detail_steplen", detail_scale)
+                    return _draw_step_chain(dwg, view, hsegs, f"dim_{view}_steplen", detail_scale)
 
                 dwg._detail_requests.append(
                     DetailRequest(
@@ -736,7 +740,7 @@ def render_step_lengths(dwg, groups) -> int:
                         kind="turned-head",
                     )
                 )
-            head = {i for run in runs for i in run}
+            head = {i for run in heads for i in run}
             main = [fsegs[i] for i in range(len(fsegs)) if i not in head] + blocks
             main.sort(key=lambda s: s[0][0])
             return _draw_step_chain(dwg, "front", main, "m_steplen")

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -44,7 +44,11 @@ from draftwright.annotations.holes import (
     _annotate_holes,
     _locate_off_axis_holes,
 )
-from draftwright.annotations.sections import _add_detail_view, _add_section_view
+from draftwright.annotations.sections import (
+    _add_section_view,
+    _request_prismatic_detail,
+    _resolve_details,
+)
 from draftwright.model import build_part_model, plan_dimensions, plan_sections
 from draftwright.recognition import (
     full_cylinders,
@@ -99,6 +103,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # not accumulate duplicate drop records.
     dwg._reset_build_issues()
     dwg._reset_dropped_callout_diams()
+    dwg._detail_requests = []  # renderers queue enlarged-detail requests here (#307)
 
     FX = a.proj.front_x
     FZ = a.proj.front_z
@@ -223,18 +228,19 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     if section is not None:
         _add_section_view(dwg, a, section)
 
-    # Detail view: only when explicitly requested via build_drawing(detail_view=True).
+    # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))
+    # — resolved with every other detail request below (#307).
     if detail_view:
-        _add_detail_view(dwg, a)
+        _request_prismatic_detail(dwg, a)
 
     # Turned-part dimensions via the IR (ADR 0008 convergence). The model is built
     # once and fed to both renderers (#229 — no per-pass rebuild):
     #  - diameters: ø leaders, row below (X) / column left (Z), one path by frame
     #    axis. Replaces _annotate_turned_diameters.
     #  - step lengths: the chain that locates every shoulder, X and Z from one path
-    #    (#223). Replaces the old X-only chain + the Z step-height ladder (skipped
-    #    above for turned parts); the envelope dim along the turning axis was
-    #    suppressed so the chain does not double-dimension the length.
+    #    (#223). A crowded X-turned head queues an enlarged detail request (#304/#307)
+    #    instead of cramming; the envelope dim along the turning axis was suppressed
+    #    so the chain does not double-dimension the length.
     render_diameters(dwg, _groups)
     if a.prof is not None:
         render_step_lengths(dwg, _groups)
@@ -248,6 +254,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (#135) — IR renderer, placed through the zone strips (shared infra). Runs
     # after every hole/diameter pass so it claims strip space last.
     render_slots(dwg, _model, a)
+
+    # Resolve every queued enlarged-detail request (#307) — prismatic step bands and
+    # crowded turned heads alike — through the one generic detailer, now that all
+    # views and main-view annotations are placed (so the detail avoids them).
+    _resolve_details(dwg, a)
 
     # Phase 7 — strip footprint debug logging + post-placement overflow check.
     # Overflow can only occur when outer_limit was tightened after allocations

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -334,7 +334,7 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
     cap_h = 8.0
 
     def _pads(s):  # annotation bands may depend on the scale (the prismatic ladder)
-        return req.pads(s) if req.pads is not None else (req.pad_right, req.pad_top)
+        return req.pads(s) if req.pads is not None else (0.0, req.pad_top)
 
     def _fits(s):
         pr, pt = _pads(s)
@@ -413,22 +413,20 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
 
 def _resolve_details(dwg, a: Analysis) -> None:
     """Resolve every queued :class:`DetailRequest` (#307) through the one generic
-    detailer. On a successful placement the request's ``redraw`` draws the detail;
-    on a placement bail-out the request's ``fallback`` draws the dims inline so
-    coverage is never silently lost (the transactional contract the bespoke turned
-    detailer lacked). Clears the queue."""
+    detailer, lettering DETAIL A/B/… On a placement bail-out nothing is drawn for that
+    request — the main view already carries the located head/block inline, so lint
+    reports any un-located interior rather than coverage being silently lost. Clears
+    the queue."""
     reqs = list(getattr(dwg, "_detail_requests", ()) or ())
     dwg._detail_requests = []
     n_placed = 0  # letters advance only on a successful placement — no A/B gaps (#307 review)
     for req in reqs:
-        letter = _DETAIL_LETTERS[n_placed] if n_placed < len(_DETAIL_LETTERS) else None
-        placed = letter is not None and _render_detail(
-            dwg, a, req, f"detail_{letter.lower()}", letter
-        )
-        if placed:
+        if n_placed >= len(_DETAIL_LETTERS):
+            _log.info("detail request '%s' dropped: detail letters A–H exhausted", req.kind)
+            continue
+        letter = _DETAIL_LETTERS[n_placed]
+        if _render_detail(dwg, a, req, f"detail_{letter.lower()}", letter):
             n_placed += 1
-        elif req.fallback is not None:
-            req.fallback(dwg)
 
 
 def _request_prismatic_detail(dwg, a: Analysis) -> None:

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -314,6 +314,13 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
                 continue
             vb = shp.bounding_box()
             obstacles.append((vb.min.X, vb.min.Y, vb.max.X, vb.max.Y))
+    # Also avoid placed dimension *labels* (not bare centre/leader lines) — a detail
+    # landing on a front-view callout reads as illegible and the repack can't see it
+    # (detail_* views are not orthographic) (#307 review). Text boxes only.
+    for _name, o in dwg.iter_annotations():
+        lb = getattr(o, "label_bbox", None)
+        if lb is not None:
+            obstacles.append(tuple(lb))
     obstacles.append(
         (a.PAGE_W - a.TB_W - _TB_CLEAR, a.margin, a.PAGE_W - _TB_CLEAR, _TB_CLEAR + _TB_H)
     )

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -33,6 +33,7 @@ from draftwright._core import (
     _TB_CLEAR,
     _TB_H,
     Analysis,
+    DetailRequest,
     _dim,
     _fmt,
     _iso_bbox,
@@ -40,6 +41,8 @@ from draftwright._core import (
     _legible_steps,
     _log,
 )
+
+_DETAIL_LETTERS = "ABCDEFGH"
 
 
 def _section_hatch_edges(face, SX, SZ, spacing):
@@ -259,66 +262,50 @@ def _add_section_view(dwg, a: Analysis, section):
         dwg.add(hatch, "section_hatch")
 
 
-def _add_detail_view(dwg, a: Analysis):
-    """Enlarged detail of a stepped region whose shoulders the legibility gate
-    dropped (#42).
-
-    Trigger: the step-height legibility gate (#41) drops one or more shoulders
-    because they are page-coincident at sheet scale. We crop the part to the
-    full step Z-band, project it at a larger standard scale into the largest
-    free rectangle on the sheet, re-draw the dropped step dimensions there at
-    a scale where they separate, mark the region on the front view, and caption
-    it "DETAIL A". Mirrors :func:`_add_section_view`: every risky boolean /
-    projection is wrapped and skips-with-log rather than aborting the drawing,
-    and the function returns early (drawing unchanged) when there is nothing to
-    detail.
-    """
-    if len(a.step_zs) < 2:
-        return
-    kept, _ = _legible_steps(a.step_zs, a.bb.min.Z, a.SCALE)
-    crowded = [z for z in a.step_zs if z not in set(kept)]
-    if len(crowded) < 1:
-        return
-
-    # Region: the full step Z-band, padded and clamped to the part bbox.
-    z0, z1 = min(a.step_zs), max(a.step_zs)
-    pad = 0.08 * (z1 - z0) + 1.0
-    band_lo = max(a.bb.min.Z, z0 - pad)
-    band_hi = min(a.bb.max.Z, z1 + pad)
-
-    # Detail scale: the smallest standard multiple in [2, 5, 10] of sheet scale
-    # that separates the closest shoulder pair (≥ _MIN_STEP_SEP_MM). Always at
-    # least 2× so the detail is a genuine enlargement.
-    s_zs = sorted(a.step_zs)
-    gaps = [b - aa for aa, b in zip(s_zs, s_zs[1:])]
-    min_gap = min(gaps)
-    need = _MIN_STEP_SEP_MM / min_gap if min_gap > 0 else float("inf")
+def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter: str) -> bool:
+    """Generic detail renderer (#307) — the single crop → project → place → caption
+    → mark machinery both the prismatic step detail (#42) and the turned-head detail
+    (#304) flow through. Crops the part to ``req``'s band along ``req.axis``, projects
+    it front-on at the detail scale into the largest free rectangle, captions and
+    marks it, then calls ``req.redraw`` to draw the feature's own dimensions in the
+    placed detail view. Every risky boolean/projection is wrapped and returns
+    ``False`` (drawing unchanged) rather than aborting; ``True`` when the detail is
+    placed. Mirrors :func:`_add_section_view`'s skip-with-log discipline."""
+    # Detail scale: smallest standard multiple in [2, 5, 10] of sheet scale that
+    # makes the region legible (>= the requested scale), always >= 2x.
     detail_scale = a.SCALE * 2
     for factor in (2, 5, 10):
         detail_scale = a.SCALE * factor
-        if detail_scale >= need:
+        if detail_scale >= req.scale_needed:
             break
 
-    # Crop to the Z-band with two fuzzy cuts (remove z<band_lo and z>band_hi).
-    # Solids only — a mixed-dimension compound (PMI curves) cannot be cut.
+    # Crop to the band along req.axis (two fuzzy cuts). Solids only — a mixed
+    # compound (PMI curves) cannot be cut.
     solids = a.part.solids()
     if not solids:
-        _log.info("Detail view skipped (no solid bodies to crop)")
-        return
+        _log.info("Detail %s skipped (no solid bodies to crop)", letter)
+        return False
     body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
     big = 4 * a.bbox_max
-    try:
-        cropped = _fuzzy_cut(body, Pos(a.cx, a.cy, band_lo - big / 2) * Box(big, big, big))
-        if cropped is not None:
-            cropped = _fuzzy_cut(cropped, Pos(a.cx, a.cy, band_hi + big / 2) * Box(big, big, big))
-    except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
-        _log.warning("Detail view skipped (crop failed: %s)", exc)
-        return
-    if cropped is None:
-        _log.warning("Detail view skipped (boolean crop produced no solid)")
-        return
+    idx = "xyz".index(req.axis)
 
-    # Placement: largest empty rectangle avoiding every placed view + title block.
+    def _cut(edge):
+        c = [a.cx, a.cy, a.cz]
+        c[idx] = edge
+        return Pos(*c) * Box(big, big, big)
+
+    try:
+        cropped = _fuzzy_cut(body, _cut(req.lo - big / 2))
+        if cropped is not None:
+            cropped = _fuzzy_cut(cropped, _cut(req.hi + big / 2))
+    except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
+        _log.warning("Detail %s skipped (crop failed: %s)", letter, exc)
+        return False
+    if cropped is None:
+        _log.warning("Detail %s skipped (boolean crop produced no solid)", letter)
+        return False
+
+    # Placement: largest empty rectangle avoiding placed views + the title block.
     drawable = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
     obstacles = []
     for vis, hid in dwg.views.values():
@@ -333,36 +320,34 @@ def _add_detail_view(dwg, a: Analysis):
     rx0, ry0, rx1, ry1 = _largest_empty_rect(drawable, obstacles)
     rect_w, rect_h = rx1 - rx0, ry1 - ry0
 
-    # Detail footprint at the chosen scale, including the step-dim ladder on the
-    # right (one rung per kept step + the overall band height) and breathing
-    # room for the caption below.  Shrink the scale to fit if necessary.
-    step_pad = _MIN_STEP_SEP_MM
-    n_rungs = len(_legible_steps(a.step_zs, a.bb.min.Z, detail_scale)[0]) + 1
-    ladder_w = n_rungs * step_pad + 6
-    while detail_scale > a.SCALE * 1.2:
-        detail_w = a.x_size * detail_scale + ladder_w
-        detail_h = (band_hi - band_lo) * detail_scale + a.DIM_PAD
-        if detail_w <= rect_w and detail_h <= rect_h:
-            break
-        detail_scale -= a.SCALE
-    n_rungs = len(_legible_steps(a.step_zs, a.bb.min.Z, detail_scale)[0]) + 1
-    ladder_w = n_rungs * step_pad + 6
-    detail_w = a.x_size * detail_scale + ladder_w
-    detail_h = (band_hi - band_lo) * detail_scale + a.DIM_PAD
-    if detail_scale <= a.SCALE * 1.2 or detail_w > rect_w or detail_h > rect_h:
-        _log.info("Detail view skipped (no room)")
-        return
-
-    # Centre the view+ladder footprint in the rect; the view itself sits left of
-    # centre so its right-hand ladder stays inside the chosen rectangle.
-    DX = (rx0 + rx1) / 2 - ladder_w / 2
-    DY = (ry0 + ry1) / 2
-
-    # Project the cropped band front-on (look from −Y, up +Z), mirroring the
-    # front view but at detail_scale around the band's own centroid (#42, like
-    # _project_iso). Then rebuild ViewCoordinates so dwg.at("detail_a", ...)
-    # maps world→page at the detail scale.
+    # Footprint = the projected cropped band + the request's annotation pads (the
+    # dim ladder/chain) + the caption row. Shrink the scale to fit if necessary.
     cb = cropped.bounding_box()
+    view_w, view_h = (cb.max.X - cb.min.X), (cb.max.Z - cb.min.Z)
+    cap_h = 8.0
+
+    def _pads(s):  # annotation bands may depend on the scale (the prismatic ladder)
+        return req.pads(s) if req.pads is not None else (req.pad_right, req.pad_top)
+
+    def _fits(s):
+        pr, pt = _pads(s)
+        return view_w * s + pr <= rect_w and view_h * s + pt + a.DIM_PAD + cap_h <= rect_h
+
+    while detail_scale > a.SCALE * 1.2 and not _fits(detail_scale):
+        detail_scale -= a.SCALE
+    if detail_scale <= a.SCALE * 1.2 or not _fits(detail_scale):
+        _log.info("Detail %s skipped (no room)", letter)
+        return False
+    pad_right, pad_top = _pads(detail_scale)
+
+    # Centre the whole footprint: bias left by the right pad, and offset for the
+    # asymmetric top pad (annotations above) vs the caption (below).
+    DX = (rx0 + rx1) / 2 - pad_right / 2
+    DY = (ry0 + ry1) / 2 - (pad_top - cap_h) / 2
+
+    # Project the cropped band front-on (look from −Y, up +Z) at detail_scale around
+    # its own centroid; rebuild ViewCoordinates so dwg.at(view_name, ...) maps
+    # world→page at the detail scale.
     dcx = (cb.min.X + cb.max.X) / 2
     dcy = (cb.min.Y + cb.max.Y) / 2
     dcz = (cb.min.Z + cb.max.Z) / 2
@@ -371,31 +356,20 @@ def _add_detail_view(dwg, a: Analysis):
     camera = (la[0], la[1] - dist_d, la[2])
     try:
         band_s = cropped.scale(detail_scale)
-        dwg.add_view("detail_a", band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True)
+        dwg.add_view(view_name, band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True)
     except Exception as exc:  # noqa: BLE001 — projection raises broadly on cast geometry
-        _log.warning("Detail view skipped (projection failed: %s)", exc)
-        return
-    dwg._coords["detail_a"] = ViewCoordinates(
+        _log.warning("Detail %s skipped (projection failed: %s)", letter, exc)
+        return False
+    dwg._coords[view_name] = ViewCoordinates(
         view_axes(camera, (0, 0, 1), la), DX, DY, dcx, dcy, dcz, detail_scale
     )
 
-    # Caption below the detail.
-    detail_bottom = DY - detail_h / 2
-    dwg.add(
-        Note(
-            f"DETAIL A — SCALE {format_drawing_scale(detail_scale)}",
-            (DX, detail_bottom - 7),
-            dwg.draft,
-        ),
-        "detail_caption",
-    )
-
-    # Marker on the front view: a rectangle around the Z-band, with an 'A' label.
-    FX = a.proj.front_x
-    FZ = a.proj.front_z
-
-    mx0, mx1 = FX(a.bb.min.X), FX(a.bb.max.X)
-    my0, my1 = FZ(band_lo), FZ(band_hi)
+    # Marker on the front view around the band (axis-aware) + letter.
+    FX, FZ = a.proj.front_x, a.proj.front_z
+    if req.axis == "z":  # band runs along page-y
+        mx0, mx1, my0, my1 = FX(a.bb.min.X), FX(a.bb.max.X), FZ(req.lo), FZ(req.hi)
+    else:  # x band runs along page-x
+        mx0, mx1, my0, my1 = FX(req.lo), FX(req.hi), FZ(a.bb.min.Z), FZ(a.bb.max.Z)
     marker = Compound(
         children=[
             Edge.make_line(Vector(mx0, my0, 0), Vector(mx1, my0, 0)),
@@ -405,48 +379,97 @@ def _add_detail_view(dwg, a: Analysis):
         ]
     )
     marker.is_centerline = True  # furniture, not a dimension — exempt from overlap lint
-    dwg.add(marker, "detail_marker")
-    dwg.add(Note("A", (mx1 + 3, my1 + 2), dwg.draft), "detail_marker_label")
+    dwg.add(marker, f"detail_marker_{letter}")
+    dwg.add(Note(letter, (mx1 + 3, my1 + 2), dwg.draft), f"detail_marker_label_{letter}")
 
-    # Detail dimensions: step heights now legible at detail_scale, plus the
-    # overall band height. Baseline-ladder to the right of the detail, mirroring
-    # the main-view step dims.
-    det_kept, _ = _legible_steps(a.step_zs, a.bb.min.Z, detail_scale)
-    base_x = dwg.at("detail_a", a.bb.max.X, dcy, a.bb.min.Z)[0] + 2
-    ladder = base_x
-    for i, z in enumerate(det_kept):
-        try:
-            p_lo = dwg.at("detail_a", a.bb.max.X, dcy, a.bb.min.Z)
-            p_hi = dwg.at("detail_a", a.bb.max.X, dcy, z)
-            det_dim = _dim(
-                (ladder, p_lo[1], 0),
-                (ladder, p_hi[1], 0),
-                "right",
-                step_pad,
-                dwg.draft,
-                label=_fmt(z - a.bb.min.Z),
-            )
-            # The detail view is drawn at detail_scale, not sheet scale; tag the
-            # dim so lint() checks label-vs-measured against the right scale (#42).
-            det_dim._dw_scale = detail_scale
-            dwg.add(det_dim, f"dim_detail_step_{i}")
-            ladder += step_pad
-        except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
-            _log.info("dim_detail_step_%d skipped (%s)", i, exc)
-
-    # Overall band height — outermost.
-    try:
-        p_lo = dwg.at("detail_a", a.bb.max.X, dcy, a.bb.min.Z)
-        p_hi = dwg.at("detail_a", a.bb.max.X, dcy, a.bb.max.Z)
-        det_dim = _dim(
-            (ladder, p_lo[1], 0),
-            (ladder, p_hi[1], 0),
-            "right",
-            step_pad,
+    # Caption below the placed view (anchored to its real footprint).
+    dvb = dwg.views[view_name][0].bounding_box()
+    dwg.add(
+        Note(
+            f"DETAIL {letter} — SCALE {format_drawing_scale(detail_scale)}",
+            ((dvb.min.X + dvb.max.X) / 2, dvb.min.Y - cap_h),
             dwg.draft,
-            label=_fmt(a.z_size),
+        ),
+        f"detail_caption_{letter}",
+    )
+
+    # The feature draws its own dims inside the detail (and any on-success furniture
+    # on the main views, e.g. the head-block dim).
+    req.redraw(dwg, view_name, detail_scale)
+    return True
+
+
+def _resolve_details(dwg, a: Analysis) -> None:
+    """Resolve every queued :class:`DetailRequest` (#307) through the one generic
+    detailer. On a successful placement the request's ``redraw`` draws the detail;
+    on a placement bail-out the request's ``fallback`` draws the dims inline so
+    coverage is never silently lost (the transactional contract the bespoke turned
+    detailer lacked). Clears the queue."""
+    reqs = list(getattr(dwg, "_detail_requests", ()) or ())
+    dwg._detail_requests = []
+    for i, req in enumerate(reqs):
+        letter = _DETAIL_LETTERS[i] if i < len(_DETAIL_LETTERS) else None
+        placed = letter is not None and _render_detail(
+            dwg, a, req, f"detail_{letter.lower()}", letter
         )
-        det_dim._dw_scale = detail_scale  # detail view scale, for label-vs-measured lint (#42)
-        dwg.add(det_dim, "dim_detail_height")
-    except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
-        _log.info("dim_detail_height skipped (%s)", exc)
+        if not placed and req.fallback is not None:
+            req.fallback(dwg)
+
+
+def _request_prismatic_detail(dwg, a: Analysis) -> None:
+    """Queue a detail of a prismatic part's crowded step-height band (#42), routed
+    through the unified pipeline (#307). Fires when the step-height legibility gate
+    drops a shoulder at sheet scale; the redraw re-draws the step-height ladder in
+    the detail view at the enlarged scale."""
+    if len(a.step_zs) < 2:
+        return
+    kept, _ = _legible_steps(a.step_zs, a.bb.min.Z, a.SCALE)
+    if not [z for z in a.step_zs if z not in set(kept)]:
+        return
+    z0, z1 = min(a.step_zs), max(a.step_zs)
+    pad = 0.08 * (z1 - z0) + 1.0
+    band_lo, band_hi = max(a.bb.min.Z, z0 - pad), min(a.bb.max.Z, z1 + pad)
+    s_zs = sorted(a.step_zs)
+    min_gap = min(b - aa for aa, b in zip(s_zs, s_zs[1:]))
+    scale_needed = a.SCALE * _MIN_STEP_SEP_MM / min_gap if min_gap > 0 else float("inf")
+    step_pad = _MIN_STEP_SEP_MM
+
+    def pads(detail_scale):  # one ladder rung per step legible at this scale, + overall
+        return (
+            (len(_legible_steps(a.step_zs, a.bb.min.Z, detail_scale)[0]) + 1) * step_pad + 6,
+            0.0,
+        )
+
+    def redraw(dwg, view, detail_scale):
+        det_kept, _ = _legible_steps(a.step_zs, a.bb.min.Z, detail_scale)
+        ladder = dwg.at(view, a.bb.max.X, a.cy, a.bb.min.Z)[0] + 2
+        for i, z in enumerate([*det_kept, a.bb.max.Z]):
+            label = _fmt(a.z_size) if z == a.bb.max.Z else _fmt(z - a.bb.min.Z)
+            try:
+                p_lo = dwg.at(view, a.bb.max.X, a.cy, a.bb.min.Z)
+                p_hi = dwg.at(view, a.bb.max.X, a.cy, z)
+                det_dim = _dim(
+                    (ladder, p_lo[1], 0),
+                    (ladder, p_hi[1], 0),
+                    "right",
+                    step_pad,
+                    dwg.draft,
+                    label=label,
+                )
+                det_dim._dw_scale = detail_scale  # detail scale, for label-vs-measured lint (#42)
+                dwg.add(det_dim, f"dim_detail_step_{i}", view=view)
+                ladder += step_pad
+            except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
+                _log.info("dim_detail_step_%d skipped (%s)", i, exc)
+
+    dwg._detail_requests.append(
+        DetailRequest(
+            axis="z",
+            lo=band_lo,
+            hi=band_hi,
+            scale_needed=scale_needed,
+            redraw=redraw,
+            pads=pads,
+            kind="prismatic-steps",
+        )
+    )

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -371,6 +371,15 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
         view_axes(camera, (0, 0, 1), la), DX, DY, dcx, dcy, dcz, detail_scale
     )
 
+    # The feature draws its own dims inside the detail. If nothing legible lands even
+    # at the detail scale, roll the view back rather than committing an empty DETAIL
+    # box — the request's fallback (if any) then runs (#307 review).
+    if not req.redraw(dwg, view_name, detail_scale):
+        dwg.views.pop(view_name, None)
+        dwg._coords.pop(view_name, None)
+        _log.info("Detail %s skipped (no legible dims at the detail scale)", letter)
+        return False
+
     # Marker on the front view around the band (axis-aware) + letter.
     FX, FZ = a.proj.front_x, a.proj.front_z
     if req.axis == "z":  # band runs along page-y
@@ -399,10 +408,6 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
         ),
         f"detail_caption_{letter}",
     )
-
-    # The feature draws its own dims inside the detail (and any on-success furniture
-    # on the main views, e.g. the head-block dim).
-    req.redraw(dwg, view_name, detail_scale)
     return True
 
 
@@ -414,12 +419,15 @@ def _resolve_details(dwg, a: Analysis) -> None:
     detailer lacked). Clears the queue."""
     reqs = list(getattr(dwg, "_detail_requests", ()) or ())
     dwg._detail_requests = []
-    for i, req in enumerate(reqs):
-        letter = _DETAIL_LETTERS[i] if i < len(_DETAIL_LETTERS) else None
+    n_placed = 0  # letters advance only on a successful placement — no A/B gaps (#307 review)
+    for req in reqs:
+        letter = _DETAIL_LETTERS[n_placed] if n_placed < len(_DETAIL_LETTERS) else None
         placed = letter is not None and _render_detail(
             dwg, a, req, f"detail_{letter.lower()}", letter
         )
-        if not placed and req.fallback is not None:
+        if placed:
+            n_placed += 1
+        elif req.fallback is not None:
             req.fallback(dwg)
 
 
@@ -438,7 +446,9 @@ def _request_prismatic_detail(dwg, a: Analysis) -> None:
     band_lo, band_hi = max(a.bb.min.Z, z0 - pad), min(a.bb.max.Z, z1 + pad)
     s_zs = sorted(a.step_zs)
     min_gap = min(b - aa for aa, b in zip(s_zs, s_zs[1:]))
-    scale_needed = a.SCALE * _MIN_STEP_SEP_MM / min_gap if min_gap > 0 else float("inf")
+    # World→page scale that renders the closest gap at the legibility floor — no sheet
+    # factor (detail_scale is itself an absolute world→page scale). (#307 review)
+    scale_needed = _MIN_STEP_SEP_MM / min_gap if min_gap > 0 else float("inf")
     step_pad = _MIN_STEP_SEP_MM
 
     def pads(detail_scale):  # one ladder rung per step legible at this scale, + overall
@@ -447,9 +457,10 @@ def _request_prismatic_detail(dwg, a: Analysis) -> None:
             0.0,
         )
 
-    def redraw(dwg, view, detail_scale):
+    def redraw(dwg, view, detail_scale):  # returns the count placed (for rollback, #307)
         det_kept, _ = _legible_steps(a.step_zs, a.bb.min.Z, detail_scale)
         ladder = dwg.at(view, a.bb.max.X, a.cy, a.bb.min.Z)[0] + 2
+        placed = 0
         for i, z in enumerate([*det_kept, a.bb.max.Z]):
             label = _fmt(a.z_size) if z == a.bb.max.Z else _fmt(z - a.bb.min.Z)
             try:
@@ -464,10 +475,14 @@ def _request_prismatic_detail(dwg, a: Analysis) -> None:
                     label=label,
                 )
                 det_dim._dw_scale = detail_scale  # detail scale, for label-vs-measured lint (#42)
-                dwg.add(det_dim, f"dim_detail_step_{i}", view=view)
+                dwg.add(
+                    det_dim, f"dim_{view}_step{i}", view=view
+                )  # view-scoped name (#307 review)
                 ladder += step_pad
+                placed += 1
             except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
-                _log.info("dim_detail_step_%d skipped (%s)", i, exc)
+                _log.info("detail step dim %d skipped (%s)", i, exc)
+        return placed
 
     dwg._detail_requests.append(
         DetailRequest(

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -373,7 +373,8 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
 
     # The feature draws its own dims inside the detail. If nothing legible lands even
     # at the detail scale, roll the view back rather than committing an empty DETAIL
-    # box — the request's fallback (if any) then runs (#307 review).
+    # box — the request is then simply dropped (the main view already locates the
+    # head/block inline, so lint reports any un-located interior) (#307 review).
     if not req.redraw(dwg, view_name, detail_scale):
         dwg.views.pop(view_name, None)
         dwg._coords.pop(view_name, None)

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -352,15 +352,16 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
         shoulder_c = {s: shoulder_coord(view, s) for s in prof.shoulders}
         dims = [
             (
+                name,
                 str(getattr(ann, "label", "") or ""),
                 {(x if use_x else y) for x, y in _dim_vertices(ann)},
             )
-            for _name, ann in dwg.annotations_in_view(view)
+            for name, ann in dwg.annotations_in_view(view)
             if isinstance(ann, Dimension)
         ]
         for i, step in enumerate(prof.steps):
             clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]
-            for label, cs in dims:
+            for name, label, cs in dims:
                 if not cs:
                     continue
                 # A plain dim locates the step when it has a witness at each shoulder.
@@ -370,10 +371,12 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
                 # A collapsed uniform-staircase dim ("N× v", #230) carries witnesses only
                 # at the extremes of its run yet locates *every* shoulder within that run
                 # (the collapse fires only when all steps are equal). Credit a step whose
-                # both shoulders fall within the dim's span — works whether the run is the
-                # whole front chain or just the head inside a detail view (#307 review).
+                # both shoulders fall within the dim's span — but ONLY for an actual
+                # step-length chain dim (name contains "steplen"), never an unrelated
+                # "n× pitch" hole-array dim that happens to span the shoulders (#307 review).
                 if (
-                    re.match(r"^\s*\d+\s*×", label)
+                    "steplen" in name
+                    and re.match(r"^\s*\d+\s*×", label)
                     and min(cs) - tol <= clo
                     and chi <= max(cs) + tol
                 ):

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -38,13 +38,37 @@ _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=No
 
 
 def _dim_vertices(ann) -> list[tuple[float, float]]:
-    """A ``Dimension``'s vertices as ``(x, y)`` page points; ``[]`` if they won't
-    evaluate. The shared, error-tolerant harvest both drawing-derived coverage
-    checks use to read placed dimensions back off the drawing."""
+    """A ``Dimension``'s witness endpoints as ``(x, y)`` page points; ``[]`` if they
+    won't evaluate. The shared, error-tolerant harvest both drawing-derived coverage
+    checks use to read placed dimensions back off the drawing.
+
+    Prefers the recorded ``_dw_spec`` endpoints (the two points the dimension was
+    built from — the shoulder/feature positions) over ``ann.vertices()``: the latter
+    returns *every* geometry vertex, including the text-glyph outline, whose points
+    scatter across the span and can falsely satisfy a shoulder match for a wide dim
+    (e.g. a head-block dim whose centred label sits over interior shoulders, #304/#307).
+    The endpoints may be tuples or build123d ``Vector``s, so both are read safely."""
+    spec = getattr(ann, "_dw_spec", None)
+    if spec is not None:
+        try:
+            return [_pt(spec.p1), _pt(spec.p2)]
+        except Exception:  # noqa: BLE001 — odd point types fall through to vertices()
+            pass
     try:
         return [(p.X, p.Y) for p in ann.vertices()]
     except Exception:  # noqa: BLE001 — a dim whose vertices won't evaluate is skipped
         return []
+
+
+def _pt(p) -> tuple[float, float]:
+    """A 2-D page point from either a ``(x, y, ...)`` tuple/sequence or a build123d
+    ``Vector`` (``.X``/``.Y``). Lets coverage read ``_dw_spec`` endpoints regardless of
+    how the caller constructed the dimension (the public ``place_dim`` DSL may pass
+    ``Vector``s, which are not subscriptable — #307 review)."""
+    try:
+        return (p[0], p[1])
+    except (TypeError, KeyError, IndexError):
+        return (p.X, p.Y)
 
 
 class CoverageState:
@@ -313,43 +337,48 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
     base = [c.X, c.Y, c.Z]
     use_x = prof.axis == "x"  # horizontal chain → match page-x; else vertical → page-y
 
-    def shoulder_coord(s: float) -> float:
+    def shoulder_coord(view: str, s: float) -> float:
         pt = list(base)
         pt[idx] = s
-        px, py, *_ = dwg.at("front", *pt)
+        px, py, *_ = dwg.at(view, *pt)
         return float(px if use_x else py)
 
-    shoulder_c = {s: shoulder_coord(s) for s in prof.shoulders}
-    dims = [
-        (
-            str(getattr(ann, "label", "") or ""),
-            {(x if use_x else y) for x, y in _dim_vertices(ann)},
-        )
-        for _name, ann in dwg.annotations_in_view("front")
-        if isinstance(ann, Dimension)
-    ]
-    # A collapsed uniform-staircase dim ("N× v", #230) spans the whole run with
-    # witnesses only at the extreme shoulders, yet locates *every* shoulder of the
-    # uniform chain — the collapse fires only when all steps are equal. Count it as
-    # full coverage when such a dim spans the shoulder extent.
-    coords = list(shoulder_c.values())
-    cmin, cmax = min(coords), max(coords)
-    for label, cs in dims:
-        if (
-            re.match(r"^\s*\d+\s*×", label)
-            and any(abs(v - cmin) <= tol for v in cs)
-            and any(abs(v - cmax) <= tol for v in cs)
-        ):
-            return len(prof.steps)
-    covered = 0
-    for step in prof.steps:
-        clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]
-        if any(
-            any(abs(v - clo) <= tol for v in cs) and any(abs(v - chi) <= tol for v in cs)
-            for _label, cs in dims
-        ):
-            covered += 1
-    return covered
+    # A crowded X-turned head is dimensioned in an enlarged detail view (#304/#307),
+    # not the front chain — so a shoulder counts as located when matched in EITHER the
+    # front view or any detail view.
+    views = ["front"] + sorted(v for v in dwg.views if v.startswith("detail_"))
+    covered_steps: set[int] = set()
+    for view in views:
+        shoulder_c = {s: shoulder_coord(view, s) for s in prof.shoulders}
+        dims = [
+            (
+                str(getattr(ann, "label", "") or ""),
+                {(x if use_x else y) for x, y in _dim_vertices(ann)},
+            )
+            for _name, ann in dwg.annotations_in_view(view)
+            if isinstance(ann, Dimension)
+        ]
+        # A collapsed uniform-staircase dim ("N× v", #230) spans the whole run with
+        # witnesses only at the extreme shoulders, yet locates *every* shoulder of the
+        # uniform chain — the collapse fires only when all steps are equal. Count it as
+        # full coverage when such a dim spans the shoulder extent.
+        coords = list(shoulder_c.values())
+        cmin, cmax = min(coords), max(coords)
+        for label, cs in dims:
+            if (
+                re.match(r"^\s*\d+\s*×", label)
+                and any(abs(v - cmin) <= tol for v in cs)
+                and any(abs(v - cmax) <= tol for v in cs)
+            ):
+                return len(prof.steps)
+        for i, step in enumerate(prof.steps):
+            clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]
+            if any(
+                any(abs(v - clo) <= tol for v in cs) and any(abs(v - chi) <= tol for v in cs)
+                for _label, cs in dims
+            ):
+                covered_steps.add(i)
+    return len(covered_steps)
 
 
 def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -358,26 +358,27 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
             for _name, ann in dwg.annotations_in_view(view)
             if isinstance(ann, Dimension)
         ]
-        # A collapsed uniform-staircase dim ("N× v", #230) spans the whole run with
-        # witnesses only at the extreme shoulders, yet locates *every* shoulder of the
-        # uniform chain — the collapse fires only when all steps are equal. Count it as
-        # full coverage when such a dim spans the shoulder extent.
-        coords = list(shoulder_c.values())
-        cmin, cmax = min(coords), max(coords)
-        for label, cs in dims:
-            if (
-                re.match(r"^\s*\d+\s*×", label)
-                and any(abs(v - cmin) <= tol for v in cs)
-                and any(abs(v - cmax) <= tol for v in cs)
-            ):
-                return len(prof.steps)
         for i, step in enumerate(prof.steps):
             clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]
-            if any(
-                any(abs(v - clo) <= tol for v in cs) and any(abs(v - chi) <= tol for v in cs)
-                for _label, cs in dims
-            ):
-                covered_steps.add(i)
+            for label, cs in dims:
+                if not cs:
+                    continue
+                # A plain dim locates the step when it has a witness at each shoulder.
+                if any(abs(v - clo) <= tol for v in cs) and any(abs(v - chi) <= tol for v in cs):
+                    covered_steps.add(i)
+                    break
+                # A collapsed uniform-staircase dim ("N× v", #230) carries witnesses only
+                # at the extremes of its run yet locates *every* shoulder within that run
+                # (the collapse fires only when all steps are equal). Credit a step whose
+                # both shoulders fall within the dim's span — works whether the run is the
+                # whole front chain or just the head inside a detail view (#307 review).
+                if (
+                    re.match(r"^\s*\d+\s*×", label)
+                    and min(cs) - tol <= clo
+                    and chi <= max(cs) + tol
+                ):
+                    covered_steps.add(i)
+                    break
     return len(covered_steps)
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3815,7 +3815,7 @@ class TestDetailView:
         assert n_dropped >= 1
         # The detail view, its caption, and at least one detail step dim exist.
         assert "detail_a" in dwg.views
-        assert "detail_caption" in dwg._named
+        assert "detail_caption_A" in dwg._named
         assert any(n.startswith("dim_detail_step") for n in dwg._named)
         # Drawn at a larger scale than the sheet.
         assert dwg._coords["detail_a"]._scale > a.SCALE
@@ -4834,25 +4834,25 @@ class TestTurnedLengths:
         ), "step-length dims overprint — chain crammed instead of skipping"
 
     def test_crowded_chain_staggers_into_two_tiers_at_current_scale(self):
-        # The gramel thumbwheel drive screw (GRM-03): fine steps near the head + one
-        # long shaft. Rather than skip (wasting the empty sheet) or cram, the chain
-        # staggers successive dims between a near and a far tier (ISO 129-1) so every
-        # step length is legible at the drawing's own scale (#293). All segments are
-        # dimensioned, the labels don't overprint each other, and axial coverage is
-        # satisfied — no rescale needed.
+        # A *moderately* crowded chain — steps just ABOVE the arrowhead floor (so no
+        # detail view is triggered), but with labels that would collide on one tier.
+        # Rather than cram, the chain staggers successive dims between a near and a far
+        # tier (ISO 129-1) so every step length stays legible at the drawing's own
+        # scale (#293). Scale pinned so the crowding regime is deterministic.
         from build123d import Align, Cylinder, Pos, Rotation
 
         from draftwright.annotations._common import _anno_box
 
         b = Align.MIN
-        specs = [(8, 1.0), (12, 1.0), (8, 1.0), (12, 1.0), (6, 30.0)]
+        specs = [(8, 3.1), (12, 2.9), (8, 3.2), (12, 2.8), (6, 3.0)]  # ~3 mm, > floor
         shaft = None
         z = 0.0
         for d, ln in specs:
             seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
             shaft = seg if shaft is None else shaft + seg
             z += ln
-        dwg = build_drawing(Rotation(0, 90, 0) * shaft)
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft, scale=2.0)
+        assert "detail_a" not in dwg.views  # above floor → no detail, staggered in place
         steps = {n: o for n, o in dwg._named.items() if n.startswith("m_steplen")}
         assert len(steps) == 5  # every segment dimensioned, none dropped
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
@@ -4870,6 +4870,27 @@ class TestTurnedLengths:
             for i in range(len(boxes))
             for j in range(i + 1, len(boxes))
         ), "staggered step-length labels overprint"
+
+    def test_subfloor_head_gets_detail_view(self):
+        # A fine head (sub-floor steps) + a long shaft (the GRM-03 pattern). The head
+        # can't be dimensioned legibly in line, so the unified detail pipeline (#307)
+        # locates it as one block on the main view + breaks it down in DETAIL A, with
+        # axial coverage satisfied across the two views (no double-dimensioning).
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        b = Align.MIN
+        specs = [(4, 1.5), (6, 2.0), (4, 2.5), (3, 25.0)]  # non-uniform sub-floor head
+        shaft = None
+        z = 0.0
+        for d, ln in specs:
+            seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
+            shaft = seg if shaft is None else shaft + seg
+            z += ln
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft, scale=2.0)
+        assert "detail_a" in dwg.views  # crowded head → enlarged detail
+        assert "25" in {o.label for n, o in dwg._named.items() if n.startswith("m_steplen")}
+        assert len([n for n in dwg._named if n.startswith("dim_detail_steplen")]) >= 3
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
 
 
 class TestStepLadderRecognition:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3816,7 +3816,7 @@ class TestDetailView:
         # The detail view, its caption, and at least one detail step dim exist.
         assert "detail_a" in dwg.views
         assert "detail_caption_A" in dwg._named
-        assert any(n.startswith("dim_detail_step") for n in dwg._named)
+        assert any(n.startswith("dim_detail_a_step") for n in dwg._named)
         # Drawn at a larger scale than the sheet.
         assert dwg._coords["detail_a"]._scale > a.SCALE
         # No error-severity lint introduced.
@@ -4889,7 +4889,29 @@ class TestTurnedLengths:
         dwg = build_drawing(Rotation(0, 90, 0) * shaft, scale=2.0)
         assert "detail_a" in dwg.views  # crowded head → enlarged detail
         assert "25" in {o.label for n, o in dwg._named.items() if n.startswith("m_steplen")}
-        assert len([n for n in dwg._named if n.startswith("dim_detail_steplen")]) >= 3
+        assert len([n for n in dwg._named if n.startswith("dim_detail_a_steplen")]) >= 3
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
+
+    def test_two_sub_floor_runs_get_separate_non_colliding_details(self):
+        # Two separated fine-step clusters → two detail views (A, B). Their dims use
+        # view-scoped names, so detail B's dims don't evict detail A's (the #307-review
+        # name-collision regression) and axial coverage holds across all views.
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        b = Align.MIN
+        specs = [(4, 1.5), (6, 2.0), (4, 2.5), (3, 22), (6, 1.5), (4, 2.0), (5, 2.5), (2, 22)]
+        shaft = None
+        z = 0.0
+        for d, ln in specs:
+            seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
+            shaft = seg if shaft is None else shaft + seg
+            z += ln
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft, page="A2", scale=2.0)
+        assert {"detail_a", "detail_b"} <= set(dwg.views)
+        names = [n for n in dwg._named if "steplen" in n and "detail" in n]
+        assert len(names) == len(set(names))  # no eviction — all detail dims survive
+        assert any(n.startswith("dim_detail_a_") for n in names)
+        assert any(n.startswith("dim_detail_b_") for n in names)
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4914,6 +4914,27 @@ class TestTurnedLengths:
         assert any(n.startswith("dim_detail_b_") for n in names)
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
 
+    def test_head_block_does_not_collapse_main_chain_to_n_times(self):
+        # When the head-block extent happens to match the legible step lengths, the main
+        # chain (block + steps) must NOT collapse to a uniform "N× v" — the block is a
+        # compound region, not a repeated step, and "N× v" would be a false claim of N
+        # equal steps (#307 review).
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        b = Align.MIN
+        # head 1.5/2.0/2.5 (sub-floor, sums to 6) + two legible 6 mm steps
+        specs = [(4, 1.5), (6, 2.0), (4, 2.5), (7, 6.0), (5, 6.0)]
+        shaft = None
+        z = 0.0
+        for d, ln in specs:
+            seg = Pos(0, 0, z) * Cylinder(d / 2, ln, align=(Align.CENTER, Align.CENTER, b))
+            shaft = seg if shaft is None else shaft + seg
+            z += ln
+        dwg = build_drawing(Rotation(0, 90, 0) * shaft, scale=2.0)
+        main = {o.label for n, o in dwg._named.items() if n.startswith("m_steplen")}
+        assert not any("×" in v for v in main)  # no false uniform-staircase collapse
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
+
 
 class TestStepLadderRecognition:
     """ADR 0008 step 1: the Z step-height ladder draws its step levels from the


### PR DESCRIPTION
## What

Replaces the **two bespoke detailers** (the prismatic Z-step detail #42 and the
proposed turned-head detail #304) with **one** `detect → DetailRequest → generic
render` pipeline, mirroring the section pipeline (`plan_sections`/`SectionPlan`).
This is the generalization called for in #307, and it folds in the turned-head
feature (#304) so a fine-headed turned part (the gramel GRM-03 drive screw) gets
an enlarged **DETAIL A** automatically.

GRM-03: main view locates the head as one `2.5` block + the `20` shaft; **DETAIL A
— SCALE 6:1** breaks it into `0.5 / 2`; lint clean but for the separate ø6 (#298).

## How

- **`DetailRequest`** (`_core`): a renderer's "I can't draw this region legibly at
  this scale" signal — band (axis + lo/hi) + `scale_needed` + a `redraw` closure
  (+ scale-aware `pads`). Renderers append to `dwg._detail_requests`.
- **`_render_detail`** (`sections`): the single crop → project → place → caption →
  mark machinery, written **once** (kills the ~70-line copy-paste), parameterised by
  the request's crop axis and annotation pads. Rolls the view back if `redraw`
  draws nothing (no empty DETAIL boxes).
- **`_resolve_details`** (`sections`): resolves every queued request, most-crowded
  first, lettering DETAIL A/B/…; letters advance only on successful placement.
- **`_request_prismatic_detail`** (`sections`): the #42 Z-step detail, now a request.
- **`render_step_lengths`** (`from_model`): extracted `_draw_step_chain` (reused for
  the main chain **and** each detail's redraw); a crowded X-turned head splits its
  contiguous **≥2-step** sub-floor run(s) into a head-block dim on the main view +
  a `DetailRequest`. Band is the sub-floor run only — never swallows the shaft.
- **coverage** (`linting`): `_dim_vertices` reads `_dw_spec` witness endpoints
  (tuple/`Vector`-safe), not text-glyph vertices; axial coverage credits any
  `detail_*` view and an `N× v` span — but only for real step-chain dims.

## Three adversarial-review rounds (8 → 5 → 2 findings, all addressed)

This branch was reviewed three times with the workflow-backed reviewer; every
CONFIRMED finding is fixed (see the fix commits):
- spurious sheet-scale factor in `scale_needed` (under-enlarged details on
  reduction sheets);
- the synthetic head-block contaminating the `N× v` collapse (false "N equal
  steps") and the coverage over-credit it enabled;
- view-scoped detail dim names (two details no longer evict each other);
- empty-detail rollback + letter-gap-on-failure;
- single-step sub-floor runs left inline (no one-step block/detail);
- removed speculative `DetailRequest.fallback`/`pad_right` (CLAUDE.md §2);
- restricted the `N× v` coverage credit to step-chain dims (not an `n× pitch`
  hole dim).

## Tests

- `test_subfloor_head_gets_detail_view`, `test_two_sub_floor_runs_get_separate_non_colliding_details`,
  `test_head_block_does_not_collapse_main_chain_to_n_times` (new regressions);
  the prismatic `#42` detail tests + staggering test retargeted to the unified path.
- Full fast tier: **612 passed**.

## Accepted as-is (documented)

- A crowded turned head auto-details **regardless of `detail_view`** — the #304
  intent (it only fires when a head genuinely can't be dimensioned inline). The
  prismatic detail stays opt-in via `detail_view=True`.
- Detail placement avoids dimension **labels** but not their extension lines; the
  largest-empty-rect placement keeps this low-risk. `detail_*` views remain outside
  the front/plan/side repack (a known boundary, shared with the section view).

Closes #304. Advances #307 (the bespoke detailers are now one path). Related: #298,
#300, #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)