### PR TITLE
docs: ADR 0009 boundary-labeling strip placement + research, roadmap, ADR-set consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ It sits on top of two Apache 2.0 libraries:
 ## Architecture
 
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
-top: leaf modules (`layout.py`, `registry.py`, `linting.py`, `fonts.py`, the
-`recognition/` subpackage) → `_core.py` → stage modules (`export.py`, `repair.py`,
-`projection.py`, `sheet.py`, `analysis.py`, `drawing.py`, the `annotations/`
-subpackage) → `builder.py` → the `make_drawing.py` / `annotate.py` compat facades.
+top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, the `linting/` and
+`recognition/` subpackages) → `_core.py` → stage modules (`export.py`,
+`repair.py`, `projection.py`, `sheet.py`, `analysis.py`, `drawing.py`, the
+`model/` IR subpackage, the `annotations/` subpackage) → `builder.py` → the
+`make_drawing.py` / `annotate.py` compat facades and the `cli.py` entry point.
 No lower module imports an upper one.
 
 - **`make_drawing.py`** — thin compat facade (~17 lines) re-exporting the public
@@ -28,9 +29,14 @@ No lower module imports an upper one.
   `FeatureInfo`, `fix_svg_page_size`, `lint_feature_coverage`) so existing imports
   and the `draftwright` CLI entry point keep working. The engine lives in:
   - **`builder.py`** — build orchestration: `build_drawing` (analyse → assemble →
-    measure-and-repack → `Drawing`), `make_drawing` (+ export), the editable-script
-    generator (`generate_script`), and the CLI (`_cli`). Imports `drawing`/`analysis`/
+    measure-and-repack → `Drawing`), `make_drawing` (+ export), and the
+    editable-script generator (`generate_script`). Imports `drawing`/`analysis`/
     the annotation orchestrator/the stage modules — never `make_drawing` (a DAG).
+    *(The CLI moved out to `cli.py`; `_cli` is now a thin shim.)*
+  - **`cli.py`** — the Typer command-line interface (#289): argument parsing,
+    `--version`, shell completion, `--format`, rich help. The engine (build123d)
+    is imported **lazily inside the command body** so completion/`--help`/
+    `--version` stay sub-second (#313). Entry point: `draftwright.cli:app`.
   - **`drawing.py`** — the `Drawing` result object (`.lint()`/`.add()`/`.place_dim()`/
     `.repair()`/`.export*()`; delegates identity to `registry`, coverage to `lint`)
     plus `_build_table` and `FeatureInfo`. Sits below `builder` (which constructs it).
@@ -40,20 +46,20 @@ No lower module imports an upper one.
   orchestrator) from `annotations/`. The annotation passes were split into the
   **`annotations/`** subpackage (#164 / ADR 0005, P5):
   - **`annotations/orchestrator.py`** — `_auto_annotate`, the single entry point
-    (called by `build_drawing`); classifies the part, places envelope/OD dims
-    inline, drives the capability passes + title block. (Envelope dims remain
-    inline here; pulling them into `annotations/envelope.py` is a deferred
-    follow-up.)
+    (called by `build_drawing`); classifies the part and drives the render passes
+    + title block. End state (ADR 0008) is `build model → plan → render`; a little
+    inline engine code (some envelope/step-ladder placement) remains here pending
+    the last convergence steps.
+  - **`annotations/from_model.py`** — the **IR render layer** (largest annotations
+    module): turns the planner's `DimensionGroup`/render-intents into placed
+    dimensions/callouts/centre marks/section triggers. This is where the turned,
+    PMI/GD&T, envelope/OD, centre-mark and step-length passes converged (ADR 0008,
+    #200/#208/#237) — the old per-feature `annotations/{turned,pmi}.py` modules
+    were deleted as each migrated here.
   - **`annotations/holes.py`** — hole/pattern callouts, balloons, location dims
-    (incl. side-drilled #133), pitch/grid dims, slots (the largest pass).
+    (incl. side-drilled #133), pitch/grid dims, slots (the largest *pass*).
   - **`annotations/sections.py`** — section A–A + detail views (ISO 128-44 arrows,
     ISO 128-50 hatching).
-  - **`annotations/turned.py`** — turned-part step-diameter callouts and the
-    axial step-length chain (X-axis turned parts; `find_turned_steps` +
-    `lint_axial_coverage` close the drive-screw gap — diameters dimensioned but
-    shoulders unlocatable).
-  - **`annotations/pmi.py`** — the PMI/GD&T annotation pass (distinct from the
-    STEP-side extraction in `pmi.py`).
   - **`annotations/_common.py`** — shared placement helpers (`_anno_box`,
     `_occupied_boxes`, `_box_hits`) at the bottom of the annotations DAG.
   Each submodule imports only `_core`/`layout`/`projection`/third-party — never
@@ -69,11 +75,17 @@ No lower module imports an upper one.
   identity/ownership/pins/build-issues (#138 / ADR 0005, Step 2). `Drawing`
   delegates here and keeps the render list; `_named`/`_anno_view`/`_pinned`/
   `_build_issues` remain `Drawing` properties during the migration.
-- **`linting.py`** — the lint module (#138 / ADR 0005): `lint_feature_coverage`
-  (feature-coverage completeness check), `_suggest_fix` (#29 fix snippets), and
-  `CoverageState` (the coverage signal — pattern callouts, patterned holes,
-  dropped diameters). Depends only on `_core` + build123d_drafting. `_QUOTED_RE`
-  (a lint-message label regex shared with the repair loop) lives in `_core`.
+- **`linting/`** — the lint subpackage (#138 / ADR 0005; ADR 0007: draftwright
+  owns linting): `coverage.py` (`lint_feature_coverage` + `CoverageState`),
+  `structural.py` (geometry/standards checks), `issues.py` (the `LintIssue` type),
+  `suggest.py` (`_suggest_fix`, #29 snippets). Depends only on `_core` +
+  build123d_drafting. `_QUOTED_RE` (a lint-message label regex shared with the
+  repair loop) lives in `_core`.
+- **`model/`** — the ADR 0008 IR waist: `ir.py` (the `Feature`/`DimParameter`/
+  `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
+  `Feature` objects, adapting `recognition/`), `planner.py` (`plan_dimensions` —
+  one rule set → a `DimensionGroup` per feature, + `plan_sections`). The narrow
+  middle of the compiler hourglass; consumed by `annotations/from_model.py`.
 - **`recognition/`** — feature recognition (ADR 0007: draftwright owns it, not
   helpers). `_features.py` (vendored from `build123d_drafting.features`; the
   hole/boss/cylinder/pattern recognisers — `find_holes`/`find_bosses`/
@@ -87,7 +99,8 @@ No lower module imports an upper one.
   cross-platform layout (ADR 0006).
 - **`export.py`** — SVG/DXF/PDF export + post-processing (page-size fix,
   attribution hyperlink/metadata, DXF metadata, arc sanitisation, element-wise
-  shape-export degradation, cairo PDF render). The first **module-split** step of
+  shape-export degradation, pure-Python PDF render via svglib + reportlab — no
+  native cairo, #288). The first **module-split** step of
   #138 (ADR 0005): `Drawing.export()` / `export_pdf()` stay as thin wrappers.
   Sits below `make_drawing.py`, above `_core.py`.
 - **`repair.py`** — the deterministic lint→repair loop (#30 / ADR 0002): the
@@ -120,19 +133,15 @@ Current ADRs:
   front-view dimensions (CTC-02) + lint clean. Execution tracked as **#121**
   (the current order — annotations placed *after* views, into shared corridors —
   is the root cause of cross-view overlap).
-- **0005** — **Accepted, in progress** (#138): compiler-pipeline module boundaries
-  + single-owner build state. `Drawing` stops being the implicit state bus;
-  annotation identity/pins/build-issues move to a `registry.py`, coverage state to
-  lint, build context (`Analysis`, edge cache) to the pipeline. Stages split into
-  `builder`/`analysis`/`sheet`/`projection`/`linting`/`repair`/`export`/`annotations/`;
-  `layout.py` unchanged. **Roadmap + per-phase issues:**
-  `docs/plans/138-module-split-roadmap.md`. **Landed** (`make_drawing.py`
-  3,907 → 3,476): golden gate (Step 0), public helper APIs (#139), `registry.py`
-  (Step 2), `linting.py` (`CoverageState` + lint functions, Step 3), `repair.py`,
-  `export.py`. **Still ahead:** P1 `_text_width`→`_core` (#160), P2 `projection.py`
-  (#161), P3 `sheet.py` (#162), P4 `analysis.py` (#163), P5 `annotations/` (#164),
-  P6 `builder.py` + build-context threading (#165), P7 mypy (#166). The module list
-  above is the *current* tree; the remaining stage modules do not exist yet.
+- **0005** — **Accepted (split complete)** (#138): compiler-pipeline module
+  boundaries + single-owner build state. `Drawing` stops being the implicit state
+  bus; annotation identity/pins/build-issues moved to `registry.py`, coverage
+  state to `linting/`, build context (`Analysis`, edge cache) into the pipeline.
+  Stages split into `builder`/`analysis`/`sheet`/`projection`/`linting/`/`repair`/
+  `export`/`annotations/` (all #160–#166 landed; `make_drawing.py` 3,907 → ~17
+  facade). `layout.py` unchanged. **Roadmap:** `docs/plans/138-module-split-roadmap.md`.
+  Two deferred follow-ups: inline envelope dims → `annotations/envelope.py`, and
+  full build-context threading off `Drawing` (§2).
 - **0006** — **Accepted** (#149): deterministic cross-platform layout via bundled,
   path-pinned fonts. Layout depends on measured text width; resolving a font *name*
   (`"Arial"`) substitutes a different font on Linux, drifting the whole sheet ~1 mm.
@@ -145,6 +154,20 @@ Current ADRs:
   was **retired** here — byte-exact digests are friction during deliberate output
   evolution; regression coverage rests on the geometry-level + `test_e2e_standards`
   suites. See ADR 0005 §3's retirement note.)
+- **0008** — **Accepted, migration complete** (one path, 2026-06-30): the
+  part-drawing **compiler** — detectors → a Feature/DimParameter **IR/PartModel**
+  → a dimensioning **planner** → render-intents → the shared layout/projection/
+  export infra. One feature inventory, detected once; orientation/feature-kind are
+  *data in the IR*, not code branches. Roadmaps: `docs/plans/0008-*-roadmap.md`.
+- **0009** — **Accepted** (decision; work pending — supersedes/subsumes #150):
+  **collect-then-solve** per-strip annotation placement (boundary labeling).
+  Strip passes stop placing-as-they-go;
+  every strip occupant is collected as a candidate and one solve per strip does
+  select → assign → order(=feature order ⇒ crossing-free) → space. Removes the
+  invisible-occupant collision class (#133/#225/#305) by construction; the inner
+  per-view layer to 0004's outer block packing; consumes 0008's render-intents.
+  Research: `docs/research/annotation-placement-boundary-labeling.md`. Roadmap:
+  `docs/plans/strip-layout-boundary-labeling-roadmap.md`.
 
 ## Dependencies
 

--- a/docs/adr/0003-constraint-based-layout.md
+++ b/docs/adr/0003-constraint-based-layout.md
@@ -1,6 +1,11 @@
 # ADR 0003 — Constraint-based layout: one solver for every placeable
 
-- **Status:** Proposed
+- **Status:** Accepted (core implemented; the unifying *global 2-D* solve stays
+  deferred — #94). The `Placeable`/`LayoutSolver` model, the 1-D strip solve,
+  `place_box`/`fit_box`, and pins (#89) have shipped. The **assignment layer**
+  and **escalation ladder** for per-view strip placement are made concrete by
+  [ADR 0009](0009-boundary-labeling-strip-placement.md) (collect-then-solve
+  boundary labeling).
 - **Date:** 2026-06-18
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -95,7 +100,10 @@ drops: zone A → zone B → **tabulate** (callouts → hole table) → **detail
 → **reduce scale**. Today's `callout_dropped` / `step_dim_dropped` /
 `location_ref_dropped` are the scattered manual version; "unsatisfiable" becomes
 a real solver outcome that drives the ladder, and a genuine drop is still
-surfaced as lint.
+surfaced as lint. *[ADR 0009](0009-boundary-labeling-strip-placement.md) makes
+this concrete for the strips: the per-strip solve's **selection** step is the
+ladder's first rung — a priority-ranked keep/escalate decision over the full
+candidate set, replacing the arrival-order drops.]*
 
 ## Consequences
 
@@ -135,10 +143,10 @@ required mitigations:
   survives every later re-solve and stays local — never re-derive over a
   deliberate placement. _Partly landed (#89):_ `dwg.pin(name)` / `dwg.unpin(name)`
   are the domain verbs, `Placeable.locked` is the solver-side flag, and
-  `repair()` already refuses to move a pinned annotation. _(The pin **state**
-  itself — today `Drawing._pinned` — is planned to move into `registry.py` as its
-  single owner per [ADR 0005](0005-pipeline-architecture-and-state-ownership.md),
-  proposed; the override contract here is unchanged, only its home.)_ **Still owed
+  `repair()` already refuses to move a pinned annotation. _(The pin **state** now
+  lives in `registry.py` as its single owner per
+  [ADR 0005](0005-pipeline-architecture-and-state-ownership.md) (split complete);
+  the override contract here is unchanged, only its home.)_ **Still owed
   by #82:**
   the global 2D solve must honour `locked` (keep it at `natural`, solve the rest
   around it). This remains a hard prerequisite for that solve, not a later nicety.
@@ -205,6 +213,10 @@ never be needed.** This is a deliberate scope correction, not an omission.
 - [ADR 0005](0005-pipeline-architecture-and-state-ownership.md) — module
   boundaries and single-owner build state; `layout.py` is unchanged, but pin
   state moves to `registry.py`.
+- [ADR 0009](0009-boundary-labeling-strip-placement.md) — makes this ADR's
+  assignment layer and escalation ladder concrete for per-view strip placement
+  (collect-then-solve boundary labeling); the per-view inner layer to ADR 0004's
+  outer block packing.
 - Issue #77 (external turned diameters — the first `Placeable`); the phased
   layout issues (protocol/solver → port callouts → port dims → tables/GD&T);
   #61/#62 (GD&T — beneficiaries of the unified placement).

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -105,9 +105,11 @@ table size, halo) collapse into one composer per view.
 ### Relationship to ADR 0003 and the deferred 2D solve
 
 - ADR 0003 governs the **inner** layout (placing a view's own annotations in its
-  zones via the `Placeable`/Cassowary system). This ADR governs the **outer**
-  layout (composing view+annotation blocks and packing them on the page). A
-  block's footprint is produced by running the ADR-0003 inner layout in
+  zones via the `Placeable`/Cassowary system) — now made concrete by
+  [ADR 0009](0009-boundary-labeling-strip-placement.md) (collect-then-solve
+  boundary labeling per strip). This ADR governs the **outer** layout (composing
+  view+annotation blocks and packing them on the page). A block's footprint is
+  the deterministic bounding box that the ADR-0009 inner solve produces in
   view-local space.
 - The **page-level packing stays fixed-topology** (plan above front sharing X;
   side beside front sharing Y; iso and table in free rectangles via

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -7,12 +7,14 @@
   [`docs/plans/138-module-split-roadmap.md`](../plans/138-module-split-roadmap.md).
   **Landed** (`make_drawing.py` 3,907 → 3,476): the golden gate (Step 0, made
   cross-platform-deterministic by the #149 font pinning), public helper APIs
-  (#139), `registry.py` (annotation identity, Step 2), `linting.py`
+  (#139), `registry.py` (annotation identity, Step 2), `linting/`
   (`CoverageState` + `lint_feature_coverage` + `_suggest_fix`, Step 3), `repair.py`
-  (the lint→repair loop), and `export.py`. **Remaining** (deeply-coupled stage
-  splits, sequenced prerequisite-first): P1 `_text_width`→`_core` (#160, done), P2
-  `projection.py` (#161), P3 `sheet.py` (#162, done; repack deferred to P6), P4 `analysis.py` (#163, done), P5
-  `annotations/` (#164), P6 `builder.py`+`drawing.py` (#165, done; context-threading deferred), P7 mypy (#166, done). All phases landed: make_drawing.py 3,907 → ~17 (facade).
+  (the lint→repair loop), and `export.py`. **Then** (the deeply-coupled stage
+  splits, sequenced prerequisite-first — **all since landed**): P1 `_text_width`→`_core`
+  (#160), P2 `projection.py` (#161), P3 `sheet.py` (#162; repack deferred to P6),
+  P4 `analysis.py` (#163), P5 `annotations/` (#164), P6 `builder.py`+`drawing.py`
+  (#165; context-threading deferred), P7 mypy (#166). All phases landed:
+  make_drawing.py 3,907 → ~17 (facade).
   Deferred follow-ups: annotations/envelope.py + build-context threading (§2). Build context (`_analysis`, edge cache) is threaded through
   `builder`/`projection` in P6, **not** parked on `Drawing` as a standalone owner.
 

--- a/docs/adr/0007-own-recognition-and-linting.md
+++ b/docs/adr/0007-own-recognition-and-linting.md
@@ -1,6 +1,7 @@
 # ADR 0007 — draftwright owns feature recognition and linting; helpers becomes the rendering library
 
-- **Status:** Proposed
+- **Status:** Accepted (recognition + linting vendored; `recognition/` and
+  `linting/` are the live homes; the golden harness was retired here)
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -124,7 +124,9 @@ scoped golden gate and X/Z parity as standing criteria):
    **prototype** a vertical slice: build the model from a real part via adapted
    detectors and run a minimal planner, proving diverse features (holes + steps +
    bosses) flow through one pipeline. *(Landed — see `src/draftwright/model/` and
-   `tests/test_part_model.py`; not yet wired into `build_drawing`.)*
+   `tests/test_part_model.py`; this initial slice was not yet wired into
+   `build_drawing` — the later amendments completed that, and the IR is now the
+   production path. See the header and Amendment 3.)*
 2. **Adapt, don't rewrite, the heuristics.** Wrap `find_holes`/`find_bosses`/
    `find_turned_steps`/`find_slots` so they emit `Feature` objects; their B-rep
    logic stays.
@@ -232,7 +234,10 @@ the inline envelope/OD/centre-mark/step-ladder code in the orchestrator) **all
 migrate onto this path and are deleted.** The orchestrator's end state is
 `build model → plan → render` — no per-feature pile. The shared layout/projection/
 export stack is *not* rewritten (ADR 0008 always fed the existing layout); what
-disappears is the duplicated feature→dimensioning logic.
+disappears is the duplicated feature→dimensioning logic. *(How that shared layout
+itself places annotations into a view's strips is settled separately by
+[ADR 0009](0009-boundary-labeling-strip-placement.md): the render-intents become
+the candidates its collect-then-solve stage consumes per strip.)*
 
 **Migration is a strangler, governed by three rules:**
 

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -1,0 +1,170 @@
+# ADR 0009 — Boundary labeling: collect-then-solve per-strip annotation placement
+
+- **Status:** Accepted (2026-06-30)
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+A run of layout fixes — #133 (locate side-drilled holes), #225 (locate *every*
+side-drilled hole), #293 (dense step-length chains), #305 (coaxial bore callout
+crossed by its location-dim line), and the `callout_dropped` /
+`location_ref_dropped` / `off_axis_location_dropped` family — keep landing in the
+same place and keep being patches, not cures. They share one root cause.
+
+draftwright places a view's annotations into **strips** (`ViewZones`:
+left/right/above/below bands around each orthographic view; `_core.py`). Inside
+those strips, placement is **imperative, single-pass, and split across mechanisms
+that do not share an occupancy model**:
+
+- a **cursor** (`Strip.allocate`) used by envelope dims, step/height ladders, and
+  off-axis location dims; and
+- a **1-D Cassowary solve** (`LayoutSolver.solve_strip`, kiwisolver; ADR 0003)
+  used by bore-callout and turned-diameter leaders.
+
+Several passes write into the **same** strip, each blind to the others. The code
+admits it (`annotations/holes.py`): *"the right/below strips are SHARED with hole
+callouts and the section hatch, which use other placers and are invisible to the
+cursor (#133). So a clean allocation is necessary but not sufficient…"* The
+workarounds are post-hoc occupancy checks and tier-retry loops; and when a strip
+is full, **which annotation gets dropped is decided by arrival order in the code,
+not by priority.**
+
+This is, precisely, the academic problem of **boundary labeling** (Bekos,
+Kaufmann, Symvonis & Wolff, 2007): point features inside a view rectangle, labels
+on the surrounding strips, joined by leaders; minimise short, **crossing-free**
+leaders. The research backing — current-engine critique, the literature, and the
+full pros/cons of the two candidate approaches — is in
+[`research/annotation-placement-boundary-labeling.md`](../research/annotation-placement-boundary-labeling.md).
+
+ADR 0003 already framed the right *shape* (assignment → placement, an escalation
+ladder) but left the assignment layer and escalation under-specified and deferred
+the global solve. The strip passes were never actually unified; they still
+place-as-they-go. This ADR settles **which concrete model finishes ADR 0003 for
+the strips, and which to reject.**
+
+## Decision
+
+Adopt **boundary labeling with a collect-then-solve per-strip stage** (the
+research note's *Approach A*). Reject the global metaheuristic/MIP optimiser
+(*Approach B*) as the primary direction — see *Alternatives*.
+
+The load-bearing change is a **control-flow inversion**. Today each pass commits
+real geometry (`dwg.add(...)`) as it runs. Instead, for each view, run three
+phases:
+
+1. **Collect.** Every contributor — bore callouts, location dims, step/
+   turned-diameter dims, the section-hatch footprint (as a fixed obstacle) —
+   emits a *candidate* (`Placeable` + priority + eligible side(s)). **Nothing is
+   placed.** This consumes the **full** per-strip set at once.
+2. **Solve.** One optimisation over that set:
+   - **Select** — if the strip cannot hold everything, keep the highest-priority
+     set that fits; the rest produce a first-class **escalation** signal.
+   - **Assign** — side/zone (the discrete, disjunctive choice).
+   - **Order** — label order along the strip = **feature order**. This is the key
+     move: with order fixed, leaders are **crossing-free by construction** and
+     non-overlap collapses to a chain of *linear* inequalities — exactly what
+     kiwisolver can solve, which is why the disjunction problem disappears.
+   - **Space** — final positions via the existing 1-D Cassowary strip solve.
+3. **Emit.** Materialise the chosen geometry from the solve's decisions.
+
+Objective: **minimise total leader length (+ kept priority) subject to
+non-overlap and bounds.** Order-fixing kills crossings for free; selection
+handles over-capacity; the optimum is a sweep / min-cost matching / dynamic
+program (O(n log n)–O(n³)) finished by the 1-D solver already in `layout.py`.
+
+**Why this and not a global solve.** It removes the actual defect class — the
+invisible-occupant collision — *by construction*, while preserving the two
+properties draftwright cannot give up: **determinism** (ADR 0001) and
+**explainability** ("label *i* sits here because order + min-gap +
+shortest-leader," not "the annealer landed there"). It is consolidation of parts
+that already exist (`Placeable`, `LayoutSolver`, the strips, the drop plumbing),
+not a rewrite, and it is the disciplined version of the already-funded #150.
+
+### Relationship to the existing layout ADRs
+
+- **ADR 0003 (constraint-based layout).** This ADR *finishes* 0003 for the
+  strips: it makes the **assignment layer** concrete (collect-then-solve, with
+  feature-ordered side/zone assignment) and turns the **escalation ladder** from
+  prose into the selection step's output. 0003's "global 2-D Cassowary solve"
+  stays deferred (#94); this is the per-view inner layer 0003 always implied.
+  `Placeable` / `LayoutSolver` are reused unchanged in spirit.
+- **ADR 0004 (compose-then-pack).** Orthogonal and complementary. 0004 is the
+  **outer** layer (each view is a block; pack blocks disjoint so cross-view
+  overlap cannot occur). 0009 is the **inner** layer (place one view's
+  annotations into its own strips, optimally). The block footprint 0004 needs is
+  exactly the bounding box this stage now produces deterministically.
+- **ADR 0008 (the dimensioning planner).** 0008 already separates *what to
+  dimension* (planner → render-intent) from *render*. 0009 slots onto that seam:
+  the layout stage consumes the **full per-strip intent set** before committing,
+  rather than each render pass committing on its own. The planner's intents are
+  the natural source of the collect-phase candidates.
+- **ADR 0001 / 0002.** Determinism is the reason A was chosen over B. Repair
+  (0002) stays a safety net; principled selection/escalation replaces the bulk of
+  the ad-hoc `*_dropped` decisions, so repair has less to clean up.
+
+## Consequences
+
+**Positive**
+- The invisible-occupant collision class (#133/#225/#305 and kin) is removed by
+  construction: one occupancy model per strip, every occupant in it.
+- Crossing-free, minimum-leader-length placement within a view; provably optimal
+  and fast (O(n log n)–O(n³)).
+- Deterministic and explainable; no stochastic placement, no golden-test drift
+  risk.
+- "Doesn't fit" becomes a **priority-ranked escalation** (→ detail view #306/#54,
+  → table) instead of an arrival-order drop. Drops that remain are still lint.
+- A new strip annotation type joins the boundary model instead of inventing
+  placement from scratch.
+
+**Negative / costs**
+- **Control-flow inversion** is real work: passes must return candidates to a
+  single layout stage rather than calling `dwg.add(...)` mid-flight. Risk of a
+  half-migrated engine running both models at once during the migration —
+  mitigated by phasing one contended strip first and keeping behaviour-preserving
+  steps.
+- **Per-view, not global:** cross-view and inner-vs-outer-zone contention still
+  rest on ADR 0004 + the assignment heuristic, not a single global optimum.
+- **Modelling friction:** dim *chains*, ladders, and hatching must be coerced
+  into the label/leader/obstacle abstraction.
+- **Leader style:** optimality results are richest for rectilinear leaders;
+  angled leaders (the #305 case) are first-class but weaken the guarantees where
+  mixed.
+
+## Alternatives considered
+
+- **Approach B — one global optimisation (MIP or simulated annealing).** Highest
+  quality ceiling and eliminates the root cause at the largest scope (across
+  placers *and* views), but it conflicts with **determinism** (SA is stochastic;
+  MIP solver-sensitive — and golden tests were retired in ADR 0007, so drift is
+  less guarded), is far heavier (NP-hard) for sheets this sparse, and is
+  hard to debug/lint/repair. **Held in reserve:** revisit only if, after A,
+  genuine cross-view / inner-vs-outer-zone conflicts survive compose-then-pack —
+  and then prefer the seeded-annealing variant with a re-introduced
+  output-stability test. (Research note §4–5.)
+- **Status quo + more patches.** Each new fixture finds a new invisible-occupant
+  collision; the cost compounds and the drop policy stays arrival-order. Rejected.
+
+## Migration
+
+Phased, behaviour-preserving where possible, contended-strip-first so the model
+is validated on the exact recurring bug before the broad sweep. Tracking issue
+**#320**; the execution plan and per-phase issues (P0–P5: #317, #321, #322, #323,
+#318, #319) live in
+[`plans/strip-layout-boundary-labeling-roadmap.md`](../plans/strip-layout-boundary-labeling-roadmap.md).
+
+## Related
+
+- [ADR 0001](0001-deterministic-generation-over-editable-dsl.md) — determinism;
+  the reason A is chosen over B.
+- [ADR 0002](0002-iterate-via-lint-critique-and-domain-repair.md) — repair stays
+  a safety net; principled escalation replaces most ad-hoc drops.
+- [ADR 0003](0003-constraint-based-layout.md) — the two-layer model this ADR
+  makes concrete for the strips; the global 2-D solve stays deferred (#94).
+- [ADR 0004](0004-compose-then-pack-view-blocks.md) — the outer block-packing
+  layer; 0009 is the inner per-view layer.
+- [ADR 0008](0008-unified-feature-model-and-dimensioning-planner.md) — the
+  planner whose intents feed the collect phase.
+- Research note: [`research/annotation-placement-boundary-labeling.md`](../research/annotation-placement-boundary-labeling.md).
+- Issues: #150 (consolidate 1-D placement — subsumed here), #301/#302/#303
+  (layout-cleanliness/convergence — closed out by the new invariants),
+  #306/#54 (detail-view escalation — the "doesn't fit" target).

--- a/docs/plans/strip-layout-boundary-labeling-roadmap.md
+++ b/docs/plans/strip-layout-boundary-labeling-roadmap.md
@@ -1,0 +1,56 @@
+# Strip-layout boundary-labeling roadmap
+
+Execution roadmap for [ADR 0009](../adr/0009-boundary-labeling-strip-placement.md)
+(collect-then-solve per-strip annotation placement). Research backing:
+[`research/annotation-placement-boundary-labeling.md`](../research/annotation-placement-boundary-labeling.md).
+Tracking issue: **#320**. Each phase below is a GitHub issue; each phase is one PR
+(split if it grows).
+
+## Why
+
+A view's annotations are placed into **strips** by several imperative passes that
+share a strip but not an occupancy model, so they overprint each other in ways no
+single placer can see (#133, #225, #305). ADR 0009 inverts the control flow:
+every strip occupant is **collected** as a candidate, **solved** as one
+boundary-labeling instance per strip (select → assign → order = feature order ⇒
+crossing-free → space), then **emitted**. This removes the invisible-occupant
+collision class by construction while keeping determinism (ADR 0001).
+
+## Principles for every phase
+
+- **Behaviour-preserving until P2.** P0/P1 route existing placers through the new
+  stage without changing *what* is shown or *where* (beyond fixing the known
+  collisions). Output may shift only where a collision is genuinely resolved.
+- **Determinism is non-negotiable** — stable candidate ordering; reproducible
+  solves; no stochastic placement (that is Approach B, rejected).
+- **One contended strip first** (P1) validates the model on the exact recurring
+  bug before the broad sweep (P3).
+- **Drops become escalation.** "Doesn't fit" is a priority-ranked signal, not an
+  arrival-order omission; genuine drops still surface as lint.
+
+## Phases
+
+| Phase | Issue | What | Behaviour change | Depends |
+|---|---|---|---|---|
+| P0 | #317 | **Collect/solve/emit seam + complete per-strip occupancy.** A `StripLayout` stage that takes a batch of candidate `Placeable`s for a view's strips and a unified occupancy that includes *every* occupant — callout/dim labels **plus** extension lines, leader shafts, and the hatch footprint (closing the `_occupied_boxes` blind spots). Route one placer (bore callouts) through it as proof. | None (scaffolding) | — |
+| P1 | #321 | **The contended strip: bore callouts + off-axis location dims as one solve.** Both placers that share the side/below strip contribute candidates to a single solve; delete the post-hoc occupancy-check + tier-retry hack. Validates the model on #133/#225. | Resolves known collisions only | P0 |
+| P2 | #322 | **Feature-ordered assignment + priority selection + escalation.** The solve fixes order = feature order (crossing-free) and turns over-capacity into a priority-ranked selection that emits an escalation signal (→ detail view #306/#54, → table), replacing the scattered `*_dropped` arrival-order decisions. | Drop *policy* changes (ranked, not arrival-order) | P1 |
+| P3 | #323 | **Migrate the remaining strip placers; retire the `Strip` cursor (#150).** Envelope dims, step-height / turned-diameter ladders, and the section-hatch footprint all become candidates; standalone `Strip.allocate` usages are retired. Fully realises #150. | Dense sheets re-pack; covered by invariants | P2 |
+| P4 | #318 | **Optimal leader assignment + angled leaders.** Replace greedy ordering/spacing with the min-cost-matching / DP optimal assignment (minimise total leader length); fold the #305 angled-leader nudge into the model as a first-class leader style. | Leader positions may improve | P3 |
+| P5 | #319 | **Remove dead patches; strengthen the cleanliness invariants.** Delete superseded occupancy patches, tier-retry loops, and ad-hoc drop codes; extend the layout-cleanliness / property tests (#301/#302/#303) to assert the new guarantees: no invisible-occupant overlap, crossing-free leaders, deterministic output. | None (cleanup + tests) | P4 |
+
+## Acceptance (overall)
+
+- The #133/#225/#305 fixtures place clean with **no** post-hoc occupancy patches
+  in the placement path.
+- A full strip has its lowest-priority members **escalated** (detail view / table),
+  not silently dropped by code order; remaining drops are lint.
+- Leaders within a view are crossing-free and near-minimum length.
+- Output is deterministic and reproducible; the property/fuzz layout-cleanliness
+  tests (#301) pass and are extended to the new guarantees.
+- `Strip.allocate` cursor usages are gone (#150 closed).
+
+## Status
+
+Not started — ADR 0009 accepted 2026-06-30; phases filed (#317, #321, #322, #323,
+#318, #319 under tracking #320).

--- a/docs/research/annotation-placement-boundary-labeling.md
+++ b/docs/research/annotation-placement-boundary-labeling.md
@@ -1,0 +1,269 @@
+# Annotation Placement in draftwright: Diagnosis and Two Forward Paths
+
+*A research note on the "strip allocation" layout engine — June 2026*
+
+> **Status.** This note is the research backing for
+> [ADR 0009](../adr/0009-boundary-labeling-strip-placement.md), which decides in
+> favour of **Approach A** (boundary labeling — unify the strips). The migration
+> plan lives in
+> [`plans/strip-layout-boundary-labeling-roadmap.md`](../plans/strip-layout-boundary-labeling-roadmap.md).
+
+## Abstract
+
+The recurring layout defects in draftwright (#133, #225, #293, #305, and the
+`*_dropped` lint family) are not independent bugs. They are symptoms of a single
+structural choice: annotation placement is **imperative, per-pass, and split
+across mechanisms that do not share an occupancy model**. This note maps the
+current engine against the established academic literature — which turns out to
+describe draftwright's problem almost exactly — and lays out the two most
+credible ways forward, with honest trade-offs. The headline finding: draftwright
+is solving a textbook **boundary-labeling** problem with ad-hoc heuristics, and
+the literature offers both a *provably-optimal, deterministic* upgrade (keep the
+strips, solve them properly) and a *higher-ceiling, higher-risk* global one
+(dissolve the strips into one optimisation).
+
+---
+
+## 1. The current engine, briefly
+
+draftwright places a view's annotations into **strips** (`ViewZones`: left /
+right / above / below bands around each orthographic view; `_core.py:166–251`).
+Two different allocation authorities run inside those strips:
+
+- A **cursor** (`Strip.allocate`) that hands out space outward from the view
+  edge, used by envelope dims, step-height ladders, and off-axis location dims.
+- A **1D Cassowary solve** (`_solve_strip_1d`, kiwisolver; `layout.py:56–91`),
+  wrapped by `LayoutSolver.solve_strip` and the `Placeable` protocol
+  (ADR 0003), used by bore-callout and turned-diameter leaders. It pulls each
+  label toward its natural position subject to bounds + min-gap, with a greedy
+  fallback.
+
+2-D placement of rigid blocks (tables, GD&T frames) is a separate exact
+free-rectangle enumeration (`fit_box`, O(n³); `layout.py:275–317`). Cross-view
+layout is the **compose-then-pack** outer loop (ADR 0004).
+
+**The root defect.** The cursor and the solver are *different allocation
+models that do not observe each other*, and several placers write into the
+**same** strip. The code says so directly (`annotations/holes.py`):
+
+> "The strip cursor only tracks dims it allocated; the right/below strips are
+> SHARED with hole callouts (`hc_*`) and the section hatch, which use other
+> placers and are invisible to the cursor (#133). So a clean allocation is
+> necessary but not sufficient…"
+
+And ADR 0003 admits the same at the architecture level:
+
+> "Today that work is spread across four mechanisms that do not compose…
+> leaders are second-class (nothing deconflicts them)… 'it fit' is decided
+> greedily, so a dense sheet silently produces long or colliding leaders
+> instead of escalating."
+
+So every recent fix has been a **post-hoc patch** to an invisible-occupant
+collision: #225 added "retry the next tier on collision"; #305 nudged a coaxial
+callout off an extension line the placer couldn't see; #43/#41 drop features
+that won't fit rather than re-plan. The placement is **single-pass with no
+convergence and no shared occupancy** — exactly the conditions under which
+local first-fit produces overlaps. Crucially, "which annotation gets dropped"
+when a strip is full is decided by **arrival order in the code**, not priority.
+
+**What is genuinely good** and worth preserving: determinism (stable variable
+ordering → reproducible solves, per ADR 0001); the crisp 1D solver interface;
+the compose-then-pack outer layer that sidesteps a global 2-D solve; explicit
+drops surfaced as lint rather than silent omission; and pins/overrides (#89).
+
+---
+
+## 2. What the literature says (best practices)
+
+draftwright's "strip allocation" is, precisely, **boundary labeling** (Bekos,
+Kaufmann, Symvonis & Wolff, 2007): point features sit inside a rectangle, labels
+are placed on 1/2/4 sides of its boundary, and each label connects to its
+feature by a **leader**; the objective is short, **crossing-free** leaders. The
+field's relevant results:
+
+1. **Fix the ordering and non-overlap becomes free.** Non-overlap is
+   *disjunctive* ("A left-of B **or** above B…"); a linear solver (Cassowary)
+   provably **cannot** express it, which is why a global 2-D solve is hard
+   (and why draftwright deferred it). Boundary labeling's escape hatch:
+   make the **label order along the boundary match the feature order** — then
+   leaders are automatically crossing-free and spacing is a chain of *linear*
+   inequalities. *draftwright already relies on this trick in its 1-D strip
+   solve; it just hasn't applied it to all strip occupants at once.*
+
+2. **The optimal sub-problems are cheap.** For uniform/po leaders the optimal
+   (min total leader length, crossing-free) assignment is a sweep in
+   O(n log n); for two-sided or non-uniform labels it is a **min-cost bipartite
+   matching** / **dynamic program**, O(n²)–O(n³). These are well within
+   draftwright's budget (dozens of annotations).
+
+3. **Leaders to circular features should be angled, not axial.** General
+   drafting practice (and the reason #305 exists): a leader to a feature should
+   be inclined > 30° to the horizontal, clear of centre-lines and other text.
+   Engineering-CAD work formalises this as **dimension-set selection first,
+   spatial layout second** (Dori), often with a **territory / zone** model
+   (inner vs outer dimension bands) — which is what `ViewZones` already is.
+
+4. **For the *global* problem, metaheuristics win on quality.** The canonical
+   empirical study (Christensen, Marks & Shieber, 1995) shows the basic
+   placement problem is **NP-hard**, and that **simulated annealing
+   substantially outperforms** greedy / gradient methods on conflict-free
+   placement, at the cost of run-time and a stochastic (non-deterministic)
+   result. Exact non-overlap at global scale is **integer programming**
+   (GRIDS; floor-layout MIP) — optimal but expensive and harder to keep
+   deterministic.
+
+The two forward paths below correspond to the two halves of finding (1): **keep
+the order fixed and solve each boundary optimally**, or **relax the order and
+optimise globally**.
+
+---
+
+## 3. Approach A — Boundary labeling done properly (keep the strips, unify the solve)
+
+**Idea.** Stop having N placers fight over a strip. For each view, build **one**
+boundary-labeling instance whose "labels" are *every* annotation that wants that
+strip — bore callouts, location dims, step/turned-diameter dims, even the
+section-hatch footprint as a fixed obstacle — and solve it as three phases:
+**collect** (every contributor emits a *candidate*, nothing is placed) →
+**solve** (one optimisation: select what fits by priority, assign side/zone,
+order = feature order ⇒ crossing-free, space via the existing 1-D solver) →
+**emit** (materialise the chosen geometry). Occupancy stops being "post-hoc
+check + retry" because **there is one model and everything is in it**.
+
+This is the disciplined version of the work already on the roadmap as **#150**
+("consolidate 1-D placement around `LayoutSolver`"), generalised from
+bore-callouts to *all* strip occupants, and it composes cleanly under the
+existing **compose-then-pack** (ADR 0004) outer layer for cross-view conflicts.
+It also slots onto ADR 0008's planner→intent seam: the layout stage consumes the
+**full** per-strip intent set instead of each render pass committing on its own.
+
+**Pros**
+- **Attacks the root cause directly:** one occupancy model per strip → the
+  invisible-occupant collision class (the source of #133/#225/#305) disappears
+  by construction, not by patch.
+- **Deterministic and explainable** — preserves ADR 0001; "label i sits here
+  because order + min-gap + shortest-leader," not "the annealer landed there."
+- **Provably optimal & fast** within a view (crossing-free, min leader length;
+  O(n log n)–O(n³)).
+- **Incremental & low-risk:** the strips, `Placeable`, the 1-D solver and the
+  drop/escalate plumbing already exist; this is consolidation, not a rewrite.
+  Matches the stated architecture (ADR 0003 §"assignment then placement").
+- **Principled escalation:** "doesn't fit" becomes a first-class, priority-ranked
+  signal feeding the detail-view ladder (#306/#54), instead of an arrival-order
+  drop.
+
+**Cons**
+- **Per-view, not global:** optimal *within* a strip/view; cross-view and
+  inner-vs-outer-zone conflicts still rely on compose-then-pack + the
+  assignment layer. (Arguably correct separation of concerns, but it means A is
+  not a single global optimum.)
+- **Modelling friction:** heterogeneous annotations (a dim *chain*, hatching, a
+  multi-segment ladder) must be coerced into the label/leader/port abstraction;
+  some don't fit the "one label, one leader" mould cleanly.
+- **Leader style:** the textbook results are richest for rectilinear (po/opo)
+  leaders; draftwright sometimes wants **angled** leaders (the #305 fix). The
+  straight-line ("s") variant exists but mixing styles weakens the optimality
+  guarantees.
+- **Control-flow inversion:** passes must stop calling `dwg.add(...)` mid-flight
+  and instead return candidates to a single layout stage — a real refactor (the
+  intent/render seam), not a patch.
+
+---
+
+## 4. Approach B — One global placement optimisation (dissolve the strips)
+
+**Idea.** Realise ADR 0003's original ambition in full: every annotation on the
+sheet is a `Placeable` with a small set of **candidate positions** (or
+continuous DOF), and a single optimiser minimises a global objective —
+overlaps, total leader length, and **soft drafting penalties** (leader < 30°,
+text on a centre-line, dim inside the part, broken alignment) — across *all*
+annotations and *all* views at once. Two realisations:
+
+- **B1 — Mixed-integer programming.** Encode pairwise non-overlap with the
+  classic big-M disjunction + binary "which side" variables (floor-layout /
+  GRIDS formulations). Exact and globally optimal.
+- **B2 — Simulated annealing / metaheuristic.** Discrete candidate positions
+  per annotation; anneal over a conflict + aesthetics cost (the Christensen–
+  Marks–Shieber recipe). Best empirical quality, scales to large sheets.
+
+**Pros**
+- **Structurally eliminates the root cause at the largest scope:** there is one
+  model for the whole sheet, so *no* occupant is ever invisible to another —
+  across placers **and** across views.
+- **Highest quality ceiling:** SA empirically resolves "all or nearly all"
+  conflicts; a global optimum can trade a slightly longer leader here to avoid
+  a collision there — something local strip solves cannot do.
+- **Extensible objective:** new ISO conventions and new annotation types become
+  *penalty terms*, not new bespoke placers.
+- Subsumes the inner/outer-zone and cross-view problems that Approach A leaves
+  to a separate layer.
+
+**Cons**
+- **Tension with determinism (ADR 0001).** SA is stochastic; reproducibility
+  needs a fixed seed and even then is brittle to input perturbation. MIP is
+  deterministic but solver-version-sensitive. Golden tests were retired
+  (ADR 0007), so silent output drift is *less* guarded now — a real risk.
+- **Cost & complexity.** MIP non-overlap is exponential in the worst case
+  (NP-hard); SA needs careful cooling/penalty tuning. Both are far heavier than
+  an O(n log n) sweep for what is usually a sparse strip.
+- **Explainability / debuggability.** "Why did it place the callout there?"
+  has no local answer — bad for a tool whose value is trustworthy, inspectable
+  drawings, and harder to lint/repair deterministically.
+- **Big-bang risk.** Replaces several working, well-tested placers at once; a
+  regression touches every drawing rather than one feature class.
+
+---
+
+## 5. Comparison and recommendation
+
+| | **A — Boundary labeling (unify the strips)** | **B — Global optimisation (dissolve them)** |
+|---|---|---|
+| Fixes invisible-occupant collisions | Per view, by construction | Whole sheet, by construction |
+| Determinism (ADR 0001) | ✅ preserved | ⚠️ SA stochastic / MIP solver-sensitive |
+| Optimality | Provable, *within* a view | Global (B1 exact, B2 near-optimal) |
+| Speed | O(n log n)–O(n³), trivial | NP-hard (B1) / tunable seconds (B2) |
+| Cross-view & zone choice | Needs assignment + ADR 0004 | Built-in |
+| Implementation risk | Low — consolidation of existing parts (#150) | High — replaces working placers |
+| Explainability / lint / repair | High | Low |
+| New annotation type | Add to the boundary model | Add a penalty term |
+
+**Recommendation.** Pursue **Approach A first**. It is the lowest-risk move that
+*actually removes the defect class* rather than patching it: one occupancy model
+per strip, optimal crossing-free leaders, full determinism, and it is already
+the funded direction (#150) sitting on top of the existing `Placeable` /
+`LayoutSolver` / compose-then-pack scaffolding. Treat the "doesn't fit" outcome
+as a first-class escalation signal into the detail-view ladder rather than a
+silent drop.
+
+Hold **Approach B in reserve.** Only reach for a global optimiser if, after A,
+genuine *cross-view* or *inner-vs-outer-zone* conflicts remain that compose-
+then-pack cannot resolve — and if so, prefer the **B2 (annealing)** variant with
+a fixed seed and a re-introduced output-stability test, since exact MIP buys
+little for sheets this sparse while costing determinism and speed. In short:
+**make the strips honest before deciding whether to abolish them.**
+
+This recommendation is adopted as [ADR 0009](../adr/0009-boundary-labeling-strip-placement.md).
+
+---
+
+## References
+
+1. Bekos, Kaufmann, Symvonis, Wolff. *Boundary labeling: Models and efficient
+   algorithms for rectangular maps.* Computational Geometry, 2007.
+   <https://www1.pub.informatik.uni-wuerzburg.de/pub/wolff/pub/bksw-blmea-06.pdf>
+2. Christensen, Marks, Shieber. *An empirical study of algorithms for
+   point-feature label placement.* ACM TOG, 1995.
+   <https://www.eecs.harvard.edu/shieber/Biblio/Papers/tog-final.pdf>
+3. Badros, Borning, Stuckey. *The Cassowary linear arithmetic constraint solving
+   algorithm.* ACM TOCHI, 2001. <http://badros.com/greg/papers/cassowary-tochi.pdf>
+4. Bekos et al. *Boundary labeling with octilinear leaders.* Algorithmica.
+   <https://link.springer.com/chapter/10.1007/978-3-540-69903-3_22>
+5. *GRIDS: Interactive Layout Design with Integer Programming.* arXiv:2001.02921.
+   <https://arxiv.org/pdf/2001.02921>
+6. *Strong mixed-integer formulations for the floor layout problem.*
+   arXiv:1602.07760. <https://arxiv.org/pdf/1602.07760>
+7. *Intelligent Dimension Annotation in Engineering Drawings (CBR + MKD-ICP).*
+   Applied Sciences, 2025. <https://www.mdpi.com/2076-3417/15/11/5992>
+8. draftwright `docs/adr/0003-constraint-based-layout.md`,
+   `0004-compose-then-pack-view-blocks.md`; `src/draftwright/layout.py`,
+   `_core.py` (`Strip`/`ViewZones`), `annotations/holes.py`, `_common.py`.


### PR DESCRIPTION
Docs only — no code change.

Decides the layout-engine direction (the recurring "strip allocation" defects) and brings the ADR set + CLAUDE.md back in sync with the shipped codebase.

## New

- **`docs/research/annotation-placement-boundary-labeling.md`** — research note: the recurring strip defects (#133/#225/#305, the `*_dropped` family) are one root cause (imperative, per-pass placement with no shared occupancy model), which is exactly the academic **boundary-labeling** problem. Two candidate approaches with full pros/cons + references.
- **`docs/adr/0009-boundary-labeling-strip-placement.md`** — decides **Approach A** (collect → solve → emit per strip; order = feature order ⇒ crossing-free; non-overlap becomes linear; keeps determinism). Rejects the global metaheuristic/MIP (Approach B) as primary, held in reserve. Tied into 0001/0002/0003/0004/0008.
- **`docs/plans/strip-layout-boundary-labeling-roadmap.md`** — phased plan P0–P5. Tracking **#320**; phases **#317 #321 #322 #323 #318 #319**.

## ADR-set consistency (audited 0001–0009 vs code + roadmaps)

An independent audit found the ADRs cross-reference each other cleanly; the real drift was two Status fields and CLAUDE.md. Fixed:

- **0007** Status `Proposed → Accepted` (recognition/linting shipped — resolved a direct ADR-vs-CLAUDE contradiction).
- **0003** Status `Proposed → Accepted` (core implemented; the unifying global 2-D solve stays deferred #94).
- **0005** §Progress: dropped the stale "Remaining" framing (all phases landed); `linting.py → linting/`.
- **0008**: reconciled the "not yet wired into `build_drawing`" sketch line with the converged header.
- **0003/0004/0008**: reciprocal cross-refs to 0009 (inner-vs-outer layer; planner intents feed the collect phase).
- **CLAUDE.md**: added the missing **0008 + 0009** ADR entries; refreshed the Architecture section to the live tree — `linting.py → linting/`, added `model/` (the ADR 0008 IR), `cli.py`, and `annotations/from_model.py`, removed the deleted `annotations/{turned,pmi}.py`, fixed "cairo PDF" → svglib+reportlab, marked the 0005 split complete.

Historical ADR *decision-time* content (e.g. 0005/0007's intended module sketches) was deliberately left intact — ADRs are records, and those were rated Nit/Judgment by the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
