### PR TITLE
Harden sheet script round-trip parity

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -13,9 +13,10 @@ detection didn't model (chamfers, fillets, turned profiles) yet reads as authori
 
 Kinds with no declarative verb yet (``step_level``/``rotational``/``pmi``) are flagged inline —
 never silently dropped — and left to the auto-pass that runs over the declared model on re-run.
-Fidelity: the script reproduces a lint-clean drawing of the same features, not a byte copy of the
-detected sheet; some aspects a declarative verb would pin are not yet reproduced faithfully — a
-turned shaft drops its centre lines and renders the base ⌀ as a leader (the #472 validity gap).
+Fidelity: the script reproduces a lint-clean drawing of the same features. The generated script is
+validated against the direct build for prismatic, slot/pattern, section, and turned/rotational
+fixtures (#472); AP242 PMI script round-trip remains separate because ``import_step`` strips the
+semantic PMI before the generated script can re-read it (#503).
 """
 
 from __future__ import annotations
@@ -110,8 +111,9 @@ def _feature_line(f) -> str:
             parts.append("members=[" + ", ".join(_pt(p) for p in f.members) + "]")
         return f"sheet.pattern({_member_hole_str(f.member)}, " + ", ".join(parts) + ")"
     # Kinds with no declarative verb yet: flag inline so they aren't silently lost. The auto-pass
-    # over the declared model still draws them on re-run, but not always faithfully — a turned /
-    # rotational part isn't parity-safe yet (the #472 validity gap), so avoid promising it here.
+    # over the declared model still draws step_level/rotational furniture faithfully (#472). PMI is
+    # the remaining non-faithful case when re-running an emitted STEP-seam script because
+    # build123d.import_step strips AP242 PMI; baking those features is tracked in #503.
     return f"# {k} @ {_pt(f.frame.origin)} — no declarative verb yet; drawn by the auto-pass"
 
 

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -7,7 +7,6 @@ Detected input only writes numbers (the part-seam form); we never fabricate geom
 import ast
 import math
 import os
-from collections import Counter
 
 import pytest
 from build123d import Box, Cylinder, Pos, Shape, export_step
@@ -586,11 +585,46 @@ class TestCli:
         assert (tmp_path / "g.svg").exists()
 
 
-def _named_signature(dwg):
-    """The multiset of annotation TYPES on a drawing — the 'annotation signature' #472 uses
-    to compare a generated-script drawing against a direct build (catches a dropped Centerline
-    or an OD that fell from Dimension to Leader)."""
-    return Counter(type(v).__name__ for v in dwg._named.values())
+def _annotation_signature(dwg):
+    """Value-aware annotation signature for #472 round-trip parity.
+
+    Names and types catch dropped/replaced annotations; dimension specs catch the old
+    OD-as-Leader gap plus side/distance drift; leader coverage catches callout text regressions
+    where the drafting helper does not expose a label string; boxes catch non-dimension
+    furniture moving or vanishing. This intentionally stays below SVG byte identity, which is
+    too brittle for a semantic script invariant.
+    """
+
+    def _r(v):
+        return round(float(v), 3)
+
+    def _box(obj):
+        try:
+            b = obj.bounding_box()
+        except Exception:
+            return None
+        return (_r(b.min.X), _r(b.min.Y), _r(b.max.X), _r(b.max.Y))
+
+    rows = []
+    for name, obj in dwg._named.items():
+        spec = getattr(obj, "_dw_spec", None)
+        if spec is not None:
+            detail = (
+                tuple(_r(x) for x in spec.p1[:2]),
+                tuple(_r(x) for x in spec.p2[:2]),
+                spec.side,
+                _r(spec.distance),
+                getattr(obj, "label", ""),
+            )
+        else:
+            detail = (
+                getattr(obj, "label", ""),
+                tuple(_r(x) for x in getattr(obj, "covers_diameters", ())),
+                getattr(obj, "covers_count", None),
+                _box(obj),
+            )
+        rows.append((name, type(obj).__name__, detail))
+    return sorted(rows)
 
 
 def _drawing_from_generated_script(step_path, tmp_path, monkeypatch):
@@ -602,7 +636,7 @@ def _drawing_from_generated_script(step_path, tmp_path, monkeypatch):
     monkeypatch.setattr(
         Sheet, "export", lambda self, stem=None: captured.setdefault("dwg", self.build())
     )
-    py = generate_sheet_script(str(step_path), out=str(tmp_path / "gen"))
+    py = generate_sheet_script(str(step_path), out=str(tmp_path / "gen"), title="PART")
     exec(compile(open(py, encoding="utf-8").read(), py, "exec"), {})
     return captured["dwg"]
 
@@ -618,10 +652,27 @@ class TestRoundTripParity:
         export_step(part, str(step))
         direct = build_drawing(step_file=str(step), title="PART")
         scripted = _drawing_from_generated_script(step, tmp_path, monkeypatch)
-        assert _named_signature(scripted) == _named_signature(direct)
+        assert _annotation_signature(scripted) == _annotation_signature(direct)
 
     def test_prismatic_plate_parity(self, tmp_path, monkeypatch):
         self._parity(_plate(), tmp_path, monkeypatch)
+
+    def test_slot_parity(self, tmp_path, monkeypatch):
+        self._parity(Box(50, 30, 20) - Box(20, 8, 30), tmp_path, monkeypatch)
+
+    def test_pattern_parity(self, tmp_path, monkeypatch):
+        part = (
+            Box(100, 80, 20)
+            - Pos(35, 25, 0) * Cylinder(4, 30)
+            - Pos(-35, 25, 0) * Cylinder(4, 30)
+            - Pos(35, -25, 0) * Cylinder(4, 30)
+            - Pos(-35, -25, 0) * Cylinder(4, 30)
+        )
+        self._parity(part, tmp_path, monkeypatch)
+
+    def test_counterbore_section_parity(self, tmp_path, monkeypatch):
+        part = Box(80, 60, 20) - Pos(0, 0, 0) * Cylinder(8, 40) - Pos(0, 0, 8) * Cylinder(14, 20)
+        self._parity(part, tmp_path, monkeypatch)
 
     def test_title_block_and_layout_aspects_round_trip(self, tmp_path, monkeypatch):
         # #474: a generated sheet script carrying drawn_by/tolerance/scale/page must reproduce the


### PR DESCRIPTION
## Summary
- make the #472 sheet-script parity signature value-aware instead of type-count-only
- compare names, types, dimension endpoints/sides/distances/labels, and non-dimension boxes
- expand round-trip coverage to slots, patterns, counterbore/section, and existing turned/rotational fixtures
- update stale sheet-emitter comments to reflect that geometry parity is covered and emitted-script PMI is split to #503

## Validation
- `uv run pytest tests/test_sheet_emit.py::TestRoundTripParity -q`
- `uv run pytest tests/test_sheet_emit.py -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`

Closes #472.