### PR TITLE
feat: section() add verb — the automatic full section A-A (#420 PR 1)

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -55,6 +55,7 @@ from draftwright.annotations.sections import (
     _request_prismatic_detail,
     _reserve_section_row,
     _resolve_details,
+    feature_holes_of,
 )
 from draftwright.model import PatternFeature, build_part_model, plan_dimensions, plan_sections
 from draftwright.recognition import (
@@ -76,13 +77,6 @@ def _wrap_rows(header, data, ncols):
             row += data[idx] if idx < len(data) else blank
         wide.append(row)
     return wide
-
-
-def _is_concentric_hole(h, a: Analysis) -> bool:
-    """True when *h* is an axial bore on the part centreline (turned base set)."""
-    if _axis_letter(h) != "z":
-        return False
-    return math.hypot(h.location[0] - a.cx, h.location[1] - a.cy) <= _CONCENTRIC_TOL_MM
 
 
 def _concentric_bore_diams(a: Analysis) -> list:
@@ -205,12 +199,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # dimensioned by the ldr_z leaders, so they are excluded here to avoid a
     # duplicate hole callout; only the off-axis features get callouts.  On a
     # prismatic part every hole flows through unchanged.
-    feature_holes = a.holes
-    if a.is_rotational:
-        feature_holes = [h for h in a.holes if not _is_concentric_hole(h, a)]
-    # The surviving feature-hole *positions* (concentric bores excluded on rotational
-    # parts) — the IR gates callouts/furniture/sections on membership in this set, so
-    # no recogniser Hole object crosses into the renderers (Amendment 6, #263/#207).
+    # The surviving feature holes + their *positions* (concentric bores excluded on
+    # rotational parts) — the IR gates callouts/furniture/sections on membership in this
+    # set, so no recogniser Hole object crosses into the renderers (Amendment 6, #263/
+    # #207). feature_holes_of is the single source shared with the section() add verb (#420).
+    feature_holes = feature_holes_of(a)
     feature_keys = {HoleRef.of(h.location) for h in feature_holes}
     # Decide the section trigger + cut-plane row now (pure function of _model/
     # feature_keys, no placement dependency) and reserve its cutting-plane arrows'

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -7,6 +7,8 @@ functions take the drawing duck-typed as `dwg`; imports stay below annotate.
 
 from __future__ import annotations
 
+import math
+
 from build123d import (
     Arrow,
     Box,
@@ -29,11 +31,14 @@ from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut
 from OCP.TopTools import TopTools_ListOfShape
 
 from draftwright._core import (
+    _CONCENTRIC_TOL_MM,
     _MIN_STEP_SEP_MM,
     _TB_CLEAR,
     _TB_H,
     Analysis,
     DetailRequest,
+    HoleRef,
+    _axis_letter,
     _dim,
     _fmt,
     _iso_bbox,
@@ -41,8 +46,61 @@ from draftwright._core import (
     _legible_steps,
     _log,
 )
+from draftwright.model import plan_sections
 
 _DETAIL_LETTERS = "ABCDEFGH"
+
+
+def _is_concentric_hole(h, a: Analysis) -> bool:
+    """True when *h* is an axial bore on the part centreline (turned base set)."""
+    if _axis_letter(h) != "z":
+        return False
+    return math.hypot(h.location[0] - a.cx, h.location[1] - a.cy) <= _CONCENTRIC_TOL_MM
+
+
+def feature_holes_of(a: Analysis) -> list:
+    """The feature holes the IR gates callouts / furniture / sections on — a turned
+    part's concentric axial bores (dimensioned by the centreline leaders) excluded,
+    every hole on a prismatic part kept. The single source shared by ``_auto_annotate``
+    and the ``section()`` add verb so their trigger set cannot drift (#420)."""
+    if not a.is_rotational:
+        return list(a.holes)
+    return [h for h in a.holes if not _is_concentric_hole(h, a)]
+
+
+def feature_hole_keys(a: Analysis) -> set[HoleRef]:
+    """The :class:`HoleRef` position keys of :func:`feature_holes_of` — the membership
+    set ``plan_sections`` gates a section trigger on (#420)."""
+    return {HoleRef.of(h.location) for h in feature_holes_of(a)}
+
+
+def add_section(dwg) -> list[str]:
+    """Add the automatic full **section A–A** (ISO 128-44 arrows + ISO 128-50 hatch)
+    — the #420 ``section()`` add verb.
+
+    Part-level, not per-feature: a section fires when a Z-axis hole/pattern has a
+    counterbore, spotface, or blind bottom (its internal profile is hidden-line-only
+    in every ortho view), and cuts through the densest qualifying row (``plan_sections``).
+    Funnels into the same :func:`_add_section_view` the auto-pass uses. Unlike the
+    other add verbs it is **not** feature-tagged and not ``drop``-compatible — a
+    section is atomic (a bare arrow without the cut view is meaningless), so it is
+    dropped by commenting the call. Returns the placed annotation names, or ``[]``
+    when the part warrants no section (an honest no-op) or there is no room.
+
+    Raises ``ValueError`` if the drawing has no detected model / analysis.
+    """
+    model = getattr(dwg, "_part_model", None)
+    if model is None:
+        raise ValueError("section(): no detected model — build the drawing first")
+    a = getattr(dwg, "_analysis", None)
+    if a is None:
+        raise ValueError("section(): no analysis — build the drawing first")
+    plan = plan_sections(model, feature_hole_keys(a))
+    if plan is None:
+        return []  # no counterbore/spotface/blind Z-hole — no section warranted
+    before = set(dwg.annotations())
+    _add_section_view(dwg, a, plan)  # calls _clear_section_reservation itself; no reserve needed
+    return sorted(set(dwg.annotations()) - before)
 
 
 def _section_hatch_edges(face, SX, SZ, spacing):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -795,6 +795,23 @@ class Drawing:
 
         return add_feature_furniture(self, feature, view=view)
 
+    def section(self) -> list[str]:
+        """Add the automatic full **section A–A** (#420) — the section half of the
+        editable surface.
+
+        Part-level, unlike the per-feature verbs: a section fires when a Z-axis
+        hole/pattern has a counterbore, spotface, or blind bottom (its internal
+        profile is hidden-line-only in every ortho view), cutting through the densest
+        qualifying row. Takes no argument (the auto A–A) and is **not** feature-tagged
+        or :meth:`drop`-compatible — a section is atomic, so it is dropped by commenting
+        the call. Returns the placed annotation names, or ``[]`` when no section is
+        warranted or there is no room. Call it *after* the per-feature verbs — the
+        section's room check clears whatever is already placed right of the side view.
+        """
+        from draftwright.annotations.sections import add_section
+
+        return add_section(self)
+
     def locate(self, feature, *, axes=None) -> list[str]:
         """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern
         (#418) — the location half of the feature-referenced **add** surface.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4608,6 +4608,25 @@ class TestFeatureEdits:
         dwg.drop(steps[0])
         assert names[1] in dwg.annotations()
 
+    def test_section_reproduces_the_auto_section(self):
+        # #420: section() adds the A–A that a counterbored hole triggers, on a
+        # detect-only build (the auto-pass would draw it, but auto_dims=False skips it).
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(60, 40, 20) - Cylinder(4, 30) - Pos(0, 0, 2) * Cylinder(7, 20)
+        dwg = build_drawing(part, auto_dims=False)
+        names = dwg.section()
+        assert "section_caption" in names and "section_line" in names
+        assert dwg.get_annotation("section_caption").label == "SECTION A–A"
+
+    def test_section_is_a_noop_without_a_trigger(self):
+        # A plain through-hole plate warrants no section → honest empty list.
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(80, 60, 20) - Pos(20, 0, 0) * Cylinder(4, 30)
+        dwg = build_drawing(part, auto_dims=False)
+        assert dwg.section() == []
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")


### PR DESCRIPTION
## `section()` add verb — #420 PR 1 (of 2)

The first half of the #400 Ph2 capstone. The second PR (flip `--script` to live intent calls) depends on this verb, since the emitted reconstruction calls `dwg.section()`.

### What it does
`Drawing.section() -> list[str]` (`annotations/sections.py::add_section`) adds the automatic full **section A–A** (ISO 128-44 arrows + ISO 128-50 hatch) that a counterbored / spotfaced / blind Z-hole triggers, funneling into the same `plan_sections` + `_add_section_view` the auto-pass uses.

### Design decision (flagged for review): part-level, not per-feature
Unlike `callout`/`locate`/`furniture`/`dimension`, a section is a **whole-part** decision (`plan_sections` returns one `SectionPlan(cut_y=…)` for the part). So `section()`:
- takes **no argument** (the auto A–A) — no `cut_y`/plane arg, which would leak raw `add_view` layout vocabulary (ADR 0001 §2/§3);
- is **not** feature-tagged and **not** `drop`-compatible — a section is atomic (a bare arrow without the cut view is meaningless), so it is dropped by commenting the call;
- returns the placed names, or `[]` when no section is warranted / there is no room (honest no-op).

### Corridor-free
`_add_section_view` uses only `a.proj`/`a.part`/`dwg.views`/`iter_annotations` and calls `_clear_section_reservation` itself — no `_auto_annotate`-only state (`_escalations`/`_corridor_batch`) — so it works on a detect-only build.

### No-drift refactor
Extracts `feature_holes_of(a)` / `feature_hole_keys(a)` into `sections.py` as the **single source** for the concentric-bore exclusion (a turned part's axial bores don't drive a section), shared by `_auto_annotate` and the verb. Removes orchestrator's duplicate `_is_concentric_hole`. The auto-pass path is byte-identical.

### Tests
2 new (`TestFeatureEdits`): section reproduced on a counterbored part (detect-only), honest `[]` no-op on a plain through-hole plate. Section/turned/finished-sheet regression suite (74) green — the refactor is non-regressive.

Part of #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
