### PR TITLE
docs: fix two stale ADR 0009 comments

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -127,8 +127,8 @@ def strip_obstacles(dwg, view=None, *, crossable=()):
     notes angled leaders weaken the bound), which only ever over-avoids, never
     under-avoids.
 
-    Not yet consumed in production — the collect-then-solve strip stage wires this
-    in at P1 (#321). Kept additive here so P0 stays behaviour-preserving."""
+    The occupancy source for the collect-then-solve carve — every migrated renderer's
+    ``place_strip_candidates`` call wires this in (#321/#150/P3)."""
     boxes = []
     for name, o in dwg.iter_annotations():
         if view is not None:

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -14,9 +14,11 @@ library, so it is unit-testable without building a drawing.
 
 Explicitly deferred to later phases (so the surface is honest about its limits):
 global 2D non-overlap (the disjunctive constraint ADR 0003 notes is non-linear),
-the assignment layer (which zone/side — still ``Strip.allocate``), the escalation
-ladder, leader-length minimisation, alignment groups, and connector crossing.
-The only solve phase 1 performs correctly is the 1D strip solve.
+the assignment layer (which zone/side — the collect-then-solve carve,
+``place_strip_candidates`` in ``annotations/_common.py``, since #150/P3 retired
+``Strip.allocate``), the escalation ladder, leader-length minimisation, alignment
+groups, and connector crossing. The only solve phase 1 performs correctly is the
+1D strip solve.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Comment-only fix, caught by an external audit of the ADR 0009 implementation state (2026-07-02):

- `layout.py` still described the zone/side assignment layer as "still `Strip.allocate`" — that cursor was fully deleted in #349 (P5-strand-1, closes #150).
- `annotations/_common.py`'s `strip_obstacles` docstring still said "not yet consumed in production" — it's been the occupancy source for `place_strip_candidates` (the shared carve every migrated renderer uses) since P3.

No behavior change.

## Test plan

- [x] `ruff format` / `ruff check` clean (comment-only diff)
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)