### PR TITLE
fix: clamp balloon-ring band depth to the drawable area (#349 follow-up)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -705,7 +705,7 @@ class Drawing:
         pl, pr = a.PV_X - a.fv_hw, a.PV_X + a.fv_hw
         pt, pb = a.PV_Y + a.pv_hh, a.PV_Y - a.pv_hh
         sv_left = a.SV_X - a.sv_hw
-        margin, ph = a.margin, a.PAGE_H
+        margin, ph, pw = a.margin, a.PAGE_H, a.PAGE_W
 
         # Stack the balloon ring *beyond* the annotations already placed around the
         # plan view, not on top of them (#121). Measure the REAL depth the dimensions
@@ -737,6 +737,18 @@ class Drawing:
                     left_dim = max(left_dim, pl - ob.min.X)
                 if ob.max.X > pr:
                     right_dim = max(right_dim, ob.max.X - pr)
+
+        # A dense part can stack many pitch dims on one side (holes._place_pitch_dim
+        # pushes each successive one 10 mm further out, #92), so the measured depth
+        # can exceed the room between the view and the page edge. Clamp each band so
+        # its *ring itself* never lands off the drawable area (#349 follow-up) — the
+        # ring then sits at the margin and overlaps the far witness lines instead,
+        # which is only a tolerated warning (structural.py compares label_bbox, not
+        # the full bbox, for overlap), never the out_of_bounds error.
+        left_dim = min(left_dim, max(0.0, pl - standoff - 2 * r - margin))
+        right_dim = min(right_dim, max(0.0, pw - margin - pr - standoff - 2 * r))
+        top_dim = min(top_dim, max(0.0, ph - margin - pt - standoff - 2 * r))
+        bot_dim = min(bot_dim, max(0.0, pb - standoff - 2 * r - margin))
 
         # A bottom band (below PV, beyond the overall-width dim) is usable only
         # when the FV↔PV gap has room for the width dim *and* a balloon row;


### PR DESCRIPTION
## Summary

Main's slow-tier CI (`test_ctc_ap242_meets_standards[02]`) has failed on every push since PR #349 (~15 hours, 12 pushes) — invisible until now because that tier isn't a PR gate.

**Root cause:** #349 switched `Drawing._add_balloons`'s per-band depth measurement (`left_dim`/`right_dim`/`top_dim`/`bot_dim`) from a stale cursor-based constant to real placed-annotation geometry — correctly, and as intended. On the dense CTC-02 AP242 fixture this newly and honestly measures `holes._place_pitch_dim`'s pre-existing uncapped outward stacking (#92): the 11th same-view pitch dimension lands 100mm left of the plan view. Before #349 this never mattered (the old measurement ignored real geometry); after #349, `left_dim=100mm` pushes the balloon ring's left band 100mm out — past the page margin — producing 8× `annotation_out_of_bounds` errors, one per balloon in that band.

**Fix:** clamp each band's measured depth to the room actually available before it feeds the ring's position, so the ring itself never lands past the drawable margin. The ring settles at the margin and may overlap the outlier dimension's witness line instead of hard-failing — a scope-appropriate fix for a regression PR; a real fix to `_place_pitch_dim`'s uncapped stacking (#92) is separate, pre-existing, and used by other consumers.

## Review notes

Two independent adversarial review rounds:
- Round 1: confirmed root cause with live debug numbers on the real fixture, verified the fix against the full test gate.
- Round 2: re-derived the clamp math independently against how the four variables are consumed (algebraically exact, correct axis/sign conventions for all 4 bands); checked the one non-obvious coupling (`bot_dim` also feeds the pre-existing `has_bottom` gate — proved the clamp can never bind tighter than that gate); investigated whether the clamp could trade the `out_of_bounds` error for a *new* `label_centerline_overlap` warning on real dimension text (not just a witness line) — confirmed CTC-02 AP242 is already a warning-heavy fixture at baseline (15 pre-existing warnings, several already `label_centerline_overlap` on real text), so this isn't a new problem class the fix introduces, and warnings don't gate this test by its own documented contract (only errors do).

## Test plan
- [x] `test_ctc_ap242_meets_standards[02]` passes (targeted + full `-m slow` tier)
- [x] Full fast tier: 674 passed, 0 failed
- [x] `-m smoke`: 48 passed
- [x] `ruff format --check` / `ruff check` / `mypy src/draftwright` clean
- [x] Regression guards specifically re-checked: `test_ctc02_top_balloon_ring_hugs_dimensions` (#125), `TestHoleTable` (all 11)
- [x] Two independent adversarial review rounds, second one clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)