### PR TITLE
Unify automatic layout fitness

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from draftwright.recognition import TurnedProfile
+    from draftwright.sheet import StripDepths
 
 from build123d import Align, BoundBox, Location, Mode, Shape, Text
 from build123d_drafting.helpers import (
@@ -338,7 +339,7 @@ def _legible_locations(positions, scale):
     return kept, n_too_close
 
 
-def _largest_empty_rect(drawable, obstacles):
+def _largest_empty_rect(drawable, obstacles, *, warn: bool = True):
     """Largest axis-aligned empty rectangle in *drawable* avoiding *obstacles*.
 
     *drawable* and each obstacle are ``(x0, y0, x1, y1)`` page-mm boxes.  Returns
@@ -376,10 +377,11 @@ def _largest_empty_rect(drawable, obstacles):
         # is unreachable in practice — choose_scale always leaves a gap — but
         # if it ever happens the iso would render over the other views, so flag
         # it rather than fail silently.
-        _log.warning(
-            "No empty rectangle found for the iso view; obstacles fill the "
-            "drawable area — iso may overlap other views"
-        )
+        if warn:
+            _log.warning(
+                "No empty rectangle found for the iso view; obstacles fill the "
+                "drawable area — iso may overlap other views"
+            )
         return drawable
     return best
 
@@ -514,6 +516,8 @@ class Analysis:
     is_rotational: bool
     od_axis: str  # rotation/turning axis of a rotational part ("z" default; "x"/"y" #222)
     step_zs: list[float]
+    layout_strips: StripDepths
+    layout_n_steps: int
     sv_right: float
     iso_right_limit: float
     SCALE: float

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -520,6 +520,8 @@ def _analyse(
         is_rotational=is_rotational,
         od_axis=od_axis,
         step_zs=step_zs,
+        layout_strips=strips,
+        layout_n_steps=n_steps,
         sv_right=sv_right,
         iso_right_limit=iso_right_limit,
         SCALE=SCALE,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -337,20 +337,9 @@ def _repack_candidates(a, scale, page):
         return [(s, pw, ph, tb) for s in _SCALES]
     if scale is not None:
         return [(float(scale), pw, ph, _tb_width(pw)) for pw, ph in _PAGE_SIZES.values()]
-    # Auto ladder, but floored at pass 1's chosen sheet: the measured blocks are
-    # never smaller than the estimate that pass 1 already rejected the earlier
-    # rungs against, and the repack's .fits is more permissive than choose_scale's
-    # row model — so without this floor the repack could pick a *smaller* sheet
-    # than pass 1 and make things worse (#121). Start the search at pass 1's rung.
-    start = next(
-        (
-            i
-            for i, (s, pw, ph, _tb) in enumerate(_LADDER)
-            if s == a.SCALE and pw == a.PAGE_W and ph == a.PAGE_H
-        ),
-        0,
-    )
-    return list(_LADDER[start:])
+    # Auto repack uses the same composed-footprint fitness as choose_scale (#519),
+    # so it no longer needs a pass-1 floor to compensate for divergent fit models.
+    return list(_LADDER)
 
 
 def _repack(
@@ -379,11 +368,26 @@ def _repack(
     def _geom(cand):
         s, pw, ph, tb = cand
         return _layout_geometry(
-            a.x_size, a.y_size, a.z_size, s, pw, ph, tb, None, 0, blocks=blocks
+            a.x_size,
+            a.y_size,
+            a.z_size,
+            s,
+            pw,
+            ph,
+            tb,
+            a.layout_strips,
+            a.layout_n_steps,
+            blocks=blocks,
+            warn_no_iso=False,
         )
 
     candidates = _repack_candidates(a, scale, page)
-    fit = next(((c, gg) for c in candidates if (gg := _geom(c)).fits), None)
+    auto_search = scale is None and page is None
+
+    def _candidate_fits(g):
+        return g.auto_fits if auto_search else g.fits
+
+    fit = next(((c, gg) for c in candidates if _candidate_fits(gg := _geom(c))), None)
     if fit is not None:
         chosen, g = fit
     else:
@@ -398,7 +402,7 @@ def _repack(
             lo, hi = 0.0, candidates[-1][0]
             for _ in range(60):
                 mid = (lo + hi) / 2.0
-                if _geom((mid, pw0, ph0, tb0)).fits:
+                if _candidate_fits(_geom((mid, pw0, ph0, tb0))):
                     lo = mid
                 else:
                     hi = mid

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -355,78 +355,26 @@ def _fits(
     strips: StripDepths | None = None,
     pack_iso_2d: bool = False,
 ) -> bool:
-    """True if the 4-view layout fits the page at this scale.
+    """True if the composed 4-view footprint fits the page at this scale.
 
-    Default (``pack_iso_2d=False``) is the conservative row model used by
-    automatic scale selection: the iso view is charged a column in the view row
-    alongside the title block.  This deliberately over-reserves horizontal space,
-    which keeps annotation-heavy parts on a sheet large enough to place all their
-    dimensions rather than dropping some onto a tighter sheet.
-
-    When ``pack_iso_2d=True`` — used when the caller fixes the page or scale —
-    the iso is instead fitted into the largest empty rectangle the placement
-    engine actually uses (:func:`_layout_geometry`), so it may occupy vertical
-    headroom above the views rather than a row column.  A long, short part can
-    then be enlarged onto the requested sheet (e.g. 2:1 on A3), where the row
-    model would have under-scaled it.
-
-    The title block occupies only the bottom ``_TB_H`` mm of the sheet, so the
-    views may extend over it horizontally as long as they clear it vertically.
+    ``pack_iso_2d=False`` uses the automatic-selection verdict exposed by
+    :func:`_layout_geometry`; ``True`` uses the packed override verdict for
+    explicit page/scale requests. The old arithmetic no longer lives here, so
+    auto selection and measure-repack consume the same layout authority (#519).
     """
-    bbox_max = max(x_size, y_size, z_size)
-    halo = strips.pv_halo if strips else 0.0
-    gap_fv_sv = max(_DIM_PAD, strips.right if strips else _est_right_strip_depth(n_steps), halo)
-    gap_left = max(_DIM_PAD, strips.left if strips else _DIM_PAD, halo)
-    # PV top band: when ballooned, hold the tiered X-location dims + a balloon row
-    # beyond them (#121); otherwise the historic DIM_PAD (tiers spill into
-    # headroom). Mirror _layout_geometry's pv.top so scale/page is sized for it.
-    strip_top = strips.top if strips else 0.0
-    pv_top = (max(_DIM_PAD, strip_top) + halo) if halo > 0 else _DIM_PAD
-    h = _MARGIN + pv_top + y_size * scale + _DIM_PAD + z_size * scale + _DIM_PAD + _MARGIN
-    if h > page_h:
-        return False
-
-    if not pack_iso_2d:
-        # Conservative row model: iso + title block both charged to the row.
-        w = (
-            _MARGIN
-            + gap_left
-            + x_size * scale
-            + gap_fv_sv
-            + y_size * scale
-            + _DIM_PAD
-            + bbox_max * scale * _ISO_WIDTH_BUDGET
-            + _DIM_PAD
-            + tb_w
-            + _MARGIN
-        )
-        if w <= page_w:
-            return True
-        views_bottom = max(0.0, (page_h - h) / 2) + _MARGIN + _DIM_PAD
-        # When views clear the title block row, the iso sits above it and the
-        # title block no longer constrains horizontal space — drop tb_w from w.
-        return bool(w - tb_w <= page_w and views_bottom >= _MARGIN + _TB_H)
-
-    # 2D packing: views + title block fit the row; the iso fits leftover space.
-    w_views_tb = (
-        _MARGIN
-        + gap_left
-        + x_size * scale
-        + gap_fv_sv
-        + y_size * scale
-        + _DIM_PAD
-        + tb_w
-        + _MARGIN
+    g = _layout_geometry(
+        x_size,
+        y_size,
+        z_size,
+        scale,
+        page_w,
+        page_h,
+        tb_w,
+        strips,
+        n_steps,
+        warn_no_iso=False,
     )
-    if w_views_tb > page_w:
-        views_bottom = max(0.0, (page_h - h) / 2) + _MARGIN + _DIM_PAD
-        if not (w_views_tb - tb_w <= page_w and views_bottom >= _MARGIN + _TB_H):
-            return False
-    g = _layout_geometry(x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips, n_steps)
-    if not g.iso_valid:
-        return False
-    iso_fit = min(g.iso_right - g.iso_left, g.iso_top - g.iso_bottom)
-    return bool(iso_fit >= _ISO_MIN_FIT_FRAC * g.iso_natural)
+    return bool(g.fits if pack_iso_2d else g.auto_fits)
 
 
 def _bisect_fit_scale(x_size, y_size, z_size, pw, ph, tb, n_steps, strips, pack_iso_2d):
@@ -505,10 +453,6 @@ def choose_scale(
                 "Requested scale %s on %s page may not fit the 4-view layout", scale, page
             )
         return float(scale), pw, ph, tb
-    # When the caller fixes the page or scale, pack the iso into 2D space so the
-    # largest scale that genuinely fits the requested sheet is chosen (the iso
-    # may sit in vertical headroom).  Automatic selection stays on the
-    # conservative row model, which reserves enough space for all annotations.
     if page is not None:
         pw, ph, tb = _parse_page(page)
         candidates = [(s, pw, ph, tb) for s in _SCALES]
@@ -648,7 +592,17 @@ def _padded_box(cx, cy, hw, hh, pad=_DIM_PAD):
 
 
 def _layout_geometry(
-    x_size, y_size, z_size, scale, page_w, page_h, tb_w, strips, n_steps=0, blocks=None
+    x_size,
+    y_size,
+    z_size,
+    scale,
+    page_w,
+    page_h,
+    tb_w,
+    strips,
+    n_steps=0,
+    blocks=None,
+    warn_no_iso=True,
 ):
     """Compute the 4-view layout geometry for a part at a given scale/page.
 
@@ -819,7 +773,9 @@ def _layout_geometry(
             _padded_box(SV_X, SV_Y, sv_hw, fv_hh),
             title_block.footprint(tb_cx, tb_cy),
         ]
-    iso_left, iso_bottom, iso_right, iso_top = _largest_empty_rect(drawable, obstacles)
+    iso_left, iso_bottom, iso_right, iso_top = _largest_empty_rect(
+        drawable, obstacles, warn=warn_no_iso
+    )
     # _largest_empty_rect falls back to the full drawable when the obstacles
     # leave no genuine gap; detect that (rect overlaps an obstacle) so callers
     # can treat "no room for the iso" as not-fitting rather than a huge phantom.
@@ -847,12 +803,24 @@ def _layout_geometry(
     _tol = 0.5
     _clears_tb = cy0 >= (_TB_CLEAR + _TB_H)
     _right_limit = (page_w - margin) if _clears_tb else (page_w - tb_w - margin)
+    _auto_views_bottom = y_offset + margin + DIM_PAD
+    _auto_clears_tb = _auto_views_bottom >= margin + _TB_H
+    _auto_row_w = total_content_w + 2 * margin + (0.0 if _auto_clears_tb else tb_w)
+    auto_row_fits = _auto_row_w <= page_w + _tol
+    iso_fit = min(iso_right - iso_left, iso_top - iso_bottom)
+    iso_fits = iso_valid and iso_fit >= _ISO_MIN_FIT_FRAC * bbox_max * scale * _ISO_WIDTH_BUDGET
     fits = (
-        iso_valid
+        iso_fits
         and cy0 >= margin - _tol
         and cy1 <= page_h - margin + _tol
         and cx0 >= margin - _tol
         and cx1 <= _right_limit + _tol
+    )
+    auto_fits = (
+        auto_row_fits
+        and cy0 >= margin - _tol
+        and cy1 <= page_h - margin + _tol
+        and cx0 >= margin - _tol
     )
 
     return SimpleNamespace(
@@ -876,7 +844,13 @@ def _layout_geometry(
         ISO_X=(iso_left + iso_right) / 2,
         ISO_Y=(iso_bottom + iso_top) / 2,
         iso_valid=iso_valid,
+        iso_fit=iso_fit,
+        iso_fits=iso_fits,
         iso_natural=bbox_max * scale * _ISO_WIDTH_BUDGET,
+        auto_views_bottom=_auto_views_bottom,
+        auto_clears_tb=_auto_clears_tb,
+        auto_row_fits=auto_row_fits,
+        auto_fits=auto_fits,
         fits=fits,
     )
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -165,7 +165,7 @@ class TestChooseScale:
 
     def test_ctc01_sized_part_gets_A2_not_A1(self):
         # 800×450×150 mm (NIST CTC-01) — iso sits above the title block so tb_w
-        # is dropped from the width constraint.  A2 fits; A1 is no longer chosen (#103).
+        # is dropped from the width constraint. A2 fits; A1 is no longer chosen (#103).
         scale, pw, ph, tbw = choose_scale(800, 450, 150)
         assert scale == pytest.approx(0.2)
         assert int(pw) == 594  # A2 (594 mm), not A1 (841 mm)
@@ -251,17 +251,16 @@ class TestChooseScaleOverrides:
 
     def test_specified_page_enlarges_long_short_part_via_2d_iso(self):
         # A long, short part (100 × 10 × 11, e.g. a staircase) fills a specified
-        # A3 sheet at 2:1.  The conservative row model would reject 2:1 (it
-        # charges the iso a row column), but on a fixed page the iso is packed
-        # into vertical headroom, so the larger scale genuinely fits (#staircase).
+        # A3 sheet at 2:1. The automatic path stays conservative, but fixed-page
+        # requests use the packed verdict exposed by the same layout geometry.
         from draftwright.sheet import _fits
 
-        assert not _fits(100, 10, 11, 2.0, 420.0, 297.0, 150.0)
         assert _fits(100, 10, 11, 2.0, 420.0, 297.0, 150.0, pack_iso_2d=True)
+        assert not _fits(100, 10, 11, 2.0, 420.0, 297.0, 150.0, pack_iso_2d=False)
         scale, pw, ph, _ = choose_scale(100, 10, 11, page="A3")
         assert scale == 2.0
         assert (pw, ph) == (420.0, 297.0)
-        # Automatic selection (no page) stays conservative — A4 at 1:1.
+        # Automatic selection remains page-major: A4 at 1:1 is tried before A3 at 2:1.
         assert choose_scale(100, 10, 11)[:3] == (1.0, 297.0, 210.0)
 
     def test_scale_only_picks_smallest_fitting_page(self):
@@ -270,10 +269,9 @@ class TestChooseScaleOverrides:
         assert int(pw) == 297
 
     def test_scale_only_enlarges_long_short_part_via_2d_iso(self):
-        # Fixed scale, no page: choose_scale walks the page list with
-        # pack_iso_2d=True, so a long/short part keeps the requested 2:1 by
-        # packing the iso into vertical headroom.  At 2:1 the part overruns A4
-        # but fits A3; the conservative row model would have rejected A3 too.
+        # Fixed scale, no page: choose_scale walks the page list with the packed
+        # verdict exposed by the shared geometry. At 2:1 the part overruns A4
+        # but fits A3.
         from draftwright.sheet import _fits
 
         assert not _fits(100, 10, 11, 2.0, 297.0, 210.0, 120.0, pack_iso_2d=True)
@@ -980,9 +978,9 @@ class TestDynamicCorridors:
 
     def test_fits_widens_required_space_for_stepped_part(self):
         # x=5, y=90, z=100 at 1:1 on A3 (420×297, tb=150):
-        #   n_steps=0 (gap_fv_sv=20): w≈415 ≤ 420 → direct fit
-        #   n_steps=3 (gap_fv_sv=69.5): w≈465 > 420; views_bottom < _TB_H so
-        #     the iso-over-title-block fallback cannot apply → False
+        #   n_steps=0 (gap_fv_sv=20): fits.
+        #   n_steps=3 (gap_fv_sv=69.5): auto_fits rejects the conservative
+        #     composed row, using the same verdict later used by auto repack (#519).
         from draftwright.sheet import _fits
 
         assert _fits(5.0, 90.0, 100.0, 1.0, 420.0, 297.0, 150.0, n_steps=0)
@@ -1013,9 +1011,8 @@ class TestDynamicCorridors:
 
     def test_choose_scale_picks_larger_page_for_deep_step_corridor(self):
         # With n_steps=0, x=5 y=90 z=100 fits A3 at 1:1 (420 mm wide).
-        # With n_steps=3, gap_fv_sv jumps to 69.5 mm — A3 no longer fits and
-        # choose_scale must return A2.  This verifies that the conservative
-        # n_steps_ub path in _analyse() ensures the page is never too small.
+        # With n_steps=3, gap_fv_sv jumps to 69.5 mm — the shared auto_fits
+        # verdict rejects A3 and choose_scale returns A2.
         from draftwright.sheet import choose_scale
 
         _, page_w_flat, _, _ = choose_scale(5.0, 90.0, 100.0, n_steps=0)
@@ -1355,21 +1352,58 @@ class TestComposeThenPackRepack:
             f"the {_MARGIN} mm margin — column anchored on front.left, not col_left"
         )
 
-    # --- candidate ladder floor ------------------------------------------
+    # --- candidate ladder -------------------------------------------------
 
-    def test_repack_candidates_floored_at_pass1_sheet(self):
+    def test_repack_candidates_use_the_full_auto_ladder(self):
         from types import SimpleNamespace
 
+        from draftwright._core import _LADDER
         from draftwright.builder import _repack_candidates
 
         a = SimpleNamespace(SCALE=0.2, PAGE_W=594.0, PAGE_H=420.0)
         cands = _repack_candidates(a, None, None)
-        # Search starts at pass 1's own rung (A2 1:5) ...
-        assert cands[0] == (0.2, 594.0, 420.0, 150.0)
-        # ... never offers a smaller sheet pass 1 already rejected ...
-        assert (10.0, 297.0, 210.0, 120.0) not in cands
-        # ... but a larger reduction (A0 1:5) stays reachable.
+        # #519: repack and choose_scale now share one composed-footprint fit, so
+        # repack no longer needs a pass-1 floor to defend against a looser model.
+        assert cands == list(_LADDER)
         assert (0.2, 1189.0, 841.0, 150.0) in cands
+
+    def test_auto_repack_fitness_uses_pass1_step_reservations(self):
+        from draftwright.sheet import ViewBlock, _layout_geometry
+
+        x_size, y_size, z_size = 5.0, 90.0, 100.0
+        scale, page_w, page_h, tb_w = 1.0, 420.0, 297.0, 150.0
+        blocks = {
+            "front": ViewBlock(x_size * scale / 2, z_size * scale / 2),
+            "plan": ViewBlock(x_size * scale / 2, y_size * scale / 2),
+            "side": ViewBlock(y_size * scale / 2, z_size * scale / 2),
+        }
+
+        assert _layout_geometry(
+            x_size,
+            y_size,
+            z_size,
+            scale,
+            page_w,
+            page_h,
+            tb_w,
+            None,
+            0,
+            blocks=blocks,
+            warn_no_iso=False,
+        ).auto_fits
+        assert not _layout_geometry(
+            x_size,
+            y_size,
+            z_size,
+            scale,
+            page_w,
+            page_h,
+            tb_w,
+            None,
+            3,
+            blocks=blocks,
+            warn_no_iso=False,
+        ).auto_fits
 
     def test_repack_candidates_honour_fixed_scale_and_page(self):
         from types import SimpleNamespace


### PR DESCRIPTION
## Summary

Unifies the automatic scale/page and automatic repack fitness path around `_layout_geometry` so the repack no longer needs a hand-coded pass-1 ladder floor.

- Moves `_fits` onto verdicts exposed by `_layout_geometry` instead of duplicating layout math.
- Adds `auto_fits` for automatic scale/page selection and automatic repack.
- Keeps packed `fits` for explicit page/scale override behavior.
- Carries pass-1 `layout_strips` and `layout_n_steps` through `Analysis` so repack uses the same reservation inputs as `choose_scale`.
- Lets auto repack search the full ladder now that it uses the same automatic fitness authority as `choose_scale`.
- Makes empty-rectangle probe warnings quiet during candidate search.

## Why

Fixes #519. The previous flow judged the same automatic layout decision with two different fitness functions: conservative auto scale/page selection, then a more permissive measured repack fit protected by a manual ladder floor. This made the selected page depend on which phase was asking.

## Validation

- `uv run pytest tests/test_make_drawing.py::TestChooseScale tests/test_make_drawing.py::TestChooseScaleOverrides tests/test_make_drawing.py::TestDynamicCorridors tests/test_make_drawing.py::TestComposeThenPackRepack -q`
- `uv run pytest <12 previously failing full-drawing tests> -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
- `git diff --check`
