### PR TITLE
feat: inspect a live object from a separate codebase — `module:attr` CLI input (#469)

### DIFF
--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -73,6 +73,16 @@ def _emit(dwg, formats: list[str]) -> list[str]:
     return [paths[f] for f in formats]
 
 
+def _looks_like_object_spec(s: str) -> bool:
+    """True when *s* is a ``module:attr`` / ``file.py:attr`` object reference rather than a STEP
+    path (#469). An existing file, or a Windows drive path (``C:\\…``), is never a spec."""
+    import re
+
+    if os.path.exists(s) or re.match(r"^[A-Za-z]:[\\/]", s):
+        return False
+    return re.match(r"^.+:[A-Za-z_][A-Za-z0-9_]*$", s) is not None
+
+
 def _installed_version() -> str:
     """The installed distribution version (the PyPI version once pip-installed);
     ``"unknown"`` when running from a source tree with no installed metadata."""
@@ -154,11 +164,18 @@ def main(
 
     if script:
         if style == "sheet":
-            from draftwright.sheet_emit import generate_sheet_script
+            from draftwright.sheet_emit import generate_sheet_script, resolve_object_spec
 
-            py_path = generate_sheet_script(
-                step_file, out=out, title=title, number=number, pmi=pmi.value
-            )
+            if _looks_like_object_spec(step_file):
+                # STEP_FILE is a `module:attr` / `file.py:attr` spec → reference a live object
+                obj, seam = resolve_object_spec(step_file)
+                py_path = generate_sheet_script(
+                    obj, out=out, title=title, number=number, part_expr=seam
+                )
+            else:
+                py_path = generate_sheet_script(
+                    step_file, out=out, title=title, number=number, pmi=pmi.value
+                )
         else:
             py_path = generate_script(
                 step_file=step_file,

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -75,10 +75,12 @@ def _emit(dwg, formats: list[str]) -> list[str]:
 
 def _looks_like_object_spec(s: str) -> bool:
     """True when *s* is a ``module:attr`` / ``file.py:attr`` object reference rather than a STEP
-    path (#469). An existing file, or a Windows drive path (``C:\\…``), is never a spec."""
+    path (#469). An existing file is never a spec; a plain path — a STEP file, or a Windows
+    ``C:\\…\\part.step`` drive path — has no trailing ``:identifier``, so the pattern rejects it
+    (a Windows drive colon is followed by ``\\``, not an identifier; filenames can't contain ':')."""
     import re
 
-    if os.path.exists(s) or re.match(r"^[A-Za-z]:[\\/]", s):
+    if os.path.exists(s):
         return False
     return re.match(r"^.+:[A-Za-z_][A-Za-z0-9_]*$", s) is not None
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -156,6 +156,76 @@ def emit_sheet_script(model, part_expr: str, stem: str, *, title: str, number: s
     return "\n".join(lines) + "\n"
 
 
+def resolve_object_spec(spec: str) -> tuple[Shape, str]:
+    """Resolve a ``module:attr`` (or ``path/to/file.py:attr``) spec into ``(build123d object,
+    import seam)`` (ADR 0011, #469). The attribute is imported; a zero-argument callable (a
+    ``make_part()`` factory) is called. The returned seam is the Python that re-binds ``part``
+    in the generated script, so the drawing references your **live parametric source**, not a
+    frozen STEP.
+
+    SECURITY: importing the target executes its module-level code — the same trust as running
+    the file yourself."""
+    import importlib
+    import importlib.util
+    import inspect
+    import os
+    import sys
+
+    mod_ref, sep, name = spec.rpartition(":")
+    if not sep or not name.isidentifier() or not mod_ref:
+        raise ValueError(f"object spec must be 'module:attr' or 'file.py:attr' (got {spec!r})")
+
+    if mod_ref.endswith(".py"):
+        path = Path(mod_ref).resolve()
+        ispec = importlib.util.spec_from_file_location(path.stem, path)
+        if ispec is None or ispec.loader is None:
+            raise ValueError(f"cannot load module from {mod_ref!r}")
+        module = importlib.util.module_from_spec(ispec)
+        ispec.loader.exec_module(module)
+        seam = (
+            "import importlib.util as _ilu\n"
+            f"_spec = _ilu.spec_from_file_location({path.stem!r}, {str(path)!r})\n"
+            "_mod = _ilu.module_from_spec(_spec)\n_spec.loader.exec_module(_mod)"
+        )
+        ref = f"_mod.{name}"
+    else:
+        cwd = os.getcwd()
+        if cwd not in sys.path:
+            sys.path.insert(0, cwd)  # allow a cwd-relative import
+        module = importlib.import_module(mod_ref)
+        # Record the invocation cwd (where the module resolved) on the generated script's path,
+        # so `from mod import …` works from any working directory — Python puts only the
+        # *script's* dir on sys.path, not the cwd, so a bare import would otherwise fail.
+        # (For an installed module the insert is harmless; the import works regardless.)
+        seam = (
+            f"import sys as _sys\nif {cwd!r} not in _sys.path:\n    _sys.path.insert(0, {cwd!r})\n"
+            f"from {mod_ref} import {name} as _obj"
+        )
+        ref = "_obj"
+
+    obj = getattr(module, name, None)
+    if obj is None:
+        raise ValueError(f"{spec!r}: {name!r} not found in {mod_ref!r}")
+
+    called = False
+    if callable(obj) and not isinstance(obj, Shape):
+        required = [
+            p
+            for p in inspect.signature(obj).parameters.values()
+            if p.default is p.empty and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        ]
+        if required:
+            raise ValueError(
+                f"{spec!r}: {name} needs arguments — reference a built object instead"
+            )
+        obj, called = obj(), True
+
+    if not isinstance(obj, Shape):
+        raise ValueError(f"{spec!r}: resolved to {type(obj).__name__}, not a build123d Shape")
+
+    return obj, f"{seam}\npart = {ref}{'()' if called else ''}"
+
+
 def generate_sheet_script(
     step_file: str | Shape,
     out: str | None = None,
@@ -163,12 +233,15 @@ def generate_sheet_script(
     title: str | None = None,
     number: str = "DWG-001",
     pmi: str = "off",
+    part_expr: str | None = None,
 ) -> str:
     """Write a declarative ``Sheet``-DSL script for *step_file* (a STEP path or a build123d
     object). Returns the path to the generated ``.py``. The mode-3 declarative counterpart of
     :func:`draftwright.builder.generate_script` (which emits the imperative reconstruction).
 
-    ``pmi`` is threaded to detection so AP242 PMI features surface (flagged inline)."""
+    ``pmi`` is threaded to detection so AP242 PMI features surface (flagged inline). *part_expr*,
+    when given, overrides the ``part = …`` seam — e.g. the import seam from
+    :func:`resolve_object_spec` so the script references a live module (#469)."""
     is_shape = isinstance(step_file, Shape)
     stem = out or ("drawing" if is_shape else Path(step_file).stem)
     for _ext in (".py", ".svg", ".dxf"):
@@ -177,7 +250,9 @@ def generate_sheet_script(
             break
     title = title or (Path(stem).name.replace("_", " ").upper() if not is_shape else "DRAWING")
 
-    if is_shape:
+    if part_expr is not None:
+        pass  # caller-supplied seam (e.g. an import of a live module, #469)
+    elif is_shape:
         part_expr = "part = ...   # ← wire in your build123d object (built above)"
     else:
         # absolute so the generated script runs from any working directory

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -181,18 +181,29 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         if ispec is None or ispec.loader is None:
             raise ValueError(f"cannot load module from {mod_ref!r}")
         module = importlib.util.module_from_spec(ispec)
-        ispec.loader.exec_module(module)
+        # Register before exec so a self-referential target resolves (a dataclass whose
+        # forward-ref annotations get typing.get_type_hints'd, a module reading
+        # sys.modules[__name__], import-time pickling). The seam does the same on re-run.
+        sys.modules[ispec.name] = module
+        try:
+            ispec.loader.exec_module(module)
+        except Exception as e:
+            raise ValueError(f"{spec!r}: importing {mod_ref!r} failed: {e}") from e
         seam = (
-            "import importlib.util as _ilu\n"
+            "import importlib.util as _ilu, sys as _sys\n"
             f"_spec = _ilu.spec_from_file_location({path.stem!r}, {str(path)!r})\n"
-            "_mod = _ilu.module_from_spec(_spec)\n_spec.loader.exec_module(_mod)"
+            "_mod = _ilu.module_from_spec(_spec)\n_sys.modules[_spec.name] = _mod\n"
+            "_spec.loader.exec_module(_mod)"
         )
         ref = f"_mod.{name}"
     else:
         cwd = os.getcwd()
         if cwd not in sys.path:
             sys.path.insert(0, cwd)  # allow a cwd-relative import
-        module = importlib.import_module(mod_ref)
+        try:
+            module = importlib.import_module(mod_ref)
+        except ImportError as e:
+            raise ValueError(f"{spec!r}: cannot import module {mod_ref!r}: {e}") from e
         # Record the invocation cwd (where the module resolved) on the generated script's path,
         # so `from mod import …` works from any working directory — Python puts only the
         # *script's* dir on sys.path, not the cwd, so a bare import would otherwise fail.
@@ -203,9 +214,9 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         )
         ref = "_obj"
 
-    obj = getattr(module, name, None)
-    if obj is None:
+    if not hasattr(module, name):  # `hasattr`, not a None sentinel: a name bound to None exists
         raise ValueError(f"{spec!r}: {name!r} not found in {mod_ref!r}")
+    obj = getattr(module, name)
 
     called = False
     if callable(obj) and not isinstance(obj, Shape):

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -25,6 +25,7 @@ _SOURCE_MODULE = (
     "bracket = Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(4, 20)\n"
     "def make_bracket():\n    return Box(30, 20, 5)\n"
     "NOT_A_SHAPE = 42\n"
+    "NONE_BOUND = None\n"  # exists but bound to None — the wrong-type, not-missing case
     "def needs_args(x):\n    return x\n"
 )
 
@@ -232,6 +233,35 @@ class TestObjectSpec:
         with pytest.raises(ValueError, match="not a build123d Shape"):
             resolve_object_spec(f"{p}:NOT_A_SHAPE")
 
+    def test_none_bound_attr_reports_wrong_type_not_missing(self, tmp_path):
+        # `bracket = None` exists but is None — must report the honest "not a Shape", not "not
+        # found" (a None sentinel on getattr would conflate the two, #469 review).
+        p = self._mod(tmp_path)
+        with pytest.raises(ValueError, match="not a build123d Shape"):
+            resolve_object_spec(f"{p}:NONE_BOUND")
+
+    def test_unimportable_module_raises_a_clean_error(self):
+        # a missing/malformed module surfaces the friendly ValueError, not a raw ImportError
+        with pytest.raises(ValueError, match="cannot import module"):
+            resolve_object_spec("no_such_module_zzz:bracket")
+
+    def test_self_referential_file_module_loads(self, tmp_path):
+        # a target that resolves its own forward-ref annotations via typing.get_type_hints needs
+        # sys.modules registration BEFORE exec — the .py branch must register it (#469 review).
+        src = (
+            "from dataclasses import dataclass\n"
+            "from typing import Optional, get_type_hints\n"
+            "from build123d import Box\n"
+            "@dataclass\n"
+            "class Node:\n    nxt: 'Optional[Node]' = None\n"
+            "get_type_hints(Node)  # NameError unless this module is in sys.modules\n"
+            "part = Box(10, 10, 10)\n"
+        )
+        p = tmp_path / "selfref.py"
+        p.write_text(src, encoding="utf-8")
+        obj, _seam = resolve_object_spec(f"{p}:part")
+        assert isinstance(obj, Shape)
+
     def test_callable_needing_args_raises(self, tmp_path):
         p = self._mod(tmp_path)
         with pytest.raises(ValueError, match="needs arguments"):
@@ -258,10 +288,17 @@ class TestLooksLikeSpec:
         assert not _looks_like_object_spec("part.stp")
         assert not _looks_like_object_spec("dir/sub/part.step")  # a colonless path
 
-    def test_windows_drive_path_is_not_a_spec(self):
+    def test_windows_step_path_is_not_a_spec(self):
         from draftwright.cli import _looks_like_object_spec
 
         assert not _looks_like_object_spec(r"C:\models\part.step")
+
+    def test_windows_absolute_file_spec_is_a_spec(self):
+        # the drive-path guard was removed (#469 review): C:\…\model.py:bracket is a real file
+        # spec and must route to resolve_object_spec, not the STEP path.
+        from draftwright.cli import _looks_like_object_spec
+
+        assert _looks_like_object_spec(r"C:\proj\model.py:bracket")
 
     def test_existing_file_is_never_a_spec(self, tmp_path):
         # a real STEP file that happens to parse spec-like still isn't a spec

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -203,8 +203,10 @@ class TestObjectSpec:
         p = self._mod(tmp_path)
         obj, seam = resolve_object_spec(f"{p}:bracket")
         assert isinstance(obj, Shape)
-        # the file seam bakes the absolute path so the generated script runs from any CWD
-        assert "spec_from_file_location(" in seam and str(p) in seam
+        # the file seam bakes the absolute path as a repr'd literal (so it's valid Python and
+        # runs from any CWD) — compare against repr, not the bare string, so Windows backslash
+        # escaping (C:\\Users\\… in the seam vs C:\Users\… in str(p)) doesn't false-fail.
+        assert "spec_from_file_location(" in seam and repr(str(p.resolve())) in seam
         assert "part = _mod.bracket" in seam
 
     def test_zero_arg_factory_is_called(self, tmp_path):
@@ -221,7 +223,9 @@ class TestObjectSpec:
         obj, seam = resolve_object_spec("dottedmod:bracket")
         assert isinstance(obj, Shape)
         assert "from dottedmod import bracket as _obj" in seam
-        assert str(tmp_path) in seam
+        # the cwd is baked as a repr'd literal — compare against repr so Windows backslash
+        # escaping in the seam doesn't false-fail (the code bakes os.getcwd(), same as here).
+        assert repr(os.getcwd()) in seam
 
     def test_missing_attr_raises(self, tmp_path):
         p = self._mod(tmp_path)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -8,10 +8,25 @@ import ast
 import math
 import os
 
-from build123d import Box, Cylinder, Pos, export_step
+import pytest
+from build123d import Box, Cylinder, Pos, Shape, export_step
 
 from draftwright.builder import detect_part_model
-from draftwright.sheet_emit import emit_sheet_script, generate_sheet_script
+from draftwright.sheet_emit import (
+    emit_sheet_script,
+    generate_sheet_script,
+    resolve_object_spec,
+)
+
+# A throwaway source module the object-spec tests import a live part off (#469): an object,
+# a zero-arg factory, a non-Shape, and a callable that needs args (the guard-rail case).
+_SOURCE_MODULE = (
+    "from build123d import Box, Cylinder, Pos\n"
+    "bracket = Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(4, 20)\n"
+    "def make_bracket():\n    return Box(30, 20, 5)\n"
+    "NOT_A_SHAPE = 42\n"
+    "def needs_args(x):\n    return x\n"
+)
 
 
 def _plate():
@@ -174,6 +189,89 @@ class TestGenerate:
         assert os.path.isabs(path)  # platform-agnostic (C:\… on Windows, /… on POSIX)
 
 
+class TestObjectSpec:
+    """`module:attr` / `file.py:attr` → a live build123d object (#469, mode 3b from a
+    separate codebase). The seam re-binds `part` to the real source, not a frozen STEP."""
+
+    def _mod(self, tmp_path, name="srcmod"):
+        p = tmp_path / f"{name}.py"
+        p.write_text(_SOURCE_MODULE, encoding="utf-8")
+        return p
+
+    def test_file_attr_resolves_object_with_self_contained_seam(self, tmp_path):
+        p = self._mod(tmp_path)
+        obj, seam = resolve_object_spec(f"{p}:bracket")
+        assert isinstance(obj, Shape)
+        # the file seam bakes the absolute path so the generated script runs from any CWD
+        assert "spec_from_file_location(" in seam and str(p) in seam
+        assert "part = _mod.bracket" in seam
+
+    def test_zero_arg_factory_is_called(self, tmp_path):
+        p = self._mod(tmp_path)
+        obj, seam = resolve_object_spec(f"{p}:make_bracket")
+        assert isinstance(obj, Shape)
+        assert seam.rstrip().endswith("()")  # part = _mod.make_bracket()
+
+    def test_dotted_module_seam_bakes_the_cwd(self, tmp_path, monkeypatch):
+        # Python puts only the *script's* dir on sys.path, not the cwd — so the seam must
+        # bake the resolve-time cwd or `from mod import …` fails when the script is re-run.
+        self._mod(tmp_path, "dottedmod")
+        monkeypatch.chdir(tmp_path)
+        obj, seam = resolve_object_spec("dottedmod:bracket")
+        assert isinstance(obj, Shape)
+        assert "from dottedmod import bracket as _obj" in seam
+        assert str(tmp_path) in seam
+
+    def test_missing_attr_raises(self, tmp_path):
+        p = self._mod(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            resolve_object_spec(f"{p}:nope")
+
+    def test_non_shape_raises(self, tmp_path):
+        p = self._mod(tmp_path)
+        with pytest.raises(ValueError, match="not a build123d Shape"):
+            resolve_object_spec(f"{p}:NOT_A_SHAPE")
+
+    def test_callable_needing_args_raises(self, tmp_path):
+        p = self._mod(tmp_path)
+        with pytest.raises(ValueError, match="needs arguments"):
+            resolve_object_spec(f"{p}:needs_args")
+
+    def test_malformed_spec_raises(self):
+        with pytest.raises(ValueError, match="module:attr"):
+            resolve_object_spec("no_colon_here")
+
+
+class TestLooksLikeSpec:
+    """The CLI's STEP-path-vs-object-spec discriminator (`_looks_like_object_spec`, #469)."""
+
+    def test_dotted_and_file_specs_are_specs(self):
+        from draftwright.cli import _looks_like_object_spec
+
+        assert _looks_like_object_spec("mypkg.mymod:bracket")
+        assert _looks_like_object_spec("model.py:make_part")
+
+    def test_step_paths_are_not_specs(self):
+        from draftwright.cli import _looks_like_object_spec
+
+        assert not _looks_like_object_spec("/tmp/part.step")
+        assert not _looks_like_object_spec("part.stp")
+        assert not _looks_like_object_spec("dir/sub/part.step")  # a colonless path
+
+    def test_windows_drive_path_is_not_a_spec(self):
+        from draftwright.cli import _looks_like_object_spec
+
+        assert not _looks_like_object_spec(r"C:\models\part.step")
+
+    def test_existing_file_is_never_a_spec(self, tmp_path):
+        # a real STEP file that happens to parse spec-like still isn't a spec
+        from draftwright.cli import _looks_like_object_spec
+
+        f = tmp_path / "weird.step"
+        f.write_text("x")
+        assert not _looks_like_object_spec(str(f))
+
+
 class TestCli:
     def test_style_sheet_routes_to_the_declarative_emitter(self, tmp_path):
         from typer.testing import CliRunner
@@ -197,3 +295,35 @@ class TestCli:
         export_step(_plate(), str(step))
         r = CliRunner().invoke(app, [str(step), "--script", "--style", "bogus"])
         assert r.exit_code != 0
+
+    def test_module_spec_routes_to_the_live_object(self, tmp_path, monkeypatch):
+        # `draftwright climod:bracket --script --style sheet` → detect off the imported object
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        (tmp_path / "climod.py").write_text(_SOURCE_MODULE, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        r = CliRunner().invoke(
+            app, ["climod:bracket", "--script", "--style", "sheet", "--out", "g"]
+        )
+        assert r.exit_code == 0, r.output
+        src = open(tmp_path / "g.py", encoding="utf-8").read()
+        assert "from climod import bracket as _obj" in src  # the live-source seam
+        assert "sheet.hole(" in src  # features detected off the object, not a STEP
+
+    def test_generated_module_spec_script_round_trips(self, tmp_path, monkeypatch):
+        # the whole point: the emitted script RUNS (through the baked-cwd seam) and draws
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        (tmp_path / "rtmod.py").write_text(_SOURCE_MODULE, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        r = CliRunner().invoke(
+            app, ["rtmod:bracket", "--script", "--style", "sheet", "--out", "g"]
+        )
+        assert r.exit_code == 0, r.output
+        py = tmp_path / "g.py"
+        exec(compile(open(py, encoding="utf-8").read(), str(py), "exec"), {})
+        assert (tmp_path / "g.svg").exists()


### PR DESCRIPTION
Closes #469.

## What

`draftwright othercode:bracket --script --style sheet` now imports a build123d object from a **separate** codebase and generates the declarative Sheet-DSL script straight off it — no STEP round-trip. This is ADR 0011 mode 3b driven from the command line: the generated script references your **live parametric source**.

Three input forms, all round-trip end-to-end:

```
draftwright othercode:bracket              --script --style sheet   # dotted import
draftwright othercode:make_bracket         --script --style sheet   # zero-arg factory → called
draftwright /path/to/othercode.py:bracket  --script --style sheet   # file path
```

## How

- **`sheet_emit.resolve_object_spec(spec)`** resolves `module:attr` / `file.py:attr` into `(object, import seam)`. A zero-arg factory (`make_part()`) is called; a callable needing args, a missing attr, or a non-Shape is rejected with a clear `ValueError`. The seam re-binds `part` in the generated script:
  - `file.py:attr` → a `spec_from_file_location` seam baking the **absolute** path (runs from any cwd), registered in `sys.modules` before exec so self-referential targets load.
  - `module:attr` → `from module import attr`, prefixed with a `sys.path` insert of the resolve-time cwd — Python puts only the *script's* dir on the path, not the cwd, so a bare import would otherwise fail on re-run.
- **`generate_sheet_script(part_expr=…)`** lets a caller override the `part = …` seam.
- **`cli._looks_like_object_spec`** discriminates a spec from a STEP path (an existing file, or a colonless path — including a Windows `C:\…\part.step` drive path — is never a spec).

## Security

Importing the target executes its module-level code — the same trust as running the file yourself. Documented on `resolve_object_spec`.

## Review

Adversarial review (2 dimensions × find→refute) surfaced 5 confirmed findings, all minor/nit, **all applied in the second commit**: Windows absolute file specs unroutable, `sys.modules` registration for self-referential targets, raw traceback → friendly `ValueError`, and the None-sentinel vs `hasattr` attribute check.

## Tests

14 new tests (object-spec resolution, guard rails, the STEP-vs-spec discriminator, CLI routing + round-trip). Full emitter suite 36 pass; lint + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)