### PR TITLE
fix: lift a coaxial bore callout on a stepped turned shaft too (#305)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -520,21 +520,26 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
 
         A bore on the turning axis is led out along the view's horizontal centre
         axis, so the centre mark / centreline runs straight through the "⌀… ↓…"
-        callout text. Detect that one bore — a rotational part, hole at the view
-        centre — and lift its row a clearance off the axis (an angled leader to a
-        central feature is standard practice), toward the roomier side. Off-axis
+        callout text. Detect that one bore — a **turned/rotational** part, hole at
+        the view centre — and lift its row a clearance off the axis (an angled leader
+        to a central feature is standard practice), toward the roomier side. Off-axis
         holes and every prismatic-part hole are untouched (front-view round parts
         place coaxial bores as vertical shafts below the view, not along an axis,
         so they can't hit this and are exempt by construction).
+
+        The "turned/rotational" gate is ``is_rotational OR prof`` — a *stepped*
+        turned shaft (e.g. the GRM-03 drive screw) has a turned step profile but is
+        not ``is_rotational`` (its varying OD doesn't fill a square cross-section),
+        yet its coaxial bore hits exactly this defect. A prismatic part has neither,
+        so it stays excluded (the regression the original gate guarded against, #305).
 
         Tactical: the principled fix is to not draw the crossing line at all — a
         centred bore is located by the axis, so its linear location dims are
         redundant (#309) — or to make this a layout-solver separation constraint
         (ADR 0003). This nudge becomes dead code once either lands."""
         tol = draft.font_size  # "hole at the view centre" tolerance (page mm)
-        if not (
-            a.is_rotational and abs(centre[0] - view_cx) < tol and abs(centre[1] - view_cy) < tol
-        ):
+        turned = a.is_rotational or a.prof is not None
+        if not (turned and abs(centre[0] - view_cx) < tol and abs(centre[1] - view_cy) < tol):
             return ny
         # Lift the row a full text height + padding clear of the axis: enough for
         # the text box (half a font tall) to sit wholly off the centre line with a

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3778,6 +3778,49 @@ class TestLayoutGeneralisation:
                         crossings.append((n, round(ym, 2)))
         assert not crossings, f"line(s) cross the bore callout text: {crossings}"
 
+    def test_coaxial_bore_callout_clears_centre_axis_on_stepped_shaft(self):
+        # #305 regression: the lift must also fire for a *stepped* turned shaft (the
+        # GRM-03 drive screw), which has a turned step profile but is NOT
+        # is_rotational (its varying OD doesn't fill a square cross-section) — the
+        # original is_rotational-only gate missed it, leaving the bore callout led
+        # straight along the centre axis. Assert no horizontal line crosses the text.
+        from build123d import Align, Cylinder, Pos, Rotation
+
+        from draftwright import build_drawing
+
+        b = Align.MIN
+        part = (
+            Cylinder(6, 12, align=(Align.CENTER, Align.CENTER, b))
+            + Pos(0, 0, 12) * Cylinder(4, 12, align=(Align.CENTER, Align.CENTER, b))
+            - Cylinder(0.8, 8, align=(Align.CENTER, Align.CENTER, b))
+        )
+        dwg = build_drawing(Rotation(0, 90, 0) * part, scale=2.0)
+        assert dwg._analysis.prof is not None and not dwg._analysis.is_rotational
+
+        hc = [(n, o) for n, o in dwg._named.items() if n.startswith("hc_side")]
+        assert hc, "expected a bore callout on the round (side) view"
+        name, leader = hc[0]
+        tx0, ty0, tx1, ty1 = leader.label_bbox
+        crossings = []
+        for n, o in dwg._named.items():
+            if n == name:
+                continue
+            try:
+                edges = list(o.edges())
+            except Exception:
+                continue
+            for e in edges:
+                vs = e.vertices()
+                if len(vs) != 2:
+                    continue
+                (x0, y0), (x1, y1) = (vs[0].X, vs[0].Y), (vs[1].X, vs[1].Y)
+                if abs(y0 - y1) < 0.05 and abs(x0 - x1) > 1.0:  # a horizontal line
+                    ym = (y0 + y1) / 2
+                    xa, xb = min(x0, x1), max(x0, x1)
+                    if ty0 + 0.3 < ym < ty1 - 0.3 and xb > tx0 + 0.3 and xa < tx1 - 0.3:
+                        crossings.append((n, round(ym, 2)))
+        assert not crossings, f"line(s) cross the bore callout text: {crossings}"
+
     def test_prismatic_central_hole_callout_not_lifted(self):
         # Scope-lock for #305: the coaxial-bore lift is gated to rotational parts.
         # A *prismatic* part's central hole stays on the plan-view centre row —

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3687,6 +3687,32 @@ class TestLintSummaryAndDrops:
 
 
 class TestLayoutGeneralisation:
+    @staticmethod
+    def _lines_crossing_label(dwg, callout_name, label_bbox):
+        """Horizontal lines (other than the callout's own shelf) that cross the
+        callout's text box — the #305 'line through the callout text' defect. Shared
+        by the coaxial-bore tests."""
+        tx0, ty0, tx1, ty1 = label_bbox
+        crossings = []
+        for n, o in dwg._named.items():
+            if n == callout_name:
+                continue
+            try:
+                edges = list(o.edges())
+            except Exception:
+                continue
+            for e in edges:
+                vs = e.vertices()
+                if len(vs) != 2:
+                    continue
+                (x0, y0), (x1, y1) = (vs[0].X, vs[0].Y), (vs[1].X, vs[1].Y)
+                if abs(y0 - y1) < 0.05 and abs(x0 - x1) > 1.0:  # a horizontal line
+                    ym = (y0 + y1) / 2
+                    xa, xb = min(x0, x1), max(x0, x1)
+                    if ty0 + 0.3 < ym < ty1 - 0.3 and xb > tx0 + 0.3 and xa < tx1 - 0.3:
+                        crossings.append((n, round(ym, 2)))
+        return crossings
+
     @pytest.mark.timeout(120)
     def test_turned_flange_gets_both_od_and_hole_furniture(self):
         # A turned-and-drilled flange (cylinder OD + centre bore + bolt circle)
@@ -3756,26 +3782,7 @@ class TestLayoutGeneralisation:
         hc = [(n, o) for n, o in dwg._named.items() if n.startswith("hc_side")]
         assert hc, "expected a bore callout on the round (side) view"
         name, leader = hc[0]
-        tx0, ty0, tx1, ty1 = leader.label_bbox
-
-        crossings = []
-        for n, o in dwg._named.items():
-            if n == name:
-                continue  # the callout's own shelf ends before its text
-            try:
-                edges = list(o.edges())
-            except Exception:
-                continue
-            for e in edges:
-                vs = e.vertices()
-                if len(vs) != 2:
-                    continue
-                (x0, y0), (x1, y1) = (vs[0].X, vs[0].Y), (vs[1].X, vs[1].Y)
-                if abs(y0 - y1) < 0.05 and abs(x0 - x1) > 1.0:  # a horizontal line
-                    ym = (y0 + y1) / 2
-                    xa, xb = min(x0, x1), max(x0, x1)
-                    if ty0 + 0.3 < ym < ty1 - 0.3 and xb > tx0 + 0.3 and xa < tx1 - 0.3:
-                        crossings.append((n, round(ym, 2)))
+        crossings = self._lines_crossing_label(dwg, name, leader.label_bbox)
         assert not crossings, f"line(s) cross the bore callout text: {crossings}"
 
     def test_coaxial_bore_callout_clears_centre_axis_on_stepped_shaft(self):
@@ -3800,25 +3807,7 @@ class TestLayoutGeneralisation:
         hc = [(n, o) for n, o in dwg._named.items() if n.startswith("hc_side")]
         assert hc, "expected a bore callout on the round (side) view"
         name, leader = hc[0]
-        tx0, ty0, tx1, ty1 = leader.label_bbox
-        crossings = []
-        for n, o in dwg._named.items():
-            if n == name:
-                continue
-            try:
-                edges = list(o.edges())
-            except Exception:
-                continue
-            for e in edges:
-                vs = e.vertices()
-                if len(vs) != 2:
-                    continue
-                (x0, y0), (x1, y1) = (vs[0].X, vs[0].Y), (vs[1].X, vs[1].Y)
-                if abs(y0 - y1) < 0.05 and abs(x0 - x1) > 1.0:  # a horizontal line
-                    ym = (y0 + y1) / 2
-                    xa, xb = min(x0, x1), max(x0, x1)
-                    if ty0 + 0.3 < ym < ty1 - 0.3 and xb > tx0 + 0.3 and xa < tx1 - 0.3:
-                        crossings.append((n, round(ym, 2)))
+        crossings = self._lines_crossing_label(dwg, name, leader.label_bbox)
         assert not crossings, f"line(s) cross the bore callout text: {crossings}"
 
     def test_prismatic_central_hole_callout_not_lifted(self):


### PR DESCRIPTION
## What

The #305 fix (PR #310) lifts a coaxial bore's callout off the round view's centre
axis — but only when `a.is_rotational`. A **stepped** turned shaft (the gramel
GRM-03 drive screw) has a turned step profile yet is **not** `is_rotational` (its
varying OD doesn't fill a square cross-section, so the rotational classifier
rejects it). Its coaxial bore callout was therefore still led straight along the
centre axis, with the centre mark / location-dim line running through the
`⌀1.6 ↓8` text — **the exact defect #305 was meant to fix.** The user hit this on
GRM-03 after v0.2.1.

## Fix

Broaden the `_coaxial_lift` gate from `a.is_rotational` to
`a.is_rotational or a.prof is not None` — a turned step profile is the same
round-end-view case. A prismatic part has neither, so it stays excluded; the
`test_prismatic_central_hole_callout_not_lifted` scope-lock (the regression the
original gate guarded against) still passes.

Before/after on GRM-03: the bore callout is now angled clear of the axis, text in
open space, centreline no longer crossing it.

## Tests

- New `test_coaxial_bore_callout_clears_centre_axis_on_stepped_shaft` — a stepped
  turned shaft (`is_rotational=False`, `prof` set) with a coaxial bore: no
  horizontal line crosses the callout text. This is the regime the original
  uniform-cylinder test missed.
- The prismatic scope-lock test and the uniform-cylinder test both still pass.
- ruff + mypy clean.

Note: the principled fix remains #309 (don't draw the redundant location dim of a
centred bore at all), after which this nudge becomes dead code — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)