### PR TITLE
feat: generated script preserves pmi/scale/page + lint-snippet imports (#388 Phase 1)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -679,9 +679,12 @@ def generate_script(
             out = out[: -len(_ext)]
             break
     title = title or stem.replace("_", " ").upper()
-    a = _analyse(
-        step_file, title, number, tolerance, drawn_by, out, scale=scale, page=page, pmi=pmi
-    )
+    # scale/page are NOT passed to this analysis: the script embeds them as literal
+    # config fields and re-validates them at run time inside build_drawing(). Validating
+    # here too would crash generation on an out-of-range value (e.g. --script --scale
+    # 0.001 / --page A9) instead of writing the script and deferring — inconsistent with
+    # a large unfittable scale, which already defers (review #401).
+    a = _analyse(step_file, title, number, tolerance, drawn_by, out, pmi=pmi)
     return _write_script(a, scale=scale, page=page)
 
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -640,8 +640,10 @@ def _write_script(a: Analysis, scale: float | None = None, page: str | None = No
         "\n"
         "# ── Export ────────────────────────────────────────────────────────────────────\n"
         "svg_path, dxf_path = dwg.export(_stem)\n"
-        'print(f"SVG \\u2192 {svg_path}")\n'
-        'print(f"DXF \\u2192 {dxf_path}")\n'
+        # ASCII arrow: a Unicode → crashes the print on a Windows cp1252 console
+        # (UnicodeEncodeError) — the generated script must run everywhere.
+        'print(f"SVG -> {svg_path}")\n'
+        'print(f"DXF -> {dxf_path}")\n'
     )
 
     content = header + cog_block + run_section

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -531,8 +531,14 @@ def make_drawing(
 # ---------------------------------------------------------------------------
 
 
-def _write_script(a: Analysis) -> str:
-    """Write an editable script at ``a.out + '.py'`` that calls make_drawing()."""
+def _write_script(a: Analysis, scale: float | None = None, page: str | None = None) -> str:
+    """Write an editable script at ``a.out + '.py'`` that calls make_drawing().
+
+    ``scale``/``page`` are the caller's *overrides* (``None`` = auto); ``pmi`` is
+    carried from the analysis (``a.pmi_mode``). All three are preserved as config
+    fields and threaded into the emitted ``build_drawing(...)`` call so the script
+    reproduces the CLI's intent (#388).
+    """
     py_path = a.out + ".py"
     py_name = Path(py_path).name
 
@@ -543,6 +549,9 @@ def _write_script(a: Analysis) -> str:
             f"NUMBER = {a.number!r}",
             f"TOLERANCE = {a.tolerance!r}",
             f"DRAWN_BY = {a.drawn_by!r}",
+            f"PMI = {a.pmi_mode!r}",
+            f"SCALE = {scale!r}",
+            f"PAGE = {page!r}",
         ]
     )
 
@@ -554,12 +563,16 @@ def _write_script(a: Analysis) -> str:
         f"_NUMBER    = {a.number!r}\n"
         f"_TOLERANCE = {a.tolerance!r}\n"
         f"_DRAWN_BY  = {a.drawn_by!r}\n"
+        f"_PMI       = {a.pmi_mode!r}   # 'off' | 'report' | 'annotate'\n"
+        f"_SCALE     = {scale!r}   # None = auto; e.g. 5 for 5:1, 0.5 for 1:2\n"
+        f"_PAGE      = {page!r}   # None = auto; e.g. 'A3' or (297, 210)\n"
         "try:\n"
         "    cog  # NameError → not under cog\n"
         "    for _k, _v in [\n"
         "        ('STEP_FILE', repr(_STEP_FILE)), ('TITLE', repr(_TITLE)),\n"
         "        ('NUMBER', repr(_NUMBER)), ('TOLERANCE', repr(_TOLERANCE)),\n"
-        "        ('DRAWN_BY', repr(_DRAWN_BY)),\n"
+        "        ('DRAWN_BY', repr(_DRAWN_BY)), ('PMI', repr(_PMI)),\n"
+        "        ('SCALE', repr(_SCALE)), ('PAGE', repr(_PAGE)),\n"
         "    ]:\n"
         "        cog.outl(f'{_k} = {_v}')\n"
         "except NameError:\n"
@@ -586,6 +599,9 @@ def _write_script(a: Analysis) -> str:
         f"import os as _os\n"
         f"from draftwright import build_drawing\n"
         f"\n"
+        f"# Available for lint-suggestion snippets (dwg.lint_summary()); unused otherwise.\n"
+        f"from build123d_drafting import Dimension, HoleCallout, Leader  # noqa: F401\n"
+        f"\n"
         f"# ── Config (auto-updated by cog) ──────────────────────────────────────────────\n"
     )
 
@@ -600,6 +616,9 @@ def _write_script(a: Analysis) -> str:
         "    number=NUMBER,\n"
         "    tolerance=TOLERANCE,\n"
         "    drawn_by=DRAWN_BY,\n"
+        "    pmi=PMI,\n"
+        "    scale=SCALE,\n"
+        "    page=PAGE,\n"
         ")\n"
         "\n"
         "# ── Customise here — runs BEFORE export, so edits land in the output ───────────\n"
@@ -639,6 +658,8 @@ def generate_script(
     tolerance: str = "ISO 2768-m",
     drawn_by: str = "",
     pmi: Literal["off", "report", "annotate"] = "off",
+    scale: float | None = None,
+    page: str | None = None,
 ) -> str:
     """Generate an editable Cog-enabled drawing script from a STEP file.
 
@@ -658,8 +679,10 @@ def generate_script(
             out = out[: -len(_ext)]
             break
     title = title or stem.replace("_", " ").upper()
-    a = _analyse(step_file, title, number, tolerance, drawn_by, out, pmi=pmi)
-    return _write_script(a)
+    a = _analyse(
+        step_file, title, number, tolerance, drawn_by, out, scale=scale, page=page, pmi=pmi
+    )
+    return _write_script(a, scale=scale, page=page)
 
 
 # ---------------------------------------------------------------------------

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -135,11 +135,6 @@ def main(
     """Generate a fully-annotated technical drawing from a STEP file."""
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING, format="%(message)s")
 
-    if script and (scale is not None or page is not None):
-        raise typer.BadParameter(
-            "--scale/--page only apply to direct output; edit the generated script instead"
-        )
-
     formats = _parse_formats(output_format)
 
     # Import the engine lazily, only on the build path: it pulls in build123d/OCP
@@ -157,6 +152,8 @@ def main(
             tolerance=tolerance,
             drawn_by=drawn_by,
             pmi=pmi.value,
+            scale=scale,
+            page=page,
         )
         print(py_path)
         return

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2303,6 +2303,17 @@ def test_generate_script_imports_lint_suggestion_classes(tmp_path):
     assert "from build123d_drafting import Dimension, HoleCallout, Leader" in content
 
 
+def test_generate_script_defers_invalid_scale_page(tmp_path):
+    # #388/#401: an out-of-range scale/page must NOT crash generation — the script is
+    # written with the value embedded and validation deferred to run time (consistent
+    # with a large unfittable scale, which already defers).
+    step = tmp_path / "p.step"
+    export_step(Box(30, 20, 10), str(step))
+    py = generate_script(str(step), out=str(tmp_path / "p"), scale=0.001, page="A9")
+    content = Path(py).read_text()
+    assert "SCALE = 0.001" in content and "PAGE = 'A9'" in content
+
+
 @pytest.mark.timeout(180)
 def test_generated_script_runs_and_preserves_pmi(tmp_path):
     # #388 acceptance: a generated --pmi annotate script preserves pmi when RUN — execute

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2318,14 +2318,23 @@ def test_generate_script_defers_invalid_scale_page(tmp_path):
 def test_generated_script_runs_and_preserves_pmi(tmp_path):
     # #388 acceptance: a generated --pmi annotate script preserves pmi when RUN — execute
     # it in a subprocess and assert it builds output without error.
+    import os
     import subprocess
     import sys
 
     step = tmp_path / "p.step"
     export_step(Box(80, 50, 8), str(step))
     py = generate_script(str(step), out=str(tmp_path / "p"), pmi="annotate")
+    # Force an ASCII stdout so a non-ASCII char in the script's own print() (e.g. a
+    # Unicode arrow) fails HERE on every platform, not only on a Windows cp1252 console.
+    env = {**os.environ, "PYTHONIOENCODING": "ascii"}
     r = subprocess.run(
-        [sys.executable, py], capture_output=True, text=True, cwd=str(tmp_path), timeout=150
+        [sys.executable, py],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        timeout=150,
+        env=env,
     )
     assert r.returncode == 0, f"generated script failed:\n{r.stderr[-1500:]}"
     assert (tmp_path / "p.svg").exists(), "generated script did not write the SVG"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2270,6 +2270,56 @@ def test_generate_script_emits_build_drawing(tmp_path):
     assert "Customise here" in content
 
 
+def test_generate_script_preserves_pmi_scale_page(tmp_path):
+    # #388: the generated script must carry the CLI's build intent — pmi/scale/page as
+    # config fields AND threaded into the emitted build_drawing() call — so running the
+    # script reproduces what the CLI would have built.
+    step = tmp_path / "p.step"
+    export_step(Box(30, 20, 10), str(step))
+    py = generate_script(str(step), out=str(tmp_path / "p"), pmi="annotate", scale=5.0, page="A3")
+    content = Path(py).read_text(encoding="utf-8")
+    assert "PMI = 'annotate'" in content
+    assert "SCALE = 5.0" in content
+    assert "PAGE = 'A3'" in content
+    assert "pmi=PMI," in content and "scale=SCALE," in content and "page=PAGE," in content
+
+
+def test_generate_script_defaults_are_auto(tmp_path):
+    # Defaults: no overrides → PMI off, SCALE/PAGE None (auto) — still emitted so the
+    # fields exist for the user to set.
+    step = tmp_path / "p.step"
+    export_step(Box(30, 20, 10), str(step))
+    content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text()
+    assert "PMI = 'off'" in content
+    assert "SCALE = None" in content and "PAGE = None" in content
+
+
+def test_generate_script_imports_lint_suggestion_classes(tmp_path):
+    # #388: lint suggestions (dwg.lint_summary()) reference Leader/HoleCallout/Dimension;
+    # the script must import them so a suggestion pastes+runs without manual imports.
+    step = tmp_path / "p.step"
+    export_step(Box(30, 20, 10), str(step))
+    content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text()
+    assert "from build123d_drafting import Dimension, HoleCallout, Leader" in content
+
+
+@pytest.mark.timeout(180)
+def test_generated_script_runs_and_preserves_pmi(tmp_path):
+    # #388 acceptance: a generated --pmi annotate script preserves pmi when RUN — execute
+    # it in a subprocess and assert it builds output without error.
+    import subprocess
+    import sys
+
+    step = tmp_path / "p.step"
+    export_step(Box(80, 50, 8), str(step))
+    py = generate_script(str(step), out=str(tmp_path / "p"), pmi="annotate")
+    r = subprocess.run(
+        [sys.executable, py], capture_output=True, text=True, cwd=str(tmp_path), timeout=150
+    )
+    assert r.returncode == 0, f"generated script failed:\n{r.stderr[-1500:]}"
+    assert (tmp_path / "p.svg").exists(), "generated script did not write the SVG"
+
+
 # ---------------------------------------------------------------------------
 # Part classification (#81) — prismatic parts skip turned-part annotations
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
First phase of #388 — make `--script` carry the CLI's build intent.

## Problem
- `pmi` was passed to `_analyse` but never emitted, so a `--script --pmi annotate` script silently built with `pmi="off"`.
- `--scale`/`--page` were rejected with "edit the generated script instead" — but the template exposed no field to edit.
- Lint suggestions from `lint_summary()` reference `Leader`/`HoleCallout`, but the script imported only `build_drawing`, so a pasted snippet failed on `NameError`.

## Change
- `generate_script` gains `scale`/`page` params; `_write_script` emits **PMI / SCALE / PAGE** as cog config fields and threads them into the emitted `build_drawing(...)` call.
- The CLI drops the `--scale`/`--script` rejection and forwards `scale`/`page`.
- The script imports `Dimension, HoleCallout, Leader` (F401-ignored) so a lint suggestion pastes and runs as-is.

## Acceptance criteria closed (of #388)
1. `--script --pmi annotate` preserves `pmi="annotate"` when run. ✅
2. Scale/page settable in the generated script without editing the call structure. ✅
4. A lint suggestion pastes without adding missing imports. ✅

(Criterion 3 — post-edit `finalize` — is **Phase 2**, a separate PR. Criteria 5 covered by the tests below.)

## Tests
- Config round-trip for set (`annotate`/`5.0`/`A3`) and default (`off`/`None`/`None`) values.
- The suggestion-import line is present.
- End-to-end: a generated `--pmi annotate` script runs in a subprocess and writes the SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)