### PR TITLE
feat: tag turned-diameter callouts (m_dia_*) — closes the last drop gap (#412)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -569,25 +569,26 @@ def _diameter_row_below(dwg, items) -> int:
     label_y = obstacle_bottom - (draft.font_size + 4 * draft.pad_around_text)
     if label_y < _MARGIN + draft.font_size:
         return 0
-    specs = []  # (tip_page, label), tip on the step's bottom silhouette
-    for anchor, dia in items:
+    specs = []  # (tip_page, label, feature), tip on the step's bottom silhouette
+    for anchor, dia, feat in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
-        specs.append((tip, f"ø{_fmt(dia)}"))
+        specs.append((tip, f"ø{_fmt(dia)}", feat))
     specs.sort(key=lambda s: s[0][0])
-    half_w = max(len(label) for _, label in specs) * draft.font_size * 0.62 / 2
+    half_w = max(len(label) for _, label, _ in specs) * draft.font_size * 0.62 / 2
     min_gap = 2 * half_w + 2 * draft.pad_around_text
-    naturals = [tip[0] for tip, _ in specs]
+    naturals = [tip[0] for tip, _, _ in specs]
     xs = _solve_strip_ys(naturals, min_gap, fx0 + half_w, fx1 - half_w) or _greedy_strip_ys(
         naturals, min_gap, fx0 + half_w, fx1 - half_w
     )
     if xs is None:
         return 0
-    for i, ((tip, label), lx) in enumerate(zip(specs, xs, strict=True)):
+    for i, ((tip, label, feat), lx) in enumerate(zip(specs, xs, strict=True)):
         dwg.add(
             Leader(tip=(tip[0], tip[1], 0), elbow=(lx, label_y, 0), label=label, draft=draft),
             f"m_dia_x{i}",
             view="front",
+            feature=feat,
         )
     return len(specs)
 
@@ -601,19 +602,19 @@ def _diameter_column_left(dwg, items) -> int:
         return 0
     draft = dwg.draft
     fx0, fy0, _, fy1 = dwg.view_bounds("front")
-    label_w = max(len(f"ø{_fmt(dia)}") for _, dia in items) * draft.font_size * 0.62
+    label_w = max(len(f"ø{_fmt(dia)}") for _, dia, _ in items) * draft.font_size * 0.62
     elbow_x = fx0 - (draft.font_size + 2 * draft.pad_around_text)
     if elbow_x - label_w < _MARGIN:
         return 0
-    specs = []  # (tip_page, label), tip on the step's left silhouette
-    for anchor, dia in items:
+    specs = []  # (tip_page, label, feature), tip on the step's left silhouette
+    for anchor, dia, feat in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax - dia / 2, ay, az)
-        specs.append((tip, f"ø{_fmt(dia)}"))
+        specs.append((tip, f"ø{_fmt(dia)}", feat))
     specs.sort(key=lambda s: s[0][1])
     half_h = draft.font_size / 2 + draft.pad_around_text
     min_gap = 2 * half_h
-    naturals = [tip[1] for tip, _ in specs]
+    naturals = [tip[1] for tip, _, _ in specs]
     ys = _solve_strip_ys(naturals, min_gap, fy0 + half_h, fy1 - half_h) or _greedy_strip_ys(
         naturals, min_gap, fy0 + half_h, fy1 - half_h
     )
@@ -625,11 +626,11 @@ def _diameter_column_left(dwg, items) -> int:
     # occupant class, #358). Centre lines stay crossable (a diameter dim may cross one).
     occupied = strip_obstacles(dwg, view="front", crossable=CROSSABLE_TYPES)
     placed = 0
-    for i, ((tip, label), ly) in enumerate(zip(specs, ys, strict=True)):
+    for i, ((tip, label, feat), ly) in enumerate(zip(specs, ys, strict=True)):
         ldr = Leader(tip=(tip[0], tip[1], 0), elbow=(elbow_x, ly, 0), label=label, draft=draft)
         if _box_hits(_anno_box(ldr), occupied):
             continue  # would overprint a bore leader / existing callout — drop just this one
-        dwg.add(ldr, f"m_dia_z{i}", view="front")
+        dwg.add(ldr, f"m_dia_z{i}", view="front", feature=feat)
         occupied.append(_anno_box(ldr))
         placed += 1
     return placed
@@ -642,25 +643,30 @@ def render_diameters(dwg, groups, tol: float = 0.15) -> int:
     frame's axis, not two passes. Replaces the engine's ``_annotate_turned_diameters``
     (ADR 0008 convergence). Diameters another annotation already covers are skipped."""
     mentioned = _mentioned_diameters(dwg)
-    seen: set[tuple[str, float]] = set()
-    rows: list = []  # X-turned (anchor, dia)
-    cols: list = []  # Z-turned (anchor, dia)
+    # One distinct callout per (axis, diameter). Accumulate EVERY feature that shares a
+    # diameter (insertion-ordered), so provenance (#412) can tag the callout with its
+    # single owner — or leave it unowned when two distinct features share the diameter
+    # (the #398c/#406 shared-value rule, so drop can't over-strip a sibling).
+    row_buckets: dict = {}  # round(dia,2) -> [anchor, dia, {features}]  (X-turned)
+    col_buckets: dict = {}  # Z-turned
     for g in groups:
         if g.feature_kind not in ("step", "boss"):
             continue
         dia = next((pd.param.value for pd in g.dims if pd.param.kind == "diameter"), None)
         if dia is None or any(abs(dia - m) <= tol for m in mentioned):
             continue
-        axis = g.feature.frame.axis
-        key = (axis, round(dia, 2))
-        if key in seen:  # one distinct callout per diameter
+        bucket = {"x": row_buckets, "z": col_buckets}.get(g.feature.frame.axis)
+        if bucket is None:
             continue
-        seen.add(key)
-        if axis == "x":
-            rows.append((g.anchor, dia))
-        elif axis == "z":
-            cols.append((g.anchor, dia))
-    return _diameter_row_below(dwg, rows) + _diameter_column_left(dwg, cols)
+        dkey = round(dia, 2)
+        bucket.setdefault(dkey, [g.anchor, dia, set()])[2].add(g.feature)
+
+    def _items(buckets):
+        return [(a, d, next(iter(fs)) if len(fs) == 1 else None) for a, d, fs in buckets.values()]
+
+    return _diameter_row_below(dwg, _items(row_buckets)) + _diameter_column_left(
+        dwg, _items(col_buckets)
+    )
 
 
 def _env_pd(group, role):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4405,6 +4405,18 @@ class TestFeatureEdits:
         owner = dwg._registry.feature_of(mdia[0])
         assert mdia[0] in dwg.drop(owner)
 
+    def test_drop_step_clears_its_diameter_callout_x_turned(self):
+        # #413 review: cover the X-row path (m_dia_x, _diameter_row_below) too — the Z-shaft
+        # above only exercises the m_dia_z column path.
+        from build123d import Cylinder, Rot
+
+        shaft = Rot(0, 90, 0) * (Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)))
+        dwg = build_drawing(shaft)
+        mdia_x = [n for n in dwg.annotations() if n.startswith("m_dia_x")]
+        assert mdia_x, "expected X-turned diameter callouts (row path)"
+        for n in mdia_x:
+            assert dwg._registry.feature_of(n) is not None, f"{n} unowned (#412 row path)"
+
     def test_drop_is_complete_for_side_drilled_holes(self):
         # #410 review F1: a side-drilled (X/Y-axis) hole's location dims (dim_loc_side/
         # front/z) must be owned so drop clears them — they route through

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4241,9 +4241,9 @@ class TestModel:
 
 # Annotation-name prefixes that are always owned by exactly ONE feature (never a shared
 # span), so every one of them on the sheet MUST have a provenance owner. Location dims
-# (m_locx/m_locy, dim_loc_*) are excluded — a coordinate shared by two distinct features
-# is intentionally unowned (#398c/#406). Turned-diameter callouts (m_dia_*) are excluded:
-# their spec-flattening render pass does not yet carry the feature (a tracked gap, #411).
+# (m_locx/m_locy, dim_loc_*) and turned-diameter callouts (m_dia_*) are excluded from the
+# blanket rule — a coordinate OR a diameter shared by two distinct features is
+# intentionally unowned (#398c/#406/#412). Their owned cases are checked in dedicated tests.
 _ALWAYS_OWNED = ("hc_", "bc_", "m_cm", "dim_pitch", "balloon_", "m_slot")
 
 
@@ -4391,6 +4391,19 @@ class TestFeatureEdits:
 
         shaft = Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25))
         _assert_drop_is_complete(build_drawing(shaft))
+
+    def test_drop_step_clears_its_diameter_callout(self):
+        # #412: a turned step owns its ⌀ callout (m_dia_) — the spec-flattening render pass
+        # now carries the feature. Without it, m_dia was feature=None and drop left it.
+        from build123d import Cylinder
+
+        dwg = build_drawing(Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)))
+        mdia = [n for n in dwg.annotations() if n.startswith("m_dia")]
+        assert mdia, "expected turned-diameter callouts"
+        for n in mdia:
+            assert dwg._registry.feature_of(n) is not None, f"{n} unowned (#412 regression)"
+        owner = dwg._registry.feature_of(mdia[0])
+        assert mdia[0] in dwg.drop(owner)
 
     def test_drop_is_complete_for_side_drilled_holes(self):
         # #410 review F1: a side-drilled (X/Y-axis) hole's location dims (dim_loc_side/

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -176,12 +176,16 @@ class TestDiameterColumnOccupancy:
             def view_of(s, n):
                 return "front"
 
-            def add(s, ann, name, view):
+            def add(s, ann, name, view, feature=None):
                 pass
 
         return _Dwg()
 
-    _ITEMS = [((10.0, 0.0, 8.0), 12.0), ((10.0, 0.0, 24.0), 8.0)]  # two Z-turned ø steps
+    # (anchor, dia, feature) — feature=None here (unit test of placement; #412 added the tag)
+    _ITEMS = [
+        ((10.0, 0.0, 8.0), 12.0, None),
+        ((10.0, 0.0, 24.0), 8.0, None),
+    ]  # two Z-turned ø steps
 
     def test_control_no_occupant_places_both(self):
         from draftwright.annotations.from_model import _diameter_column_left


### PR DESCRIPTION
Closes #412 — the one documented drop-completeness exclusion after #410. Turned-diameter ø callouts (`m_dia_x*`/`m_dia_z*`) were `feature=None`, so `drop(step)` left them.

## Cause + fix
`render_diameters` flattened IR features into `(anchor, dia)` specs, dropping the source feature. Now it accumulates **every** feature sharing a diameter into insertion-ordered buckets and passes `(anchor, dia, feature)` items; `_diameter_row_below` / `_diameter_column_left` thread the feature to the `m_dia_*` `dwg.add`.

A callout whose diameter is shared by two **distinct** features is left **unowned** (the #398c/#406 shared-value rule → `drop` can't over-strip a sibling); a single-owner diameter is tagged.

## Verification
- Dedicated test: a turned step **owns + drops** its `m_dia_` callout; every `m_dia` on the sheet is owned (for distinct diameters).
- Additive metadata → **no output drift**: the bucket restructure places identically (snapshots + cleanliness 30 passed).
- Full lint gate (ruff check + format + mypy) clean.

**`drop(feature)` is now complete for every feature kind, with no carve-outs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
