### PR TITLE
feat: inert detected-feature/intent listing in --script (#400 Ph1)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -38,6 +38,7 @@ from draftwright.analysis import _analyse
 from draftwright.annotate import _auto_annotate, build_model
 from draftwright.drawing import Drawing
 from draftwright.fonts import PLEX_MONO
+from draftwright.model import display
 from draftwright.projection import (
     _fit_iso_view,
     _project_iso,
@@ -535,6 +536,60 @@ def make_drawing(
 # ---------------------------------------------------------------------------
 
 
+def _fmt_pt(p) -> str:
+    """A compact ``x, y, z`` for a model-space point (integers stay integers)."""
+    return ", ".join(f"{c:.0f}" if abs(c - round(c)) < 1e-6 else f"{c:.1f}" for c in p)
+
+
+def _feature_listing(a: Analysis) -> str:
+    """An inert, commented listing of the detected features and their dimensionable
+    parameters (#400 Ph1) — developer visibility into what the engine auto-dimensioned.
+
+    Each feature is referenced as ``dwg.model().features[i]`` so an uncommented line runs
+    against the real read surface (#397, ADR 0008 IR). A **linear** param becomes an
+    editable ``dwg.dimension(...)`` call; a leader-callout param (a hole's ø/depth, a
+    pattern's furniture) is noted inert — a callout add verb is tracked as #414. The
+    auto-pass already drew these, so *overriding* one means :meth:`~Drawing.drop` then
+    re-add, shown in the header. Pure function of *a*; no annotation pass runs.
+    """
+    feats = getattr(build_model(a), "features", [])
+    if not feats:
+        return (
+            "# ── Detected features (#400 Ph1) ──────────────────────────────────────────────\n"
+            "# No dimensionable features detected.\n"
+        )
+    lines = [
+        "# ── Detected features (#400 Ph1) ──────────────────────────────────────────────",
+        "# What the engine detected and auto-dimensioned, listed for visibility. Reference a",
+        "# feature as dwg.model().features[i] (the ADR-0008 IR). A dwg.dimension(...) line",
+        "# below reproduces the dim the engine drew for that param. The auto-pass already",
+        "# drew everything, so to CHANGE a feature, drop it then re-add only the dims you want",
+        "# (an uncommented bare line double-dimensions):",
+        "#     f = dwg.model().features[0]",
+        "#     dwg.drop(f)                             # remove f's auto annotations",
+        '#     dwg.dimension(f, "length", role="...")  # re-add a chosen linear dim',
+        "#",
+    ]
+    for i, feat in enumerate(feats):
+        lines.append(f"# features[{i}]  {feat.kind} @ ({_fmt_pt(feat.frame.origin)})")
+        for p in feat.parameters():
+            if p.span is not None or feat.kind == "slot":  # a linear dim dimension() accepts
+                lines.append(
+                    f'#     dwg.dimension(dwg.model().features[{i}], "{p.kind}", '
+                    f'role="{p.role}")   # {display(p)}'
+                )
+            elif p.kind in ("diameter", "depth"):  # a hole ø/depth — a leader callout
+                lines.append(
+                    f"#     {display(p)} ({p.role}) -> auto leader callout; "
+                    f"a callout() add verb is #414"
+                )
+            else:  # an auto-drawn linear dim (step height, pitch, …) not yet a dimension() target
+                lines.append(
+                    f"#     {display(p)} ({p.role}) -> auto-drawn; not a dimension() target yet"
+                )
+    return "\n".join(lines) + "\n"
+
+
 def _write_script(a: Analysis, scale: float | None = None, page: str | None = None) -> str:
     """Write an editable script at ``a.out + '.py'`` that calls make_drawing().
 
@@ -641,7 +696,7 @@ def _write_script(a: Analysis, scale: float | None = None, page: str | None = No
         "# Example — add a linear dim (place_dim auto-stacks; endpoints via dwg.at):\n"
         "#   p1, p2 = dwg.at('front', 0, 0, 0), dwg.at('front', 40, 0, 0)\n"
         "#   dwg.place_dim(p1, p2, 'above', 'front', dwg.draft, name='dim_len')\n"
-        "\n"
+        "\n" + _feature_listing(a) + "\n"
         "# ── Export ────────────────────────────────────────────────────────────────────\n"
         "svg_path, dxf_path = dwg.export(_stem)\n"
         # ASCII arrow: a Unicode → crashes the print on a Windows cp1252 console

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -537,8 +537,12 @@ def make_drawing(
 
 
 def _fmt_pt(p) -> str:
-    """A compact ``x, y, z`` for a model-space point (integers stay integers)."""
-    return ", ".join(f"{c:.0f}" if abs(c - round(c)) < 1e-6 else f"{c:.1f}" for c in p)
+    """A compact ``x, y, z`` for a model-space point (integers stay integers).
+
+    Near-integer coords round to an ``int`` (not ``f"{c:.0f}"``) so a symmetric part's
+    tiny-negative bbox-centre float (``-1e-16``) prints ``0``, never ``-0`` (#416 review).
+    """
+    return ", ".join(f"{round(c)}" if abs(c - round(c)) < 1e-6 else f"{c:.1f}" for c in p)
 
 
 def _feature_listing(a: Analysis) -> str:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2314,6 +2314,35 @@ def test_generate_script_defers_invalid_scale_page(tmp_path):
     assert "SCALE = 0.001" in content and "PAGE = 'A9'" in content
 
 
+def test_generate_script_lists_detected_features(tmp_path):
+    # #400 Ph1: the script's Customise section carries an inert listing of the detected
+    # features + their dimensionable params. A hole → an inert leader-callout note (#414);
+    # the envelope's length params → editable dwg.dimension(...) lines against model().
+    step = tmp_path / "p.step"
+    export_step(Box(60, 60, 12) - Pos(0, 0, 0) * Cylinder(4, 40), str(step))
+    content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text(encoding="utf-8")
+    assert "# ── Detected features (#400 Ph1)" in content
+    assert "# features[0]  hole @" in content  # detected + indexed by model().features[i]
+    # a hole ø is a leader callout → inert note pointing at the callout add verb (#414)
+    assert "auto leader callout; a callout() add verb is #414" in content
+    # the envelope's width/height/depth are linear → editable dimension() calls
+    assert "dwg.dimension(dwg.model().features[" in content
+    assert 'role="width")' in content
+
+
+def test_feature_listing_is_fully_inert(tmp_path):
+    # #400 Ph1: the whole listing is commented — never executes, so it cannot double-apply
+    # or crash a run. Every non-blank line between the header and the Export banner is a #.
+    step = tmp_path / "p.step"
+    export_step(Box(40, 30, 8) - Pos(0, 0, 0) * Cylinder(3, 20), str(step))
+    content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text(encoding="utf-8")
+    start = content.index("# ── Detected features (#400 Ph1)")
+    end = content.index("# ── Export", start)
+    block = [ln for ln in content[start:end].splitlines() if ln.strip()]
+    assert block, "listing block was empty"
+    assert all(ln.lstrip().startswith("#") for ln in block), "listing must be fully commented"
+
+
 @pytest.mark.timeout(180)
 def test_generated_script_runs_and_preserves_pmi(tmp_path):
     # #388 acceptance: a generated --pmi annotate script preserves pmi when RUN — execute
@@ -2323,7 +2352,9 @@ def test_generated_script_runs_and_preserves_pmi(tmp_path):
     import sys
 
     step = tmp_path / "p.step"
-    export_step(Box(80, 50, 8), str(step))
+    # A hole so the #400 listing carries a non-ASCII ø in a comment — proves the utf-8
+    # source runs even under an ASCII stdout (source encoding is independent of stdout).
+    export_step(Box(80, 50, 8) - Pos(0, 0, 0) * Cylinder(4, 40), str(step))
     py = generate_script(str(step), out=str(tmp_path / "p"), pmi="annotate")
     # Force an ASCII stdout so a non-ASCII char in the script's own print() (e.g. a
     # Unicode arrow) fails HERE on every platform, not only on a Windows cp1252 console.


### PR DESCRIPTION
## What

**#400 Phase 1** — the cheap developer-visibility win of the editable-surface epic (#388). The generated `--script` now emits an **inert, fully-commented listing** of the detected features and their dimensionable parameters in the *Customise* section: *"here is what the engine auto-dimensioned; edit to override."*

Example (a box + through hole + a step):
```python
# ── Detected features (#400 Ph1) ──────────────────────────────────────────────
# What the engine detected and auto-dimensioned, listed for visibility. Reference a
# feature as dwg.model().features[i] (the ADR-0008 IR). ...
# features[0]  hole @ (0, 0, 6)
#     ø8 (bore) -> auto leader callout; a callout() add verb is #414
# features[1]  envelope @ (0, 0, 0)
#     dwg.dimension(dwg.model().features[1], "length", role="width")   # 80
#     dwg.dimension(dwg.model().features[1], "length", role="height")  # 12
#     dwg.dimension(dwg.model().features[1], "length", role="depth")   # 50
```

## Design

- Each feature is referenced as `dwg.model().features[i]` — the real **#397 read surface** — so an uncommented line runs against the live API.
- A **linear** param (step length, envelope w/h/d, slot size) → an editable `dwg.dimension(...)` call. Classification mirrors exactly what `dimension()` accepts (`span is not None or slot`), so a shown call never raises if uncommented.
- A hole **ø/depth** → an inert *auto leader callout* note pointing at the callout add verb (**#414**). Other auto-drawn linears (step height, pitch) → *not-yet-a-dimension()-target* note. No line misrepresents the mechanism.
- The header gives the **override recipe** (`drop(f)` then re-add) and warns that a naive uncomment of a bare `dimension(...)` line double-dimensions — the honest Ph1 limitation (Ph2's detect-only build removes it).

## Scope / honesty

Pure function of the analysis (`build_model`) — no annotation pass runs, so it **depends only on #397** and adds **zero layout drift** (30 snapshot/cleanliness tests unchanged). **Phase 2** (a faithful *executable* emitter with a detect-only `new_drawing` and a byte-exact round-trip) stays **evidence-gated** and is out of scope here, per the issue.

## Testing

- `test_generate_script_lists_detected_features` — hole → callout note (#414); envelope → editable `dwg.dimension(...)` lines.
- `test_feature_listing_is_fully_inert` — every listing line is commented; it can never execute/crash a run.
- `test_generated_script_runs_and_preserves_pmi` extended with a hole so the listing's non-ASCII `ø` is exercised under `PYTHONIOENCODING=ascii` (utf-8 source runs regardless of stdout encoding).
- Full lint gate (`ruff check` + `ruff format --check` + `mypy src/draftwright/`) clean; drift check (30) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
