### PR TITLE
feat: migrate off-axis location dims onto the complete occupancy (P1 groundwork, #321)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -56,9 +56,18 @@ def _geom_box(o):
         return None
 
 
-def strip_obstacles(dwg, view=None):
+CROSSABLE_TYPES = frozenset({"Centerline", "CenterlineCircle", "CenterMark"})
+"""Annotation types a *dimension* may legitimately cross (ISO 128): centre lines
+and centre marks. A **leader**, by contrast, must avoid them (#305) — so this is a
+per-consumer choice, passed as ``crossable`` to :func:`strip_obstacles`."""
+
+
+def strip_obstacles(dwg, view=None, *, crossable=()):
     """The COMPLETE occupancy for strip placement (ADR 0009): every placed
-    annotation's full rendered footprint, optionally restricted to *view*.
+    annotation's full rendered footprint, optionally restricted to *view*, minus
+    any annotation whose type name is in *crossable* (things this particular
+    consumer may legitimately overlap — e.g. a location dim crosses a centre line
+    but a leader does not; see :data:`CROSSABLE_TYPES`).
 
     Unlike :func:`_occupied_boxes` (label boxes only, with bare centrelines
     excluded), this captures the geometry a label box hides — leader shafts and
@@ -88,6 +97,8 @@ def strip_obstacles(dwg, view=None):
             owner = dwg.view_of(name)
             if owner is not None and owner != view:
                 continue  # owned by a different ortho view → its own (disjoint) block
+        if type(o).__name__ in crossable:
+            continue  # this consumer may cross it (centre lines/marks for a dim)
         bb = _geom_box(o)
         if bb is not None:
             boxes.append(bb)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -28,7 +28,12 @@ from draftwright._core import (
     _iso_bbox,
     _log,
 )
-from draftwright.annotations._common import _anno_box, _box_hits, _occupied_boxes
+from draftwright.annotations._common import (
+    CROSSABLE_TYPES,
+    _anno_box,
+    _box_hits,
+    strip_obstacles,
+)
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
 from draftwright.layout import LayoutSolver, Placeable
 from draftwright.model.ir import HoleFeature, PatternFeature
@@ -107,7 +112,12 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
     FX, FZ = a.proj.front_x, a.proj.front_z
     dx, dy, dz = a.bb.min.X, a.bb.min.Y, a.bb.min.Z
     tier = draft.font_size + 2 * draft.pad_around_text
-    occupied = _occupied_boxes(dwg)
+    # Complete occupancy (#321): the full footprint of every placed annotation a
+    # location dim must not overprint — crucially the bore-callout LEADER SHAFTS
+    # the old label-only `_occupied_boxes` missed (#133/#225) — minus the centre
+    # lines/marks a dim may legitimately cross. This is the P1 migration onto the
+    # ADR 0009 occupancy model.
+    occupied = strip_obstacles(dwg, crossable=CROSSABLE_TYPES)
 
     def _drop(axis, view):
         # Recorded at INFO under a code DISTINCT from the plan path's


### PR DESCRIPTION
P1 groundwork (#321, tracking #320). Migrates the off-axis location-dim placer onto the ADR 0009 complete occupancy model (`strip_obstacles`, P0b).

## What
`_locate_off_axis_holes` checked candidates against `_occupied_boxes` (label boxes only, centrelines excluded) with a tier-retry. It now checks against `strip_obstacles(dwg, crossable=CROSSABLE_TYPES)` — the **full** footprint of every placed annotation (crucially the bore-callout **leader shafts** the old label-only set missed, #133/#225) **minus** the centre lines/marks a location dim may legitimately cross (ISO 128). Adds `CROSSABLE_TYPES` + a `crossable=` filter to `strip_obstacles` (default unchanged → P0b tests hold).

## Honest scope — byte-identical
This is a **structural migration, not a visible fix**: on the whole corpus it is **byte-identical** (gate unchanged). I rendered `side_drilled` and looked — the callout and location dim already coexist cleanly; the earlier visible collision of this class (#305) was already fixed by the angled-leader work. So it removes the label-only blind spot *as a class* (robustness) without changing any current drawing. The substantive placement change — routing bore callouts + off-axis dims through one `plan_strip` solve — is the next PR, and it will carry before/after renders.

## Verification
Gate byte-identical (8 passed); P0b occupancy tests unchanged (`crossable` defaults empty); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
