### PR TITLE
feat: migrate render_height_ladder onto a position-returning carve, preserving the leapfrog (ADR 0009, #323 P3)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -281,3 +281,43 @@ def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False):
                 continue
             dwg.add(dim, name, view=view)
     return todo
+
+
+def carve_free_position(dwg, strip, view, axis, tier, perp_span, *, outermost=False):
+    """The single free tier POSITION on *strip* at which a dim of height *tier* spanning
+    *perp_span* ``(lo, hi)`` on the perpendicular axis clears every placed obstacle in
+    *view* — the innermost (nearest the view) tier by default, or the outermost fitting
+    one when *outermost*. Returns the dim-line page coord, or None if the strip is full.
+
+    The position-returning counterpart of :func:`place_strip_candidates` (which batches,
+    builds and adds): a caller that needs a dim's assigned position BEFORE building the
+    next — the height-ladder leapfrog chain, where each step dim's witness base is the
+    previous dim's line — uses this. Same carve: outer-label tier reservation, the
+    perpendicular-band filter (*perp_span* drops obstacles disjoint from this dim's own
+    perpendicular extent), and innermost-first fill. No corridor check (a single-strip
+    ladder has no alternate view to route to; obstacle tiers are still avoided)."""
+    if strip is None:
+        return None
+    lo, hi, inner = strip_free_span(strip)
+    idx = 1 if axis == "y" else 0
+    perp = 0 if axis == "y" else 1
+    pad = tier + strip.spacing
+    band_lo, band_hi = perp_span
+    occ = [
+        b
+        for b in strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+        if b[perp] < band_hi and b[perp + 2] > band_lo
+    ]
+    segs = carve_free_segments(lo, hi, [(b[idx], b[idx + 2]) for b in occ], pad)
+    # A segment holds the dim iff it is at least `tier` wide (the label height). This IS
+    # the outer-label reservation — inclusive at the boundary (a strip exactly `gap+tier`
+    # wide fits one dim, as the old `allocate` did) — so it must NOT be combined with a
+    # separate `hi -= tier` pull-in, which would double-reserve and drop that dim.
+    fitting = [s for s in segs if s[1] - s[0] >= tier - 1e-9]
+    if not fitting:
+        return None
+    if inner == lo:  # inner edge = seg lo; outermost = the segment reaching furthest out
+        seg = max(fitting, key=lambda s: s[1]) if outermost else min(fitting, key=lambda s: s[0])
+        return seg[0]
+    seg = min(fitting, key=lambda s: s[0]) if outermost else max(fitting, key=lambda s: s[1])
+    return seg[1]

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -47,6 +47,7 @@ from draftwright.annotations._common import (
     _anno_box,
     _box_hits,
     _occupied_boxes,
+    carve_free_position,
     carve_free_segments,
     place_strip_candidates,
     strip_free_span,
@@ -849,7 +850,8 @@ def render_height_ladder(dwg, model, a) -> int:
     if rep is not None:
         n_rep, rise = rep
         first = sorted(levels)[0]
-        px = a.fv_zones.right.allocate(_SLOT_DIM_STEP)
+        perp = tuple(sorted((FZ(a.bb.min.Z), FZ(first))))
+        px = carve_free_position(dwg, a.fv_zones.right, "front", "x", _SLOT_DIM_STEP, perp)
         if px is not None:
             dwg.add(
                 _dim(
@@ -881,7 +883,8 @@ def render_height_ladder(dwg, model, a) -> int:
                 "(use a detail view)",
             )
         for col, z in enumerate(kept):
-            px = a.fv_zones.right.allocate(_SLOT_DIM_STEP)
+            perp = tuple(sorted((FZ(a.bb.min.Z), FZ(z))))
+            px = carve_free_position(dwg, a.fv_zones.right, "front", "x", _SLOT_DIM_STEP, perp)
             if px is None:
                 dwg._record_build_issue(
                     "error",
@@ -912,7 +915,19 @@ def render_height_ladder(dwg, model, a) -> int:
     rot = next((f for f in model.features if f.kind == "rotational"), None)
     od_is_height = rot is not None and rot.frame.axis in ("x", "y")
     suppress_height = model.orientation == "z" or od_is_height
-    px = None if suppress_height else a.fv_zones.right.allocate(_SLOT_DIM_HEIGHT)
+    px = (
+        None
+        if suppress_height
+        else carve_free_position(
+            dwg,
+            a.fv_zones.right,
+            "front",
+            "x",
+            _SLOT_DIM_HEIGHT,
+            tuple(sorted((FZ(a.bb.min.Z), FZ(a.bb.max.Z)))),
+            outermost=True,
+        )
+    )
     if px is not None:
         dwg.add(
             _dim(

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -294,6 +294,31 @@ def test_place_strip_candidates_ignores_perpendicular_disjoint_obstacle():
     assert not left and len(dwg.added) == 1, "perpendicular-disjoint obstacle must not block"
 
 
+def test_carve_free_position_exact_fit_and_innermost_outermost():
+    # carve_free_position must place on a strip EXACTLY gap+tier wide — the label reaches
+    # outer_limit inclusively, as the old Strip.allocate did (the double-reserve bug
+    # dropped it). And it returns the innermost tier by default, outermost when asked.
+    from draftwright._core import Strip
+    from draftwright.annotations._common import carve_free_position
+
+    class _Dwg:
+        def iter_annotations(s):
+            return []
+
+        def view_of(s, n):
+            return "front"
+
+    # right strip near=116 .. outer=126: exactly one 10 mm tier fits
+    tight = Strip(anchor=108.0, outer_limit=126.0, direction=1.0, gap=8.0, spacing=4.0)
+    assert carve_free_position(_Dwg(), tight, "front", "x", 10.0, (0.0, 50.0)) == 116.0
+
+    # a roomy strip: innermost is the inner edge (near); outermost still fits within bounds
+    wide = Strip(anchor=108.0, outer_limit=160.0, direction=1.0, gap=8.0, spacing=4.0)  # near=116
+    inner = carve_free_position(_Dwg(), wide, "front", "x", 10.0, (0.0, 50.0))
+    outer = carve_free_position(_Dwg(), wide, "front", "x", 10.0, (0.0, 50.0), outermost=True)
+    assert inner == 116.0 and outer + 10.0 <= 160.0 and outer >= inner
+
+
 def test_plan_strip_empty():
     res = plan_strip([], 0, 100, 5)
     assert res.placed == {} and res.dropped == ()


### PR DESCRIPTION
Retires the `Strip.allocate` cursor from the front-view step/height ladder (#150)
while keeping its **chained ("running") dimensioning style** — each step dim's witness
base is the *previous* dim's line (`right_ladder = px`), which needs a dim's assigned
position **before** building the next.

## What

- New `_common.carve_free_position(dwg, strip, view, axis, tier, perp_span, *,
  outermost=False)` — the **position-returning** counterpart of
  `place_strip_candidates`: same carve (perpendicular-band filter + innermost/outermost
  tier selection) but returns the assigned dim-line coord instead of building+adding.
  So the ladder places sequentially and leapfrogs each base.
- Step dims take the innermost free tier (each avoids the prior via `strip_obstacles`);
  the overall height takes the outermost. `perp_span` = the dim's Z-extent, so a
  perpendicular-disjoint occupant doesn't false-block.

## Output impact

- **Byte-identical** on the corpus (single `dim_height`; snapshot + cleanliness green, 27).
- **Leapfrog chain preserved** — 44 stepped-part tests in `test_make_drawing` pass.

## A real bug caught by the snapshot gate

The label-height reservation must be the **inclusive `seg_width >= tier` check alone**.
Combining it with a separate `hi -= tier` pull-in double-reserved and dropped a dim on a
strip exactly `gap+tier` wide (box's `dim_height`). Fixed; unit tests added (exact-fit +
innermost/outermost).

Retires **3** allocate sites. Remaining cursor users: `render_pmi` (10) + the public
`place_dim`.

## Verification

- Full fast tier green (**668**); ruff + mypy clean.
- Independent adversarial review: (gated on CLEAN + green CI before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)