### PR TITLE
docs: ADR 0011 Amendment 1 — the three authoring modes + mode-3 generation surface

### DIFF
--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -9,8 +9,8 @@
   execution plan:
   [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
   **Amendment 1** (2026-07-05): the three authoring modes + the **mode-3 generation surface**
-  (a declarative `Sheet`-DSL emitter, #461/#462/#463) — sequenced *before* P2b; carries one
-  **open decision** (for detected input: reconstruct the part vs. leave a seam).
+  (a declarative `Sheet`-DSL emitter, #461/#462/#463) — sequenced *before* P2b. Decided: for
+  detected input, emit a **part-seam** with detected numbers; reconstruction deferred.
 - **Date:** 2026-07-05
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -165,13 +165,22 @@ Mode 3 has two fundamentally different ceilings, set by whether source objects e
   size-carrying *aspects* still take numbers (a counterbore's `cbore=(30, 14)`) — closed by the
   object-reading aspect verbs (#462).
 
-### Open decision — for 3a, reconstruct the part or leave a seam?
+### Decision — for 3a, a part-seam; reconstruction deferred
 
 The one fork that shapes the whole emitter. From a detected solid we can either **reconstruct**
 a build123d part (so the drawing layer can be reference-based / number-free too), or leave a
 **seam** for the caller's own part and write the detected numbers into the drawing.
 
-**Option A — reconstruct the part (number-free drawing layer, self-contained).**
+**Decided: the part-seam (Option B) only, for now.** It is the honest baseline — the generated
+script says exactly what detection knows, works for *any* geometry however complex, and lets the
+caller plug in their real (parametric) part at the seam. Reconstruction (Option A) is **deferred,
+not rejected**: it is the more beautiful output but a lossy CSG approximation that only round-trips
+for a subset of parts, and it would move numbers into a *synthetic* part the user never wrote — not
+worth the fidelity risk before the emitter itself exists. It can return later as an opt-in
+(`reconstruct=True`) once the seam emitter is solid. Both options are recorded below because the
+contrast *is* the rationale.
+
+**Option A — reconstruct the part (number-free drawing layer, self-contained) — DEFERRED.**
 
 ```python
 from build123d import Box, Cylinder, Pos
@@ -223,12 +232,10 @@ sheet.export("mounting_plate")
 *Pros:* honest (it *is* detected data); works for **any** geometry, however complex; the caller
 plugs in their real (parametric) part at the seam. *Cons:* the drawing layer carries magic
 numbers — the very thing mode 3 wants to avoid — and there is no object to re-read, so it does
-not track a parametric part.
-
-**Recommendation (pending sign-off):** ship **B first** (it is the honest, universal baseline and
-unblocks the emitter), and offer **A as an opt-in** (`reconstruct=True`) for the parts whose
-features reconstruct cleanly (prismatic + holes + simple counterbores), falling back to B when
-reconstruction is lossy. The two are not exclusive; the fork is really *which is the default*.
+not track a parametric part. **This is the chosen baseline.** The magic-number cost is mitigated
+where the caller *does* have objects (3b): they wire their part into the seam and swap the
+number-based lines for `sheet.hole(obj)` references — the emitter's numbers are a starting point,
+not a ceiling.
 
 ### Fidelity contract (proposed)
 

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -171,16 +171,22 @@ The one fork that shapes the whole emitter. From a detected solid we can either 
 a build123d part (so the drawing layer can be reference-based / number-free too), or leave a
 **seam** for the caller's own part and write the detected numbers into the drawing.
 
-**Decided: the part-seam (Option B) only, for now.** It is the honest baseline — the generated
-script says exactly what detection knows, works for *any* geometry however complex, and lets the
-caller plug in their real (parametric) part at the seam. Reconstruction (Option A) is **deferred,
-not rejected**: it is the more beautiful output but a lossy CSG approximation that only round-trips
-for a subset of parts, and it would move numbers into a *synthetic* part the user never wrote — not
-worth the fidelity risk before the emitter itself exists. It can return later as an opt-in
-(`reconstruct=True`) once the seam emitter is solid. Both options are recorded below because the
+**Decided: the part-seam (Option B) only.** It is the honest baseline — the generated script says
+exactly what detection knows, works for *any* geometry however complex, and lets the caller plug in
+their real (parametric) part at the seam. **Magic numbers are acceptable precisely because they are
+honest detected values** — for a STEP file or a recovered solid, a number *is* the ground truth.
+
+Reconstruction (Option A) is **rejected on principle, not just deferred for effort.** The core
+objection: it fabricates build123d objects that *pretend to be the geometry when they are not
+correct*. A synthesised `Cylinder(...)` / `Box(...)` reconstruction silently drops what detection
+did not model — chamfers, fillets, drafts, blends, turned profiles, non-through slots — yet reads as
+authoritative build123d source. A wrong number is visibly a number to check; a wrong *solid* masquerades
+as the part. That is a correctness/honesty failure worse than a magic number, so we do not emit
+reconstructed geometry. (If a caller wants number-free references, they have the real objects already —
+that is 3b, and they wire their part into the seam.) Both options are recorded below because the
 contrast *is* the rationale.
 
-**Option A — reconstruct the part (number-free drawing layer, self-contained) — DEFERRED.**
+**Option A — reconstruct the part (number-free drawing layer, self-contained) — REJECTED (fabricates geometry).**
 
 ```python
 from build123d import Box, Cylinder, Pos

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -8,6 +8,9 @@
   P2b GD&T+finish / P2c aspect verbs / P2d PMI still pending per the #446 roadmap. Phase 2
   execution plan:
   [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
+  **Amendment 1** (2026-07-05): the three authoring modes + the **mode-3 generation surface**
+  (a declarative `Sheet`-DSL emitter, #461/#462/#463) — sequenced *before* P2b; carries one
+  **open decision** (for detected input: reconstruct the part vs. leave a seam).
 - **Date:** 2026-07-05
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -126,6 +129,123 @@ detected drawing needs one more thing"). Two complementary modes, one IR.
 - **Extend the frozen IR with tolerance/GD&T fields.** Rejected for the schema churn and
   because tolerance is per-dimension, not per-feature; the decoration side-layer keeps
   the IR minimal and the existing consumers untouched.
+
+## Amendment 1 — the three authoring modes and the mode-3 *generation* surface (2026-07-05)
+
+`model=` made the IR an **input**; #400 made it a **read+edit** surface. Stepping back, that
+gives three ways to author a drawing, in increasing control — and naming them clarifies what
+is done and what is still missing:
+
+1. **Just do it.** `make_drawing(part_or_step)` → SVG/DXF. *(done)*
+2. **Auto, then tweak.** `build_drawing()` returns a live `Drawing`; edit it (`remove`,
+   `place_dim`, `del views[…]`, `pin`, `repair`) then `.export()`. *(done)*
+3. **Generate an editable beautiful-Python DSL script** that captures *every* view, feature,
+   and dimension as commentable lines the user edits / drops / extends. *(partial — this
+   amendment)*
+
+Mode 3 exists today only as the **imperative** `--script` emitter (the #400/#426 verb
+reconstruction, STEP-only). The target is a **declarative `Sheet`-DSL emitter** (#461). The
+value of mode 3 is a *single source of truth*: reference a feature and read its size off the
+geometry, so the drawing tracks the part parametrically (change `Cylinder(9, 40)`, the callout
+follows ⌀18 → ⌀20) — no restated numbers to drift.
+
+### The 3a / 3b split (accepted)
+
+Mode 3 has two fundamentally different ceilings, set by whether source objects exist:
+
+- **3a — detected input** (STEP, or a finished solid with no handles). Features were recovered
+  from silhouettes; there are **no source objects**, so a *from-scratch* generation cannot
+  reference them. This is a **generation** problem.
+- **3b — build123d objects with handles**. The drawing *references* the objects and reads every
+  size off geometry → a **number-free drawing layer**, numbers staying in the part build. This
+  is fundamentally **authored, not generated**: a finished solid cannot recover *variable names*
+  or *semantic intent* (bore vs boss, needs-a-fit). A tool can at most *scaffold* reference lines
+  from a caller-supplied `{name: object}` map. `sheet.hole(obj)` / `diameter(obj)` / `step(obj)`
+  / `envelope()` read size off objects **today** (proven lint-clean); the remaining gap is that
+  size-carrying *aspects* still take numbers (a counterbore's `cbore=(30, 14)`) — closed by the
+  object-reading aspect verbs (#462).
+
+### Open decision — for 3a, reconstruct the part or leave a seam?
+
+The one fork that shapes the whole emitter. From a detected solid we can either **reconstruct**
+a build123d part (so the drawing layer can be reference-based / number-free too), or leave a
+**seam** for the caller's own part and write the detected numbers into the drawing.
+
+**Option A — reconstruct the part (number-free drawing layer, self-contained).**
+
+```python
+from build123d import Box, Cylinder, Pos
+from draftwright import Sheet
+
+# Part — RECONSTRUCTED from detected features. Numbers live HERE, in the geometry.
+plate = Box(100, 70, 24)
+bore  = Pos(0, 0, 0) * Cylinder(9, 40)
+cbore = Pos(0, 0, 8) * Cylinder(15, 20)
+h0 = Pos(-38, -24, 0) * Cylinder(4, 40)
+h1 = Pos(38, -24, 0)  * Cylinder(4, 40)
+h2 = Pos(-38, 24, 0)  * Cylinder(4, 40)
+h3 = Pos(38, 24, 0)   * Cylinder(4, 40)
+part = plate - bore - cbore - h0 - h1 - h2 - h3
+
+# Drawing — references the objects; sizes READ off geometry (number-free, bar the
+# counterbore, which is exactly what #462 removes with .cbore(cbore)).
+sheet = Sheet(part, title="Mounting Plate", number="DWG-001")
+sheet.envelope()
+sheet.hole(bore, cbore=(30, 14))
+for h in (h0, h1, h2, h3):
+    sheet.hole(h)
+sheet.export("mounting_plate")
+```
+
+*Pros:* the drawing layer is references, not numbers — the mode-3 ideal; self-contained (no
+STEP file / no `part` to supply); the whole script is runnable as-is. *Cons:* the reconstruction
+is a **flat CSG approximation**, not the caller's parametric intent, and reconstructing arbitrary
+geometry from detected features is itself lossy/hard (counterbores need two cuts; fillets, drafts,
+turned profiles, and slots may not round-trip). Numbers still exist — they have moved into a
+*synthetic* part build the user didn't write.
+
+**Option B — part-seam (detected numbers in the drawing, honest, always works).**
+
+```python
+from draftwright import Sheet
+from draftwright.model import hole
+
+part = ...   # ← YOUR build123d object, or import_step("plate.step")
+
+sheet = Sheet(part, title="Mounting Plate", number="DWG-001")
+sheet.hole(diameter=8, at=(-38, -24, 12), axis="z", count=4)
+sheet.hole(diameter=18, at=(0, 0, 12), axis="z", cbore=(30, 14))
+sheet.envelope()   # 100 × 24 × 70
+# step_level @ (0, 0, -12) — auto-dimensioned (no declarative verb yet)
+sheet.export("mounting_plate")
+```
+
+*Pros:* honest (it *is* detected data); works for **any** geometry, however complex; the caller
+plugs in their real (parametric) part at the seam. *Cons:* the drawing layer carries magic
+numbers — the very thing mode 3 wants to avoid — and there is no object to re-read, so it does
+not track a parametric part.
+
+**Recommendation (pending sign-off):** ship **B first** (it is the honest, universal baseline and
+unblocks the emitter), and offer **A as an opt-in** (`reconstruct=True`) for the parts whose
+features reconstruct cleanly (prismatic + holes + simple counterbores), falling back to B when
+reconstruction is lossy. The two are not exclusive; the fork is really *which is the default*.
+
+### Fidelity contract (proposed)
+
+The generated script guarantees **a lint-clean drawing of the same features**, not a byte-identical
+copy of the auto-pass. (The imperative `--script` chases auto-pass quality via `finalize()`; the
+declarative emitter re-runs the auto-pass over the declared model, so placement is auto-pass by
+construction.)
+
+### Coverage honesty (accepted)
+
+Kinds with no declarative verb yet (`step_level`, `rotational`, `pmi`) are **flagged inline** as
+auto-dimensioned, never silently dropped — matching the fail-loud discipline of the constructors
+(#452). Growing verbs for them is follow-up, not a blocker.
+
+Tracked by **#461** (the emitter), **#462** (object-reading aspects → number-free 3b), **#463**
+(`sheet.of(feature)` → decorate a generated feature). Sequenced **before** the P2b GD&T work: the
+generation surface is the differentiator; GD&T is additive rendering behind the same façade.
 
 ## Relationship to other ADRs
 


### PR DESCRIPTION
Records the design for **mode 3** (generate an editable declarative `Sheet`-DSL script) as an amendment to ADR 0011, sequenced **before** the P2b GD&T work per the direction that the *generation* surface is the differentiator.

Captures:
- **The three authoring modes** — auto / auto+tweak / generate-an-editable-DSL.
- **The 3a/3b split (accepted)** — detected input → numbers unavoidable; build123d objects → number-free references (single source of truth).
- **The fidelity + coverage contracts (proposed)**.
- **One OPEN decision** — for a detected part, *reconstruct* the build123d part (number-free drawing layer, self-contained, but a lossy CSG approximation) vs. leave a `part = ...` *seam* (detected numbers, honest, works for any geometry). Both shown with a runnable example; recommendation is B-default + A opt-in (`reconstruct=True`).

Tracks #461 (emitter), #462 (object-reading aspects), #463 (`sheet.of()`).

**This PR is up for review to settle the open fork before the emitter work starts** — I'll fold the decision into the amendment text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)