### PR TITLE
feat: carry title-block + layout aspects through the Sheet DSL (#474)

### DIFF
--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -168,34 +168,33 @@ def main(
         if style == "sheet":
             from draftwright.sheet_emit import generate_sheet_script, resolve_object_spec
 
-            # The Sheet DSL doesn't yet model the title-block / layout aspects the
-            # imperative script embeds. Warn rather than silently drop them so a
-            # `--script --drawn-by … --scale …` invocation isn't quietly a no-op.
-            ignored = [
-                flag
-                for flag, set_ in (
-                    ("--tolerance", tolerance != "ISO 2768-m"),
-                    ("--drawn-by", bool(drawn_by)),
-                    ("--scale", scale is not None),
-                    ("--page", page is not None),
-                )
-                if set_
-            ]
-            if ignored:
-                typer.echo(
-                    f"warning: {', '.join(ignored)} not supported by --style sheet; ignored "
-                    "(use --style imperative to embed them)",
-                    err=True,
-                )
+            # The Sheet DSL now carries the title-block / layout aspects (#474), so forward all
+            # four flags — the generated script reproduces them on re-run (no more inert warning).
             if _looks_like_object_spec(step_file):
                 # STEP_FILE is a `module:attr` / `file.py:attr` spec → reference a live object
                 obj, seam = resolve_object_spec(step_file)
                 py_path = generate_sheet_script(
-                    obj, out=out, title=title, number=number, part_expr=seam
+                    obj,
+                    out=out,
+                    title=title,
+                    number=number,
+                    tolerance=tolerance,
+                    drawn_by=drawn_by,
+                    scale=scale,
+                    page=page,
+                    part_expr=seam,
                 )
             else:
                 py_path = generate_sheet_script(
-                    step_file, out=out, title=title, number=number, pmi=pmi.value
+                    step_file,
+                    out=out,
+                    title=title,
+                    number=number,
+                    tolerance=tolerance,
+                    drawn_by=drawn_by,
+                    scale=scale,
+                    page=page,
+                    pmi=pmi.value,
                 )
         else:
             if _looks_like_object_spec(step_file):

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -302,7 +302,18 @@ class Sheet:
     features to the engine with detection skipped.
     """
 
-    def __init__(self, part, *, title=None, number="DWG-001", scale=None, page=None, out=None):
+    def __init__(
+        self,
+        part,
+        *,
+        title=None,
+        number="DWG-001",
+        drawn_by=None,
+        tolerance=None,
+        scale=None,
+        page=None,
+        out=None,
+    ):
         self._part = part
         self._features: list = []
         # P2a ± tolerances, keyed by (feature index, ParamKind) so a handle survives a later
@@ -319,6 +330,12 @@ class Sheet:
         self._opts = dict(
             title=title, number=number, scale=_parse_scale(scale), page=page, out=out
         )
+        # drawn_by / tolerance (title block, #474) forward to build_drawing only when set, so an
+        # unset value keeps build_drawing's own defaults ("" / "ISO 2768-m") rather than None.
+        if drawn_by is not None:
+            self._opts["drawn_by"] = drawn_by
+        if tolerance is not None:
+            self._opts["tolerance"] = tolerance
 
     @classmethod
     def from_part(cls, part, **opts) -> Sheet:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -138,12 +138,36 @@ line for a reference — e.g.  sheet.hole(my_bore)  — to read the size off the
 """'''
 
 
-def emit_sheet_script(model, part_expr: str, stem: str, *, title: str, number: str) -> str:
+def emit_sheet_script(
+    model,
+    part_expr: str,
+    stem: str,
+    *,
+    title: str,
+    number: str,
+    drawn_by: str = "",
+    tolerance: str = "ISO 2768-m",
+    scale=None,
+    page=None,
+) -> str:
     """The generated declarative ``Sheet`` script text for a detected *model*.
 
     *part_expr* is the Python that binds ``part`` (a STEP ``import_step`` or a ``part = …``
-    seam); *stem* is the output basename the script exports to."""
+    seam); *stem* is the output basename the script exports to. The title-block / layout aspects
+    (``drawn_by``/``tolerance``/``scale``/``page``, #474) are emitted into the ``Sheet(...)``
+    constructor only when non-default, so a plain drawing keeps a clean one-line constructor."""
     needs_hole = any(f.kind in ("hole", "pattern") for f in model.features)
+    # Only carry an aspect into the emitted constructor when it differs from build_drawing's
+    # default (mirrors the CLI's inert-flag test) — an unset aspect stays off the script.
+    ctor = [f"title={title!r}", f"number={number!r}"]
+    if drawn_by:
+        ctor.append(f"drawn_by={drawn_by!r}")
+    if tolerance != "ISO 2768-m":
+        ctor.append(f"tolerance={tolerance!r}")
+    if scale is not None:
+        ctor.append(f"scale={scale!r}")
+    if page is not None:
+        ctor.append(f"page={page!r}")
     lines = [
         _HEADER,
         "from draftwright import Sheet",
@@ -151,7 +175,7 @@ def emit_sheet_script(model, part_expr: str, stem: str, *, title: str, number: s
         "",
         part_expr,
         "",
-        f"sheet = Sheet(part, title={title!r}, number={number!r})",
+        f"sheet = Sheet(part, {', '.join(ctor)})",
         "",
         "# ── Features (each line is one declared feature) ──────────────────────────────",
         *(_feature_line(f) for f in model.features),
@@ -272,6 +296,10 @@ def generate_sheet_script(
     *,
     title: str | None = None,
     number: str = "DWG-001",
+    tolerance: str = "ISO 2768-m",
+    drawn_by: str = "",
+    scale=None,
+    page=None,
     pmi: str = "off",
     part_expr: str | None = None,
 ) -> str:
@@ -279,8 +307,10 @@ def generate_sheet_script(
     object). Returns the path to the generated ``.py``. The mode-3 declarative counterpart of
     :func:`draftwright.builder.generate_script` (which emits the imperative reconstruction).
 
-    ``pmi`` is threaded to detection so AP242 PMI features surface (flagged inline). *part_expr*,
-    when given, overrides the ``part = …`` seam — e.g. the import seam from
+    ``tolerance``/``drawn_by``/``scale``/``page`` are the title-block / layout aspects (#474):
+    when non-default they are emitted into the generated ``Sheet(...)`` so a re-run reproduces
+    them. ``pmi`` is threaded to detection so AP242 PMI features surface (flagged inline).
+    *part_expr*, when given, overrides the ``part = …`` seam — e.g. the import seam from
     :func:`resolve_object_spec` so the script references a live module (#469)."""
     is_shape = isinstance(step_file, Shape)
     stem = out or ("drawing" if is_shape else Path(step_file).stem)
@@ -300,7 +330,17 @@ def generate_sheet_script(
         part_expr = f"from build123d import import_step\npart = import_step({abspath!r})"
 
     model = detect_part_model(step_file, pmi=pmi)
-    script = emit_sheet_script(model, part_expr, stem, title=title, number=number)
+    script = emit_sheet_script(
+        model,
+        part_expr,
+        stem,
+        title=title,
+        number=number,
+        drawn_by=drawn_by,
+        tolerance=tolerance,
+        scale=scale,
+        page=page,
+    )
     py_path = f"{stem}.py"
     Path(py_path).write_text(script, encoding="utf-8")  # the script has box-drawing / × / ← glyphs
     return py_path

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -57,6 +57,25 @@ class TestEmit:
         assert "sheet.envelope()" in src
         assert src.rstrip().endswith("sheet.export('drawing')")
 
+    def test_title_block_and_layout_aspects_emitted_when_set(self):
+        # #474: non-default drawn_by/tolerance/scale/page ride the Sheet(...) constructor.
+        ctor = next(
+            ln
+            for ln in _script_for(
+                _plate(), drawn_by="PF", tolerance="ISO 2768-f", scale=2.0, page="A3"
+            ).splitlines()
+            if "Sheet(part" in ln
+        )
+        assert "drawn_by='PF'" in ctor
+        assert "tolerance='ISO 2768-f'" in ctor
+        assert "scale=2.0" in ctor
+        assert "page='A3'" in ctor
+
+    def test_default_aspects_stay_off_the_constructor(self):
+        # unset aspects (and tolerance left at the ISO 2768-m default) never appear.
+        ctor = next(ln for ln in _script_for(_plate()).splitlines() if "Sheet(part" in ln)
+        assert ctor == "sheet = Sheet(part, title='T', number='N')"
+
     def test_count_group_hole_carries_its_members(self):
         # a count>1 hole MUST emit members= with every position — without them the render
         # collapses to a single hole at the anchor (fidelity loss). The plate has two ⌀8 holes.
@@ -457,9 +476,9 @@ class TestCli:
         # a bordered line — normalise ANSI + box borders + whitespace before the substring check
         assert "--style sheet" in _norm(r.output)
 
-    def test_sheet_style_warns_on_unsupported_flags(self, tmp_path):
-        # the Sheet DSL can't embed --drawn-by/--tolerance/--scale/--page yet; the default
-        # sheet path must WARN rather than silently drop them (else the flags are a no-op)
+    def test_sheet_style_embeds_title_block_and_layout_flags(self, tmp_path):
+        # #474: the Sheet DSL now carries --drawn-by/--tolerance/--scale/--page, so the sheet path
+        # forwards them into the generated Sheet(...) constructor (no more inert-flag warning).
         from typer.testing import CliRunner
 
         from draftwright.cli import app
@@ -473,18 +492,27 @@ class TestCli:
                 "--script",
                 "--drawn-by",
                 "Paul",
+                "--tolerance",
+                "ISO 2768-f",
                 "--scale",
                 "2",
+                "--page",
+                "A3",
                 "--out",
                 str(tmp_path / "g"),
             ],
         )
         assert r.exit_code == 0, r.output
-        assert "--drawn-by" in r.output and "--scale" in r.output
-        assert "--style imperative" in r.output
+        assert "warning:" not in r.output  # the flags are honoured, not dropped
+        src = (tmp_path / "g.py").read_text(encoding="utf-8")
+        ctor = next(line for line in src.splitlines() if "Sheet(part" in line)
+        assert "drawn_by='Paul'" in ctor
+        assert "tolerance='ISO 2768-f'" in ctor
+        assert "scale=2.0" in ctor
+        assert "page='A3'" in ctor
 
-    def test_sheet_style_silent_when_no_unsupported_flags(self, tmp_path):
-        # no spurious warning when only supported flags are given
+    def test_sheet_style_omits_default_flags(self, tmp_path):
+        # A plain invocation keeps a clean one-line constructor — unset aspects stay off the script.
         from typer.testing import CliRunner
 
         from draftwright.cli import app
@@ -494,6 +522,15 @@ class TestCli:
         r = CliRunner().invoke(app, [str(step), "--script", "--out", str(tmp_path / "g")])
         assert r.exit_code == 0, r.output
         assert "warning:" not in r.output
+        ctor = next(
+            line
+            for line in (tmp_path / "g.py").read_text(encoding="utf-8").splitlines()
+            if "Sheet(part" in line
+        )
+        # only title + number; no title-block / layout aspect kwargs when unset
+        assert "number='DWG-001'" in ctor
+        for kw in ("drawn_by=", "tolerance=", "scale=", "page="):
+            assert kw not in ctor
 
     def test_bad_style_is_rejected(self, tmp_path):
         from typer.testing import CliRunner
@@ -574,6 +611,32 @@ class TestRoundTripParity:
 
     def test_prismatic_plate_parity(self, tmp_path, monkeypatch):
         self._parity(_plate(), tmp_path, monkeypatch)
+
+    def test_title_block_and_layout_aspects_round_trip(self, tmp_path, monkeypatch):
+        # #474: a generated sheet script carrying drawn_by/tolerance/scale/page must reproduce the
+        # same title-block + scale + page as a direct build with the same flags. Compare the
+        # Analysis the drawing was built from (title-block text is path-vectorised, not greppable).
+        from draftwright import Sheet
+
+        flags = dict(drawn_by="PF", tolerance="ISO 2768-f", scale=2.0, page="A3")
+        step = tmp_path / "part.step"
+        export_step(_plate(), str(step))
+
+        direct = build_drawing(step_file=str(step), title="PART", **flags)
+
+        captured = {}
+        monkeypatch.setattr(
+            Sheet, "export", lambda self, stem=None: captured.setdefault("dwg", self.build())
+        )
+        py = generate_sheet_script(str(step), out=str(tmp_path / "gen"), title="PART", **flags)
+        exec(compile(open(py, encoding="utf-8").read(), py, "exec"), {})
+        scripted = captured["dwg"]
+
+        def aspects(dwg):
+            a = dwg._analysis
+            return (a.title, a.tolerance, a.drawn_by, round(a.SCALE, 4), a.PAGE_W, a.PAGE_H)
+
+        assert aspects(scripted) == aspects(direct)
 
     def test_turned_x_shaft_parity(self, tmp_path, monkeypatch):
         # a horizontal turned shaft (X axis) — genuinely rotational: is_rotational + od_axis='x',


### PR DESCRIPTION
## What

`--drawn-by` / `--tolerance` / `--scale` / `--page` were **inert** on the `--script` (sheet) path — `generate_sheet_script` dropped them and the CLI only warned. This threads all four through so a generated sheet script reproduces the title block, scale and page on re-run. Fixes #474.

## Why

The engine (`build_drawing` + the title block) already accepts all four; only the **Sheet facade** and the **emitter** were missing them, so the CLI sheet path warned instead of honoring. This closes the gap (ADR 0011 fidelity: running the generated sheet script == the direct build) so #473 can flip `--script` to default `--style sheet` without silently losing flags.

## Change

- **Sheet facade** (`sheet_dsl.py`): accept `drawn_by` / `tolerance` on construction (`scale` / `page` were already wired); forward to `build_drawing` **only when set**, so an unset value keeps `build_drawing`'s own defaults (`""` / `"ISO 2768-m"`).
- **Emitter** (`sheet_emit.py`): `emit_sheet_script` / `generate_sheet_script` thread all four and write them into the emitted `Sheet(...)` — **only when non-default**, so a plain drawing keeps a clean one-line constructor.
- **CLI** (`cli.py`): forward the four on the sheet path; drop the inert-flag warning.

## Tests

- Emitter unit: non-default aspects ride the constructor; defaults stay off.
- CLI: `--script --drawn-by … --tolerance … --scale … --page …` embeds them in the generated `.py` with no warning; a plain invocation omits them.
- **Round-trip parity**: a generated script carrying the four, exec'd, produces the same `Analysis` (title / tolerance / drawn_by / scale / page) as a direct `build_drawing` with the same flags (title-block text is path-vectorised, so parity is asserted on the Analysis, not SVG text).

Full lint gate (ruff check + format + mypy) and the sheet/object-aspect suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)