### PR TITLE
feat: toleranced dimensions — ± / limit on ⌀, step, hole (ADR 0011 P2a, #28)

### DIFF
--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -1,8 +1,10 @@
 # ADR 0011 — The IR as a public input: declare features, don't only detect them
 
 - **Status:** Accepted — Phase 0 (the `model=` seam + object→feature constructors) and
-  Phase 1 (the `Sheet` façade) landed; Phase 2 (aspect renderers — tolerance/GD&T/finish)
-  pending per the #446 roadmap. Phase 2 execution plan:
+  Phase 1 (the `Sheet` façade) landed; Phase 2 (aspect renderers) underway: **P2a
+  toleranced dimensions** (±/limit on a diameter/step/hole, via a `decorations=` side-layer
+  → `DimParameter.tolerance`) landing; P2a.2 fit-class / P2b GD&T+finish / P2c aspect verbs
+  / P2d PMI still pending per the #446 roadmap. Phase 2 execution plan:
   [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
 - **Date:** 2026-07-05
 - **Deciders:** Paul Fremantle (pzfreo)

--- a/docs/plans/0011-phase2-aspects-roadmap.md
+++ b/docs/plans/0011-phase2-aspects-roadmap.md
@@ -69,24 +69,44 @@ placement API, because **neither the IR nor the renderer has any hook today**:
 Ordered to front-load the cheapest, highest-value item and isolate the
 placement-hard GD&T behind a reusable primitive.
 
-### P2a — Toleranced dimensions (bilateral / limit) · #28
+### P2a — Toleranced dimensions (bilateral / limit) · #28 · **DONE**
 
-The self-contained value-shipping PR.
+The self-contained value-shipping PR. **Full-uniform** scope (per the user's call):
+the tolerance renders on the linear `Dimension` path AND the `Leader` / `HoleCallout`
+⌀ path, so every P2a verb shows a ±.
 
-- Add optional `tolerance: float | tuple[float, float] | None = None` to
-  `DimParameter` (`model/ir.py:52`). ADR 0011 §4 sanctions "tolerance is a property
-  of a `DimParameter`."
-- A `decorations` side-layer `{(feature, role) → tolerance}` (keyed by frozen
-  feature value-equality + `Role`), threaded via
-  `build_drawing(part, model=…, decorations=…)` and through `_repack`.
-- `plan_dimensions` consults it to set the tolerance on the `PlannedDimension` /
-  param (`planner.py:207-220`).
-- `_core._dim` gains a `tolerance` passthrough to `Dimension(tolerance=…)`
-  (`_core.py:149`) — the helpers primitive does the formatting.
-- `Sheet`: `.tolerance(x)` / `.tolerance(lo, hi)` chainable handle on the
-  `diameter` / `step` / `hole` declarations.
-- Tests: bilateral + limit render into the label; decoration survives repack;
-  no-decoration path byte-unchanged.
+- `DimParameter.tolerance: float | tuple[float, float] | None` (`model/ir.py`) — a
+  symmetric float or an `(lower, upper)` limit pair.
+- A `decorations` side-layer `{(feature, kind) → tolerance}` on `PartModel`, threaded
+  via `build_drawing(part, model=…, decorations=…)` and through **both** assemble passes
+  (`_repack`). **Key is `(feature, kind)`, not `(feature, role)`** — a step's length and
+  diameter share `role="step"`, so `kind` is what disambiguates them.
+- `plan_dimensions` reads `model.decorations` (zero call-site changes) and
+  `replace(param, tolerance=…)`.
+- Linear dims: `_core._dim` forwards `tolerance=` to `Dimension(tolerance=…)` (already
+  splats `**kwargs`; also survives repair/repack). Wired in `render_step_lengths` /
+  `_draw_step_chain` (a uniform `N× v` collapse carries no ± — can't tolerance N steps).
+- ⌀ callouts: helpers' `Leader`/`HoleCallout` take no `tolerance=`, so draftwright owns
+  **`_core._tol_suffix`** — the `±t` / `+hi -lo` suffix baked into the label string,
+  byte-matching helpers' `Dimension` `_format_label` (same draft precision). Wired in
+  `render_diameters` (the boss/step OD leaders) and `hole_callout_spec` /
+  `callout_from_spec` (the bore string; `HoleCallout` accepts a diameter carrying tol text).
+- `Sheet`: `.tolerance(x)` / `.tolerance(lo, hi)` on `hole` (bore ⌀), `diameter`/`boss`
+  (OD), and `step` (length by default, `on="diameter"` for the OD). Keyed by feature
+  index so a handle survives a later `.depth()` feature replacement.
+
+**Shipped caveats (document, follow up):**
+- **Precision.** The suffix rounds to the sheet's `decimal_precision` (1 dp today, to
+  match `Dimension`), so a `±0.05` renders `±0.1`. Fine tolerances (≤0.05) need a
+  per-dimension precision knob — a follow-up (likely a helpers change so both paths agree).
+- **A toleranced ⌀ callout is wider** and, in the iso-bounded plan-view strip, can drop
+  via the existing place-what-fits (`callout_dropped` warning) where a plain one fit —
+  the same behaviour as any wide callout. The estimate uses the real `callout_width`, so
+  there is no silent overflow. Tracked as **#450** (prefer the left strip / escalate the
+  sheet for a deliberately-wider toleranced callout — engine layout work).
+- **Extract to helpers.** `_tol_suffix` exists only because `Leader`/`HoleCallout` lack a
+  `tolerance=` param; file an upstream issue to add one, then delete the suffix and pass
+  the tolerance through like `Dimension` does. Tracked as **#449**.
 
 ### P2a.2 — Fit-class deviation (`.fit("h6")`) · #29
 

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -86,6 +86,25 @@ def _fmt(v: float) -> str:
     return str(r) if abs(v - r) < 1e-6 else f"{v:.1f}"
 
 
+def _tol_suffix(tolerance, draft) -> str:
+    """The ``±`` / limit tolerance suffix to append to a **callout** label (a ø leader
+    or a hole callout), matching byte-for-byte what ``Dimension(tolerance=…)`` renders
+    on a linear dim (helpers ``_format_label``): a symmetric ``float`` → ``" ±t"``; an
+    ``(lower, upper)`` pair → ``" +upper -lower"`` — all rounded to the draft precision.
+
+    draftwright owns this suffix ONLY because the pinned helpers' ``Leader`` /
+    ``HoleCallout`` take no ``tolerance=`` yet, so we bake it into the label string
+    ourselves. Delete this once helpers grows a first-class tolerance parameter for
+    those two (extraction tracked as #449) — ``Dimension`` formats its own (#28 / P2a)."""
+    if tolerance is None:
+        return ""
+    prec = draft.decimal_precision
+    if isinstance(tolerance, (int, float)):
+        return f" ±{round(tolerance, prec):.{prec}f}"
+    lo, hi = tolerance
+    return f" +{round(hi, prec):.{prec}f} -{round(lo, prec):.{prec}f}"
+
+
 def _tag_sequence(n):
     """``A, B, …, Z, AA, AB, …`` — deterministic hole-table tags for *n* rows."""
     tags = []

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -41,6 +41,7 @@ from draftwright._core import (
     _legible_steps,
     _log,
     _solve_strip_ys,
+    _tol_suffix,
 )
 from draftwright.annotations._common import (
     CROSSABLE_TYPES,
@@ -82,6 +83,14 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     bore = _first(group, "diameter", "bore")
     if bore is None:
         return None
+    bore_tol = next(
+        (
+            pd.param.tolerance
+            for pd in group.dims
+            if pd.param.kind == "diameter" and pd.param.role == "bore"
+        ),
+        None,
+    )
     depth = _first(group, "depth", "bore")
     count = feat.count
     suffix = None
@@ -99,6 +108,7 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
         "cbore_dia": _first(group, "diameter", "counterbore", "spotface"),
         "cbore_depth": _first(group, "depth", "counterbore", "spotface"),
         "suffix": suffix,
+        "tolerance": bore_tol,  # P2a: ± on the bore ⌀, baked into the callout string below
     }
 
 
@@ -120,8 +130,14 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
     def f(v):  # see the #261 note above — every value crosses as a formatted string
         return _fmt(v) if v is not None else None
 
+    dia = f(spec["diameter"])
+    if dia is not None:
+        # P2a: bake the ± tolerance into the bore string (helpers' HoleCallout accepts a
+        # diameter carrying tolerance/fit text, "8 ±0.05"); no tolerance → empty suffix.
+        dia += _tol_suffix(spec.get("tolerance"), draft)
+
     return HoleCallout(
-        f(spec["diameter"]),
+        dia,
         count=count,
         through=spec["through"],
         depth=f(spec["depth"]),
@@ -622,10 +638,10 @@ def _diameter_row_below(dwg, items, start: int = 0) -> int:
     if label_y < _MARGIN + draft.font_size:
         return 0
     specs = []  # (tip_page, dia, label, feature), tip on the step's bottom silhouette
-    for anchor, dia, feat in items:
+    for anchor, dia, feat, dtol in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
-        specs.append((tip, dia, f"ø{_fmt(dia)}", feat))
+        specs.append((tip, dia, f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}", feat))
     half_w = max(len(label) for _, _, label, _ in specs) * draft.font_size * 0.62 / 2
     min_gap = 2 * half_w + 2 * draft.pad_around_text
     # Place what fits; drop the smallest ø first, never the whole row (#298).
@@ -649,15 +665,19 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
         return 0
     draft = dwg.draft
     fx0, fy0, _, fy1 = dwg.view_bounds("front")
-    label_w = max(len(f"ø{_fmt(dia)}") for _, dia, _ in items) * draft.font_size * 0.62
+    label_w = (
+        max(len(f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}") for _, dia, _, dtol in items)
+        * draft.font_size
+        * 0.62
+    )
     elbow_x = fx0 - (draft.font_size + 2 * draft.pad_around_text)
     if elbow_x - label_w < _MARGIN:
         return 0
     specs = []  # (tip_page, dia, label, feature), tip on the step's left silhouette
-    for anchor, dia, feat in items:
+    for anchor, dia, feat, dtol in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax - dia / 2, ay, az)
-        specs.append((tip, dia, f"ø{_fmt(dia)}", feat))
+        specs.append((tip, dia, f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}", feat))
     half_h = draft.font_size / 2 + draft.pad_around_text
     min_gap = 2 * half_h
     # Place what fits; drop the smallest ø first, never the whole column (#298).
@@ -694,24 +714,35 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, only=None) -> int:
     # diameter (insertion-ordered), so provenance (#412) can tag the callout with its
     # single owner — or leave it unowned when two distinct features share the diameter
     # (the #398c/#406 shared-value rule, so drop can't over-strip a sibling).
-    row_buckets: dict = {}  # round(dia,2) -> [anchor, dia, {features}]  (X-turned)
+    row_buckets: dict = {}  # round(dia,2) -> [anchor, dia, {features}, tolerance]  (X-turned)
     col_buckets: dict = {}  # Z-turned
     for g in groups:
         if g.feature_kind not in ("step", "boss"):
             continue
         if only is not None and g.feature not in only:  # #426 finalize: recorded subset
             continue
-        dia = next((pd.param.value for pd in g.dims if pd.param.kind == "diameter"), None)
-        if dia is None or any(abs(dia - m) <= tol for m in mentioned):
+        dpd = next((pd for pd in g.dims if pd.param.kind == "diameter"), None)
+        if dpd is None:
+            continue
+        dia = dpd.param.value
+        if any(abs(dia - m) <= tol for m in mentioned):
             continue
         bucket = {"x": row_buckets, "z": col_buckets}.get(g.feature.frame.axis)
         if bucket is None:
             continue
         dkey = round(dia, 2)
-        bucket.setdefault(dkey, [g.anchor, dia, set()])[2].add(g.feature)
+        dtol = dpd.param.tolerance
+        # entry = [anchor, dia, {features}, ± tolerance]. A callout is per (axis, ⌀); the
+        # first authored tolerance on a shared ⌀ wins (P2a — a single callout, one label).
+        entry = bucket.setdefault(dkey, [g.anchor, dia, set(), dtol])
+        entry[2].add(g.feature)
+        if entry[3] is None:
+            entry[3] = dtol
 
     def _items(buckets):
-        return [(a, d, next(iter(fs)) if len(fs) == 1 else None) for a, d, fs in buckets.values()]
+        return [
+            (a, d, next(iter(fs)) if len(fs) == 1 else None, t) for a, d, fs, t in buckets.values()
+        ]
 
     # The placers name leaders m_dia_{x,z}{start+i} CONTIGUOUSLY from one start. The auto-pass
     # (only None) uses start=0 — byte-identical. The finalize path (only set) may run after
@@ -879,12 +910,14 @@ def _draw_step_chain(
     draft = dwg.draft
     gap = draft.font_size + 4 * draft.pad_around_text
     horizontal = abs(segs[0][1][0] - segs[0][0][0]) >= abs(segs[0][1][1] - segs[0][0][1])
-    vals = [v for *_, v in segs]
+    vals = [s[2] for s in segs]  # value is index 2 (segs are 4-tuples: pa, pb, value, tol)
     mean_v = sum(vals) / len(vals)
     if allow_collapse and len(segs) >= 3 and (max(vals) - min(vals)) <= 0.10 * mean_v:
+        # A uniform run collapses to one "N× v" dim; a per-step ± would be a false claim on
+        # N equal steps, so the collapse carries NO tolerance (#28 / P2a).
         label = f"{len(segs)}× {_fmt(mean_v)}"
-        xs = [p[0] for pa, pb, _ in segs for p in (pa, pb)]
-        ys = [p[1] for pa, pb, _ in segs for p in (pa, pb)]
+        xs = [p[0] for pa, pb, *_ in segs for p in (pa, pb)]
+        ys = [p[1] for pa, pb, *_ in segs for p in (pa, pb)]
         if horizontal:
             dim = _dim((min(xs), y1, 0), (max(xs), y1, 0), "above", gap, draft, label=label)
         else:
@@ -896,7 +929,8 @@ def _draw_step_chain(
         tiers = [0] * len(segs)
         if horizontal:
             cw = [
-                ((pa[0] + pb[0]) / 2, len(_fmt(v)) * draft.font_size * 0.62) for pa, pb, v in segs
+                ((pa[0] + pb[0]) / 2, len(_fmt(v)) * draft.font_size * 0.62)
+                for pa, pb, v, *_ in segs
             ]
 
             def _clear(items):  # (center, width) pairs in x order — labels don't overlap
@@ -916,14 +950,14 @@ def _draw_step_chain(
                 )
                 return 0
         else:
-            shoulder_ys = sorted({c for pa, pb, _ in segs for c in (pa[1], pb[1])})
+            shoulder_ys = sorted({c for pa, pb, *_ in segs for c in (pa[1], pb[1])})
             if any(b - a < tier_step for a, b in zip(shoulder_ys, shoulder_ys[1:])):
                 _log.info("step-length chain skipped: shoulders too close to dimension")
                 _record_step_chain_drop(dwg, "turned shoulders too closely spaced to dimension")
                 return 0
 
         candidates = []
-        for i, (pa, pb, value) in enumerate(segs):
+        for i, (pa, pb, value, seg_tol) in enumerate(segs):
             if horizontal:
                 p1, p2, side = (pa[0], y1, 0), (pb[0], y1, 0), "above"
                 dist = gap + tiers[i] * tier_step
@@ -931,7 +965,10 @@ def _draw_step_chain(
                 p1, p2, side = (x1, pa[1], 0), (x1, pb[1], 0), "right"
                 dist = gap
             candidates.append(
-                (f"{name_prefix}{start + i}", _dim(p1, p2, side, dist, draft, label=_fmt(value)))
+                (
+                    f"{name_prefix}{start + i}",
+                    _dim(p1, p2, side, dist, draft, label=_fmt(value), tolerance=seg_tol),
+                )
             )
 
     # Room guard: if any dim would fall off the drawable page, place NONE.
@@ -992,14 +1029,14 @@ def render_step_lengths(dwg, groups, *, only=None) -> int:
         )
         if length is None or length.span is None:
             continue
-        rows.append((length.span[0], length.span[1], length.value))
+        rows.append((length.span[0], length.span[1], length.value, length.tolerance))
     if not rows:
         return 0
     draft = dwg.draft
     # only=None (auto-pass) → start=0, historical m_steplen naming, byte-identical. The
     # finalize path (only set) starts past existing m_steplen names (#426 naming seam).
     start = _next_steplen_start(dwg) if only is not None else 0
-    fsegs = [(dwg.at("front", *a), dwg.at("front", *b), v) for a, b, v in rows]
+    fsegs = [(dwg.at("front", *a), dwg.at("front", *b), v, t) for a, b, v, t in rows]
     horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
 
     # X-turned crowded-head detour (#307): split off each contiguous *run of ≥2*
@@ -1009,7 +1046,7 @@ def render_step_lengths(dwg, groups, *, only=None) -> int:
     # (#307 review). The legible steps + blocks stay as the main chain.
     if horizontal:
         floor_pg = 2 * draft.arrow_length
-        sub = [i for i, (pa, pb, _) in enumerate(fsegs) if abs(pb[0] - pa[0]) < floor_pg]
+        sub = [i for i, (pa, pb, *_) in enumerate(fsegs) if abs(pb[0] - pa[0]) < floor_pg]
         runs: list[list[int]] = []
         for j in sub:
             (runs[-1].append(j) if runs and j == runs[-1][-1] + 1 else runs.append([j]))
@@ -1018,17 +1055,20 @@ def render_step_lengths(dwg, groups, *, only=None) -> int:
             blocks = []
             for run in heads:
                 ra = [rows[i] for i in run]
-                hlo = min(min(a[0], b[0]) for a, b, _ in ra)
-                hhi = max(max(a[0], b[0]) for a, b, _ in ra)
-                minlen = min(v for *_, v in ra)
+                hlo = min(min(a[0], b[0]) for a, b, *_ in ra)
+                hhi = max(max(a[0], b[0]) for a, b, *_ in ra)
+                minlen = min(r[2] for r in ra)  # value is index 2 (rows are 4-tuples: a,b,v,tol)
                 # World→page scale for the detail (no sheet factor — detail_scale is an
                 # absolute world→page scale). (#307 review)
                 scale_needed = _MIN_STEP_SEP_MM / minlen if minlen > 0 else float("inf")
-                blocks.append((dwg.at("front", hlo, 0, 0), dwg.at("front", hhi, 0, 0), hhi - hlo))
+                # A head *block* is a synthetic span, not one toleranced step — carry no ± (None).
+                blocks.append(
+                    (dwg.at("front", hlo, 0, 0), dwg.at("front", hhi, 0, 0), hhi - hlo, None)
+                )
 
                 def _redraw(dwg, view, detail_scale, _hw=ra):
                     # View-scoped name prefix so two detail views never collide (#307 review).
-                    hsegs = [(dwg.at(view, *a), dwg.at(view, *b), v) for a, b, v in _hw]
+                    hsegs = [(dwg.at(view, *a), dwg.at(view, *b), v, t) for a, b, v, t in _hw]
                     return _draw_step_chain(dwg, view, hsegs, f"dim_{view}_steplen", detail_scale)
 
                 dwg._detail_requests.append(

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -388,12 +388,13 @@ def add_feature_diameter(dwg, feature) -> str:
             "pass one from dwg.model().features"
         )
     group = next((g for g in plan_dimensions(model) if g.feature is feature), None)
-    dia = (
-        next((pd.param.value for pd in group.dims if pd.param.kind == "diameter"), None)
+    dpd = (
+        next((pd for pd in group.dims if pd.param.kind == "diameter"), None)
         if group is not None
         else None
     )
-    if group is None or dia is None:
+    dia = dpd.param.value if dpd is not None else None
+    if group is None or dpd is None or dia is None:
         raise ValueError(
             f"callout(): {type(feature).__name__} exposes no step/boss diameter callout"
         )
@@ -403,7 +404,9 @@ def add_feature_diameter(dwg, feature) -> str:
             f"callout(): a {axis!r}-turned step/boss diameter is not placeable "
             "(only X- and Z-turned parts)"
         )
-    items = [(group.anchor, dia, feature)]
+    # 4-tuple (anchor, dia, feature, tolerance): a manual callout honours a declared ±
+    # tolerance too, like the auto-pass (P2a, #28).
+    items = [(group.anchor, dia, feature, dpd.param.tolerance)]
     # The row/column placers name leaders m_dia_{x,z}{start+i} — pass the first FREE
     # index so a second callout() (or a call on an already-annotated turned part) never
     # collides on m_dia_x0/z0 and clobbers an existing leader (#419 review F1).

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -198,11 +198,13 @@ def _coerce_model(model, a, decorations=None) -> PartModel:
     ``StepFeature`` (so a declared shaft renders as turned).
 
     ``decorations`` (P2a) is the authored aspect side-layer — ``{(feature, kind) ->
-    tolerance}`` — attached to the model so the planner can read it; only applied when
-    given (a bare ``PartModel`` keeps its own decorations otherwise)."""
+    tolerance}`` — merged onto the model so the planner can read it; only applied when
+    given (a bare ``PartModel`` keeps its own decorations otherwise). A verbatim
+    ``PartModel`` is never mutated — decorations merge into a copy so the caller's
+    reusable public input (ADR 0011) stays clean across builds."""
     if isinstance(model, PartModel):
         if decorations:
-            model.decorations = decorations
+            return replace(model, decorations={**model.decorations, **decorations})
         return model
     features = list(model)
     bbox = a.part.bounding_box()

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -190,22 +190,34 @@ def _measure_blocks(dwg, a) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _coerce_model(model, a) -> PartModel:
+def _coerce_model(model, a, decorations=None) -> PartModel:
     """Wrap a caller-supplied ``model=`` (ADR 0011) into a :class:`PartModel`. A
     ``PartModel`` is used verbatim; a sequence of features is wrapped with the part's
     bbox, a default corner location datum (matching ``detect.py``, so hole location
     dims measure from the min corner), and an orientation inferred from any turned
-    ``StepFeature`` (so a declared shaft renders as turned)."""
+    ``StepFeature`` (so a declared shaft renders as turned).
+
+    ``decorations`` (P2a) is the authored aspect side-layer — ``{(feature, kind) ->
+    tolerance}`` — attached to the model so the planner can read it; only applied when
+    given (a bare ``PartModel`` keeps its own decorations otherwise)."""
     if isinstance(model, PartModel):
+        if decorations:
+            model.decorations = decorations
         return model
     features = list(model)
     bbox = a.part.bounding_box()
     orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
     datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
-    return PartModel(bbox=bbox, orientation=orientation, features=features, datums=[datum])
+    return PartModel(
+        bbox=bbox,
+        orientation=orientation,
+        features=features,
+        datums=[datum],
+        decorations=decorations or {},
+    )
 
 
-def _assemble(a, out, assembly, detail_view, auto_dims, model=None) -> Drawing:
+def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=None) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
     repacked analysis it is also pass 2 of the measure-and-repack loop (#121)."""
@@ -230,7 +242,7 @@ def _assemble(a, out, assembly, detail_view, auto_dims, model=None) -> Drawing:
     # Detect the IR here — before the auto_dims gate — so dwg.model() and feature edits
     # work even in manual mode (#398). _auto_annotate reads this attached model rather
     # than rebuilding. On a repack this runs again on the pass-2 drawing (freshness).
-    dwg._part_model = _coerce_model(model, a) if model is not None else build_model(a)
+    dwg._part_model = _coerce_model(model, a, decorations) if model is not None else build_model(a)
 
     part_s = a.part.scale(a.SCALE)
     dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)
@@ -292,7 +304,9 @@ def _repack_candidates(a, scale, page):
     return list(_LADDER[start:])
 
 
-def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None, model=None):
+def _repack(
+    a, dwg, out, assembly, detail_view, scale=None, page=None, model=None, decorations=None
+):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
     when a view collides across views, pack the blocks disjoint — escalating the
     sheet/scale until the packed layout fits — then re-assemble (#121, ADR 0004 —
@@ -407,7 +421,9 @@ def _repack(a, dwg, out, assembly, detail_view, scale=None, page=None, model=Non
         pv_zones=pv_zones,
         sv_zones=sv_zones,
     )
-    dwg2 = _assemble(a2, out, assembly, detail_view, auto_dims=True, model=model)
+    dwg2 = _assemble(
+        a2, out, assembly, detail_view, auto_dims=True, model=model, decorations=decorations
+    )
     return a2, dwg2
 
 
@@ -426,6 +442,7 @@ def build_drawing(
     repair: bool = True,
     assembly: bool | None = None,
     model: Sequence[Feature] | PartModel | None = None,
+    decorations: dict | None = None,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -483,9 +500,19 @@ def build_drawing(
     # per-view footprints and re-pack the blocks disjoint if a view actually
     # moves (#121, ADR 0004 — "lay out, don't predict").  Non-ballooned parts
     # measure ≈ estimate, so they skip pass 2 and stand byte-identical.
-    dwg = _assemble(a, out, assembly, detail_view, auto_dims, model=model)
+    dwg = _assemble(a, out, assembly, detail_view, auto_dims, model=model, decorations=decorations)
     if auto_dims:
-        repacked = _repack(a, dwg, out, assembly, detail_view, scale=scale, page=page, model=model)
+        repacked = _repack(
+            a,
+            dwg,
+            out,
+            assembly,
+            detail_view,
+            scale=scale,
+            page=page,
+            model=model,
+            decorations=decorations,
+        )
         if repacked is not None:
             a, dwg = repacked
     if repair:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -59,6 +59,10 @@ class DimParameter:
     value: float
     span: tuple[Point, Point] | None = None
     refs: tuple[str, ...] = ()
+    # An authored ± tolerance (ADR 0011 §4 / P2a): a symmetric ``float`` or an
+    # ``(lower, upper)`` limit pair, ``None`` when the dimension is untoleranced. Set by
+    # the planner from the caller's ``decorations`` — geometry never supplies it.
+    tolerance: float | tuple[float, float] | None = None
 
 
 def _fmt(v: float) -> str:
@@ -335,3 +339,7 @@ class PartModel:
     orientation: str | None  # turning axis if rotational, else None
     features: list[Feature] = field(default_factory=list)
     datums: list[Datum] = field(default_factory=list)
+    # Authored aspects the frozen features can't carry (ADR 0011 §4). P2a uses it for
+    # per-dimension tolerances: ``{(feature, ParamKind) -> float | (lo, hi)}``. The
+    # planner consults it to set ``DimParameter.tolerance``; empty on a detected model.
+    decorations: dict = field(default_factory=dict)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -20,7 +20,7 @@ ISO/ASME rule set grows here as real features demand it.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from draftwright._core import _END_ON, HoleRef
 from draftwright.model.ir import (
@@ -208,6 +208,13 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
         for p in feature.parameters():
             if p.kind == "location":
                 continue
+            # An authored ± tolerance (ADR 0011 §4 / P2a) rides on the decorations side-
+            # layer keyed by (feature, kind); fold it onto the param so every renderer
+            # sees one carrier. `kind` (not `role`) is the key — a step's length and
+            # diameter share role="step", so role alone can't tell them apart.
+            tol = model.decorations.get((feature, p.kind))
+            if tol is not None:
+                p = replace(p, tolerance=tol)
             suppressed, reason = _suppression(model, feature, p)
             dims.append(
                 PlannedDimension(

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -12,13 +12,14 @@ detection is skipped and the auto-pass dimensions exactly the declared features:
     sheet.diameter(boss_cyl)
     sheet.export("plate")
 
-**Phase 1 scope (this module):** the *feature-declaration* surface over the
-renderers the engine has today — dimensions, ⌀ callouts, holes (through / blind),
-turned steps, slots, patterns, the overall envelope, and the auto section. The
-richer aspect verbs from the #445 vision that need *new* rendering — ``.fit`` /
-``.tolerance`` (toleranced dims), ``.thread``, ``.finish`` (surface symbols) and
-``control(...)`` (GD&T) — are Phase 2 (roadmap #446) and are deliberately **not**
-stubbed here, so the surface only exposes what actually draws.
+**Scope (this module):** the *feature-declaration* surface over the renderers the
+engine has today — dimensions, ⌀ callouts, holes (through / blind), turned steps,
+slots, patterns, the overall envelope, and the auto section — plus the P2a
+**``.tolerance``** aspect (a ± / limit tolerance on a diameter, a step, or a hole
+bore). The remaining #445 aspect verbs that still need new rendering — ``.fit``
+(fit-class → ISO 286 deviation), ``.thread``, ``.finish`` (surface symbols) and
+``control(...)`` (GD&T) — are the later Phase-2 items (roadmap #446) and are
+deliberately **not** stubbed here, so the surface only exposes what actually draws.
 
 **Hybrid.** :meth:`Sheet.from_part` seeds the declared set from *detection*, so you
 can start from the detected model and override specific features (declaration is for
@@ -57,9 +58,16 @@ def _parse_scale(scale):
     raise TypeError(f"scale must be a number, ratio string, or None — got {type(scale).__name__}")
 
 
+def _tol_value(lo, hi):
+    """A ± tolerance value from the handle args: a symmetric ``float`` (``hi is None``) or
+    an ``(lower, upper)`` limit pair. The pair renders ``+upper -lower`` (helpers'
+    convention), so ``.tolerance(0.0, 0.1)`` → ``+0.1 -0.0`` — both magnitudes positive."""
+    return lo if hi is None else (lo, hi)
+
+
 class _Hole:
-    """A fluent handle for one declared hole — the only feature with a Phase-1 aspect
-    (through vs blind, which changes the callout)."""
+    """A fluent handle for one declared hole — through vs blind (which changes the callout),
+    and the P2a ± tolerance on its bore ⌀."""
 
     def __init__(self, sheet: Sheet, index: int) -> None:
         self._sheet = sheet
@@ -73,8 +81,32 @@ class _Hole:
         """A blind hole *d* mm deep — adds a depth callout."""
         return self._set(through=False, depth=d)
 
+    def tolerance(self, lo: float, hi: float | None = None) -> _Hole:
+        """A ± tolerance on the bore ⌀: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a
+        limit pair ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``)."""
+        self._sheet._tolerances[(self._i, "diameter")] = _tol_value(lo, hi)
+        return self
+
     def _set(self, **kw) -> _Hole:
         self._sheet._features[self._i] = replace(self._sheet._features[self._i], **kw)
+        return self
+
+
+class _Dim:
+    """A fluent handle for a declared dimension-bearing feature (a diameter / boss OD, or a
+    turned step), carrying the P2a ``.tolerance`` aspect. ``default_kind`` is the parameter a
+    bare ``.tolerance(...)`` targets — ``"diameter"`` for an OD, ``"length"`` for a step."""
+
+    def __init__(self, sheet: Sheet, index: int, default_kind: str) -> None:
+        self._sheet = sheet
+        self._i = index
+        self._kind = default_kind
+
+    def tolerance(self, lo: float, hi: float | None = None, *, on: str | None = None) -> _Dim:
+        """A ± tolerance on this dimension: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a
+        limit pair ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` picks the parameter for
+        a multi-dim feature — a step's ``"length"`` (default) vs its ``"diameter"`` (OD)."""
+        self._sheet._tolerances[(self._i, on or self._kind)] = _tol_value(lo, hi)
         return self
 
 
@@ -91,6 +123,9 @@ class Sheet:
     def __init__(self, part, *, title=None, number="DWG-001", scale=None, page=None, out=None):
         self._part = part
         self._features: list = []
+        # P2a ± tolerances, keyed by (feature index, ParamKind) so a handle survives a later
+        # feature replacement (e.g. hole().depth()); materialized to (feature, kind) at build.
+        self._tolerances: dict = {}
         self._opts = dict(
             title=title, number=number, scale=_parse_scale(scale), page=page, out=out
         )
@@ -118,21 +153,22 @@ class Sheet:
         self._features.append(_hole(obj, **kw))
         return _Hole(self, len(self._features) - 1)
 
-    def diameter(self, obj=None, **kw) -> Sheet:
+    def diameter(self, obj=None, **kw) -> _Dim:
         """Declare an external cylindrical diameter (a boss / OD) — the ⌀ is read off the
-        object. The turned/external ⌀-callout verb of the #445 vision."""
+        object. Returns a handle: chain ``.tolerance(...)`` for a ± on the ⌀ (P2a)."""
         self._features.append(_boss(obj, **kw))
-        return self
+        return _Dim(self, len(self._features) - 1, "diameter")
 
-    def boss(self, obj=None, **kw) -> Sheet:
+    def boss(self, obj=None, **kw) -> _Dim:
         """Alias of :meth:`diameter` — an external cylindrical boss / OD."""
         return self.diameter(obj, **kw)
 
-    def step(self, obj=None, **kw) -> Sheet:
-        """Declare one axial segment of a turned profile (its OD + length). A model with
-        any step renders as a turned part."""
+    def step(self, obj=None, **kw) -> _Dim:
+        """Declare one axial segment of a turned profile (its OD + length). A model with any
+        step renders as a turned part. Returns a handle: ``.tolerance(...)`` tolerances the
+        step *length* by default, ``.tolerance(..., on="diameter")`` its OD (P2a)."""
         self._features.append(_step(obj, **kw))
-        return self
+        return _Dim(self, len(self._features) - 1, "length")
 
     def slot(self, obj=None, **kw) -> Sheet:
         """Declare a milled slot / reduced across-flats section (width + length)."""
@@ -164,7 +200,15 @@ class Sheet:
     def build(self):
         """Build the :class:`~draftwright.drawing.Drawing` — detection skipped; only the
         declared features are drawn."""
-        return build_drawing(self._part, model=self._features, **self._opts)
+        # Materialize the index-keyed tolerances against the final features (a handle may
+        # have been recorded before a later .depth()/… replaced the feature) → the
+        # (feature, kind) decoration map the planner reads (P2a).
+        decorations = {
+            (self._features[i], kind): tol for (i, kind), tol in self._tolerances.items()
+        }
+        return build_drawing(
+            self._part, model=self._features, decorations=decorations, **self._opts
+        )
 
     def export(self, stem=None):
         """Build and export the drawing (SVG + DXF). *stem* defaults to the drawing

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -181,10 +181,11 @@ class TestDiameterColumnOccupancy:
 
         return _Dwg()
 
-    # (anchor, dia, feature) — feature=None here (unit test of placement; #412 added the tag)
+    # (anchor, dia, feature, tolerance) — feature=None (unit test of placement; #412 added the
+    # tag); tolerance=None (untoleranced — the item grew a P2a ± field, #28)
     _ITEMS = [
-        ((10.0, 0.0, 8.0), 12.0, None),
-        ((10.0, 0.0, 24.0), 8.0, None),
+        ((10.0, 0.0, 8.0), 12.0, None, None),
+        ((10.0, 0.0, 24.0), 8.0, None, None),
     ]  # two Z-turned ø steps
 
     def test_control_no_occupant_places_both(self):

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -1,0 +1,189 @@
+"""P2a — toleranced dimensions (ADR 0011 Phase 2, #28).
+
+A caller attaches a ± / limit tolerance to a declared dimension (via the ``decorations``
+side-layer or the ``Sheet.tolerance()`` handle); it rides ``DimParameter.tolerance`` through
+the planner and renders on **both** the linear ``Dimension`` path (step length) and the
+``Leader`` / ``HoleCallout`` ⌀ path — the latter via draftwright's own ``_tol_suffix`` baked
+into the label string, matching what ``Dimension(tolerance=…)`` formats (helpers has no
+``tolerance=`` on ``Leader``/``HoleCallout`` yet). Tolerances render at the sheet's decimal
+precision (1 dp today), so tests use tolerances that survive 1 dp.
+"""
+
+from build123d import Box, Cylinder, Pos, Rot
+from build123d_drafting.helpers import draft_preset
+
+from draftwright import Sheet
+from draftwright._core import _tol_suffix
+from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
+from draftwright.model import PartModel, hole, step
+from draftwright.model.planner import plan_dimensions
+
+
+def _spec(diameter, **over):
+    base = {
+        "diameter": diameter,
+        "count": None,
+        "through": True,
+        "depth": None,
+        "cbore_dia": None,
+        "cbore_depth": None,
+        "suffix": None,
+    }
+    base.update(over)
+    return base
+
+
+class TestTolSuffix:
+    """The owned callout formatter — must byte-match helpers' ``_format_label`` suffix."""
+
+    def test_symmetric_float(self):
+        d = draft_preset(font_size=2.5, decimal_precision=2)
+        assert _tol_suffix(0.05, d) == " ±0.05"
+
+    def test_symmetric_respects_precision(self):
+        d1 = draft_preset(font_size=2.5, decimal_precision=1)
+        assert _tol_suffix(0.05, d1) == " ±0.1"  # rounds to the draft precision, like Dimension
+
+    def test_limit_pair_is_plus_upper_minus_lower(self):
+        d = draft_preset(font_size=2.5, decimal_precision=1)
+        # tuple is (lower, upper) → "+upper -lower" (helpers' convention)
+        assert _tol_suffix((0.0, 0.2), d) == " +0.2 -0.0"
+
+    def test_none_is_empty(self):
+        d = draft_preset(font_size=2.5, decimal_precision=1)
+        assert _tol_suffix(None, d) == ""
+
+
+class TestPlannerDecorations:
+    def test_decoration_sets_param_tolerance_keyed_by_kind(self):
+        # A step carries BOTH a length and a diameter param with role="step"; the decoration
+        # key is (feature, kind), so length and diameter are toleranced independently.
+        part = Rot(0, 90, 0) * Cylinder(4, 20)
+        st = step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        model = PartModel(
+            bbox=part.bounding_box(),
+            orientation="x",
+            features=[st],
+            decorations={(st, "length"): 0.2, (st, "diameter"): 0.1},
+        )
+        groups = plan_dimensions(model)
+        dims = {pd.param.kind: pd.param.tolerance for pd in groups[0].dims}
+        assert dims["length"] == 0.2
+        assert dims["diameter"] == 0.1
+
+    def test_no_decoration_leaves_tolerance_none(self):
+        part = Rot(0, 90, 0) * Cylinder(4, 20)
+        st = step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        model = PartModel(bbox=part.bounding_box(), orientation="x", features=[st])
+        groups = plan_dimensions(model)
+        assert all(pd.param.tolerance is None for pd in groups[0].dims)
+
+
+class TestCalloutRendering:
+    def test_hole_bore_spec_carries_tolerance_and_widens_callout(self):
+        # The bore tolerance rides the spec and bakes into the HoleCallout diameter string,
+        # so the rendered callout is geometrically WIDER than the untoleranced one (the
+        # HoleCallout exposes no text attribute, so width is the observable end-to-end proof).
+        d = draft_preset(font_size=2.5, decimal_precision=1)
+        plain = callout_from_spec(_spec(8), d, None)
+        toll = callout_from_spec(_spec(8, tolerance=0.1), d, None)
+        assert toll.bounding_box().size.X > plain.bounding_box().size.X
+
+    def test_hole_callout_spec_reads_bore_tolerance_from_plan(self):
+        h = hole(diameter=8, at=(20, 10, 4), axis="z")
+        model = PartModel(
+            bbox=Box(40, 40, 8).bounding_box(),
+            orientation=None,
+            features=[h],
+            decorations={(h, "diameter"): 0.1},
+        )
+        group = next(g for g in plan_dimensions(model) if g.feature_kind == "hole")
+        assert hole_callout_spec(group)["tolerance"] == 0.1
+
+
+class TestSheetTolerance:
+    @staticmethod
+    def _stepped_shaft():
+        # a genuine 2-diameter turned shaft: distinct shoulders → both a step chain and ⌀ leaders
+        return (Rot(0, 90, 0) * Cylinder(4, 20)) + (
+            Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)
+        )
+
+    def _dias(self, dwg):
+        return {n: dwg._named[n].label for n in dwg._named if n.startswith("m_dia")}
+
+    def _steplen_tol(self, dwg, name):
+        o = dwg._named[name]
+        return o._dw_spec.kwargs.get("tolerance")
+
+    def test_boss_diameter_tolerance_renders_on_leader(self):
+        shaft = self._stepped_shaft()
+        s = Sheet(shaft)
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        s.diameter(diameter=12, at=(15, 0, 0), axis="x").tolerance(0.1)
+        dwg = s.build()
+        assert any(lbl == "ø12 ±0.1" for lbl in self._dias(dwg).values()), self._dias(dwg)
+
+    def test_boss_limit_pair_renders(self):
+        shaft = self._stepped_shaft()
+        s = Sheet(shaft)
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        s.diameter(diameter=12, at=(15, 0, 0), axis="x").tolerance(0.0, 0.2)
+        dwg = s.build()
+        assert any(lbl == "ø12 +0.2 -0.0" for lbl in self._dias(dwg).values()), self._dias(dwg)
+
+    def test_step_length_tolerance_reaches_dimension(self):
+        shaft = self._stepped_shaft()
+        s = Sheet(shaft)
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").tolerance(0.0, 0.2)
+        s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
+        dwg = s.build()
+        tols = {self._steplen_tol(dwg, n) for n in dwg._named if n.startswith("m_steplen")}
+        assert (0.0, 0.2) in tols
+
+    def test_step_tolerance_defaults_to_length_not_diameter(self):
+        shaft = self._stepped_shaft()
+        s = Sheet(shaft)
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").tolerance(0.1)
+        s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
+        dwg = s.build()
+        # the bare .tolerance() went to the length dim; the OD leader stays plain
+        assert all("±" not in lbl and "+" not in lbl for lbl in self._dias(dwg).values())
+        assert 0.1 in {self._steplen_tol(dwg, n) for n in dwg._named if n.startswith("m_steplen")}
+
+    def test_step_on_diameter_tolerances_the_od(self):
+        shaft = self._stepped_shaft()
+        s = Sheet(shaft)
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").tolerance(0.1, on="diameter")
+        s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
+        dwg = s.build()
+        assert any(lbl == "ø8 ±0.1" for lbl in self._dias(dwg).values()), self._dias(dwg)
+
+    def test_no_tolerance_is_inert(self):
+        # The same declared model without any .tolerance() carries no ± anywhere and leaves
+        # every step dim untoleranced — the tolerance path is a no-op without decorations.
+        shaft = self._stepped_shaft()
+        s = Sheet(shaft)
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
+        dwg = s.build()
+        assert all("±" not in lbl and "+" not in lbl for lbl in self._dias(dwg).values())
+        assert all(
+            self._steplen_tol(dwg, n) is None for n in dwg._named if n.startswith("m_steplen")
+        )
+
+
+class TestToleranceHandle:
+    def test_hole_tolerance_survives_feature_replacement(self):
+        # .depth() replaces the feature object; the tolerance is keyed by index, so it still
+        # lands on the final (blind) hole's bore.
+        plate = Box(60, 40, 8)
+        h = Pos(0, 0, 4) * Cylinder(4, 6)
+        part = plate - h
+        s = Sheet(part)
+        s.hole(diameter=8, at=(0, 0, 4), axis="z").depth(6).tolerance(0.1)
+        model = s.build().model()
+        hf = next(f for f in model.features if f.kind == "hole")
+        assert s._tolerances == {(0, "diameter"): 0.1}
+        # the decoration resolves to the FINAL feature (through=False after .depth)
+        assert hf.through is False

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -187,3 +187,32 @@ class TestToleranceHandle:
         assert s._tolerances == {(0, "diameter"): 0.1}
         # the decoration resolves to the FINAL feature (through=False after .depth)
         assert hf.through is False
+
+
+class TestCoerceModelPurity:
+    def test_verbatim_partmodel_is_not_mutated_by_decorations(self):
+        # A PartModel is a reusable public input (ADR 0011); _coerce_model must merge
+        # decorations into a COPY, never mutate the caller's object — else a second build
+        # (with no decorations) inherits stale tolerances from the first.
+        from draftwright.builder import _coerce_model
+
+        st = step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        pm = PartModel(bbox=None, orientation="x", features=[st])
+        # the verbatim-PartModel path never reads `a`; None keeps the test focused.
+        out = _coerce_model(pm, None, decorations={(st, "length"): 0.2})
+        assert out.decorations == {(st, "length"): 0.2}
+        assert pm.decorations == {}, "caller's PartModel was mutated in place"
+
+        # a subsequent bare build sees no leaked tolerance
+        bare = _coerce_model(pm, None)
+        assert bare.decorations == {}
+
+    def test_verbatim_partmodel_decorations_merge_not_replace(self):
+        from draftwright.builder import _coerce_model
+
+        st = step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        pm = PartModel(
+            bbox=None, orientation="x", features=[st], decorations={(st, "diameter"): 0.1}
+        )
+        out = _coerce_model(pm, None, decorations={(st, "length"): 0.2})
+        assert out.decorations == {(st, "diameter"): 0.1, (st, "length"): 0.2}


### PR DESCRIPTION
## What

ADR 0011 **Phase 2 P2a** — a caller attaches a **± / limit tolerance** to a declared dimension, and it renders on **both** the linear `Dimension` path (step length) **and** the ⌀-callout path (boss / step OD leaders, hole bore callouts). Full-uniform scope: the same tolerance renders identically whether it lands on a linear dim or a diameter callout.

## How

- **`DimParameter.tolerance: float | (lower, upper) | None`** (`model/ir.py`) — the value carrier that rides the IR through the planner.
- **`PartModel.decorations: {(feature, kind) -> tolerance}`** (`model/ir.py`) — the authored aspect side-layer. Keyed by `(feature, KIND)` not `(feature, role)` because a `StepFeature` emits a length param and a diameter param **both** with `role="step"`; kind disambiguates.
- **`builder.py`** threads `decorations=` through `build_drawing → _assemble → _repack → _coerce_model`, mirroring the existing `model=` threading. `_coerce_model` **merges** decorations into the model without mutating a caller-supplied `PartModel` (it's a reusable public input).
- **`planner.plan_dimensions`** reads `model.decorations` and folds the tolerance onto the param via `replace(p, tolerance=tol)`.
- **`_core._tol_suffix(tolerance, draft)`** — the `± t` / `+hi -lo` suffix for a **callout** label, mirroring helpers' `_format_label` exactly (float → ` ±{t}`; `(lo,hi)` → ` +{hi} -{lo}`; both rounded to `draft.decimal_precision`). draftwright owns this **only** because pinned helpers' `Leader`/`HoleCallout` take no `tolerance=` yet — extraction upstream tracked as **#449**. The linear `Dimension` path uses helpers' own `tolerance=` param.
- **`annotations/from_model.py`** — `render_step_lengths` / `_draw_step_chain` carry the tolerance in 4-tuples and pass `tolerance=` into the per-segment `_dim()`; a uniform `N× v` collapse drops it. `render_diameters` carries it in the bucket + item 4-tuples and appends `_tol_suffix` to the `ø{dia}` label. `hole_callout_spec` adds `tolerance` to the spec; `callout_from_spec` appends `_tol_suffix` to the bore diameter string. The manual `callout()` verb honours declared tolerances too.
- **`sheet_dsl.py`** — `_Hole.tolerance` / the new `_Dim.tolerance` handle record `{(feature_index, kind) -> value}`; `Sheet.build()` materialises `{(feature, kind) -> value}` against the final features (so a tolerance recorded before a `.depth()` feature-replacement still lands).

## Caveats (documented)

- Tolerances round to `draft.decimal_precision` (**1 dp** today), so `±0.05` renders `±0.1` — this keeps the callout suffix **uniform** with what `Dimension` formats on the same sheet.
- A wider toleranced ⌀ callout can drop in the plan-view strip via existing place-what-fits behaviour — filed **#450** (not a regression: the estimate uses the real `callout.callout_width`, so estimate and render agree).

## Tests

New `tests/test_tolerances.py` (17): `_tol_suffix` format-match, planner decoration keying, callout rendering (spec + width), the `Sheet.tolerance()` handle (± / limit / step length / defaults-to-length / `on="diameter"` / inert), tolerance-survives-feature-replacement, and `_coerce_model` purity (no caller mutation, decorations merge). `test_render_seam.py` item tuples updated to 4-tuples. Full byte-sensitive regression subset (e2e_standards, turned_steps, layout_snapshot, render_seam, make_drawing, part_model, declare) — **green**. ruff + full mypy clean.

## Review

Two adversarial-review passes (Workflow tool): the first caught a real regression (the diameter-placer item tuple grew a tolerance field but the manual `callout()` verb + a render-seam test still built 3-tuples — fixed in `0c66e3b`); the second caught the `_coerce_model` caller-mutation leak (fixed in `3e31b75`, with regression tests).

Follow-ups filed: **#449** (extract `_tol_suffix` to helpers), **#450** (toleranced callout drops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)