### PR TITLE
feat: migrate render_pmi onto the carve, retiring Strip.allocate from from_model (ADR 0009, #323 P3)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1193,9 +1193,9 @@ def render_pmi(dwg, model, a) -> int:
         if strip is None:
             return False
         witness_y = max(p1[1], p2[1]) + 2
-        if strip.peek(_SLOT) is None or strip.peek(_SLOT) <= witness_y:
+        slot = carve_free_position(dwg, strip, view, "y", _SLOT, tuple(sorted((p1[0], p2[0]))))
+        if slot is None or slot <= witness_y:
             return False
-        slot = strip.allocate(_SLOT)
         dwg.add(
             _dim(
                 (p1[0], witness_y, 0),
@@ -1215,9 +1215,9 @@ def render_pmi(dwg, model, a) -> int:
         if strip is None:
             return False
         witness_y = min(p1[1], p2[1]) - 2
-        if strip.peek(_SLOT) is None or strip.peek(_SLOT) >= witness_y:
+        slot = carve_free_position(dwg, strip, view, "y", _SLOT, tuple(sorted((p1[0], p2[0]))))
+        if slot is None or slot >= witness_y:
             return False
-        slot = strip.allocate(_SLOT)
         dwg.add(
             _dim(
                 (p1[0], witness_y, 0),
@@ -1237,9 +1237,9 @@ def render_pmi(dwg, model, a) -> int:
         if strip is None:
             return False
         witness_x = max(p1[0], p2[0]) + 2
-        if strip.peek(_SLOT) is None or strip.peek(_SLOT) <= witness_x:
+        slot = carve_free_position(dwg, strip, view, "x", _SLOT, tuple(sorted((p1[1], p2[1]))))
+        if slot is None or slot <= witness_x:
             return False
-        slot = strip.allocate(_SLOT)
         dwg.add(
             _dim(
                 (witness_x, p1[1], 0),
@@ -1259,9 +1259,9 @@ def render_pmi(dwg, model, a) -> int:
         if strip is None:
             return False
         witness_x = min(p1[0], p2[0]) - 2
-        if strip.peek(_SLOT) is None or strip.peek(_SLOT) >= witness_x:
+        slot = carve_free_position(dwg, strip, view, "x", _SLOT, tuple(sorted((p1[1], p2[1]))))
+        if slot is None or slot >= witness_x:
             return False
-        slot = strip.allocate(_SLOT)
         dwg.add(
             _dim(
                 (witness_x, p1[1], 0),
@@ -1313,14 +1313,18 @@ def render_pmi(dwg, model, a) -> int:
                     ) or _try_below(p1, p2, a.pv_zones.below, label, name_d, "plan")
                 else:
                     tip = (PX(cx_f), PY(cy_f) + half_pg, 0)
-                    slot = a.pv_zones.above.allocate(_SLOT)
+                    slot = carve_free_position(
+                        dwg, a.pv_zones.above, "plan", "y", _SLOT, (PX(cx_f), PX(cx_f))
+                    )
                     if slot is not None:
                         dwg.add(
                             Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d, view="plan"
                         )
                         placed = True
                     else:
-                        slot = a.pv_zones.below.allocate(_SLOT)
+                        slot = carve_free_position(
+                            dwg, a.pv_zones.below, "plan", "y", _SLOT, (PX(cx_f), PX(cx_f))
+                        )
                         if slot is not None:
                             tip = (PX(cx_f), PY(cy_f) - half_pg, 0)
                             dwg.add(
@@ -1338,14 +1342,18 @@ def render_pmi(dwg, model, a) -> int:
                     ) or _try_below(p1, p2, a.sv_zones.below, label, name_d, "side")
                 else:
                     tip = (SX(cy_f), SZ(cz_f) + half_pg, 0)
-                    slot = a.sv_zones.above.allocate(_SLOT)
+                    slot = carve_free_position(
+                        dwg, a.sv_zones.above, "side", "y", _SLOT, (SX(cy_f), SX(cy_f))
+                    )
                     if slot is not None:
                         dwg.add(
                             Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d, view="side"
                         )
                         placed = True
                     else:
-                        slot = a.sv_zones.below.allocate(_SLOT)
+                        slot = carve_free_position(
+                            dwg, a.sv_zones.below, "side", "y", _SLOT, (SX(cy_f), SX(cy_f))
+                        )
                         if slot is not None:
                             tip = (SX(cy_f), SZ(cz_f) - half_pg, 0)
                             dwg.add(
@@ -1364,14 +1372,18 @@ def render_pmi(dwg, model, a) -> int:
                 else:
                     # Narrow bore: leader from bore bottom into the below strip.
                     tip = (FX(cx_f), FZ(cz_f) - half_pg, 0)
-                    slot = a.fv_zones.below.allocate(_SLOT)
+                    slot = carve_free_position(
+                        dwg, a.fv_zones.below, "front", "y", _SLOT, (FX(cx_f), FX(cx_f))
+                    )
                     if slot is not None:
                         elbow = (FX(cx_f), slot, 0)
                         dwg.add(Leader(tip, elbow, label, draft), name_d, view="front")
                         placed = True
                     else:
                         # Fall back: leader upward into the above strip.
-                        slot = a.fv_zones.above.allocate(_SLOT)
+                        slot = carve_free_position(
+                            dwg, a.fv_zones.above, "front", "y", _SLOT, (FX(cx_f), FX(cx_f))
+                        )
                         if slot is not None:
                             tip = (FX(cx_f), FZ(cz_f) + half_pg, 0)
                             elbow = (FX(cx_f), slot, 0)

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -319,6 +319,51 @@ def test_carve_free_position_exact_fit_and_innermost_outermost():
     assert inner == 116.0 and outer + 10.0 <= 160.0 and outer >= inner
 
 
+def test_carve_free_position_zero_width_perp_band_leader():
+    # A narrow-bore PMI Leader queries with a ZERO-WIDTH perp band (px, px) at the leader's
+    # x-line. An obstacle straddling px blocks the tier; one perpendicular-disjoint (off to
+    # the side) is filtered out and does NOT block. Guards the six Leader sites in
+    # render_pmi, which the PMI test fixtures (all wide bores) never exercise.
+    from draftwright._core import Strip
+    from draftwright.annotations._common import carve_free_position
+
+    def _obj(x0, y0, x1, y1):
+        class _P:
+            def __init__(s, x, y):
+                s.X, s.Y = x, y
+
+        class _BB:
+            def __init__(s):
+                s.min, s.max = _P(x0, y0), _P(x1, y1)
+
+        return type("Dimension", (), {"bounding_box": lambda s: _BB()})()
+
+    class _Dwg:
+        def __init__(s, obst):
+            s._o = obst
+
+        def iter_annotations(s):
+            return list(s._o)
+
+        def view_of(s, n):
+            return "plan"
+
+    # above strip (axis y, perp X): near=108 .. outer=145; leader at px=50
+    strip = Strip(anchor=100.0, outer_limit=145.0, direction=1.0, gap=8.0, spacing=4.0)
+    # obstacle covering the inner tier [108,118] and STRADDLING x=50 → blocks → pushed out
+    blocked = carve_free_position(
+        _Dwg([("o", _obj(45, 108, 55, 118))]), strip, "plan", "y", 10.0, (50.0, 50.0)
+    )
+    # same obstacle shifted off to x=[70,80] → perp-disjoint from px=50 → filtered, not blocking
+    free = carve_free_position(
+        _Dwg([("o", _obj(70, 108, 80, 118))]), strip, "plan", "y", 10.0, (50.0, 50.0)
+    )
+    assert free == 108.0, "perp-disjoint obstacle must not block a zero-width-band leader"
+    assert blocked != 108.0, (
+        "obstacle straddling the leader's x-line must push it off the inner tier"
+    )
+
+
 def test_plan_strip_empty():
     res = plan_strip([], 0, 100, 5)
     assert res.placed == {} and res.dropped == ()


### PR DESCRIPTION
Routes the last 10 `Strip.allocate` sites in `from_model.py` — the PMI/GD&T renderer —
through `carve_free_position`. After this, **`from_model.py` is cursor-free**; the only
remaining `Strip.allocate` in the codebase is the public `Drawing.place_dim`.

## What

- The four `_try_{above,below,right,left}` bracket-dim helpers and the six narrow-bore
  Leader placements drop their `strip.peek(_SLOT)` + `strip.allocate(_SLOT)` cursor
  pattern for the shared carve, keeping their directional witness guards (the returned
  tier must sit beyond the witness).
- PMI runs **last** (after every automatic dimension), so the old cursor — blind to
  other passes' dims — could place a PMI dim *over* them; the carve's full
  `strip_obstacles` avoids that by construction. The perpendicular-band arg is each
  dim's cross-axis span (a point, for a Leader), so a perpendicular-disjoint occupant
  doesn't false-block.

## Output impact

- **Byte-identical** on the corpus (no PMI parts; fast tier 668).
- All **15** tests in `test_pmi.py` pass (`pmi='annotate'` placement, lint-clean, unique
  names, SVG/DXF export).

## Verification

- Full fast tier green (668); ruff + mypy clean; `test_pmi.py` 15/15.
- Independent adversarial review: (gated on CLEAN + green CI before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)