### PR TITLE
feat: detect the PartModel in the pipeline — dwg.model() works in manual mode (#398a)

### DIFF
--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -10,4 +10,5 @@ from draftwright.annotations.from_model import _detect_step_repeat  # noqa: F401
 from draftwright.annotations.orchestrator import (  # noqa: F401
     _auto_annotate,
     _wrap_rows,
+    build_model,
 )

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -104,6 +104,31 @@ def _concentric_bore_diams(a: Analysis) -> list:
     return [d for d in a.z_diams if d != a.od_diam and any(abs(d - c) <= 0.15 for c in concentric)]
 
 
+def build_model(a: Analysis):
+    """Build the ADR-0008 :class:`PartModel` from an analysis — the detected feature
+    inventory (a pure function of *a*).
+
+    Extracted from :func:`_auto_annotate` so the pipeline can build the model
+    **regardless of** ``auto_dims`` (#398): the read surface :meth:`Drawing.model` and
+    feature-referenced edits must work even in manual mode, where the annotation pass
+    never runs. Concentric bore leaders are a Z-axis construction (bores on the vertical
+    rotation axis); a horizontal (X/Y) round body gets OD + centrelines only (#222), so
+    its bore set is empty.
+    """
+    _bores = tuple(_concentric_bore_diams(a)) if a.is_rotational and a.od_axis == "z" else ()
+    return build_part_model(
+        a.part,
+        holes=a.holes,
+        patterns=a.patterns,
+        bosses=a.bosses,
+        slots=a.slots,
+        prof=a.prof,
+        step_zs=a.step_zs,
+        rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
+        pmi=a.pmi,
+    )
+
+
 def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     """Add the standard automatic dimensions, centrelines, and title block."""
     # Idempotent: clear build-time lint state so a second annotation pass does
@@ -153,26 +178,12 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         "x": ("side", lambda loc: (SX(loc[1]), SZ(loc[2]))),
     }
 
-    # The part model — built once and rendered from for the IR-migrated passes
-    # (centre marks, turned diameters/lengths); ADR 0008 convergence / #229.
-    # Concentric bore leaders are a Z-axis construction (bores on the vertical
-    # rotation axis); a horizontal (X/Y) round body gets OD + centrelines only
-    # (#222), so its bore set is empty.
-    _bores = tuple(_concentric_bore_diams(a)) if a.is_rotational and a.od_axis == "z" else ()
-    _model = build_part_model(
-        a.part,
-        holes=a.holes,
-        patterns=a.patterns,
-        bosses=a.bosses,
-        slots=a.slots,
-        prof=a.prof,
-        step_zs=a.step_zs,
-        rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
-        pmi=a.pmi,
-    )
-    # Retain the IR on the drawing as the read surface for semantic edits (#397). On a
-    # repack this runs again on the final (pass-2) drawing, so dwg.model() always
-    # reflects the drawing that was actually rendered.
+    # The part model — the IR-migrated passes (centre marks, turned diameters/lengths)
+    # render from it (ADR 0008 convergence / #229). Built once by the pipeline
+    # (:func:`build_model`, attached to the drawing before this pass) so the read surface
+    # (dwg.model()) and feature edits work even in manual mode (#398); fall back to
+    # building it here for any direct caller that skipped _assemble.
+    _model = dwg._part_model if dwg._part_model is not None else build_model(a)
     dwg._part_model = _model
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them
     # (was recomputed per renderer, #275). One rule set over DimParameters, literally.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -35,7 +35,7 @@ from draftwright._core import (
     _tb_width,
 )
 from draftwright.analysis import _analyse
-from draftwright.annotate import _auto_annotate
+from draftwright.annotate import _auto_annotate, build_model
 from draftwright.drawing import Drawing
 from draftwright.fonts import PLEX_MONO
 from draftwright.projection import (
@@ -209,6 +209,10 @@ def _assemble(a, out, assembly, detail_view, auto_dims) -> Drawing:
         assembly=assembly,
     )
     dwg._analysis = a  # expose analysis namespace for testing and future strip access
+    # Detect the IR here — before the auto_dims gate — so dwg.model() and feature edits
+    # work even in manual mode (#398). _auto_annotate reads this attached model rather
+    # than rebuilding. On a repack this runs again on the pass-2 drawing (freshness).
+    dwg._part_model = build_model(a)
 
     part_s = a.part.scale(a.SCALE)
     dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -531,9 +531,10 @@ class Drawing:
         drawing. **Experimental**: exposes the raw IR dataclasses, which may still
         evolve (a stabilised public projection is deferred to the write surface #398).
 
-        Returns ``None`` when no model is available — before a build, or when built
-        with ``auto_dims=False`` (detection currently runs inside the annotation pass;
-        hoisting it so the model is always present is the #398 prerequisite).
+        Populated for every built drawing, including a manual-mode (``auto_dims=False``)
+        build — detection runs in the pipeline, not the annotation pass (#398), so a
+        script can dimension detected features even when it suppressed the automatic
+        ones. ``None`` only on a bare, unbuilt ``Drawing``.
         """
         return self._part_model
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4222,10 +4222,21 @@ class TestModel:
         assert "hole" in kinds
         assert len(m.datums) >= 1
 
-    def test_model_none_without_auto_dims(self):
-        # D1 (documented limitation): detection runs inside the annotation pass, so a
-        # manual-mode build has no model yet. Hoisting detection is the #398 prerequisite.
-        assert build_drawing(_holed_plate(), auto_dims=False).model() is None
+    def test_model_present_without_auto_dims(self):
+        # #398 detect-hoist: detection runs in the pipeline, not the annotation pass, so a
+        # manual-mode build still exposes the model — a script can dimension detected
+        # features even when it suppressed the automatic ones.
+        m = build_drawing(_holed_plate(), auto_dims=False).model()
+        assert m is not None
+        assert any(f.kind == "hole" for f in m.features)
+
+    def test_model_identical_across_auto_and_manual(self):
+        # Same detection regardless of whether dimensions were auto-placed — the model is
+        # a property of the part, not the annotation pass.
+        part = _holed_plate()
+        assert _model_signature(build_drawing(part).model()) == _model_signature(
+            build_drawing(part, auto_dims=False).model()
+        )
 
     def test_model_structurally_equivalent_across_step_and_b123d_input(self, tmp_path):
         # D5 / the convergence property (ADR 0001 Amendment 1): a STEP import re-tessellates


### PR DESCRIPTION
First of three PRs delivering #398 (edit-by-feature). This is the **detect-hoist** prerequisite; #398b adds `drop(feature)`, #398c adds `dimension(feature, …)`.

## Why
Feature-referenced edits must work in **manual mode** (`auto_dims=False`, then hand-annotate) — that's when you most want to dimension detected features. But detection lived inside `_auto_annotate` (gated on `auto_dims`), so `build_drawing(part, auto_dims=False).model()` returned `None` (the D1 limitation flagged in #397).

## Change
- Extract `build_model(a)` (a pure function of the analysis) from `_auto_annotate`.
- Call it in `_assemble` **before** the `auto_dims` gate, so the model is attached to *every* built drawing.
- `_auto_annotate` reads the attached model (with a fallback build for any direct caller) — so **auto builds are unchanged**: one build per assemble, identical model, identical render. On a repack, pass-2 rebuilds from `a2` exactly as before (freshness preserved).

## Tests
- `model()` is present + has features under `auto_dims=False`.
- The model is **identical across auto and manual** builds (it's a property of the part, not the annotation pass).
- Smoke tier green (70 real builds); no behavioural change to auto-dimensioned output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)