### PR TITLE
docs: ADR 0009 Amendment 1 — escalation objects (P5-strand-2 design)

### DIFF
--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -159,6 +159,56 @@ is validated on the exact recurring bug before the broad sweep. Tracking issue
 #318, #319) live in
 [`plans/strip-layout-boundary-labeling-roadmap.md`](../plans/strip-layout-boundary-labeling-roadmap.md).
 
+## Amendment 1 — Escalation objects (P5-strand-2, 2026-07-01)
+
+**Status:** Accepted (design); scaffolding first. Tracker **#351**.
+
+**Problem.** Today "this couldn't be placed" is a stringly-typed side effect: seven
+scattered codes (`callout_dropped`, `location_ref_dropped`, `off_axis_location_dropped`,
+`slot_dim_dropped`, `step_dim_dropped`, `placement_unsatisfiable`, `table_dropped`) are
+emitted via `_record_build_issue(...)`, and the escalators *pattern-match the strings* to
+act — `_maybe_tabulate_holes` greps for two of them and always applies **one** remedy
+(hole table + **one balloon per hole**), while step crowding routes through a separate
+channel (`_detail_requests`/`_resolve_details`). So the escalation *policy* is entangled
+with lint text, and the remedy is one-size — the root cause of the CTC-02 balloon ring
+that cannot fit (#348).
+
+**Decision.** Make "couldn't place" a **first-class object** emitted at the failure point,
+and separate *collecting* failures from *deciding* remedies.
+
+```
+Escalation(kind, view, feature, reason, remedies)
+  kind:     "callout" | "location" | "slot" | "step" | "pmi"
+  feature:  IR feature/key ref — carries PATTERN membership
+  reason:   "strip_full" | "illegible" | "corridor_blocked" | "no_room"
+  remedies: ranked candidates the resolver may pick, e.g. ("group_balloon","table","detail","drop")
+```
+
+- **Placers collect, don't decide:** append an `Escalation` to `dwg._escalations` instead
+  of recording a `*_dropped` string. The strip carve already knows *why* it failed, so
+  `reason` is free.
+- **One resolver pass** (subsuming `_maybe_tabulate_holes` + detail resolution): group by
+  `(view, feature-or-pattern)`; pick a remedy per group by a fixed policy ladder (the D4
+  order); execute it; and emit the **same `*_dropped` codes only for what stays
+  unresolved** — so coverage lint + the cleanliness ratchet keep working unchanged (the
+  strings remain the lint *surface*; the *decision* is now object-driven).
+
+**Ratified sub-decisions (user, 2026-07-01):**
+1. **Pattern grouping = ISO** — a recognised bolt-circle / linear / grid escalates to
+   **one balloon tagging the pattern once** (with an `n×` count) near the feature, not one
+   balloon per member. CTC-02 is largely patterned, so its ring collapses from dozens to a
+   handful — this is the #348 fix.
+2. **Scattered-hole fallback = table + balloons** (today's behaviour) for now; a **zone
+   grid reference** (A1/B2) is a separate, later option — filed as its own issue (**#352**).
+3. **PR-1 = scaffolding only** (the `Escalation` type + `dwg._escalations` collector, no
+   routing) so the first diff is byte-identical; routing + the ISO grouping follow.
+
+**Migration (each its own gated PR).** (1) scaffolding — type + collector, no behaviour
+change; (2) route the hole path (callouts + locations) through it, resolver *reproduces*
+`_maybe_tabulate_holes` → byte-identical; (3) add ISO pattern-grouping (`group_balloon`) →
+first intended drift, fixes #348, re-bless CTC-02; (4) fold in slots/step/pmi, delete the
+string-grep. Keeps the byte-identity tripwire through steps 1–2.
+
 ## Related
 
 - [ADR 0001](0001-deterministic-generation-over-editable-dsl.md) — determinism;

--- a/docs/plans/strip-layout-boundary-labeling-roadmap.md
+++ b/docs/plans/strip-layout-boundary-labeling-roadmap.md
@@ -72,22 +72,28 @@ Updated 2026-07-01.
   (user, 2026-07-01):* make dropped keys **first-class escalation objects**, not just
   `*_dropped` build-issue codes — a structured signal the table/detail escalators
   consume. Tracked into P5.
-- **P3 (#323)** — **in progress.** Envelope dims decoupled from the cursor (#334). The
-  shared collect-then-solve placer extracted to `_common.place_strip_candidates` (#337),
-  which now reserves the outermost label's `tier` at the strip boundary (#338 review
-  fix). `render_locations` (plan-view X/Y locations) migrated (#338). **Remaining
-  `Strip.allocate` production paths, one renderer at a time:** the front-view
-  height/step ladder (`render_height_ladder` — note its leapfrog witness cursor), the
-  turned step-length chain, PMI/GD&T (`render_pmi`), milled slots (`render_slots`), and
-  `drawing.py`. When the last is migrated, delete `Strip.allocate` and close #150.
-- **P4 (#318)** — **not started, and intentionally deferred until P3 completes** (user,
-  2026-07-01): optimising leader assignment while some placers still use the cursor
-  would optimise around mixed placement semantics.
-- **P5 (#319)** — **not started.** Delete dead patches + the cursor; promote the
-  escalation signal to first-class objects (see P2 refinement); **burn down the
-  `_KNOWN_OVERLAPS` allowlist** (relocate/rescale the remaining real crossings — e.g.
-  `side_drilled` `{hc_side0, dim_loc_side_z2300}`, an outer-layout concern) then convert
-  the cleanliness ratchet from an allowlist into an **absolute** no-overlap invariant.
+- **P3 (#323)** — **DONE.** Every placer migrated to the shared carve, one renderer at a
+  time: envelope (#334), P1b locations (#335), the shared placer + tier reservation
+  (#337/#340), `render_locations` (#338), `render_slots` + perpendicular-band filter
+  (#341), the height/step ladder with its leapfrog preserved via a position-returning
+  carve (#342), `render_pmi` (#343), and the public `place_dim` (#344). Shared primitives
+  in `annotations/_common.py`: `place_strip_candidates`, `carve_free_position`,
+  `strip_free_span`/`carve_free_segments`/`corridor_blockers`/`strip_obstacles`.
+- **P5 (#319)** — **in progress.**
+  - **Strand 1 — DONE (#349, closes #150):** deleted the `Strip.allocate`/`peek`/`_cursor`
+    machinery + the dead orchestrator overflow check; migrated the last state consumer
+    (the balloon-ring depth) from `depth_used` to real placed-geometry measurement.
+  - **Strand 2 — escalation objects** (see **Amendment 1** in the ADR; tracker **#351**):
+    `*_dropped` string codes → first-class `Escalation` objects + one resolver that picks
+    a remedy per group (ISO pattern-grouped balloons, fixing #348; table + balloons for
+    scattered holes; zone grid-ref #352 deferred).
+  - **Strand 3 — burn down the `_KNOWN_OVERLAPS` allowlist** (SPACE-CONSTRAINED + PENDING —
+    e.g. `side_drilled` `{hc_side0, dim_loc_side_z2300}`, an outer-layout concern) then flip
+    the cleanliness ratchet from an allowlist into an **absolute** no-overlap invariant.
+  - **Strand 4 — strengthen the property/fuzz cleanliness tests.**
+- **P4 (#318)** — **not started, and intentionally deferred until P5** (user, 2026-07-01):
+  optimising leader assignment before the placement model is fully settled would optimise
+  around a moving target.
 
 Overlap allowlist classes (`tests/test_layout_cleanliness.py`): **BENIGN** (permanent
 datum-chain witness corridors), **SPACE-CONSTRAINED** (real crossing, no roomy


### PR DESCRIPTION
Records the escalation-objects design as **ADR 0009 Amendment 1**, with the three
ratified sub-decisions:
1. Pattern grouping = **ISO** (one balloon per recognised pattern with `n×`) → the #348 fix.
2. Scattered-hole fallback = **table + balloons**; zone grid-ref (A1/B2) deferred → #352.
3. **PR-1 = scaffolding only** (`Escalation` type + collector, no routing) → byte-identical.

Also refreshes the roadmap Status: P3 **done**, P5-strand-1 **done** (#150 closed),
strands 2-4 outlined, P4 deferred until P5.

Epic tracker: #351. Zone grid-ref: #352.

Doc-only — no adversarial review (no code/logic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)