### PR TITLE
feat: callout() add verb for hole ø/depth leader callouts (#414)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -84,8 +84,8 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
     callout = callout_from_spec(spec, draft, spec["count"])
     assert callout is not None  # spec is non-None here, so callout_from_spec returns one
     view = view or _END_ON[feature.frame.axis]
-    if view not in getattr(dwg, "_coords", {}):
-        raise ValueError(f"callout(): view {view!r} is not rendered on this drawing")
+    if view not in _END_ON.values():  # front/plan/side — the ortho end-on views only
+        raise ValueError(f"callout(): view {view!r} is not a hole-callout view (front/plan/side)")
     gap = draft.pad_around_text
     w = callout.callout_width
     tier = draft.font_size + 2 * gap

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -64,6 +64,11 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
     model = getattr(dwg, "_part_model", None)
     if model is None:
         raise ValueError("callout(): no detected model — build the drawing first")
+    if not any(f is feature for f in model.features):
+        raise ValueError(
+            "callout(): feature is not from this drawing's model — "
+            "pass one from dwg.model().features"
+        )
     group = next((g for g in plan_dimensions(model) if g.feature is feature), None)
     spec = hole_callout_spec(group) if group is not None else None
     if spec is None:
@@ -74,10 +79,13 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
     draft = dwg.draft
     a = getattr(dwg, "_analysis", None)
     members = feature.members or (feature.frame.origin,)
-    count = len(members) if len(members) > 1 else None
-    callout = callout_from_spec(spec, draft, count)
+    # count comes from the spec (== feat.count) — the same source the auto-pass's
+    # bare path uses — not re-derived from len(members) (#414 review).
+    callout = callout_from_spec(spec, draft, spec["count"])
     assert callout is not None  # spec is non-None here, so callout_from_spec returns one
     view = view or _END_ON[feature.frame.axis]
+    if view not in getattr(dwg, "_coords", {}):
+        raise ValueError(f"callout(): view {view!r} is not rendered on this drawing")
     gap = draft.pad_around_text
     w = callout.callout_width
     tier = draft.font_size + 2 * gap

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -17,6 +17,7 @@ from build123d_drafting.helpers import (
 
 from draftwright._core import (
     _CONCENTRIC_TOL_MM,
+    _END_ON,
     _MIN_LOC_SEP_MM,
     _TB_CLEAR,
     _TB_H,
@@ -34,13 +35,117 @@ from draftwright.annotations._common import (
     _box_hits,
     _geom_box,
     _segment_hits_box,
+    carve_free_position,
     carve_free_segments,
     place_strip_candidates,
     strip_obstacles,
 )
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
 from draftwright.layout import StripCandidate, plan_strip
+from draftwright.model import plan_dimensions
 from draftwright.model.ir import HoleFeature, PatternFeature
+
+
+def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | None = None) -> str:
+    """Add a hole/pattern ø-depth **leader callout** for *feature* — the #414 add verb,
+    the callout-mechanism half of the editable surface (symmetric with :meth:`Drawing.drop`).
+
+    Funnels into the same :func:`hole_callout_spec` / :func:`callout_from_spec` the
+    auto-pass uses, so the callout text (ø, ``n×``, through/depth, cbore, pattern suffix)
+    is identical. Placement is a single reasonable leader beside the feature's end-on view
+    — not the auto-pass's whole-set priority solve (byte-identity is not a goal, #400 Ph2):
+    a lone added callout goes into free strip space and leans on :meth:`Drawing.repair` /
+    the coverage lint for the rest. The leader is tagged with *feature* so :meth:`drop` /
+    :meth:`annotations_of` find it. Returns the annotation name.
+
+    Raises ``ValueError`` if the drawing has no detected model, *feature* is not in it, or
+    the feature exposes no hole callout (use :meth:`dimension` for a linear param instead).
+    """
+    model = getattr(dwg, "_part_model", None)
+    if model is None:
+        raise ValueError("callout(): no detected model — build the drawing first")
+    group = next((g for g in plan_dimensions(model) if g.feature is feature), None)
+    spec = hole_callout_spec(group) if group is not None else None
+    if spec is None:
+        raise ValueError(
+            f"callout() draws a hole/pattern ø-depth leader callout; "
+            f"{type(feature).__name__} exposes none — use dimension() for a linear param"
+        )
+    draft = dwg.draft
+    a = getattr(dwg, "_analysis", None)
+    members = feature.members or (feature.frame.origin,)
+    count = len(members) if len(members) > 1 else None
+    callout = callout_from_spec(spec, draft, count)
+    assert callout is not None  # spec is non-None here, so callout_from_spec returns one
+    view = view or _END_ON[feature.frame.axis]
+    gap = draft.pad_around_text
+    w = callout.callout_width
+    tier = draft.font_size + 2 * gap
+    dia = spec["diameter"]
+
+    def _rim_tip(centre, elbow):
+        # Pull the leader tip from the hole centre to its circumference (bore dia mm).
+        r = dia * dwg.scale / 2
+        dx, dy = elbow[0] - centre[0], elbow[1] - centre[1]
+        norm = math.hypot(dx, dy)
+        return centre if norm <= r else (centre[0] + dx / norm * r, centre[1] + dy / norm * r)
+
+    vb = dwg.view_bounds(view) or (0.0, 0.0, 0.0, 0.0)
+    vx0, vy0, vx1, vy1 = vb
+    # tip on the member nearest the placement side (rightmost in page X)
+    centre = dwg.at(view, *max(members, key=lambda m: dwg.at(view, *m)[0]))[:2]
+
+    if view == "front":  # below the view (matches the auto-pass's front-callout side)
+        zones = getattr(a, "fv_zones", None) if a is not None else None
+        strip = getattr(zones, "below", None) if zones is not None else None
+        elbow_y = vy0 - max(tier, 0.6 * getattr(a, "DIM_PAD", 12.0))
+        if strip is not None:
+            coord = carve_free_position(
+                dwg, strip, view, "y", tier, (centre[0], centre[0] + gap + w)
+            )
+            if coord is not None:
+                elbow_y = coord
+        elbow = (centre[0], elbow_y)
+        room_right = (a.PAGE_W - a.margin) if a is not None else centre[0] + gap + w
+        tside = "right" if centre[0] + gap + w <= room_right else "left"
+    else:  # plan / side → to the right of the view
+        zones = (
+            getattr(a, {"plan": "pv_zones", "side": "sv_zones"}[view], None)
+            if a is not None
+            else None
+        )
+        strip = getattr(zones, "right", None) if zones is not None else None
+        elbow_x = vx1 + gap
+        if strip is not None:
+            coord = carve_free_position(
+                dwg, strip, view, "x", tier, (centre[1] - tier / 2, centre[1] + tier / 2)
+            )
+            if coord is not None:
+                elbow_x = coord
+        elbow = (elbow_x, centre[1])
+        tside = "right"
+
+    if name is None:
+        i = 0
+        name = f"hc_{view}0"
+        while name in dwg._named:
+            i += 1
+            name = f"hc_{view}{i}"
+    tip = _rim_tip(centre, elbow)
+    dwg.add(
+        Leader(
+            tip=(tip[0], tip[1], 0),
+            elbow=(elbow[0], elbow[1], 0),
+            label="",
+            draft=draft,
+            text_side=tside,
+            callout=callout,
+        ),
+        name,
+        view=view,
+        feature=feature,
+    )
+    return name
 
 
 def _legible_locations(positions, scale):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -756,6 +756,24 @@ class Drawing:
         self.place_dim(p1, p2, side, view, self.draft, name=name, feature=feature, **kwargs)
         return name
 
+    def callout(self, feature, *, view=None, name=None) -> str:
+        """Add a hole/pattern ø-depth **leader callout** for *feature* (#414) — the
+        callout half of the feature-referenced **add** surface, symmetric with :meth:`drop`.
+
+        Where :meth:`dimension` draws a linear dim, ``callout`` draws the hole's ø / ``n×`` /
+        through-or-depth / counterbore leader (the same text the auto-pass builds). *feature*
+        is a hole/pattern from :meth:`model`; ``view`` defaults to the feature's end-on view.
+        The callout is placed into free space beside that view and tagged with *feature* so
+        :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
+
+        Raises ``ValueError`` if *feature* exposes no hole callout (use :meth:`dimension` for a
+        linear param). A lone added callout is placed reasonably, not via the auto-pass's
+        whole-set solve (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the rest.
+        """
+        from draftwright.annotations.holes import add_feature_callout
+
+        return add_feature_callout(self, feature, view=view, name=name)
+
     def annotations(self) -> dict:
         """Return ``{name: type_name}`` for every *named* annotation (#27).
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4418,6 +4418,15 @@ class TestFeatureEdits:
         assert name in dwg.annotations_of(pat)
         assert name in set(dwg.drop(pat))
 
+    def test_callout_rejects_a_foreign_feature(self):
+        # #414 review: a hole from a *different* build is value-similar but not identity-equal,
+        # so callout() points at model().features rather than the misleading "exposes none".
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        other = build_drawing(_holed_plate(), auto_dims=False)
+        foreign = next(f for f in other.model().features if f.kind == "hole")
+        with pytest.raises(ValueError, match="not from this drawing"):
+            dwg.callout(foreign)
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4377,6 +4377,47 @@ class TestFeatureEdits:
         assert {nl, nw} <= set(dwg.annotations_of(slot))
         assert nl in dwg.drop(slot)
 
+    def test_callout_adds_a_hole_leader_and_round_trips(self):
+        # #414 / #400 Ph2: the callout add verb — detect-only build, then add the hole's
+        # ø leader explicitly; it is a leader-attached callout, tagged, and drops.
+        from build123d_drafting.helpers import Leader
+
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        name = dwg.callout(hole)
+        assert name.startswith("hc_")
+        assert name in dwg.annotations() and name in dwg.annotations_of(hole)
+        assert isinstance(dwg.get_annotation(name), Leader)  # funnels through callout_from_spec
+        assert name in set(dwg.drop(hole))
+        assert name not in dwg.annotations()  # drop removed it
+
+    def test_callout_rejects_a_linear_feature(self):
+        # A step/envelope has no hole callout — clear ValueError pointing at dimension().
+        from build123d import Cylinder
+
+        dwg = build_drawing(
+            Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)), auto_dims=False
+        )
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        with pytest.raises(ValueError, match="hole"):
+            dwg.callout(step)
+
+    def test_callout_carries_a_pattern_count(self):
+        # A bolt circle → one counted callout for the whole pattern, tagged to the pattern.
+        import math
+
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(120, 120, 20)
+        for k in range(6):
+            ang = math.radians(60 * k)
+            part -= Pos(35 * math.cos(ang), 35 * math.sin(ang), 0) * Cylinder(4, 20)
+        dwg = build_drawing(part, auto_dims=False)
+        pat = next(f for f in dwg.model().features if f.kind == "pattern")
+        name = dwg.callout(pat)
+        assert name in dwg.annotations_of(pat)
+        assert name in set(dwg.drop(pat))
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4427,6 +4427,14 @@ class TestFeatureEdits:
         with pytest.raises(ValueError, match="not from this drawing"):
             dwg.callout(foreign)
 
+    def test_callout_rejects_a_non_ortho_view(self):
+        # #414 review: "iso" is a rendered view (in _coords) but not a hole-callout view —
+        # it must raise a clean ValueError, not a raw KeyError from the placement dict.
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        with pytest.raises(ValueError, match="hole-callout view"):
+            dwg.callout(hole, view="iso")
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")


### PR DESCRIPTION
## What

`dwg.callout(feature)` — the **callout half** of the feature-referenced *add* surface, symmetric with `drop()`. First verb of the **#400 Ph2 editing toolkit** (byte-identity dropped by decision; acceptance is *runs + lint-clean + droppable*, not pixel-exact).

Where `dimension()` draws a linear dim, `callout()` draws a hole/pattern's **ø / n× / through-or-depth / counterbore** leader:

```python
dwg  = build_drawing(part, auto_dims=False)   # detect-only
bore = next(f for f in dwg.model().features if f.kind == "hole")
dwg.callout(bore)                             # add the ø leader
dwg.drop(bore)                                # …and it round-trips
```

## Design

- **Funnels into the exact same `hole_callout_spec` / `callout_from_spec`** the auto-pass uses, so the callout *text* is identical (bore ø, `n×` count, through/depth, counterbore precedence, pattern `EQ SP ON … BC` / `(r×c)` suffix). No second formatter.
- **Placement is a single reasonable leader** beside the feature's end-on view (front → below; plan/side → right), into free strip space via `carve_free_position`, with the leader tip pulled to the hole rim. Deliberately **not** the auto-pass's whole-set priority solve — a lone added callout leans on `repair()` / the coverage lint. (Byte-identity is explicitly not a goal, #400 Ph2.)
- Tagged with the feature, so `drop()` / `annotations_of()` find it.
- Clear `ValueError` if the feature exposes no hole callout (a step/envelope → points at `dimension()`).
- Lives in `annotations/holes.py` taking `dwg` duck-typed (no import cycle, like `repair_drawing`); `Drawing.callout()` is a thin lazy-import delegator.

## Scope

Additive — **not called by the auto-pass** — so **zero layout drift** (30 snapshot/cleanliness tests unchanged). This is the write-API piece; the `--script` emitter that uses it comes in a later PR.

## Testing

- `test_callout_adds_a_hole_leader_and_round_trips` — detect-only build → `callout(hole)` is a tagged `Leader`, and `drop` removes it.
- `test_callout_rejects_a_linear_feature` — a step raises `ValueError` pointing at `dimension()`.
- `test_callout_carries_a_pattern_count` — a bolt circle → one counted callout, tagged to the pattern, droppable.
- Full `TestFeatureEdits` + `test_render_seam` (37) green; full lint gate (`ruff` + `mypy`) clean; drift check (30) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
