### PR TITLE
fix: registry snapshot completeness + review-cleanup smells (review follow-ups)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -372,8 +372,15 @@ def carve_free_position(dwg, strip, view, axis, tier, perp_span, *, outermost=Fa
     next — the height-ladder leapfrog chain, where each step dim's witness base is the
     previous dim's line — uses this. Same carve: outer-label tier reservation, the
     perpendicular-band filter (*perp_span* drops obstacles disjoint from this dim's own
-    perpendicular extent), and innermost-first fill. No corridor check (a single-strip
-    ladder has no alternate view to route to; obstacle tiers are still avoided)."""
+    perpendicular extent), and innermost-first fill.
+
+    **No corridor check** — unlike :func:`place_strip_candidates`, this avoids obstacle
+    *tiers* on the strip but does not reject a position whose witness *corridor* back to
+    the view would cross a leader/callout, nor relocate to an alternate view. That is
+    correct for the height ladder (a single-strip chain with no alternate view), but this
+    is now also called by the PMI/slot renderers and public ``Drawing.place_dim``, which
+    therefore do NOT get corridor semantics — a known gap (whether those callers should
+    is a design call, tracked separately)."""
     if strip is None:
         return None
     lo, hi, inner = strip_free_span(strip)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1372,7 +1372,6 @@ def render_pmi(dwg, model, a) -> int:
             view=view,
         )
         return True
-        return False
 
     emitted = 0
     for idx, rec in enumerate(usable):

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -521,13 +521,13 @@ def _request_prismatic_detail(dwg, a: Analysis) -> None:
 
     Prismatic only, by construction: `render_height_ladder` never emits this
     escalation for a turned part (no `StepLevelFeature`). A crowded **Z-turned**
-    step-length chain has its own, separate, still-silent drop in
-    `_draw_step_chain`'s vertical branch (`return 0`, no lint/escalation at
-    all) — this function no longer accidentally, unreliably papers over that
-    with prismatic-semantics dims (wrong anchor/labeling for a turned chain);
-    see #362 for the real fix (a Z-turned-appropriate detail remedy, analogous
-    to the X-turned crowded-head block + `DetailRequest` this docstring's
-    sibling, `render_step_lengths`, already has).
+    step-length chain has its own, separate drop in `_draw_step_chain`'s vertical
+    branch (`return 0`) — this function no longer accidentally, unreliably papers
+    over that with prismatic-semantics dims (wrong anchor/labeling for a turned
+    chain). That drop is now reported (a `step_dim_dropped` lint warning, #362);
+    still outstanding is a Z-turned-appropriate *detail* remedy, analogous to the
+    X-turned crowded-head block + `DetailRequest` this docstring's sibling,
+    `render_step_lengths`, already has.
 
     The redraw re-draws the step-height ladder in the detail view at the
     enlarged scale."""

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -68,13 +68,24 @@ class AnnotationRegistry:
                 self._named[name] = new
 
     def snapshot(self) -> dict:
-        """An opaque snapshot of the name → object map, for restore() (repair undo)."""
-        return dict(self._named)
+        """An opaque snapshot of the annotation identity state — the name → object map
+        AND its per-name view/pin metadata — for restore() (repair undo). Snapshotting
+        only ``_named`` would let a rolled-back pass leave ``_anno_view``/``_pinned``
+        referencing names it added (or the wrong view for a re-placed dim)."""
+        return {
+            "named": dict(self._named),
+            "anno_view": dict(self._anno_view),
+            "pinned": set(self._pinned),
+        }
 
     def restore(self, snap: dict) -> None:
         """Restore a :meth:`snapshot` (repair undo of a net-worsening pass)."""
         self._named.clear()
-        self._named.update(snap)
+        self._named.update(snap["named"])
+        self._anno_view.clear()
+        self._anno_view.update(snap["anno_view"])
+        self._pinned.clear()
+        self._pinned.update(snap["pinned"])
 
     def add(self, obj, name, view):
         """Register *obj* under *name* and record its owning *view*.

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -83,7 +83,7 @@ def repair_drawing(dwg, max_iter: int = 3):
         if not before:
             break
         snap_annotations = list(dwg.items)
-        snap_named = dwg._registry.snapshot()
+        snap_registry = dwg._registry.snapshot()
         changed = False
         for issue in before:
             if issue.code not in _REPAIRABLE_CODES:
@@ -103,6 +103,6 @@ def repair_drawing(dwg, max_iter: int = 3):
         if len(dwg.lint()) > len(before):
             # The repairs net-worsened the sheet — undo this pass and stop.
             dwg.items[:] = snap_annotations
-            dwg._registry.restore(snap_named)
+            dwg._registry.restore(snap_registry)
             break
     return dwg

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -103,3 +103,31 @@ def test_drop_issues_by_code_and_reset():
     r.record_issue(_Issue("x"))
     r.reset_issues()
     assert r._build_issues == []
+
+
+def test_snapshot_restore_round_trips_view_and_pin_metadata():
+    # Repair-undo (repair.py) restores a snapshot when a pass net-worsens the sheet.
+    # The snapshot must carry the view/pin metadata, not only the name->object map —
+    # else a rolled-back pass leaves `_anno_view`/`_pinned` referencing names it added
+    # or the wrong view for a re-placed dim (the identity state would be inconsistent
+    # with the restored objects).
+    r = AnnotationRegistry()
+    a, b = object(), object()
+    r.add(a, "d1", "front")
+    r.add(b, "d2", "plan")
+    r.pin("d1")
+    snap = r.snapshot()
+
+    # A worsening pass: move d2 to another view, add a new dim, pin it, unpin d1.
+    r.add(object(), "d2", "side")  # d2 re-placed onto a different view
+    r.add(object(), "d3", "front")  # a brand-new annotation
+    r.pin("d3")
+    r.unpin("d1")
+
+    r.restore(snap)
+
+    assert r.named("d1") is a and r.named("d2") is b
+    assert "d3" not in r  # the added annotation is gone from identity
+    assert r.view_of("d2") == "plan"  # NOT the repaired "side"
+    assert r.view_of("d3") is None  # its stale view entry is gone
+    assert r.is_pinned("d1") and not r.is_pinned("d3")  # pins restored exactly


### PR DESCRIPTION
Addresses the clearly-correct items from the review pass:

**Registry snapshot completeness (medium)** — `AnnotationRegistry.snapshot()` captured only `_named`, so a repair-undo rollback restored objects but not `_anno_view`/`_pinned`, leaving identity state inconsistent with the restored objects. Now snapshots + restores all three. New round-trip unit test.

**Smells (byte-identical):**
- Deleted the unreachable `return False` after `return True` in `render_pmi._try_left`.
- Refreshed the stale `sections.py` comment claiming the Z-turned step-chain drop is 'still-silent' — #362 added the `step_dim_dropped` lint (only the detail-view remedy remains).
- `carve_free_position` docstring now notes it's used by PMI/`Drawing.place_dim` too, so its 'no corridor check' is a real gap for those callers (tracked design item).

**Deferred (flagged to the author, need a design call):** the balloon silent-prefix-drop + the `callout_dropped` over-clearing when scattered rows and pattern balloons coexist (one coupled resolver fix), and whether `carve_free_position`'s broader callers should gain corridor semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)