### PR TITLE
[codex] Consolidate solver placement paths

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import math
 import warnings
+from collections.abc import Callable
 
 from build123d import Compound, Shape
 from build123d_drafting.helpers import draft_preset
@@ -40,6 +41,7 @@ from draftwright.recognition import (
     full_cylinders,
 )
 from draftwright.sheet import (
+    StripDepths,
     _build_zones,
     _layout_geometry,
     _measure_strips,
@@ -54,6 +56,7 @@ _log = logging.getLogger(__name__)
 _SQUARENESS_TOL = 0.05
 _OD_FILL_MIN = 0.8
 _OD_AXIS_TOL = 0.05
+_ScalePick = tuple[float, float, float, float]
 
 
 def _import_step(path) -> Compound:
@@ -104,6 +107,54 @@ def _is_rotational(x_size, y_size, od_diam, od_axis_offset) -> bool:
         and od_diam >= _OD_FILL_MIN * envelope
         and od_axis_offset <= _OD_AXIS_TOL * envelope
     )
+
+
+def _converge_step_sizing(
+    initial_steps: int,
+    measure_strips: Callable[[int], StripDepths],
+    pick_scale: Callable[[int, StripDepths], _ScalePick],
+    count_legible: Callable[[float], int],
+) -> tuple[_ScalePick, StripDepths, int]:
+    """Choose scale/page with a step-corridor count that matches legibility.
+
+    The right-side step ladder is reserved before the scale is known, but the
+    actual step list is filtered by the chosen scale. Iterate that dependency
+    until it reaches a fixed point; if it cycles, reserve the largest count seen
+    so the sheet is sized conservatively instead of silently accepting whichever
+    value happened to appear on a fixed iteration budget (#520).
+    """
+    n_for_sizing = initial_steps
+    seen: set[int] = set()
+    attempted: list[int] = []
+    max_iter = max(4, initial_steps + 2)
+
+    for _ in range(max_iter):
+        if n_for_sizing in seen:
+            break
+        seen.add(n_for_sizing)
+        attempted.append(n_for_sizing)
+
+        strips = measure_strips(n_for_sizing)
+        scale_pick = pick_scale(n_for_sizing, strips)
+        n_next = count_legible(scale_pick[0])
+        if n_next == n_for_sizing:
+            return scale_pick, strips, n_for_sizing
+        if n_next in seen:
+            n_for_sizing = n_next
+            break
+        n_for_sizing = n_next
+
+    conservative_n = max(attempted + [n_for_sizing], default=initial_steps)
+    strips = measure_strips(conservative_n)
+    scale_pick = pick_scale(conservative_n, strips)
+    _log.warning(
+        "Step-corridor sizing did not converge from %d steps (tried %s); "
+        "reserving %d steps",
+        initial_steps,
+        attempted,
+        conservative_n,
+    )
+    return scale_pick, strips, conservative_n
 
 
 # A hole is "concentric" with a turned part's rotation axis when its drilling
@@ -324,24 +375,33 @@ def _analyse(
     # with 15 tiny treads) reserves a phantom step ladder that blocks a larger
     # scale. Seed conservatively (all faces), then re-gate at the chosen scale;
     # converges in a couple of rounds.
-    n_for_sizing = len(step_zs)
-    strips_i = None
-    for _ in range(3):
-        strips_i = _measure_strips(
+    def _measure_for_step_count(n_steps_i: int) -> StripDepths:
+        return _measure_strips(
             holes,
             patterns,
-            n_for_sizing,
+            n_steps_i,
             bb,
             arrow_length=_arrow_length,
             pad_around_text=_pad_around_text,
         )
-        SCALE, PAGE_W, PAGE_H, TB_W = choose_scale(
-            x_size, y_size, z_size, n_steps=n_for_sizing, scale=scale, page=page, strips=strips_i
+
+    def _pick_for_step_count(n_steps_i: int, strips_i: StripDepths) -> _ScalePick:
+        return choose_scale(
+            x_size,
+            y_size,
+            z_size,
+            n_steps=n_steps_i,
+            scale=scale,
+            page=page,
+            strips=strips_i,
         )
-        n_next = len(_legible_steps(step_zs, bb.min.Z, SCALE)[0])
-        if n_next == n_for_sizing:
-            break
-        n_for_sizing = n_next
+
+    (SCALE, PAGE_W, PAGE_H, TB_W), strips_i, n_for_sizing = _converge_step_sizing(
+        len(step_zs),
+        _measure_for_step_count,
+        _pick_for_step_count,
+        lambda scale_i: len(_legible_steps(step_zs, bb.min.Z, scale_i)[0]),
+    )
     if scale is not None:
         # An explicit scale is the user's call — honour it (#489). Two floors apply:
         #  - _MIN_RENDER_MM: a hard geometry limit; below it OCCT's annotation arcs degenerate

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -148,8 +148,7 @@ def _converge_step_sizing(
     strips = measure_strips(conservative_n)
     scale_pick = pick_scale(conservative_n, strips)
     _log.warning(
-        "Step-corridor sizing did not converge from %d steps (tried %s); "
-        "reserving %d steps",
+        "Step-corridor sizing did not converge from %d steps (tried %s); reserving %d steps",
         initial_steps,
         attempted,
         conservative_n,

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -537,30 +537,30 @@ def place_strip_candidates(
     # Fill innermost-first (nearest the view), matching the old cursor's stack order.
     segs.sort(key=lambda s: abs((s[0] if inner == lo else s[1]) - inner))
     todo = list(cands)
-    for seg_lo, seg_hi in segs:
-        if not todo:
-            break
-        cap = int((seg_hi - seg_lo) / pad) + 1
-        if len(todo) > cap:
-            # Do not let segment-cap slicing preempt the ranked selection step (#357/#393).
-            # `plan_strip` drops the lowest (priority, generated-key), but a narrow segment
-            # can only see the candidates we hand it. Preselect the highest-priority members
-            # for this segment, preserving their original order for crossing-free placement;
-            # ties mirror the generated key below (inner=lo keeps later candidates, inner=hi
-            # keeps earlier candidates).
-            ranked = sorted(
-                enumerate(todo),
-                key=lambda item: (
-                    (priorities or {}).get(item[1][0], 0.0),
-                    item[0] if inner == lo else -item[0],
-                ),
-                reverse=True,
-            )
-            chosen = {i for i, _ in ranked[:cap]}
-            take = [nb for i, nb in enumerate(todo) if i in chosen]
-            todo = [nb for i, nb in enumerate(todo) if i not in chosen]
-        else:
-            take, todo = todo, []
+
+    def _take_for_segment(items, n):
+        if len(items) <= n:
+            return items, []
+        # Do not let segment-cap slicing preempt the ranked selection step (#357/#393).
+        # `plan_strip` drops the lowest (priority, generated-key), but a narrow segment
+        # can only see the candidates we hand it. Preselect the highest-priority members
+        # for this segment, preserving their original order for crossing-free placement;
+        # ties mirror the generated key below (inner=lo keeps later candidates, inner=hi
+        # keeps earlier candidates).
+        ranked = sorted(
+            enumerate(items),
+            key=lambda item: (
+                (priorities or {}).get(item[1][0], 0.0),
+                item[0] if inner == lo else -item[0],
+            ),
+            reverse=True,
+        )
+        chosen = {i for i, _ in ranked[:n]}
+        take = [nb for i, nb in enumerate(items) if i in chosen]
+        rest = [nb for i, nb in enumerate(items) if i not in chosen]
+        return take, rest
+
+    def _evaluate_segment(take, seg_lo, seg_hi):
         nat = seg_lo if inner == lo else seg_hi
         anch = (0.0, nat) if axis == "y" else (nat, 0.0)
         # Keys order the tiers so the FIRST candidate lands on the inner tier: for an
@@ -579,14 +579,16 @@ def place_strip_candidates(
             for k, nb in enumerate(take)
         ]
         res = plan_strip([sc for sc, _ in triples], seg_lo, seg_hi, pad, axis=axis)
+        accepted = []
+        rejected = []
         for sc, (name, build) in triples:
             pos = res.placed.get(sc.key)
             if pos is None:  # segment over its estimated capacity (shouldn't occur)
-                todo.append((name, build))
+                rejected.append((name, build))
                 continue
             dim = build(pos)
             if not force and _box_hits(_geom_box(dim), blockers):  # corridor crosses a leader
-                todo.append((name, build))
+                rejected.append((name, build))
                 continue
             # A forbidden box (the title block, #481) is rejected even under force — it is
             # placed after the drain, so the strip carve can't see it; a force-kept GD&T frame
@@ -594,8 +596,27 @@ def place_strip_candidates(
             # so dims are byte-identical). Returned unplaced → the caller's on_drop fallthrough.
             fb = (forbid or {}).get(name)
             if fb is not None and _box_hits(_geom_box(dim), (fb,)):
-                todo.append((name, build))
+                rejected.append((name, build))
                 continue
+            accepted.append(((name, build), dim))
+        return accepted, rejected
+
+    for seg_lo, seg_hi in segs:
+        if not todo:
+            break
+        cap = int((seg_hi - seg_lo) / pad) + 1
+        take, todo = _take_for_segment(todo, cap)
+        rejected_total = []
+        while take:
+            accepted, rejected = _evaluate_segment(take, seg_lo, seg_hi)
+            rejected_total.extend(rejected)
+            vacancies = cap - len(accepted)
+            if vacancies <= 0 or not todo:
+                break
+            fill, todo = _take_for_segment(todo, vacancies)
+            take = [nb for nb, _dim in accepted] + fill
+        todo = todo + rejected_total
+        for (name, _build), dim in accepted:
             # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
             # dims — `features` maps this batch's names to their source IR feature.
             dwg.add(dim, name, view=view, feature=(features or {}).get(name))

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -541,7 +541,26 @@ def place_strip_candidates(
         if not todo:
             break
         cap = int((seg_hi - seg_lo) / pad) + 1
-        take, todo = todo[:cap], todo[cap:]
+        if len(todo) > cap:
+            # Do not let segment-cap slicing preempt the ranked selection step (#357/#393).
+            # `plan_strip` drops the lowest (priority, generated-key), but a narrow segment
+            # can only see the candidates we hand it. Preselect the highest-priority members
+            # for this segment, preserving their original order for crossing-free placement;
+            # ties mirror the generated key below (inner=lo keeps later candidates, inner=hi
+            # keeps earlier candidates).
+            ranked = sorted(
+                enumerate(todo),
+                key=lambda item: (
+                    (priorities or {}).get(item[1][0], 0.0),
+                    item[0] if inner == lo else -item[0],
+                ),
+                reverse=True,
+            )
+            chosen = {i for i, _ in ranked[:cap]}
+            take = [nb for i, nb in enumerate(todo) if i in chosen]
+            todo = [nb for i, nb in enumerate(todo) if i not in chosen]
+        else:
+            take, todo = todo, []
         nat = seg_lo if inner == lo else seg_hi
         anch = (0.0, nat) if axis == "y" else (nat, 0.0)
         # Keys order the tiers so the FIRST candidate lands on the inner tier: for an

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1790,12 +1790,8 @@ def render_pmi(dwg, model, a) -> int:
                     p2 = (FX(cx_f + half), FZ(cz_f), 0)
                     placed = _queue_options(
                         [
-                            _dim_spec(
-                                p1, p2, a.fv_zones.above, label, name_d, "front", "above"
-                            ),
-                            _dim_spec(
-                                p1, p2, a.fv_zones.below, label, name_d, "front", "below"
-                            ),
+                            _dim_spec(p1, p2, a.fv_zones.above, label, name_d, "front", "above"),
+                            _dim_spec(p1, p2, a.fv_zones.below, label, name_d, "front", "below"),
                         ],
                         ax,
                         label,
@@ -1883,12 +1879,8 @@ def render_pmi(dwg, model, a) -> int:
                 if avg_sz >= a.SV_Y:
                     placed = _queue_options(
                         [
-                            _dim_spec(
-                                p1, p2, a.sv_zones.above, label, name_y, "side", "above"
-                            ),
-                            _dim_spec(
-                                p1, p2, a.sv_zones.below, label, name_y, "side", "below"
-                            ),
+                            _dim_spec(p1, p2, a.sv_zones.above, label, name_y, "side", "above"),
+                            _dim_spec(p1, p2, a.sv_zones.below, label, name_y, "side", "below"),
                         ],
                         ax,
                         label,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1440,14 +1440,21 @@ def _bore_half_span(pmi_kind: str, value: float) -> float:
     return value / 2 if pmi_kind == "diameter" else value
 
 
+# PMI is pre-authored manufacturing intent from the STEP file. When a strip is over
+# capacity it should survive ahead of auto-generated dims (priority 0), like declared
+# GD&T. It still lives in the outer run so it does not land between size/location dims.
+_PMI_SUBCHAIN = 3
+_PMI_CORRIDOR_PRIORITY = 1.0
+
+
 def render_pmi(dwg, model, a) -> int:
     """Render pre-authored PMI annotations (STEP AP242) from the IR `PmiFeature`s
-    into remaining strip space (#208). Replaces the engine's `_annotate_pmi`.
+    as first-class corridor candidates (#208/#393). Replaces the engine's
+    `_annotate_pmi`.
 
-    Called from ``_auto_annotate`` after all automatic dimensions are placed so
-    PMI dims consume the strips' leftover capacity.  Skips records whose page
-    projection is degenerate (< 3 mm span) or whose extension lines would exceed
-    twice the nominal value.
+    Called from ``_auto_annotate`` before ``drain_corridors`` so authored PMI
+    co-solves with automatic strip candidates. Skips records whose page
+    projection is degenerate (< 3 mm span).
 
     View assignment:
     - dominant X → front view, fv_zones.above / fv_zones.below
@@ -1556,95 +1563,118 @@ def render_pmi(dwg, model, a) -> int:
             return None
         return p1, p2, avg_t
 
-    def _try_above(p1, p2, strip, label, name, view):
-        """Place a horizontal dimension line ABOVE the witness points."""
+    def _dim_spec(p1, p2, strip, label, name, view, side):
         if strip is None:
+            return None
+        if side in ("above", "below"):
+            axis = "y"
+            perp = tuple(sorted((p1[0], p2[0])))
+            witness = max(p1[1], p2[1]) + 2 if side == "above" else min(p1[1], p2[1]) - 2
+            q1, q2 = (p1[0], witness, 0), (p2[0], witness, 0)
+        else:
+            axis = "x"
+            perp = tuple(sorted((p1[1], p2[1])))
+            witness = max(p1[0], p2[0]) + 2 if side == "right" else min(p1[0], p2[0]) - 2
+            q1, q2 = (witness, p1[1], 0), (witness, p2[1], 0)
+        lo, hi, _inner = strip_free_span(strip)
+        if side in ("above", "right") and hi <= witness:
+            return None
+        if side in ("below", "left") and lo >= witness:
+            return None
+
+        def _build(pos, _q1=q1, _q2=q2, _side=side, _w=witness, _label=label):
+            dist = pos - _w if _side in ("above", "right") else _w - pos
+            return _dim(_q1, _q2, _side, dist, draft, label=_label)
+
+        order_coord = min(perp)
+        return {
+            "name": name,
+            "build": _build,
+            "strip": strip,
+            "view": view,
+            "side": side,
+            "axis": axis,
+            "perp": perp,
+            "order": (_PMI_SUBCHAIN, order_coord, name),
+        }
+
+    def _leader_spec(tip, strip, label, name, view, side):
+        if strip is None:
+            return None
+        axis = "y" if side in ("above", "below") else "x"
+        perp = (tip[0], tip[0]) if axis == "y" else (tip[1], tip[1])
+        order_coord = tip[0] if axis == "y" else tip[1]
+
+        def _build(pos, _tip=tip, _axis=axis, _label=label):
+            elbow = (_tip[0], pos, 0) if _axis == "y" else (pos, _tip[1], 0)
+            return Leader(_tip, elbow, _label, draft)
+
+        return {
+            "name": name,
+            "build": _build,
+            "strip": strip,
+            "view": view,
+            "side": side,
+            "axis": axis,
+            "perp": perp,
+            "order": (_PMI_SUBCHAIN, order_coord, name),
+        }
+
+    def _place_one(spec, rec):
+        left = place_strip_candidates(
+            dwg,
+            spec["strip"],
+            spec["view"],
+            spec["axis"],
+            [(spec["name"], spec["build"])],
+            _SLOT,
+            force=True,
+            features={spec["name"]: rec},
+            priorities={spec["name"]: _PMI_CORRIDOR_PRIORITY},
+        )
+        return not left
+
+    def _queue_options(options, ax, label, rec):
+        specs = [s for s in options if s is not None]
+        if not specs:
             return False
-        witness_y = max(p1[1], p2[1]) + 2
-        slot = carve_free_position(dwg, strip, view, "y", _SLOT, tuple(sorted((p1[0], p2[0]))))
-        if slot is None or slot <= witness_y:
-            return False
-        dwg.add(
-            _dim(
-                (p1[0], witness_y, 0),
-                (p2[0], witness_y, 0),
-                "above",
-                slot - witness_y,
-                draft,
-                label=label,
+        primary, alternates = specs[0], specs[1:]
+
+        def _drop(nm, _alts=alternates, _ax=ax, _label=label, _rec=rec):
+            for alt in _alts:
+                if _place_one(alt, _rec):
+                    _log.info(
+                        "PMI dim %s placed on fallback %s/%s",
+                        nm,
+                        alt["view"],
+                        alt["side"],
+                    )
+                    return
+            _record_pmi_drop(dwg, _ax, _label, _rec)
+
+        register_corridor(
+            dwg,
+            (primary["view"], primary["side"]),
+            primary["strip"],
+            primary["view"],
+            primary["axis"],
+            _SLOT,
+            CorridorCandidate(
+                name=primary["name"],
+                build=primary["build"],
+                order=primary["order"],
+                on_place=lambda nm, _ax=ax, _label=label, _rec=rec: _log.info(
+                    "PMI dim %s %.3g → annotated (%s)", _ax, _rec.value, _label
+                ),
+                on_drop=_drop,
+                priority=_PMI_CORRIDOR_PRIORITY,
+                force=True,
+                feature=rec,
             ),
-            name,
-            view=view,
         )
         return True
 
-    def _try_below(p1, p2, strip, label, name, view):
-        """Place a horizontal dimension line BELOW the witness points."""
-        if strip is None:
-            return False
-        witness_y = min(p1[1], p2[1]) - 2
-        slot = carve_free_position(dwg, strip, view, "y", _SLOT, tuple(sorted((p1[0], p2[0]))))
-        if slot is None or slot >= witness_y:
-            return False
-        dwg.add(
-            _dim(
-                (p1[0], witness_y, 0),
-                (p2[0], witness_y, 0),
-                "below",
-                witness_y - slot,
-                draft,
-                label=label,
-            ),
-            name,
-            view=view,
-        )
-        return True
-
-    def _try_right(p1, p2, strip, label, name, view):
-        """Place a vertical dimension line to the RIGHT of the witness points."""
-        if strip is None:
-            return False
-        witness_x = max(p1[0], p2[0]) + 2
-        slot = carve_free_position(dwg, strip, view, "x", _SLOT, tuple(sorted((p1[1], p2[1]))))
-        if slot is None or slot <= witness_x:
-            return False
-        dwg.add(
-            _dim(
-                (witness_x, p1[1], 0),
-                (witness_x, p2[1], 0),
-                "right",
-                slot - witness_x,
-                draft,
-                label=label,
-            ),
-            name,
-            view=view,
-        )
-        return True
-
-    def _try_left(p1, p2, strip, label, name, view):
-        """Place a vertical dimension line to the LEFT of the witness points."""
-        if strip is None:
-            return False
-        witness_x = min(p1[0], p2[0]) - 2
-        slot = carve_free_position(dwg, strip, view, "x", _SLOT, tuple(sorted((p1[1], p2[1]))))
-        if slot is None or slot >= witness_x:
-            return False
-        dwg.add(
-            _dim(
-                (witness_x, p1[1], 0),
-                (witness_x, p2[1], 0),
-                "left",
-                witness_x - slot,
-                draft,
-                label=label,
-            ),
-            name,
-            view=view,
-        )
-        return True
-
-    emitted = 0
+    queued = 0
     for idx, rec in enumerate(usable):
         ax = rec.dominant_axis
         label = rec.label
@@ -1680,87 +1710,122 @@ def render_pmi(dwg, model, a) -> int:
                 if half_pg >= 4.0:
                     p1 = (PX(cx_f - half), PY(cy_f), 0)
                     p2 = (PX(cx_f + half), PY(cy_f), 0)
-                    placed = _try_above(
-                        p1, p2, a.pv_zones.above, label, name_d, "plan"
-                    ) or _try_below(p1, p2, a.pv_zones.below, label, name_d, "plan")
-                else:
-                    tip = (PX(cx_f), PY(cy_f) + half_pg, 0)
-                    slot = carve_free_position(
-                        dwg, a.pv_zones.above, "plan", "y", _SLOT, (PX(cx_f), PX(cx_f))
+                    placed = _queue_options(
+                        [
+                            _dim_spec(p1, p2, a.pv_zones.above, label, name_d, "plan", "above"),
+                            _dim_spec(p1, p2, a.pv_zones.below, label, name_d, "plan", "below"),
+                        ],
+                        ax,
+                        label,
+                        rec,
                     )
-                    if slot is not None:
-                        dwg.add(
-                            Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d, view="plan"
-                        )
-                        placed = True
-                    else:
-                        slot = carve_free_position(
-                            dwg, a.pv_zones.below, "plan", "y", _SLOT, (PX(cx_f), PX(cx_f))
-                        )
-                        if slot is not None:
-                            tip = (PX(cx_f), PY(cy_f) - half_pg, 0)
-                            dwg.add(
-                                Leader(tip, (PX(cx_f), slot, 0), label, draft), name_d, view="plan"
-                            )
-                            placed = True
+                else:
+                    placed = _queue_options(
+                        [
+                            _leader_spec(
+                                (PX(cx_f), PY(cy_f) + half_pg, 0),
+                                a.pv_zones.above,
+                                label,
+                                name_d,
+                                "plan",
+                                "above",
+                            ),
+                            _leader_spec(
+                                (PX(cx_f), PY(cy_f) - half_pg, 0),
+                                a.pv_zones.below,
+                                label,
+                                name_d,
+                                "plan",
+                                "below",
+                            ),
+                        ],
+                        ax,
+                        label,
+                        rec,
+                    )
 
             elif bore_axis == "X":
                 # X-axis bore: circle visible in side view.
                 if half_pg >= 4.0:
                     p1 = (SX(cy_f - half), SZ(cz_f), 0)
                     p2 = (SX(cy_f + half), SZ(cz_f), 0)
-                    placed = _try_above(
-                        p1, p2, a.sv_zones.above, label, name_d, "side"
-                    ) or _try_below(p1, p2, a.sv_zones.below, label, name_d, "side")
-                else:
-                    tip = (SX(cy_f), SZ(cz_f) + half_pg, 0)
-                    slot = carve_free_position(
-                        dwg, a.sv_zones.above, "side", "y", _SLOT, (SX(cy_f), SX(cy_f))
+                    placed = _queue_options(
+                        [
+                            _dim_spec(p1, p2, a.sv_zones.above, label, name_d, "side", "above"),
+                            _dim_spec(p1, p2, a.sv_zones.below, label, name_d, "side", "below"),
+                        ],
+                        ax,
+                        label,
+                        rec,
                     )
-                    if slot is not None:
-                        dwg.add(
-                            Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d, view="side"
-                        )
-                        placed = True
-                    else:
-                        slot = carve_free_position(
-                            dwg, a.sv_zones.below, "side", "y", _SLOT, (SX(cy_f), SX(cy_f))
-                        )
-                        if slot is not None:
-                            tip = (SX(cy_f), SZ(cz_f) - half_pg, 0)
-                            dwg.add(
-                                Leader(tip, (SX(cy_f), slot, 0), label, draft), name_d, view="side"
-                            )
-                            placed = True
+                else:
+                    placed = _queue_options(
+                        [
+                            _leader_spec(
+                                (SX(cy_f), SZ(cz_f) + half_pg, 0),
+                                a.sv_zones.above,
+                                label,
+                                name_d,
+                                "side",
+                                "above",
+                            ),
+                            _leader_spec(
+                                (SX(cy_f), SZ(cz_f) - half_pg, 0),
+                                a.sv_zones.below,
+                                label,
+                                name_d,
+                                "side",
+                                "below",
+                            ),
+                        ],
+                        ax,
+                        label,
+                        rec,
+                    )
 
             elif bore_axis == "Y":
                 # Y-axis bore: circle visible in front view as a circle.
                 if half_pg >= 4.0:
                     p1 = (FX(cx_f - half), FZ(cz_f), 0)
                     p2 = (FX(cx_f + half), FZ(cz_f), 0)
-                    placed = _try_above(
-                        p1, p2, a.fv_zones.above, label, name_d, "front"
-                    ) or _try_below(p1, p2, a.fv_zones.below, label, name_d, "front")
-                else:
-                    # Narrow bore: leader from bore bottom into the below strip.
-                    tip = (FX(cx_f), FZ(cz_f) - half_pg, 0)
-                    slot = carve_free_position(
-                        dwg, a.fv_zones.below, "front", "y", _SLOT, (FX(cx_f), FX(cx_f))
+                    placed = _queue_options(
+                        [
+                            _dim_spec(
+                                p1, p2, a.fv_zones.above, label, name_d, "front", "above"
+                            ),
+                            _dim_spec(
+                                p1, p2, a.fv_zones.below, label, name_d, "front", "below"
+                            ),
+                        ],
+                        ax,
+                        label,
+                        rec,
                     )
-                    if slot is not None:
-                        elbow = (FX(cx_f), slot, 0)
-                        dwg.add(Leader(tip, elbow, label, draft), name_d, view="front")
-                        placed = True
-                    else:
-                        # Fall back: leader upward into the above strip.
-                        slot = carve_free_position(
-                            dwg, a.fv_zones.above, "front", "y", _SLOT, (FX(cx_f), FX(cx_f))
-                        )
-                        if slot is not None:
-                            tip = (FX(cx_f), FZ(cz_f) + half_pg, 0)
-                            elbow = (FX(cx_f), slot, 0)
-                            dwg.add(Leader(tip, elbow, label, draft), name_d, view="front")
-                            placed = True
+                else:
+                    # Narrow Y-axis bore historically prefers below, then above.
+                    placed = _queue_options(
+                        [
+                            _leader_spec(
+                                (FX(cx_f), FZ(cz_f) - half_pg, 0),
+                                a.fv_zones.below,
+                                label,
+                                name_d,
+                                "front",
+                                "below",
+                            ),
+                            _leader_spec(
+                                (FX(cx_f), FZ(cz_f) + half_pg, 0),
+                                a.fv_zones.above,
+                                label,
+                                name_d,
+                                "front",
+                                "above",
+                            ),
+                        ],
+                        ax,
+                        label,
+                        rec,
+                    )
 
         elif ax == "X":
             wp = _witness_from_bbox(rec, "front")
@@ -1769,9 +1834,22 @@ def render_pmi(dwg, model, a) -> int:
                 continue
             p1, p2, avg_pz = wp
             if avg_pz >= a.FV_Y:
-                placed = _try_above(p1, p2, a.fv_zones.above, label, name_x, "front")
+                placed = _queue_options(
+                    [
+                        _dim_spec(p1, p2, a.fv_zones.above, label, name_x, "front", "above"),
+                        _dim_spec(p1, p2, a.fv_zones.below, label, name_x, "front", "below"),
+                    ],
+                    ax,
+                    label,
+                    rec,
+                )
             if not placed:
-                placed = _try_below(p1, p2, a.fv_zones.below, label, name_x, "front")
+                placed = _queue_options(
+                    [_dim_spec(p1, p2, a.fv_zones.below, label, name_x, "front", "below")],
+                    ax,
+                    label,
+                    rec,
+                )
 
         elif ax == "Z":
             wp = _witness_from_bbox(rec, "front")
@@ -1780,9 +1858,22 @@ def render_pmi(dwg, model, a) -> int:
                 continue
             p1, p2, avg_px = wp
             if avg_px >= a.FV_X:
-                placed = _try_right(p1, p2, a.fv_zones.right, label, name_z, "front")
+                placed = _queue_options(
+                    [
+                        _dim_spec(p1, p2, a.fv_zones.right, label, name_z, "front", "right"),
+                        _dim_spec(p1, p2, a.fv_zones.left, label, name_z, "front", "left"),
+                    ],
+                    ax,
+                    label,
+                    rec,
+                )
             if not placed:
-                placed = _try_left(p1, p2, a.fv_zones.left, label, name_z, "front")
+                placed = _queue_options(
+                    [_dim_spec(p1, p2, a.fv_zones.left, label, name_z, "front", "left")],
+                    ax,
+                    label,
+                    rec,
+                )
 
         elif ax == "Y":
             # Try side view (Y maps to SX horizontal).
@@ -1790,25 +1881,46 @@ def render_pmi(dwg, model, a) -> int:
             if wp is not None:
                 p1, p2, avg_sz = wp
                 if avg_sz >= a.SV_Y:
-                    placed = _try_above(p1, p2, a.sv_zones.above, label, name_y, "side")
+                    placed = _queue_options(
+                        [
+                            _dim_spec(
+                                p1, p2, a.sv_zones.above, label, name_y, "side", "above"
+                            ),
+                            _dim_spec(
+                                p1, p2, a.sv_zones.below, label, name_y, "side", "below"
+                            ),
+                        ],
+                        ax,
+                        label,
+                        rec,
+                    )
                 if not placed:
-                    placed = _try_below(p1, p2, a.sv_zones.below, label, name_y, "side")
+                    placed = _queue_options(
+                        [_dim_spec(p1, p2, a.sv_zones.below, label, name_y, "side", "below")],
+                        ax,
+                        label,
+                        rec,
+                    )
             # Fall back: plan view (Y maps to PY vertical).
             if not placed:
                 wp = _witness_from_bbox(rec, "plan")
                 if wp is not None:
                     p1, p2, _ = wp
-                    placed = _try_below(p1, p2, a.pv_zones.below, label, name_y, "plan")
+                    placed = _queue_options(
+                        [_dim_spec(p1, p2, a.pv_zones.below, label, name_y, "plan", "below")],
+                        ax,
+                        label,
+                        rec,
+                    )
 
         if placed:
-            emitted += 1
-            _log.info("PMI dim[%d] %s %.3g → annotated (%s)", idx, ax, rec.value, label)
+            queued += 1
         else:
-            _log.info("PMI dim[%d] %s %.3g → no strip space", idx, ax, rec.value)
+            _log.info("PMI dim[%d] %s %.3g → no viable strip", idx, ax, rec.value)
             _record_pmi_drop(dwg, ax, label, rec)
 
-    _log.info("PMI annotate: %d/%d dims placed", emitted, len(usable))
-    return emitted
+    _log.info("PMI annotate: %d/%d dims queued", queued, len(usable))
+    return queued
 
 
 # GD&T aspect side-layer (ADR 0011 §4, #61) — declared feature control frames / datum
@@ -1853,13 +1965,12 @@ def render_gdt(dwg, model, a) -> int:
     """Place declared GD&T frames / datum symbols / surface finishes (#61) as first-class
     ADR 0009 corridor candidates — registered into the SAME strip the feature's dimensions
     use, BEFORE ``drain_corridors``, so one solve orders and spaces them crossing-free with
-    the dims (not a leftover first-fit like :func:`render_pmi`). Each item carries its target
-    ``(view, side)`` strip + model-space site; the leader hangs the glyph off the site into
-    that strip. The strip footprint is the GLYPH's own box — NOT the leader+glyph box, whose
-    shaft back to the feature would inflate the stacking extent (the same reason dims reserve
-    one label-height). Cross-view separation is the compose-then-pack repack's job (ADR 0004):
-    every placed frame is ``view=``-tagged, so ``_measure_blocks`` folds it into the block.
-    Returns the count registered."""
+    the dims. Each item carries its target ``(view, side)`` strip + model-space site; the
+    leader hangs the glyph off the site into that strip. The strip footprint is the GLYPH's
+    own box — NOT the leader+glyph box, whose shaft back to the feature would inflate the
+    stacking extent (the same reason dims reserve one label-height). Cross-view separation
+    is the compose-then-pack repack's job (ADR 0004): every placed frame is ``view=``-tagged,
+    so ``_measure_blocks`` folds it into the block. Returns the count registered."""
     items = [f for f in model.features if f.kind in _GDT_KINDS]
     if not items:
         return 0

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -928,6 +928,22 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
         base = reach_i + 8
         for k in range(int(limit / step) + 1):
             offset = base + k * step
+            line_x = mid[0] + side_vec[0] * (offset + 6)
+            line_y = mid[1] + side_vec[1] * (offset + 6)
+            if (
+                line_x < page_box[0]
+                or line_x > page_box[2]
+                or line_y < page_box[1]
+                or line_y > page_box[3]
+            ):
+                if (
+                    (line_x < page_box[0] and side_vec[0] <= 0)
+                    or (line_x > page_box[2] and side_vec[0] >= 0)
+                    or (line_y < page_box[1] and side_vec[1] <= 0)
+                    or (line_y > page_box[3] and side_vec[1] >= 0)
+                ):
+                    break
+                continue
             probe = _make(offset, side_vec)
             bb = _geom_box(probe)
             if bb is None:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -861,21 +861,20 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
     else:
         pref = (-0.3, 1.0) if view == "plan" else (-0.3, -1.0)
         side, reach = max(cands, key=lambda c: c[0][0] * pref[0] + c[0][1] * pref[1])
+    fallback_sides = [(side, reach)] + [c for c in cands if c[0] != side]
 
-    def _place(off):
-        dwg.add(
-            _dim(
-                (p1[0], p1[1], 0),
-                (p2[0], p2[1], 0),
-                side,
-                off,
-                dwg.draft,
-                label=f"{n - 1}× {_fmt(pitch)}",
-            ),
-            name,
-            view=view,
-            feature=feature,
+    def _make(off, side_vec=side):
+        return _dim(
+            (p1[0], p1[1], 0),
+            (p2[0], p2[1], 0),
+            side_vec,
+            off,
+            dwg.draft,
+            label=f"{n - 1}× {_fmt(pitch)}",
         )
+
+    def _place(off, side_vec=side):
+        dwg.add(_make(off, side_vec), name, view=view, feature=feature)
 
     # Place onto the zone strip for the chosen side (#374): each side is its own strip, so the
     # obstacle-aware carve stacks this dim clear of placed content — where an arbitrary-direction
@@ -913,19 +912,38 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
         tier = max(10.0, dwg.draft.font_size * 3.0)
         pos = carve_free_position(dwg, strip, view, axis, tier, perp)
         if pos is not None:
-            _place(sgn * (pos - witness))
+            _place(sgn * (pos - witness), side)
             return
 
-    # Fallback: diagonal side / absent strip / full strip → the pre-#374 bounded vector placement,
-    # count-stacked and margin-guarded, so those residual cases are byte-identical to before.
-    prior = sum(1 for nm, _ in dwg.iter_annotations() if nm.startswith(f"dim_pitch_{view}"))
-    offset = reach + 8 + 10 * prior
-    ox = mid[0] + side[0] * (offset + 6)
-    oy = mid[1] + side[1] * (offset + 6)
-    if not (a.margin <= ox <= a.PAGE_W - a.margin and a.margin <= oy <= a.PAGE_H - a.margin):
-        _log.info("Pitch dimension for the %s× %s array skipped (no room)", n, _fmt(pitch))
-        return
-    _place(offset)
+    # Fallback: diagonal side / absent strip / full strip. This cannot cleanly occupy an
+    # axis-aligned strip tier, so search bounded offsets along the chosen outward vector and
+    # test the full generated dimension footprint against this view's placed obstacles (#514).
+    # Rotated grids can need the two perpendicular pitch dims on opposite sides, so try the
+    # preferred side first and then its opposite before declaring the row genuinely full.
+    step = max(2.5, dwg.draft.font_size)
+    limit = math.hypot(a.PAGE_W, a.PAGE_H)
+    page_box = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
+    obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+    for side_vec, reach_i in fallback_sides:
+        base = reach_i + 8
+        for k in range(int(limit / step) + 1):
+            offset = base + k * step
+            probe = _make(offset, side_vec)
+            bb = _geom_box(probe)
+            if bb is None:
+                continue
+            if (
+                bb[0] < page_box[0]
+                or bb[1] < page_box[1]
+                or bb[2] > page_box[2]
+                or bb[3] > page_box[3]
+            ):
+                continue
+            if _box_hits(bb, obstacles):
+                continue
+            dwg.add(probe, name, view=view, feature=feature)
+            return
+    _log.info("Pitch dimension for the %s× %s array skipped (no room)", n, _fmt(pitch))
 
 
 def build_view_of_axis(a: Analysis):
@@ -954,10 +972,9 @@ def _annotate_holes(
     Placement: plan- and side-view callouts go to the right of their view
     (the strip before the iso view / page margin; plan falls back to its
     left, the side view has no usable left strip), front-view callouts go
-    below the front view, deconflicted so no leader shaft crosses an earlier
-    callout's text. Each callout is width-checked; anything that fits
-    nowhere is logged and skipped — never force-placed — and then surfaces
-    through the coverage lint as ``feature_not_dimensioned``.
+    below the front view through the strip solver. Each callout is width-checked;
+    anything that fits nowhere is logged and skipped — never force-placed — and
+    then surfaces through the coverage lint as ``feature_not_dimensioned``.
     """
     draft = dwg.draft
     gap = draft.pad_around_text
@@ -971,7 +988,6 @@ def _annotate_holes(
     plan_right = a.proj.plan_x(a.bb.max.X)
     plan_left = a.proj.plan_x(a.bb.min.X)
     side_right = a.proj.side_x(a.bb.max.Y)
-    front_bottom = a.proj.front_z(a.bb.min.Z)
     tb_left = a.PAGE_W - a.TB_W - _TB_CLEAR
     tb_top = _TB_CLEAR + _TB_H
 
@@ -1052,9 +1068,13 @@ def _annotate_holes(
         if only is None:
             return f"hc_{view}{i}"
         j = 0
-        while f"hc_{view}{j}" in dwg._named:
+        while f"hc_{view}{j}" in _hc_used:
             j += 1
-        return f"hc_{view}{j}"
+        name = f"hc_{view}{j}"
+        _hc_used.add(name)
+        return name
+
+    _hc_used = set(dwg._named)
 
     def _add(view, i, tip, elbow, side, callout):
         dwg.add(
@@ -1082,42 +1102,78 @@ def _annotate_holes(
         specs.sort(key=lambda s: s[1], reverse=True)
 
         if view == "front":
-            # Below the view, vertical shafts. Rows are assigned right-to-
-            # left so a deeper row's shaft never crosses a shallower row's
-            # right-running label; left-side labels get an explicit guard.
+            # Below the view, vertical shafts. Rows are solved as one strip batch rather
+            # than assigned by `i * min_gap` (#513). Candidate order stays right-to-left
+            # so inner-to-outer rows preserve the historical crossing guard shape, but
+            # over-capacity is now priority-ranked by bore diameter.
             specs.sort(key=lambda s: max(to_page(loc)[0] for loc in s[0]), reverse=True)
-            occupied: list[tuple] = []  # (x0, x1, row_y) of placed labels
+            cands = []
+            features = {}
+            priorities = {}
+            forbid = {}
+            furniture = {}
+            meta = {}
+            tb_box = (tb_left, _TB_CLEAR, a.PAGE_W - _TB_CLEAR, tb_top)
             for i, (locs, dia, callout, feat) in enumerate(specs):
                 w = callout.callout_width
                 centre = to_page(max(locs, key=lambda loc: to_page(loc)[0]))
-                elbow_y = front_bottom - 0.6 * a.DIM_PAD - i * min_gap
                 if centre[0] + gap + w <= a.PAGE_W - a.margin:
-                    side, x0, x1 = "right", centre[0] + gap, centre[0] + gap + w
+                    side = "right"
                 elif centre[0] - gap - w >= a.margin:
-                    side, x0, x1 = "left", centre[0] - gap - w, centre[0] - gap
+                    side = "left"
                 else:
                     _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
                     _record_callout_drop(dwg, view, dia, "no room beside the view", feat)
                     continue
-                # the title block only constrains rows that reach its x-range
-                floor = (tb_top + 4) if x1 > tb_left - 4 else a.margin + 4
-                if elbow_y < floor:
+
+                name = _hc_name(view, i)
+
+                def _build(
+                    pos,
+                    _centre=centre,
+                    _dia=dia,
+                    _side=side,
+                    _callout=callout,
+                ):
+                    elbow = (_centre[0], pos)
+                    tip = _rim_tip(_centre, elbow, _dia)
+                    return Leader(
+                        tip=(tip[0], tip[1], 0),
+                        elbow=(elbow[0], elbow[1], 0),
+                        label="",
+                        draft=draft,
+                        text_side=_side,
+                        callout=_callout,
+                    )
+
+                cands.append((name, _build))
+                features[name] = _feat_of_callout.get(id(callout))
+                priorities[name] = dia
+                forbid[name] = tb_box
+                furniture[name] = (i, feat)
+                meta[name] = (dia, feat)
+
+            left = place_strip_candidates(
+                dwg,
+                a.fv_zones.below,
+                "front",
+                "y",
+                cands,
+                min_gap,
+                features=features,
+                priorities=priorities,
+                forbid=forbid,
+            )
+            left_names = {name for name, _ in left}
+            for name, _build in cands:
+                if name in left_names:
+                    dia, feat = meta[name]
                     _log.info("Hole callout ø%s skipped (front strip full)", _fmt(dia))
                     _record_callout_drop(dwg, view, dia, "front strip full", feat)
                     continue
-                if any(
-                    ox0 <= centre[0] <= ox1 and row_y > elbow_y for ox0, ox1, row_y in occupied
-                ):
-                    _log.info(
-                        "Hole callout ø%s skipped (shaft would cross another callout)", _fmt(dia)
-                    )
-                    _record_callout_drop(dwg, view, dia, "shaft would cross another callout", feat)
-                    continue
-                elbow = (centre[0], elbow_y)
-                occupied.append((x0, x1, elbow_y))
-                _add(view, i, _rim_tip(centre, elbow, dia), elbow, side, callout)
                 if place_furniture:  # #426: finalize's furniture() replay owns furniture
-                    _add_furniture(dwg, a, view, i, feat, to_page)
+                    idx, feat = furniture[name]
+                    _add_furniture(dwg, a, view, idx, feat, to_page)
             continue
 
         # plan / side: two-pass leader placement.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -350,23 +350,23 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # after every hole/diameter pass so it claims strip space last.
     render_slots(dwg, _model, a)
 
-    # Declared GD&T frames / datum symbols / surface finishes (ADR 0011 §4, #61) — register
-    # into the same strips as first-class candidates BEFORE the drain, so the one solve orders
-    # and spaces them crossing-free with the dims (not a leftover first-fit like render_pmi).
+    # Declared GD&T frames / datum symbols / surface finishes (ADR 0011 §4, #61) and
+    # authored STEP PMI dims (#393) register into the same strips as first-class
+    # candidates BEFORE the drain, so the one solve orders and spaces them crossing-free
+    # with locations/slots rather than consuming leftovers as first-fit placements.
     render_gdt(dwg, _model, a)
+    if a.pmi_mode == "annotate":
+        render_pmi(dwg, _model, a)
 
-    # Now every feeder pass (locations + slots) has registered; solve each shared above
-    # corridor once (ADR 0009 end state, #345/#346) — dedup coincident spans, order the
-    # ladder — BEFORE detail views and PMI, so they see the placed ladder as an obstacle.
+    # Now every corridor feeder pass has registered; solve each shared strip once
+    # (ADR 0009 end state, #345/#346/#393) — dedup coincident spans, order the ladder —
+    # BEFORE detail views so they see the placed ladder as an obstacle.
     drain_corridors(dwg)
 
     # Resolve every queued enlarged-detail request (#307) — prismatic step bands and
     # crowded turned heads alike — through the one generic detailer, now that all
     # views and main-view annotations are placed (so the detail avoids them).
     _resolve_details(dwg, a)
-
-    if a.pmi_mode == "annotate":
-        render_pmi(dwg, _model, a)
 
     _add_title_block(dwg, a)
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1554,7 +1554,9 @@ class Drawing:
         mechanically-clear violations and re-lint, bounded to *max_iter* passes:
 
         - ``dim_inside_part`` — the offset is on the wrong side; flip it once.
-        - ``annotation_overlap`` — two labels collide; push one further out.
+        ``annotation_overlap`` is intentionally not repaired here anymore: the
+        corridor/strip solvers own primary placement, and a fixed-step nudge would
+        reintroduce a second placement policy.
 
         Only engine-built dimensions (carrying ``_dw_spec``) are re-placeable;
         leaders, callouts and standards-judgement issues (e.g.

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -1,20 +1,19 @@
-"""The deterministic lint→repair loop (#138 / ADR 0005; #30 / ADR 0002).
+"""The deterministic lint→repair safety net (#138 / ADR 0005; #30 / ADR 0002).
 
-After the greedy initial placement, re-place the engine-built dimensions behind
-the mechanically-clear violations (a dim on the wrong side, two overlapping
-labels) and re-lint — bounded and monotonic, so it terminates and never worsens a
-sheet. `Drawing.repair()` is the public wrapper; these helpers take the drawing as
-`dwg` (duck-typed — `lint` / `items` / `_registry`), so this module
-imports only `_core`, never `make_drawing` — no cycle.
+The solver path now owns annotation placement. Repair is deliberately narrow:
+it only handles the mechanically-clear wrong-side dimension case and never performs
+fixed-step overlap placement. `Drawing.repair()` remains the public wrapper; these
+helpers take the drawing as `dwg` (duck-typed — `lint` / `items` / `_registry`), so
+this module imports only `_core`, never `make_drawing` — no cycle.
 """
 
 from __future__ import annotations
 
-from draftwright._core import _QUOTED_RE, _SLOT_DIM_HEIGHT, _STRIP_SPACING, _dim
+from draftwright._core import _QUOTED_RE, _dim
 
 # Lint codes the repair loop can mechanically resolve, and the side flip used to
 # move a dimension that landed on the wrong side of its witness points.
-_REPAIRABLE_CODES = frozenset({"annotation_overlap", "dim_inside_part"})
+_REPAIRABLE_CODES = frozenset({"dim_inside_part"})
 _OPPOSITE_SIDE = {"above": "below", "below": "above", "left": "right", "right": "left"}
 
 
@@ -60,20 +59,6 @@ def _repair_dim_inside_part(dwg, issue) -> bool:
     return True
 
 
-def _repair_overlap(dwg, issue) -> bool:
-    """Push the first re-placeable label in an overlap one strip-row further out
-    so the two labels separate. Monotonic, so repeated passes converge."""
-    step = _STRIP_SPACING + _SLOT_DIM_HEIGHT
-    for label in _QUOTED_RE.findall(issue.message):
-        dim = _find_dim(dwg, label)
-        if dim is None:
-            continue
-        s = dim._dw_spec
-        _replace_dim(dwg, dim, _dim(s.p1, s.p2, s.side, s.distance + step, s.draft, **s.kwargs))
-        return True
-    return False
-
-
 def repair_drawing(dwg, max_iter: int = 3):
     """Close the lint→repair loop; see :meth:`Drawing.repair` for the contract.
     Returns *dwg* for chaining."""
@@ -96,8 +81,6 @@ def repair_drawing(dwg, max_iter: int = 3):
                 if _repair_dim_inside_part(dwg, issue):
                     flipped.add(key)
                     changed = True
-            elif issue.code == "annotation_overlap":
-                changed |= _repair_overlap(dwg, issue)
         if not changed:
             break
         if len(dwg.lint()) > len(before):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1,5 +1,6 @@
 """Tests for draftwright.make_drawing."""
 
+import logging
 import math
 import os
 import subprocess
@@ -13,12 +14,17 @@ from build123d_drafting import HoleCallout, Leader, ViewCoordinates, view_axes
 
 from draftwright import Drawing, build_drawing, make_drawing
 from draftwright._core import _MIN_VIEW_MM, _fmt
-from draftwright.analysis import _is_rotational, analyse_face_levels, dedup_diams
+from draftwright.analysis import (
+    _converge_step_sizing,
+    _is_rotational,
+    analyse_face_levels,
+    dedup_diams,
+)
 from draftwright.drawing import analyse_cylinders
 from draftwright.export import _export_shape
 from draftwright.make_drawing import generate_script, lint_feature_coverage
 from draftwright.recognition import Slot, find_slots
-from draftwright.sheet import _fits, choose_scale
+from draftwright.sheet import StripDepths, _fits, choose_scale
 
 _skip_011 = pytest.mark.skipif(B123D_GE_011, reason=SKIP_011)
 
@@ -96,6 +102,52 @@ class TestDedupDiams:
         ]
         result = dedup_diams(cyls)
         assert result == [20.0, 10.0, 5.0]
+
+
+class TestStepSizingConvergence:
+    def test_step_sizing_converges_past_the_old_three_pass_limit(self):
+        measure_calls = []
+
+        def measure(n_steps):
+            measure_calls.append(n_steps)
+            return StripDepths(right=float(n_steps), left=0.0)
+
+        def pick(n_steps, strips):
+            assert strips.right == pytest.approx(n_steps)
+            return float(n_steps), 297.0, 210.0, 120.0
+
+        def legible_count(scale):
+            return {7.0: 5, 5.0: 4, 4.0: 2, 2.0: 2}[scale]
+
+        pick_result, strips, n_steps = _converge_step_sizing(7, measure, pick, legible_count)
+
+        assert pick_result == (2.0, 297.0, 210.0, 120.0)
+        assert strips.right == pytest.approx(2.0)
+        assert n_steps == 2
+        assert measure_calls == [7, 5, 4, 2]
+
+    def test_step_sizing_cycle_uses_the_larger_reservation(self, caplog):
+        measure_calls = []
+
+        def measure(n_steps):
+            measure_calls.append(n_steps)
+            return StripDepths(right=float(n_steps), left=0.0)
+
+        def pick(n_steps, strips):
+            assert strips.right == pytest.approx(n_steps)
+            return float(n_steps), 297.0, 210.0, 120.0
+
+        def legible_count(scale):
+            return {4.0: 2, 2.0: 4}[scale]
+
+        with caplog.at_level(logging.WARNING, logger="draftwright.analysis"):
+            pick_result, strips, n_steps = _converge_step_sizing(4, measure, pick, legible_count)
+
+        assert pick_result == (4.0, 297.0, 210.0, 120.0)
+        assert strips.right == pytest.approx(4.0)
+        assert n_steps == 4
+        assert measure_calls == [4, 2, 4]
+        assert "did not converge" in caplog.text
 
 
 class TestChooseScale:
@@ -5954,11 +6006,11 @@ class TestLintSuggestions:
 
 
 class TestRepair:
-    """#30: bounded lint→repair loop acts on violations instead of only reporting."""
+    """#30/#521: repair is a narrow safety net, not a second placement engine."""
 
-    def test_repair_clears_annotation_overlap(self):
-        # Two dimensions forced onto the same page location → their labels
-        # collide; the repair loop pushes one further out to separate them.
+    def test_repair_does_not_fixed_step_annotation_overlap(self):
+        # Two dimensions forced onto the same page location → their labels collide. The
+        # solver path owns placement; repair must not hide this with a fixed-step nudge.
         from draftwright._core import _dim
 
         dwg = build_drawing(Box(60, 40, 20))
@@ -5969,7 +6021,9 @@ class TestRepair:
         assert [i for i in dwg.lint() if i.code == "annotation_overlap"]
 
         dwg.repair()
-        assert not [i for i in dwg.lint() if i.code == "annotation_overlap"]
+        assert dwg._named["ov1"]._dw_spec.distance == 8
+        assert dwg._named["ov2"]._dw_spec.distance == 8
+        assert [i for i in dwg.lint() if i.code == "annotation_overlap"]
 
     def test_repair_dim_inside_part_flips_side(self):
         # dim_inside_part is dormant in the multi-view sheet (lint passes no
@@ -6033,11 +6087,9 @@ class TestRepair:
             fixed = ew(build_drawing(part, repair=True))
             assert fixed <= raw
 
-    def test_repair_rolls_back_a_pass_that_makes_things_worse(self):
-        # Guard: if a repair (e.g. an overlap push off a tight sheet) net-raises
-        # the issue count, that pass is undone and the loop stops — repair never
-        # makes a drawing worse. Drive it with a stateful lint stub: one fixable
-        # overlap before, two issues after the push.
+    def test_repair_ignores_annotation_overlap_without_mutation(self):
+        # annotation_overlap is no longer repairable (#521). It remains visible
+        # to lint rather than being moved by a fixed-step fallback.
         from draftwright._core import _dim
         from draftwright.linting import LintIssue
 
@@ -6048,20 +6100,17 @@ class TestRepair:
             message="labels 'RB' and 'QQ' overlap",
             code="annotation_overlap",
         )
-        worse = LintIssue(
-            severity="warning", message="label 'RB' off sheet", code="label_out_of_frame"
-        )
         calls = {"n": 0}
 
         def fake_lint():
             calls["n"] += 1
-            return [overlap] if calls["n"] == 1 else [overlap, worse]
+            return [overlap]
 
         dwg.lint = fake_lint
         dwg.repair(max_iter=3)
-        # The pushed dim was reverted: 'x' is the original object, offset intact.
         assert dwg._named["x"] is orig
         assert dwg._named["x"]._dw_spec.distance == 8
+        assert calls["n"] == 1
 
     def test_build_drawing_repair_flag_is_respected(self):
         # repair=False leaves the greedy placement untouched; the default repairs.
@@ -6091,20 +6140,21 @@ class TestPin:
         return dwg
 
     def test_repair_does_not_move_a_pinned_dim(self):
-        # 'a' is the first re-placeable in the overlap, so repair would push it;
-        # pinned, it stays at distance 8 and 'b' is pushed instead.
+        # Overlaps are not repaired by fixed-step placement anymore, so pinned and
+        # unpinned dimensions alike stay put.
         dwg = self._two_overlapping()
         dwg.pin("a")
         dwg.repair()
-        assert dwg._named["a"]._dw_spec.distance == 8  # untouched
-        assert dwg._named["b"]._dw_spec.distance > 8  # moved in its place
+        assert dwg._named["a"]._dw_spec.distance == 8
+        assert dwg._named["b"]._dw_spec.distance == 8
 
     def test_unpin_lets_repair_move_it_again(self):
         dwg = self._two_overlapping()
         dwg.pin("a").unpin("a")
         dwg.repair()
-        # With nothing pinned, the overlap is resolved (one of them moved).
-        assert not [i for i in dwg.lint() if i.code == "annotation_overlap"]
+        assert dwg._named["a"]._dw_spec.distance == 8
+        assert dwg._named["b"]._dw_spec.distance == 8
+        assert [i for i in dwg.lint() if i.code == "annotation_overlap"]
 
     def test_pin_unknown_name_raises(self):
         dwg = build_drawing(Box(60, 40, 20))
@@ -6151,7 +6201,7 @@ class TestPin:
         dwg.add(_dim((40.0, 20.0, 0.0), (80.0, 20.0, 0.0), "above", 8, dwg.draft, label="AA"), "a")
         assert "a" not in dwg._pinned
         dwg.repair()
-        assert not [i for i in dwg.lint() if i.code == "annotation_overlap"]
+        assert dwg._named["a"]._dw_spec.distance == 8
 
 
 class TestAnnotationsQuery:

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -160,10 +160,13 @@ class TestDeclaredModelPmi:
         declared = build_drawing(
             str(CTC01), out=str(tmp_path / "d"), title="P", model=[], pmi="annotate"
         )
-        n_auto = sum(1 for n in auto._named if n.startswith("pmi_"))
-        n_decl = sum(1 for n in declared._named if n.startswith("pmi_"))
-        assert n_auto >= 1
-        assert n_decl == n_auto  # declared path reproduces the auto PMI dims (was 0 before #472)
+        auto_pmi = {n for n in auto._named if n.startswith("pmi_")}
+        decl_pmi = {n for n in declared._named if n.startswith("pmi_")}
+        assert auto_pmi
+        # The declared path has fewer auto-generated dimensions competing for strip capacity,
+        # so it may place extra authored PMI. The #472 invariant is no loss: every PMI dim the
+        # detected path placed must also be reproduced by the declared path.
+        assert auto_pmi <= decl_pmi
 
     def test_declared_model_pmi_off_stays_clean(self, tmp_path):
         # the synthesis is gated on pmi_mode == 'annotate' — a declared build without PMI stays 0

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -573,6 +573,59 @@ def test_place_strip_candidates_priority_survives_key_order():
     assert placed1 == {"a"} and left1 == {"b"}
 
 
+def test_place_strip_candidates_refills_after_late_forbid_rejection():
+    # #524 review: segment preselection must not waste capacity when the chosen
+    # high-priority candidate is rejected only after rendering (e.g. title-block
+    # forbid). A lower-priority candidate that fits the same segment should backfill it.
+    from draftwright._core import Strip
+    from draftwright.annotations._common import place_strip_candidates
+
+    class _P:
+        def __init__(s, x, y):
+            s.X, s.Y = x, y
+
+    class _Obj:
+        def __init__(s, x0, y0, x1, y1):
+            s._bb = type("_BB", (), {"min": _P(x0, y0), "max": _P(x1, y1)})()
+
+        def bounding_box(s):
+            return s._bb
+
+    class _Dwg:
+        def __init__(s):
+            s.added = []
+
+        def iter_annotations(s):
+            return list(s.added)
+
+        def view_of(s, n):
+            return "plan"
+
+        def add(s, obj, name, view=None, feature=None):
+            s.added.append((name, obj))
+
+    strip = Strip(anchor=0.0, outer_limit=13.0, direction=1.0, gap=0.0, spacing=4.0)
+    cands = [
+        ("hi", lambda pos: _Obj(-1.0, pos, 1.0, pos + 1.0)),
+        ("lo", lambda pos: _Obj(10.0, pos, 12.0, pos + 1.0)),
+    ]
+    dwg = _Dwg()
+    left = place_strip_candidates(
+        dwg,
+        strip,
+        "plan",
+        "y",
+        cands,
+        tier=5.0,
+        force=True,
+        priorities={"hi": 10.0, "lo": 1.0},
+        forbid={"hi": (-2.0, -1.0, 2.0, 2.0)},
+    )
+
+    assert {name for name, _ in dwg.added} == {"lo"}
+    assert {name for name, _ in left} == {"hi"}
+
+
 def test_place_strip_candidates_ignores_perpendicular_disjoint_obstacle():
     # A right strip stacks along X; the carve projects obstacles onto X. An obstacle that
     # overlaps in X (even after pad inflation) but is DISJOINT in Y — a dim on ANOTHER


### PR DESCRIPTION
## Summary

Consolidates the annotation placement path so authored and generated annotations use the corridor/strip solvers more consistently.

- Queue STEP PMI as corridor candidates before `drain_corridors`, with authored-intent priority.
- Move front-view hole callouts from fixed row stepping onto the strip solver.
- Replace pitch-dimension count-stacking fallback with bounded obstacle-aware placement, including opposite-side fallback for rotated grids.
- Narrow `repair()` back to a safety net by removing fixed-step `annotation_overlap` nudging.
- Replace the silent three-pass scale/step sizing loop with explicit convergence and conservative cycle handling.
- Address review findings by making the branch format-clean and refilling strip segment capacity after late `forbid`/corridor rejection.

## Why

The previous paths had several parallel placement policies: direct PMI carving after corridor drain, fixed front-callout rows, count-based pitch fallback, and repair-time overlap nudging. Those made solver behavior harder to reason about and could hide placement bugs instead of exposing them through lint.

The review follow-up also closes a subtle strip-capacity bug: if a high-priority candidate won preselection but was rejected only after rendering, the segment could waste a usable slot instead of trying the next candidate.

## Validation

- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/draftwright/`
- `uv run pytest tests/test_strip_layout.py -q`
- `uv run pytest tests/test_make_drawing.py::TestHolePatternCallouts tests/test_make_drawing.py::TestRepair tests/test_make_drawing.py::TestPin -q`
- `uv run pytest tests/test_layout_cleanliness.py tests/test_layout_property.py tests/test_pmi.py tests/test_render_seam.py -q`
- `uv run pytest tests/test_layout_property.py::TestGeneratedPartDeterminism::test_build_is_deterministic[6] -q`
- Initial solver-consolidation commit was also validated with `uv run pytest -q` -> `1117 passed, 17 deselected, 8 warnings`.

GitHub CI lint is green on the review-fix commit `e22f1d6`; matrix tests are running.