### PR TITLE
feat: plumb candidate priority through the corridor solve (#357)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -288,6 +288,11 @@ class CorridorCandidate:
             the same physical dimension; the higher-``precedence`` one survives (#345).
         precedence: dedup survivor rank — a hole *location* dim (feeds coverage/table
             escalation) outranks a coincident slot *position* line.
+        priority:   over-capacity survival rank (#357). When a strip cannot hold every
+            candidate, :func:`plan_strip` drops the lowest ``(priority, key)`` — so a higher
+            ``priority`` is kept. An authored GD&T frame sets this above the auto dims so it
+            is not dropped in favour of a lower-value auto dim purely by stacking-key order.
+            Default 0 (every auto dim) → key order, unchanged.
         on_place/on_drop: the pass's own post-placement bookkeeping — coverage
             registration / drop lint + `Escalation`, or a slot's below-side fallthrough.
         force:      policy-B force-keep after the corridor-respecting pass (locations have
@@ -301,6 +306,7 @@ class CorridorCandidate:
     on_drop: object
     dedup: tuple | None = None
     precedence: int = 0
+    priority: float = 0
     force: bool = False
     # The source IR feature this dim was rendered for — recorded as provenance when the
     # dim is placed at drain (ADR 0010). ``None`` leaves the annotation feature-less.
@@ -369,10 +375,20 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
     feats = {c.name: c.feature for c in kept if c.feature is not None}  # provenance (ADR 0010)
     sizes = {c.name: c.size for c in kept if c.size is not None}  # real footprint (#61)
     forbid = {c.name: c.forbid for c in kept if c.forbid is not None}  # title-block box (#481)
+    prio = {c.name: c.priority for c in kept if c.priority}  # over-capacity survival rank (#357)
     left = {
         n
         for n, _ in place_strip_candidates(
-            dwg, strip, view, axis, pairs, tier, features=feats, sizes=sizes, forbid=forbid
+            dwg,
+            strip,
+            view,
+            axis,
+            pairs,
+            tier,
+            features=feats,
+            sizes=sizes,
+            forbid=forbid,
+            priorities=prio,
         )
     }
     force_pairs = [(c.name, c.build) for c in kept if c.name in left and c.force]
@@ -390,6 +406,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
                 features=feats,
                 sizes=sizes,
                 forbid=forbid,
+                priorities=prio,
             )
         }
         if force_pairs
@@ -424,7 +441,18 @@ def drain_corridors(dwg):
 
 
 def place_strip_candidates(
-    dwg, strip, view, axis, cands, tier, *, force=False, features=None, sizes=None, forbid=None
+    dwg,
+    strip,
+    view,
+    axis,
+    cands,
+    tier,
+    *,
+    force=False,
+    features=None,
+    sizes=None,
+    forbid=None,
+    priorities=None,
 ):
     """Collect-then-solve placement of location/feature dims on one strip (ADR 0009).
     The single shared strip placer that retires the ``Strip.allocate`` cursor (#150,
@@ -449,6 +477,11 @@ def place_strip_candidates(
     names use the dimension default ``(tier, tier)``. A wide/tall occupant (a GD&T
     frame, #61) sets it so :func:`plan_strip` enforces its true stacking gap — over
     capacity it is relocated to the next segment or dropped, never overlapped.
+
+    *priorities* maps a candidate's name to its over-capacity survival rank (#357);
+    absent names default to 0. When a segment is over capacity :func:`plan_strip` drops
+    the lowest ``(priority, key)``, so a higher priority is kept — an authored GD&T frame
+    is not dropped for a lower-value auto dim purely by stacking-key order.
 
     ``force=True`` skips that corridor check — the caller's last resort when no view took
     the dim cleanly: keep it on its natural view and accept the (same-feature) leader
@@ -520,6 +553,7 @@ def place_strip_candidates(
                     f"{(k if inner == lo else len(take) - 1 - k):04d}",
                     anch,
                     (sizes or {}).get(nb[0], (tier, tier)),
+                    priority=(priorities or {}).get(nb[0], 0.0),
                 ),
                 nb,
             )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1788,6 +1788,10 @@ _GDT_KINDS = ("control_frame", "datum_ref", "finish", "note")
 # (_SIZE_SUBCHAIN=0) and datum-location (_LOC_SUBCHAIN=1) dim runs, so a frame never lands
 # mid-ladder among the dimensions it annotates.
 _GDT_SUBCHAIN = 2
+# Over-capacity survival rank for an authored GD&T frame (#357): a declared control frame /
+# datum / finish / note is deliberate intent, so on a strip too full for every candidate it is
+# kept over the auto dims (locations/slots, priority 0) rather than dropped by stacking-key order.
+_GDT_CORRIDOR_PRIORITY = 1.0
 # Minimum GD&T leader shaft length (page-mm). A zero-length Leader (site == solved tier)
 # makes OCC's edge builder raise; nudging to this keeps `_build` total (#61 review).
 _MIN_LEADER = 0.05
@@ -1946,6 +1950,7 @@ def render_gdt(dwg, model, a) -> int:
                 on_drop=_drop,
                 dedup=None,
                 precedence=0,
+                priority=_GDT_CORRIDOR_PRIORITY,  # authored intent outranks auto dims (#357)
                 # A declared frame has no alternate view — force-keep (policy B) rather than
                 # drop a user-authored annotation; only a physically full strip drops.
                 force=True,

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -448,6 +448,55 @@ def test_place_strip_candidates_reserves_outermost_label_within_bounds():
     assert len(left) == 1, "the unplaceable candidate must be returned, not dropped silently"
 
 
+def test_place_strip_candidates_priority_survives_key_order():
+    # #357: over-capacity, plan_strip drops the lowest (priority, key). place_strip_candidates
+    # must PLUMB a per-name priority into StripCandidate — otherwise every candidate is priority 0
+    # and the drop is by stacking-key alone. Here the two candidates cannot both fit (tall sizes
+    # force a 40 mm gap into a ~22 mm span). Candidate "a" gets the smaller key (dropped by key
+    # order alone), so a HIGH priority on "a" must flip the outcome: "a" survives, "b" drops.
+    from draftwright._core import Strip
+    from draftwright.annotations._common import place_strip_candidates
+
+    class _Dwg:
+        def __init__(s):
+            s.added = []
+
+        def iter_annotations(s):
+            return list(s.added)
+
+        def view_of(s, n):
+            return "plan"
+
+        def add(s, obj, name, view=None, feature=None):
+            s.added.append((name, obj))
+
+    def _run(priorities):
+        strip = Strip(anchor=0.0, outer_limit=50.0, direction=1.0, gap=8.0, spacing=4.0)
+        dwg = _Dwg()
+        cands = [("a", lambda pos: ("dim", pos)), ("b", lambda pos: ("dim", pos))]
+        sizes = {"a": (6.0, 40.0), "b": (6.0, 40.0)}  # tall → 40 mm stacking gap, only one fits
+        left = place_strip_candidates(
+            dwg,
+            strip,
+            "plan",
+            "y",
+            cands,
+            tier=5.0,
+            force=True,
+            sizes=sizes,
+            priorities=priorities,
+        )
+        placed = {nm for nm, _ in dwg.added}
+        return placed, {nm for nm, _ in left}
+
+    # equal priority → "a" (smaller key) is the victim by key order
+    placed0, left0 = _run({})
+    assert placed0 == {"b"} and left0 == {"a"}
+    # priority on "a" flips it: the important candidate is kept, "b" drops
+    placed1, left1 = _run({"a": 5.0})
+    assert placed1 == {"a"} and left1 == {"b"}
+
+
 def test_place_strip_candidates_ignores_perpendicular_disjoint_obstacle():
     # A right strip stacks along X; the carve projects obstacles onto X. An obstacle that
     # overlaps in X (even after pad inflation) but is DISJOINT in Y — a dim on ANOTHER


### PR DESCRIPTION
## What

The ADR 0009 unified strip solve (`register_corridor` → `solve_corridor` → `place_strip_candidates`) never set a candidate **priority**, so every corridor candidate was priority 0 and `plan_strip`'s over-capacity drop fell back to stacking-**key** order. An authored GD&T frame could therefore be dropped for a lower-value auto dim purely by name. This plumbs a real priority through. Fixes #357 — the **#477 enabler**.

## Context (verified)

- `plan_strip` already selects the victim by priority: `min(keep, key=lambda c: (c.priority, c.key))` (layout.py:502).
- The hole-callout column pass already feeds real priorities (bore ø, holes.py).
- The **only** gap was the corridor path: `CorridorCandidate` had no `priority`, and `place_strip_candidates` built `StripCandidate(...)` leaving it at the default 0.

## Change

- Add `priority: float = 0` to `CorridorCandidate`.
- Thread it: `solve_corridor` builds a `{name: priority}` map → new `priorities=` kwarg on `place_strip_candidates` → `StripCandidate(priority=…)`.
- `render_gdt` registers its frames with `_GDT_CORRIDOR_PRIORITY` (above the auto dims). Locations/slots stay at 0, so their relative order — and existing snapshots — are undisturbed. Finer location-vs-slot ranking is a natural follow-up.

## Tests

`test_place_strip_candidates_priority_survives_key_order`: over-capacity, the candidate with the smaller key (dropped by key order alone) is given a high priority and now survives while the other drops — proving the plumbing reaches `plan_strip`. Full fast tier green (**1111 passed**); the layout/GD&T/strip suites (127) unchanged.

Part of #477 (ADR 0009 unification). Next: #374 (Bucket C → carve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)