### PR TITLE
feat: Sheet.of(feature) — decorate a generated/existing feature (ADR 0011, #463)

### DIFF
--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -233,14 +233,16 @@ class Sheet:
         return self._match_object(ref)
 
     def _match_object(self, obj) -> int:
-        """The index of the declared feature the build123d *obj* refers to, by ⌀ + the two
-        in-plane coordinates (the axial position is where they legitimately differ)."""
+        """The index of the declared feature the build123d *obj* refers to, by axis + ⌀ + the
+        two in-plane coordinates (the axial position is where they legitimately differ)."""
         axis, dia, center = _read_cylinder(obj)
-        perp = [k for k in range(3) if k != "xyz".index(_norm_axis(axis))]
+        axis = _norm_axis(axis)
+        perp = [k for k in range(3) if k != "xyz".index(axis)]
         matches = [
             i
             for i, f in enumerate(self._features)
             if getattr(f, "diameter", None) is not None
+            and _norm_axis(f.frame.axis) == axis  # same axis — a cross-hole must not match
             and abs(f.diameter - dia) <= 0.2
             and all(abs(f.frame.origin[k] - center[k]) <= 0.5 for k in perp)
         ]

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -23,7 +23,9 @@ deliberately **not** stubbed here, so the surface only exposes what actually dra
 
 **Hybrid.** :meth:`Sheet.from_part` seeds the declared set from *detection*, so you
 can start from the detected model and override specific features (declaration is for
-where you know better than detection, not everywhere — ADR 0011 §3).
+where you know better than detection, not everywhere — ADR 0011 §3); :meth:`Sheet.of`
+returns a fluent handle onto one of those generated features (by object, index, or the
+feature itself) so you can ``.fit(...)`` / ``.tolerance(...)`` it without re-declaring (#463).
 """
 
 from __future__ import annotations
@@ -33,13 +35,14 @@ from dataclasses import replace
 from draftwright.analysis import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
+from draftwright.model import Feature
 from draftwright.model import boss as _boss
 from draftwright.model import envelope as _envelope
 from draftwright.model import hole as _hole
 from draftwright.model import pattern as _pattern
 from draftwright.model import slot as _slot
 from draftwright.model import step as _step
-from draftwright.model.declare import _require_positive
+from draftwright.model.declare import _norm_axis, _read_cylinder, _require_positive
 from draftwright.model.declare import read_bore_step as _read_bore_step
 
 
@@ -197,6 +200,55 @@ class Sheet:
         the constructors this façade does not surface directly, e.g. PMI)."""
         self._features.append(feature)
         return self
+
+    def of(self, ref) -> _Hole | _Dim:
+        """A decoratable handle onto an **existing** feature — the hybrid seam (#463).
+
+        *ref* is a feature index, a :class:`Feature` already in :attr:`features` (e.g. seeded by
+        :meth:`from_part`), or the build123d **object** you built (matched by ⌀ + in-plane
+        position). Returns the same fluent handle the declaration verbs do, so you can
+        ``.fit(...)`` / ``.tolerance(...)`` — and, for a hole, ``.cbore(...)`` — a feature you
+        did not declare from scratch. Raises if the object matches no feature or is ambiguous."""
+        i = self._index_of(ref)
+        kind = self._features[i].kind
+        if kind == "hole":
+            return _Hole(self, i)
+        if kind in ("boss", "step"):
+            return _Dim(self, i, "diameter" if kind == "boss" else "length")
+        raise ValueError(f"of(): no aspect handle for a {kind!r} feature (holes / bosses / steps)")
+
+    def _index_of(self, ref) -> int:
+        if isinstance(ref, bool):
+            raise TypeError("of(): ref must be an index, a Feature, or a build123d object")
+        if isinstance(ref, int):
+            n = len(self._features)
+            if not -n <= ref < n:
+                raise IndexError(f"of(): feature index {ref} out of range (have {n})")
+            return ref % n
+        if isinstance(ref, Feature):
+            for i, f in enumerate(self._features):
+                if f is ref:
+                    return i
+            raise ValueError("of(): that Feature is not in this sheet's features")
+        return self._match_object(ref)
+
+    def _match_object(self, obj) -> int:
+        """The index of the declared feature the build123d *obj* refers to, by ⌀ + the two
+        in-plane coordinates (the axial position is where they legitimately differ)."""
+        axis, dia, center = _read_cylinder(obj)
+        perp = [k for k in range(3) if k != "xyz".index(_norm_axis(axis))]
+        matches = [
+            i
+            for i, f in enumerate(self._features)
+            if getattr(f, "diameter", None) is not None
+            and abs(f.diameter - dia) <= 0.2
+            and all(abs(f.frame.origin[k] - center[k]) <= 0.5 for k in perp)
+        ]
+        if not matches:
+            raise ValueError("of(): no declared feature matches that object (⌀ + position)")
+        if len(matches) > 1:
+            raise ValueError("of(): the object matches several features — pass an index instead")
+        return matches[0]
 
     def hole(self, obj=None, **kw) -> _Hole:
         """Declare a hole from the tool cylinder you subtracted (or explicit values).

--- a/tests/test_sheet_of.py
+++ b/tests/test_sheet_of.py
@@ -1,0 +1,72 @@
+"""sheet.of(feature) — decorate a generated/existing feature (ADR 0011, #463).
+
+Where the from_part-generated feature list and the aspect layer (P2a/P2a.2) meet: a handle
+onto an existing feature so `.fit(...)` / `.tolerance(...)` reach a feature you didn't declare
+from scratch.
+"""
+
+import pytest
+from build123d import Box, Cylinder, Pos, Rot
+
+from draftwright import Sheet
+
+
+def _shaft():
+    return (Rot(0, 90, 0) * Cylinder(4, 20)) + (Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10))
+
+
+class TestOf:
+    def test_of_object_decorates_a_generated_step(self):
+        # the headline: from_part generates the list; .of(object).fit() decorates one, end to end
+        s = Sheet.from_part(_shaft())
+        s.of(Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)).fit("g6")  # the ⌀12 collar
+        dwg = s.build()
+        dias = {n: dwg._named[n].label for n in dwg._named if n.startswith("m_dia")}
+        assert any(lbl == "ø12 g6" for lbl in dias.values()), dias
+
+    def test_of_index_returns_a_decoratable_handle(self):
+        s = Sheet.from_part(Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(4, 20))
+        i = next(i for i, f in enumerate(s.features) if f.kind == "hole")
+        s.of(i).fit("H7")  # records the fit on the hole's bore ⌀
+        assert (i, "diameter") in s._tolerances
+
+    def test_of_feature_identity(self):
+        s = Sheet.from_part(_shaft())
+        step = next(f for f in s.features if f.kind == "step")
+        s.of(step).tolerance(0.0, 0.1)  # by the Feature object itself
+        assert any(k[1] == "length" for k in s._tolerances)
+
+    def test_of_hole_handle_supports_cbore(self):
+        part = Box(100, 70, 24) - Pos(0, 0, 0) * Cylinder(9, 40) - Pos(0, 0, 8) * Cylinder(15, 20)
+        s = Sheet.from_part(part)
+        i = next(i for i, f in enumerate(s.features) if f.kind == "hole")
+        s.of(i).cbore(Pos(0, 0, 8) * Cylinder(15, 20))  # the hole handle carries .cbore
+        assert s.features[i].cbore == pytest.approx((30.0, 14.0))
+
+    def test_of_unmatched_object_raises(self):
+        s = Sheet.from_part(Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(4, 20))
+        with pytest.raises(ValueError):
+            s.of(Pos(0, 0, 0) * Cylinder(3, 10))  # ⌀6 at origin — no such feature
+
+    def test_of_ambiguous_object_raises(self):
+        s = Sheet(Box(40, 40, 30))
+        s.hole(diameter=8, at=(0, 0, 5), axis="z")
+        s.hole(diameter=8, at=(0, 0, 20), axis="z")  # same ⌀ + in-plane (0,0)
+        with pytest.raises(ValueError):
+            s.of(Pos(0, 0, 10) * Cylinder(4, 10))  # matches both → ambiguous
+
+    def test_of_non_diameter_feature_raises(self):
+        s = Sheet(Box(30, 20, 5))
+        s.envelope()
+        with pytest.raises(ValueError):
+            s.of(0)  # an envelope has no ⌀ aspect handle
+
+    def test_of_out_of_range_index_raises(self):
+        s = Sheet.from_part(Box(30, 20, 5))
+        with pytest.raises(IndexError):
+            s.of(99)
+
+    def test_of_bool_rejected(self):
+        s = Sheet.from_part(Box(30, 20, 5))
+        with pytest.raises(TypeError):
+            s.of(True)

--- a/tests/test_sheet_of.py
+++ b/tests/test_sheet_of.py
@@ -48,6 +48,15 @@ class TestOf:
         with pytest.raises(ValueError):
             s.of(Pos(0, 0, 0) * Cylinder(3, 10))  # ⌀6 at origin — no such feature
 
+    def test_of_matches_on_axis_not_just_in_plane(self):
+        # #463 review: a same-⌀ feature on a DIFFERENT axis (a cross-hole) sharing the in-plane
+        # coords must not match — the axis is part of the identity.
+        s = Sheet(Box(40, 40, 40))
+        s.hole(diameter=8, at=(0, 0, 0), axis="z")  # the intended target
+        s.diameter(diameter=8, at=(0, 0, 0), axis="x")  # same ⌀ + in-plane, different axis
+        h = s.of(Pos(0, 0, 0) * Cylinder(4, 20))  # a z-axis tool → only the z hole
+        assert s.features[h._i].frame.axis == "z"
+
     def test_of_ambiguous_object_raises(self):
         s = Sheet(Box(40, 40, 30))
         s.hole(diameter=8, at=(0, 0, 5), axis="z")


### PR DESCRIPTION
## What

The last piece of the mode-3 authoring cluster. `Sheet.from_part()` **generates** the feature list, but `.fit()`/`.tolerance()` handles came only from the *declaration* verbs — a generated feature couldn't be decorated fluently. Now:

```python
s = Sheet.from_part(part)     # GENERATED feature list
s.of(bore).fit("H7")          # decorate a generated feature — by the object you built
s.of(1).tolerance(0.0, 0.1)   # …or by index, or the Feature itself
```

`sheet.of(ref)` returns the same `_Hole` / `_Dim` handle the declaration verbs do, for an **existing** feature. This is where the generated feature list and the aspect layer (P2a/P2a.2) meet — the hybrid seam of ADR 0011 §3.

## How

- **`ref` resolution** (`_index_of`): an **index** (range-checked, negatives normalised), a **`Feature`** already in `.features` (identity), or the **build123d object** (`_match_object`, matched by **axis + ⌀ + in-plane position**; raises on no match / ambiguous).
- **Handle dispatch**: a hole → `_Hole` (`.fit`/`.tolerance`/`.cbore`/`.spotface`/`.depth`), a boss/step → `_Dim`; other kinds raise. Bool/out-of-range guarded.

## Tests

10 tests in `tests/test_sheet_of.py`: the headline end-to-end (`of(collar).fit("g6")` → `ø12 g6` on a `from_part` step), index / `Feature` / object matching, a hole handle's `.cbore`, and the guards — **axis-aware matching** (a cross-hole of the same ⌀ must not match), no-match, ambiguous, non-⌀ feature, out-of-range, bool. ruff + full mypy clean; 103 Sheet-consumer tests green.

## Review

One adversarial round → one low finding: `_match_object` compared ⌀ + in-plane but **not axis**, so a same-⌀ cross-hole could spuriously match. Fixed (axis added to the filter) with a regression test.

Refs #445, #446, ADR 0011 Amendment 1. **Completes the mode-3 cluster** (#461 emitter, #462 object-reading aspects, #463 hybrid decorate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)