### PR TITLE
feat: first-class feature provenance — drop()/annotations_of() by feature (#398b)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -513,7 +513,7 @@ def render_centermarks(dwg, groups) -> int:
         members = feat.members or (g.anchor,)
         for loc in members:
             px, py, *_ = dwg.at(view, *loc)
-            dwg.add(CenterMark((px, py, 0), size, dwg.draft), f"m_cm{n}", view=view)
+            dwg.add(CenterMark((px, py, 0), size, dwg.draft), f"m_cm{n}", view=view, feature=feat)
             n += 1
     return n
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -589,7 +589,7 @@ class Drawing:
         return self.add(_dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name)
 
     # -- annotations ----------------------------------------------------------
-    def add(self, obj, name=None, view=None):
+    def add(self, obj, name=None, view=None, feature=None):
         """Register an annotation so lint and export include it; returns ``obj``.
 
         Re-using an existing ``name`` replaces the previously added object (it is
@@ -600,25 +600,50 @@ class Drawing:
         annotations as a single footprint block (#121).  Pass ``None`` for
         drawing-level marks (title block, iso/section notes) that belong to no
         single view.
+
+        ``feature`` records the source IR feature this annotation was rendered for
+        (#398), so :meth:`drop` / :meth:`annotations_of` can operate by feature. The
+        render layer passes it (it knows the feature); ``None`` for part-level marks.
         """
         displaced = self._registry.named(name) if name is not None else None
         if displaced is not None:
             self.items.remove(displaced)
         annotate(obj, name)
         self.items.append(obj)
-        # The registry records name -> obj and the owning view, and drops any pin
-        # the replaced name carried — a replacement is a fresh object (#89) — and
-        # clears a stale ownership tag when re-added view-less (#121).
-        self._registry.add(obj, name, view)
+        # The registry records name -> obj, the owning view, and the source feature,
+        # and drops any pin the replaced name carried — a replacement is a fresh object
+        # (#89) — and clears stale view/feature tags when re-added without them (#121/#398).
+        self._registry.add(obj, name, view, feature)
         return obj
 
     def remove(self, name):
         """Remove a previously named annotation. Raises ``KeyError`` if absent."""
-        obj = self._registry.remove(name)  # forgets object, view, and pin (#89)
+        obj = self._registry.remove(name)  # forgets object, view, feature, and pin (#89)
         if obj is None:
             raise KeyError(f"no annotation named {name!r}")
         self.items.remove(obj)
         return obj
+
+    def annotations_of(self, feature) -> dict:
+        """``{name: object}`` for every annotation rendered for *feature* (#398).
+
+        *feature* is an IR feature from :meth:`model` (``dwg.model().features[i]``).
+        Matched by value, so the exact object is not required. Empty if the feature has
+        no annotations (or its render pass does not yet tag provenance — coverage grows
+        as passes are migrated)."""
+        return {n: self._registry.named(n) for n in self._registry.names_for_feature(feature)}
+
+    def drop(self, feature) -> list:
+        """Remove every annotation rendered for *feature* (#398) — the semantic curation
+        verb: "stop dimensioning this feature". Returns the removed names.
+
+        Use a feature from :meth:`model`: ``dwg.drop(dwg.model().features[0])``. Removing
+        a feature's callout/centre-mark/size-dims is a page-level edit; call
+        :func:`finalize_drawing` afterwards (when available) to recompose the sheet."""
+        names = self._registry.names_for_feature(feature)
+        for n in names:
+            self.remove(n)
+        return names
 
     def annotations(self) -> dict:
         """Return ``{name: type_name}`` for every *named* annotation (#27).

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -35,6 +35,12 @@ class AnnotationRegistry:
     def __init__(self) -> None:
         self._named: dict = {}
         self._anno_view: dict = {}
+        # name -> the source IR Feature this annotation was rendered for (#398). Peer to
+        # _anno_view: another ownership axis of annotation identity, set at add time by
+        # the render layer (which knows the feature) and snapshot/restored with the rest,
+        # so a repack/repair preserves provenance. Absent for part-level marks (title
+        # block, section arrows) that belong to no single feature.
+        self._anno_feature: dict = {}
         self._pinned: set = set()
         self._build_issues: list = []
 
@@ -54,6 +60,15 @@ class AnnotationRegistry:
     def view_of(self, name):
         """The owning view for *name* ("front"/"plan"/"side"), or ``None``."""
         return self._anno_view.get(name)
+
+    def feature_of(self, name):
+        """The source IR feature *name* was rendered for, or ``None`` (#398)."""
+        return self._anno_feature.get(name)
+
+    def names_for_feature(self, feature) -> list:
+        """Every annotation name owned by *feature* (matched by value equality, so a
+        feature from ``dwg.model()`` finds the annotations rendered for it) (#398)."""
+        return [n for n, f in self._anno_feature.items() if f == feature]
 
     def iter_named(self):
         """Iterate ``(name, annotation object)`` for every named annotation — the
@@ -75,6 +90,7 @@ class AnnotationRegistry:
         return {
             "named": dict(self._named),
             "anno_view": dict(self._anno_view),
+            "anno_feature": dict(self._anno_feature),
             "pinned": set(self._pinned),
         }
 
@@ -84,11 +100,13 @@ class AnnotationRegistry:
         self._named.update(snap["named"])
         self._anno_view.clear()
         self._anno_view.update(snap["anno_view"])
+        self._anno_feature.clear()
+        self._anno_feature.update(snap.get("anno_feature", {}))
         self._pinned.clear()
         self._pinned.update(snap["pinned"])
 
-    def add(self, obj, name, view):
-        """Register *obj* under *name* and record its owning *view*.
+    def add(self, obj, name, view, feature=None):
+        """Register *obj* under *name* and record its owning *view* (and source *feature*).
 
         Returns the object previously registered under *name* (so the caller can
         drop it from the render list), or ``None``. A replacement under the same
@@ -106,6 +124,12 @@ class AnnotationRegistry:
                 self._anno_view[name] = view
             else:
                 self._anno_view.pop(name, None)
+            # Feature provenance mirrors the view tag: a replacement re-asserts (or
+            # clears, when re-added feature-less) the source feature so it never lags.
+            if feature is not None:
+                self._anno_feature[name] = feature
+            else:
+                self._anno_feature.pop(name, None)
         return displaced
 
     def remove(self, name):
@@ -114,6 +138,7 @@ class AnnotationRegistry:
         if obj is not None:
             self._pinned.discard(name)  # a removed name carries no pin (#89)
             self._anno_view.pop(name, None)
+            self._anno_feature.pop(name, None)
         return obj
 
     def clear(self, keep) -> dict:
@@ -124,6 +149,7 @@ class AnnotationRegistry:
         self._named = kept_named
         self._pinned &= keep_set  # drop pins for cleared names (#89)
         self._anno_view = {n: v for n, v in self._anno_view.items() if n in keep_set}
+        self._anno_feature = {n: f for n, f in self._anno_feature.items() if n in keep_set}
         return kept_named
 
     # -- pins -----------------------------------------------------------------

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4238,6 +4238,54 @@ class TestModel:
             build_drawing(part, auto_dims=False).model()
         )
 
+
+class TestFeatureEdits:
+    """#398b: first-class feature provenance — drop()/annotations_of() by feature.
+
+    Coverage today is centre marks (the first render pass to carry provenance); slots,
+    locations, callouts and diameters thread `feature` in follow-up PRs. annotations_of()
+    returns exactly the covered set, so drop() is transparent about what it removes."""
+
+    def test_annotations_of_returns_a_features_centermarks(self):
+        dwg = build_drawing(_holed_plate())
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        owned = dwg.annotations_of(hole)
+        assert owned, "hole should own at least its centre mark(s)"
+        assert all(n.startswith("m_cm") for n in owned)
+
+    def test_drop_removes_a_features_annotations(self):
+        dwg = build_drawing(_holed_plate())
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        names = set(dwg.annotations_of(hole))
+        removed = dwg.drop(hole)
+        assert set(removed) == names
+        assert dwg.annotations_of(hole) == {}
+        for n in names:
+            assert n not in dwg.annotations()  # gone from the registry + render list
+
+    def test_drop_feature_with_no_annotations_is_noop(self):
+        dwg = build_drawing(_holed_plate())
+        # An envelope feature carries no centre marks (its dims aren't tagged yet).
+        env = next((f for f in dwg.model().features if f.kind == "envelope"), None)
+        if env is not None:
+            assert dwg.drop(env) == []
+
+    def test_manual_add_records_feature_provenance(self):
+        from build123d_drafting import CenterMark
+
+        dwg = build_drawing(_holed_plate())
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        dwg.add(CenterMark((0, 0, 0), 3.0, dwg.draft), "my_mark", view="plan", feature=hole)
+        assert "my_mark" in dwg.annotations_of(hole)
+
+    def test_provenance_survives_repair(self):
+        # Snapshot/restore (the repair undo path) must preserve feature ownership.
+        dwg = build_drawing(_holed_plate())
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        before = set(dwg.annotations_of(hole))
+        dwg.repair()
+        assert set(dwg.annotations_of(hole)) == before
+
     def test_model_structurally_equivalent_across_step_and_b123d_input(self, tmp_path):
         # D5 / the convergence property (ADR 0001 Amendment 1): a STEP import re-tessellates
         # the solid, so coordinates differ — but the DETECTED feature structure must be the


### PR DESCRIPTION
Second of the #398 series. Delivers the **fix** the earlier design settled on: feature provenance as a first-class axis of annotation identity, not a bolt-on lookup.

## The fix (per the design discussion)
Annotations were tracked by *view* but not by the *feature* they were rendered for. Rather than reconstruct that link heuristically, this makes **feature-ownership a peer of view-ownership** in the registry (ADR 0005 — the single owner of annotation identity):
- `registry._anno_feature`: name → source IR feature, threaded through `add`/`remove`/`clear`/`snapshot`/`restore` exactly like `_anno_view`, so a repack/repair preserves provenance.
- `Drawing.add(..., feature=)`: the render layer (which already has the feature in scope) tags what it creates.
- `Drawing.drop(feature)` — remove every annotation a feature owns ("stop dimensioning this feature"); `Drawing.annotations_of(feature)` — the read accessor.

## Coverage (transparent + growing)
`render_centermarks` is the first pass to carry provenance (it cleanly has `g.feature`). The other passes flatten features into specs or route through the ADR-0009 corridor layer before adding, so they thread `feature` in focused follow-ups:
- **#398c** — thread provenance through the corridor/strip placement layer (slots, locations).
- **#398d** — hole callouts / balloons (the recognition→IR path).
- **#398e** — `dimension(feature, …)` (the add verb).

`annotations_of()` returns *exactly* the covered set, so `drop()` never silently under-removes — it's transparent about scope.

## Verification
- `annotations_of(hole)` returns its centre marks (a grouped hole → one per member); `drop` removes them from the registry + render list; provenance survives `repair()` (snapshot round-trip); manual `add(feature=)` is retrievable.
- **Additive metadata — no output change:** layout snapshots + cleanliness unchanged (30 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)