### PR TITLE
feat: declare constructors honour explicit overrides + validate IR invariants (#451, #452)

### DIFF
--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -50,7 +50,7 @@ def _norm_axis(axis: str) -> str:
 
 
 def _is_positive(v) -> bool:
-    return isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v) and v > 0
 
 
 def _require_positive(**named) -> None:
@@ -69,6 +69,13 @@ def _positive(name: str, v) -> None:
         raise ValueError(f"{name} must be a positive number (got {v!r})")
 
 
+def _require_count(name: str, count) -> None:
+    """A count must be a positive *int* — a fractional/None count is nonsensical and would
+    otherwise store silently or crash later in ``range(count)`` with a raw TypeError (#452)."""
+    if not (isinstance(count, int) and not isinstance(count, bool) and count >= 1):
+        raise ValueError(f"{name} needs count >= 1 as an int (got {count!r})")
+
+
 def _require_point(name: str, pt) -> None:
     """A location/point kwarg must be an ``(x, y, z)`` triple of numbers."""
     if not (
@@ -85,7 +92,8 @@ def _require_pair_positive(name: str, pair) -> None:
         return
     if not (isinstance(pair, (tuple, list)) and len(pair) == 2):
         raise ValueError(f"{name} must be a (diameter, depth) pair (got {pair!r})")
-    _require_positive(**{f"{name} diameter": pair[0], f"{name} depth": pair[1]})
+    _positive(f"{name} diameter", pair[0])  # both required — a None slot must fail too
+    _positive(f"{name} depth", pair[1])
 
 
 def _bbox_axis_dia(obj) -> tuple[str, float, Point]:
@@ -161,8 +169,7 @@ def hole(
     _require_pair_positive("cbore", cbore)
     _require_pair_positive("spotface", spotface)
     _require_point("at", at)
-    if count < 1:
-        raise ValueError(f"hole() needs count >= 1 (got {count!r})")
+    _require_count("hole()", count)
     return HoleFeature(
         frame=Frame(origin=at, axis=axis),
         diameter=diameter,
@@ -392,8 +399,7 @@ def pattern(
         raise ValueError(
             f"pattern(kind={kind!r}) is not a known arrangement (bolt_circle / linear / grid / other)"
         )
-    if count < 1:
-        raise ValueError(f"pattern() needs count >= 1 (got {count!r})")
+    _require_count("pattern()", count)
     if members and len(members) != count:
         raise ValueError(f"pattern() count={count} must equal len(members)={len(members)}")
 
@@ -401,8 +407,10 @@ def pattern(
         _positive("pattern(kind='bolt_circle') bcd=", bcd)  # furniture reads it even w/ members=
     elif kind == "linear":
         _positive("pattern(kind='linear') pitch=", pitch)  # pitch dim reads it even w/ members=
-        if direction is not None and not any(direction):
-            raise ValueError("pattern(kind='linear') direction= must be nonzero")
+        if direction is not None:
+            _require_point("direction", direction)  # a (dx, dy, dz) triple of numbers
+            if not any(direction):
+                raise ValueError("pattern(kind='linear') direction= must be nonzero")
     elif kind == "grid":
         if grid is None or rows is None or cols is None:
             raise ValueError("pattern(kind='grid') needs grid= pitch and rows= and cols=")

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -49,6 +49,45 @@ def _norm_axis(axis: str) -> str:
     return a
 
 
+def _is_positive(v) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0
+
+
+def _require_positive(**named) -> None:
+    """Each supplied (non-``None``) value must be a positive number. These constructors are
+    a public compiler input (ADR 0011); a negative/zero size must fail at declaration time
+    with a clear ``ValueError``, not later in layout or as a misleading drawing (#452). A
+    ``None`` is skipped (the field is optional) — use :func:`_positive` for a required one."""
+    for name, v in named.items():
+        if v is not None and not _is_positive(v):
+            raise ValueError(f"{name} must be a positive number (got {v!r})")
+
+
+def _positive(name: str, v) -> None:
+    """A *required* positive number — ``None`` fails too (a missing defining dim, #452)."""
+    if not _is_positive(v):
+        raise ValueError(f"{name} must be a positive number (got {v!r})")
+
+
+def _require_point(name: str, pt) -> None:
+    """A location/point kwarg must be an ``(x, y, z)`` triple of numbers."""
+    if not (
+        isinstance(pt, (tuple, list))
+        and len(pt) == 3
+        and all(isinstance(c, (int, float)) and not isinstance(c, bool) for c in pt)
+    ):
+        raise ValueError(f"{name} must be an (x, y, z) tuple of numbers (got {pt!r})")
+
+
+def _require_pair_positive(name: str, pair) -> None:
+    """A ``(diameter, depth)`` pair (``cbore`` / ``spotface``) must be two positive numbers."""
+    if pair is None:
+        return
+    if not (isinstance(pair, (tuple, list)) and len(pair) == 2):
+        raise ValueError(f"{name} must be a (diameter, depth) pair (got {pair!r})")
+    _require_positive(**{f"{name} diameter": pair[0], f"{name} depth": pair[1]})
+
+
 def _bbox_axis_dia(obj) -> tuple[str, float, Point]:
     """Read an axis-aligned cylinder's (axis, diameter, centre) off its bounding box:
     the two near-equal spans are the diameter; the odd one out is the bore/OD axis."""
@@ -107,12 +146,23 @@ def hole(
     build123d object you subtracted — or ``hole(diameter=6, at=(20, 10, 0), axis="z")``.
 
     ``cbore`` / ``spotface`` are ``(diameter, depth)`` pairs; ``count`` + ``members``
-    describe a machining-spec group drawn as one ``count×`` callout."""
+    describe a machining-spec group drawn as one ``count×`` callout.
+
+    An object supplies *defaults*; any explicit keyword overrides that field (#451)."""
     if obj is not None:
-        axis, diameter, at = _read_cylinder(obj)
+        r_axis, r_diameter, r_at = _read_cylinder(obj)
+        axis = r_axis if axis is None else axis
+        diameter = r_diameter if diameter is None else diameter
+        at = r_at if at is None else at
     if diameter is None or at is None or axis is None:
         raise ValueError("hole() needs an object, or explicit diameter=, at= and axis=")
     axis = _norm_axis(axis)
+    _require_positive(diameter=diameter, depth=depth)
+    _require_pair_positive("cbore", cbore)
+    _require_pair_positive("spotface", spotface)
+    _require_point("at", at)
+    if count < 1:
+        raise ValueError(f"hole() needs count >= 1 (got {count!r})")
     return HoleFeature(
         frame=Frame(origin=at, axis=axis),
         diameter=diameter,
@@ -127,12 +177,18 @@ def hole(
 
 def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:
     """An external cylindrical boss / OD. Either ``boss(cylinder)`` or
-    ``boss(diameter=6, at=(0, 0, 0), axis="x")`` (parametric)."""
+    ``boss(diameter=6, at=(0, 0, 0), axis="x")`` (parametric). An object supplies
+    *defaults*; any explicit keyword overrides that field (#451)."""
     if obj is not None:
-        axis, diameter, at = _read_cylinder(obj)
+        r_axis, r_diameter, r_at = _read_cylinder(obj)
+        axis = r_axis if axis is None else axis
+        diameter = r_diameter if diameter is None else diameter
+        at = r_at if at is None else at
     if diameter is None or at is None or axis is None:
         raise ValueError("boss() needs an object, or explicit diameter=, at= and axis=")
     axis = _norm_axis(axis)
+    _require_positive(diameter=diameter)
+    _require_point("at", at)
     return BossFeature(frame=Frame(origin=at, axis=axis), diameter=diameter)
 
 
@@ -140,14 +196,21 @@ def step(obj=None, *, diameter=None, length=None, at=None, axis=None, span=None)
     """One axial segment of a turned profile — its OD + length. Either ``step(segment)``
     (⌀ from the cylindrical face, length + centre from the bbox along its axis) or
     explicit ``step(diameter=4, length=10, at=(0, 0, 0), axis="x")``. ``span`` (the two
-    axial end-points) is derived from ``at`` + ``length`` when not given."""
+    axial end-points) is derived from ``at`` + ``length`` when not given. An object supplies
+    *defaults*; any explicit keyword overrides that field (#451)."""
     if obj is not None:
-        axis, diameter, at = _read_cylinder(obj)
-        bb = obj.bounding_box()
-        length = [bb.size.X, bb.size.Y, bb.size.Z]["xyz".index(axis)]
+        r_axis, r_diameter, r_at = _read_cylinder(obj)
+        axis = r_axis if axis is None else axis
+        diameter = r_diameter if diameter is None else diameter
+        at = r_at if at is None else at
+        if length is None:
+            bb = obj.bounding_box()
+            length = [bb.size.X, bb.size.Y, bb.size.Z]["xyz".index(_norm_axis(axis))]
     if diameter is None or length is None or at is None or axis is None:
         raise ValueError("step() needs an object, or explicit diameter=, length=, at= and axis=")
     axis = _norm_axis(axis)
+    _require_positive(diameter=diameter, length=length)
+    _require_point("at", at)
     if span is None:
         span = _span(at, axis, length)
     return StepFeature(
@@ -162,7 +225,7 @@ def slot(
     length=None,
     long_axis=None,
     width_axis=None,
-    w_center=0.0,
+    w_center=None,
     lo=None,
     hi=None,
     at=None,
@@ -170,7 +233,7 @@ def slot(
     """A milled slot / reduced across-flats section. From an object the three bbox spans
     are read as long_axis (longest) / width_axis (middle) / depth (shortest, not stored);
     ``lo``/``hi`` are the extent along the long axis and ``w_center`` the centre across the
-    width axis. Explicit values override any read.
+    width axis. An object supplies *defaults*; any explicit keyword overrides that field (#451).
 
     Caveat: the object read assumes width > depth (a slot wider than it is deep). For a
     slot cut *deeper than it is wide* the middle/shortest spans swap — pass explicit
@@ -187,14 +250,31 @@ def slot(
             key=lambda s: s[1],
             reverse=True,
         )
-        (long_axis, length, lo, hi, _), (width_axis, width, _, _, w_center), _ = spans
-        at = (c.X, c.Y, c.Z)
+        (r_long_axis, r_length, r_lo, r_hi, _), (r_width_axis, r_width, _, _, r_w_center), _ = (
+            spans
+        )
+        long_axis = r_long_axis if long_axis is None else long_axis
+        width_axis = r_width_axis if width_axis is None else width_axis
+        length = r_length if length is None else length
+        width = r_width if width is None else width
+        lo = r_lo if lo is None else lo
+        hi = r_hi if hi is None else hi
+        w_center = r_w_center if w_center is None else w_center
+        at = (c.X, c.Y, c.Z) if at is None else at
     if None in (width, length, long_axis, width_axis, lo, hi):
         raise ValueError(
             "slot() needs an object, or explicit width=, length=, long_axis=, width_axis=, lo= and hi="
         )
     long_axis = _norm_axis(long_axis)
     width_axis = _norm_axis(width_axis)
+    if long_axis == width_axis:
+        raise ValueError(f"slot() long_axis and width_axis must differ (both {long_axis!r})")
+    _require_positive(width=width, length=length)
+    if not lo < hi:
+        raise ValueError(f"slot() needs lo < hi (got lo={lo!r}, hi={hi!r})")
+    if not math.isclose(hi - lo, length, rel_tol=1e-6, abs_tol=1e-6):
+        raise ValueError(f"slot() length={length!r} must equal hi - lo ({hi - lo!r})")
+    w_center = 0.0 if w_center is None else w_center
     if at is None:
         # Centre on the long axis at the slot midpoint; other coords irrelevant to the size dims.
         origin = [0.0, 0.0, 0.0]
@@ -297,7 +377,10 @@ def pattern(
     ``members=`` explicitly to override the computed layout (required for ``kind="other"``)."""
     axis = _norm_axis(axis or member.frame.axis)
     center = at if at is not None else member.frame.origin
+    _require_point("at", center)
     members = tuple(members)
+    for m in members:
+        _require_point("members", m)
 
     # Validate the arrangement up front, *whether or not* members are supplied: the furniture
     # pass reads bcd/pitch/grid to draw the BCD centreline / pitch / grid dims, so a known
@@ -305,23 +388,40 @@ def pattern(
     # (a missing or zero dim else crashes the furniture, or collapses computed members onto
     # the centre). Only 'other' — a bare group with no arrangement furniture — is exempt, and
     # it must carry explicit members. Fail loudly, matching the hole/boss/step/slot guards.
-    if kind == "bolt_circle" and not bcd:
-        raise ValueError("pattern(kind='bolt_circle') needs a nonzero bcd= (or explicit members=)")
-    elif kind == "linear" and not pitch:
-        raise ValueError("pattern(kind='linear') needs a nonzero pitch= (or explicit members=)")
-    elif kind == "grid" and (not grid or not all(grid) or rows is None or cols is None):
-        raise ValueError(
-            "pattern(kind='grid') needs a nonzero grid= pitch and rows= and cols= "
-            "(or explicit members=)"
-        )
-    elif kind == "other" and not members:
-        raise ValueError("pattern(kind='other') needs explicit members=")
-    elif kind not in ("bolt_circle", "linear", "grid", "other"):
+    if kind not in ("bolt_circle", "linear", "grid", "other"):
         raise ValueError(
             f"pattern(kind={kind!r}) is not a known arrangement (bolt_circle / linear / grid / other)"
         )
     if count < 1:
         raise ValueError(f"pattern() needs count >= 1 (got {count!r})")
+    if members and len(members) != count:
+        raise ValueError(f"pattern() count={count} must equal len(members)={len(members)}")
+
+    if kind == "bolt_circle":
+        _positive("pattern(kind='bolt_circle') bcd=", bcd)  # furniture reads it even w/ members=
+    elif kind == "linear":
+        _positive("pattern(kind='linear') pitch=", pitch)  # pitch dim reads it even w/ members=
+        if direction is not None and not any(direction):
+            raise ValueError("pattern(kind='linear') direction= must be nonzero")
+    elif kind == "grid":
+        if grid is None or rows is None or cols is None:
+            raise ValueError("pattern(kind='grid') needs grid= pitch and rows= and cols=")
+        if not (isinstance(grid, (tuple, list)) and len(grid) == 2):
+            raise ValueError(
+                f"pattern() grid= must be a (row_pitch, col_pitch) pair (got {grid!r})"
+            )
+        _positive("pattern() grid row pitch", grid[0])
+        _positive("pattern() grid col pitch", grid[1])
+        if not (isinstance(rows, int) and isinstance(cols, int) and rows >= 1 and cols >= 1):
+            raise ValueError(
+                f"pattern() rows= and cols= must be positive ints (got rows={rows!r}, cols={cols!r})"
+            )
+        if rows * cols != count:
+            raise ValueError(
+                f"pattern(kind='grid') needs rows*cols == count ({rows}*{cols} != {count})"
+            )
+    elif kind == "other" and not members:
+        raise ValueError("pattern(kind='other') needs explicit members=")
 
     if not members:
         members = _pattern_members(

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -249,6 +249,28 @@ class TestConstructorInvariants:
         with pytest.raises(ValueError):
             pattern(member, kind="other", count=1, members=((1, 0),))  # not an (x, y, z)
 
+    def test_pattern_malformed_direction_raises(self):
+        # a 2-tuple direction must fail cleanly, not IndexError deep in _pattern_members
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="linear", count=3, pitch=5, direction=(1, 0))
+
+    def test_hole_cbore_none_element_raises(self):
+        # a required (diameter, depth) pair must reject a None slot, not store it
+        with pytest.raises(ValueError):
+            hole(diameter=6, at=(0, 0, 0), axis="z", cbore=(10, None))
+
+    def test_fractional_count_raises(self):
+        with pytest.raises(ValueError):
+            hole(diameter=6, at=(0, 0, 0), axis="z", count=2.5)
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="bolt_circle", count=None, bcd=20)
+
+    def test_infinite_size_raises(self):
+        with pytest.raises(ValueError):
+            step(diameter=float("inf"), length=10, at=(0, 0, 0), axis="x")
+
 
 class TestModelSeam:
     def test_declared_model_skips_detection(self):

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -140,6 +140,116 @@ class TestConstructors:
             slot(width=6, length=20)  # missing axes / lo / hi
 
 
+class TestExplicitOverridesObject:
+    """#451: an object supplies DEFAULTS; each explicit keyword overrides that field
+    independently. The reliable escape hatch for tricky geometry (tubes, counterbores,
+    multi-cylinder tools) is to pass the object and override the fields inference gets wrong."""
+
+    def test_hole_explicit_kwargs_override_object_read(self):
+        # the exact probe from #451: object reads ø6/z/(0,0,0); the kwargs must win.
+        f = hole(Cylinder(3, 8), diameter=2, at=(9, 9, 9), axis="x")
+        assert f.diameter == 2
+        assert f.frame.origin == (9, 9, 9)
+        assert f.frame.axis == "x"
+
+    def test_hole_partial_override_keeps_read_defaults(self):
+        # override only the diameter; axis + location still come from the object.
+        f = hole(Pos(20, 10, 4) * Cylinder(3, 8), diameter=2)
+        assert f.diameter == 2
+        assert f.frame.axis == "z" and f.frame.origin == pytest.approx((20, 10, 4))
+
+    def test_boss_explicit_kwargs_override_object_read(self):
+        f = boss(Cylinder(3, 8), diameter=99, at=(1, 2, 3), axis="y")
+        assert f.diameter == 99 and f.frame.origin == (1, 2, 3) and f.frame.axis == "y"
+
+    def test_step_explicit_kwargs_override_object_read(self):
+        f = step(Rot(0, 90, 0) * Cylinder(2, 10), diameter=99, length=77, at=(1, 2, 3), axis="y")
+        assert f.diameter == 99 and f.length == 77
+        assert f.frame.origin == (1, 2, 3) and f.frame.axis == "y"
+
+    def test_slot_explicit_kwarg_overrides_object_read(self):
+        # override only the width; length / axes still read off the Box(20, 6, 4) tool.
+        f = slot(Box(20, 6, 4), width=5)
+        assert f.width == 5
+        assert f.length == pytest.approx(20.0) and f.long_axis == "x" and f.width_axis == "y"
+
+
+class TestConstructorInvariants:
+    """#452: these constructors are a public compiler input; invalid data must fail at
+    declaration with a clear ValueError, not later in layout or as a misleading drawing."""
+
+    def test_hole_negative_diameter_raises(self):
+        with pytest.raises(ValueError):
+            hole(diameter=-6, at=(0, 0, 0), axis="z")
+
+    def test_hole_zero_diameter_raises(self):
+        with pytest.raises(ValueError):
+            hole(diameter=0, at=(0, 0, 0), axis="z")
+
+    def test_hole_negative_depth_raises(self):
+        with pytest.raises(ValueError):
+            hole(diameter=6, at=(0, 0, 0), axis="z", depth=-1)
+
+    def test_hole_malformed_cbore_raises(self):
+        with pytest.raises(ValueError):
+            hole(diameter=6, at=(0, 0, 0), axis="z", cbore=(10,))  # not a (dia, depth) pair
+        with pytest.raises(ValueError):
+            hole(diameter=6, at=(0, 0, 0), axis="z", cbore=(10, -1))  # negative depth
+
+    def test_hole_malformed_at_raises(self):
+        with pytest.raises(ValueError):
+            hole(diameter=6, at=(0, 0), axis="z")  # not an (x, y, z) triple
+
+    def test_boss_negative_diameter_raises(self):
+        with pytest.raises(ValueError):
+            boss(diameter=-6, at=(0, 0, 0), axis="x")
+
+    def test_step_nonpositive_length_raises(self):
+        with pytest.raises(ValueError):
+            step(diameter=4, length=0, at=(0, 0, 0), axis="x")
+
+    def test_slot_same_axes_raises(self):
+        with pytest.raises(ValueError):
+            slot(width=6, length=20, long_axis="x", width_axis="x", lo=-10, hi=10)
+
+    def test_slot_lo_not_less_than_hi_raises(self):
+        with pytest.raises(ValueError):
+            slot(width=6, length=20, long_axis="x", width_axis="y", lo=10, hi=-10)
+
+    def test_slot_length_must_match_span(self):
+        with pytest.raises(ValueError):
+            slot(width=6, length=25, long_axis="x", width_axis="y", lo=-10, hi=10)  # span=20≠25
+
+    def test_slot_negative_width_raises(self):
+        with pytest.raises(ValueError):
+            slot(width=-6, length=20, long_axis="x", width_axis="y", lo=-10, hi=10)
+
+    def test_pattern_negative_bcd_raises(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="bolt_circle", count=4, bcd=-40)
+
+    def test_pattern_zero_direction_raises(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="linear", count=3, pitch=10, direction=(0, 0, 0))
+
+    def test_pattern_grid_rows_cols_must_multiply_to_count(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="grid", count=4, grid=(10, 10), rows=1, cols=1)
+
+    def test_pattern_explicit_members_must_match_count(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="bolt_circle", count=4, bcd=40, members=((1, 0, 0), (2, 0, 0)))
+
+    def test_pattern_malformed_member_point_raises(self):
+        member = hole(diameter=3, at=(0, 0, 0), axis="z")
+        with pytest.raises(ValueError):
+            pattern(member, kind="other", count=1, members=((1, 0),))  # not an (x, y, z)
+
+
 class TestModelSeam:
     def test_declared_model_skips_detection(self):
         # The plate has TWO holes; declare only ONE. Detection would find both, so a


### PR DESCRIPTION
## What

Two hardening fixes to the ADR 0011 public object→feature constructors (`draftwright.model.hole`/`boss`/`step`/`slot`/`pattern`), surfaced by the #447 review. First of the declaration-surface hardening cluster.

### #451 — explicit keywords override object-read defaults

The constructors advertise two modes: read geometry off a build123d object, or supply explicit values. Previously, when `obj` was supplied, the object-read branch **overwrote** any explicit `diameter`/`axis`/`at`/`length` before validation — defeating the escape hatch for tricky geometry (tubes, counterbores, multi-cylinder tools, chamfered/partial cylinders) where you naturally pass the object *and* override the fields inference gets wrong.

Now the object supplies **defaults**; each explicit keyword overrides that field independently. `hole(Cylinder(3, 8), diameter=2, at=(9, 9, 9), axis="x")` returns ø2 at (9,9,9)/x, not the read ø6.

### #452 — validate public IR constructor invariants

These constructors are a public compiler input; invalid data now fails at declaration with a clear `ValueError` instead of later in layout, wrong output, or silently-collapsed geometry:

- **positive sizes** — diameter, length, width, depth, cbore/spotface (dia & depth), bcd, pitch, grid pitch (finite, non-bool, > 0);
- **well-formed tuples** — `at`/`members`/`direction` are `(x,y,z)` triples of numbers; `cbore`/`spotface` are `(dia, depth)` pairs; `grid` is a `(row_pitch, col_pitch)` pair;
- **slot** — `long_axis != width_axis`, `lo < hi`, and `length == hi − lo`;
- **pattern** — `count ≥ 1` as an int, `len(members) == count` when explicit, `rows*cols == count` for grids, positive-int rows/cols, nonzero linear `direction`.

Also aligns the `pattern()` defining-dim messages with the real contract (the furniture reads `bcd`/`pitch`/`grid` even when `members=` is explicit — the message no longer says "or explicit members="), folding in part of #454.

## Notes

- `slot()` `w_center` default changed `0.0 → None` so an object read is overridable per #451; converted back to `0.0` at construction. No production caller passes it.
- Detection-only and Sheet paths are untouched — this is validation + override semantics on the declaration constructors only.

## Tests

26 new tests in `tests/test_declare.py` (`TestExplicitOverridesObject`, `TestConstructorInvariants`): explicit-override for each constructor, and each invariant's failure case. 62 pass total; `test_tolerances` + `test_part_model` regressions green; ruff + full mypy clean.

## Review

One adversarial round (Workflow tool) found four too-loose spots in the new validation itself — a malformed `direction` 2-tuple, a `None` element in a `cbore`/`spotface` pair, an untyped fractional `count`, and `_is_positive` accepting `+inf`. All four fixed in the second commit with regression tests.

Refs #447, #446, ADR 0011. Next in the cluster: #448 (model-driven hole/pattern render membership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)