### PR TITLE
fix: reproduce turned-shaft rotational furniture through the declared-model path (#472)

### DIFF
--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -11,4 +11,5 @@ from draftwright.annotations.orchestrator import (  # noqa: F401
     _auto_annotate,
     _wrap_rows,
     build_model,
+    build_rotational_feature,
 )

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -59,8 +59,10 @@ from draftwright.annotations.sections import (
     feature_holes_of,
 )
 from draftwright.model import (
+    Frame,
     HoleFeature,
     PatternFeature,
+    RotationalFeature,
     build_part_model,
     plan_dimensions,
     plan_sections,
@@ -128,6 +130,20 @@ def build_model(a: Analysis):
         rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
         pmi=a.pmi,
     )
+
+
+def build_rotational_feature(a: Analysis):
+    """The rotational furniture feature (OD + centrelines + concentric bores) for *a*,
+    or ``None`` when the part isn't rotational. Mirrors the ``rotational`` branch of
+    :func:`build_model` / ``detect.build_part_model`` (detect.py) so the declared-model
+    path can synthesise the same furniture detection produces: a declared turned shaft
+    otherwise renders with no centrelines and its OD as a leader, not a dimension (#472).
+    Concentric bores are a Z-axis construction (as in :func:`build_model`)."""
+    if not a.is_rotational or a.od_diam is None:
+        return None
+    bores = tuple(_concentric_bore_diams(a)) if a.od_axis == "z" else ()
+    c = a.part.bounding_box().center()
+    return RotationalFeature(frame=Frame((c.X, c.Y, c.Z), a.od_axis), od=a.od_diam, bores=bores)
 
 
 def _declared_feature_keys(groups, a: Analysis) -> set:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -36,7 +36,7 @@ from draftwright._core import (
     _tb_width,
 )
 from draftwright.analysis import _analyse
-from draftwright.annotate import _auto_annotate, build_model
+from draftwright.annotate import _auto_annotate, build_model, build_rotational_feature
 from draftwright.annotations.sections import feature_hole_keys
 from draftwright.drawing import Drawing
 from draftwright.fonts import PLEX_MONO
@@ -263,6 +263,17 @@ def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=
     dwg._part_model = (
         _coerce_model(model, a.part, decorations) if model is not None else build_model(a)
     )
+    if model is not None:
+        # A declared model skips detection, so a turned shaft carries no RotationalFeature —
+        # and that feature is the sole driver of the turned-axis centrelines + the OD dimension
+        # (rot furniture). Synthesise it from the (unconditional) analysis so a declared /
+        # emitted-script turned part reproduces the detected drawing (#472). Gated on the
+        # caller not having declared one, so an explicit choice wins.
+        pm = dwg._part_model
+        if not any(f.kind == "rotational" for f in pm.features):
+            rot = build_rotational_feature(a)
+            if rot is not None:
+                dwg._part_model = replace(pm, features=[*pm.features, rot])
     dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
 
     part_s = a.part.scale(a.SCALE)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -510,14 +510,34 @@ class TestRoundTripParity:
         self._parity(_plate(), tmp_path, monkeypatch)
 
     def test_turned_x_shaft_parity(self, tmp_path, monkeypatch):
-        # a horizontal turned shaft (X axis) — steps + OD + centrelines
-        shaft = Pos(0, 0, 20) * Cylinder(15, 40) + Pos(0, 0, 55) * Cylinder(8, 30)
+        # a horizontal turned shaft (X axis) — genuinely rotational: is_rotational + od_axis='x',
+        # driving the non-Z branch of build_rotational_feature (bores=(), Frame axis='x'). A
+        # two-diameter cross body would trip the #222 fallback and classify prismatic instead,
+        # exercising no rotational furniture — so keep this a single-diameter cylinder.
         from build123d import Rotation
 
-        self._parity(Rotation(0, 90, 0) * shaft, tmp_path, monkeypatch)
+        self._parity(Rotation(0, 90, 0) * Cylinder(15, 80), tmp_path, monkeypatch)
 
     def test_rotational_bored_shaft_parity(self, tmp_path, monkeypatch):
         # the #472 fixture: a Z-axis stepped cylinder with a concentric bore — the case that
         # dropped both centrelines and the OD dimension before the RotationalFeature synthesis
         shaft = Pos(0, 0, 20) * Cylinder(15, 40) + Pos(0, 0, 55) * Cylinder(8, 30)
         self._parity(shaft - Pos(0, 0, 0) * Cylinder(2.5, 200), tmp_path, monkeypatch)
+
+    def test_declared_rotational_wins_no_double_add(self):
+        # The synthesis gate (builder.py) must not fire when the caller already declared a
+        # rotational feature: an explicit choice wins, and the furniture is never double-added.
+        # Use a genuinely rotational part (single-diam horizontal cylinder ⇒ synthesis WOULD
+        # otherwise add od=30) but declare od=99 — assert exactly one rotational feature survives
+        # and it is the declared one.
+        from build123d import Rotation
+
+        from draftwright.model.ir import Frame, PartModel, RotationalFeature
+
+        shaft = Rotation(0, 90, 0) * Cylinder(15, 80)
+        declared = RotationalFeature(frame=Frame((0.0, 0.0, 0.0), "x"), od=99.0)
+        m = PartModel(
+            bbox=shaft.bounding_box(), orientation=None, features=[declared], datums=[]
+        )
+        rot = [f for f in build_drawing(shaft, model=m).model().features if f.kind == "rotational"]
+        assert len(rot) == 1 and rot[0].od == 99.0

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -536,8 +536,6 @@ class TestRoundTripParity:
 
         shaft = Rotation(0, 90, 0) * Cylinder(15, 80)
         declared = RotationalFeature(frame=Frame((0.0, 0.0, 0.0), "x"), od=99.0)
-        m = PartModel(
-            bbox=shaft.bounding_box(), orientation=None, features=[declared], datums=[]
-        )
+        m = PartModel(bbox=shaft.bounding_box(), orientation=None, features=[declared], datums=[])
         rot = [f for f in build_drawing(shaft, model=m).model().features if f.kind == "rotational"]
         assert len(rot) == 1 and rot[0].od == 99.0

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -7,11 +7,12 @@ Detected input only writes numbers (the part-seam form); we never fabricate geom
 import ast
 import math
 import os
+from collections import Counter
 
 import pytest
 from build123d import Box, Cylinder, Pos, Shape, export_step
 
-from draftwright.builder import detect_part_model
+from draftwright.builder import build_drawing, detect_part_model
 from draftwright.sheet_emit import (
     emit_sheet_script,
     generate_sheet_script,
@@ -469,3 +470,54 @@ class TestCli:
         py = tmp_path / "g.py"
         exec(compile(open(py, encoding="utf-8").read(), str(py), "exec"), {})
         assert (tmp_path / "g.svg").exists()
+
+
+def _named_signature(dwg):
+    """The multiset of annotation TYPES on a drawing — the 'annotation signature' #472 uses
+    to compare a generated-script drawing against a direct build (catches a dropped Centerline
+    or an OD that fell from Dimension to Leader)."""
+    return Counter(type(v).__name__ for v in dwg._named.values())
+
+
+def _drawing_from_generated_script(step_path, tmp_path, monkeypatch):
+    """Run the ACTUAL generated sheet script (STEP-seam form, self-runnable) and capture the
+    Drawing it builds, by intercepting Sheet.export — the true end-to-end sheet-script path."""
+    from draftwright import Sheet
+
+    captured = {}
+    monkeypatch.setattr(
+        Sheet, "export", lambda self, stem=None: captured.setdefault("dwg", self.build())
+    )
+    py = generate_sheet_script(str(step_path), out=str(tmp_path / "gen"))
+    exec(compile(open(py, encoding="utf-8").read(), py, "exec"), {})
+    return captured["dwg"]
+
+
+class TestRoundTripParity:
+    """#472: the generated sheet script must reproduce the direct build's annotation set — the
+    invariant that makes the default `--script` (sheet) trustworthy. Turned/rotational parts were
+    the known gap (dropped centrelines + OD-as-leader) because the declared model carried no
+    RotationalFeature; the builder now synthesises it from the analysis."""
+
+    def _parity(self, part, tmp_path, monkeypatch):
+        step = tmp_path / "part.step"
+        export_step(part, str(step))
+        direct = build_drawing(step_file=str(step), title="PART")
+        scripted = _drawing_from_generated_script(step, tmp_path, monkeypatch)
+        assert _named_signature(scripted) == _named_signature(direct)
+
+    def test_prismatic_plate_parity(self, tmp_path, monkeypatch):
+        self._parity(_plate(), tmp_path, monkeypatch)
+
+    def test_turned_x_shaft_parity(self, tmp_path, monkeypatch):
+        # a horizontal turned shaft (X axis) — steps + OD + centrelines
+        shaft = Pos(0, 0, 20) * Cylinder(15, 40) + Pos(0, 0, 55) * Cylinder(8, 30)
+        from build123d import Rotation
+
+        self._parity(Rotation(0, 90, 0) * shaft, tmp_path, monkeypatch)
+
+    def test_rotational_bored_shaft_parity(self, tmp_path, monkeypatch):
+        # the #472 fixture: a Z-axis stepped cylinder with a concentric bore — the case that
+        # dropped both centrelines and the OD dimension before the RotationalFeature synthesis
+        shaft = Pos(0, 0, 20) * Cylinder(15, 40) + Pos(0, 0, 55) * Cylinder(8, 30)
+        self._parity(shaft - Pos(0, 0, 0) * Cylinder(2.5, 200), tmp_path, monkeypatch)


### PR DESCRIPTION
## What

Closes the turned/rotational half of the **#472 validity gap**: a drawing generated via the declarative `Sheet` script (`--script --style sheet`, now the default) should reproduce the direct build. Prismatic parts already did; turned shafts dropped their **centre lines** and rendered the base ⌀ as a **`Leader`** instead of a **`Dimension`**.

## Root cause

The declared-model path (`build_drawing(part, model=…)`) skips detection. A turned part's centre lines *and* OD dimension are both driven by a single `RotationalFeature` in the IR (`f.kind == "rotational"`), which only the detection path synthesises. With no such feature, `render_rotational` returns early — emitting neither the centrelines nor the OD dim — and the base ⌀ then falls through to `render_diameters` as a leader.

## Fix

`_analyse` runs **unconditionally** (for projection), so `a.is_rotational` / `a.od_diam` / `a.od_axis` are always available. In `_assemble`, when the caller passed a `model=` and didn't declare a `RotationalFeature`, synthesise one from the analysis via a new shared `build_rotational_feature(a)` that mirrors the detection path's construction — so the furniture is byte-identical. Gated so an explicit caller choice wins; no emitter change needed.

This makes the emitter's existing "auto-dimensioned" promise for `rotational` truthful (ADR 0011 / issue item 3).

## Test

New `TestRoundTripParity` (issue item 4) runs the **actual generated sheet script** end-to-end (generate → exec → capture the built `Drawing`) and asserts its annotation signature equals the direct build, across **prismatic / X-turned / Z-rotational-bored** fixtures.

## Verification

- New parity tests pass (the Z-rotational-bored fixture is the exact #472 case).
- Full fast tier: **1021 passed**. Lint + mypy clean.

## Not in scope

PMI parity (issue mentions it needs the same treatment) — deferred; this PR closes the turned/rotational gap that gated the default flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)