### PR TITLE
refactor: delete the annotation-name-prefix string-grep in _maybe_tabulate_holes (ADR 0009 Amdt 1, #351 PR-4c)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -342,6 +342,11 @@ def render_locations(dwg, model, a) -> int:
         )
     _left = place_strip_candidates(dwg, a.pv_zones.above, "plan", "y", x_cands, tier)
     _left = place_strip_candidates(dwg, a.pv_zones.above, "plan", "y", _left, tier, force=True)
+    _dropped_x = {_name for _name, _ in _left}
+    for _name, _ in x_cands:
+        if _name not in _dropped_x:
+            # A candidate the scattered-hole table may replace (#351 PR-4c).
+            dwg._cover_scattered_hole_doc(_name)
     for _name, _ in _left:
         dwg._record_build_issue(
             "warning",
@@ -395,6 +400,11 @@ def render_locations(dwg, model, a) -> int:
         )
     _left = place_strip_candidates(dwg, a.sv_zones.above, "side", "y", y_cands, tier)
     _left = place_strip_candidates(dwg, a.sv_zones.above, "side", "y", _left, tier, force=True)
+    _dropped_y = {_name for _name, _ in _left}
+    for _name, _ in y_cands:
+        if _name not in _dropped_y:
+            # A candidate the scattered-hole table may replace (#351 PR-4c).
+            dwg._cover_scattered_hole_doc(_name)
     for _name, _ in _left:
         dwg._record_build_issue(
             "warning",

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -241,6 +241,11 @@ def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_pa
     IR `PatternFeature` *feat* (members / bcd / pitch / grid), not a recogniser
     `Pattern` — ADR 0008 Amendment 6."""
     if feat is None:
+        if view == "plan":
+            # A plain (unpatterned) plan-view callout — a candidate the scattered-hole
+            # table may replace (#351 PR-4c). Scoped to plan only, matching the table's
+            # own scope: front/side callouts are never table-replaceable.
+            dwg._cover_scattered_hole_doc(f"hc_{view}{j}")
         return
     members = feat.members
     # Remember the bore-callout name AND the holes it documents (by position), so a

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -382,11 +382,10 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
         # Remove the callouts and location dims the table replaces FIRST: it frees
         # their space for the table and shrinks the obstacle set fit_box scans (the
         # dense parts have dozens), which is the dominant cost on heavy sheets (#93).
-        replaced = {
-            n: o
-            for n, o in list(dwg.iter_annotations())
-            if n.startswith(("hc_plan", "m_locx", "m_locy")) and not dwg._is_pattern_callout(n)
-        }
+        # Structured coverage state (registered at placement time, #351 PR-4c), not
+        # an annotation-name-prefix grep — the last stringly-typed inference this
+        # resolver relied on (ADR 0009 Amdt 1).
+        replaced = {n: o for n, o in list(dwg.iter_annotations()) if dwg._is_scattered_hole_doc(n)}
         replaced_view = {n: dwg.view_of(n) for n in replaced}
         for n in replaced:
             dwg.remove(n)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -354,13 +354,17 @@ class Drawing:
         """Record that placed *callout_name* documents *holes* (#92)."""
         self._coverage.cover_pattern(callout_name, holes)
 
-    def _is_pattern_callout(self, name) -> bool:
-        """Is *name* a placed pattern (grouped ``n× ⌀``) callout?"""
-        return self._coverage.is_pattern_callout(name)
-
     def _is_hole_patterned(self, hole) -> bool:
         """Is *hole* already documented by a placed pattern callout?"""
         return self._coverage.is_hole_patterned(hole)
+
+    def _cover_scattered_hole_doc(self, name) -> None:
+        """Record that placed *name* is a scattered hole callout / location dim (#351 PR-4c)."""
+        self._coverage.cover_scattered_hole_doc(name)
+
+    def _is_scattered_hole_doc(self, name) -> bool:
+        """Is *name* a placed scattered hole callout / location dim?"""
+        return self._coverage.is_scattered_hole_doc(name)
 
     def _reset_dropped_callout_diams(self):
         """Clear dropped-diameter tracking (top of :func:`_auto_annotate`)."""

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -81,6 +81,12 @@ class CoverageState:
         # holes no placed pattern callout documents (#92).
         self._pattern_callouts: set = set()
         self._patterned_holes: set = set()
+        # Names of placed plan-view hole callouts / X/Y location dims that are NOT
+        # part of a recognised pattern — the scattered-hole table (#93) replaces
+        # exactly these. Registered at placement time (holes.py/from_model.py) so
+        # the resolver reads structured coverage state instead of inferring
+        # "table-replaceable" from annotation NAME PREFIXES (#351 PR-4c).
+        self._scattered_hole_docs: set = set()
         # Diameters dropped by the per-view callout cap, so lint can suppress the
         # redundant feature_not_dimensioned for them. Reset at the top of
         # _auto_annotate so re-annotation does not accumulate.
@@ -103,6 +109,15 @@ class CoverageState:
     def is_hole_patterned(self, ref: HoleRef) -> bool:
         """Is the hole at *ref* already documented by a placed pattern callout?"""
         return ref in self._patterned_holes
+
+    def cover_scattered_hole_doc(self, name) -> None:
+        """Record that placed *name* is a scattered (unpatterned) plan-view hole
+        callout or X/Y location dim — a candidate the hole table may replace."""
+        self._scattered_hole_docs.add(name)
+
+    def is_scattered_hole_doc(self, name) -> bool:
+        """Is *name* a placed scattered hole callout / location dim (#351 PR-4c)?"""
+        return name in self._scattered_hole_docs
 
     # -- dropped diameters ----------------------------------------------------
 


### PR DESCRIPTION
## Summary

Last of a 3-way split of epic #351's PR-4, completing the Amendment 1 migration plan's step 4 ("fold in slots/step/pmi; delete the string-grep").

`_maybe_tabulate_holes` used to infer "which annotations does the scattered-hole table replace" by matching annotation **name prefixes** (`hc_plan*`/`m_locx*`/`m_locy*`, minus whatever `dwg._is_pattern_callout` already knew about) — the last stringly-typed inference this resolver relied on, after PR-2/3/4a/4b moved everything else onto first-class `Escalation` objects.

Replaced with a structured registry mirroring the *existing* `cover_pattern`/`is_pattern_callout` mechanism:
- `CoverageState` gains `_scattered_hole_docs: set`, `cover_scattered_hole_doc(name)`, `is_scattered_hole_doc(name)`.
- Registered at placement time: `holes.py`'s `_add_furniture` (for plan-view-only plain callouts — scoped to `view == "plan"` to preserve the old filter's `hc_plan`-only behavior) and `from_model.py`'s `render_locations` (for X/Y location dims, diffing the final "dropped" list against the candidate list to register only what actually got placed).
- `Drawing._is_pattern_callout` was deleted as dead code — its only call site was the line this PR replaces. The underlying `CoverageState.is_pattern_callout` stays (still directly tested in `test_linting.py`, still used by `is_hole_patterned`'s sibling relationship).

## Review

An independent adversarial review came back with **zero findings** — verified: every `hc_plan*`/`m_locx*`/`m_locy*` creation site in the codebase is now covered by the new registration points (no missed or extra creation site); `place_strip_candidates`'s return contract makes the "placed vs dropped" diffing exact; no cross-pass staleness risk (a fresh `Drawing`/`CoverageState` is built on every `_assemble` pass, and registration always runs before consumption within one pass); the `Drawing._is_pattern_callout` deletion is genuinely dead code; and this composes cleanly with PR-3/4a/4b's logic already in the same function (only the `replaced = {...}` line changed).

## Test plan

- [x] `ruff format` / `ruff check` / `mypy src/draftwright/` clean
- [x] Targeted tests (36: `TestHoleTable`/`TestEscalation`/`TestHolePatternCallouts`/`TestPatternGroupBalloon`/`TestLocationDimsAndSection`/`test_strip_layout.py`/`test_linting.py`) pass
- [x] Smoke tier: 48 passed
- [x] Full fast test tier: 674 passed

This completes epic #351's escalation-objects redesign (PR-1 through PR-4, the latter now split 4a/4b/4c). Will do a brief epic status check after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)