### PR TITLE
perf: lazy CLI/engine imports so completion isn't ~6s (#313)

### DIFF
--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -11,40 +11,81 @@ Requires build123d-drafting-helpers for annotation primitives.
 Licensed under the GNU Affero General Public License v3 (AGPL-3.0).
 """
 
+import importlib as _importlib
 import sys as _sys
 import types as _types
+from typing import TYPE_CHECKING
 
-from draftwright.analysis import analyse_face_levels, dedup_diams
-from draftwright.builder import (
-    build_drawing,
-    generate_script,
-    make_drawing,
-)
-from draftwright.drawing import Drawing, FeatureInfo
-from draftwright.export import fix_svg_page_size
-from draftwright.linting import lint_feature_coverage
-from draftwright.pmi import PmiRecord, extract_pmi
-from draftwright.sheet import choose_scale
+# Public API resolved lazily (PEP 562): `import draftwright` — and, crucially,
+# `import draftwright.cli` (which runs this __init__ first) — must NOT eagerly
+# pull in the engine. The engine drags build123d/OCP, ~5 s of CAD-kernel import.
+# The CLI's shell completion, --help and --version import this package but touch
+# none of these names, so they stay sub-second instead of paying for the kernel
+# on every TAB press (#313). Each name maps to the submodule that provides it.
+_LAZY = {
+    "analyse_face_levels": "draftwright.analysis",
+    "dedup_diams": "draftwright.analysis",
+    "build_drawing": "draftwright.builder",
+    "generate_script": "draftwright.builder",
+    "make_drawing": "draftwright.builder",
+    "Drawing": "draftwright.drawing",
+    "FeatureInfo": "draftwright.drawing",
+    "fix_svg_page_size": "draftwright.export",
+    "lint_feature_coverage": "draftwright.linting",
+    "PmiRecord": "draftwright.pmi",
+    "extract_pmi": "draftwright.pmi",
+    "choose_scale": "draftwright.sheet",
+}
 
-_make_drawing_function = make_drawing
+
+def _resolve(name):
+    """Import the providing submodule and cache the public object on the package."""
+    value = getattr(_importlib.import_module(_LAZY[name]), name)
+    _types.ModuleType.__setattr__(_sys.modules[__name__], name, value)
+    return value
 
 
 class _DraftwrightModule(_types.ModuleType):
+    def __getattr__(self, name):
+        # PEP 562 miss handler: resolve a public name on first access.
+        if name in _LAZY:
+            return _resolve(name)
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
     def __getattribute__(self, name):
+        # `draftwright.make_drawing` must be the FUNCTION even after the compat
+        # SUBMODULE of the same name is imported and shadows it as a package
+        # attribute (importing draftwright.make_drawing binds the module here).
         if name == "make_drawing":
             namespace = _types.ModuleType.__getattribute__(self, "__dict__")
-            value = namespace.get(name)
+            value = namespace.get("make_drawing")
             if (
                 isinstance(value, _types.ModuleType)
                 and value.__name__ == "draftwright.make_drawing"
             ):
-                public = namespace["_make_drawing_function"]
-                _types.ModuleType.__setattr__(self, name, public)
-                return public
+                return _resolve("make_drawing")
         return _types.ModuleType.__getattribute__(self, name)
 
 
 _sys.modules[__name__].__class__ = _DraftwrightModule
+
+
+if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel cost
+    from draftwright.analysis import analyse_face_levels, dedup_diams
+    from draftwright.builder import build_drawing, generate_script, make_drawing
+    from draftwright.drawing import Drawing, FeatureInfo
+    from draftwright.export import fix_svg_page_size
+    from draftwright.linting import lint_feature_coverage
+    from draftwright.pmi import PmiRecord, extract_pmi
+    from draftwright.sheet import choose_scale
+
+
+def __dir__():
+    # Surface the lazy public names (not in __dict__ until first accessed)
+    # *alongside* the normal module contents — dunders, imported submodules — so
+    # introspection / REPL completion sees the full surface, not a subset.
+    return sorted(set(globals()) | set(__all__))
+
 
 __all__ = [
     "Drawing",

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -17,8 +17,6 @@ from importlib.metadata import version as _pkg_version
 
 import typer
 
-from draftwright.builder import build_drawing, generate_script
-
 app = typer.Typer(
     add_completion=True,
     # Plain tracebacks on an engine error, matching the old argparse CLI — a rich
@@ -143,6 +141,12 @@ def main(
         )
 
     formats = _parse_formats(output_format)
+
+    # Import the engine lazily, only on the build path: it pulls in build123d/OCP
+    # (~5 s of CAD-kernel import). Keeping it out of module scope means shell
+    # completion, --help and --version (which import this module but never call
+    # the command) stay sub-second instead of paying for the kernel every time.
+    from draftwright.builder import build_drawing, generate_script
 
     if script:
         py_path = generate_script(

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1648,6 +1648,42 @@ def test_cli_version_reports_installed_version():
     assert result.stdout.strip() == f"draftwright {_pkg_version('draftwright')}"
 
 
+def test_cli_import_does_not_load_the_engine():
+    """Importing the CLI must not pull in build123d/OCP (#313). Shell completion,
+    --help and --version import this module on every invocation; loading the
+    ~5 s CAD kernel there made each TAB press take ~6 s. Guard the lazy boundary:
+    the engine is imported only on the actual build path, in a fresh process so
+    other tests' imports can't mask a regression."""
+    code = (
+        "import sys, draftwright.cli; "
+        "heavy = [m for m in ('build123d', 'OCP') if m in sys.modules]; "
+        "print(','.join(heavy)); sys.exit(1 if heavy else 0)"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"`import draftwright.cli` eagerly loaded: {result.stdout.strip()}"
+    )
+
+
+def test_lazy_public_api_preserves_make_drawing_identity():
+    """The lazy package __init__ (#313) must still expose the public API, and
+    `draftwright.make_drawing` must stay the FUNCTION even after the compat
+    submodule of the same name is imported and would otherwise shadow it."""
+    code = (
+        "import types, draftwright as d; "
+        "from draftwright import make_drawing, build_drawing, Drawing, choose_scale; "
+        "assert callable(make_drawing) and not isinstance(make_drawing, types.ModuleType); "
+        "assert d.make_drawing is make_drawing; "
+        "import draftwright.make_drawing; "  # provoke the shadowing path
+        "assert callable(d.make_drawing) and not isinstance(d.make_drawing, types.ModuleType); "
+        "print('ok')"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0 and result.stdout.strip() == "ok", (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # --format selector (#288) — pure logic, no OCP build needed
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #313.

`draftwright` shell completion took **~6 s per TAB** — and so did `--help` and `--version`.

## Cause
Completion re-invokes the program on every TAB. Each invocation imports `draftwright.cli`, which runs `draftwright/__init__.py`, which **eagerly imported the whole engine** → build123d → **OCP (OpenCASCADE)**. Measured: `import draftwright.cli` = 4.6 s (~all OCP) + ~1.5 s startup. Completion only needs option *names* — it never builds a drawing.

## Fix
- **`cli.py`** — lazy-import `build_drawing`/`generate_script` inside `main()`; only the build path needs the engine.
- **`__init__.py`** — resolve the public API lazily (PEP 562 `__getattr__` over a name→submodule map) instead of eagerly importing every engine submodule. Preserves the `make_drawing` module/function **shadowing guard**, adds a `TYPE_CHECKING` block (static analysers still see the names), and `__dir__` merges the lazy names with the live module contents.

## Result (measured)
| | before | after |
|---|---|---|
| completion (TAB) | 6.25 s | **0.24 s** |
| `--version` | 5.81 s | 0.23 s |
| `--help` | 6.25 s | 0.50 s |

`import draftwright.cli` now loads **zero** engine modules. The build path is unchanged. Also unblocks #276 (the TUI will care about startup cost).

## Tests
- `test_cli_import_does_not_load_the_engine` — no build123d/OCP after `import draftwright.cli` (fresh process).
- `test_lazy_public_api_preserves_make_drawing_identity` — public API resolves + `make_drawing` stays the function even after the compat submodule is imported.

## Verification
- Full fast tier: **616 passed** (the suite leans heavily on `from draftwright import …`); ruff + format + mypy clean.
- **Fresh adversarial review** (independent agent) across the shadowing guard, recursion, thread races, pickle, `hasattr`, `dir`, and `import *` — no correctness regression. Its one finding (a `dir()` that hid dunders/submodules) is fixed here by merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
