### PR TITLE
refactor: delete the retired Strip cursor + measure balloon-ring depth from geometry (ADR 0009, #319 P5; closes #150)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -14,7 +14,7 @@ import functools
 import logging
 import re
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -166,16 +166,17 @@ def _dim(p1, p2, side, distance, draft, **kwargs):
 class Strip:
     """A one-dimensional annotation band adjacent to an orthographic view.
 
-    Annotations are stacked outward from the view edge by calling
-    :meth:`allocate`.  The cursor starts at ``anchor + direction * gap`` and
-    advances after each successful allocation.
+    A plain geometry record: the collect-then-solve placers (ADR 0009) read its
+    bounds (:func:`~draftwright.annotations._common.strip_free_span`) and carve
+    around the placed annotations. The mutable ``allocate``/``peek`` cursor was
+    retired once every placer moved to the carve (#150).
 
     Attributes:
         anchor:      Page coordinate of the view edge this strip starts from.
         outer_limit: Page coordinate at which the strip ends (page margin,
                      neighbouring view, or title-block boundary).
-        direction:   ``+1`` — cursor moves away from anchor (right/above);
-                     ``-1`` — cursor retreats from anchor (left/below).
+        direction:   ``+1`` — stacks away from anchor (right/above);
+                     ``-1`` — stacks back toward smaller coords (left/below).
         gap:         Clearance between the view edge and the first annotation.
         spacing:     Clearance between successive annotations.
     """
@@ -185,55 +186,11 @@ class Strip:
     direction: float = 1.0
     gap: float = 8.0
     spacing: float = 4.0
-    _cursor: float = field(init=False, compare=False, repr=False)
-
-    def __post_init__(self):
-        self._cursor = self.anchor + self.direction * self.gap
-
-    # ------------------------------------------------------------------
-    # Public API
 
     @property
     def available(self) -> float:
         """Total space available in this strip (mm)."""
         return abs(self.outer_limit - self.anchor)
-
-    @property
-    def depth_used(self) -> float:
-        """How far the cursor has advanced from the anchor (mm)."""
-        return abs(self._cursor - self.anchor)
-
-    def peek(self, size: float) -> float | None:
-        """Return what ``allocate(size)`` would return without advancing the cursor."""
-        if self.direction == 1:
-            start = self._cursor
-            return start if (start + size) <= self.outer_limit else None
-        else:
-            end = self._cursor
-            return end if (end - size) >= self.outer_limit else None
-
-    def allocate(self, size: float) -> float | None:
-        """Reserve *size* mm; return the near-edge page coordinate, or ``None`` if full.
-
-        The returned value is the page coordinate of the annotation's
-        dimension line (or leader elbow).  Convert to a relative offset with::
-
-            distance = abs(page_coord - strip.anchor)
-        """
-        if self.direction == 1:
-            start = self._cursor
-            end = start + size
-            if end > self.outer_limit:
-                return None
-            self._cursor = end + self.spacing
-            return start
-        else:
-            end = self._cursor
-            start = end - size
-            if start < self.outer_limit:
-                return None
-            self._cursor = start - self.spacing
-            return end
 
 
 @dataclass

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -137,13 +137,6 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             _right_strips.append(_rs)
     for _rs in _right_strips:
         _rs.outer_limit = min(_rs.outer_limit, _iso_x_limit)
-        if _rs._cursor >= _iso_x_limit:
-            _log.warning(
-                "right-strip cursor %.1f >= iso_x limit %.1f: right-strip dims"
-                " may overlap iso view (iso view overflows into annotation zone)",
-                _rs._cursor,
-                _iso_x_limit,
-            )
 
     # Per-hole annotations from the feature records (#91, #92, #95): each
     # hole is annotated in the view its axis is normal to.
@@ -287,51 +280,6 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # crowded turned heads alike — through the one generic detailer, now that all
     # views and main-view annotations are placed (so the detail avoids them).
     _resolve_details(dwg, a)
-
-    # Phase 7 — strip footprint debug logging + post-placement overflow check.
-    # Overflow can only occur when outer_limit was tightened after allocations
-    # were already committed (e.g. iso-x tightening or iso-y cap guard).
-    _all_strips = [
-        ("fv.right", a.fv_zones.right),
-        ("fv.left", a.fv_zones.left),
-        ("fv.above", a.fv_zones.above),
-        ("fv.below", a.fv_zones.below),
-        ("pv.right", a.pv_zones.right),
-        ("pv.left", a.pv_zones.left),
-        ("pv.above", a.pv_zones.above),
-        ("pv.below", a.pv_zones.below),
-        ("sv.right", a.sv_zones.right),
-        ("sv.left", a.sv_zones.left),
-        ("sv.above", a.sv_zones.above),
-        ("sv.below", a.sv_zones.below),
-    ]
-    for _sn, _st in _all_strips:
-        if _st is None:
-            continue
-        _log.debug(
-            "strip %-10s  anchor=%.1f  limit=%.1f  used=%.1f/%.1f mm",
-            _sn,
-            _st.anchor,
-            _st.outer_limit,
-            _st.depth_used,
-            _st.available,
-        )
-        # Overflow check: if at least one allocation was made, the end of the
-        # last slot must not have exceeded outer_limit.
-        _initial = _st.anchor + _st.direction * _st.gap
-        if abs(_st._cursor - _initial) > 0.1:  # at least one allocation
-            _last_end = _st._cursor - _st.direction * _st.spacing
-            _over = _st.direction * (_last_end - _st.outer_limit)
-            if _over > 0.5:
-                _log.warning(
-                    "strip %s overflowed outer_limit by %.1f mm "
-                    "(limit=%.1f, last-slot-end=%.1f) — limit was likely "
-                    "tightened after allocations were committed",
-                    _sn,
-                    _over,
-                    _st.outer_limit,
-                    _last_end,
-                )
 
     if a.pmi_mode == "annotate":
         render_pmi(dwg, _model, a)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -702,35 +702,36 @@ class Drawing:
         sv_left = a.SV_X - a.sv_hw
         margin, ph = a.margin, a.PAGE_H
 
-        # Stack the balloon ring *beyond* the annotations already placed around
-        # the plan view, not on top of them (#121).
-        za = a.pv_zones
-        bot_dim = za.below.depth_used if za and za.below else 0.0
-        left_dim = za.left.depth_used if za and za.left else 0.0
-        right_dim = za.right.depth_used if za and za.right else 0.0
-        # The TOP band is the one that goes stale: the hole-table escalation
-        # deletes the X-location dims but never rewinds the above-strip cursor, so
-        # za.above.depth_used keeps their high-water mark (~240 mm of phantom
-        # corridor on CTC-02) and the top ring floats ~150 mm over empty space
-        # (#125). Top balloons vary in X at a fixed Y, so they must clear the
-        # DIMENSIONS spanning the plan's width above it — measure the real depth
-        # of those (pitch dims dim_* AND PMI bore dims pmi_*). Construction
-        # centrelines (bc_*) are crossable, not obstructions, so they are
-        # excluded — their bolt-circle bbox would otherwise re-inflate the band.
-        # Left/right/bottom are NOT stale: the deleted X-location dims only ever
-        # allocated into the above strip (m_locy tiers (the IR location renderer) above the *side* view,
-        # the width dim below is never removed), so those keep their correct
-        # shallow strip depth.
-        top_dim = 0.0
+        # Stack the balloon ring *beyond* the annotations already placed around the
+        # plan view, not on top of them (#121). Measure the REAL depth the dimensions
+        # extend into each band from their placed bounding boxes — the strip cursor's
+        # `depth_used` is retired (ADR 0009 / #150) and would report a constant gap.
+        # (This is what the top band already did because `depth_used` went stale under
+        # the hole-table escalation, #125; now every side measures the same way.) Match
+        # on DIMENSION type (not a `dim_` name prefix — that would drop the m_env_*/
+        # m_loc*/m_slot* dims below/beside the view), plus PMI leaders (pmi_*). Balloons,
+        # the table, construction centrelines (bc_*) and callouts are not Dimensions and
+        # are correctly excluded (centrelines are crossable; callouts route separately).
+        top_dim = bot_dim = left_dim = right_dim = 0.0
         for nm, obj in self._named.items():
-            if not nm.startswith(("dim_", "pmi_")) or self._anno_view.get(nm) != view:
+            if self._anno_view.get(nm) != view:
+                continue
+            if type(obj).__name__ != "Dimension" and not nm.startswith("pmi_"):
                 continue
             try:
                 ob = obj.bounding_box()
             except Exception:  # noqa: BLE001 — a mark with no bbox can't obstruct
                 continue
-            if ob.max.X > pl and ob.min.X < pr and ob.max.Y > pt:
-                top_dim = max(top_dim, ob.max.Y - pt)
+            if ob.max.X > pl and ob.min.X < pr:  # spans the plan's width → top/bottom bands
+                if ob.max.Y > pt:
+                    top_dim = max(top_dim, ob.max.Y - pt)
+                if ob.min.Y < pb:
+                    bot_dim = max(bot_dim, pb - ob.min.Y)
+            if ob.max.Y > pb and ob.min.Y < pt:  # spans the plan's height → left/right bands
+                if ob.min.X < pl:
+                    left_dim = max(left_dim, pl - ob.min.X)
+                if ob.max.X > pr:
+                    right_dim = max(right_dim, ob.max.X - pr)
 
         # A bottom band (below PV, beyond the overall-width dim) is usable only
         # when the FV↔PV gap has room for the width dim *and* a balloon row;

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -311,44 +311,11 @@ class TestStripZones:
     def test_strip_import(self):
         pass
 
-    def test_outward_strip_allocates_and_advances(self):
-        from draftwright._core import Strip
-
-        s = Strip(anchor=100.0, outer_limit=200.0, direction=1, gap=8.0, spacing=4.0)
-        pos = s.allocate(10.0)
-        assert pos == pytest.approx(108.0)  # anchor + gap
-        pos2 = s.allocate(10.0)
-        assert pos2 == pytest.approx(122.0)  # 108 + 10 + 4
-
-    def test_inward_strip_allocates_and_retreats(self):
-        from draftwright._core import Strip
-
-        s = Strip(anchor=100.0, outer_limit=0.0, direction=-1, gap=8.0, spacing=4.0)
-        pos = s.allocate(10.0)
-        assert pos == pytest.approx(92.0)  # anchor - gap (near edge of first slot)
-        pos2 = s.allocate(10.0)
-        assert pos2 == pytest.approx(78.0)  # 92 - 10 - 4
-
-    def test_strip_returns_none_when_full(self):
-        from draftwright._core import Strip
-
-        s = Strip(anchor=0.0, outer_limit=20.0, direction=1, gap=2.0, spacing=2.0)
-        assert s.allocate(10.0) is not None  # fits: 2..12
-        assert s.allocate(10.0) is None  # would need 14..24, over limit=20
-
     def test_strip_available(self):
         from draftwright._core import Strip
 
         s = Strip(anchor=50.0, outer_limit=150.0, direction=1)
         assert s.available == pytest.approx(100.0)
-
-    def test_strip_depth_used(self):
-        from draftwright._core import Strip
-
-        s = Strip(anchor=100.0, outer_limit=200.0, direction=1, gap=8.0, spacing=4.0)
-        s.allocate(10.0)
-        # cursor is now at 108 + 10 + 4 = 122; depth_used = 122 - 100 = 22
-        assert s.depth_used == pytest.approx(22.0)
 
     def test_analyse_returns_view_zones(self):
         from build123d import Box, Cylinder
@@ -390,11 +357,8 @@ class TestStripZones:
 
         part = Box(60, 40, 30)
         dwg = build_drawing(part)
-        a = dwg._analysis
         assert "dim_height" in dwg._named
         ann = dwg._named["dim_height"]
-        # The strip consumed at least one slot: cursor has advanced past anchor+gap
-        assert a.fv_zones.right.depth_used > 0
         # label is the part height
         assert ann.label == "30"
 
@@ -423,11 +387,9 @@ class TestStripZones:
         # renderer m_env_width, still routed through pv_zones.below).
         part = Box(80, 40, 20)
         dwg = build_drawing(part)
-        a = dwg._analysis
         assert "m_env_width" in dwg._named
         ann = dwg._named["m_env_width"]
         assert ann.label == "80"
-        assert a.pv_zones.below.depth_used > 0
 
     def test_dim_locx_routed_through_pv_above_strip(self):
         # dim_locx dims must be above plan_top and allocated from pv_zones.above
@@ -437,12 +399,10 @@ class TestStripZones:
 
         part = Box(80, 60, 20) - Pos(20, 10, 0) * Cylinder(5, 20)
         dwg = build_drawing(part)
-        a = dwg._analysis
         locx_dims = [v for n, v in dwg._named.items() if n.startswith("m_locx")]
         assert len(locx_dims) >= 1, "expected m_locx0 to be generated for off-datum cylinder"
         plan_top = dwg.views["plan"][0].bounding_box().max.Y
         assert all(d.dim_level_y > plan_top for d in locx_dims)
-        assert a.pv_zones.above.depth_used > 0
 
     def test_dim_locy_routed_through_sv_above_strip(self):
         # dim_locy dims must be above side_top and allocated from sv_zones.above
@@ -453,12 +413,10 @@ class TestStripZones:
         # Cylinder at Y=10 → offset from datum_y=bb.min.Y → generates dim_locy0
         part = Box(80, 60, 20) - Pos(0, 10, 0) * Cylinder(5, 20)
         dwg = build_drawing(part)
-        a = dwg._analysis
         locy_dims = [v for n, v in dwg._named.items() if n.startswith("m_locy")]
         assert len(locy_dims) >= 1, "expected m_locy0 to be generated for off-datum cylinder"
         side_top = dwg.views["side"][0].bounding_box().max.Y
         assert all(d.dim_level_y > side_top for d in locy_dims)
-        assert a.sv_zones.above.depth_used > 0
 
     def test_dim_step_placed_after_phase3_corridor_widening(self):
         # Phase 3 widens fv_zones.right dynamically for stepped parts.
@@ -591,11 +549,9 @@ class TestStripZones:
         # (IR renderer m_env_depth, still routed through sv_zones.below).
         part = Box(80, 40, 20)
         dwg = build_drawing(part)
-        a = dwg._analysis
         assert "m_env_depth" in dwg._named, "expected m_env_depth for part with width != depth"
         ann = dwg._named["m_env_depth"]
         assert ann.label == "40", f"depth label should be y_size=40, got {ann.label!r}"
-        assert a.sv_zones.below.depth_used > 0
 
     def test_dim_depth_absent_for_square_plan(self):
         # dim_depth must be omitted when x_size == y_size (within 5%).
@@ -658,32 +614,26 @@ class TestDepthEstimators:
         assert _est_pv_below_depth() == pytest.approx(16.0, abs=0.01)
 
     def test_right_depth_fits_in_exact_corridor(self):
-        # A Strip whose available width equals _est_right_strip_depth(n) must
-        # accept exactly n+1 allocations (dim_height + n dim_steps).
-        from draftwright._core import _SLOT_DIM_HEIGHT, _SLOT_DIM_STEP, Strip
+        # _est_right_strip_depth(n) must reserve enough corridor for dim_height + n
+        # dim_steps stacked from the view edge (gap, then `spacing` between dims) — the
+        # cursor-free capacity condition the carve places into (ADR 0009 / #150).
+        from draftwright._core import _SLOT_DIM_HEIGHT, _SLOT_DIM_STEP, _STRIP_SPACING
         from draftwright.drawing import _STRIP_GAP
         from draftwright.sheet import _est_right_strip_depth
 
         for n_steps in (0, 1, 3):
             est = _est_right_strip_depth(n_steps)
-            s = Strip(anchor=0.0, outer_limit=est, direction=1, gap=_STRIP_GAP)
-            assert s.allocate(_SLOT_DIM_HEIGHT) is not None, (
-                f"dim_height must fit for n_steps={n_steps}"
-            )
-            for i in range(n_steps):
-                assert s.allocate(_SLOT_DIM_STEP) is not None, (
-                    f"dim_step_{i} must fit for n_steps={n_steps}"
-                )
+            sizes = [_SLOT_DIM_HEIGHT] + [_SLOT_DIM_STEP] * n_steps
+            needed = _STRIP_GAP + sum(sizes) + _STRIP_SPACING * (len(sizes) - 1)
+            assert needed <= est + 1e-9, f"n_steps={n_steps}: needs {needed} > est {est}"
 
     def test_pv_below_depth_fits_in_exact_corridor(self):
-        # A Strip of _est_pv_below_depth() width must accept one dim_width allocation.
-        from draftwright._core import _SLOT_DIM_WIDTH, Strip
+        # _est_pv_below_depth() must reserve enough for one dim_width from the view edge.
+        from draftwright._core import _SLOT_DIM_WIDTH
         from draftwright.drawing import _STRIP_GAP
         from draftwright.sheet import _est_pv_below_depth
 
-        est = _est_pv_below_depth()
-        s = Strip(anchor=100.0, outer_limit=100.0 - est, direction=-1, gap=_STRIP_GAP)
-        assert s.allocate(_SLOT_DIM_WIDTH) is not None, "dim_width must fit in pv_below corridor"
+        assert _STRIP_GAP + _SLOT_DIM_WIDTH <= _est_pv_below_depth() + 1e-9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
First P5 strand. P3 retired the `Strip.allocate` cursor from every placer; this
**deletes** the now-dead machinery and migrates its remaining state consumers.

## What

- **`_core.Strip`**: drop `allocate`/`peek`/`_cursor`/`__post_init__`/`depth_used` —
  now a plain geometry record (`anchor`/`outer_limit`/`direction`/`gap`/`spacing` +
  `available`). **Closes #150.**
- **orchestrator**: remove the dead cursor iso-warning and the whole Phase-7 footprint
  / overflow-check block (both read `_cursor`/`depth_used`, now meaningless). The
  functional iso `outer_limit` cap stays.
- **drawing.py balloon ring**: `depth_used` (the cursor high-water mark) is gone and
  would read a constant `gap`, so the ring's bot/left/right offsets are now measured
  from the **real placed-annotation geometry** — the same way the top band already did
  (#125). Matches on **Dimension type** (not a `dim_` name prefix, which dropped the
  `m_env_*`/`m_loc*`/`m_slot*` dims below/beside the view) + PMI leaders.

## Regression caught by the gate (and fixed)
The naive `dim_`/`pmi_` prefix filter regressed the two `TestHoleTable` lint-clean tests
(bottom ring stacked over `m_env_width`). The type-based measurement fixes them.

## Verification

- Full fast tier green (**665**); ruff + format + mypy clean.
- **CTC-02 AP242 baseline unchanged vs `main`**: `items=164, errors=8, out_of_bounds=8`
  on both — i.e. **no regression**; those 8 are the pre-existing balloon-ring scaling
  limit (#348), not this change.
- Cursor unit tests removed; strip-depth sizing tests rewritten as cursor-free capacity
  checks.

## Reviewer focus (higher-risk change)
1. Does the type-based real-depth balloon measurement match the old `depth_used` on
   **every** band/part, not just the ones checked?
2. Does anything still read a now-dead `_cursor`/`depth_used`/`allocate`/`peek`?
3. Is the `Strip` deletion complete + does `available` (kept, tested) still hold?

🤖 Generated with [Claude Code](https://claude.com/claude-code)