### PR TITLE
test: shared-build fixtures for the hot read-only builds (#153)

### DIFF
--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5387,10 +5387,19 @@ class TestHoleTable:
             assert self._area(tb, dwg.view_bounds(v)) == 0.0, v
 
 
+@pytest.fixture(scope="module")
+def dense_plate_dwg():
+    """Shared **read-only** build of ``_dense_plate()`` for the escalation assertions
+    that only inspect the finished drawing (#153 — each rebuilt the ~20 s dense-plate
+    just to read a different property). Tests that mutate the drawing (append an
+    escalation, record an issue, run the resolver) must build their own."""
+    return build_drawing(_dense_plate())
+
+
 class TestEscalation:
     """#93: a too-dense plan view auto-escalates to a hole chart + balloons."""
 
-    def test_dense_part_groups_and_types(self):
+    def test_dense_part_groups_and_types(self, dense_plate_dwg):
         # Sized honestly for its real annotation footprint (#121, ADR 0004), the
         # sheet grows so the X-location dims + grouped spec-callouts fit — so this
         # moderately-dense plate no longer escalates to a per-hole table + balloon
@@ -5398,7 +5407,7 @@ class TestEscalation:
         # group-and-types instead: spec-group callouts (5× ⌀…) + location dims,
         # lint clean. The table/balloon escalation path remains for parts too
         # dense to fit even that — covered by the CTC-02 slow-tier test.
-        dwg = build_drawing(_dense_plate())
+        dwg = dense_plate_dwg
         ann = dwg.annotations()
         assert "hole_table_plan" not in ann
         assert not any(n.startswith("balloon_") for n in ann)
@@ -5406,11 +5415,11 @@ class TestEscalation:
         assert any(n.startswith("m_locx") for n in ann)  # location dims placed, not dropped
         assert [i for i in dwg.lint() if i.severity in ("warning", "error")] == []
 
-    def test_escalation_clears_density_lint(self):
+    def test_escalation_clears_density_lint(self, dense_plate_dwg):
         # No callout_dropped / location_ref_dropped / count-mismatch warnings
         # survive once the dense plate is dimensioned — whether by group-and-type
         # (now, on the auto-sized sheet) or by the table escalation it used to need.
-        dwg = build_drawing(_dense_plate())
+        dwg = dense_plate_dwg
         warns = {i.code for i in dwg.lint() if i.severity in ("warning", "error")}
         assert "callout_dropped" not in warns
         assert "location_ref_dropped" not in warns

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -97,6 +97,17 @@ class TestExtractPmi:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(scope="module")
+def ctc01_annotated(tmp_path_factory):
+    """One ``pmi='annotate'`` build of CTC-01, shared **read-only** across the
+    annotate assertions below — each used to rebuild the ~18 s CTC AP242 import +
+    annotate just to check a different read-only property (#153). Any test that
+    MUTATES the drawing (add/remove/pin/repair/export-to-a-new-path) must build its
+    own, not use this fixture."""
+    stem = str(tmp_path_factory.mktemp("ctc01_pmi") / "ctc01")
+    return build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="annotate")
+
+
 class TestBuildDrawingPmi:
     def test_pmi_off_leaves_drawing_unchanged(self, tmp_path):
         """pmi='off' produces an identical drawing to not passing pmi at all."""
@@ -115,33 +126,24 @@ class TestBuildDrawingPmi:
         pmi_names = [n for n in dwg._named if n.startswith("pmi_")]
         assert pmi_names == [], "pmi='report' should not add drawing annotations"
 
-    def test_pmi_annotate_adds_dims(self, tmp_path):
+    def test_pmi_annotate_adds_dims(self, ctc01_annotated):
         """pmi='annotate' adds at least one pmi_ dimension to the drawing."""
-        stem = str(tmp_path / "ctc01_annotate")
-        dwg = build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="annotate")
-        pmi_names = [n for n in dwg._named if n.startswith("pmi_")]
+        pmi_names = [n for n in ctc01_annotated._named if n.startswith("pmi_")]
         assert len(pmi_names) >= 1, f"expected ≥1 pmi_ annotation, got {pmi_names}"
 
-    def test_pmi_annotate_drawing_lint_clean(self, tmp_path):
+    def test_pmi_annotate_drawing_lint_clean(self, ctc01_annotated):
         """Drawing with PMI annotations passes lint with no errors."""
-
-        stem = str(tmp_path / "ctc01_lint")
-        dwg = build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="annotate")
-        issues = dwg.lint()
+        issues = ctc01_annotated.lint()
         errors = [i for i in issues if i.severity == "error"]
         assert errors == [], f"lint errors with PMI: {[str(i) for i in errors]}"
 
-    def test_pmi_annotate_exports_svg_dxf(self, tmp_path):
+    def test_pmi_annotate_exports_svg_dxf(self, ctc01_annotated):
         """build_drawing + export with PMI produces valid SVG and DXF files."""
-        stem = str(tmp_path / "ctc01_export")
-        dwg = build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="annotate")
-        svg_path, dxf_path = dwg.export()
+        svg_path, dxf_path = ctc01_annotated.export()
         assert Path(svg_path).exists() and Path(svg_path).stat().st_size > 0
         assert Path(dxf_path).exists() and Path(dxf_path).stat().st_size > 0
 
-    def test_pmi_annotation_names_unique(self, tmp_path):
+    def test_pmi_annotation_names_unique(self, ctc01_annotated):
         """All pmi_ annotation names in the drawing are unique."""
-        stem = str(tmp_path / "ctc01_unique")
-        dwg = build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="annotate")
-        pmi_names = [n for n in dwg._named if n.startswith("pmi_")]
+        pmi_names = [n for n in ctc01_annotated._named if n.startswith("pmi_")]
         assert len(pmi_names) == len(set(pmi_names)), f"duplicate pmi names: {pmi_names}"


### PR DESCRIPTION
## What

Share expensive OCC builds across the read-only assertion tests that only inspect a finished drawing (#153). The default (fast) test tier is CPU-bound on real builds; several tests rebuilt the same part just to check a different property.

- **`test_pmi.py`** — one `pmi='annotate'` CTC-01 AP242 build (~18 s) shared via a module fixture across the 4 read-only annotate tests. `test_pmi.py`: **~127 s → 70 s**.
- **`test_make_drawing.py::TestEscalation`** — one `_dense_plate()` build shared across the 2 read-only escalation-inspection tests.

Only genuinely read-only tests share. The pattern-drop / table-escalation tests **mutate** the drawing (`_escalations.append`, `_record_build_issue`, `_maybe_tabulate_holes`) and keep building their own. No assertion changed; no cross-test state leak.

## Why this is the proportionate fix

Measured findings on #153:
- `-m smoke` is **~27 s** (target ≤45 s) — this already solves the local "did I break something" loop.
- The full fast tier is **CPU-bound**, not distribution-bound: `--dist worksteal` ≈ `--dist loadscope`; the win is only from *doing fewer builds*.
- Most repeated builds **mutate**, so the shared-fixture ceiling is limited. The two conversions here are the clean, safe wins (~77 s of redundant build work removed); a broader refactor would fight the isolation caveat for diminishing returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
