### PR TITLE
docs: Sheet DSL emitter cleanup — honest non-declarable comment + blind-pattern test (#475)

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -109,8 +109,10 @@ def _feature_line(f) -> str:
         if f.members:
             parts.append("members=[" + ", ".join(_pt(p) for p in f.members) + "]")
         return f"sheet.pattern({_member_hole_str(f.member)}, " + ", ".join(parts) + ")"
-    # kinds with no declarative verb yet — the auto-pass still dimensions them.
-    return f"# {k} @ {_pt(f.frame.origin)} — auto-dimensioned (no declarative verb yet)"
+    # Kinds with no declarative verb yet: flag inline so they aren't silently lost. The auto-pass
+    # over the declared model still draws them on re-run, but not always faithfully — a turned /
+    # rotational part isn't parity-safe yet (the #472 validity gap), so avoid promising it here.
+    return f"# {k} @ {_pt(f.frame.origin)} — no declarative verb yet; drawn by the auto-pass"
 
 
 def _needs_section(model) -> bool:

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -124,6 +124,17 @@ class TestEmit:
         src = _script_for(self._bolt_circle(cbore=True))
         assert "Section A–A auto-triggers" in src
 
+    def test_blind_pattern_flags_the_auto_section(self):
+        # #475: a BLIND bolt circle also auto-sections (the trigger is `not member.through`, not
+        # just cbore/spotface). The trigger lives on the pattern's member hole, so the generated
+        # comment must fire here too — the companion to the counterbored-pattern case.
+        part = Cylinder(40, 20)  # 20 mm-thick disc
+        for i in range(6):
+            a = i * math.pi / 3
+            # drill from the top face, blind (does not exit the bottom)
+            part -= Pos(25 * math.cos(a), 25 * math.sin(a), 6) * Cylinder(3, 16)
+        assert "Section A–A auto-triggers" in _script_for(part)
+
     def test_plain_pattern_does_not_flag_a_section(self):
         # regression guard: a through-hole bolt circle needs no section — no false-positive comment
         assert "Section A–A auto-triggers" not in _script_for(self._bolt_circle())


### PR DESCRIPTION
## What

Closes the stale-docs / misleading-comment findings of #475.

## Findings & status

Two of the three findings were **already resolved** by later work — verified on current `main`:
- ✅ `sheet_dsl.py` module docstring already lists `.fit` as an implemented aspect (P2a.2); only `.thread` is the un-stubbed verb.
- ✅ `sheet_emit._needs_section()` already checks a pattern's **member** bore (`bore = f.member if f.kind == "pattern" else f`), with a counterbored-pattern test.

Remaining, fixed here:
- **Misleading emitter comment** — the inline comment written for kinds with no declarative verb yet (`step_level`/`rotational`/`pmi`) said *"auto-dimensioned"*, overstating parity. The turned/rotational auto-pass is not parity-safe (the #472 validity gap). Reworded the generated comment to *"drawn by the auto-pass"* (no fidelity promise); the code comment now names #472.
- **Missing blind-pattern test** — the acceptance asks for counterbored **and blind** pattern section behavior. The counterbored case existed; added the blind one (a blind bolt circle auto-sections via `not member.through`, so the `Section A–A` comment must fire).

## Also

Filed **#501** for the `"ISO 2768-m"` default-sentinel duplication (9 spots / 4 files) — a nit from the #500 review, deliberately kept out of this focused PR.

## Tests

`test_sheet_emit.py`: added `test_blind_pattern_flags_the_auto_section`. Full suite (53) + lint gate (ruff check + format + mypy) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)