### PR TITLE
feat: route hole/pattern callouts through _annotate_holes in finalize() (#426 Phase 3a)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1005,6 +1005,18 @@ def _annotate_holes(
             return centre
         return (centre[0] + dx / norm * r, centre[1] + dy / norm * r)
 
+    def _hc_name(view, i):
+        # The auto-pass (only is None) numbers callouts positionally hc_{view}{i} — the
+        # historical byte-identical scheme. The #426 finalize path (only set) may run after
+        # a prior batch already placed hc_ names on this view, so it allocates the first FREE
+        # index to avoid Drawing.add silently replacing an earlier callout (#430 review).
+        if only is None:
+            return f"hc_{view}{i}"
+        j = 0
+        while f"hc_{view}{j}" in dwg._named:
+            j += 1
+        return f"hc_{view}{j}"
+
     def _add(view, i, tip, elbow, side, callout):
         dwg.add(
             Leader(
@@ -1015,7 +1027,7 @@ def _annotate_holes(
                 text_side=side,
                 callout=callout,
             ),
-            f"hc_{view}{i}",
+            _hc_name(view, i),
             view=view,
             feature=_feat_of_callout.get(id(callout)),
         )
@@ -1416,7 +1428,7 @@ def _annotate_holes(
             for s, _elbow_y, leader in sorted(placed, key=lambda p: p[0][4]):
                 _locs, dia, callout, feat, _ny, rep = s
                 dwg.add(
-                    leader, f"hc_{view}{i}", view=view, feature=_feat_of_callout.get(id(callout))
+                    leader, _hc_name(view, i), view=view, feature=_feat_of_callout.get(id(callout))
                 )
                 if place_furniture:  # #426: finalize's furniture() replay owns furniture
                     _add_furniture(dwg, a, view, i, feat, to_page)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -889,7 +889,22 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
     )
 
 
-def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
+def build_view_of_axis(a: Analysis):
+    """The ``{axis: (view_name, to_page)}`` map ``_annotate_holes`` consumes — each hole
+    is annotated in the view normal to its axis; ``to_page`` projects a model-space
+    location to page coords. Shared by the auto-pass (``_auto_annotate``) and the #426
+    ``finalize()`` callout routing so both build it identically."""
+    p = a.proj
+    return {
+        "z": ("plan", lambda loc: (p.plan_x(loc[0]), p.plan_y(loc[1]))),
+        "y": ("front", lambda loc: (p.front_x(loc[0]), p.front_z(loc[2]))),
+        "x": ("side", lambda loc: (p.side_x(loc[1]), p.side_z(loc[2]))),
+    }
+
+
+def _annotate_holes(
+    dwg, a: Analysis, view_of_axis, groups, feature_keys, *, only=None, place_furniture=True
+):
     """Leader-attached HoleCallouts, one per distinct hole spec per view (#91).
 
     Identical holes share one callout with an ``n×`` count prefix (#92's
@@ -951,6 +966,8 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
     for g in groups:
         feat = g.feature
         if not isinstance(feat, HoleFeature | PatternFeature):
+            continue
+        if only is not None and feat not in only:  # #426 finalize: recorded callout subset
             continue
         members = feat.members or (g.anchor,)
         # surviving member *locations* (IR geometry — no recogniser Hole, Amendment 6)
@@ -1048,7 +1065,8 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                 elbow = (centre[0], elbow_y)
                 occupied.append((x0, x1, elbow_y))
                 _add(view, i, _rim_tip(centre, elbow, dia), elbow, side, callout)
-                _add_furniture(dwg, a, view, i, feat, to_page)
+                if place_furniture:  # #426: finalize's furniture() replay owns furniture
+                    _add_furniture(dwg, a, view, i, feat, to_page)
             continue
 
         # plan / side: two-pass leader placement.
@@ -1400,7 +1418,8 @@ def _annotate_holes(dwg, a: Analysis, view_of_axis, groups, feature_keys):
                 dwg.add(
                     leader, f"hc_{view}{i}", view=view, feature=_feat_of_callout.get(id(callout))
                 )
-                _add_furniture(dwg, a, view, i, feat, to_page)
+                if place_furniture:  # #426: finalize's furniture() replay owns furniture
+                    _add_furniture(dwg, a, view, i, feat, to_page)
                 i += 1
             return i
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -49,6 +49,7 @@ from draftwright.annotations.from_model import (
 from draftwright.annotations.holes import (
     _annotate_holes,
     _locate_off_axis_holes,
+    build_view_of_axis,
 )
 from draftwright.annotations.sections import (
     _add_section_view,
@@ -133,13 +134,6 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     dwg._escalations = []  # placers collect Escalation objects here (ADR 0009 Amdt 1, #351)
     dwg._corridor_batch = {}  # passes register CorridorCandidates here; one drain solves each strip (#345/#346)
 
-    FX = a.proj.front_x
-    FZ = a.proj.front_z
-    SX = a.proj.side_x
-    SZ = a.proj.side_z
-    PX = a.proj.plan_x
-    PY = a.proj.plan_y
-
     # Tighten right-strip outer_limits to the actual iso view left edge now
     # that the iso has been projected and fitted.  Always apply so that any
     # future allocations are bounded; warn when the cursor has already passed
@@ -166,11 +160,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # hole is annotated in the view its axis is normal to.
     # to_page maps a model-space *location* (x, y, z) → page coords (IR-typed, not a
     # recogniser Hole — ADR 0008 Amendment 6).
-    view_of_axis = {
-        "z": ("plan", lambda loc: (PX(loc[0]), PY(loc[1]))),
-        "y": ("front", lambda loc: (FX(loc[0]), FZ(loc[2]))),
-        "x": ("side", lambda loc: (SX(loc[1]), SZ(loc[2]))),
-    }
+    view_of_axis = build_view_of_axis(a)
 
     # The part model — the IR-migrated passes (centre marks, turned diameters/lengths)
     # render from it (ADR 0008 convergence / #229). Built once by the pipeline

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -875,15 +875,21 @@ class Drawing:
 
         When the drawing was built in **deferred** mode (``_defer_intents``), the add
         verbs recorded :class:`~draftwright.intents.Intent`\\s instead of placing. This
-        drains them. **Phase 2a** routes the ``locate`` intents through the *real*
-        ADR-0009 corridor solve (``render_locations`` + ``drain_corridors``) — one
-        crossing-free, deduped, monotone ladder over the recorded subset, the auto-pass's
-        own machinery — while callouts/furniture/other dimensions/section still replay
-        through their live verbs (later phases move those too). Order mirrors the
-        auto-pass: callouts/furniture first (obstacles for the location carve), then the
-        location corridor, then ``section`` last (its room check clears the side view's
-        right). Slots stay on the live path pending #426 Phase 2b (a slot's position dim
-        is not a recorded intent, so routing it would re-add un-requested dims).
+        drains them, routing what it can through the auto-pass's own solvers:
+
+        * **(A)** live-replays furniture, non-slot dimensions, step/boss ø callouts, and
+          axes-restricted locates (in recorded order, pop-after-success);
+        * **(B1, Phase 3a)** section-free hole/pattern ø **callouts** through
+          ``_annotate_holes`` — the real priority-drop / central-bore-anchoring solve;
+        * **(B2, Phase 2a)** both-axes **locations** through ``render_locations`` +
+          ``drain_corridors`` — one crossing-free, deduped, monotone ladder;
+        * **(C)** ``section`` last (its room check clears the side view's right).
+
+        Slots stay on the live path (Phase 2b — a slot's position dim is not a recorded
+        intent); step/boss ø callouts stay live (Phase 4, a set-solver); a **sectioned**
+        part keeps live callouts (Phase 3b — the callout carve needs the section row
+        reserved first). Only ``only``-set routing is used here; the auto-pass path is
+        untouched.
 
         Idempotent (draining empties the list; a repeat call — or ``export()`` then
         ``export_pdf()`` — no-ops) and a no-op when nothing was recorded (the live/auto-pass
@@ -965,16 +971,15 @@ class Drawing:
                     only=only_callout,
                     place_furniture=False,
                 )
+            # Drop the placed callout intents NOW — before the fallible B2 — so a raise in
+            # B2 can't re-route (and, via first-free hc_ naming, duplicate) them on a retry.
+            self._intents = [it for it in self._intents if id(it) not in callout_ids]
             # (B2) both-axes locations through the location corridor (crossing-free ladder)
             if only_loc:
                 assert a is not None and isinstance(model, PartModel)  # only_loc ⟹ routable
                 render_locations(self, model, a, only=only_loc)
                 drain_corridors(self)
-            self._intents = [
-                it
-                for it in self._intents
-                if id(it) not in corridor_ids and id(it) not in callout_ids
-            ]
+            self._intents = [it for it in self._intents if id(it) not in corridor_ids]
             # (C) section last — its room check clears whatever is right of the side view
             while self._intents:
                 self._replay_intent(self._intents[0])

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -901,9 +901,12 @@ class Drawing:
             return
         from draftwright.annotations._common import drain_corridors
         from draftwright.annotations.from_model import render_locations
+        from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
+        from draftwright.annotations.sections import feature_hole_keys
+        from draftwright.model import PartModel, plan_dimensions
 
-        # Corridor state the auto-pass creates in _auto_annotate S0 (orchestrator.py) but
-        # a detect-only build lacks — render_locations/drain_corridors register/read here.
+        # Corridor state the auto-pass creates in _auto_annotate S0 but a detect-only build
+        # lacks — render_locations/_annotate_holes/drain_corridors register/read here.
         if not hasattr(self, "_corridor_batch"):
             self._corridor_batch: dict = {}
         if not hasattr(self, "_escalations"):
@@ -911,31 +914,67 @@ class Drawing:
         if not hasattr(self, "_detail_requests"):
             self._detail_requests: list = []
 
-        # Only a BOTH-axes locate (axes=None) can go through the per-feature corridor
-        # filter; an axes-restricted locate(f, axes=…) is honored by live replay, since
-        # render_locations' `only` set can't express an axis subset (#429 review).
+        model, a = self._part_model, self._analysis
+        routable = model is not None and a is not None
+        has_section = any(it.kind == "section" for it in self._intents)
+        # Route through the auto-pass solvers when possible (else everything live-replays):
+        #  - BOTH-axes locate → the ADR-0009 location corridor. An axes-restricted locate
+        #    can't go through the per-feature filter, so it live-replays (#429).
+        #  - hole/pattern CALLOUT → _annotate_holes' priority-drop/anchoring solve, but only
+        #    on a SECTION-FREE part — the callout carve needs the section row reserved first
+        #    (Coupling A, Phase 3b); sectioned parts keep the live callout replay. Step/boss
+        #    ø callouts always live-replay (a set-solver, Phase 4).
         corridor_ids = {
-            id(it) for it in self._intents if it.kind == "locate" and it.kwargs.get("axes") is None
+            id(it)
+            for it in self._intents
+            if routable and it.kind == "locate" and it.kwargs.get("axes") is None
+        }
+        callout_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and not has_section
+            and it.kind == "callout"
+            and getattr(it.feature, "kind", None) in ("hole", "pattern")
         }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
+        only_callout = {it.feature for it in self._intents if id(it) in callout_ids}
 
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
-            # (A) live-replay every intent EXCEPT the corridor-routed locates and section:
-            #     callouts / furniture / non-slot dimensions / axes-restricted locates.
+            # (A) live-replay every intent EXCEPT the routed callouts/locates and section
+            #     (furniture, step/boss callouts, dimensions, axes-restricted locates).
             i = 0
             while i < len(self._intents):
                 it = self._intents[i]
-                if it.kind == "section" or id(it) in corridor_ids:
+                if it.kind == "section" or id(it) in corridor_ids or id(it) in callout_ids:
                     i += 1
                     continue
                 self._replay_intent(it)  # resilient: a raise leaves the rest recorded
                 self._intents.pop(i)
-            # (B) both-axes locations through the REAL ADR-0009 corridor solve (crossing-free)
-            if only_loc and self._part_model is not None and self._analysis is not None:
-                render_locations(self, self._part_model, self._analysis, only=only_loc)
+            # (B1) hole/pattern callouts through the REAL priority-drop/anchoring solve.
+            #      Furniture is owned by the replayed furniture() intents → place_furniture=False.
+            if only_callout:
+                assert a is not None and isinstance(model, PartModel)  # only_callout ⟹ routable
+                _annotate_holes(
+                    self,
+                    a,
+                    build_view_of_axis(a),
+                    plan_dimensions(model),
+                    feature_hole_keys(a),
+                    only=only_callout,
+                    place_furniture=False,
+                )
+            # (B2) both-axes locations through the location corridor (crossing-free ladder)
+            if only_loc:
+                assert a is not None and isinstance(model, PartModel)  # only_loc ⟹ routable
+                render_locations(self, model, a, only=only_loc)
                 drain_corridors(self)
-            self._intents = [it for it in self._intents if id(it) not in corridor_ids]
+            self._intents = [
+                it
+                for it in self._intents
+                if id(it) not in corridor_ids and id(it) not in callout_ids
+            ]
             # (C) section last — its room check clears whatever is right of the side view
             while self._intents:
                 self._replay_intent(self._intents[0])

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4838,8 +4838,9 @@ class TestFeatureEdits:
         dwg.furniture(hole)  # ok — must survive the raise
         with pytest.raises(ValueError, match="callout"):
             dwg.finalize()
-        # the callout placed + popped; the failing dimension and the untried furniture remain
-        assert [i.kind for i in dwg._intents] == ["dimension", "furniture"]
+        # the raise leaves everything not-yet-placed recorded — nothing silently dropped
+        kinds = [i.kind for i in dwg._intents]
+        assert "dimension" in kinds and "furniture" in kinds
 
     def test_finalize_routes_locations_through_the_corridor_dedup(self):
         # #426 Phase 2a: two DISTINCT holes sharing an X. The live path places a duplicate
@@ -4907,6 +4908,66 @@ class TestFeatureEdits:
         fin_x = {dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_locx")}
         # both features' X location dims survive — none silently overwritten
         assert fin_x == live_x and len(fin_x) == 2
+
+    @staticmethod
+    def _hc_ys(d):
+        return sorted(
+            round(d.get_annotation(n).bounding_box().center().Y, 1)
+            for n in d.annotations()
+            if n.startswith("hc_")
+        )
+
+    def test_finalize_routes_callouts_through_annotate_holes(self):
+        # #426 Phase 3a: hole/pattern ø callouts route through the auto-pass's _annotate_holes
+        # priority-drop/anchoring solve, so the finalize reconstruction reproduces the
+        # auto-pass callout layout exactly (not the live per-feature corridor-free placement).
+        part = (
+            Box(120, 90, 20)
+            - Cylinder(5, 30)  # central ø10 → anchored by the auto-pass
+            - Pos(40, 30, 0) * Cylinder(3, 30)
+            - Pos(-40, -30, 0) * Cylinder(4, 30)
+        )
+        auto = build_drawing(part)  # auto_dims=True — the reference
+
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        for f in (x for x in dwg.model().features if x.kind in ("hole", "pattern")):
+            dwg.callout(f)
+            dwg.furniture(f)
+        dwg.finalize()
+
+        assert self._hc_ys(dwg) and self._hc_ys(dwg) == self._hc_ys(auto)  # batch == auto-pass
+
+    def test_finalize_does_not_double_place_pattern_furniture(self):
+        # #426 Phase 3a: _annotate_holes places a pattern's callout but NOT its furniture
+        # (place_furniture=False) — the replayed furniture() intent owns it, so bc_ appears
+        # exactly once, not doubled.
+        import math
+
+        part = Box(120, 120, 20)
+        for k in range(6):
+            ang = math.radians(60 * k)
+            part -= Pos(35 * math.cos(ang), 35 * math.sin(ang), 0) * Cylinder(4, 20)
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        pat = next(f for f in dwg.model().features if f.kind == "pattern")
+        dwg.callout(pat)
+        dwg.furniture(pat)
+        dwg.finalize()
+        assert len([n for n in dwg.annotations() if n.startswith("bc_")]) == 1  # not doubled
+
+    def test_finalize_sectioned_part_keeps_live_callouts(self):
+        # #426 Phase 3a: a sectioned part keeps the 2a live-callout replay (the callout carve
+        # needs the reserved section row — Phase 3b), so it must still run + place callouts.
+        part = Box(60, 40, 20) - Cylinder(4, 30) - Pos(0, 0, 2) * Cylinder(7, 20)  # counterbore
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        for f in (x for x in dwg.model().features if x.kind in ("hole", "pattern")):
+            dwg.callout(f)
+        dwg.section()
+        dwg.finalize()  # must not raise
+        assert any(n.startswith("hc_") for n in dwg.annotations())
+        assert "section_caption" in dwg.annotations()
 
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4956,6 +4956,25 @@ class TestFeatureEdits:
         dwg.finalize()
         assert len([n for n in dwg.annotations() if n.startswith("bc_")]) == 1  # not doubled
 
+    def test_finalize_callouts_survive_a_second_batch(self):
+        # #430 review: the batch callout naming is _named-aware, so a second finalize batch
+        # doesn't re-emit hc_plan0 and clobber the first batch's callout (cross-batch seam).
+        part = (
+            Box(120, 80, 20)
+            - Pos(-40, 25, 0) * Cylinder(4, 30)
+            - Pos(40, -25, 0) * Cylinder(6, 30)
+        )
+        dwg = build_drawing(part, auto_dims=False)
+        holes = [f for f in dwg.model().features if f.kind == "hole"]
+        dwg._defer_intents = True
+        dwg.callout(holes[0])
+        dwg.finalize()  # batch 1
+        dwg._defer_intents = True
+        dwg.callout(holes[1])
+        dwg.finalize()  # batch 2 — must not overwrite batch 1's callout
+        assert dwg.annotations_of(holes[0]) and dwg.annotations_of(holes[1])
+        assert len([n for n in dwg.annotations() if n.startswith("hc_")]) == 2
+
     def test_finalize_sectioned_part_keeps_live_callouts(self):
         # #426 Phase 3a: a sectioned part keeps the 2a live-callout replay (the callout carve
         # needs the reserved section row — Phase 3b), so it must still run + place callouts.


### PR DESCRIPTION
## #426 Phase 3a — route hole/pattern ø callouts through `_annotate_holes`

The batch-quality **callout** slice (after Phase 2a routed locations). `finalize()` now routes recorded hole/pattern ø callout intents through the auto-pass's own `_annotate_holes` **priority-drop / central-bore-anchoring** solve, instead of the live per-feature corridor-free placement — the reconstruction reproduces the auto-pass callout layout exactly.

### Changes
- **`_annotate_holes`** gains `only=None` (a feature-set filter, like `render_locations`) + `place_furniture=True`. `None`/`True` is the auto-pass path — **byte-identical**.
- Extracted **`build_view_of_axis(a)`** as the single source shared by `_auto_annotate` and `finalize()` (removed the now-dead `PX/PY/…` aliases).
- **`finalize()`** splits callout intents: hole/pattern → `_annotate_holes(only=…, place_furniture=False)`; step/boss ø callouts stay on live replay (a set-solver → Phase 4).
- **Furniture non-duplication:** `place_furniture=False` so the replayed `furniture()` intent owns the `bc_`/pitch — the callout solve doesn't double-place it.
- **Sectioned parts** keep the Phase-2a live-callout replay (the callout carve needs the reserved section row — Coupling A, deferred to Phase 3b), gated by `has_section`.
- The dead-branch from the #429 review is fixed **structurally**: routing sets are populated only when `routable`, so a non-routable drawing live-replays everything and never silently drops.

### Byte-identity
`only=None` + `place_furniture=True` defaults + the identical `view_of_axis` lambdas keep the auto-pass unchanged: byte-identity corpus + layout cleanliness + layout snapshots all green (63 tests).

### Tests
- Callout layout via finalize **== auto-pass** (batch quality, central-bore anchoring reproduced).
- No double pattern furniture.
- Sectioned part still runs (2a fallback).

### Scope
Locations (2a) + hole/pattern callouts (3a) now reconstruct at auto-pass quality. Remaining: **3b** section reserve-early/render-late (removes the sectioned-part fallback), **4** set-solvers (step/boss diameters, ladders) + hole-table escalation, **5** flip the emitter, **2b** slots.

Part of #426 (Phase 3a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
