### PR TITLE
feat: route step/boss ø diameters through render_diameters in finalize() (#426 Phase 4a)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -658,12 +658,17 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
     return placed
 
 
-def render_diameters(dwg, groups, tol: float = 0.15) -> int:
+def render_diameters(dwg, groups, tol: float = 0.15, *, only=None) -> int:
     """ø leaders for a turned part's external step/boss diameters, from the IR —
     one distinct callout per diameter, in a tidy row below the front view
     (X-turning) or a column to its left (Z-turning). Orientation is the feature
     frame's axis, not two passes. Replaces the engine's ``_annotate_turned_diameters``
-    (ADR 0008 convergence). Diameters another annotation already covers are skipped."""
+    (ADR 0008 convergence). Diameters another annotation already covers are skipped.
+
+    *only*, when given, restricts placement to step/boss features in the set — the #426
+    finalize() path passes the recorded step/boss ``callout`` intents' features. ``None``
+    (the auto-pass) places every diameter with the historical 0-based ``m_dia_{x,z}``
+    naming, byte-identically."""
     mentioned = _mentioned_diameters(dwg)
     # One distinct callout per (axis, diameter). Accumulate EVERY feature that shares a
     # diameter (insertion-ordered), so provenance (#412) can tag the callout with its
@@ -673,6 +678,8 @@ def render_diameters(dwg, groups, tol: float = 0.15) -> int:
     col_buckets: dict = {}  # Z-turned
     for g in groups:
         if g.feature_kind not in ("step", "boss"):
+            continue
+        if only is not None and g.feature not in only:  # #426 finalize: recorded subset
             continue
         dia = next((pd.param.value for pd in g.dims if pd.param.kind == "diameter"), None)
         if dia is None or any(abs(dia - m) <= tol for m in mentioned):
@@ -686,8 +693,18 @@ def render_diameters(dwg, groups, tol: float = 0.15) -> int:
     def _items(buckets):
         return [(a, d, next(iter(fs)) if len(fs) == 1 else None) for a, d, fs in buckets.values()]
 
-    return _diameter_row_below(dwg, _items(row_buckets)) + _diameter_column_left(
-        dwg, _items(col_buckets)
+    # The placers name leaders m_dia_{x,z}{start+i}. The auto-pass (only None) uses start=0
+    # — byte-identical. The finalize path (only set) may run after live-replayed m_dia names
+    # (a step callout, or a prior batch) already exist, so it starts past them (#419/#430
+    # naming seam), else the 0-based names would silently overwrite an earlier leader.
+    start_x = start_z = 0
+    if only is not None:
+        while f"m_dia_x{start_x}" in dwg._named:
+            start_x += 1
+        while f"m_dia_z{start_z}" in dwg._named:
+            start_z += 1
+    return _diameter_row_below(dwg, _items(row_buckets), start=start_x) + _diameter_column_left(
+        dwg, _items(col_buckets), start=start_z
     )
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -693,16 +693,22 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, only=None) -> int:
     def _items(buckets):
         return [(a, d, next(iter(fs)) if len(fs) == 1 else None) for a, d, fs in buckets.values()]
 
-    # The placers name leaders m_dia_{x,z}{start+i}. The auto-pass (only None) uses start=0
-    # — byte-identical. The finalize path (only set) may run after live-replayed m_dia names
-    # (a step callout, or a prior batch) already exist, so it starts past them (#419/#430
-    # naming seam), else the 0-based names would silently overwrite an earlier leader.
-    start_x = start_z = 0
-    if only is not None:
-        while f"m_dia_x{start_x}" in dwg._named:
-            start_x += 1
-        while f"m_dia_z{start_z}" in dwg._named:
-            start_z += 1
+    # The placers name leaders m_dia_{x,z}{start+i} CONTIGUOUSLY from one start. The auto-pass
+    # (only None) uses start=0 — byte-identical. The finalize path (only set) may run after
+    # existing m_dia names (a prior batch), so it starts past the MAX existing index — NOT the
+    # first-free (which is unsound for a multi-item run when the names are non-contiguous, e.g.
+    # after drop(): a gap below an occupied index would let the run wrap onto it and silently
+    # overwrite an earlier leader — #432 review). Starting past the max keeps the whole run free.
+    def _next_start(prefix):
+        idxs = [
+            int(n[len(prefix) :])
+            for n in dwg._named
+            if n.startswith(prefix) and n[len(prefix) :].isdigit()
+        ]
+        return max(idxs) + 1 if idxs else 0
+
+    start_x = _next_start("m_dia_x") if only is not None else 0
+    start_z = _next_start("m_dia_z") if only is not None else 0
     return _diameter_row_below(dwg, _items(row_buckets), start=start_x) + _diameter_column_left(
         dwg, _items(col_buckets), start=start_z
     )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -901,7 +901,7 @@ class Drawing:
         if not self._intents:
             return
         from draftwright.annotations._common import drain_corridors
-        from draftwright.annotations.from_model import render_locations
+        from draftwright.annotations.from_model import render_diameters, render_locations
         from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
         from draftwright.annotations.sections import (
             _add_section_view,
@@ -931,8 +931,8 @@ class Drawing:
         #  - BOTH-axes locate → the ADR-0009 location corridor. An axes-restricted locate
         #    can't go through the per-feature filter, so it live-replays (#429).
         #  - hole/pattern CALLOUT → _annotate_holes' priority-drop/anchoring solve (the
-        #    section row, if any, is reserved first below). Step/boss ø callouts always
-        #    live-replay (a set-solver, Phase 4).
+        #    section row, if any, is reserved first below).
+        #  - step/boss ø CALLOUT → render_diameters' row-below/column-left set-solve (Phase 4a).
         corridor_ids = {
             id(it)
             for it in self._intents
@@ -945,8 +945,16 @@ class Drawing:
             and it.kind == "callout"
             and getattr(it.feature, "kind", None) in ("hole", "pattern")
         }
+        dia_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and it.kind == "callout"
+            and getattr(it.feature, "kind", None) in ("step", "boss")
+        }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         only_callout = {it.feature for it in self._intents if id(it) in callout_ids}
+        only_dia = {it.feature for it in self._intents if id(it) in dia_ids}
 
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
@@ -960,7 +968,7 @@ class Drawing:
             i = 0
             while i < len(self._intents):
                 it = self._intents[i]
-                if it.kind == "section" or id(it) in corridor_ids or id(it) in callout_ids:
+                if it.kind == "section" or id(it) in corridor_ids | callout_ids | dia_ids:
                     i += 1
                     continue
                 self._replay_intent(it)  # resilient: a raise leaves the rest recorded
@@ -987,6 +995,12 @@ class Drawing:
                 render_locations(self, model, a, only=only_loc)
                 drain_corridors(self)
             self._intents = [it for it in self._intents if id(it) not in corridor_ids]
+            # (B3) step/boss ø diameters through render_diameters' set-solve (row-below /
+            #      column-left) — auto-pass S11b, after callouts/locations, before section.
+            if only_dia:
+                assert a is not None and isinstance(model, PartModel)  # only_dia ⟹ routable
+                render_diameters(self, plan_dimensions(model), only=only_dia)
+            self._intents = [it for it in self._intents if id(it) not in dia_ids]
             # (C) render the section LAST, reusing the reserved plan (its room check clears
             #     everything right of the side view; _add_section_view clears the reservation).
             #     A recorded section with no trigger (_section is None) is a no-op.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -877,19 +877,22 @@ class Drawing:
         verbs recorded :class:`~draftwright.intents.Intent`\\s instead of placing. This
         drains them, routing what it can through the auto-pass's own solvers:
 
-        * **(A)** live-replays furniture, non-slot dimensions, step/boss ø callouts, and
-          axes-restricted locates (in recorded order, pop-after-success);
+        * **(A)** live-replays furniture, non-slot dimensions, and axes-restricted locates
+          (in recorded order, pop-after-success);
         * **(reserve, Phase 3b)** if a ``section`` was recorded, its cutting-plane row is
           reserved first so the callout carve sees it as an obstacle (Coupling A);
         * **(B1, Phase 3a)** hole/pattern ø **callouts** through ``_annotate_holes`` — the
           real priority-drop / central-bore-anchoring solve;
         * **(B2, Phase 2a)** both-axes **locations** through ``render_locations`` +
           ``drain_corridors`` — one crossing-free, deduped, monotone ladder;
+        * **(B3, Phase 4a)** X/Z-turned step/boss ø **diameters** through ``render_diameters``
+          — the row-below / column-left set-solve;
         * **(C)** the ``section`` renders last (its room check clears the side view's right).
 
         Slots stay on the live path (Phase 2b — a slot's position dim is not a recorded
-        intent); step/boss ø callouts stay live (Phase 4, a set-solver). Only ``only``-set
-        routing is used here; the auto-pass path is untouched.
+        intent); an unsupported-axis (Y-turned) step/boss callout also live-replays, so it
+        surfaces the same ValueError the live verb raises. Only ``only``-set routing is used
+        here; the auto-pass path is untouched.
 
         Idempotent (draining empties the list; a repeat call — or ``export()`` then
         ``export_pdf()`` — no-ops) and a no-op when nothing was recorded (the live/auto-pass
@@ -951,6 +954,9 @@ class Drawing:
             if routable
             and it.kind == "callout"
             and getattr(it.feature, "kind", None) in ("step", "boss")
+            # X/Z-turned only — render_diameters can't place a Y-turned diameter, so leave
+            # it on live replay where callout() raises the same clear error (#432 review).
+            and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "z")
         }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         only_callout = {it.feature for it in self._intents if id(it) in callout_ids}

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5051,6 +5051,38 @@ class TestFeatureEdits:
         for n, lbl in first.items():  # batch 1's leaders survive with their labels
             assert n in after and after[n] == lbl
 
+    def test_finalize_step_diameters_no_overwrite_after_drop(self):
+        # #432 review: render_diameters starts past the MAX existing m_dia index (not
+        # first-free), so a batch after drop() leaves a GAP can't wrap onto an occupied
+        # higher index and silently overwrite an earlier diameter leader.
+        from build123d import Cylinder
+
+        shaft = Cylinder(26, 10)
+        for k, r in enumerate((22, 18, 14, 10, 6), start=1):
+            shaft += Cylinder(r, 10).translate((0, 0, 10 * k))
+        dwg = build_drawing(shaft, auto_dims=False)
+        steps = [f for f in dwg.model().features if f.kind == "step"]
+        assert len(steps) >= 5
+
+        dwg._defer_intents = True
+        for s in steps[:3]:
+            dwg.callout(s)
+        dwg.finalize()  # m_dia_z0/1/2
+        dwg.drop(steps[1])  # removes its m_dia → a gap in the index sequence
+        survivors = {
+            n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia")
+        }
+
+        dwg._defer_intents = True
+        for s in steps[3:5]:
+            dwg.callout(s)
+        dwg.finalize()  # must start past the max index, not wrap onto a survivor
+        after = {
+            n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia")
+        }
+        for n, lbl in survivors.items():
+            assert n in after and after[n] == lbl
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4992,6 +4992,65 @@ class TestFeatureEdits:
         # the callout carve saw the reserved section row → callouts match the auto-pass
         assert self._hc_ys(dwg) and self._hc_ys(dwg) == self._hc_ys(auto)
 
+    @staticmethod
+    def _dia_ys(d):
+        return sorted(
+            round(d.get_annotation(n).bounding_box().center().Y, 1)
+            for n in d.annotations()
+            if n.startswith("m_dia")
+        )
+
+    def test_finalize_routes_step_diameters_through_render_diameters(self):
+        # #426 Phase 4a: step/boss ø callouts route through render_diameters' row/column
+        # set-solve, so each step diameter lands at the same position the auto-pass gives it.
+        # finalize may place ONE EXTRA (the OD/base diameter): the auto-pass suppresses it
+        # because render_rotational already shows it as dim_od, but that rotational furniture
+        # is a gap kind not reconstructed here (#424) — so the auto-pass diameters are a
+        # SUBSET of finalize's, matching where they overlap.
+        from build123d import Cylinder
+
+        shaft = (
+            Cylinder(24, 15)
+            + Cylinder(16, 15).translate((0, 0, 15))
+            + Cylinder(9, 15).translate((0, 0, 30))
+        )
+        auto = build_drawing(shaft)  # auto_dims=True — the reference
+
+        dwg = build_drawing(shaft, auto_dims=False)
+        dwg._defer_intents = True
+        for f in (x for x in dwg.model().features if x.kind in ("step", "boss")):
+            dwg.callout(f)
+        dwg.finalize()
+        assert self._dia_ys(dwg) and set(self._dia_ys(auto)) <= set(self._dia_ys(dwg))
+
+    def test_finalize_step_diameters_survive_a_second_batch(self):
+        # #426 Phase 4a: render_diameters names m_dia_{x,z} _named-aware when only set, so a
+        # second finalize batch does not overwrite the first batch's diameter leader.
+        from build123d import Cylinder
+
+        shaft = (
+            Cylinder(24, 15)
+            + Cylinder(16, 15).translate((0, 0, 15))
+            + Cylinder(9, 15).translate((0, 0, 30))
+        )
+        dwg = build_drawing(shaft, auto_dims=False)
+        steps = [f for f in dwg.model().features if f.kind == "step"]
+        assert len(steps) >= 2
+        dwg._defer_intents = True
+        dwg.callout(steps[0])
+        dwg.finalize()
+        first = {
+            n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia")
+        }
+        dwg._defer_intents = True
+        dwg.callout(steps[1])
+        dwg.finalize()
+        after = {
+            n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia")
+        }
+        for n, lbl in first.items():  # batch 1's leaders survive with their labels
+            assert n in after and after[n] == lbl
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")


### PR DESCRIPTION
## #426 Phase 4a — route step/boss ø diameters through `render_diameters`

The first **set-solver** slice (Phase 4). `finalize()` now routes recorded step/boss ø callout intents through the auto-pass's `render_diameters` row-below / column-left set-solve (one leader per *distinct* diameter, tidy packing) instead of the live per-feature `add_feature_diameter` — so a turned/stepped part reconstructs its diameters at the auto-pass positions.

### Changes
- **`render_diameters`** gains `only=None` (a step/boss feature-set filter). `None` — the auto-pass call site — is byte-identical (`start=0`, no filter).
- **Naming seam pre-empted** (this class has bitten 3× — m_locx #429, hc_ #430): when `only` is set, `render_diameters` computes the first-free `m_dia_x`/`m_dia_z` start so a cross-batch or mixed finalize never overwrites an earlier diameter leader; `only=None` keeps the 0-based names.
- **`finalize()`** splits callout intents by feature kind: hole/pattern → `_annotate_holes` (B1), **step/boss → `render_diameters` (B3**, after locations, before section — auto-pass S11b).

### Rotational-gap interaction (documented, #424)
For a **turned** part, finalize may place **one extra** diameter — the OD/base. The auto-pass suppresses it because `render_rotational` already shows it as `dim_od`, but that rotational furniture is a **gap kind** (no add verb, emitted as a comment) so it isn't reconstructed here. Result: the auto-pass diameters are a **subset** of finalize's, matching where they overlap. This is the honest #424 fidelity gap for turned parts, not a routing bug.

### Tests
- Step diameters land at the auto-pass positions (subset assertion, accounting for the OD extra).
- Cross-batch survival (the naming seam — a second batch's diameter doesn't overwrite the first's).
- Byte-identity (`only=None`) + turned/diameter regression + layout snapshots green.

### Phase 4 plan
4a (diameters, this PR) → **4b** (step-length chain → `render_step_lengths`) → **4c** (hole-table escalation). The height ladder is *out* (its `step_level`/`rotational` inputs are gap kinds with no verb); envelope stays live.

Part of #426 (Phase 4a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
