### PR TITLE
feat: route dense-scattered hole-table escalation through finalize() — #426 Phase 4c (#434)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -693,13 +693,10 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
 def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_page):
     """Pattern sheet furniture, added once its callout is placed (#92). Driven by the
     IR `PatternFeature` *feat* (members / bcd / pitch / grid), not a recogniser
-    `Pattern` — ADR 0008 Amendment 6."""
+    `Pattern` — ADR 0008 Amendment 6. Plain (unpatterned) plan callouts carry no
+    furniture; their scattered-hole-table coverage is recorded at the emit site (not
+    here) so it survives finalize's ``place_furniture=False`` (#426 Ph4c)."""
     if feat is None:
-        if view == "plan":
-            # A plain (unpatterned) plan-view callout — a candidate the scattered-hole
-            # table may replace (#351 PR-4c). Scoped to plan only, matching the table's
-            # own scope: front/side callouts are never table-replaceable.
-            dwg._cover_scattered_hole_doc(f"hc_{view}{j}")
         return
     members = feat.members
     # Remember the bore-callout name AND the holes it documents (by position), so a
@@ -1427,9 +1424,15 @@ def _annotate_holes(
             i = start_i
             for s, _elbow_y, leader in sorted(placed, key=lambda p: p[0][4]):
                 _locs, dia, callout, feat, _ny, rep = s
-                dwg.add(
-                    leader, _hc_name(view, i), view=view, feature=_feat_of_callout.get(id(callout))
-                )
+                name = _hc_name(view, i)
+                dwg.add(leader, name, view=view, feature=_feat_of_callout.get(id(callout)))
+                # A plain (unpatterned) plan callout is a scattered-hole-table candidate
+                # (#351): record its coverage against the ACTUAL placed name, regardless of
+                # place_furniture, so finalize (place_furniture=False) still lets
+                # _maybe_tabulate_holes find + replace it (#426 Ph4c). Coverage-only, so the
+                # auto-pass (place_furniture=True) set is unchanged → byte-identical.
+                if view == "plan" and feat is None:
+                    dwg._cover_scattered_hole_doc(name)
                 if place_furniture:  # #426: finalize's furniture() replay owns furniture
                     _add_furniture(dwg, a, view, i, feat, to_page)
                 i += 1

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -920,7 +920,12 @@ class Drawing:
           — the row-below / column-left set-solve;
         * **(B3b, Phase 4b)** a turned shaft's step-length **chain** through
           ``render_step_lengths`` — the unified chain / ``N× v`` collapse / staggered tiers;
-        * **(C)** the ``section`` renders last (its room check clears the side view's right).
+        * **(C)** the ``section`` renders last (its room check clears the side view's right);
+        * **(D, Phase 4c)** dense-scattered plan holes escalate to the hole **table** + balloon
+          ring via ``_maybe_tabulate_holes`` — last, so it sees the section + title block as
+          obstacles. The density gate counts *all* analysis holes, so this is a full-
+          reconstruction escalation (a partial hand-edit still tabulates the full count, #434);
+          ``_escalations`` is cleared after so a repeat batch can't re-fire the fixed-name table.
 
         A slot records two size dims (``slot_width``/``slot_length``) on one feature; routing
         the feature also regenerates its model-derived datum **position** dim, so finalize
@@ -947,6 +952,7 @@ class Drawing:
             render_step_lengths,
         )
         from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
+        from draftwright.annotations.orchestrator import _maybe_tabulate_holes
         from draftwright.annotations.sections import (
             _add_section_view,
             _reserve_section_row,
@@ -1097,6 +1103,21 @@ class Drawing:
             if _section is not None:
                 assert a is not None
                 _add_section_view(self, a, _section)
+            # (D, Phase 4c) dense-scattered plan-view holes escalate to the hole TABLE +
+            #     balloon ring — LAST, mirroring the auto-pass (_maybe_tabulate_holes runs
+            #     last in _auto_annotate) so the resolver sees the section + title block as
+            #     obstacles. It reads _escalations (the callout/location drops B1/B2 collected)
+            #     and the scattered-hole coverage recorded at the hole emit site even under
+            #     place_furniture=False (#426 Ph4c) to find + replace the plan callouts. The
+            #     density gate counts ALL analysis holes (a.holes), so this is a FULL-
+            #     reconstruction escalation: a partial hand-edit that drops some callout() lines
+            #     still tabulates the full count (documented full-reconstruction scope, #434).
+            #     Clear _escalations after so a repeat finalize batch can't re-fire against stale
+            #     drops and collide on the fixed name hole_table_plan.
+            if routable:
+                assert a is not None
+                _maybe_tabulate_holes(self, a)
+                self._escalations = []
         finally:
             self._defer_intents = deferred
 

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -173,3 +173,65 @@ def test_ctc02_top_balloon_ring_hugs_dimensions():
         f"a plan balloon floats {gap:.0f} mm above the dimension stack — the pre-#125 "
         f"stale-cursor phantom corridor was ~150 mm; expected a small standoff"
     )
+
+
+def _dense_scattered_plate():
+    """20 unpatterned Z-holes of distinct diameters — dense enough that even the
+    auto-grown sheet (#121) can't fit their callouts, so the plan view escalates to a
+    hole table + balloon ring (#93). The naturally-occurring escalation trigger in the
+    fast-buildable range (CTC-02 is the STEP-fixture equivalent)."""
+    import itertools
+
+    from build123d import Box, Cylinder, Pos
+
+    cols = [-40 + i * 20 for i in range(5)]  # 5 columns × 4 rows = 20 holes
+    part = Box(90, 60, 12)
+    for i, (c, y) in enumerate(itertools.product(range(5), [-18, -6, 6, 18])):
+        part -= Pos(cols[c], y, 0) * Cylinder(1.0 + i * 0.2, 20)  # distinct radii → unpatterned
+    return part
+
+
+@pytest.mark.slow
+@pytest.mark.timeout(600)
+def test_dense_scattered_reconstruction_rebuilds_the_hole_table():
+    """#426 Phase 4c: a dense scattered plan view escalates to a hole TABLE + balloon ring.
+    A detect-only record→finalize reconstruction (mirroring what the --script emitter writes
+    per hole: callout + locate + furniture) must reproduce the SAME escalation the auto-pass
+    produces — the table, the balloon tag set, and NO orphaned hc_plan* callouts — and stay
+    lint-clean. Before the Phase 4c fix (coverage recorded under place_furniture=False + leg D
+    running _maybe_tabulate_holes), finalize left every plan callout on the sheet alongside the
+    table (duplicate documentation), because the coverage the resolver removes was never
+    registered."""
+    part = _dense_scattered_plate()
+
+    def snap(dwg):
+        ann = dwg.annotations()
+        return (
+            "hole_table_plan" in ann,
+            frozenset(n.split("_")[2] for n in ann if n.startswith("balloon_plan_")),
+            frozenset(n for n in ann if n.startswith("hc_plan")),
+        )
+
+    auto = build_drawing(part)
+    assert "hole_table_plan" in auto.annotations(), "fixture must escalate in the auto-pass"
+    auto_codes = {i.code for i in auto.lint() if i.severity in ("warning", "error")}
+
+    dwg = build_drawing(part, auto_dims=False)
+    with dwg.deferred():
+        for f in dwg.model().features:
+            if getattr(f, "kind", None) in ("hole", "pattern"):
+                dwg.callout(f)
+                dwg.locate(f)
+                dwg.furniture(f)
+
+    assert snap(dwg) == snap(auto)  # same table + balloon tags, no orphaned callouts
+    assert not [n for n in dwg.annotations() if n.startswith("hc_plan")]  # no duplicate callouts
+    assert dwg._intents == []  # drained
+    assert dwg._escalations == []  # leg D cleared the consumed escalations (retry-safe)
+    # Lint no worse than the auto-pass (the epic's soft-acceptance bar): the reconstruction
+    # introduces NO warning/error code the auto-pass doesn't already have — no new
+    # callout_dropped / location_ref_dropped / table_dropped. (It is a strict subset here:
+    # the table covers the tabulated holes identically, but the finalize routing happens to
+    # avoid an incidental view_annotation_overlap the auto-pass leaves.)
+    fin_codes = {i.code for i in dwg.lint() if i.severity in ("warning", "error")}
+    assert fin_codes <= auto_codes

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5029,6 +5029,33 @@ class TestFeatureEdits:
         assert "m_slot0_pos" not in dwg.annotations()  # deduped against the coincident hole
         assert dwg._intents == []
 
+    def test_finalize_records_scattered_hole_coverage_without_furniture(self):
+        # #426 Phase 4c: finalize routes hole callouts through _annotate_holes with
+        # place_furniture=False (furniture is replayed by its own furniture() intents). The
+        # scattered-hole-table COVERAGE — which plan callouts _maybe_tabulate_holes may replace
+        # — used to be recorded ONLY inside _add_furniture, gated behind place_furniture, so
+        # finalize never registered it. The fix records coverage at the callout emit site
+        # regardless of the gate; the finalize scattered-doc set must equal the auto-pass set
+        # (and be non-empty), so the resolver can find + replace those callouts. Coverage-only,
+        # so the auto-pass output is unchanged (guarded by the byte-identity corpus).
+        part = _multi_hole_plate()
+
+        def docs(d):
+            return {n for n in d.annotations() if d._is_scattered_hole_doc(n)}
+
+        auto = build_drawing(part)
+        assert docs(auto), "auto-pass must register scattered-hole-doc coverage"
+
+        dwg = build_drawing(part, auto_dims=False)
+        with dwg.deferred():
+            for f in dwg.model().features:
+                if getattr(f, "kind", None) in ("hole", "pattern"):
+                    dwg.callout(f)
+                    dwg.locate(f)
+        assert docs(dwg) == docs(auto)  # coverage restored under place_furniture=False
+        assert dwg._intents == []  # drained
+        assert dwg._escalations == []  # leg D ran + cleared them for retry safety
+
     @staticmethod
     def _hc_ys(d):
         return sorted(


### PR DESCRIPTION
The final deferred piece of the **#426 record-then-finalize** build-out. A detect-only `record→finalize` reconstruction of a genuinely dense scattered part (≥16 unpatterned Z-holes) now escalates to the same **hole table + balloon ring** the auto-pass produces, instead of orphaning per-hole callouts alongside the table.

## Why it wasn't a one-leg add (the #434 blocker)

finalize's leg B1 runs `_annotate_holes(place_furniture=False)`, and the *only* site that recorded a plain plan callout into the scattered-hole coverage state was `_add_furniture` — behind the `place_furniture` gate. So finalize never registered the `hc_plan*` callouts that `_maybe_tabulate_holes` **removes** before adding the table. Dropping the resolver in as-is would add the table **and leave the callouts** → duplicate documentation.

## The 3-part fix

1. **`holes.py`** — record `_cover_scattered_hole_doc(name)` for plain plan callouts at the **emit site** (against the actual placed name), regardless of `place_furniture`. Coverage-only, so the auto-pass (`place_furniture=True`) set is unchanged → **byte-identical**.
2. **`drawing.py`** — add **leg D**: `_maybe_tabulate_holes(self, a)` last (mirroring the auto-pass, so it sees the section + title block as obstacles), then **clear `_escalations`** so a repeat finalize batch can't re-fire against stale drops and collide on the fixed name `hole_table_plan`.
3. **Density-gate scope = full-reconstruction-only (Option A)** — the gate counts *all* analysis holes, not the recorded subset. A partial hand-edit that drops some `callout()` lines still tabulates the full count; documented, **not** plumbed through the auto-pass resolver (avoids poking the most byte-identity-sensitive fn for a case the emitter never produces). Option B (thread `only` into the gate) rejected as scope-creep for a corner the emitter can't reach.

## Tests

- **Fast** — coverage parity: finalize's scattered-hole-doc set equals the auto-pass set under `place_furniture=False` (proves fix 1, the unblock).
- **Slow** (`@pytest.mark.slow`) — end-to-end WIN: a 20-hole distinct-diameter plate reconstructs the **same table + balloon tag set, zero `hc_plan` orphans**, intents drained + escalations cleared, and lint **no-worse-than the auto-pass** (it's actually a strict subset — finalize avoids an incidental `view_annotation_overlap` the auto-pass leaves). The escalation trigger is slow-tier by nature (only parts too dense for even the auto-grown sheet escalate — CTC-02 is the STEP equivalent).

Full local gate clean: ruff + `ruff format` + full-package `mypy src/draftwright/`; byte-identity corpus + drop-completeness + escalation/hole-table + finalize suite green.

Closes #434. **This completes the #426 record-then-finalize epic** (P1–P5 + 2b + 4c all landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)