### PR TITLE
fix: choose_scale never returns an overflowing layout (#350)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -583,7 +583,11 @@ _PAGE_SIZES = {
     "A0": (1189.0, 841.0),
 }
 
-_SCALES = [10.0, 5.0, 2.0, 1.0, 0.5, 0.2]
+# ISO 5455 scale series (1-2-5 decades). Enlargements + 1:1 first, then reductions
+# down to 1:10000 so a very large part still gets a scale that FITS rather than an
+# overflowing layout (#350). Ordered largest-scale-first for "least reduction first".
+_SCALES = [10.0, 5.0, 2.0, 1.0]
+_SCALES += [0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.002, 0.001, 0.0005, 0.0002, 0.0001]
 
 # Horizontal page budget to reserve for the isometric view during scale
 # selection and view placement, as a fraction of bbox_max * scale.  This is a
@@ -634,6 +638,19 @@ _LADDER = [
     (0.2, 841.0, 594.0, 150.0),  # A1 1:5
     (0.5, 1189.0, 841.0, 150.0),  # A0 1:2
     (0.2, 1189.0, 841.0, 150.0),  # A0 1:5
+    # Past 1:5 keep reducing on A0 (the largest sheet) through the rest of the ISO 5455
+    # series, so a part too big for A0 1:5 still gets a scale that FITS rather than an
+    # overflowing layout (#350). A0 1:10000 holds anything up to ~8.4 m of drawn height.
+    (0.1, 1189.0, 841.0, 150.0),  # A0 1:10
+    (0.05, 1189.0, 841.0, 150.0),  # A0 1:20
+    (0.02, 1189.0, 841.0, 150.0),  # A0 1:50
+    (0.01, 1189.0, 841.0, 150.0),  # A0 1:100
+    (0.005, 1189.0, 841.0, 150.0),  # A0 1:200
+    (0.002, 1189.0, 841.0, 150.0),  # A0 1:500
+    (0.001, 1189.0, 841.0, 150.0),  # A0 1:1000
+    (0.0005, 1189.0, 841.0, 150.0),  # A0 1:2000
+    (0.0002, 1189.0, 841.0, 150.0),  # A0 1:5000
+    (0.0001, 1189.0, 841.0, 150.0),  # A0 1:10000
 ]
 
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -299,27 +299,40 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
 
     candidates = _repack_candidates(a, scale, page)
     fit = next(((c, gg) for c in candidates if (gg := _geom(c)).fits), None)
-    if fit is None:
-        # No standard ISO 5455 scale fits the measured layout (an out-of-domain-huge
-        # part). Rather than keep an overflowing sheet (#350), bisect for the largest
-        # scale that fits on the largest candidate sheet — the packed layout is monotone
-        # in scale — mirroring choose_scale's backstop.
-        _, pw0, ph0, tb0 = candidates[-1]
-        lo, hi = 0.0, candidates[-1][0]
-        for _ in range(60):
-            mid = (lo + hi) / 2.0
-            if _geom((mid, pw0, ph0, tb0)).fits:
-                lo = mid
-            else:
-                hi = mid
-        chosen = (lo, pw0, ph0, tb0)
-        g = _geom(chosen)
-        _log.warning(
-            "measure-repack: no standard sheet fits the measured layout; using computed %s",
-            format_drawing_scale(lo),
-        )
-    else:
+    if fit is not None:
         chosen, g = fit
+    else:
+        chosen = None
+        # No standard ISO 5455 scale fits the measured layout. When the scale is NOT
+        # pinned, bisect for the largest scale that fits on the largest candidate sheet
+        # (the packed layout is monotone in scale) so we never keep an overflowing sheet
+        # (#350) — mirroring choose_scale's backstop, including its two guards: honour a
+        # pinned scale (may not reduce it), and fall back if no positive scale fits.
+        if scale is None:
+            _, pw0, ph0, tb0 = candidates[-1]
+            lo, hi = 0.0, candidates[-1][0]
+            for _ in range(60):
+                mid = (lo + hi) / 2.0
+                if _geom((mid, pw0, ph0, tb0)).fits:
+                    lo = mid
+                else:
+                    hi = mid
+            if lo > 0.0:
+                chosen = (lo, pw0, ph0, tb0)
+                g = _geom(chosen)
+                _log.warning(
+                    "measure-repack: no standard sheet fits the measured layout; "
+                    "using computed %s",
+                    format_drawing_scale(lo),
+                )
+        if chosen is None:
+            # Pinned scale, or no positive scale fits the measured blocks on this page:
+            # keep the largest candidate and let lint report the overflow (as before).
+            chosen = candidates[-1]
+            g = _geom(chosen)
+            _log.warning(
+                "measure-repack: no sheet/scale fits the measured layout; using %s", chosen
+            )
     s, pw, ph, tb = chosen
     moved = max(
         abs(g.FV_X - a.FV_X),

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -18,6 +18,7 @@ from build123d import (
 )
 from build123d_drafting.helpers import (
     draft_preset,
+    format_drawing_scale,
 )
 
 from draftwright._core import (
@@ -299,12 +300,23 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
     candidates = _repack_candidates(a, scale, page)
     fit = next(((c, gg) for c in candidates if (gg := _geom(c)).fits), None)
     if fit is None:
-        # Nothing fits — keep the largest candidate and let lint report the
-        # overflow (mirrors choose_scale's fallback rather than crashing).
-        chosen = candidates[-1]
+        # No standard ISO 5455 scale fits the measured layout (an out-of-domain-huge
+        # part). Rather than keep an overflowing sheet (#350), bisect for the largest
+        # scale that fits on the largest candidate sheet — the packed layout is monotone
+        # in scale — mirroring choose_scale's backstop.
+        _, pw0, ph0, tb0 = candidates[-1]
+        lo, hi = 0.0, candidates[-1][0]
+        for _ in range(60):
+            mid = (lo + hi) / 2.0
+            if _geom((mid, pw0, ph0, tb0)).fits:
+                lo = mid
+            else:
+                hi = mid
+        chosen = (lo, pw0, ph0, tb0)
         g = _geom(chosen)
         _log.warning(
-            "measure-repack: no standard sheet fits the measured layout; using %s", chosen
+            "measure-repack: no standard sheet fits the measured layout; using computed %s",
+            format_drawing_scale(lo),
         )
     else:
         chosen, g = fit

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -16,6 +16,8 @@ import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+from build123d_drafting.helpers import format_drawing_scale
+
 from draftwright._core import (
     _DIM_PAD,
     _FONT_SIZE,
@@ -427,6 +429,34 @@ def _fits(
     return bool(iso_fit >= _ISO_MIN_FIT_FRAC * g.iso_natural)
 
 
+def _bisect_fit_scale(x_size, y_size, z_size, pw, ph, tb, n_steps, strips, pack_iso_2d):
+    """Largest scale at which the 4-view layout fits ``(pw, ph)``, found by bisection —
+    the layout is monotone in scale (a smaller scale never fits worse). Used only as the
+    #350 backstop when even the smallest ISO 5455 ladder scale (1:10000) overflows, i.e.
+    an out-of-domain-huge part. Returns ``None`` only if the page cannot hold the layout
+    at any positive scale (a degenerate page)."""
+    hi = _SCALES[-1]  # 1:10000 — the smallest laddered scale, already known not to fit
+    lo = 0.0
+    for _ in range(60):
+        mid = (lo + hi) / 2.0
+        if _fits(
+            x_size,
+            y_size,
+            z_size,
+            mid,
+            pw,
+            ph,
+            tb,
+            n_steps=n_steps,
+            strips=strips,
+            pack_iso_2d=pack_iso_2d,
+        ):
+            lo = mid
+        else:
+            hi = mid
+    return lo if lo > 0.0 else None
+
+
 def choose_scale(
     x_size: float,
     y_size: float,
@@ -494,6 +524,23 @@ def choose_scale(
             x_size, y_size, z_size, *cand, n_steps=n_steps, strips=strips, pack_iso_2d=pack_iso_2d
         ):
             return cand
+    # The ISO 5455 ladder exhausted with no standard fit (a part too large even for
+    # A0 1:10000). Rather than return a layout that overflows (#350), bisect for the
+    # largest scale that genuinely fits on the largest candidate sheet — the layout is
+    # monotone in scale — so choose_scale never hands back an overflowing (scale, page).
+    # A pinned scale is the one thing we may not reduce (that path returned above).
+    if scale is None:
+        _pw, _ph, _tb = candidates[-1][1], candidates[-1][2], candidates[-1][3]
+        s = _bisect_fit_scale(x_size, y_size, z_size, _pw, _ph, _tb, n_steps, strips, pack_iso_2d)
+        if s is not None:
+            _log.warning(
+                "No standard scale fits %.0f × %.0f × %.0f mm; using computed %s",
+                x_size,
+                y_size,
+                z_size,
+                format_drawing_scale(s),
+            )
+            return s, _pw, _ph, _tb
     _log.warning(
         "No layout fits %.0f × %.0f × %.0f mm; falling back to %s",
         x_size,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1288,6 +1288,23 @@ class TestComposeThenPackRepack:
         cands = _repack_candidates(a, 2.0, "A3")
         assert len(cands) == 1 and cands[0][0] == 2.0
 
+    @pytest.mark.timeout(120)
+    def test_repack_honours_pinned_scale_on_oversized_part(self):
+        # #350 review: when no candidate fits the measured layout, the repack backstop
+        # bisects for a fitting scale ONLY when the scale is not pinned. A user-pinned
+        # scale must be honoured (overflow accepted, as asked) — not silently reduced —
+        # and the backstop must never crash on the degenerate no-positive-scale case.
+        dwg = build_drawing(Box(4200, 1600, 5400), scale=1)
+        assert dwg.scale == 1.0  # pin honoured, not silently rescaled
+
+    @pytest.mark.timeout(120)
+    def test_repack_reduces_an_oversized_part_when_scale_is_free(self):
+        # The complement: with the scale free, an oversized part is reduced to a scale
+        # that fits rather than overflowing (#350) — through the full pass-1 + repack.
+        dwg = build_drawing(Box(4200, 1600, 5400))
+        assert dwg.scale < 0.2  # a deeper ISO 5455 reduction than the old A0 1:5 floor
+        assert not any(i.code.endswith("out_of_bounds") for i in dwg.lint())
+
     # --- ownership-map lifecycle -----------------------------------------
 
     @pytest.mark.timeout(60)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -144,6 +144,41 @@ class TestChooseScale:
         assert scale == 10.0
         assert int(pw) == 297
 
+    # #350 — never return an overflowing layout for an oversized part.
+
+    def test_oversized_part_gets_a_fitting_reduction(self):
+        # 4200 × 1600 × 5400 mm (a civil/weldment-scale part) overflowed A0 1:5 before —
+        # the ladder floored at 1:5, so choose_scale returned a layout it had just proved
+        # did not fit. It now walks the rest of the ISO 5455 reductions to A0 1:10.
+        x, y, z = 4200.0, 1600.0, 5400.0
+        scale, pw, ph, tbw = choose_scale(x, y, z)
+        assert scale == 0.1 and (pw, ph) == (1189.0, 841.0)  # A0 1:10
+        assert _fits(x, y, z, scale, pw, ph, tbw)
+
+    def test_choose_scale_never_overflows_across_the_size_range(self):
+        # The invariant: automatic choose_scale never hands back a (scale, page) that
+        # _fits reports as overflowing — from tiny to absurdly large (#350).
+        for x, y, z in [
+            (5, 5, 5),
+            (300, 300, 300),
+            (4200, 1600, 5400),
+            (40000, 2000, 60000),
+            (500000, 5000, 800000),
+        ]:
+            scale, pw, ph, tbw = choose_scale(x, y, z)
+            assert _fits(x, y, z, scale, pw, ph, tbw), (
+                f"{(x, y, z)} -> {(scale, pw, ph)} overflows"
+            )
+
+    def test_backstop_computes_a_fit_beyond_the_ladder(self):
+        # A part too large even for A0 1:10000 falls to the bisection backstop and still
+        # returns a scale that fits — a non-standard scale is acceptable for an
+        # out-of-domain part; anything beats an overflowing layout.
+        x, y, z = 20_000_000.0, 5000.0, 30_000_000.0  # ~30 km — deliberately absurd
+        scale, pw, ph, tbw = choose_scale(x, y, z)
+        assert 0.0 < scale < 0.0001
+        assert _fits(x, y, z, scale, pw, ph, tbw)
+
 
 class TestChooseScaleOverrides:
     def test_scale_and_page_used_verbatim(self):


### PR DESCRIPTION
Closes #350.

## Problem
When no candidate in the automatic scale/page ladder fit, `choose_scale` (and the measure-and-repack pass) returned the *last* candidate anyway — an oversized layout that **overflows the page** — because the ISO 5455 reduction ladder floored at **A0 1:5**. A part too large for A0 1:5 (the reported repro: a 4200 × 1600 × 5400 mm civil/weldment part) got the A0 1:5 candidate it had just proved does not fit, and every downstream view and annotation landed out of bounds (10+ `*_out_of_bounds` errors).

## Fix
- **Extend the ISO 5455 reduction ladder** (`_SCALES`, `_LADDER`) past 1:5 on A0 — 1:10, 1:20, 1:50, … 1:10000 — so a too-big part keeps reducing, least-reduction-first, until it genuinely fits. A0 1:10000 holds ~8.4 m of drawn extent.
- **Bisection backstop** for the out-of-domain case where even A0 1:10000 overflows (`_bisect_fit_scale` in `sheet.py`; inline in `_repack`) — the layout is monotone in scale, so bisection finds the largest fitting scale.

**Invariant:** automatic `choose_scale`/`_repack` never return a `(scale, page)` that `_fits` reports as overflowing. A pinned scale (which we may not reduce) is the one exception and already warns + honours the override.

## Verification
- **Byte-identical on the corpus** — the new ladder rungs are only reached after A0 1:5 fails, which no corpus part does (snapshot + cleanliness: 27 passed).
- The repro (4200 × 1600 × 5400) now builds cleanly at **1:10 on A0, 0 out-of-bounds, 0 errors**.
- Tests: oversized part → fitting reduction; the no-overflow invariant across tiny→absurd sizes; the bisection backstop beyond the ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
