### PR TITLE
feat: P2c.1 — Sheet .finish() + sheet.datum() with geometric target derivation (#479)

### DIFF
--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -21,7 +21,16 @@ width/depth, slots) and by the lint coverage checks. Remaining engine passes
 
 from __future__ import annotations
 
-from draftwright.model.declare import boss, envelope, hole, pattern, slot, step
+from draftwright.model.declare import (
+    boss,
+    datum,
+    envelope,
+    finish,
+    hole,
+    pattern,
+    slot,
+    step,
+)
 from draftwright.model.detect import build_part_model
 from draftwright.model.ir import (
     BossFeature,
@@ -67,7 +76,9 @@ __all__ = [
     "StepLevelFeature",
     "build_part_model",
     "boss",
+    "datum",
     "envelope",
+    "finish",
     "hole",
     "pattern",
     "slot",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -28,7 +28,10 @@ import math
 
 from draftwright.model.ir import (
     BossFeature,
+    DatumRef,
     EnvelopeFeature,
+    Feature,
+    Finish,
     Frame,
     HoleFeature,
     PatternFeature,
@@ -513,3 +516,89 @@ def envelope(obj) -> EnvelopeFeature:
         bbox_min=(bb.min.X, bb.min.Y, bb.min.Z),
         bbox_max=(bb.max.X, bb.max.Y, bb.max.Z),
     )
+
+
+# -- GD&T aspect targets (ADR 0011 P2c, #479) -------------------------------------
+# The P2b IR items (ControlFrame/DatumRef/Finish) carry (view, side, site) explicitly.
+# These constructors DERIVE that target from a reference — an IR feature (site = its axis)
+# or a build123d planar face (site = its centre, axis = its normal) — the geometric work
+# P2b deferred. Derivation runs at declaration time (no Analysis), so it is purely
+# geometric; `view=`/`side=` overrides always win (a best-effort default + an escape hatch).
+
+# A feature's axis points AT the viewer in this view (a z-hole is a circle in plan).
+_FACE_ON_VIEW = {"x": "side", "y": "front", "z": "plan"}
+# A planar face whose normal is this axis shows as an EDGE here (prefer front, else side).
+_EDGE_ON_VIEW = {"x": "front", "y": "side", "z": "front"}
+# The model-space axis a view stacks its above/below strips along (its vertical).
+_VERTICAL_MODEL_AXIS = {"plan": 1, "front": 2, "side": 2}
+_VALID_SIDES = ("above", "below", "left", "right")
+
+
+def _axis_from_vec(v) -> str:
+    """The dominant axis letter of a direction vector, or a clear error if it is not
+    axis-aligned (a skew face has no letter-based Frame — pass an explicit ``view``/``axis``)."""
+    comps = [abs(v.X), abs(v.Y), abs(v.Z)]
+    k = max(range(3), key=lambda i: comps[i])
+    others = sum(comps) - comps[k]
+    if comps[k] < 1e-6 or others > 0.1 * comps[k]:
+        raise ValueError(
+            "GD&T target face is not axis-aligned — pass an explicit view=/side= (or use an "
+            f"axis-aligned face); normal was ({v.X:.3g}, {v.Y:.3g}, {v.Z:.3g})"
+        )
+    return "xyz"[k]
+
+
+def _side_for(site: Point, part, view: str) -> str:
+    """Default strip side for a face target: above/below by the site's position vs the part
+    centre along the view's vertical axis (mirrors render_pmi's centre comparison)."""
+    vi = _VERTICAL_MODEL_AXIS[view]
+    c = part.bounding_box().center()
+    return "above" if site[vi] >= (c.X, c.Y, c.Z)[vi] else "below"
+
+
+def gdt_target(ref, part=None, *, view=None, side=None) -> tuple[str, str, Point, str]:
+    """Resolve a GD&T target *ref* to ``(view, side, site, axis)``.
+
+    *ref* is either an IR :class:`~draftwright.model.ir.Feature` (site = its ``frame.origin``,
+    axis = its ``frame.axis``, placed face-on and below by default) or a build123d **planar
+    face** (site = its centre, axis = its normal, placed edge-on with the side by position).
+    *part* is needed only to derive a face's side (skip with an explicit ``side``).
+    ``view``/``side`` override the derived defaults."""
+    if isinstance(ref, Feature):
+        site = ref.frame.origin
+        axis = _norm_axis(ref.frame.axis)
+        d_view, d_side = _FACE_ON_VIEW[axis], "below"
+    else:  # a build123d planar face
+        try:
+            n, c = ref.normal_at(), ref.center()
+        except AttributeError as e:
+            raise ValueError("GD&T target must be an IR feature or a build123d planar face") from e
+        axis = _axis_from_vec(n)
+        site = (c.X, c.Y, c.Z)
+        d_view = _EDGE_ON_VIEW[axis]
+        d_side = side or (_side_for(site, part, view or d_view) if part is not None else "below")
+    v, s = view or d_view, side or d_side
+    if v not in ("plan", "front", "side"):
+        raise ValueError(f"view must be 'plan'/'front'/'side' (got {v!r})")
+    if s not in _VALID_SIDES:
+        raise ValueError(f"side must be one of {_VALID_SIDES} (got {s!r})")
+    return v, s, site, axis
+
+
+def datum(letter: str, ref, part=None, *, view=None, side=None) -> DatumRef:
+    """A datum feature symbol (ISO 5459) on *ref* — a feature or a planar face (ADR 0011 P2c)."""
+    if not (isinstance(letter, str) and letter.strip()):
+        raise ValueError(f"datum needs a non-empty letter (got {letter!r})")
+    v, s, site, axis = gdt_target(ref, part, view=view, side=side)
+    origin = ref if isinstance(ref, Feature) else None
+    return DatumRef(frame=Frame(site, axis), letter=letter.strip(), view=v, side=s, origin=origin)
+
+
+def finish(ra, ref, part=None, *, view=None, side=None) -> Finish:
+    """A surface-finish symbol (ISO 1302, Ra) on *ref* — a feature or a planar face (P2c)."""
+    ra = str(ra).strip()
+    if not ra:
+        raise ValueError("finish needs a roughness value (e.g. '3.2')")
+    v, s, site, axis = gdt_target(ref, part, view=view, side=side)
+    origin = ref if isinstance(ref, Feature) else None
+    return Finish(frame=Frame(site, axis), ra=ra, view=v, side=s, origin=origin)

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -16,10 +16,12 @@ detection is skipped and the auto-pass dimensions exactly the declared features:
 engine has today — dimensions, ⌀ callouts, holes (through / blind), turned steps,
 slots, patterns, the overall envelope, and the auto section — plus the P2a
 **``.tolerance``** (a ± / limit tolerance on a diameter, a step, or a hole bore) and
-**``.fit``** (fit-class → ISO 286 deviation, P2a.2) aspects. The remaining #445 aspect
-verbs that still need new rendering — ``.thread``, ``.finish`` (surface symbols) and
-``control(...)`` (GD&T) — are the later Phase-2 items (roadmap #446) and are
-deliberately **not** stubbed here, so the surface only exposes what actually draws.
+**``.fit``** (fit-class → ISO 286 deviation, P2a.2) aspects, and the P2c GD&T side-layer
+(**``.finish``** surface symbols + **``sheet.datum``** feature symbols, ADR 0011 #479),
+which derive their target view/strip from the referenced feature or planar face. The
+remaining #445 aspect verbs that still need wiring — ``.thread`` and ``control(...)`` (the
+GD&T feature-control-frame builder, P2c.2) — are deliberately **not** stubbed here yet, so
+the surface only exposes what actually draws.
 
 **Hybrid.** :meth:`Sheet.from_part` seeds the declared set from *detection*, so you
 can start from the detected model and override specific features (declaration is for
@@ -37,7 +39,9 @@ from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
 from draftwright.model import Feature
 from draftwright.model import boss as _boss
+from draftwright.model import datum as _declare_datum
 from draftwright.model import envelope as _envelope
+from draftwright.model import finish as _declare_finish
 from draftwright.model import hole as _hole
 from draftwright.model import pattern as _pattern
 from draftwright.model import slot as _slot
@@ -131,6 +135,12 @@ class _Hole:
         _require_positive(**{f"{kind} diameter": diameter, f"{kind} depth": depth})
         return (diameter, depth)
 
+    def finish(self, ra, *, view: str | None = None, side: str | None = None) -> _Hole:
+        """A surface-finish symbol (Ra) on this hole's bore (ADR 0011 P2c). ``.finish("1.6")``
+        — the roughness text; ``view``/``side`` override the derived strip."""
+        self._sheet._add_finish(ra, self._sheet._features[self._i], view=view, side=side)
+        return self
+
     def _set(self, **kw) -> _Hole:
         self._sheet._features[self._i] = replace(self._sheet._features[self._i], **kw)
         return self
@@ -161,6 +171,12 @@ class _Dim:
         self._sheet._tolerances[(self._i, "diameter")] = fit_class(
             code, self._sheet._features[self._i].diameter, show
         )
+        return self
+
+    def finish(self, ra, *, view: str | None = None, side: str | None = None) -> _Dim:
+        """A surface-finish symbol (Ra) on this feature's surface (ADR 0011 P2c).
+        ``diameter(journal).finish("0.8")``; ``view``/``side`` override the derived strip."""
+        self._sheet._add_finish(ra, self._sheet._features[self._i], view=view, side=side)
         return self
 
 
@@ -290,6 +306,37 @@ class Sheet:
         """Declare the overall bounding dimensions. Defaults to the whole part."""
         self._features.append(_envelope(obj if obj is not None else self._part))
         return self
+
+    # -- GD&T / finish aspects (ADR 0011 P2c, #479) ---------------------------
+
+    def datum(
+        self, letter: str, ref, *, view: str | None = None, side: str | None = None
+    ) -> Sheet:
+        """Declare a datum feature symbol (ISO 5459). *ref* is a build123d **planar face**, or
+        a feature handle / :class:`Feature` / index for a feature's axis. The target view + strip
+        side are derived from the geometry; ``view``/``side`` override them (ADR 0011 P2c)."""
+        self._features.append(
+            _declare_datum(letter, self._gdt_ref(ref), self._part, view=view, side=side)
+        )
+        return self
+
+    def finish(self, ra, ref, *, view: str | None = None, side: str | None = None) -> Sheet:
+        """Declare a surface-finish symbol (ISO 1302, Ra) on *ref* — a build123d planar face or
+        a feature. ``sheet.finish("3.2", top_face)``; ``view``/``side`` override the strip."""
+        self._add_finish(ra, self._gdt_ref(ref), view=view, side=side)
+        return self
+
+    def _add_finish(self, ra, ref, *, view=None, side=None) -> None:
+        self._features.append(_declare_finish(ra, ref, self._part, view=view, side=side))
+
+    def _gdt_ref(self, ref):
+        """Resolve a GD&T target: a fluent handle / index → its :class:`Feature`; a
+        :class:`Feature` or a build123d face passes straight through to :func:`gdt_target`."""
+        if isinstance(ref, (_Hole, _Dim)):
+            return self._features[ref._i]
+        if isinstance(ref, int) and not isinstance(ref, bool):
+            return self._features[self._index_of(ref)]
+        return ref
 
     # -- inspection / output --------------------------------------------------
 

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -138,7 +138,7 @@ class _Hole:
     def finish(self, ra, *, view: str | None = None, side: str | None = None) -> _Hole:
         """A surface-finish symbol (Ra) on this hole's bore (ADR 0011 P2c). ``.finish("1.6")``
         — the roughness text; ``view``/``side`` override the derived strip."""
-        self._sheet._add_finish(ra, self._sheet._features[self._i], view=view, side=side)
+        self._sheet._gdt_finish(ra, self._i, view=view, side=side)
         return self
 
     def _set(self, **kw) -> _Hole:
@@ -176,7 +176,7 @@ class _Dim:
     def finish(self, ra, *, view: str | None = None, side: str | None = None) -> _Dim:
         """A surface-finish symbol (Ra) on this feature's surface (ADR 0011 P2c).
         ``diameter(journal).finish("0.8")``; ``view``/``side`` override the derived strip."""
-        self._sheet._add_finish(ra, self._sheet._features[self._i], view=view, side=side)
+        self._sheet._gdt_finish(ra, self._i, view=view, side=side)
         return self
 
 
@@ -196,6 +196,10 @@ class Sheet:
         # P2a ± tolerances, keyed by (feature index, ParamKind) so a handle survives a later
         # feature replacement (e.g. hole().depth()); materialized to (feature, kind) at build.
         self._tolerances: dict = {}
+        # P2c GD&T provenance: (gdt_feature_index -> source_feature_index). A finish/datum stores
+        # its origin by INDEX, not the object, so a later size verb replacing the source feature
+        # (hole().depth()) doesn't strand the link; materialized to the FINAL object at build.
+        self._gdt_src: list = []
         self._opts = dict(
             title=title, number=number, scale=_parse_scale(scale), page=page, out=out
         )
@@ -315,28 +319,52 @@ class Sheet:
         """Declare a datum feature symbol (ISO 5459). *ref* is a build123d **planar face**, or
         a feature handle / :class:`Feature` / index for a feature's axis. The target view + strip
         side are derived from the geometry; ``view``/``side`` override them (ADR 0011 P2c)."""
-        self._features.append(
-            _declare_datum(letter, self._gdt_ref(ref), self._part, view=view, side=side)
-        )
+        target, src = self._gdt_ref(ref)
+        self._append_gdt(_declare_datum(letter, target, self._part, view=view, side=side), src)
         return self
 
     def finish(self, ra, ref, *, view: str | None = None, side: str | None = None) -> Sheet:
         """Declare a surface-finish symbol (ISO 1302, Ra) on *ref* — a build123d planar face or
         a feature. ``sheet.finish("3.2", top_face)``; ``view``/``side`` override the strip."""
-        self._add_finish(ra, self._gdt_ref(ref), view=view, side=side)
+        target, src = self._gdt_ref(ref)
+        self._append_gdt(_declare_finish(ra, target, self._part, view=view, side=side), src)
         return self
 
-    def _add_finish(self, ra, ref, *, view=None, side=None) -> None:
-        self._features.append(_declare_finish(ra, ref, self._part, view=view, side=side))
+    def _gdt_finish(self, ra, src_index: int, *, view=None, side=None) -> None:
+        """A finish declared through a fluent handle — sources its provenance from the handle's
+        feature INDEX (not the object), so a later size verb on the same handle can't strand it."""
+        item = _declare_finish(ra, self._features[src_index], self._part, view=view, side=side)
+        self._append_gdt(item, src_index)
+
+    def _append_gdt(self, item, src_index) -> None:
+        """Append a GD&T IR item, recording its source-feature index for build-time provenance
+        re-materialization (``None`` for a bare face — no source feature to track)."""
+        self._features.append(item)
+        if src_index is not None:
+            self._gdt_src.append((len(self._features) - 1, src_index))
 
     def _gdt_ref(self, ref):
-        """Resolve a GD&T target: a fluent handle / index → its :class:`Feature`; a
-        :class:`Feature` or a build123d face passes straight through to :func:`gdt_target`."""
+        """Resolve a GD&T target to ``(target, source_index)``: a fluent handle / index / a
+        :class:`Feature` already in :attr:`features` → its feature + index (the index re-binds
+        provenance at build); a build123d face or an external Feature → ``(ref, None)``."""
         if isinstance(ref, (_Hole, _Dim)):
-            return self._features[ref._i]
+            return self._features[ref._i], ref._i
         if isinstance(ref, int) and not isinstance(ref, bool):
-            return self._features[self._index_of(ref)]
-        return ref
+            i = self._index_of(ref)
+            return self._features[i], i
+        if isinstance(ref, Feature):
+            for i, f in enumerate(self._features):
+                if f is ref:
+                    return ref, i
+            return ref, None  # an external feature this sheet does not manage
+        return ref, None  # a build123d face — no source feature
+
+    def _materialize_gdt(self) -> None:
+        """Re-bind each handle-sourced GD&T item's ``origin`` to the FINAL source feature (a
+        size verb may have replaced it since declaration). Idempotent; mirrors P2a's
+        :meth:`_decorations`. Called before handing features to the engine."""
+        for gi, si in self._gdt_src:
+            self._features[gi] = replace(self._features[gi], origin=self._features[si])
 
     # -- inspection / output --------------------------------------------------
 
@@ -359,11 +387,13 @@ class Sheet:
         cost and can't hit a layout/render failure. Wraps the *solids body* (as :func:`_analyse`
         does), so the bbox/datum match what ``build()`` draws even when the part carries
         bbox-extending non-solid geometry."""
+        self._materialize_gdt()
         return _coerce_model(self._features, _solids_body(self._part), self._decorations())
 
     def build(self):
         """Build the :class:`~draftwright.drawing.Drawing` — detection skipped; only the
         declared features are drawn."""
+        self._materialize_gdt()
         return build_drawing(
             self._part, model=self._features, decorations=self._decorations(), **self._opts
         )

--- a/tests/test_sheet_gdt.py
+++ b/tests/test_sheet_gdt.py
@@ -86,6 +86,26 @@ def test_face_datum_places_lint_clean():
     assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
 
 
+def test_finish_before_depth_keeps_provenance():
+    # Adversarial-review finding (CONFIRMED): declaring .finish() then a size verb (.depth) on
+    # the SAME handle replaces the source feature; the finish's origin must re-bind to the FINAL
+    # feature at build (index-sourced), else annotations_of() misses it and drop() orphans it.
+    part = Box(80, 50, 20) - Pos(0, 0, 0) * Cylinder(6, 20)
+    s = Sheet(part)
+    s.envelope()
+    h = s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    h.finish("1.6", view="front", side="above")  # declared BEFORE the size verb
+    h.depth(5)  # replaces the hole feature (through=False)
+    dwg = s.build()
+    hole_feat = next(f for f in s.features if f.kind == "hole")
+    fin_names = [n for n in dwg._named if "gdt" in n]
+    assert fin_names, "the finish placed"
+    # provenance re-bound to the FINAL (depth=5) hole, not the stale through hole
+    assert set(fin_names) <= set(dwg.annotations_of(hole_feat))
+    removed = dwg.drop(hole_feat)
+    assert all(n in removed for n in fin_names)  # dropped with its feature, not orphaned
+
+
 def test_override_recovers_a_congested_default():
     # The feature-path default (plan/below) is congested by the envelope width dim, so a bare
     # finish there drops with a warning; an explicit free side recovers it (the override seam).

--- a/tests/test_sheet_gdt.py
+++ b/tests/test_sheet_gdt.py
@@ -1,0 +1,99 @@
+"""Sheet declarative GD&T aspect verbs — P2c.1: `.finish()` + `sheet.datum()` (ADR 0011 #479).
+
+The fluent surface over the P2b render core: point at a feature or a build123d planar face,
+declare a surface finish / datum symbol, and the target view + strip side are DERIVED from the
+geometry (feature axis → face-on view; face normal → edge-on view). `view=`/`side=` override.
+These tests pin the derivation (view/side/site/origin) and that a placed symbol is lint-clean.
+"""
+
+import pytest
+from build123d import Box, Cylinder, Pos, Rotation
+
+from draftwright.model.declare import gdt_target
+from draftwright.sheet_dsl import Sheet
+
+
+def _part():
+    return Box(80, 50, 20) - Pos(0, 0, 0) * Cylinder(6, 20)
+
+
+def _top_face(part):
+    return part.faces().sort_by()[-1]  # +Z top
+
+
+def test_finish_on_feature_derives_face_on_view():
+    part = _part()
+    s = Sheet(part)
+    s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).finish("1.6")
+    fin = next(f for f in s.features if f.kind == "finish")
+    assert fin.ra == "1.6"
+    assert fin.view == "plan"  # a z-axis feature is face-on in plan
+    assert fin.side == "below"
+    assert fin.frame.origin == (0.0, 0.0, 0.0)
+    assert fin.origin is s.features[0]  # provenance → the hole feature (finish is features[1])
+
+
+def test_datum_on_planar_face_derives_edge_on_view():
+    part = _part()
+    s = Sheet(part)
+    s.datum("A", _top_face(part))
+    d = next(f for f in s.features if f.kind == "datum_ref")
+    assert d.letter == "A"
+    assert d.view == "front"  # a +Z face shows edge-on in front
+    assert d.side == "above"  # face sits above the part centre (z=10 > 0)
+    assert d.frame.axis == "z"
+    assert d.origin is None  # a bare face has no source feature
+
+
+def test_dim_handle_finish():
+    part = _part()
+    s = Sheet(part)
+    s.diameter(Pos(30, 0, 0) * Cylinder(8, 20)).finish("3.2")
+    fin = next(f for f in s.features if f.kind == "finish")
+    assert fin.ra == "3.2" and fin.view == "plan"
+
+
+def test_view_side_overrides_win():
+    part = _part()
+    v, side, site, axis = gdt_target(_top_face(part), part, view="plan", side="left")
+    assert v == "plan" and side == "left"
+
+
+def test_non_axis_aligned_face_raises():
+    part = Rotation(0, 30, 0) * Box(40, 40, 40)
+    skew = max(part.faces(), key=lambda f: abs(f.normal_at().X * f.normal_at().Z))
+    with pytest.raises(ValueError, match="not axis-aligned"):
+        gdt_target(skew, part)
+
+
+def test_bad_inputs_raise():
+    part = _part()
+    s = Sheet(part)
+    with pytest.raises(ValueError, match="letter"):
+        s.datum("", _top_face(part))
+    with pytest.raises(ValueError, match="roughness"):
+        s.finish("   ", _top_face(part))
+
+
+def test_face_datum_places_lint_clean():
+    part = _part()
+    s = Sheet(part)
+    s.envelope()
+    s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    s.datum("A", _top_face(part))
+    dwg = s.build()
+    assert [n for n in dwg._named if "gdt" in n]  # the datum placed
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
+
+
+def test_override_recovers_a_congested_default():
+    # The feature-path default (plan/below) is congested by the envelope width dim, so a bare
+    # finish there drops with a warning; an explicit free side recovers it (the override seam).
+    part = _part()
+    s = Sheet(part)
+    s.envelope()
+    h = s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    h.finish("1.6", view="front", side="above")  # a roomy strip
+    dwg = s.build()
+    assert "m_gdt0" in dwg._named
+    assert not [i for i in dwg._build_issues if i.code == "gdt_dropped"]


### PR DESCRIPTION
## What

ADR 0011 **P2c.1** — the first slice of the fluent Sheet GD&T surface (#479), over the P2b
render core (#478, now on main). Point at a feature or a build123d planar face; declare a
**surface finish** or **datum symbol**; the target view + strip side are **derived from the
geometry** (with overrides).

```python
sheet.hole(bore).finish("1.6")            # finish on a feature (face-on view)
sheet.diameter(journal).finish("0.8")
sheet.datum("A", top_face)                # datum on a planar face (edge-on view)
sheet.datum("B", hole_handle, side="left")   # override the derived strip
```

## The new work: `(view, side, site)` derivation

P2b left the IR items (`ControlFrame`/`DatumRef`/`Finish`) carrying `(view, side, site)`
explicitly — P2c computes them. There was **no face→view helper** (only `render_pmi`'s
`dominant_axis` precedent), so this is the real engineering. It runs at **declaration time**
(no `Analysis`/projectors), so it is purely geometric:

- **`declare.gdt_target(ref, part) → (view, side, site, axis)`**:
  - a **feature** (has `.frame`) → `site = frame.origin`, face-on view of the axis
    (`z→plan`, `x→side`, `y→front`), default side `below`;
  - a **planar face** → `site = face.center()`, `normal → axis`, edge-on view
    (`z→front`, `x→front`, `y→side`), side above/below by the face's position vs the part
    centre (mirrors `render_pmi`).
  - `view=`/`side=` overrides always win — the derivation is a best-effort default plus an
    escape hatch, so the default can be refined over the corpus without blocking the verbs.
- A non-axis-aligned face raises a clear `ValueError` (no letter-based `Frame`).

## Verbs

- `declare.datum()` / `declare.finish()` build the P2b IR items; exported from
  `draftwright.model`.
- Sheet: `_Hole.finish(ra)`, `_Dim.finish(ra)`, `sheet.datum(letter, ref)`,
  `sheet.finish(ra, ref)` — each with `view=`/`side=` overrides; `_gdt_ref` resolves a
  fluent handle / index / `Feature` / face.

## Scope / follow-ups (called out honestly)

- **P2c.2** (next PR) — `sheet.control(ref)` + the 14 ISO 1101 characteristic methods
  (`.position(0.1, to="A B", diameter=True)` …) + datum-letter validation.
- **Feature-path congestion**: the feature default (plan/below) is congested by the envelope
  width dim, so a bare `.finish()` on a central hole **drops with a `gdt_dropped` warning** —
  recoverable via `side=` (a test covers this). It argues for a **side-fallthrough in
  `render_gdt`** (try the other side before dropping) — a P2b follow-up, not scoped here.
- Cylindrical-face and freeform targets → use a feature handle / explicit `view=`.

## Tests

`tests/test_sheet_gdt.py` (8): derivation (view/side/site/origin) for feature + face paths,
face-datum places lint-clean, overrides win, skew-face / empty-letter / empty-Ra raise,
congested-default drop recovered by an explicit side.

Verified locally: 8 new + 74 Sheet/declare/model + 18 GD&T tests green; ruff check + `ruff
format --check` + mypy clean.

Depends on: #478 (P2b, merged). Plan: #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
