### PR TITLE
feat: route turned step-length chain through render_step_lengths in finalize() (#426 Phase 4b)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -836,7 +836,9 @@ def _record_step_chain_drop(dwg, why: str) -> None:
     )
 
 
-def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True) -> int:
+def _draw_step_chain(
+    dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True, *, start=0
+) -> int:
     """Place a turned step-length chain in *view* from *segs* — each ``(pa, pb,
     value)`` already projected to *view*'s page coords, in axis order. Orientation is
     data (the projected span direction): horizontal → chain above the view, vertical
@@ -867,7 +869,8 @@ def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_coll
             dim = _dim((min(xs), y1, 0), (max(xs), y1, 0), "above", gap, draft, label=label)
         else:
             dim = _dim((x1, min(ys), 0), (x1, max(ys), 0), "right", gap, draft, label=label)
-        candidates = [(f"{name_prefix}_typ", dim)]
+        typ_name = f"{name_prefix}_typ" if start == 0 else f"{name_prefix}_typ{start}"
+        candidates = [(typ_name, dim)]
     else:
         tier_step = draft.font_size + 2 * draft.pad_around_text
         tiers = [0] * len(segs)
@@ -908,7 +911,7 @@ def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_coll
                 p1, p2, side = (x1, pa[1], 0), (x1, pb[1], 0), "right"
                 dist = gap
             candidates.append(
-                (f"{name_prefix}{i}", _dim(p1, p2, side, dist, draft, label=_fmt(value)))
+                (f"{name_prefix}{start + i}", _dim(p1, p2, side, dist, draft, label=_fmt(value)))
             )
 
     # Room guard: if any dim would fall off the drawable page, place NONE.
@@ -927,7 +930,24 @@ def _draw_step_chain(dwg, view, segs, name_prefix, detail_scale=None, allow_coll
     return len(candidates)
 
 
-def render_step_lengths(dwg, groups) -> int:
+def _next_steplen_start(dwg, prefix: str = "m_steplen") -> int:
+    """First free m_steplen index past the MAX existing one — the #426 finalize path names
+    the chain as a contiguous run from one start, so it must clear every existing name (max+1,
+    not first-free: a gap below an occupied index would let the run wrap onto it, #432)."""
+    idxs: list[int] = []
+    for n in dwg._named:
+        if not n.startswith(prefix):
+            continue
+        rest = n[len(prefix) :]
+        if rest.isdigit():
+            idxs.append(int(rest))
+        elif rest.startswith("_typ"):  # the N× collapse name m_steplen_typ{start}
+            tail = rest[4:]
+            idxs.append(int(tail) if tail.isdigit() else 0)
+    return max(idxs) + 1 if idxs else 0
+
+
+def render_step_lengths(dwg, groups, *, only=None) -> int:
     """Unified turned step-length chain (ADR 0008 #223): each `StepFeature`'s length
     span projects into the front view and joins the chain that tiles the turning axis
     so every shoulder is located. X-turned → horizontal chain above the view;
@@ -944,6 +964,8 @@ def render_step_lengths(dwg, groups) -> int:
     for g in groups:
         if g.feature_kind != "step":
             continue
+        if only is not None and g.feature not in only:  # #426 finalize: recorded subset
+            continue
         length = next(
             (pd.param for pd in g.dims if pd.param.kind == "length" and pd.param.span is not None),
             None,
@@ -954,6 +976,9 @@ def render_step_lengths(dwg, groups) -> int:
     if not rows:
         return 0
     draft = dwg.draft
+    # only=None (auto-pass) → start=0, historical m_steplen naming, byte-identical. The
+    # finalize path (only set) starts past existing m_steplen names (#426 naming seam).
+    start = _next_steplen_start(dwg) if only is not None else 0
     fsegs = [(dwg.at("front", *a), dwg.at("front", *b), v) for a, b, v in rows]
     horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
 
@@ -1003,9 +1028,11 @@ def render_step_lengths(dwg, groups) -> int:
             main.sort(key=lambda s: s[0][0])
             # The chain now mixes head-block(s) with real steps — never collapse it to a
             # uniform "N× v" representative (a block is not a repeated step, #307 review).
-            return _draw_step_chain(dwg, "front", main, "m_steplen", allow_collapse=False)
+            return _draw_step_chain(
+                dwg, "front", main, "m_steplen", allow_collapse=False, start=start
+            )
 
-    return _draw_step_chain(dwg, "front", fsegs, "m_steplen")
+    return _draw_step_chain(dwg, "front", fsegs, "m_steplen", start=start)
 
 
 def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -887,6 +887,8 @@ class Drawing:
           ``drain_corridors`` — one crossing-free, deduped, monotone ladder;
         * **(B3, Phase 4a)** X/Z-turned step/boss ø **diameters** through ``render_diameters``
           — the row-below / column-left set-solve;
+        * **(B3b, Phase 4b)** a turned shaft's step-length **chain** through
+          ``render_step_lengths`` — the unified chain / ``N× v`` collapse / staggered tiers;
         * **(C)** the ``section`` renders last (its room check clears the side view's right).
 
         Slots stay on the live path (Phase 2b — a slot's position dim is not a recorded
@@ -904,7 +906,11 @@ class Drawing:
         if not self._intents:
             return
         from draftwright.annotations._common import drain_corridors
-        from draftwright.annotations.from_model import render_diameters, render_locations
+        from draftwright.annotations.from_model import (
+            render_diameters,
+            render_locations,
+            render_step_lengths,
+        )
         from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
         from draftwright.annotations.sections import (
             _add_section_view,
@@ -958,9 +964,24 @@ class Drawing:
             # it on live replay where callout() raises the same clear error (#432 review).
             and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "z")
         }
+        # step LENGTH dimension intents (role="step") → render_step_lengths' chain (Phase 4b),
+        # but only on a TURNED part (a.prof is not None, mirroring the auto-pass guard) — else
+        # they live-replay. Excludes the step's ø (a callout routed in dia_ids above).
+        len_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and a is not None
+            and a.prof is not None
+            and it.kind == "dimension"
+            and getattr(it.feature, "kind", None) == "step"
+            and it.kwargs.get("param") == "length"
+            and it.kwargs.get("role") == "step"
+        }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         only_callout = {it.feature for it in self._intents if id(it) in callout_ids}
         only_dia = {it.feature for it in self._intents if id(it) in dia_ids}
+        only_len = {it.feature for it in self._intents if id(it) in len_ids}
 
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
@@ -974,7 +995,10 @@ class Drawing:
             i = 0
             while i < len(self._intents):
                 it = self._intents[i]
-                if it.kind == "section" or id(it) in corridor_ids | callout_ids | dia_ids:
+                if (
+                    it.kind == "section"
+                    or id(it) in corridor_ids | callout_ids | dia_ids | len_ids
+                ):
                     i += 1
                     continue
                 self._replay_intent(it)  # resilient: a raise leaves the rest recorded
@@ -1007,6 +1031,12 @@ class Drawing:
                 assert a is not None and isinstance(model, PartModel)  # only_dia ⟹ routable
                 render_diameters(self, plan_dimensions(model), only=only_dia)
             self._intents = [it for it in self._intents if id(it) not in dia_ids]
+            # (B3b) turned step-length CHAIN through render_step_lengths (N× collapse /
+            #       staggered tiers) — auto-pass S11b, after diameters, before section.
+            if only_len:
+                assert a is not None and isinstance(model, PartModel)  # only_len ⟹ routable
+                render_step_lengths(self, plan_dimensions(model), only=only_len)
+            self._intents = [it for it in self._intents if id(it) not in len_ids]
             # (C) render the section LAST, reusing the reserved plan (its room check clears
             #     everything right of the side view; _add_section_view clears the reservation).
             #     A recorded section with no trigger (_section is None) is a no-op.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5083,6 +5083,42 @@ class TestFeatureEdits:
         for n, lbl in survivors.items():
             assert n in after and after[n] == lbl
 
+    def test_finalize_routes_step_lengths_through_render_step_lengths(self):
+        # #426 Phase 4b: a turned shaft's step-length dims route through render_step_lengths'
+        # chain, so the finalize reconstruction reproduces the auto-pass step-length layout
+        # (m_steplen* at the same positions), not the live per-feature independent dims.
+        from build123d import Cylinder, Rot
+
+        shaft = Rot(0, 90, 0) * (
+            Cylinder(20, 12)
+            + Cylinder(15, 18).translate((0, 0, 12))
+            + Cylinder(10, 25).translate((0, 0, 30))
+        )
+        auto = build_drawing(shaft)  # auto_dims=True — the reference
+
+        dwg = build_drawing(shaft, auto_dims=False)
+        dwg._defer_intents = True
+        for f in dwg.model().features:
+            if f.kind == "step":
+                dwg.dimension(f, "length", role="step")
+        dwg.finalize()
+
+        def steplen_pos(d):
+            return sorted(
+                (
+                    n,
+                    round(d.get_annotation(n).bounding_box().center().X, 1),
+                    round(d.get_annotation(n).bounding_box().center().Y, 1),
+                )
+                for n in d.annotations()
+                if n.startswith("m_steplen")
+            )
+
+        assert steplen_pos(dwg) and steplen_pos(dwg) == steplen_pos(auto)  # the chain, not singles
+        assert not any(
+            n.startswith("dim_length") for n in dwg.annotations()
+        )  # no live single dims
+
     def test_place_dim_feature_kwarg_tags_provenance(self):
         dwg = build_drawing(_holed_plate())
         hole = next(f for f in dwg.model().features if f.kind == "hole")


### PR DESCRIPTION
## #426 Phase 4b — route the turned step-length chain through `render_step_lengths`

The second set-solver slice. `finalize()` now routes recorded step-length dimension intents (`dwg.dimension(step, "length", role="step")`) through the auto-pass's `render_step_lengths` — the unified **chain / `N× v` collapse / staggered-tier** set-solve — instead of the live per-feature independent dims. A turned shaft's step lengths reconstruct at auto-pass quality.

### Changes
- **`render_step_lengths`** gains `only=None` (a step feature-set filter). `None` — the auto-pass call site — is byte-identical (`start=0`, no filter).
- **Naming seam** pre-empted with the **contiguous-batch** variant (the #432 lesson): `_draw_step_chain` places the whole chain from one `start`, so `_next_steplen_start` returns `max(existing m_steplen index)+1` — **not** first-free (which would wrap onto a gap and overwrite). Offsets both `m_steplen{i}` *and* the `m_steplen_typ` collapse name.
- **`finalize()`** routes `len_ids` (dimension intents on step features, `role="step"`) through a new leg **B3b** after B3 diameters, before section C — with `a.prof is not None` embedded so a non-turned part's step dims live-replay instead of vanishing.
- The crowded-head `DetailRequest` is left **inert** (finalize doesn't call `_resolve_details`); the head degrades to its block dim (out of scope, like 4a's OD extra).

### Byte-identity
`only=None` + the identical chain geometry keep the auto-pass unchanged: byte-identity corpus + turned regression + layout snapshots green (55 tests).

### Tests
- Multi-step X-turned shaft's `m_steplen` chain (names + positions) **== auto-pass**, with no live `dim_length*` single dims remaining.

### Phase 4 status
4a diameters ✅ · 4b step-lengths (this PR) · **4c** hole-table escalation next. Then **Phase 5** flips the emitter to record-then-`finalize()` — the payoff.

Part of #426 (Phase 4b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
