### PR TITLE
feat: route bore-callout Pass-2 through plan_strip — first production placer (P1a, #321)

### DIFF
--- a/docs/plans/strip-layout-boundary-labeling-roadmap.md
+++ b/docs/plans/strip-layout-boundary-labeling-roadmap.md
@@ -33,7 +33,7 @@ collision class by construction while keeping determinism (ADR 0001).
 | Phase | Issue | What | Behaviour change | Depends |
 |---|---|---|---|---|
 | P0 | #317 | **Collect/solve/emit seam + complete per-strip occupancy.** A `StripLayout` stage that takes a batch of candidate `Placeable`s for a view's strips and a unified occupancy that includes *every* occupant — callout/dim labels **plus** extension lines, leader shafts, and the hatch footprint (closing the `_occupied_boxes` blind spots). Route one placer (bore callouts) through it as proof. | None (scaffolding) | — |
-| P1 | #321 | **The contended strip: bore callouts + off-axis location dims as one solve.** Both placers that share the side/below strip contribute candidates to a single solve; delete the post-hoc occupancy-check + tier-retry hack. Validates the model on #133/#225. | Resolves known collisions only | P0 |
+| P1 | #321 | **The contended strip: route both shared-strip placers through `plan_strip`.** Bore callouts and off-axis location dims both become `StripCandidate`s solved by `plan_strip`; delete the post-hoc occupancy-check + tier-retry hack. *Correction (2026-07-01, from implementation):* the two placers stack on **orthogonal axes** (callouts spaced along Y at a fixed X-column; height dims stacked along X-tiers) — so they are two perpendicular 1-D `plan_strip` solves sharing **one occupancy model** (option (c): pre-shrink/split each strip's `[lo,hi]` around `strip_obstacles`), **not** one fused solve. True fusion (collect both placers before either emits, retiring the `_coaxial_lift` forward-reference) is P2/P3. Split into **P1a** (route bore-callout Pass-2 through `plan_strip` — byte-identical, deletes `_solve_strip_via_layout`/greedy prefix-drop) and **P1b** (route `_locate_off_axis_holes`, build the occupancy carve, delete the tier-retry hack **and** `_coaxial_lift`). Validates the model on #133/#225. | Resolves known collisions only | P0 |
 | P2 | #322 | **Feature-ordered assignment + priority selection + escalation.** The solve fixes order = feature order (crossing-free) and turns over-capacity into a priority-ranked selection that emits an escalation signal (→ detail view #306/#54, → table), replacing the scattered `*_dropped` arrival-order decisions. | Drop *policy* changes (ranked, not arrival-order) | P1 |
 | P3 | #323 | **Migrate the remaining strip placers; retire the `Strip` cursor (#150).** Envelope dims, step-height / turned-diameter ladders, and the section-hatch footprint all become candidates; standalone `Strip.allocate` usages are retired. Fully realises #150. | Dense sheets re-pack; covered by invariants | P2 |
 | P4 | #318 | **Optimal leader assignment + angled leaders.** Replace greedy ordering/spacing with the min-cost-matching / DP optimal assignment (minimise total leader length); fold the #305 angled-leader nudge into the model as a first-class leader style. | Leader positions may improve | P3 |
@@ -52,5 +52,21 @@ collision class by construction while keeping determinism (ADR 0001).
 
 ## Status
 
-Not started — ADR 0009 accepted 2026-06-30; phases filed (#317, #321, #322, #323,
-#318, #319 under tracking #320).
+Foundation landed (2026-07-01):
+
+- **P0 (#317)** — done: characterization gate (#326), `strip_obstacles` complete
+  per-strip occupancy (#327), `StripCandidate` + `plan_strip` + `StripPlacement`
+  collect→solve→emit seam (#328).
+- **P2 core (#322)** — landed: `plan_strip` priority selection / ranked over-capacity
+  drops (#330). Feature-ordered assignment + escalation signal still pending routing.
+- **P1 (#321)** — in progress. #329 migrated off-axis dims onto the complete
+  occupancy; #331 fixed the D-profile / `side_drilled` coaxial overlap on the model
+  (`_coaxial_lift` generalised to cause-driven `reserved_rows`). **P1a** routes the
+  bore-callout Pass-2 through `plan_strip` (byte-identical; deletes
+  `_solve_strip_via_layout` + the greedy prefix-drop) — the first production placer
+  on the seam. **P1b** (next) routes `_locate_off_axis_holes`, builds the occupancy
+  carve, and deletes the tier-retry hack + `_coaxial_lift`.
+- **P3 (#323) / P4 (#318) / P5 (#319)** — not started.
+
+Key gap: until P1b, `plan_strip` is load-bearing only for the bore-callout Pass-2;
+the off-axis dims still use the tier-retry + post-hoc `_box_hits` hack.

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -24,7 +24,6 @@ from draftwright._core import (
     _axis_letter,
     _dim,
     _fmt,
-    _greedy_strip_ys,
     _iso_bbox,
     _log,
 )
@@ -35,7 +34,7 @@ from draftwright.annotations._common import (
     strip_obstacles,
 )
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.layout import LayoutSolver, Placeable
+from draftwright.layout import StripCandidate, plan_strip
 from draftwright.model.ir import HoleFeature, PatternFeature
 
 
@@ -428,38 +427,6 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
     )
 
 
-def _solve_strip_via_layout(naturals, min_gap, lo, hi, key_prefix):
-    """Place a pre-sorted, uniform-gap 1D stack through the shared LayoutSolver
-    (ADR 0003 phase 2, #80), returning positions in input order, or ``None`` if
-    the stack does not fit.
-
-    *naturals* must be ascending (the caller sorts the queue), so the solver's
-    ``(natural, key)`` ordering — with the zero-padded keys built here — is the
-    identity, and the result is byte-identical to the bare ``_solve_strip_1d``
-    this replaces. The label width is irrelevant to a vertical stack, so each
-    placeable carries the uniform ``min_gap`` as its height.
-    """
-    solver = LayoutSolver()
-    keys = [f"{key_prefix}{j:04d}" for j in range(len(naturals))]
-    for key, nat in zip(keys, naturals, strict=True):
-        solver.register(
-            Placeable(
-                key=key,
-                anchors=((0.0, nat),),
-                size=(0.0, min_gap),
-                dof_axis="y",
-                natural=nat,
-                min_gap=min_gap,
-            )
-        )
-    # greedy_fallback=False so this returns exactly what the bare primitive did:
-    # None when the strip is full, leaving the caller's prefix-drop to fire (#80).
-    placed = solver.solve_strip(lo=lo, hi=hi, axis="y", greedy_fallback=False)
-    if placed is None:
-        return None
-    return [placed[k] for k in keys]
-
-
 def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
     """Leader-attached HoleCallouts, one per distinct hole spec per view (#91).
 
@@ -755,61 +722,61 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
         right_queue.sort(key=lambda s: s[4])
         left_queue.sort(key=lambda s: s[4])
 
-        # --- Pass 2: Y placement (through the LayoutSolver, #80) ---
-        right_ys = _solve_strip_via_layout(
-            [s[4] for s in right_queue], min_gap, y_min, y_max, "hc_r"
-        )
-        left_ys = _solve_strip_via_layout(
-            [s[4] for s in left_queue], min_gap, y_min, y_max, "hc_l"
-        )
-
-        if right_ys is None and right_queue:
-            right_ys = _greedy_strip_ys(
-                [s[4] for s in right_queue], min_gap, y_min, y_max, prefix=True
-            )
-            n_drop = len(right_queue) - len(right_ys)
-            if n_drop:
-                _log.warning(
-                    "plan/side right strip: %d of %d bore callouts skipped (strip full)",
-                    n_drop,
-                    len(right_queue),
+        # --- Pass 2: Y placement + selection via the collect-then-solve seam ---
+        # Each queued callout becomes a StripCandidate (a measured render-intent);
+        # one plan_strip per side does the site-ordered spacing and the over-capacity
+        # drop (ADR 0009 / #321 P1a). This is the first *production* placer routed
+        # through plan_strip — it replaces the bespoke _solve_strip_via_layout + the
+        # greedy prefix-drop. Byte-identical to that path by construction: plan_strip
+        # bottoms out in the same _solve_strip_1d, the queue is pre-sorted by natural
+        # Y (so plan_strip's (anchor_y, key) order is the queue order), and
+        # priority=n-j reproduces the old "lowest natural Y survives" prefix drop.
+        # (_coaxial_lift still pre-adjusts each anchor row; folding that into a
+        # plan_strip occupancy carve — and routing the off-axis location dims through
+        # the same seam, deleting their tier-retry hack — is P1b.)
+        def _place_queue(queue, edge, side, key_prefix, start_i):
+            if not queue:
+                return start_i
+            n = len(queue)
+            cands = [
+                StripCandidate(
+                    key=f"{key_prefix}{j:04d}",
+                    anchor=(edge, s[4]),
+                    size=(s[2].callout_width, min_gap),
+                    priority=n - j,  # smaller j = lower natural Y = drops last, i.e.
+                    # the old prefix-keep policy; real per-feature priorities are P2.
                 )
-                for _locs, dia, *_ in right_queue[len(right_ys) :]:
-                    _record_callout_drop(dwg, view, dia, "right strip full")
-            right_queue = right_queue[: len(right_ys)]
-        if left_ys is None and left_queue:
-            left_ys = _greedy_strip_ys(
-                [s[4] for s in left_queue], min_gap, y_min, y_max, prefix=True
-            )
-            n_drop = len(left_queue) - len(left_ys)
-            if n_drop:
+                for j, s in enumerate(queue)
+            ]
+            res = plan_strip(cands, y_min, y_max, min_gap)
+            by_key = {c.key: s for c, s in zip(cands, queue, strict=True)}
+            if res.dropped:
                 _log.warning(
-                    "plan/side left strip: %d of %d bore callouts skipped (strip full)",
-                    n_drop,
-                    len(left_queue),
+                    "plan/side %s strip: %d of %d bore callouts skipped (strip full)",
+                    side,
+                    len(res.dropped),
+                    n,
                 )
-                for _locs, dia, *_ in left_queue[len(left_ys) :]:
-                    _record_callout_drop(dwg, view, dia, "left strip full")
-            left_queue = left_queue[: len(left_ys)]
+                for k in res.dropped:
+                    _record_callout_drop(dwg, view, by_key[k][1], f"{side} strip full")
+            i = start_i
+            for k, elbow_y in sorted(res.placed.items(), key=lambda kv: (by_key[kv[0]][4], kv[0])):
+                _locs, dia, callout, feat, _ny, rep = by_key[k]
+                centre = to_page(rep)
+                if side == "right":
+                    elbow = (edge + elbow_dx, elbow_y)
+                    tip = _rim_tip(centre, elbow, dia)
+                    # Safety clamp: arrowhead must sit inside the view boundary.
+                    tip = (min(tip[0], edge - draft.arrow_length), tip[1])
+                else:
+                    elbow = (edge - elbow_dx, elbow_y)
+                    tip = _rim_tip(centre, elbow, dia)
+                    tip = (max(tip[0], edge + draft.arrow_length), tip[1])
+                _add(view, i, tip, elbow, side, callout)
+                _add_furniture(dwg, a, view, i, feat, to_page)
+                i += 1
+            return i
 
-        for i, ((locs, dia, callout, feat, _, rep), elbow_y) in enumerate(
-            zip(right_queue, right_ys, strict=True)
-        ):
-            centre = to_page(rep)
-            elbow = (edge_right + elbow_dx, elbow_y)
-            tip = _rim_tip(centre, elbow, dia)
-            # Safety clamp: arrowhead must sit inside the view boundary.
-            tip = (min(tip[0], edge_right - draft.arrow_length), tip[1])
-            _add(view, i, tip, elbow, "right", callout)
-            _add_furniture(dwg, a, view, i, feat, to_page)
-
+        next_i = _place_queue(right_queue, edge_right, "right", "hc_r", 0)
         assert edge_left is not None or not left_queue  # populated only when edge_left is set
-        for i, ((locs, dia, callout, feat, _, rep), elbow_y) in enumerate(
-            zip(left_queue, left_ys, strict=True), start=len(right_queue)
-        ):
-            centre = to_page(rep)
-            elbow = (edge_left - elbow_dx, elbow_y)  # type: ignore[operator]
-            tip = _rim_tip(centre, elbow, dia)
-            tip = (max(tip[0], edge_left + draft.arrow_length), tip[1])
-            _add(view, i, tip, elbow, "left", callout)
-            _add_furniture(dwg, a, view, i, feat, to_page)
+        _place_queue(left_queue, edge_left, "left", "hc_l", next_i)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -759,6 +759,9 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                 )
                 for k in res.dropped:
                     _record_callout_drop(dwg, view, by_key[k][1], f"{side} strip full")
+            # Emit survivors in natural-Y order (== plan_strip's solve order, since
+            # keys are Y-monotonic) so the hc_{view}{i} names + centre-mark indices
+            # land on the same callouts as the old queue-order emit.
             i = start_i
             for k, elbow_y in sorted(res.placed.items(), key=lambda kv: (by_key[kv[0]][4], kv[0])):
                 _locs, dia, callout, feat, _ny, rep = by_key[k]

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -251,9 +251,11 @@ class TestFitBox:
 
 
 def test_layout_engine_is_wired_into_the_drawing_path():
-    # Phase 2 (#80): hole-callout placement now flows through the LayoutSolver.
-    # The hole pass that wires it in moved to annotations/holes.py (#164, P5d).
+    # The hole-callout Y-stack flows through the shared layout engine. Phase 2 (#80)
+    # wired it via the LayoutSolver; ADR 0009 P1a (#321) re-routed it through the
+    # collect-then-solve seam — plan_strip over StripCandidates — so this guard now
+    # tracks that seam (the first production placer on it).
     src = (L.__file__).replace("layout.py", "annotations/holes.py")
     text = open(src).read()
-    assert "Placeable(" in text
-    assert "LayoutSolver(" in text
+    assert "StripCandidate(" in text
+    assert "plan_strip(" in text

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2893,33 +2893,6 @@ class TestAutoHoleAnnotations:
 
         assert _solve_strip_ys([], min_gap=8.0, lo=0.0, hi=100.0) == []
 
-    @pytest.mark.timeout(60)
-    def test_solve_strip_via_layout_is_byte_identical_to_primitive(self):
-        # #80: the hole-callout Y-stack now routes through the LayoutSolver. The
-        # adapter must return exactly what the bare primitive did — including for
-        # tied natural Ys, where the solver's (natural, key) order must reduce to
-        # the input order via the zero-padded keys.
-        from draftwright._core import _solve_strip_ys
-        from draftwright.annotations.holes import _solve_strip_via_layout
-
-        # (naturals, gap, lo, hi)
-        cases = [
-            ([10.0, 12.0, 14.0, 16.0], 8.0, 0.0, 100.0),  # distinct, feasible
-            ([5.0, 5.0, 5.0], 8.0, 0.0, 100.0),  # all tied
-            ([0.0, 0.0, 20.0, 20.0], 8.0, 0.0, 100.0),  # paired ties
-            ([], 8.0, 0.0, 10.0),  # empty
-            ([0.0, 0.0, 0.0], 8.0, 0.0, 10.0),  # infeasible, greedy also overflows
-            # Knife-edge: exact solve reports infeasible at (n-1)*gap == hi-lo, but
-            # a non-prefix greedy packing would just fit. The adapter must still
-            # return None here (matching the primitive), or the caller's drop is
-            # silently skipped (#80 review).
-            ([4.52, 5.29, 16.07, 22.13], 4.73, 8.44, 22.63),
-        ]
-        for naturals, gap, lo, hi in cases:
-            adapter = _solve_strip_via_layout(naturals, gap, lo, hi, "k")
-            primitive = _solve_strip_ys(naturals, gap, lo, hi)
-            assert adapter == primitive, naturals
-
 
 class TestHolePatternAnnotations:
     """Bolt-circle and linear-array sheet furniture + count-aware lint (#92)."""

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -158,6 +158,22 @@ def test_plan_strip_selection_drops_are_lowest_first_and_deterministic():
     assert res.dropped == ("b", "a"), "dropped lowest-priority first (1, then 2)"
 
 
+def test_plan_strip_drops_at_exact_feasibility_boundary_not_greedy():
+    # At (n-1)*min_gap == hi-lo the exact 1-D solve is infeasible (strict); a greedy
+    # pack from lo would just fit all n, but plan_strip DROPS one and re-solves. This
+    # is the one intended behaviour change when the bore-callout Pass-2 moved off the
+    # old greedy prefix-drop onto plan_strip (#321 P1a) — pin it against drift. The
+    # numbers are the deleted adapter test's knife-edge case: gap 4.73 in [8.44, 22.63]
+    # gives (4-1)*4.73 == 14.19 == hi-lo, the exact boundary.
+    anchors = [4.52, 5.29, 16.07, 22.13]
+    cands = [StripCandidate(f"c{i}", (0.0, y), (6, 3)) for i, y in enumerate(anchors)]
+    res = plan_strip(cands, lo=8.44, hi=22.63, min_gap=4.73)
+    assert len(res.placed) == 3 and len(res.dropped) == 1, "must drop at the exact boundary"
+    # a strictly looser strip fits all four (proves the boundary, not a blanket drop)
+    loose = plan_strip(cands, lo=8.44, hi=22.64, min_gap=4.73)
+    assert len(loose.placed) == 4 and loose.dropped == ()
+
+
 def test_plan_strip_x_axis():
     cands = [StripCandidate("a", (10, 0), (6, 3)), StripCandidate("b", (14, 0), (6, 3))]
     p = plan_strip(cands, 0, 100, 5, axis="x").placed


### PR DESCRIPTION
## What

Routes the hole bore-callout Y-stack (Pass-2 of `_annotate_holes`) through the **ADR 0009 collect-then-solve seam** — `plan_strip` over `StripCandidate`s — replacing the bespoke `_solve_strip_via_layout` (LayoutSolver adapter, #80) + greedy prefix-drop.

**This is the first *production* placer on `plan_strip`.** Until now the seam was unit-tested but unused; this makes it load-bearing (the actual goal of roadmap phase P1).

## Byte-identical on the corpus

Zero snapshot re-bless across all 9 characterization parts. By construction:
- `plan_strip` bottoms out in the same `_solve_strip_1d`.
- the queue is pre-sorted by natural Y, so `plan_strip`'s `(anchor_y, key)` order **is** the queue order.
- `priority = n − j` reproduces the old "lowest natural Y survives" prefix-keep.

The one intended change is on an **over-capacity** strip (none in the corpus): drops now come from `plan_strip`'s exact-resolve-then-drop rather than greedy-prefix packing — a knife-edge case can keep a different count. Roadmap-sanctioned (P1 "resolves known collisions only"; P2 owns drop policy). Verified against the **slow CTC tier** locally.

## Deletions / cleanup

- `_solve_strip_via_layout`, the greedy prefix-drop blocks, dead `LayoutSolver`/`Placeable`/`_greedy_strip_ys` imports.
- the obsolete adapter characterization test (`test_solve_strip_via_layout_is_byte_identical_to_primitive`).
- rewrote the layout-wiring guard to assert the `plan_strip` seam.

`_coaxial_lift` stays as a **temporary** anchor pre-adjustment — folding it into a `plan_strip` occupancy carve, and routing the off-axis location dims through the same seam (deleting their tier-retry hack), is **P1b**.

## Roadmap

Refreshes the stale `Status` and corrects the "one solve" framing: the two shared-strip placers stack on **orthogonal axes** (callouts spaced along Y at a fixed X-column; height dims stacked along X-tiers) — two perpendicular `plan_strip` solves sharing one occupancy model, not one fused solve.

## Tests

- Full fast tier: **640 passed**. mypy clean. Snapshot gate: zero drift.
- Slow tier: running locally to confirm the overflow drop-policy change doesn't regress CTC-scale sheets.

Part of ADR 0009 (tracking #320).

🤖 Generated with [Claude Code](https://claude.com/claude-code)