### PR TITLE
feat: declarative drawing surface — the IR as a public input (ADR 0011 Phase 0+1, #446)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,16 @@ Current ADRs:
   `intent → [names]` **once** at the intent→render seam, with an `origin` back-link
   on IR features. The registry's `_anno_feature` (#398b) is the sink; the seam is
   the automatic populator. Re-plans #398c–e, enables #400.
+- **0011** — **Accepted** (Phase 0+1 landed; Phase 2 pending): **the IR as a public
+  input** — declare features, don't only detect them. `build_drawing(part, model=…)`
+  accepts a caller-supplied `PartModel`/`Sequence[Feature]` and **skips detection**;
+  object→feature constructors (`model.hole`/`boss`/`step`/`slot`/`pattern`/`envelope`)
+  read a feature's size off the build123d object you built (⌀ from the cylindrical
+  face; axis/location from the bbox), with an explicit-value flavour. The fluent
+  `Sheet` façade (`draftwright.Sheet`) is the "beautiful-Python" surface over the
+  existing renderers. Aspects geometry can't carry (tolerance/GD&T/finish) are a
+  side-layer, deferred to Phase 2 (#61/#62). Sidesteps #298 misdetection; complements
+  #400 (read + edit → now also input). Roadmap: #446; vision: #445.
 
 ## Dependencies
 

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -1,0 +1,120 @@
+# ADR 0011 — The IR as a public input: declare features, don't only detect them
+
+- **Status:** Accepted — Phase 0 (the `model=` seam + object→feature constructors) and
+  Phase 1 (the `Sheet` façade) landed; Phase 2 (aspect renderers — tolerance/GD&T/finish)
+  pending per the #446 roadmap.
+- **Date:** 2026-07-05
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+draftwright compiles a solid into a drawing through one waist: the **IR
+`PartModel`** — a list of frozen `Feature` dataclasses (ADR 0008). Everything
+downstream of it — the planner, render-intents, the ADR-0009 layout, lint,
+export — reads *that*, never the raw solid. Today there is exactly **one producer**
+of the IR: **feature detection** (`recognition/` → `build_part_model`), which
+recovers features from the finished solid's silhouettes.
+
+Detection is the right default — the common case is "hand me a STEP, draw it." But
+it has two structural limits:
+
+1. **It can be wrong.** Silhouette recognition misclassifies. #298 is the canonical
+   case: a ⌀6 band nested under a ⌀10 OD collapsed to ⌀10 in the max-silhouette read
+   and went silently undimensioned; detection's own `feature_diameters` also *missed
+   a blind hole entirely* in the #445 prototype. The engine cannot always out-detect
+   the person who built the part.
+2. **It re-derives what the caller already knows.** When the part is built
+   parametrically (e.g. the `pzfreo/gramel` `thumbwheel_drive_screw`, which holds
+   `boss_diameter = 6`, `thread = "M3"` as literal parameters), re-recovering ⌀6 from
+   the silhouette is redundant at best and, per (1), unreliable at worst.
+
+ADR 0001 Amendment 1 established that *both inputs converge at the detected IR* and
+that the edit surface is the model; #400 made the model a **read** surface
+(`dwg.model()`) plus imperative edit verbs (`callout`/`locate`/`dimension`/`section`).
+The missing half is symmetric: let the caller **supply the IR as an input**, so
+detection becomes *a* producer of the model, not the *only* one.
+
+The `proto/declare-features` spike proved the seam is small: the orchestrator already
+honours a pre-set `dwg._part_model` (`orchestrator.py:170`) — `build_drawing` merely
+always overwrote it with detection.
+
+## Decision
+
+Make the IR `PartModel` a **first-class public input**, on equal footing with
+detection. Concretely:
+
+1. **A `model=` input to the build entry point.** `build_drawing(part, model=…)`
+   accepts a caller-supplied `PartModel` (or a `Sequence[Feature]`, wrapped with the
+   part's bbox + a default corner datum). When supplied, **detection is skipped** and
+   the auto-pass renders the declared features. `model=None` is the unchanged default —
+   detect. Detection and declaration are two producers of the *same* IR; **everything
+   downstream is untouched.**
+
+2. **Object → feature constructors.** `hole` / `boss` / `step` / `slot` / `pattern` /
+   `envelope` read a feature's geometry off a known build123d object (a cylindrical
+   face → radius / axis / location) — *geometry supplies the value* — with an
+   explicit-value flavour (`hole(diameter=6, at=…, axis="z")`) for parametric code
+   that never built a discrete tool.
+
+3. **Declaration is not all-or-nothing — the hybrid is first-class.** The caller may
+   start from `dwg.model()` (detected) and **override** specific features. Declaration
+   is for where you know better than detection, not everywhere.
+
+4. **Aspects geometry cannot carry attach as decorations, not on the frozen IR.** A
+   *tolerance* is a property of a **dimension** (`DimParameter`); *GD&T* and *surface
+   finish* are annotation kinds **keyed to a feature/face** in a decoration side-layer
+   consumed by their renderers. The frozen `Feature` schema stays clean, so every
+   existing consumer keeps ignoring what it does not understand. (The renderers
+   themselves are deferred engine work — #61 / #62.)
+
+The declarative `model=` path is the **from-scratch authoring** mode ("I know all the
+features"); the #400 imperative verbs remain the **incremental-edit** mode ("this
+detected drawing needs one more thing"). Two complementary modes, one IR.
+
+## Consequences
+
+- **Misdetection becomes recoverable by construction** — you declare ⌀6 and it is
+  drawn as ⌀6, full stop. The #298 class of bug cannot silence a feature you named.
+- **Parametric/generated code reads as the drawing** — you reference the feature you
+  built and decorate it with intent; no restating numbers the model owns. This is the
+  foundation of the #445 "beautiful-Python drawing DSL".
+- **The IR schema becomes a public contract.** Its field shapes are now an API surface,
+  so changes to `Feature`/`DimParameter` carry versioning discipline they did not before.
+- **The detector is no longer privileged.** It is one front-end; a future front-end
+  (PMI, a CAD feature tree, an LLM) can produce the same IR.
+- **Known caveat — analysis and the coverage lint still detect.** `_analyse` recovers
+  `a.holes` etc. to size the sheet and estimate strips, and `lint_feature_coverage`
+  re-detects the part's holes/diameters to check coverage — both independently of
+  `model=`. So a supplied model overrides *dimensioning*, but sheet estimation still
+  detects (the auto-scale heuristic may differ slightly), and a **partial** declaration
+  is correctly flagged by the coverage lint for the geometry it left undimensioned (the
+  drawing is right — those features genuinely have no callout). A full declared-model
+  bypass of estimation + coverage is a follow-up, not a blocker.
+
+## Alternatives considered
+
+- **Improve detection only.** Necessary and ongoing, but it cannot close the gap: #298
+  shows the engine cannot always out-detect the author, and parametric callers already
+  hold the exact values. Detection stays the default; this ADR adds a second producer,
+  it does not replace the first.
+- **Imperative edit verbs only (the #400 surface).** Complementary, kept — but
+  "I know every feature" is inherently *declarative*, and driving a from-scratch drawing
+  through per-annotation imperative calls is more ceremony than declaring the model and
+  letting the auto-pass place it coherently.
+- **Tag build123d objects with drawing metadata as you model.** Couples the modelling
+  code to draftwright's vocabulary and spreads drawing intent through the part build;
+  the `model=` input keeps the two concerns separate (build the part, then describe its
+  drawing).
+- **Extend the frozen IR with tolerance/GD&T fields.** Rejected for the schema churn and
+  because tolerance is per-dimension, not per-feature; the decoration side-layer keeps
+  the IR minimal and the existing consumers untouched.
+
+## Relationship to other ADRs
+
+- **Extends ADR 0001 Amendment 1** (both inputs converge at the detected IR) — the
+  caller is now a first-class *producer* of that IR, not only an editor of it.
+- **Builds on ADR 0008** (the unified feature model / dimensioning planner) — the
+  PartModel waist is exactly the seam that makes a single `model=` input possible with
+  zero downstream change.
+- **Complements #400** (the editable surface): read (`dwg.model()`) + edit (verbs) +
+  now **input** (`model=`).

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -91,6 +91,18 @@ detected drawing needs one more thing"). Two complementary modes, one IR.
   is correctly flagged by the coverage lint for the geometry it left undimensioned (the
   drawing is right — those features genuinely have no callout). A full declared-model
   bypass of estimation + coverage is a follow-up, not a blocker.
+- **Known caveat — the hole/pattern render path is gated on detected positions.**
+  Distinct from the diameter/step/boss/envelope path (which renders straight from the IR),
+  the *hole and pattern* renderers gate on `feature_keys` — the set of detected hole
+  positions (`feature_holes_of(a)`, the Amendment-6 invariant that no recogniser `Hole`
+  crosses into the renderers). So a declared hole/pattern only renders where its members
+  coincide (to 3 dp) with a **detected** hole; a hole that detection *missed* renders
+  nothing (it surfaces as a coverage **warning**, not silently). This means declaration
+  fully sidesteps misdetection for the #298 class (a band under an OD — a *diameter*
+  feature, not gated) but **not** for a missed hole. The canonical fix — sourcing
+  `feature_keys` from the declared model when `model=` is supplied — is tracked as a
+  follow-up (**#448**), not a blocker: the common declared-hole case (declared positions
+  match the built geometry) renders correctly.
 
 ## Alternatives considered
 

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -2,7 +2,8 @@
 
 - **Status:** Accepted — Phase 0 (the `model=` seam + object→feature constructors) and
   Phase 1 (the `Sheet` façade) landed; Phase 2 (aspect renderers — tolerance/GD&T/finish)
-  pending per the #446 roadmap.
+  pending per the #446 roadmap. Phase 2 execution plan:
+  [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
 - **Date:** 2026-07-05
 - **Deciders:** Paul Fremantle (pzfreo)
 

--- a/docs/plans/0011-phase2-aspects-roadmap.md
+++ b/docs/plans/0011-phase2-aspects-roadmap.md
@@ -1,0 +1,160 @@
+# ADR 0011 Phase 2 — aspect renderers roadmap
+
+Execution roadmap for **Phase 2** of [ADR 0011](../adr/0011-ir-as-public-input.md)
+(the IR as a public input). Phase 0 (the `model=` seam + object→feature
+constructors) and Phase 1 (the fluent `Sheet` façade over today's renderers) have
+landed; Phase 2 is the **aspect layer** — the drawing information geometry cannot
+carry: tolerance, fit, surface finish, and GD&T. Vision: **#445**. Parent
+roadmap: **#446**. Each work item below is one PR (split if it grows).
+
+## The reframing: Phase 2 is wiring + placement, not primitive authoring
+
+ADR 0011 §4 and the #446 north-star describe GD&T / finish as "the genuinely new
+engine work." A survey of the installed `build123d-drafting-helpers` **0.13.0**
+(the pinned floor) shows that is **no longer true at the primitive level** — every
+glyph already exists:
+
+| Aspect | Helpers primitive (0.13.0) | Status |
+|---|---|---|
+| Bilateral ± tolerance | `Dimension(tolerance=float)` → `"20.00 ±0.05"` | renders today |
+| Limit tolerance | `Dimension(tolerance=(lo, hi))` → `"20 +0.1 -0.0"` | renders today |
+| Basic (boxed) dim | `Dimension(basic=True)` | renders today |
+| Surface finish (Ra check-mark, ISO 1302) | `SurfaceFinish(ra_value, position)` | renders today |
+| Feature control frame (all 14 ISO 1101 chars, ⌀, Ⓜ/Ⓛ/Ⓟ) | `FeatureControlFrame`, `CompositeFeatureControlFrame` | renders today |
+| Datum feature / datum target (ISO 5459) | `DatumFeature`, `DatumTarget` | renders today |
+| Fit-class `⌀20 H7` → ± deviation | — | **the one real gap (ISO 286 table)** |
+
+So Phase 2 is **carrying the authored intent through the compiler and placing the
+symbol**, not drawing it. The current state confirms the work is threading + one
+placement API, because **neither the IR nor the renderer has any hook today**:
+
+- **IR** — `DimParameter` (`model/ir.py:52`) and every `Feature` subclass are
+  `@dataclass(frozen=True)` and **value-only**; no `tolerance`/`fit`/GD&T/`finish`
+  field anywhere. The one "tolerance" in the system is the drawing-level general
+  tolerance string in the title block (`_core.py:512`, `_add_title_block`).
+- **Planner** — `plan_dimensions` (`model/planner.py:201`) wraps each `DimParameter`
+  in a frozen `PlannedDimension` (`planner.py:64`) whose only reserved-for-future
+  intent field is `datum` (for #238 location work). No tolerance path.
+- **Renderer** — every dimension label is a bare `_fmt(value)` string passed to the
+  `_dim(...)` helper (`_core.py:149`) → `Dimension(..., label=…)`. There is **no
+  tolerance-suffix or symbol hook** in the label chain.
+- **Registry** — the ADR 0010 provenance sink `AnnotationRegistry._anno_feature`
+  (`registry.py:43`, name→feature, post-render) proves feature-keyed side maps work
+  (value-equality keying on frozen features, `names_for_feature` `registry.py:68`),
+  but it points the *opposite* direction from what an authored decoration needs
+  (feature→aspect, pre-render). A decoration side-layer is a **new but structurally
+  identical peer map** that slots into the same snapshot/restore/clear machinery.
+- **Lint** — `linting/structural.py:134-138` already exempts datum targets, datum
+  features, and *surface-finish marks* from view-overlap linting — anticipatory
+  carve-outs for renderers that don't exist yet. So placed GD&T/finish participates
+  in `lint()` for free.
+
+## Where aspects live (ADR 0011 §4, confirmed against the code)
+
+1. **Tolerance / fit → the dimension.** A tolerance is a property of a
+   `DimParameter` (a dimension is toleranced). It rides as an optional field on the
+   IR's value carrier — *not* on a `Feature`, keeping the frozen feature schema
+   clean.
+2. **GD&T / finish → a decoration side-layer keyed to a feature/face.** A new peer
+   map on `AnnotationRegistry`, authored pre-render, consumed by a render pass that
+   calls the placement API. The placed annotations then get `feature=`-tagged
+   through the existing `add(...)` seam, so they flow into the same provenance sink
+   with zero new plumbing.
+3. **Authored intent enters via a `decorations=` input**, threaded alongside
+   `model=` through `build_drawing` → `_assemble` → `_repack` (both passes), exactly
+   as `model=` is today (`builder.py:208/295/482/484`).
+
+## Work items
+
+Ordered to front-load the cheapest, highest-value item and isolate the
+placement-hard GD&T behind a reusable primitive.
+
+### P2a — Toleranced dimensions (bilateral / limit) · #28
+
+The self-contained value-shipping PR.
+
+- Add optional `tolerance: float | tuple[float, float] | None = None` to
+  `DimParameter` (`model/ir.py:52`). ADR 0011 §4 sanctions "tolerance is a property
+  of a `DimParameter`."
+- A `decorations` side-layer `{(feature, role) → tolerance}` (keyed by frozen
+  feature value-equality + `Role`), threaded via
+  `build_drawing(part, model=…, decorations=…)` and through `_repack`.
+- `plan_dimensions` consults it to set the tolerance on the `PlannedDimension` /
+  param (`planner.py:207-220`).
+- `_core._dim` gains a `tolerance` passthrough to `Dimension(tolerance=…)`
+  (`_core.py:149`) — the helpers primitive does the formatting.
+- `Sheet`: `.tolerance(x)` / `.tolerance(lo, hi)` chainable handle on the
+  `diameter` / `step` / `hole` declarations.
+- Tests: bilateral + limit render into the label; decoration survives repack;
+  no-decoration path byte-unchanged.
+
+### P2a.2 — Fit-class deviation (`.fit("h6")`) · #29
+
+The lone genuine (c) gap — helpers has no fit-code semantics.
+
+- A small ISO 286 table in draftwright: `(fit_code, nominal_⌀) → (lower, upper)`
+  deviation (h6/H7/g6/js… — the common shaft/hole classes), feeding P2a's
+  tolerance path.
+- `Sheet`: `.fit("h6")` on a diameter handle.
+- Optional label form: render `⌀20 H7` (class) vs `⌀20 ±dev` (deviation) — config,
+  default deviation.
+
+### P2b — GD&T + finish placement API (#61) · #30
+
+The reusable low-level primitive both the declarative verbs (P2c) and the PMI
+auto-path (P2d) render through. Purely manual placement (caller supplies the target
+point) per #61 v1.
+
+- `dwg.place_fcf(target, characteristic, tolerance, datums=…, diameter=…,
+  modifier=…)`, `dwg.place_datum(letter, target, side=…)`,
+  `dwg.place_finish(ra_value, target)`.
+- Each builds a `Leader(callout=FeatureControlFrame | DatumFeature |
+  SurfaceFinish)` (the helpers `Leader.callout=` param hangs any sketch at the shelf
+  end) and routes through the **`Strip`** layout so frames stack clear of the part
+  and of each other — mirroring `place_dim()` (#25).
+- The hard part is anchoring + leader routing + strip stacking; the glyphs are all
+  helpers primitives.
+- Read-side pairing (#61 note): a `datum_candidates()` helper surfacing the part's
+  natural datum edges/faces (the min-X / min-Y corner is already the dimension
+  datum) so a script can anchor `place_datum` without guessing coordinates.
+
+### P2c — Sheet declarative aspect verbs · #31
+
+The #445 vision surface over P2a + P2b.
+
+- `sheet.datum("A", face)`, `diameter(journal).finish("Ra 0.8")`,
+  `sheet.control(target).cylindricity(0.02).circular_runout(0.05, to=A)
+  .perpendicular(0.05, to=B)` — each verb returns a small chainable handle.
+- Records into the new `AnnotationRegistry` decoration peer map keyed to
+  feature/face; a render pass reads it and calls the P2b placement API.
+- **No fake verbs** — a verb ships only once the renderer behind it exists
+  (the Phase-1 discipline).
+
+### P2d — Auto-GD&T from STEP PMI (#62) · #32 · later
+
+Complementary, not on the P2a→P2c critical path.
+
+- Wire `pmi.py`'s already-extracted `gtol` / `datum` `PmiRecord`s into P2b's
+  `place_fcf` / `place_datum` under `pmi="annotate"` (today they hit a "not yet
+  annotatable (Phase 4)" debug log).
+- Second producer, same placement path — the read/auto complement to P2c's
+  declarative authoring.
+
+## Dependency graph
+
+```
+P2a (#28) ─┬─ P2a.2 (#29)
+           └─ P2c (#31) ── (also needs) ── P2b (#30) ── P2d (#32)
+```
+
+Suggested landing order: **P2a → P2a.2** (tolerance is a small, self-contained PR
+that ships visible value fast), then **P2b → P2c** (the GD&T / finish stack),
+**P2d** whenever PMI-carrying STEP input matters.
+
+## Non-goals for Phase 2
+
+- Surface-finish variants beyond the basic Ra check-mark (no-removal circle, lay
+  direction, machining allowance) — helpers doesn't model them; defer.
+- Composite/exotic GD&T modifiers beyond the common set already in helpers.
+- The two Phase-0 caveats (sheet estimation + coverage lint still detect
+  independently of `model=`) — tracked separately; not aspect work.

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -30,6 +30,7 @@ _LAZY = {
     "make_drawing": "draftwright.builder",
     "Drawing": "draftwright.drawing",
     "FeatureInfo": "draftwright.drawing",
+    "Sheet": "draftwright.sheet_dsl",
     "fix_svg_page_size": "draftwright.export",
     "lint_feature_coverage": "draftwright.linting",
     "PmiRecord": "draftwright.pmi",
@@ -78,6 +79,7 @@ if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel co
     from draftwright.linting import lint_feature_coverage
     from draftwright.pmi import PmiRecord, extract_pmi
     from draftwright.sheet import choose_scale
+    from draftwright.sheet_dsl import Sheet
 
 
 def __dir__():
@@ -91,6 +93,7 @@ __all__ = [
     "Drawing",
     "FeatureInfo",
     "PmiRecord",
+    "Sheet",
     "analyse_face_levels",
     "build_drawing",
     "choose_scale",

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -698,7 +698,7 @@ def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_pa
     here) so it survives finalize's ``place_furniture=False`` (#426 Ph4c)."""
     if feat is None:
         return
-    members = feat.members
+    members = feat.members or (feat.frame.origin,)  # guard a declared pattern's empty members
     # Remember the bore-callout name AND the holes it documents (by position), so a
     # later hole-table escalation leaves the grouped pattern callout standing and
     # tabulates only the holes no *placed* pattern callout covers (#92).

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -391,8 +391,12 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
             # Anchor on an actual member hole, not `feat.frame.origin` — for a
             # bolt circle / grid that's the pattern's geometric centre, which
             # isn't a hole, so the leader would point at solid material instead
-            # of the pattern it documents.
-            SimpleNamespace(location=feat.members[0], diameter=feat.member.diameter),
+            # of the pattern it documents.  Fall back to the centre only if a
+            # declared pattern left `members` empty (detected ones never do).
+            SimpleNamespace(
+                location=(feat.members or (feat.frame.origin,))[0],
+                diameter=feat.member.diameter,
+            ),
         )
         for tag, feat in zip(pattern_tags, pattern_feats, strict=True)
     ]

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -455,9 +455,13 @@ def build_drawing(
             ``boss``, ``step``, … from the objects you built). When given, **feature
             detection is skipped** and the auto-pass dimensions exactly the declared
             features; ``None`` (default) detects normally. Detection and declaration are
-            two producers of the same IR — everything downstream is untouched. (Note:
+            two producers of the same IR — everything downstream is untouched. (Notes:
             sheet scale/zone estimation and the coverage lint still detect independently,
-            so a *partial* declaration will flag the undeclared geometry — ADR 0011.)
+            so a *partial* declaration will flag the undeclared geometry; and the
+            hole/pattern renderer gates on detected hole positions, so a declared
+            hole/pattern renders only where it coincides with a detected hole — a missed
+            hole is flagged, not drawn (#448). Diameter/step/boss/envelope features are
+            not gated. See ADR 0011.)
 
     Returns:
         A :class:`Drawing` with the standard front/plan/side/iso views projected

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -9,6 +9,7 @@ stage modules -- never make_drawing -- so the graph stays a DAG.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
 from typing import Literal
@@ -39,7 +40,7 @@ from draftwright.annotate import _auto_annotate, build_model
 from draftwright.annotations.sections import feature_hole_keys
 from draftwright.drawing import Drawing
 from draftwright.fonts import PLEX_MONO
-from draftwright.model import display, plan_sections
+from draftwright.model import Datum, Feature, PartModel, StepFeature, display, plan_sections
 from draftwright.projection import (
     _fit_iso_view,
     _project_iso,
@@ -189,7 +190,22 @@ def _measure_blocks(dwg, a) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _assemble(a, out, assembly, detail_view, auto_dims) -> Drawing:
+def _coerce_model(model, a) -> PartModel:
+    """Wrap a caller-supplied ``model=`` (ADR 0011) into a :class:`PartModel`. A
+    ``PartModel`` is used verbatim; a sequence of features is wrapped with the part's
+    bbox, a default corner location datum (matching ``detect.py``, so hole location
+    dims measure from the min corner), and an orientation inferred from any turned
+    ``StepFeature`` (so a declared shaft renders as turned)."""
+    if isinstance(model, PartModel):
+        return model
+    features = list(model)
+    bbox = a.part.bounding_box()
+    orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
+    datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
+    return PartModel(bbox=bbox, orientation=orientation, features=features, datums=[datum])
+
+
+def _assemble(a, out, assembly, detail_view, auto_dims, model=None) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
     repacked analysis it is also pass 2 of the measure-and-repack loop (#121)."""
@@ -214,7 +230,7 @@ def _assemble(a, out, assembly, detail_view, auto_dims) -> Drawing:
     # Detect the IR here — before the auto_dims gate — so dwg.model() and feature edits
     # work even in manual mode (#398). _auto_annotate reads this attached model rather
     # than rebuilding. On a repack this runs again on the pass-2 drawing (freshness).
-    dwg._part_model = build_model(a)
+    dwg._part_model = _coerce_model(model, a) if model is not None else build_model(a)
 
     part_s = a.part.scale(a.SCALE)
     dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)
@@ -276,7 +292,7 @@ def _repack_candidates(a, scale, page):
     return list(_LADDER[start:])
 
 
-def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
+def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None, model=None):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
     when a view collides across views, pack the blocks disjoint — escalating the
     sheet/scale until the packed layout fits — then re-assemble (#121, ADR 0004 —
@@ -391,7 +407,7 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None):
         pv_zones=pv_zones,
         sv_zones=sv_zones,
     )
-    dwg2 = _assemble(a2, out, assembly, detail_view, auto_dims=True)
+    dwg2 = _assemble(a2, out, assembly, detail_view, auto_dims=True, model=model)
     return a2, dwg2
 
 
@@ -409,6 +425,7 @@ def build_drawing(
     pmi: Literal["off", "report", "annotate"] = "off",
     repair: bool = True,
     assembly: bool | None = None,
+    model: Sequence[Feature] | PartModel | None = None,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -433,6 +450,14 @@ def build_drawing(
             assembly, whose per-part bores are reported at ``info`` rather than
             ``warning`` (a GA omits them by design). Force with ``True``/``False``
             (#69).
+        model: a caller-supplied IR (ADR 0011) — a :class:`PartModel`, or a sequence
+            of :class:`Feature`\\ s (declared with :func:`draftwright.model.hole`,
+            ``boss``, ``step``, … from the objects you built). When given, **feature
+            detection is skipped** and the auto-pass dimensions exactly the declared
+            features; ``None`` (default) detects normally. Detection and declaration are
+            two producers of the same IR — everything downstream is untouched. (Note:
+            sheet scale/zone estimation and the coverage lint still detect independently,
+            so a *partial* declaration will flag the undeclared geometry — ADR 0011.)
 
     Returns:
         A :class:`Drawing` with the standard front/plan/side/iso views projected
@@ -454,9 +479,9 @@ def build_drawing(
     # per-view footprints and re-pack the blocks disjoint if a view actually
     # moves (#121, ADR 0004 — "lay out, don't predict").  Non-ballooned parts
     # measure ≈ estimate, so they skip pass 2 and stand byte-identical.
-    dwg = _assemble(a, out, assembly, detail_view, auto_dims)
+    dwg = _assemble(a, out, assembly, detail_view, auto_dims, model=model)
     if auto_dims:
-        repacked = _repack(a, dwg, out, assembly, detail_view, scale=scale, page=page)
+        repacked = _repack(a, dwg, out, assembly, detail_view, scale=scale, page=page, model=model)
         if repacked is not None:
             a, dwg = repacked
     if repair:

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -21,6 +21,7 @@ width/depth, slots) and by the lint coverage checks. Remaining engine passes
 
 from __future__ import annotations
 
+from draftwright.model.declare import boss, envelope, hole, pattern, slot, step
 from draftwright.model.detect import build_part_model
 from draftwright.model.ir import (
     BossFeature,
@@ -65,6 +66,12 @@ __all__ = [
     "StepFeature",
     "StepLevelFeature",
     "build_part_model",
+    "boss",
+    "envelope",
+    "hole",
+    "pattern",
+    "slot",
+    "step",
     "display",
     "SectionPlan",
     "plan_dimensions",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -24,6 +24,8 @@ shape with no cylindrical face, should use the explicit flavour.
 
 from __future__ import annotations
 
+import math
+
 from draftwright.model.ir import (
     BossFeature,
     EnvelopeFeature,
@@ -51,7 +53,11 @@ def _bbox_axis_dia(obj) -> tuple[str, float, Point]:
 def _read_cylinder(obj) -> tuple[str, float, Point]:
     """(axis, diameter, centre) for a cylindrical tool. The diameter is taken from the
     largest cylindrical *face* — robust where a bbox drifts (a chamfered or partial
-    cylinder); axis + centre come from the bbox (sufficient for the letter-based IR)."""
+    cylinder); axis + centre come from the bbox (sufficient for the letter-based IR).
+
+    Caveat: on an object with several cylindrical faces (a counterbore, a tube) the
+    *largest* radius wins — it reads the counterbore / OD, not the bore. Pass an explicit
+    ``diameter=`` for those (a counterbore is declared via the ``cbore=`` param anyway)."""
     axis, dia, center = _bbox_axis_dia(obj)
     try:
         from build123d import GeomType
@@ -93,7 +99,8 @@ def hole(
     describe a machining-spec group drawn as one ``count×`` callout."""
     if obj is not None:
         axis, diameter, at = _read_cylinder(obj)
-    assert diameter is not None and at is not None and axis is not None
+    if diameter is None or at is None or axis is None:
+        raise ValueError("hole() needs an object, or explicit diameter=, at= and axis=")
     return HoleFeature(
         frame=Frame(origin=at, axis=axis),
         diameter=diameter,
@@ -111,7 +118,8 @@ def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:
     ``boss(diameter=6, at=(0, 0, 0), axis="x")`` (parametric)."""
     if obj is not None:
         axis, diameter, at = _read_cylinder(obj)
-    assert diameter is not None and at is not None and axis is not None
+    if diameter is None or at is None or axis is None:
+        raise ValueError("boss() needs an object, or explicit diameter=, at= and axis=")
     return BossFeature(frame=Frame(origin=at, axis=axis), diameter=diameter)
 
 
@@ -124,7 +132,8 @@ def step(obj=None, *, diameter=None, length=None, at=None, axis=None, span=None)
         axis, diameter, at = _read_cylinder(obj)
         bb = obj.bounding_box()
         length = [bb.size.X, bb.size.Y, bb.size.Z]["xyz".index(axis)]
-    assert diameter is not None and length is not None and at is not None and axis is not None
+    if diameter is None or length is None or at is None or axis is None:
+        raise ValueError("step() needs an object, or explicit diameter=, length=, at= and axis=")
     if span is None:
         span = _span(at, axis, length)
     return StepFeature(
@@ -147,7 +156,11 @@ def slot(
     """A milled slot / reduced across-flats section. From an object the three bbox spans
     are read as long_axis (longest) / width_axis (middle) / depth (shortest, not stored);
     ``lo``/``hi`` are the extent along the long axis and ``w_center`` the centre across the
-    width axis. Explicit values override any read."""
+    width axis. Explicit values override any read.
+
+    Caveat: the object read assumes width > depth (a slot wider than it is deep). For a
+    slot cut *deeper than it is wide* the middle/shortest spans swap — pass explicit
+    ``width_axis=``/``width=`` for that case."""
     if obj is not None:
         bb = obj.bounding_box()
         c = bb.center()
@@ -162,14 +175,10 @@ def slot(
         )
         (long_axis, length, lo, hi, _), (width_axis, width, _, _, w_center), _ = spans
         at = (c.X, c.Y, c.Z)
-    assert (
-        width is not None
-        and length is not None
-        and long_axis is not None
-        and width_axis is not None
-        and lo is not None
-        and hi is not None
-    )
+    if None in (width, length, long_axis, width_axis, lo, hi):
+        raise ValueError(
+            "slot() needs an object, or explicit width=, length=, long_axis=, width_axis=, lo= and hi="
+        )
     if at is None:
         # Centre on the long axis at the slot midpoint; other coords irrelevant to the size dims.
         origin = [0.0, 0.0, 0.0]
@@ -188,6 +197,64 @@ def slot(
     )
 
 
+def _plane_axes(axis: str) -> tuple[Point, Point]:
+    """The two in-plane unit directions for a pattern lying perpendicular to *axis*."""
+    return {
+        "x": ((0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),
+        "y": ((0.0, 0.0, 1.0), (1.0, 0.0, 0.0)),
+        "z": ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
+    }[axis]
+
+
+def _pattern_members(
+    kind, center: Point, axis: str, count, *, bcd, pitch, direction, grid, rows, cols, angle
+) -> tuple[Point, ...]:
+    """The member-hole centres for an arrangement, so a declared pattern is shaped like a
+    detected one (``detect._pattern_feature`` always populates ``members``; the balloon /
+    BCD / pitch furniture index them). Points are laid out about *center* — matching the
+    detector's convention that a bolt-circle / grid frame origin is the pattern centre."""
+    u, v = _plane_axes(axis)
+
+    def pt(du: float, dv: float) -> Point:
+        return tuple(center[k] + du * u[k] + dv * v[k] for k in range(3))  # type: ignore[return-value]
+
+    if kind == "bolt_circle":
+        r = (bcd or 0.0) / 2
+        a0 = math.radians(angle or 0.0)
+        return tuple(
+            pt(
+                r * math.cos(a0 + 2 * math.pi * i / count),
+                r * math.sin(a0 + 2 * math.pi * i / count),
+            )
+            for i in range(count)
+        )
+    if kind == "linear":
+        d = direction or u
+        n = math.sqrt(sum(c * c for c in d)) or 1.0
+        d = tuple(c / n for c in d)
+        p = pitch or 0.0
+        return tuple(
+            tuple(center[k] + (i - (count - 1) / 2) * p * d[k] for k in range(3))
+            for i in range(count)
+        )
+    if kind == "grid":
+        rp, cp = grid or (0.0, 0.0)
+        a0 = math.radians(angle or 0.0)
+        pts = []
+        for rr in range(rows or 1):
+            for cc in range(cols or 1):
+                gx = (cc - ((cols or 1) - 1) / 2) * cp
+                gy = (rr - ((rows or 1) - 1) / 2) * rp
+                pts.append(
+                    pt(
+                        gx * math.cos(a0) - gy * math.sin(a0),
+                        gx * math.sin(a0) + gy * math.cos(a0),
+                    )
+                )
+        return tuple(pts)
+    return ()  # "other" — no defined arrangement; the caller must pass members explicitly
+
+
 def pattern(
     member: HoleFeature,
     *,
@@ -204,17 +271,35 @@ def pattern(
     cols=None,
     angle=None,
 ) -> PatternFeature:
-    """A hole pattern = ``count`` × a *member* hole (build one with :func:`hole`).
-    Explicit only — the arrangement (``bolt_circle`` / ``linear`` / ``grid``) and its
-    defining dims (``bcd`` / ``pitch`` / ``grid``) are supplied, not read. ``at`` / ``axis``
-    default to the member's frame."""
-    frame = Frame(origin=at, axis=axis) if at is not None and axis is not None else member.frame
+    """A hole pattern = ``count`` × a *member* hole (build one with :func:`hole`). The
+    arrangement (``bolt_circle`` / ``linear`` / ``grid``) and its defining dims (``bcd`` /
+    ``pitch`` / ``grid`` + ``rows``/``cols``/``angle``) are supplied, not read.
+
+    ``at`` (the pattern **centre**) and ``axis`` default to the member's frame. The member
+    centres are computed from the arrangement so the pattern renders like a detected one
+    (its ``count×`` balloon, BCD centreline and pitch dims anchor on ``members``); pass
+    ``members=`` explicitly to override the computed layout (required for ``kind="other"``)."""
+    axis = axis or member.frame.axis
+    center = at if at is not None else member.frame.origin
+    members = tuple(members) or _pattern_members(
+        kind,
+        center,
+        axis,
+        count,
+        bcd=bcd,
+        pitch=pitch,
+        direction=direction,
+        grid=grid,
+        rows=rows,
+        cols=cols,
+        angle=angle,
+    )
     return PatternFeature(
-        frame=frame,
+        frame=Frame(origin=center, axis=axis),
         pattern=kind,
         count=count,
         member=member,
-        members=tuple(members),
+        members=members,
         bcd=bcd,
         pitch=pitch,
         direction=direction,

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -281,19 +281,30 @@ def pattern(
     ``members=`` explicitly to override the computed layout (required for ``kind="other"``)."""
     axis = axis or member.frame.axis
     center = at if at is not None else member.frame.origin
-    members = tuple(members) or _pattern_members(
-        kind,
-        center,
-        axis,
-        count,
-        bcd=bcd,
-        pitch=pitch,
-        direction=direction,
-        grid=grid,
-        rows=rows,
-        cols=cols,
-        angle=angle,
-    )
+    members = tuple(members)
+    if not members:
+        # Compute the arrangement — but only if its defining dim is present, else the
+        # members would silently collapse onto the centre (r=0 / pitch=0) and the pattern
+        # would never render. Fail loudly instead, matching the hole/boss/step/slot guards.
+        _defining = {"bolt_circle": bcd, "linear": pitch, "grid": grid}
+        if kind == "other" or (kind in _defining and _defining[kind] is None):
+            raise ValueError(
+                f"pattern(kind={kind!r}) needs its arrangement dim "
+                "(bolt_circle→bcd, linear→pitch, grid→grid), or explicit members="
+            )
+        members = _pattern_members(
+            kind,
+            center,
+            axis,
+            count,
+            bcd=bcd,
+            pitch=pitch,
+            direction=direction,
+            grid=grid,
+            rows=rows,
+            cols=cols,
+            angle=angle,
+        )
     return PatternFeature(
         frame=Frame(origin=center, axis=axis),
         pattern=kind,

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -298,31 +298,32 @@ def pattern(
     axis = _norm_axis(axis or member.frame.axis)
     center = at if at is not None else member.frame.origin
     members = tuple(members)
+
+    # Validate the arrangement up front, *whether or not* members are supplied: the furniture
+    # pass reads bcd/pitch/grid to draw the BCD centreline / pitch / grid dims, so a known
+    # rendered kind needs its defining dim even when the caller overrides the member layout
+    # (a missing or zero dim else crashes the furniture, or collapses computed members onto
+    # the centre). Only 'other' — a bare group with no arrangement furniture — is exempt, and
+    # it must carry explicit members. Fail loudly, matching the hole/boss/step/slot guards.
+    if kind == "bolt_circle" and not bcd:
+        raise ValueError("pattern(kind='bolt_circle') needs a nonzero bcd= (or explicit members=)")
+    elif kind == "linear" and not pitch:
+        raise ValueError("pattern(kind='linear') needs a nonzero pitch= (or explicit members=)")
+    elif kind == "grid" and (not grid or not all(grid) or rows is None or cols is None):
+        raise ValueError(
+            "pattern(kind='grid') needs a nonzero grid= pitch and rows= and cols= "
+            "(or explicit members=)"
+        )
+    elif kind == "other" and not members:
+        raise ValueError("pattern(kind='other') needs explicit members=")
+    elif kind not in ("bolt_circle", "linear", "grid", "other"):
+        raise ValueError(
+            f"pattern(kind={kind!r}) is not a known arrangement (bolt_circle / linear / grid / other)"
+        )
+    if count < 1:
+        raise ValueError(f"pattern() needs count >= 1 (got {count!r})")
+
     if not members:
-        # Compute the arrangement — but only for a known kind with its defining dims
-        # present, else the members would silently collapse onto the centre (r=0 /
-        # pitch=0, or a 1×1 grid) and the pattern would never render. Fail loudly
-        # instead, matching the hole/boss/step/slot guards.
-        _defining = {"bolt_circle": bcd, "linear": pitch, "grid": grid}
-        if kind not in _defining:
-            raise ValueError(
-                f"pattern(kind={kind!r}) needs a computed arrangement "
-                "(bolt_circle→bcd, linear→pitch, grid→grid), or explicit members="
-            )
-        # Reject a missing OR zero defining dim — both collapse every member onto the
-        # centre (r=0 / pitch=0). Truthiness covers None and 0 for the scalar dims; a
-        # grid needs a nonzero pitch in *both* axes plus rows/cols.
-        if kind == "grid":
-            if not grid or not all(grid) or rows is None or cols is None:
-                raise ValueError(
-                    "pattern(kind='grid') needs a nonzero grid= pitch and rows= and cols= "
-                    "(or explicit members=)"
-                )
-        elif not _defining[kind]:
-            raise ValueError(
-                f"pattern(kind={kind!r}) needs a nonzero arrangement dim "
-                "(bolt_circle→bcd, linear→pitch), or explicit members="
-            )
         members = _pattern_members(
             kind,
             center,

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -304,13 +304,25 @@ def pattern(
         # pitch=0, or a 1×1 grid) and the pattern would never render. Fail loudly
         # instead, matching the hole/boss/step/slot guards.
         _defining = {"bolt_circle": bcd, "linear": pitch, "grid": grid}
-        if kind not in _defining or _defining[kind] is None:
+        if kind not in _defining:
             raise ValueError(
                 f"pattern(kind={kind!r}) needs a computed arrangement "
                 "(bolt_circle→bcd, linear→pitch, grid→grid), or explicit members="
             )
-        if kind == "grid" and (rows is None or cols is None):
-            raise ValueError("pattern(kind='grid') needs rows= and cols= (or explicit members=)")
+        # Reject a missing OR zero defining dim — both collapse every member onto the
+        # centre (r=0 / pitch=0). Truthiness covers None and 0 for the scalar dims; a
+        # grid needs a nonzero pitch in *both* axes plus rows/cols.
+        if kind == "grid":
+            if not grid or not all(grid) or rows is None or cols is None:
+                raise ValueError(
+                    "pattern(kind='grid') needs a nonzero grid= pitch and rows= and cols= "
+                    "(or explicit members=)"
+                )
+        elif not _defining[kind]:
+            raise ValueError(
+                f"pattern(kind={kind!r}) needs a nonzero arrangement dim "
+                "(bolt_circle→bcd, linear→pitch), or explicit members="
+            )
         members = _pattern_members(
             kind,
             center,

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -38,6 +38,17 @@ from draftwright.model.ir import (
 )
 
 
+def _norm_axis(axis: str) -> str:
+    """Normalise a user-supplied axis letter to the lowercase ``{x,y,z}`` the IR uses.
+    build123d callers naturally reach for ``"X"``/``"Z"`` (à la ``Axis.X``); the
+    lowercase-letter convention is an IR-internal detail, so accept either and fail
+    clearly on anything else rather than crashing deep in ``"xyz".index(...)``."""
+    a = str(axis).lower()
+    if a not in ("x", "y", "z"):
+        raise ValueError(f"axis must be one of 'x'/'y'/'z' (got {axis!r})")
+    return a
+
+
 def _bbox_axis_dia(obj) -> tuple[str, float, Point]:
     """Read an axis-aligned cylinder's (axis, diameter, centre) off its bounding box:
     the two near-equal spans are the diameter; the odd one out is the bore/OD axis."""
@@ -101,6 +112,7 @@ def hole(
         axis, diameter, at = _read_cylinder(obj)
     if diameter is None or at is None or axis is None:
         raise ValueError("hole() needs an object, or explicit diameter=, at= and axis=")
+    axis = _norm_axis(axis)
     return HoleFeature(
         frame=Frame(origin=at, axis=axis),
         diameter=diameter,
@@ -120,6 +132,7 @@ def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:
         axis, diameter, at = _read_cylinder(obj)
     if diameter is None or at is None or axis is None:
         raise ValueError("boss() needs an object, or explicit diameter=, at= and axis=")
+    axis = _norm_axis(axis)
     return BossFeature(frame=Frame(origin=at, axis=axis), diameter=diameter)
 
 
@@ -134,6 +147,7 @@ def step(obj=None, *, diameter=None, length=None, at=None, axis=None, span=None)
         length = [bb.size.X, bb.size.Y, bb.size.Z]["xyz".index(axis)]
     if diameter is None or length is None or at is None or axis is None:
         raise ValueError("step() needs an object, or explicit diameter=, length=, at= and axis=")
+    axis = _norm_axis(axis)
     if span is None:
         span = _span(at, axis, length)
     return StepFeature(
@@ -179,6 +193,8 @@ def slot(
         raise ValueError(
             "slot() needs an object, or explicit width=, length=, long_axis=, width_axis=, lo= and hi="
         )
+    long_axis = _norm_axis(long_axis)
+    width_axis = _norm_axis(width_axis)
     if at is None:
         # Centre on the long axis at the slot midpoint; other coords irrelevant to the size dims.
         origin = [0.0, 0.0, 0.0]
@@ -279,19 +295,22 @@ def pattern(
     centres are computed from the arrangement so the pattern renders like a detected one
     (its ``count×`` balloon, BCD centreline and pitch dims anchor on ``members``); pass
     ``members=`` explicitly to override the computed layout (required for ``kind="other"``)."""
-    axis = axis or member.frame.axis
+    axis = _norm_axis(axis or member.frame.axis)
     center = at if at is not None else member.frame.origin
     members = tuple(members)
     if not members:
-        # Compute the arrangement — but only if its defining dim is present, else the
-        # members would silently collapse onto the centre (r=0 / pitch=0) and the pattern
-        # would never render. Fail loudly instead, matching the hole/boss/step/slot guards.
+        # Compute the arrangement — but only for a known kind with its defining dims
+        # present, else the members would silently collapse onto the centre (r=0 /
+        # pitch=0, or a 1×1 grid) and the pattern would never render. Fail loudly
+        # instead, matching the hole/boss/step/slot guards.
         _defining = {"bolt_circle": bcd, "linear": pitch, "grid": grid}
-        if kind == "other" or (kind in _defining and _defining[kind] is None):
+        if kind not in _defining or _defining[kind] is None:
             raise ValueError(
-                f"pattern(kind={kind!r}) needs its arrangement dim "
+                f"pattern(kind={kind!r}) needs a computed arrangement "
                 "(bolt_circle→bcd, linear→pitch, grid→grid), or explicit members="
             )
+        if kind == "grid" and (rows is None or cols is None):
+            raise ValueError("pattern(kind='grid') needs rows= and cols= (or explicit members=)")
         members = _pattern_members(
             kind,
             center,

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1,0 +1,240 @@
+"""declare — build IR features directly from known build123d objects (ADR 0011).
+
+The normal path detects features from the finished solid's silhouettes
+(``recognition/`` → ``build_part_model``). When you *built* the part you already
+know its features, so re-detecting them is redundant — and, on nested/exotic
+geometry, unreliable (cf. #298). These constructors turn a known build123d object
+(or explicit values) into the same IR ``Feature`` the detector would emit, so you
+can hand a ``model=[...]`` to :func:`draftwright.build_drawing` (or a
+:class:`draftwright.Sheet`) and skip detection.
+
+Every constructor has two flavours:
+
+- **reference an object** — ``hole(tool_cylinder)`` reads the geometry (⌀ from the
+  cylindrical *face*, axis + location from the bounding box); or
+- **explicit values** — ``hole(diameter=6, at=(20, 10, 0), axis="z")`` for
+  parametric code that never built a discrete tool.
+
+Geometry read is deliberately conservative: the diameter comes from the true
+cylindrical-face radius (robust on a chamfered / partial cylinder, where a bbox
+would drift), while axis + centre come from the bounding box — enough for the IR's
+letter-based :class:`~draftwright.model.ir.Frame`. A non-axis-aligned feature, or a
+shape with no cylindrical face, should use the explicit flavour.
+"""
+
+from __future__ import annotations
+
+from draftwright.model.ir import (
+    BossFeature,
+    EnvelopeFeature,
+    Frame,
+    HoleFeature,
+    PatternFeature,
+    Point,
+    SlotFeature,
+    StepFeature,
+)
+
+
+def _bbox_axis_dia(obj) -> tuple[str, float, Point]:
+    """Read an axis-aligned cylinder's (axis, diameter, centre) off its bounding box:
+    the two near-equal spans are the diameter; the odd one out is the bore/OD axis."""
+    bb = obj.bounding_box()
+    sizes = [bb.size.X, bb.size.Y, bb.size.Z]
+    # The equal pair (smallest span-difference) is the diameter; its complement is the axis.
+    i, j, k = min([(0, 1, 2), (0, 2, 1), (1, 2, 0)], key=lambda p: abs(sizes[p[0]] - sizes[p[1]]))
+    dia = (sizes[i] + sizes[j]) / 2
+    c = bb.center()
+    return "xyz"[k], dia, (c.X, c.Y, c.Z)
+
+
+def _read_cylinder(obj) -> tuple[str, float, Point]:
+    """(axis, diameter, centre) for a cylindrical tool. The diameter is taken from the
+    largest cylindrical *face* — robust where a bbox drifts (a chamfered or partial
+    cylinder); axis + centre come from the bbox (sufficient for the letter-based IR)."""
+    axis, dia, center = _bbox_axis_dia(obj)
+    try:
+        from build123d import GeomType
+
+        faces = obj.faces().filter_by(GeomType.CYLINDER)
+        if faces:
+            dia = 2 * max(f.radius for f in faces)
+    except Exception:
+        pass  # no B-rep face query available — fall back to the bbox diameter
+    return axis, dia, center
+
+
+def _span(at: Point, axis: str, length: float) -> tuple[Point, Point]:
+    """The two axial end-points of a segment of *length* centred at *at* along *axis*."""
+    idx = "xyz".index(axis)
+    lo, hi = list(at), list(at)
+    lo[idx] = at[idx] - length / 2
+    hi[idx] = at[idx] + length / 2
+    return (lo[0], lo[1], lo[2]), (hi[0], hi[1], hi[2])
+
+
+def hole(
+    obj=None,
+    *,
+    diameter=None,
+    at=None,
+    axis=None,
+    through=True,
+    depth=None,
+    cbore=None,
+    spotface=None,
+    count=1,
+    members=(),
+) -> HoleFeature:
+    """A drilled hole. Either ``hole(tool_cylinder)`` — read ⌀ / axis / location off the
+    build123d object you subtracted — or ``hole(diameter=6, at=(20, 10, 0), axis="z")``.
+
+    ``cbore`` / ``spotface`` are ``(diameter, depth)`` pairs; ``count`` + ``members``
+    describe a machining-spec group drawn as one ``count×`` callout."""
+    if obj is not None:
+        axis, diameter, at = _read_cylinder(obj)
+    assert diameter is not None and at is not None and axis is not None
+    return HoleFeature(
+        frame=Frame(origin=at, axis=axis),
+        diameter=diameter,
+        depth=depth,
+        through=through,
+        count=count,
+        members=tuple(members),
+        cbore=cbore,
+        spotface=spotface,
+    )
+
+
+def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:
+    """An external cylindrical boss / OD. Either ``boss(cylinder)`` or
+    ``boss(diameter=6, at=(0, 0, 0), axis="x")`` (parametric)."""
+    if obj is not None:
+        axis, diameter, at = _read_cylinder(obj)
+    assert diameter is not None and at is not None and axis is not None
+    return BossFeature(frame=Frame(origin=at, axis=axis), diameter=diameter)
+
+
+def step(obj=None, *, diameter=None, length=None, at=None, axis=None, span=None) -> StepFeature:
+    """One axial segment of a turned profile — its OD + length. Either ``step(segment)``
+    (⌀ from the cylindrical face, length + centre from the bbox along its axis) or
+    explicit ``step(diameter=4, length=10, at=(0, 0, 0), axis="x")``. ``span`` (the two
+    axial end-points) is derived from ``at`` + ``length`` when not given."""
+    if obj is not None:
+        axis, diameter, at = _read_cylinder(obj)
+        bb = obj.bounding_box()
+        length = [bb.size.X, bb.size.Y, bb.size.Z]["xyz".index(axis)]
+    assert diameter is not None and length is not None and at is not None and axis is not None
+    if span is None:
+        span = _span(at, axis, length)
+    return StepFeature(
+        frame=Frame(origin=at, axis=axis), length=length, diameter=diameter, span=span
+    )
+
+
+def slot(
+    obj=None,
+    *,
+    width=None,
+    length=None,
+    long_axis=None,
+    width_axis=None,
+    w_center=0.0,
+    lo=None,
+    hi=None,
+    at=None,
+) -> SlotFeature:
+    """A milled slot / reduced across-flats section. From an object the three bbox spans
+    are read as long_axis (longest) / width_axis (middle) / depth (shortest, not stored);
+    ``lo``/``hi`` are the extent along the long axis and ``w_center`` the centre across the
+    width axis. Explicit values override any read."""
+    if obj is not None:
+        bb = obj.bounding_box()
+        c = bb.center()
+        spans = sorted(
+            (
+                ("x", bb.size.X, bb.min.X, bb.max.X, c.X),
+                ("y", bb.size.Y, bb.min.Y, bb.max.Y, c.Y),
+                ("z", bb.size.Z, bb.min.Z, bb.max.Z, c.Z),
+            ),
+            key=lambda s: s[1],
+            reverse=True,
+        )
+        (long_axis, length, lo, hi, _), (width_axis, width, _, _, w_center), _ = spans
+        at = (c.X, c.Y, c.Z)
+    assert (
+        width is not None
+        and length is not None
+        and long_axis is not None
+        and width_axis is not None
+        and lo is not None
+        and hi is not None
+    )
+    if at is None:
+        # Centre on the long axis at the slot midpoint; other coords irrelevant to the size dims.
+        origin = [0.0, 0.0, 0.0]
+        origin["xyz".index(long_axis)] = (lo + hi) / 2
+        origin["xyz".index(width_axis)] = w_center
+        at = (origin[0], origin[1], origin[2])
+    return SlotFeature(
+        frame=Frame(origin=at, axis=long_axis),
+        width_axis=width_axis,
+        long_axis=long_axis,
+        width=width,
+        length=length,
+        w_center=w_center,
+        lo=lo,
+        hi=hi,
+    )
+
+
+def pattern(
+    member: HoleFeature,
+    *,
+    kind,
+    count,
+    at=None,
+    axis=None,
+    members=(),
+    bcd=None,
+    pitch=None,
+    direction=None,
+    grid=None,
+    rows=None,
+    cols=None,
+    angle=None,
+) -> PatternFeature:
+    """A hole pattern = ``count`` × a *member* hole (build one with :func:`hole`).
+    Explicit only — the arrangement (``bolt_circle`` / ``linear`` / ``grid``) and its
+    defining dims (``bcd`` / ``pitch`` / ``grid``) are supplied, not read. ``at`` / ``axis``
+    default to the member's frame."""
+    frame = Frame(origin=at, axis=axis) if at is not None and axis is not None else member.frame
+    return PatternFeature(
+        frame=frame,
+        pattern=kind,
+        count=count,
+        member=member,
+        members=tuple(members),
+        bcd=bcd,
+        pitch=pitch,
+        direction=direction,
+        grid=grid,
+        rows=rows,
+        cols=cols,
+        angle=angle,
+    )
+
+
+def envelope(obj) -> EnvelopeFeature:
+    """The overall bounding box of *obj* as width (X) / height (Z) / depth (Y),
+    matching the detector's prismatic envelope."""
+    bb = obj.bounding_box()
+    c = bb.center()
+    return EnvelopeFeature(
+        frame=Frame((c.X, c.Y, bb.min.Z), "z"),
+        width=bb.size.X,
+        height=bb.size.Z,
+        depth=bb.size.Y,
+        bbox_min=(bb.min.X, bb.min.Y, bb.min.Z),
+        bbox_max=(bb.max.X, bb.max.Y, bb.max.Z),
+    )

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -1,0 +1,164 @@
+"""sheet_dsl — the fluent feature-referencing drawing surface (ADR 0011, #445/#446).
+
+Reference the build123d objects you built, declare the drawing aspects they need,
+export. Geometry supplies the size (⌀ read off the object); you supply only the
+intent. Built on the ``model=`` seam (:func:`draftwright.build_drawing`), so
+detection is skipped and the auto-pass dimensions exactly the declared features::
+
+    sheet = Sheet(part, title="PLATE", number="DWG-001")
+    sheet.envelope()
+    sheet.hole(h1)
+    sheet.hole(h2).depth(5)          # a blind hole — adds a depth callout
+    sheet.diameter(boss_cyl)
+    sheet.export("plate")
+
+**Phase 1 scope (this module):** the *feature-declaration* surface over the
+renderers the engine has today — dimensions, ⌀ callouts, holes (through / blind),
+turned steps, slots, patterns, the overall envelope, and the auto section. The
+richer aspect verbs from the #445 vision that need *new* rendering — ``.fit`` /
+``.tolerance`` (toleranced dims), ``.thread``, ``.finish`` (surface symbols) and
+``control(...)`` (GD&T) — are Phase 2 (roadmap #446) and are deliberately **not**
+stubbed here, so the surface only exposes what actually draws.
+
+**Hybrid.** :meth:`Sheet.from_part` seeds the declared set from *detection*, so you
+can start from the detected model and override specific features (declaration is for
+where you know better than detection, not everywhere — ADR 0011 §3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from draftwright.builder import build_drawing
+from draftwright.model import boss as _boss
+from draftwright.model import envelope as _envelope
+from draftwright.model import hole as _hole
+from draftwright.model import pattern as _pattern
+from draftwright.model import slot as _slot
+from draftwright.model import step as _step
+
+
+def _parse_scale(scale):
+    """Accept a float multiplier, a ratio string (``"2:1"`` → 2.0, ``"1:2"`` → 0.5),
+    or ``None`` (auto). The engine's ``scale=`` is a raw float; the ratio string is the
+    drawing-sheet spelling."""
+    if isinstance(scale, str) and ":" in scale:
+        num, den = scale.split(":", 1)
+        return float(num) / float(den)
+    return scale
+
+
+class _Hole:
+    """A fluent handle for one declared hole — the only feature with a Phase-1 aspect
+    (through vs blind, which changes the callout)."""
+
+    def __init__(self, sheet: Sheet, index: int) -> None:
+        self._sheet = sheet
+        self._i = index
+
+    def through(self) -> _Hole:
+        """A through hole (the default) — ⌀ only."""
+        return self._set(through=True, depth=None)
+
+    def depth(self, d: float) -> _Hole:
+        """A blind hole *d* mm deep — adds a depth callout."""
+        return self._set(through=False, depth=d)
+
+    def _set(self, **kw) -> _Hole:
+        self._sheet._features[self._i] = replace(self._sheet._features[self._i], **kw)
+        return self
+
+
+class Sheet:
+    """Reference features, declare their drawing aspects, export.
+
+    Each declaration method mirrors a :mod:`draftwright.model` constructor: pass the
+    build123d object to read its geometry, or explicit values. :meth:`hole` returns a
+    chainable :class:`_Hole` (``.through()`` / ``.depth()``); the others return the
+    ``Sheet`` so declarations can chain. :meth:`build` / :meth:`export` hand the declared
+    features to the engine with detection skipped.
+    """
+
+    def __init__(self, part, *, title=None, number="DWG-001", scale=None, page=None, out=None):
+        self._part = part
+        self._features: list = []
+        self._opts = dict(
+            title=title, number=number, scale=_parse_scale(scale), page=page, out=out
+        )
+
+    @classmethod
+    def from_part(cls, part, **opts) -> Sheet:
+        """Seed the declared set from *detection* (the hybrid mode, ADR 0011 §3): start
+        from the model the detector recovers, then override specific features (edit the
+        list via :attr:`features`, or re-declare) before :meth:`build`."""
+        sheet = cls(part, **opts)
+        sheet._features = list(build_drawing(part).model().features)
+        return sheet
+
+    # -- feature declaration --------------------------------------------------
+
+    def add(self, feature) -> Sheet:
+        """Append a pre-built IR :class:`~draftwright.model.Feature` (escape hatch for
+        the constructors this façade does not surface directly, e.g. PMI)."""
+        self._features.append(feature)
+        return self
+
+    def hole(self, obj=None, **kw) -> _Hole:
+        """Declare a hole from the tool cylinder you subtracted (or explicit values).
+        Returns a fluent handle: ``.through()`` (default) / ``.depth(d)``."""
+        self._features.append(_hole(obj, **kw))
+        return _Hole(self, len(self._features) - 1)
+
+    def diameter(self, obj=None, **kw) -> Sheet:
+        """Declare an external cylindrical diameter (a boss / OD) — the ⌀ is read off the
+        object. The turned/external ⌀-callout verb of the #445 vision."""
+        self._features.append(_boss(obj, **kw))
+        return self
+
+    def boss(self, obj=None, **kw) -> Sheet:
+        """Alias of :meth:`diameter` — an external cylindrical boss / OD."""
+        return self.diameter(obj, **kw)
+
+    def step(self, obj=None, **kw) -> Sheet:
+        """Declare one axial segment of a turned profile (its OD + length). A model with
+        any step renders as a turned part."""
+        self._features.append(_step(obj, **kw))
+        return self
+
+    def slot(self, obj=None, **kw) -> Sheet:
+        """Declare a milled slot / reduced across-flats section (width + length)."""
+        self._features.append(_slot(obj, **kw))
+        return self
+
+    def pattern(self, member, **kw) -> Sheet:
+        """Declare a hole pattern (bolt circle / linear array / grid) — build the
+        *member* with :func:`draftwright.model.hole`."""
+        self._features.append(_pattern(member, **kw))
+        return self
+
+    def envelope(self, obj=None) -> Sheet:
+        """Declare the overall bounding dimensions. Defaults to the whole part."""
+        self._features.append(_envelope(obj if obj is not None else self._part))
+        return self
+
+    # -- inspection / output --------------------------------------------------
+
+    @property
+    def features(self) -> list:
+        """The declared IR features (mutable — override or drop before :meth:`build`)."""
+        return self._features
+
+    def model(self):
+        """The IR the engine will draw (detection skipped) — for inspection."""
+        return self.build().model()
+
+    def build(self):
+        """Build the :class:`~draftwright.drawing.Drawing` — detection skipped; only the
+        declared features are drawn."""
+        return build_drawing(self._part, model=self._features, **self._opts)
+
+    def export(self, stem=None):
+        """Build and export the drawing (SVG + DXF). *stem* defaults to the drawing
+        number, lower-cased."""
+        stem = stem or self._opts["out"] or self._opts["number"].lower()
+        return self.build().export(stem)

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -40,12 +40,21 @@ from draftwright.model import step as _step
 
 def _parse_scale(scale):
     """Accept a float multiplier, a ratio string (``"2:1"`` → 2.0, ``"1:2"`` → 0.5),
-    or ``None`` (auto). The engine's ``scale=`` is a raw float; the ratio string is the
-    drawing-sheet spelling."""
-    if isinstance(scale, str) and ":" in scale:
-        num, den = scale.split(":", 1)
-        return float(num) / float(den)
-    return scale
+    a bare numeric string, or ``None`` (auto). The engine's ``scale=`` is a raw float;
+    the ratio string is the drawing-sheet spelling. Raises ``ValueError`` on a malformed
+    string so a bad scale fails here, not deep in the engine with a str where a float is
+    expected."""
+    if scale is None or isinstance(scale, (int, float)):
+        return scale
+    if isinstance(scale, str):
+        if ":" in scale:
+            num, den = scale.split(":", 1)
+            denom = float(den)
+            if denom == 0:
+                raise ValueError(f"invalid scale ratio {scale!r}: zero denominator")
+            return float(num) / denom
+        return float(scale)  # a bare numeric string; ValueError if not a number
+    raise TypeError(f"scale must be a number, ratio string, or None — got {type(scale).__name__}")
 
 
 class _Hole:

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -242,6 +242,17 @@ class TestModelSeam:
         f = pattern(member, kind="grid", count=4, grid=(10, 10), rows=2, cols=2, at=(0, 0, 0))
         assert len(f.members) == 4
 
+    def test_pattern_zero_arrangement_dim_raises(self):
+        # A zero-valued defining dim collapses every member onto the centre exactly like a
+        # missing one; the guard must reject truthiness, not just is-None.
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="bolt_circle", count=4, bcd=0)
+        with pytest.raises(ValueError):
+            pattern(member, kind="linear", count=3, pitch=0)
+        with pytest.raises(ValueError):
+            pattern(member, kind="grid", count=4, grid=(0, 0), rows=2, cols=2)
+
     def test_pattern_unknown_kind_raises(self):
         # A typo'd / unsupported arrangement name must fail loudly, not fall through to an
         # empty-member degenerate pattern (which renders a wrong count× callout).

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1,0 +1,210 @@
+"""Tests for the declarative drawing surface (ADR 0011): the ``model=`` seam, the
+object→feature constructors (:mod:`draftwright.model.declare`), and the fluent
+:class:`draftwright.Sheet` façade.
+
+The constructors are pure geometry reads (fast); the seam / Sheet tests do a real
+OCC build (fast tier — not marked slow).
+"""
+
+import pytest
+from build123d import Box, Cylinder, GeomType, Pos, Rot
+
+from draftwright import Sheet, build_drawing
+from draftwright.model import (
+    BossFeature,
+    EnvelopeFeature,
+    HoleFeature,
+    PartModel,
+    PatternFeature,
+    SlotFeature,
+    StepFeature,
+    boss,
+    envelope,
+    hole,
+    pattern,
+    slot,
+    step,
+)
+from draftwright.sheet_dsl import _parse_scale
+
+
+class TestConstructors:
+    def test_hole_reads_diameter_axis_location_off_object(self):
+        h = Pos(20, 10, 4) * Cylinder(3, 8)  # r3 -> ø6, axis z, centre (20,10,4)
+        f = hole(h)
+        assert isinstance(f, HoleFeature)
+        assert f.frame.axis == "z"
+        assert f.diameter == pytest.approx(6.0)
+        assert f.frame.origin == pytest.approx((20, 10, 4))
+        assert f.through is True and f.depth is None
+
+    def test_hole_explicit_values(self):
+        f = hole(diameter=6, at=(1, 2, 3), axis="x", through=False, depth=5)
+        assert f.diameter == 6 and f.frame.axis == "x"
+        assert f.through is False and f.depth == 5
+        assert f.frame.origin == (1, 2, 3)
+
+    def test_hole_explicit_cbore(self):
+        f = hole(diameter=6, at=(0, 0, 0), axis="z", cbore=(10, 3), count=4)
+        assert f.cbore == (10, 3) and f.count == 4
+
+    def test_read_cylinder_diameter_is_face_radius(self):
+        c = Pos(0, 0, 0) * Cylinder(3, 8)
+        r = max(fc.radius for fc in c.faces().filter_by(GeomType.CYLINDER))
+        assert boss(c).diameter == pytest.approx(2 * r)
+
+    def test_read_cylinder_falls_back_to_bbox_without_a_cylindrical_face(self):
+        # A box has no cylindrical face — the reader falls back to the bbox heuristic
+        # rather than raising.
+        b = Box(4, 4, 10)  # equal pair (X,Y)=4 -> ø4, odd axis z
+        f = boss(b)
+        assert f.frame.axis == "z" and f.diameter == pytest.approx(4.0)
+
+    def test_boss_explicit(self):
+        f = boss(diameter=6, at=(0, 0, 0), axis="x")
+        assert isinstance(f, BossFeature) and f.diameter == 6 and f.frame.axis == "x"
+
+    def test_step_reads_diameter_length_off_object(self):
+        seg = Rot(0, 90, 0) * Cylinder(2, 10)  # r2 -> ø4, length 10, axis x
+        f = step(seg)
+        assert isinstance(f, StepFeature)
+        assert f.frame.axis == "x"
+        assert f.diameter == pytest.approx(4.0)
+        assert f.length == pytest.approx(10.0)
+        # span is the two axial end-points, ±length/2 along the axis
+        (lo, hi) = f.span
+        assert hi[0] - lo[0] == pytest.approx(10.0)
+
+    def test_step_explicit_derives_span(self):
+        f = step(diameter=4, length=10, at=(0, 0, 0), axis="x")
+        assert f.span == ((-5.0, 0.0, 0.0), (5.0, 0.0, 0.0))
+
+    def test_slot_explicit(self):
+        f = slot(width=6, length=20, long_axis="x", width_axis="y", lo=-10, hi=10, w_center=0)
+        assert isinstance(f, SlotFeature)
+        assert f.width == 6 and f.length == 20
+        assert f.long_axis == "x" and f.width_axis == "y"
+
+    def test_slot_reads_axes_off_object_by_span(self):
+        # A milled slot tool: longest span = length/long axis, middle = width/width axis.
+        tool = Box(20, 6, 4)  # X longest -> long_axis x, Y middle -> width_axis y
+        f = slot(tool)
+        assert f.long_axis == "x" and f.width_axis == "y"
+        assert f.length == pytest.approx(20.0) and f.width == pytest.approx(6.0)
+
+    def test_envelope_reads_bbox(self):
+        f = envelope(Box(80, 50, 8))
+        assert isinstance(f, EnvelopeFeature)
+        assert f.width == pytest.approx(80) and f.depth == pytest.approx(50)
+        assert f.height == pytest.approx(8)
+
+    def test_pattern_composes_member(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        f = pattern(member, kind="bolt_circle", count=6, bcd=40)
+        assert isinstance(f, PatternFeature)
+        assert f.pattern == "bolt_circle" and f.count == 6 and f.bcd == 40
+        assert f.member is member
+
+
+class TestModelSeam:
+    def test_declared_model_skips_detection(self):
+        # The plate has TWO holes; declare only ONE. Detection would find both, so a
+        # model with exactly one hole proves detection was bypassed.
+        plate = Box(80, 50, 8)
+        h1 = Pos(20, 10, 4) * Cylinder(3, 8)
+        h2 = Pos(-20, 10, 4) * Cylinder(3, 8)
+        part = plate - h1 - h2
+        dwg = build_drawing(part, model=[envelope(plate), hole(h1)])
+        kinds = [f.kind for f in dwg.model().features]
+        assert kinds.count("hole") == 1
+
+    def test_fully_declared_plate_is_lint_clean(self):
+        plate = Box(80, 50, 8)
+        h1 = Pos(20, 10, 4) * Cylinder(3, 8)
+        h2 = Pos(-20, 10, 4) * Cylinder(3, 8)
+        part = plate - h1 - h2
+        dwg = build_drawing(part, model=[envelope(plate), hole(h1), hole(h2)])
+        warns = [i for i in dwg.lint() if i.severity in ("warning", "error")]
+        assert warns == [], [i.code for i in warns]
+
+    def test_partial_declaration_is_flagged_by_coverage_lint(self):
+        # ADR 0011 caveat: the coverage lint re-detects, so a partial declaration is
+        # correctly flagged for the geometry it left undimensioned.
+        plate = Box(80, 50, 8)
+        h1 = Pos(20, 10, 4) * Cylinder(3, 8)
+        h2 = Pos(-20, 10, 4) * Cylinder(3, 8)
+        part = plate - h1 - h2
+        dwg = build_drawing(part, model=[envelope(plate), hole(h1)])
+        codes = {i.code for i in dwg.lint() if i.severity in ("warning", "error")}
+        assert "feature_count_mismatch" in codes
+
+    def test_orientation_inferred_from_step(self):
+        shaft = Rot(0, 90, 0) * Cylinder(4, 30)  # a round bar along x
+        dwg = build_drawing(shaft, model=[step(diameter=8, length=30, at=(0, 0, 0), axis="x")])
+        assert dwg.model().orientation == "x"
+
+    def test_partmodel_used_verbatim(self):
+        plate = Box(40, 40, 6)
+        m = PartModel(
+            bbox=plate.bounding_box(),
+            orientation=None,
+            features=[envelope(plate)],
+            datums=[],
+        )
+        dwg = build_drawing(plate, model=m)
+        assert [f.kind for f in dwg.model().features] == ["envelope"]
+
+
+class TestSheet:
+    def test_parse_scale(self):
+        assert _parse_scale("2:1") == 2.0
+        assert _parse_scale("1:2") == 0.5
+        assert _parse_scale(3.0) == 3.0
+        assert _parse_scale(None) is None
+
+    def test_sheet_builds_declared_drawing_lint_clean(self):
+        plate = Box(80, 50, 8)
+        h1 = Pos(20, 10, 4) * Cylinder(3, 8)
+        h2 = Pos(-20, 10, 4) * Cylinder(3, 8)
+        part = plate - h1 - h2
+        sheet = Sheet(part, title="PLATE", number="DWG-777", scale="2:1")
+        sheet.envelope()
+        sheet.hole(h1)
+        sheet.hole(h2)
+        dwg = sheet.build()
+        assert sheet._opts["scale"] == 2.0
+        warns = [i for i in dwg.lint() if i.severity in ("warning", "error")]
+        assert warns == [], [i.code for i in warns]
+
+    def test_hole_depth_makes_it_blind(self):
+        part = Box(40, 40, 10) - Pos(0, 0, 5) * Cylinder(3, 10)
+        sheet = Sheet(part)
+        sheet.hole(Pos(0, 0, 5) * Cylinder(3, 10)).depth(6)
+        f = sheet.features[0]
+        assert f.through is False and f.depth == 6
+
+    def test_hole_through_is_default(self):
+        sheet = Sheet(Box(10, 10, 10))
+        h = sheet.hole(diameter=3, at=(0, 0, 0), axis="z")
+        assert sheet.features[0].through is True
+        # the handle is chainable and idempotent
+        h.through()
+        assert sheet.features[0].through is True
+
+    def test_from_part_seeds_detection(self):
+        plate = Box(80, 50, 8)
+        h1 = Pos(20, 10, 4) * Cylinder(3, 8)
+        part = plate - h1
+        sheet = Sheet.from_part(part)
+        # detection recovered at least the envelope + the hole
+        kinds = {f.kind for f in sheet.features}
+        assert "hole" in kinds
+        # ... and the seeded set is editable for a hybrid override
+        assert isinstance(sheet.features, list)
+
+    def test_envelope_defaults_to_the_part(self):
+        part = Box(30, 20, 5)
+        sheet = Sheet(part)
+        sheet.envelope()
+        f = sheet.features[0]
+        assert f.width == pytest.approx(30) and f.depth == pytest.approx(20)

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -177,30 +177,59 @@ class TestModelSeam:
         dwg = build_drawing(shaft, model=[step(diameter=8, length=30, at=(0, 0, 0), axis="x")])
         assert dwg.model().orientation == "x"
 
-    def test_declared_bolt_circle_renders_without_crashing(self):
-        # Regression: declare.pattern once defaulted members=(), so a declared pattern
-        # was shaped unlike a detected one and the balloon / BCD furniture crashed
-        # (IndexError at orchestrator.py:395, ZeroDivisionError at holes.py:708) or
-        # silently under-rendered. Drill the holes where the arrangement puts them so the
-        # declared pattern matches the real geometry.
+    @staticmethod
+    def _bolt_circle_part(r, z, angles):
         import math
 
         plate = Box(80, 80, 8)
-        r, z = 25.0, 4.0
-        centres = [
-            (r * math.cos(math.radians(a)), r * math.sin(math.radians(a)), z)
-            for a in (0, 90, 180, 270)
-        ]
         part = plate
-        for cx, cy, _ in centres:
-            part -= Pos(cx, cy, z) * Cylinder(3, 8)
+        for a in angles:
+            part -= Pos(
+                r * math.cos(math.radians(a)), r * math.sin(math.radians(a)), z
+            ) * Cylinder(3, 8)
+        return plate, part
+
+    def test_declared_bolt_circle_actually_renders(self):
+        # Regression: declare.pattern once defaulted members=(), so a declared pattern
+        # was shaped unlike a detected one and the balloon / BCD furniture crashed
+        # (IndexError at orchestrator.py:395, ZeroDivisionError at holes.py:708) or
+        # silently under-rendered. With the arrangement matching the real holes, the
+        # bolt-circle furniture must actually appear — a wrong _pattern_members basis
+        # would populate members but render nothing, which this asserts against.
+        r, z = 25.0, 4.0
+        plate, part = self._bolt_circle_part(r, z, (0, 90, 180, 270))
         member = hole(diameter=6, at=(r, 0, z), axis="z")
-        pat = pattern(member, kind="bolt_circle", count=4, bcd=50, at=(0, 0, z))
-        # must not raise, and the pattern's member locations must be populated
+        pat = pattern(member, kind="bolt_circle", count=4, bcd=2 * r, at=(0, 0, z))
         dwg = build_drawing(part, model=[envelope(plate), pat])
         assert len(dwg.model().features[-1].members) == 4
-        errors = [i for i in dwg.lint() if i.severity == "error"]
-        assert errors == [], [i.code for i in errors]
+        assert not [i for i in dwg.lint() if i.severity == "error"]
+        # the bolt-circle centreline furniture (bc_*) proves the pattern rendered, not
+        # just that members were populated
+        assert any(n.startswith("bc_") for n in dwg._named), sorted(dwg._named)
+
+    def test_declared_pattern_off_detected_positions_is_flagged_not_rendered(self):
+        # ADR 0011 caveat (widened after review): the hole/pattern render path gates on
+        # feature_keys built from DETECTION (a.holes), so a declared pattern whose members
+        # do not coincide (to 3 dp) with the detected holes is not rendered — it surfaces
+        # as a coverage warning, not silently. Full model-driven hole rendering is a
+        # follow-up (#448). Here the holes sit at 45° but the pattern is declared at 0°.
+        r, z = 25.0, 4.0
+        plate, part = self._bolt_circle_part(r, z, (45, 135, 225, 315))
+        member = hole(diameter=6, at=(r, 0, z), axis="z")
+        pat = pattern(member, kind="bolt_circle", count=4, bcd=2 * r, at=(0, 0, z), angle=0)
+        dwg = build_drawing(part, model=[envelope(plate), pat])
+        assert not any(n.startswith("bc_") for n in dwg._named)  # not rendered
+        warns = {i.code for i in dwg.lint() if i.severity in ("warning", "error")}
+        assert warns  # but flagged, not silent
+
+    def test_pattern_requires_arrangement_dim(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="bolt_circle", count=4)  # no bcd
+        with pytest.raises(ValueError):
+            pattern(member, kind="linear", count=3)  # no pitch
+        with pytest.raises(ValueError):
+            pattern(member, kind="other", count=2)  # needs explicit members
 
     def test_partmodel_used_verbatim(self):
         plate = Box(40, 40, 6)

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -105,6 +105,40 @@ class TestConstructors:
         assert f.pattern == "bolt_circle" and f.count == 6 and f.bcd == 40
         assert f.member is member
 
+    def test_pattern_populates_member_locations(self):
+        # A declared pattern must be shaped like a detected one: members populated with
+        # the arrangement's hole centres (the balloon / BCD furniture anchors on them).
+        member = hole(diameter=3, at=(0, 0, 5), axis="z")
+        f = pattern(member, kind="bolt_circle", count=6, bcd=40, at=(0, 0, 5))
+        assert len(f.members) == 6
+        # every member sits on the ⌀40 bolt circle (r=20) about the centre, in the z-plane
+        for mx, my, mz in f.members:
+            assert (mx**2 + my**2) == pytest.approx(20.0**2)
+            assert mz == pytest.approx(5.0)
+        # the frame origin is the pattern CENTRE (detector convention), not a member
+        assert f.frame.origin == pytest.approx((0, 0, 5))
+
+    def test_pattern_explicit_members_preserved(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        locs = ((10, 0, 0), (-10, 0, 0))
+        f = pattern(member, kind="other", count=2, members=locs)
+        assert f.members == locs
+
+    def test_linear_pattern_members_spaced_by_pitch(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        f = pattern(member, kind="linear", count=3, pitch=15, direction=(1, 0, 0), at=(0, 0, 0))
+        xs = sorted(m[0] for m in f.members)
+        assert xs == pytest.approx([-15, 0, 15])
+
+    def test_constructors_raise_valueerror_not_assert(self):
+        # Under python -O bare asserts vanish; required-arg validation must be a real error.
+        with pytest.raises(ValueError):
+            hole()
+        with pytest.raises(ValueError):
+            boss(diameter=5)  # missing at / axis
+        with pytest.raises(ValueError):
+            slot(width=6, length=20)  # missing axes / lo / hi
+
 
 class TestModelSeam:
     def test_declared_model_skips_detection(self):
@@ -143,6 +177,31 @@ class TestModelSeam:
         dwg = build_drawing(shaft, model=[step(diameter=8, length=30, at=(0, 0, 0), axis="x")])
         assert dwg.model().orientation == "x"
 
+    def test_declared_bolt_circle_renders_without_crashing(self):
+        # Regression: declare.pattern once defaulted members=(), so a declared pattern
+        # was shaped unlike a detected one and the balloon / BCD furniture crashed
+        # (IndexError at orchestrator.py:395, ZeroDivisionError at holes.py:708) or
+        # silently under-rendered. Drill the holes where the arrangement puts them so the
+        # declared pattern matches the real geometry.
+        import math
+
+        plate = Box(80, 80, 8)
+        r, z = 25.0, 4.0
+        centres = [
+            (r * math.cos(math.radians(a)), r * math.sin(math.radians(a)), z)
+            for a in (0, 90, 180, 270)
+        ]
+        part = plate
+        for cx, cy, _ in centres:
+            part -= Pos(cx, cy, z) * Cylinder(3, 8)
+        member = hole(diameter=6, at=(r, 0, z), axis="z")
+        pat = pattern(member, kind="bolt_circle", count=4, bcd=50, at=(0, 0, z))
+        # must not raise, and the pattern's member locations must be populated
+        dwg = build_drawing(part, model=[envelope(plate), pat])
+        assert len(dwg.model().features[-1].members) == 4
+        errors = [i for i in dwg.lint() if i.severity == "error"]
+        assert errors == [], [i.code for i in errors]
+
     def test_partmodel_used_verbatim(self):
         plate = Box(40, 40, 6)
         m = PartModel(
@@ -160,7 +219,14 @@ class TestSheet:
         assert _parse_scale("2:1") == 2.0
         assert _parse_scale("1:2") == 0.5
         assert _parse_scale(3.0) == 3.0
+        assert _parse_scale("3") == 3.0
         assert _parse_scale(None) is None
+
+    def test_parse_scale_rejects_malformed(self):
+        with pytest.raises(ValueError):
+            _parse_scale("2:0")  # zero denominator
+        with pytest.raises(ValueError):
+            _parse_scale("abc")  # not a number, not a ratio
 
     def test_sheet_builds_declared_drawing_lint_clean(self):
         plate = Box(80, 50, 8)

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -231,6 +231,35 @@ class TestModelSeam:
         with pytest.raises(ValueError):
             pattern(member, kind="other", count=2)  # needs explicit members
 
+    def test_pattern_grid_requires_rows_and_cols(self):
+        # A grid pitch alone (grid=) doesn't define the layout — without rows/cols the
+        # member loop collapses to a single 1×1 centre point (count disagrees with members).
+        # Fail loudly instead, like the other arrangements.
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="grid", count=4, grid=(10, 10))  # no rows/cols
+        # a full grid spec succeeds and yields rows×cols members
+        f = pattern(member, kind="grid", count=4, grid=(10, 10), rows=2, cols=2, at=(0, 0, 0))
+        assert len(f.members) == 4
+
+    def test_pattern_unknown_kind_raises(self):
+        # A typo'd / unsupported arrangement name must fail loudly, not fall through to an
+        # empty-member degenerate pattern (which renders a wrong count× callout).
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="circular", count=6, bcd=50)
+
+    def test_constructors_normalize_uppercase_axis(self):
+        # build123d callers naturally write axis="X"/"Z"; the lowercase IR convention is
+        # internal, so uppercase must be accepted (normalized), not crash in "xyz".index().
+        assert hole(diameter=6, at=(0, 0, 0), axis="Z").frame.axis == "z"
+        assert step(diameter=4, length=10, at=(0, 0, 0), axis="X").frame.axis == "x"
+        member = hole(diameter=3, at=(0, 0, 0), axis="Z")
+        assert pattern(member, kind="bolt_circle", count=4, bcd=40).frame.axis == "z"
+        # an invalid axis letter fails clearly
+        with pytest.raises(ValueError):
+            hole(diameter=6, at=(0, 0, 0), axis="w")
+
     def test_partmodel_used_verbatim(self):
         plate = Box(40, 40, 6)
         m = PartModel(

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -253,6 +253,27 @@ class TestModelSeam:
         with pytest.raises(ValueError):
             pattern(member, kind="grid", count=4, grid=(0, 0), rows=2, cols=2)
 
+    def test_pattern_explicit_members_still_need_defining_dim(self):
+        # A known rendered kind needs its defining dim even when the caller overrides the
+        # member layout with explicit members= — the furniture pass reads feat.bcd/pitch/grid
+        # to draw the BCD / pitch / grid dims, so bcd=None would crash the render (not just
+        # the computed-members path). Only kind='other' is exempt.
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        locs = ((20, 0, 0), (-20, 0, 0))
+        with pytest.raises(ValueError):
+            pattern(member, kind="bolt_circle", count=2, members=locs)  # bcd missing
+        with pytest.raises(ValueError):
+            pattern(member, kind="linear", count=2, members=locs)  # pitch missing
+        # kind="other" needs no defining dim
+        assert pattern(member, kind="other", count=2, members=locs).members == locs
+
+    def test_pattern_requires_positive_count(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="bolt_circle", count=0, bcd=40)
+        with pytest.raises(ValueError):
+            pattern(member, kind="linear", count=-3, pitch=10)
+
     def test_pattern_unknown_kind_raises(self):
         # A typo'd / unsupported arrangement name must fail loudly, not fall through to an
         # empty-member degenerate pattern (which renders a wrong count× callout).


### PR DESCRIPTION
Implements **Phase 0 + Phase 1** of the ADR 0011 declarative drawing surface (#446), turning the `proto/declare-features` spike into production. Vision: #445.

## What this adds

Make the IR `PartModel` a **first-class build input** alongside detection. When you *built* the part you already know its features, so re-detecting them from the finished silhouette is redundant — and, on nested/exotic geometry, unreliable (#298). Declaration recovers those cases by construction: you declare ⌀6 and it is drawn as ⌀6.

### Phase 0 — the seam
- `build_drawing(part, model=Sequence[Feature] | PartModel)` **skips detection** and dimensions exactly the declared features; `model=None` detects as before. Threaded through `_repack` (both passes); a `Sequence` is wrapped with the part bbox + a default corner datum, and orientation is inferred from any declared step.
- `model/declare.py` — object→feature constructors `hole` / `boss` / `step` / `slot` / `pattern` / `envelope`. Diameter is read from the true **cylindrical-face radius** (robust on a chamfered / partial cylinder, where a bbox drifts); axis + location from the bbox. An explicit-value flavour (`diameter=…, at=…, axis=…`) is always available for parametric code that never built a discrete tool.

### Phase 1 — the façade
- `draftwright.Sheet` — a fluent feature-declaration surface over **today's** renderers (holes with through/depth, diameters, steps, slots, patterns, envelope, auto section). `Sheet.from_part` seeds detection for a hybrid override.
- **No fake tolerance/GD&T/finish verbs** — those render nothing yet and are Phase 2 (#61/#62); a fluent method that draws nothing is worse than its absence.

## Aspects / decisions
- `docs/adr/0011-ir-as-public-input.md` landed (status: Phase 0+1); CLAUDE.md ADR list updated.
- Phase 2 execution plan captured in `docs/plans/0011-phase2-aspects-roadmap.md` (key finding: helpers 0.13.0 already ships every aspect primitive, so Phase 2 is wiring + placement, not primitive authoring).
- **Documented caveat:** analysis + the coverage lint still detect independently of `model=`, so a full declaration is lint-clean while a partial one is correctly flagged (`feature_count_mismatch`).

## Review-driven fixes (in this PR)
An adversarial review of the diff caught a high-severity bug, fixed here:
- `declare.pattern()` now **computes member-hole locations** from the arrangement and sets the frame to the pattern centre, so a declared pattern is shaped like a detected one — previously `members=()` crashed the balloon path (`IndexError`) / BCD furniture (`ZeroDivisionError`) or silently under-rendered. Plus defense-in-depth guards at the two consumer sites that lacked the `feat.members or (…)` fallback, `ValueError`s replacing bare asserts (survive `python -O`), and `_parse_scale` malformed-input rejection.

## Tests
`tests/test_declare.py` — 29 tests: constructors (object read + explicit for each feature type, face-radius, bbox fallback), the `model=` seam (skips detection, fully-declared lint-clean, partial flagged, orientation-from-step, PartModel verbatim), pattern member-location math, a **render regression** for a declared bolt circle, and the `Sheet` façade. Full fast tier green; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)