### PR TITLE
Preserve detected Sheet envelopes

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -75,7 +75,13 @@ def _member_hole_str(m) -> str:
 def _feature_line(f) -> str:
     k = f.kind
     if k == "envelope":
-        return f"sheet.envelope()   # {_n(f.width)} × {_n(f.height)} × {_n(f.depth)}"
+        return (
+            "sheet.add(EnvelopeFeature("
+            f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
+            f"width={_n(f.width)}, height={_n(f.height)}, depth={_n(f.depth)}, "
+            f"bbox_min={_pt(f.bbox_min)}, bbox_max={_pt(f.bbox_max)}"
+            f"))   # envelope {_n(f.width)} × {_n(f.height)} × {_n(f.depth)}"
+        )
     if k == "hole":
         return _hole_line(f)
     if k == "boss":
@@ -164,7 +170,11 @@ def emit_sheet_script(
     PMI is deliberately NOT emitted here: the seam binds ``part`` via ``import_step``, which
     strips AP242 PMI, so a re-run cannot re-extract it — the faithful fix bakes PMI as declared
     features (#503 / #422)."""
-    needs_hole = any(f.kind in ("hole", "pattern") for f in model.features)
+    model_imports = []
+    if any(f.kind in ("hole", "pattern") for f in model.features):
+        model_imports.append("hole")
+    if any(f.kind == "envelope" for f in model.features):
+        model_imports.extend(["EnvelopeFeature", "Frame"])
     # Only carry an aspect into the emitted constructor when it differs from build_drawing's
     # default (mirrors the CLI's inert-flag test) — an unset aspect stays off the script.
     ctor = [f"title={title!r}", f"number={number!r}"]
@@ -179,7 +189,11 @@ def emit_sheet_script(
     lines = [
         _HEADER,
         "from draftwright import Sheet",
-        *(["from draftwright.model import hole"] if needs_hole else []),
+        *(
+            ["from draftwright.model import " + ", ".join(sorted(model_imports))]
+            if model_imports
+            else []
+        ),
         "",
         part_expr,
         "",

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -7,6 +7,7 @@ Detected input only writes numbers (the part-seam form); we never fabricate geom
 import ast
 import math
 import os
+from pathlib import Path
 
 import pytest
 from build123d import Box, Cylinder, Pos, Shape, export_step
@@ -53,8 +54,22 @@ class TestEmit:
         src = _script_for(_plate())
         assert "sheet = Sheet(part, title='T', number='N')" in src
         assert "sheet.hole(diameter=8" in src  # the ⌀8 holes
-        assert "sheet.envelope()" in src
+        assert "sheet.add(EnvelopeFeature(" in src
         assert src.rstrip().endswith("sheet.export('drawing')")
+
+    def test_step_seam_preserves_detected_ctc01_envelope(self, tmp_path):
+        # #536: build123d.import_step reports CTC01's raw bbox as 1170 × 650, but the
+        # detector's solid-body envelope is 800 × 450. The generated STEP-seam script
+        # must preserve the detected EnvelopeFeature literally instead of remeasuring
+        # the raw imported object with sheet.envelope().
+        step = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap203.stp"
+        py = generate_sheet_script(str(step), out=str(tmp_path / "ctc01"))
+        src = Path(py).read_text(encoding="utf-8")
+        assert "sheet.envelope()" not in src
+        assert "sheet.add(EnvelopeFeature(" in src
+        assert "width=800" in src
+        assert "depth=450" in src
+        assert "1170" not in src
 
     def test_title_block_and_layout_aspects_emitted_when_set(self):
         # #474: non-default drawn_by/tolerance/scale/page ride the Sheet(...) constructor.


### PR DESCRIPTION
## Summary

Fixes #536.

Generated Sheet scripts for STEP inputs now preserve the detected `EnvelopeFeature` literally instead of emitting `sheet.envelope()` and remeasuring the raw imported object. This keeps CTC01's detected 800 x 450 envelope from becoming the raw import bounding box of 1170 x 650 when the generated script is re-run.

## Root Cause

The STEP-seam Sheet script imported the original STEP file and called `sheet.envelope()`. For CTC01, `build123d.import_step()` includes extra model-space extents, so that remeasurement diverged from the detector's solid-body envelope and produced an out-of-bounds `1170` envelope dimension.

## Validation

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
- `uv run pytest tests/test_sheet_emit.py -q`
- Generated and re-ran the CTC01 Sheet script; it no longer reports the `1170` annotation out-of-bounds lint.