### PR TITLE
feat: sheet.table() + sheet.notes() — corner-block tables on the declarative surface (#488)

### DIFF
--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -596,8 +596,11 @@ class Sheet:
                 warnings.warn(
                     f"table name {t['name']!r} is already taken — placed as {name!r}", stacklevel=2
                 )
-            dwg.add_table(t["rows"], prefer=t["prefer"], name=name, block_cols=t["block_cols"])
-            used.add(name)
+            placed = dwg.add_table(
+                t["rows"], prefer=t["prefer"], name=name, block_cols=t["block_cols"]
+            )
+            if placed is not None:  # a dropped table (didn't fit) frees its name (#493 review)
+                used.add(name)
         return dwg
 
     def export(self, stem=None):

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -510,6 +510,15 @@ class Sheet:
         (``"tr"``/``"tl"``/``"br"``/``"bl"``). A table with no free corner records a
         ``table_dropped`` lint — it never overlaps. Revision blocks, BOMs and schedules all use
         this; :meth:`notes` is the single-column convenience over it."""
+        rows = list(rows)
+        # A str/bytes row would iterate character-by-character into columns — a silent-garbage
+        # trap, especially since notes() legitimately takes a flat list of strings. Reject it and
+        # point at notes() (the single-column convenience).
+        if any(isinstance(r, (str, bytes)) for r in rows):
+            raise ValueError(
+                "table rows must be sequences of cells, not strings — for a single-column table "
+                "of text use sheet.notes([...])"
+            )
         norm = [tuple(str(c) for c in r) for r in rows]
         if not norm:
             raise ValueError("table needs at least one row")
@@ -572,10 +581,23 @@ class Sheet:
         dwg = build_drawing(
             self._part, model=self._features, decorations=self._decorations(), **self._opts
         )
+        # Add each declared table, uniquifying its name against everything already on the sheet
+        # (feature annotations + earlier tables) so a table NEVER silently overwrites another
+        # object via dwg.add (#493 review). A collision with an explicit name is warned; a table
+        # that doesn't fit still records `table_dropped` lint inside add_table.
+        used = set(dwg._named)
         for t in self._tables:
-            dwg.add_table(
-                t["rows"], prefer=t["prefer"], name=t["name"], block_cols=t["block_cols"]
-            )
+            name = t["name"]
+            if name in used:
+                base, k = name, 1
+                while f"{base}_{k}" in used:
+                    k += 1
+                name = f"{base}_{k}"
+                warnings.warn(
+                    f"table name {t['name']!r} is already taken — placed as {name!r}", stacklevel=2
+                )
+            dwg.add_table(t["rows"], prefer=t["prefer"], name=name, block_cols=t["block_cols"])
+            used.add(name)
         return dwg
 
     def export(self, stem=None):

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -16,12 +16,14 @@ detection is skipped and the auto-pass dimensions exactly the declared features:
 engine has today — dimensions, ⌀ callouts, holes (through / blind), turned steps,
 slots, patterns, the overall envelope, and the auto section — plus the P2a
 **``.tolerance``** (a ± / limit tolerance on a diameter, a step, or a hole bore) and
-**``.fit``** (fit-class → ISO 286 deviation, P2a.2) aspects, and the P2c GD&T side-layer
-(**``.finish``** surface symbols + **``sheet.datum``** feature symbols, ADR 0011 #479),
-which derive their target view/strip from the referenced feature or planar face. The
-remaining #445 aspect verbs that still need wiring — ``.thread`` and ``control(...)`` (the
-GD&T feature-control-frame builder, P2c.2) — are deliberately **not** stubbed here yet, so
-the surface only exposes what actually draws.
+**``.fit``** (fit-class → ISO 286 deviation, P2a.2) aspects, the P2c GD&T side-layer
+(**``.finish``** surface symbols, **``sheet.datum``** feature symbols, and
+**``sheet.control(...)``** feature control frames — all 14 ISO 1101 characteristics, ADR 0011
+#479 — which derive their target view/strip from the referenced feature or planar face), and
+**``sheet.table()``** / **``sheet.notes()``** corner-block tables (notes / revision / BOM /
+schedule, over the engine's auto-placed ``Drawing.add_table``, #488). The remaining #445 aspect
+verbs that still need wiring — ``.thread`` and a general anchored ``.note()`` leader (#488) —
+are deliberately **not** stubbed here yet, so the surface only exposes what actually draws.
 
 **Hybrid.** :meth:`Sheet.from_part` seeds the declared set from *detection*, so you
 can start from the detected model and override specific features (declaration is for
@@ -294,6 +296,10 @@ class Sheet:
         # its origin by INDEX, not the object, so a later size verb replacing the source feature
         # (hole().depth()) doesn't strand the link; materialized to the FINAL object at build.
         self._gdt_src: list = []
+        # Corner-block tables (notes / revision / BOM / schedule) — applied at build() via the
+        # engine's generic auto-placed Drawing.add_table, AFTER the drawing is built so they sit
+        # clear of the views + title block (like the hole table). Each: {rows, prefer, name}.
+        self._tables: list = []
         self._opts = dict(
             title=title, number=number, scale=_parse_scale(scale), page=page, out=out
         )
@@ -492,6 +498,48 @@ class Sheet:
         self._materialize_gdt()
         self._validate_datums()
 
+    # -- corner-block tables (notes / revision / BOM / schedule) --------------
+
+    def table(
+        self, rows, *, prefer: str = "tr", name: str | None = None, block_cols=None
+    ) -> Sheet:
+        """Declare a corner-block data table — positioned at :meth:`build` by the engine's generic
+        auto-placer, clear of the views, title block, and annotations (the same machinery as the
+        hole table), and lint-checked. *rows* is a sequence of equal-length row sequences (row 0
+        the header); cells are stringified. *prefer* is the page corner to sit nearest
+        (``"tr"``/``"tl"``/``"br"``/``"bl"``). A table with no free corner records a
+        ``table_dropped`` lint — it never overlaps. Revision blocks, BOMs and schedules all use
+        this; :meth:`notes` is the single-column convenience over it."""
+        norm = [tuple(str(c) for c in r) for r in rows]
+        if not norm:
+            raise ValueError("table needs at least one row")
+        width = len(norm[0])
+        if width == 0 or any(len(r) != width for r in norm):
+            raise ValueError("table rows must all have the same (non-zero) number of columns")
+        self._tables.append(
+            {
+                "rows": norm,
+                "prefer": prefer,
+                "name": name or f"table{len(self._tables)}",
+                "block_cols": block_cols,
+            }
+        )
+        return self
+
+    def notes(
+        self, lines, *, title: str | None = "NOTES", number: bool = True, prefer="tr"
+    ) -> Sheet:
+        """Declare a manufacturing NOTES block — a single-column :meth:`table` of *lines* with a
+        *title* header (``None`` to omit) and optional ``1  …`` auto-numbering::
+
+            sheet.notes(["BREAK ALL EDGES 0.3", "DEBURR", "M3x0.5 TAP"])
+        """
+        rows = [(title,)] if title else []
+        rows += [(f"{i}  {line}" if number else str(line),) for i, line in enumerate(lines, 1)]
+        if len(rows) <= (1 if title else 0):
+            raise ValueError("notes needs at least one line")
+        return self.table(rows, prefer=prefer, name=f"notes{len(self._tables)}")
+
     # -- inspection / output --------------------------------------------------
 
     @property
@@ -518,11 +566,17 @@ class Sheet:
 
     def build(self):
         """Build the :class:`~draftwright.drawing.Drawing` — detection skipped; only the
-        declared features are drawn."""
+        declared features are drawn. Declared corner-block tables (:meth:`table`/:meth:`notes`)
+        are placed last, clear of everything already on the sheet."""
         self._prepare()
-        return build_drawing(
+        dwg = build_drawing(
             self._part, model=self._features, decorations=self._decorations(), **self._opts
         )
+        for t in self._tables:
+            dwg.add_table(
+                t["rows"], prefer=t["prefer"], name=t["name"], block_cols=t["block_cols"]
+            )
+        return dwg
 
     def export(self, stem=None):
         """Build and export the drawing (SVG + DXF). *stem* defaults to the drawing

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -1,0 +1,85 @@
+"""Sheet corner-block tables — `sheet.table()` / `sheet.notes()` (ADR 0011 #488).
+
+The declarative surface over the engine's generic auto-placed `Drawing.add_table` (the same
+machinery as the hole table): notes blocks / revision blocks / BOMs / schedules, positioned
+clear of the views + title block at build, and lint-checked.
+"""
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet
+
+
+def _sheet():
+    s = Sheet(Box(120, 80, 20) - Pos(0, 0, 0) * Cylinder(4, 20), title="Plate", number="DWG-T")
+    s.envelope()
+    s.hole(Pos(0, 0, 0) * Cylinder(4, 20))
+    return s
+
+
+def test_notes_block_places_lint_clean():
+    s = _sheet()
+    s.notes(["BREAK ALL EDGES 0.3", "DEBURR", "M3x0.5 TAP"])
+    dwg = s.build()
+    assert "notes0" in dwg._named
+    assert not [
+        x for x in dwg.lint() if x.code in ("annotation_overlap", "annotation_out_of_bounds")
+    ]
+
+
+def test_notes_autonumbers_under_a_title():
+    s = _sheet()
+    s.notes(["A", "B"], title="NOTES")
+    rows = s._tables[0]["rows"]
+    assert rows[0] == ("NOTES",)  # title header
+    assert rows[1] == ("1  A",) and rows[2] == ("2  B",)  # auto-numbered single column
+
+
+def test_notes_can_omit_number_and_title():
+    s = _sheet()
+    s.notes(["JUST TEXT"], title=None, number=False)
+    assert s._tables[0]["rows"] == [("JUST TEXT",)]
+
+
+def test_generic_table_places_and_stringifies():
+    s = _sheet()
+    s.table([("REV", "DATE", "BY"), ("A", "2026-07-06", "PF")], prefer="br")
+    dwg = s.build()
+    assert "table0" in dwg._named
+    # cells are stringified (a non-str is accepted)
+    s2 = _sheet()
+    s2.table([("QTY",), (3,)])
+    assert s2._tables[0]["rows"][1] == ("3",)
+
+
+def test_multiple_tables_get_unique_names():
+    s = _sheet()
+    s.notes(["x"])
+    s.table([("a",), ("b",)])
+    dwg = s.build()
+    assert {"notes0", "table1"} <= set(dwg._named)
+
+
+def test_chains_and_returns_sheet():
+    s = _sheet()
+    assert s.notes(["x"]) is s and s.table([("a",), ("b",)]) is s
+
+
+def test_validation():
+    s = _sheet()
+    with pytest.raises(ValueError, match="at least one row"):
+        s.table([])
+    with pytest.raises(ValueError, match="same .* number of columns"):
+        s.table([("a", "b"), ("c",)])
+    with pytest.raises(ValueError, match="at least one line"):
+        s.notes([])
+
+
+def test_model_inspection_ignores_tables():
+    # model() is the cheap no-render inspection path — tables are render-time, so declaring one
+    # must not affect the IR model or raise.
+    s = _sheet()
+    s.notes(["x"])
+    m = s.model()
+    assert not any(getattr(f, "kind", None) in ("table", "notes") for f in m.features)

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -104,6 +104,17 @@ def test_auto_name_does_not_collide_with_an_explicit_one():
     assert "table1" in dwg._named and any(n.startswith("table1_") for n in dwg._named)
 
 
+def test_a_dropped_table_frees_its_name():
+    # #493 review r2: a table that doesn't fit is dropped (table_dropped lint) — its name must be
+    # freed, so a later same-named table that DOES fit gets the clean name, not a misleading rename.
+    s = _sheet()
+    s.table([("H",)] + [(str(i),) for i in range(300)], name="rev")  # too tall → dropped
+    s.table([("A",), ("B",)], name="rev")  # small, same name → should get the freed "rev"
+    dwg = s.build()
+    assert "rev" in dwg._named  # the fitting table took the freed name
+    assert any(i.code == "table_dropped" for i in dwg._build_issues)  # the drop is still recorded
+
+
 def test_model_inspection_ignores_tables():
     # model() is the cheap no-render inspection path — tables are render-time, so declaring one
     # must not affect the IR model or raise.

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -76,6 +76,34 @@ def test_validation():
         s.notes([])
 
 
+def test_flat_string_list_is_rejected_with_a_notes_hint():
+    # #493 review: a str row iterates char-by-char into columns — a silent-garbage trap. Since
+    # notes() takes a flat list of strings, table(["REV","DATE","BY"]) is an easy mistake; reject it.
+    s = _sheet()
+    with pytest.raises(ValueError, match="notes"):
+        s.table(["REV", "DATE", "BY"])
+
+
+def test_table_never_overwrites_a_feature_annotation():
+    # #493 review: an explicit name colliding with an existing annotation used to silently delete
+    # it via dwg.add. It must be uniquified (both survive) and warned, never overwrite.
+    s = _sheet()
+    s.table([("R",), ("A",)], name="m_env_width")  # a real feature-annotation name
+    with pytest.warns(UserWarning, match="already taken"):
+        dwg = s.build()
+    assert "m_env_width" in dwg._named  # the original width dimension survives
+    assert any(n.startswith("m_env_width_") for n in dwg._named)  # table placed under a fresh name
+
+
+def test_auto_name_does_not_collide_with_an_explicit_one():
+    # #493 review: the auto name f"table{len}" could equal a user's explicit "table1"; both must survive.
+    s = _sheet()
+    s.table([("x",), ("y",)], name="table1")
+    s.table([("p",), ("q",)])  # auto-names table1 -> collision
+    dwg = s.build()
+    assert "table1" in dwg._named and any(n.startswith("table1_") for n in dwg._named)
+
+
 def test_model_inspection_ignores_tables():
     # model() is the cheap no-render inspection path — tables are render-time, so declaring one
     # must not affect the IR model or raise.


### PR DESCRIPTION
Part of #488 (Gramel trial gaps). Exposes the engine's **existing** generic auto-placed `Drawing.add_table` on the declarative `Sheet` surface — no new layout machinery.

```python
sheet.notes(["BREAK ALL EDGES 0.3", "DEBURR", "M3x0.5 TAP"])          # auto-numbered NOTES block
sheet.table([("REV","DATE","BY"), ("A","2026-07-06","PF")], prefer="br")  # revision / BOM / schedule
```

## What
- `Sheet.table(rows, *, prefer, name, block_cols)` — records a corner-block table; `Sheet.notes(lines, *, title, number)` — single-column sugar (title header + `1  …` numbering).
- Applied **last** at `build()` via `dwg.add_table`, so tables sit clear of the views + title block and are lint-checked (`table_dropped` if no free corner) — exactly like the hole table. **Byte-identical** for sheets with no tables (empty loop).
- Validation: empty/ragged rows + empty notes raise `ValueError`; cells stringified. `model()` (cheap inspection) ignores tables (they're render-time).
- Module docstring refreshed (also corrected a stale line claiming `control(...)` wasn't stubbed).

## Why
A **NOTES block** covers much of the manufacturing intent detection can't infer (the biggest gap from the Gramel trials); revision/BOM/schedule come free. The anchored `.note()` leader (#488.3) is the heavier follow-up.

## Tests
`tests/test_sheet_tables.py` (8): notes/table place lint-clean, auto-number/title, stringify, unique names, chaining, validation, model() ignores tables. 60 Sheet-suite tests green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)