### PR TITLE
feat: dwg.dimension(feature, param) — the feature-referenced add verb (#398e)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -652,7 +652,9 @@ class Drawing:
             self.remove(n)
         return names
 
-    def dimension(self, feature, param, *, side="above", view=None, name=None, **kwargs):
+    def dimension(
+        self, feature, param, *, role=None, side="above", view=None, name=None, **kwargs
+    ):
         """Add a dimension for *feature*'s *param*, attributed to the feature (#398e).
 
         The feature-referenced **add** verb: pair to :meth:`drop`. *feature* is an IR
@@ -661,32 +663,46 @@ class Drawing:
         dimension is placed into free strip space and tagged with *feature*, so
         :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
 
-        Value-only parameters (a slot's dims, or a hole's ``"diameter"``/``"depth"`` —
-        which need the feature's own geometry or a leader callout) are not yet supported;
-        that coverage lands with the callout provenance work (#398d).
+        A feature may expose several params of one kind (an envelope's width/height/depth
+        are all ``"length"``); pass ``role=`` to pick one — a bare kind matching more than
+        one raises rather than guessing.
 
-        ``view`` defaults to the feature's end-on view (its ``frame.axis``); ``side``
-        defaults to ``"above"``. ``kwargs`` forward to the dimension (e.g. ``label=``).
+        ``view`` is chosen automatically as the orthographic view (``"front"``/``"plan"``/
+        ``"side"``) where the span projects non-degenerate — a length along the turning
+        axis vanishes in its end-on view, so the view follows the geometry. Pass ``view=``
+        to force one of those three (a non-orthographic view foreshortens the span and is
+        rejected). ``side`` defaults to ``"above"``; ``kwargs`` forward to the dimension.
 
-        Raises ``ValueError`` if the feature has no span-carrying parameter of that kind.
-        Callout-style parameters (``"diameter"``/``"depth"``, which need a leader) are not
-        yet supported here — that path lands with the callout provenance work (#398d).
+        Raises ``ValueError`` if no span-carrying param of that kind/role exists, if the
+        kind is ambiguous, or if *view* is not orthographic. Value-only params (a slot's
+        dims, a hole's ``"diameter"``/``"depth"`` — which need the feature's own geometry
+        or a leader callout) are not yet supported; that lands with the callout work (#398d).
         """
-        p = next(
-            (q for q in feature.parameters() if q.kind == param and q.span is not None),
-            None,
-        )
-        if p is None:
+        _ortho = ("front", "plan", "side")
+        if view is not None and view not in _ortho:
             raise ValueError(
-                f"{type(feature).__name__} has no span-carrying '{param}' parameter to "
+                f"view must be one of {_ortho}, not {view!r} (it foreshortens the span)"
+            )
+        matches = [
+            q
+            for q in feature.parameters()
+            if q.kind == param and q.span is not None and (role is None or q.role == role)
+        ]
+        if not matches:
+            r = f"/{role!r}" if role else ""
+            raise ValueError(
+                f"{type(feature).__name__} has no span-carrying '{param}'{r} parameter to "
                 f"dimension (callout params like diameter/depth are not yet supported — #398d)"
             )
-        # Dimension in a view where the span is VISIBLE (projects non-degenerate): a
-        # length along the turning axis vanishes in the end-on view, so pick by the
-        # geometry, not a fixed axis→view map. The caller can force a specific view.
-        (lo, hi) = p.span
+        if len(matches) > 1:
+            roles = sorted(q.role for q in matches)
+            raise ValueError(
+                f"{type(feature).__name__} has {len(matches)} '{param}' params (roles {roles}) "
+                f"— pass role= to choose one"
+            )
+        (lo, hi) = matches[0].span
         p1 = p2 = None
-        for v in [view] if view else ("front", "plan", "side"):
+        for v in [view] if view else _ortho:
             q1, q2 = self.at(v, *lo), self.at(v, *hi)
             if math.hypot(q2[0] - q1[0], q2[1] - q1[1]) > 1e-6:
                 view, p1, p2 = v, q1, q2
@@ -694,7 +710,7 @@ class Drawing:
         if p1 is None:
             raise ValueError(
                 f"'{param}' span projects to a point in "
-                f"{'the requested view' if view else 'every view'} — nothing to dimension"
+                f"{'the requested view' if view else 'every orthographic view'} — nothing to dimension"
             )
         if name is None:
             i = 0

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -538,7 +538,7 @@ class Drawing:
         """
         return self._part_model
 
-    def place_dim(self, p1, p2, side, view, draft, *, name=None, slot=8.0, **kwargs):
+    def place_dim(self, p1, p2, side, view, draft, *, name=None, slot=8.0, feature=None, **kwargs):
         """Add a :class:`~build123d_drafting.helpers.Dimension` that stacks cleanly
         with the auto-generated dimensions by delegating to the same strip-allocation
         system (:class:`Strip`) that :func:`build_drawing` uses internally.
@@ -551,7 +551,14 @@ class Drawing:
             draft: the drawing's :attr:`draft` preset.
             name: optional annotation name for later :meth:`remove` / replace.
             slot: strip slot depth (mm); the perpendicular space reserved per dim.
+            feature: optional source IR feature to attribute this dim to, so
+                :meth:`drop` / :meth:`annotations_of` can find it (#398).
             **kwargs: forwarded to ``Dimension`` (e.g. ``label=``, ``tolerance=``).
+
+        Uses the single-position strip carve, not the ADR-0009 collect-then-solve
+        path the automatic placers use — fine for adding a dimension into free
+        space, but it does not re-solve the strip or dedup against existing dims
+        (#396). Prefer :meth:`dimension` for a feature-referenced edit.
 
         Falls back to a fixed ``slot`` offset when the strip is full or when no
         layout analysis is available (e.g. when ``auto_dims=False`` was not used
@@ -586,7 +593,7 @@ class Drawing:
         if "label" not in kwargs:
             page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
             kwargs["label"] = _fmt(page_len / self.scale)
-        return self.add(_dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name)
+        return self.add(_dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name, feature=feature)
 
     # -- annotations ----------------------------------------------------------
     def add(self, obj, name=None, view=None, feature=None):
@@ -644,6 +651,57 @@ class Drawing:
         for n in names:
             self.remove(n)
         return names
+
+    def dimension(self, feature, param, *, side="above", view=None, name=None, **kwargs):
+        """Add a dimension for *feature*'s *param*, attributed to the feature (#398e).
+
+        The feature-referenced **add** verb: pair to :meth:`drop`. *feature* is an IR
+        feature from :meth:`model`; *param* is a parameter kind it exposes that carries a
+        two-point ``span`` — a linear dimension (e.g. a turned step's ``"length"``). The
+        dimension is placed into free strip space and tagged with *feature*, so
+        :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
+
+        Value-only parameters (a slot's dims, or a hole's ``"diameter"``/``"depth"`` —
+        which need the feature's own geometry or a leader callout) are not yet supported;
+        that coverage lands with the callout provenance work (#398d).
+
+        ``view`` defaults to the feature's end-on view (its ``frame.axis``); ``side``
+        defaults to ``"above"``. ``kwargs`` forward to the dimension (e.g. ``label=``).
+
+        Raises ``ValueError`` if the feature has no span-carrying parameter of that kind.
+        Callout-style parameters (``"diameter"``/``"depth"``, which need a leader) are not
+        yet supported here — that path lands with the callout provenance work (#398d).
+        """
+        p = next(
+            (q for q in feature.parameters() if q.kind == param and q.span is not None),
+            None,
+        )
+        if p is None:
+            raise ValueError(
+                f"{type(feature).__name__} has no span-carrying '{param}' parameter to "
+                f"dimension (callout params like diameter/depth are not yet supported — #398d)"
+            )
+        # Dimension in a view where the span is VISIBLE (projects non-degenerate): a
+        # length along the turning axis vanishes in the end-on view, so pick by the
+        # geometry, not a fixed axis→view map. The caller can force a specific view.
+        (lo, hi) = p.span
+        p1 = p2 = None
+        for v in [view] if view else ("front", "plan", "side"):
+            q1, q2 = self.at(v, *lo), self.at(v, *hi)
+            if math.hypot(q2[0] - q1[0], q2[1] - q1[1]) > 1e-6:
+                view, p1, p2 = v, q1, q2
+                break
+        if p1 is None:
+            raise ValueError(
+                f"'{param}' span projects to a point in "
+                f"{'the requested view' if view else 'every view'} — nothing to dimension"
+            )
+        if name is None:
+            i = 0
+            while (name := f"dim_{param}{i}") in self._named:
+                i += 1
+        self.place_dim(p1, p2, side, view, self.draft, name=name, feature=feature, **kwargs)
+        return name
 
     def annotations(self) -> dict:
         """Return ``{name: type_name}`` for every *named* annotation (#27).

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4308,6 +4308,39 @@ class TestFeatureEdits:
         dwg.place_dim(p1, p2, "above", "plan", dwg.draft, name="mine", feature=hole)
         assert "mine" in dwg.annotations_of(hole)
 
+    def test_dimension_rejects_non_orthographic_view(self):
+        # #407 review: a linear dim on the foreshortening iso view mislabels the length.
+        from build123d import Cylinder
+
+        dwg = build_drawing(Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)))
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        with pytest.raises(ValueError, match="front"):
+            dwg.dimension(step, "length", view="iso")
+
+    def test_dimension_unknown_view_raises_valueerror_not_keyerror(self):
+        # #407 review: a bad view= must be a clean ValueError, not a bare KeyError.
+        from build123d import Cylinder
+
+        dwg = build_drawing(Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)))
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        with pytest.raises(ValueError):
+            dwg.dimension(step, "length", view="back")
+
+    def test_dimension_ambiguous_kind_requires_role(self):
+        # #407 review: an envelope exposes width/height/depth all as 'length' — a bare
+        # kind must raise (not silently pick width), and role= must disambiguate.
+        from build123d import Box
+
+        dwg = build_drawing(Box(40, 30, 10))
+        env = next((f for f in dwg.model().features if f.kind == "envelope"), None)
+        assert env is not None
+        roles = sorted(q.role for q in env.parameters() if q.kind == "length" and q.span)
+        assert len(roles) > 1
+        with pytest.raises(ValueError, match="role="):
+            dwg.dimension(env, "length")
+        name = dwg.dimension(env, "length", role=roles[0])
+        assert name in dwg.annotations_of(env)
+
     def test_shared_coordinate_location_dim_is_unowned(self):
         # #398c review (#406): a single location dim shared by two DISTINCT holes at the
         # same X belongs to neither — it must be unowned so drop(one) can't over-strip the

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4278,6 +4278,36 @@ class TestFeatureEdits:
         assert set(dwg.drop(slot)) == owned
         assert dwg.annotations_of(slot) == {}
 
+    def test_dimension_adds_and_tags_a_feature(self):
+        # #398e: the add verb — dimension a span-carrying param (a turned step's length),
+        # tagged with the feature so it pairs with drop/annotations_of.
+        from build123d import Cylinder
+
+        shaft = Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25))
+        dwg = build_drawing(shaft)
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        name = dwg.dimension(step, "length")
+        assert isinstance(name, str)
+        assert name in dwg.annotations()
+        assert name in dwg.annotations_of(step)
+        assert name in set(dwg.drop(step))
+        assert name not in dwg.annotations()  # drop removed it
+
+    def test_dimension_rejects_non_span_param(self):
+        from build123d import Cylinder
+
+        dwg = build_drawing(Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)))
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        with pytest.raises(ValueError, match="span"):
+            dwg.dimension(step, "diameter")  # value-only param, needs a callout (#398d)
+
+    def test_place_dim_feature_kwarg_tags_provenance(self):
+        dwg = build_drawing(_holed_plate())
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        p1, p2 = dwg.at("plan", 0, 0, 0), dwg.at("plan", 20, 0, 0)
+        dwg.place_dim(p1, p2, "above", "plan", dwg.draft, name="mine", feature=hole)
+        assert "mine" in dwg.annotations_of(hole)
+
     def test_shared_coordinate_location_dim_is_unowned(self):
         # #398c review (#406): a single location dim shared by two DISTINCT holes at the
         # same X belongs to neither — it must be unowned so drop(one) can't over-strip the


### PR DESCRIPTION
Fourth of the #398 series — the **add** verb, pairing to `drop()`. (Callouts, #398d, deferred by your call to do this first.)

## API
```python
m = dwg.model()
step = next(f for f in m.features if f.kind == "step")
name = dwg.dimension(step, "length")   # adds a length dim, tagged to the step
dwg.annotations_of(step)               # includes `name`
dwg.drop(step)                         # removes it
```
- **`place_dim(..., feature=…)`** — the general tagged-place primitive; its docstring now states it uses the single-carve path (not the ADR-0009 solve, #396).
- **`dimension(feature, param)`** — resolves the feature's span-carrying parameter, picks a view where the span projects **non-degenerate** (a length along the turning axis vanishes in the end-on view, so it's chosen by geometry, not a fixed axis→view map), places it tagged with the feature, returns the annotation name.

## Coverage (honest + growing)
Span-carrying params — a turned step's `"length"` today. **Value-only params** (a slot's dims; a hole's `"diameter"`/`"depth"`, which need the feature's own geometry or a leader callout) raise a clear `ValueError` and land with the callout work (**#398d**).

## Verification
- Tests: `dimension()` adds+tags+drops a step length; a non-span param raises; `place_dim(feature=…)` tags provenance.
- User-called methods, not the auto-pass → **no output drift** (snapshots + cleanliness 30 passed).
- Full lint gate (ruff check + `ruff format --check src/ tests/` + `mypy src/draftwright/`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
