### PR TITLE
Use full footprints for furniture placement

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -74,10 +74,7 @@ def _declared_will_section(model, *, is_rotational=False, cx=0.0, cy=0.0) -> boo
     features = getattr(model, "features", model)
 
     def feature_member(pt) -> bool:
-        return not (
-            is_rotational
-            and math.hypot(pt[0] - cx, pt[1] - cy) <= _CONCENTRIC_TOL_MM
-        )
+        return not (is_rotational and math.hypot(pt[0] - cx, pt[1] - cy) <= _CONCENTRIC_TOL_MM)
 
     for feat in features:
         if getattr(feat, "kind", None) not in ("hole", "pattern"):

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -449,13 +449,11 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
                 continue
             vb = shp.bounding_box()
             obstacles.append((vb.min.X, vb.min.Y, vb.max.X, vb.max.Y))
-    # Also avoid placed dimension *labels* (not bare centre/leader lines) — a detail
-    # landing on a front-view callout reads as illegible and the repack can't see it
-    # (detail_* views are not orthographic) (#307 review). Text boxes only.
-    for _name, o in dwg.iter_annotations():
-        lb = getattr(o, "label_bbox", None)
-        if lb is not None:
-            obstacles.append(tuple(lb))
+    # Also avoid placed annotations by their full rendered footprints — leader
+    # shafts, centrelines, extension lines, labels, and drawing-level furniture
+    # alike. Detail views are not orthographic, so repack cannot later rescue a
+    # detail placed on invisible occupant geometry (#518).
+    obstacles.extend(strip_obstacles(dwg))
     obstacles.append(
         (a.PAGE_W - a.TB_W - _TB_CLEAR, a.margin, a.PAGE_W - _TB_CLEAR, _TB_CLEAR + _TB_H)
     )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -28,9 +28,7 @@ from build123d import (
     Vector,
 )
 from build123d_drafting.helpers import (
-    Dimension,
     Leader,
-    SafeDimension,
     ViewCoordinates,
     annotate,
     view_axes,
@@ -48,7 +46,7 @@ from draftwright._core import (
     _tag_sequence,
     _text_width,
 )
-from draftwright.annotations._common import carve_free_position
+from draftwright.annotations._common import carve_free_position, strip_obstacles
 from draftwright.export import (
     _export_shape,
     _render_pdf,
@@ -1202,6 +1200,7 @@ class Drawing:
         ph = a.PAGE_H if a is not None else self.page_h
         region = (margin, margin, pw - margin, ph - margin)
         obstacles = [b for v in self.views if (b := self.view_bounds(v)) is not None]
+        obstacles.extend(strip_obstacles(self))
         for o in self.items:
             try:
                 bb = o.bounding_box()
@@ -1261,35 +1260,23 @@ class Drawing:
         margin, ph, pw = a.margin, a.PAGE_H, a.PAGE_W
 
         # Stack the balloon ring *beyond* the annotations already placed around the
-        # plan view, not on top of them (#121). Measure the REAL depth the dimensions
-        # extend into each band from their placed bounding boxes — the strip cursor's
-        # `depth_used` is retired (ADR 0009 / #150) and would report a constant gap.
-        # (This is what the top band already did because `depth_used` went stale under
-        # the hole-table escalation, #125; now every side measures the same way.) Match
-        # on DIMENSION type (not a `dim_` name prefix — that would drop the m_env_*/
-        # m_loc*/m_slot* dims below/beside the view), plus PMI leaders (pmi_*). Balloons,
-        # the table, construction centrelines (bc_*) and callouts are not Dimensions and
-        # are correctly excluded (centrelines are crossable; callouts route separately).
+        # plan view, not on top of them (#121). Measure the REAL depth every placed
+        # occupant extends into each band from its full rendered footprint — leader
+        # shafts, centreline geometry, tables, and bare extension lines included.
+        # This intentionally shares the same full-footprint occupancy source as
+        # corridor placement (#518), instead of re-growing a per-furniture allowlist.
         top_dim = bot_dim = left_dim = right_dim = 0.0
-        for nm, obj in self._named.items():
-            if self._anno_view.get(nm) != view:
-                continue
-            if not isinstance(obj, (Dimension, SafeDimension)) and not nm.startswith("pmi_"):
-                continue
-            try:
-                ob = obj.bounding_box()
-            except Exception:  # noqa: BLE001 — a mark with no bbox can't obstruct
-                continue
-            if ob.max.X > pl and ob.min.X < pr:  # spans the plan's width → top/bottom bands
-                if ob.max.Y > pt:
-                    top_dim = max(top_dim, ob.max.Y - pt)
-                if ob.min.Y < pb:
-                    bot_dim = max(bot_dim, pb - ob.min.Y)
-            if ob.max.Y > pb and ob.min.Y < pt:  # spans the plan's height → left/right bands
-                if ob.min.X < pl:
-                    left_dim = max(left_dim, pl - ob.min.X)
-                if ob.max.X > pr:
-                    right_dim = max(right_dim, ob.max.X - pr)
+        for x0, y0, x1, y1 in strip_obstacles(self, view=view):
+            if x1 > pl and x0 < pr:  # spans the plan's width → top/bottom bands
+                if y1 > pt:
+                    top_dim = max(top_dim, y1 - pt)
+                if y0 < pb:
+                    bot_dim = max(bot_dim, pb - y0)
+            if y1 > pb and y0 < pt:  # spans the plan's height → left/right bands
+                if x0 < pl:
+                    left_dim = max(left_dim, pl - x0)
+                if x1 > pr:
+                    right_dim = max(right_dim, x1 - pr)
 
         # A dense part can stack many pitch dims on one side (holes._place_pitch_dim
         # pushes each successive one 10 mm further out, #92), so the measured depth

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -143,14 +143,16 @@ def _will_section(holes, patterns, *, is_rotational=False, cx=0.0, cy=0.0) -> bo
     def feature_hole(h) -> bool:
         if _axis_letter(h) != "z":
             return False
-        if is_rotational and math.hypot(h.location[0] - cx, h.location[1] - cy) <= _CONCENTRIC_TOL_MM:
+        if (
+            is_rotational
+            and math.hypot(h.location[0] - cx, h.location[1] - cy) <= _CONCENTRIC_TOL_MM
+        ):
             return False
         return True
 
     def qualifies(h) -> bool:
-        return (
-            feature_hole(h)
-            and (h.cbore is not None or h.spotface is not None or h.bottom != "through")
+        return feature_hole(h) and (
+            h.cbore is not None or h.spotface is not None or h.bottom != "through"
         )
 
     return any(qualifies(h) for p in patterns for h in p.holes[:1]) or any(

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6808,6 +6808,19 @@ def _dense_plate():
 class TestHoleTable:
     """#93: hole table placed in a free corner via place_box."""
 
+    class _Boxed:
+        def __init__(self, bb):
+            from types import SimpleNamespace
+
+            x0, y0, x1, y1 = bb
+            self._bb = SimpleNamespace(
+                min=SimpleNamespace(X=x0, Y=y0),
+                max=SimpleNamespace(X=x1, Y=y1),
+            )
+
+        def bounding_box(self):
+            return self._bb
+
     @staticmethod
     def _area(a, b):
         ox = max(0.0, min(a[2], b[2]) - max(a[0], b[0]))
@@ -6855,6 +6868,50 @@ class TestHoleTable:
         members = [("t", 0, object(), 0.0, float(i)) for i in range(5)]
         dropped = Drawing._place_band(stub, "plan", members, "y", 50.0, 0.0, 20.0, 10.0, 3.0, 5.0)
         assert dropped == 2 and len(rendered) == 3
+
+    def test_balloon_ring_depth_uses_bare_obstacle_footprints(self):
+        from types import SimpleNamespace
+
+        from draftwright._core import _STRIP_GAP
+
+        calls = []
+        a = SimpleNamespace(
+            PV_X=50.0,
+            PV_Y=50.0,
+            fv_hw=20.0,
+            pv_hh=10.0,
+            SV_X=95.0,
+            sv_hw=10.0,
+            margin=0.0,
+            PAGE_H=120.0,
+            PAGE_W=120.0,
+            FV_Y=20.0,
+            fv_hh=5.0,
+        )
+        pt = a.PV_Y + a.pv_hh
+        bare_obstacle = self._Boxed((35.0, pt + 2.0, 65.0, pt + 12.0))
+
+        def place_band(view, members, axis, line, lo, hi, gap, fs, r):
+            calls.append((view, members, axis, line, lo, hi, gap, fs, r))
+            return 0
+
+        stub = SimpleNamespace(
+            _analysis=a,
+            _coords={"plan": SimpleNamespace(pp=lambda *_loc: (50.0, 58.0))},
+            draft=SimpleNamespace(font_size=3.0),
+            iter_annotations=lambda: iter([("bare_obstacle", bare_obstacle)]),
+            view_of=lambda _name: "plan",
+            _place_band=place_band,
+            _record_build_issue=lambda *_args: None,
+        )
+        hole = SimpleNamespace(location=(0.0, 0.0, 0.0), diameter=4.0)
+
+        Drawing._add_balloons(stub, "plan", [("A", 0, hole)])
+
+        top_call = next(call for call in calls if call[2] == "x" and call[1])
+        _view, _members, _axis, line, *_rest, fs, r = top_call
+        assert line == pytest.approx(pt + 12.0 + _STRIP_GAP + r)
+        assert fs == 3.0
 
     def test_table_and_balloons_keep_lint_clean(self):
         # covers_diameters lets coverage lint count the tabulated holes, and the


### PR DESCRIPTION
## Summary

Implements #518 by routing remaining 2D furniture placement obstacle checks through the same full-footprint occupancy model used by strip placement.

- Detail-view placement now avoids full rendered annotation footprints, not only label boxes.
- Generic table placement includes `strip_obstacles()` occupancy before fitting the table, while preserving prior view/item bbox avoidance.
- Balloon ring depth now measures full rendered footprints for the live view/drawing-level obstacle set instead of a Dimension/PMI allowlist.
- Adds a regression proving a bare, label-less obstacle above the plan view pushes the balloon ring outward.

Section placement was already moved to `strip_obstacles()` in #527 / #515, so this PR covers the remaining #518 furniture surfaces.

## Review notes

I reviewed the live table escalation order after the change: scattered callouts/location dims are removed before `add_table()`, so the table and balloon obstacle scans measure the live sheet rather than replaced furniture.

No substantive findings remain from the local adversarial pass.

## Validation

- `uv run ruff check src/draftwright tests/test_make_drawing.py`
- `uv run pytest tests/test_make_drawing.py::TestHoleTable::test_balloon_ring_depth_uses_bare_obstacle_footprints tests/test_make_drawing.py::TestHoleTable tests/test_make_drawing.py::TestDetailView tests/test_make_drawing.py::TestPatternGroupBalloon -q`
- `uv run pytest tests/test_make_drawing.py::TestChooseScale tests/test_make_drawing.py::TestComposeThenPackRepack tests/test_make_drawing.py::TestLocationDimsAndSection tests/test_make_drawing.py::TestHoleTable tests/test_make_drawing.py::TestDetailView tests/test_make_drawing.py::TestPatternGroupBalloon -q`
- `uv run pytest tests/test_layout_snapshot.py -q`