### PR TITLE
feat: dwg.model() — expose the detected PartModel as the read surface (#397)

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -170,6 +170,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
         pmi=a.pmi,
     )
+    # Retain the IR on the drawing as the read surface for semantic edits (#397). On a
+    # repack this runs again on the final (pass-2) drawing, so dwg.model() always
+    # reflects the drawing that was actually rendered.
+    dwg._part_model = _model
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them
     # (was recomputed per renderer, #275). One rule set over DimParameters, literally.
     _groups = plan_dimensions(_model)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -286,6 +286,9 @@ class Drawing:
         self.svg_path: str | None = None
         self.dxf_path: str | None = None
         self._analysis: Analysis | None = None
+        # The detected ADR-0008 PartModel this drawing was built from (attached by
+        # the annotation orchestrator). Read surface for semantic edits (#397).
+        self._part_model: object | None = None
 
     # -- annotation registry (compat accessors, ADR 0005 §4) ------------------
     # The registry owns these four; they are exposed as their live containers so
@@ -512,6 +515,27 @@ class Drawing:
                 )
             )
         return result
+
+    def model(self):
+        """The detected **PartModel** this drawing was built from (ADR 0008 IR) — the
+        read surface for semantic edits (#397, ADR 0001 Amendment 1).
+
+        Both input scenarios converge here: a STEP file and a build123d solid both
+        normalise to a solid, are detected once, and produce the *same* feature model
+        (``.features`` — holes/slots/steps/patterns, ``.datums``, ``.orientation``,
+        ``.bbox``). This is the provenance-agnostic "what is in this drawing and why"
+        — richer than :meth:`features` (grouped holes, per view) and the future target
+        for feature-referenced edits (#398).
+
+        **Read-only** — a view of what was built; mutating it does not change the
+        drawing. **Experimental**: exposes the raw IR dataclasses, which may still
+        evolve (a stabilised public projection is deferred to the write surface #398).
+
+        Returns ``None`` when no model is available — before a build, or when built
+        with ``auto_dims=False`` (detection currently runs inside the annotation pass;
+        hoisting it so the model is always present is the #398 prerequisite).
+        """
+        return self._part_model
 
     def place_dim(self, p1, p2, side, view, draft, *, name=None, slot=8.0, **kwargs):
         """Add a :class:`~build123d_drafting.helpers.Dimension` that stacks cleanly

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4201,6 +4201,47 @@ def _holed_plate():
     )
 
 
+def _model_signature(m):
+    """Provenance-agnostic structural signature of a PartModel: orientation + sorted
+    (feature-kind, count) + datum count. Byte coordinates differ across a STEP round-trip;
+    the semantic structure must not."""
+    kinds: dict = {}
+    for f in m.features:
+        kinds[f.kind] = kinds.get(f.kind, 0) + 1
+    return (m.orientation, tuple(sorted(kinds.items())), len(m.datums))
+
+
+class TestModel:
+    """#397: dwg.model() exposes the detected ADR-0008 PartModel as the read surface."""
+
+    def test_model_exposes_detected_features(self):
+        m = build_drawing(_holed_plate()).model()
+        assert m is not None
+        assert m.orientation is None  # prismatic plate
+        kinds = {f.kind for f in m.features}
+        assert "hole" in kinds
+        assert len(m.datums) >= 1
+
+    def test_model_none_without_auto_dims(self):
+        # D1 (documented limitation): detection runs inside the annotation pass, so a
+        # manual-mode build has no model yet. Hoisting detection is the #398 prerequisite.
+        assert build_drawing(_holed_plate(), auto_dims=False).model() is None
+
+    def test_model_structurally_equivalent_across_step_and_b123d_input(self, tmp_path):
+        # D5 / the convergence property (ADR 0001 Amendment 1): a STEP import re-tessellates
+        # the solid, so coordinates differ — but the DETECTED feature structure must be the
+        # same whether the input was a build123d object or a STEP file of that object.
+        part = _holed_plate()
+        step = tmp_path / "plate.step"
+        export_step(part, str(step))
+        m_obj = build_drawing(part).model()
+        m_step = build_drawing(str(step)).model()
+        assert _model_signature(m_obj) == _model_signature(m_step), (
+            f"model diverged across provenance: obj={_model_signature(m_obj)} "
+            f"step={_model_signature(m_step)}"
+        )
+
+
 class TestFeatures:
     """#26: dwg.features(view) exposes analysis to scripts."""
 


### PR DESCRIPTION
Closes #397. First read half of the shared edit surface (ADR 0001 Amendment 1).

## What
The ADR-0008 `PartModel` was built as a local in the annotation orchestrator and thrown away. This retains it on the `Drawing` and exposes it **read-only** via `dwg.model()` — the provenance-agnostic "what is in this drawing and why" that both STEP and build123d inputs converge on.

```python
m = build_drawing(part).model()   # or build_drawing(step_path).model() — same model
m.features   # holes / slots / steps / patterns / envelope (frozen IR dataclasses)
m.datums; m.orientation; m.bbox
```

## Design calls (flagged for review, per the read-first/minimal rule)
- **Raw IR exposed** (frozen dataclasses), documented *experimental* — a stabilised public projection is deferred to the write surface #398, which will define what the write side references.
- **D1 limitation:** detection runs inside the annotation pass, so a manual-mode (`auto_dims=False`) build has `model() is None`. Hoisting `build_part_model` so the model is always present is the **#398 prerequisite** — documented, not silently shipped.
- `_part_model` lives on `Drawing` alongside `_analysis` (same ADR-0005 §2 deferred build-context pattern; the natural home for a user-facing read surface).

## Tests
- `model()` exposes detected features + datums; `orientation is None` for a prismatic plate.
- `None` under `auto_dims=False` (locks the documented D1 behaviour).
- **Convergence property (D5):** a build123d part and a `export_step`→`import_step` of it produce **structurally equivalent** models (same feature kinds/counts/orientation) — asserted via a real round-trip, not byte-identity, since a STEP import re-tessellates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)