### PR TITLE
feat: StripCandidate + plan_strip — collect-then-solve seam (P0c, #317)

### DIFF
--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -54,8 +54,9 @@ phases:
 
 1. **Collect.** The stage consumes the planner's **render-intents** for this view
    (ADR 0008) and *measures* each into a placement **candidate** — a geometry-only
-   `StripCandidate` carrying the site anchor, label-box size, priority, and
-   eligible side(s). The candidate **is a measured render-intent**: the collect
+   `StripCandidate` carrying the site anchor, label-box size, and priority (and an
+   eligible-sides field once the multi-side *assign* step lands, P2). The candidate
+   **is a measured render-intent**: the collect
    step (in `annotations/`, which may depend on the IR) projects intent → page
    geometry, and hands the solver only that geometry, so the solver stays a leaf
    with no dependency on the IR. Fixed obstacles that are *not* placed — the

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -52,10 +52,16 @@ The load-bearing change is a **control-flow inversion**. Today each pass commits
 real geometry (`dwg.add(...)`) as it runs. Instead, for each view, run three
 phases:
 
-1. **Collect.** Every contributor — bore callouts, location dims, step/
-   turned-diameter dims, the section-hatch footprint (as a fixed obstacle) —
-   emits a *candidate* (`Placeable` + priority + eligible side(s)). **Nothing is
-   placed.** This consumes the **full** per-strip set at once.
+1. **Collect.** The stage consumes the planner's **render-intents** for this view
+   (ADR 0008) and *measures* each into a placement **candidate** — a geometry-only
+   `StripCandidate` carrying the site anchor, label-box size, priority, and
+   eligible side(s). The candidate **is a measured render-intent**: the collect
+   step (in `annotations/`, which may depend on the IR) projects intent → page
+   geometry, and hands the solver only that geometry, so the solver stays a leaf
+   with no dependency on the IR. Fixed obstacles that are *not* placed — the
+   section-hatch footprint, the title block (`strip_obstacles`, P0b) — enter the
+   solve as things to avoid, not as candidates. **Nothing is placed yet**; this
+   consumes the **full** per-strip set at once.
 2. **Solve.** One optimisation over that set:
    - **Select** — if the strip cannot hold everything, keep the highest-priority
      set that fits; the rest produce a first-class **escalation** signal.

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -164,11 +164,16 @@ class StripCandidate:
     Attributes:
         key: stable id — deterministic ordering tie-break and result lookup.
         anchor: the site the leader connects to, in page coords ``(x, y)``. Its
-            position along the strip axis sets the label order, and **label order =
-            site order** is what makes the leaders crossing-free by construction.
+            position along the strip axis sets the label order; placing labels in
+            site order keeps leaders crossing-free **for sites with distinct
+            strip-axis coordinates** (sites sharing that coordinate are a tie — see
+            :func:`plan_strip`).
         size: the label box ``(width, height)`` in page-mm.
         priority: higher wins when the strip is over capacity — the *selection*
             step's ranking (P2, #322). Unused by the P0 seam (all-or-nothing).
+
+    An ``eligible_sides`` field joins when the multi-side *assign* step lands
+    (P2, #322); the P0 seam places on a single, caller-chosen strip.
     """
 
     key: str
@@ -180,10 +185,16 @@ class StripCandidate:
 def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     """Collect-then-solve placement of *candidates* along one strip (ADR 0009).
 
-    Orders the labels in **site order** along *axis* (the boundary-labeling move
-    that keeps leaders crossing-free), then spaces them within ``[lo, hi]`` at
-    least *min_gap* apart via :func:`_solve_strip_1d`. Returns ``{key: position}``
-    for the placed candidates, or ``None`` when the strip cannot hold them all.
+    Orders the labels in **site order** along *axis* — placing them in site order
+    keeps leaders crossing-free when the sites have **distinct** strip-axis
+    coordinates. Sites that share that coordinate are ordered deterministically by
+    ``key``; that tie-break is *not* crossing-optimal (it doesn't see the
+    perpendicular coordinate that decides those crossings) — resolving ties
+    crossing-optimally is the P4 assign/order step (#318). This matches the
+    engine's current natural-Y strip sort. Then spaces the labels within
+    ``[lo, hi]`` at least *min_gap* apart via :func:`_solve_strip_1d`. Returns
+    ``{key: position}`` for the placed candidates, or ``None`` when the strip
+    cannot hold them all. Candidate *keys* must be unique (they key the result).
 
     This is the P0 seam (#317): order-by-site + 1-D spacing, reproducing the
     engine's current all-or-nothing strip contract. Spacing is the caller's single
@@ -196,6 +207,9 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     """
     if not candidates:
         return {}
+    keys = [c.key for c in candidates]
+    if len(set(keys)) != len(keys):  # like LayoutSolver.register — never silently drop
+        raise ValueError("plan_strip: candidate keys must be unique")
     idx = 1 if axis == "y" else 0
     ordered = sorted(candidates, key=lambda c: (c.anchor[idx], c.key))
     positions = _solve_strip_1d([c.anchor[idx] for c in ordered], min_gap, lo, hi)

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -147,6 +147,64 @@ def _solve_strip_1d_var(naturals, gaps, lo, hi):
 
 
 # ---------------------------------------------------------------------------
+# Collect-then-solve strip stage (ADR 0009)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StripCandidate:
+    """One *measured render-intent* ready for strip placement (ADR 0009).
+
+    The boundary-labeling solve reasons over geometry, not semantics: the collect
+    step (in ``annotations/``, which may depend on the IR) projects each planner
+    render-intent to its page geometry and hands the solver only this — so the
+    solver stays a leaf, with no dependency on the IR. A ``StripCandidate`` *is*
+    that measured intent.
+
+    Attributes:
+        key: stable id — deterministic ordering tie-break and result lookup.
+        anchor: the site the leader connects to, in page coords ``(x, y)``. Its
+            position along the strip axis sets the label order, and **label order =
+            site order** is what makes the leaders crossing-free by construction.
+        size: the label box ``(width, height)`` in page-mm.
+        priority: higher wins when the strip is over capacity — the *selection*
+            step's ranking (P2, #322). Unused by the P0 seam (all-or-nothing).
+    """
+
+    key: str
+    anchor: tuple[float, float]
+    size: tuple[float, float]
+    priority: int = 0
+
+
+def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
+    """Collect-then-solve placement of *candidates* along one strip (ADR 0009).
+
+    Orders the labels in **site order** along *axis* (the boundary-labeling move
+    that keeps leaders crossing-free), then spaces them within ``[lo, hi]`` at
+    least *min_gap* apart via :func:`_solve_strip_1d`. Returns ``{key: position}``
+    for the placed candidates, or ``None`` when the strip cannot hold them all.
+
+    This is the P0 seam (#317): order-by-site + 1-D spacing, reproducing the
+    engine's current all-or-nothing strip contract. Spacing is the caller's single
+    *min_gap* (as the engine's strips do today) — the candidate's ``size`` is
+    carried for the per-pair, label-height-aware gaps that come with the optimal
+    packing (P4, #318), and is not consulted here, so *min_gap* must clear the
+    tallest label. The *priority* selection + escalation for an over-full strip is
+    P2 (#322). Deterministic: candidates are ordered by ``(anchor-along-axis, key)``
+    and the 1-D solve is deterministic in input order.
+    """
+    if not candidates:
+        return {}
+    idx = 1 if axis == "y" else 0
+    ordered = sorted(candidates, key=lambda c: (c.anchor[idx], c.key))
+    positions = _solve_strip_1d([c.anchor[idx] for c in ordered], min_gap, lo, hi)
+    if positions is None:
+        return None
+    return {c.key: p for c, p in zip(ordered, positions, strict=True)}
+
+
+# ---------------------------------------------------------------------------
 # Placeable protocol + solver
 # ---------------------------------------------------------------------------
 

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -145,3 +145,12 @@ def test_plan_strip_x_axis():
 
 def test_plan_strip_empty():
     assert plan_strip([], 0, 100, 5) == {}
+
+
+def test_plan_strip_rejects_duplicate_keys():
+    # keys key the result — a silent overwrite would drop a candidate (cf.
+    # LayoutSolver.register, which also raises).
+    import pytest
+
+    with pytest.raises(ValueError, match="unique"):
+        plan_strip([_cand("a", 10), _cand("a", 20)], lo=0, hi=100, min_gap=5)

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -2,7 +2,9 @@
 
 Grows with the boundary-labeling migration (tracking #320). P0b (#317): the
 complete per-strip occupancy model — `strip_obstacles` — that closes the
-`_occupied_boxes` blind spots behind #133/#225/#305.
+`_occupied_boxes` blind spots behind #133/#225/#305. P0c (#317): the
+collect-then-solve seam — `StripCandidate` (a measured render-intent) + `plan_strip`
+(order = site order ⇒ crossing-free, then 1-D spacing).
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ from draftwright.annotations._common import (
     _occupied_boxes,
     strip_obstacles,
 )
+from draftwright.layout import StripCandidate, plan_strip
 
 
 def _same(a, b, tol=1e-6):
@@ -96,3 +99,49 @@ def test_strip_obstacles_keeps_section_hatch_in_every_per_view_query():
     hbox = (b.min.X, b.min.Y, b.max.X, b.max.Y)
     for v in ("front", "plan", "side"):
         assert any(_same(x, hbox) for x in strip_obstacles(dwg, view=v)), f"hatch dropped from {v}"
+
+
+# --- plan_strip: the collect-then-solve seam (pure geometry, no OCC) --------
+
+
+def _cand(key, y, w=6.0, h=3.0, priority=0):
+    return StripCandidate(key=key, anchor=(0.0, y), size=(w, h), priority=priority)
+
+
+def test_plan_strip_places_in_site_order_spaced_and_in_bounds():
+    pos = plan_strip([_cand("a", 10), _cand("b", 12), _cand("c", 14)], lo=0, hi=100, min_gap=5)
+    assert set(pos) == {"a", "b", "c"}
+    assert pos["a"] <= pos["b"] <= pos["c"], "site order (crossing-free) not preserved"
+    ys = sorted(pos.values())
+    assert all(b - a >= 5 - 1e-9 for a, b in zip(ys, ys[1:])), "min_gap violated"
+    assert all(0 <= v <= 100 for v in pos.values()), "out of bounds"
+
+
+def test_plan_strip_orders_by_site_regardless_of_input_order():
+    # shuffled input still resolves to site (anchor) order — the crossing-free move
+    pos = plan_strip([_cand("c", 14), _cand("a", 10), _cand("b", 12)], lo=0, hi=100, min_gap=5)
+    assert pos["a"] <= pos["b"] <= pos["c"]
+
+
+def test_plan_strip_deterministic_key_tiebreak():
+    cands = [_cand("b", 10), _cand("a", 10)]  # equal anchors → ordered by key
+    p1 = plan_strip(cands, 0, 100, 5)
+    p2 = plan_strip(list(reversed(cands)), 0, 100, 5)
+    assert p1 == p2
+    assert p1["a"] <= p1["b"]
+
+
+def test_plan_strip_returns_none_when_over_capacity():
+    # three labels, 5 mm gaps, into a 6 mm strip → cannot fit (all-or-nothing, P0)
+    over = [_cand("a", 0), _cand("b", 0), _cand("c", 0)]
+    assert plan_strip(over, lo=0, hi=6, min_gap=5) is None
+
+
+def test_plan_strip_x_axis():
+    cands = [StripCandidate("a", (10, 0), (6, 3)), StripCandidate("b", (14, 0), (6, 3))]
+    pos = plan_strip(cands, 0, 100, 5, axis="x")
+    assert pos["a"] <= pos["b"]
+
+
+def test_plan_strip_empty():
+    assert plan_strip([], 0, 100, 5) == {}


### PR DESCRIPTION
P0c of the ADR 0009 strip-layout refactor (#317, tracking #320). Builds on P0a (gate, #326) and P0b (occupancy, #327).

Establishes the **collect-then-solve seam** on the shape the maintainer chose after discussion: the candidate is a **measured render-intent** (not a `Placeable`) — because ADR 0009 is the boundary-labeling research *situated in the ADR-0008 compiler pipeline*, so the strip layout consumes the planner's render-intents.

## What
- **`layout.py` → `StripCandidate`** — a *geometry-only* candidate (`key`, `anchor`, label `size`, `priority`): the measured render-intent the solver sees. Geometry-only so the solver stays a **DAG leaf**, unaware of the IR; the intent-aware *collect* (measuring intent → page geometry) lives up in `annotations/` (P1).
- **`plan_strip(candidates, lo, hi, min_gap, axis)`** — orders labels in **site order** (the boundary-labeling move that makes leaders crossing-free *by construction*), then spaces them via the existing `_solve_strip_1d`. Returns `{key: pos}`, or `None` when the strip can't hold them all (today's all-or-nothing contract).
- **ADR 0009 reconciled** — §Decision "Collect" now says candidate = measured render-intent → geometry-only `StripCandidate`; fixed obstacles (hatch, title block) enter via `strip_obstacles` (P0b), not as candidates.

## Scope / deferrals (explicit in the docstrings)
- Spacing uses the caller's uniform `min_gap` (as the engine's strips do today); `size` is carried for the per-pair, label-height-aware gaps that come with **P4** (#318). `min_gap` must clear the tallest label.
- Priority **selection + escalation** for an over-full strip is **P2** (#322).

## Behaviour-preserving
Additive and **unused in production** → the layout characterization gate is **byte-identical**; full fast tier **638 passed**. 6 pure (no-OCC) unit tests cover crossing-free ordering, spacing, determinism, capacity, and both axes.

Next (P1, #321): the *collect* step measures the contended side/below strip's intents (bore callouts + off-axis location dims) into `StripCandidate`s, solves them together against `strip_obstacles`, and emits — killing the #133/#225 collision class. That PR's gate changes are the deliberate, re-blessed fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
