### PR TITLE
feat: wire per-candidate label-size gaps into plan_strip (ADR 0009 P4a, #318)

### DIFF
--- a/docs/plans/strip-layout-boundary-labeling-roadmap.md
+++ b/docs/plans/strip-layout-boundary-labeling-roadmap.md
@@ -147,15 +147,18 @@ Updated 2026-07-02.
     tracked as a P349 follow-up, landing separately. Lesson: the slow tier's "catch it
     right after merge, not on every PR" tradeoff (README/CLAUDE.md) only works if
     someone actually looks at `gh run list` after merging — nothing was, for 12 pushes.
-- **P4 (#318)** — **not started, and intentionally deferred until P5** (user, 2026-07-01):
-  optimising leader assignment before the placement model is fully settled would optimise
-  around a moving target. *Sequencing reconfirmed 2026-07-02:* still holds — P5 strands
-  3–4 (the allowlist burn-down + property tests) are the "settle the model" work P4 was
-  waiting on, so they land **before** P4 starts, not after. Once P5 is fully done, P4
-  splits into three gated PRs (mirroring the P1a/b and PR-4a/b/c pattern):
-  - **P4a** — wire per-candidate label-size gaps into `plan_strip` (use the already-tested
-    `_solve_strip_1d_var`/`_greedy_strip_1d_var` per-pair-gap primitives instead of one
-    caller-supplied uniform `min_gap` per strip). Low risk, no new algorithm.
+- **P4 (#318)** — P5 is done; P4 splits into three gated PRs (mirroring the P1a/b and
+  PR-4a/b/c pattern):
+  - **P4a — DONE (2026-07-02):** wired per-candidate label-size gaps into `plan_strip`.
+    Each adjacent pair's required gap is now `max(size[idx] of the two neighbours,
+    caller's min_gap)` — the same "larger of the two neighbours' requirements" rule
+    `LayoutSolver.solve_strip` already used for heterogeneous `Placeable`s (#81), applied
+    to `StripCandidate.size` — solved via the already-tested `_solve_strip_1d_var`
+    primitive instead of the uniform-gap `_solve_strip_1d`. No caller was changed to pass
+    heterogeneous sizes (that is deliberately out of scope, deferred with P4b/P4c below),
+    so every current call site still passes a uniform `size[idx]` per strip and the floor
+    dominates — confirmed byte-identical on the full `tests/test_layout_snapshot.py`
+    corpus and the full fast tier.
   - **P4b** — replace `plan_strip`'s "pull toward natural position" Cassowary spacing
     objective with a proper min-total-leader-length solve (isotonic regression / DP) —
     order stays fixed by anchor position (crossing-free, already established by P2), this

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -735,7 +735,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
         # one plan_strip per side does the site-ordered spacing and the over-capacity
         # drop (ADR 0009 / #321 P1a). This is the first *production* placer routed
         # through plan_strip — it replaces the bespoke _solve_strip_via_layout + the
-        # greedy prefix-drop. plan_strip bottoms out in the same _solve_strip_1d, and
+        # greedy prefix-drop. plan_strip bottoms out in _solve_strip_1d_var, and
         # the queue is pre-sorted by natural Y (so plan_strip's (anchor_y, key) order is
         # the queue order → leaders stay crossing-free). Over-capacity selection is now
         # by real per-feature priority — the hole DIAMETER (D3/#322): when the strip

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -205,7 +205,8 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     ``key``; that tie-break is *not* crossing-optimal (it doesn't see the
     perpendicular coordinate that decides those crossings) — resolving ties
     crossing-optimally is the P4 assign/order step (#318). Then spaces the labels
-    within ``[lo, hi]`` at least *min_gap* apart via :func:`_solve_strip_1d`.
+    within ``[lo, hi]``, at least *min_gap* apart, via the per-pair solve
+    described below.
 
     **Selection (P2, #322):** when the strip cannot hold everything, the
     lowest-priority candidates are dropped (ties by key, deterministic) until the
@@ -213,11 +214,17 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     (``placed`` {key: position}, ``dropped`` keys). This is the ranked, priority-
     aware replacement for the engine's arrival-order / prefix drops.
 
-    Spacing is the caller's single *min_gap* (as the engine's strips do today) — the
-    candidate's ``size`` is carried for the per-pair, label-height-aware gaps that
-    come with the optimal packing (P4, #318), and is not consulted here, so
-    *min_gap* must clear the tallest label. Candidate *keys* must be unique (they
-    key the result). Deterministic throughout.
+    **Spacing (P4a, #318):** each adjacent pair's required gap is the larger of
+    the two candidates' strip-axis extents (``size[idx]``), floored at the
+    caller's *min_gap* — the same "larger of the two neighbours' requirements"
+    rule :meth:`LayoutSolver.solve_strip` already uses for heterogeneous
+    ``Placeable``s, applied here to ``StripCandidate.size`` instead of an
+    explicit per-item ``min_gap`` field. *min_gap* is therefore a floor (minimum
+    clearance/padding regardless of label size), not the whole story; solved via
+    :func:`_solve_strip_1d_var`. When every candidate's ``size[idx]`` is the same
+    value (every current caller), this reduces exactly to the old uniform-gap
+    solve. Candidate *keys* must be unique (they key the result). Deterministic
+    throughout.
     """
     if not candidates:
         return StripPlacement({}, ())
@@ -230,7 +237,12 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     dropped: list[str] = []
     while keep:
         ordered = sorted(keep, key=lambda c: (c.anchor[idx], c.key))
-        positions = _solve_strip_1d([c.anchor[idx] for c in ordered], min_gap, lo, hi)
+        naturals = [c.anchor[idx] for c in ordered]
+        gaps = [
+            max(ordered[i].size[idx], ordered[i + 1].size[idx], min_gap)
+            for i in range(len(ordered) - 1)
+        ]
+        positions = _solve_strip_1d_var(naturals, gaps, lo, hi)
         if positions is not None:
             placed = {c.key: p for c, p in zip(ordered, positions, strict=True)}
             return StripPlacement(placed, tuple(dropped))

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -308,6 +308,35 @@ def test_plan_strip_x_axis():
     assert p["a"] <= p["b"]
 
 
+def test_plan_strip_uses_per_pair_gaps_for_heterogeneous_sizes():
+    # P4a (#318): candidates with different strip-axis sizes are spaced by the
+    # LARGER of each pair's own size (or the floor min_gap), not one global gap —
+    # the same rule LayoutSolver.solve_strip already uses for heterogeneous
+    # Placeables (#81). Exercises plan_strip's own gap-list wiring (ordered[i]/
+    # [i+1] indexing, idx selection), not just the underlying _solve_strip_1d_var
+    # primitive (which is already covered elsewhere, in isolation).
+    cands = [
+        StripCandidate("a", (0.0, 0.0), (6, 4), priority=0),
+        StripCandidate("b", (0.0, 0.0), (6, 4), priority=0),
+        StripCandidate("c", (0.0, 0.0), (6, 12), priority=0),
+    ]
+    res = plan_strip(cands, lo=0, hi=100, min_gap=1)
+    p = res.placed
+    assert abs((p["b"] - p["a"]) - 4) < 1e-6  # max(4, 4, floor 1)
+    assert abs((p["c"] - p["b"]) - 12) < 1e-6  # max(4, 12, floor 1)
+
+
+def test_plan_strip_min_gap_floors_a_pair_smaller_than_it():
+    # A pair whose sizes are both below the caller's min_gap floor must still get
+    # at least min_gap of separation — min_gap is a floor, not just a fallback.
+    cands = [
+        StripCandidate("a", (0.0, 0.0), (6, 1), priority=0),
+        StripCandidate("b", (0.0, 0.0), (6, 1), priority=0),
+    ]
+    res = plan_strip(cands, lo=0, hi=100, min_gap=5)
+    assert abs((res.placed["b"] - res.placed["a"]) - 5) < 1e-6
+
+
 def test_bore_callout_priority_is_the_hole_diameter(monkeypatch):
     # D3 (#322) wiring: each bore-callout StripCandidate's priority is the hole
     # DIAMETER (largest wins over-capacity), not the old n-j prefix-keep placeholder.


### PR DESCRIPTION
## Summary
- `plan_strip` spaced every candidate with one caller-supplied `min_gap`, forcing callers to pick a gap wide enough for the tallest label and over-spacing everything else.
- Reuses the "larger of the two neighbours' requirements" rule `LayoutSolver.solve_strip` already applies to heterogeneous `Placeable`s (#81), via the existing `_solve_strip_1d_var` primitive: each adjacent pair's gap is now `max(size[idx] of both candidates, min_gap floor)`.
- When every candidate's `size` is uniform (every current caller today), this is a no-op — it just removes the one-size-fits-all constraint so future callers can pass real per-label sizes (ADR 0009 P4, #318).

Part of ADR 0009's P4/P5 sub-phase plan (docs/plans/strip-layout-boundary-labeling-roadmap.md).

## Test plan
- [x] `uv run pytest -k "strip_layout or plan_strip"` — 30 passed
- [x] `uv run pytest -m smoke -n auto --dist loadscope` — 48 passed
- [x] `ruff format --check`, `ruff check`, `mypy` — clean