### PR TITLE
fix: two layout backlog bugs — silent step-chain drop (#362) + coaxial-bore over-dimension (#309)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -667,6 +667,22 @@ def render_envelope(dwg, groups, a) -> int:
     return n
 
 
+def _record_step_chain_drop(dwg, why: str) -> None:
+    """Record the ``step_dim_dropped`` lint warning when a turned step-length chain
+    is dropped whole (#362). These drops were silent (debug log only) — the user got
+    a drawing with no step-length dimensioning and no signal. Mirrors
+    ``render_height_ladder``'s prismatic drop, but records ONLY the lint code (not an
+    ``Escalation(kind="step")``): that escalation is consumed by
+    ``_request_prismatic_detail`` (sections.py), which would redraw *prismatic*
+    height-above-base dims for a *turned* chain — the wrong semantics #351 PR-4b
+    removed. A Z-turned-appropriate detail-view remedy is a tracked follow-up."""
+    dwg._record_build_issue(
+        "warning",
+        "step_dim_dropped",
+        f"step-length chain dropped: {why} at this scale (use a detail view)",
+    )
+
+
 def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True) -> int:
     """Place a turned step-length chain in *view* from *segs* — each ``(pa, pb,
     value)`` already projected to *view*'s page coords, in axis order. Orientation is
@@ -719,11 +735,15 @@ def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_coll
                 tiers = [i % 2 for i in range(len(segs))]  # alternate to make room
             else:
                 _log.info("step-length chain skipped: too dense even when staggered")
+                _record_step_chain_drop(
+                    dwg, "shoulders too dense to dimension even when staggered"
+                )
                 return 0
         else:
             shoulder_ys = sorted({c for pa, pb, _ in segs for c in (pa[1], pb[1])})
             if any(b - a < tier_step for a, b in zip(shoulder_ys, shoulder_ys[1:])):
                 _log.info("step-length chain skipped: shoulders too close to dimension")
+                _record_step_chain_drop(dwg, "turned shoulders too closely spaced to dimension")
                 return 0
 
         candidates = []
@@ -745,6 +765,7 @@ def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_coll
         if box is not None and not (
             page[0] <= box[0] and box[2] <= page[2] and page[1] <= box[1] and box[3] <= page[3]
         ):
+            _record_step_chain_drop(dwg, "a dimension would fall off the drawable page")
             return 0
     for name, dim in candidates:
         if detail_scale is not None:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -16,6 +16,7 @@ from build123d_drafting.helpers import (
 )
 
 from draftwright._core import (
+    _CONCENTRIC_TOL_MM,
     _MIN_LOC_SEP_MM,
     _TB_CLEAR,
     _TB_H,
@@ -120,7 +121,29 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
     draft = dwg.draft
     all_holes = a.holes if holes_in is None else holes_in
     patterned = {h for p in a.patterns for h in p.holes}
-    off = [h for h in all_holes if _axis_letter(h) in ("x", "y") and h not in patterned]
+
+    def _coaxial(h):
+        # The turning-axis bore of a rotational part is located by its centreline, not
+        # a position dim (#309) — mirrors render_locations' concentric filter (the
+        # Z-turned/plan case) and coverage.py's coaxial exemption, for the X/Y-turned
+        # case whose dims come through THIS path. Suppresses the redundant offset+height
+        # dims; coverage already credits the bore via its centre mark, so lint stays
+        # clean. Non-rotational parts and genuine off-centre side-drilled holes keep
+        # their dims (the a.od_axis + perpendicular-centre gates).
+        if not a.is_rotational or _axis_letter(h) != a.od_axis:
+            return False
+        centre = (a.cx, a.cy, a.cz)
+        return all(
+            abs(h.location[i] - centre[i]) <= _CONCENTRIC_TOL_MM
+            for i, ax in enumerate("xyz")
+            if ax != a.od_axis
+        )
+
+    off = [
+        h
+        for h in all_holes
+        if _axis_letter(h) in ("x", "y") and h not in patterned and not _coaxial(h)
+    ]
     if not off:
         return
     SX, SZ = a.proj.side_x, a.proj.side_z

--- a/tests/layout_snapshots/drive_screw_x.json
+++ b/tests/layout_snapshots/drive_screw_x.json
@@ -28,42 +28,6 @@
     },
     {
       "geom_bbox": [
-        77.0,
-        72.0,
-        85.0,
-        84.1
-      ],
-      "label": "6",
-      "label_bbox": [
-        82.0,
-        77.3,
-        84.1,
-        78.7
-      ],
-      "name": "dim_loc_front_z600",
-      "type": "Dimension",
-      "view": "front"
-    },
-    {
-      "geom_bbox": [
-        100.0,
-        62.0,
-        112.1,
-        68.0
-      ],
-      "label": "6",
-      "label_bbox": [
-        105.4,
-        62.9,
-        106.8,
-        65.1
-      ],
-      "name": "dim_loc_side_y600",
-      "type": "Dimension",
-      "view": "side"
-    },
-    {
-      "geom_bbox": [
         23.0,
         72.0,
         31.0,
@@ -161,7 +125,7 @@
       "view": null
     }
   ],
-  "item_count": 10,
+  "item_count": 8,
   "views": {
     "front": [
       35.0,

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -97,3 +97,45 @@ class TestBoreHalfSpan:
         assert rec.kind == "pmi"  # feature kind (ClassVar), NOT the PMI category
         assert _bore_half_span(rec.kind, rec.value) == 35.0  # the old bug: no halving
         assert _bore_half_span(rec.pmi_kind, rec.value) == 17.5  # the fix: radius
+
+
+class TestStepChainDrop:
+    """#362: dropping a whole turned step-length chain (shoulders too crowded to
+    dimension) must record the `step_dim_dropped` lint warning — it was silent
+    (debug log only), leaving the user a drawing with no step dims and no signal.
+    Must NOT emit an Escalation(kind='step') (that is the prismatic-detail consumer,
+    wrong semantics for a turned chain)."""
+
+    def _stub_dwg(self):
+        from types import SimpleNamespace
+
+        class _Dwg:
+            def __init__(s):
+                s.draft = SimpleNamespace(font_size=3.0, pad_around_text=0.5)
+                s.issues = []
+                # NOTE: deliberately no _escalations — if the code tried to append a
+                # step Escalation it would AttributeError, so a clean run proves it doesn't.
+
+            def view_bounds(s, view):
+                return (0.0, 0.0, 100.0, 100.0)
+
+            def _record_build_issue(s, sev, code, msg):
+                s.issues.append((sev, code, msg))
+
+        return _Dwg()
+
+    def test_crowded_vertical_chain_records_the_drop(self):
+        from draftwright.annotations.from_model import _draw_step_chain
+
+        dwg = self._stub_dwg()
+        # Vertical (chain-to-the-right) segs whose shoulder Ys are 0.1 mm apart —
+        # far below tier_step (= font_size + 2*pad = 4). Values differ so the
+        # uniform-collapse path is not taken. The chain is dropped whole.
+        segs = [
+            ((80.0, 10.0, 0), (80.0, 10.1, 0), 5.0),
+            ((80.0, 10.1, 0), (80.0, 10.2, 0), 8.0),
+        ]
+        placed = _draw_step_chain(dwg, "front", segs, "m_steplen")
+        assert placed == 0
+        codes = [code for _sev, code, _msg in dwg.issues]
+        assert "step_dim_dropped" in codes, "silent drop no longer allowed (#362)"

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -70,6 +70,21 @@ def test_strip_obstacles_captures_full_leader_footprint_not_just_label():
     assert not any(_same(x, full) for x in occ)
 
 
+def test_coaxial_bore_on_rotational_part_is_not_over_located():
+    # #309: the turning-axis bore of a rotational part is located by its centreline,
+    # not a redundant position dim. The X-turned drive screw's coaxial bore emitted a
+    # y-offset dim (side-below) AND a z-height dim (right) both reading its offset from
+    # the datum — the "6"/"6" over-dimensioning. `_locate_off_axis_holes` now excludes
+    # the coaxial bore, so no dim_loc_* is placed, and lint stays clean because
+    # coverage already credits the bore via its centre mark. (Non-rotational parts and
+    # genuine off-centre side-drilled holes are unaffected — the byte-identical
+    # side_drilled/dshape/plate_holes snapshots guard that.)
+    dwg = build_drawing(_drive_screw_x())
+    locs = [n for n, _ in dwg.iter_annotations() if n.startswith("dim_loc")]
+    assert locs == [], f"coaxial bore over-located: {locs}"
+    assert not any(getattr(i, "code", None) == "feature_not_located" for i in dwg.lint())
+
+
 def test_strip_obstacles_view_filter_drops_other_ortho_views():
     # A box with a side-drilled hole: the side query excludes front/plan-owned
     # blocks (compose-then-pack keeps them disjoint) but is narrower than the whole.


### PR DESCRIPTION
## Two ADR-0009-era layout backlog bugs

Both surfaced by the layout-backlog triage; each is a small, well-scoped fix with its own commit.

### #362 — a dropped turned step-length chain is no longer silent
`_draw_step_chain` drops the **whole** step-length chain when the turned shoulders are too closely spaced to dimension (or a dim would fall off the page), but did so with only a `_log.info` — the user got a drawing with zero step-length dimensioning and **no lint/UI signal**. Now records a `step_dim_dropped` warning at all three silent `return 0` sites.

Deliberately records **only the lint code**, not an `Escalation(kind="step")` — that escalation is consumed by `_request_prismatic_detail`, which would redraw *prismatic* height-above-base dims for a *turned* chain (the wrong semantics #351 PR-4b removed). A Z-turned-appropriate detail-view remedy is a tracked follow-up.

**Byte-identical** (lint metadata only). Unit test pins the drop records the code and emits no step escalation.

### #309 — coaxial central bore over-dimensioned on a rotational part
On an **X/Y-turned** rotational part, the bore coaxial with the turning axis was swept into `_locate_off_axis_holes`' `off` list and got a redundant offset dim (below) **plus** a height dim (right) — the "6"/"6" double dimension on the drive screw. The Z-turned/plan case was already filtered (`render_locations`), and coverage already credits a coaxial bore via its centre mark; only this path lacked the exclusion. Added a `_coaxial(h)` gate (`is_rotational` + axis == `od_axis` + perpendicular coords within `_CONCENTRIC_TOL_MM` of the part centre), mirroring the concentric filter + coverage exemption. Lint stays clean.

**Corpus impact:** only `drive_screw_x` (its two `dim_loc` entries drop, `item_count` 10→8, nothing else shifts) — re-blessed. Non-rotational parts and genuine off-centre side-drilled holes keep their dims (byte-identical `side_drilled`/`dshape`/`plate_holes`).

Verified locally: snapshot + cleanliness (drive_screw_x re-blessed, rest unchanged), the two new tests, and the affected test modules (51 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
