### PR TITLE
docs: GD&T epic complete — roadmap P2c DONE + README declarative section + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,16 +176,21 @@ Current ADRs:
   `intent → [names]` **once** at the intent→render seam, with an `origin` back-link
   on IR features. The registry's `_anno_feature` (#398b) is the sink; the seam is
   the automatic populator. Re-plans #398c–e, enables #400.
-- **0011** — **Accepted** (Phase 0+1 landed; Phase 2 pending): **the IR as a public
-  input** — declare features, don't only detect them. `build_drawing(part, model=…)`
-  accepts a caller-supplied `PartModel`/`Sequence[Feature]` and **skips detection**;
-  object→feature constructors (`model.hole`/`boss`/`step`/`slot`/`pattern`/`envelope`)
-  read a feature's size off the build123d object you built (⌀ from the cylindrical
-  face; axis/location from the bbox), with an explicit-value flavour. The fluent
-  `Sheet` façade (`draftwright.Sheet`) is the "beautiful-Python" surface over the
-  existing renderers. Aspects geometry can't carry (tolerance/GD&T/finish) are a
-  side-layer, deferred to Phase 2 (#61/#62). Sidesteps #298 misdetection; complements
-  #400 (read + edit → now also input). Roadmap: #446; vision: #445.
+- **0011** — **Accepted** (Phase 0+1 + Phase 2 aspects landed; P2d PMI-source pending):
+  **the IR as a public input** — declare features, don't only detect them.
+  `build_drawing(part, model=…)` accepts a caller-supplied `PartModel`/`Sequence[Feature]`
+  and **skips detection**; object→feature constructors
+  (`model.hole`/`boss`/`step`/`slot`/`pattern`/`envelope`) read a feature's size off the
+  build123d object you built (⌀ from the cylindrical face; axis/location from the bbox),
+  with an explicit-value flavour. The fluent `Sheet` façade (`draftwright.Sheet`) is the
+  "beautiful-Python" surface over the existing renderers. **Aspects geometry can't carry
+  are now built:** tolerance/fit ride `DimParameter` (P2a/P2a.2); **GD&T + surface finish**
+  are standalone IR features (`ControlFrame`/`DatumRef`/`Finish`, `model/ir.py`) placed as
+  first-class ADR 0009 corridor candidates by `render_gdt` (P2b #478), authored via
+  `sheet.datum`/`sheet.control(…).position(…)`/`.finish` whose target view+strip derive
+  from the referenced feature/face (`declare.gdt_target`, P2c #480/#482). PMI-sourced
+  auto-GD&T is the last item (#62). Sidesteps #298 misdetection; complements #400 (read +
+  edit → now also input). Roadmap: `docs/plans/0011-phase2-aspects-roadmap.md`; #446/#445.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,36 @@ issues = dwg.lint()                       # list[LintIssue] — coverage, page b
 svg_path, dxf_path = dwg.export("my_part")
 ```
 
+### Declarative drawings — reference features, declare intent
+
+Instead of relying on detection, **reference the build123d objects you built** and declare
+only the drawing intent — geometry supplies the sizes (⌀ read off the object), you supply
+tolerances, fits, datums, GD&T, and surface finish. The fluent `Sheet` skips detection and
+dimensions exactly what you declare (ADR 0011):
+
+```python
+from build123d import Box, Cylinder, Pos
+from draftwright import Sheet
+
+plate = Box(120, 80, 20)
+bore = Pos(0, 0, 0) * Cylinder(4, 20)
+
+sheet = Sheet(plate - bore, title="Plate", number="DWG-002")
+sheet.envelope()
+sheet.datum("A", plate.faces().sort_by()[-1])             # datum A on the top face
+hole = sheet.hole(bore).finish("1.6")                     # ⌀8 bore, Ra 1.6
+sheet.control(hole).position(0.1, to="A", diameter=True)  # ⌀0.1 position wrt A
+sheet.export("plate")                                     # writes plate.svg + plate.dxf
+```
+
+Every aspect the geometry can't carry is a declared verb: `.tolerance(±)` / `.fit("H7")`
+(ISO 286), `.finish("Ra")` (ISO 1302), `sheet.datum(letter, ref)` (ISO 5459), and
+`sheet.control(ref)` with all 14 ISO 1101 characteristics
+(`.position`/`.flatness`/`.perpendicularity`/`.circular_runout`/…). A feature verb returns
+a chainable handle (`sheet.hole(bore)`) that the aspect and `control(...)` verbs decorate;
+targets are placed automatically — the view and strip are derived from the referenced
+feature or face, with `view=`/`side=` overrides.
+
 ## What it produces
 
 - **Three orthographic views** (front, plan, side) sized and scaled automatically to the

--- a/docs/plans/0011-phase2-aspects-roadmap.md
+++ b/docs/plans/0011-phase2-aspects-roadmap.md
@@ -180,38 +180,57 @@ above/below; the read-side `datum_candidates()` helper (surface the part's natur
 datum edges so a script anchors without guessing coordinates) moves to P2c where the
 face→site projection lives.
 
-### P2c — Sheet declarative aspect verbs · #31
+### P2c — Sheet declarative aspect verbs · #479 · **DONE**
 
-The #445 vision surface over P2a + P2b.
+The #445 vision surface over P2a + P2b. Shipped in two PRs (#31 in the original heading
+was a stale ref to a closed layout issue; the plan lived in **#479**).
 
-- `sheet.datum("A", face)`, `diameter(journal).finish("Ra 0.8")`,
-  `sheet.control(target).cylindricity(0.02).circular_runout(0.05, to=A)
-  .perpendicular(0.05, to=B)` — each verb returns a small chainable handle.
-- Records into the new `AnnotationRegistry` decoration peer map keyed to
-  feature/face; a render pass reads it and calls the P2b placement API.
-- **No fake verbs** — a verb ships only once the renderer behind it exists
-  (the Phase-1 discipline).
+**P2c.1 (#480) — `.finish()` / `sheet.datum()` + the target derivation.** The genuinely-new
+work: `declare.gdt_target(ref, part) → (view, side, site, axis)` resolves a GD&T target
+geometrically at *declaration* time (no `Analysis`): a **feature** → its axis site, face-on
+view (`z→plan`, `x→side`, `y→front`); a build123d **planar face** → its centre, normal→axis,
+edge-on view. `view=`/`side=` always override. `declare.datum()`/`finish()` build the P2b IR
+items; the Sheet verbs `_Hole/_Dim.finish`, `sheet.datum`, `sheet.finish` append them (a
+handle-sourced item records `origin` by feature **index** and re-binds at build, mirroring
+P2a — so a later `.depth()` doesn't strand provenance).
 
-### P2d — Auto-GD&T from STEP PMI (#62) · #32 · later
+**P2c.2 (#482) — `sheet.control()` + the feature-control-frame builder.** `_Control` exposes
+one method per **all 14 ISO 1101 characteristics** (form tolerances take no `to=`;
+position/concentricity default `⌀`); `_parse_datums` accepts `"A"`/`"A B"`/`"A|B"`/`("A","B")`;
+`diameter=`/`modifier=` pass through. Datum-letter **validation** warns at build on a `to="A"`
+with no declared `sheet.datum("A", …)`. A **view-aware default side** (`_FEATURE_SIDE`:
+plan→above, front/side→below — the roomiest per view) so the flagship two-frame stack places
+without an override.
+
+- Aspects are standalone IR **features** appended to `Sheet._features` (not a `decorations`
+  peer map — that's P2a's tolerance path); consumed by the already-wired `render_gdt`.
+- **No fake verbs** — both shipped only because #478's renderer exists.
+- Four adversarial-review rounds across P2b+P2c fixed 3 real defects (public-IR crash,
+  off-sheet overshoot, degenerate-leader crash, provenance staleness).
+- **Follow-up #481** — `render_gdt` side-fallthrough: on a congested default side, try the
+  other side before dropping (the view-aware default is the current stopgap).
+
+### P2d — Auto-GD&T from STEP PMI (#62) · later · **the last Phase-2 item**
 
 Complementary, not on the P2a→P2c critical path.
 
-- Wire `pmi.py`'s already-extracted `gtol` / `datum` `PmiRecord`s into P2b's
-  `place_fcf` / `place_datum` under `pmi="annotate"` (today they hit a "not yet
-  annotatable (Phase 4)" debug log).
-- Second producer, same placement path — the read/auto complement to P2c's
-  declarative authoring.
+- Wire `pmi.py`'s already-extracted `gtol` / `datum` `PmiRecord`s into the P2b IR items
+  (`ControlFrame` / `DatumRef`) under `pmi="annotate"` (today they hit a "not yet
+  annotatable (Phase 4)" debug log in `render_pmi`) — a detector that emits the same IR
+  the declarative verbs do, so `render_gdt` places them with no new plumbing.
+- Second producer, same placement path — the read/auto complement to P2c's declarative
+  authoring.
 
 ## Dependency graph
 
 ```
-P2a (#28) ─┬─ P2a.2 (#29)
-           └─ P2c (#31) ── (also needs) ── P2b (#30) ── P2d (#32)
+P2a (#28, DONE) ─┬─ P2a.2 (#29, DONE)
+                 └─ P2c (#479, DONE) ── (needs) ── P2b (#478, DONE) ── P2d (#62, next)
 ```
 
-Suggested landing order: **P2a → P2a.2** (tolerance is a small, self-contained PR
-that ships visible value fast), then **P2b → P2c** (the GD&T / finish stack),
-**P2d** whenever PMI-carrying STEP input matters.
+Landing order (as executed): **P2a → P2a.2** → **P2b (#478) → P2c.1 (#480) → P2c.2 (#482)**.
+Remaining: **P2d (#62)** whenever PMI-carrying STEP input matters, and the **#481**
+placement-fallthrough quality follow-up.
 
 ## Non-goals for Phase 2
 


### PR DESCRIPTION
Documentation-only. Reflects the merged ADR 0011 GD&T epic (#478/#480/#482):

- **Roadmap** (`0011-phase2-aspects-roadmap.md`): P2c → **DONE** (P2c.1 #480 + P2c.2 #482); P2d reframed as the last item; dependency graph + landing order updated to as-executed.
- **README**: new *Declarative drawings* section — the `Sheet` surface was previously undocumented. Includes a **runnable** GD&T example (`sheet.datum` + `.finish` + `sheet.control(...).position(...)`), verified to export lint-clean.
- **CLAUDE.md**: ADR 0011 line — Phase 2 aspects (tolerance/fit/GD&T/finish) landed; PMI-sourced auto-GD&T (#62) is the last item.

No code changes. Closes the doc half of the epic wrap-up (issues #61/#479 already closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)