### PR TITLE
feat: Sheet.model() / from_part() skip the full drawing build (#453)

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -179,6 +179,26 @@ _STEP_MIN_AREA_FRAC = 0.01
 # ---------------------------------------------------------------------------
 
 
+def _solids_body(part, src: str = "part"):
+    """The part reduced to just its solids — the geometry the drawing is *of*.
+
+    AP242 STEP files (and hand-built Compounds) can carry non-solid geometry beside
+    the solid — PMI presentation wires, leader curves, construction edges/sketches —
+    which, left in, draw as phantom rectangles in every view and inflate the bounding
+    box, corrupting the scale choice and the envelope dimensions. Shared by
+    :func:`_analyse` and :meth:`draftwright.Sheet.model` (#453) so the model a caller
+    *inspects* is wrapped from the exact same body the engine *draws*."""
+    solids = part.solids()
+    if not solids:
+        return part
+    body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
+    if body.bounding_box().size != part.bounding_box().size or len(part.edges()) != len(
+        body.edges()
+    ):
+        _log.info("Dropping non-solid geometry from %s (PMI presentation data)", src)
+    return body
+
+
 def _analyse(
     step_file, title, number, tolerance, drawn_by, out, scale=None, page=None, pmi="off"
 ) -> Analysis:
@@ -192,22 +212,7 @@ def _analyse(
     else:
         part = _import_step(step_file)
         src = str(step_file)
-    # AP242 STEP files carry PMI presentation geometry (annotation-plane
-    # border wires, leader curves) beside the solid; left in, it draws as
-    # phantom rectangles in every view and inflates the bounding box —
-    # corrupting the scale choice and the envelope dimensions. The drawing
-    # is of the solids.
-    solids = part.solids()
-    if solids:
-        body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
-        if body.bounding_box().size != part.bounding_box().size or len(part.edges()) != len(
-            body.edges()
-        ):
-            _log.info(
-                "Dropping non-solid geometry from %s (PMI presentation data)",
-                src,
-            )
-        part = body
+    part = _solids_body(part, src)
 
     # Semantic PMI extraction (AP242 only; separate read-only pass).
     pmi_records: list = []

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -190,12 +190,16 @@ def _measure_blocks(dwg, a) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _coerce_model(model, a, decorations=None) -> PartModel:
+def _coerce_model(model, part, decorations=None) -> PartModel:
     """Wrap a caller-supplied ``model=`` (ADR 0011) into a :class:`PartModel`. A
     ``PartModel`` is used verbatim; a sequence of features is wrapped with the part's
     bbox, a default corner location datum (matching ``detect.py``, so hole location
     dims measure from the min corner), and an orientation inferred from any turned
     ``StepFeature`` (so a declared shaft renders as turned).
+
+    Takes the *part* directly (not the full :class:`Analysis`) so it needs only the bbox —
+    the cheap wrapping path behind :meth:`draftwright.Sheet.model` (#453), which materialises
+    the IR without projecting or annotating a drawing.
 
     ``decorations`` (P2a) is the authored aspect side-layer — ``{(feature, kind) ->
     tolerance}`` — merged onto the model so the planner can read it; only applied when
@@ -207,7 +211,7 @@ def _coerce_model(model, a, decorations=None) -> PartModel:
             return replace(model, decorations={**model.decorations, **decorations})
         return model
     features = list(model)
-    bbox = a.part.bounding_box()
+    bbox = part.bounding_box()
     orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
     datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
     return PartModel(
@@ -217,6 +221,18 @@ def _coerce_model(model, a, decorations=None) -> PartModel:
         datums=[datum],
         decorations=decorations or {},
     )
+
+
+def detect_part_model(part, *, pmi="off") -> PartModel:
+    """The **detected** :class:`PartModel` for *part* — feature recognition + analysis only,
+    with no view projection, annotation, repack, repair, or export (ADR 0011 #453). The cheap
+    seed path behind :meth:`draftwright.Sheet.from_part`, so pure feature inspection no longer
+    pays for a full drawing (nor its layout/rendering failure modes)."""
+    a = _analyse(
+        part, title="", number="", tolerance="ISO 2768-m", drawn_by="", out="model", pmi=pmi
+    )
+    model: PartModel = build_model(a)  # build_model is untyped; it returns a PartModel
+    return model
 
 
 def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=None) -> Drawing:
@@ -244,7 +260,9 @@ def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=
     # Detect the IR here — before the auto_dims gate — so dwg.model() and feature edits
     # work even in manual mode (#398). _auto_annotate reads this attached model rather
     # than rebuilding. On a repack this runs again on the pass-2 drawing (freshness).
-    dwg._part_model = _coerce_model(model, a, decorations) if model is not None else build_model(a)
+    dwg._part_model = (
+        _coerce_model(model, a.part, decorations) if model is not None else build_model(a)
+    )
     dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
 
     part_s = a.part.scale(a.SCALE)

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from draftwright.analysis import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.model import boss as _boss
 from draftwright.model import envelope as _envelope
@@ -204,8 +205,10 @@ class Sheet:
         declared features into a :class:`PartModel` **without** rendering a drawing (#453):
         the same wrapping :meth:`build` hands the engine (part bbox + corner datum + step-
         inferred orientation + the P2a decorations), so inspection pays no projection/anno
-        cost and can't hit a layout/render failure."""
-        return _coerce_model(self._features, self._part, self._decorations())
+        cost and can't hit a layout/render failure. Wraps the *solids body* (as :func:`_analyse`
+        does), so the bbox/datum match what ``build()`` draws even when the part carries
+        bbox-extending non-solid geometry."""
+        return _coerce_model(self._features, _solids_body(self._part), self._decorations())
 
     def build(self):
         """Build the :class:`~draftwright.drawing.Drawing` — detection skipped; only the

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from draftwright.builder import build_drawing
+from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.model import boss as _boss
 from draftwright.model import envelope as _envelope
 from draftwright.model import hole as _hole
@@ -136,7 +136,7 @@ class Sheet:
         from the model the detector recovers, then override specific features (edit the
         list via :attr:`features`, or re-declare) before :meth:`build`."""
         sheet = cls(part, **opts)
-        sheet._features = list(build_drawing(part).model().features)
+        sheet._features = list(detect_part_model(part).features)  # detect only, no render (#453)
         return sheet
 
     # -- feature declaration --------------------------------------------------
@@ -193,21 +193,25 @@ class Sheet:
         """The declared IR features (mutable — override or drop before :meth:`build`)."""
         return self._features
 
+    def _decorations(self) -> dict:
+        """Materialize the index-keyed ± tolerances against the FINAL features (a handle may
+        have been recorded before a later .depth()/… replaced the feature) → the
+        ``(feature, kind)`` decoration map the planner reads (P2a)."""
+        return {(self._features[i], kind): tol for (i, kind), tol in self._tolerances.items()}
+
     def model(self):
-        """The IR the engine will draw (detection skipped) — for inspection."""
-        return self.build().model()
+        """The IR the engine will draw (detection skipped) — for inspection. Wraps the
+        declared features into a :class:`PartModel` **without** rendering a drawing (#453):
+        the same wrapping :meth:`build` hands the engine (part bbox + corner datum + step-
+        inferred orientation + the P2a decorations), so inspection pays no projection/anno
+        cost and can't hit a layout/render failure."""
+        return _coerce_model(self._features, self._part, self._decorations())
 
     def build(self):
         """Build the :class:`~draftwright.drawing.Drawing` — detection skipped; only the
         declared features are drawn."""
-        # Materialize the index-keyed tolerances against the final features (a handle may
-        # have been recorded before a later .depth()/… replaced the feature) → the
-        # (feature, kind) decoration map the planner reads (P2a).
-        decorations = {
-            (self._features[i], kind): tol for (i, kind), tol in self._tolerances.items()
-        }
         return build_drawing(
-            self._part, model=self._features, decorations=decorations, **self._opts
+            self._part, model=self._features, decorations=self._decorations(), **self._opts
         )
 
     def export(self, stem=None):

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -529,12 +529,32 @@ class TestSheet:
         assert [f.kind for f in m.features] == ["envelope", "hole"]
 
     def test_model_matches_what_build_would_draw(self):
-        # The cheap model() returns the same IR build() hands the engine.
+        # The cheap model() returns the same IR build() hands the engine — features AND the
+        # bbox/datum (the wrapping the engine draws), not just the feature list.
         part = Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(3, 8)
         sheet = Sheet(part)
         sheet.envelope()
         sheet.hole(Pos(20, 10, 4) * Cylinder(3, 8))
-        assert sheet.model().features == sheet.build().model().features
+        m, built = sheet.model(), sheet.build().model()
+        assert m.features == built.features
+        assert m.bbox.min.X == pytest.approx(built.bbox.min.X)
+        assert m.bbox.max.X == pytest.approx(built.bbox.max.X)
+        assert [d.at for d in m.datums] == [d.at for d in built.datums]
+
+    def test_model_wraps_the_solids_body_like_build(self):
+        # #453 review: model() must wrap the SOLIDS body, matching _analyse — else a part
+        # carrying bbox-extending non-solid geometry (a stray edge) gives model() a wider
+        # bbox/datum than build() draws.
+        from build123d import Compound, Edge
+
+        box = Box(40, 40, 8)
+        stray = Edge.make_line((-80, 0, 0), (0, 0, 0))  # extends the min-X corner past the solid
+        part = Compound(children=[*box.solids(), stray])
+        sheet = Sheet(part)
+        sheet.envelope()
+        m, built = sheet.model(), sheet.build().model()
+        assert m.bbox.min.X == pytest.approx(built.bbox.min.X)  # both drop the stray edge
+        assert [d.at for d in m.datums] == [d.at for d in built.datums]
 
     def test_from_part_does_not_render_a_drawing(self, monkeypatch):
         # #453: the hybrid seed detects the model without a full drawing.

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -28,6 +28,10 @@ from draftwright.model import (
 from draftwright.sheet_dsl import _parse_scale
 
 
+def _boom(*a, **k):
+    raise AssertionError("build_drawing must not be called for a no-render model path (#453)")
+
+
 class TestConstructors:
     def test_hole_reads_diameter_axis_location_off_object(self):
         h = Pos(20, 10, 4) * Cylinder(3, 8)  # r3 -> ø6, axis z, centre (20,10,4)
@@ -509,3 +513,34 @@ class TestSheet:
         sheet.envelope()
         f = sheet.features[0]
         assert f.width == pytest.approx(30) and f.depth == pytest.approx(20)
+
+    def test_model_does_not_render_a_drawing(self, monkeypatch):
+        # #453: Sheet.model() must wrap the features into a PartModel WITHOUT building a
+        # drawing — no projection/annotation/repack/render. Patch build_drawing to explode
+        # so any accidental render is caught.
+        import draftwright.sheet_dsl as sd
+
+        monkeypatch.setattr(sd, "build_drawing", _boom)
+        part = Box(40, 40, 8) - Pos(10, 10, 4) * Cylinder(3, 8)
+        sheet = Sheet(part)
+        sheet.envelope()
+        sheet.hole(Pos(10, 10, 4) * Cylinder(3, 8))
+        m = sheet.model()  # must not call build_drawing
+        assert [f.kind for f in m.features] == ["envelope", "hole"]
+
+    def test_model_matches_what_build_would_draw(self):
+        # The cheap model() returns the same IR build() hands the engine.
+        part = Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(3, 8)
+        sheet = Sheet(part)
+        sheet.envelope()
+        sheet.hole(Pos(20, 10, 4) * Cylinder(3, 8))
+        assert sheet.model().features == sheet.build().model().features
+
+    def test_from_part_does_not_render_a_drawing(self, monkeypatch):
+        # #453: the hybrid seed detects the model without a full drawing.
+        import draftwright.sheet_dsl as sd
+
+        monkeypatch.setattr(sd, "build_drawing", _boom)
+        part = Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(3, 8)
+        sheet = Sheet.from_part(part)  # must not call build_drawing
+        assert "hole" in {f.kind for f in sheet.features}


### PR DESCRIPTION
## What

ADR 0011 **#453** — the last of the declaration-surface hardening cluster. Two `Sheet` inspection/seeding methods built a **whole `Drawing`** just to get the IR:

- `Sheet.model()` → `self.build().model()`
- `Sheet.from_part()` → `build_drawing(part).model()`

So pure feature inspection paid for view projection, auto-annotation, repack/repair, and rendering-adjacent failure modes it never needed.

## The fix

- **`_coerce_model(model, part, decorations)`** now takes the part directly (it only ever used `a.part.bounding_box()`), not the full `Analysis`. `Sheet.model()` reuses it to wrap the declared features into the **same** `PartModel` `build()` hands the engine — no render.
- **`detect_part_model(part)`** = `_analyse` + `build_model` with no assembly (analysis + recognition only); the cheap seed behind `Sheet.from_part()`.
- **`Sheet._decorations()`** removes the duplicated ± tolerance-materialisation shared by `build()` and `model()`.
- **`analysis._solids_body(part)`** factors out `_analyse`'s "drop non-solid geometry" step so `Sheet.model()` wraps the **same solids body** the engine draws (see review below).

The detection/render output is unchanged — `_coerce_model(model, a.part)` is the same bbox as before, and the new helpers are reached only by the `Sheet` inspection paths.

## Review

One adversarial round (Workflow, 3 dimensions: equivalence, no-op/analyse, decorations/imports) found one real low-severity gap: `Sheet.model()` wrapped `self._part` directly, but `build()` drops non-solid geometry via `_analyse`. For a part carrying **bbox-extending non-solid geometry** (a stray edge/wire), `model()`'s bbox/datum diverged from what `build()` draws — breaking the documented "model() == build().model()" contract. **Fixed** by extracting `_solids_body` and applying it in `model()`, with a stray-edge regression test.

## Tests

`model()` / `from_part()` assert `build_drawing` is never called (monkeypatched to raise); `model()` equals what `build()` draws — now comparing **features + bbox + datum**, plus the non-solid-geometry case. 67 pass in `test_declare.py`. smoke (70) + e2e_standards green; ruff + full mypy clean.

Refs #447, #446, ADR 0011. Closes #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)