### PR TITLE
feat: GD&T + finish placement as first-class ADR 0009 corridor candidates (P2b, #61)

### DIFF
--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -573,6 +573,15 @@ stacked frames spaced by one label-height would overlap.
   `(tier, tier)` default, so **every existing dimension is byte-identical** — this is a
   pure extension, not a re-tiering. `plan_strip` already spaces by `size[idx]` (P4a), so
   no solver change is needed; the real gap simply flows through.
+- The **strip-edge reservation** (`place_strip_candidates` pulls the outer boundary in so
+  the outermost label doesn't overshoot `outer_limit`) also uses the real outward extent,
+  not a fixed `tier` — else a glyph wider than `tier` renders off the sheet
+  (`annotation_out_of_bounds`) instead of dropping when the strip is too narrow. It is
+  orientation-aware: the Leader **centres** the glyph on the elbow for an above/below
+  strip (outward extent = `height/2`) but places it **one-sided** for left/right (extent =
+  full width). Dims carry no size → the reservation stays `tier`, byte-identical.
+  *(Both this and the leader-box footnote above were adversarial-review findings on the
+  P2b commit — a wide multi-datum frame rendered 17 mm off-sheet before the fix.)*
 - The footprint is the **glyph's own box**, NOT the leader+glyph box. The leader shaft
   runs back to the feature, so measuring the composite would inflate the stacking-axis
   extent — exactly the reason dims reserve one label-height and not their witness span.

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -555,6 +555,41 @@ shared solve); the pure-location and hole-free fixtures stay byte-identical. A `
 corpus fixture (a hole X coincident with a slot edge) plus explicit dedup + monotonic-order
 assertions lock both bugs; 85 layout/e2e tests unchanged green.
 
+## Amendment 7 — Real per-candidate footprint; GD&T frames as first-class candidates (#61)
+
+**Status:** Accepted (2026-07-06). The first candidate whose footprint is *not* one
+label-height, and the first non-dimension occupant of a shared corridor.
+
+**Problem.** `place_strip_candidates` built every `StripCandidate` with
+`size=(tier, tier)` — the label-height square that is right for a dimension but wrong for
+a wide/tall occupant. ADR 0011's GD&T aspect layer (#61) needs to place a **feature
+control frame** (~24×6 mm) through the same collect-then-solve strip stage, and two
+stacked frames spaced by one label-height would overlap.
+
+**Decision.**
+- `CorridorCandidate.size` (optional) carries a candidate's real page-mm footprint;
+  `solve_corridor` forwards a `{name: (w, h)}` map into `place_strip_candidates`, which
+  feeds it to the `StripCandidate` instead of the `(tier, tier)` hardcode. Absent → the
+  `(tier, tier)` default, so **every existing dimension is byte-identical** — this is a
+  pure extension, not a re-tiering. `plan_strip` already spaces by `size[idx]` (P4a), so
+  no solver change is needed; the real gap simply flows through.
+- The footprint is the **glyph's own box**, NOT the leader+glyph box. The leader shaft
+  runs back to the feature, so measuring the composite would inflate the stacking-axis
+  extent — exactly the reason dims reserve one label-height and not their witness span.
+- **GD&T is placed at build time, as a first-class corridor candidate** (`render_gdt`,
+  registered before the drain), not post-hoc. A frame placed after `build_drawing`
+  returns is blind to the shared cross-view corridor and never triggers a repack — it
+  overlapped a plan-view dim in a first cut. In the corridor it is ordered and spaced
+  crossing-free *with* the dims, and `view=`-tagged so ADR 0004's `_measure_blocks` +
+  repack separate cross-view. This is the disciplined answer to "where does a new
+  annotation family go" — the collect-then-solve corridor, not `Strip.allocate`.
+
+**Scope.** The `sizes` map is threaded but only GD&T sets it today; every dimension pass
+still passes the default. This is the down-payment on the broader real-footprint
+migration (diameters/envelope will want it next). Roadmap: `0011-phase2-aspects-roadmap.md`
+(P2b). Tests: `tests/test_gdt_placement.py` (stacked frames reserve real footprint; a full
+strip drops with a `gdt_dropped` warning; placement is lint-clean).
+
 ## Related
 
 - [ADR 0001](0001-deterministic-generation-over-editable-dsl.md) — determinism;

--- a/docs/plans/0011-phase2-aspects-roadmap.md
+++ b/docs/plans/0011-phase2-aspects-roadmap.md
@@ -132,24 +132,53 @@ The lone genuine (c) gap — helpers has no fit-code semantics.
   cleaner and a shared-sign fit can't use P2a's `+hi/-lo` formatter; the deviation form
   needs its own precision — fit deviations show 3–4 dp, not the sheet's 1 dp.)*
 
-### P2b — GD&T + finish placement API (#61) · #30
+### P2b — GD&T + finish placement API (#61) · #30 · **DONE**
 
-The reusable low-level primitive both the declarative verbs (P2c) and the PMI
-auto-path (P2d) render through. Purely manual placement (caller supplies the target
-point) per #61 v1.
+The build-time render core both the declarative verbs (P2c) and the PMI auto-path
+(P2d) render through.
 
-- `dwg.place_fcf(target, characteristic, tolerance, datums=…, diameter=…,
-  modifier=…)`, `dwg.place_datum(letter, target, side=…)`,
-  `dwg.place_finish(ra_value, target)`.
-- Each builds a `Leader(callout=FeatureControlFrame | DatumFeature |
-  SurfaceFinish)` (the helpers `Leader.callout=` param hangs any sketch at the shelf
-  end) and routes through the **`Strip`** layout so frames stack clear of the part
-  and of each other — mirroring `place_dim()` (#25).
-- The hard part is anchoring + leader routing + strip stacking; the glyphs are all
-  helpers primitives.
-- Read-side pairing (#61 note): a `datum_candidates()` helper surfacing the part's
-  natural datum edges/faces (the min-X / min-Y corner is already the dimension
-  datum) so a script can anchor `place_datum` without guessing coordinates.
+**Amended (2026-07-06): build-time corridor candidate, NOT an imperative primitive.**
+The original bullets below proposed `dwg.place_fcf(target, …)` routing through
+`Strip.allocate` mirroring `place_dim`. Two problems surfaced in a first cut and were
+rejected by the user:
+
+1. **Imperative post-build placement is blind to the shared cross-view corridor.** A
+   frame placed *after* `build_drawing` returns (past `_auto_annotate`, past the
+   measure-and-repack) never carves around the other view's dims and never triggers a
+   repack — it overlapped a plan-view dimension exactly where ADR 0004's compose-then-pack
+   is supposed to prevent it. GD&T must be placed *during* the build, like every other
+   annotation, so `_measure_blocks` folds it into its `ViewBlock` and the repack net
+   separates cross-view (ADR 0004).
+2. **`Strip.allocate` is the legacy cursor ADR 0009 retires.** Routing new work through
+   it would add to the deprecated path. New annotations join the **collect-then-solve
+   corridor** (ADR 0009), the target architecture.
+
+**Delivered design (Tier 1):**
+- Three frozen IR items — `ControlFrame` / `DatumRef` / `Finish` (`model/ir.py`), peers
+  of `PmiFeature` (`parameters()` empty, so they bypass the dimension planner). Each
+  carries its target `(view, side)` strip + model-space site; the Sheet layer (P2c)
+  computes those from a build123d face.
+- `render_gdt` (`annotations/from_model.py`) — builds each glyph, hangs it on a
+  `Leader`, and **registers a `CorridorCandidate` into the target strip before
+  `drain_corridors`**, so the one ADR 0009 solve orders and spaces frames crossing-free
+  *with* the dims (a first-class candidate, not a leftover first-fit like `render_pmi`).
+  Wired into `_auto_annotate` after `render_slots`, before the drain.
+- **Real-footprint plumbing (the ADR 0009 down-payment):** `CorridorCandidate.size`
+  carries the glyph's own box (a frame is ~24×6 mm); `solve_corridor` forwards a
+  `sizes` map into `place_strip_candidates`, which now feeds it to the `StripCandidate`
+  instead of the `(tier, tier)` label-height hardcode. Absent → `(tier, tier)`, so every
+  existing dimension stays byte-identical. The footprint is the *glyph* box, not the
+  leader+glyph box — the shaft back to the feature would inflate the stacking extent
+  (the same reason dims reserve one label-height). See ADR 0009 Amendment 7.
+- A declared frame is **force-kept** (policy B) — no alternate view — so a full strip
+  drops it with a first-class `gdt_dropped` warning rather than a silent vanish; the
+  placed frame gets `feature=`-tagged through `add(...)` into the ADR 0010 provenance
+  sink for free.
+
+**Deferred to P2c / follow-ups:** left/right strips render but the common case is
+above/below; the read-side `datum_candidates()` helper (surface the part's natural
+datum edges so a script anchors without guessing coordinates) moves to P2c where the
+face→site projection lives.
 
 ### P2c — Sheet declarative aspect verbs · #31
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -445,6 +445,7 @@ def place_strip_candidates(
         return list(cands)
     lo, hi, inner = strip_free_span(strip)
     idx = 1 if axis == "y" else 0
+
     # Reserve the outermost label's OUTWARD extent at the strip boundary. plan_strip bounds
     # the dim-LINE position, but the label extends outward from it — so without this the last
     # tier's label overshoots outer_limit (into the iso view / page margin), unlike the old

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -305,6 +305,12 @@ class CorridorCandidate:
     # The source IR feature this dim was rendered for — recorded as provenance when the
     # dim is placed at drain (ADR 0010). ``None`` leaves the annotation feature-less.
     feature: object | None = None
+    # Real stacking-axis + perpendicular footprint ``(w, h)`` in page-mm, or ``None`` to
+    # use the dimension default ``(tier, tier)``. Wide/tall occupants (a GD&T feature
+    # control frame is ~24×6 mm) set this so the strip solve reserves their true extent
+    # instead of one label-height (ADR 0009 real-footprint plumbing, #61). A dim leaves
+    # it ``None`` — byte-identical to the pre-plumbing placement.
+    size: tuple | None = None
 
 
 def solve_corridor(dwg, strip, view, axis, cands, tier):
@@ -357,15 +363,19 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
         return
     pairs = [(c.name, c.build) for c in kept]
     feats = {c.name: c.feature for c in kept if c.feature is not None}  # provenance (ADR 0010)
+    sizes = {c.name: c.size for c in kept if c.size is not None}  # real footprint (#61)
     left = {
-        n for n, _ in place_strip_candidates(dwg, strip, view, axis, pairs, tier, features=feats)
+        n
+        for n, _ in place_strip_candidates(
+            dwg, strip, view, axis, pairs, tier, features=feats, sizes=sizes
+        )
     }
     force_pairs = [(c.name, c.build) for c in kept if c.name in left and c.force]
     still = (
         {
             n
             for n, _ in place_strip_candidates(
-                dwg, strip, view, axis, force_pairs, tier, force=True, features=feats
+                dwg, strip, view, axis, force_pairs, tier, force=True, features=feats, sizes=sizes
             )
         }
         if force_pairs
@@ -399,7 +409,9 @@ def drain_corridors(dwg):
     dwg._corridor_batch = {}
 
 
-def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False, features=None):
+def place_strip_candidates(
+    dwg, strip, view, axis, cands, tier, *, force=False, features=None, sizes=None
+):
     """Collect-then-solve placement of location/feature dims on one strip (ADR 0009).
     The single shared strip placer that retires the ``Strip.allocate`` cursor (#150,
     P3): each candidate in *cands* — an ``(name, build(pos)->dim)`` pair — is spaced by
@@ -418,6 +430,12 @@ def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False, 
     1-D strip carve cannot represent: a leader in that corridor is crossed no matter how
     far out the dim line lands. By default such a placement is rejected so the caller can
     route the dim to the other view (its disjoint block cannot cross this leader).
+
+    *sizes* maps a candidate's name to its real page-mm footprint ``(w, h)``; absent
+    names use the dimension default ``(tier, tier)``. A wide/tall occupant (a GD&T
+    frame, #61) sets it so :func:`plan_strip` enforces its true stacking gap — over
+    capacity it is relocated to the next segment or dropped, never overlapped.
+
     ``force=True`` skips that corridor check — the caller's last resort when no view took
     the dim cleanly: keep it on its natural view and accept the (same-feature) leader
     crossing rather than drop a real dimension (policy B). Candidates that find no strip
@@ -471,7 +489,9 @@ def place_strip_candidates(dwg, strip, view, axis, cands, tier, *, force=False, 
         triples = [
             (
                 StripCandidate(
-                    f"{(k if inner == lo else len(take) - 1 - k):04d}", anch, (tier, tier)
+                    f"{(k if inner == lo else len(take) - 1 - k):04d}",
+                    anch,
+                    (sizes or {}).get(nb[0], (tier, tier)),
                 ),
                 nb,
             )

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -444,17 +444,30 @@ def place_strip_candidates(
     if strip is None or not cands:
         return list(cands)
     lo, hi, inner = strip_free_span(strip)
-    # Reserve the outermost label's height at the strip boundary. plan_strip bounds the
-    # dim-LINE position, but the label extends `tier` OUTWARD from it — so without this
-    # the last tier's label overshoots outer_limit (into the iso view / page margin),
-    # unlike the old Strip.allocate which checked `start + tier <= outer_limit` (#338
-    # review). The strip edge is not an obstacle (obstacles carry their own footprint +
-    # pad), so only the boundary needs it; obstacle-bounded segments are unaffected.
-    if inner == lo:
-        hi -= tier
-    else:
-        lo += tier
     idx = 1 if axis == "y" else 0
+    # Reserve the outermost label's OUTWARD extent at the strip boundary. plan_strip bounds
+    # the dim-LINE position, but the label extends outward from it — so without this the last
+    # tier's label overshoots outer_limit (into the iso view / page margin), unlike the old
+    # Strip.allocate which checked `start + tier <= outer_limit` (#338 review). A plain dim's
+    # label extends one `tier` outward (one-sided). A GD&T glyph (#61) hangs off a Leader that
+    # CENTRES it on the elbow for an above/below strip (real outward extent = height/2) but
+    # places it one-sided for a left/right strip (extent = full width). Reserve the MAX real
+    # outward extent among these candidates — else a glyph wider than `tier` renders off the
+    # sheet (annotation_out_of_bounds) instead of dropping when the strip is too narrow (ADR
+    # 0009 Amdt 7 fixed inter-candidate gaps but not this edge). With no `sizes` (every dim)
+    # this is `tier`, byte-identical. The strip edge is not an obstacle (obstacles carry their
+    # own footprint + pad), so only the boundary needs it.
+    def _outward(name):
+        sz = (sizes or {}).get(name)
+        if sz is None:
+            return tier  # a dim: one-sided tier reservation (unchanged)
+        return sz[idx] if axis == "x" else sz[idx] / 2  # GD&T: one-sided (L/R) vs centred (A/B)
+
+    reserve = max([tier, *(_outward(n) for n, _ in cands)])
+    if inner == lo:
+        hi -= reserve
+    else:
+        lo += reserve
     perp = 0 if axis == "y" else 1  # the axis the dims do NOT stack along
     pad = tier + strip.spacing  # min separation between stacked dim lines
     # Perpendicular band of these candidates. The 1-D carve projects obstacles onto the

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1843,7 +1843,17 @@ def render_gdt(dwg, model, a) -> int:
         px, py = hproj(o[hi]), vproj(o[vi])
         horizontal = item.side in ("above", "below")  # frame stacks along y
         axis = "y" if horizontal else "x"
-        gb = _gdt_glyph(item, draft).bounding_box().size
+        # The IR is public input (ADR 0011), so an invalid glyph spec (a mistyped
+        # characteristic, a bad tolerance) must drop THIS item with a warning — never crash
+        # the whole drawing build. The helper raises on a bad spec; catch it at the measure
+        # (the first build) so `_build` below, with the same args, cannot then raise mid-place.
+        try:
+            gb = _gdt_glyph(item, draft).bounding_box().size
+        except Exception as e:  # noqa: BLE001 — any glyph-spec error drops one item, not the build
+            dwg._record_build_issue(
+                "warning", "gdt_dropped", f"{name}: cannot render ({type(e).__name__}: {e})"
+            )
+            continue
         size = (gb.X, gb.Y)
 
         def _build(pos, _px=px, _py=py, _hz=horizontal, _it=item):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1786,6 +1786,9 @@ _GDT_KINDS = ("control_frame", "datum_ref", "finish")
 # (_SIZE_SUBCHAIN=0) and datum-location (_LOC_SUBCHAIN=1) dim runs, so a frame never lands
 # mid-ladder among the dimensions it annotates.
 _GDT_SUBCHAIN = 2
+# Minimum GD&T leader shaft length (page-mm). A zero-length Leader (site == solved tier)
+# makes OCC's edge builder raise; nudging to this keeps `_build` total (#61 review).
+_MIN_LEADER = 0.05
 
 
 def _gdt_glyph(item, draft):
@@ -1846,7 +1849,9 @@ def render_gdt(dwg, model, a) -> int:
         # The IR is public input (ADR 0011), so an invalid glyph spec (a mistyped
         # characteristic, a bad tolerance) must drop THIS item with a warning — never crash
         # the whole drawing build. The helper raises on a bad spec; catch it at the measure
-        # (the first build) so `_build` below, with the same args, cannot then raise mid-place.
+        # (the first build) and drop. `_build` below re-runs `_gdt_glyph` with the same args
+        # (so a spec error can't reappear there) AND is made total against the OTHER raise
+        # source — a zero-length Leader shaft (see the min-leader guard in `_build`).
         try:
             gb = _gdt_glyph(item, draft).bounding_box().size
         except Exception as e:  # noqa: BLE001 — any glyph-spec error drops one item, not the build
@@ -1859,7 +1864,23 @@ def render_gdt(dwg, model, a) -> int:
         def _build(pos, _px=px, _py=py, _hz=horizontal, _it=item):
             g = _gdt_glyph(_it, draft)
             tip = (_px, _py)
-            elbow = (_px, pos) if _hz else (pos, _py)
+            # A zero-length leader shaft (the projected site coincides with the solved tier —
+            # `pos == py` above/below, `pos == px` left/right) makes OCC's edge builder raise,
+            # which would crash the whole build on a public-IR declaration. Guarantee a
+            # minimum shaft along the stacking axis (nudge outward; 0.05 mm is invisible) so
+            # `_build` is total — the drop-don't-crash invariant holds for every build() call.
+            if _hz:
+                dy = pos - _py
+                pos = (
+                    pos if abs(dy) >= _MIN_LEADER else _py + math.copysign(_MIN_LEADER, dy or 1.0)
+                )
+                elbow = (_px, pos)
+            else:
+                dx = pos - _px
+                pos = (
+                    pos if abs(dx) >= _MIN_LEADER else _px + math.copysign(_MIN_LEADER, dx or 1.0)
+                )
+                elbow = (pos, _py)
             return Leader(tip=tip, elbow=elbow, label="", draft=draft, callout=g)
 
         def _drop(nm, _v=item.view, _s=item.side):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import math
 
+from build123d_drafting import DatumFeature, FeatureControlFrame, SurfaceFinish
 from build123d_drafting.helpers import Centerline, CenterMark, HoleCallout, Leader, TitleBlock
 
 from draftwright._core import (
@@ -1775,3 +1776,108 @@ def render_pmi(dwg, model, a) -> int:
 
     _log.info("PMI annotate: %d/%d dims placed", emitted, len(usable))
     return emitted
+
+
+# GD&T aspect side-layer (ADR 0011 §4, #61) — declared feature control frames / datum
+# feature symbols / surface finishes. Placed as first-class ADR 0009 corridor candidates,
+# NOT through the dimension planner (their IR items carry no DimParameters).
+_GDT_KINDS = ("control_frame", "datum_ref", "finish")
+# Outer run of the shared corridor ladder: GD&T frames tier BEYOND the feature-size
+# (_SIZE_SUBCHAIN=0) and datum-location (_LOC_SUBCHAIN=1) dim runs, so a frame never lands
+# mid-ladder among the dimensions it annotates.
+_GDT_SUBCHAIN = 2
+
+
+def _gdt_glyph(item, draft):
+    """Build the ISO 1101/5459/1302 glyph sketch for one GD&T IR item at the origin
+    (the :class:`Leader` repositions it). A fresh sketch per call — the leader translate
+    must not alias a shared object across the strip solve's repeated probe builds."""
+    if item.kind == "control_frame":
+        return FeatureControlFrame(
+            item.characteristic,
+            item.tolerance,
+            datums=item.datums,
+            draft=draft,
+            diameter=item.diameter,
+            modifier=item.modifier,
+        )
+    if item.kind == "datum_ref":
+        return DatumFeature(item.letter, draft=draft)
+    return SurfaceFinish(item.ra, position=(0.0, 0.0), draft=draft)
+
+
+def render_gdt(dwg, model, a) -> int:
+    """Place declared GD&T frames / datum symbols / surface finishes (#61) as first-class
+    ADR 0009 corridor candidates — registered into the SAME strip the feature's dimensions
+    use, BEFORE ``drain_corridors``, so one solve orders and spaces them crossing-free with
+    the dims (not a leftover first-fit like :func:`render_pmi`). Each item carries its target
+    ``(view, side)`` strip + model-space site; the leader hangs the glyph off the site into
+    that strip. The strip footprint is the GLYPH's own box — NOT the leader+glyph box, whose
+    shaft back to the feature would inflate the stacking extent (the same reason dims reserve
+    one label-height). Cross-view separation is the compose-then-pack repack's job (ADR 0004):
+    every placed frame is ``view=``-tagged, so ``_measure_blocks`` folds it into the block.
+    Returns the count registered."""
+    items = [f for f in model.features if f.kind in _GDT_KINDS]
+    if not items:
+        return 0
+    draft = dwg.draft
+    tier = draft.font_size + 2 * draft.pad_around_text
+    # (zones, h-projector, v-projector, h-model-index, v-model-index) per view.
+    views = {
+        "plan": (a.pv_zones, a.proj.plan_x, a.proj.plan_y, 0, 1),
+        "front": (a.fv_zones, a.proj.front_x, a.proj.front_z, 0, 2),
+        "side": (a.sv_zones, a.proj.side_x, a.proj.side_z, 1, 2),
+    }
+    n = 0
+    for i, item in enumerate(items):
+        name = f"m_gdt{i}"
+        vk = views.get(item.view)
+        if vk is None or item.side not in ("above", "below", "left", "right"):
+            dwg._record_build_issue(
+                "warning", "gdt_dropped", f"{name}: bad target {item.view!r}/{item.side!r}"
+            )
+            continue
+        zones, hproj, vproj, hi, vi = vk
+        strip = getattr(zones, item.side)
+        o = item.frame.origin
+        px, py = hproj(o[hi]), vproj(o[vi])
+        horizontal = item.side in ("above", "below")  # frame stacks along y
+        axis = "y" if horizontal else "x"
+        gb = _gdt_glyph(item, draft).bounding_box().size
+        size = (gb.X, gb.Y)
+
+        def _build(pos, _px=px, _py=py, _hz=horizontal, _it=item):
+            g = _gdt_glyph(_it, draft)
+            tip = (_px, _py)
+            elbow = (_px, pos) if _hz else (pos, _py)
+            return Leader(tip=tip, elbow=elbow, label="", draft=draft, callout=g)
+
+        def _drop(nm, _v=item.view, _s=item.side):
+            dwg._record_build_issue(
+                "warning", "gdt_dropped", f"{nm} not placed (no room in the {_v} {_s} strip)"
+            )
+
+        register_corridor(
+            dwg,
+            (item.view, item.side),
+            strip,
+            item.view,
+            axis,
+            tier,
+            CorridorCandidate(
+                name=name,
+                build=_build,
+                order=(_GDT_SUBCHAIN, px if horizontal else py, name),
+                on_place=lambda nm: None,
+                on_drop=_drop,
+                dedup=None,
+                precedence=0,
+                # A declared frame has no alternate view — force-keep (policy B) rather than
+                # drop a user-authored annotation; only a physically full strip drops.
+                force=True,
+                feature=item.origin,  # provenance (ADR 0010): the decorated feature
+                size=size,
+            ),
+        )
+        n += 1
+    return n

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -39,6 +39,7 @@ from draftwright.annotations.from_model import (
     render_centermarks,
     render_diameters,
     render_envelope,
+    render_gdt,
     render_height_ladder,
     render_locations,
     render_pmi,
@@ -348,6 +349,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (#135) — IR renderer, placed through the zone strips (shared infra). Runs
     # after every hole/diameter pass so it claims strip space last.
     render_slots(dwg, _model, a)
+
+    # Declared GD&T frames / datum symbols / surface finishes (ADR 0011 §4, #61) — register
+    # into the same strips as first-class candidates BEFORE the drain, so the one solve orders
+    # and spaces them crossing-free with the dims (not a leftover first-fit like render_pmi).
+    render_gdt(dwg, _model, a)
 
     # Now every feeder pass (locations + slots) has registered; solve each shared above
     # corridor once (ADR 0009 end state, #345/#346) — dedup coincident spans, order the

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -335,6 +335,76 @@ class PmiFeature:
         return []
 
 
+@dataclass(frozen=True)
+class ControlFrame:
+    """A geometric-tolerance feature control frame (ISO 1101) declared on the drawing
+    (ADR 0011 §4 aspect side-layer, #61). Placed as a first-class ADR 0009 corridor
+    candidate by ``render_gdt`` — NOT through the dimension planner, so ``parameters()``
+    is empty (like :class:`PmiFeature`). The target ``(view, side)`` strip and the
+    model-space site (``frame.origin``) the leader hangs from are carried explicitly:
+    render-core places into that strip's corridor; the Sheet layer (P2c) computes them
+    from a build123d face."""
+
+    frame: Frame  # the site the leader hangs from + its axis
+    characteristic: str  # ISO 1101 lowercase name: "position" | "flatness" | ...
+    tolerance: str  # the tolerance value text, e.g. "0.1"
+    view: str  # target view: "front" | "side" | "plan"
+    side: str  # target strip: "above" | "below" | "left" | "right"
+    datums: tuple[str, ...] = ()
+    diameter: bool = False  # ⌀ prefix on the tolerance zone
+    modifier: str | None = None  # material-condition modifier: "M" | "L" | "P" | ...
+    # The IR feature this frame decorates — recorded as provenance (ADR 0010); ``None``
+    # leaves it feature-less. Untyped to avoid an import cycle with the geometric features.
+    origin: object | None = None
+    kind: ClassVar[str] = "control_frame"
+
+    def parameters(self) -> list[DimParameter]:
+        return []
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
+class DatumRef:
+    """A datum feature symbol (ISO 5459) — a boxed letter tagging a surface/axis as a
+    datum (#61). Placed as an ADR 0009 corridor candidate by ``render_gdt``, not through
+    the dimension planner (``parameters()`` is empty)."""
+
+    frame: Frame
+    letter: str
+    view: str
+    side: str
+    origin: object | None = None
+    kind: ClassVar[str] = "datum_ref"
+
+    def parameters(self) -> list[DimParameter]:
+        return []
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
+class Finish:
+    """A surface-finish symbol (ISO 1302) — a roughness callout on a surface (#61).
+    Placed as an ADR 0009 corridor candidate by ``render_gdt``, not through the
+    dimension planner (``parameters()`` is empty)."""
+
+    frame: Frame
+    ra: str  # roughness value text, e.g. "3.2" (Ra, µm)
+    view: str
+    side: str
+    origin: object | None = None
+    kind: ClassVar[str] = "finish"
+
+    def parameters(self) -> list[DimParameter]:
+        return []
+
+    def references(self) -> list[Datum]:
+        return []
+
+
 @dataclass
 class PartModel:
     """The whole-part IR: the oriented part plus its features and datums."""

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -1,0 +1,152 @@
+"""GD&T aspect side-layer placement (ADR 0011 §4 / ADR 0009, #61).
+
+Declared feature control frames / datum feature symbols / surface finishes are placed
+as first-class ADR 0009 corridor candidates — through the SAME collect-then-solve strip
+machinery as the auto-dimensions, NOT a leftover first-fit. These tests lock down: the
+glyphs render into their target strip, they carry their real footprint so stacked frames
+never overlap, a full strip drops honestly (a warning, not a silent vanish), and the
+placement stays lint-clean.
+"""
+
+from build123d import Box, Cylinder, Draft, Pos
+from build123d_drafting import FeatureControlFrame
+
+from draftwright.builder import build_drawing, detect_part_model
+from draftwright.model.ir import ControlFrame, DatumRef, Finish, Frame
+
+
+def _part():
+    """A prismatic block with a central through-hole — roomy plan/front views."""
+    return Box(80, 50, 20) - Pos(0, 0, 0) * Cylinder(6, 20)
+
+
+def _build(*extra_features, part=None):
+    part = part if part is not None else _part()
+    m = detect_part_model(part)
+    m.features.extend(extra_features)
+    return build_drawing(part, model=m)
+
+
+def _fcf_height():
+    """The bare feature-control-frame glyph height — the strip footprint a frame reserves
+    (NOT the leader+frame box). Two stacked frames must sit at least this far apart."""
+    g = FeatureControlFrame("position", "0.1", datums=("A",), draft=Draft(font_size=3.0))
+    return g.bounding_box().size.Y
+
+
+def test_control_frame_places_first_class():
+    frame = ControlFrame(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        characteristic="position",
+        tolerance="0.1",
+        view="plan",
+        side="above",
+        datums=("A",),
+        diameter=True,
+    )
+    dwg = _build(frame)
+    assert "m_gdt0" in dwg._named
+    assert not [i for i in dwg._build_issues if i.code == "gdt_dropped"]
+    # It rendered the actual frame geometry (a wide box, not an empty leader).
+    assert dwg._named["m_gdt0"].bounding_box().size.X > 15
+
+
+def test_datum_and_finish_place():
+    datum = DatumRef(frame=Frame((30.0, 0.0, 0.0), "z"), letter="A", view="plan", side="above")
+    finish = Finish(frame=Frame((0.0, 25.0, 0.0), "z"), ra="3.2", view="front", side="above")
+    dwg = _build(datum, finish)
+    placed = {n for n in dwg._named if n.startswith("m_gdt")}
+    assert placed == {"m_gdt0", "m_gdt1"}
+
+
+def test_stacked_frames_reserve_real_footprint():
+    # Two frames on the same above strip. If placement reserved only one label-height
+    # (the pre-#61 (tier, tier) hardcode) the ~6 mm-tall glyphs would overlap; the real
+    # footprint keeps their centres >= one glyph-height apart. Different sites so the
+    # leader shafts are not collinear and each frame's glyph edge is the strip-far bbox
+    # edge (an above strip stacks the glyph at the TOP: centre = max.Y - h/2).
+    f0 = ControlFrame(
+        frame=Frame((-20.0, 0.0, 0.0), "z"),
+        characteristic="position",
+        tolerance="0.1",
+        view="plan",
+        side="above",
+    )
+    f1 = ControlFrame(
+        frame=Frame((20.0, 0.0, 0.0), "z"),
+        characteristic="flatness",
+        tolerance="0.05",
+        view="plan",
+        side="above",
+    )
+    dwg = _build(f0, f1)
+    assert {"m_gdt0", "m_gdt1"} <= set(dwg._named)
+    h = _fcf_height()
+    c0 = dwg._named["m_gdt0"].bounding_box().max.Y - h / 2
+    c1 = dwg._named["m_gdt1"].bounding_box().max.Y - h / 2
+    assert abs(c0 - c1) >= h - 1e-6  # glyphs do not overlap in the stack
+
+
+def test_full_strip_drops_with_warning():
+    # The plan-below strip carries the overall-width envelope dim — a wide frame there has
+    # no free tier. It must drop with a first-class gdt_dropped warning, never silently.
+    frame = ControlFrame(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        characteristic="position",
+        tolerance="0.1",
+        view="plan",
+        side="below",
+    )
+    dwg = _build(frame)
+    dropped = [i for i in dwg._build_issues if i.code == "gdt_dropped"]
+    assert dropped and "m_gdt0" in dropped[0].message
+    assert "m_gdt0" not in dwg._named
+
+
+def test_bad_target_drops_without_crashing():
+    frame = ControlFrame(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        characteristic="position",
+        tolerance="0.1",
+        view="nope",
+        side="above",
+    )
+    dwg = _build(frame)
+    assert [i for i in dwg._build_issues if i.code == "gdt_dropped"]
+    assert "m_gdt0" not in dwg._named
+
+
+def test_placement_is_lint_clean():
+    # The Tier-1 claim: a frame placed through the strip solve does not overlap the dims
+    # it annotates (the failure mode that motivated routing GD&T through the solver).
+    frame = ControlFrame(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        characteristic="position",
+        tolerance="0.1",
+        view="plan",
+        side="above",
+        datums=("A",),
+        diameter=True,
+    )
+    dwg = _build(frame)
+    overlaps = [x for x in dwg.lint() if x.code == "annotation_overlap"]
+    assert not overlaps
+
+
+def test_provenance_back_link():
+    # A frame decorating a detected hole records that hole as its annotation's feature
+    # (ADR 0010 provenance) so the read/edit surface can find it.
+    m = detect_part_model(_part())
+    hole = next(f for f in m.features if f.kind == "hole")
+    m.features.append(
+        ControlFrame(
+            frame=Frame((0.0, 0.0, 0.0), "z"),
+            characteristic="position",
+            tolerance="0.1",
+            view="plan",
+            side="above",
+            origin=hole,
+        )
+    )
+    dwg = build_drawing(_part(), model=m)
+    assert "m_gdt0" in dwg.annotations_of(hole)

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -152,6 +152,22 @@ def test_wide_frame_in_narrow_strip_drops_not_overshoots():
     assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
 
 
+def test_degenerate_leader_site_does_not_crash():
+    # Focused-review finding (CONFIRMED): a declared site that projects ONTO the solved strip
+    # tier (pos == py) makes the leader shaft zero-length, which raised in OCC and crashed the
+    # whole build (public IR). _build now guarantees a minimum shaft, so it places instead.
+    # oy=44.5 is the reviewer's reproduced coincidence for this part/part-of-strip geometry.
+    frame = ControlFrame(
+        frame=Frame((0.0, 44.5, 0.0), "z"),
+        characteristic="position",
+        tolerance="0.1",
+        view="plan",
+        side="above",
+    )
+    dwg = _build(frame)  # must not raise
+    assert "m_gdt0" in dwg._named
+
+
 def test_placement_is_lint_clean():
     # The Tier-1 claim: a frame placed through the strip solve does not overlap the dims
     # it annotates (the failure mode that motivated routing GD&T through the solver).

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -116,6 +116,22 @@ def test_bad_target_drops_without_crashing():
     assert "m_gdt0" not in dwg._named
 
 
+def test_invalid_glyph_spec_drops_not_crashes():
+    # The IR is public input (ADR 0011): a mistyped characteristic must drop the one item
+    # with a gdt_dropped warning, NOT raise ValueError and take down the whole drawing.
+    frame = ControlFrame(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        characteristic="postion",  # typo — helper raises "Unknown characteristic"
+        tolerance="0.1",
+        view="plan",
+        side="above",
+    )
+    dwg = _build(frame)  # must not raise
+    dropped = [i for i in dwg._build_issues if i.code == "gdt_dropped"]
+    assert dropped and "m_gdt0" in dropped[0].message
+    assert "m_gdt0" not in dwg._named
+
+
 def test_placement_is_lint_clean():
     # The Tier-1 claim: a frame placed through the strip solve does not overlap the dims
     # it annotates (the failure mode that motivated routing GD&T through the solver).

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -132,6 +132,26 @@ def test_invalid_glyph_spec_drops_not_crashes():
     assert "m_gdt0" not in dwg._named
 
 
+def test_wide_frame_in_narrow_strip_drops_not_overshoots():
+    # Adversarial-review finding (CONFIRMED): a wide GD&T glyph (multi-datum FCF ~33 mm) on
+    # a left/right strip narrower than the glyph must DROP with a gdt_dropped warning — not
+    # render off the drawable area. Pre-fix it placed at min.X=-7.17 (17 mm past outer_limit,
+    # annotation_out_of_bounds error). The boundary reservation now uses the glyph's real
+    # outward extent, so a too-narrow strip has no feasible tier and the frame drops.
+    frame = ControlFrame(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        characteristic="position",
+        tolerance="0.1",
+        view="plan",
+        side="left",
+        datums=("A", "B"),
+    )
+    dwg = _build(frame)
+    assert [i for i in dwg._build_issues if i.code == "gdt_dropped"]
+    assert "m_gdt0" not in dwg._named
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
+
+
 def test_placement_is_lint_clean():
     # The Tier-1 claim: a frame placed through the strip solve does not overlap the dims
     # it annotates (the failure mode that motivated routing GD&T through the solver).


### PR DESCRIPTION
## What

GD&T aspect side-layer (ADR 0011 Phase 2b, #61): declare **feature control frames**,
**datum feature symbols**, and **surface finishes** on the build123d / declared-model
drawing path. They are placed **at build time** as first-class ADR 0009 collect-then-solve
strip-corridor candidates — the same machinery as the auto-dimensions — not via a post-hoc
imperative primitive.

## Why this design (Tier 1, not `place_fcf`)

An earlier imperative cut (`dwg.place_control(...)` after `build_drawing`) placed frames
*outside* the build, so they were blind to the shared cross-view corridor and the repack
net — a frame overlapped a plan-view dimension exactly where ADR 0004 compose-then-pack is
meant to prevent it. The roadmap's original plan (route through `Strip.allocate` mirroring
`place_dim`) also targets the legacy cursor **ADR 0009 retires**. So GD&T joins the target
architecture instead: registered into its strip's corridor before `drain_corridors`, ordered
and spaced crossing-free *with* the dims, and `view=`-tagged so `_measure_blocks` + repack
separate cross-view.

## Changes

- **IR** (`model/ir.py`) — `ControlFrame` / `DatumRef` / `Finish`, frozen peers of
  `PmiFeature` (`parameters()` empty → bypass the dimension planner). Each carries its target
  `(view, side)` strip + model-space site + provenance `origin`. The Sheet layer (P2c)
  will compute view/side/site from a build123d face.
- **`render_gdt`** (`annotations/from_model.py`) — build glyph → hang on a `Leader` →
  register a `CorridorCandidate`; wired into `_auto_annotate` after `render_slots`, before
  the drain.
- **Real-footprint plumbing (ADR 0009 Amendment 7)** — `CorridorCandidate.size` →
  `solve_corridor` `sizes` map → `place_strip_candidates` uses the **glyph's own box** (not
  the leader+glyph box, whose shaft would inflate the stacking extent) for both the
  inter-candidate gap and the strip-edge reservation. Absent → `(tier, tier)` default, so
  **every existing dimension is byte-identical**.
- **ADR/roadmap** — amended roadmap 0011 P2b (documents the rejected imperative approach and
  the delivered Tier-1 design) + ADR 0009 Amendment 7.

## Adversarial review (2 confirmed, both fixed)

A workflow reviewed the feature commit across 4 dimensions, each finding verified by an
independent skeptic. Two confirmed, both fixed with regression tests:

1. **Invalid glyph spec crashed the whole build** — the IR is public input, so a mistyped
   `characteristic` raised `ValueError` up through `build_drawing`. Now drops the one item
   with a `gdt_dropped` warning (`d8fc490`).
2. **Wide-glyph boundary overshoot** — a multi-datum frame (~33 mm) on a narrow left/right
   strip rendered 17 mm off the drawable area (`annotation_out_of_bounds`), silently. The
   strip-edge reservation now uses each candidate's real, orientation-aware outward extent
   (one-sided width for left/right; centred height/2 for above/below), so a too-wide glyph
   drops cleanly instead of overshooting (`ef7a12d`).

Two findings refuted (left/right "systematic drop"; off-view garbage-site blowup — P2c owns
site-from-face computation).

## Scope / follow-ups

- Above/below is the primary, fully-exercised case; left/right renders but drops when the
  strip is too narrow (documented). Full left/right support is a follow-up.
- GD&T candidates use the default `priority=0` — the selection-step gap tracked in **#357**
  (commented there). Broader ADR 0009 unification tracked in the new umbrella **#477**.
- P2c (the fluent `Sheet.control(face)…/.datum/.finish` verbs over this render core) is the
  next PR.

## Tests

`tests/test_gdt_placement.py` (9): first-class placement, datum+finish, real-footprint
stacking, full-strip drop warning, invalid-spec drop (no crash), wide-glyph narrow-strip
drop (no overshoot), lint-clean placement, provenance back-link.

Verified locally: 132 strip/layout/snapshot/cleanliness/e2e tests (byte-identity for dims) +
9 GD&T + 509 e2e-standards/make_drawing, all green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
