### PR TITLE
feat: route real per-feature priority (bore diameter) into plan_strip (ADR 0009, #322 P2/D3)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -778,24 +778,22 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
         # one plan_strip per side does the site-ordered spacing and the over-capacity
         # drop (ADR 0009 / #321 P1a). This is the first *production* placer routed
         # through plan_strip — it replaces the bespoke _solve_strip_via_layout + the
-        # greedy prefix-drop. Byte-identical to that path by construction: plan_strip
-        # bottoms out in the same _solve_strip_1d, the queue is pre-sorted by natural
-        # Y (so plan_strip's (anchor_y, key) order is the queue order), and
-        # priority=n-j reproduces the old "lowest natural Y survives" prefix drop.
-        # (_coaxial_lift still pre-adjusts each anchor row; folding that into a
-        # plan_strip occupancy carve — and routing the off-axis location dims through
-        # the same seam, deleting their tier-retry hack — is P1b.)
+        # greedy prefix-drop. plan_strip bottoms out in the same _solve_strip_1d, and
+        # the queue is pre-sorted by natural Y (so plan_strip's (anchor_y, key) order is
+        # the queue order → leaders stay crossing-free). Over-capacity selection is now
+        # by real per-feature priority — the hole DIAMETER (D3/#322): when the strip
+        # cannot hold every callout, the smallest-bore features drop first so the most
+        # significant survive (the same "largest wins" policy the front-view shaft rows
+        # already use, line 638). Ties (equal bore) fall back to key = natural-Y order.
         def _place_queue(queue, edge, side, key_prefix, start_i):
             if not queue:
                 return start_i
-            n = len(queue)
             cands = [
                 StripCandidate(
                     key=f"{key_prefix}{j:04d}",
                     anchor=(edge, s[4]),
                     size=(s[2].callout_width, min_gap),
-                    priority=n - j,  # smaller j = lower natural Y = drops last, i.e.
-                    # the old prefix-keep policy; real per-feature priorities are P2.
+                    priority=s[1],  # bore diameter — largest wins over-capacity (D3)
                 )
                 for j, s in enumerate(queue)
             ]
@@ -806,7 +804,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                     "plan/side %s strip: %d of %d bore callouts skipped (strip full)",
                     side,
                     len(res.dropped),
-                    n,
+                    len(queue),
                 )
                 for k in res.dropped:
                     _record_callout_drop(dwg, view, by_key[k][1], f"{side} strip full")

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -170,7 +170,9 @@ class StripCandidate:
             :func:`plan_strip`).
         size: the label box ``(width, height)`` in page-mm.
         priority: higher wins when the strip is over capacity — the *selection*
-            step's ranking (P2, #322). Unused by the P0 seam (all-or-nothing).
+            step's ranking (P2, #322). A magnitude (e.g. a hole's diameter), so it
+            is a ``float``; ``int`` ranks remain valid (the numeric tower). Unused by
+            the P0 seam (all-or-nothing).
 
     An ``eligible_sides`` field joins when the multi-side *assign* step lands
     (P2, #322); the P0 seam places on a single, caller-chosen strip.
@@ -179,7 +181,7 @@ class StripCandidate:
     key: str
     anchor: tuple[float, float]
     size: tuple[float, float]
-    priority: int = 0
+    priority: float = 0
 
 
 class StripPlacement(NamedTuple):

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -174,10 +174,55 @@ def test_plan_strip_drops_at_exact_feasibility_boundary_not_greedy():
     assert len(loose.placed) == 4 and loose.dropped == ()
 
 
+def test_plan_strip_priority_is_a_float_magnitude_drops_smallest():
+    # D3 (#322): priority is a per-feature magnitude (a hole's diameter) — a float, not
+    # just an int rank. Over capacity, the smallest-bore candidate drops first.
+    cands = [
+        StripCandidate("big", (0.0, 0.0), (6, 3), priority=6.0),
+        StripCandidate("mid", (0.0, 2.0), (6, 3), priority=3.2),
+        StripCandidate("small", (0.0, 4.0), (6, 3), priority=1.5),
+    ]
+    res = plan_strip(cands, lo=0, hi=6, min_gap=5)  # 6 mm strip holds ~2 at 5 mm gap
+    assert res.dropped == ("small",), "smallest bore should drop first"
+    assert set(res.placed) == {"big", "mid"}
+
+
 def test_plan_strip_x_axis():
     cands = [StripCandidate("a", (10, 0), (6, 3)), StripCandidate("b", (14, 0), (6, 3))]
     p = plan_strip(cands, 0, 100, 5, axis="x").placed
     assert p["a"] <= p["b"]
+
+
+def test_bore_callout_priority_is_the_hole_diameter(monkeypatch):
+    # D3 (#322) wiring: each bore-callout StripCandidate's priority is the hole
+    # DIAMETER (largest wins over-capacity), not the old n-j prefix-keep placeholder.
+    # Spy on plan_strip because the corpus never over-fills a callout strip, so the
+    # policy is otherwise unobservable (byte-identical output).
+    from build123d import Box, BuildPart, Cylinder, Mode, Pos
+
+    import draftwright.annotations.holes as holes_mod
+
+    captured = []
+    orig = holes_mod.plan_strip
+
+    def _spy(cands, *a, **k):
+        captured.extend(cands)
+        return orig(cands, *a, **k)
+
+    monkeypatch.setattr(holes_mod, "plan_strip", _spy)
+
+    with BuildPart() as p:
+        Box(80, 60, 10)
+        with BuildPart(mode=Mode.SUBTRACT):
+            Pos(-25, 15, 0) * Cylinder(radius=3, height=12)  # ø6
+        with BuildPart(mode=Mode.SUBTRACT):
+            Pos(20, -18, 0) * Cylinder(radius=1.5, height=12)  # ø3
+    build_drawing(p.part)
+
+    pri = {round(c.priority, 1) for c in captured if c.key.startswith("hc_")}
+    assert pri, "no bore-callout candidates were routed through plan_strip"
+    assert pri <= {3.0, 6.0}, f"priorities should be hole diameters, got {pri}"
+    assert 6.0 in pri, "the ø6 bore's priority should be its diameter, not an n-j rank"
 
 
 def test_plan_strip_empty():


### PR DESCRIPTION
## Why

P2 (#322) routes **real** per-feature priorities into `plan_strip`'s over-capacity
selection, replacing the placeholder rank left in P1a. The bore-callout Pass-2 carried
`priority = n - j` (a natural-Y prefix-keep rank) — a stand-in until the real policy
(D3) landed.

## What

- **Priority = bore diameter** (D3): when a plan/side callout strip cannot hold every
  callout, the smallest-bore features drop first so the most significant survive — the
  same "largest wins" policy the front-view shaft rows already use. Ties (equal bore)
  fall back to key = natural-Y order, so leaders stay crossing-free and the result is
  deterministic.
- `StripCandidate.priority` becomes a `float` (a magnitude, not just an int rank); int
  ranks stay valid via the numeric tower.

## Output impact

**Byte-identical on the corpus** — no corpus part over-fills a callout strip, so no
drop occurs and `plan_strip`'s anchor-ordered placement is unchanged. This is a policy
correctness fix for dense sheets.

## Verification

- Full fast tier green; ruff + mypy clean; snapshot + cleanliness gates green (27).
- New tests: a float-priority selection unit test (smallest bore drops) + a spy test
  that bore callouts carry **diameter** priorities (guards against the old `n-j`).
- Independent adversarial review: **CLEAN** (7 scrutiny points, no defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)