### PR TITLE
feat: route slot + PMI dim drops through Escalation objects (ADR 0009 Amdt 1, #351 PR-4a)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -131,6 +131,25 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
     )
 
 
+def _record_slot_drop(dwg, kind, idx, view, feat):
+    """Record a slot dim the layout could not place (#135).
+
+    Info severity — a dim with no clear room is dropped as "place what fits",
+    not an error. Alongside the lint code, appends a first-class ``Escalation``
+    (ADR 0009 Amdt 1, #351 PR-4a) so the drop is object-visible too; slots have
+    no natural grouping remedy like a recognised hole pattern, so no resolver
+    consumes this yet — purely additive.
+    """
+    dwg._record_build_issue(
+        "info",
+        "slot_dim_dropped",
+        f"slot{idx} {kind} dim not placed (no room beside the {view})",
+    )
+    dwg._escalations.append(
+        Escalation(kind="slot", view=view, feature=feat, reason=f"no room beside the {view}")
+    )
+
+
 def render_slots(dwg, model, a) -> int:
     """Dimension milled slots from the IR — width (the defining size, across
     ``width_axis``) + length (along ``long_axis``) + a position dim from the part
@@ -151,13 +170,6 @@ def render_slots(dwg, model, a) -> int:
 
     def _bb(axis, hi):
         return getattr(a.bb.max if hi else a.bb.min, axis.upper())
-
-    def _drop(kind, idx, view):
-        dwg._record_build_issue(
-            "info",
-            "slot_dim_dropped",
-            f"slot{idx} {kind} dim not placed (no room beside the {view})",
-        )
 
     count = 0
     for i, s in enumerate(slots):
@@ -227,13 +239,13 @@ def render_slots(dwg, model, a) -> int:
         ):
             count += 1
         else:
-            _drop("width", i, name)
+            _record_slot_drop(dwg, "width", i, name, s)
         if _place(
             s.long_axis, s.lo, s.hi, s.w_center - half, s.w_center + half, s.length, "length"
         ):
             count += 1
         else:
-            _drop("length", i, name)
+            _record_slot_drop(dwg, "length", i, name, s)
         datum = _bb(s.long_axis, False)
         if (s.lo - datum) * a.SCALE >= 1.0:
             if _place(
@@ -248,7 +260,7 @@ def render_slots(dwg, model, a) -> int:
             ):
                 count += 1
             else:
-                _drop("position", i, name)
+                _record_slot_drop(dwg, "position", i, name, s)
     return count
 
 
@@ -1077,6 +1089,33 @@ def render_rotational(dwg, model, a) -> int:
     return n
 
 
+def _record_pmi_drop(dwg, ax, label, rec):
+    """Record a PMI dim the layout could not place (#208).
+
+    Previously silent (#351 PR-4a) — a PMI dim that found no strip space just
+    vanished with no trace beyond a debug log line, unlike every other placer.
+    Now records a warning-severity lint code plus a first-class ``Escalation``
+    (ADR 0009 Amdt 1). No resolver remedy yet — purely additive visibility.
+
+    *ax* is ``rec.dominant_axis`` (resolved, never ``"?"`` — see the bore-diameter
+    call site). The view table differs by ``rec.pmi_kind``: a bore diameter/radius
+    is placed in the view where the bore appears as a circle (Z→plan, X→side,
+    Y→front — the bbox-perpendicular view), while a linear dim follows the
+    dominant-axis table above (X/Z→front, Y→side primary). Conflating the two
+    mislabels every dropped bore diameter/radius (review finding, #351 PR-4a).
+    """
+    if rec.pmi_kind in ("diameter", "radius"):
+        view = {"Z": "plan", "X": "side", "Y": "front"}.get(ax, "front")
+    else:
+        view = "front" if ax in ("X", "Z") else "side"
+    dwg._record_build_issue(
+        "warning", "pmi_dropped", f"PMI {label!r} not placed (no room beside the {view})"
+    )
+    dwg._escalations.append(
+        Escalation(kind="pmi", view=view, feature=rec, reason="no room beside the view")
+    )
+
+
 def render_pmi(dwg, model, a) -> int:
     """Render pre-authored PMI annotations (STEP AP242) from the IR `PmiFeature`s
     into remaining strip space (#208). Replaces the engine's `_annotate_pmi`.
@@ -1299,6 +1338,11 @@ def render_pmi(dwg, model, a) -> int:
                 _log.debug("PMI dim[%d] diam: no ref_bbox, skip", idx)
                 continue
             bore_axis, cx_f, cy_f, cz_f = info
+            # Resolved axis (handles the '?' degenerate-bbox fallback _bore_info does
+            # internally) — reused below for the drop escalation's view, since the
+            # bore-diameter view table (Z→plan, X→side, Y→front) differs from the
+            # linear-dim one just below (#351 PR-4a review).
+            ax = bore_axis
             half = rec.value / 2 if rec.kind == "diameter" else rec.value
 
             # Bore diameter page span = diameter × scale.  When the span is
@@ -1438,6 +1482,7 @@ def render_pmi(dwg, model, a) -> int:
             _log.info("PMI dim[%d] %s %.3g → annotated (%s)", idx, ax, rec.value, label)
         else:
             _log.info("PMI dim[%d] %s %.3g → no strip space", idx, ax, rec.value)
+            _record_pmi_drop(dwg, ax, label, rec)
 
     _log.info("PMI annotate: %d/%d dims placed", emitted, len(usable))
     return emitted

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -177,6 +177,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "location_ref_dropped",
         "step_dim_dropped",
         "placement_unsatisfiable",
+        "pmi_dropped",
     }
 )
 

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -139,6 +139,63 @@ def test_record_callout_drop_emits_a_callout_escalation():
     assert d2._escalations[0].feature is sentinel
 
 
+def test_record_slot_drop_emits_a_slot_escalation():
+    # #351 PR-4a: a dropped slot dim (width/length/position) emits a first-class
+    # "slot" Escalation alongside the existing slot_dim_dropped lint code — purely
+    # additive, no resolver consumes it yet (slots have no natural grouping remedy).
+    from draftwright.annotations.from_model import _record_slot_drop
+
+    class _Dwg:
+        def __init__(s):
+            s._escalations, s._codes = [], []
+
+        def _record_build_issue(s, sev, code, msg):
+            s._codes.append((sev, code))
+
+    d = _Dwg()
+    sentinel = object()
+    _record_slot_drop(d, "width", 0, "plan", sentinel)
+    assert d._codes == [("info", "slot_dim_dropped")]
+    assert len(d._escalations) == 1
+    e = d._escalations[0]
+    assert e.kind == "slot" and e.view == "plan" and e.feature is sentinel
+
+
+def test_record_pmi_drop_emits_a_pmi_escalation():
+    # #351 PR-4a: a PMI dim that finds no strip space was previously silent (no lint
+    # code at all). Now records pmi_dropped + a first-class "pmi" Escalation.
+    from types import SimpleNamespace
+
+    from draftwright.annotations.from_model import _record_pmi_drop
+
+    class _Dwg:
+        def __init__(s):
+            s._escalations, s._codes = [], []
+
+        def _record_build_issue(s, sev, code, msg):
+            s._codes.append((sev, code))
+
+    d = _Dwg()
+    rec = SimpleNamespace(pmi_kind="linear")
+    _record_pmi_drop(d, "X", "12.0", rec)
+    assert d._codes == [("warning", "pmi_dropped")]
+    assert len(d._escalations) == 1
+    e = d._escalations[0]
+    assert e.kind == "pmi" and e.view == "front" and e.feature is rec
+
+    d2 = _Dwg()
+    _record_pmi_drop(d2, "Y", "12.0", SimpleNamespace(pmi_kind="linear"))
+    assert d2._escalations[0].view == "side"
+
+    # A bore diameter/radius uses a DIFFERENT view table (the view where the bore
+    # appears as a circle) from linear dims — conflating the two mislabelled every
+    # dropped bore diameter/radius (caught by review, #351 PR-4a).
+    for ax, want_view in (("Z", "plan"), ("X", "side"), ("Y", "front")):
+        d3 = _Dwg()
+        _record_pmi_drop(d3, ax, "ø12.0", SimpleNamespace(pmi_kind="diameter"))
+        assert d3._escalations[0].view == want_view, ax
+
+
 def test_escalation_is_a_frozen_value_with_default_remedies():
     import dataclasses
 


### PR DESCRIPTION
## Summary

First of a 3-way split of epic #351's PR-4 ("fold in slots/step/pmi; delete the string-grep in `_maybe_tabulate_holes`"). This sub-PR extends the `Escalation` routing PR-2/PR-3 already did for hole callouts/locations to slot and PMI drops:

- `render_slots`' inline `_drop` closure is now the module-level `_record_slot_drop(dwg, kind, idx, view, feat)` — unchanged lint behavior (same `slot_dim_dropped` info code, same message), now also appending an `Escalation(kind="slot", ...)`.
- `render_pmi`'s failure path was **completely silent** before this PR — no lint code, nothing beyond a debug log line a user would never see. Now records a new `pmi_dropped` warning (added to `_GEOMETRY_AWARE_CODES`, matching how `callout_dropped`/`step_dim_dropped`/etc. are treated) plus an `Escalation(kind="pmi", ...)`.

Purely additive: no resolver consumes `"slot"`/`"pmi"` escalations yet (mirrors how PR-2 first routed holes before PR-3 added the pattern-balloon remedy) — no existing lint-clean test is affected, since both new codes are non-error severity and `repair.py` has no dispatch on any `*_dropped` code.

## Caught in review

Two independent adversarial review rounds. The first caught a real bug: the PMI escalation's view heuristic used the linear-dim axis table (X/Z→front, Y→side) for *every* `pmi_kind`, but a dropped bore diameter/radius is actually placed in a different view — whichever one the bore appears as a circle in (Z→plan, X→side, Y→front). Fixed by branching on `rec.pmi_kind` and resolving the degenerate `'?'` dominant-axis case before recording the escalation. Second review confirmed the fix and traced it against every reachable `render_pmi` branch + every `pmi_kind` the codebase actually generates.

Along the way, three unrelated pre-existing issues were found and filed separately (not fixed here, to keep this PR scoped):
- #357 — `place_strip_candidates`'s `StripCandidate.priority` is always 0, so over-capacity victim selection isn't feature-priority-ranked.
- #358 — `_diameter_row_below`/`_diameter_column_left` still use raw `dwg.items` scans / `_occupied_boxes`/`_box_hits` instead of the shared carve.
- #360 — `render_pmi`'s bore-diameter witness span uses `rec.kind == "diameter"`, which is always `False` (`PmiFeature.kind` is a fixed `ClassVar = "pmi"`; the real category is `rec.pmi_kind`) — so a diameter bore's extension-line span is 2× too wide.

## Test plan

- [x] `ruff format` / `ruff check` / `mypy src/draftwright/` clean
- [x] Two new unit tests (`test_record_slot_drop_emits_a_slot_escalation`, `test_record_pmi_drop_emits_a_pmi_escalation`) exercising both new module-level functions directly, mirroring the existing `test_record_callout_drop_emits_a_callout_escalation` pattern — including all 3 axis cases of the bore-diameter view mapping
- [x] Full fast test tier: 673 passed, both before and after the review-driven fix

Next: PR-4b (unify the illegible-step → detail-view remedy — `render_height_ladder`'s legibility gate and `sections.py`'s `_request_prismatic_detail` currently independently recompute the same check), then PR-4c (delete the annotation-name-prefix string-grep in `_maybe_tabulate_holes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)