### PR TITLE
feat: migrate Drawing.place_dim onto the carve — cursor fully retired (ADR 0009, #323 P3)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -45,6 +45,7 @@ from draftwright._core import (
     _tag_sequence,
     _text_width,
 )
+from draftwright.annotations._common import carve_free_position
 from draftwright.export import (
     _export_shape,
     _render_pdf,
@@ -533,9 +534,15 @@ class Drawing:
                 strip = getattr(zones, side, None)
         dist = slot
         if strip is not None:
-            coord = strip.allocate(slot)
+            # Cursor-free tier placement (ADR 0009, #150): find a free tier that clears
+            # every placed annotation, replacing Strip.allocate. axis = the stacking axis
+            # (X for left/right, Y for above/below); perp_span = the dim's cross-axis span
+            # so a perpendicular-disjoint occupant does not false-block.
+            ax = 0 if side in ("left", "right") else 1
+            axis = "x" if ax == 0 else "y"
+            perp = tuple(sorted((p1[1 - ax], p2[1 - ax])))
+            coord = carve_free_position(self, strip, view, axis, slot, perp)
             if coord is not None:
-                ax = 0 if side in ("left", "right") else 1
                 if side in ("right", "above"):
                     dist = coord - max(p[ax] for p in (p1, p2))
                 else:


### PR DESCRIPTION
`Drawing.place_dim` — the public single-dim API — was the **last** `Strip.allocate`
caller. Routing it through `carve_free_position` **completes P3's cursor retirement**:
every renderer *and* the public API now place through the shared collect-then-solve
carve, and `Strip.allocate`/`peek` have **zero callers**.

## What

- Pick the stacking axis from `side` (X for left/right, Y for above/below), pass the
  dim's cross-axis span as `perp_span` (perpendicular-disjoint occupants don't
  false-block), keep the fixed-slot fallback when there's no strip / no room.
- `drawing.py` imports `carve_free_position` from `annotations/_common` — acyclic
  (`annotations` imports nothing from `drawing`; its `__init__` is empty), and
  `annotations` is a stage module, matching drawing.py's stated import contract.

## Output impact

Byte-identical on the corpus (fast tier 669); `place_dim` tests pass (8).

## Scope note

This retires the cursor (all users migrated). **Deleting** the now-dead
`Strip.allocate`/`peek`/`_cursor` + the cursor-based overflow check — closing **#150** —
is P5's "remove dead machinery" strand, done once this lands.

## Verification

- Full fast tier green (669); ruff + mypy clean; place_dim tests 8/8.
- Independent adversarial review: (gated on CLEAN + green CI before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)