### PR TITLE
fix: balloon drops are non-silent + callout_dropped cleared precisely (review 1a+1b)

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -388,6 +388,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     ]
 
     scattered_specs: list = []
+    table_placed = False
     if tabulate_scattered:
         header = ("TAG", "⌀", "X", "Y")
         data = [
@@ -427,7 +428,14 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
             # diameter.
             table.covers_diameters = tuple(h.diameter for h in holes)
             scattered_specs = [(tag, 0, h) for tag, h in zip(scattered_tags, holes, strict=True)]
-            dwg._drop_build_issues("callout_dropped", "location_ref_dropped")
+            table_placed = True
+            # The table's X/Y columns document every scattered hole's location, so the
+            # location refs ARE resolved here. `callout_dropped`, however, is cleared
+            # below — only after the balloons are placed and per feature — because a
+            # pattern balloon sharing this resolver's combined band can still drop
+            # (review follow-up: this used to clear callout_dropped wholesale here,
+            # masking a dropped pattern balloon).
+            dwg._drop_build_issues("location_ref_dropped")
 
     balloon_specs = scattered_specs + pattern_specs
     placed_names: set = set()
@@ -438,24 +446,29 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
         dwg._add_balloons("plan", balloon_specs)
         placed_names = {n for n, _ in dwg.iter_annotations()}
 
-    # Pattern balloons resolve their own "callout_dropped" issues only for patterns
-    # whose balloon actually landed on the sheet — a crowded band can silently drop
-    # the tail (_place_band's strip-solver prefix fallback, layout.py) with no
-    # signal back here — AND only when no OTHER callout drop is left unaddressed
-    # (the scattered-table success path above already cleared them when it ran).
-    # Never hide a genuine remaining drop (a table that didn't fit, a pattern
-    # balloon that didn't fit its band, or a dropped pattern in a non-plan view,
-    # which this resolver does not cover).
-    if pattern_specs and not scattered_specs:
-        resolved_feats = {
-            feat
-            for (full_tag, _, _), feat in zip(pattern_specs, pattern_feats, strict=True)
-            if f"balloon_plan_{full_tag}_0" in placed_names
-        }
-        unresolved = [
-            e
-            for e in escalations
-            if e.kind == "callout" and not (e.view == "plan" and e.feature in resolved_feats)
-        ]
-        if not unresolved:
-            dwg._drop_build_issues("callout_dropped")
+    # Clear `callout_dropped` only when EVERY dropped plan-view callout is now
+    # documented — one unified check across both remedies (the scattered table and the
+    # pattern balloons), so neither hides the other. A plan-view callout escalation is
+    # resolved iff:
+    #   - it is a pattern whose balloon actually LANDED on the sheet (a crowded band
+    #     can drop the tail — _place_band's strip-solver prefix fallback — leaving the
+    #     pattern undocumented), or
+    #   - it is a scattered hole and the table was placed (its X/Y row documents it).
+    # A drop this resolver does not cover — a table that didn't fit, a balloon that
+    # didn't land, or any callout dropped in a non-plan view — leaves the lint standing.
+    resolved_feats = {
+        feat
+        for (full_tag, _, _), feat in zip(pattern_specs, pattern_feats, strict=True)
+        if f"balloon_plan_{full_tag}_0" in placed_names
+    }
+
+    def _resolved(e) -> bool:
+        if e.view != "plan":
+            return False
+        if isinstance(e.feature, PatternFeature):
+            return e.feature in resolved_feats
+        return table_placed  # a scattered plan-hole callout is documented by the table
+
+    unresolved = [e for e in escalations if e.kind == "callout" and not _resolved(e)]
+    if not unresolved:
+        dwg._drop_build_issues("callout_dropped")

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -770,7 +770,8 @@ class Drawing:
         # left/right balloons vary in Y at a fixed X just outside the part; top
         # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
         # offset by its side's dim depth so the ring sits clear of the dims.
-        self._place_band(
+        dropped = 0
+        dropped += self._place_band(
             view,
             bands["left"],
             "y",
@@ -781,7 +782,7 @@ class Drawing:
             fs,
             r,
         )
-        self._place_band(
+        dropped += self._place_band(
             view,
             bands["right"],
             "y",
@@ -792,7 +793,7 @@ class Drawing:
             fs,
             r,
         )
-        self._place_band(
+        dropped += self._place_band(
             view,
             bands["top"],
             "x",
@@ -803,7 +804,7 @@ class Drawing:
             fs,
             r,
         )
-        self._place_band(
+        dropped += self._place_band(
             view,
             bands["bottom"],
             "x",
@@ -814,17 +815,30 @@ class Drawing:
             fs,
             r,
         )
+        # A band too crowded to hold every balloon drops its tail (the strip solver's
+        # prefix fallback) — record it instead of letting the balloons vanish silently
+        # (review follow-up). The resolver keeps the callout_dropped lint for a pattern
+        # whose balloon did not land, so a missing pattern balloon is still a coverage gap.
+        if dropped:
+            self._record_build_issue(
+                "warning",
+                "balloon_dropped",
+                f"{dropped} balloon(s) could not fit their reserved band and were dropped",
+            )
 
-    def _place_band(self, view, members, axis, line, lo, hi, gap, fs, r):
+    def _place_band(self, view, members, axis, line, lo, hi, gap, fs, r) -> int:
         """Spread *members* (``(tag, j, hole, cx, cy)``) along one reserved band
         with the strip solver, then render a leadered balloon for each (#111).
 
         *axis* is the band's free axis (``"y"`` for the left/right bands, ``"x"``
         for the top); *line* is the fixed coordinate of the other axis.  Overflow
         beyond ``[lo, hi]`` drops the tail rather than running balloons off-page.
+        Returns the number of members dropped, so the caller can surface it as lint
+        (a silently truncated balloon leaves a hole undocumented — the resolver
+        must know, review follow-up).
         """
         if not members:
-            return
+            return 0
         k = 4 if axis == "y" else 3  # index of cy / cx in the member tuple
         members.sort(key=lambda m: m[k])
         naturals = [m[k] for m in members]
@@ -836,6 +850,7 @@ class Drawing:
         for (tag, j, hole, cx, cy), c in zip(members, coords):
             bx, by = (line, c) if axis == "y" else (c, line)
             self._render_balloon(view, tag, j, hole, cx, cy, bx, by, fs, r)
+        return len(members) - len(coords)
 
     def _render_balloon(self, view, tag, j, hole, cx, cy, bx, by, fs, r):
         """Build and add one balloon glyph + leader at solved centre ``(bx, by)``

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5244,6 +5244,20 @@ class TestHoleTable:
         dwg.add_hole_table("plan", balloons=False)
         assert not any(n.startswith("balloon_") for n in dwg.annotations())
 
+    def test_place_band_reports_dropped_overflow(self):
+        # #1a review follow-up: a band too small for every balloon drops its tail
+        # (the strip solver's prefix fallback) — _place_band must REPORT the dropped
+        # count so _add_balloons can surface it as `balloon_dropped` lint, instead of
+        # the balloons vanishing silently. 5 balloons needing a 10 mm gap in a 20 mm
+        # band fit only 3 (at 0, 10, 20); the other 2 are dropped and reported.
+        from types import SimpleNamespace
+
+        rendered: list = []
+        stub = SimpleNamespace(_render_balloon=lambda *a: rendered.append(a))
+        members = [("t", 0, object(), 0.0, float(i)) for i in range(5)]
+        dropped = Drawing._place_band(stub, "plan", members, "y", 50.0, 0.0, 20.0, 10.0, 3.0, 5.0)
+        assert dropped == 2 and len(rendered) == 3
+
     def test_table_and_balloons_keep_lint_clean(self):
         # covers_diameters lets coverage lint count the tabulated holes, and the
         # balloons are furniture (is_centerline) so they do not trip overlap lint.


### PR DESCRIPTION
Addresses the two coupled balloon-resolver findings from the review (option 1 — minimal: signal the drop + clear precisely, keep the existing strip solver).

### 1a — overflow balloons no longer vanish silently
`_place_band` spread balloons along a reserved band and, when the band could not hold them all, dropped the tail via the strip solver's prefix fallback — the extra balloons disappeared with **no lint or signal**. It now returns the dropped count; `_add_balloons` sums it across the four bands and records a `balloon_dropped` warning.

### 1b — `callout_dropped` cleared precisely, not wholesale
When scattered table rows **and** pattern balloons resolved in the same call, the scattered-table success cleared `callout_dropped` wholesale (before the balloons were even placed), masking a pattern balloon then silently dropped in the shared band. The careful "only-clear-for-landed-balloons" check was gated behind `not scattered_specs`, so it never ran in that combined case.

Now unified: the table-success path clears only `location_ref_dropped` (which the table's X/Y columns always resolve); after balloons are placed, one check clears `callout_dropped` iff **every** plan-view callout escalation is resolved — a pattern whose balloon landed (`placed_names`) or a scattered hole the table placed. Drops this resolver can't cover (table didn't fit, balloon didn't land, a non-plan drop) leave the lint standing.

### Impact
**Lint-only — no geometry change** (the same balloons are placed; only which build-issues are recorded/cleared changes). Snapshot/cleanliness (geometry gates) are unaffected. The balloon/table/standards suites (67 tests) stay green; a unit test pins `_place_band`'s dropped count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
