### PR TITLE
feat: synthesise PMI into a declared model so the declared path reproduces it (#472)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -40,7 +40,15 @@ from draftwright.annotate import _auto_annotate, build_model, build_rotational_f
 from draftwright.annotations.sections import feature_hole_keys
 from draftwright.drawing import Drawing
 from draftwright.fonts import PLEX_MONO
-from draftwright.model import Datum, Feature, PartModel, StepFeature, display, plan_sections
+from draftwright.model import (
+    Datum,
+    Feature,
+    PartModel,
+    StepFeature,
+    build_pmi_features,
+    display,
+    plan_sections,
+)
 from draftwright.projection import (
     _fit_iso_view,
     _project_iso,
@@ -274,6 +282,15 @@ def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=
             rot = build_rotational_feature(a)
             if rot is not None:
                 dwg._part_model = replace(pm, features=[*pm.features, rot])
+        # PMI (STEP AP242) is likewise detection-sourced, so a declared / emitted-script model
+        # carries none. When PMI annotation is on, synthesise the same PmiFeatures detection
+        # would (render_pmi reads them off the model, gated on a.pmi_mode) so a re-run reproduces
+        # the PMI dims (#472). Gated on the caller not having declared PMI, so an explicit set wins.
+        pm = dwg._part_model
+        if a.pmi_mode == "annotate" and not any(f.kind == "pmi" for f in pm.features):
+            pmi_feats = build_pmi_features(a.pmi, a.part.bounding_box())
+            if pmi_feats:
+                dwg._part_model = replace(pm, features=[*pm.features, *pmi_feats])
     dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
 
     part_s = a.part.scale(a.SCALE)

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -33,7 +33,7 @@ from draftwright.model.declare import (
     slot,
     step,
 )
-from draftwright.model.detect import build_part_model
+from draftwright.model.detect import build_part_model, build_pmi_features
 from draftwright.model.ir import (
     BossFeature,
     Datum,
@@ -77,6 +77,7 @@ __all__ = [
     "StepFeature",
     "StepLevelFeature",
     "build_part_model",
+    "build_pmi_features",
     "boss",
     "control_frame",
     "datum",

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -121,6 +121,36 @@ _DIA_TOL = 0.15  # two ø values within this (mm) are the same diameter (#298)
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
 
 
+def build_pmi_features(pmi, bbox) -> list[PmiFeature]:
+    """Re-home extracted STEP AP242 PMI records into IR :class:`PmiFeature`s (#208).
+
+    Shared by :func:`build_part_model` (the detection path) and the declared-model PMI
+    synthesis in ``builder._assemble`` (#472) so both construct features identically — a
+    declared / emitted-script build reproduces the same PMI the auto path draws. ``pmi`` is
+    the list of extracted records (``a.pmi``); ``bbox`` the part bounding box (for the
+    fallback origin when a record carries no ``ref_bbox``). Empty/``None`` ``pmi`` → ``[]``."""
+    out: list[PmiFeature] = []
+    for r in pmi or ():
+        if r.ref_bbox is not None:
+            x0, y0, z0, x1, y1, z1 = r.ref_bbox
+            pmi_origin = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
+        else:
+            pmi_origin = (bbox.center().X, bbox.center().Y, bbox.center().Z)
+        ax = r.dominant_axis.lower() if r.dominant_axis in ("X", "Y", "Z") else "z"
+        out.append(
+            PmiFeature(
+                frame=Frame(origin=pmi_origin, axis=ax),
+                pmi_kind=r.kind,
+                value=r.value,
+                label=r.label,
+                dominant_axis=r.dominant_axis,
+                ref_bbox=r.ref_bbox,
+                ref_pts=tuple(r.ref_pts),
+            )
+        )
+    return out
+
+
 def build_part_model(
     part,
     *,
@@ -281,25 +311,7 @@ def build_part_model(
 
     # Pre-authored PMI annotations (STEP AP242) — re-homed into the IR as features
     # (#208). Rendered directly by render_pmi (the planner adds nothing — see PmiFeature).
-    if pmi:
-        for r in pmi:
-            if r.ref_bbox is not None:
-                x0, y0, z0, x1, y1, z1 = r.ref_bbox
-                pmi_origin = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
-            else:
-                pmi_origin = (bbox.center().X, bbox.center().Y, bbox.center().Z)
-            ax = r.dominant_axis.lower() if r.dominant_axis in ("X", "Y", "Z") else "z"
-            features.append(
-                PmiFeature(
-                    frame=Frame(origin=pmi_origin, axis=ax),
-                    pmi_kind=r.kind,
-                    value=r.value,
-                    label=r.label,
-                    dominant_axis=r.dominant_axis,
-                    ref_bbox=r.ref_bbox,
-                    ref_pts=tuple(r.ref_pts),
-                )
-            )
+    features.extend(build_pmi_features(pmi, bbox))
 
     # The default location datum — the part's min-X/min-Y/min-Z corner (lower-left
     # in the plan view), per inspection practice. Hole location dims measure from

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -157,7 +157,11 @@ def emit_sheet_script(
     *part_expr* is the Python that binds ``part`` (a STEP ``import_step`` or a ``part = …``
     seam); *stem* is the output basename the script exports to. The title-block / layout aspects
     (``drawn_by``/``tolerance``/``scale``/``page``, #474) are emitted into the ``Sheet(...)``
-    constructor only when non-default, so a plain drawing keeps a clean one-line constructor."""
+    constructor only when non-default, so a plain drawing keeps a clean one-line constructor.
+
+    PMI is deliberately NOT emitted here: the seam binds ``part`` via ``import_step``, which
+    strips AP242 PMI, so a re-run cannot re-extract it — the faithful fix bakes PMI as declared
+    features (#503 / #422)."""
     needs_hole = any(f.kind in ("hole", "pattern") for f in model.features)
     # Only carry an aspect into the emitted constructor when it differs from build_drawing's
     # default (mirrors the CLI's inert-flag test) — an unset aspect stays off the script.

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -147,3 +147,43 @@ class TestBuildDrawingPmi:
         """All pmi_ annotation names in the drawing are unique."""
         pmi_names = [n for n in ctc01_annotated._named if n.startswith("pmi_")]
         assert len(pmi_names) == len(set(pmi_names)), f"duplicate pmi names: {pmi_names}"
+
+
+class TestDeclaredModelPmi:
+    """#472: a DECLARED-model build (build_drawing(path, model=…)) skips detection, so it carried
+    no PmiFeatures and dropped PMI even with pmi='annotate'. _assemble now synthesises them from
+    the analysis (the same build_pmi_features detection uses), so PMI reproduces on the declared
+    path. (The emitted Sheet-script round-trip is a separate gap — import_step strips AP242 PMI.)"""
+
+    def test_declared_model_annotate_matches_auto(self, tmp_path):
+        auto = build_drawing(str(CTC01), out=str(tmp_path / "a"), title="P", pmi="annotate")
+        declared = build_drawing(
+            str(CTC01), out=str(tmp_path / "d"), title="P", model=[], pmi="annotate"
+        )
+        n_auto = sum(1 for n in auto._named if n.startswith("pmi_"))
+        n_decl = sum(1 for n in declared._named if n.startswith("pmi_"))
+        assert n_auto >= 1
+        assert n_decl == n_auto  # declared path reproduces the auto PMI dims (was 0 before #472)
+
+    def test_declared_model_pmi_off_stays_clean(self, tmp_path):
+        # the synthesis is gated on pmi_mode == 'annotate' — a declared build without PMI stays 0
+        dwg = build_drawing(str(CTC01), out=str(tmp_path / "off"), title="P", model=[])
+        assert [n for n in dwg._named if n.startswith("pmi_")] == []
+
+
+def test_build_pmi_features_mirrors_detection():
+    """build_pmi_features (shared by build_part_model and the declared-model synthesis) builds one
+    PmiFeature per record; both callers must construct them identically (#472)."""
+    from draftwright.model import build_pmi_features
+
+    recs = extract_pmi(CTC01)
+    dims = [r for r in recs if r.kind not in ("gtol", "datum")]
+    from build123d import import_step
+
+    bbox = import_step(CTC01).bounding_box()
+    feats = build_pmi_features(recs, bbox)
+    assert len(feats) == len(recs)
+    assert all(f.kind == "pmi" for f in feats)
+    # a dim record's value/label ride onto its PmiFeature verbatim
+    assert {f.label for f in feats} >= {r.label for r in dims}
+    assert build_pmi_features(None, bbox) == []  # None/empty → no features


### PR DESCRIPTION
## What

`build_drawing(path, model=…, pmi="annotate")` previously **dropped PMI** — the declared-model path skips detection, so it carried no `PmiFeature`s, while the auto path drew them. This is the PMI analogue of the `RotationalFeature` synthesis that closed turned-shaft parity. Now the declared path reproduces the auto path's PMI dims.

Verified on CTC-01 AP242: auto = **8** PMI dims, declared+annotate = **8** (was 0), pmi-off = **0**.

## How

- Extract the PMI construction from `build_part_model` into a shared `build_pmi_features(pmi, bbox)` helper, so detection and the declared-model synthesis build **identical** `PmiFeature`s (no drift).
- `_assemble`: when `model` is supplied and `a.pmi_mode == "annotate"` (and the caller hasn't declared PMI), synthesise `PmiFeature`s from `a.pmi`. `render_pmi` reads them off the model, so the declared path draws them — gated so an explicit declared PMI wins and pmi-off stays clean.

## Scope — this is the narrow, correct half of #472

The turned/rotational gap #472 was filed for is already closed (verified). This PR closes the **path-input declared** PMI case.

The **emitted Sheet-script round-trip** for PMI is a *separate* gap, filed as **#503**: `import_step()` strips AP242 semantic PMI, so the generated script's `part = import_step(path)` Shape has no PMI to re-extract — the faithful fix bakes PMI as declared features (#422). Documented in the emitter docstring; no misleading `pmi=` is emitted into the script.

## Tests

`test_pmi.py` (gated on `_PMI_AVAILABLE`): `build_pmi_features` unit; declared-model-vs-auto PMI parity; pmi-off stays clean. Full lint gate (ruff + mypy) + `test_part_model` + `test_sheet_emit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)