### PR TITLE
Add pinned locate candidates

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -365,12 +365,27 @@ _OVERALL_SUBCHAIN = 2
 _MANDATORY_OVERALL_PRIORITY = 100.0
 
 
-def _location_candidate(dwg, name, *, view, span_key, distance, build, feature=None):
+def _location_candidate(
+    dwg,
+    name,
+    *,
+    view,
+    span_key,
+    distance,
+    build,
+    feature=None,
+    pinned=False,
+):
     """A :class:`CorridorCandidate` for a datum-referenced hole/pattern location dim.
     Location dims outrank a coincident slot-position line in dedup (#345) and form the
     outer, datum-distance-ordered run of the ladder (#346). Force-kept (policy B): a plan-X
     / side-Y location has no alternate view, so a corridor block keeps it rather than drops
     it; only a physically full strip drops (``location_ref_dropped`` → hole-table escalate)."""
+
+    def _placed(nm):
+        dwg._cover_scattered_hole_doc(nm)
+        if pinned:
+            dwg.pin(nm)
 
     def _drop(nm):
         edge = "plan view" if view == "plan" else "side view"
@@ -384,16 +399,17 @@ def _location_candidate(dwg, name, *, view, span_key, distance, build, feature=N
         build=build,
         order=(_LOC_SUBCHAIN, distance, name),
         # A placed location may later be replaced by the scattered-hole table (#351 PR-4c).
-        on_place=lambda nm: dwg._cover_scattered_hole_doc(nm),
+        on_place=_placed,
         on_drop=_drop,
         dedup=(view, span_key[0], span_key[1]),
-        precedence=2,
+        precedence=3 if pinned else 2,
+        priority=100.0 if pinned else 0.0,
         force=True,
         feature=feature,  # provenance (ADR 0010): the located hole/pattern
     )
 
 
-def render_locations(dwg, model, a, *, only=None) -> int:
+def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
     """Baseline X/Y hole-location dims from the IR (#238). The planner decides the
     intent (`plan_locations`: which refs, from which datum); this renderer owns the
     layout (Amendment 4) — X dims tier above the plan view, Y dims above the side
@@ -404,7 +420,11 @@ def render_locations(dwg, model, a, *, only=None) -> int:
     *only*, when given, restricts placement to refs whose source feature is in the set —
     the #426 finalize() path passes the recorded ``locate`` intents' features so the
     corridor solve runs over the user's edited subset. ``None`` (the auto-pass) places
-    every ref, byte-identically."""
+    every ref, byte-identically.
+
+    *pinned* carries the #511 first slice: deferred user ``locate(..., pin=True)`` calls
+    remain first-class corridor candidates, but get higher survival/dedup priority and
+    pin their placed names instead of being hand-added after the solve."""
     planned = plan_locations(model)
     if not planned:
         return 0
@@ -432,6 +452,7 @@ def render_locations(dwg, model, a, *, only=None) -> int:
         refs.append((rx, ry, pd.feature))  # carry the source feature for provenance (ADR 0010)
     if not refs:
         return 0
+    pinned_set = set(pinned or ())
     tier = draft.font_size + 2 * draft.pad_around_text
     n = 0
 
@@ -454,8 +475,12 @@ def render_locations(dwg, model, a, *, only=None) -> int:
     PX, PY = a.proj.plan_x, a.proj.plan_y
     x_refs: list = []
     for r in refs:
-        if not any(abs(r[0] - u[0]) < 0.5 for u in x_refs):
-            x_refs.append(r)
+        for u in x_refs:
+            if abs(r[0] - u[0]) < 0.5:
+                u[3] = u[3] or r[2] in pinned_set
+                break
+        else:
+            x_refs.append([r[0], r[1], r[2], r[2] in pinned_set])
     _x_drawable = {r[0] for r in x_refs if abs(r[0] - datum_x) * a.SCALE >= 1.0}
     _kept_x, _n_x_close = _legible_locations(_x_drawable, a.SCALE)
     if _n_x_close:
@@ -474,7 +499,7 @@ def render_locations(dwg, model, a, *, only=None) -> int:
     # pass carving around the other and interleaving. No alternate view for a plan-X
     # location, so a corridor-blocked dim is force-kept (policy B), not relocated; only a
     # physically full strip drops (→ location_ref_dropped, escalates the hole table).
-    for i, (rx, ry, feat) in enumerate(sorted(x_refs, key=lambda r: abs(r[0] - datum_x))):
+    for i, (rx, ry, feat, pin_ref) in enumerate(sorted(x_refs, key=lambda r: abs(r[0] - datum_x))):
         if abs(rx - datum_x) * a.SCALE < 1.0:
             continue  # on the datum edge — nothing to dimension
         n += 1
@@ -504,6 +529,7 @@ def render_locations(dwg, model, a, *, only=None) -> int:
                     label=_fmt(_rx - datum_x),
                 ),
                 feature=_xfeat,
+                pinned=pin_ref,
             ),
         )
 
@@ -513,8 +539,12 @@ def render_locations(dwg, model, a, *, only=None) -> int:
     iso_x0, iso_y0, _, _ = _iso_bbox(dwg)
     y_refs: list = []
     for r in refs:
-        if not any(abs(r[1] - u[1]) < 0.5 for u in y_refs):
-            y_refs.append(r)
+        for u in y_refs:
+            if abs(r[1] - u[1]) < 0.5:
+                u[3] = u[3] or r[2] in pinned_set
+                break
+        else:
+            y_refs.append([r[0], r[1], r[2], r[2] in pinned_set])
     _y_drawable = {r[1] for r in y_refs if abs(r[1] - datum_y) * a.SCALE >= 1.0}
     _kept_y, _n_y_close = _legible_locations(_y_drawable, a.SCALE)
     if _n_y_close:
@@ -530,9 +560,9 @@ def render_locations(dwg, model, a, *, only=None) -> int:
     # Cap the side-above strip below the iso view so Y-location dims never run under it
     # (the carve respects outer_limit); the dim_pitch_side dims are obstacles the carve
     # avoids structurally, retiring the old manual allocate(10.0) reservation + cursor.
-    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _ in y_refs):
+    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _feat, _pin in y_refs):
         a.sv_zones.above.outer_limit = min(a.sv_zones.above.outer_limit, iso_y0 - 4)
-    for i, (rx, ry, feat) in enumerate(sorted(y_refs, key=lambda r: abs(r[1] - datum_y))):
+    for i, (rx, ry, feat, pin_ref) in enumerate(sorted(y_refs, key=lambda r: abs(r[1] - datum_y))):
         if abs(ry - datum_y) * a.SCALE < 1.0:
             continue
         n += 1
@@ -560,6 +590,7 @@ def render_locations(dwg, model, a, *, only=None) -> int:
                     label=_fmt(_ry - datum_y),
                 ),
                 feature=_yfeat,
+                pinned=pin_ref,
             ),
         )
     return n

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -165,7 +165,9 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
     return name
 
 
-def add_feature_location(dwg, feature, *, axes: tuple[str, ...] | None = None) -> list[str]:
+def add_feature_location(
+    dwg, feature, *, axes: tuple[str, ...] | None = None, pin: bool = False
+) -> list[str]:
     """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern —
     the #418 ``locate()`` add verb (symmetric with :meth:`Drawing.drop`).
 
@@ -181,7 +183,8 @@ def add_feature_location(dwg, feature, *, axes: tuple[str, ...] | None = None) -
     offset; empty for a concentric/on-datum bore that has nothing to dimension).
 
     ``axes`` selects the in-plane axes to emit (default both); ``"x"`` = the plan-X
-    position, ``"y"`` = the side-Y position.
+    position, ``"y"`` = the side-Y position. ``pin=True`` records each placed dim as a
+    deliberate user edit so later repair/finalize work leaves its placement fixed (#511).
 
     Raises ``ValueError`` if the drawing has no detected model/analysis, *feature*
     is not in the model, or is not a Z-axis hole/pattern (side-drilled bores are placed
@@ -253,6 +256,8 @@ def add_feature_location(dwg, feature, *, axes: tuple[str, ...] | None = None) -
             view=view,
             feature=feature,
         )
+        if pin:
+            dwg.pin(nm)
         return nm
 
     names: list[str] = []

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -946,7 +946,7 @@ class Drawing:
 
         return add_section(self)
 
-    def locate(self, feature, *, axes=None) -> list[str]:
+    def locate(self, feature, *, axes=None, pin=False) -> list[str]:
         """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern
         (#418) — the location half of the feature-referenced **add** surface.
 
@@ -954,9 +954,11 @@ class Drawing:
         location dim measures the *datum → feature-centre* offset, which no feature
         exposes as a parameter. *feature* is a hole/pattern from :meth:`model`; ``axes``
         selects the in-plane axes (default both — ``"x"`` above the plan view, ``"y"``
-        above the side view). Each dim is placed into free space beside its view and
-        tagged with *feature* so :meth:`drop` / :meth:`annotations_of` find it. Returns
-        the placed names (0–2 — one per axis with a real offset).
+        above the side view). ``pin=True`` marks the placed dimensions as deliberate user
+        edits: in deferred mode they still flow through the shared corridor solve, but
+        survive/dedup as high-priority candidates and pin themselves once placed (#511).
+        Each dim is tagged with *feature* so :meth:`drop` / :meth:`annotations_of` find it.
+        Returns the placed names (0–2 — one per axis with a real offset).
 
         Raises ``ValueError`` if *feature* is not a Z-axis hole/pattern (side-drilled
         bores are placed by the auto-pass). A feature with no datum-referenced ref (a
@@ -965,11 +967,11 @@ class Drawing:
         (byte-identity is not a goal, #400 Ph2).
         """
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
-            self._intents.append(Intent("locate", feature, {"axes": axes}))
+            self._intents.append(Intent("locate", feature, {"axes": axes, "pin": pin}))
             return []
         from draftwright.annotations.holes import add_feature_location
 
-        return add_feature_location(self, feature, axes=axes)
+        return add_feature_location(self, feature, axes=axes, pin=pin)
 
     @contextlib.contextmanager
     def deferred(self):
@@ -1138,6 +1140,9 @@ class Drawing:
             and it.kwargs.get("role") in ("slot_width", "slot_length")
         }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
+        pinned_loc = {
+            it.feature for it in self._intents if id(it) in corridor_ids and it.kwargs.get("pin")
+        }
         only_callout = {it.feature for it in self._intents if id(it) in callout_ids}
         only_dia = {it.feature for it in self._intents if id(it) in dia_ids}
         only_len = {it.feature for it in self._intents if id(it) in len_ids}
@@ -1186,7 +1191,7 @@ class Drawing:
             if only_loc or slot_feats:
                 assert a is not None and isinstance(model, PartModel)  # either ⟹ routable
                 if only_loc:
-                    render_locations(self, model, a, only=only_loc)
+                    render_locations(self, model, a, only=only_loc, pinned=pinned_loc)
                 if slot_feats:
                     render_slots(self, model, a, only=slot_feats)
                 drain_corridors(self)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4665,6 +4665,15 @@ class TestFeatureEdits:
         assert len(names) == 1 and names[0].startswith("m_locx")
         assert dwg.get_annotation(names[0]).label == "40"
 
+    def test_locate_pin_marks_live_location_dims(self):
+        # #511 slice 1: a user location edit can be declared pinned at creation time, so
+        # later repair/finalize work sees the same pin state as if pin(name) ran after.
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        centre = next(f for f in dwg.model().features if f.kind == "hole" and len(f.members) == 1)
+        names = dwg.locate(centre, pin=True)
+        assert names
+        assert set(names) <= dwg._pinned
+
     def test_locate_dedups_coincident_members(self):
         # The 4 corner ø10 holes group into one HoleFeature (X∈{25,-25}, Y∈{20,-20});
         # locate() places one dim per distinct axis position, not one per member.
@@ -5128,6 +5137,38 @@ class TestFeatureEdits:
         auto = build_drawing(part)  # auto_dims=True — the reference the corridor matches
         assert len(fin_locx) == len([n for n in auto.annotations() if n.startswith("m_locx")])
 
+    def test_finalize_routes_pinned_locate_as_corridor_candidate(self):
+        # #511 slice 1: a deferred user locate(pin=True) is not hand-added after layout.
+        # It routes through render_locations' corridor candidates and pins the resulting
+        # names after the shared solve chooses legal positions.
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        hole = next(f for f in dwg.model().features if f.kind == "hole" and len(f.members) == 1)
+        with dwg.deferred():
+            dwg.locate(hole, pin=True)
+        locs = {n for n in dwg.annotations_of(hole) if n.startswith("m_loc")}
+        assert locs
+        assert locs <= dwg._pinned
+        assert dwg._intents == []
+
+    def test_finalize_pins_shared_location_when_later_ref_requested_pin(self):
+        # #511 review: render_locations dedups same-coordinate refs before candidate
+        # creation. The pin bit must survive that dedup even when the pinned feature is
+        # not the first representative chosen for the shared dimension.
+        part = (
+            Box(100, 80, 20) - Pos(20, 25, 0) * Cylinder(4, 30) - Pos(20, -25, 0) * Cylinder(6, 30)
+        )
+        dwg = build_drawing(part, auto_dims=False)
+        holes = [f for f in dwg.model().features if f.kind == "hole"]
+        dwg._defer_intents = True
+        dwg.locate(holes[0])
+        dwg.locate(holes[1], pin=True)
+        dwg.finalize()
+        shared_x = {
+            n for n in dwg.annotations() if n.startswith("m_locx") and dwg.get_annotation(n).label
+        }
+        assert shared_x
+        assert shared_x <= dwg._pinned
+
     def test_finalize_honors_locate_axes_restriction(self):
         # #429 review: a recorded locate(f, axes=("x",)) must place only the X dim. The
         # per-feature corridor filter can't express an axis subset, so finalize live-replays
@@ -5140,6 +5181,19 @@ class TestFeatureEdits:
         dwg.finalize()
         locs = [n for n in dwg.annotations() if n.startswith("m_loc")]
         assert locs and all(n.startswith("m_locx") for n in locs)  # X only — no m_locy
+
+    def test_finalize_replayed_axes_restricted_locate_can_pin(self):
+        # #511 slice 1: axes-restricted locates intentionally bypass the shared corridor
+        # filter, but their pin intent must still survive live replay during finalize.
+        part = Box(100, 80, 20) - Pos(20, 15, 0) * Cylinder(4, 30)
+        dwg = build_drawing(part, auto_dims=False)
+        dwg._defer_intents = True
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        dwg.locate(hole, axes=("x",), pin=True)
+        dwg.finalize()
+        locs = {n for n in dwg.annotations_of(hole) if n.startswith("m_locx")}
+        assert locs
+        assert locs <= dwg._pinned
 
     def test_finalize_mixes_axes_restricted_and_both_axes_locate(self):
         # #429 review: an axes-restricted locate (live, names m_locx0) + a both-axes locate


### PR DESCRIPTION
## Summary
- add `dwg.locate(..., pin=True)` for live and deferred location edits
- route deferred pinned locates through the existing shared corridor as high-priority candidates
- pin placed corridor output names after the solve instead of hand-adding them post-layout

## Why
First slice of #511 / ADR 0012: prove user edits can enter the existing layout model as pinned candidates rather than bypassing automatic placement.

## Validation
- `uv run pytest tests/test_make_drawing.py::TestFeatureEdits -q`
- `uv run ruff format --check src tests && uv run ruff check src tests && uv run mypy src`

Refs #511