### PR TITLE
docs: record P5-strand-2 completion + the P4a/b/c and P5-strand-3/4 sub-phase plan

### DIFF
--- a/docs/plans/strip-layout-boundary-labeling-roadmap.md
+++ b/docs/plans/strip-layout-boundary-labeling-roadmap.md
@@ -36,8 +36,8 @@ collision class by construction while keeping determinism (ADR 0001).
 | P1 | #321 | **The contended strip: route both shared-strip placers through `plan_strip`.** Bore callouts and off-axis location dims both become `StripCandidate`s solved by `plan_strip`; delete the post-hoc occupancy-check + tier-retry hack. *Correction (2026-07-01, from implementation):* the two placers stack on **orthogonal axes** (callouts spaced along Y at a fixed X-column; height dims stacked along X-tiers) — so they are two perpendicular 1-D `plan_strip` solves sharing **one occupancy model** (option (c): pre-shrink/split each strip's `[lo,hi]` around `strip_obstacles`), **not** one fused solve. True fusion (collect both placers before either emits, retiring the `_coaxial_lift` forward-reference) is P2/P3. Split into **P1a** (route bore-callout Pass-2 through `plan_strip` — byte-identical, deletes `_solve_strip_via_layout`/greedy prefix-drop) and **P1b** (route `_locate_off_axis_holes`, build the occupancy carve, delete the tier-retry hack **and** `_coaxial_lift`). Validates the model on #133/#225. | Resolves known collisions only | P0 |
 | P2 | #322 | **Feature-ordered assignment + priority selection + escalation.** The solve fixes order = feature order (crossing-free) and turns over-capacity into a priority-ranked selection that emits an escalation signal (→ detail view #306/#54, → table), replacing the scattered `*_dropped` arrival-order decisions. | Drop *policy* changes (ranked, not arrival-order) | P1 |
 | P3 | #323 | **Migrate the remaining strip placers; retire the `Strip` cursor (#150).** Envelope dims, step-height / turned-diameter ladders, and the section-hatch footprint all become candidates; standalone `Strip.allocate` usages are retired. Fully realises #150. | Dense sheets re-pack; covered by invariants | P2 |
-| P4 | #318 | **Optimal leader assignment + angled leaders.** Replace greedy ordering/spacing with the min-cost-matching / DP optimal assignment (minimise total leader length); fold the #305 angled-leader nudge into the model as a first-class leader style. | Leader positions may improve | P3 |
-| P5 | #319 | **Remove dead patches; strengthen the cleanliness invariants.** Delete superseded occupancy patches, tier-retry loops, and ad-hoc drop codes; extend the layout-cleanliness / property tests (#301/#302/#303) to assert the new guarantees: no invisible-occupant overlap, crossing-free leaders, deterministic output. | None (cleanup + tests) | P4 |
+| P4 | #318 | **Optimal leader assignment + angled leaders.** Replace greedy ordering/spacing with the min-cost-matching / DP optimal assignment (minimise total leader length); fold the #305 angled-leader nudge into the model as a first-class leader style. *Scheduling correction (user, 2026-07-01, reconfirmed 2026-07-02):* run **after P5**, not before — optimising leaders before the placement model is fully settled would optimise around a moving target. Split into **P4a** (per-candidate label-size gaps into `plan_strip`), **P4b** (min-total-leader-length isotonic/DP solve, replacing the pull-toward-natural objective), **P4c** (fold the #305 angled-leader nudge in as a first-class constraint). | Leader positions may improve | P3, and in practice P5 |
+| P5 | #319 | **Remove dead patches; strengthen the cleanliness invariants.** Delete superseded occupancy patches, tier-retry loops, and ad-hoc drop codes; extend the layout-cleanliness / property tests (#301/#302/#303) to assert the new guarantees: no invisible-occupant overlap, crossing-free leaders, deterministic output. Four strands (see Status): cursor deletion (done), escalation objects (done, #351), `_KNOWN_OVERLAPS` burn-down (not started), property/fuzz tests (not started). | None (cleanup + tests) | P3 |
 
 ## Acceptance (overall)
 
@@ -52,7 +52,7 @@ collision class by construction while keeping determinism (ADR 0001).
 
 ## Status
 
-Updated 2026-07-01.
+Updated 2026-07-02.
 
 - **P0 (#317)** — done: characterization gate (#326), `strip_obstacles` complete
   per-strip occupancy (#327), `StripCandidate` + `plan_strip` + `StripPlacement`
@@ -83,17 +83,45 @@ Updated 2026-07-01.
   - **Strand 1 — DONE (#349, closes #150):** deleted the `Strip.allocate`/`peek`/`_cursor`
     machinery + the dead orchestrator overflow check; migrated the last state consumer
     (the balloon-ring depth) from `depth_used` to real placed-geometry measurement.
-  - **Strand 2 — escalation objects** (see **Amendment 1** in the ADR; tracker **#351**):
-    `*_dropped` string codes → first-class `Escalation` objects + one resolver that picks
-    a remedy per group (ISO pattern-grouped balloons, fixing #348; table + balloons for
-    scattered holes; zone grid-ref #352 deferred).
+  - **Strand 2 — escalation objects — DONE (2026-07-02, tracker #351, epic closed out
+    across 6 PRs):** `*_dropped` string codes → first-class `Escalation` objects + one
+    resolver that picks a remedy per group. `#354` scaffolding, `#355` routes the hole
+    path (byte-identical), `#356` adds ISO pattern-grouped balloons (fixes #348),
+    `#361`/`#363`/`#364` (the PR-4 split) route slot/PMI drops, unify the illegible-step
+    → detail-view remedy, and delete the last annotation-name-prefix string-grep. Zone
+    grid-ref (#352) stays deferred, a separate later option, not a #351 blocker. Four
+    real bugs found and filed as side-discoveries during the work, not fixed in-epic:
+    #357 (`StripCandidate.priority` always 0), #358 (two turned-diameter placers still
+    on pre-carve occupancy idioms), #360 (PMI bore-diameter witness span 2× too wide —
+    `rec.kind`/`rec.pmi_kind` mixup), #362 (Z-turned crowded shoulders silently drop the
+    whole step-length chain, no lint at all).
   - **Strand 3 — burn down the `_KNOWN_OVERLAPS` allowlist** (SPACE-CONSTRAINED + PENDING —
     e.g. `side_drilled` `{hc_side0, dim_loc_side_z2300}`, an outer-layout concern) then flip
     the cleanliness ratchet from an allowlist into an **absolute** no-overlap invariant.
-  - **Strand 4 — strengthen the property/fuzz cleanliness tests.**
+    **Not started.** Plan: audit each allowlisted entry against the now-complete P0–P3 +
+    P5-strand-2 carve/escalation machinery — some may already be resolved incidentally;
+    remove what's fixed, then flip the ratchet. One PR.
+  - **Strand 4 — strengthen the property/fuzz cleanliness tests** (#301/#302/#303).
+    **Not started.** Plan: generative/property-based coverage (varied hole counts,
+    patterns, slot/step mixes) asserting no invisible-occupant overlap, crossing-free
+    leaders, and determinism — beyond today's fixed fixture set. One PR, after strand 3
+    so the absolute ratchet is what gets property-tested, not the allowlisted one.
 - **P4 (#318)** — **not started, and intentionally deferred until P5** (user, 2026-07-01):
   optimising leader assignment before the placement model is fully settled would optimise
-  around a moving target.
+  around a moving target. *Sequencing reconfirmed 2026-07-02:* still holds — P5 strands
+  3–4 (the allowlist burn-down + property tests) are the "settle the model" work P4 was
+  waiting on, so they land **before** P4 starts, not after. Once P5 is fully done, P4
+  splits into three gated PRs (mirroring the P1a/b and PR-4a/b/c pattern):
+  - **P4a** — wire per-candidate label-size gaps into `plan_strip` (use the already-tested
+    `_solve_strip_1d_var`/`_greedy_strip_1d_var` per-pair-gap primitives instead of one
+    caller-supplied uniform `min_gap` per strip). Low risk, no new algorithm.
+  - **P4b** — replace `plan_strip`'s "pull toward natural position" Cassowary spacing
+    objective with a proper min-total-leader-length solve (isotonic regression / DP) —
+    order stays fixed by anchor position (crossing-free, already established by P2), this
+    only changes *where within that order* each label sits. The algorithmic core.
+  - **P4c** — fold the #305 angled-leader nudge (today a bespoke post-hoc special case)
+    into the P4b solve as a first-class ≥30°-from-horizontal constraint/penalty; retire
+    the special case.
 
 Overlap allowlist classes (`tests/test_layout_cleanliness.py`): **BENIGN** (permanent
 datum-chain witness corridors), **SPACE-CONSTRAINED** (real crossing, no roomy


### PR DESCRIPTION
## Summary

Docs-only update to the ADR 0009 roadmap, per your request to write down the plan before starting implementation.

- Marks P5-strand-2 (escalation objects, epic #351) **DONE** — links the 6 PRs, lists the 4 real bugs found and filed as side-discoveries but not fixed in-epic (#357/#358/#360/#362).
- Records the plan for the two remaining phases: P5 strands 3–4 (burn down `_KNOWN_OVERLAPS` → absolute ratchet; strengthen property/fuzz tests) run **first**, then P4 splits into P4a/P4b/P4c. This reconfirms — doesn't override — the already-ratified "P4 waits for a settled model" scheduling decision from 2026-07-01, which I'd missed in my initial proposal to you (I'd suggested P4 before P5).
- Fixes a real inconsistency I found in the phase table while updating it: P5's `Depends` column said `P4` while P4's said `P3` — circular once P4 was rescheduled after P5. Corrected P5's `Depends` to `P3` (P5 is cleanup + tests, doesn't substantively need P4).

No code changes.

## Test plan

N/A (docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)