### PR TITLE
feat: place pitch dims onto per-side zone strips via the carve (#374 part 2)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -883,30 +883,36 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
     # axis-aligned side maps to a populated strip; a diagonal side, the side view's absent left
     # strip, or a genuinely full strip fall through to the bounded vector placement below
     # (behaviour unchanged for those residual cases).
+    # Only a GENUINELY axis-aligned row uses the strip carve: its dim is a clean horizontal /
+    # vertical line occupying one strip tier, and the coord bridge is exact. `_dim` places the
+    # line at `mid + side*distance`, so the witness is the MIDPOINT component on the strip axis and
+    # `sgn` the exact outward sign (±1); `distance = sgn*(pos - mid[axis])` then lands the line at
+    # the carved `pos`. The tight threshold (≈1.6°) keeps a tilted row off this path — its dim
+    # isn't axis-aligned, so it can't cleanly occupy a tier — routing it to the vector fallback.
     zones = {"plan": a.pv_zones, "front": a.fv_zones, "side": a.sv_zones}[view]
     sx, sy = side[0], side[1]
     strip = axis = perp = None
     witness = sgn = 0.0
-    if abs(sx) > 0.99:  # horizontal side ⟂ a vertical row → left/right strip, stacks along x
+    if abs(sx) > 0.9996:  # horizontal side ⟂ a vertical row → left/right strip, stacks along x
         strip, axis, perp, witness, sgn = (
             (zones.right if sx > 0 else zones.left),
             "x",
             tuple(sorted((p1[1], p2[1]))),
-            p1[0],
-            sx,
+            mid[0],
+            math.copysign(1.0, sx),
         )
-    elif abs(sy) > 0.99:  # vertical side ⟂ a horizontal row → above/below strip, stacks along y
+    elif abs(sy) > 0.9996:  # vertical side ⟂ a horizontal row → above/below strip, stacks along y
         strip, axis, perp, witness, sgn = (
             (zones.above if sy > 0 else zones.below),
             "y",
             tuple(sorted((p1[0], p2[0]))),
-            p1[1],
-            sy,
+            mid[1],
+            math.copysign(1.0, sy),
         )
     if strip is not None:
         tier = max(10.0, dwg.draft.font_size * 3.0)
         pos = carve_free_position(dwg, strip, view, axis, tier, perp)
-        if pos is not None:  # sgn ∈ {+1,-1} makes the outward distance positive
+        if pos is not None:
             _place(sgn * (pos - witness))
             return
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -861,32 +861,65 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
     else:
         pref = (-0.3, 1.0) if view == "plan" else (-0.3, -1.0)
         side, reach = max(cands, key=lambda c: c[0][0] * pref[0] + c[0][1] * pref[1])
-    # stack further pitch dims in this view on outer tiers
+
+    def _place(off):
+        dwg.add(
+            _dim(
+                (p1[0], p1[1], 0),
+                (p2[0], p2[1], 0),
+                side,
+                off,
+                dwg.draft,
+                label=f"{n - 1}× {_fmt(pitch)}",
+            ),
+            name,
+            view=view,
+            feature=feature,
+        )
+
+    # Place onto the zone strip for the chosen side (#374): each side is its own strip, so the
+    # obstacle-aware carve stacks this dim clear of placed content — where an arbitrary-direction
+    # 1-D search would be defeated by a dim on a *different* side (rotated/two-axis grids). An
+    # axis-aligned side maps to a populated strip; a diagonal side, the side view's absent left
+    # strip, or a genuinely full strip fall through to the bounded vector placement below
+    # (behaviour unchanged for those residual cases).
+    zones = {"plan": a.pv_zones, "front": a.fv_zones, "side": a.sv_zones}[view]
+    sx, sy = side[0], side[1]
+    strip = axis = perp = None
+    witness = sgn = 0.0
+    if abs(sx) > 0.99:  # horizontal side ⟂ a vertical row → left/right strip, stacks along x
+        strip, axis, perp, witness, sgn = (
+            (zones.right if sx > 0 else zones.left),
+            "x",
+            tuple(sorted((p1[1], p2[1]))),
+            p1[0],
+            sx,
+        )
+    elif abs(sy) > 0.99:  # vertical side ⟂ a horizontal row → above/below strip, stacks along y
+        strip, axis, perp, witness, sgn = (
+            (zones.above if sy > 0 else zones.below),
+            "y",
+            tuple(sorted((p1[0], p2[0]))),
+            p1[1],
+            sy,
+        )
+    if strip is not None:
+        tier = max(10.0, dwg.draft.font_size * 3.0)
+        pos = carve_free_position(dwg, strip, view, axis, tier, perp)
+        if pos is not None:  # sgn ∈ {+1,-1} makes the outward distance positive
+            _place(sgn * (pos - witness))
+            return
+
+    # Fallback: diagonal side / absent strip / full strip → the pre-#374 bounded vector placement,
+    # count-stacked and margin-guarded, so those residual cases are byte-identical to before.
     prior = sum(1 for nm, _ in dwg.iter_annotations() if nm.startswith(f"dim_pitch_{view}"))
     offset = reach + 8 + 10 * prior
-    # never force-place: skip (and log) when the dim line would leave the page
     ox = mid[0] + side[0] * (offset + 6)
     oy = mid[1] + side[1] * (offset + 6)
     if not (a.margin <= ox <= a.PAGE_W - a.margin and a.margin <= oy <= a.PAGE_H - a.margin):
-        _log.info(
-            "Pitch dimension for the %s× %s array skipped (no room)",
-            n,
-            _fmt(pitch),
-        )
+        _log.info("Pitch dimension for the %s× %s array skipped (no room)", n, _fmt(pitch))
         return
-    dwg.add(
-        _dim(
-            (p1[0], p1[1], 0),
-            (p2[0], p2[1], 0),
-            side,
-            offset,
-            dwg.draft,
-            label=f"{n - 1}× {_fmt(pitch)}",
-        ),
-        name,
-        view=view,
-        feature=feature,
-    )
+    _place(offset)
 
 
 def build_view_of_axis(a: Analysis):

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -143,6 +143,24 @@ def test_rotational_bore_leader_overflow_excluded_from_coverage():
     assert kept and max(dropped) < min(kept), "the ranking should drop the smallest bores first"
 
 
+def test_linear_array_pitch_dim_placed_via_side_strip_clean():
+    # #374 part 2: an axis-aligned linear-array pitch dim is placed onto its side's zone strip via
+    # the obstacle-aware carve (not the old count-based `10*prior` stack). Assert it is present,
+    # on-page, and overlaps nothing (no annotation_overlap lint) — the carve's job.
+    from build123d import Box, Cylinder, Pos
+
+    part = Box(120, 40, 10)
+    for x in (-45, -15, 15, 45):  # a 4-hole row along X → one "3× 30" pitch dim
+        part -= Pos(x, 0, 0) * Cylinder(3, 10)
+    dwg = build_drawing(part)
+    pitch = [o for n, o in dwg.iter_annotations() if n.startswith("dim_pitch")]
+    assert len(pitch) == 1, "the linear array should get exactly one pitch dim"
+    b = pitch[0].bounding_box()
+    a = dwg._analysis
+    assert -1 <= b.min.X and b.max.X <= a.PAGE_W + 1 and -1 <= b.min.Y and b.max.Y <= a.PAGE_H + 1
+    assert not any(i.code == "annotation_overlap" for i in dwg.lint())
+
+
 def test_strip_obstacles_view_filter_drops_other_ortho_views():
     # A box with a side-drilled hole: the side query excludes front/plan-owned
     # blocks (compose-then-pack keeps them disjoint) but is narrower than the whole.


### PR DESCRIPTION
## What

`_place_pitch_dim` (linear-array + grid pitch dims) stacked at a blind `offset = reach + 8 + 10*prior` — a fragile name-prefix count with no obstacle-awareness (the Bucket-C defect shape, #374). This migrates it onto the obstacle-aware carve, **per side**. Completes #374 (part 1, bore leaders, was #506).

## The design (and why the 1-D approach failed first)

An earlier attempt used a 1-D obstacle-aware search along the pitch dim's arbitrary `side` vector. It couldn't work: a pitch dim on one side (a grid's row-pitch, *above*) is blocked by a dim on a *different* side (its column-pitch, *left*), and stepping outward along one side never escapes the other. Three iterations each traded drop ↔ overlap (documented on #374).

The fix: keep `side`/`reach` unchanged, and map the chosen `side` to the view's **zone strip** for that side, then `carve_free_position` on *that* strip:

| `side` | strip | axis | perp span | offset |
|---|---|---|---|---|
| up | `.above` | y | x-span | `pos − p1.y` |
| down | `.below` | y | x-span | `p1.y − pos` |
| right | `.right` | x | y-span | `pos − p1.x` |
| left | `.left` | x | y-span | `p1.x − pos` |

Each side is an independent strip with perpendicular-band filtering, so cross-side blocking is gone. Same infra `render_locations` / `render_height_ladder` use.

## Residual cases fall back (cannot regress)

A genuinely **diagonal** `side` (rotated/two-axis grid, no axis-aligned zone), the **side view's absent left strip** (`sv_zones.left is None`), or a **full strip** fall through to the exact pre-#374 bounded vector placement — byte-identical for those.

## Tests

All three fixtures that defeated the 1-D attempts now pass (`test_rect_grid_pitch_dims_not_diagonal_when_rotated` via the diagonal fallback; `test_perimeter_rows…` and `TestEscalation::test_dense_part_groups_and_types` via the carve). New `test_linear_array_pitch_dim_placed_via_side_strip_clean`. **Full fast tier green (1114) with no snapshot changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)