### PR TITLE
fix: reserve the outermost label's height at the strip boundary (ADR 0009, #323 P3; #338 review)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -218,6 +218,16 @@ def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False):
     if strip is None or not cands:
         return list(cands)
     lo, hi, inner = strip_free_span(strip)
+    # Reserve the outermost label's height at the strip boundary. plan_strip bounds the
+    # dim-LINE position, but the label extends `tier` OUTWARD from it — so without this
+    # the last tier's label overshoots outer_limit (into the iso view / page margin),
+    # unlike the old Strip.allocate which checked `start + tier <= outer_limit` (#338
+    # review). The strip edge is not an obstacle (obstacles carry their own footprint +
+    # pad), so only the boundary needs it; obstacle-bounded segments are unaffected.
+    if inner == lo:
+        hi -= tier
+    else:
+        lo += tier
     idx = 1 if axis == "y" else 0
     pad = tier + strip.spacing  # min separation between stacked dim lines
     occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -225,6 +225,35 @@ def test_bore_callout_priority_is_the_hole_diameter(monkeypatch):
     assert 6.0 in pri, "the ø6 bore's priority should be its diameter, not an n-j rank"
 
 
+def test_place_strip_candidates_reserves_outermost_label_within_bounds():
+    # #338: the outermost label extends `tier` beyond its dim line; place_strip_candidates
+    # must keep it within outer_limit (the old Strip.allocate checked start+tier<=limit).
+    # An above-strip near=8..limit=20 (range 12) fits 2 dim LINES at pad=9 (8, 17), but the
+    # 2nd label [17,22] overshoots 20 — so only 1 may be placed; the 2nd is returned.
+    from draftwright._core import Strip
+    from draftwright.annotations._common import place_strip_candidates
+
+    class _Dwg:
+        def __init__(s):
+            s.added = []
+
+        def iter_annotations(s):
+            return list(s.added)
+
+        def view_of(s, n):
+            return "plan"
+
+        def add(s, obj, name, view=None):
+            s.added.append((name, obj))
+
+    strip = Strip(anchor=0.0, outer_limit=20.0, direction=1.0, gap=8.0, spacing=4.0)  # near=8
+    dwg = _Dwg()
+    cands = [("a", lambda pos: ("dim", pos)), ("b", lambda pos: ("dim", pos))]
+    left = place_strip_candidates(dwg, strip, "plan", "y", cands, tier=5.0, force=True)
+    assert len(dwg.added) == 1, "outermost label would overshoot outer_limit — must not place it"
+    assert len(left) == 1, "the unplaceable candidate must be returned, not dropped silently"
+
+
 def test_plan_strip_empty():
     res = plan_strip([], 0, 100, 5)
     assert res.placed == {} and res.dropped == ()


### PR DESCRIPTION
## Why

Follow-up to the #338 review: `place_strip_candidates` (the shared P3 placer) bounded
only the dim-LINE position (`plan_strip`'s `v <= hi`), but a label extends `tier`
OUTWARD from its dim line. On a fully-packed strip the outermost label overshot
`outer_limit` by up to one tier — into the iso view (past `iso_y0-4`) or the page
margin — whereas the retired `Strip.allocate` checked `start + tier <= outer_limit`.
Every remaining P3 migration builds on this helper, so it's hardened now.

## What

After `strip_free_span`, pull the strip's outer boundary in by `tier` before carving
(`inner==lo → hi-=tier`, else `lo+=tier`). The strip edge is not an obstacle (obstacles
carry their own footprint + `pad`), so only the boundary needs it; obstacle-bounded
segments are untouched (their label-to-obstacle clearance stays `spacing`).

## Output impact

**Byte-identical** on the corpus (uncontended strips never reach their last tier —
snapshot + cleanliness green, 27).

## Verification

- Full fast tier green; ruff + mypy clean.
- New unit test: a strip that fits 2 dim lines but whose 2nd label would overshoot
  places only 1 (verified to FAIL on pre-fix code).
- Independent adversarial review: **CLEAN** (sign correctness both directions, no
  obstacle double-count, degenerate strip handled, byte-identity confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)