### PR TITLE
Make table and balloon escalation layout-aware

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -519,6 +519,7 @@ class Analysis:
     layout_strips: StripDepths
     layout_n_steps: int
     layout_section: bool
+    layout_table_sizes: tuple[tuple[float, float], ...]
     sv_right: float
     iso_right_limit: float
     SCALE: float

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -44,6 +44,7 @@ from draftwright.recognition import (
 from draftwright.sheet import (
     StripDepths,
     _build_zones,
+    _est_hole_table_sizes,
     _layout_geometry,
     _measure_strips,
     _will_section,
@@ -419,6 +420,13 @@ def _analyse(
         cx=cx,
         cy=cy,
     ) or _declared_will_section(model, is_rotational=is_rotational, cx=cx, cy=cy)
+    layout_table_sizes = _est_hole_table_sizes(
+        holes,
+        patterns,
+        bb,
+        font_size=_FONT_SIZE,
+        pad_around_text=_pad_around_text,
+    )
 
     # Choose scale/page, iterating so the reserved step corridor matches the
     # number of steps the legibility gate will actually place (#1) — not the raw
@@ -446,6 +454,7 @@ def _analyse(
             page=page,
             strips=strips_i,
             section=layout_section,
+            table_sizes=layout_table_sizes,
         )
 
     (SCALE, PAGE_W, PAGE_H, TB_W), strips_i, n_for_sizing = _converge_step_sizing(
@@ -482,6 +491,7 @@ def _analyse(
             page=page,
             strips=strips_i,
             section=layout_section,
+            table_sizes=layout_table_sizes,
         )
         # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
         # legible) but the requested scale is below the floor. A part illegible at every
@@ -523,6 +533,7 @@ def _analyse(
         strips,
         n_steps,
         section=layout_section,
+        table_sizes=layout_table_sizes,
     )
     fv_hw = _g.fv_hw
     fv_hh = _g.fv_hh
@@ -594,6 +605,7 @@ def _analyse(
         layout_strips=strips,
         layout_n_steps=n_steps,
         layout_section=layout_section,
+        layout_table_sizes=layout_table_sizes,
         sv_right=sv_right,
         iso_right_limit=iso_right_limit,
         SCALE=SCALE,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -379,6 +379,7 @@ def _repack(
             a.layout_n_steps,
             blocks=blocks,
             section=a.layout_section,
+            table_sizes=a.layout_table_sizes,
             warn_no_iso=False,
         )
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -163,6 +163,103 @@ def _build_table(rows, draft, block_cols=None):
     return table
 
 
+@dataclass
+class _FlowEdge:
+    to: int
+    rev: int
+    cap: int
+    cost: int
+
+
+def _strip_capacity(lo: float, hi: float, gap: float) -> int:
+    """Number of uniform balloon centres that can fit in ``[lo, hi]``."""
+
+    if hi < lo:
+        return 0
+    return int(math.floor((hi - lo) / gap + 1e-9)) + 1
+
+
+def _assign_balloon_bands(members, choices_by_member, capacities):
+    """Global max-cardinality/min-cost assignment of balloons to side bands (#516)."""
+
+    band_order = ("left", "right", "top", "bottom")
+    bands = [b for b in band_order if capacities.get(b, 0) > 0]
+    assigned: dict[str, list] = {b: [] for b in band_order}
+    if not members or not bands:
+        return assigned, len(members)
+
+    source = 0
+    member0 = 1
+    band0 = member0 + len(members)
+    sink = band0 + len(bands)
+    graph: list[list[_FlowEdge]] = [[] for _ in range(sink + 1)]
+
+    def add_edge(fr: int, to: int, cap: int, cost: int) -> _FlowEdge:
+        fwd = _FlowEdge(to, len(graph[to]), cap, cost)
+        rev = _FlowEdge(fr, len(graph[fr]), 0, -cost)
+        graph[fr].append(fwd)
+        graph[to].append(rev)
+        return fwd
+
+    used_edges: dict[tuple[int, str], _FlowEdge] = {}
+    for i, choices in enumerate(choices_by_member):
+        add_edge(source, member0 + i, 1, 0)
+        for j, band in enumerate(bands):
+            if band not in choices:
+                continue
+            # Costs are integerised for deterministic shortest paths; the tiny band
+            # ordinal keeps exact ties stable without changing real distance order.
+            cost = int(round(max(0.0, choices[band]) * 1000)) + band_order.index(band)
+            used_edges[(i, band)] = add_edge(member0 + i, band0 + j, 1, cost)
+    for j, band in enumerate(bands):
+        add_edge(band0 + j, sink, capacities[band], 0)
+
+    def shortest_path():
+        dist = [math.inf] * len(graph)
+        prev: list[tuple[int, int] | None] = [None] * len(graph)
+        in_queue = [False] * len(graph)
+        queue = [source]
+        dist[source] = 0
+        in_queue[source] = True
+        while queue:
+            v = queue.pop(0)
+            in_queue[v] = False
+            for ei, edge in enumerate(graph[v]):
+                if edge.cap <= 0:
+                    continue
+                nd = dist[v] + edge.cost
+                if nd >= dist[edge.to]:
+                    continue
+                dist[edge.to] = nd
+                prev[edge.to] = (v, ei)
+                if not in_queue[edge.to]:
+                    queue.append(edge.to)
+                    in_queue[edge.to] = True
+        return prev if prev[sink] is not None else None
+
+    max_flow = min(len(members), sum(capacities.get(b, 0) for b in bands))
+    flow = 0
+    while flow < max_flow and (prev := shortest_path()) is not None:
+        v = sink
+        while v != source:
+            pv, ei = prev[v]
+            edge = graph[pv][ei]
+            edge.cap -= 1
+            graph[v][edge.rev].cap += 1
+            v = pv
+        flow += 1
+
+    placed = 0
+    for i, member in enumerate(members):
+        for band in bands:
+            edge = used_edges.get((i, band))
+            if edge is not None and edge.cap == 0:
+                assigned[band].append(member)
+                placed += 1
+                break
+    return assigned, len(members) - placed
+
+
 # Codes that check standards/geometry correctness rather than pure page
 # layout. Grouped so a caller (and the #30 repair loop) can tell a wrong
 # drawing from a merely tight one.
@@ -1296,26 +1393,43 @@ class Drawing:
         bottom_line = pb - bot_dim - standoff - r
         has_bottom = pb - (a.FV_Y + a.fv_hh) > bot_dim + standoff + 2 * r
 
-        # Assign each hole to the nearest reserved band.
-        bands: dict = {"left": [], "right": [], "top": [], "bottom": []}
-        for tag, j, hole in specs:
-            cx, cy = pp(*hole.location)
-            choices = {"left": cx - pl, "right": pr - cx, "top": pt - cy}
-            if has_bottom:
-                choices["bottom"] = cy - pb
-            bands[min(choices, key=lambda s: choices[s])].append((tag, j, hole, cx, cy))
-
         # left/right balloons vary in Y at a fixed X just outside the part; top
         # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
         # offset by its side's dim depth so the ring sits clear of the dims.
-        dropped = 0
+        band_defs = {
+            "left": ("y", pl - left_dim - standoff - r, margin + r, ph - margin - r),
+            "right": ("y", pr + right_dim + standoff + r, margin + r, ph - margin - r),
+            "top": ("x", pt + top_dim + standoff + r, pl - standoff, sv_left - r),
+            "bottom": ("x", bottom_line, pl - standoff, sv_left - r),
+        }
+
+        # Globally assign holes across the usable reserved bands.  Nearest-band
+        # greedy could crowd one side and drop balloons while another side sat
+        # empty; the assignment maximises placed balloons first, then minimises
+        # leader distance to the ACTUAL post-depth band lines (#516).
+        members = []
+        choices_by_member = []
+        for tag, j, hole in specs:
+            cx, cy = pp(*hole.location)
+            choices = {
+                "left": abs(cx - band_defs["left"][1]),
+                "right": abs(band_defs["right"][1] - cx),
+                "top": abs(band_defs["top"][1] - cy),
+            }
+            if has_bottom:
+                choices["bottom"] = abs(cy - band_defs["bottom"][1])
+            members.append((tag, j, hole, cx, cy))
+            choices_by_member.append(choices)
+
+        capacities = {
+            name: (_strip_capacity(lo, hi, gap) if name != "bottom" or has_bottom else 0)
+            for name, (_axis, _line, lo, hi) in band_defs.items()
+        }
+        bands, dropped = _assign_balloon_bands(members, choices_by_member, capacities)
         dropped += self._place_band(
             view,
             bands["left"],
-            "y",
-            pl - left_dim - standoff - r,
-            margin + r,
-            ph - margin - r,
+            *band_defs["left"],
             gap,
             fs,
             r,
@@ -1323,10 +1437,7 @@ class Drawing:
         dropped += self._place_band(
             view,
             bands["right"],
-            "y",
-            pr + right_dim + standoff + r,
-            margin + r,
-            ph - margin - r,
+            *band_defs["right"],
             gap,
             fs,
             r,
@@ -1334,10 +1445,7 @@ class Drawing:
         dropped += self._place_band(
             view,
             bands["top"],
-            "x",
-            pt + top_dim + standoff + r,
-            pl - standoff,
-            sv_left - r,
+            *band_defs["top"],
             gap,
             fs,
             r,
@@ -1345,10 +1453,7 @@ class Drawing:
         dropped += self._place_band(
             view,
             bands["bottom"],
-            "x",
-            bottom_line,
-            pl - standoff,
-            sv_left - r,
+            *band_defs["bottom"],
             gap,
             fs,
             r,

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -43,9 +43,11 @@ from draftwright._core import (
     _fmt,
     _largest_empty_rect,
     _parse_page,
+    _tag_sequence,
     _tb_width,
     _text_width,
 )
+from draftwright.layout import fit_box
 from draftwright.recognition import BoltCircle, HoleSpec, RectGrid
 
 _log = logging.getLogger(__name__)
@@ -126,6 +128,79 @@ def _will_balloon(holes, patterns) -> bool:
         return False
     covered = sum(len(p.holes) for p in patterns if p.holes and _axis_letter(p.holes[0]) == "z")
     return covered < 0.8 * len(z)
+
+
+def _wrap_table_rows(header, data, ncols):
+    """Local mirror of the hole-table row wrapping used by the annotation pass."""
+
+    per = math.ceil(len(data) / ncols)
+    blank = ("",) * len(header)
+    wide = [tuple(header) * ncols]
+    for r in range(per):
+        row: tuple = ()
+        for c in range(ncols):
+            idx = c * per + r
+            row += data[idx] if idx < len(data) else blank
+        wide.append(row)
+    return wide
+
+
+def _est_table_size(
+    rows, font_size: float = _FONT_SIZE, pad_around_text: float = 2.0, block_cols=None
+):
+    """Table footprint estimate matching ``drawing._build_table``'s sizing model."""
+
+    if not rows:
+        return None
+    fs = font_size
+    pad = pad_around_text
+    row_h = fs + 2 * pad
+    ncol = len(rows[0])
+    bc = block_cols if (block_cols and ncol % block_cols == 0 and block_cols < ncol) else ncol
+    block_gap = 3 * pad
+    col_w = [
+        max(max(_text_width(str(r[c]), fs) for r in rows) + 2 * pad, fs * 2.5) for c in range(ncol)
+    ]
+    total_w = sum(col_w) + (max(ncol // bc - 1, 0) * block_gap)
+    total_h = row_h * len(rows)
+    return (total_w, total_h)
+
+
+def _est_hole_table_sizes(
+    holes,
+    patterns,
+    bb,
+    font_size: float = _FONT_SIZE,
+    pad_around_text: float = 2.0,
+) -> tuple[tuple[float, float], ...]:
+    """Possible wrapped hole-chart footprints for scale/page fitness (#517).
+
+    The runtime resolver tries the same one-to-four wrapped table blocks after
+    replacing dense scattered plan-hole dimensions. This estimate lets the outer
+    layout reject a page/scale where none of those table shapes can coexist with
+    the placed blocks, instead of discovering that only after annotation.
+    """
+
+    patterned = {h for p in patterns for h in p.holes}
+    z_holes = [h for h in holes if _axis_letter(h) == "z" and h not in patterned]
+    if len(z_holes) < _TABULATE_MIN_HOLES:
+        return ()
+    dx, dy = bb.min.X, bb.min.Y
+    header = ("TAG", "ø", "X", "Y")
+    data = [
+        (tag, f"ø{_fmt(h.diameter)}", _fmt(h.location[0] - dx), _fmt(h.location[1] - dy))
+        for tag, h in zip(_tag_sequence(len(z_holes)), z_holes, strict=True)
+    ]
+    return tuple(
+        size
+        for ncols in (1, 2, 3, 4)
+        if (
+            size := _est_table_size(
+                _wrap_table_rows(header, data, ncols), font_size, pad_around_text, len(header)
+            )
+        )
+        is not None
+    )
 
 
 def _will_section(holes, patterns, *, is_rotational=False, cx=0.0, cy=0.0) -> bool:
@@ -389,6 +464,7 @@ def _fits(
     strips: StripDepths | None = None,
     pack_iso_2d: bool = False,
     section: bool = False,
+    table_sizes=(),
 ) -> bool:
     """True if the composed 4-view footprint fits the page at this scale.
 
@@ -408,13 +484,14 @@ def _fits(
         strips,
         n_steps,
         section=section,
+        table_sizes=table_sizes,
         warn_no_iso=False,
     )
     return bool(g.fits if pack_iso_2d else g.auto_fits)
 
 
 def _bisect_fit_scale(
-    x_size, y_size, z_size, pw, ph, tb, n_steps, strips, pack_iso_2d, section=False
+    x_size, y_size, z_size, pw, ph, tb, n_steps, strips, pack_iso_2d, section=False, table_sizes=()
 ):
     """Largest scale at which the 4-view layout fits ``(pw, ph)``, found by bisection —
     the layout is monotone in scale (a smaller scale never fits worse). Used only as the
@@ -437,6 +514,7 @@ def _bisect_fit_scale(
             strips=strips,
             pack_iso_2d=pack_iso_2d,
             section=section,
+            table_sizes=table_sizes,
         ):
             lo = mid
         else:
@@ -453,6 +531,7 @@ def choose_scale(
     page=None,
     strips: StripDepths | None = None,
     section: bool = False,
+    table_sizes=(),
 ) -> tuple:
     """Return (SCALE, PAGE_W, PAGE_H, TB_W) for a 4-view layout.
 
@@ -489,6 +568,7 @@ def choose_scale(
             strips=strips,
             pack_iso_2d=True,
             section=section,
+            table_sizes=table_sizes,
         ):
             _log.warning(
                 "Requested scale %s on %s page may not fit the 4-view layout", scale, page
@@ -514,6 +594,7 @@ def choose_scale(
             strips=strips,
             pack_iso_2d=pack_iso_2d,
             section=section,
+            table_sizes=table_sizes,
         ):
             return cand
     # The ISO 5455 ladder exhausted with no standard fit (a part too large even for
@@ -524,7 +605,17 @@ def choose_scale(
     if scale is None:
         _pw, _ph, _tb = candidates[-1][1], candidates[-1][2], candidates[-1][3]
         s = _bisect_fit_scale(
-            x_size, y_size, z_size, _pw, _ph, _tb, n_steps, strips, pack_iso_2d, section
+            x_size,
+            y_size,
+            z_size,
+            _pw,
+            _ph,
+            _tb,
+            n_steps,
+            strips,
+            pack_iso_2d,
+            section,
+            table_sizes,
         )
         if s is not None:
             _log.warning(
@@ -653,6 +744,7 @@ def _layout_geometry(
     n_steps=0,
     blocks=None,
     section: bool = False,
+    table_sizes=(),
     warn_no_iso=True,
 ):
     """Compute the 4-view layout geometry for a part at a given scale/page.
@@ -878,8 +970,26 @@ def _layout_geometry(
     auto_row_fits = _auto_row_w <= page_w + _tol
     iso_fit = min(iso_right - iso_left, iso_top - iso_bottom)
     iso_fits = iso_valid and iso_fit >= _ISO_MIN_FIT_FRAC * bbox_max * scale * _ISO_WIDTH_BUDGET
+    # Tables are late furniture and must reserve against the same composed view
+    # footprints the fit model validates, not the iso's byte-identity padded-box
+    # obstacles. Otherwise a table can be accepted in space already reserved for
+    # planned strips/halos and then drop after real annotations are rendered.
+    table_obstacles = [
+        fv.footprint(FV_X, FV_Y),
+        pv.footprint(PV_X, PV_Y),
+        sv.footprint(SV_X, SV_Y),
+        title_block.footprint(tb_cx, tb_cy),
+    ]
+    if section:
+        table_obstacles.append(section_block.footprint(SECTION_X, SECTION_Y))
+    if iso_valid:
+        table_obstacles.append((iso_left, iso_bottom, iso_right, iso_top))
+    table_fits = not table_sizes or any(
+        fit_box(size, drawable, table_obstacles, "tr") is not None for size in table_sizes
+    )
     fits = (
         iso_fits
+        and table_fits
         and cy0 >= margin - _tol
         and cy1 <= page_h - margin + _tol
         and cx0 >= margin - _tol
@@ -887,6 +997,7 @@ def _layout_geometry(
     )
     auto_fits = (
         auto_row_fits
+        and table_fits
         and cy0 >= margin - _tol
         and cy1 <= page_h - margin + _tol
         and cx0 >= margin - _tol
@@ -917,6 +1028,7 @@ def _layout_geometry(
         iso_valid=iso_valid,
         iso_fit=iso_fit,
         iso_fits=iso_fits,
+        table_fits=table_fits,
         iso_natural=bbox_max * scale * _ISO_WIDTH_BUDGET,
         auto_views_bottom=_auto_views_bottom,
         auto_clears_tb=_auto_clears_tb,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -191,6 +191,38 @@ class TestChooseScale:
         assert choose_scale(40, 10, 20, section=False)[:3] == (2.0, 297.0, 210.0)
         assert choose_scale(40, 10, 20, section=True)[:3] == (1.0, 297.0, 210.0)
 
+    def test_table_footprint_participates_in_auto_scale_choice(self):
+        # The compact 40×10×20 layout fits A4 at 2:1, but once a hole table must
+        # share the sheet with the view blocks and iso, A4 has no table slot and
+        # the shared fitness model escalates the page instead of dropping it later.
+        assert choose_scale(40, 10, 20)[:3] == (2.0, 297.0, 210.0)
+        assert choose_scale(40, 10, 20, table_sizes=((100.0, 60.0),))[:3] == (
+            2.0,
+            420.0,
+            297.0,
+        )
+
+    def test_table_footprint_uses_composed_view_blocks(self):
+        from draftwright.sheet import _layout_geometry
+
+        bare = _layout_geometry(
+            40, 10, 20, 1.0, 420.0, 297.0, 150.0, None, table_sizes=((100.0, 60.0),)
+        )
+        stripped = _layout_geometry(
+            40,
+            10,
+            20,
+            1.0,
+            420.0,
+            297.0,
+            150.0,
+            StripDepths(right=20.0, left=20.0, top=60.0, pv_halo=30.0),
+            table_sizes=((100.0, 60.0),),
+        )
+
+        assert bare.table_fits
+        assert not stripped.table_fits
+
     # Enlargement scales for small parts (#62)
 
     def test_small_part_gets_enlargement_scale(self):
@@ -6912,6 +6944,97 @@ class TestHoleTable:
         _view, _members, _axis, line, *_rest, fs, r = top_call
         assert line == pytest.approx(pt + 12.0 + _STRIP_GAP + r)
         assert fs == 3.0
+
+    def test_balloon_assignment_rebalances_across_bands_before_dropping(self):
+        from types import SimpleNamespace
+
+        from draftwright._core import _STRIP_GAP, _STRIP_SPACING
+        from draftwright.drawing import _strip_capacity
+
+        calls = []
+        a = SimpleNamespace(
+            PV_X=50.0,
+            PV_Y=50.0,
+            fv_hw=20.0,
+            pv_hh=10.0,
+            SV_X=82.0,
+            sv_hw=10.0,
+            margin=0.0,
+            PAGE_H=120.0,
+            PAGE_W=120.0,
+            FV_Y=30.0,
+            fv_hh=5.0,
+        )
+
+        def place_band(view, members, axis, line, lo, hi, gap, fs, r):
+            calls.append((view, list(members), axis, line, lo, hi, gap, fs, r))
+            return 0
+
+        stub = SimpleNamespace(
+            _analysis=a,
+            _coords={"plan": SimpleNamespace(pp=lambda *_loc: (50.0, 58.0))},
+            draft=SimpleNamespace(font_size=3.0),
+            iter_annotations=lambda: iter(()),
+            view_of=lambda _name: "plan",
+            _place_band=place_band,
+            _record_build_issue=lambda *_args: None,
+        )
+        holes = [SimpleNamespace(location=(float(i), 0.0, 0.0), diameter=4.0) for i in range(6)]
+
+        Drawing._add_balloons(
+            stub, "plan", [(chr(ord("A") + i), 0, h) for i, h in enumerate(holes)]
+        )
+
+        fs = stub.draft.font_size
+        r = fs * 1.5
+        gap = 2 * r + 2 * _STRIP_SPACING
+        top_cap = _strip_capacity(a.PV_X - a.fv_hw - _STRIP_GAP, a.SV_X - a.sv_hw - r, gap)
+        top_members = next(call[1] for call in calls if call[2] == "x" and call[3] > a.PV_Y)
+        side_members = [m for call in calls if call[2] == "y" for m in call[1]]
+
+        assert len(top_members) == top_cap
+        assert len(side_members) == len(holes) - top_cap
+
+    def test_balloon_assignment_cost_uses_actual_band_line_after_furniture_depth(self):
+        from types import SimpleNamespace
+
+        calls = []
+        a = SimpleNamespace(
+            PV_X=50.0,
+            PV_Y=50.0,
+            fv_hw=20.0,
+            pv_hh=10.0,
+            SV_X=34.0,
+            sv_hw=10.0,
+            margin=0.0,
+            PAGE_H=120.0,
+            PAGE_W=140.0,
+            FV_Y=30.0,
+            fv_hh=5.0,
+        )
+        right_obstacle = self._Boxed((71.0, 45.0, 115.0, 55.0))
+
+        def place_band(view, members, axis, line, lo, hi, gap, fs, r):
+            calls.append((view, list(members), axis, line, lo, hi, gap, fs, r))
+            return 0
+
+        stub = SimpleNamespace(
+            _analysis=a,
+            _coords={"plan": SimpleNamespace(pp=lambda *_loc: (60.0, 50.0))},
+            draft=SimpleNamespace(font_size=3.0),
+            iter_annotations=lambda: iter([("right_obstacle", right_obstacle)]),
+            view_of=lambda _name: "plan",
+            _place_band=place_band,
+            _record_build_issue=lambda *_args: None,
+        )
+        hole = SimpleNamespace(location=(0.0, 0.0, 0.0), diameter=4.0)
+
+        Drawing._add_balloons(stub, "plan", [("A", 0, hole)])
+
+        left_members = next(call[1] for call in calls if call[2] == "y" and call[3] < a.PV_X)
+        right_members = next(call[1] for call in calls if call[2] == "y" and call[3] > a.PV_X)
+        assert [m[0] for m in left_members] == ["A"]
+        assert right_members == []
 
     def test_table_and_balloons_keep_lint_clean(self):
         # covers_diameters lets coverage lint count the tabulated holes, and the


### PR DESCRIPTION
## Summary

- add estimated wrapped hole-table footprints to the shared scale/page and repack fitness model
- carry table layout requirements through `Analysis` so table-capable sheets are selected consistently
- replace nearest-band balloon assignment with a global max-cardinality/min-cost assignment before per-band strip solving
- add focused regressions for table-aware page selection and cross-band balloon rebalancing

## Why

The hole/data table and balloon ring were still late, greedy escalation surfaces. A sheet could choose a page/scale that had no table slot, then drop the table after annotations were already placed. Balloon placement could also crowd one nearest band and drop balloons while adjacent bands had capacity.

## Validation

- `uv run ruff format src/draftwright/drawing.py`
- `uv run ruff check src/draftwright/sheet.py src/draftwright/analysis.py src/draftwright/builder.py src/draftwright/drawing.py tests/test_make_drawing.py`
- `uv run mypy src/draftwright`
- `uv run pytest tests/test_make_drawing.py::TestChooseScale::test_table_footprint_participates_in_auto_scale_choice tests/test_make_drawing.py::TestHoleTable::test_balloon_assignment_rebalances_across_bands_before_dropping`
- `uv run pytest` before the final type-annotation-only patch: 1126 passed, 17 deselected, 8 warnings
