### PR TITLE
feat: P2c.2 — sheet.control() GD&T feature-control-frame builder (#479)

### DIFF
--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from draftwright.model.declare import (
     boss,
+    control_frame,
     datum,
     envelope,
     finish,
@@ -76,6 +77,7 @@ __all__ = [
     "StepLevelFeature",
     "build_part_model",
     "boss",
+    "control_frame",
     "datum",
     "envelope",
     "finish",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -28,6 +28,7 @@ import math
 
 from draftwright.model.ir import (
     BossFeature,
+    ControlFrame,
     DatumRef,
     EnvelopeFeature,
     Feature,
@@ -529,6 +530,11 @@ def envelope(obj) -> EnvelopeFeature:
 _FACE_ON_VIEW = {"x": "side", "y": "front", "z": "plan"}
 # A planar face whose normal is this axis shows as an EDGE here (prefer front, else side).
 _EDGE_ON_VIEW = {"x": "front", "y": "side", "z": "front"}
+# Default strip side for a FEATURE target, per its face-on view — the empirically roomiest
+# one: the plan's below strip always carries the overall-width envelope dim (so use above),
+# while the front/side above strips are the shallow gaps between stacked views (so use below).
+# A congested default still drops-with-warning; ``side=`` overrides. Fallthrough is #481.
+_FEATURE_SIDE = {"plan": "above", "front": "below", "side": "below"}
 # The model-space axis a view stacks its above/below strips along (its vertical).
 _VERTICAL_MODEL_AXIS = {"plan": 1, "front": 2, "side": 2}
 _VALID_SIDES = ("above", "below", "left", "right")
@@ -567,7 +573,8 @@ def gdt_target(ref, part=None, *, view=None, side=None) -> tuple[str, str, Point
     if isinstance(ref, Feature):
         site = ref.frame.origin
         axis = _norm_axis(ref.frame.axis)
-        d_view, d_side = _FACE_ON_VIEW[axis], "below"
+        d_view = _FACE_ON_VIEW[axis]
+        d_side = _FEATURE_SIDE[d_view]
     else:  # a build123d planar face
         try:
             n, c = ref.normal_at(), ref.center()
@@ -602,3 +609,37 @@ def finish(ra, ref, part=None, *, view=None, side=None) -> Finish:
     v, s, site, axis = gdt_target(ref, part, view=view, side=side)
     origin = ref if isinstance(ref, Feature) else None
     return Finish(frame=Frame(site, axis), ra=ra, view=v, side=s, origin=origin)
+
+
+def control_frame(
+    characteristic: str,
+    tolerance,
+    ref,
+    part=None,
+    *,
+    datums=(),
+    diameter=False,
+    modifier=None,
+    view=None,
+    side=None,
+) -> ControlFrame:
+    """A geometric-tolerance feature control frame (ISO 1101) on *ref* — a feature or a planar
+    face (ADR 0011 P2c.2). *characteristic* is a lowercase ISO 1101 name (``"position"`` …);
+    *datums* the referenced datum letters; *diameter* prefixes the zone with ``⌀``; *modifier*
+    a material-condition symbol (``"M"``/``"L"``/``"P"``)."""
+    tol = str(tolerance).strip()
+    if not tol:
+        raise ValueError("control frame needs a tolerance value")
+    v, s, site, axis = gdt_target(ref, part, view=view, side=side)
+    origin = ref if isinstance(ref, Feature) else None
+    return ControlFrame(
+        frame=Frame(site, axis),
+        characteristic=str(characteristic),
+        tolerance=tol,
+        view=v,
+        side=s,
+        datums=tuple(str(d).strip() for d in datums),
+        diameter=bool(diameter),
+        modifier=modifier,
+        origin=origin,
+    )

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -32,6 +32,7 @@ feature itself) so you can ``.fit(...)`` / ``.tolerance(...)`` it without re-dec
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import replace
 
 from draftwright.analysis import _solids_body
@@ -39,6 +40,7 @@ from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
 from draftwright.model import Feature
 from draftwright.model import boss as _boss
+from draftwright.model import control_frame as _declare_control
 from draftwright.model import datum as _declare_datum
 from draftwright.model import envelope as _envelope
 from draftwright.model import finish as _declare_finish
@@ -46,8 +48,18 @@ from draftwright.model import hole as _hole
 from draftwright.model import pattern as _pattern
 from draftwright.model import slot as _slot
 from draftwright.model import step as _step
-from draftwright.model.declare import _norm_axis, _read_cylinder, _require_positive
+from draftwright.model.declare import _norm_axis, _read_cylinder, _require_positive, gdt_target
 from draftwright.model.declare import read_bore_step as _read_bore_step
+
+
+def _parse_datums(to) -> tuple[str, ...]:
+    """The datum letters a ``to=`` argument names: ``None`` → ``()``; a sequence →
+    stripped letters; a string split on spaces / ``|`` / ``,`` (``"A B"`` / ``"A|B"``)."""
+    if to is None:
+        return ()
+    if isinstance(to, (tuple, list)):
+        return tuple(str(d).strip() for d in to if str(d).strip())
+    return tuple(str(to).replace("|", " ").replace(",", " ").split())
 
 
 def _parse_scale(scale):
@@ -178,6 +190,88 @@ class _Dim:
         ``diameter(journal).finish("0.8")``; ``view``/``side`` override the derived strip."""
         self._sheet._gdt_finish(ra, self._i, view=view, side=side)
         return self
+
+
+class _Control:
+    """A fluent GD&T feature-control-frame builder (ADR 0011 P2c.2). One method per ISO 1101
+    characteristic — each appends a control frame on the same target, so chained calls stack::
+
+        sheet.control(bore).position(0.1, to="A B").perpendicularity(0.05, to="A")
+
+    ``to=`` names the referenced datum letter(s) (``"A"`` / ``"A B"`` / ``("A", "B")``);
+    ``diameter=`` prefixes the zone with ``⌀`` (the default for position/concentricity);
+    ``modifier=`` a material-condition symbol (``"M"``/``"L"``/``"P"``). The target view + strip
+    are derived once (from the feature/face) when :meth:`Sheet.control` runs; ``view=``/``side=``
+    there override them."""
+
+    def __init__(self, sheet: Sheet, target, src, view: str, side: str) -> None:
+        self._sheet = sheet
+        self._target = target
+        self._src = src
+        self._view = view
+        self._side = side
+
+    def _add(self, characteristic, tol, *, to=None, diameter=False, modifier=None) -> _Control:
+        item = _declare_control(
+            characteristic,
+            tol,
+            self._target,
+            self._sheet._part,
+            datums=_parse_datums(to),
+            diameter=diameter,
+            modifier=modifier,
+            view=self._view,
+            side=self._side,
+        )
+        self._sheet._append_gdt(item, self._src)
+        return self
+
+    # Form tolerances (no datum reference) --------------------------------------------------
+    def straightness(self, tol, *, modifier=None) -> _Control:
+        return self._add("straightness", tol, modifier=modifier)
+
+    def flatness(self, tol, *, modifier=None) -> _Control:
+        return self._add("flatness", tol, modifier=modifier)
+
+    def circularity(self, tol, *, modifier=None) -> _Control:
+        return self._add("circularity", tol, modifier=modifier)
+
+    def cylindricity(self, tol, *, modifier=None) -> _Control:
+        return self._add("cylindricity", tol, modifier=modifier)
+
+    # Profile ------------------------------------------------------------------------------
+    def profile_line(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("profile_line", tol, to=to, modifier=modifier)
+
+    def profile_surface(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("profile_surface", tol, to=to, modifier=modifier)
+
+    # Orientation --------------------------------------------------------------------------
+    def angularity(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("angularity", tol, to=to, modifier=modifier)
+
+    def perpendicularity(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("perpendicularity", tol, to=to, modifier=modifier)
+
+    def parallelism(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("parallelism", tol, to=to, modifier=modifier)
+
+    # Location (a position/concentricity zone is diametral by default) ---------------------
+    def position(self, tol, *, to=None, diameter=True, modifier=None) -> _Control:
+        return self._add("position", tol, to=to, diameter=diameter, modifier=modifier)
+
+    def concentricity(self, tol, *, to=None, diameter=True, modifier=None) -> _Control:
+        return self._add("concentricity", tol, to=to, diameter=diameter, modifier=modifier)
+
+    def symmetry(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("symmetry", tol, to=to, modifier=modifier)
+
+    # Runout -------------------------------------------------------------------------------
+    def circular_runout(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("circular_runout", tol, to=to, modifier=modifier)
+
+    def total_runout(self, tol, *, to=None, modifier=None) -> _Control:
+        return self._add("total_runout", tol, to=to, modifier=modifier)
 
 
 class Sheet:
@@ -330,6 +424,15 @@ class Sheet:
         self._append_gdt(_declare_finish(ra, target, self._part, view=view, side=side), src)
         return self
 
+    def control(self, ref, *, view: str | None = None, side: str | None = None) -> _Control:
+        """A GD&T feature-control-frame builder on *ref* — a feature handle / :class:`Feature` /
+        index, or a build123d planar face. Chain one method per ISO 1101 characteristic
+        (``.position(0.1, to="A B")`` …); each stacks a frame on the target. The target view +
+        strip are derived from the geometry; ``view``/``side`` override them (ADR 0011 P2c.2)."""
+        target, src = self._gdt_ref(ref)
+        v, s, _site, _axis = gdt_target(target, self._part, view=view, side=side)
+        return _Control(self, target, src, v, s)
+
     def _gdt_finish(self, ra, src_index: int, *, view=None, side=None) -> None:
         """A finish declared through a fluent handle — sources its provenance from the handle's
         feature INDEX (not the object), so a later size verb on the same handle can't strand it."""
@@ -366,6 +469,29 @@ class Sheet:
         for gi, si in self._gdt_src:
             self._features[gi] = replace(self._features[gi], origin=self._features[si])
 
+    def _validate_datums(self) -> None:
+        """Warn (non-fatal) if a control frame references a datum letter no ``sheet.datum`` on
+        this sheet declared — a likely typo (``to="A"`` with no datum A). ADR 0011 P2c.2."""
+        declared = {f.letter for f in self._features if getattr(f, "kind", None) == "datum_ref"}
+        referenced = {
+            d
+            for f in self._features
+            if getattr(f, "kind", None) == "control_frame"
+            for d in f.datums
+        }
+        missing = sorted(referenced - declared)
+        if missing:
+            warnings.warn(
+                f"control frame references undeclared datum(s) {missing} — declare each with "
+                "sheet.datum(letter, ref)",
+                stacklevel=3,
+            )
+
+    def _prepare(self) -> None:
+        """Resolve deferred GD&T state before handing features to the engine."""
+        self._materialize_gdt()
+        self._validate_datums()
+
     # -- inspection / output --------------------------------------------------
 
     @property
@@ -387,13 +513,13 @@ class Sheet:
         cost and can't hit a layout/render failure. Wraps the *solids body* (as :func:`_analyse`
         does), so the bbox/datum match what ``build()`` draws even when the part carries
         bbox-extending non-solid geometry."""
-        self._materialize_gdt()
+        self._prepare()
         return _coerce_model(self._features, _solids_body(self._part), self._decorations())
 
     def build(self):
         """Build the :class:`~draftwright.drawing.Drawing` — detection skipped; only the
         declared features are drawn."""
-        self._materialize_gdt()
+        self._prepare()
         return build_drawing(
             self._part, model=self._features, decorations=self._decorations(), **self._opts
         )

--- a/tests/test_sheet_gdt.py
+++ b/tests/test_sheet_gdt.py
@@ -10,7 +10,7 @@ import pytest
 from build123d import Box, Cylinder, Pos, Rotation
 
 from draftwright.model.declare import gdt_target
-from draftwright.sheet_dsl import Sheet
+from draftwright.sheet_dsl import Sheet, _parse_datums
 
 
 def _part():
@@ -28,7 +28,7 @@ def test_finish_on_feature_derives_face_on_view():
     fin = next(f for f in s.features if f.kind == "finish")
     assert fin.ra == "1.6"
     assert fin.view == "plan"  # a z-axis feature is face-on in plan
-    assert fin.side == "below"
+    assert fin.side == "above"  # the plan's roomy strip (below carries the width envelope)
     assert fin.frame.origin == (0.0, 0.0, 0.0)
     assert fin.origin is s.features[0]  # provenance → the hole feature (finish is features[1])
 
@@ -106,14 +106,83 @@ def test_finish_before_depth_keeps_provenance():
     assert all(n in removed for n in fin_names)  # dropped with its feature, not orphaned
 
 
-def test_override_recovers_a_congested_default():
-    # The feature-path default (plan/below) is congested by the envelope width dim, so a bare
-    # finish there drops with a warning; an explicit free side recovers it (the override seam).
+def test_feature_default_side_is_view_aware_and_places():
+    # A z-feature defaults to plan/ABOVE (the plan's below strip always carries the width
+    # envelope). A bare finish on the default side places, no override needed.
     part = _part()
     s = Sheet(part)
     s.envelope()
-    h = s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
-    h.finish("1.6", view="front", side="above")  # a roomy strip
+    s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).finish("1.6")
     dwg = s.build()
     assert "m_gdt0" in dwg._named
     assert not [i for i in dwg._build_issues if i.code == "gdt_dropped"]
+
+
+# -- P2c.2: control frames -----------------------------------------------------------------
+
+
+def test_parse_datums():
+    assert _parse_datums(None) == ()
+    assert _parse_datums("A") == ("A",)
+    assert _parse_datums("A B") == ("A", "B")
+    assert _parse_datums("A|B") == ("A", "B")
+    assert _parse_datums(("A", "B")) == ("A", "B")
+
+
+def test_control_frame_chain_builds_stacked_frames():
+    part = _part()
+    s = Sheet(part)
+    s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    s.control(0).position(0.1, to="A B").perpendicularity(0.05, to="A")
+    cfs = [f for f in s.features if f.kind == "control_frame"]
+    assert len(cfs) == 2
+    pos, perp = cfs
+    assert pos.characteristic == "position" and pos.tolerance == "0.1"
+    assert pos.datums == ("A", "B") and pos.diameter is True  # position zone is ⌀ by default
+    assert perp.characteristic == "perpendicularity" and perp.datums == ("A",)
+    assert perp.diameter is False
+
+
+def test_form_tolerance_has_no_datums():
+    part = _part()
+    s = Sheet(part)
+    s.diameter(Pos(30, 0, 0) * Cylinder(8, 20))
+    s.control(0).cylindricity(0.02)
+    cf = next(f for f in s.features if f.kind == "control_frame")
+    assert cf.characteristic == "cylindricity" and cf.datums == () and cf.diameter is False
+
+
+def test_control_frames_place_lint_clean():
+    part = _part()
+    s = Sheet(part)
+    s.envelope()
+    s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    s.control(0).position(0.1, to="A").perpendicularity(0.05, to="A")  # default plan/above
+    dwg = s.build()
+    placed = [n for n in dwg._named if "gdt" in n]
+    assert len(placed) == 2  # both frames stack
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
+
+
+def test_undeclared_datum_warns():
+    part = _part()
+    s = Sheet(part)
+    s.envelope()
+    s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    s.control(0).position(0.1, to="Z")  # no sheet.datum("Z", …) declared
+    with pytest.warns(UserWarning, match="undeclared datum"):
+        s.build()
+
+
+def test_declared_datum_does_not_warn():
+    part = _part()
+    s = Sheet(part)
+    s.envelope()
+    s.datum("A", _top_face(part))
+    s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    s.control(0).position(0.1, to="A")
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would fail
+        s.build()


### PR DESCRIPTION
## What

ADR 0011 **P2c.2** — the GD&T feature-control-frame builder, completing the fluent Sheet
aspect surface (#479) over the P2b render core. `sheet.control(ref)` returns a chainable
builder with one method per ISO 1101 characteristic:

```python
sheet.control(bore).position(0.1, to="A B", diameter=True).perpendicularity(0.05, to="A")
sheet.control(shaft).cylindricity(0.02)          # form tolerance — no datum
sheet.datum("A", base_face)                      # (P2c.1) the datum it references
```

Each characteristic call stacks a control frame on the same target; the target `(view, side)`
is derived once from the feature/face (P2c.1's `gdt_target`), with `view=`/`side=` overrides.

## Verbs

- `declare.control_frame(characteristic, tolerance, ref, *, datums, diameter, modifier, view,
  side)` — builds the P2b `ControlFrame` IR item; exported from `draftwright.model`.
- `_Control` with all **14 ISO 1101 characteristics**, grouped by whether they take a datum:
  form (`straightness`/`flatness`/`circularity`/`cylindricity` — no `to=`), profile, orientation
  (`angularity`/`perpendicularity`/`parallelism`), location (`position`/`concentricity` default
  `⌀`, `symmetry`), runout (`circular_runout`/`total_runout`).
- `_parse_datums` accepts `"A"` / `"A B"` / `"A|B"` / `("A", "B")`; `diameter=`/`modifier=`
  (`"M"`/`"L"`/`"P"`) pass through.
- **Datum-letter validation**: a control frame referencing a letter no `sheet.datum` declared
  warns at build (a likely `to="A"` typo).

## A placement improvement (found while testing)

The flagship two-frame stack was **dropping one frame**: the P2c.1 feature default side
(`"below"`) is congested per view. Fixed with a **view-aware default** — `_FEATURE_SIDE`
(plan→above, front/side→below), the empirically roomiest strip per view (the plan's below
strip always carries the overall-width envelope; the front/side above strips are the shallow
gaps between stacked views). The no-override flagship now places both frames, 0 drops, lint
clean. (The P2c.1 unit test's default-side assertion updated `below`→`above` accordingly.)

## Scope / follow-up

- A genuinely congested default still drops-with-warning (`side=` recovers it). The real cure —
  `render_gdt` falling through to another side before dropping — is **#481** (a P2b render
  enhancement; the code references it). Composite (shared-leader) stacked frames noted there too.

## Tests

`tests/test_sheet_gdt.py` +7 (15 total): chain builds stacked frames with correct
characteristic/tolerance/datums/⌀, form tolerance carries no datums, frames place lint-clean,
undeclared/declared datum warn behaviour, `_parse_datums`, view-aware default places.

Verified locally: 91 Sheet/model/gdt tests green; ruff check + `ruff format --check` + mypy
clean.

Depends on: #480 (P2c.1, merged). Plan: #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
