### PR TITLE
feat: Escalation object + collector scaffolding (ADR 0009 Amendment 1, #351 P5-strand-2 PR-1)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -8,10 +8,43 @@ and an AABB overlap test (`_box_hits`). Bottom of the annotations DAG.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 
 from draftwright.layout import StripCandidate, plan_strip
 
 _log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Escalation:
+    """A first-class "could not place this here" signal (ADR 0009 Amendment 1, P5-strand-2).
+
+    Placers *collect* one of these into ``dwg._escalations`` at the point of failure —
+    instead of recording a stringly-typed ``*_dropped`` lint code and letting the escalators
+    grep for it — and one later resolver pass groups them by ``(view, feature-or-pattern)``,
+    picks a remedy per group (ISO pattern-grouped balloon / table / detail / drop), and emits
+    the ``*_dropped`` lint codes only for what stays unresolved (so coverage lint + the
+    cleanliness ratchet keep working). See the ADR / epic #351.
+
+    Scaffolding only (#351 PR-1): the type + the ``dwg._escalations`` collector exist, but no
+    placer emits and nothing consumes them yet — so this PR is behaviour-preserving.
+
+    Attributes:
+        kind:     what could not be placed — ``"callout" | "location" | "slot" | "step" | "pmi"``.
+        view:     the owning orthographic view (``None`` for drawing-level).
+        feature:  reference to the IR feature / ``HoleRef`` / key it belongs to — carries the
+                  pattern membership the resolver groups on. Left untyped to keep this module a
+                  leaf (no dependency on ``model.ir``).
+        reason:   why placement failed — ``"strip_full" | "illegible" | "corridor_blocked" | "no_room"``.
+        remedies: ranked candidate remedies the resolver may pick, e.g.
+                  ``("group_balloon", "table", "detail", "drop")``. Empty = resolver's default ladder.
+    """
+
+    kind: str
+    view: str | None
+    feature: object
+    reason: str
+    remedies: tuple[str, ...] = field(default_factory=tuple)
 
 
 def _anno_box(o):

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -108,6 +108,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     dwg._reset_build_issues()
     dwg._reset_dropped_callout_diams()
     dwg._detail_requests = []  # renderers queue enlarged-detail requests here (#307)
+    dwg._escalations = []  # placers collect Escalation objects here (ADR 0009 Amdt 1, #351)
 
     FX = a.proj.front_x
     FZ = a.proj.front_z

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -104,6 +104,32 @@ def test_strip_obstacles_keeps_section_hatch_in_every_per_view_query():
         assert any(_same(x, hbox) for x in strip_obstacles(dwg, view=v)), f"hatch dropped from {v}"
 
 
+# --- Escalation objects (ADR 0009 Amendment 1, P5-strand-2 scaffolding, #351) -----
+
+
+def test_escalation_is_a_frozen_value_with_default_remedies():
+    import dataclasses
+
+    import pytest
+
+    from draftwright.annotations._common import Escalation
+
+    e = Escalation(kind="callout", view="plan", feature=("hole", 1), reason="strip_full")
+    assert (e.kind, e.view, e.reason) == ("callout", "plan", "strip_full")
+    assert e.remedies == ()  # default: the resolver's ladder decides
+    e2 = Escalation("location", None, None, "no_room", ("table", "drop"))
+    assert e2.view is None and e2.remedies == ("table", "drop")
+    with pytest.raises(dataclasses.FrozenInstanceError):  # immutable value object
+        e.kind = "x"
+
+
+def test_build_initialises_empty_escalations_collector():
+    # Scaffolding only: the collector exists and starts empty; no placer emits into it
+    # yet, so the build stays behaviour-preserving.
+    dwg = build_drawing(Box(40, 30, 10))
+    assert dwg._escalations == []
+
+
 # --- plan_strip: the collect-then-solve seam (pure geometry, no OCC) --------
 
 


### PR DESCRIPTION
First step of the escalation-objects redesign (ADR 0009 Amendment 1, epic **#351**).
Pure scaffolding — introduce the type + the collector, **no routing**. Byte-identical.

## What
- `annotations/_common.Escalation` — a frozen value object (`kind` / `view` / `feature`
  / `reason` / `remedies`): the first-class "could not place this here" signal that
  placers will collect instead of recording a stringly-typed `*_dropped` lint code.
  `feature` is left untyped so `_common` stays a leaf (no `model.ir` dependency).
- orchestrator `_auto_annotate`: reset `dwg._escalations = []` per build, next to the
  existing `_detail_requests` collector.

## Not in this PR
No placer emits and nothing consumes `Escalation` yet — so **behaviour-preserving**.
Routing the hole callout/location path + a resolver that *reproduces*
`_maybe_tabulate_holes` (still byte-identical) is PR-2.

## Verification
- Full fast tier (running); ruff + mypy clean.
- Tests: frozen value semantics + a build initialises an empty `_escalations` collector.
- Independent adversarial review: (gated on CLEAN + green CI before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)