### PR TITLE
feat: complete hole/pattern provenance — drop() clears callouts, furniture, balloons (#408)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -171,11 +171,23 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
             f"{axis} location dim for a {view}-view hole not placed (no room beside the view)",
         )
 
-    def _emit(strip, view, axis, cands, force=False):
+    def _emit(strip, view, axis, cands, force=False, features=None):
         # The collect-then-solve strip placer now lives in _common as the shared
         # place_strip_candidates (P3, retiring the Strip cursor #150); this thin wrapper
         # binds the pass's dwg + tier so the across/along/Z callers below are unchanged.
-        return place_strip_candidates(dwg, strip, view, axis, cands, tier, force=force)
+        # *features* (name -> IR feature) attributes each dim for drop() (#408).
+        return place_strip_candidates(
+            dwg, strip, view, axis, cands, tier, force=force, features=features
+        )
+
+    def _off_axis_owner(hole_locs):
+        # The IR hole feature owning a side-drilled location dim, or None when the dim's
+        # offset is shared by >1 distinct feature (unowned, so drop can't over-strip a
+        # sibling — mirrors the #398c shared-coordinate rule). *hole_locs* are the model
+        # locations of every hole that contributed to this (deduped-by-offset) dim.
+        feats = {dwg._feature_of_hole_at(loc) for loc in hole_locs}
+        feats.discard(None)
+        return next(iter(feats)) if len(feats) == 1 else None
 
     # "across" phase — an X-axis hole's Y position below the SIDE view, placed BEFORE
     # the envelope so the overall depth dim stacks outside it (ISO order). Confined to
@@ -188,21 +200,29 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
         yw = SZ(dz) - 2
         seen_y: set = set()
         cands = []
+        loc_by_name: dict = {}  # dim name -> contributing hole locations (for provenance)
         for h in (h for h in off if _axis_letter(h) == "x"):
             yo = round(abs(h.location[1] - dy), 2)
-            if yo * a.SCALE >= 1.0 and yo not in seen_y:
+            if yo * a.SCALE < 1.0:
+                continue
+            name = f"dim_loc_side_y{round(yo * 100)}"
+            loc_by_name.setdefault(name, []).append(h.location)
+            if yo not in seen_y:
                 seen_y.add(yo)
                 p_lo, p_hi = (SX(dy), yw, 0), (SX(h.location[1]), yw, 0)
                 cands.append(
                     (
-                        f"dim_loc_side_y{round(yo * 100)}",
+                        name,
                         lambda pos, pl=p_lo, ph=p_hi, lb=yo: _dim(
                             pl, ph, "below", yw - pos, draft, label=_fmt(lb)
                         ),
                     )
                 )
-        leftover = _emit(a.sv_zones.below, "side", "y", cands)
-        leftover = _emit(a.sv_zones.below, "side", "y", leftover, force=True)  # keep, don't drop
+        feats = {nm: _off_axis_owner(locs) for nm, locs in loc_by_name.items()}
+        leftover = _emit(a.sv_zones.below, "side", "y", cands, features=feats)
+        leftover = _emit(
+            a.sv_zones.below, "side", "y", leftover, force=True, features=feats
+        )  # keep, don't drop
         for _ in leftover:
             _drop("y", "side")
         return
@@ -212,21 +232,29 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
     xw = FZ(dz) - 2
     seen_x: set = set()
     x_cands = []
+    x_loc_by_name: dict = {}
     for h in (h for h in off if _axis_letter(h) == "y"):
         xo = round(abs(h.location[0] - dx), 2)
-        if xo * a.SCALE >= 1.0 and xo not in seen_x:
+        if xo * a.SCALE < 1.0:
+            continue
+        name = f"dim_loc_front_x{round(xo * 100)}"
+        x_loc_by_name.setdefault(name, []).append(h.location)
+        if xo not in seen_x:
             seen_x.add(xo)
             p_lo, p_hi = (FX(dx), xw, 0), (FX(h.location[0]), xw, 0)
             x_cands.append(
                 (
-                    f"dim_loc_front_x{round(xo * 100)}",
+                    name,
                     lambda pos, pl=p_lo, ph=p_hi, lb=xo: _dim(
                         pl, ph, "below", xw - pos, draft, label=_fmt(lb)
                     ),
                 )
             )
-    x_leftover = _emit(a.fv_zones.below, "front", "y", x_cands)
-    x_leftover = _emit(a.fv_zones.below, "front", "y", x_leftover, force=True)  # keep, don't drop
+    x_feats = {nm: _off_axis_owner(locs) for nm, locs in x_loc_by_name.items()}
+    x_leftover = _emit(a.fv_zones.below, "front", "y", x_cands, features=x_feats)
+    x_leftover = _emit(
+        a.fv_zones.below, "front", "y", x_leftover, force=True, features=x_feats
+    )  # keep, don't drop
     for _ in x_leftover:
         _drop("x", "front")
 
@@ -240,6 +268,11 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
     # never drop a real dimension (policy B, #133 rework); only a physically full strip
     # still drops.
     zr, zrf = SX(a.bb.max.Y), FX(a.bb.max.X)
+    z_locs: dict = {}  # z-offset -> contributing hole locations (for provenance)
+    for h in off:
+        zo = round(abs(h.location[2] - dz), 2)
+        if zo * a.SCALE >= 1.0:
+            z_locs.setdefault(zo, []).append(h.location)
     seen_z = set()
     for h in off:
         zo = round(abs(h.location[2] - dz), 2)
@@ -247,6 +280,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
             continue
         seen_z.add(zo)
         hz = h.location[2]
+        owner = _off_axis_owner(z_locs[zo])
 
         def _zc(view, p_lo, p_hi, edge, _zo=zo):
             return (
@@ -256,15 +290,20 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
                 ),
             )
 
+        def _zf(view, _zo=zo, _owner=owner):  # provenance map for the z dim in this view
+            return {f"dim_loc_{view}_z{round(_zo * 100)}": _owner}
+
         side_cand = (a.sv_zones.right, "side", (zr, SZ(dz), 0), (zr, SZ(hz), 0), zr)
         front_cand = (a.fv_zones.right, "front", (zrf, FZ(dz), 0), (zrf, FZ(hz), 0), zrf)
         order = (side_cand, front_cand) if _axis_letter(h) == "x" else (front_cand, side_cand)
         for strip, view, p_lo, p_hi, edge in order:
-            if not _emit(strip, view, "x", [_zc(view, p_lo, p_hi, edge)]):
+            if not _emit(strip, view, "x", [_zc(view, p_lo, p_hi, edge)], features=_zf(view)):
                 break
         else:
             strip, view, p_lo, p_hi, edge = order[0]
-            if _emit(strip, view, "x", [_zc(view, p_lo, p_hi, edge)], force=True):
+            if _emit(
+                strip, view, "x", [_zc(view, p_lo, p_hi, edge)], force=True, features=_zf(view)
+            ):
                 _drop("Z", view)
 
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -288,7 +288,13 @@ def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_pa
         assert feat.bcd is not None  # a bolt circle always carries its BCD
         cx = sum(to_page(m)[0] for m in members) / len(members)
         cy = sum(to_page(m)[1] for m in members) / len(members)
-        dwg.add(CenterlineCircle((cx, cy), feat.bcd * a.SCALE), f"bc_{view}{j}", view=view)
+        # Furniture provenance (#408): the pattern owns its centre line + pitch dims.
+        dwg.add(
+            CenterlineCircle((cx, cy), feat.bcd * a.SCALE),
+            f"bc_{view}{j}",
+            view=view,
+            feature=feat,
+        )
     elif feat.pattern == "linear":
         assert feat.pitch is not None  # a linear array always carries its pitch
         _place_pitch_dim(
@@ -301,13 +307,14 @@ def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_pa
             feat.pitch,
             to_page,
             f"dim_pitch_{view}{j}",
+            feature=feat,
         )
     elif feat.pattern == "grid":
         assert feat.grid is not None  # a grid always carries its (row, col) pitch
-        _add_grid_pitch_dims(dwg, a, view, j, members, feat.grid, to_page)
+        _add_grid_pitch_dims(dwg, a, view, j, members, feat.grid, to_page, feature=feat)
 
 
-def _add_grid_pitch_dims(dwg, a: Analysis, view, j, members, nominals, to_page):
+def _add_grid_pitch_dims(dwg, a: Analysis, view, j, members, nominals, to_page, feature=None):
     """Both pitch dimensions of a rectangular grid — one along each lattice axis,
     each labelled ``(n-1)× pitch`` (#92).  The two axes are recovered as the two
     shortest near-orthogonal inter-hole page vectors (the recogniser's own
@@ -379,16 +386,17 @@ def _add_grid_pitch_dims(dwg, a: Analysis, view, j, members, nominals, to_page):
             pitch,
             to_page,
             f"dim_pitch_{view}{j}_{sub}",
+            feature=feature,
         )
 
     _axis_dim(u1, l1, 0)
     _axis_dim(u2, l2, 1)
 
 
-def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name):
+def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name, feature=None):
     """Pitch dimension between two hole-centre *locations* ``loc1``→``loc2``, labelled
     ``(n-1)× pitch``, placed just outside the view on the side of the row's
-    outward perpendicular (#92)."""
+    outward perpendicular (#92). *feature* attributes it to the source pattern (#408)."""
     p1 = to_page(loc1)
     p2 = to_page(loc2)
     ux, uy = p2[0] - p1[0], p2[1] - p1[1]
@@ -455,6 +463,7 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
         ),
         name,
         view=view,
+        feature=feature,
     )
 
 
@@ -513,6 +522,10 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
     # surviving feature-hole positions, supplied by the orchestrator) gates which
     # members are dimensioned; no recogniser Hole/Pattern object is used.
     by_view: dict = {}
+    # Callout → source IR feature, for provenance (#408 / ADR 0010). The callout object
+    # flows unchanged from here through the by_view/queue tuples to both emit sites, so an
+    # id() map tags it there without threading a feature through the placement machinery.
+    _feat_of_callout: dict[int, object] = {}
     for g in groups:
         feat = g.feature
         if not isinstance(feat, HoleFeature | PatternFeature):
@@ -541,6 +554,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
         if callout is None:
             continue
         view = view_of_axis[feat.frame.axis][0]
+        _feat_of_callout[id(callout)] = feat  # provenance (#408)
         by_view.setdefault(view, []).append((locs, dia, callout, pat))
 
     def _rim_tip(centre, elbow, dia):
@@ -564,6 +578,7 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
             ),
             f"hc_{view}{i}",
             view=view,
+            feature=_feat_of_callout.get(id(callout)),
         )
 
     for view, view_groups in by_view.items():
@@ -960,7 +975,9 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
             i = start_i
             for s, _elbow_y, leader in sorted(placed, key=lambda p: p[0][4]):
                 _locs, dia, callout, feat, _ny, rep = s
-                dwg.add(leader, f"hc_{view}{i}", view=view)
+                dwg.add(
+                    leader, f"hc_{view}{i}", view=view, feature=_feat_of_callout.get(id(callout))
+                )
                 _add_furniture(dwg, a, view, i, feat, to_page)
                 i += 1
             return i

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -289,6 +289,9 @@ class Drawing:
         # The detected ADR-0008 PartModel this drawing was built from (attached by
         # the annotation orchestrator). Read surface for semantic edits (#397).
         self._part_model: object | None = None
+        # Lazy model-location → IR hole/pattern feature index (#408), so a balloon —
+        # which holds a recognition hole, not the IR feature — can attribute itself.
+        self._hole_feature_index: dict | None = None
 
     # -- annotation registry (compat accessors, ADR 0005 §4) ------------------
     # The registry owns these four; they are exposed as their live containers so
@@ -976,6 +979,23 @@ class Drawing:
             self._render_balloon(view, tag, j, hole, cx, cy, bx, by, fs, r)
         return len(members) - len(coords)
 
+    def _feature_of_hole_at(self, location):
+        """The IR hole/pattern feature whose member sits at model-space *location*, or
+        ``None`` (#408). Attributes a balloon (which carries a recognition hole, not the
+        IR feature) to its feature so :meth:`drop` clears it. Cached — the model is fixed
+        after build."""
+        m = self._part_model
+        if m is None:
+            return None
+        if self._hole_feature_index is None:
+            idx: dict = {}
+            for f in getattr(m, "features", []):
+                if getattr(f, "kind", None) in ("hole", "pattern"):
+                    for loc in getattr(f, "members", None) or (f.frame.origin,):
+                        idx[tuple(round(c, 3) for c in loc)] = f
+            self._hole_feature_index = idx
+        return self._hole_feature_index.get(tuple(round(c, 3) for c in location))
+
     def _render_balloon(self, view, tag, j, hole, cx, cy, bx, by, fs, r):
         """Build and add one balloon glyph + leader at solved centre ``(bx, by)``
         for hole ``(cx, cy)`` (#111)."""
@@ -1006,7 +1026,12 @@ class Drawing:
         # Furniture that legitimately sits on the view geometry — exempt from the
         # annotation-overlap / centreline lint, as the section arrows do.
         balloon.is_centerline = True
-        self.add(balloon, f"balloon_{view}_{tag}_{j}", view=view)
+        self.add(
+            balloon,
+            f"balloon_{view}_{tag}_{j}",
+            view=view,
+            feature=self._feature_of_hole_at(hole.location),
+        )
 
     def _add_balloon(self, view, tag, j, hole):
         """Single-balloon convenience over :meth:`_add_balloons` (#111)."""

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4239,6 +4239,18 @@ class TestModel:
         )
 
 
+def _assert_drop_is_complete(dwg):
+    """The #408 consistency invariant: for EVERY feature, drop() removes exactly what
+    annotations_of() reports, and nothing the feature owned survives. Distinct features
+    never share an owned annotation (shared spans are left unowned), so dropping each in
+    turn is independent."""
+    for f in list(dwg.model().features):
+        owned = set(dwg.annotations_of(f))
+        removed = set(dwg.drop(f))
+        assert removed == owned, f"{f.kind}: drop removed {removed} != annotations_of {owned}"
+        assert not dwg.annotations_of(f), f"{f.kind}: annotations remain after drop"
+
+
 class TestFeatureEdits:
     """#398b: first-class feature provenance — drop()/annotations_of() by feature.
 
@@ -4247,13 +4259,13 @@ class TestFeatureEdits:
     returns exactly the covered set, so drop() is transparent about what it removes."""
 
     def test_annotations_of_returns_a_features_centermarks_and_locations(self):
-        # #398c broadened coverage: a hole owns its centre mark(s) AND its location dims
-        # (the corridor-placed m_locx/m_locy), now that provenance threads the corridor.
+        # A hole owns its centre mark(s), location dims (#398c, corridor-placed
+        # m_locx/m_locy), and its ⌀ callout (#408, hc_).
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")
         owned = dwg.annotations_of(hole)
         assert any(n.startswith("m_cm") for n in owned), "hole should own its centre mark(s)"
-        assert all(n.startswith(("m_cm", "m_loc")) for n in owned)
+        assert all(n.startswith(("m_cm", "m_loc", "hc_")) for n in owned)
 
     def test_drop_removes_a_features_annotations(self):
         dwg = build_drawing(_holed_plate())
@@ -4307,6 +4319,61 @@ class TestFeatureEdits:
         p1, p2 = dwg.at("plan", 0, 0, 0), dwg.at("plan", 20, 0, 0)
         dwg.place_dim(p1, p2, "above", "plan", dwg.draft, name="mine", feature=hole)
         assert "mine" in dwg.annotations_of(hole)
+
+    def test_drop_hole_clears_its_callout(self):
+        # #408 A: a hole owns its ⌀ callout, so drop clears it (not just centre marks).
+        dwg = build_drawing(_holed_plate())
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        owned = dwg.annotations_of(hole)
+        assert any(n.startswith("hc_") for n in owned), "hole should own its callout"
+        assert any(n.startswith("hc_") for n in dwg.drop(hole))
+
+    def test_drop_pattern_clears_its_furniture(self):
+        # #408 B: a pattern owns its callout AND its centre line / pitch furniture.
+        import math
+
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(120, 120, 20)
+        for k in range(6):
+            ang = math.radians(60 * k)
+            part -= Pos(35 * math.cos(ang), 35 * math.sin(ang), 0) * Cylinder(4, 20)
+        dwg = build_drawing(part)
+        pat = next(f for f in dwg.model().features if f.kind == "pattern")
+        owned = dwg.annotations_of(pat)
+        assert any(n.startswith("hc_") for n in owned) and any(n.startswith("bc_") for n in owned)
+        removed = set(dwg.drop(pat))
+        assert removed == set(owned)
+
+    def test_balloon_is_owned_by_its_hole(self):
+        # #408 C: a balloon (which carries a recognition hole) attributes to the IR feature.
+        dwg = build_drawing(_holed_plate())
+        a = dwg._analysis
+        hole_obj = a.holes[0]
+        feat = dwg._feature_of_hole_at(hole_obj.location)
+        assert feat is not None
+        dwg._add_balloon("plan", "A", 0, hole_obj)
+        bln = next(n for n in dwg.annotations() if n.startswith("balloon_"))
+        assert bln in dwg.annotations_of(feat)
+
+    def test_drop_is_complete_for_a_multi_feature_prismatic_part(self):
+        # #408 audit: holes + bolt pattern + slot — drop(feature) leaves nothing behind.
+        import math
+
+        from build123d import Box, Cylinder, Mode, Pos
+
+        part = Box(140, 120, 20) - Pos(-45, 0, 0) * Box(24, 8, 30, mode=Mode.SUBTRACT)
+        for k in range(6):
+            ang = math.radians(60 * k)
+            part -= Pos(40 + 25 * math.cos(ang), 25 * math.sin(ang), 0) * Cylinder(4, 20)
+        _assert_drop_is_complete(build_drawing(part))
+
+    def test_drop_is_complete_for_a_turned_part(self):
+        # #408 audit: a turned stepped shaft (steps + OD).
+        from build123d import Cylinder
+
+        shaft = Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25))
+        _assert_drop_is_complete(build_drawing(shaft))
 
     def test_dimension_rejects_non_orthographic_view(self):
         # #407 review: a linear dim on the foreshortening iso view mislabels the length.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4239,11 +4239,28 @@ class TestModel:
         )
 
 
+# Annotation-name prefixes that are always owned by exactly ONE feature (never a shared
+# span), so every one of them on the sheet MUST have a provenance owner. Location dims
+# (m_locx/m_locy, dim_loc_*) are excluded — a coordinate shared by two distinct features
+# is intentionally unowned (#398c/#406). Turned-diameter callouts (m_dia_*) are excluded:
+# their spec-flattening render pass does not yet carry the feature (a tracked gap, #411).
+_ALWAYS_OWNED = ("hc_", "bc_", "m_cm", "dim_pitch", "balloon_", "m_slot")
+
+
 def _assert_drop_is_complete(dwg):
-    """The #408 consistency invariant: for EVERY feature, drop() removes exactly what
-    annotations_of() reports, and nothing the feature owned survives. Distinct features
-    never share an owned annotation (shared spans are left unowned), so dropping each in
+    """The #408 consistency invariant, in two non-tautological parts.
+
+    (1) COMPLETENESS: every single-feature-owned annotation on the sheet has a provenance
+    owner — this catches a render pass that stops tagging (which the drop==annotations_of
+    check alone cannot, since both derive from the same name set; #410 review).
+
+    (2) CONSISTENCY: for every feature, drop() removes exactly annotations_of() and leaves
+    nothing behind. Distinct features never share an owned annotation, so dropping each in
     turn is independent."""
+    reg = dwg._registry
+    for name in dwg.annotations():
+        if name.startswith(_ALWAYS_OWNED):
+            assert reg.feature_of(name) is not None, f"{name}: feature annotation left unowned"
     for f in list(dwg.model().features):
         owned = set(dwg.annotations_of(f))
         removed = set(dwg.drop(f))
@@ -4374,6 +4391,26 @@ class TestFeatureEdits:
 
         shaft = Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25))
         _assert_drop_is_complete(build_drawing(shaft))
+
+    def test_drop_is_complete_for_side_drilled_holes(self):
+        # #410 review F1: a side-drilled (X/Y-axis) hole's location dims (dim_loc_side/
+        # front/z) must be owned so drop clears them — they route through
+        # _locate_off_axis_holes, which now tags via place_strip_candidates(features=).
+        from build123d import Box, Cylinder, Pos, Rot
+
+        part = (
+            Box(120, 90, 40)
+            - Pos(0, 0, 5) * Rot(0, 90, 0) * Cylinder(5, 120)  # X-axis bore
+            - Pos(0, 0, -8) * Rot(90, 0, 0) * Cylinder(5, 90)  # Y-axis bore
+        )
+        dwg = build_drawing(part)
+        side_loc = [n for n in dwg.annotations() if n.startswith("dim_loc_")]
+        assert side_loc, "expected side-drilled location dims"
+        # Directly: each (distinct-offset) side-drilled dim is owned by its hole — the F1
+        # fix. Without it these were feature=None and drop(hole) left them behind.
+        for n in side_loc:
+            assert dwg._registry.feature_of(n) is not None, f"{n} unowned (F1 regression)"
+        _assert_drop_is_complete(dwg)
 
     def test_dimension_rejects_non_orthographic_view(self):
         # #407 review: a linear dim on the foreshortening iso view mislabels the length.


### PR DESCRIPTION
The **drop-completeness** half of #408 (the consistency bar, ADR 0010 Amendment 1). `drop(feature)` now removes **everything** a hole/pattern produced — not just its centre marks + locations.

## Coverage added
- **Callouts (`hc_*`)** — an `id(callout)→g.feature` map in `_annotate_holes`. The callout object flows unchanged from creation to both emit sites (front `_add`, plan/side), so it tags there **without threading through the placement/Cassowary machinery**.
- **Pattern furniture (`bc_*` centre lines, pitch dims)** — `feature=feat` (the `PatternFeature`) threaded through `_add_furniture` → the `bc_` add + `_place_pitch_dim` / `_add_grid_pitch_dims`.
- **Balloons** — they carry a *recognition* hole, not the IR feature, so a lazy model-location→IR-feature index (`Drawing._feature_of_hole_at`) attributes them (no IR schema change).

## The consistency invariant, encoded
`_assert_drop_is_complete`: for **every** feature, `drop(feature)` removes *exactly* `annotations_of(feature)` and leaves nothing behind. Asserted on a multi-feature **prismatic** part (holes + bolt pattern + slot) and a **turned** part (steps + OD). A future render pass can't silently reintroduce a gap.

## Verification
- Additive metadata → **no output change**: layout snapshots + cleanliness unchanged (30 passed); smoke 70.
- Full lint gate (ruff check + `ruff format --check` + `mypy`) clean.

## Split (your call)
This is A+B+C+audit. The **`dimension()`-completeness** for value-only params (slots' derived geometry; hole diameter/depth callouts) — a render-one-feature refactor, the *add* half of the bar — is the **next PR**, isolated for careful review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
