### PR TITLE
feat: honor an intentional explicit scale below the legibility floor (#489)

### DIFF
--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -102,14 +102,17 @@ scale↔footprint loop to iterate — `compose(scale)` fixes the legibility and
 escalation choices for that scale. The scattered estimators (`_est_*_depth`,
 table size, halo) collapse into one composer per view.
 
-**The legibility floor is advisory for an *explicit* scale (#489).** The
-`_MIN_VIEW_MM` (10 mm) floor decides *which annotations exist* at a scale and
-bounds the **auto** search (`choose_scale` won't pick below it). It does **not**
-veto a user-requested scale: a caller who sets an intentional 1:1 (or `scale="1:10"`)
-has accepted the cramping, so an explicit scale below the floor is honoured with a
-legibility *warning*, not a `ValueError`. The only hard rejection is `_MIN_RENDER_MM`
-(0.1 mm) — a true geometry floor below which OCCT's annotation arcs degenerate
-(`Geom_TrimmedCurve U1==U2`); there we raise a clean message rather than crash.
+**The legibility floor is advisory for an *explicit* scale (#489).** `_MIN_VIEW_MM`
+(10 mm) is purely the threshold below which an explicit scale earns a legibility
+*warning*. It does **not** bound the auto scale (`choose_scale` picks by a pure
+geometric page fit) and does **not** gate which annotations exist (step/location
+legibility use `_MIN_STEP_*`/`_MIN_LOC_SEP_MM`). A caller who sets an intentional
+1:1 (or `scale="1:10"`) has accepted the cramping, so an explicit scale below the
+floor is honoured, not vetoed — and the warning fires only when the auto scale
+would *itself* be legible, so its "omit the scale" advice is always real. The one
+hard rejection is `_MIN_RENDER_MM` (0.1 mm) — a conservative geometry floor well
+above where OCCT's annotation arcs actually degenerate (`Geom_TrimmedCurve U1==U2`,
+~1e-4 mm); there we raise a clean message rather than crash.
 
 ### Relationship to ADR 0003 and the deferred 2D solve
 

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -102,6 +102,15 @@ scale↔footprint loop to iterate — `compose(scale)` fixes the legibility and
 escalation choices for that scale. The scattered estimators (`_est_*_depth`,
 table size, halo) collapse into one composer per view.
 
+**The legibility floor is advisory for an *explicit* scale (#489).** The
+`_MIN_VIEW_MM` (10 mm) floor decides *which annotations exist* at a scale and
+bounds the **auto** search (`choose_scale` won't pick below it). It does **not**
+veto a user-requested scale: a caller who sets an intentional 1:1 (or `scale="1:10"`)
+has accepted the cramping, so an explicit scale below the floor is honoured with a
+legibility *warning*, not a `ValueError`. The only hard rejection is `_MIN_RENDER_MM`
+(0.1 mm) — a true geometry floor below which OCCT's annotation arcs degenerate
+(`Geom_TrimmedCurve U1==U2`); there we raise a clean message rather than crash.
+
 ### Relationship to ADR 0003 and the deferred 2D solve
 
 - ADR 0003 governs the **inner** layout (placing a view's own annotations in its

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -255,15 +255,18 @@ _SLOT_DIM_HEIGHT = 2 * _FONT_SIZE + 2 * _PAD  # fv_zones.right: overall height d
 
 
 _MIN_VIEW_MM = (
-    10.0  # min projected view dimension for a *legible* drawing; below it annotations crowd.
-    # This is a legibility floor, not a hard geometry limit: it binds the AUTO scale (choose_scale
-    # won't pick below it), but an explicit user scale is honoured with a warning (#489).
+    10.0  # legibility floor: the projected size below which an *explicit* scale earns a warning.
+    # It is NOT a bound on the auto scale (choose_scale is a pure geometric page fit) and does NOT
+    # gate which annotations exist (step/location legibility use _MIN_STEP_*/_MIN_LOC_SEP_MM). Its
+    # only use is the explicit-scale advisory in analysis.py: below it a user scale is honoured
+    # with a warning, not rejected (#489).
 )
 
 
 # Hard geometry floor: below this projected size OCCT's annotation arcs collapse
-# (Geom_TrimmedCurve U1==U2, ~1e-4 mm empirically). Far below any real drawing; an explicit
-# scale under it is rejected with a clean message rather than a cryptic OCP error (#489).
+# (Geom_TrimmedCurve U1==U2), which happens near 1e-4 mm empirically — 0.1 mm is a conservative
+# floor far above that and far below any real drawing. An explicit scale under it is rejected with
+# a clean message rather than a cryptic OCP error (#489).
 _MIN_RENDER_MM = 0.1
 
 

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -255,8 +255,16 @@ _SLOT_DIM_HEIGHT = 2 * _FONT_SIZE + 2 * _PAD  # fv_zones.right: overall height d
 
 
 _MIN_VIEW_MM = (
-    10.0  # min projected view dimension; below it annotation geometry degenerates (#129)
+    10.0  # min projected view dimension for a *legible* drawing; below it annotations crowd.
+    # This is a legibility floor, not a hard geometry limit: it binds the AUTO scale (choose_scale
+    # won't pick below it), but an explicit user scale is honoured with a warning (#489).
 )
+
+
+# Hard geometry floor: below this projected size OCCT's annotation arcs collapse
+# (Geom_TrimmedCurve U1==U2, ~1e-4 mm empirically). Far below any real drawing; an explicit
+# scale under it is rejected with a clean message rather than a cryptic OCP error (#489).
+_MIN_RENDER_MM = 0.1
 
 
 _SLOT_DIM_STEP = 4 * _FONT_SIZE + _PAD  # fv_zones.right: step-height dimension

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
+import warnings
 
 from build123d import Compound, Shape
 from build123d_drafting.helpers import draft_preset
@@ -22,6 +23,7 @@ from draftwright._core import (
     _DIM_PAD,
     _FONT_SIZE,
     _MARGIN,
+    _MIN_RENDER_MM,
     _MIN_VIEW_MM,
     Analysis,
     _legible_steps,
@@ -341,21 +343,34 @@ def _analyse(
             break
         n_for_sizing = n_next
     if scale is not None:
+        # An explicit scale is the user's call — honour it (#489). Two floors apply:
+        #  - _MIN_RENDER_MM: a hard geometry limit; below it OCCT's annotation arcs degenerate,
+        #    so reject with a clean message (there is no meaningful drawing this small anyway).
+        #  - _MIN_VIEW_MM: a legibility floor; below it annotations crowd but the drawing is
+        #    valid. The user who asked for an intentional 1:1 has accepted that — warn, don't
+        #    raise (only the AUTO scale is bound by legibility; choose_scale won't pick below it).
+        min_dim = min(x_size, y_size, z_size)
+        min_view = min_dim * SCALE
+        if min_view < _MIN_RENDER_MM:
+            safe = _MIN_RENDER_MM / min_dim
+            raise ValueError(
+                f"scale {SCALE!r} projects the smallest part dimension "
+                f"({min_dim:.0f} mm) to {min_view:.3g} mm — the drawing geometry degenerates "
+                f"below {_MIN_RENDER_MM:g} mm (OCCT arc construction fails). "
+                f"Use scale ≥ {safe:.3g} or omit the scale for automatic selection."
+            )
         auto_scale, _, _, _ = choose_scale(
             x_size, y_size, z_size, n_steps=n_for_sizing, scale=None, page=page, strips=strips_i
         )
-        if SCALE < auto_scale:
-            min_dim = min(x_size, y_size, z_size)
-            min_view = min_dim * SCALE
-            if min_view < _MIN_VIEW_MM:
-                safe = _MIN_VIEW_MM / min_dim
-                raise ValueError(
-                    f"scale {SCALE!r} projects the smallest part dimension "
-                    f"({min_dim:.0f} mm) to {min_view:.1f} mm — "
-                    f"annotation geometry degenerates below {_MIN_VIEW_MM:.0f} mm "
-                    f"(OCCT Standard_DomainError / SIGABRT). "
-                    f"Use scale ≥ {safe:.3g} or omit --scale for automatic selection."
-                )
+        if SCALE < auto_scale and min_view < _MIN_VIEW_MM:
+            safe = _MIN_VIEW_MM / min_dim
+            warnings.warn(
+                f"scale {SCALE!r} projects the smallest part dimension ({min_dim:.0f} mm) to "
+                f"{min_view:.1f} mm, below the {_MIN_VIEW_MM:.0f} mm legibility floor — "
+                f"annotations may crowd or overlap. Honouring the requested scale; use "
+                f"scale ≥ {safe:.3g} or omit the scale for an automatic legible fit.",
+                stacklevel=2,
+            )
     DIM_PAD = _DIM_PAD
     margin = _MARGIN
     # Refine: apply the same legibility gate _auto_annotate uses for dim_step.

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -344,11 +344,13 @@ def _analyse(
         n_for_sizing = n_next
     if scale is not None:
         # An explicit scale is the user's call — honour it (#489). Two floors apply:
-        #  - _MIN_RENDER_MM: a hard geometry limit; below it OCCT's annotation arcs degenerate,
-        #    so reject with a clean message (there is no meaningful drawing this small anyway).
+        #  - _MIN_RENDER_MM: a hard geometry limit; below it OCCT's annotation arcs degenerate
+        #    (Geom_TrimmedCurve U1==U2, ~1e-4 mm empirically — 0.1 mm is a conservative floor).
+        #    Reject with a clean message; there is no meaningful drawing this small anyway.
         #  - _MIN_VIEW_MM: a legibility floor; below it annotations crowd but the drawing is
-        #    valid. The user who asked for an intentional 1:1 has accepted that — warn, don't
-        #    raise (only the AUTO scale is bound by legibility; choose_scale won't pick below it).
+        #    valid, so honour the scale with a warning. This floor does NOT bound the auto scale
+        #    (choose_scale is a pure geometric page fit), so a warning is only useful when a
+        #    legible page-fitting scale actually exists — i.e. the auto scale is itself legible.
         min_dim = min(x_size, y_size, z_size)
         min_view = min_dim * SCALE
         if min_view < _MIN_RENDER_MM:
@@ -362,14 +364,19 @@ def _analyse(
         auto_scale, _, _, _ = choose_scale(
             x_size, y_size, z_size, n_steps=n_for_sizing, scale=None, page=page, strips=strips_i
         )
-        if SCALE < auto_scale and min_view < _MIN_VIEW_MM:
+        # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
+        # legible) but the requested scale is below the floor. A part illegible at every
+        # page-fitting scale can't be helped by a bigger one, so nagging there would be false.
+        if min_view < _MIN_VIEW_MM <= auto_scale * min_dim:
             safe = _MIN_VIEW_MM / min_dim
+            # No stacklevel that reaches user code: this fires deep in _analyse, and the public
+            # entry points (make_drawing, Sheet.export, build_drawing) sit at different depths.
+            # The message is self-contained (names the scale, the projection, and the fix).
             warnings.warn(
                 f"scale {SCALE!r} projects the smallest part dimension ({min_dim:.0f} mm) to "
                 f"{min_view:.1f} mm, below the {_MIN_VIEW_MM:.0f} mm legibility floor — "
                 f"annotations may crowd or overlap. Honouring the requested scale; use "
-                f"scale ≥ {safe:.3g} or omit the scale for an automatic legible fit.",
-                stacklevel=2,
+                f"scale ≥ {safe:.3g} or omit the scale for an automatic legible fit."
             )
     DIM_PAD = _DIM_PAD
     margin = _MARGIN

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -323,6 +323,19 @@ class TestScaleMinimum:
         result = make_drawing(part, out=str(tmp_path / "out"))
         assert result is not None
 
+    def test_inherently_subfloor_part_does_not_warn(self, tmp_path):
+        # A huge, thin part is below the legibility floor at EVERY page-fitting scale (even auto),
+        # so a bigger scale can't help — the legibility warning would be false advice. It must stay
+        # silent (like the auto path) and still render. (min_view 0.75 mm is > the 0.1 mm hard floor.)
+        import warnings
+
+        part = Box(3000, 3000, 15)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = make_drawing(part, out=str(tmp_path / "out"), scale=0.05)
+        assert result is not None
+        assert not [w for w in caught if "legibility floor" in str(w.message)]
+
     def test_sheet_explicit_scale_below_floor_is_honoured(self, tmp_path):
         # #489 public surface: Sheet(scale="1:10") on a thin part is below the legibility floor
         # (80 mm × 0.1 = 8 mm) but is the user's intentional choice — warn, render, don't raise.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -276,38 +276,62 @@ class TestIsoEmptyRect:
 
 
 class TestScaleMinimum:
-    """Scale too small → ValueError before OCCT degenerates (#129)."""
+    """An explicit scale below the legibility floor is honoured with a warning (#489);
+    only a genuinely degenerate scale (below the hard geometry floor) raises."""
 
-    def test_tiny_scale_raises(self, tmp_path):
-        # 80 mm thin part at scale=0.1 → 8 mm projection < _MIN_VIEW_MM
+    def test_explicit_illegible_scale_warns_and_renders(self, tmp_path):
+        # 80 mm thin part at scale=0.1 → 8 mm projection < _MIN_VIEW_MM (10) but ≫ the hard
+        # floor. The user asked for it (#489): honour it with a legibility warning, don't raise.
         part = Box(680, 860, 80)
-        with pytest.raises(ValueError, match="annotation geometry degenerates"):
-            make_drawing(part, out=str(tmp_path / "out"), scale=0.1)
+        with pytest.warns(UserWarning, match="legibility floor"):
+            result = make_drawing(part, out=str(tmp_path / "out"), scale=0.1)
+        assert result is not None
 
-    def test_error_message_suggests_safe_scale(self, tmp_path):
-        part = Box(680, 860, 80)
-        with pytest.raises(ValueError) as exc:
-            make_drawing(part, out=str(tmp_path / "out"), scale=0.1)
-        msg = str(exc.value)
-        assert "scale" in msg.lower()
-        # Should mention the minimum safe scale (≥ 10/80 = 0.125)
+    def test_warning_suggests_safe_scale(self, tmp_path):
         import re
 
+        part = Box(680, 860, 80)
+        with pytest.warns(UserWarning) as record:
+            make_drawing(part, out=str(tmp_path / "out"), scale=0.1)
+        msg = str(record[0].message)
+        assert "scale" in msg.lower()
+        # Names the minimum legible scale (≥ 10/80 = 0.125).
         nums = re.findall(r"\d+\.?\d*", msg)
         safe_scales = [float(n) for n in nums if 0.1 < float(n) < 1.0]
         assert any(s >= _MIN_VIEW_MM / 80 for s in safe_scales)
 
-    def test_safe_scale_does_not_raise(self, tmp_path):
-        # 0.2 → 80*0.2 = 16 mm > _MIN_VIEW_MM
+    def test_degenerate_scale_raises(self, tmp_path):
+        # Below the hard geometry floor (80 mm × 0.001 = 0.08 mm < _MIN_RENDER_MM): no meaningful
+        # drawing exists and OCCT arcs would degenerate — raise a clean error, not a cryptic OCP one.
         part = Box(680, 860, 80)
-        result = make_drawing(part, out=str(tmp_path / "out"), scale=0.2)
+        with pytest.raises(ValueError, match="geometry degenerates"):
+            make_drawing(part, out=str(tmp_path / "out"), scale=0.001)
+
+    def test_safe_scale_does_not_warn(self, tmp_path):
+        # 0.2 → 80*0.2 = 16 mm > _MIN_VIEW_MM: legible, no warning.
+        import warnings
+
+        part = Box(680, 860, 80)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any legibility warning would fail here
+            result = make_drawing(part, out=str(tmp_path / "out"), scale=0.2)
         assert result is not None
 
     def test_auto_scale_thin_part_does_not_raise(self, tmp_path):
-        # Auto-selected scale for a thin plate must not trigger the SIGABRT guard.
+        # Auto scale for a thin plate is never bound by the legibility floor (it's the auto path).
         part = Box(80, 50, 8)
         result = make_drawing(part, out=str(tmp_path / "out"))
         assert result is not None
+
+    def test_sheet_explicit_scale_below_floor_is_honoured(self, tmp_path):
+        # #489 public surface: Sheet(scale="1:10") on a thin part is below the legibility floor
+        # (80 mm × 0.1 = 8 mm) but is the user's intentional choice — warn, render, don't raise.
+        from draftwright import Sheet
+
+        with pytest.warns(UserWarning, match="legibility floor"):
+            sheet = Sheet(Box(680, 860, 80), scale="1:10")
+            sheet.export(str(tmp_path / "s"))
+        assert (tmp_path / "s.svg").exists()
 
 
 class TestSectionHatchEdges:


### PR DESCRIPTION
## What

An explicit `scale=` (e.g. `Sheet(scale="1:1")` / `make_drawing(part, scale=1.0)`) below the 10 mm legibility floor is now **honoured with a warning** instead of raising `ValueError`. Fixes #489 (the Gramel shaft, intentionally 1:1, was forced up to ~1.35).

## Why

The `_MIN_VIEW_MM` (10 mm) floor is a **legibility** floor, not a geometry limit. An empirical probe (render a featured thin part at shrinking scales, each in its own subprocess) shows OCCT annotation arcs only degenerate (`Geom_TrimmedCurve U1==U2`) at **~1e-4 mm projected** — six orders of magnitude below 10 mm. So a scale that projects a feature to, say, 8 mm is illegible-cramped but perfectly renderable, and a user who asked for it has accepted that trade-off (ADR 0004: user-fixed scale is honoured).

## Change

- `analysis.py`: the explicit-scale guard's `raise` → `warnings.warn` (names the minimum legible scale). The floor still binds only the **auto** scale (`choose_scale` won't pick below it — unchanged).
- New hard floor `_MIN_RENDER_MM` (0.1 mm, ~1e6× above OCCT's degeneracy, 100× below the legibility floor) still raises a **clean** error below it, rather than a cryptic OCP `ConstructionError`.
- Scoped to the explicit-scale path; the auto path is untouched. Applies to both `make_drawing` and the fluent `Sheet`.
- ADR 0004 updated (legibility floor is advisory for an explicit scale).

## Tests

`TestScaleMinimum` reworked: explicit illegible scale warns + renders; degenerate scale (< 0.1 mm) raises; safe scale is silent; a Sheet-level test locks the public surface. Full regression sweep (`test_make_drawing` + `test_layout_snapshot` + `test_e2e_standards` + `test_sheet_emit`): **563 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)