### PR TITLE
docs: clarify place_dim is an incremental edit, not a corridor re-solve (#396)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -570,10 +570,17 @@ class Drawing:
                 :meth:`drop` / :meth:`annotations_of` can find it (#398).
             **kwargs: forwarded to ``Dimension`` (e.g. ``label=``, ``tolerance=``).
 
-        Uses the single-position strip carve, not the ADR-0009 collect-then-solve
-        path the automatic placers use — fine for adding a dimension into free
-        space, but it does not re-solve the strip or dedup against existing dims
-        (#396). Prefer :meth:`dimension` for a feature-referenced edit.
+        Uses the single-position strip carve (obstacle-aware: it clears every
+        placed annotation), **not** the ADR-0009 collect-then-solve path the
+        automatic placers use — **by design** (#396). ``place_dim`` is an
+        *incremental edit* run after the build's corridor is already committed, so
+        it deliberately does not re-solve the strip: a full solve would reorder or
+        dedup **already-placed** dims (surprising for a deliberate edit). It
+        therefore has no cross-pass priority selection, crossing-free re-ordering,
+        or dedup against a coincident auto dim — those are properties of the batch
+        build, recovered by a *recompose* (:func:`finalize_drawing`, when
+        available) or a rebuild, not of a single incremental placement. Prefer
+        :meth:`dimension` for a feature-referenced edit.
 
         Falls back to a fixed ``slot`` offset when the strip is full or when no
         layout analysis is available (e.g. when ``auto_dims=False`` was not used


### PR DESCRIPTION
## What

Resolves #396 per **the issue's own recommendation (Option 1)**: document that `Drawing.place_dim()` is a single-slot *incremental* placement, not the ADR-0009 collect-then-solve batch — rather than force the re-solve (Option 2).

## Why Option 1 is the correct engineering (not a shortcut)

`place_dim()` runs **after** the build's corridor batch is already committed. The three properties #396 lists — priority selection, crossing-free re-ordering, dedup against a coincident auto dim — are **batch-build** properties. Recovering them post-build would mean **re-solving the strip and moving already-placed dims**, which is:
- surprising for a deliberate incremental edit, and
- properly the job of a **recompose** (`finalize_drawing` / rebuild), not a single placement.

The issue author flagged exactly this ("re-solves a strip already committed at build time — real work, interacts with finalize_drawing's repack") and recommended Option 1. `place_dim` is already **obstacle-aware** (the carve clears every placed annotation), so it has no invisible-occupant collision class — it shares no strip with a *concurrent* build pass, so it is **not** an ADR 0009 co-solve gap (#477).

## Change

Docstring only: state the single-carve is **by design**, enumerate the three properties it lacks and where they come from (the recompose), and point at `finalize_drawing` (when available) like `drop()` does. README already says "auto-placed" (accurate) — unchanged.

Docs-only; existing `place_dim` tests unchanged.

Closes #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)