### PR TITLE
feat: flip --script to a runnable intent reconstruction (#420 PR 2, Ph2 capstone)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -182,8 +182,9 @@ def add_feature_location(dwg, feature, *, axes: tuple[str, ...] | None = None) -
     position, ``"y"`` = the side-Y position.
 
     Raises ``ValueError`` if the drawing has no detected model/analysis, *feature*
-    is not in the model, is not a Z-axis hole/pattern (side-drilled bores are placed
-    by the auto-pass), or the model has no datum.
+    is not in the model, or is not a Z-axis hole/pattern (side-drilled bores are placed
+    by the auto-pass). A feature with no datum-referenced ref (a datum-less model, a
+    concentric/on-datum bore, or a ref deduped against a sibling) returns ``[]``.
     """
     model = getattr(dwg, "_part_model", None)
     if model is None:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -418,7 +418,11 @@ def add_feature_diameter(dwg, feature) -> str:
         _diameter_column_left(dwg, items, start=start)
     new = sorted(set(dwg.annotations()) - before)
     if not new:
-        raise ValueError(f"callout(): no room to place the ø{_fmt(dia)} step/boss leader")
+        # No room — degrade like the auto-pass (render_diameters places what fits and drops
+        # the overflow to feature_not_dimensioned), NOT a raise: the emitted reconstruction
+        # calls callout() per step, so a crowded turned shaft must not abort (#427 review).
+        _log.info("Step/boss ø%s callout skipped (no room)", _fmt(dia))
+        return ""
     return str(new[0])
 
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -210,12 +210,15 @@ def add_feature_location(dwg, feature, *, axes: tuple[str, ...] | None = None) -
     if not want <= {"x", "y"}:
         raise ValueError("locate(): axes must be a subset of ('x', 'y')")
 
+    # A feature with no datum-referenced ref — a concentric/on-axis bore (located by a
+    # centre mark), an on-datum hole, or one whose ref coincides with another feature's
+    # (deduped by plan_locations) — has nothing to dimension here. An honest empty
+    # result (as the docstring promises), not an error, so the verb composes: the emitted
+    # #400 Ph2 script calls locate() on every hole and this no-ops the ones the auto-pass
+    # would also skip, matching its dedup rather than crashing.
     mine = [pd for pd in plan_locations(model) if pd.feature is feature]
     if not mine:
-        raise ValueError(
-            "locate(): feature has no datum-referenced location (concentric/on-axis bore?) "
-            "— it is located by a centre mark, not a position dim"
-        )
+        return []
     draft = dwg.draft
     datum = mine[0].datum
     assert datum is not None  # plan_locations always sets the datum

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -606,7 +606,15 @@ def _feature_listing(a: Analysis) -> str:
                 )
             lines.append("dwg.furniture(f)")
         elif kind in ("step", "boss"):
-            lines.append("dwg.callout(f)")
+            if feat.frame.axis in ("x", "z"):
+                lines.append("dwg.callout(f)")
+            else:
+                # callout() places X/Z-turned diameters only; a Y-turned step/boss is
+                # auto-pass-only (its diameter is not placeable, and the auto-pass skips it too).
+                lines.append(
+                    f"#     callout() places X/Z-turned diameters only — this "
+                    f"{feat.frame.axis}-turned step/boss is auto-pass-only. auto_dims=True to keep it."
+                )
         for p in feat.parameters():
             if p.span is not None or kind == "slot":  # a linear dim dimension() accepts
                 lines.append(f'dwg.dimension(f, "{p.kind}", role="{p.role}")   # {display(p)}')

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -595,7 +595,15 @@ def _feature_listing(a: Analysis) -> str:
         lines.append(f"f = dwg.model().features[{i}]")
         if kind in ("hole", "pattern"):
             lines.append("dwg.callout(f)")
-            lines.append("dwg.locate(f)")
+            if feat.frame.axis == "z":
+                lines.append("dwg.locate(f)")
+            else:
+                # locate() is Z-axis only (it rejects side-drilled bores by contract, #133);
+                # an off-axis bore's position is auto-pass-only. Flag it like a gap kind (#424).
+                lines.append(
+                    f"#     locate() is Z-axis only — this {feat.frame.axis}-drilled bore's "
+                    "position is auto-pass-only (#133). auto_dims=True to keep it."
+                )
             lines.append("dwg.furniture(f)")
         elif kind in ("step", "boss"):
             lines.append("dwg.callout(f)")

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -36,9 +36,10 @@ from draftwright._core import (
 )
 from draftwright.analysis import _analyse
 from draftwright.annotate import _auto_annotate, build_model
+from draftwright.annotations.sections import feature_hole_keys
 from draftwright.drawing import Drawing
 from draftwright.fonts import PLEX_MONO
-from draftwright.model import display
+from draftwright.model import display, plan_sections
 from draftwright.projection import (
     _fit_iso_view,
     _project_iso,
@@ -545,52 +546,68 @@ def _fmt_pt(p) -> str:
     return ", ".join(f"{round(c)}" if abs(c - round(c)) < 1e-6 else f"{c:.1f}" for c in p)
 
 
-def _feature_listing(a: Analysis) -> str:
-    """An inert, commented listing of the detected features and their dimensionable
-    parameters (#400 Ph1) — developer visibility into what the engine auto-dimensioned.
+# Feature kinds with no intent verb yet — emitted as a flagged comment, never a broken
+# call. The build_drawing(auto_dims=True) pointer recovers the full auto drawing (#424).
+_GAP_KINDS = {
+    "step_level": "auto-pass draws the prismatic height ladder; no intent verb yet "
+    "(dimension() needs a span, which step_height lacks)",
+    "rotational": "auto-pass draws the overall OD + centrelines + concentric bore leaders; "
+    "out of scope for the intent verbs (#419)",
+    "pmi": "pre-authored PMI, rendered by --pmi annotate; an add verb is deferred to #422",
+}
 
-    Each feature is referenced as ``dwg.model().features[i]`` so an uncommented line runs
-    against the real read surface (#397, ADR 0008 IR). A **linear** param becomes an
-    editable ``dwg.dimension(...)`` call; a leader-callout param (a hole's ø/depth, a
-    pattern's furniture) is noted inert — a callout add verb is tracked as #414. The
-    auto-pass already drew these, so *overriding* one means :meth:`~Drawing.drop` then
-    re-add, shown in the header. Pure function of *a*; no annotation pass runs.
+
+def _feature_listing(a: Analysis) -> str:
+    """Emit the detected features as **runnable intent-verb calls** (#400 Ph2) that
+    reconstruct the drawing on the detect-only build (``auto_dims=False``) above.
+
+    Each feature is redrawn by the domain add verbs against the detected model
+    (``dwg.model().features[i]``, the ADR-0008 IR): holes/patterns → ``callout`` +
+    ``locate`` + ``furniture``; steps/bosses → ``callout`` (ø); steps/envelopes/slots →
+    ``dimension(...)`` per linear param. A section A–A is added last when a
+    counterbored/spotfaced/blind Z-hole warrants one. Feature kinds with no verb yet
+    (step_level, rotational, pmi) are emitted as flagged comments naming the gap
+    (#424) — never silently dropped. Commenting any line drops exactly that annotation
+    (nothing is auto-drawn, so there is no double-dimension risk). Pure function of *a*.
     """
-    feats = getattr(build_model(a), "features", [])
+    model = build_model(a)
+    feats = getattr(model, "features", [])
     if not feats:
         return (
-            "# ── Detected features (#400 Ph1) ──────────────────────────────────────────────\n"
+            "# ── Reconstruct the drawing (#400 Ph2) ────────────────────────────────────────\n"
             "# No dimensionable features detected.\n"
         )
     lines = [
-        "# ── Detected features (#400 Ph1) ──────────────────────────────────────────────",
-        "# What the engine detected and auto-dimensioned, listed for visibility. Reference a",
-        "# feature as dwg.model().features[i] (the ADR-0008 IR). A dwg.dimension(...) line",
-        "# below reproduces the dim the engine drew for that param. The auto-pass already",
-        "# drew everything, so to CHANGE a feature, drop it then re-add only the dims you want",
-        "# (an uncommented bare line double-dimensions):",
-        "#     f = dwg.model().features[0]",
-        "#     dwg.drop(f)                             # remove f's auto annotations",
-        '#     dwg.dimension(f, "length", role="...")  # re-add a chosen linear dim',
+        "# ── Reconstruct the drawing at intent level (#400 Ph2) ────────────────────────",
+        "# Each feature is redrawn by domain verbs against the detected model (ADR-0008 IR).",
+        "# Comment any single line to drop exactly that annotation; comment a whole block to",
+        "# stop dimensioning that feature. The build above is detect-only, so nothing is drawn",
+        "# twice. Kinds with no verb yet are flagged inline — build_drawing(auto_dims=True)",
+        "# recovers the full automatic drawing for those.",
         "#",
     ]
     for i, feat in enumerate(feats):
-        lines.append(f"# features[{i}]  {feat.kind} @ ({_fmt_pt(feat.frame.origin)})")
+        kind = feat.kind
+        lines.append(f"# features[{i}]  {kind} @ ({_fmt_pt(feat.frame.origin)})")
+        if kind in _GAP_KINDS:
+            lines.append(f"#     {kind} — {_GAP_KINDS[kind]}. auto_dims=True to keep it.")
+            continue
+        lines.append(f"f = dwg.model().features[{i}]")
+        if kind in ("hole", "pattern"):
+            lines.append("dwg.callout(f)")
+            lines.append("dwg.locate(f)")
+            lines.append("dwg.furniture(f)")
+        elif kind in ("step", "boss"):
+            lines.append("dwg.callout(f)")
         for p in feat.parameters():
-            if p.span is not None or feat.kind == "slot":  # a linear dim dimension() accepts
-                lines.append(
-                    f'#     dwg.dimension(dwg.model().features[{i}], "{p.kind}", '
-                    f'role="{p.role}")   # {display(p)}'
-                )
-            elif p.kind in ("diameter", "depth"):  # a hole ø/depth — a leader callout
-                lines.append(
-                    f"#     {display(p)} ({p.role}) -> auto leader callout; "
-                    f"a callout() add verb is #414"
-                )
-            else:  # an auto-drawn linear dim (step height, pitch, …) not yet a dimension() target
-                lines.append(
-                    f"#     {display(p)} ({p.role}) -> auto-drawn; not a dimension() target yet"
-                )
+            if p.span is not None or kind == "slot":  # a linear dim dimension() accepts
+                lines.append(f'dwg.dimension(f, "{p.kind}", role="{p.role}")   # {display(p)}')
+    if plan_sections(model, feature_hole_keys(a)) is not None:
+        lines += [
+            "",
+            "# Section A–A (part-level; comment to drop the whole section)",
+            "dwg.section()",
+        ]
     return "\n".join(lines) + "\n"
 
 
@@ -670,7 +687,7 @@ def _write_script(a: Analysis, scale: float | None = None, page: str | None = No
 
     run_section = (
         "\n"
-        "# ── Build drawing (standard 4-view layout + automatic dimensions) ─────────────\n"
+        "# ── Build drawing (detect-only 4-view layout; dimensions added below) ──────────\n"
         "_stem = _os.path.splitext(__file__)[0]\n"
         "dwg = build_drawing(\n"
         "    STEP_FILE,\n"
@@ -682,10 +699,11 @@ def _write_script(a: Analysis, scale: float | None = None, page: str | None = No
         "    pmi=PMI,\n"
         "    scale=SCALE,\n"
         "    page=PAGE,\n"
+        "    auto_dims=False,   # detect-only — the intent verbs below add every dimension\n"
         ")\n"
         "\n"
         "# ── Customise here — runs BEFORE export, so edits land in the output ───────────\n"
-        "# Prefer domain edits (place_dim / features) over page mechanics (at / Leader);\n"
+        "# Prefer domain edits (the intent verbs below) over page mechanics (at / Leader);\n"
         "# the engine places annotations automatically — say WHAT, not WHERE.\n"
         "# dwg.features(view)       → detected features → [FeatureInfo(.diameter .count .page_pos)]\n"
         "# dwg.place_dim(p1, p2, side, view, dwg.draft, name=…)  → add a dimension, auto-placed\n"
@@ -701,6 +719,10 @@ def _write_script(a: Analysis, scale: float | None = None, page: str | None = No
         "#   p1, p2 = dwg.at('front', 0, 0, 0), dwg.at('front', 40, 0, 0)\n"
         "#   dwg.place_dim(p1, p2, 'above', 'front', dwg.draft, name='dim_len')\n"
         "\n" + _feature_listing(a) + "\n"
+        "# Tidy any mechanically-fixable overlaps the incremental verbs left — repair()\n"
+        "# never worsens the sheet (the corridor-free add verbs lean on it, #400 Ph2).\n"
+        "dwg.repair()\n"
+        "\n"
         "# ── Export ────────────────────────────────────────────────────────────────────\n"
         "svg_path, dxf_path = dwg.export(_stem)\n"
         # ASCII arrow: a Unicode → crashes the print on a Windows cp1252 console

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -769,7 +769,9 @@ class Drawing:
 
         Raises ``ValueError`` if *feature* exposes no callout (use :meth:`dimension` for a
         linear param). Placed reasonably, not via the auto-pass's whole-set solve
-        (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the rest.
+        (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the rest. A
+        step/boss diameter that finds no room returns ``""`` (a warning-level drop, like
+        the auto-pass), rather than raising, so a reconstruction script never aborts.
         """
         from draftwright.annotations.holes import add_feature_callout, add_feature_diameter
 
@@ -825,8 +827,10 @@ class Drawing:
         the placed names (0–2 — one per axis with a real offset).
 
         Raises ``ValueError`` if *feature* is not a Z-axis hole/pattern (side-drilled
-        bores are placed by the auto-pass) or the model has no datum. Placed reasonably,
-        not via the auto-pass's corridor solve (byte-identity is not a goal, #400 Ph2).
+        bores are placed by the auto-pass). A feature with no datum-referenced ref (a
+        datum-less model, a concentric/on-datum bore, or a ref deduped against a sibling)
+        returns ``[]``. Placed reasonably, not via the auto-pass's corridor solve
+        (byte-identity is not a goal, #400 Ph2).
         """
         from draftwright.annotations.holes import add_feature_location
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4657,7 +4657,8 @@ class TestFeatureEdits:
         for f in dwg.model().features:
             if f.kind in ("hole", "pattern"):
                 dwg.callout(f)
-                dwg.locate(f)
+                if f.frame.axis == "z":  # locate() is Z-axis only (side-drilled → auto-pass)
+                    dwg.locate(f)
                 dwg.furniture(f)
             elif f.kind in ("step", "boss"):
                 dwg.callout(f)
@@ -4677,6 +4678,36 @@ class TestFeatureEdits:
         self._reconstruct(dwg)
         dwg.repair()
         assert dwg.lint_summary()["errors"] == 0, dwg.lint_summary()["by_code"]
+
+    def test_intent_reconstruction_runs_on_a_side_drilled_part(self):
+        # #427 review F1: a side-drilled (non-Z) bore is kind="hole" axis!="z". locate()
+        # rejects it by contract (#133), so the emitter must NOT emit locate() for it —
+        # else the reconstruction crashes. Exercise the (fixed) dispatch: it must not raise.
+        from build123d import Box, Cylinder, Pos, Rot
+
+        part = Box(120, 90, 40) - Pos(0, 0, 5) * Rot(0, 90, 0) * Cylinder(5, 120)
+        dwg = build_drawing(part, auto_dims=False)
+        assert any(f.kind == "hole" and f.frame.axis != "z" for f in dwg.model().features)
+        self._reconstruct(dwg)  # must not raise on the side-drilled bore
+        dwg.repair()
+        assert dwg.lint_summary()["errors"] == 0, dwg.lint_summary()["by_code"]
+
+    def test_generated_script_flags_side_drilled_locate_as_a_comment(self):
+        # #427 review F1: the emitted --script must gate dwg.locate(f) on a Z-axis hole —
+        # a side-drilled bore gets a flagged comment, not a bare locate() that would crash.
+        import tempfile
+        from pathlib import Path
+
+        from build123d import Box, Cylinder, Pos, Rot, export_step
+
+        from draftwright.make_drawing import generate_script
+
+        part = Box(120, 90, 40) - Pos(0, 0, 5) * Rot(0, 90, 0) * Cylinder(5, 120)
+        with tempfile.TemporaryDirectory() as d:
+            step = Path(d) / "sd.step"
+            export_step(part, str(step))
+            content = Path(generate_script(str(step), out=str(Path(d) / "sd"))).read_text()
+        assert "locate() is Z-axis only" in content  # the gate fired, no bare locate() crash
 
     def test_intent_reconstruction_comment_drops_exactly_that(self):
         # #400 Ph2 soft acceptance: commenting one verb line drops exactly that annotation.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2314,33 +2314,37 @@ def test_generate_script_defers_invalid_scale_page(tmp_path):
     assert "SCALE = 0.001" in content and "PAGE = 'A9'" in content
 
 
-def test_generate_script_lists_detected_features(tmp_path):
-    # #400 Ph1: the script's Customise section carries an inert listing of the detected
-    # features + their dimensionable params. A hole → an inert leader-callout note (#414);
-    # the envelope's length params → editable dwg.dimension(...) lines against model().
+def test_generate_script_reconstructs_features_as_intent_calls(tmp_path):
+    # #400 Ph2: the Customise section is a runnable detect-only reconstruction — each
+    # feature redrawn by the domain add verbs against model().features[i], not the Ph1
+    # inert listing. The build is auto_dims=False and ends with dwg.repair().
     step = tmp_path / "p.step"
     export_step(Box(60, 60, 12) - Pos(0, 0, 0) * Cylinder(4, 40), str(step))
     content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text(encoding="utf-8")
-    assert "# ── Detected features (#400 Ph1)" in content
-    assert "# features[0]  hole @" in content  # detected + indexed by model().features[i]
-    # a hole ø is a leader callout → inert note pointing at the callout add verb (#414)
-    assert "auto leader callout; a callout() add verb is #414" in content
-    # the envelope's width/height/depth are linear → editable dimension() calls
-    assert "dwg.dimension(dwg.model().features[" in content
-    assert 'role="width")' in content
+    assert "# ── Reconstruct the drawing at intent level (#400 Ph2)" in content
+    assert "auto_dims=False" in content  # the build is detect-only
+    assert "# features[0]  hole @" in content  # indexed by model().features[i]
+    assert "dwg.callout(f)" in content  # hole ø via the callout verb
+    assert "dwg.locate(f)" in content  # its datum position
+    assert "dwg.furniture(f)" in content  # its centre mark
+    assert 'dwg.dimension(f, "length", role="width")' in content  # envelope, editable
+    assert "dwg.repair()" in content  # finalize — tidy corridor-free overlaps
 
 
-def test_feature_listing_is_fully_inert(tmp_path):
-    # #400 Ph1: the whole listing is commented — never executes, so it cannot double-apply
-    # or crash a run. Every non-blank line between the header and the Export banner is a #.
+def test_feature_listing_is_live_intent_calls(tmp_path):
+    # #400 Ph2 (was Ph1 "fully inert"): the reconstruction block now contains BARE,
+    # uncommented verb calls — the Ph1 inert guarantee is intentionally replaced. Verify
+    # there are runnable calls and they reference the read surface.
     step = tmp_path / "p.step"
     export_step(Box(40, 30, 8) - Pos(0, 0, 0) * Cylinder(3, 20), str(step))
     content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text(encoding="utf-8")
-    start = content.index("# ── Detected features (#400 Ph1)")
+    start = content.index("# ── Reconstruct the drawing at intent level")
     end = content.index("# ── Export", start)
     block = [ln for ln in content[start:end].splitlines() if ln.strip()]
-    assert block, "listing block was empty"
-    assert all(ln.lstrip().startswith("#") for ln in block), "listing must be fully commented"
+    live = [ln for ln in block if not ln.lstrip().startswith("#")]
+    assert live, "reconstruction must contain runnable (uncommented) calls"
+    assert any(ln.startswith("dwg.") for ln in live)
+    assert any("dwg.model().features[" in ln for ln in live)
 
 
 @pytest.mark.timeout(180)
@@ -4626,6 +4630,73 @@ class TestFeatureEdits:
         part = Box(80, 60, 20) - Pos(20, 0, 0) * Cylinder(4, 30)
         dwg = build_drawing(part, auto_dims=False)
         assert dwg.section() == []
+
+    def test_locate_composes_over_every_feature_without_raising(self):
+        # #420 flip fix: locate() returns [] (not ValueError) when a feature's datum ref is
+        # deduped/concentric — so the emitted script can call it on every hole/pattern. Here
+        # the central hole coincides with the bolt-circle centre, so its ref is deduped.
+        import math
+
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(100, 100, 20)
+        for k in range(6):
+            ang = math.radians(60 * k)
+            part -= Pos(30 * math.cos(ang), 30 * math.sin(ang), 0) * Cylinder(3, 20)
+        part -= Pos(0, 0, 5) * Cylinder(5, 10)  # central hole on the bolt-circle centre
+        dwg = build_drawing(part, auto_dims=False)
+        holes = [f for f in dwg.model().features if f.kind in ("hole", "pattern")]
+        assert len(holes) >= 2
+        results = [dwg.locate(f) for f in holes]  # none may raise
+        assert all(isinstance(r, list) for r in results)
+
+    @staticmethod
+    def _reconstruct(dwg):
+        # The per-feature verb dispatch the #400 Ph2 emitter writes (mirrors
+        # builder._feature_listing) — used to exercise the reconstruction in-process.
+        for f in dwg.model().features:
+            if f.kind in ("hole", "pattern"):
+                dwg.callout(f)
+                dwg.locate(f)
+                dwg.furniture(f)
+            elif f.kind in ("step", "boss"):
+                dwg.callout(f)
+            for p in f.parameters():
+                if p.span is not None or f.kind == "slot":
+                    dwg.dimension(f, p.kind, role=p.role)
+        dwg.section()
+
+    def test_intent_reconstruction_is_error_free(self):
+        # #400 Ph2 soft acceptance: a fully reconstructed prismatic part, after repair(),
+        # has no lint ERRORS. Placement WARNINGS from the corridor-free verbs are the
+        # documented #424 fidelity gap, not a failure.
+        part = (
+            Box(80, 60, 12) - Pos(20, 10, 0) * Cylinder(4, 40) - Pos(-20, -10, 0) * Cylinder(4, 40)
+        )
+        dwg = build_drawing(part, auto_dims=False)
+        self._reconstruct(dwg)
+        dwg.repair()
+        assert dwg.lint_summary()["errors"] == 0, dwg.lint_summary()["by_code"]
+
+    def test_intent_reconstruction_comment_drops_exactly_that(self):
+        # #400 Ph2 soft acceptance: commenting one verb line drops exactly that annotation.
+        # With auto_dims=False nothing is auto-drawn, so omitting callout(f) removes exactly
+        # the callout — no double-dimension, no collateral on locate/furniture.
+        part = Box(80, 60, 12) - Pos(20, 10, 0) * Cylinder(4, 40)
+        full = build_drawing(part, auto_dims=False)
+        hole = next(f for f in full.model().features if f.kind == "hole")
+        full.callout(hole)
+        full.locate(hole)
+        full.furniture(hole)
+        before = set(full.annotations())
+
+        partial = build_drawing(part, auto_dims=False)
+        h2 = next(f for f in partial.model().features if f.kind == "hole")
+        partial.locate(h2)  # callout(h2) "commented out"
+        partial.furniture(h2)
+        dropped = before - set(partial.annotations())
+        assert dropped == {n for n in before if n.startswith("hc_")}
+        assert dropped, "commenting callout() should drop the hole's leader"
 
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4661,7 +4661,8 @@ class TestFeatureEdits:
                     dwg.locate(f)
                 dwg.furniture(f)
             elif f.kind in ("step", "boss"):
-                dwg.callout(f)
+                if f.frame.axis in ("x", "z"):  # callout() places X/Z-turned diameters only
+                    dwg.callout(f)
             for p in f.parameters():
                 if p.span is not None or f.kind == "slot":
                     dwg.dimension(f, p.kind, role=p.role)
@@ -4691,6 +4692,20 @@ class TestFeatureEdits:
         self._reconstruct(dwg)  # must not raise on the side-drilled bore
         dwg.repair()
         assert dwg.lint_summary()["errors"] == 0, dwg.lint_summary()["by_code"]
+
+    def test_intent_reconstruction_runs_on_a_crowded_turned_shaft(self):
+        # #427 review F2: callout() on a step/boss must DEGRADE (drop the overflow leader
+        # like the auto-pass), not raise "no room" — else a multi-step turned shaft's
+        # reconstruction (one callout() per step) aborts. Must run to completion.
+        from build123d import Cylinder
+
+        shaft = Cylinder(24, 12)
+        for k in range(1, 10):  # 10 stacked, decreasing-radius steps along Z
+            shaft += Cylinder(24 - 2 * k, 12).translate((0, 0, 12 * k))
+        dwg = build_drawing(shaft, auto_dims=False)
+        assert sum(f.kind == "step" for f in dwg.model().features) >= 5
+        self._reconstruct(dwg)  # many callout(step) calls — none may raise "no room"
+        dwg.repair()  # the script must reach repair(), not abort before it
 
     def test_generated_script_flags_side_drilled_locate_as_a_comment(self):
         # #427 review F1: the emitted --script must gate dwg.locate(f) on a Z-axis hole —


### PR DESCRIPTION
## Flip `--script` to a runnable intent reconstruction — #420 PR 2 (of 2), the Ph2 capstone

Depends on #425 (the `section()` verb). Replaces the Ph1 inert listing with a **runnable detect-only reconstruction**: the generated `--script`'s Customise section now redraws every feature with the domain add verbs against the detected model.

### The emitted reconstruction
```python
dwg = build_drawing(STEP_FILE, ..., auto_dims=False)   # detect-only
# features[0]  hole @ (…)
f = dwg.model().features[0]
dwg.callout(f); dwg.locate(f); dwg.furniture(f)
# features[3]  envelope
dwg.dimension(f, "length", role="width")   # …height/depth
# features[4]  step_level — auto-pass draws the height ladder; no intent verb yet … auto_dims=True to keep it.
dwg.section()          # when a counterbored/blind Z-hole warrants it
dwg.repair()           # tidy corridor-free overlaps (never worsens)
```

**Per-feature mapping:** hole/pattern → `callout` + `locate` + `furniture`; step/boss → `callout` (+`dimension` for span params); envelope/slot → `dimension`. Section last, then `repair()`.

### Honest coverage (accepted contract)
Feature kinds with **no verb yet** — `step_level`, `rotational`, `pmi` (#422) — are emitted as **flagged comments** naming the gap and pointing at `build_drawing(auto_dims=True)` to recover the full auto drawing (#424). Never silently dropped. So the reconstruction is fully faithful for prismatic hole/slot/envelope parts and honest-partial for the rest (the gaps surface as `feature_not_dimensioned` lint).

### Bug fixed (surfaced by actually running the output)
`locate()` now **returns `[]`** (as its own docstring already promised) instead of raising when a hole's datum ref is deduped/concentric/on-datum — so the emitted unconditional `locate()` calls compose. Previously the raise contradicted the docstring and crashed the reconstruction.

### Public-API change (flagged)
- The default `--script` output changes from an inert commented listing to a runnable `auto_dims=False` reconstruction. **Replaced outright — no `--inert` flag** (Ph1 was days old, same epic, no external consumers). The two Ph1 inertness tests are rewritten for the live output.
- Commenting any verb line drops exactly that annotation; with `auto_dims=False` nothing is auto-drawn, so **no double-dimension risk** (strictly cleaner than the Ph1 drop-then-re-add caveat).

### Tests
- Rewrote `test_generate_script_lists_detected_features` → `…reconstructs_features_as_intent_calls` and `…is_fully_inert` → `…is_live_intent_calls`.
- New soft-acceptance (`TestFeatureEdits`): reconstruction error-free after `repair()` (warnings = documented #424 gap), `callout()` comment drops exactly the leader, `locate()` composes over every feature without raising.
- The existing subprocess test now runs the **flipped artifact** end-to-end (green).

Closes #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
