### PR TITLE
feat: reconciliation lint — flag a declared feature absent from geometry (#487)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1652,8 +1652,10 @@ class Drawing:
             )
             # Reverse direction (#487): a DECLARED feature with no matching geometry (a stale
             # phantom callout). Only for a caller-supplied model — detection can't over-declare.
+            # _part_model is typed `object` (deliberately loose, #397); read features duck-typed.
             if self._model_declared and self._part_model is not None:
-                issues += lint_declaration_reconciliation(self._part_model.features, cyls)
+                features = getattr(self._part_model, "features", ())
+                issues += lint_declaration_reconciliation(features, cyls)
         issues += list(self._build_issues)
         # Attach a ready-to-paste fix snippet where one is computable (#29).
         # str | None — None when no concrete repair can be inferred.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -70,6 +70,7 @@ from draftwright.linting import (
     LintIssue,
     _suggest_fix,
     lint_axial_coverage,
+    lint_declaration_reconciliation,
     lint_drawing,
     lint_feature_coverage,
     lint_location_coverage,
@@ -1649,6 +1650,10 @@ class Drawing:
                 holes=holes,
                 patterns=patterns,
             )
+            # Reverse direction (#487): a DECLARED feature with no matching geometry (a stale
+            # phantom callout). Only for a caller-supplied model — detection can't over-declare.
+            if self._model_declared and self._part_model is not None:
+                issues += lint_declaration_reconciliation(self._part_model.features, cyls)
         issues += list(self._build_issues)
         # Attach a ready-to-paste fix snippet where one is computable (#29).
         # str | None — None when no concrete repair can be inferred.

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from draftwright.linting.coverage import (
     CoverageState,
     lint_axial_coverage,
+    lint_declaration_reconciliation,
     lint_feature_coverage,
     lint_location_coverage,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "LintIssue",
     "_suggest_fix",
     "lint_axial_coverage",
+    "lint_declaration_reconciliation",
     "lint_drawing",
     "lint_feature_coverage",
     "lint_location_coverage",

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -36,6 +36,16 @@ from draftwright.recognition import (
 
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
 
+# Reconciliation tolerances (#487) mirror sheet_dsl._match_object (⌀ ≤ 0.2 mm, in-plane ≤ 0.5 mm):
+# a declared feature matches a recognised cylinder within these. Kept in sync by comment — linting/
+# sits below sheet_dsl in the DAG, so the literals cannot be shared by import.
+_RECON_DIA_TOL = 0.2
+_RECON_POS_TOL = 0.5
+
+# Declared feature kinds with a single defining cylinder to confirm against geometry. Envelope
+# always exists; patterns/slots (multi-member / prismatic) and aspects are out of scope (#488 debt).
+_RECON_KINDS = ("hole", "boss", "step")
+
 
 def _dim_vertices(ann) -> list[tuple[float, float]]:
     """A ``Dimension``'s witness endpoints as ``(x, y)`` page points; ``[]`` if they
@@ -440,3 +450,54 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
             ),
         )
     ]
+
+
+def lint_declaration_reconciliation(features, cyls) -> list:
+    """Flag a *declared* cylindrical feature with no matching geometry in the part (#487).
+
+    On the declarative path (``Sheet`` / ``build_drawing(part, model=…)``) a declaration can go
+    **stale**: the part is edited to remove a hole while the script still declares it, so a callout
+    renders over solid material yet coverage lint (which checks *detected → dimensioned*) stays
+    clean. This is the reverse direction — *declared → exists* — cross-checking each declared
+    feature against recognised geometry.
+
+    Only meaningful for a caller-DECLARED model; the detection path cannot over-declare, so the
+    caller gates on ``_model_declared``. ``features`` is the declared ``PartModel.features``, read
+    duck-typed (``.kind``/``.diameter``/``.frame`` — linting/ must not import ``model``); ``cyls``
+    is the ``(z_cyls, cross_cyls)`` from :func:`analyse_cylinders`. Scope is the cylindrical
+    singletons (hole/boss/step); a declared feature matches a recognised cylinder on same axis,
+    ⌀ within ``_RECON_DIA_TOL`` and in-plane position within ``_RECON_POS_TOL`` — the same test
+    ``sheet_dsl._match_object`` uses. Non-fatal: every issue is a ``warning``.
+    """
+    records = [*cyls[0], *cyls[1]]
+    issues = []
+    for f in features:
+        if getattr(f, "kind", None) not in _RECON_KINDS:
+            continue
+        dia = getattr(f, "diameter", None)
+        frame = getattr(f, "frame", None)
+        if dia is None or frame is None:
+            continue
+        axis = str(frame.axis).lower()
+        origin = frame.origin
+        perp = [k for k in range(3) if k != "xyz".index(axis)]
+        matched = any(
+            str(c["axis"]).lower() == axis
+            and abs(c["diameter"] - dia) <= _RECON_DIA_TOL
+            and all(abs(origin[k] - c["axis_xyz"][k]) <= _RECON_POS_TOL for k in perp)
+            for c in records
+        )
+        if matched:
+            continue
+        issues.append(
+            LintIssue(
+                severity="warning",
+                code="declared_feature_absent",
+                message=(
+                    f"declared {f.kind} ⌀{_fmt(dia)} at "
+                    f"({_fmt(origin[0])}, {_fmt(origin[1])}, {_fmt(origin[2])}) has no matching "
+                    f"{axis}-axis cylinder in the part — stale declaration or the feature was removed"
+                ),
+            )
+        )
+    return issues

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -470,8 +470,10 @@ def lint_declaration_reconciliation(features, cyls) -> list:
     duck-typed (``.kind``/``.diameter``/``.frame`` — linting/ must not import ``model``); ``cyls``
     is the ``(z_cyls, cross_cyls)`` from :func:`analyse_cylinders`. Scope is the cylindrical
     singletons (hole/boss/step); a declared feature matches a recognised cylinder on same axis,
-    ⌀ within ``_RECON_DIA_TOL`` and in-plane position within ``_RECON_POS_TOL`` — the same test
-    ``sheet_dsl._match_object`` uses. Non-fatal: every issue is a ``warning``.
+    ⌀ within ``_RECON_DIA_TOL`` and in-plane position within ``_RECON_POS_TOL`` (the axis + ⌀ +
+    in-plane test ``sheet_dsl._match_object`` uses) **plus** a polarity check (``_RECON_EXTERNAL``)
+    that ``_match_object`` lacks — a hole reconciles against a bore, a boss/step against external
+    material. Non-fatal: every issue is a ``warning``.
     """
     records = [*cyls[0], *cyls[1]]
     issues = []

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -42,9 +42,13 @@ _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=No
 _RECON_DIA_TOL = 0.2
 _RECON_POS_TOL = 0.5
 
-# Declared feature kinds with a single defining cylinder to confirm against geometry. Envelope
-# always exists; patterns/slots (multi-member / prismatic) and aspects are out of scope (#499).
-_RECON_KINDS = ("hole", "boss", "step")
+# Declared feature kinds with a single defining cylinder to confirm against geometry, mapped to the
+# cylinder polarity that confirms them: a hole is a bore (external=False); a boss / turned step is
+# external material (external=True). Checking polarity stops a phantom hole being silenced by a
+# coaxial boss/OD of the same ⌀ (and vice-versa) — a callout over the wrong material (#487 review).
+# Envelope always exists; patterns/slots and aspects are out of scope (#499).
+_RECON_EXTERNAL = {"hole": False, "boss": True, "step": True}
+_RECON_KINDS = tuple(_RECON_EXTERNAL)  # derive to keep the kind list and polarity map in sync
 
 
 def _dim_vertices(ann) -> list[tuple[float, float]]:
@@ -481,8 +485,10 @@ def lint_declaration_reconciliation(features, cyls) -> list:
         axis = str(frame.axis).lower()
         origin = frame.origin
         perp = [k for k in range(3) if k != "xyz".index(axis)]
+        want_external = _RECON_EXTERNAL[f.kind]
         matched = any(
             str(c["axis"]).lower() == axis
+            and bool(c["external"]) == want_external
             and abs(c["diameter"] - dia) <= _RECON_DIA_TOL
             and all(abs(origin[k] - c["axis_xyz"][k]) <= _RECON_POS_TOL for k in perp)
             for c in records

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -43,7 +43,7 @@ _RECON_DIA_TOL = 0.2
 _RECON_POS_TOL = 0.5
 
 # Declared feature kinds with a single defining cylinder to confirm against geometry. Envelope
-# always exists; patterns/slots (multi-member / prismatic) and aspects are out of scope (#488 debt).
+# always exists; patterns/slots (multi-member / prismatic) and aspects are out of scope (#499).
 _RECON_KINDS = ("hole", "boss", "step")
 
 

--- a/tests/test_lint_reconciliation.py
+++ b/tests/test_lint_reconciliation.py
@@ -1,0 +1,110 @@
+"""Declaration-vs-geometry reconciliation lint (#487).
+
+The declarative path (`Sheet` / `build_drawing(part, model=…)`) has one blind spot: a declared
+feature that no longer corresponds to real geometry (the part was edited to remove it) renders a
+callout at empty space while coverage lint — which checks *detected → dimensioned* — stays clean.
+`lint_declaration_reconciliation` closes the reverse direction (*declared → exists*).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting import lint_declaration_reconciliation
+
+
+def _feat(kind, dia, origin, axis="z"):
+    return SimpleNamespace(
+        kind=kind, diameter=dia, frame=SimpleNamespace(origin=origin, axis=axis)
+    )
+
+
+def _cyl(dia, axis_xyz, axis="z"):
+    return {"diameter": dia, "axis": axis, "axis_xyz": axis_xyz}
+
+
+class TestMatcherUnit:
+    """Fast unit tests of the matcher — no OCC build."""
+
+    def test_matching_feature_no_issue(self):
+        feats = [_feat("hole", 8.0, (0, 0, 0))]
+        cyls = ([_cyl(8.0, (0, 0, 5))], [])  # same axis + ⌀, in-plane at origin
+        assert lint_declaration_reconciliation(feats, cyls) == []
+
+    def test_absent_feature_warns(self):
+        feats = [_feat("hole", 8.0, (0, 0, 0))]
+        issues = lint_declaration_reconciliation(feats, ([], []))
+        assert len(issues) == 1
+        assert issues[0].code == "declared_feature_absent"
+        assert issues[0].severity == "warning"
+
+    def test_diameter_out_of_tolerance_warns(self):
+        # ⌀ off by 0.5 mm (> _RECON_DIA_TOL 0.2) → no match → warn
+        feats = [_feat("hole", 8.0, (0, 0, 0))]
+        cyls = ([_cyl(8.5, (0, 0, 0))], [])
+        assert len(lint_declaration_reconciliation(feats, cyls)) == 1
+
+    def test_diameter_within_tolerance_matches(self):
+        feats = [_feat("hole", 8.0, (0, 0, 0))]
+        cyls = ([_cyl(8.15, (0, 0, 0))], [])  # 0.15 <= 0.2
+        assert lint_declaration_reconciliation(feats, cyls) == []
+
+    def test_in_plane_offset_out_of_tolerance_warns(self):
+        # moved 1 mm in-plane (> _RECON_POS_TOL 0.5) → no match → warn (a moved declaration)
+        feats = [_feat("hole", 8.0, (0, 0, 0))]
+        cyls = ([_cyl(8.0, (1.0, 0, 0))], [])
+        assert len(lint_declaration_reconciliation(feats, cyls)) == 1
+
+    def test_axial_position_ignored(self):
+        # in-plane matches; the axis-position component (z) differs — must still match (mirrors
+        # _match_object, which is in-plane only).
+        feats = [_feat("hole", 8.0, (0, 0, 0))]
+        cyls = ([_cyl(8.0, (0, 0, 999))], [])
+        assert lint_declaration_reconciliation(feats, cyls) == []
+
+    def test_different_axis_warns(self):
+        feats = [_feat("hole", 8.0, (0, 0, 0), axis="z")]
+        cyls = ([], [_cyl(8.0, (0, 0, 0), axis="x")])
+        assert len(lint_declaration_reconciliation(feats, cyls)) == 1
+
+    def test_non_cylindrical_kinds_skipped(self):
+        # envelope / pattern / slot / aspects carry no single defining cylinder — never reconciled.
+        feats = [
+            _feat("envelope", None, (0, 0, 0)),
+            _feat("pattern", 8.0, (0, 0, 0)),
+            _feat("slot", None, (0, 0, 0)),
+            _feat("control_frame", None, (0, 0, 0)),
+        ]
+        assert lint_declaration_reconciliation(feats, ([], [])) == []
+
+    def test_boss_and_step_reconciled(self):
+        feats = [_feat("boss", 30.0, (0, 0, 0)), _feat("step", 20.0, (0, 0, 0))]
+        cyls = ([_cyl(30.0, (0, 0, 0))], [])  # boss present, step ⌀20 absent
+        codes = [i.code for i in lint_declaration_reconciliation(feats, cyls)]
+        assert codes == ["declared_feature_absent"]  # only the step is missing
+
+
+class TestEndToEnd:
+    def test_phantom_hole_warns(self):
+        # part is a solid box; the script still declares a hole (its Cylinder is only read for ⌀).
+        s = Sheet(Box(120, 80, 20))
+        s.envelope()
+        s.hole(Pos(0, 0, 0) * Cylinder(4, 20))
+        codes = [i.code for i in s.build().lint()]
+        assert "declared_feature_absent" in codes
+
+    def test_real_hole_clean(self):
+        part = Box(120, 80, 20) - Pos(0, 0, 0) * Cylinder(4, 20)
+        s = Sheet(part)
+        s.envelope()
+        s.hole(Pos(0, 0, 0) * Cylinder(4, 20))
+        codes = [i.code for i in s.build().lint()]
+        assert "declared_feature_absent" not in codes
+
+    def test_detection_path_never_reconciles(self):
+        # No model= → _model_declared is False → the check is a no-op even on a featureless box.
+        dwg = build_drawing(Box(120, 80, 20))
+        assert "declared_feature_absent" not in [i.code for i in dwg.lint()]

--- a/tests/test_lint_reconciliation.py
+++ b/tests/test_lint_reconciliation.py
@@ -22,8 +22,9 @@ def _feat(kind, dia, origin, axis="z"):
     )
 
 
-def _cyl(dia, axis_xyz, axis="z"):
-    return {"diameter": dia, "axis": axis, "axis_xyz": axis_xyz}
+def _cyl(dia, axis_xyz, axis="z", external=False):
+    # external defaults to False (a bore) so a plain hole matches; bosses/steps pass external=True.
+    return {"diameter": dia, "axis": axis, "axis_xyz": axis_xyz, "external": external}
 
 
 class TestMatcherUnit:
@@ -82,9 +83,23 @@ class TestMatcherUnit:
 
     def test_boss_and_step_reconciled(self):
         feats = [_feat("boss", 30.0, (0, 0, 0)), _feat("step", 20.0, (0, 0, 0))]
-        cyls = ([_cyl(30.0, (0, 0, 0))], [])  # boss present, step ⌀20 absent
+        cyls = ([_cyl(30.0, (0, 0, 0), external=True)], [])  # boss present, step ⌀20 absent
         codes = [i.code for i in lint_declaration_reconciliation(feats, cyls)]
         assert codes == ["declared_feature_absent"]  # only the step is missing
+
+    def test_hole_not_matched_by_external_cylinder(self):
+        # #487 review: a phantom bore must NOT be silenced by a coaxial boss/OD of the same ⌀ — the
+        # callout would render over solid material. A hole reconciles only against external=False.
+        feats = [_feat("hole", 20.0, (0, 0, 0))]
+        cyls = ([_cyl(20.0, (0, 0, 0), external=True)], [])  # only an OD/boss of the same ⌀ exists
+        assert len(lint_declaration_reconciliation(feats, cyls)) == 1
+
+    def test_boss_not_matched_by_bore(self):
+        # The mirror: a phantom boss callout over a bore of the same ⌀ must warn — a boss reconciles
+        # only against external=True.
+        feats = [_feat("boss", 30.0, (0, 0, 0))]
+        cyls = ([_cyl(30.0, (0, 0, 0), external=False)], [])  # only an internal bore exists
+        assert len(lint_declaration_reconciliation(feats, cyls)) == 1
 
 
 class TestEndToEnd:
@@ -103,6 +118,16 @@ class TestEndToEnd:
         s.hole(Pos(0, 0, 0) * Cylinder(4, 20))
         codes = [i.code for i in s.build().lint()]
         assert "declared_feature_absent" not in codes
+
+    def test_phantom_hole_over_solid_od_warns(self):
+        # #487 review: a declared bore coincident with the part's external OD (same ⌀ + axis) must
+        # still warn — there is no bore, the callout renders over solid material. Exercises the real
+        # analyse_cylinders external flag end-to-end.
+        part = Cylinder(10, 40)  # solid shaft, OD ⌀20, no bore
+        s = Sheet(part)
+        s.envelope()
+        s.hole(Cylinder(10, 40))  # declares a phantom ⌀20 bore
+        assert "declared_feature_absent" in [i.code for i in s.build().lint()]
 
     def test_detection_path_never_reconciles(self):
         # No model= → _model_declared is False → the check is a no-op even on a featureless box.


### PR DESCRIPTION
## What

Adds `lint_declaration_reconciliation`: on the declarative path (`Sheet` / `build_drawing(part, model=…)`), a declared cylindrical feature (hole/boss/step) with **no matching geometry** in the part now raises a non-fatal `declared_feature_absent` warning through `lint()`. Fixes #487.

## Why

Coverage lint checks *detected → dimensioned* (under-declaration). The blind spot was the reverse: edit the part to **remove** a hole while the script still declares it, and a callout renders over solid material while `lint()` stays clean. This closes *declared → exists* (stale/phantom over-declaration) — the odd one out in the "did my edit break the drawing?" loop.

```python
s = Sheet(Box(120, 80, 20)); s.envelope(); s.hole(Pos(0,0,0) * Cylinder(4, 20))
s.build().lint()   # before: []  —  now: [declared_feature_absent: hole ⌀8 at (0,0,0) …]
```

## How

- New `lint_declaration_reconciliation(features, cyls)` in `linting/coverage.py`. For each declared hole/boss/step it searches the recognised cylinders (`analyse_cylinders` output, reused from the build's single inventory) and matches on **same axis, ⌀ ≤ 0.2 mm, in-plane ≤ 0.5 mm** — the exact test `sheet_dsl._match_object` uses. No match → one `warning`.
- Wired into `Drawing.lint()` gated on `_model_declared and _part_model is not None` (the detection path can't over-declare, so it's a no-op there).
- Reads features **duck-typed** (`.kind`/`.diameter`/`.frame`) — `linting/` sits below `model/` in the DAG, so it must not import IR types.
- Surfaces automatically through `lint()` / `lint_summary()` / the CLI.

## Scope

Cylindrical singletons (hole/boss/step) — the common phantom case. Envelope always exists; **patterns/slots** (multi-member / prismatic) and **GD&T/finish/datum aspects** are out of scope, tracked as follow-up debt (see linked issue). No `Sheet.validate()` helper yet (an optional "consider" in the issue) — the gap is closed via `lint()`.

## Tests

`tests/test_lint_reconciliation.py`: fast matcher units (⌀/in-plane tolerances, axis, axial-position-ignored, kind filtering, boss/step) + end-to-end phantom-warns / real-clean / detection-path-no-op. Regression: `test_linting` + `test_lint_structural` + `test_part_model` + `test_e2e_slice` + `test_object_aspects` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)