### PR TITLE
feat: fit-class deviation (.fit("H7")) — ISO 286 (ADR 0011 P2a.2, #29)

### DIFF
--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -3,8 +3,10 @@
 - **Status:** Accepted — Phase 0 (the `model=` seam + object→feature constructors) and
   Phase 1 (the `Sheet` façade) landed; Phase 2 (aspect renderers) underway: **P2a
   toleranced dimensions** (±/limit on a diameter/step/hole, via a `decorations=` side-layer
-  → `DimParameter.tolerance`) landing; P2a.2 fit-class / P2b GD&T+finish / P2c aspect verbs
-  / P2d PMI still pending per the #446 roadmap. Phase 2 execution plan:
+  → `DimParameter.tolerance`) and **P2a.2 fit-class** (`.fit("H7")` → ISO 286 deviation,
+  `draftwright/fits.py`, riding the same `tolerance` field as a `FitClass` marker) landed;
+  P2b GD&T+finish / P2c aspect verbs / P2d PMI still pending per the #446 roadmap. Phase 2
+  execution plan:
   [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
 - **Date:** 2026-07-05
 - **Deciders:** Paul Fremantle (pzfreo)

--- a/docs/plans/0011-phase2-aspects-roadmap.md
+++ b/docs/plans/0011-phase2-aspects-roadmap.md
@@ -108,16 +108,29 @@ the tolerance renders on the linear `Dimension` path AND the `Leader` / `HoleCal
   `tolerance=` param; file an upstream issue to add one, then delete the suffix and pass
   the tolerance through like `Dimension` does. Tracked as **#449**.
 
-### P2a.2 — Fit-class deviation (`.fit("h6")`) · #29
+### P2a.2 — Fit-class deviation (`.fit("h6")`) · #29 · **DONE**
 
 The lone genuine (c) gap — helpers has no fit-code semantics.
 
-- A small ISO 286 table in draftwright: `(fit_code, nominal_⌀) → (lower, upper)`
-  deviation (h6/H7/g6/js… — the common shaft/hole classes), feeding P2a's
-  tolerance path.
-- `Sheet`: `.fit("h6")` on a diameter handle.
-- Optional label form: render `⌀20 H7` (class) vs `⌀20 ±dev` (deviation) — config,
-  default deviation.
+- **`draftwright/fits.py`** — the ISO 286 table `fit_deviation(code, nominal) → (lower,
+  upper)` signed deviations (mm), computed from the standard IT-grade + fundamental-
+  deviation tables over the common classes (holes `H`/`G`/`F` via the EI=−es mirror;
+  shafts `h`/`g`/`f`/`js`/`k`/`n`/`p`) and ⌀ ≤ 250 mm. **Fails loud** outside coverage —
+  never a silent wrong number (the delta-rule K/N/P *holes* are intentionally out). 20
+  tests pin every value against published ISO 286 deviations.
+- **`FitClass`** (in `fits.py`) is a resolved fit that rides `DimParameter.tolerance` as
+  an aspect marker, so it reuses **all** of P2a's threading — `_core._tol_suffix`
+  dispatches it, zero planner / render-tuple changes. It carries the deviations for tooling
+  and renders its own suffix.
+- **`Sheet`**: `.fit("H7")` on a `hole` (bore ⌀) or a `diameter`/`boss`/`step` (the OD — a
+  fit is always diametral). Resolved + validated at declaration against the feature's
+  nominal ⌀.
+- **Label form (decided):** **default the fit-class code** (`ø20 H7`) — the compact,
+  unambiguous, always-correct single-line form — with **`show="deviation"`** for the signed
+  deviations (`ø20 +0.021/0`, both-negative like `g6` → `-0.007/-0.020`). *(Amends the
+  original "default deviation" note: on a single-line ⌀ callout the class code reads
+  cleaner and a shared-sign fit can't use P2a's `+hi/-lo` formatter; the deviation form
+  needs its own precision — fit deviations show 3–4 dp, not the sheet's 1 dp.)*
 
 ### P2b — GD&T + finish placement API (#61) · #30
 

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -30,6 +30,7 @@ from build123d_drafting.helpers import (
     format_drawing_scale,
 )
 
+from draftwright.fits import FitClass
 from draftwright.fonts import PLEX_MONO, PLEX_SANS_CONDENSED
 from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
 
@@ -95,9 +96,14 @@ def _tol_suffix(tolerance, draft) -> str:
     draftwright owns this suffix ONLY because the pinned helpers' ``Leader`` /
     ``HoleCallout`` take no ``tolerance=`` yet, so we bake it into the label string
     ourselves. Delete this once helpers grows a first-class tolerance parameter for
-    those two (extraction tracked as #449) — ``Dimension`` formats its own (#28 / P2a)."""
+    those two (extraction tracked as #449) — ``Dimension`` formats its own (#28 / P2a).
+
+    A resolved fit (:class:`~draftwright.fits.FitClass`, P2a.2) renders its own class-code
+    or deviation suffix — it rides the same ``tolerance`` field as an aspect marker."""
     if tolerance is None:
         return ""
+    if isinstance(tolerance, FitClass):
+        return tolerance.suffix()
     prec = draft.decimal_precision
     if isinstance(tolerance, (int, float)):
         return f" ±{round(tolerance, prec):.{prec}f}"

--- a/src/draftwright/fits.py
+++ b/src/draftwright/fits.py
@@ -17,6 +17,7 @@ number (matching the declaration-constructor discipline, #452). The transition/i
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 # ISO 286 size bands: upper bound (mm) of each step "over prev, up to and including this".
 _BANDS = (3, 6, 10, 18, 30, 50, 80, 120, 180, 250)
@@ -47,6 +48,44 @@ _EI: dict[str, tuple[int, ...]] = {
 }
 
 _CODE_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
+
+
+def _fmt_dev(v: float) -> str:
+    """A single limit deviation for a callout label: signed, trailing-zero trimmed to the
+    µm digit (3 dp), with the half-µm (``js``) case kept at 4 dp; an exact ``0`` renders ``0``
+    (ISO convention). Not the sheet's ``decimal_precision`` — a fit deviation must show its
+    real precision (``±0.05`` must not round to ``±0.1``)."""
+    if abs(v) < 5e-5:
+        return "0"
+    s = f"{v:+.4f}"
+    return s[:-1] if s.endswith("0") else s  # 4 dp -> 3 dp when the µm digit is whole
+
+
+@dataclass(frozen=True)
+class FitClass:
+    """A resolved fit sitting in ``DimParameter.tolerance`` as an aspect marker (P2a.2). It
+    renders through the owned ``_core._tol_suffix`` like any other diameter tolerance, so it
+    reuses all of P2a's threading — either as the class code (``H7``, default) or the signed
+    limit deviations (``+0.021/0``)."""
+
+    code: str
+    lower: float
+    upper: float
+    show: str = "class"  # "class" -> " H7"; "deviation" -> " +0.021/0"
+
+    def suffix(self) -> str:
+        if self.show == "deviation":
+            return f" {_fmt_dev(self.upper)}/{_fmt_dev(self.lower)}"
+        return f" {self.code}"
+
+
+def fit_class(code: str, nominal: float, show: str = "class") -> FitClass:
+    """Resolve *code* at nominal ⌀ into a :class:`FitClass` (raising for a class/size outside
+    the table, so a fit fails at declaration). ``show`` selects the label form."""
+    if show not in ("class", "deviation"):
+        raise ValueError(f"fit show= must be 'class' or 'deviation' (got {show!r})")
+    lower, upper = fit_deviation(code, nominal)
+    return FitClass(code=code, lower=lower, upper=upper, show=show)
 
 
 def parse_fit(code: str) -> tuple[str, int]:

--- a/src/draftwright/fits.py
+++ b/src/draftwright/fits.py
@@ -141,7 +141,10 @@ def fit_deviation(code: str, nominal: float) -> tuple[float, float]:
         es = _ES[letter][i]
         lo, hi = es - it, es
     elif letter in _EI:  # interference shafts k/n/p: ei is the lower deviation, es = ei + IT
-        ei = _EI[letter][i]
+        # k's tabulated fundamental deviation holds ONLY for grades IT4–IT7; for coarser
+        # grades (>IT7) ISO 286 defines ei = 0 (n and p are grade-independent — the standard
+        # tabulates them for all grades). Without this k8+ would silently over-shift (#29 review).
+        ei = 0 if (letter == "k" and grade > 7) else _EI[letter][i]
         lo, hi = ei, ei + it
     else:
         raise ValueError(

--- a/src/draftwright/fits.py
+++ b/src/draftwright/fits.py
@@ -1,0 +1,112 @@
+"""fits — ISO 286 fit-class → limit-deviation lookup (ADR 0011 P2a.2, #29).
+
+A fit code like ``H7`` / ``h6`` / ``g6`` names a *tolerance class*, not a number: the
+actual ± deviation depends on the nominal diameter's ISO 286 size band. This module is
+the one genuine (c)-gap of Phase 2 — helpers renders tolerances but has no fit-code
+semantics — so draftwright owns the small standard table that turns ``(code, ⌀) →
+(lower, upper)`` signed deviations (mm), feeding P2a's tolerance path.
+
+Coverage is deliberately the **common** machining classes over nominal ⌀ ≤ 250 mm:
+holes ``H``/``G``/``F`` (the EI = −es mirror rule) and shafts
+``h``/``g``/``f``/``js``/``k``/``n``/``p``. Anything outside the table fails loudly with a
+``ValueError`` pointing at an explicit ``.tolerance(lo, hi)`` — never a silent wrong
+number (matching the declaration-constructor discipline, #452). The transition/interference
+*hole* classes (``K``/``N``/``P`` — the ISO delta rule) are intentionally not modelled.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ISO 286 size bands: upper bound (mm) of each step "over prev, up to and including this".
+_BANDS = (3, 6, 10, 18, 30, 50, 80, 120, 180, 250)
+
+# Standard tolerance grade IT values (µm), index-aligned to _BANDS (ISO 286-1 Table 1).
+_IT: dict[int, tuple[int, ...]] = {
+    5: (4, 5, 6, 8, 9, 11, 13, 15, 18, 20),
+    6: (6, 8, 9, 11, 13, 16, 19, 22, 25, 29),
+    7: (10, 12, 15, 18, 21, 25, 30, 35, 40, 46),
+    8: (14, 18, 22, 27, 33, 39, 46, 54, 63, 72),
+    9: (25, 30, 36, 43, 52, 62, 74, 87, 100, 115),
+    10: (40, 48, 58, 70, 84, 100, 120, 140, 160, 185),
+    11: (60, 75, 90, 110, 130, 160, 190, 220, 250, 290),
+}
+
+# Shaft fundamental UPPER deviation es (µm) for the clearance letters (≤ 0), index-aligned.
+_ES: dict[str, tuple[int, ...]] = {
+    "h": (0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+    "g": (-2, -4, -5, -6, -7, -9, -10, -12, -14, -15),
+    "f": (-6, -10, -13, -16, -20, -25, -30, -36, -43, -50),
+}
+
+# Shaft fundamental LOWER deviation ei (µm) for the interference letters (≥ 0), index-aligned.
+_EI: dict[str, tuple[int, ...]] = {
+    "k": (0, 1, 1, 1, 2, 2, 2, 3, 3, 4),
+    "n": (4, 8, 10, 12, 15, 17, 20, 23, 27, 31),
+    "p": (6, 12, 15, 18, 22, 26, 32, 37, 43, 50),
+}
+
+_CODE_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
+
+
+def parse_fit(code: str) -> tuple[str, int]:
+    """Split a fit code into (letters, IT grade): ``"H7" → ("H", 7)``, ``"js6" → ("js", 6)``.
+    Case is significant — an UPPER-case letter is a hole class, lower-case a shaft class."""
+    m = _CODE_RE.match(str(code).strip())
+    if m is None:
+        raise ValueError(f"fit code must be letters + a grade number (got {code!r})")
+    return m.group(1), int(m.group(2))
+
+
+def _band_index(nominal: float) -> int:
+    if not (isinstance(nominal, (int, float)) and not isinstance(nominal, bool) and nominal > 0):
+        raise ValueError(f"nominal diameter must be a positive number (got {nominal!r})")
+    for i, upper in enumerate(_BANDS):
+        if nominal <= upper:
+            return i
+    raise ValueError(
+        f"nominal ⌀{nominal} mm is outside the built-in ISO 286 table (≤ {_BANDS[-1]} mm) — "
+        "supply an explicit .tolerance(lo, hi)"
+    )
+
+
+def fit_deviation(code: str, nominal: float) -> tuple[float, float]:
+    """The signed ``(lower, upper)`` limit deviations (mm) for fit *code* at nominal ⌀.
+
+    ``fit_deviation("H7", 20) == (0.0, 0.021)``; ``fit_deviation("g6", 20) ==
+    (-0.020, -0.007)``. Raises ``ValueError`` for a class or size outside the built-in
+    table so a fit is never silently wrong — the caller should fall back to an explicit
+    ``.tolerance(lo, hi)``."""
+    letters, grade = parse_fit(code)
+    if grade not in _IT:
+        raise ValueError(f"fit {code!r}: IT grade {grade} outside the built-in table (5–11)")
+    i = _band_index(nominal)
+    it = _IT[grade][i]
+    letter = letters.lower()
+    is_hole = letters[0].isupper()
+
+    lo: float
+    hi: float
+    if is_hole:
+        # Holes via the EI = −es(shaft) mirror rule (valid for A–H, i.e. H/G/F here).
+        if letter not in _ES:
+            raise ValueError(
+                f"hole fit class {letters!r} is not in the built-in table "
+                "(supported: H, G, F) — use an explicit .tolerance(lo, hi)"
+            )
+        ei = -_ES[letter][i]
+        lo, hi = ei, ei + it
+    elif letter == "js":
+        lo, hi = -it / 2, it / 2
+    elif letter in _ES:  # clearance shafts h/g/f: es is the upper deviation, ei = es − IT
+        es = _ES[letter][i]
+        lo, hi = es - it, es
+    elif letter in _EI:  # interference shafts k/n/p: ei is the lower deviation, es = ei + IT
+        ei = _EI[letter][i]
+        lo, hi = ei, ei + it
+    else:
+        raise ValueError(
+            f"shaft fit class {letters!r} is not in the built-in table "
+            "(supported: h, g, f, js, k, n, p) — use an explicit .tolerance(lo, hi)"
+        )
+    return (lo / 1000.0, hi / 1000.0)

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -21,7 +21,10 @@ stay one callout.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import ClassVar, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from draftwright.fits import FitClass
 
 Point = tuple[float, float, float]
 ParamKind = Literal["diameter", "length", "depth", "radius", "angle", "location", "thread"]
@@ -60,9 +63,10 @@ class DimParameter:
     span: tuple[Point, Point] | None = None
     refs: tuple[str, ...] = ()
     # An authored ± tolerance (ADR 0011 §4 / P2a): a symmetric ``float`` or an
-    # ``(lower, upper)`` limit pair, ``None`` when the dimension is untoleranced. Set by
-    # the planner from the caller's ``decorations`` — geometry never supplies it.
-    tolerance: float | tuple[float, float] | None = None
+    # ``(lower, upper)`` limit pair; or a resolved fit class (``FitClass``, P2a.2) that
+    # renders its own class-code / deviation suffix; ``None`` when untoleranced. Set by the
+    # planner from the caller's ``decorations`` — geometry never supplies it.
+    tolerance: float | tuple[float, float] | FitClass | None = None
 
 
 def _fmt(v: float) -> str:

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -32,6 +32,7 @@ from dataclasses import replace
 
 from draftwright.analysis import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
+from draftwright.fits import fit_class
 from draftwright.model import boss as _boss
 from draftwright.model import envelope as _envelope
 from draftwright.model import hole as _hole
@@ -88,6 +89,15 @@ class _Hole:
         self._sheet._tolerances[(self._i, "diameter")] = _tol_value(lo, hi)
         return self
 
+    def fit(self, code: str, *, show: str = "class") -> _Hole:
+        """An ISO 286 fit class on the bore ⌀ — ``.fit("H7")`` renders ``ø8 H7`` (the class,
+        default) or, with ``show="deviation"``, the signed deviations ``ø8 +0.015/0`` resolved
+        for the bore's nominal ⌀. Raises for a class/size outside the built-in table (#29)."""
+        self._sheet._tolerances[(self._i, "diameter")] = fit_class(
+            code, self._sheet._features[self._i].diameter, show
+        )
+        return self
+
     def _set(self, **kw) -> _Hole:
         self._sheet._features[self._i] = replace(self._sheet._features[self._i], **kw)
         return self
@@ -108,6 +118,16 @@ class _Dim:
         limit pair ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` picks the parameter for
         a multi-dim feature — a step's ``"length"`` (default) vs its ``"diameter"`` (OD)."""
         self._sheet._tolerances[(self._i, on or self._kind)] = _tol_value(lo, hi)
+        return self
+
+    def fit(self, code: str, *, show: str = "class") -> _Dim:
+        """An ISO 286 fit class on this feature's ⌀ (always the diameter — a fit is diametral,
+        so a step's fit is on its OD, not its length). ``.fit("h6")`` renders ``ø12 h6`` (the
+        class, default) or ``show="deviation"`` the signed deviations ``ø12 0/-0.011`` resolved
+        for the nominal ⌀. Raises for a class/size outside the built-in table (#29)."""
+        self._sheet._tolerances[(self._i, "diameter")] = fit_class(
+            code, self._sheet._features[self._i].diameter, show
+        )
         return self
 
 

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -160,8 +160,14 @@ class TestCalloutFit:
     @staticmethod
     def _spec(diameter, **over):
         base = {
-            "diameter": diameter, "count": None, "through": True, "depth": None,
-            "cbore_dia": None, "cbore_depth": None, "suffix": None, "tolerance": None,
+            "diameter": diameter,
+            "count": None,
+            "through": True,
+            "depth": None,
+            "cbore_dia": None,
+            "cbore_depth": None,
+            "suffix": None,
+            "tolerance": None,
         }
         base.update(over)
         return base
@@ -190,7 +196,9 @@ class TestCalloutFit:
 class TestSheetFit:
     @staticmethod
     def _stepped_shaft():
-        return (Rot(0, 90, 0) * Cylinder(4, 20)) + (Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10))
+        return (Rot(0, 90, 0) * Cylinder(4, 20)) + (
+            Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)
+        )
 
     def _dias(self, dwg):
         return {n: dwg._named[n].label for n in dwg._named if n.startswith("m_dia")}

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -71,6 +71,18 @@ class TestOtherBands:
         # F8 hole @ 18–30: EI = -es(f) = +20, ES = +20 + IT8(33) = +53
         assert fit_deviation("F8", 20) == pytest.approx((0.020, 0.053))
 
+    def test_k_grade_dependency(self):
+        # ISO 286: shaft k fundamental deviation ei applies only for IT4–7; for coarser
+        # grades ei = 0. k7 @ 50–80 keeps ei=+2; k8 @ 50–80 drops to ei=0 (#29 review).
+        assert fit_deviation("k7", 60) == pytest.approx((0.002, 0.032))  # ei=+2, IT7=30
+        assert fit_deviation("k8", 60) == pytest.approx((0.0, 0.046))  # ei=0, IT8=46
+        assert fit_deviation("k9", 60) == pytest.approx((0.0, 0.074))  # ei=0, IT9=74
+
+    def test_n_and_p_are_grade_independent(self):
+        # only k has the grade cutoff; n/p keep their tabulated ei at every grade
+        assert fit_deviation("n8", 20) == pytest.approx((0.015, 0.048))  # ei=+15, IT8=33
+        assert fit_deviation("p8", 20) == pytest.approx((0.022, 0.055))  # ei=+22, IT8=33
+
     def test_band_boundary_is_inclusive_upper(self):
         # nominal exactly on a band's upper bound belongs to that band (over-X, up-to-Y]
         assert fit_deviation("H7", 30) == pytest.approx((0.0, 0.021))  # still 18–30

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,0 +1,94 @@
+"""ISO 286 fit-class → deviation table (ADR 0011 P2a.2, #29).
+
+Every expected value below is a published ISO 286 limit deviation (µm → mm), so the
+table is pinned against the standard, not against itself.
+"""
+
+import pytest
+
+from draftwright.fits import fit_deviation, parse_fit
+
+
+class TestParseFit:
+    def test_hole_and_shaft_case(self):
+        assert parse_fit("H7") == ("H", 7)
+        assert parse_fit("h6") == ("h", 6)
+        assert parse_fit("js6") == ("js", 6)
+
+    def test_malformed_raises(self):
+        with pytest.raises(ValueError):
+            parse_fit("7")  # no letters
+        with pytest.raises(ValueError):
+            parse_fit("H")  # no grade
+
+
+class TestDeviationsAt20mm:
+    """The 18–30 mm band (⌀20) — the textbook worked example for every common class."""
+
+    def test_H7(self):
+        assert fit_deviation("H7", 20) == pytest.approx((0.0, 0.021))
+
+    def test_h6(self):
+        assert fit_deviation("h6", 20) == pytest.approx((-0.013, 0.0))
+
+    def test_g6(self):
+        assert fit_deviation("g6", 20) == pytest.approx((-0.020, -0.007))
+
+    def test_f7(self):
+        assert fit_deviation("f7", 20) == pytest.approx((-0.041, -0.020))
+
+    def test_k6(self):
+        assert fit_deviation("k6", 20) == pytest.approx((0.002, 0.015))
+
+    def test_n6(self):
+        assert fit_deviation("n6", 20) == pytest.approx((0.015, 0.028))
+
+    def test_p6(self):
+        assert fit_deviation("p6", 20) == pytest.approx((0.022, 0.035))
+
+    def test_js6_is_symmetric(self):
+        assert fit_deviation("js6", 20) == pytest.approx((-0.0065, 0.0065))
+
+    def test_H8(self):
+        assert fit_deviation("H8", 20) == pytest.approx((0.0, 0.033))
+
+
+class TestOtherBands:
+    def test_H7_small_bore(self):
+        # 6–10 mm band, IT7 = 15 µm
+        assert fit_deviation("H7", 8) == pytest.approx((0.0, 0.015))
+
+    def test_h6_large(self):
+        # 80–120 mm band, IT6 = 22 µm
+        assert fit_deviation("h6", 100) == pytest.approx((-0.022, 0.0))
+
+    def test_f8_hole_mirror(self):
+        # F8 hole @ 18–30: EI = -es(f) = +20, ES = +20 + IT8(33) = +53
+        assert fit_deviation("F8", 20) == pytest.approx((0.020, 0.053))
+
+    def test_band_boundary_is_inclusive_upper(self):
+        # nominal exactly on a band's upper bound belongs to that band (over-X, up-to-Y]
+        assert fit_deviation("H7", 30) == pytest.approx((0.0, 0.021))  # still 18–30
+        assert fit_deviation("H7", 30.5) == pytest.approx((0.0, 0.025))  # now 30–50, IT7=25
+
+
+class TestFailLoud:
+    def test_unsupported_hole_class_raises(self):
+        with pytest.raises(ValueError):
+            fit_deviation("P7", 20)  # interference hole (delta rule) — not modelled
+
+    def test_unsupported_shaft_class_raises(self):
+        with pytest.raises(ValueError):
+            fit_deviation("a11", 20)
+
+    def test_grade_outside_table_raises(self):
+        with pytest.raises(ValueError):
+            fit_deviation("H2", 20)  # IT2 not in the common-grade table
+
+    def test_oversize_nominal_raises(self):
+        with pytest.raises(ValueError):
+            fit_deviation("H7", 400)  # beyond the ≤250 mm coverage
+
+    def test_nonpositive_nominal_raises(self):
+        with pytest.raises(ValueError):
+            fit_deviation("H7", 0)

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -5,8 +5,13 @@ table is pinned against the standard, not against itself.
 """
 
 import pytest
+from build123d import Box, Cylinder, Pos, Rot
 
-from draftwright.fits import fit_deviation, parse_fit
+from draftwright import Sheet
+from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
+from draftwright.fits import FitClass, fit_class, fit_deviation, parse_fit
+from draftwright.model import PartModel, hole
+from draftwright.model.planner import plan_dimensions
 
 
 class TestParseFit:
@@ -92,3 +97,109 @@ class TestFailLoud:
     def test_nonpositive_nominal_raises(self):
         with pytest.raises(ValueError):
             fit_deviation("H7", 0)
+
+
+class TestFitClass:
+    def test_class_suffix_is_the_code(self):
+        assert fit_class("H7", 20).suffix() == " H7"
+
+    def test_deviation_suffix_is_upper_over_lower(self):
+        # H7 @ 20 = (0, +0.021) → upper/lower = "+0.021/0"
+        assert fit_class("H7", 20, show="deviation").suffix() == " +0.021/0"
+
+    def test_deviation_suffix_both_negative(self):
+        # g6 @ 20 = (-0.020, -0.007) → "-0.007/-0.020" (upper over lower)
+        assert fit_class("g6", 20, show="deviation").suffix() == " -0.007/-0.020"
+
+    def test_deviation_keeps_half_micron_precision(self):
+        # js6 @ 20 = ±0.0065 — must NOT round to the sheet's 1 dp
+        assert fit_class("js6", 20, show="deviation").suffix() == " +0.0065/-0.0065"
+
+    def test_carries_the_resolved_deviations(self):
+        f = fit_class("H7", 20)
+        assert isinstance(f, FitClass)
+        assert (f.lower, f.upper) == pytest.approx((0.0, 0.021))
+
+    def test_bad_show_raises(self):
+        with pytest.raises(ValueError):
+            fit_class("H7", 20, show="both")
+
+    def test_bad_code_raises_at_resolution(self):
+        with pytest.raises(ValueError):
+            fit_class("Z9", 20)
+
+
+class TestPlannerFit:
+    def test_fit_decoration_sets_param_tolerance(self):
+        h = hole(diameter=8, at=(20, 10, 4), axis="z")
+        model = PartModel(
+            bbox=Box(40, 40, 8).bounding_box(),
+            orientation=None,
+            features=[h],
+            decorations={(h, "diameter"): fit_class("H7", 8)},
+        )
+        group = next(g for g in plan_dimensions(model) if g.feature_kind == "hole")
+        bore = next(pd for pd in group.dims if pd.param.kind == "diameter")
+        assert isinstance(bore.param.tolerance, FitClass)
+        assert bore.param.tolerance.code == "H7"
+
+
+class TestCalloutFit:
+    @staticmethod
+    def _spec(diameter, **over):
+        base = {
+            "diameter": diameter, "count": None, "through": True, "depth": None,
+            "cbore_dia": None, "cbore_depth": None, "suffix": None, "tolerance": None,
+        }
+        base.update(over)
+        return base
+
+    def test_hole_bore_callout_carries_the_fit_class(self):
+        from build123d_drafting.helpers import draft_preset
+
+        d = draft_preset(font_size=2.5, decimal_precision=1)
+        plain = callout_from_spec(self._spec(8), d, None)
+        fitted = callout_from_spec(self._spec(8, tolerance=fit_class("H7", 8)), d, None)
+        # the fit widens the callout exactly like a ± tolerance (label carries " H7")
+        assert fitted.bounding_box().size.X > plain.bounding_box().size.X
+
+    def test_hole_callout_spec_reads_the_bore_fit(self):
+        h = hole(diameter=8, at=(20, 10, 4), axis="z")
+        model = PartModel(
+            bbox=Box(40, 40, 8).bounding_box(),
+            orientation=None,
+            features=[h],
+            decorations={(h, "diameter"): fit_class("H7", 8)},
+        )
+        group = next(g for g in plan_dimensions(model) if g.feature_kind == "hole")
+        assert hole_callout_spec(group)["tolerance"].code == "H7"
+
+
+class TestSheetFit:
+    @staticmethod
+    def _stepped_shaft():
+        return (Rot(0, 90, 0) * Cylinder(4, 20)) + (Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10))
+
+    def _dias(self, dwg):
+        return {n: dwg._named[n].label for n in dwg._named if n.startswith("m_dia")}
+
+    def test_boss_fit_class_renders_on_leader(self):
+        s = Sheet(self._stepped_shaft())
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        s.diameter(diameter=12, at=(15, 0, 0), axis="x").fit("g6")
+        dwg = s.build()
+        assert any(lbl == "ø12 g6" for lbl in self._dias(dwg).values()), self._dias(dwg)
+
+    def test_boss_fit_deviation_renders_on_leader(self):
+        s = Sheet(self._stepped_shaft())
+        s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        # h6 @ ⌀12 (10–18 band, IT6=11) = (-0.011, 0) → "0/-0.011"
+        s.diameter(diameter=12, at=(15, 0, 0), axis="x").fit("h6", show="deviation")
+        dwg = s.build()
+        assert any(lbl == "ø12 0/-0.011" for lbl in self._dias(dwg).values()), self._dias(dwg)
+
+    def test_fit_bad_class_raises_at_declaration(self):
+        s = Sheet(self._stepped_shaft())
+        d = s.diameter(diameter=12, at=(15, 0, 0), axis="x")
+        with pytest.raises(ValueError):
+            d.fit("Z9")  # unknown class


### PR DESCRIPTION
## What

ADR 0011 **Phase 2 P2a.2** — the lone genuine gap of Phase 2 (helpers renders tolerances but has no fit-code semantics). A fit code like `H7` / `h6` / `g6` names an ISO 286 tolerance *class*; the actual ± deviation depends on the nominal diameter's size band. This turns `.fit("H7")` into a rendered callout.

## How

- **`draftwright/fits.py`** — `fit_deviation(code, nominal) → (lower, upper)` signed limit deviations (mm), computed from the standard **IT-grade + fundamental-deviation tables**. Coverage is the common machining classes: holes `H`/`G`/`F` (via the `EI = −es` mirror rule), shafts `h`/`g`/`f`/`js`/`k`/`n`/`p`, nominal ⌀ ≤ 250 mm, IT grades 5–11. Anything outside **fails loud** with a `ValueError` pointing at an explicit `.tolerance(lo, hi)` — never a silent wrong number. (The delta-rule `K`/`N`/`P` *holes* are intentionally out of scope.)
- **`FitClass`** — a resolved fit that rides `DimParameter.tolerance` as an aspect marker, so it reuses **all** of P2a's threading: `_core._tol_suffix` dispatches it, with **zero planner or render-tuple changes** (the planner already does `replace(p, tolerance=dec)` for any decoration; the diameter render paths already call `_tol_suffix` on `param.tolerance`).
- **`Sheet`** — `.fit("H7")` on a `hole` (bore ⌀) or a `diameter`/`boss`/`step` (the OD — a fit is always diametral). Resolved + validated at declaration against the feature's nominal ⌀.

## Label form

**Default is the fit-class code** — `ø20 H7` — the compact, unambiguous, always-correct single-line form. **`show="deviation"`** renders the signed limit deviations — `ø20 +0.021/0`, and correctly handles shared-sign fits like `g6` → `ø20 -0.007/-0.020` (which P2a's `+hi/-lo` formatter can't) — at the deviation's own **3–4 dp precision** (a fit deviation must not round to the sheet's 1 dp). This amends the roadmap's original "default deviation" note (documented in the roadmap + ADR).

## Tests

`tests/test_fits.py` (35): every deviation value **pinned against published ISO 286** (the ⌀20 worked example for all classes + other bands + the k grade-dependency), the `FitClass` suffix (class + deviation + half-µm precision), planner + callout-spec integration, and **end-to-end Sheet** (`ø12 g6`, `ø12 0/-0.011` on the leader). Non-fit output byte-identical: P2a `test_tolerances` + `test_render_seam` + `test_e2e_standards` + `test_declare` all green. ruff + full mypy clean.

## Review

One adversarial round (Workflow, 3 dimensions weighted on ISO 286 correctness) found one real medium bug — the shaft-`k` fundamental deviation was applied at every grade, but ISO 286 tabulates it only for IT4–7 (`ei=0` above IT7), so `k8`+ over-shifted. **Fixed** (`ei=0` for `k` grade > 7) and re-verified against published values (n/p correctly grade-independent; no off-by-one at IT7).

Refs #446, ADR 0011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)