### PR TITLE
Normalize AP242 dimensions into drafting IR and Sheet API

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -59,7 +59,7 @@ from draftwright.annotations._common import (
     strip_obstacles,
 )
 from draftwright.layout import StripCandidate, plan_strip
-from draftwright.model.ir import HoleFeature, PatternFeature
+from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, HoleFeature, PatternFeature
 from draftwright.model.planner import DimensionGroup, plan_locations
 
 
@@ -1490,9 +1490,9 @@ def _bore_half_span(pmi_kind: str, value: float) -> float:
     """Half the perpendicular span of a bore-size dim from the bore centroid — the
     distance to each witness base point. A ``"diameter"`` record stores the full
     diameter (so half = radius = value/2); a ``"radius"`` record already stores the
-    radius (half = value). Keyed on ``PmiFeature.pmi_kind`` (the PMI category), NOT
-    ``.kind`` (the feature kind, always ``"pmi"``) — the #360 bug used the latter, so
-    the diameter branch was dead and every diameter dim spanned ±diameter (2× wide)."""
+    radius (half = value). Keyed on the drafting dimension category, NOT ``.kind`` (the
+    IR feature kind) — the #360 bug used the latter, so the diameter branch was dead and
+    every diameter dim spanned ±diameter (2× wide)."""
     return value / 2 if pmi_kind == "diameter" else value
 
 
@@ -1503,10 +1503,26 @@ _PMI_SUBCHAIN = 3
 _PMI_CORRIDOR_PRIORITY = 1.0
 
 
+def _renderable_pmi_records(records):
+    """PMI records the dimension renderer may place.
+
+    Raw ``PmiFeature`` fallbacks can preserve unsupported AP242 records. Do not render those
+    just because they happen to carry a numeric value and references; only drafting dimension
+    categories belong in this placement path.
+    """
+    return [
+        r
+        for r in records
+        if r.pmi_kind in AUTHORED_DIMENSION_KINDS and r.value > 0 and len(r.ref_pts) >= 2
+    ]
+
+
 def render_pmi(dwg, model, a) -> int:
-    """Render pre-authored PMI annotations (STEP AP242) from the IR `PmiFeature`s
-    as first-class corridor candidates (#208/#393). Replaces the engine's
-    `_annotate_pmi`.
+    """Render imported authored dimensions from concept IR as first-class candidates.
+
+    AP242 dimensional PMI lowers to ``AuthoredDimension``; unsupported raw PMI fallback
+    records still ride as ``PmiFeature`` so they remain visible to diagnostics (#208/#393).
+    Replaces the engine's ``_annotate_pmi``.
 
     Called from ``_auto_annotate`` before ``drain_corridors`` so authored PMI
     co-solves with automatic strip candidates. Skips records whose page
@@ -1520,26 +1536,9 @@ def render_pmi(dwg, model, a) -> int:
                     too compressed in the side view)
     """
     draft = dwg.draft
-    pmi = [f for f in model.features if f.kind == "pmi"]
-    usable = [r for r in pmi if r.value > 0 and len(r.ref_pts) >= 2]
-    n_gtol = sum(
-        1
-        for r in pmi
-        if r.pmi_kind
-        not in (
-            "linear",
-            "diameter",
-            "radius",
-            "angular",
-            "curved_dist",
-            "oriented",
-            "curve_length",
-            "thickness",
-            "label",
-            "presentation",
-        )
-        and r.value > 0
-    )
+    pmi = [f for f in model.features if f.kind in ("authored_dimension", "pmi")]
+    usable = _renderable_pmi_records(pmi)
+    n_gtol = sum(1 for r in pmi if r.pmi_kind not in AUTHORED_DIMENSION_KINDS and r.value > 0)
     if n_gtol:
         _log.debug("PMI annotate: %d gtol/datum record(s) not yet annotatable (Phase 4)", n_gtol)
     if not usable:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -325,7 +325,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # candidates BEFORE the drain, so the one solve orders and spaces them crossing-free
     # with locations/slots rather than consuming leftovers as first-fit placements.
     render_gdt(dwg, _model, a)
-    if a.pmi_mode == "annotate":
+    if a.pmi_mode == "annotate" or (
+        getattr(dwg, "_model_declared", False)
+        and any(f.kind in ("authored_dimension", "pmi") for f in _model.features)
+    ):
         render_pmi(dwg, _model, a)
 
     # Now every corridor feeder pass has registered; solve each shared strip once

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -283,11 +283,14 @@ def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=
             if rot is not None:
                 dwg._part_model = replace(pm, features=[*pm.features, rot])
         # PMI (STEP AP242) is likewise detection-sourced, so a declared / emitted-script model
-        # carries none. When PMI annotation is on, synthesise the same PmiFeatures detection
-        # would (render_pmi reads them off the model, gated on a.pmi_mode) so a re-run reproduces
-        # the PMI dims (#472). Gated on the caller not having declared PMI, so an explicit set wins.
+        # carries none. When PMI annotation is on, synthesise the same imported drafting
+        # annotations detection would (render_pmi reads them off the model, gated on a.pmi_mode)
+        # so a re-run reproduces the PMI dims (#472). Gated on the caller not having declared
+        # imported authored annotations, so an explicit set wins.
         pm = dwg._part_model
-        if a.pmi_mode == "annotate" and not any(f.kind == "pmi" for f in pm.features):
+        if a.pmi_mode == "annotate" and not any(
+            f.kind in ("authored_dimension", "pmi") for f in pm.features
+        ):
             pmi_feats = build_pmi_features(a.pmi, a.part.bounding_box())
             if pmi_feats:
                 dwg._part_model = replace(pm, features=[*pm.features, *pmi_feats])

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -35,6 +35,8 @@ from draftwright.model.declare import (
 )
 from draftwright.model.detect import build_part_model, build_pmi_features
 from draftwright.model.ir import (
+    AUTHORED_DIMENSION_KINDS,
+    AuthoredDimension,
     BossFeature,
     Datum,
     DimParameter,
@@ -60,6 +62,8 @@ from draftwright.model.planner import (
 )
 
 __all__ = [
+    "AuthoredDimension",
+    "AUTHORED_DIMENSION_KINDS",
     "BossFeature",
     "Datum",
     "DimParameter",

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from draftwright._core import _axis_letter, _xyz
 from draftwright.model.ir import (
+    AUTHORED_DIMENSION_KINDS,
+    AuthoredDimension,
     BossFeature,
     Datum,
     EnvelopeFeature,
@@ -121,15 +123,16 @@ _DIA_TOL = 0.15  # two ø values within this (mm) are the same diameter (#298)
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
 
 
-def build_pmi_features(pmi, bbox) -> list[PmiFeature]:
-    """Re-home extracted STEP AP242 PMI records into IR :class:`PmiFeature`s (#208).
+def build_pmi_features(pmi, bbox) -> list[AuthoredDimension | PmiFeature]:
+    """Re-home extracted STEP AP242 PMI records into drafting-concept IR (#208).
 
     Shared by :func:`build_part_model` (the detection path) and the declared-model PMI
-    synthesis in ``builder._assemble`` (#472) so both construct features identically — a
-    declared / emitted-script build reproduces the same PMI the auto path draws. ``pmi`` is
-    the list of extracted records (``a.pmi``); ``bbox`` the part bounding box (for the
-    fallback origin when a record carries no ``ref_bbox``). Empty/``None`` ``pmi`` → ``[]``."""
-    out: list[PmiFeature] = []
+    synthesis in ``builder._assemble`` (#472) so both construct features identically.
+    Dimensional PMI becomes :class:`AuthoredDimension`, because users edit drafting
+    dimensions rather than source-format PMI. Unsupported GD&T/datum records remain raw
+    :class:`PmiFeature` fallbacks until their concept lowering lands. Empty/``None``
+    ``pmi`` → ``[]``."""
+    out: list[AuthoredDimension | PmiFeature] = []
     for r in pmi or ():
         if r.ref_bbox is not None:
             x0, y0, z0, x1, y1, z1 = r.ref_bbox
@@ -137,6 +140,22 @@ def build_pmi_features(pmi, bbox) -> list[PmiFeature]:
         else:
             pmi_origin = (bbox.center().X, bbox.center().Y, bbox.center().Z)
         ax = r.dominant_axis.lower() if r.dominant_axis in ("X", "Y", "Z") else "z"
+        if r.kind in AUTHORED_DIMENSION_KINDS:
+            out.append(
+                AuthoredDimension(
+                    frame=Frame(origin=pmi_origin, axis=ax),
+                    dimension_kind=r.kind,
+                    value=r.value,
+                    label=r.label,
+                    dominant_axis=r.dominant_axis,
+                    upper_tol=r.upper_tol,
+                    lower_tol=r.lower_tol,
+                    ref_bbox=r.ref_bbox,
+                    ref_pts=tuple(r.ref_pts),
+                    source_kind=r.kind,
+                )
+            )
+            continue
         out.append(
             PmiFeature(
                 frame=Frame(origin=pmi_origin, axis=ax),
@@ -309,8 +328,8 @@ def build_part_model(
             RotationalFeature(frame=Frame((c.X, c.Y, c.Z), rot_axis), od=od, bores=tuple(bores))
         )
 
-    # Pre-authored PMI annotations (STEP AP242) — re-homed into the IR as features
-    # (#208). Rendered directly by render_pmi (the planner adds nothing — see PmiFeature).
+    # STEP AP242 PMI — re-homed into drafting-concept IR where possible (#208).
+    # Rendered directly by render_pmi; the planner adds nothing.
     features.extend(build_pmi_features(pmi, bbox))
 
     # The default location datum — the part's min-X/min-Y/min-Z corner (lower-left

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -28,6 +28,18 @@ if TYPE_CHECKING:
 
 Point = tuple[float, float, float]
 ParamKind = Literal["diameter", "length", "depth", "radius", "angle", "location", "thread"]
+AUTHORED_DIMENSION_KINDS = frozenset(
+    {
+        "linear",
+        "diameter",
+        "radius",
+        "angular",
+        "curved_dist",
+        "oriented",
+        "curve_length",
+        "thickness",
+    }
+)
 # `role` is the semantic origin of the measurement (open set — new features add
 # roles): "bore", "counterbore", "spotface", "od", "step", "boss", "thread",
 # "pattern", "slot", "envelope", "location", …
@@ -308,16 +320,48 @@ class RotationalFeature:
 
 
 @dataclass(frozen=True)
-class PmiFeature:
-    """A *pre-authored* PMI annotation extracted from a STEP AP242 file (#208) — its
-    value, label, tolerances, and referenced geometry were set by the CAD author.
+class AuthoredDimension:
+    """A pre-authored drafting dimension imported from an external semantic source.
 
-    Unlike the geometric features, the planner derives nothing here (no convention or
-    view selection): the label is baked and the view follows from `dominant_axis` +
-    `ref_bbox`. So `parameters()` is empty — PMI does not flow through the planner; the
-    renderer (`render_pmi`) consumes `PmiFeature`s directly from the model, the same way
-    `render_slots` reads `SlotFeature`s. This keeps PMI on the one path (it is an IR
-    feature) without pretending it benefits from the dimension planner."""
+    This is the concept-shaped IR for AP242 dimensional PMI: the source file may call it
+    PMI, but the drawing model sees an authored linear/diameter/radius/etc. dimension with
+    baked label and referenced geometry. The normal dimension planner does not derive or
+    duplicate it, so ``parameters()`` is empty; renderers consume it directly while keeping
+    the source/provenance fields for round-trip and diagnostics."""
+
+    frame: Frame
+    dimension_kind: str  # "linear" | "diameter" | "radius" | "angular" | ...
+    value: float
+    label: str
+    dominant_axis: str
+    upper_tol: float | None = None
+    lower_tol: float | None = None
+    ref_bbox: tuple[float, float, float, float, float, float] | None = None
+    ref_pts: tuple[Point, ...] = ()
+    source: str = "ap242_pmi"
+    source_kind: str | None = None
+    kind: ClassVar[str] = "authored_dimension"
+
+    @property
+    def pmi_kind(self) -> str:
+        """Compatibility alias for the existing AP242 renderer until it is renamed."""
+        return self.dimension_kind
+
+    def parameters(self) -> list[DimParameter]:
+        return []
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
+class PmiFeature:
+    """Raw AP242 PMI fallback for records not yet lowered to drafting concepts.
+
+    Dimensional AP242 PMI should become :class:`AuthoredDimension`; GD&T/datum/surface
+    records should eventually lower to ``ControlFrame`` / ``DatumRef`` / ``Finish``. This
+    type remains as an explicit provenance-preserving escape hatch so unsupported records
+    are visible instead of silently lost."""
 
     frame: Frame
     pmi_kind: str  # the PMI category: "linear" | "diameter" | "radius" | "angular" | ...

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -43,7 +43,7 @@ from dataclasses import replace
 from draftwright.analysis import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
-from draftwright.model import Feature
+from draftwright.model import AuthoredDimension, Feature, Frame
 from draftwright.model import boss as _boss
 from draftwright.model import control_frame as _declare_control
 from draftwright.model import datum as _declare_datum
@@ -56,6 +56,14 @@ from draftwright.model import slot as _slot
 from draftwright.model import step as _step
 from draftwright.model.declare import _norm_axis, _read_cylinder, _require_positive, gdt_target
 from draftwright.model.declare import read_bore_step as _read_bore_step
+from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, Point
+
+
+def _point3(name: str, p) -> Point:
+    vals = tuple(float(c) for c in p)
+    if len(vals) != 3:
+        raise ValueError(f"dimension() {name} must be a 3-tuple")
+    return (vals[0], vals[1], vals[2])
 
 
 def _parse_datums(to) -> tuple[str, ...]:
@@ -352,6 +360,70 @@ class Sheet:
         """Append a pre-built IR :class:`~draftwright.model.Feature` (escape hatch for
         the constructors this façade does not surface directly, e.g. PMI)."""
         self._features.append(feature)
+        return self
+
+    def dimension(
+        self,
+        *,
+        kind: str,
+        value: float,
+        label: str,
+        dominant_axis: str,
+        ref_pts,
+        ref_bbox=None,
+        at=None,
+        axis: str | None = None,
+        upper_tol: float | None = None,
+        lower_tol: float | None = None,
+        source: str = "sheet",
+        source_kind: str | None = None,
+    ) -> Sheet:
+        """Declare a pre-authored drafting dimension from explicit measured values.
+
+        This is the concept-shaped Sheet API used by generated AP242 scripts: the source file
+        may call the record PMI, but the editable script declares a dimension category, value,
+        label, referenced model points, and optional structured tolerances. For ordinary
+        geometry-backed edits prefer feature handles such as ``sheet.hole(...).tolerance(...)``.
+        """
+        _require_positive(value=value)
+        dim_kind = str(kind).lower()
+        if dim_kind not in AUTHORED_DIMENSION_KINDS:
+            allowed = ", ".join(sorted(AUTHORED_DIMENSION_KINDS))
+            raise ValueError(f"dimension() kind must be one of: {allowed}")
+        pts = tuple(_point3("ref_pts item", p) for p in ref_pts)
+        if len(pts) < 2:
+            raise ValueError("dimension() needs at least two ref_pts")
+        bbox = None if ref_bbox is None else tuple(float(c) for c in ref_bbox)
+        if bbox is not None and len(bbox) != 6:
+            raise ValueError("dimension() ref_bbox must be a 6-tuple")
+        dom = str(dominant_axis).upper()
+        if dom not in ("X", "Y", "Z"):
+            if not (dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None):
+                raise ValueError("dimension() dominant_axis must be X, Y, or Z")
+        if at is None:
+            if bbox is not None:
+                x0, y0, z0, x1, y1, z1 = bbox
+                at = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
+            else:
+                n = len(pts)
+                at = tuple(sum(p[i] for p in pts) / n for i in range(3))
+        origin = _point3("at", at)
+        ax = _norm_axis(axis or (dom.lower() if dom in ("X", "Y", "Z") else "z"))
+        self._features.append(
+            AuthoredDimension(
+                frame=Frame(origin, ax),
+                dimension_kind=dim_kind,
+                value=float(value),
+                label=str(label),
+                dominant_axis=dom,
+                upper_tol=upper_tol,
+                lower_tol=lower_tol,
+                ref_bbox=bbox,
+                ref_pts=pts,
+                source=source,
+                source_kind=source_kind or dim_kind,
+            )
+        )
         return self
 
     def of(self, ref) -> _Hole | _Dim:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -11,12 +11,12 @@ detection didn't model (chamfers, fillets, turned profiles) yet reads as authori
 *has* the objects (mode 3b) wires their real part into the seam and swaps the number lines for
 ``sheet.hole(obj)`` references — the emitter's numbers are a starting point, not a ceiling.
 
-Kinds with no declarative verb yet (``step_level``/``rotational``/``pmi``) are flagged inline —
-never silently dropped — and left to the auto-pass that runs over the declared model on re-run.
+Kinds with no declarative verb yet (``rotational``) are flagged inline — never silently dropped —
+and left to the auto-pass that runs over the declared model on re-run. Imported authored
+dimensions, including AP242 dimensional PMI, emit as Sheet ``dimension(...)`` declarations.
 Fidelity: the script reproduces a lint-clean drawing of the same features. The generated script is
 validated against the direct build for prismatic, slot/pattern, section, and turned/rotational
-fixtures (#472); AP242 PMI script round-trip remains separate because ``import_step`` strips the
-semantic PMI before the generated script can re-read it (#503).
+fixtures (#472).
 """
 
 from __future__ import annotations
@@ -36,6 +36,21 @@ def _n(v) -> float | int:
 
 def _pt(p) -> str:
     return "(" + ", ".join(str(_n(c)) for c in p) + ")"
+
+
+def _pts_arg(points) -> str:
+    return "[" + ", ".join(_pt(p) for p in points) + "]"
+
+
+def _bbox_arg(bbox) -> str:
+    return "None" if bbox is None else _pt(bbox)
+
+
+def _tuple_arg(values) -> str:
+    vals = [str(_n(v)) for v in values]
+    if len(vals) == 1:
+        return f"({vals[0]},)"
+    return "(" + ", ".join(vals) + ")"
 
 
 def _hole_line(f) -> str:
@@ -72,8 +87,45 @@ def _member_hole_str(m) -> str:
     return f"hole({', '.join(kw)})"
 
 
+def _authored_dimension_line(f) -> str:
+    kw = [
+        f"kind={f.dimension_kind!r}",
+        f"value={_n(f.value)}",
+        f"label={f.label!r}",
+        f"dominant_axis={f.dominant_axis!r}",
+        f"ref_pts={_pts_arg(f.ref_pts)}",
+        f"ref_bbox={_bbox_arg(f.ref_bbox)}",
+        f"at={_pt(f.frame.origin)}",
+        f"axis={f.frame.axis!r}",
+    ]
+    if f.upper_tol is not None:
+        kw.append(f"upper_tol={_n(f.upper_tol)}")
+    if f.lower_tol is not None:
+        kw.append(f"lower_tol={_n(f.lower_tol)}")
+    if f.source != "sheet":
+        kw.append(f"source={f.source!r}")
+    if f.source_kind is not None and f.source_kind != f.dimension_kind:
+        kw.append(f"source_kind={f.source_kind!r}")
+    return "sheet.dimension(" + ", ".join(kw) + ")"
+
+
+def _raw_pmi_line(f) -> str:
+    return (
+        "sheet.add(PmiFeature("
+        f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
+        f"pmi_kind={f.pmi_kind!r}, value={_n(f.value)}, label={f.label!r}, "
+        f"dominant_axis={f.dominant_axis!r}, ref_bbox={_bbox_arg(f.ref_bbox)}, "
+        f"ref_pts=tuple({_pts_arg(f.ref_pts)})"
+        "))   # raw AP242 PMI fallback; not yet lowered to a drafting concept"
+    )
+
+
 def _feature_line(f) -> str:
     k = f.kind
+    if k == "authored_dimension":
+        return _authored_dimension_line(f)
+    if k == "pmi":
+        return _raw_pmi_line(f)
     if k == "envelope":
         return (
             "sheet.add(EnvelopeFeature("
@@ -81,6 +133,13 @@ def _feature_line(f) -> str:
             f"width={_n(f.width)}, height={_n(f.height)}, depth={_n(f.depth)}, "
             f"bbox_min={_pt(f.bbox_min)}, bbox_max={_pt(f.bbox_max)}"
             f"))   # envelope {_n(f.width)} × {_n(f.height)} × {_n(f.depth)}"
+        )
+    if k == "step_level":
+        return (
+            "sheet.add(StepLevelFeature("
+            f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
+            f"base={_n(f.base)}, levels={_tuple_arg(f.levels)}"
+            "))   # prismatic height ladder"
         )
     if k == "hole":
         return _hole_line(f)
@@ -117,9 +176,7 @@ def _feature_line(f) -> str:
             parts.append("members=[" + ", ".join(_pt(p) for p in f.members) + "]")
         return f"sheet.pattern({_member_hole_str(f.member)}, " + ", ".join(parts) + ")"
     # Kinds with no declarative verb yet: flag inline so they aren't silently lost. The auto-pass
-    # over the declared model still draws step_level/rotational furniture faithfully (#472). PMI is
-    # the remaining non-faithful case when re-running an emitted STEP-seam script because
-    # build123d.import_step strips AP242 PMI; baking those features is tracked in #503.
+    # over the declared model still draws rotational furniture faithfully (#472).
     return f"# {k} @ {_pt(f.frame.origin)} — no declarative verb yet; drawn by the auto-pass"
 
 
@@ -167,14 +224,18 @@ def emit_sheet_script(
     (``drawn_by``/``tolerance``/``scale``/``page``, #474) are emitted into the ``Sheet(...)``
     constructor only when non-default, so a plain drawing keeps a clean one-line constructor.
 
-    PMI is deliberately NOT emitted here: the seam binds ``part`` via ``import_step``, which
-    strips AP242 PMI, so a re-run cannot re-extract it — the faithful fix bakes PMI as declared
-    features (#503 / #422)."""
-    model_imports = []
+    AP242 PMI cannot be re-extracted from the ``import_step`` seam, so detected dimensional PMI is
+    emitted as declared Sheet dimensions; unsupported raw PMI records are kept as explicit
+    ``sheet.add(PmiFeature(...))`` fallbacks (#503 / #422)."""
+    model_imports = set()
     if any(f.kind in ("hole", "pattern") for f in model.features):
-        model_imports.append("hole")
+        model_imports.add("hole")
     if any(f.kind == "envelope" for f in model.features):
-        model_imports.extend(["EnvelopeFeature", "Frame"])
+        model_imports.update(["EnvelopeFeature", "Frame"])
+    if any(f.kind == "step_level" for f in model.features):
+        model_imports.update(["Frame", "StepLevelFeature"])
+    if any(f.kind == "pmi" for f in model.features):
+        model_imports.update(["Frame", "PmiFeature"])
     # Only carry an aspect into the emitted constructor when it differs from build_drawing's
     # default (mirrors the CLI's inert-flag test) — an unset aspect stays off the script.
     ctor = [f"title={title!r}", f"number={number!r}"]

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -151,9 +151,10 @@ class TestBuildDrawingPmi:
 
 class TestDeclaredModelPmi:
     """#472: a DECLARED-model build (build_drawing(path, model=…)) skips detection, so it carried
-    no PmiFeatures and dropped PMI even with pmi='annotate'. _assemble now synthesises them from
-    the analysis (the same build_pmi_features detection uses), so PMI reproduces on the declared
-    path. (The emitted Sheet-script round-trip is a separate gap — import_step strips AP242 PMI.)"""
+    no imported authored annotations and dropped PMI even with pmi='annotate'. _assemble now
+    synthesises them from the analysis (the same build_pmi_features detection uses), so PMI
+    reproduces on the declared path. (The emitted Sheet-script round-trip is a separate gap —
+    import_step strips AP242 PMI.)"""
 
     def test_declared_model_annotate_matches_auto(self, tmp_path):
         auto = build_drawing(str(CTC01), out=str(tmp_path / "a"), title="P", pmi="annotate")
@@ -176,17 +177,37 @@ class TestDeclaredModelPmi:
 
 def test_build_pmi_features_mirrors_detection():
     """build_pmi_features (shared by build_part_model and the declared-model synthesis) builds one
-    PmiFeature per record; both callers must construct them identically (#472)."""
-    from draftwright.model import build_pmi_features
+    imported drafting annotation per record; both callers construct them identically (#472)."""
+    from draftwright.model import AuthoredDimension, PmiFeature, build_pmi_features
 
     recs = extract_pmi(CTC01)
-    dims = [r for r in recs if r.kind not in ("gtol", "datum")]
+    dim_kinds = {
+        "linear",
+        "diameter",
+        "radius",
+        "angular",
+        "curved_dist",
+        "oriented",
+        "curve_length",
+        "thickness",
+    }
+    dims = [r for r in recs if r.kind in dim_kinds]
     from build123d import import_step
 
     bbox = import_step(CTC01).bounding_box()
     feats = build_pmi_features(recs, bbox)
     assert len(feats) == len(recs)
-    assert all(f.kind == "pmi" for f in feats)
-    # a dim record's value/label ride onto its PmiFeature verbatim
-    assert {f.label for f in feats} >= {r.label for r in dims}
+    authored = [f for f in feats if isinstance(f, AuthoredDimension)]
+    raw = [f for f in feats if isinstance(f, PmiFeature)]
+    assert authored
+    assert raw  # GD&T/datum AP242 records are explicit raw fallbacks until concept lowering.
+    assert all(f.kind == "authored_dimension" for f in authored)
+    assert all(f.kind == "pmi" for f in raw)
+    # a dimensional PMI record's value/label ride onto its authored dimension verbatim
+    assert {f.label for f in authored} >= {r.label for r in dims}
+    for r in dims:
+        assert any(
+            f.label == r.label and f.upper_tol == r.upper_tol and f.lower_tol == r.lower_tol
+            for f in authored
+        )
     assert build_pmi_features(None, bbox) == []  # None/empty → no features

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -64,10 +64,10 @@ class TestCalloutSpec:
 
 
 class TestBoreHalfSpan:
-    """#360: a PMI bore-size dim's half-span from the bore centroid. A diameter
+    """#360: an imported bore-size dim's half-span from the bore centroid. A diameter
     record stores the diameter (half = radius); a radius record stores the radius
-    (half = value). The bug keyed on the feature `.kind` (always 'pmi') instead of
-    `.pmi_kind`, so the diameter branch was dead and every diameter dim spanned
+    (half = value). The bug keyed on the IR feature `.kind` instead of the drafting
+    dimension category, so the diameter branch was dead and every diameter dim spanned
     ±diameter — 2× too wide."""
 
     def test_diameter_halves_to_the_radius(self):
@@ -80,23 +80,46 @@ class TestBoreHalfSpan:
 
         assert _bore_half_span("radius", 8.0) == 8.0
 
-    def test_the_pmifeature_kind_attr_never_triggers_the_diameter_branch(self):
-        # The regression itself: a PmiFeature's `.kind` is always "pmi" (a ClassVar),
-        # so keying on it (as the old code did) never halves. Pin that pmi_kind is
-        # the right key and .kind is the wrong one.
+    def test_the_ir_kind_attr_never_triggers_the_diameter_branch(self):
+        # The regression itself: an authored dimension's `.kind` identifies the IR concept,
+        # so keying on it (as the old code did) never halves. Pin that pmi_kind is the
+        # compatibility category and .kind is the wrong one.
         from draftwright.annotations.from_model import _bore_half_span
-        from draftwright.model import Frame, PmiFeature
+        from draftwright.model import AuthoredDimension, Frame
 
-        rec = PmiFeature(
+        rec = AuthoredDimension(
             frame=Frame((0, 0, 0), "z"),
-            pmi_kind="diameter",
+            dimension_kind="diameter",
             value=35.0,
             label="ø35",
             dominant_axis="Z",
         )
-        assert rec.kind == "pmi"  # feature kind (ClassVar), NOT the PMI category
+        assert rec.kind == "authored_dimension"  # IR concept, NOT the dimension category
         assert _bore_half_span(rec.kind, rec.value) == 35.0  # the old bug: no halving
         assert _bore_half_span(rec.pmi_kind, rec.value) == 17.5  # the fix: radius
+
+    def test_raw_unsupported_pmi_is_not_renderable_as_a_dimension(self):
+        from draftwright.annotations.from_model import _renderable_pmi_records
+        from draftwright.model import AuthoredDimension, Frame, PmiFeature
+
+        dim = AuthoredDimension(
+            frame=Frame((0, 0, 0), "x"),
+            dimension_kind="linear",
+            value=10.0,
+            label="10",
+            dominant_axis="X",
+            ref_pts=((0, 0, 0), (10, 0, 0)),
+        )
+        raw_gtol = PmiFeature(
+            frame=Frame((0, 0, 0), "x"),
+            pmi_kind="position",
+            value=0.1,
+            label="position 0.1",
+            dominant_axis="X",
+            ref_pts=((0, 0, 0), (10, 0, 0)),
+        )
+
+        assert _renderable_pmi_records([dim, raw_gtol]) == [dim]
 
 
 class TestStepChainDrop:

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -13,6 +13,7 @@ import pytest
 from build123d import Box, Cylinder, Pos, Shape, export_step
 
 from draftwright.builder import build_drawing, detect_part_model
+from draftwright.pmi import _PMI_AVAILABLE
 from draftwright.sheet_emit import (
     emit_sheet_script,
     generate_sheet_script,
@@ -29,6 +30,8 @@ _SOURCE_MODULE = (
     "NONE_BOUND = None\n"  # exists but bound to None — the wrong-type, not-missing case
     "def needs_args(x):\n    return x\n"
 )
+
+AP242_CTC01 = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap242.stp"
 
 
 def _norm(s: str) -> str:
@@ -70,6 +73,72 @@ class TestEmit:
         assert "width=800" in src
         assert "depth=450" in src
         assert "1170" not in src
+
+    @pytest.mark.skipif(not _PMI_AVAILABLE, reason="OCP GDT support not available")
+    def test_step_seam_emits_ap242_pmi_as_sheet_dimensions(self, tmp_path):
+        py = generate_sheet_script(str(AP242_CTC01), out=str(tmp_path / "ctc01"), pmi="annotate")
+        src = Path(py).read_text(encoding="utf-8")
+        ast.parse(src)
+        assert "sheet.dimension(" in src
+        assert "sheet.pmi(" not in src
+        assert "# authored_dimension" not in src
+        assert "source='ap242_pmi'" in src
+        assert "sheet.add(PmiFeature(" in src
+        assert "sheet.add(StepLevelFeature(" in src
+        import_line = next(
+            ln for ln in src.splitlines() if ln.startswith("from draftwright.model")
+        )
+        assert "Frame" in import_line and "PmiFeature" in import_line
+        assert "StepLevelFeature" in import_line
+
+    def test_sheet_dimension_declares_renderable_authored_dimension(self, tmp_path):
+        from draftwright import Sheet
+
+        sheet = Sheet(Box(40, 20, 10), title="P", out=str(tmp_path / "dim"))
+        sheet.dimension(
+            kind="linear",
+            value=40,
+            label="40",
+            dominant_axis="X",
+            ref_bbox=(-20, -10, -5, 20, 10, 5),
+            ref_pts=[(-20, 0, 0), (20, 0, 0)],
+            upper_tol=0.1,
+            lower_tol=0.0,
+        )
+
+        feat = next(f for f in sheet.model().features if f.kind == "authored_dimension")
+        assert feat.upper_tol == 0.1
+        assert feat.lower_tol == 0.0
+        assert feat.source == "sheet"
+        assert any(n.startswith("pmi_") for n in sheet.build()._named)
+
+    def test_sheet_dimension_rejects_unrenderable_kind(self):
+        from draftwright import Sheet
+
+        sheet = Sheet(Box(40, 20, 10), title="P")
+        with pytest.raises(ValueError, match="kind must be one of"):
+            sheet.dimension(
+                kind="liner",
+                value=40,
+                label="40",
+                dominant_axis="X",
+                ref_pts=[(-20, 0, 0), (20, 0, 0)],
+                ref_bbox=(-20, -10, -5, 20, 10, 5),
+            )
+
+    def test_sheet_dimension_rejects_unrenderable_axis(self):
+        from draftwright import Sheet
+
+        sheet = Sheet(Box(40, 20, 10), title="P")
+        with pytest.raises(ValueError, match="dominant_axis must be X, Y, or Z"):
+            sheet.dimension(
+                kind="linear",
+                value=40,
+                label="40",
+                dominant_axis="XX",
+                ref_pts=[(-20, 0, 0), (20, 0, 0)],
+                ref_bbox=(-20, -10, -5, 20, 10, 5),
+            )
 
     def test_title_block_and_layout_aspects_emitted_when_set(self):
         # #474: non-default drawn_by/tolerance/scale/page ride the Sheet(...) constructor.
@@ -172,14 +241,24 @@ class TestEmit:
         )
         assert "cbore=(" in line  # on the member hole(...) template
 
-    def test_non_declarable_kind_is_flagged_not_dropped(self):
-        # a counterbored plate carries a step_level (horizontal face levels) with no Sheet verb —
-        # it must surface as an inline comment, never silently vanish
+    def test_step_level_emits_as_ir_fallback(self):
+        # A counterbored plate carries a step_level (horizontal face levels). It must
+        # round-trip as an explicit IR fallback so the generated script preserves the
+        # front-right height ladder occupancy that other dimensions negotiate against.
         part = Box(100, 70, 24) - Pos(0, 0, 0) * Cylinder(9, 40) - Pos(0, 0, 8) * Cylinder(15, 20)
         src = _script_for(part)
-        assert any(
-            ln.startswith("#") and "no declarative verb yet" in ln for ln in src.splitlines()
-        )
+        assert "sheet.add(StepLevelFeature(" in src
+        assert "# step_level" not in src
+
+    @pytest.mark.skipif(not _PMI_AVAILABLE, reason="OCP GDT support not available")
+    def test_ap242_script_keeps_side_hole_z_location_on_side_ladder(self, tmp_path):
+        py = generate_sheet_script(str(AP242_CTC01), out=str(tmp_path / "ctc01"), pmi="annotate")
+        ns = {}
+        exec(compile(Path(py).read_text(encoding="utf-8"), py, "exec"), ns)
+        dwg = ns["sheet"].build()
+        assert "dim_loc_side_z7500" in dwg._named
+        assert "dim_loc_front_z7500" not in dwg._named
+        assert "dim_step_0" in dwg._named
 
     def test_needs_hole_import_only_when_a_pattern_is_present(self):
         # `hole` is only imported when a pattern line references it


### PR DESCRIPTION
## Summary

First PR in the PMI Sheet split, now carrying the concept-shaped Sheet API as requested.

- Adds `AuthoredDimension` as the drafting-concept IR for imported authored dimensions.
- Lowers AP242 dimensional PMI records into `AuthoredDimension` instead of source-shaped `PmiFeature`.
- Adds `Sheet.dimension(...)` for pre-authored drafting dimensions with value, label, references, axis, and structured tolerances.
- Emits detected AP242 dimensional PMI as `sheet.dimension(...)` in generated Sheet scripts.
- Keeps `PmiFeature` as an explicit raw fallback for unsupported PMI records such as GD&T/datum until their concept lowering lands.
- Preserves `pmi="report"` as extract/report only; explicit Sheet-authored dimensions render from declared models without needing `pmi="annotate"`.

## Why

Users and Sheet scripts should model drafting concepts, not source-format PMI. AP242 can still be the import source, but the editable API now exposes authored dimensions as drafting dimensions and reserves raw PMI for unsupported fallback records.

## Validation

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
- `uv run pytest tests/test_sheet_emit.py tests/test_pmi.py tests/test_render_seam.py -q`
- `uv run pytest tests/test_sheet_emit.py::TestEmit::test_step_seam_emits_ap242_pmi_as_sheet_dimensions -q`

Refs #503, #422, #62.