### PR TITLE
feat: route slots through the shared corridor solve in finalize() (#426 Phase 2b)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -151,13 +151,19 @@ def _record_slot_drop(dwg, kind, idx, view, feat):
     )
 
 
-def render_slots(dwg, model, a) -> int:
+def render_slots(dwg, model, a, *, only=None) -> int:
     """Dimension milled slots from the IR — width (the defining size, across
     ``width_axis``) + length (along ``long_axis``) + a position dim from the part
     datum, in the view the two axes span. Places through the engine's zone strips
     (shared infra, ADR 0008 Amend. 4); a dim with no clear room is dropped and
     recorded at info severity (place-what-fits). Sources `SlotFeature`s from the
-    model; replaces the engine's `_annotate_slots`. Returns the count placed."""
+    model; replaces the engine's `_annotate_slots`. Returns the count placed.
+
+    ``only`` (a set of `SlotFeature`s, #426 Phase 2b) restricts placement to a recorded
+    subset for ``finalize()``; ``only=None`` (the auto-pass) places all slots, byte-
+    identically. Skips filtered slots **in place** so ``i`` stays the slot's model index
+    (the ``m_slot{i}_*`` names must match the auto-pass — never re-enumerate a compacted
+    list)."""
     slots = [f for f in model.features if f.kind == "slot"]
     if not slots:
         return 0
@@ -174,6 +180,8 @@ def render_slots(dwg, model, a) -> int:
 
     count = 0
     for i, s in enumerate(slots):
+        if only is not None and s not in only:
+            continue  # #426 Ph2b: skip in place — i must stay the model index
         view = views[frozenset((s.width_axis, s.long_axis))]
         name, zones, h_axis, h_proj, _v_axis, v_proj = view
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -912,18 +912,23 @@ class Drawing:
           reserved first so the callout carve sees it as an obstacle (Coupling A);
         * **(B1, Phase 3a)** hole/pattern ø **callouts** through ``_annotate_holes`` — the
           real priority-drop / central-bore-anchoring solve;
-        * **(B2, Phase 2a)** both-axes **locations** through ``render_locations`` +
-          ``drain_corridors`` — one crossing-free, deduped, monotone ladder;
+        * **(B2, Phase 2a+2b)** both-axes **locations** (``render_locations``) and
+          **slots** (``render_slots``) through the SHARED corridor + one ``drain_corridors``
+          — one crossing-free, deduped, monotone ladder (a slot position coincident with a
+          hole location collapses to one dim, #345);
         * **(B3, Phase 4a)** X/Z-turned step/boss ø **diameters** through ``render_diameters``
           — the row-below / column-left set-solve;
         * **(B3b, Phase 4b)** a turned shaft's step-length **chain** through
           ``render_step_lengths`` — the unified chain / ``N× v`` collapse / staggered tiers;
         * **(C)** the ``section`` renders last (its room check clears the side view's right).
 
-        Slots stay on the live path (Phase 2b — a slot's position dim is not a recorded
-        intent); an unsupported-axis (Y-turned) step/boss callout also live-replays, so it
-        surfaces the same ValueError the live verb raises. Only ``only``-set routing is used
-        here; the auto-pass path is untouched.
+        A slot records two size dims (``slot_width``/``slot_length``) on one feature; routing
+        the feature also regenerates its model-derived datum **position** dim, so finalize
+        places a *superset* of the recorded slot intents (auto-pass parity by design —
+        commenting one of a slot's two lines still routes the feature). An unsupported-axis
+        (Y-turned) step/boss callout live-replays, so it surfaces the same ValueError the
+        live verb raises. Only ``only``-set routing is used here; the auto-pass path is
+        untouched.
 
         Idempotent (draining empties the list; a repeat call — or ``export()`` then
         ``export_pdf()`` — no-ops) and a no-op when nothing was recorded (the live/auto-pass
@@ -938,6 +943,7 @@ class Drawing:
         from draftwright.annotations.from_model import (
             render_diameters,
             render_locations,
+            render_slots,
             render_step_lengths,
         )
         from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
@@ -1007,10 +1013,22 @@ class Drawing:
             and it.kwargs.get("param") == "length"
             and it.kwargs.get("role") == "step"
         }
+        # SLOT dimension intents (#426 Phase 2b) → render_slots' corridor placement. A slot
+        # records TWO dims (slot_width + slot_length) on ONE SlotFeature; both route the
+        # feature, which regenerates width + length + the datum position (a superset — the
+        # position dim is model-derived, not recorded). Slots share the location corridor,
+        # so they register alongside B2's locations and drain in the SAME solve (the #345
+        # dedup of a slot position coincident with a hole location needs one combined pass).
+        slot_ids = {
+            id(it)
+            for it in self._intents
+            if routable and it.kind == "dimension" and getattr(it.feature, "kind", None) == "slot"
+        }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         only_callout = {it.feature for it in self._intents if id(it) in callout_ids}
         only_dia = {it.feature for it in self._intents if id(it) in dia_ids}
         only_len = {it.feature for it in self._intents if id(it) in len_ids}
+        slot_feats = {it.feature for it in self._intents if id(it) in slot_ids}
 
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
@@ -1026,7 +1044,7 @@ class Drawing:
                 it = self._intents[i]
                 if (
                     it.kind == "section"
-                    or id(it) in corridor_ids | callout_ids | dia_ids | len_ids
+                    or id(it) in corridor_ids | callout_ids | dia_ids | len_ids | slot_ids
                 ):
                     i += 1
                     continue
@@ -1048,12 +1066,18 @@ class Drawing:
             # Drop the placed callout intents NOW — before the fallible B2 — so a raise in
             # B2 can't re-route (and, via first-free hc_ naming, duplicate) them on a retry.
             self._intents = [it for it in self._intents if id(it) not in callout_ids]
-            # (B2) both-axes locations through the location corridor (crossing-free ladder)
-            if only_loc:
-                assert a is not None and isinstance(model, PartModel)  # only_loc ⟹ routable
-                render_locations(self, model, a, only=only_loc)
+            # (B2) both-axes locations + slots through the SHARED location corridor — one
+            #      crossing-free ladder, one drain (auto-pass registers locations then slots,
+            #      then a single drain_corridors, so a slot position coincident with a hole
+            #      location dedups, #345). Register both, then drain once (Phase 2a + 2b).
+            if only_loc or slot_feats:
+                assert a is not None and isinstance(model, PartModel)  # either ⟹ routable
+                if only_loc:
+                    render_locations(self, model, a, only=only_loc)
+                if slot_feats:
+                    render_slots(self, model, a, only=slot_feats)
                 drain_corridors(self)
-            self._intents = [it for it in self._intents if id(it) not in corridor_ids]
+            self._intents = [it for it in self._intents if id(it) not in corridor_ids | slot_ids]
             # (B3) step/boss ø diameters through render_diameters' set-solve (row-below /
             #      column-left) — auto-pass S11b, after callouts/locations, before section.
             if only_dia:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4972,6 +4972,63 @@ class TestFeatureEdits:
         # both features' X location dims survive — none silently overwritten
         assert fin_x == live_x and len(fin_x) == 2
 
+    def test_finalize_routes_slots_through_render_slots(self):
+        # #426 Phase 2b: a slot's recorded size dims route through render_slots' corridor
+        # placement (m_slot* names), NOT the live dim_length* replay — reaching auto-pass
+        # parity. Routing the feature also regenerates its datum POSITION dim (a superset:
+        # model-derived, not a recorded intent).
+        part = Box(50, 30, 20) - Box(20, 8, 30)  # an enclosed through-slot (#135)
+
+        auto = build_drawing(part)  # auto_dims=True — the reference
+        auto_slot = {n for n in auto.annotations() if n.startswith("m_slot")}
+        assert auto_slot, "auto-pass must place m_slot* dims"
+
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        slot = next(f for f in dwg.model().features if f.kind == "slot")
+        dwg.dimension(slot, "length", role="slot_width")
+        dwg.dimension(slot, "length", role="slot_length")
+        dwg.finalize()
+        fin_slot = {n for n in dwg.annotations() if n.startswith("m_slot")}
+        assert fin_slot == auto_slot  # same corridor-placed names (m_slot0_width/length/pos)
+        # routed, not live-replayed: no dim_length* singles, and both intents drained
+        assert not [n for n in dwg.annotations() if n.startswith("dim_length")]
+        assert dwg._intents == []
+
+    def test_finalize_slot_position_dedups_with_a_coincident_hole_location(self):
+        # #426 Phase 2b: slots share the location corridor with hole locates and drain in ONE
+        # solve. Here the slot's near edge (x=-10) coincides with a hole's X-location, so the
+        # slot POSITION line and that hole location are the SAME datum→10 span — the #345
+        # dedup collapses them (no m_slot0_pos survives; the hole's m_locx covers it). The
+        # win is exact parity with the auto-pass, which only the combined single drain gives
+        # (draining slots and locations separately would place the un-deduped slot position).
+        part = (
+            Box(60, 40, 20)
+            - Box(20, 8, 30)  # slot: long_axis X, near edge x=-10
+            - Pos(-10, 14, 0) * Cylinder(3, 30)  # hole X coincides with the slot near edge
+            - Pos(20, 14, 0) * Cylinder(3, 30)
+            - Pos(8, -14, 0) * Cylinder(3, 30)
+        )
+        keys = lambda d: {  # noqa: E731
+            n for n in d.annotations() if n.startswith("m_slot") or n.startswith("m_loc")
+        }
+        auto = build_drawing(part)
+
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        slot = next(f for f in dwg.model().features if f.kind == "slot")
+        dwg.dimension(slot, "length", role="slot_width")
+        dwg.dimension(slot, "length", role="slot_length")
+        for h in (f for f in dwg.model().features if f.kind in ("hole", "pattern")):
+            dwg.locate(h)
+        dwg.finalize()
+
+        # exact parity with the auto-pass: the coincident slot-position + hole-location
+        # collapsed to one in the shared solve (no stray m_slot0_pos), size dims placed.
+        assert keys(dwg) == keys(auto)
+        assert "m_slot0_pos" not in dwg.annotations()  # deduped against the coincident hole
+        assert dwg._intents == []
+
     @staticmethod
     def _hc_ys(d):
         return sorted(


### PR DESCRIPTION
## What

**Phase 2b of #426 — the last planned piece of the record-then-finalize epic.** Phase 2a routed both-axes `locate()` intents through the ADR-0009 location corridor but deferred **slots**. This routes them, so a `--script` reconstruction places slots at auto-pass quality instead of greedy live-replay.

## The deferred "granularity" question, resolved

A `SlotFeature` records only its two **size** dims (`slot_width`/`slot_length`) via `dimension()`, but the auto-pass `render_slots` also places a model-derived datum **position** dim that no verb records. Today those recorded slot dimension intents fall to **leg-A live-replay** (greedy `dim_length*` names, no corridor, no `#345` dedup, no position dim).

## How — widen B2, don't add a leg

Slots register into the **same** plan/side corridor as hole locations and must drain in **one** `solve_corridor` pass — that's what lets a slot position coincident with a hole location collapse to a single dim (`#345`). So finalize's B2 becomes: register locations → register slots → **single** `drain_corridors`.

- `render_slots` gains `only=None` — skips filtered slots **in place** (keeps `enumerate`, so `i` stays the model index and `m_slot{i}_*` names match the auto-pass). `only=None` (auto-pass) is byte-identical. The private `m_slot` namespace never collides, so this is the *entire* naming seam — no per-item re-scan / max-index+1 needed (simpler than every prior phase).
- `finalize()` builds `slot_ids`/`slot_feats`, skips them in leg A, calls `render_slots(only=slot_feats)` alongside `render_locations` in B2, drains once, prunes `slot_ids` after (retry-safe).

**Granularity caveat (documented in the finalize docstring):** routing a slot feature regenerates its position dim, so finalize places a *superset* of the recorded slot intents — auto-pass parity by design; commenting one of a slot's two `dimension()` lines still routes the feature.

## Tests

- `test_finalize_routes_slots_through_render_slots` — slot size dims reach auto-pass `m_slot*` parity (not live `dim_length*`), intents drained.
- `test_finalize_slot_position_dedups_with_a_coincident_hole_location` — a slot position coincident with a hole location dedups to exact auto-pass parity via the single shared drain (no stray `m_slot0_pos`).
- Full local gate: ruff + format + full-package mypy clean; byte-identity corpus + slot snapshots + `TestFeatureEdits` (74) green.

Refs #426 (Phase 2b), #345 (the dedup this relies on), ADR 0009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)