### PR TITLE
fix: dimension a narrow band hidden under a larger OD silhouette (#298)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -578,6 +578,28 @@ def _mentioned_diameters(dwg) -> set[float]:
     return diams
 
 
+def _place_what_fits(specs, axis: int, min_gap: float, lo: float, hi: float):
+    """Fit as many ø specs as the strip ``[lo, hi]`` holds at ``min_gap`` spacing,
+    dropping the SMALLEST-diameter spec first when the full set overflows — so the
+    significant ODs survive and only the finest bands fall to ``feature_not_dimensioned``,
+    never the whole row/column (#298). ``specs`` = ``[(tip, dia, label, feat), ...]``;
+    ``axis`` selects the strip coordinate of ``tip`` (0 = page-x for the row-below, 1 =
+    page-y for the column-left). Returns ``(survivors_in_strip_order, positions)`` —
+    ``([], [])`` if not even one fits. A part whose full row already fits keeps every
+    spec in strip order, so existing output is unchanged."""
+    survivors = sorted(specs, key=lambda s: s[0][axis])
+    while survivors:
+        naturals = [s[0][axis] for s in survivors]
+        pos = _solve_strip_ys(naturals, min_gap, lo, hi) or _greedy_strip_ys(
+            naturals, min_gap, lo, hi
+        )
+        if pos is not None:
+            return survivors, pos
+        drop = min(range(len(survivors)), key=lambda i: survivors[i][1])
+        survivors.pop(drop)
+    return [], []
+
+
 def _diameter_row_below(dwg, items, start: int = 0) -> int:
     """ø-callout row BELOW the front view for X-turned step/boss diameters (#77).
     *items* is ``[(anchor, diameter), ...]``. The row is dropped clear of anything
@@ -599,28 +621,23 @@ def _diameter_row_below(dwg, items, start: int = 0) -> int:
     label_y = obstacle_bottom - (draft.font_size + 4 * draft.pad_around_text)
     if label_y < _MARGIN + draft.font_size:
         return 0
-    specs = []  # (tip_page, label, feature), tip on the step's bottom silhouette
+    specs = []  # (tip_page, dia, label, feature), tip on the step's bottom silhouette
     for anchor, dia, feat in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
-        specs.append((tip, f"ø{_fmt(dia)}", feat))
-    specs.sort(key=lambda s: s[0][0])
-    half_w = max(len(label) for _, label, _ in specs) * draft.font_size * 0.62 / 2
+        specs.append((tip, dia, f"ø{_fmt(dia)}", feat))
+    half_w = max(len(label) for _, _, label, _ in specs) * draft.font_size * 0.62 / 2
     min_gap = 2 * half_w + 2 * draft.pad_around_text
-    naturals = [tip[0] for tip, _, _ in specs]
-    xs = _solve_strip_ys(naturals, min_gap, fx0 + half_w, fx1 - half_w) or _greedy_strip_ys(
-        naturals, min_gap, fx0 + half_w, fx1 - half_w
-    )
-    if xs is None:
-        return 0
-    for i, ((tip, label, feat), lx) in enumerate(zip(specs, xs, strict=True)):
+    # Place what fits; drop the smallest ø first, never the whole row (#298).
+    survivors, xs = _place_what_fits(specs, 0, min_gap, fx0 + half_w, fx1 - half_w)
+    for i, ((tip, dia, label, feat), lx) in enumerate(zip(survivors, xs, strict=True)):
         dwg.add(
             Leader(tip=(tip[0], tip[1], 0), elbow=(lx, label_y, 0), label=label, draft=draft),
             f"m_dia_x{start + i}",
             view="front",
             feature=feat,
         )
-    return len(specs)
+    return len(survivors)
 
 
 def _diameter_column_left(dwg, items, start: int = 0) -> int:
@@ -636,27 +653,22 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
     elbow_x = fx0 - (draft.font_size + 2 * draft.pad_around_text)
     if elbow_x - label_w < _MARGIN:
         return 0
-    specs = []  # (tip_page, label, feature), tip on the step's left silhouette
+    specs = []  # (tip_page, dia, label, feature), tip on the step's left silhouette
     for anchor, dia, feat in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax - dia / 2, ay, az)
-        specs.append((tip, f"ø{_fmt(dia)}", feat))
-    specs.sort(key=lambda s: s[0][1])
+        specs.append((tip, dia, f"ø{_fmt(dia)}", feat))
     half_h = draft.font_size / 2 + draft.pad_around_text
     min_gap = 2 * half_h
-    naturals = [tip[1] for tip, _, _ in specs]
-    ys = _solve_strip_ys(naturals, min_gap, fy0 + half_h, fy1 - half_h) or _greedy_strip_ys(
-        naturals, min_gap, fy0 + half_h, fy1 - half_h
-    )
-    if ys is None:
-        return 0
+    # Place what fits; drop the smallest ø first, never the whole column (#298).
+    survivors, ys = _place_what_fits(specs, 1, min_gap, fy0 + half_h, fy1 - half_h)
     # Full-footprint occupancy (leader shafts, witness/extension lines, hatch) — NOT
     # the label-box-only `_occupied_boxes`, which is blind to a bore callout's leader
     # SHAFT, so a ø label could silently overprint it (the #133/#225/#305 invisible-
     # occupant class, #358). Centre lines stay crossable (a diameter dim may cross one).
     occupied = strip_obstacles(dwg, view="front", crossable=CROSSABLE_TYPES)
     placed = 0
-    for i, ((tip, label, feat), ly) in enumerate(zip(specs, ys, strict=True)):
+    for i, ((tip, dia, label, feat), ly) in enumerate(zip(survivors, ys, strict=True)):
         ldr = Leader(tip=(tip[0], tip[1], 0), elbow=(elbow_x, ly, 0), label=label, draft=draft)
         if _box_hits(_anno_box(ldr), occupied):
             continue  # would overprint a bore leader / existing callout — drop just this one

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -117,6 +117,7 @@ def _distinct_by_diameter(bosses, tol: float = 0.15):
     return list(out.values())
 
 
+_DIA_TOL = 0.15  # two ø values within this (mm) are the same diameter (#298)
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
 
 
@@ -216,6 +217,21 @@ def build_part_model(
                     span=((lo[0], lo[1], lo[2]), (hi[0], hi[1], hi[2])),
                 )
             )
+        # A narrow external band nested under / beside a larger OD reads as that OD in
+        # local_od's max(), so it never becomes a step diameter and goes silently
+        # undimensioned (#298). Emit each band the silhouette steps miss as a boss, so
+        # render_diameters still gives it a ø callout — aligning the callout inventory
+        # with the feature_diameters inventory the coverage lint checks against.
+        step_dias = [s.diameter for s in prof.steps]
+        raw_bosses = find_bosses(part) if bosses is None else bosses
+        for b in _distinct_by_diameter(raw_bosses):
+            if all(abs(b.diameter - d) > _DIA_TOL for d in step_dias):
+                features.append(
+                    BossFeature(
+                        frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
+                        diameter=b.diameter,
+                    )
+                )
     else:
         raw_bosses = find_bosses(part) if bosses is None else bosses
         bosses_d = _distinct_by_diameter(raw_bosses)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6277,6 +6277,41 @@ class TestTurnedDiameters:
         dwg = build_drawing(_x_stepped_shaft())  # must not raise
         assert not any(n.startswith("m_dia") for n in dwg._named)
 
+    def test_nested_band_under_silhouette_gets_a_callout(self):
+        # #298: a narrow ø6 external band sits under the ø30 flange silhouette, so
+        # find_turned_steps' local_od max() reads it as ø30 and it never becomes a step
+        # diameter. detect.py now emits the missed band as a boss, so it still gets a ø
+        # callout (matching the feature_diameters coverage inventory) and the part lints
+        # clean. The overall part is large enough for all three callouts to fit the row.
+        from build123d import Align
+
+        def cyl(r, h, z):
+            return Pos(0, 0, z) * Cylinder(r, h, align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+        part = Rotation(0, 90, 0) * (cyl(3, 0.5, 0.0) + cyl(15, 20, 0.5) + cyl(10, 15, 20.5))
+        dwg = build_drawing(part)
+        labels = {o.label for n, o in dwg._named.items() if n.startswith("m_dia")}
+        assert {"ø6", "ø30", "ø20"} <= labels  # the nested ø6 is now called out
+        assert dwg.lint_summary()["by_code"].get("feature_not_dimensioned", 0) == 0
+
+    def test_diameter_row_places_what_fits_not_all_or_nothing(self):
+        # #298 hardening: on a part too small to fit every ø callout in the row, the
+        # placer keeps the significant ODs and drops only the smallest — never the whole
+        # row (the pre-fix all-or-nothing dropped all three). The finest band honestly
+        # surfaces as feature_not_dimensioned.
+        from build123d import Align
+
+        def cyl(r, h, z):
+            return Pos(0, 0, z) * Cylinder(r, h, align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+        # A ~4 mm shaft: ø6 tip, ø10 flange, ø8 body — three callouts won't fit the row.
+        part = Rotation(0, 90, 0) * (cyl(3, 0.5, 0.0) + cyl(5, 1.7, 0.5) + cyl(4, 2.0, 2.2))
+        dwg = build_drawing(part)
+        labels = {o.label for n, o in dwg._named.items() if n.startswith("m_dia")}
+        assert {"ø10", "ø8"} <= labels  # the significant ODs survive, not dropped wholesale
+        undim = {i.message.split()[2] for i in dwg.lint() if i.code == "feature_not_dimensioned"}
+        assert "ø6" in undim  # only the finest band falls to honest lint
+
 
 class TestTurnedLengths:
     """Axial step-length chain for X-axis turned parts (the drive-screw gap:


### PR DESCRIPTION
On a turned part, a short external band nested under a longer flange's silhouette — **GRM-03's ø6 boss under the ø10 thumbwheel disc** — was silently undimensioned: lint reported `feature_not_dimensioned: cylindrical feature ø6 has no diameter callout`.

## Root cause — two disagreeing inventories
- **Callout path** (`detect.py`) builds `StepFeature`s from `find_turned_steps`, whose `local_od()` takes the **max** external radius over each axial position (padded by `_OD_SPAN_PAD=0.7 mm`). A narrow band under a larger OD collapses to that OD, so it never becomes a step diameter — and a `StepFeature` carries only *one* diameter, so the nested band has nowhere to live.
- **Coverage lint** checks `feature_diameters` (via `find_bosses`), which enumerates *every* external band including the nested one → correctly flags the gap.

## Fix (two parts)
1. **`detect.py`** — in the turned branch, emit a `BossFeature` for each external band the silhouette steps *miss* (diameter not already a step diameter), so `render_diameters` gives it a ø callout, aligning the callout inventory with the lint inventory. A normal stepped shaft misses no band → no bosses added → **output unchanged**.
2. **`from_model.py`** — the ø-callout **row-below / column-left placers were all-or-nothing**: if the extra callout didn't fit the strip, they dropped the *whole* row (worse than before on a tiny part). New `_place_what_fits` keeps the significant ODs and **drops the smallest ø first**, so only the finest band falls to `feature_not_dimensioned`, never the whole row. A part whose full row already fits is byte-identical.

## Verified against the real GRM-03 geometry
Reconstructed from the `pzfreo/gramel` `thumbwheel_drive_screw` parameters (journal ø4, boss ø6, disc ø10 — the `0.3` edge chamfer gives the issue's `ø10 [0.8, 2.2]` band, unthreaded ø5, M3 thread ø3):

| | `m_dia` callouts | `feature_not_dimensioned` |
|---|---|---|
| **before (main)** | ø3, ø4, ø5, ø10 | **ø6** |
| **after** | ø3, ø4, ø5, ø6, ø10 | *(none)* |

All 5 diameters fit the row, so GRM-03 never hits the place-what-fits drop.

## Tests
- `test_nested_band_under_silhouette_gets_a_callout` — a large part with a tiny ø6 tip now calls out ø6/ø20/ø30, lint clean.
- `test_diameter_row_places_what_fits_not_all_or_nothing` — a ~4 mm shaft keeps ø10/ø8 and drops only ø6 (place-what-fits, not all-or-nothing).
- Existing turned diameter/length/step tests, the byte-identity corpus, and the layout snapshots are unchanged; smoke tier green.

The **spurious sub-mm phantom step** (the issue's secondary symptom) is geometry-specific and did not reproduce in the reconstruction — left for a follow-up.

Closes #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)