### PR TITLE
feat: route dropped ISO pattern callouts through Escalation objects (ADR 0009 Amdt 1, #351 PR-3, closes #348)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -26,15 +26,18 @@ class Escalation:
     the ``*_dropped`` lint codes only for what stays unresolved (so coverage lint + the
     cleanliness ratchet keep working). See the ADR / epic #351.
 
-    Scaffolding only (#351 PR-1): the type + the ``dwg._escalations`` collector exist, but no
-    placer emits and nothing consumes them yet — so this PR is behaviour-preserving.
+    The hole callout/location placers emit these (#351 PR-2); the resolver in
+    ``annotations/orchestrator.py`` (``_maybe_tabulate_holes``) consumes them, including
+    the ISO pattern-grouped balloon fallback for a dropped pattern callout (#351 PR-3).
 
     Attributes:
         kind:     what could not be placed — ``"callout" | "location" | "slot" | "step" | "pmi"``.
         view:     the owning orthographic view (``None`` for drawing-level).
         feature:  reference to the IR feature / ``HoleRef`` / key it belongs to — carries the
-                  pattern membership the resolver groups on. Left untyped to keep this module a
-                  leaf (no dependency on ``model.ir``).
+                  pattern membership the resolver groups on (a ``"callout"`` escalation's
+                  feature is the dropped group's ``PatternFeature`` when it is a
+                  fully-surviving recognised pattern, else ``None``). Left untyped to keep
+                  this module a leaf (no dependency on ``model.ir``).
         reason:   why placement failed — ``"strip_full" | "illegible" | "corridor_blocked" | "no_room"``.
         remedies: ranked candidate remedies the resolver may pick, e.g.
                   ``("group_balloon", "table", "detail", "drop")``. Empty = resolver's default ladder.

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -56,13 +56,18 @@ def _legible_locations(positions, scale):
     return kept, n_too_close
 
 
-def _record_callout_drop(dwg, view, diam, reason):
+def _record_callout_drop(dwg, view, diam, reason, feat=None):
     """Record a hole callout the layout could not place (#36).
 
     A warning (the drawing is incomplete, not invalid), whose diameter is
     excluded from ``feature_not_dimensioned`` like the old per-view cap drop —
     so a callout that genuinely doesn't fit is surfaced once, with a reason,
     and not double-reported.
+
+    *feat* is the dropped group's ``PatternFeature`` when it is a fully-surviving
+    recognised pattern (the ``pat`` value threaded through ``_annotate_holes``),
+    else ``None`` — carried on the Escalation so the resolver can group by pattern
+    identity (#351 PR-3).
     """
     dwg._drop_callout_diam(diam)
     dwg._record_build_issue(
@@ -73,7 +78,7 @@ def _record_callout_drop(dwg, view, diam, reason):
     # First-class escalation object alongside the lint code (ADR 0009 Amdt 1, #351 PR-2).
     # The resolver (`_maybe_tabulate_holes`) triggers on these; the lint code stays for
     # coverage. 1:1 with the code emit, so the object trigger is byte-identical.
-    dwg._escalations.append(Escalation(kind="callout", view=view, feature=diam, reason=reason))
+    dwg._escalations.append(Escalation(kind="callout", view=view, feature=feat, reason=reason))
 
 
 def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
@@ -591,13 +596,13 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                     side, x0, x1 = "left", centre[0] - gap - w, centre[0] - gap
                 else:
                     _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
-                    _record_callout_drop(dwg, view, dia, "no room beside the view")
+                    _record_callout_drop(dwg, view, dia, "no room beside the view", feat)
                     continue
                 # the title block only constrains rows that reach its x-range
                 floor = (tb_top + 4) if x1 > tb_left - 4 else a.margin + 4
                 if elbow_y < floor:
                     _log.info("Hole callout ø%s skipped (front strip full)", _fmt(dia))
-                    _record_callout_drop(dwg, view, dia, "front strip full")
+                    _record_callout_drop(dwg, view, dia, "front strip full", feat)
                     continue
                 if any(
                     ox0 <= centre[0] <= ox1 and row_y > elbow_y for ox0, ox1, row_y in occupied
@@ -605,7 +610,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                     _log.info(
                         "Hole callout ø%s skipped (shaft would cross another callout)", _fmt(dia)
                     )
-                    _record_callout_drop(dwg, view, dia, "shaft would cross another callout")
+                    _record_callout_drop(dwg, view, dia, "shaft would cross another callout", feat)
                     continue
                 elbow = (centre[0], elbow_y)
                 occupied.append((x0, x1, elbow_y))
@@ -693,7 +698,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
 
             if not can_right and not can_left:
                 _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
-                _record_callout_drop(dwg, view, dia, "no room beside the view")
+                _record_callout_drop(dwg, view, dia, "no room beside the view", feat)
                 continue
 
             if can_right and (not can_left or d_right <= d_left):
@@ -745,7 +750,9 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                     len(queue),
                 )
                 for k in res.dropped:
-                    _record_callout_drop(dwg, view, by_key[k][1], f"{side} strip full")
+                    _record_callout_drop(
+                        dwg, view, by_key[k][1], f"{side} strip full", by_key[k][3]
+                    )
             # Emit survivors in natural-Y order (== plan_strip's solve order, since
             # keys are Y-monotonic) so the hc_{view}{i} names + centre-mark indices
             # land on the same callouts as the old queue-order emit.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -16,6 +16,7 @@ bore set, side-drilled locations, the hole table) + the section/PMI passes.
 from __future__ import annotations
 
 import math
+from types import SimpleNamespace
 
 from draftwright._core import (
     _CONCENTRIC_TOL_MM,
@@ -53,7 +54,7 @@ from draftwright.annotations.sections import (
     _request_prismatic_detail,
     _resolve_details,
 )
-from draftwright.model import build_part_model, plan_dimensions, plan_sections
+from draftwright.model import PatternFeature, build_part_model, plan_dimensions, plan_sections
 from draftwright.recognition import (
     full_cylinders,
 )
@@ -295,7 +296,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
 def _maybe_tabulate_holes(dwg, a: Analysis):
     """Escalate to a per-instance hole table + balloons when the plan view is too
-    dense to dimension every hole individually (#93).
+    dense to dimension every hole individually (#93); a dropped ISO pattern
+    callout gets one grouped balloon of its own (#351 PR-3, ADR 0009 Amdt 1
+    decision 1 — the #348 fix).
 
     When callouts or location references had to be dropped, the individual
     plan-view callouts and X/Y location dims are removed and replaced by a
@@ -306,14 +309,31 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
 
     If the table itself will not fit, nothing is removed and the drop lint is
     kept — the sheet is never left with neither.
+
+    Independent of that density gate: a recognised pattern (bolt circle / linear
+    array / grid) whose own grouped ``n×`` callout could not be placed inline
+    gets **one balloon tagging the whole pattern**, not one balloon per member —
+    a dropped pattern is a real coverage gap on any part, not just a dense one.
+    Both kinds of balloon share one strip-solved band per side (one
+    ``_add_balloons`` call) so they never overlap each other.
     """
     # Trigger on the first-class Escalation objects the hole placers collect (ADR 0009
     # Amdt 1, #351 PR-2), not by grepping the `*_dropped` lint strings. Byte-identical:
     # a "callout"/"location" Escalation is emitted 1:1 with each callout_dropped/
     # location_ref_dropped code. `getattr` default guards the auto_dims=False path (which
     # skips this whole pass anyway). The lint codes stay as the coverage surface.
-    if not any(e.kind in ("callout", "location") for e in getattr(dwg, "_escalations", ())):
+    escalations = getattr(dwg, "_escalations", ())
+    if not any(e.kind in ("callout", "location") for e in escalations):
         return
+
+    # A "callout" escalation's feature is the dropped group's PatternFeature only when
+    # it is a fully-surviving recognised pattern (_annotate_holes's `pat`, holes.py) —
+    # scoped to the plan view, the only one `_add_balloons`'s halo covers.
+    pattern_feats = [
+        e.feature
+        for e in escalations
+        if e.kind == "callout" and e.view == "plan" and isinstance(e.feature, PatternFeature)
+    ]
 
     # Tabulate only the genuinely UNpatterned plan-view holes: holes in a
     # recognised pattern are documented by their grouped ``n× ⌀`` callout +
@@ -328,45 +348,100 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     # A chart is warranted only for a *genuinely* dense plan view — a part that
     # merely dropped one too-close location ref keeps its individual dims (the
     # legibility gate already handled it). #93.
-    if len(holes) < _TABULATE_MIN_HOLES:
+    tabulate_scattered = len(holes) >= _TABULATE_MIN_HOLES
+    if not tabulate_scattered and not pattern_feats:
         return
-    dx, dy = a.bb.min.X, a.bb.min.Y
-    tags = _tag_sequence(len(holes))
-    header = ("TAG", "⌀", "X", "Y")
-    data = [
-        (tag, f"ø{_fmt(h.diameter)}", _fmt(h.location[0] - dx), _fmt(h.location[1] - dy))
-        for tag, h in zip(tags, holes, strict=True)
-    ]
-    # Remove the callouts and location dims the table replaces FIRST: it frees
-    # their space for the table and shrinks the obstacle set fit_box scans (the
-    # dense parts have dozens), which is the dominant cost on heavy sheets (#93).
-    replaced = {
-        n: o
-        for n, o in list(dwg.iter_annotations())
-        if n.startswith(("hc_plan", "m_locx", "m_locy")) and not dwg._is_pattern_callout(n)
-    }
-    replaced_view = {n: dwg.view_of(n) for n in replaced}
-    for n in replaced:
-        dwg.remove(n)
 
-    # Widen the chart into more column-blocks until it fits the page.
-    table = None
-    for ncols in (1, 2, 3, 4):
-        table = dwg.add_table(
-            _wrap_rows(header, data, ncols), name="hole_table_plan", block_cols=len(header)
+    dx, dy = a.bb.min.X, a.bb.min.Y
+    n_scattered = len(holes) if tabulate_scattered else 0
+    tags = _tag_sequence(n_scattered + len(pattern_feats))
+    scattered_tags, pattern_tags = tags[:n_scattered], tags[n_scattered:]
+    # One balloon per pattern, tagged with its member count so the ring reads
+    # "6×A" rather than one glyph per member (#348) — no table row needed, the
+    # count + diameter travel with the balloon itself.
+    pattern_specs = [
+        (
+            f"{feat.count}×{tag}",
+            0,
+            # Anchor on an actual member hole, not `feat.frame.origin` — for a
+            # bolt circle / grid that's the pattern's geometric centre, which
+            # isn't a hole, so the leader would point at solid material instead
+            # of the pattern it documents.
+            SimpleNamespace(location=feat.members[0], diameter=feat.member.diameter),
         )
-        if table is not None:
-            break
-    dwg._drop_build_issues("table_dropped")
-    if table is None:
-        # Even wrapped it will not fit — restore the callouts/dims and keep the
-        # drop lint, so the sheet is never left with neither.
-        for n, obj in replaced.items():
-            dwg.add(obj, n, view=replaced_view.get(n))
-        dwg._record_build_issue("warning", "table_dropped", "hole table did not fit the sheet")
-        return
-    # One entry per hole (with repeats) so the coverage *count* check sees that
-    # the table documents every instance, not just each distinct diameter.
-    table.covers_diameters = tuple(h.diameter for h in holes)
-    dwg._add_balloons("plan", [(tag, 0, h) for tag, h in zip(tags, holes, strict=True)])
-    dwg._drop_build_issues("callout_dropped", "location_ref_dropped")
+        for tag, feat in zip(pattern_tags, pattern_feats, strict=True)
+    ]
+
+    scattered_specs: list = []
+    if tabulate_scattered:
+        header = ("TAG", "⌀", "X", "Y")
+        data = [
+            (tag, f"ø{_fmt(h.diameter)}", _fmt(h.location[0] - dx), _fmt(h.location[1] - dy))
+            for tag, h in zip(scattered_tags, holes, strict=True)
+        ]
+        # Remove the callouts and location dims the table replaces FIRST: it frees
+        # their space for the table and shrinks the obstacle set fit_box scans (the
+        # dense parts have dozens), which is the dominant cost on heavy sheets (#93).
+        replaced = {
+            n: o
+            for n, o in list(dwg.iter_annotations())
+            if n.startswith(("hc_plan", "m_locx", "m_locy")) and not dwg._is_pattern_callout(n)
+        }
+        replaced_view = {n: dwg.view_of(n) for n in replaced}
+        for n in replaced:
+            dwg.remove(n)
+
+        # Widen the chart into more column-blocks until it fits the page.
+        table = None
+        for ncols in (1, 2, 3, 4):
+            table = dwg.add_table(
+                _wrap_rows(header, data, ncols), name="hole_table_plan", block_cols=len(header)
+            )
+            if table is not None:
+                break
+        dwg._drop_build_issues("table_dropped")
+        if table is None:
+            # Even wrapped it will not fit — restore the callouts/dims and keep the
+            # drop lint, so the sheet is never left with neither. The pattern
+            # balloons below are unaffected — nothing of theirs was removed.
+            for n, obj in replaced.items():
+                dwg.add(obj, n, view=replaced_view.get(n))
+            dwg._record_build_issue("warning", "table_dropped", "hole table did not fit the sheet")
+        else:
+            # One entry per hole (with repeats) so the coverage *count* check sees
+            # that the table documents every instance, not just each distinct
+            # diameter.
+            table.covers_diameters = tuple(h.diameter for h in holes)
+            scattered_specs = [(tag, 0, h) for tag, h in zip(scattered_tags, holes, strict=True)]
+            dwg._drop_build_issues("callout_dropped", "location_ref_dropped")
+
+    balloon_specs = scattered_specs + pattern_specs
+    placed_names: set = set()
+    if balloon_specs:
+        # One call: the strip solver must see every band member together, or two
+        # independent _add_balloons calls could stack a pattern balloon on a
+        # per-hole one in the same band.
+        dwg._add_balloons("plan", balloon_specs)
+        placed_names = {n for n, _ in dwg.iter_annotations()}
+
+    # Pattern balloons resolve their own "callout_dropped" issues only for patterns
+    # whose balloon actually landed on the sheet — a crowded band can silently drop
+    # the tail (_place_band's strip-solver prefix fallback, layout.py) with no
+    # signal back here — AND only when no OTHER callout drop is left unaddressed
+    # (the scattered-table success path above already cleared them when it ran).
+    # Never hide a genuine remaining drop (a table that didn't fit, a pattern
+    # balloon that didn't fit its band, or a dropped pattern in a non-plan view,
+    # which this resolver does not cover).
+    if pattern_specs and not scattered_specs:
+        resolved_feats = {
+            feat
+            for (full_tag, _, _), feat in zip(pattern_specs, pattern_feats, strict=True)
+            if f"balloon_plan_{full_tag}_0" in placed_names
+        }
+        unresolved = [
+            e
+            for e in escalations
+            if e.kind == "callout" and not (e.view == "plan" and e.feature in resolved_feats)
+        ]
+        if not unresolved:
+            dwg._drop_build_issues("callout_dropped")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5339,6 +5339,101 @@ class TestEscalation:
         assert wide[3] == ("c", "3", "", "")  # ragged tail padded blank
 
 
+class TestPatternGroupBalloon:
+    """#351 PR-3 (ADR 0009 Amdt 1 decision 1, the #348 fix): a dropped ISO
+    pattern callout gets ONE balloon tagging the whole pattern, not one per
+    member. Exercised directly against the resolver with a synthetic dropped
+    Escalation — forcing a real drop needs a part crowded enough that even the
+    auto-grown page can't fit it (the CTC-02 slow-tier fixture is the
+    naturally-occurring case)."""
+
+    @staticmethod
+    def _fake_pattern(count, diameter, origin=(0.0, 0.0, 0.0)):
+        from draftwright.model import Frame, HoleFeature, PatternFeature
+
+        member = HoleFeature(
+            frame=Frame(origin=origin, axis="z"), diameter=diameter, depth=None, through=True
+        )
+        # Real recognised patterns always populate `members` (detect.py's
+        # `_pattern_feature`) — the resolver anchors the balloon on a real member,
+        # not the pattern's abstract centre, so the fixture must match.
+        members = tuple((origin[0] + i, origin[1], origin[2]) for i in range(count))
+        return PatternFeature(
+            frame=Frame(origin=origin, axis="z"),
+            pattern="bolt_circle",
+            count=count,
+            member=member,
+            members=members,
+        )
+
+    def test_dropped_pattern_gets_one_grouped_balloon(self):
+        from draftwright.annotations._common import Escalation
+        from draftwright.annotations.orchestrator import _maybe_tabulate_holes
+
+        dwg = build_drawing(_multi_hole_plate())  # sparse — density gate stays shut
+        before = set(dwg.annotations())
+        feat = self._fake_pattern(count=6, diameter=5.0)
+        dwg._escalations.append(
+            Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
+        )
+        # Mirror what _record_callout_drop does in production, so clearing it below
+        # actually exercises the resolve path rather than trivially passing.
+        dwg._record_build_issue("warning", "callout_dropped", "synthetic plan-view drop")
+        _maybe_tabulate_holes(dwg, dwg._analysis)
+
+        assert "hole_table_plan" not in dwg.annotations()  # density gate untouched
+        new_balloons = [
+            n for n in dwg.annotations() if n.startswith("balloon_") and n not in before
+        ]
+        assert len(new_balloons) == 1
+        assert new_balloons[0].split("_")[2] == "6×A"
+        assert "callout_dropped" not in {i.code for i in dwg.lint()}  # resolved, not just hidden
+
+    def test_multiple_dropped_patterns_get_distinct_non_overlapping_balloons(self):
+        from draftwright.annotations._common import Escalation
+        from draftwright.annotations.orchestrator import _maybe_tabulate_holes
+
+        dwg = build_drawing(_multi_hole_plate())
+        feats = [
+            self._fake_pattern(count=4, diameter=3.0, origin=(-15.0, -8.0, 0.0)),
+            self._fake_pattern(count=6, diameter=5.0, origin=(15.0, 8.0, 0.0)),
+        ]
+        for feat in feats:
+            dwg._escalations.append(
+                Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
+            )
+        _maybe_tabulate_holes(dwg, dwg._analysis)
+
+        balloons = [n for n in dwg.annotations() if n.startswith("balloon_plan_")]
+        assert {n.split("_")[2] for n in balloons} == {"4×A", "6×B"}
+        # The shared-band placement (one _add_balloons call) must not stack them.
+        boxes = [dwg._named[n].bounding_box() for n in balloons]
+        b0, b1 = boxes
+        overlaps = (
+            b0.min.X < b1.max.X
+            and b1.min.X < b0.max.X
+            and (b0.min.Y < b1.max.Y and b1.min.Y < b0.max.Y)
+        )
+        assert not overlaps
+
+    def test_unresolved_pattern_in_other_view_keeps_the_drop_lint(self):
+        # A pattern drop the resolver does not cover (a non-plan view) must not
+        # have its callout_dropped warning silently cleared.
+        from draftwright.annotations._common import Escalation
+        from draftwright.annotations.orchestrator import _maybe_tabulate_holes
+
+        dwg = build_drawing(_multi_hole_plate())
+        feat = self._fake_pattern(count=3, diameter=4.0)
+        dwg._escalations.append(
+            Escalation(kind="callout", view="front", feature=feat, reason="front strip full")
+        )
+        dwg._record_build_issue("warning", "callout_dropped", "synthetic front-view drop")
+        _maybe_tabulate_holes(dwg, dwg._analysis)
+
+        assert not any(n.startswith("balloon_") for n in dwg.annotations())
+        assert "callout_dropped" in {i.code for i in dwg.lint()}
+
+
 class TestDraftwrightAttribution:
     """draftwright self-attribution in the title block + clickable SVG link."""
 

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -111,6 +111,9 @@ def test_record_callout_drop_emits_a_callout_escalation():
     # PR-2 routing: a dropped hole callout emits a first-class Escalation into
     # dwg._escalations (which the tabulation resolver now triggers on), alongside the
     # `callout_dropped` lint code (kept for coverage). 1:1 with the code → byte-identical.
+    # PR-3 (#351): `feature` now carries the dropped group's IR feature (a PatternFeature
+    # when it's a fully-surviving recognised pattern, else None) rather than the diameter —
+    # the resolver groups pattern balloons on it.
     from draftwright.annotations.holes import _record_callout_drop
 
     class _Dwg:
@@ -128,7 +131,12 @@ def test_record_callout_drop_emits_a_callout_escalation():
     assert d._codes == ["callout_dropped"] and d._dropped == [6.0]
     assert len(d._escalations) == 1
     e = d._escalations[0]
-    assert e.kind == "callout" and e.view == "plan" and e.feature == 6.0
+    assert e.kind == "callout" and e.view == "plan" and e.feature is None
+
+    d2 = _Dwg()
+    sentinel = object()
+    _record_callout_drop(d2, "plan", 6.0, "no room beside the view", sentinel)
+    assert d2._escalations[0].feature is sentinel
 
 
 def test_escalation_is_a_frozen_value_with_default_remedies():


### PR DESCRIPTION
## Summary

- Extends `_maybe_tabulate_holes` to trigger on a dropped ISO pattern callout (bolt circle / linear array / grid) independently of the existing density gate (`_TABULATE_MIN_HOLES=16`) — previously a pattern's grouped `n×` callout that couldn't be placed inline was silently undocumented on any part that wasn't dense enough for the scattered-hole table.
- A fully-surviving recognised pattern whose callout was dropped now gets **one balloon tagging the whole pattern** (e.g. `"6×A"`), reusing the existing balloon-band machinery unmodified via duck-typed `SimpleNamespace` stand-ins.
- Scattered-hole balloons and pattern balloons share one strip-solved band per side (a single `_add_balloons` call) so they can never overlap each other.
- The density-gated table-building code is now scoped behind `tabulate_scattered`, so a pattern-only trigger never touches/removes the existing per-hole callouts/dims on a sparse part — this was the main regression risk in this change.
- `Escalation.feature` (threaded through `_record_callout_drop`'s existing `feat` local, already in scope at every call site from PR-2) now carries the dropped group's `PatternFeature` when applicable, instead of always being `None`.

This is PR-3 of epic #351 (ADR 0009 Amendment 1), the concrete fix for #348.

## Caught in review

An independent adversarial review before this PR flagged two real bugs, both fixed:
1. **Wrong leader anchor** — the balloon anchored on `feat.frame.origin` (a bolt circle's geometric centre, not a hole), so the leader pointed at solid material instead of an actual hole. Fixed to anchor on `feat.members[0]`, a real member location (real `PatternFeature`s always populate `members`, per `detect.py`'s `_pattern_feature`).
2. **Lint could be cleared for a balloon that never landed** — the `callout_dropped` lint was cleared once a balloon was *attempted* for every pattern escalation, not once it was confirmed *placed*. A crowded band's strip-solver prefix fallback (`layout.py`) can silently drop the tail with no signal back to the resolver. Fixed to check the real annotation name (`balloon_plan_{tag}_0`) actually landed before clearing.

## Test plan

- [x] `ruff format` / `ruff check` / `mypy src/draftwright/` clean
- [x] New `TestPatternGroupBalloon` (3 tests): single dropped pattern → one balloon; multiple dropped patterns → distinct non-overlapping balloons; a pattern drop in a non-plan view keeps the lint (proves the resolver never hides an unresolved drop)
- [x] Updated `test_record_callout_drop_emits_a_callout_escalation` (was asserting the old `feature=diam` behavior)
- [x] Full fast test tier: 671 passed, no regressions
- [x] Manual check against the real CTC-02 fixture (`tests/fixtures/nist_ctc_02_asme1_ap203.stp`): 0 `annotation_out_of_bounds`, no regressions (this fixture doesn't happen to trigger a dropped-pattern scenario itself, so no pattern balloon appears on it — evidence of no breakage, not of the new path firing)

Next (PR-4, #351): fold in slots/step/pmi escalation handling; delete the string-grep in `_maybe_tabulate_holes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)