### PR TITLE
feat: unify the illegible-step -> detail-view remedy via Escalation objects (ADR 0009 Amdt 1, #351 PR-4b)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -899,6 +899,15 @@ def render_height_ladder(dwg, model, a) -> int:
                 f"{n_close} step height(s) too closely spaced to dimension at this scale "
                 "(use a detail view)",
             )
+            # First-class escalation alongside the lint code (ADR 0009 Amdt 1, #351
+            # PR-4b) — `_request_prismatic_detail` (sections.py) triggers the detail-view
+            # remedy on this instead of independently recomputing the same legibility
+            # gate, which previously could queue a spurious detail even when the uniform-
+            # staircase branch above already fully documented the part with one
+            # representative dim (a real bug this routing fixes as a side effect).
+            dwg._escalations.append(
+                Escalation(kind="step", view="front", feature=step, reason="illegible")
+            )
         for col, z in enumerate(kept):
             perp = tuple(sorted((FZ(a.bb.min.Z), FZ(z))))
             px = carve_free_position(dwg, a.fv_zones.right, "front", "x", _SLOT_DIM_STEP, perp)

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -432,13 +432,33 @@ def _resolve_details(dwg, a: Analysis) -> None:
 
 def _request_prismatic_detail(dwg, a: Analysis) -> None:
     """Queue a detail of a prismatic part's crowded step-height band (#42), routed
-    through the unified pipeline (#307). Fires when the step-height legibility gate
-    drops a shoulder at sheet scale; the redraw re-draws the step-height ladder in
-    the detail view at the enlarged scale."""
+    through the unified pipeline (#307).
+
+    Fires on the "step"/"illegible" ``Escalation`` `render_height_ladder`
+    (from_model.py) appends (ADR 0009 Amdt 1, #351 PR-4b) rather than
+    independently recomputing the legibility gate from ``a.step_zs`` — a uniform
+    staircase (``_detect_step_repeat``) collapses to one representative dim with
+    no drop at all, and re-deriving legibility straight from the raw z-list here
+    missed that case, queuing a spurious detail even though nothing was actually
+    dropped (a real bug the escalation routing fixes as a side effect).
+
+    Prismatic only, by construction: `render_height_ladder` never emits this
+    escalation for a turned part (no `StepLevelFeature`). A crowded **Z-turned**
+    step-length chain has its own, separate, still-silent drop in
+    `_draw_step_chain`'s vertical branch (`return 0`, no lint/escalation at
+    all) — this function no longer accidentally, unreliably papers over that
+    with prismatic-semantics dims (wrong anchor/labeling for a turned chain);
+    see #362 for the real fix (a Z-turned-appropriate detail remedy, analogous
+    to the X-turned crowded-head block + `DetailRequest` this docstring's
+    sibling, `render_step_lengths`, already has).
+
+    The redraw re-draws the step-height ladder in the detail view at the
+    enlarged scale."""
     if len(a.step_zs) < 2:
         return
-    kept, _ = _legible_steps(a.step_zs, a.bb.min.Z, a.SCALE)
-    if not [z for z in a.step_zs if z not in set(kept)]:
+    if not any(
+        e.kind == "step" and e.reason == "illegible" for e in getattr(dwg, "_escalations", ())
+    ):
         return
     z0, z1 = min(a.step_zs), max(a.step_zs)
     pad = 0.08 * (z1 - z0) + 1.0

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3937,6 +3937,35 @@ class TestDetailView:
         # No error-severity lint introduced.
         assert [i for i in dwg.lint() if i.severity == "error"] == []
 
+    def test_prismatic_detail_gates_on_the_step_escalation_not_raw_legibility(self):
+        # #351 PR-4b: _request_prismatic_detail previously recomputed the legibility
+        # gate straight from a.step_zs as its own trigger — independent of whether
+        # render_height_ladder actually dropped anything. A uniform staircase
+        # (_detect_step_repeat) collapses to ONE representative dim with no drop at
+        # all even when the raw z-list would look "illegible" in isolation, so the old
+        # trigger could queue a spurious, unused detail view. Now it gates on the
+        # "step"/"illegible" Escalation render_height_ladder emits instead.
+        from types import SimpleNamespace
+
+        from draftwright.annotations._common import Escalation
+        from draftwright.annotations.sections import _request_prismatic_detail
+
+        a = SimpleNamespace(
+            step_zs=[1.0, 1.1, 1.2, 1.3],  # tightly spaced — "illegible" if recomputed raw
+            bb=SimpleNamespace(min=SimpleNamespace(Z=0.0), max=SimpleNamespace(Z=2.0)),
+            SCALE=1.0,
+        )
+        no_escalation = SimpleNamespace(_escalations=[], _detail_requests=[])
+        _request_prismatic_detail(no_escalation, a)
+        assert no_escalation._detail_requests == []
+
+        with_escalation = SimpleNamespace(
+            _escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")],
+            _detail_requests=[],
+        )
+        _request_prismatic_detail(with_escalation, a)
+        assert len(with_escalation._detail_requests) == 1
+
     def test_plain_part_gets_no_detail_view(self):
         dwg = build_drawing(Box(60, 40, 20))
         assert "detail_a" not in dwg.views


### PR DESCRIPTION
## Summary

Second of a 3-way split of epic #351's PR-4. `render_height_ladder`'s legibility gate (close-together prismatic step heights) and `sections.py`'s `_request_prismatic_detail` were coupled only by convention — both independently recomputed `_legible_steps` on the same underlying z-values, with no data flow between them. Exactly the "policy entangled with lint text" problem ADR 0009 Amendment 1 targets.

`render_height_ladder` now appends `Escalation(kind="step", reason="illegible", ...)` alongside its existing `step_dim_dropped` warning. `_request_prismatic_detail` no longer recomputes legibility itself — it gates on that escalation.

This isn't just a refactor — it fixes a real, live bug the independent recomputation caused: a uniform staircase (`_detect_step_repeat`) can collapse to ONE representative `"N× rise"` dim with no drop at all, but the old `_request_prismatic_detail` had no way to know that, so a uniform-but-finely-pitched staircase (e.g. a ribbed/knurled shoulder pattern) would still queue a spurious, unused detail view even though nothing was ever dropped.

**Sequencing note** (why this couldn't be one unified late resolver pass, per the ADR's literal wording): `_resolve_details` (which actually draws queued detail views) runs *before* the escalation resolver (`_maybe_tabulate_holes`) in the pipeline. So the detail-remedy decision has to happen at `_request_prismatic_detail`'s existing call site — reading escalations `render_height_ladder` already appended earlier in the same pass — not in one late pass. Escalation objects still drive the decision; it just executes at two points instead of one.

## Caught in review

An adversarial review caught a real side effect: this also removes an accidental, unreliable partial mitigation for a **separate, pre-existing** bug — a crowded Z-turned step-length chain silently drops its *entire* chain with zero lint at all (`_draw_step_chain`'s vertical branch, a plain `return 0`). The old `_request_prismatic_detail` sometimes incidentally queued a detail view for such parts too, since it read `a.step_zs` directly with no part-type awareness — but with wrong-semantics dims (prismatic height-above-base labeling applied to a turned chain's own projection). Filed as #362 for its own dedicated fix (needs a genuine Z-turned-appropriate remedy, analogous to the X-turned crowded-head + `DetailRequest` mechanism that already exists — not a one-line patch) rather than silently expanding this PR's scope or leaving the unreliable accident in place. No existing test exercised a turned part with `detail_view=True`, confirmed via the full suite passing unchanged.

## Test plan

- [x] `ruff format` / `ruff check` / `mypy src/draftwright/` clean
- [x] New regression test (`test_prismatic_detail_gates_on_the_step_escalation_not_raw_legibility`) directly proving the fixed bug: illegible `step_zs` with no matching escalation → no detail request queued (would have queued one under the old logic)
- [x] `TestDetailView` class (4 tests, including the real `_crowded_shoulder_part` end-to-end trigger case) passes unchanged
- [x] Full fast test tier: 674 passed

Next: PR-4c (delete the annotation-name-prefix string-grep in `_maybe_tabulate_holes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)