### PR TITLE
fix: harden Dimension type check to isinstance, catching SafeDimension (#335/#349)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 
+from build123d_drafting.helpers import Dimension, SafeDimension
+
 from draftwright.layout import StripCandidate, plan_strip
 
 _log = logging.getLogger(__name__)
@@ -205,8 +207,7 @@ def corridor_blockers(dwg, view):
             owner = dwg.view_of(name)
             if owner is not None and owner != view:
                 continue
-        tn = type(o).__name__
-        if tn == "Dimension" or tn in CROSSABLE_TYPES:
+        if isinstance(o, (Dimension, SafeDimension)) or type(o).__name__ in CROSSABLE_TYPES:
             continue  # datum-chained dims share the corridor; centre lines are crossable
         bb = _geom_box(o)
         if bb is not None:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -27,7 +27,9 @@ from build123d import (
     Vector,
 )
 from build123d_drafting.helpers import (
+    Dimension,
     Leader,
+    SafeDimension,
     ViewCoordinates,
     annotate,
     view_axes,
@@ -721,7 +723,7 @@ class Drawing:
         for nm, obj in self._named.items():
             if self._anno_view.get(nm) != view:
                 continue
-            if type(obj).__name__ != "Dimension" and not nm.startswith("pmi_"):
+            if not isinstance(obj, (Dimension, SafeDimension)) and not nm.startswith("pmi_"):
                 continue
             try:
                 ob = obj.bounding_box()

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -549,6 +549,13 @@ def _fake_dwg(obstacles, view="side", types=None):
     # annotations exposing a bounding_box() and a single owning view. obstacles:
     # {name: (x0, y0, x1, y1)}; *types* optionally maps a name to its annotation
     # class name (default "_Obst") so corridor_blockers' type filter can be exercised.
+    # "Dimension"/"SafeDimension" build a real *subclass* (so the `isinstance` filter,
+    # not a name string-match, is exercised — #335/#349 hardening); other names build a
+    # plain class of that name (for the crossable/leader name checks).
+    from build123d_drafting.helpers import Dimension, SafeDimension
+
+    _dim_bases = {"Dimension": (Dimension,), "SafeDimension": (SafeDimension,)}
+
     class _P:
         def __init__(s, x, y):
             s.X, s.Y = x, y
@@ -559,7 +566,9 @@ def _fake_dwg(obstacles, view="side", types=None):
 
     def _make(name, bb):
         tn = (types or {}).get(name, "_Obst")
-        return type(tn, (), {"bounding_box": lambda s, _b=_BB(*bb): _b})()
+        bases = _dim_bases.get(tn, ())
+        body = {"bounding_box": lambda s, _b=_BB(*bb): _b, "__init__": lambda s: None}
+        return type(tn, bases, body)()
 
     class _Dwg:
         def iter_annotations(s):
@@ -574,11 +583,24 @@ def _fake_dwg(obstacles, view="side", types=None):
 def test_corridor_blockers_keeps_leaders_excludes_dim_chains_and_centrelines():
     # A dimension's witness corridor may cross datum-chained dims and centre lines but
     # NOT a leader (#321 P1b). corridor_blockers returns only the blocking geometry.
+    # A SafeDimension (helper sibling of Dimension, NOT a subclass) must be excluded
+    # exactly like a Dimension — the #335/#349 isinstance-not-string-name hardening; a
+    # bare name match would have wrongly kept it as a blocker.
     from draftwright.annotations._common import corridor_blockers
 
     dwg = _fake_dwg(
-        {"dim_loc_side_y100": (0, 0, 5, 3), "m_cl": (0, 0, 5, 3), "hc_side0": (10, 10, 20, 15)},
-        types={"dim_loc_side_y100": "Dimension", "m_cl": "Centerline", "hc_side0": "Leader"},
+        {
+            "dim_loc_side_y100": (0, 0, 5, 3),
+            "m_env_depth_safe": (1, 1, 6, 4),
+            "m_cl": (0, 0, 5, 3),
+            "hc_side0": (10, 10, 20, 15),
+        },
+        types={
+            "dim_loc_side_y100": "Dimension",
+            "m_env_depth_safe": "SafeDimension",
+            "m_cl": "Centerline",
+            "hc_side0": "Leader",
+        },
     )
     assert corridor_blockers(dwg, "side") == [(10.0, 10.0, 20.0, 15.0)]
 


### PR DESCRIPTION
## Harden the `Dimension` type check: `isinstance`, not a name string-match (#335 / #349)

Two strip/ring placement filters gated on the **string** type name
`type(o).__name__ == "Dimension"` — flagged by two separate ADR 0009 reviews as
name-fragile:

- **`corridor_blockers`** (`_common.py`): dims are *excluded* from a dimension's
  witness-corridor blockers (datum-chained dims legitimately share the corridor).
- **balloon-ring depth filter** (`drawing.py`): only Dimensions (+ `pmi_` leaders)
  are measured for the ring's band depth.

The helper lib ships **`SafeDimension`** — a *sibling* of `Dimension` (shared
`_Annotation` base, **not** a subclass), returned by some dim builders. A name
match silently treats it as neither:
- a `SafeDimension` in a corridor → wrongly kept as a blocker → spurious relocation;
- a `SafeDimension` in a band → dropped from the ring measurement → under-measured
  band → overlap.

Any future `Dimension` **subclass** hits the same blind spot (a subclass's
`__name__` isn't `"Dimension"`).

### Fix
`isinstance(o, (Dimension, SafeDimension))` at both sites — catches both dimension
types **and** any subclass. **Byte-identical on the corpus** (draftwright only ever
builds `Dimension` via `_dim()`); this future-proofs the checks.

`_fake_dwg` (the strip-layout test helper) now builds a real `Dimension`/
`SafeDimension` *subclass* for those type names, so the `corridor_blockers` test
exercises the `isinstance` filter (not a name), and asserts a `SafeDimension` is
excluded exactly like a `Dimension`.

### Tests
- `test_corridor_blockers_...` extended with a `SafeDimension` occupant.
- Corpus byte-identical (54 corridor/balloon-ring/cleanliness/e2e tests green
  locally); CI runs the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
