### PR TITLE
feat: locate() add verb for datum-referenced hole position dims (#418)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -44,6 +44,7 @@ from draftwright.annotations.from_model import callout_from_spec, hole_callout_s
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.model import plan_dimensions
 from draftwright.model.ir import HoleFeature, PatternFeature
+from draftwright.model.planner import plan_locations
 
 
 def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | None = None) -> str:
@@ -154,6 +155,144 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
         feature=feature,
     )
     return name
+
+
+def add_feature_location(dwg, feature, *, axes: tuple[str, ...] | None = None) -> list[str]:
+    """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern —
+    the #418 ``locate()`` add verb (symmetric with :meth:`Drawing.drop`).
+
+    Distinct from :meth:`dimension` (a feature's own *intrinsic* linear params):
+    a location dim measures the *datum → feature-centre* offset, which no feature
+    exposes as a ``parameter()``. Reuses the planner's :func:`plan_locations`
+    *intent* (which ref, from which datum) and this renderer's projection, then
+    places each dim into free strip space beside the view (corridor-free, like
+    :meth:`callout` — the auto-pass's shared corridor batch does not exist on a
+    detect-only build). X dims tier above the plan view, Y dims above the side
+    view; each is tagged with *feature* so :meth:`drop` / :meth:`annotations_of`
+    find it. Returns the placed names (0–2 — one per in-plane axis with a real
+    offset; empty for a concentric/on-datum bore that has nothing to dimension).
+
+    ``axes`` selects the in-plane axes to emit (default both); ``"x"`` = the plan-X
+    position, ``"y"`` = the side-Y position.
+
+    Raises ``ValueError`` if the drawing has no detected model/analysis, *feature*
+    is not in the model, is not a Z-axis hole/pattern (side-drilled bores are placed
+    by the auto-pass), or the model has no datum.
+    """
+    model = getattr(dwg, "_part_model", None)
+    if model is None:
+        raise ValueError("locate(): no detected model — build the drawing first")
+    if not any(f is feature for f in model.features):
+        raise ValueError(
+            "locate(): feature is not from this drawing's model — "
+            "pass one from dwg.model().features"
+        )
+    if not isinstance(feature, HoleFeature | PatternFeature):
+        raise ValueError(
+            f"locate() places a hole/pattern's datum-referenced position; "
+            f"{type(feature).__name__} exposes none — use dimension() for a linear param"
+        )
+    if feature.frame.axis != "z":
+        raise ValueError(
+            "locate(): only Z-axis holes/patterns have plan location dims; a side-drilled "
+            "bore is located by the auto-pass, not this verb"
+        )
+    a = getattr(dwg, "_analysis", None)
+    if a is None:
+        raise ValueError("locate(): no analysis — build the drawing first")
+    want = {"x", "y"} if axes is None else {ax.lower() for ax in axes}
+    if not want <= {"x", "y"}:
+        raise ValueError("locate(): axes must be a subset of ('x', 'y')")
+
+    mine = [pd for pd in plan_locations(model) if pd.feature is feature]
+    if not mine:
+        raise ValueError(
+            "locate(): feature has no datum-referenced location (concentric/on-axis bore?) "
+            "— it is located by a centre mark, not a position dim"
+        )
+    draft = dwg.draft
+    datum = mine[0].datum
+    assert datum is not None  # plan_locations always sets the datum
+    dx, dy = datum.at[0], datum.at[1]
+    tier = draft.font_size + 2 * draft.pad_around_text
+    PX, PY = a.proj.plan_x, a.proj.plan_y
+    SX, SZ = a.proj.side_x, a.proj.side_z
+
+    def _uniq(prefix: str) -> str:
+        j = 0
+        nm = f"{prefix}{j}"
+        while nm in dwg._named:
+            j += 1
+            nm = f"{prefix}{j}"
+        return nm
+
+    def _place(view: str, strip, p1, p2, baseline, label: str) -> str:
+        perp = (min(p1, p2), max(p1, p2))
+        pos = carve_free_position(dwg, strip, view, "y", tier, perp) if strip is not None else None
+        if pos is None:  # strip full / absent — fall back just above the view
+            vb = dwg.view_bounds(view) or (0.0, 0.0, 0.0, baseline)
+            pos = vb[3] + tier
+        nm = _uniq("m_locx" if view == "plan" else "m_locy")
+        dwg.add(
+            _dim(
+                (p1, baseline, 0), (p2, baseline, 0), "above", pos - baseline, draft, label=label
+            ),
+            nm,
+            view=view,
+            feature=feature,
+        )
+        return nm
+
+    names: list[str] = []
+    seen_x: list[float] = []
+    seen_y: list[float] = []
+    for pd in mine:
+        if pd.param.span is None:
+            continue
+        rx, ry = pd.param.span[1][0], pd.param.span[1][1]
+        # A rotational part's on-axis *hole* is located by the centreline, not a
+        # position dim (matches render_locations); a pattern ref is never filtered.
+        if (
+            pd.param.role == "location"
+            and a.is_rotational
+            and math.hypot(rx - a.cx, ry - a.cy) <= _CONCENTRIC_TOL_MM
+        ):
+            continue
+        # Coincident X (or Y) across this feature's own members → one dim, not a stack
+        # of identical position dims (matches render_locations' x_refs/y_refs dedup).
+        if (
+            "x" in want
+            and abs(rx - dx) * a.SCALE >= 1.0
+            and not any(abs(rx - s) < 0.5 for s in seen_x)
+        ):
+            seen_x.append(rx)
+            names.append(
+                _place(
+                    "plan",
+                    getattr(a.pv_zones, "above", None),
+                    PX(dx),
+                    PX(rx),
+                    PY(ry),
+                    _fmt(rx - dx),
+                )
+            )
+        if (
+            "y" in want
+            and abs(ry - dy) * a.SCALE >= 1.0
+            and not any(abs(ry - s) < 0.5 for s in seen_y)
+        ):
+            seen_y.append(ry)
+            names.append(
+                _place(
+                    "side",
+                    getattr(a.sv_zones, "above", None),
+                    SX(dy),
+                    SX(ry),
+                    SZ(a.bb.max.Z),
+                    _fmt(ry - dy),
+                )
+            )
+    return names
 
 
 def _legible_locations(positions, scale):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -774,6 +774,26 @@ class Drawing:
 
         return add_feature_callout(self, feature, view=view, name=name)
 
+    def locate(self, feature, *, axes=None) -> list[str]:
+        """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern
+        (#418) — the location half of the feature-referenced **add** surface.
+
+        Distinct from :meth:`dimension` (a feature's own intrinsic linear params): a
+        location dim measures the *datum → feature-centre* offset, which no feature
+        exposes as a parameter. *feature* is a hole/pattern from :meth:`model`; ``axes``
+        selects the in-plane axes (default both — ``"x"`` above the plan view, ``"y"``
+        above the side view). Each dim is placed into free space beside its view and
+        tagged with *feature* so :meth:`drop` / :meth:`annotations_of` find it. Returns
+        the placed names (0–2 — one per axis with a real offset).
+
+        Raises ``ValueError`` if *feature* is not a Z-axis hole/pattern (side-drilled
+        bores are placed by the auto-pass) or the model has no datum. Placed reasonably,
+        not via the auto-pass's corridor solve (byte-identity is not a goal, #400 Ph2).
+        """
+        from draftwright.annotations.holes import add_feature_location
+
+        return add_feature_location(self, feature, axes=axes)
+
     def annotations(self) -> dict:
         """Return ``{name: type_name}`` for every *named* annotation (#27).
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4435,6 +4435,70 @@ class TestFeatureEdits:
         with pytest.raises(ValueError, match="hole-callout view"):
             dwg.callout(hole, view="iso")
 
+    def test_locate_adds_position_dims_and_round_trips(self):
+        # #418 / #400 Ph2: locate() places datum-referenced X/Y position dims for a
+        # Z-hole, tagged + droppable. Centre ø6 at (0,0) vs datum at bbox-min (-40,-30)
+        # → X offset 40, Y offset 30.
+        from build123d_drafting.helpers import Dimension
+
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        centre = next(f for f in dwg.model().features if f.kind == "hole" and len(f.members) == 1)
+        names = dwg.locate(centre)
+        assert len(names) == 2
+        assert all(isinstance(dwg.get_annotation(n), Dimension) for n in names)
+        assert set(names) <= set(dwg.annotations_of(centre))
+        labels = {dwg.get_annotation(n).label for n in names}
+        assert labels == {"40", "30"}
+        assert set(names) <= set(dwg.drop(centre))
+        assert dwg.annotations_of(centre) == []  # drop removed them all
+
+    def test_locate_axes_filter(self):
+        # axes=("x",) emits only the plan-X position dim.
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        centre = next(f for f in dwg.model().features if f.kind == "hole" and len(f.members) == 1)
+        names = dwg.locate(centre, axes=("x",))
+        assert len(names) == 1 and names[0].startswith("m_locx")
+        assert dwg.get_annotation(names[0]).label == "40"
+
+    def test_locate_dedups_coincident_members(self):
+        # The 4 corner ø10 holes group into one HoleFeature (X∈{25,-25}, Y∈{20,-20});
+        # locate() places one dim per distinct axis position, not one per member.
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        corners = next(f for f in dwg.model().features if f.kind == "hole" and len(f.members) == 4)
+        names = dwg.locate(corners)
+        labels = sorted(dwg.get_annotation(n).label for n in names)
+        # X offsets 25→65 / -25→15; Y offsets 20→50 / -20→10 — four distinct dims.
+        assert labels == ["10", "15", "50", "65"]
+
+    def test_locate_rejects_side_drilled_feature(self):
+        # A side-drilled (X-axis) bore has no plan location dim — clear ValueError.
+        from build123d import Box, Cylinder, Pos, Rot
+
+        part = Box(120, 90, 40) - Pos(0, 0, 5) * Rot(0, 90, 0) * Cylinder(5, 120)
+        dwg = build_drawing(part, auto_dims=False)
+        bore = next(f for f in dwg.model().features if f.kind == "hole" and f.frame.axis == "x")
+        with pytest.raises(ValueError, match="side-drilled"):
+            dwg.locate(bore)
+
+    def test_locate_rejects_a_linear_feature(self):
+        # A turned step is not a hole/pattern — point at dimension().
+        from build123d import Cylinder
+
+        dwg = build_drawing(
+            Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)), auto_dims=False
+        )
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        with pytest.raises(ValueError, match="dimension"):
+            dwg.locate(step)
+
+    def test_locate_rejects_a_foreign_feature(self):
+        # A hole from a different build is not identity-equal → point at model().features.
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        other = build_drawing(_holed_plate(), auto_dims=False)
+        foreign = next(f for f in other.model().features if f.kind == "hole")
+        with pytest.raises(ValueError, match="not from this drawing"):
+            dwg.locate(foreign)
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4450,7 +4450,7 @@ class TestFeatureEdits:
         labels = {dwg.get_annotation(n).label for n in names}
         assert labels == {"40", "30"}
         assert set(names) <= set(dwg.drop(centre))
-        assert dwg.annotations_of(centre) == []  # drop removed them all
+        assert not dwg.annotations_of(centre)  # drop removed them all
 
     def test_locate_axes_filter(self):
         # axes=("x",) emits only the plan-X position dim.


### PR DESCRIPTION
## `locate()` add verb — datum-referenced hole position dims (#418)

The **location** verb of the #400 Ph2 editing toolkit (verb 2 of 4, after `callout()` #417).

### Design decision: genuinely distinct from `dimension()`, not a duplicate
The scorecard claimed `dimension()` already covered "locations" — a trace disproved it:
- `dimension()` only reaches params a feature exposes via `parameters()`, and **no feature exposes a location param** (`HoleFeature.parameters()`: *"Location is the group's anchor, not a parameter."*).
- Datum-referenced positions come from a *separate* planner entrypoint, `plan_locations()`, which `plan_dimensions()` explicitly **skips**.
- `dimension()` measures a feature's own intrinsic span; a location dim measures **datum → hole-centre**. Different machinery, real gap.

### What it does
`Drawing.locate(feature, *, axes=None) -> list[str]` → `annotations/holes.py::add_feature_location`:
- Reuses the planner's `plan_locations` *intent* (which ref, from which datum) and `render_locations`' projection.
- Places each dim **corridor-free** into free strip space beside its view (X above plan, Y above side), mirroring how `callout()` places — the auto-pass's shared corridor batch doesn't exist on a detect-only build.
- Tags each dim with the source feature for `drop()`/`annotations_of()`; dedups coincident X/Y across a feature's own members.
- Returns 0–2 names (one per in-plane axis with a real offset).

### Scope (v1)
- **Z-axis holes/patterns only.** A side-drilled (X/Y-axis) bore uses a different path (`_locate_off_axis_holes`) → clear `ValueError`. A non-hole feature → points at `dimension()`. A foreign feature → points at `model().features`.

### Public API for review
`locate(feature, *, axes=None) -> list[str]` — returns a **list** (unlike `callout`/`dimension`'s single `str`) because a hole has up to two position dims. `axes` is a subset of `("x","y")`.

### Tests
6 new (`TestFeatureEdits`): round-trip+drop (centre ø6 → offsets 40/30), axes filter, member dedup (grouped corners → 4 distinct dims 10/15/50/65), + side-drilled / linear-feature / foreign-feature rejections. Full class (34) green. Additive — not called by `_auto_annotate`, zero layout drift.

Closes #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
