### PR TITLE
feat: thread feature provenance through the ADR-0009 corridor layer (#398c)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -302,6 +302,9 @@ class CorridorCandidate:
     dedup: tuple | None = None
     precedence: int = 0
     force: bool = False
+    # The source IR feature this dim was rendered for — recorded as provenance when the
+    # dim is placed at drain (ADR 0010). ``None`` leaves the annotation feature-less.
+    feature: object | None = None
 
 
 def solve_corridor(dwg, strip, view, axis, cands, tier):
@@ -353,13 +356,16 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
                 _promote_losers(c)
         return
     pairs = [(c.name, c.build) for c in kept]
-    left = {n for n, _ in place_strip_candidates(dwg, strip, view, axis, pairs, tier)}
+    feats = {c.name: c.feature for c in kept if c.feature is not None}  # provenance (ADR 0010)
+    left = {
+        n for n, _ in place_strip_candidates(dwg, strip, view, axis, pairs, tier, features=feats)
+    }
     force_pairs = [(c.name, c.build) for c in kept if c.name in left and c.force]
     still = (
         {
             n
             for n, _ in place_strip_candidates(
-                dwg, strip, view, axis, force_pairs, tier, force=True
+                dwg, strip, view, axis, force_pairs, tier, force=True, features=feats
             )
         }
         if force_pairs
@@ -393,7 +399,7 @@ def drain_corridors(dwg):
     dwg._corridor_batch = {}
 
 
-def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False):
+def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False, features=None):
     """Collect-then-solve placement of location/feature dims on one strip (ADR 0009).
     The single shared strip placer that retires the ``Strip.allocate`` cursor (#150,
     P3): each candidate in *cands* — an ``(name, build(pos)->dim)`` pair — is spaced by
@@ -481,7 +487,9 @@ def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False):
             if not force and _box_hits(_geom_box(dim), blockers):  # corridor crosses a leader
                 todo.append((name, build))
                 continue
-            dwg.add(dim, name, view=view)
+            # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
+            # dims — `features` maps this batch's names to their source IR feature.
+            dwg.add(dim, name, view=view, feature=(features or {}).get(name))
     return todo
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -427,6 +427,10 @@ def render_locations(dwg, model, a) -> int:
         if abs(rx - datum_x) * a.SCALE < 1.0:
             continue  # on the datum edge — nothing to dimension
         n += 1
+        # A single X-location dim shared by two *distinct* features at this X belongs to
+        # neither exclusively — leave it unowned so drop() cannot over-strip a sibling's
+        # dimension and annotations_of never over-claims it (review #406, ADR 0010).
+        _xfeat = None if any(abs(o[0] - rx) < 0.5 and o[2] != feat for o in refs) else feat
         register_corridor(
             dwg,
             ("plan", "above"),
@@ -448,7 +452,7 @@ def render_locations(dwg, model, a) -> int:
                     draft,
                     label=_fmt(_rx - datum_x),
                 ),
-                feature=feat,
+                feature=_xfeat,
             ),
         )
 
@@ -481,6 +485,8 @@ def render_locations(dwg, model, a) -> int:
         if abs(ry - datum_y) * a.SCALE < 1.0:
             continue
         n += 1
+        # Shared-Y location dim → unowned (see the X loop; review #406).
+        _yfeat = None if any(abs(o[1] - ry) < 0.5 and o[2] != feat for o in refs) else feat
         register_corridor(
             dwg,
             ("side", "above"),
@@ -502,7 +508,7 @@ def render_locations(dwg, model, a) -> int:
                     draft,
                     label=_fmt(_ry - datum_y),
                 ),
-                feature=feat,
+                feature=_yfeat,
             ),
         )
     return n

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -244,7 +244,7 @@ def render_slots(dwg, model, a) -> int:
 
                 def _below_or_drop(nm, _bs=below_strip, _bh=below_hi, _feat=s, _dw=drop_word):
                     if _bs is not None and not place_strip_candidates(
-                        dwg, _bs, vw[0], "y", [_cand_for("below", _bh)], tier
+                        dwg, _bs, vw[0], "y", [_cand_for("below", _bh)], tier, features={cname: _feat}
                     ):
                         return  # placed on the below strip
                     _record_slot_drop(dwg, _dw, idx, vw[0], _feat)
@@ -275,6 +275,7 @@ def render_slots(dwg, model, a) -> int:
                         ),
                         precedence=1 if is_pos else 0,
                         force=False,
+                        feature=s,  # provenance (ADR 0010): this dim belongs to the slot
                     ),
                 )
                 return True  # deferred — the callback owns the drop; caller's else must not fire
@@ -286,7 +287,7 @@ def render_slots(dwg, model, a) -> int:
                     continue
                 axis = "y" if side in ("above", "below") else "x"
                 if not place_strip_candidates(
-                    dwg, strip, vw[0], axis, [_cand_for(side, hi)], tier
+                    dwg, strip, vw[0], axis, [_cand_for(side, hi)], tier, features={cname: s}
                 ):
                     return True
             return False
@@ -329,7 +330,7 @@ _SIZE_SUBCHAIN = 0
 _LOC_SUBCHAIN = 1
 
 
-def _location_candidate(dwg, name, *, view, span_key, distance, build):
+def _location_candidate(dwg, name, *, view, span_key, distance, build, feature=None):
     """A :class:`CorridorCandidate` for a datum-referenced hole/pattern location dim.
     Location dims outrank a coincident slot-position line in dedup (#345) and form the
     outer, datum-distance-ordered run of the ladder (#346). Force-kept (policy B): a plan-X
@@ -353,6 +354,7 @@ def _location_candidate(dwg, name, *, view, span_key, distance, build):
         dedup=(view, span_key[0], span_key[1]),
         precedence=2,
         force=True,
+        feature=feature,  # provenance (ADR 0010): the located hole/pattern
     )
 
 
@@ -385,7 +387,7 @@ def render_locations(dwg, model, a) -> int:
             and math.hypot(rx - a.cx, ry - a.cy) <= _CONCENTRIC_TOL_MM
         ):
             continue
-        refs.append((rx, ry))
+        refs.append((rx, ry, pd.feature))  # carry the source feature for provenance (ADR 0010)
     if not refs:
         return 0
     tier = draft.font_size + 2 * draft.pad_around_text
@@ -415,7 +417,7 @@ def render_locations(dwg, model, a) -> int:
     # pass carving around the other and interleaving. No alternate view for a plan-X
     # location, so a corridor-blocked dim is force-kept (policy B), not relocated; only a
     # physically full strip drops (→ location_ref_dropped, escalates the hole table).
-    for i, (rx, ry) in enumerate(sorted(x_refs, key=lambda r: abs(r[0] - datum_x))):
+    for i, (rx, ry, feat) in enumerate(sorted(x_refs, key=lambda r: abs(r[0] - datum_x))):
         if abs(rx - datum_x) * a.SCALE < 1.0:
             continue  # on the datum edge — nothing to dimension
         n += 1
@@ -440,6 +442,7 @@ def render_locations(dwg, model, a) -> int:
                     draft,
                     label=_fmt(_rx - datum_x),
                 ),
+                feature=feat,
             ),
         )
 
@@ -466,9 +469,9 @@ def render_locations(dwg, model, a) -> int:
     # Cap the side-above strip below the iso view so Y-location dims never run under it
     # (the carve respects outer_limit); the dim_pitch_side dims are obstacles the carve
     # avoids structurally, retiring the old manual allocate(10.0) reservation + cursor.
-    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry in y_refs):
+    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _ in y_refs):
         a.sv_zones.above.outer_limit = min(a.sv_zones.above.outer_limit, iso_y0 - 4)
-    for i, (rx, ry) in enumerate(sorted(y_refs, key=lambda r: abs(r[1] - datum_y))):
+    for i, (rx, ry, feat) in enumerate(sorted(y_refs, key=lambda r: abs(r[1] - datum_y))):
         if abs(ry - datum_y) * a.SCALE < 1.0:
             continue
         n += 1
@@ -493,6 +496,7 @@ def render_locations(dwg, model, a) -> int:
                     draft,
                     label=_fmt(_ry - datum_y),
                 ),
+                feature=feat,
             ),
         )
     return n

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -244,7 +244,13 @@ def render_slots(dwg, model, a) -> int:
 
                 def _below_or_drop(nm, _bs=below_strip, _bh=below_hi, _feat=s, _dw=drop_word):
                     if _bs is not None and not place_strip_candidates(
-                        dwg, _bs, vw[0], "y", [_cand_for("below", _bh)], tier, features={cname: _feat}
+                        dwg,
+                        _bs,
+                        vw[0],
+                        "y",
+                        [_cand_for("below", _bh)],
+                        tier,
+                        features={cname: _feat},
                     ):
                         return  # placed on the below strip
                     _record_slot_drop(dwg, _dw, idx, vw[0], _feat)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -66,6 +66,9 @@ class PlannedDimension:
     suppressed: bool = False
     reason: str | None = None
     datum: Datum | None = None
+    # The source IR feature this dim locates — carried so the renderer can record
+    # provenance (ADR 0010). ``None`` for dims not tied to a single feature.
+    feature: Feature | None = None
 
 
 @dataclass(frozen=True)
@@ -158,24 +161,26 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
     # (ref_point, role): role distinguishes a hole ref from a pattern ref — the
     # renderer's concentric-bore exclusion applies to holes only (a bolt circle on
     # the axis is still located by its centre), matching the engine.
-    refs: list[tuple[Point, str]] = []
+    # (ref_point, role, source feature): the feature is carried so the renderer can
+    # record provenance on the placed location dim (ADR 0010).
+    refs: list[tuple[Point, str, object]] = []
     for f in model.features:
         if f.frame.axis != "z":
             continue
         if isinstance(f, HoleFeature):
             # un-patterned holes — a HoleFeature may group identical holes
             for m in f.members or (f.frame.origin,):
-                refs.append((m, "location"))
+                refs.append((m, "location", f))
         elif isinstance(f, PatternFeature):
             if f.pattern == "bolt_circle":
-                refs.append((f.frame.origin, "location_pattern"))
+                refs.append((f.frame.origin, "location_pattern", f))
             elif f.members:
                 near = min(f.members, key=lambda m: (m[0] - dx) ** 2 + (m[1] - dy) ** 2)
-                refs.append((near, "location_pattern"))
-    unique: list[tuple[Point, str]] = []
-    for r, role in refs:
-        if not any(abs(r[0] - u[0]) < 0.5 and abs(r[1] - u[1]) < 0.5 for u, _ in unique):
-            unique.append((r, role))
+                refs.append((near, "location_pattern", f))
+    unique: list[tuple[Point, str, object]] = []
+    for r, role, feat in refs:
+        if not any(abs(r[0] - u[0]) < 0.5 and abs(r[1] - u[1]) < 0.5 for u, _, _ in unique):
+            unique.append((r, role, feat))
     return [
         PlannedDimension(
             param=DimParameter(
@@ -187,8 +192,9 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
             ),
             convention="location",
             datum=datum,
+            feature=feat,
         )
-        for r, role in unique
+        for r, role, feat in unique
     ]
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -163,7 +163,7 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
     # the axis is still located by its centre), matching the engine.
     # (ref_point, role, source feature): the feature is carried so the renderer can
     # record provenance on the placed location dim (ADR 0010).
-    refs: list[tuple[Point, str, object]] = []
+    refs: list[tuple[Point, str, Feature]] = []
     for f in model.features:
         if f.frame.axis != "z":
             continue
@@ -177,7 +177,7 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
             elif f.members:
                 near = min(f.members, key=lambda m: (m[0] - dx) ** 2 + (m[1] - dy) ** 2)
                 refs.append((near, "location_pattern", f))
-    unique: list[tuple[Point, str, object]] = []
+    unique: list[tuple[Point, str, Feature]] = []
     for r, role, feat in refs:
         if not any(abs(r[0] - u[0]) < 0.5 and abs(r[1] - u[1]) < 0.5 for u, _, _ in unique):
             unique.append((r, role, feat))

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -67,7 +67,12 @@ class AnnotationRegistry:
 
     def names_for_feature(self, feature) -> list:
         """Every annotation name owned by *feature* (matched by value equality, so a
-        feature from ``dwg.model()`` finds the annotations rendered for it) (#398)."""
+        feature from ``dwg.model()`` finds the annotations rendered for it) (#398).
+
+        Value equality is safe because IR features are location-distinct — every
+        ``Feature`` is a frozen dataclass whose ``frame.origin`` participates in ``==``,
+        so two genuinely different features never compare equal. If a location-less
+        feature type is ever added, switch this to identity (``f is feature``)."""
         return [n for n, f in self._anno_feature.items() if f == feature]
 
     def iter_named(self):

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -69,10 +69,13 @@ class AnnotationRegistry:
         """Every annotation name owned by *feature* (matched by value equality, so a
         feature from ``dwg.model()`` finds the annotations rendered for it) (#398).
 
-        Value equality is safe because IR features are location-distinct — every
-        ``Feature`` is a frozen dataclass whose ``frame.origin`` participates in ``==``,
-        so two genuinely different features never compare equal. If a location-less
-        feature type is ever added, switch this to identity (``f is feature``)."""
+        Value equality is safe because IR features are value-distinct: every ``Feature``
+        is a frozen dataclass in which *all* fields participate in ``==``, including the
+        one(s) that encode position (``frame.origin`` for a hole; ``w_center``/``lo``/
+        ``hi`` for a slot whose ``frame.origin`` is the *bbox centre*, not the slot's
+        offset). So two physically distinct features never compare equal. If a feature
+        type is ever added that can be field-for-field equal for distinct instances,
+        switch this to identity (``f is feature``)."""
         return [n for n, f in self._anno_feature.items() if f == feature]
 
     def iter_named(self):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4278,6 +4278,27 @@ class TestFeatureEdits:
         assert set(dwg.drop(slot)) == owned
         assert dwg.annotations_of(slot) == {}
 
+    def test_shared_coordinate_location_dim_is_unowned(self):
+        # #398c review (#406): a single location dim shared by two DISTINCT holes at the
+        # same X belongs to neither — it must be unowned so drop(one) can't over-strip the
+        # dim the sibling still needs.
+        from build123d import Box, Cylinder, Pos
+
+        part = (
+            Box(80, 60, 20) - Pos(30, -20, 0) * Cylinder(6, 20) - Pos(30, 20, 0) * Cylinder(4, 20)
+        )
+        dwg = build_drawing(part)
+        holes = [f for f in dwg.model().features if f.kind == "hole"]
+        assert len(holes) == 2  # distinct specs → not grouped
+        locx = {n for n in dwg.annotations() if n.startswith("m_locx")}
+        assert locx, "expected a shared X-location dim"
+        # Neither hole owns the shared X dim...
+        for h in holes:
+            assert not (locx & set(dwg.annotations_of(h)))
+        # ...so dropping one leaves it in place for the other.
+        dwg.drop(holes[0])
+        assert locx <= set(dwg.annotations()), "shared location dim was over-stripped by drop"
+
     def test_drop_feature_with_no_annotations_is_noop(self):
         dwg = build_drawing(_holed_plate())
         # An envelope feature carries no centre marks (its dims aren't tagged yet).

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4246,12 +4246,14 @@ class TestFeatureEdits:
     locations, callouts and diameters thread `feature` in follow-up PRs. annotations_of()
     returns exactly the covered set, so drop() is transparent about what it removes."""
 
-    def test_annotations_of_returns_a_features_centermarks(self):
+    def test_annotations_of_returns_a_features_centermarks_and_locations(self):
+        # #398c broadened coverage: a hole owns its centre mark(s) AND its location dims
+        # (the corridor-placed m_locx/m_locy), now that provenance threads the corridor.
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")
         owned = dwg.annotations_of(hole)
-        assert owned, "hole should own at least its centre mark(s)"
-        assert all(n.startswith("m_cm") for n in owned)
+        assert any(n.startswith("m_cm") for n in owned), "hole should own its centre mark(s)"
+        assert all(n.startswith(("m_cm", "m_loc")) for n in owned)
 
     def test_drop_removes_a_features_annotations(self):
         dwg = build_drawing(_holed_plate())
@@ -4262,6 +4264,19 @@ class TestFeatureEdits:
         assert dwg.annotations_of(hole) == {}
         for n in names:
             assert n not in dwg.annotations()  # gone from the registry + render list
+
+    def test_drop_removes_all_slot_dims(self):
+        # #398c: slot dims flow through the ADR-0009 corridor; provenance now threads it,
+        # so drop(slot) removes the whole set (length + width + position).
+        from build123d import Box, Mode, Pos
+
+        part = Box(80, 60, 20) - Pos(0, 0, 0) * Box(24, 8, 30, mode=Mode.SUBTRACT)
+        dwg = build_drawing(part)
+        slot = next(f for f in dwg.model().features if f.kind == "slot")
+        owned = set(dwg.annotations_of(slot))
+        assert owned and all(n.startswith("m_slot") for n in owned)
+        assert set(dwg.drop(slot)) == owned
+        assert dwg.annotations_of(slot) == {}
 
     def test_drop_feature_with_no_annotations_is_noop(self):
         dwg = build_drawing(_holed_plate())

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -437,7 +437,7 @@ def test_place_strip_candidates_reserves_outermost_label_within_bounds():
         def view_of(s, n):
             return "plan"
 
-        def add(s, obj, name, view=None):
+        def add(s, obj, name, view=None, feature=None):
             s.added.append((name, obj))
 
     strip = Strip(anchor=0.0, outer_limit=20.0, direction=1.0, gap=8.0, spacing=4.0)  # near=8
@@ -477,7 +477,7 @@ def test_place_strip_candidates_ignores_perpendicular_disjoint_obstacle():
         def view_of(s, n):
             return "plan"
 
-        def add(s, o, n, view=None):
+        def add(s, o, n, view=None, feature=None):
             s.added.append((n, o))
 
     # obstacle spans the whole strip in X but sits at y=[0,5]; the candidate dim is y=[30,40]


### PR DESCRIPTION
Third of the #398 series — the first **seam** PR under ADR 0010. Extends feature provenance to the corridor-placed dims (slots + locations), which #398b couldn't reach because they route through the ADR-0009 placement layer that drops the feature link.

## Mechanism (ADR 0010 drain-time seam)
- `CorridorCandidate` gains a `feature` field.
- `place_strip_candidates` takes an optional `features` map (`name -> feature`) and records it at the drain-time `dwg.add(..., feature=…)`. The param is optional, so the 6 existing callers are unaffected unless they opt in.
- `solve_corridor` builds the map from the kept candidates and passes it to both the non-force and force placement passes.

## Populated at the register sites
- **`render_slots`** tags its corridor candidate + the immediate/below-strip paths with the slot IR feature.
- **`plan_locations` / `PlannedDimension`** now carry the source hole/pattern feature (it was dropped in the ref dedup); **`render_locations`** threads it into the X/Y location candidates.

## Result
- `drop(slot)` removes all slot dims (length / width / position).
- `drop(hole)` now removes its centre marks **and** location dims (was centre marks only in #398b).
- Hole **callouts** (`holes.py`, recognition→IR) remain **#398d**; `dimension()` is **#398e**. `annotations_of()` still returns exactly the covered set.

## Verification
- New tests: slot-drop removes all slot dims; the hole test broadened to centre marks + locations.
- `place_strip_candidates` unit tests' fake `_Dwg.add` updated for the `feature=` kwarg.
- **Additive metadata — no output change:** layout snapshots + cleanliness unchanged (30 passed).
- Folded in the equality-vs-identity hardening note on `names_for_feature` (from the #398b review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
