### PR TITLE
fix: left ø-diameter column uses full-footprint occupancy, not label boxes (#358)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -47,7 +47,6 @@ from draftwright.annotations._common import (
     Escalation,
     _anno_box,
     _box_hits,
-    _occupied_boxes,
     carve_free_position,
     carve_free_segments,
     place_strip_candidates,
@@ -521,7 +520,11 @@ def _diameter_column_left(dwg, items) -> int:
     )
     if ys is None:
         return 0
-    occupied = _occupied_boxes(dwg)  # bore leaders + other left-column callouts
+    # Full-footprint occupancy (leader shafts, witness/extension lines, hatch) — NOT
+    # the label-box-only `_occupied_boxes`, which is blind to a bore callout's leader
+    # SHAFT, so a ø label could silently overprint it (the #133/#225/#305 invisible-
+    # occupant class, #358). Centre lines stay crossable (a diameter dim may cross one).
+    occupied = strip_obstacles(dwg, view="front", crossable=CROSSABLE_TYPES)
     placed = 0
     for i, ((tip, label), ly) in enumerate(zip(specs, ys, strict=True)):
         ldr = Leader(tip=(tip[0], tip[1], 0), elbow=(elbow_x, ly, 0), label=label, draft=draft)

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -139,3 +139,62 @@ class TestStepChainDrop:
         assert placed == 0
         codes = [code for _sev, code, _msg in dwg.issues]
         assert "step_dim_dropped" in codes, "silent drop no longer allowed (#362)"
+
+
+class TestDiameterColumnOccupancy:
+    """#358: the left ø-diameter column's occupancy is the FULL footprint
+    (`strip_obstacles`), not the label-box-only `_occupied_boxes` that was blind to a
+    bore callout's leader SHAFT. A ø label overprinting a shaft is now dropped."""
+
+    def _dwg(self, occupants):
+        from types import SimpleNamespace
+
+        from build123d_drafting.helpers import Draft
+
+        class _Occ:  # a fake placed annotation exposing only a full bounding_box
+            def __init__(s, box):
+                s._box = box
+
+            def bounding_box(s):
+                x0, y0, x1, y1 = s._box
+                return SimpleNamespace(
+                    min=SimpleNamespace(X=x0, Y=y0), max=SimpleNamespace(X=x1, Y=y1)
+                )
+
+        class _Dwg:
+            draft = Draft(font_size=3.0)
+
+            def view_bounds(s, v):
+                return (40.0, 0.0, 80.0, 40.0)  # ample room to the left of fx0=40
+
+            def at(s, v, x, y, z):
+                return (x, z, 0.0)  # identity-ish projection: tip Y follows the axial z
+
+            def iter_annotations(s):
+                return [(f"hc_front{i}", _Occ(b)) for i, b in enumerate(occupants)]
+
+            def view_of(s, n):
+                return "front"
+
+            def add(s, ann, name, view):
+                pass
+
+        return _Dwg()
+
+    _ITEMS = [((10.0, 0.0, 8.0), 12.0), ((10.0, 0.0, 24.0), 8.0)]  # two Z-turned ø steps
+
+    def test_control_no_occupant_places_both(self):
+        from draftwright.annotations.from_model import _diameter_column_left
+
+        # No occupant → both labels placed (proves the column has room; the drop below
+        # is due to occupancy, not the room guard).
+        assert _diameter_column_left(self._dwg([]), self._ITEMS) == 2
+
+    def test_bore_shaft_footprint_drops_the_overprinting_labels(self):
+        from draftwright.annotations.from_model import _diameter_column_left
+
+        # A bore leader whose FULL footprint blankets the left column. The old
+        # label-box-only `_occupied_boxes` never recorded this shaft (the occupant has
+        # no label_bbox), so both ø labels would have been placed straight over it;
+        # strip_obstacles sees the full box, so both are dropped.
+        assert _diameter_column_left(self._dwg([(-100.0, -100.0, 100.0, 100.0)]), self._ITEMS) == 0


### PR DESCRIPTION
## Left ø-diameter column: full-footprint occupancy, not label boxes (#358)

`_diameter_column_left` (the Z-turned turned-diameter callouts, left of the front view) dropped a ø label only when its box overprinted an existing annotation's **label** box via `_occupied_boxes` — which is blind to a bore callout's leader **shaft** (and witness/extension lines, hatch). So a ø label could silently overprint a bore leader shaft — the #133/#225/#305 **invisible-occupant** class the ADR 0009 `strip_obstacles` occupancy model exists to close.

### Fix
Swap the occupancy source to `strip_obstacles(dwg, view="front", crossable=CROSSABLE_TYPES)` — the full rendered footprint. Centre lines stay crossable (a diameter dim may legitimately cross one). Drops the now-unused `_occupied_boxes` import.

### Scope note (critical-partner call)
The issue also names `_diameter_row_below`. I left it: its scan already uses full `bounding_box()` (not the label-box blind spot) **and** drops the row below *all* obstacles, so it isn't invisible-occupant-blind — migrating it is cosmetic and would risk needless snapshot churn. The real defect is the column-left occupancy, fixed here.

### Impact & tests
- **Byte-identical** on the corpus (no part currently has the overprint — a latent blind spot; the `test_layout_cleanliness` ratchet already guards it forward).
- A **demonstrative** unit test (`TestDiameterColumnOccupancy`): a control places both ø labels; a bore-shaft footprint blanketing the column drops both — where the label-box idiom (the occupant carries no label box) was blind. Reverting to `_occupied_boxes` makes the drop test place both, so the test is meaningful.
- snapshot + cleanliness green (27, byte-identical incl. `turned_shaft`'s `m_dia_z`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
