### PR TITLE
Add deferred intent for prismatic height ladder

### DIFF
--- a/docs/layout-algorithm-primer.md
+++ b/docs/layout-algorithm-primer.md
@@ -43,6 +43,9 @@ Recent work has moved most automatic layout surfaces toward that destination:
 - Generated scripts, README examples, and lint suggestions now steer normal edits toward
   feature-backed `dimension(...)` / `locate(...)` calls instead of raw page-coordinate
   `place_dim(...)`.
+- The prismatic step-height ladder now has a semantic editable-script intent:
+  `dimension(step_level, "length", role="step_height")` regenerates the correlated ladder
+  during `finalize()` instead of leaving that auto surface as a script gap.
 - Generated Sheet scripts now have a value-aware round-trip parity guard for normal geometry:
   prismatic parts, slots, patterns, counterbore/section cases, and turned/rotational parts
   are checked against direct builds by annotation name, type, dimension geometry, labels,
@@ -51,8 +54,10 @@ Recent work has moved most automatic layout surfaces toward that destination:
 Remaining gaps are narrower and more explicit:
 
 - Some placements are intentionally still outside the shared candidate model because they are
-  not independent candidates yet. The main example is the front-right prismatic height ladder,
-  where each dimension's witness base depends on the previous placed tier.
+  not independent candidates yet. The main example is still the front-right prismatic height
+  ladder's internal placement: scripts can now request it semantically, but each rung's witness
+  base depends on the previous placed tier, so the renderer remains a correlated specialized
+  pass rather than a set of independent corridor candidates.
 - Raw page-coordinate `place_dim(...)` is now deprecated for normal editable scripts and
   remains only as an escape hatch. It can place a one-off annotation, but feature-referenced
   `dimension(...)` is the route that participates in re-solving.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1178,7 +1178,7 @@ def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):
     return n, mean_rise
 
 
-def render_height_ladder(dwg, model, a) -> int:
+def render_height_ladder(dwg, model, a, *, include_overall: bool = True) -> int:
     """Front-view right ladder: prismatic step heights (from `StepLevelFeature`)
     stacked inner→outer, then the overall height outermost — through `fv_zones.right`,
     preserving the leapfrog witness cursor (#237). Replaces the engine's inline
@@ -1270,7 +1270,7 @@ def render_height_ladder(dwg, model, a) -> int:
     # — #222).
     rot = next((f for f in model.features if f.kind == "rotational"), None)
     od_is_height = rot is not None and rot.frame.axis in ("x", "y")
-    suppress_height = model.orientation == "z" or od_is_height
+    suppress_height = (not include_overall) or model.orientation == "z" or od_is_height
     px = (
         None
         if suppress_height

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -669,8 +669,6 @@ def _fmt_pt(p) -> str:
 # Feature kinds with no intent verb yet — emitted as a flagged comment, never a broken
 # call. The build_drawing(auto_dims=True) pointer recovers the full auto drawing (#424).
 _GAP_KINDS = {
-    "step_level": "auto-pass draws the prismatic height ladder; no intent verb yet "
-    "(dimension() needs a span, which step_height lacks)",
     "rotational": "auto-pass draws the overall OD + centrelines + concentric bore leaders; "
     "out of scope for the intent verbs (#419)",
     "pmi": "pre-authored PMI, rendered by --pmi annotate; an add verb is deferred to #422",
@@ -689,12 +687,13 @@ def _feature_listing(a: Analysis) -> str:
 
     Each feature is redrawn against the detected model (``dwg.model().features[i]``, the
     ADR-0008 IR): holes/patterns → ``callout`` + ``locate`` + ``furniture``; steps/bosses →
-    ``callout`` (ø); steps/envelopes/slots → ``dimension(...)`` per linear param. A section
-    A–A is recorded when a counterbored/spotfaced/blind Z-hole warrants one (finalize
-    renders it last). Feature kinds with no verb yet (step_level, rotational, pmi) are
-    emitted as flagged comments naming the gap (#424) — never silently dropped. Commenting
-    any line drops exactly that intent (nothing is auto-drawn, so there is no
-    double-dimension risk). Pure function of *a*.
+    ``callout`` (ø); steps/envelopes/slots → ``dimension(...)`` per linear param; prismatic
+    step levels → one ``dimension(..., role="step_height")`` intent that regenerates the
+    correlated height ladder. A section A–A is recorded when a counterbored/spotfaced/blind
+    Z-hole warrants one (finalize renders it last). Feature kinds with no verb yet
+    (rotational, pmi) are emitted as flagged comments naming the gap (#424) — never silently
+    dropped. Commenting any line drops exactly that intent (nothing is auto-drawn, so there
+    is no double-dimension risk). Pure function of *a*.
     """
     model = build_model(a)
     feats = getattr(model, "features", [])
@@ -734,6 +733,11 @@ def _feature_listing(a: Analysis) -> str:
                     f"#     callout() places X/Z-turned diameters only — this "
                     f"{feat.frame.axis}-turned step/boss is auto-pass-only. auto_dims=True to keep it."
                 )
+        elif kind == "step_level":
+            body.append(
+                'dwg.dimension(f, "length", role="step_height")   # prismatic height ladder'
+            )
+            continue
         for p in feat.parameters():
             if p.span is not None or kind == "slot":  # a linear dim dimension() accepts
                 body.append(f'dwg.dimension(f, "{p.kind}", role="{p.role}")   # {display(p)}')

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1203,6 +1203,7 @@ class Drawing:
         from draftwright.annotations._common import drain_corridors
         from draftwright.annotations.from_model import (
             render_diameters,
+            render_height_ladder,
             render_locations,
             render_slots,
             render_step_lengths,
@@ -1293,6 +1294,28 @@ class Drawing:
             and it.kwargs.get("param") == "length"
             and it.kwargs.get("role") in ("slot_width", "slot_length")
         }
+        # Prismatic height-ladder intent. StepLevelFeature exposes one value per interior
+        # level, but those rungs are a correlated chain whose witness bases leapfrog from
+        # the previous placed tier. Treat one semantic dimension intent as "rebuild the
+        # whole height ladder" through the existing auto-pass renderer, instead of trying
+        # to flatten each rung into an independent corridor candidate.
+        height_ladder_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and it.kind == "dimension"
+            and getattr(it.feature, "kind", None) == "step_level"
+            and it.kwargs.get("param") == "length"
+            and it.kwargs.get("role") in (None, "step_height")
+        }
+        explicit_envelope_height = any(
+            routable
+            and it.kind == "dimension"
+            and getattr(it.feature, "kind", None) == "envelope"
+            and it.kwargs.get("param") == "length"
+            and it.kwargs.get("role") == "height"
+            for it in self._intents
+        )
 
         # User-authored generic feature dimensions with pin/priority join the shared
         # corridor directly. Slot and turned-step length dimensions keep their specialized
@@ -1301,7 +1324,7 @@ class Drawing:
             if (
                 not routable
                 or it.kind != "dimension"
-                or id(it) in (len_ids | slot_ids)
+                or id(it) in (len_ids | slot_ids | height_ladder_ids)
                 or not (it.kwargs.get("pin") or it.kwargs.get("priority"))
                 or it.kwargs.get("side", "above") not in ("above", "below", "left", "right")
             ):
@@ -1334,6 +1357,14 @@ class Drawing:
             if _section is not None:
                 assert a is not None
                 _reserve_section_row(self, a, _section)
+            # (A0) prismatic step-height ladder through the auto-pass renderer, before
+            # generic live-replayed dimensions. The auto-pass places this ladder before
+            # envelope dimensions; doing the same here prevents generic envelope edits
+            # from starving the correlated step rungs.
+            if height_ladder_ids:
+                assert a is not None and isinstance(model, PartModel)
+                render_height_ladder(self, model, a, include_overall=not explicit_envelope_height)
+            self._intents = [it for it in self._intents if id(it) not in height_ladder_ids]
             # (A) live-replay every intent EXCEPT the routed callouts/locates and section
             #     (furniture, step/boss callouts, dimensions, axes-restricted locates).
             i = 0
@@ -1342,7 +1373,13 @@ class Drawing:
                 if (
                     it.kind == "section"
                     or id(it)
-                    in corridor_ids | callout_ids | dia_ids | len_ids | slot_ids | user_dim_ids
+                    in corridor_ids
+                    | callout_ids
+                    | dia_ids
+                    | len_ids
+                    | slot_ids
+                    | height_ladder_ids
+                    | user_dim_ids
                 ):
                     i += 1
                     continue

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2510,6 +2510,20 @@ def test_generate_script_reconstructs_features_as_intent_calls(tmp_path):
     assert "dwg.repair()" in content  # a peephole net after the batch solve
 
 
+def test_generate_script_emits_prismatic_step_level_intent(tmp_path):
+    # The prismatic height ladder is a correlated chain, but it now has a semantic
+    # reconstruction verb instead of a gap comment.
+    step = tmp_path / "stepped.step"
+    part = Box(40, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20)
+    export_step(part, str(step))
+    content = Path(generate_script(str(step), out=str(tmp_path / "stepped"))).read_text(
+        encoding="utf-8"
+    )
+    assert 'dwg.dimension(f, "length", role="step_height")' in content
+    assert 'dwg.dimension(f, "length", role="height")' in content
+    assert "step_level — auto-pass draws the prismatic height ladder" not in content
+
+
 def test_feature_listing_is_deferred_intent_calls(tmp_path):
     # #400 Ph2 / #426 Ph5 (was Ph1 "fully inert"): the reconstruction block now contains
     # BARE, uncommented verb calls recorded inside `with dwg.deferred()`. Verify there are
@@ -4583,6 +4597,22 @@ class TestFeatureEdits:
         assert {nl, nw} <= set(dwg.annotations_of(slot))
         assert nl in dwg.drop(slot)
 
+    def test_deferred_dimension_rebuilds_prismatic_step_height_ladder(self):
+        # StepLevelFeature's rungs are a correlated ladder, not independent spans. The
+        # deferred dimension intent regenerates the auto-pass ladder on a detect-only build.
+        from build123d import Box, Pos
+
+        part = Box(40, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20)
+        dwg = build_drawing(part, auto_dims=False)
+        step_level = next(f for f in dwg.model().features if f.kind == "step_level")
+
+        with dwg.deferred():
+            dwg.dimension(step_level, "length", role="step_height")
+
+        assert "dim_height" in dwg.annotations()
+        assert any(n.startswith("dim_step") for n in dwg.annotations())
+        assert dwg._intents == []
+
     def test_callout_adds_a_hole_leader_and_round_trips(self):
         # #414 / #400 Ph2: the callout add verb — detect-only build, then add the hole's
         # ø leader explicitly; it is a leader-attached callout, tagged, and drops.
@@ -4874,10 +4904,33 @@ class TestFeatureEdits:
             elif f.kind in ("step", "boss"):
                 if f.frame.axis in ("x", "z"):  # callout() places X/Z-turned diameters only
                     dwg.callout(f)
+            elif f.kind == "step_level":
+                dwg.dimension(f, "length", role="step_height")
+                continue
             for p in f.parameters():
                 if p.span is not None or f.kind == "slot":
                     dwg.dimension(f, p.kind, role=p.role)
         dwg.section()
+
+    def test_deferred_reconstruction_avoids_duplicate_prismatic_step_height(self):
+        # The envelope owns overall height when the generated reconstruction records it
+        # explicitly; the step-level ladder must then emit only the internal rungs.
+        from build123d import Box, Pos
+
+        part = Box(60, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20)
+        dwg = build_drawing(part, auto_dims=False)
+
+        with dwg.deferred():
+            self._reconstruct(dwg)
+
+        dims = {
+            n: getattr(ann, "label", None)
+            for n, ann in dwg.iter_annotations()
+            if n.startswith(("dim_height", "dim_length", "dim_step"))
+        }
+        assert "dim_height" not in dims
+        assert [name for name, label in dims.items() if label == "40"] == ["dim_length1"]
+        assert any(name.startswith("dim_step") for name in dims)
 
     def test_intent_reconstruction_is_error_free(self):
         # #400 Ph2 soft acceptance: a fully reconstructed prismatic part, after repair(),


### PR DESCRIPTION
## Summary

- add a deferred `dimension(step_level, "length", role="step_height")` intent for prismatic height ladders
- route that intent through the existing `render_height_ladder` auto-pass renderer during `finalize()`
- emit the new intent in generated editable Drawing scripts and update the layout primer

## Why

The prismatic height ladder already comes from IR, but generated editable scripts still flagged `step_level` as an auto-pass-only gap. This gives users a semantic reconstruction/edit surface while keeping the ladder renderer specialized because its rung witness bases are correlated.

## Validation

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
- `uv run pytest tests/test_make_drawing.py::test_generate_script_emits_prismatic_step_level_intent tests/test_make_drawing.py::TestFeatureEdits::test_deferred_dimension_rebuilds_prismatic_step_height_ladder tests/test_make_drawing.py::test_generate_script_reconstructs_features_as_intent_calls tests/test_make_drawing.py::test_feature_listing_is_deferred_intent_calls -q`
- `uv run pytest tests/test_make_drawing.py::TestFeatureEdits tests/test_strip_layout.py -q`
