### PR TITLE
fix: PMI bore-diameter witness uses radius not full diameter (#360)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1135,6 +1135,16 @@ def _record_pmi_drop(dwg, ax, label, rec):
     )
 
 
+def _bore_half_span(pmi_kind: str, value: float) -> float:
+    """Half the perpendicular span of a bore-size dim from the bore centroid — the
+    distance to each witness base point. A ``"diameter"`` record stores the full
+    diameter (so half = radius = value/2); a ``"radius"`` record already stores the
+    radius (half = value). Keyed on ``PmiFeature.pmi_kind`` (the PMI category), NOT
+    ``.kind`` (the feature kind, always ``"pmi"``) — the #360 bug used the latter, so
+    the diameter branch was dead and every diameter dim spanned ±diameter (2× wide)."""
+    return value / 2 if pmi_kind == "diameter" else value
+
+
 def render_pmi(dwg, model, a) -> int:
     """Render pre-authored PMI annotations (STEP AP242) from the IR `PmiFeature`s
     into remaining strip space (#208). Replaces the engine's `_annotate_pmi`.
@@ -1362,7 +1372,7 @@ def render_pmi(dwg, model, a) -> int:
             # bore-diameter view table (Z→plan, X→side, Y→front) differs from the
             # linear-dim one just below (#351 PR-4a review).
             ax = bore_axis
-            half = rec.value / 2 if rec.kind == "diameter" else rec.value
+            half = _bore_half_span(rec.pmi_kind, rec.value)
 
             # Bore diameter page span = diameter × scale.  When the span is
             # narrower than ~8 mm the centred label text overflows the gap

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -61,3 +61,39 @@ class TestCalloutSpec:
         g = plan_dimensions(PartModel(bbox=None, orientation=None, features=[hole]))[0]
         s = hole_callout_spec(g)
         assert s["cbore_dia"] == 14.0 and s["cbore_depth"] == 1.0
+
+
+class TestBoreHalfSpan:
+    """#360: a PMI bore-size dim's half-span from the bore centroid. A diameter
+    record stores the diameter (half = radius); a radius record stores the radius
+    (half = value). The bug keyed on the feature `.kind` (always 'pmi') instead of
+    `.pmi_kind`, so the diameter branch was dead and every diameter dim spanned
+    ±diameter — 2× too wide."""
+
+    def test_diameter_halves_to_the_radius(self):
+        from draftwright.annotations.from_model import _bore_half_span
+
+        assert _bore_half_span("diameter", 35.0) == 17.5
+
+    def test_radius_is_used_as_is(self):
+        from draftwright.annotations.from_model import _bore_half_span
+
+        assert _bore_half_span("radius", 8.0) == 8.0
+
+    def test_the_pmifeature_kind_attr_never_triggers_the_diameter_branch(self):
+        # The regression itself: a PmiFeature's `.kind` is always "pmi" (a ClassVar),
+        # so keying on it (as the old code did) never halves. Pin that pmi_kind is
+        # the right key and .kind is the wrong one.
+        from draftwright.annotations.from_model import _bore_half_span
+        from draftwright.model import Frame, PmiFeature
+
+        rec = PmiFeature(
+            frame=Frame((0, 0, 0), "z"),
+            pmi_kind="diameter",
+            value=35.0,
+            label="ø35",
+            dominant_axis="Z",
+        )
+        assert rec.kind == "pmi"  # feature kind (ClassVar), NOT the PMI category
+        assert _bore_half_span(rec.kind, rec.value) == 35.0  # the old bug: no halving
+        assert _bore_half_span(rec.pmi_kind, rec.value) == 17.5  # the fix: radius


### PR DESCRIPTION
## PMI bore-diameter witness span uses radius, not the full diameter (#360)

`render_pmi` computed the half-span from a bore's centroid to each witness base
point as:

```python
half = rec.value / 2 if rec.kind == "diameter" else rec.value
```

But `rec.kind` is the **feature** kind — a `ClassVar` on `PmiFeature` that is
**always `"pmi"`**; the PMI category is `rec.pmi_kind`. So the `== "diameter"`
branch was **dead**, `half` was always `rec.value` (the full diameter), and a
diameter dimension's witness lines landed at centroid ± **diameter** instead of
± **radius** — 2× too wide, missing the bore edges entirely. The adjacent comment
(`# bore radius on page`) confirms `half` is meant to be the radius.

Verified end-to-end: building `nist_ctc_01_asme1_ap242.stp` with `pmi="annotate"`,
a ø35 diameter dim's horizontal span is ~35 mm with the fix vs ~70 mm before.

### Fix
Extract a pure `_bore_half_span(pmi_kind, value)` keyed on `pmi_kind` and call it.

### Scope
Only the `pmi="annotate"` path (STEP AP242 PMI rendering) is affected. The default
`pmi="off"` build never calls `render_pmi`, so the **corpus is byte-identical** and
no existing fast/slow test exercised this branch (which is why it went unnoticed).

### Tests
`TestBoreHalfSpan` (fast, no OCP): diameter halves to the radius, radius is used
as-is, and the exact regression — `_bore_half_span(rec.kind, ...)` never halves
while `_bore_half_span(rec.pmi_kind, ...)` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
