### PR TITLE
fix: file.py:attr object spec puts the helper's dir + cwd on sys.path (#488)

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -190,19 +190,22 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         if ispec is None or ispec.loader is None:
             raise ValueError(f"cannot load module from {mod_ref!r}")
         module = importlib.util.module_from_spec(ispec)
-        # Put the invocation cwd AND the helper file's OWN directory on sys.path before exec, so
-        # the loaded file's repo-relative / sibling imports resolve. spec_from_file_location adds
-        # NEITHER (unlike `python file.py`, which adds the script dir), so they would otherwise
-        # fail unless the helper hand-managed sys.path (#488). Insert cwd first then the file's
-        # dir, so the file's OWN dir lands at index 0 and WINS a name clash — matching
-        # `python file.py` (a sibling next to the helper beats a same-named module in cwd). Both
-        # are baked into the seam as resolve-time absolute literals (like the module-spec branch's
-        # cwd), so a re-run adds the SAME paths in the SAME order from any CWD (#491 review).
+        # Force the helper file's OWN directory to the FRONT of sys.path, with the invocation cwd
+        # just behind it, so its repo-relative / sibling imports resolve like `python file.py` (the
+        # script dir wins a name clash) — spec_from_file_location adds NEITHER (#488). Remove any
+        # existing occurrence first, then re-insert in a fixed order: a plain `not in sys.path`
+        # guard can't reorder a dir that's ALREADY on the path (e.g. a driver run as
+        # `python tools/driver.py` puts the helper dir on sys.path), so cwd could otherwise land
+        # ahead of it and win the clash, AND the in-process build would diverge from the standalone
+        # re-run seam (#491 review). Removing then front-inserting makes the order deterministic and
+        # identical between build and re-run; the seam bakes both as resolve-time absolute literals.
         file_dir = str(path.parent)
         cwd = os.getcwd()
         for _p in (cwd, file_dir):
-            if _p not in sys.path:
-                sys.path.insert(0, _p)
+            while _p in sys.path:
+                sys.path.remove(_p)
+        for _p in (cwd, file_dir):  # cwd first, file_dir last -> file_dir at index 0 (wins)
+            sys.path.insert(0, _p)
         # Register before exec so a self-referential target resolves (a dataclass whose
         # forward-ref annotations get typing.get_type_hints'd, a module reading
         # sys.modules[__name__], import-time pickling). The seam does the same on re-run.
@@ -214,7 +217,9 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         seam = (
             "import importlib.util as _ilu, sys as _sys\n"
             f"for _p in ({cwd!r}, {file_dir!r}):\n"
-            "    _p in _sys.path or _sys.path.insert(0, _p)\n"
+            "    while _p in _sys.path:\n        _sys.path.remove(_p)\n"
+            f"for _p in ({cwd!r}, {file_dir!r}):\n"
+            "    _sys.path.insert(0, _p)\n"
             f"_spec = _ilu.spec_from_file_location({path.stem!r}, {str(path)!r})\n"
             "_mod = _ilu.module_from_spec(_spec)\n_sys.modules[_spec.name] = _mod\n"
             "_spec.loader.exec_module(_mod)"

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -190,12 +190,17 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         if ispec is None or ispec.loader is None:
             raise ValueError(f"cannot load module from {mod_ref!r}")
         module = importlib.util.module_from_spec(ispec)
-        # Put the helper file's OWN directory and the invocation cwd on sys.path before exec,
-        # so the loaded file's imports resolve. spec_from_file_location adds NEITHER (unlike
-        # `python file.py`, which adds the script dir), so a repo-relative or sibling import in
-        # the helper would otherwise fail unless it hand-managed sys.path (#488). The module-spec
-        # branch below already does the cwd insert; do the same here + the file's parent.
-        for _p in (str(path.parent), os.getcwd()):
+        # Put the invocation cwd AND the helper file's OWN directory on sys.path before exec, so
+        # the loaded file's repo-relative / sibling imports resolve. spec_from_file_location adds
+        # NEITHER (unlike `python file.py`, which adds the script dir), so they would otherwise
+        # fail unless the helper hand-managed sys.path (#488). Insert cwd first then the file's
+        # dir, so the file's OWN dir lands at index 0 and WINS a name clash — matching
+        # `python file.py` (a sibling next to the helper beats a same-named module in cwd). Both
+        # are baked into the seam as resolve-time absolute literals (like the module-spec branch's
+        # cwd), so a re-run adds the SAME paths in the SAME order from any CWD (#491 review).
+        file_dir = str(path.parent)
+        cwd = os.getcwd()
+        for _p in (cwd, file_dir):
             if _p not in sys.path:
                 sys.path.insert(0, _p)
         # Register before exec so a self-referential target resolves (a dataclass whose
@@ -207,8 +212,8 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         except Exception as e:
             raise ValueError(f"{spec!r}: importing {mod_ref!r} failed: {e}") from e
         seam = (
-            "import importlib.util as _ilu, sys as _sys, os as _os\n"
-            f"for _p in ({str(path.parent)!r}, _os.getcwd()):\n"
+            "import importlib.util as _ilu, sys as _sys\n"
+            f"for _p in ({cwd!r}, {file_dir!r}):\n"
             "    _p in _sys.path or _sys.path.insert(0, _p)\n"
             f"_spec = _ilu.spec_from_file_location({path.stem!r}, {str(path)!r})\n"
             "_mod = _ilu.module_from_spec(_spec)\n_sys.modules[_spec.name] = _mod\n"

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -190,6 +190,14 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         if ispec is None or ispec.loader is None:
             raise ValueError(f"cannot load module from {mod_ref!r}")
         module = importlib.util.module_from_spec(ispec)
+        # Put the helper file's OWN directory and the invocation cwd on sys.path before exec,
+        # so the loaded file's imports resolve. spec_from_file_location adds NEITHER (unlike
+        # `python file.py`, which adds the script dir), so a repo-relative or sibling import in
+        # the helper would otherwise fail unless it hand-managed sys.path (#488). The module-spec
+        # branch below already does the cwd insert; do the same here + the file's parent.
+        for _p in (str(path.parent), os.getcwd()):
+            if _p not in sys.path:
+                sys.path.insert(0, _p)
         # Register before exec so a self-referential target resolves (a dataclass whose
         # forward-ref annotations get typing.get_type_hints'd, a module reading
         # sys.modules[__name__], import-time pickling). The seam does the same on re-run.
@@ -199,7 +207,9 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
         except Exception as e:
             raise ValueError(f"{spec!r}: importing {mod_ref!r} failed: {e}") from e
         seam = (
-            "import importlib.util as _ilu, sys as _sys\n"
+            "import importlib.util as _ilu, sys as _sys, os as _os\n"
+            f"for _p in ({str(path.parent)!r}, _os.getcwd()):\n"
+            "    _p in _sys.path or _sys.path.insert(0, _p)\n"
             f"_spec = _ilu.spec_from_file_location({path.stem!r}, {str(path)!r})\n"
             "_mod = _ilu.module_from_spec(_spec)\n_sys.modules[_spec.name] = _mod\n"
             "_spec.loader.exec_module(_mod)"

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -245,25 +245,44 @@ class TestObjectSpec:
         assert isinstance(obj, Shape)
         assert "from dottedmod import bracket as _obj" in seam
 
-    def test_file_spec_helper_can_import_a_sibling(self, tmp_path, monkeypatch):
-        # #488: a file helper's OWN imports must resolve — spec_from_file_location adds neither
-        # the file's dir nor the cwd to sys.path (unlike `python file.py`), so a repo-relative
-        # or sibling import used to fail unless the helper hand-managed sys.path.
-        (tmp_path / "sib_shapes488.py").write_text(
-            "from build123d import Box\ndef base():\n    return Box(8, 8, 8)\n", encoding="utf-8"
+    def test_file_spec_helper_sibling_import_wins_and_seam_is_cwd_independent(
+        self, tmp_path, monkeypatch
+    ):
+        # #488 + #491 review: a subdir helper importing a sibling must (1) resolve to the sibling
+        # next to it — NOT a same-named module in cwd (match `python file.py`); and (2) the baked
+        # seam must re-build the SAME object from any CWD (bake cwd as a resolve-time literal, not
+        # a runtime getcwd, and preserve insert order so the initial build == the re-run).
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "sib491.py").write_text(  # a COLLIDING module in cwd
+            "from build123d import Box\ndef base():\n    return Box(9, 9, 9)\n", encoding="utf-8"
         )
-        (tmp_path / "sib_helper488.py").write_text(
-            "from sib_shapes488 import base\ndef make():\n    return base()\n", encoding="utf-8"
+        (sub / "sib491.py").write_text(  # the true sibling next to the helper
+            "from build123d import Box\ndef base():\n    return Box(3, 3, 3)\n", encoding="utf-8"
+        )
+        (sub / "helper491.py").write_text(
+            "from sib491 import base\ndef make():\n    return base()\n", encoding="utf-8"
         )
         monkeypatch.chdir(tmp_path)
-        obj, seam = resolve_object_spec(
-            "sib_helper488.py:make"
-        )  # sibling import, no sys.path help
-        assert isinstance(obj, Shape)
-        assert "_sys.path.insert" in seam  # the re-run seam restores the import roots
-        # the cwd is baked as a repr'd literal — compare against repr so Windows backslash
-        # escaping in the seam doesn't false-fail (the code bakes os.getcwd(), same as here).
-        assert repr(os.getcwd()) in seam
+        obj, seam = resolve_object_spec("sub/helper491.py:make")
+        assert round(obj.bounding_box().size.X) == 3  # helper's own dir wins the clash
+
+        # the seam bakes cwd as an absolute literal (no runtime getcwd), so re-run is cwd-stable
+        assert "getcwd" not in seam
+        assert repr(str(tmp_path)) in seam
+
+        # exec the seam from a DIFFERENT cwd with the modules purged -> must build the SAME object
+        import sys as _sys
+
+        for _m in ("sib491", "helper491"):
+            _sys.modules.pop(_m, None)
+        for _p in (str(tmp_path), str(sub)):
+            while _p in _sys.path:
+                _sys.path.remove(_p)
+        monkeypatch.chdir(tmp_path.parent)
+        ns: dict = {}
+        exec(seam, ns)  # noqa: S102 — exercising the generated re-run seam
+        assert round(ns["_mod"].make().bounding_box().size.X) == 3  # build == re-run
 
     def test_missing_attr_raises(self, tmp_path):
         p = self._mod(tmp_path)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -284,6 +284,36 @@ class TestObjectSpec:
         exec(seam, ns)  # noqa: S102 — exercising the generated re-run seam
         assert round(ns["_mod"].make().bounding_box().size.X) == 3  # build == re-run
 
+    def test_file_spec_helper_dir_wins_even_when_preloaded_on_syspath(self, tmp_path, monkeypatch):
+        # #491 review: a `not in sys.path` guard can't reorder an ALREADY-present file_dir — a
+        # driver run as `python tools/driver.py` preloads the helper dir, so cwd could win a clash
+        # (opposite of script semantics) and the build diverge from the re-run. Force-front fixes it.
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (tmp_path / "sibZ.py").write_text(
+            "from build123d import Box\ndef base():\n    return Box(9, 9, 9)\n", encoding="utf-8"
+        )
+        (sub / "sibZ.py").write_text(
+            "from build123d import Box\ndef base():\n    return Box(3, 3, 3)\n", encoding="utf-8"
+        )
+        (sub / "helperZ.py").write_text(
+            "from sibZ import base\ndef make():\n    return base()\n", encoding="utf-8"
+        )
+        monkeypatch.chdir(tmp_path)
+        import sys as _sys
+
+        saved = list(_sys.path)
+        try:
+            _sys.path.insert(0, str(sub))  # file_dir ALREADY present (driver-on-path)
+            while str(tmp_path) in _sys.path:  # cwd absent
+                _sys.path.remove(str(tmp_path))
+            obj, _seam = resolve_object_spec("sub/helperZ.py:make")
+            assert round(obj.bounding_box().size.X) == 3  # helper dir wins despite being preloaded
+        finally:
+            _sys.path[:] = saved
+            for _m in ("sibZ", "helperZ"):
+                _sys.modules.pop(_m, None)
+
     def test_missing_attr_raises(self, tmp_path):
         p = self._mod(tmp_path)
         with pytest.raises(ValueError, match="not found"):

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -244,6 +244,23 @@ class TestObjectSpec:
         obj, seam = resolve_object_spec("dottedmod:bracket")
         assert isinstance(obj, Shape)
         assert "from dottedmod import bracket as _obj" in seam
+
+    def test_file_spec_helper_can_import_a_sibling(self, tmp_path, monkeypatch):
+        # #488: a file helper's OWN imports must resolve — spec_from_file_location adds neither
+        # the file's dir nor the cwd to sys.path (unlike `python file.py`), so a repo-relative
+        # or sibling import used to fail unless the helper hand-managed sys.path.
+        (tmp_path / "sib_shapes488.py").write_text(
+            "from build123d import Box\ndef base():\n    return Box(8, 8, 8)\n", encoding="utf-8"
+        )
+        (tmp_path / "sib_helper488.py").write_text(
+            "from sib_shapes488 import base\ndef make():\n    return base()\n", encoding="utf-8"
+        )
+        monkeypatch.chdir(tmp_path)
+        obj, seam = resolve_object_spec(
+            "sib_helper488.py:make"
+        )  # sibling import, no sys.path help
+        assert isinstance(obj, Shape)
+        assert "_sys.path.insert" in seam  # the re-run seam restores the import roots
         # the cwd is baked as a repr'd literal — compare against repr so Windows backslash
         # escaping in the seam doesn't false-fail (the code bakes os.getcwd(), same as here).
         assert repr(os.getcwd()) in seam


### PR DESCRIPTION
Closes the #488.2 gap from the Gramel trial.

## What
`sheet_emit.resolve_object_spec`'s **file-spec** path (`file.py:attr`) loaded the helper via `spec_from_file_location` but added **neither** the file's own directory **nor** the invocation cwd to `sys.path` — unlike `python file.py` (which adds the script dir) and unlike the **module-spec** branch (which adds cwd). So a `file.py:attr` helper whose own imports are repo-relative or sibling **failed** unless it hand-managed `sys.path` (exactly the footgun in the Gramel trial: `dist/…/gramel_dw_objects.py:thumbwheel_drive_screw` needed a manual `sys.path` insert).

## Fix
Insert both the file's parent dir and `os.getcwd()` before `exec_module`, and bake the same inserts into the **re-run seam** so the generated script works from any CWD.

## Test
`test_file_spec_helper_can_import_a_sibling` — a `file.py:attr` helper importing a sibling module now resolves with no `sys.path` plumbing; the seam restores the import roots. 48 `test_sheet_emit` tests green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)