### PR TITLE
feat: complete per-strip occupancy model (P0b, #317)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -7,6 +7,10 @@ and an AABB overlap test (`_box_hits`). Bottom of the annotations DAG.
 
 from __future__ import annotations
 
+import logging
+
+_log = logging.getLogger(__name__)
+
 
 def _anno_box(o):
     """Page-space bbox ``(x0, y0, x1, y1)`` of an annotation — its text
@@ -41,11 +45,14 @@ def _occupied_boxes(dwg):
 def _geom_box(o):
     """Full rendered-geometry bbox ``(x0, y0, x1, y1)`` of an annotation — leader
     shafts and arrow tips, dimension witness/extension lines, centrelines, hatch —
-    *not* just its label box. ``None`` if it does not bbox cleanly."""
+    *not* just its label box. ``None`` if it does not bbox cleanly (logged at
+    debug: a silently dropped occupant is the wrong failure mode for an occupancy
+    model, so the omission is at least observable)."""
     try:
         b = o.bounding_box()
         return (b.min.X, b.min.Y, b.max.X, b.max.Y)
-    except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+    except Exception as exc:  # noqa: BLE001 — not every annotation bbox-es cleanly
+        _log.debug("strip occupancy: %s did not bbox (%s); omitted", type(o).__name__, exc)
         return None
 
 
@@ -60,14 +67,27 @@ def strip_obstacles(dwg, view=None):
     recurring strip overlaps (#133/#225/#305): a placer that consults only label
     boxes commits a callout into space a leader or extension line already crosses.
 
-    Returns a list of ``(x0, y0, x1, y1)`` AABBs (use with :func:`_box_hits`).
+    *view* scoping keeps this view's own annotations **and** drawing-level obstacles
+    that no orthographic view owns (the section hatch, title block, …) — those a
+    strip placer must still avoid — and drops only the *other* ortho views' blocks
+    (which compose-then-pack keeps disjoint, ADR 0004). The section hatch
+    (``view_of`` ``None``) is therefore present in every per-view query, the way
+    :func:`_occupied_boxes` special-cased it; restricting it to ``view=None`` would
+    re-open the very blind spot this closes.
+
+    Boxes are AABBs ``(x0, y0, x1, y1)`` (use with :func:`_box_hits`) — intentionally
+    conservative: a diagonal leader's box over-claims its empty triangle (ADR 0009
+    notes angled leaders weaken the bound), which only ever over-avoids, never
+    under-avoids.
 
     Not yet consumed in production — the collect-then-solve strip stage wires this
     in at P1 (#321). Kept additive here so P0 stays behaviour-preserving."""
     boxes = []
     for name, o in dwg.iter_annotations():
-        if view is not None and dwg.view_of(name) != view:
-            continue
+        if view is not None:
+            owner = dwg.view_of(name)
+            if owner is not None and owner != view:
+                continue  # owned by a different ortho view → its own (disjoint) block
         bb = _geom_box(o)
         if bb is not None:
             boxes.append(bb)

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -38,6 +38,42 @@ def _occupied_boxes(dwg):
     return boxes
 
 
+def _geom_box(o):
+    """Full rendered-geometry bbox ``(x0, y0, x1, y1)`` of an annotation — leader
+    shafts and arrow tips, dimension witness/extension lines, centrelines, hatch —
+    *not* just its label box. ``None`` if it does not bbox cleanly."""
+    try:
+        b = o.bounding_box()
+        return (b.min.X, b.min.Y, b.max.X, b.max.Y)
+    except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+        return None
+
+
+def strip_obstacles(dwg, view=None):
+    """The COMPLETE occupancy for strip placement (ADR 0009): every placed
+    annotation's full rendered footprint, optionally restricted to *view*.
+
+    Unlike :func:`_occupied_boxes` (label boxes only, with bare centrelines
+    excluded), this captures the geometry a label box hides — leader shafts and
+    arrow tips, dimension witness/extension lines, centrelines, and the section
+    hatch. That hidden geometry is the 'invisible occupant' class behind the
+    recurring strip overlaps (#133/#225/#305): a placer that consults only label
+    boxes commits a callout into space a leader or extension line already crosses.
+
+    Returns a list of ``(x0, y0, x1, y1)`` AABBs (use with :func:`_box_hits`).
+
+    Not yet consumed in production — the collect-then-solve strip stage wires this
+    in at P1 (#321). Kept additive here so P0 stays behaviour-preserving."""
+    boxes = []
+    for name, o in dwg.iter_annotations():
+        if view is not None and dwg.view_of(name) != view:
+            continue
+        bb = _geom_box(o)
+        if bb is not None:
+            boxes.append(bb)
+    return boxes
+
+
 def _box_hits(bb, boxes):
     """True when ``bb`` overlaps any box in ``boxes`` (strict AABB test). Slightly
     more conservative than the within-view label lint (which tolerates a 0.5 mm

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1,0 +1,79 @@
+"""Unit tests for the ADR 0009 collect-then-solve strip-placement stage.
+
+Grows with the boundary-labeling migration (tracking #320). P0b (#317): the
+complete per-strip occupancy model — `strip_obstacles` — that closes the
+`_occupied_boxes` blind spots behind #133/#225/#305.
+"""
+
+from __future__ import annotations
+
+from build123d import Box, BuildPart, Cylinder, Hole, Pos, Rotation
+
+from draftwright import build_drawing
+from draftwright.annotations._common import (
+    _occupied_boxes,
+    strip_obstacles,
+)
+
+
+def _same(a, b, tol=1e-6):
+    return a is not None and b is not None and all(abs(x - y) <= tol for x, y in zip(a, b))
+
+
+def _drive_screw_x():
+    # X-turned cylinder + coaxial axial bore: centrelines + a bore-callout leader.
+    with BuildPart() as p:
+        Cylinder(radius=6, height=20)
+        Hole(0.8, depth=8)
+    return Rotation(0, 90, 0) * p.part
+
+
+def test_strip_obstacles_captures_centreline_that_occupied_boxes_drops():
+    # _occupied_boxes excludes bare centrelines; the complete occupancy must not —
+    # a centreline through a callout's row is exactly the #305 blind spot.
+    dwg = build_drawing(_drive_screw_x())
+    cl = dwg._named["centerline_front"]
+    b = cl.bounding_box()
+    cbox = (b.min.X, b.min.Y, b.max.X, b.max.Y)
+
+    obst = strip_obstacles(dwg)
+    occ = _occupied_boxes(dwg)
+
+    assert any(_same(x, cbox) for x in obst), "centreline missing from strip_obstacles"
+    assert not any(_same(x, cbox) for x in occ), "expected _occupied_boxes to exclude centrelines"
+
+
+def test_strip_obstacles_captures_full_leader_footprint_not_just_label():
+    # A bore callout's leader shaft extends well past its text box. _occupied_boxes
+    # records only the label box; strip_obstacles must record the full footprint,
+    # or a placer thinks the shaft's row is free (#133/#225).
+    dwg = build_drawing(_drive_screw_x())
+    name, leader = next((n, o) for n, o in dwg.iter_annotations() if n.startswith("hc_"))
+
+    lb = leader.label_bbox
+    gb = leader.bounding_box()
+    full = (gb.min.X, gb.min.Y, gb.max.X, gb.max.Y)
+
+    # the leader genuinely extends beyond its label (else the test proves nothing)
+    assert gb.min.X < lb[0] - 0.5 or gb.max.X > lb[2] + 0.5, "leader shaft not past its label?"
+
+    obst = strip_obstacles(dwg)
+    occ = _occupied_boxes(dwg)
+    assert any(_same(x, full) for x in obst), "full leader footprint missing from strip_obstacles"
+    # _occupied_boxes records (at most) the narrower label box for this leader
+    assert not any(_same(x, full) for x in occ)
+
+
+def test_strip_obstacles_view_filter():
+    # A box with a side-drilled hole: side-view occupancy excludes front/plan items.
+    part = Box(60, 40, 30) - Pos(0, 0, 8) * Rotation(0, 90, 0) * Cylinder(3, 80)
+    dwg = build_drawing(part)
+
+    everywhere = strip_obstacles(dwg)
+    side = strip_obstacles(dwg, view="side")
+    side_annos = list(dwg.annotations_in_view("side"))
+
+    assert side, "expected some side-view obstacles"
+    assert len(side) < len(everywhere), "view filter should narrow the set"
+    # one obstacle per side-view annotation that bbox-es (≤ the annotation count)
+    assert len(side) <= len(side_annos)

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -64,16 +64,35 @@ def test_strip_obstacles_captures_full_leader_footprint_not_just_label():
     assert not any(_same(x, full) for x in occ)
 
 
-def test_strip_obstacles_view_filter():
-    # A box with a side-drilled hole: side-view occupancy excludes front/plan items.
+def test_strip_obstacles_view_filter_drops_other_ortho_views():
+    # A box with a side-drilled hole: the side query excludes front/plan-owned
+    # blocks (compose-then-pack keeps them disjoint) but is narrower than the whole.
     part = Box(60, 40, 30) - Pos(0, 0, 8) * Rotation(0, 90, 0) * Cylinder(3, 80)
     dwg = build_drawing(part)
 
     everywhere = strip_obstacles(dwg)
     side = strip_obstacles(dwg, view="side")
-    side_annos = list(dwg.annotations_in_view("side"))
+    assert 0 < len(side) < len(everywhere), "view filter should narrow the set"
 
-    assert side, "expected some side-view obstacles"
-    assert len(side) < len(everywhere), "view filter should narrow the set"
-    # one obstacle per side-view annotation that bbox-es (≤ the annotation count)
-    assert len(side) <= len(side_annos)
+    # a front/plan-owned annotation is present overall but excluded from the side query
+    other = next(
+        (n for n, _ in dwg.iter_annotations() if dwg.view_of(n) in ("front", "plan")), None
+    )
+    assert other is not None, "fixture should place a front/plan annotation"
+    b = dwg._named[other].bounding_box()
+    obox = (b.min.X, b.min.Y, b.max.X, b.max.Y)
+    assert any(_same(x, obox) for x in everywhere)
+    assert not any(_same(x, obox) for x in side), f"{other} (other ortho view) leaked into side"
+
+
+def test_strip_obstacles_keeps_section_hatch_in_every_per_view_query():
+    # The section hatch is owned by no ortho view (view_of is None); a per-view
+    # strip solve must still avoid it — _occupied_boxes special-cased it by name,
+    # and restricting it to view=None would re-open that blind spot (review S1).
+    part = Box(80, 60, 20) - Cylinder(4, 20) - Pos(10, 5, -7) * Cylinder(6, 6)
+    dwg = build_drawing(part)
+    assert "section_hatch" in dwg._named and dwg.view_of("section_hatch") is None
+    b = dwg._named["section_hatch"].bounding_box()
+    hbox = (b.min.X, b.min.Y, b.max.X, b.max.Y)
+    for v in ("front", "plan", "side"):
+        assert any(_same(x, hbox) for x in strip_obstacles(dwg, view=v)), f"hatch dropped from {v}"


### PR DESCRIPTION
P0b of the ADR 0009 strip-layout refactor (#317, tracking #320). Builds on the characterization gate (P0a, #326, merged).

## What
The recurring strip overlaps (#133/#225/#305) are the **invisible-occupant** class: placers consult `_occupied_boxes`, which records only *label* boxes (and excludes bare centrelines), so a callout gets committed into space a **leader shaft / dimension extension line / centreline** already crosses — invisibly.

This adds the complete occupancy the collect-then-solve stage needs:
- **`strip_obstacles(dwg, view=None)`** (`annotations/_common.py`) — every placed annotation's **full rendered footprint** (leader shafts/arrow tips, witness/extension lines, centrelines, hatch), optionally per view.

## Behaviour-preserving
`strip_obstacles` is **additive and not yet consumed in production** — P1 (#321) wires it into the contended-strip solve. So this PR changes no output: the **layout characterization gate is byte-identical**, and the full fast tier is 631 passed.

## Tests
`tests/test_strip_layout.py` proves the completeness the old occupancy lacks:
- `strip_obstacles` captures a **centreline** that `_occupied_boxes` drops (the #305 blind spot).
- it captures a bore-callout's **full leader footprint**, where `_occupied_boxes` records only the narrower label box (#133/#225).
- the `view=` filter narrows correctly.

## Note — your call before P1
The `StripLayout` candidate abstraction (P0c) is the load-bearing design decision; I've left it out of this PR. Options in the thread: minimal `StripCandidate`, extend `Placeable` (my lean), or intent-based (ties to ADR 0008). P0b commits to none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
