### PR TITLE
Route pinned dimension intents through corridor

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -293,6 +293,10 @@ class CorridorCandidate:
             ``priority`` is kept. An authored GD&T frame sets this above the auto dims so it
             is not dropped in favour of a lower-value auto dim purely by stacking-key order.
             Default 0 (every auto dim) → key order, unchanged.
+        anchored/natural: when ``anchored`` is true, the strip solve keeps this candidate
+            near its own natural stacking-axis page coordinate instead of the segment edge.
+            This is how user-authored pinned dimension intents join the shared solve
+            without being invalidated by a later first-fit pass.
         on_place/on_drop: the pass's own post-placement bookkeeping — coverage
             registration / drop lint + `Escalation`, or a slot's below-side fallthrough.
         force:      policy-B force-keep after the corridor-respecting pass (locations have
@@ -307,6 +311,8 @@ class CorridorCandidate:
     dedup: tuple | None = None
     precedence: int = 0
     priority: float = 0
+    anchored: bool = False
+    natural: float | None = None
     force: bool = False
     # The source IR feature this dim was rendered for — recorded as provenance when the
     # dim is placed at drain (ADR 0010). ``None`` leaves the annotation feature-less.
@@ -376,6 +382,8 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
     sizes = {c.name: c.size for c in kept if c.size is not None}  # real footprint (#61)
     forbid = {c.name: c.forbid for c in kept if c.forbid is not None}  # title-block box (#481)
     prio = {c.name: c.priority for c in kept if c.priority}  # over-capacity survival rank (#357)
+    anchored = {c.name: c.anchored for c in kept if c.anchored}
+    naturals = {c.name: c.natural for c in kept if c.natural is not None}
     left = {
         n
         for n, _ in place_strip_candidates(
@@ -389,6 +397,8 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
             sizes=sizes,
             forbid=forbid,
             priorities=prio,
+            anchored=anchored,
+            naturals=naturals,
         )
     }
     force_pairs = [(c.name, c.build) for c in kept if c.name in left and c.force]
@@ -407,6 +417,8 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
                 sizes=sizes,
                 forbid=forbid,
                 priorities=prio,
+                anchored=anchored,
+                naturals=naturals,
             )
         }
         if force_pairs
@@ -456,6 +468,8 @@ def place_strip_candidates(
     sizes=None,
     forbid=None,
     priorities=None,
+    anchored=None,
+    naturals=None,
 ):
     """Collect-then-solve placement of location/feature dims on one strip (ADR 0009).
     The single shared strip placer that retires the ``Strip.allocate`` cursor (#150,
@@ -485,6 +499,11 @@ def place_strip_candidates(
     absent names default to 0. When a segment is over capacity :func:`plan_strip` drops
     the lowest ``(priority, key)``, so a higher priority is kept — an authored GD&T frame
     is not dropped for a lower-value auto dim purely by stacking-key order.
+
+    *anchored* and *naturals* opt individual candidates into the weighted anchoring
+    mode in :func:`plan_strip`. This preserves the old segment-edge natural for every
+    caller that does not pass them, while letting authored pinned candidates express the
+    page coordinate they asked for inside the same shared solve.
 
     ``force=True`` skips that corridor check — the caller's last resort when no view took
     the dim cleanly: keep it on its natural view and accept the (same-feature) leader
@@ -565,7 +584,6 @@ def place_strip_candidates(
 
     def _evaluate_segment(take, seg_lo, seg_hi):
         nat = seg_lo if inner == lo else seg_hi
-        anch = (0.0, nat) if axis == "y" else (nat, 0.0)
         # Keys order the tiers so the FIRST candidate lands on the inner tier: for an
         # inner=lo strip that is the lowest position (ascending keys); for a below strip
         # (inner=hi) it is the highest, so the keys reverse.
@@ -573,9 +591,14 @@ def place_strip_candidates(
             (
                 StripCandidate(
                     f"{(k if inner == lo else len(take) - 1 - k):04d}",
-                    anch,
+                    (
+                        (0.0, (naturals or {}).get(nb[0], nat))
+                        if axis == "y"
+                        else ((naturals or {}).get(nb[0], nat), 0.0)
+                    ),
                     (sizes or {}).get(nb[0], (tier, tier)),
                     priority=(priorities or {}).get(nb[0], 0.0),
+                    anchored=(anchored or {}).get(nb[0], False),
                 ),
                 nb,
             )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -788,49 +788,8 @@ class Drawing:
             return tuple(a), tuple(b)
         return None
 
-    def dimension(
-        self, feature, param, *, role=None, side="above", view=None, name=None, **kwargs
-    ):
-        """Add a dimension for *feature*'s *param*, attributed to the feature (#398e).
-
-        The feature-referenced **add** verb: pair to :meth:`drop`. *feature* is an IR
-        feature from :meth:`model`; *param* is a **linear** parameter kind it exposes — a
-        turned step's ``"length"`` or a slot's ``"length"``/``"width"`` (which the feature
-        carries as value-only geometry, derived here via :meth:`_derive_span`).
-        The dimension is placed into free strip space and tagged with *feature*, so
-        :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
-
-        A feature may expose several params of one kind (an envelope's width/height/depth,
-        or a slot's ``slot_width``/``slot_length``, are all ``"length"``); pass ``role=`` to
-        pick one — a bare kind matching more than one raises rather than guessing.
-
-        ``view`` is chosen automatically as the orthographic view (``"front"``/``"plan"``/
-        ``"side"``) where the span projects non-degenerate — a length along the turning
-        axis vanishes in its end-on view, so the view follows the geometry. Pass ``view=``
-        to force one of those three (a non-orthographic view foreshortens the span and is
-        rejected). ``side`` defaults to ``"above"``; ``kwargs`` forward to the dimension.
-
-        Raises ``ValueError`` if the feature has no such param, the kind is ambiguous, or
-        *view* is not orthographic. A hole's ``"diameter"``/``"depth"`` are **leader
-        callouts**, not linear dimensions, so they raise here — a callout add verb is a
-        separate mechanism, tracked apart from this one.
-        """
-        if self._defer_intents:  # #426: record, don't place — finalize() drains it
-            self._intents.append(
-                Intent(
-                    "dimension",
-                    feature,
-                    {
-                        "param": param,
-                        "role": role,
-                        "side": side,
-                        "view": view,
-                        "name": name,
-                        **kwargs,
-                    },
-                )
-            )
-            return ""
+    def _resolve_dimension_span(self, feature, param, *, role=None, view=None):
+        """Return ``(param_record, view, p1, p2)`` for a feature linear dimension."""
         _ortho = ("front", "plan", "side")
         if view is not None and view not in _ortho:
             raise ValueError(
@@ -862,21 +821,176 @@ class Drawing:
             )
         (lo, hi) = span
         p1 = p2 = None
+        chosen = view
         for v in [view] if view else _ortho:
             q1, q2 = self.at(v, *lo), self.at(v, *hi)
             if math.hypot(q2[0] - q1[0], q2[1] - q1[1]) > 1e-6:
-                view, p1, p2 = v, q1, q2
+                chosen, p1, p2 = v, q1, q2
                 break
         if p1 is None:
             raise ValueError(
                 f"'{param}' span projects to a point in "
                 f"{'the requested view' if view else 'every orthographic view'} — nothing to dimension"
             )
+        return matches[0], chosen, p1, p2
+
+    def _queue_dimension_intent(self, it, a, *, used_names=None) -> bool:
+        """Queue a pinned/prioritized feature dimension into a shared corridor."""
+        from draftwright.annotations._common import CorridorCandidate, register_corridor
+
+        side = it.kwargs.get("side", "above")
+        view = it.kwargs.get("view")
+        if side not in ("above", "below", "left", "right"):
+            return False
+        zones_name = {"front": "fv_zones", "plan": "pv_zones", "side": "sv_zones"}
+        rec, view, p1, p2 = self._resolve_dimension_span(
+            it.feature,
+            it.kwargs["param"],
+            role=it.kwargs.get("role"),
+            view=view,
+        )
+        zones = getattr(a, zones_name.get(view, ""), None)
+        strip = getattr(zones, side, None) if zones is not None else None
+        if strip is None:
+            return False
+
+        name = it.kwargs.get("name")
+        if name is None:
+            used_names = used_names if used_names is not None else set()
+            i = 0
+            while (name := f"dim_{it.kwargs['param']}{i}") in self._named or name in used_names:
+                i += 1
+            used_names.add(name)
+
+        dim_kwargs = {
+            k: v
+            for k, v in it.kwargs.items()
+            if k not in {"param", "role", "side", "view", "name", "pin", "priority", "slot"}
+        }
+        if "label" not in dim_kwargs:
+            page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
+            dim_kwargs["label"] = _fmt(page_len / self.scale)
+        slot = it.kwargs.get("slot", 8.0)
+        axis = "y" if side in ("above", "below") else "x"
+        ax = 1 if axis == "y" else 0
+        if side in ("right", "above"):
+            natural = max(p[ax] for p in (p1, p2)) + slot
+        else:
+            natural = min(p[ax] for p in (p1, p2)) - slot
+        tier = self.draft.font_size + 2 * self.draft.pad_around_text
+        p_lo, p_hi = sorted((p1[1 - ax], p2[1 - ax]))
+
+        def _build(pos, _p1=p1, _p2=p2, _side=side, _ax=ax, _kwargs=dim_kwargs):
+            if _side in ("right", "above"):
+                dist = pos - max(p[_ax] for p in (_p1, _p2))
+            else:
+                dist = min(p[_ax] for p in (_p1, _p2)) - pos
+            return _dim(_p1, _p2, _side, max(dist, 4.0), self.draft, **_kwargs)
+
+        def _placed(nm, _pin=it.kwargs.get("pin", False)):
+            if _pin:
+                self.pin(nm)
+
+        def _drop(nm):
+            self._record_build_issue(
+                "warning",
+                "dimension_dropped",
+                f"{nm} not placed (no room on the {view} {side} strip)",
+            )
+
+        priority = float(it.kwargs.get("priority", 0.0) or 0.0)
+        if it.kwargs.get("pin"):
+            priority = max(priority, 100.0)
+        register_corridor(
+            self,
+            (view, side),
+            strip,
+            view,
+            axis,
+            tier,
+            CorridorCandidate(
+                name=name,
+                build=_build,
+                order=(0, natural, name),
+                on_place=_placed,
+                on_drop=_drop,
+                dedup=(view, side, round(p_lo, 6), round(p_hi, 6), rec.role),
+                precedence=4,
+                priority=priority,
+                anchored=bool(it.kwargs.get("pin")),
+                natural=natural,
+                feature=it.feature,
+            ),
+        )
+        return True
+
+    def dimension(
+        self,
+        feature,
+        param,
+        *,
+        role=None,
+        side="above",
+        view=None,
+        name=None,
+        pin=False,
+        priority=0.0,
+        **kwargs,
+    ):
+        """Add a dimension for *feature*'s *param*, attributed to the feature (#398e).
+
+        The feature-referenced **add** verb: pair to :meth:`drop`. *feature* is an IR
+        feature from :meth:`model`; *param* is a **linear** parameter kind it exposes — a
+        turned step's ``"length"`` or a slot's ``"length"``/``"width"`` (which the feature
+        carries as value-only geometry, derived here via :meth:`_derive_span`).
+        The dimension is placed into free strip space and tagged with *feature*, so
+        :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
+
+        A feature may expose several params of one kind (an envelope's width/height/depth,
+        or a slot's ``slot_width``/``slot_length``, are all ``"length"``); pass ``role=`` to
+        pick one — a bare kind matching more than one raises rather than guessing.
+
+        ``view`` is chosen automatically as the orthographic view (``"front"``/``"plan"``/
+        ``"side"``) where the span projects non-degenerate — a length along the turning
+        axis vanishes in its end-on view, so the view follows the geometry. Pass ``view=``
+        to force one of those three (a non-orthographic view foreshortens the span and is
+        rejected). ``side`` defaults to ``"above"``; ``kwargs`` forward to the dimension.
+        In deferred mode, ``pin=True`` anchors the dimension at its natural slot coordinate
+        inside the shared corridor solve, and ``priority=`` controls over-capacity survival.
+        Live placement still uses the single-position escape hatch and pins only the placed
+        annotation name.
+
+        Raises ``ValueError`` if the feature has no such param, the kind is ambiguous, or
+        *view* is not orthographic. A hole's ``"diameter"``/``"depth"`` are **leader
+        callouts**, not linear dimensions, so they raise here — a callout add verb is a
+        separate mechanism, tracked apart from this one.
+        """
+        if self._defer_intents:  # #426: record, don't place — finalize() drains it
+            self._intents.append(
+                Intent(
+                    "dimension",
+                    feature,
+                    {
+                        "param": param,
+                        "role": role,
+                        "side": side,
+                        "view": view,
+                        "name": name,
+                        "pin": pin,
+                        "priority": priority,
+                        **kwargs,
+                    },
+                )
+            )
+            return ""
+        _rec, view, p1, p2 = self._resolve_dimension_span(feature, param, role=role, view=view)
         if name is None:
             i = 0
             while (name := f"dim_{param}{i}") in self._named:
                 i += 1
         self.place_dim(p1, p2, side, view, self.draft, name=name, feature=feature, **kwargs)
+        if pin:
+            self.pin(name)
         return name
 
     def callout(self, feature, *, view=None, name=None) -> str:
@@ -1139,6 +1253,31 @@ class Drawing:
             and it.kwargs.get("param") == "length"
             and it.kwargs.get("role") in ("slot_width", "slot_length")
         }
+
+        # User-authored generic feature dimensions with pin/priority join the shared
+        # corridor directly. Slot and turned-step length dimensions keep their specialized
+        # routes above, because those renderers regenerate correlated measurements as a set.
+        def _user_dim_uses_corridor(it):
+            if (
+                not routable
+                or it.kind != "dimension"
+                or id(it) in (len_ids | slot_ids)
+                or not (it.kwargs.get("pin") or it.kwargs.get("priority"))
+                or it.kwargs.get("side", "above") not in ("above", "below", "left", "right")
+            ):
+                return False
+            try:
+                self._resolve_dimension_span(
+                    it.feature,
+                    it.kwargs["param"],
+                    role=it.kwargs.get("role"),
+                    view=it.kwargs.get("view"),
+                )
+            except ValueError:
+                return False
+            return True
+
+        user_dim_ids = {id(it) for it in self._intents if _user_dim_uses_corridor(it)}
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         pinned_loc = {
             it.feature for it in self._intents if id(it) in corridor_ids and it.kwargs.get("pin")
@@ -1162,7 +1301,8 @@ class Drawing:
                 it = self._intents[i]
                 if (
                     it.kind == "section"
-                    or id(it) in corridor_ids | callout_ids | dia_ids | len_ids | slot_ids
+                    or id(it)
+                    in corridor_ids | callout_ids | dia_ids | len_ids | slot_ids | user_dim_ids
                 ):
                     i += 1
                     continue
@@ -1188,14 +1328,24 @@ class Drawing:
             #      crossing-free ladder, one drain (auto-pass registers locations then slots,
             #      then a single drain_corridors, so a slot position coincident with a hole
             #      location dedups, #345). Register both, then drain once (Phase 2a + 2b).
-            if only_loc or slot_feats:
+            queued_dim_ids = set()
+            if only_loc or slot_feats or user_dim_ids:
                 assert a is not None and isinstance(model, PartModel)  # either ⟹ routable
                 if only_loc:
                     render_locations(self, model, a, only=only_loc, pinned=pinned_loc)
                 if slot_feats:
                     render_slots(self, model, a, only=slot_feats)
+                used_dim_names: set[str] = set()
+                for it in self._intents:
+                    if id(it) in user_dim_ids:
+                        if self._queue_dimension_intent(it, a, used_names=used_dim_names):
+                            queued_dim_ids.add(id(it))
                 drain_corridors(self)
-            self._intents = [it for it in self._intents if id(it) not in corridor_ids | slot_ids]
+            self._intents = [
+                it
+                for it in self._intents
+                if id(it) not in (corridor_ids | slot_ids | queued_dim_ids)
+            ]
             # (B3) step/boss ø diameters through render_diameters' set-solve (row-below /
             #      column-left) — auto-pass S11b, after callouts/locations, before section.
             if only_dia:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5169,6 +5169,67 @@ class TestFeatureEdits:
         assert shared_x
         assert shared_x <= dwg._pinned
 
+    def test_finalize_routes_pinned_dimension_as_corridor_candidate(self):
+        # #511: a deferred user dimension(pin=True) is a feature intent, not a raw
+        # page-coordinate placement after layout. It joins the shared strip solve, remains
+        # feature-owned, and pins the placed name only after legal placement.
+        dwg = build_drawing(Box(80, 50, 20), auto_dims=False)
+        env = next(f for f in dwg.model().features if f.kind == "envelope")
+        with dwg.deferred():
+            dwg.dimension(
+                env,
+                "length",
+                role="width",
+                side="below",
+                name="user_width",
+                slot=12,
+                pin=True,
+                priority=25,
+            )
+
+        assert "user_width" in dwg.annotations_of(env)
+        assert "user_width" in dwg._pinned
+        assert dwg._named["user_width"]._dw_spec.side == "below"
+        assert dwg._named["user_width"]._dw_spec.distance == 12
+        assert dwg._intents == []
+
+    def test_deferred_dimension_generated_names_do_not_collide_in_one_batch(self):
+        # #511 review: generated names must be reserved before the corridor drain. Otherwise
+        # two same-kind dimensions recorded in one deferred batch both choose dim_length0 and
+        # the second add silently replaces the first.
+        dwg = build_drawing(Box(80, 50, 20), auto_dims=False)
+        env = next(f for f in dwg.model().features if f.kind == "envelope")
+        with dwg.deferred():
+            dwg.dimension(env, "length", role="width", side="below", pin=True)
+            dwg.dimension(env, "length", role="depth", side="below", pin=True)
+
+        names = {n for n in dwg.annotations_of(env) if n.startswith("dim_length")}
+        assert names == {"dim_length0", "dim_length1"}
+        assert names <= dwg._pinned
+
+    def test_live_dimension_pin_pins_raw_escape_hatch_result(self):
+        # #511/ADR 0012: live dimension() still uses the single-position page-coordinate
+        # escape hatch, but pin=True must persist on the resulting annotation name.
+        dwg = build_drawing(Box(80, 50, 20), auto_dims=False)
+        env = next(f for f in dwg.model().features if f.kind == "envelope")
+        name = dwg.dimension(env, "length", role="width", name="live_width", pin=True)
+
+        assert name == "live_width"
+        assert "live_width" in dwg.annotations_of(env)
+        assert "live_width" in dwg._pinned
+
+    def test_malformed_pinned_dimension_still_surfaces_live_valueerror(self):
+        # #511 review: pin=True must not make a non-linear hole diameter look corridor
+        # routable. It falls through to live replay and leaves the intent recorded.
+        dwg = build_drawing(_holed_plate(), auto_dims=False)
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        dwg._defer_intents = True
+        dwg.dimension(hole, "diameter", pin=True)
+
+        with pytest.raises(ValueError, match="callout"):
+            dwg.finalize()
+        assert any(it.kind == "dimension" for it in dwg._intents)
+
     def test_finalize_honors_locate_axes_restriction(self):
         # #429 review: a recorded locate(f, axes=("x",)) must place only the X dim. The
         # per-feature corridor filter can't express an axis subset, so finalize live-replays

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -654,6 +654,44 @@ def test_place_strip_candidates_refills_after_late_forbid_rejection():
     assert {name for name, _ in left} == {"hi"}
 
 
+def test_place_strip_candidates_honors_per_candidate_natural_anchor():
+    # #511: pinned user dimensions enter the shared corridor with their own natural
+    # page coordinate. Unspecified candidates keep the old segment-edge natural.
+    from draftwright._core import Strip
+    from draftwright.annotations._common import place_strip_candidates
+
+    class _Dwg:
+        def __init__(s):
+            s.added = []
+
+        def iter_annotations(s):
+            return []
+
+        def view_of(s, n):
+            return "plan"
+
+        def add(s, obj, name, view=None, feature=None):
+            s.added.append((name, obj))
+
+    strip = Strip(anchor=0.0, outer_limit=60.0, direction=1.0, gap=0.0, spacing=4.0)
+    dwg = _Dwg()
+    left = place_strip_candidates(
+        dwg,
+        strip,
+        "plan",
+        "y",
+        [("a", lambda pos: ("a", pos)), ("b", lambda pos: ("b", pos))],
+        tier=5.0,
+        force=True,
+        anchored={"b": True},
+        naturals={"b": 30.0},
+    )
+
+    placed = {name: obj[1] for name, obj in dwg.added}
+    assert left == []
+    assert placed["b"] == 30.0
+
+
 def test_place_strip_candidates_ignores_perpendicular_disjoint_obstacle():
     # A right strip stacks along X; the carve projects obstacles onto X. An obstacle that
     # overlaps in X (even after pad inflation) but is DISJOINT in Y — a dim on ANOTHER


### PR DESCRIPTION
## Summary
- add per-candidate anchoring/natural coordinates to shared corridor placement
- route deferred generic dimension intents with `pin`/`priority` through the corridor solver
- preserve the raw live dimension placement escape hatch while allowing `pin=True` to pin its result
- cover pinned dimensions, generated-name reservation, malformed fallback behavior, and corridor natural anchoring

## Validation
- `uv run pytest tests/test_strip_layout.py::test_place_strip_candidates_honors_per_candidate_natural_anchor tests/test_make_drawing.py::TestFeatureEdits::test_finalize_routes_pinned_dimension_as_corridor_candidate tests/test_make_drawing.py::TestFeatureEdits::test_deferred_dimension_generated_names_do_not_collide_in_one_batch tests/test_make_drawing.py::TestFeatureEdits::test_live_dimension_pin_pins_raw_escape_hatch_result tests/test_make_drawing.py::TestFeatureEdits::test_malformed_pinned_dimension_still_surfaces_live_valueerror -q`
- `uv run pytest tests/test_strip_layout.py tests/test_make_drawing.py::TestFeatureEdits -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`

Closes #511.