### PR TITLE
feat: plan_strip priority selection (P2 core, #322)

### DIFF
--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -22,7 +22,7 @@ The only solve phase 1 performs correctly is the 1D strip solve.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NamedTuple
 
 Axis = Literal["x", "y"]
 
@@ -182,6 +182,16 @@ class StripCandidate:
     priority: int = 0
 
 
+class StripPlacement(NamedTuple):
+    """Result of :func:`plan_strip`: ``placed`` maps each placed candidate's key to
+    its solved position along the strip axis; ``dropped`` is the keys the strip
+    could not hold, lowest-priority first (the caller escalates them — detail view,
+    table — or surfaces them as lint)."""
+
+    placed: dict
+    dropped: tuple
+
+
 def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     """Collect-then-solve placement of *candidates* along one strip (ADR 0009).
 
@@ -190,32 +200,41 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     coordinates. Sites that share that coordinate are ordered deterministically by
     ``key``; that tie-break is *not* crossing-optimal (it doesn't see the
     perpendicular coordinate that decides those crossings) — resolving ties
-    crossing-optimally is the P4 assign/order step (#318). This matches the
-    engine's current natural-Y strip sort. Then spaces the labels within
-    ``[lo, hi]`` at least *min_gap* apart via :func:`_solve_strip_1d`. Returns
-    ``{key: position}`` for the placed candidates, or ``None`` when the strip
-    cannot hold them all. Candidate *keys* must be unique (they key the result).
+    crossing-optimally is the P4 assign/order step (#318). Then spaces the labels
+    within ``[lo, hi]`` at least *min_gap* apart via :func:`_solve_strip_1d`.
 
-    This is the P0 seam (#317): order-by-site + 1-D spacing, reproducing the
-    engine's current all-or-nothing strip contract. Spacing is the caller's single
-    *min_gap* (as the engine's strips do today) — the candidate's ``size`` is
-    carried for the per-pair, label-height-aware gaps that come with the optimal
-    packing (P4, #318), and is not consulted here, so *min_gap* must clear the
-    tallest label. The *priority* selection + escalation for an over-full strip is
-    P2 (#322). Deterministic: candidates are ordered by ``(anchor-along-axis, key)``
-    and the 1-D solve is deterministic in input order.
+    **Selection (P2, #322):** when the strip cannot hold everything, the
+    lowest-priority candidates are dropped (ties by key, deterministic) until the
+    rest fit — keeping the most important. Returns a :class:`StripPlacement`
+    (``placed`` {key: position}, ``dropped`` keys). This is the ranked, priority-
+    aware replacement for the engine's arrival-order / prefix drops.
+
+    Spacing is the caller's single *min_gap* (as the engine's strips do today) — the
+    candidate's ``size`` is carried for the per-pair, label-height-aware gaps that
+    come with the optimal packing (P4, #318), and is not consulted here, so
+    *min_gap* must clear the tallest label. Candidate *keys* must be unique (they
+    key the result). Deterministic throughout.
     """
     if not candidates:
-        return {}
+        return StripPlacement({}, ())
     keys = [c.key for c in candidates]
     if len(set(keys)) != len(keys):  # like LayoutSolver.register — never silently drop
         raise ValueError("plan_strip: candidate keys must be unique")
     idx = 1 if axis == "y" else 0
-    ordered = sorted(candidates, key=lambda c: (c.anchor[idx], c.key))
-    positions = _solve_strip_1d([c.anchor[idx] for c in ordered], min_gap, lo, hi)
-    if positions is None:
-        return None
-    return {c.key: p for c, p in zip(ordered, positions, strict=True)}
+
+    keep = list(candidates)
+    dropped: list[str] = []
+    while keep:
+        ordered = sorted(keep, key=lambda c: (c.anchor[idx], c.key))
+        positions = _solve_strip_1d([c.anchor[idx] for c in ordered], min_gap, lo, hi)
+        if positions is not None:
+            placed = {c.key: p for c, p in zip(ordered, positions, strict=True)}
+            return StripPlacement(placed, tuple(dropped))
+        # over capacity → drop the lowest-priority candidate (ties by key) and retry
+        victim = min(keep, key=lambda c: (c.priority, c.key))
+        keep.remove(victim)
+        dropped.append(victim.key)
+    return StripPlacement({}, tuple(dropped))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -4,7 +4,10 @@ Grows with the boundary-labeling migration (tracking #320). P0b (#317): the
 complete per-strip occupancy model — `strip_obstacles` — that closes the
 `_occupied_boxes` blind spots behind #133/#225/#305. P0c (#317): the
 collect-then-solve seam — `StripCandidate` (a measured render-intent) + `plan_strip`
-(order = site order ⇒ crossing-free, then 1-D spacing).
+(order = site order ⇒ crossing-free, then 1-D spacing). P2 (#322): `plan_strip`
+priority selection — drop the lowest-priority candidates until the rest fit, the
+ranked replacement for the engine's arrival-order drops (prerequisite for routing a
+production placer without regressing busy strips).
 """
 
 from __future__ import annotations
@@ -109,18 +112,21 @@ def _cand(key, y, w=6.0, h=3.0, priority=0):
 
 
 def test_plan_strip_places_in_site_order_spaced_and_in_bounds():
-    pos = plan_strip([_cand("a", 10), _cand("b", 12), _cand("c", 14)], lo=0, hi=100, min_gap=5)
-    assert set(pos) == {"a", "b", "c"}
-    assert pos["a"] <= pos["b"] <= pos["c"], "site order (crossing-free) not preserved"
-    ys = sorted(pos.values())
+    res = plan_strip([_cand("a", 10), _cand("b", 12), _cand("c", 14)], lo=0, hi=100, min_gap=5)
+    assert set(res.placed) == {"a", "b", "c"} and res.dropped == ()
+    p = res.placed
+    assert p["a"] <= p["b"] <= p["c"], "site order (crossing-free) not preserved"
+    ys = sorted(p.values())
     assert all(b - a >= 5 - 1e-9 for a, b in zip(ys, ys[1:])), "min_gap violated"
-    assert all(0 <= v <= 100 for v in pos.values()), "out of bounds"
+    assert all(0 <= v <= 100 for v in p.values()), "out of bounds"
 
 
 def test_plan_strip_orders_by_site_regardless_of_input_order():
     # shuffled input still resolves to site (anchor) order — the crossing-free move
-    pos = plan_strip([_cand("c", 14), _cand("a", 10), _cand("b", 12)], lo=0, hi=100, min_gap=5)
-    assert pos["a"] <= pos["b"] <= pos["c"]
+    p = plan_strip(
+        [_cand("c", 14), _cand("a", 10), _cand("b", 12)], lo=0, hi=100, min_gap=5
+    ).placed
+    assert p["a"] <= p["b"] <= p["c"]
 
 
 def test_plan_strip_deterministic_key_tiebreak():
@@ -128,23 +134,39 @@ def test_plan_strip_deterministic_key_tiebreak():
     p1 = plan_strip(cands, 0, 100, 5)
     p2 = plan_strip(list(reversed(cands)), 0, 100, 5)
     assert p1 == p2
-    assert p1["a"] <= p1["b"]
+    assert p1.placed["a"] <= p1.placed["b"]
 
 
-def test_plan_strip_returns_none_when_over_capacity():
-    # three labels, 5 mm gaps, into a 6 mm strip → cannot fit (all-or-nothing, P0)
-    over = [_cand("a", 0), _cand("b", 0), _cand("c", 0)]
-    assert plan_strip(over, lo=0, hi=6, min_gap=5) is None
+def test_plan_strip_selection_drops_lowest_priority():
+    # three 5 mm-gapped labels can't fit a 6 mm strip → keep the two highest-priority
+    cands = [
+        StripCandidate("hi", (0.0, 0.0), (6, 3), priority=5),
+        StripCandidate("mid", (0.0, 2.0), (6, 3), priority=3),
+        StripCandidate("lo", (0.0, 4.0), (6, 3), priority=1),
+    ]
+    res = plan_strip(cands, lo=0, hi=6, min_gap=5)
+    assert res.dropped == ("lo",), "should drop only the lowest-priority candidate"
+    assert set(res.placed) == {"hi", "mid"}
+
+
+def test_plan_strip_selection_drops_are_lowest_first_and_deterministic():
+    # a zero-width strip fits exactly one → drop the two lowest priorities, in
+    # lowest-first order; the highest-priority survivor is kept
+    cands = [_cand("a", 0, priority=2), _cand("b", 0, priority=1), _cand("c", 0, priority=3)]
+    res = plan_strip(cands, lo=0, hi=0, min_gap=5)
+    assert set(res.placed) == {"c"}, "highest priority should survive"
+    assert res.dropped == ("b", "a"), "dropped lowest-priority first (1, then 2)"
 
 
 def test_plan_strip_x_axis():
     cands = [StripCandidate("a", (10, 0), (6, 3)), StripCandidate("b", (14, 0), (6, 3))]
-    pos = plan_strip(cands, 0, 100, 5, axis="x")
-    assert pos["a"] <= pos["b"]
+    p = plan_strip(cands, 0, 100, 5, axis="x").placed
+    assert p["a"] <= p["b"]
 
 
 def test_plan_strip_empty():
-    assert plan_strip([], 0, 100, 5) == {}
+    res = plan_strip([], 0, 100, 5)
+    assert res.placed == {} and res.dropped == ()
 
 
 def test_plan_strip_rejects_duplicate_keys():


### PR DESCRIPTION
P2 core (#322, tracking #320) — brought forward because it's a **prerequisite for P1's routing** (a roadmap inversion I found while studying the bore-callout Pass-2: routing bore callouts through an all-or-nothing `plan_strip` would regress busy strips, since the engine today drops only the *overflow*).

## What
`plan_strip` gains the boundary-labeling **selection** step: over capacity, it drops the **lowest-priority** candidates (ties by key, deterministic) until the rest fit — keeping the most important. It now returns a `StripPlacement(placed={key:pos}, dropped=(keys,))`; the caller escalates the dropped set (detail view / table) or lints it. This is the ranked replacement for the engine's arrival-order / prefix drops.

## Why it matters for the D-shape
This + P0b occupancy + P0c seam are the three pieces the **combined contended-strip solve** needs to fix the D-profile callout-hits-dim-line defect (and #305, and any future profile) *by construction* — callout and location dim solved together, mutually aware — and to retire the `is_rotational`-gated `_coaxial_lift` band-aid.

## Behaviour-preserving
Additive and **unused in production** → the layout gate is **byte-identical**; full fast tier **640 passed**. 8 pure unit tests cover crossing-free ordering, spacing, both axes, determinism, the dup-key guard, and the two selection cases (drop lowest-priority; lowest-first ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
