### PR TITLE
feat: precise leader-shaft collision geometry + policy B for the plan-view hole-callout carve (ADR 0009 P5 strand 3)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -227,6 +227,47 @@ def _box_hits(bb, boxes):
     return False
 
 
+def _segment_hits_box(p1, p2, box) -> bool:
+    """True when line segment *p1*-*p2* intersects axis-aligned *box*
+    ``(x0, y0, x1, y1)`` — the precise counterpart of :func:`_box_hits` for a
+    genuinely diagonal shaft (ADR 0009 P4/#318, #305: "a diagonal leader's box
+    over-claims its empty triangle"). Boxing an angled segment for a coarse
+    reject is correct and cheap; boxing it for the final accept/reject decision
+    over-avoids free space a real diagonal never crosses. Endpoint-in-box and
+    the 4 edge-crossing cases (a standard segment/AABB test).
+
+    The crossing test uses strict inequality deliberately, not an inclusive
+    ``<= 0`` — an inclusive test also treats a segment merely COLLINEAR with
+    one of the box's (infinite) edge lines as a hit, regardless of whether it
+    is anywhere near the box along that line (verified: a vertical segment at
+    ``x == box.x0`` but far outside ``[y0, y1]`` false-hits under `<=`). That
+    false-positive class is common (any axis-aligned shaft sharing an X or Y
+    coordinate with an edge), unlike the strict form's own known gap — a
+    segment passing exactly through two opposite corners is a measure-zero
+    event for the continuous, non-integer leader positions this computes over
+    (review finding, #351 P5 strand 3: tried the inclusive form, reverted)."""
+    x0, y0, x1, y1 = box
+
+    def _inside(p):
+        return x0 <= p[0] <= x1 and y0 <= p[1] <= y1
+
+    if _inside(p1) or _inside(p2):
+        return True
+
+    def _cross(o, a, b):
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    def _seg_seg(a1, a2, b1, b2):
+        d1, d2 = _cross(b1, b2, a1), _cross(b1, b2, a2)
+        d3, d4 = _cross(a1, a2, b1), _cross(a1, a2, b2)
+        return ((d1 > 0 and d2 < 0) or (d1 < 0 and d2 > 0)) and (
+            (d3 > 0 and d4 < 0) or (d3 < 0 and d4 > 0)
+        )
+
+    corners = ((x0, y0), (x1, y0), (x1, y1), (x0, y1))
+    return any(_seg_seg(p1, p2, corners[i], corners[(i + 1) % 4]) for i in range(4))
+
+
 def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False):
     """Collect-then-solve placement of location/feature dims on one strip (ADR 0009).
     The single shared strip placer that retires the ``Strip.allocate`` cursor (#150,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -27,7 +27,16 @@ from draftwright._core import (
     _iso_bbox,
     _log,
 )
-from draftwright.annotations._common import Escalation, place_strip_candidates
+from draftwright.annotations._common import (
+    CROSSABLE_TYPES,
+    Escalation,
+    _box_hits,
+    _geom_box,
+    _segment_hits_box,
+    carve_free_segments,
+    place_strip_candidates,
+    strip_obstacles,
+)
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.model.ir import HoleFeature, PatternFeature
@@ -733,48 +742,213 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
         # cannot hold every callout, the smallest-bore features drop first so the most
         # significant survive (the same "largest wins" policy the front-view shaft rows
         # already use, line 638). Ties (equal bore) fall back to key = natural-Y order.
+        def _build_leader_at(s, edge, side, y):
+            """The Leader `_add` would draw for queue entry *s* at elbow-Y *y* —
+            built but not placed, so its footprint can be checked before
+            committing (ADR 0009 P5 strand 3). Returns ``(leader, tip, elbow)``."""
+            _locs, dia, callout, _feat, _ny, rep = s
+            centre = to_page(rep)
+            if side == "right":
+                elbow = (edge + elbow_dx, y)
+                tip = _rim_tip(centre, elbow, dia)
+                tip = (min(tip[0], edge - draft.arrow_length), tip[1])
+            else:
+                elbow = (edge - elbow_dx, y)
+                tip = _rim_tip(centre, elbow, dia)
+                tip = (max(tip[0], edge + draft.arrow_length), tip[1])
+            leader = Leader(
+                tip=(tip[0], tip[1], 0),
+                elbow=(elbow[0], elbow[1], 0),
+                label="",
+                draft=draft,
+                text_side=side,
+                callout=callout,
+            )
+            return leader, tip, elbow
+
+        def _leader_hits(leader, tip, elbow, side, obstacles):
+            """True when *leader*'s rendered footprint truly overlaps any
+            *obstacles* box — split into the diagonal tip→elbow SHAFT (checked
+            precisely via `_segment_hits_box`, since its AABB over-claims the
+            empty triangle it doesn't occupy — #305, precise angled-leader
+            geometry is P4/#318) and the elbow→label shelf+text (genuinely
+            axis-aligned, so the coarse AABB check there is already exact)."""
+            full_box = _geom_box(leader)
+            if full_box is None or not _box_hits(full_box, obstacles):
+                return False  # fast reject: nowhere near any obstacle
+            if any(_segment_hits_box(tip, elbow, o) for o in obstacles):
+                return True
+            label_box = (
+                (elbow[0], full_box[1], full_box[2], full_box[3])
+                if side == "right"
+                else (full_box[0], full_box[1], elbow[0], full_box[3])
+            )
+            return _box_hits(label_box, obstacles)
+
         def _place_queue(queue, edge, side, key_prefix, start_i):
             if not queue:
                 return start_i
-            cands = [
+
+            # Baseline: the single full-range solve the pre-#351-P5-strand-3 code
+            # always did, ignoring drawing-level obstacles entirely — every
+            # candidate pulled toward its own natural Y, respecting only min_gap
+            # from its queue siblings. Used below as the "cost of NOT avoiding"
+            # reference a carve-based relocation must beat to be worth taking.
+            base_cands = [
                 StripCandidate(
                     key=f"{key_prefix}{j:04d}",
                     anchor=(edge, s[4]),
                     size=(s[2].callout_width, min_gap),
-                    priority=s[1],  # bore diameter — largest wins over-capacity (D3)
+                    priority=s[1],
                 )
                 for j, s in enumerate(queue)
             ]
-            res = plan_strip(cands, y_min, y_max, min_gap)
-            by_key = {c.key: s for c, s in zip(cands, queue, strict=True)}
-            if res.dropped:
+            base_res = plan_strip(base_cands, y_min, y_max, min_gap)
+            base_by_key = {c.key: s for c, s in zip(base_cands, queue, strict=True)}
+            base_y = {id(base_by_key[k]): y for k, y in base_res.placed.items()}
+            base_dropped = {id(base_by_key[k]) for k in base_res.dropped}
+
+            # Carve [y_min, y_max] around drawing-level obstacles this column's
+            # leaders would cross (e.g. the section cutting-plane arrow — #351 P5
+            # strand 3): a Y-only solve can't see an obstacle it never measures,
+            # the textbook invisible-occupant defect. Probed at each candidate's
+            # OWN natural Y, not a shared reference — a callout's leader shaft is
+            # position-dependent geometry (it runs from the fixed hole location to
+            # the elbow), so probing everyone at one far-away Y badly misjudges it.
+            def _probe_box(s):
+                # Unlike the old code (which only ever built a Leader for a
+                # candidate already chosen for placement), this probes EVERY
+                # queued candidate up front, including ones that may end up
+                # dropped — so a degenerate geometry unreachable before now
+                # (e.g. a hole essentially coincident with the strip edge) gets
+                # a defensive catch here too, matching _geom_box's own
+                # established "not every annotation bbox-es cleanly" idiom.
+                try:
+                    leader, _, _ = _build_leader_at(s, edge, side, s[4])
+                except Exception as exc:  # noqa: BLE001 — geometry construction raises broadly
+                    _log.debug("plan/side %s strip: probe leader failed (%s); omitted", side, exc)
+                    return None
+                return _geom_box(leader)
+
+            probe_boxes = [b for s in queue if (b := _probe_box(s)) is not None]
+            occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+            if probe_boxes:
+                band_lo = min(b[0] for b in probe_boxes)
+                band_hi = max(b[2] for b in probe_boxes)
+                occupied = [o for o in occupied if o[0] < band_hi and o[2] > band_lo]
+            segs = carve_free_segments(y_min, y_max, [(o[1], o[3]) for o in occupied], min_gap)
+
+            # Assign each candidate to the free segment nearest its natural Y
+            # (containing it if possible, else the closer boundary) — the
+            # multi-segment analogue of the single plan_strip call this replaces.
+            # In practice at most one obstacle (the section arrow) ever splits
+            # this column, so a per-segment solve stays close to the
+            # single-segment optimum while never overprinting the carved gap.
+            def _nearest_seg(ny):
+                for lo, hi in segs:
+                    if lo <= ny <= hi:
+                        return (lo, hi)
+                return min(
+                    segs, key=lambda sg: min(abs(ny - sg[0]), abs(ny - sg[1])), default=None
+                )
+
+            by_seg: dict = {seg: [] for seg in segs}
+            for s in queue:
+                seg = _nearest_seg(s[4])
+                if seg is not None:
+                    by_seg[seg].append(s)
+            # A candidate whose natural Y fell outside every free segment (the
+            # whole column blocked, or between two far-apart obstacles) is simply
+            # absent from `by_seg` — the final per-candidate loop below already
+            # falls back to the baseline position for it (no special "unassigned"
+            # bucket needed; `plan_strip`'s own dropped set, from a segment truly
+            # out of capacity, is likewise just absent from `seg_y` below).
+
+            seg_y: dict = {}  # id(s) -> elbow_y, from the carve-aware per-segment solves
+
+            def _solve_segment(cands_in, lo, hi, key_prefix_local):
+                cands = [
+                    StripCandidate(
+                        key=f"{key_prefix_local}{j:04d}",
+                        anchor=(edge, s[4]),
+                        size=(s[2].callout_width, min_gap),
+                        priority=s[1],  # bore diameter — largest wins over-capacity (D3)
+                    )
+                    for j, s in enumerate(cands_in)
+                ]
+                res = plan_strip(cands, lo, hi, min_gap)
+                by_key = {c.key: s for c, s in zip(cands, cands_in, strict=True)}
+                for k, y in res.placed.items():
+                    seg_y[id(by_key[k])] = y
+
+            for (seg_lo, seg_hi), members in by_seg.items():
+                if members:
+                    _solve_segment(members, seg_lo, seg_hi, key_prefix)
+            # A candidate whose natural Y fell outside every free segment (the
+            # whole column blocked, or between two far-apart obstacles) never
+            # entered `by_seg` — it has no carve-aware position to compare below,
+            # so the baseline (with crossing accepted, policy B) is its only shot.
+
+            # Decide per candidate: take the carve-aware (obstacle-avoiding)
+            # position ONLY when a free one exists AND it doesn't cost much more
+            # displacement than simply accepting a crossing at the natural-pull
+            # baseline (user, 2026-07-02 — a large relocation to dodge a thin
+            # obstacle is worse than a small, visible, correctable crossing,
+            # matching the existing side_drilled corridor-relocate precedent).
+            # A tight avoidance win is still taken: it is a genuine improvement.
+            # One row's worth of nudge (min_gap, the smallest spacing unit this
+            # placer already reasons in) is "cheap"; more than that is a real
+            # repositioning, not a nudge.
+            _RELOCATE_TOLERANCE = min_gap
+            placed: list = []  # (s, elbow_y, leader) — leader built once, reused at emit
+            crossing: list = []  # ditto, kept despite an obstacle crossing (policy B)
+            dropped: list = []  # s — genuinely no room anywhere, not just a crossing
+            for s in queue:
+                sid = id(s)
+                natural = s[4]
+                cand_y = seg_y.get(sid)
+                base_ok = sid in base_y and sid not in base_dropped
+                if cand_y is not None and base_ok:
+                    d_seg = abs(cand_y - natural)
+                    d_base = abs(base_y[sid] - natural)
+                    y = cand_y if d_seg <= d_base + _RELOCATE_TOLERANCE else base_y[sid]
+                elif cand_y is not None:
+                    y = cand_y  # baseline dropped it outright — the carve saved it
+                elif base_ok:
+                    y = base_y[sid]  # no free segment took it — fall back to baseline
+                else:
+                    dropped.append(s)
+                    continue
+                leader, tip, elbow = _build_leader_at(s, edge, side, y)
+                if _leader_hits(leader, tip, elbow, side, occupied):
+                    crossing.append((s, y, leader))
+                else:
+                    placed.append((s, y, leader))
+
+            if dropped:
                 _log.warning(
                     "plan/side %s strip: %d of %d bore callouts skipped (strip full)",
                     side,
-                    len(res.dropped),
+                    len(dropped),
                     len(queue),
                 )
-                for k in res.dropped:
-                    _record_callout_drop(
-                        dwg, view, by_key[k][1], f"{side} strip full", by_key[k][3]
-                    )
-            # Emit survivors in natural-Y order (== plan_strip's solve order, since
-            # keys are Y-monotonic) so the hc_{view}{i} names + centre-mark indices
-            # land on the same callouts as the old queue-order emit.
+                for s in dropped:
+                    _record_callout_drop(dwg, view, s[1], f"{side} strip full", s[3])
+            if crossing:
+                _log.info(
+                    "plan/side %s strip: %d bore callout(s) placed despite crossing an "
+                    "obstacle (policy B — kept, not dropped)",
+                    side,
+                    len(crossing),
+                )
+            placed.extend(crossing)
+            # Emit survivors in natural-Y order so the hc_{view}{i} names + centre-
+            # mark indices land on the same callouts as the old queue-order emit
+            # (the queue itself was already sorted by natural Y before Pass 2).
             i = start_i
-            for k, elbow_y in sorted(res.placed.items(), key=lambda kv: (by_key[kv[0]][4], kv[0])):
-                _locs, dia, callout, feat, _ny, rep = by_key[k]
-                centre = to_page(rep)
-                if side == "right":
-                    elbow = (edge + elbow_dx, elbow_y)
-                    tip = _rim_tip(centre, elbow, dia)
-                    # Safety clamp: arrowhead must sit inside the view boundary.
-                    tip = (min(tip[0], edge - draft.arrow_length), tip[1])
-                else:
-                    elbow = (edge - elbow_dx, elbow_y)
-                    tip = _rim_tip(centre, elbow, dia)
-                    tip = (max(tip[0], edge + draft.arrow_length), tip[1])
-                _add(view, i, tip, elbow, side, callout)
+            for s, _elbow_y, leader in sorted(placed, key=lambda p: p[0][4]):
+                _locs, dia, callout, feat, _ny, rep = s
+                dwg.add(leader, f"hc_{view}{i}", view=view)
                 _add_furniture(dwg, a, view, i, feat, to_page)
                 i += 1
             return i

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -52,6 +52,7 @@ from draftwright.annotations.holes import (
 from draftwright.annotations.sections import (
     _add_section_view,
     _request_prismatic_detail,
+    _reserve_section_row,
     _resolve_details,
 )
 from draftwright.model import PatternFeature, build_part_model, plan_dimensions, plan_sections
@@ -194,6 +195,19 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # parts) — the IR gates callouts/furniture/sections on membership in this set, so
     # no recogniser Hole object crosses into the renderers (Amendment 6, #263/#207).
     feature_keys = {HoleRef.of(h.location) for h in feature_holes}
+    # Decide the section trigger + cut-plane row now (pure function of _model/
+    # feature_keys, no placement dependency) and reserve its cutting-plane arrows'
+    # row BEFORE the plan-view hole callouts place (ADR 0009 P5 strand 3) — the
+    # section itself still renders last (its own room check clears everything else
+    # placed), this only gives the (now strip_obstacles-aware) callout carve a
+    # real obstacle to see and, where a cheap relocation exists, avoid — instead
+    # of an invisible one it could never even detect. When avoiding would cost a
+    # large relocation, policy B keeps the callout at its natural position and
+    # accepts the crossing rather than pay that cost or drop it (holes.py); the
+    # `bracket` fixture's known hc_plan0/section_arrow_right overlap
+    # (tests/test_layout_cleanliness.py) is exactly this accepted case.
+    _section = plan_sections(_model, feature_keys)
+    _reserve_section_row(dwg, a, _section)
     if feature_holes:
         _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
@@ -243,10 +257,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     # The section view goes last: its room check clears every annotation already
     # placed right of the side view (callout labels, height/step dim ladders). The
-    # *trigger* + cut-plane row are the planner's decision (`plan_sections`, #207);
-    # the renderer just draws the planned section. Concentric bores on a turned part
-    # are excluded via feature_keys (the ldr_z leaders cover them).
-    section = plan_sections(_model, feature_keys)
+    # *trigger* + cut-plane row were already decided (`_section`, above — reused so
+    # the pure planner call isn't repeated); the renderer just draws the planned
+    # section. Concentric bores on a turned part are excluded via feature_keys (the
+    # ldr_z leaders cover them).
+    section = _section
     if section is not None:
         _add_section_view(dwg, a, section)
 

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -166,12 +166,14 @@ def _add_section_view(dwg, a: Analysis, section):
     tb_left = a.PAGE_W - a.TB_W - _TB_CLEAR
     if a.FV_Y - half_h - 10 < _TB_CLEAR + _TB_H and pos_x + half_w > tb_left - 4:
         _log.info("Section A–A skipped (would collide with the title block)")
+        _clear_section_reservation(dwg)
         return
     if pos_x + half_w > right_limit:
         _log.warning(
             "Section A–A skipped (no room right of the side view; "
             "a wider step-dimension corridor may have reduced the available space)"
         )
+        _clear_section_reservation(dwg)
         return
 
     big = 4 * a.bbox_max
@@ -181,6 +183,7 @@ def _add_section_view(dwg, a: Analysis, section):
     solids = a.part.solids()
     if not solids:
         _log.info("Section A–A skipped (no solid bodies to cut)")
+        _clear_section_reservation(dwg)
         return
     body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
     try:
@@ -189,9 +192,11 @@ def _add_section_view(dwg, a: Analysis, section):
         keep_behind = _fuzzy_cut(body, Pos(a.cx, y_star - big / 2, a.cz) * Box(big, big, big))
     except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
         _log.warning("Section A–A skipped (cut failed: %s)", exc)
+        _clear_section_reservation(dwg)
         return
     if keep_behind is None:
         _log.warning("Section A–A skipped (boolean cut produced no solid)")
+        _clear_section_reservation(dwg)
         return
     camera = (dwg.look_at[0], dwg.look_at[1] - dwg.dist, dwg.look_at[2])
     dwg.add_view("section_aa", keep_behind, camera, (0, 0, 1), (pos_x, a.FV_Y))
@@ -217,8 +222,39 @@ def _add_section_view(dwg, a: Analysis, section):
     x0, x1 = ext_x0 - 4, ext_x1 + 4
     dwg.add(Centerline((x0, y_page, 0), (x1, y_page, 0)), "section_line")
 
-    # ISO 128-44: cutting-plane end indicators — thick wing stubs with solid
-    # filled arrowheads at the tips pointing in the viewing direction (−Y).
+    # The row was reserved early (ADR 0009 P5 strand 3) with a conservative
+    # (unwidened) x-extent so the plan-view hole-callout carve could avoid it
+    # before this function runs — replace it with the final, possibly-wider
+    # geometry now that the bolt-circle extent is known.
+    _clear_section_reservation(dwg)
+    _add_cutting_plane_arrows(dwg, y_page, x0, x1)
+    _add_section_letters(dwg, y_page, x0, x1)
+
+    # ISO 128-50: 45° hatching on the cut face, in page coordinates. The section
+    # is drawn in its own frame: X is offset to the section's page slot (pos_x),
+    # while the height axis matches the front view — so SZ is exactly front_z.
+    def SX(wx):
+        return pos_x + (wx - a.cx) * a.SCALE
+
+    SZ = a.proj.front_z
+
+    hatch_spacing = dwg.draft.font_size * 1.5
+    cut_faces = [f for f in keep_behind.faces() if f.normal_at().Y < -0.9]
+    hatch_edges = []
+    for cf in cut_faces:
+        hatch_edges.extend(_section_hatch_edges(cf, SX, SZ, hatch_spacing))
+    if hatch_edges:
+        hatch = Compound(children=hatch_edges)
+        hatch.is_section_hatch = True  # exempt from view_annotation_overlap lint
+        dwg.add(hatch, "section_hatch")
+
+
+def _add_cutting_plane_arrows(dwg, y_page, x0, x1):
+    """ISO 128-44 cutting-plane end indicators at ``(x0, y_page)``/``(x1, y_page)`` —
+    thick wing stubs with solid filled arrowheads pointing in the viewing direction
+    (−Y). Named ``section_arrow_{left,right}``/``section_wing_{left,right}``, shared
+    between the early row reservation (:func:`_reserve_section_row`) and the final
+    section render (:func:`_add_section_view`, ADR 0009 P5 strand 3)."""
     arrow_sz = dwg.draft.arrow_length
     wing_h = 2.5 * arrow_sz  # perpendicular stub length
     for x_end, side in ((x0, "left"), (x1, "right")):
@@ -238,28 +274,69 @@ def _add_section_view(dwg, a: Analysis, section):
             f"section_wing_{side}",
         )
 
-    # 'A' letters sit above the line ends, clear of any callout leaders
+
+def _add_section_letters(dwg, y_page, x0, x1):
+    """The 'A' identification letters above the cutting-plane line ends, clear of
+    any callout leaders. Named ``section_a_{left,right}`` — shared between the
+    early row reservation and the final section render, same as
+    :func:`_add_cutting_plane_arrows` (ADR 0009 P5 strand 3): a callout's full
+    footprint can land on the letters just as easily as on the arrows, so both
+    need to be visible to the plan-view callout carve before it places."""
     lift = dwg.draft.font_size * 1.4
     dwg.add(Note("A", (x0 - 3, y_page + lift), dwg.draft), "section_a_left")
     dwg.add(Note("A", (x1 + 3, y_page + lift), dwg.draft), "section_a_right")
 
-    # ISO 128-50: 45° hatching on the cut face, in page coordinates. The section
-    # is drawn in its own frame: X is offset to the section's page slot (pos_x),
-    # while the height axis matches the front view — so SZ is exactly front_z.
-    def SX(wx):
-        return pos_x + (wx - a.cx) * a.SCALE
 
-    SZ = a.proj.front_z
+def _clear_section_reservation(dwg) -> None:
+    """Remove the placeholder :func:`_reserve_section_row` may have added, if
+    present (idempotent — a no-op once :func:`_add_section_view` has already
+    replaced it, or if no section ever triggered)."""
+    existing = dwg.annotations()
+    for name in (
+        "section_arrow_left",
+        "section_arrow_right",
+        "section_wing_left",
+        "section_wing_right",
+        "section_a_left",
+        "section_a_right",
+    ):
+        if name in existing:
+            dwg.remove(name)
 
-    hatch_spacing = dwg.draft.font_size * 1.5
-    cut_faces = [f for f in keep_behind.faces() if f.normal_at().Y < -0.9]
-    hatch_edges = []
-    for cf in cut_faces:
-        hatch_edges.extend(_section_hatch_edges(cf, SX, SZ, hatch_spacing))
-    if hatch_edges:
-        hatch = Compound(children=hatch_edges)
-        hatch.is_section_hatch = True  # exempt from view_annotation_overlap lint
-        dwg.add(hatch, "section_hatch")
+
+def _reserve_section_row(dwg, a: Analysis, section) -> None:
+    """Reserve the section A–A cutting-plane arrows' row BEFORE the plan-view hole
+    callouts place (ADR 0009 P5 strand 3, burns down the ``bracket`` fixture's
+    ``hc_plan0``/``section_arrow_right`` overlap in ``tests/test_layout_cleanliness.py``).
+
+    ``_add_section_view`` runs last deliberately (its own room check clears
+    everything already placed) — so until now, the plan-view hole-callout carve's
+    ``strip_obstacles`` had no way to see the section arrows it hadn't drawn yet,
+    the textbook invisible-occupant defect ADR 0009 targets. Placing a conservative
+    placeholder early (the arrows' actual row, at the un-widened part-bbox extent —
+    the bolt-circle widening in ``_add_section_view`` depends on furniture
+    ``_annotate_holes`` hasn't placed yet either, so it is not yet knowable) gives
+    the carve a real obstacle to avoid; ``_add_section_view`` replaces it with the
+    final, possibly-wider geometry once that furniture exists.
+
+    A no-op when *section* is ``None`` (no section triggers) — nothing is reserved,
+    and ``_add_section_view`` is never called either.
+
+    **Known residual (review finding, #351 P5 strand 3, filed as #366):** the
+    un-widened reservation is a real gap, not just a conservative approximation
+    — for a part whose bolt-circle centreline crosses this exact Y-row, the
+    FINAL arrow can widen beyond what was reserved, and the callout carve never
+    re-checks against that later growth. Rare in practice (needs a bolt-circle
+    pattern at the precise section-cut row) and no corpus fixture exercises it
+    today; a full fix needs a second, post-widen verification pass, which is
+    out of scope for this PR."""
+    if section is None:
+        return
+    PX, PY = a.proj.plan_x, a.proj.plan_y
+    y_page = PY(section.cut_y)
+    x0, x1 = PX(a.bb.min.X) - 4, PX(a.bb.max.X) + 4
+    _add_cutting_plane_arrows(dwg, y_page, x0, x1)
+    _add_section_letters(dwg, y_page, x0, x1)
 
 
 def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter: str) -> bool:

--- a/tests/test_layout_cleanliness.py
+++ b/tests/test_layout_cleanliness.py
@@ -62,10 +62,21 @@ _TOL_MM = 0.5
 _KNOWN_OVERLAPS: dict[str, set[frozenset[str]]] = {
     # BENIGN: two location dims off a common datum share their extension-line span.
     "plate_holes": {frozenset({"m_locx0", "m_locx1"}), frozenset({"m_locy0", "m_locy1"})},
-    # bracket: two BENIGN datum pairs (as plate_holes) PLUS one PENDING defect —
-    # PENDING (P3/P4): a plan-view hole-callout leader runs under the drawing-level
-    # section cutting-plane arrow (a view=None occupant). An invisible-occupant
-    # overlap that clears once this callout's placer consults the full strip_obstacles.
+    # bracket: two BENIGN datum pairs (as plate_holes) PLUS one SPACE-CONSTRAINED
+    # crossing (reclassified from PENDING, #351 P5 strand 3):
+    #  - _annotate_holes's plan/side callout placer now carves the column around
+    #    strip_obstacles (the section arrow reserved early via _reserve_section_row,
+    #    sections.py) and verifies each solved position with PRECISE (not
+    #    AABB-only) leader-footprint geometry (_segment_hits_box for the diagonal
+    #    tip->elbow shaft) — so a callout is never dropped or misjudged just for
+    #    being NEAR an obstacle.
+    #  - SPACE-CONSTRAINED {hc_plan0, section_arrow_right}: for THIS hole, avoiding
+    #    the section row costs a large relocation (the free segment is far from its
+    #    natural row); policy B (user, 2026-07-02, matching the existing
+    #    side_drilled precedent below) keeps it at its natural, near-original
+    #    position and accepts the crossing rather than pay that cost or drop a
+    #    real callout. Reproduces the exact pre-#351 placement — not a
+    #    regression, a confirmed-correct trade-off.
     "bracket": {
         frozenset({"m_locx0", "m_locx1"}),
         frozenset({"m_locy0", "m_locy1"}),


### PR DESCRIPTION
## Summary

Burns down `tests/test_layout_cleanliness.py`'s `bracket` PENDING overlap by making `_annotate_holes`'s plan/side hole-callout placer (`holes.py`) consult `strip_obstacles` — the shared occupancy model every other placer already uses, which this one never did (it predates the P0–P3 carve migration).

This went through several iterations before landing:
1. **Naive fix (didn't work at all):** add the section arrow to the drawing early so the callout carve can see it. Turned out `_annotate_holes` never consulted `strip_obstacles` in the first place — no amount of adding a real obstacle helps if nothing looks at it.
2. **Migrated onto `strip_obstacles` + plain AABB collision check:** fixed correctness (zero overlaps) but caused **5 regressions** on ordinary fixtures with no section involved — a diagonal leader shaft's bounding box over-claims the empty triangle it doesn't occupy (ADR 0009 already flagged this: precise angled-leader geometry is P4/#318), so holes merely *near* the section row got dropped for a collision their true diagonal shaft never had.
3. **Precise geometry (`_segment_hits_box`):** fixed 4 of 5 regressions by splitting the leader into its diagonal shaft (checked precisely) and its axis-aligned label region (checked as an ordinary box, since it genuinely is one).
4. **Policy B (explicit user direction):** the last regression was a *genuine* collision, not an AABB artifact — a central-hole callout whose natural row coincided with the section's cut row. Rather than relocate it far from its natural position to dodge the obstacle, only relocate when it costs at most one `min_gap` of extra displacement; otherwise keep it at its natural position and accept the crossing (logged, not dropped) — matching the existing `side_drilled` corridor-relocate precedent ("never drop a real dimension/callout for a crossing you can't cheaply avoid").

`bracket`'s overlap entry in `_KNOWN_OVERLAPS` is reclassified from PENDING to SPACE-CONSTRAINED (not removed): for that specific hole, avoidance costs more than the tolerance allows, so policy B reproduces the exact pre-existing placement — a confirmed-correct trade-off, not a regression.

## Review

Three rounds of independent adversarial review (warranted given how many design decisions this diff packs in). Findings fixed along the way: two dead variables (`unassigned`, `seg_dropped`), a probe-step exception-safety gap (the new code builds `Leader` geometry for every queued candidate up front, unlike the old code which only ever built one for a candidate already chosen — needed the same defensive catch `_geom_box` already uses elsewhere), an attempted `_segment_hits_box` precision improvement that turned out to introduce a *worse* false-positive class (any segment collinear with an obstacle's edge line, regardless of position — reverted, documented instead), and a 2–3× redundant `Leader` rebuild per candidate (fixed by caching the leader built during the hit-check and reusing it at emit). Two narrow, currently-unexercised residual gaps documented and filed rather than fixed in this already-large PR:
- #366 — the early section-row reservation's un-widened extent can miss bolt-circle-driven widening; no corpus fixture combines both features.
- #367 — the precise shaft check ignores the rendered arrowhead's flare/line width; no corpus fixture clips only that.

Third review round: clean, zero findings.

## Test plan

- [x] `ruff format` / `ruff check` / `mypy src/draftwright/` clean
- [x] `tests/test_layout_cleanliness.py` (18 tests, the overlap ratchet + determinism) — 18 passed
- [x] Hole/callout test suite (61 tests) — 61 passed
- [x] Smoke tier — 48 passed
- [x] Full fast test tier — 674 passed, verified 3 times across iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)