### PR TITLE
feat: furniture() add verb + extend callout() to step/boss ø (#419)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -548,7 +548,7 @@ def _mentioned_diameters(dwg) -> set[float]:
     return diams
 
 
-def _diameter_row_below(dwg, items) -> int:
+def _diameter_row_below(dwg, items, start: int = 0) -> int:
     """ø-callout row BELOW the front view for X-turned step/boss diameters (#77).
     *items* is ``[(anchor, diameter), ...]``. The row is dropped clear of anything
     already below the profile; labels spread along page-x by the ADR-0003 strip
@@ -586,14 +586,14 @@ def _diameter_row_below(dwg, items) -> int:
     for i, ((tip, label, feat), lx) in enumerate(zip(specs, xs, strict=True)):
         dwg.add(
             Leader(tip=(tip[0], tip[1], 0), elbow=(lx, label_y, 0), label=label, draft=draft),
-            f"m_dia_x{i}",
+            f"m_dia_x{start + i}",
             view="front",
             feature=feat,
         )
     return len(specs)
 
 
-def _diameter_column_left(dwg, items) -> int:
+def _diameter_column_left(dwg, items, start: int = 0) -> int:
     """ø-callout column to the LEFT of the front view for Z-turned step/boss
     diameters (#131) — the page-Y mirror of the row-below. A per-label occupancy
     gate drops only a label that would overprint a bore leader / existing callout
@@ -630,7 +630,7 @@ def _diameter_column_left(dwg, items) -> int:
         ldr = Leader(tip=(tip[0], tip[1], 0), elbow=(elbow_x, ly, 0), label=label, draft=draft)
         if _box_hits(_anno_box(ldr), occupied):
             continue  # would overprint a bore leader / existing callout — drop just this one
-        dwg.add(ldr, f"m_dia_z{i}", view="front", feature=feat)
+        dwg.add(ldr, f"m_dia_z{start + i}", view="front", feature=feat)
         occupied.append(_anno_box(ldr))
         placed += 1
     return placed

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -12,6 +12,7 @@ import math
 
 from build123d_drafting.helpers import (
     CenterlineCircle,
+    CenterMark,
     Leader,
 )
 
@@ -40,7 +41,12 @@ from draftwright.annotations._common import (
     place_strip_candidates,
     strip_obstacles,
 )
-from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
+from draftwright.annotations.from_model import (
+    _diameter_column_left,
+    _diameter_row_below,
+    callout_from_spec,
+    hole_callout_spec,
+)
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.model import plan_dimensions
 from draftwright.model.ir import HoleFeature, PatternFeature
@@ -293,6 +299,108 @@ def add_feature_location(dwg, feature, *, axes: tuple[str, ...] | None = None) -
                 )
             )
     return names
+
+
+def add_feature_furniture(dwg, feature, *, view: str | None = None) -> list[str]:
+    """Add a hole/pattern's non-dimensional **sheet furniture** — the #419 ``furniture()``
+    add verb (symmetric with :meth:`Drawing.drop`).
+
+    Unifies the two geometric marks a feature carries that no other verb emits: per-hole
+    **centre marks** (every member) and, for a pattern, its **centre-cross** (bolt circle)
+    or **pitch/grid dimensions** (linear/grid array). Funnels into the same
+    :func:`render_centermarks` centre-mark math and :func:`_add_furniture` the auto-pass
+    uses — both already corridor-free and feature-tagged — so a detect-only build can
+    reconstruct them. Each mark is tagged with *feature* so :meth:`drop` /
+    :meth:`annotations_of` find it. Returns the placed names (varies by pattern kind).
+
+    Raises ``ValueError`` if the drawing has no detected model/analysis, *feature* is not
+    in it, or *feature* is not a hole/pattern (use :meth:`dimension` for a linear param).
+    """
+    model = getattr(dwg, "_part_model", None)
+    if model is None:
+        raise ValueError("furniture(): no detected model — build the drawing first")
+    if not any(f is feature for f in model.features):
+        raise ValueError(
+            "furniture(): feature is not from this drawing's model — "
+            "pass one from dwg.model().features"
+        )
+    if not isinstance(feature, HoleFeature | PatternFeature):
+        raise ValueError(
+            f"furniture() draws a hole/pattern's centre marks + pattern furniture; "
+            f"{type(feature).__name__} exposes none — use dimension() for a linear param"
+        )
+    a = getattr(dwg, "_analysis", None)
+    if a is None:
+        raise ValueError("furniture(): no analysis — build the drawing first")
+    view = view or _END_ON[feature.frame.axis]
+    before = set(dwg.annotations())
+
+    # Centre marks — one per member, mirroring render_centermarks' size/placement.
+    dia = feature.member.diameter if isinstance(feature, PatternFeature) else feature.diameter
+    size = max(2.5, dia * dwg.scale + 2.0)
+    for loc in feature.members or (feature.frame.origin,):
+        px, py, *_ = dwg.at(view, *loc)
+        j = 0
+        while (nm := f"m_cm{j}") in dwg._named:
+            j += 1
+        dwg.add(CenterMark((px, py, 0), size, dwg.draft), nm, view=view, feature=feature)
+
+    # Pattern furniture — bolt-circle centre-cross / linear-or-grid pitch dims.
+    if isinstance(feature, PatternFeature):
+        j = 0
+        while f"bc_{view}{j}" in dwg._named or f"dim_pitch_{view}{j}" in dwg._named:
+            j += 1
+        _add_furniture(dwg, a, view, j, feature, lambda loc: dwg.at(view, *loc))
+
+    return sorted(set(dwg.annotations()) - before)
+
+
+def add_feature_diameter(dwg, feature) -> str:
+    """Add a turned **step/boss diameter** ø-leader — the #419 extension of the callout
+    add verb to :class:`StepFeature` / :class:`BossFeature`.
+
+    A turned step's diameter is a leader callout the hole-callout path does not reach and
+    :meth:`dimension` rejects (its diameter param carries no span). Funnels into the same
+    :func:`_diameter_row_below` (X-turned) / :func:`_diameter_column_left` (Z-turned) the
+    auto-pass uses — already corridor-free and feature-tagged (#412). Returns the name.
+
+    Raises ``ValueError`` if the feature exposes no step/boss diameter, its turning axis
+    is unsupported, or there is no room to place the leader.
+    """
+    model = getattr(dwg, "_part_model", None)
+    if model is None:
+        raise ValueError("callout(): no detected model — build the drawing first")
+    if not any(f is feature for f in model.features):
+        raise ValueError(
+            "callout(): feature is not from this drawing's model — "
+            "pass one from dwg.model().features"
+        )
+    group = next((g for g in plan_dimensions(model) if g.feature is feature), None)
+    dia = (
+        next((pd.param.value for pd in group.dims if pd.param.kind == "diameter"), None)
+        if group is not None
+        else None
+    )
+    if group is None or dia is None:
+        raise ValueError(
+            f"callout(): {type(feature).__name__} exposes no step/boss diameter callout"
+        )
+    axis = feature.frame.axis
+    if axis not in ("x", "z"):
+        raise ValueError(
+            f"callout(): a {axis!r}-turned step/boss diameter is not placeable "
+            "(only X- and Z-turned parts)"
+        )
+    items = [(group.anchor, dia, feature)]
+    before = set(dwg.annotations())
+    if axis == "x":
+        _diameter_row_below(dwg, items)
+    else:
+        _diameter_column_left(dwg, items)
+    new = sorted(set(dwg.annotations()) - before)
+    if not new:
+        raise ValueError(f"callout(): no room to place the ø{_fmt(dia)} step/boss leader")
+    return str(new[0])
 
 
 def _legible_locations(positions, scale):

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -347,8 +347,16 @@ def add_feature_furniture(dwg, feature, *, view: str | None = None) -> list[str]
 
     # Pattern furniture — bolt-circle centre-cross / linear-or-grid pitch dims.
     if isinstance(feature, PatternFeature):
+        # Scan for a free furniture slot j across all three name shapes: a bolt-circle
+        # centre-cross (bc_{view}{j}), a linear pitch (dim_pitch_{view}{j}), and a grid's
+        # two suffixed pitch dims (dim_pitch_{view}{j}_0/_1) — the bare key is never used
+        # by a grid, so probing it alone would collide on a second grid (#419 review F4).
         j = 0
-        while f"bc_{view}{j}" in dwg._named or f"dim_pitch_{view}{j}" in dwg._named:
+        while any(
+            nm in (f"bc_{view}{j}", f"dim_pitch_{view}{j}")
+            or nm.startswith(f"dim_pitch_{view}{j}_")
+            for nm in dwg._named
+        ):
             j += 1
         _add_furniture(dwg, a, view, j, feature, lambda loc: dwg.at(view, *loc))
 
@@ -392,11 +400,18 @@ def add_feature_diameter(dwg, feature) -> str:
             "(only X- and Z-turned parts)"
         )
     items = [(group.anchor, dia, feature)]
+    # The row/column placers name leaders m_dia_{x,z}{start+i} — pass the first FREE
+    # index so a second callout() (or a call on an already-annotated turned part) never
+    # collides on m_dia_x0/z0 and clobbers an existing leader (#419 review F1).
+    prefix = "m_dia_x" if axis == "x" else "m_dia_z"
+    start = 0
+    while f"{prefix}{start}" in dwg._named:
+        start += 1
     before = set(dwg.annotations())
     if axis == "x":
-        _diameter_row_below(dwg, items)
+        _diameter_row_below(dwg, items, start=start)
     else:
-        _diameter_column_left(dwg, items)
+        _diameter_column_left(dwg, items, start=start)
     new = sorted(set(dwg.annotations()) - before)
     if not new:
         raise ValueError(f"callout(): no room to place the ø{_fmt(dia)} step/boss leader")

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -757,22 +757,43 @@ class Drawing:
         return name
 
     def callout(self, feature, *, view=None, name=None) -> str:
-        """Add a hole/pattern ø-depth **leader callout** for *feature* (#414) — the
-        callout half of the feature-referenced **add** surface, symmetric with :meth:`drop`.
+        """Add a **ø leader callout** for *feature* (#414/#419) — the callout half of the
+        feature-referenced **add** surface, symmetric with :meth:`drop`.
 
-        Where :meth:`dimension` draws a linear dim, ``callout`` draws the hole's ø / ``n×`` /
-        through-or-depth / counterbore leader (the same text the auto-pass builds). *feature*
-        is a hole/pattern from :meth:`model`; ``view`` defaults to the feature's end-on view.
-        The callout is placed into free space beside that view and tagged with *feature* so
-        :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
+        Where :meth:`dimension` draws a linear dim, ``callout`` draws a leader: for a
+        **hole/pattern**, the ø / ``n×`` / through-or-depth / counterbore callout (the same
+        text the auto-pass builds), placed beside the feature's end-on view (``view``
+        defaults to it); for a turned **step/boss**, the ``ø…`` diameter leader in the row
+        below (X-turned) or column left of (Z-turned) the front view. Tagged with *feature*
+        so :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
 
-        Raises ``ValueError`` if *feature* exposes no hole callout (use :meth:`dimension` for a
-        linear param). A lone added callout is placed reasonably, not via the auto-pass's
-        whole-set solve (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the rest.
+        Raises ``ValueError`` if *feature* exposes no callout (use :meth:`dimension` for a
+        linear param). Placed reasonably, not via the auto-pass's whole-set solve
+        (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the rest.
         """
-        from draftwright.annotations.holes import add_feature_callout
+        from draftwright.annotations.holes import add_feature_callout, add_feature_diameter
 
+        if getattr(feature, "kind", None) in ("step", "boss"):
+            return add_feature_diameter(self, feature)
         return add_feature_callout(self, feature, view=view, name=name)
+
+    def furniture(self, feature, *, view=None) -> list[str]:
+        """Add a hole/pattern's non-dimensional **sheet furniture** (#419) — centre marks
+        (every member) plus a pattern's centre-cross (bolt circle) or pitch/grid dims.
+
+        The geometric marks a feature carries that no other verb emits: where
+        :meth:`callout` draws the ø leader and :meth:`locate` the position dims, ``furniture``
+        draws the centre marks and pattern furniture. *feature* is a hole/pattern from
+        :meth:`model`; ``view`` defaults to its end-on view. Each mark is tagged with
+        *feature* so :meth:`drop` / :meth:`annotations_of` find it. Returns the placed names
+        (varies by pattern kind — a bolt circle emits a centre-cross, a linear/grid array a
+        pitch dim).
+
+        Raises ``ValueError`` if *feature* is not a hole/pattern (use :meth:`dimension`).
+        """
+        from draftwright.annotations.holes import add_feature_furniture
+
+        return add_feature_furniture(self, feature, view=view)
 
     def locate(self, feature, *, axes=None) -> list[str]:
         """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4499,6 +4499,93 @@ class TestFeatureEdits:
         with pytest.raises(ValueError, match="not from this drawing"):
             dwg.locate(foreign)
 
+    def test_furniture_adds_hole_centre_mark(self):
+        # #419: furniture() places a hole's centre mark(s), tagged + droppable.
+        from build123d_drafting.helpers import CenterMark
+
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        centre = next(f for f in dwg.model().features if f.kind == "hole" and len(f.members) == 1)
+        names = dwg.furniture(centre)
+        assert names and all(n.startswith("m_cm") for n in names)
+        assert all(isinstance(dwg.get_annotation(n), CenterMark) for n in names)
+        assert set(names) <= set(dwg.annotations_of(centre))
+        assert set(names) <= set(dwg.drop(centre))
+
+    def test_furniture_adds_pattern_centre_cross_and_round_trips(self):
+        # A bolt circle's furniture is member centre marks + the bc_ centre-cross.
+        import math
+
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(120, 120, 20)
+        for k in range(6):
+            ang = math.radians(60 * k)
+            part -= Pos(35 * math.cos(ang), 35 * math.sin(ang), 0) * Cylinder(4, 20)
+        dwg = build_drawing(part, auto_dims=False)
+        pat = next(f for f in dwg.model().features if f.kind == "pattern")
+        names = dwg.furniture(pat)
+        assert any(n.startswith("bc_") for n in names)
+        assert set(names) <= set(dwg.annotations_of(pat))
+        assert set(names) <= set(dwg.drop(pat))
+        assert not dwg.annotations_of(pat)  # drop removed them all
+
+    def test_furniture_grid_emits_pitch_dims(self):
+        # A rectangular grid's furniture includes both (n-1)× pitch dims.
+        from build123d import Box, Cylinder, Pos
+        from build123d_drafting.helpers import Dimension
+
+        part = Box(140, 70, 12)
+        for r in range(2):
+            for c in range(4):
+                part -= Pos(-37.5 + c * 25, -10 + r * 20, 0) * Cylinder(4, 12)
+        dwg = build_drawing(part, auto_dims=False)
+        grid = next(f for f in dwg.model().features if f.kind == "pattern")
+        names = dwg.furniture(grid)
+        pitch = [n for n in names if n.startswith("dim_pitch_")]
+        assert len(pitch) == 2
+        assert all(isinstance(dwg.get_annotation(n), Dimension) for n in pitch)
+        assert set(names) <= set(dwg.annotations_of(grid))
+        assert set(names) <= set(dwg.drop(grid))
+
+    def test_furniture_rejects_a_linear_feature(self):
+        # A turned step is not a hole/pattern → point at dimension().
+        from build123d import Cylinder
+
+        dwg = build_drawing(
+            Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)), auto_dims=False
+        )
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        with pytest.raises(ValueError, match="dimension"):
+            dwg.furniture(step)
+
+    def test_callout_adds_a_turned_step_diameter(self):
+        # #419: callout() extended to a turned step's ø leader (Z-turned → column left).
+        from build123d import Cylinder
+        from build123d_drafting.helpers import Leader
+
+        dwg = build_drawing(
+            Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)), auto_dims=False
+        )
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        name = dwg.callout(step)
+        assert name.startswith("m_dia")
+        assert isinstance(dwg.get_annotation(name), Leader)
+        assert name in dwg.annotations_of(step)
+        assert name in dwg.drop(step)
+
+    def test_callout_step_x_turned_uses_row_path(self):
+        # The X-turned path places m_dia_x in the row below the front view.
+        from build123d import Cylinder, Rot
+        from build123d_drafting.helpers import Leader
+
+        shaft = Rot(0, 90, 0) * (Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)))
+        dwg = build_drawing(shaft, auto_dims=False)
+        step = next(f for f in dwg.model().features if f.kind == "step")
+        name = dwg.callout(step)
+        assert name.startswith("m_dia_x")
+        assert isinstance(dwg.get_annotation(name), Leader)
+        assert name in dwg.drop(step)
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4391,16 +4391,16 @@ class TestFeatureEdits:
         assert name in set(dwg.drop(hole))
         assert name not in dwg.annotations()  # drop removed it
 
-    def test_callout_rejects_a_linear_feature(self):
-        # A step/envelope has no hole callout — clear ValueError pointing at dimension().
-        from build123d import Cylinder
+    def test_callout_rejects_a_non_callout_feature(self):
+        # A slot has no ø leader callout (a step/boss now does, #419) — clear ValueError
+        # pointing at dimension().
+        from build123d import Box, Mode, Pos
 
-        dwg = build_drawing(
-            Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)), auto_dims=False
-        )
-        step = next(f for f in dwg.model().features if f.kind == "step")
+        part = Box(80, 60, 20) - Pos(0, 0, 0) * Box(24, 8, 30, mode=Mode.SUBTRACT)
+        dwg = build_drawing(part, auto_dims=False)
+        slot = next(f for f in dwg.model().features if f.kind == "slot")
         with pytest.raises(ValueError, match="hole"):
-            dwg.callout(step)
+            dwg.callout(slot)
 
     def test_callout_carries_a_pattern_count(self):
         # A bolt circle → one counted callout for the whole pattern, tagged to the pattern.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4586,6 +4586,28 @@ class TestFeatureEdits:
         assert isinstance(dwg.get_annotation(name), Leader)
         assert name in dwg.drop(step)
 
+    def test_callout_multiple_step_diameters_do_not_collide(self):
+        # #419 review F1: each step gets a DISTINCT m_dia name; a second callout() must
+        # not clobber the first's leader or raise a false "no room". X-turned uses the
+        # row placer (no occupancy gate), so both leaders always land.
+        from build123d import Cylinder, Rot
+
+        shaft = Rot(0, 90, 0) * (
+            Cylinder(20, 30)
+            + Cylinder(14, 24).translate((0, 0, 27))
+            + Cylinder(9, 18).translate((0, 0, 48))
+        )
+        dwg = build_drawing(shaft, auto_dims=False)
+        steps = [f for f in dwg.model().features if f.kind == "step"]
+        assert len(steps) >= 2
+        names = [dwg.callout(s) for s in steps[:2]]
+        assert len(set(names)) == 2, f"expected distinct names, got {names}"
+        for s, n in zip(steps[:2], names, strict=False):
+            assert n in dwg.annotations() and n in dwg.annotations_of(s)
+        # dropping the first step leaves the second's leader intact (no clobber)
+        dwg.drop(steps[0])
+        assert names[1] in dwg.annotations()
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")


### PR DESCRIPTION
## Furniture bundle — `furniture()` + `callout()` step/boss extension (#419)

Verb 3 of the #400 Ph2 editing toolkit. A skeptical investigation showed the four
candidates should **not** be four verbs — this ships **1 new verb + 1 widened verb**,
and defers `pmi()` to its own issue.

### `furniture(feature, *, view=None) -> list[str]` — NEW
The non-dimensional sheet furniture a hole/pattern carries that no other verb emits:
- per-member **centre marks** (funnels into `render_centermarks`' size/placement math)
- a pattern's **centre-cross** (bolt circle) or **pitch/grid dims** (linear/grid) — funnels into `_add_furniture`/`_place_pitch_dim`/`_add_grid_pitch_dims`

Both renderers are already corridor-free *and* already `feature=`-tagged (#398b/#408B), so this is near-pure delegation. Unifies the "centre-marks" and "pattern-furniture" candidates (centre marks are the per-hole half of furniture — too thin for their own verb).

### `callout()` extended to `StepFeature`/`BossFeature`
A turned step/boss ø is a leader callout the hole-callout path doesn't reach and `dimension()` rejects (its diameter param carries no span). `callout()` now dispatches step/boss → `add_feature_diameter`, funneling into `_diameter_row_below` (X-turned) / `_diameter_column_left` (Z-turned) — already `feature=`-tagged (#412). Absorbs the useful half of "rotational"; OD/bore-leaders are untagged part-level base geometry, out of scope.

### Dropped / deferred
- **centre-marks** as a standalone verb → folded into `furniture()`.
- **rotational OD/bore-leaders** → dropped (part-level base geometry, not a per-feature intent).
- **pmi()** → **#422** (STEP-AP242-only; needs fresh `render_pmi` provenance wiring).

### Public API for review
- `furniture(feature, *, view=None) -> list[str]` — returns the placed names (varies by pattern kind).
- `callout()` unchanged signature, broadened to step/boss (`callout(step)` no longer raises — it places the ø leader).

### Tests
7 new (`TestFeatureEdits`): hole centre mark, bolt-circle centre-cross round-trip, grid pitch dims, step ø (Z + X turned), + reject paths. Updated `test_callout_rejects_*` (a step now *gets* a callout — the reject test uses a slot). Full class (39) green. Additive — not called by `_auto_annotate`, zero layout drift.

Closes #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
