### PR TITLE
feat: declared holes/patterns render at their declared position (#448, #454)

### DIFF
--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -93,18 +93,19 @@ detected drawing needs one more thing"). Two complementary modes, one IR.
   is correctly flagged by the coverage lint for the geometry it left undimensioned (the
   drawing is right — those features genuinely have no callout). A full declared-model
   bypass of estimation + coverage is a follow-up, not a blocker.
-- **Known caveat — the hole/pattern render path is gated on detected positions.**
-  Distinct from the diameter/step/boss/envelope path (which renders straight from the IR),
-  the *hole and pattern* renderers gate on `feature_keys` — the set of detected hole
-  positions (`feature_holes_of(a)`, the Amendment-6 invariant that no recogniser `Hole`
-  crosses into the renderers). So a declared hole/pattern only renders where its members
-  coincide (to 3 dp) with a **detected** hole; a hole that detection *missed* renders
-  nothing (it surfaces as a coverage **warning**, not silently). This means declaration
-  fully sidesteps misdetection for the #298 class (a band under an OD — a *diameter*
-  feature, not gated) but **not** for a missed hole. The canonical fix — sourcing
-  `feature_keys` from the declared model when `model=` is supplied — is tracked as a
-  follow-up (**#448**), not a blocker: the common declared-hole case (declared positions
-  match the built geometry) renders correctly.
+- **Hole/pattern render membership is model-driven (#448, resolved).** Originally the
+  *hole and pattern* renderers gated on `feature_keys` — the set of *detected* hole
+  positions (`feature_holes_of(a)`) — so a declared hole/pattern only rendered where its
+  members coincided (to 3 dp) with a detected hole, and a detection-*missed* hole rendered
+  nothing (surfacing only as a coverage warning). When `model=` is supplied, the callout
+  membership set is now sourced from the declared IR groups too (`_declared_feature_keys`),
+  mirroring the exact member source and rotational concentric-bore exclusion of the callout
+  filter — so a declared hole/pattern renders at its **declared** position regardless of
+  detection. Gated on the declared flag, so the detection-only path is byte-identical. The
+  Amendment-6 invariant still holds (no recogniser `Hole` crosses into the renderers — the
+  keys are IR-derived). One detection-dependent bit remains: off-axis side-drilled hole
+  *location* dims (`_locate_off_axis_holes`) still need recogniser-`Hole` geometry a declared
+  feature doesn't carry, so a detection-missed side hole's location dim is a further follow-up.
 
 ## Alternatives considered
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -58,7 +58,13 @@ from draftwright.annotations.sections import (
     _resolve_details,
     feature_holes_of,
 )
-from draftwright.model import PatternFeature, build_part_model, plan_dimensions, plan_sections
+from draftwright.model import (
+    HoleFeature,
+    PatternFeature,
+    build_part_model,
+    plan_dimensions,
+    plan_sections,
+)
 from draftwright.recognition import (
     full_cylinders,
 )
@@ -122,6 +128,29 @@ def build_model(a: Analysis):
         rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
         pmi=a.pmi,
     )
+
+
+def _declared_feature_keys(groups, a: Analysis) -> set:
+    """The :class:`HoleRef` position keys of every DECLARED hole/pattern member (ADR 0011
+    #448), so a caller-declared hole/pattern renders at its declared position even where
+    detection missed it. Mirrors the member source (``feat.members or g.anchor``) and the
+    rotational concentric-bore exclusion of the ``_annotate_holes`` filter so the callout
+    gate matches exactly — an on-axis bore stays excluded (dimensioned by the ldr_z
+    centreline)."""
+    keys: set = set()
+    for g in groups:
+        feat = g.feature
+        if not isinstance(feat, HoleFeature | PatternFeature):
+            continue
+        for m in feat.members or (g.anchor,):
+            if (
+                a.is_rotational
+                and feat.frame.axis == "z"
+                and math.hypot(m[0] - a.cx, m[1] - a.cy) <= _CONCENTRIC_TOL_MM
+            ):
+                continue
+            keys.add(HoleRef.of(m))
+    return keys
 
 
 def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
@@ -195,6 +224,17 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # #207). feature_holes_of is the single source shared with the section() add verb (#420).
     feature_holes = feature_holes_of(a)
     feature_keys = {HoleRef.of(h.location) for h in feature_holes}
+    # ADR 0011 #448: when the caller DECLARED the model (model=), a hole/pattern renders at
+    # its declared position even where detection missed it — source the callout membership
+    # set from the declared IR groups too, not only a.holes. A no-op for the detection-only
+    # path (gated on the declared flag; and on a fully-detected declared part the declared
+    # keys already coincide with the detected ones). NOTE: off-axis side-drilled *location*
+    # dims (_locate_off_axis_holes below) still gate on detected holes — they need recogniser
+    # -Hole geometry (diameter/depth/bottom) a declared IR feature doesn't carry — a follow-up.
+    declared_keys: set = set()
+    if getattr(dwg, "_model_declared", False):
+        declared_keys = _declared_feature_keys(_groups, a)
+        feature_keys = feature_keys | declared_keys
     # Decide the section trigger + cut-plane row now (pure function of _model/
     # feature_keys, no placement dependency) and reserve its cutting-plane arrows'
     # row BEFORE the plan-view hole callouts place (ADR 0009 P5 strand 3) — the
@@ -208,7 +248,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (tests/test_layout_cleanliness.py) is exactly this accepted case.
     _section = plan_sections(_model, feature_keys)
     _reserve_section_row(dwg, a, _section)
-    if feature_holes:
+    if feature_holes or declared_keys:  # declared holes render even where detection missed them
         _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
     # through the existing above-view strips. Replaces the engine's _add_location_dims.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -245,6 +245,7 @@ def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=
     # work even in manual mode (#398). _auto_annotate reads this attached model rather
     # than rebuilding. On a repack this runs again on the pass-2 drawing (freshness).
     dwg._part_model = _coerce_model(model, a, decorations) if model is not None else build_model(a)
+    dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
 
     part_s = a.part.scale(a.SCALE)
     dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)
@@ -476,11 +477,11 @@ def build_drawing(
             features; ``None`` (default) detects normally. Detection and declaration are
             two producers of the same IR — everything downstream is untouched. (Notes:
             sheet scale/zone estimation and the coverage lint still detect independently,
-            so a *partial* declaration will flag the undeclared geometry; and the
-            hole/pattern renderer gates on detected hole positions, so a declared
-            hole/pattern renders only where it coincides with a detected hole — a missed
-            hole is flagged, not drawn (#448). Diameter/step/boss/envelope features are
-            not gated. See ADR 0011.)
+            so a *partial* declaration will flag the undeclared geometry. A declared
+            hole/pattern now renders at its declared position even where detection missed
+            it (#448); the one remaining detection-dependent bit is the off-axis
+            side-drilled hole *location* dim, which needs recogniser-Hole geometry a
+            declared feature doesn't carry. See ADR 0011.)
 
     Returns:
         A :class:`Drawing` with the standard front/plan/side/iso views projected

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -291,6 +291,10 @@ class Drawing:
         # The detected ADR-0008 PartModel this drawing was built from (attached by
         # the annotation orchestrator). Read surface for semantic edits (#397).
         self._part_model: object | None = None
+        # True when the caller SUPPLIED the model (build_drawing(model=…), ADR 0011) rather
+        # than it being detected — gates the model-driven hole/pattern render membership so a
+        # declared hole draws even where detection missed it, no-op for the detected path (#448).
+        self._model_declared: bool = False
         # Lazy model-location → IR hole/pattern feature index (#408), so a balloon —
         # which holds a recognition hole, not the IR feature — can attribute itself.
         self._hole_feature_index: dict | None = None

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -339,20 +339,33 @@ class TestModelSeam:
         # just that members were populated
         assert any(n.startswith("bc_") for n in dwg._named), sorted(dwg._named)
 
-    def test_declared_pattern_off_detected_positions_is_flagged_not_rendered(self):
-        # ADR 0011 caveat (widened after review): the hole/pattern render path gates on
-        # feature_keys built from DETECTION (a.holes), so a declared pattern whose members
-        # do not coincide (to 3 dp) with the detected holes is not rendered — it surfaces
-        # as a coverage warning, not silently. Full model-driven hole rendering is a
-        # follow-up (#448). Here the holes sit at 45° but the pattern is declared at 0°.
+    def test_declared_pattern_renders_at_its_declared_position(self):
+        # #448: a declared hole/pattern renders at its DECLARED position even where it does
+        # not coincide with a detected hole — the callout membership is now sourced from the
+        # declared IR, not only detection (was the ADR 0011 caveat: gated on a.holes, so a
+        # detection-missed declaration was silently undrawn). Here the holes physically sit at
+        # 45° but the pattern is declared at 0°; the declared pattern must still render (its
+        # bc_ furniture appears at the declared position), and the coverage lint still flags
+        # the 45° holes the declaration left undimensioned — the declaration is authoritative,
+        # not silently dropped.
         r, z = 25.0, 4.0
         plate, part = self._bolt_circle_part(r, z, (45, 135, 225, 315))
         member = hole(diameter=6, at=(r, 0, z), axis="z")
         pat = pattern(member, kind="bolt_circle", count=4, bcd=2 * r, at=(0, 0, z), angle=0)
         dwg = build_drawing(part, model=[envelope(plate), pat])
-        assert not any(n.startswith("bc_") for n in dwg._named)  # not rendered
+        assert any(n.startswith("bc_") for n in dwg._named), sorted(dwg._named)  # rendered
         warns = {i.code for i in dwg.lint() if i.severity in ("warning", "error")}
-        assert warns  # but flagged, not silent
+        assert warns  # the physically-present 45° holes remain flagged as undimensioned
+
+    def test_detection_only_hole_render_unchanged_by_the_declared_gate(self):
+        # The #448 model-driven membership is gated on model= being supplied — a plain
+        # detection build is untouched (a.holes still drives the callouts).
+        plate = Box(80, 50, 8)
+        h1 = Pos(20, 10, 4) * Cylinder(3, 8)
+        part = plate - h1
+        dwg = build_drawing(part)  # no model= → detection path
+        assert dwg._model_declared is False
+        assert not [i for i in dwg.lint() if i.severity == "error"]
 
     def test_pattern_requires_arrangement_dim(self):
         member = hole(diameter=3, at=(0, 0, 0), axis="z")


### PR DESCRIPTION
## What

ADR 0011 **#448** — the priority blocker of the declaration-surface hardening cluster. A caller-declared hole/pattern now renders its callout at the **declared** position even where detection missed it, closing the last gap where declaration didn't fully sidestep misdetection.

## Background

Before this change, the hole/pattern **callout** renderer (`_annotate_holes`) gated on `feature_keys` — a set of HoleRef position keys built from **detected** holes (`feature_holes_of(a)`, reading `a.holes`). Its filter drops a feature whose members don't coincide (to 3 dp) with a detected hole. So a *declared* hole that detection missed rendered nothing (surfacing only as a coverage warning). The diameter/step/boss/envelope path already renders straight from the IR; only holes/patterns were gated — partially undercutting ADR 0011's premise for holes.

## The fix (narrow)

`render_locations` already reads declared X/Y hole locations from the model (not detection), so the **only** detection gate on declared holes was the callout path:

- **`builder.py`** — `dwg._model_declared = model is not None`, set on both the pass-1 and repack pass-2 `_assemble` calls; default `False` on the `Drawing` class.
- **`orchestrator.py`** — new `_declared_feature_keys(groups, a)` walks the planned `DimensionGroup`s and collects `HoleRef.of(m)` for `m in (feat.members or g.anchor)` — mirroring the **exact** member source and rotational concentric-bore exclusion of the `_annotate_holes` filter, so the callout gate matches. When `model=` was supplied, these keys are unioned into `feature_keys`, and the callout gate becomes `if feature_holes or declared_keys:` so callouts render even when detection found zero holes.
- `_annotate_holes` is **unchanged** — it reads projection geometry + groups + `feature_keys`, never `a.holes`.

Gated entirely on the declared flag, so the detection-only path is **byte-identical**. The Amendment-6 invariant still holds — the keys are IR-derived; no recogniser `Hole` crosses into the renderers.

## Remaining gap (documented)

Off-axis **side-drilled** hole *location* dims (`_locate_off_axis_holes`) still need recogniser-`Hole` geometry (diameter/depth/bottom) a declared feature doesn't carry — a detection-missed side hole's location dim is a further follow-up, noted in the code + ADR.

## #454 docs

Folds in the #454 doc corrections: the ADR 0011 caveat and `build_drawing(model=)` docstring no longer over-claim that declared holes render "only where they coincide with a detected hole" — they now describe the model-driven behaviour and the one remaining side-drilled-location caveat.

## Tests

The old caveat test (`..._is_flagged_not_rendered`) is flipped to `test_declared_pattern_renders_at_its_declared_position` (a pattern declared at 0° while holes sit physically at 45° now renders at 0°, and the coverage lint still flags the real 45° holes). New `test_detection_only_hole_render_unchanged_by_the_declared_gate` guards the no-op. 38 pass in `test_declare.py`.

**Byte-identity verified for the detection path:** `test_make_drawing` + `test_render_seam` + `test_layout_snapshot` (519 passed) and `test_e2e_standards` + `test_turned_steps` (13 passed). ruff + full mypy clean.

## Review

One adversarial round (Workflow, 3 dimensions: no-op/repack byte-identity, `_declared_feature_keys` correctness vs the filter, section-trigger + gate safety) — **0 confirmed findings**.

Refs #447, #446, ADR 0011. Closes #448, #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)