### PR TITLE
feat: route locate() through the real corridor solve in finalize() (#426 Phase 2a)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -364,13 +364,18 @@ def _location_candidate(dwg, name, *, view, span_key, distance, build, feature=N
     )
 
 
-def render_locations(dwg, model, a) -> int:
+def render_locations(dwg, model, a, *, only=None) -> int:
     """Baseline X/Y hole-location dims from the IR (#238). The planner decides the
     intent (`plan_locations`: which refs, from which datum); this renderer owns the
     layout (Amendment 4) — X dims tier above the plan view, Y dims above the side
     view, nearest-datum-first, legibility-gated, allocated from the existing strips;
     a ref with no room is dropped as `location_ref_dropped`. Replaces the engine's
-    `_add_location_dims`. Returns the count placed."""
+    `_add_location_dims`. Returns the count placed.
+
+    *only*, when given, restricts placement to refs whose source feature is in the set —
+    the #426 finalize() path passes the recorded ``locate`` intents' features so the
+    corridor solve runs over the user's edited subset. ``None`` (the auto-pass) places
+    every ref, byte-identically."""
     planned = plan_locations(model)
     if not planned:
         return 0
@@ -380,6 +385,8 @@ def render_locations(dwg, model, a) -> int:
     datum_x, datum_y = datum.at[0], datum.at[1]
     refs = []
     for pd in planned:
+        if only is not None and pd.feature not in only:  # #426: recorded subset only
+            continue
         if pd.param.span is None:
             continue
         rx, ry = pd.param.span[1][0], pd.param.span[1][1]

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -406,6 +406,21 @@ def render_locations(dwg, model, a, *, only=None) -> int:
     tier = draft.font_size + 2 * draft.pad_around_text
     n = 0
 
+    # Location-dim names. The auto-pass (only is None) numbers them positionally —
+    # m_locx{i}, the historical byte-identical scheme. The finalize() path (only set) may
+    # run AFTER live-replayed locate() dims already hold m_loc names, so there it allocates
+    # the first FREE index to avoid Drawing.add silently replacing one (#429 review).
+    _loc_used = set(dwg._named) if only is not None else None
+
+    def _loc_name(prefix: str, i: int) -> str:
+        if _loc_used is None:
+            return f"{prefix}{i}"  # auto-pass: unchanged, byte-identical
+        j = 0
+        while f"{prefix}{j}" in _loc_used:
+            j += 1
+        _loc_used.add(f"{prefix}{j}")
+        return f"{prefix}{j}"
+
     # --- X locations: tier above the plan view ---
     PX, PY = a.proj.plan_x, a.proj.plan_y
     x_refs: list = []
@@ -447,7 +462,7 @@ def render_locations(dwg, model, a, *, only=None) -> int:
             tier,
             _location_candidate(
                 dwg,
-                f"m_locx{i}",
+                _loc_name("m_locx", i),
                 view="plan",
                 span_key=(round(PX(datum_x), 1), round(PX(rx), 1)),
                 distance=abs(rx - datum_x),
@@ -503,7 +518,7 @@ def render_locations(dwg, model, a, *, only=None) -> int:
             tier,
             _location_candidate(
                 dwg,
-                f"m_locy{i}",
+                _loc_name("m_locy", i),
                 view="side",
                 span_key=(round(SX(datum_y), 1), round(SX(ry), 1)),
                 distance=abs(ry - datum_y),

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -905,11 +905,11 @@ class Drawing:
         # Corridor state the auto-pass creates in _auto_annotate S0 (orchestrator.py) but
         # a detect-only build lacks — render_locations/drain_corridors register/read here.
         if not hasattr(self, "_corridor_batch"):
-            self._corridor_batch = {}
+            self._corridor_batch: dict = {}
         if not hasattr(self, "_escalations"):
-            self._escalations = []
+            self._escalations: list = []
         if not hasattr(self, "_detail_requests"):
-            self._detail_requests = []
+            self._detail_requests: list = []
 
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -871,28 +871,67 @@ class Drawing:
         return add_feature_location(self, feature, axes=axes)
 
     def finalize(self) -> None:
-        """Drain the recorded placement intents (#426 Phase 1).
+        """Drain the recorded placement intents (#426).
 
         When the drawing was built in **deferred** mode (``_defer_intents``), the add
         verbs recorded :class:`~draftwright.intents.Intent`\\s instead of placing. This
-        drains them — **Phase 1 replays each through the live verb** (identical to
-        placing live, in recorded order); later phases route the recorded set through the
-        shared ``_auto_annotate`` orchestration for auto-pass-quality packing.
+        drains them. **Phase 2a** routes the ``locate`` intents through the *real*
+        ADR-0009 corridor solve (``render_locations`` + ``drain_corridors``) — one
+        crossing-free, deduped, monotone ladder over the recorded subset, the auto-pass's
+        own machinery — while callouts/furniture/other dimensions/section still replay
+        through their live verbs (later phases move those too). Order mirrors the
+        auto-pass: callouts/furniture first (obstacles for the location carve), then the
+        location corridor, then ``section`` last (its room check clears the side view's
+        right). Slots stay on the live path pending #426 Phase 2b (a slot's position dim
+        is not a recorded intent, so routing it would re-add un-requested dims).
 
-        Idempotent (draining empties the list, so a repeat call — or ``export()`` then
+        Idempotent (draining empties the list; a repeat call — or ``export()`` then
         ``export_pdf()`` — no-ops) and a no-op when nothing was recorded (the live/auto-pass
-        path), so ``export()`` calls it unconditionally. **Resilient:** each intent is
-        removed only after it places, so a verb that raises mid-drain surfaces the error and
-        leaves the remaining intents recorded for a retry rather than silently dropping them.
-        A record → finalize → record-more → finalize sequence drains each batch (#428 review).
+        path), so ``export()`` calls it unconditionally. **Resilient:** a live-replayed
+        intent is removed only after it places, so a verb that raises surfaces the error
+        and leaves the rest recorded. A record → finalize → record-more → finalize
+        sequence drains each batch (#428 review).
+
+        Known Phase-2a residual: for a part with **both** a section and locations the
+        finalize layout can differ from the auto-pass (the auto-pass reserves the section
+        row *before* the location carve; finalize places the section after) — acceptable
+        until section reservation moves to the batch (Phase 3).
         """
         if not self._intents:
             return
+        from draftwright.annotations._common import drain_corridors
+        from draftwright.annotations.from_model import render_locations
+
+        # Corridor state the auto-pass creates in _auto_annotate S0 (orchestrator.py) but
+        # a detect-only build lacks — render_locations/drain_corridors register/read here.
+        if not hasattr(self, "_corridor_batch"):
+            self._corridor_batch = {}
+        if not hasattr(self, "_escalations"):
+            self._escalations = []
+        if not hasattr(self, "_detail_requests"):
+            self._detail_requests = []
+
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
+            only_loc = {it.feature for it in self._intents if it.kind == "locate"}
+            # (A) live-replay every non-corridor, non-section intent (callout / furniture /
+            #     non-slot dimension) in recorded order — locate is routed below, section last.
+            i = 0
+            while i < len(self._intents):
+                if self._intents[i].kind in ("locate", "section"):
+                    i += 1
+                    continue
+                self._replay_intent(self._intents[i])  # resilient: a raise leaves the rest
+                self._intents.pop(i)
+            # (B) locations through the REAL ADR-0009 corridor solve (crossing-free ladder)
+            if only_loc and self._part_model is not None and self._analysis is not None:
+                render_locations(self, self._part_model, self._analysis, only=only_loc)
+                drain_corridors(self)
+            self._intents = [it for it in self._intents if it.kind != "locate"]
+            # (C) section last — its room check clears whatever is right of the side view
             while self._intents:
                 self._replay_intent(self._intents[0])
-                self._intents.pop(0)  # consumed only after it places — a raise leaves the rest
+                self._intents.pop(0)
         finally:
             self._defer_intents = deferred
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -911,23 +911,31 @@ class Drawing:
         if not hasattr(self, "_detail_requests"):
             self._detail_requests: list = []
 
+        # Only a BOTH-axes locate (axes=None) can go through the per-feature corridor
+        # filter; an axes-restricted locate(f, axes=…) is honored by live replay, since
+        # render_locations' `only` set can't express an axis subset (#429 review).
+        corridor_ids = {
+            id(it) for it in self._intents if it.kind == "locate" and it.kwargs.get("axes") is None
+        }
+        only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
+
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
-            only_loc = {it.feature for it in self._intents if it.kind == "locate"}
-            # (A) live-replay every non-corridor, non-section intent (callout / furniture /
-            #     non-slot dimension) in recorded order — locate is routed below, section last.
+            # (A) live-replay every intent EXCEPT the corridor-routed locates and section:
+            #     callouts / furniture / non-slot dimensions / axes-restricted locates.
             i = 0
             while i < len(self._intents):
-                if self._intents[i].kind in ("locate", "section"):
+                it = self._intents[i]
+                if it.kind == "section" or id(it) in corridor_ids:
                     i += 1
                     continue
-                self._replay_intent(self._intents[i])  # resilient: a raise leaves the rest
+                self._replay_intent(it)  # resilient: a raise leaves the rest recorded
                 self._intents.pop(i)
-            # (B) locations through the REAL ADR-0009 corridor solve (crossing-free ladder)
+            # (B) both-axes locations through the REAL ADR-0009 corridor solve (crossing-free)
             if only_loc and self._part_model is not None and self._analysis is not None:
                 render_locations(self, self._part_model, self._analysis, only=only_loc)
                 drain_corridors(self)
-            self._intents = [it for it in self._intents if it.kind != "locate"]
+            self._intents = [it for it in self._intents if id(it) not in corridor_ids]
             # (C) section last — its room check clears whatever is right of the side view
             while self._intents:
                 self._replay_intent(self._intents[0])

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4866,6 +4866,19 @@ class TestFeatureEdits:
         auto = build_drawing(part)  # auto_dims=True — the reference the corridor matches
         assert len(fin_locx) == len([n for n in auto.annotations() if n.startswith("m_locx")])
 
+    def test_finalize_honors_locate_axes_restriction(self):
+        # #429 review: a recorded locate(f, axes=("x",)) must place only the X dim. The
+        # per-feature corridor filter can't express an axis subset, so finalize live-replays
+        # axes-restricted locates (routing only both-axes ones through the corridor).
+        part = Box(100, 80, 20) - Pos(20, 15, 0) * Cylinder(4, 30)
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        dwg.locate(hole, axes=("x",))
+        dwg.finalize()
+        locs = [n for n in dwg.annotations() if n.startswith("m_loc")]
+        assert locs and all(n.startswith("m_locx") for n in locs)  # X only — no m_locy
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4841,6 +4841,31 @@ class TestFeatureEdits:
         # the callout placed + popped; the failing dimension and the untried furniture remain
         assert [i.kind for i in dwg._intents] == ["dimension", "furniture"]
 
+    def test_finalize_routes_locations_through_the_corridor_dedup(self):
+        # #426 Phase 2a: two DISTINCT holes sharing an X. The live path places a duplicate
+        # m_locx (each locate() is independent); finalize routes them through the real
+        # ADR-0009 corridor solve, which dedups the coincident X span to ONE dim — matching
+        # the auto-pass. The crossing-free / dedup win.
+        part = (
+            Box(100, 80, 20) - Pos(20, 25, 0) * Cylinder(4, 30) - Pos(20, -25, 0) * Cylinder(6, 30)
+        )
+
+        live = build_drawing(part, auto_dims=False)
+        for h in (f for f in live.model().features if f.kind == "hole"):
+            live.locate(h)
+        live_locx = [n for n in live.annotations() if n.startswith("m_locx")]
+
+        deferred = build_drawing(part, auto_dims=False)
+        deferred._defer_intents = True
+        for h in (f for f in deferred.model().features if f.kind == "hole"):
+            deferred.locate(h)
+        deferred.finalize()
+        fin_locx = [n for n in deferred.annotations() if n.startswith("m_locx")]
+
+        assert len(fin_locx) < len(live_locx)  # corridor deduped the coincident X=20 span
+        auto = build_drawing(part)  # auto_dims=True — the reference the corridor matches
+        assert len(fin_locx) == len([n for n in auto.annotations() if n.startswith("m_locx")])
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4879,6 +4879,35 @@ class TestFeatureEdits:
         locs = [n for n in dwg.annotations() if n.startswith("m_loc")]
         assert locs and all(n.startswith("m_locx") for n in locs)  # X only — no m_locy
 
+    def test_finalize_mixes_axes_restricted_and_both_axes_locate(self):
+        # #429 review: an axes-restricted locate (live, names m_locx0) + a both-axes locate
+        # (corridor) must NOT collide — the corridor names its dims against _named, so both
+        # survive. Regression for the silent-overwrite bug.
+        part = (
+            Box(120, 80, 20)
+            - Pos(-40, 25, 0) * Cylinder(4, 30)
+            - Pos(40, -25, 0) * Cylinder(6, 30)
+        )
+        holes = lambda d: [f for f in d.model().features if f.kind == "hole"]  # noqa: E731
+
+        live = build_drawing(part, auto_dims=False)
+        hs = holes(live)
+        live.locate(hs[0], axes=("x",))
+        live.locate(hs[1])
+        live_x = {
+            live.get_annotation(n).label for n in live.annotations() if n.startswith("m_locx")
+        }
+
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        hs2 = holes(dwg)
+        dwg.locate(hs2[0], axes=("x",))
+        dwg.locate(hs2[1])
+        dwg.finalize()
+        fin_x = {dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_locx")}
+        # both features' X location dims survive — none silently overwritten
+        assert fin_x == live_x and len(fin_x) == 2
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")


### PR DESCRIPTION
## #426 Phase 2a — route `locate()` through the real ADR-0009 corridor solve

The first **batch-quality** slice of record-then-finalize. Builds on Phase 1 (#428, the intent-recording layer).

### What changes
`finalize()` now routes the recorded **`locate` intents** through the auto-pass's own collect-then-solve — `render_locations` + `drain_corridors` — instead of the live, per-feature, corridor-free placement. That yields **one crossing-free, deduped, monotone location ladder** over the recorded subset, exactly what the auto-pass produces.

`finalize()` order mirrors the auto-pass:
- **(A)** live-replay callouts / furniture / non-slot dimensions (obstacles for the location carve, before it — the auto-pass S5→S6 order),
- **(B)** locations through the real corridor (`render_locations(only=…)` → `drain_corridors`),
- **(C)** `section` last (its room check clears right of the side view).

It seeds the `_corridor_batch` / `_escalations` / `_detail_requests` state the detect-only build lacks.

### Byte-identical auto-pass
`render_locations` gains an `only=None` param (restrict to a feature set). `None` — the auto-pass call site — short-circuits before any behavior, so the auto-pass is **byte-identical**: the byte-identity corpus (59) + layout snapshots (10) stay green. The plan confirmed the above-strip location corridor has **zero reservation coupling** (the section-row/envelope reservations touch *other* strips), so it runs standalone.

### Scope: locations only (Phase 2a)
Slots stay on the live path pending **Phase 2b** — a slot's *position* dim is not a recorded `dimension()` intent, so routing a slot feature through `render_slots` would re-add un-requested dims (a per-param-vs-per-feature granularity decision, deferred).

### Known residual (documented)
For a part with **both** a section and locations, finalize's layout can differ from the auto-pass (the auto-pass reserves the section row *before* the location carve; finalize places the section after). Resolved when section reservation moves into the batch (Phase 3).

### Tests
- **Win:** two distinct holes sharing an X — the live path leaves a duplicate `m_locx`, finalize dedups it to one, **matching the auto-pass**.
- Phase-1 finalize tests stay green; byte-identity corpus + layout snapshots unaffected.

Part of #426 (Phase 2a of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
