### PR TITLE
Reserve declared callout footprints in layout

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -14,6 +14,7 @@ import logging
 import math
 import warnings
 from collections.abc import Callable
+from dataclasses import replace
 
 from build123d import Compound, Shape
 from build123d_drafting.helpers import draft_preset
@@ -31,6 +32,8 @@ from draftwright._core import (
     _legible_steps,
     _Projector,
 )
+from draftwright.model.ir import Datum, PartModel, StepFeature
+from draftwright.model.planner import plan_dimensions
 from draftwright.recognition import (
     analyse_cylinders,
     analyse_face_levels,
@@ -45,6 +48,7 @@ from draftwright.sheet import (
     StripDepths,
     _build_zones,
     _est_hole_table_sizes,
+    _est_planned_bore_callout_width,
     _layout_geometry,
     _measure_strips,
     _will_section,
@@ -94,6 +98,32 @@ def _declared_will_section(model, *, is_rotational=False, cx=0.0, cy=0.0) -> boo
         ):
             return True
     return False
+
+
+def _coerce_layout_model(model, part, decorations=None) -> PartModel | None:
+    """Return the caller-declared IR with authored decorations for layout sizing.
+
+    This mirrors the builder's render-time coercion, but stays local to analysis so
+    page/scale/strip selection can see the same authored callout text the renderer
+    will later place (#450).
+    """
+    if model is None:
+        return None
+    if isinstance(model, PartModel):
+        if decorations:
+            return replace(model, decorations={**model.decorations, **decorations})
+        return model
+    features = list(model)
+    bbox = part.bounding_box()
+    orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
+    datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
+    return PartModel(
+        bbox=bbox,
+        orientation=orientation,
+        features=features,
+        datums=[datum],
+        decorations=decorations or {},
+    )
 
 
 def _import_step(path) -> Compound:
@@ -299,6 +329,7 @@ def _analyse(
     page=None,
     pmi="off",
     model=None,
+    decorations=None,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -409,6 +440,17 @@ def _analyse(
     _draft_est = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
     _arrow_length = _draft_est.arrow_length
     _pad_around_text = _draft_est.pad_around_text
+    layout_model = _coerce_layout_model(model, part, decorations)
+    declared_bore_width = (
+        _est_planned_bore_callout_width(
+            plan_dimensions(layout_model),
+            _draft_est,
+            font_size=_FONT_SIZE,
+            pad_around_text=_pad_around_text,
+        )
+        if layout_model is not None
+        else 0.0
+    )
     holes = find_holes(part, cyls=(z_cyls, cross_cyls))
     patterns = find_hole_patterns(holes)
     bosses = find_bosses(part, cyls=(z_cyls, cross_cyls))  # detect once — the one inventory (#264)
@@ -442,6 +484,7 @@ def _analyse(
             bb,
             arrow_length=_arrow_length,
             pad_around_text=_pad_around_text,
+            declared_bore_callout_width=declared_bore_width,
         )
 
     def _pick_for_step_count(n_steps_i: int, strips_i: StripDepths) -> _ScalePick:
@@ -518,6 +561,7 @@ def _analyse(
         bb,
         arrow_length=_arrow_length,
         pad_around_text=_pad_around_text,
+        declared_bore_callout_width=declared_bore_width,
     )
     # View positions + iso empty-rectangle, shared with scale selection (_fits)
     # via _layout_geometry so placement and fit never diverge (#11).  _fit_iso_view

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -561,6 +561,7 @@ def build_drawing(
         page=page,
         pmi=pmi,
         model=model,
+        decorations=decorations,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -46,6 +46,7 @@ from draftwright._core import (
     _tag_sequence,
     _tb_width,
     _text_width,
+    _tol_suffix,
 )
 from draftwright.layout import fit_box
 from draftwright.recognition import BoltCircle, HoleSpec, RectGrid
@@ -337,6 +338,80 @@ def _est_bore_callout_width(
     return max_w
 
 
+def _est_planned_bore_callout_width(
+    groups, draft, font_size: float = _FONT_SIZE, pad_around_text: float = 2.0
+) -> float:
+    """Estimate widest hole/pattern callout from planned IR dimensions.
+
+    This is the declared-model companion to :func:`_est_bore_callout_width`.
+    Detection-derived ``HoleSpec`` values cannot see authored decorations such as
+    bore tolerances; planned groups can. Keep this in the layout estimator layer
+    so page/scale selection does not import renderers just to size text (#450).
+    """
+
+    def _first(group, kind: str, *roles: str) -> float | None:
+        for role in roles:
+            for pd in group.dims:
+                if pd.param.kind == kind and pd.param.role == role:
+                    return float(pd.param.value)
+        return None
+
+    def _tol(group):
+        return next(
+            (
+                pd.param.tolerance
+                for pd in group.dims
+                if pd.param.kind == "diameter" and pd.param.role == "bore"
+            ),
+            None,
+        )
+
+    gap = 0.45 * font_size
+    sym_w = font_size
+    max_w = 0.0
+    for group in groups:
+        feat = group.feature
+        if getattr(feat, "kind", None) not in ("hole", "pattern"):
+            continue
+        bore = _first(group, "diameter", "bore")
+        if bore is None:
+            continue
+        depth = _first(group, "depth", "bore")
+        cbore_dia = _first(group, "diameter", "counterbore", "spotface")
+        cbore_depth = _first(group, "depth", "counterbore", "spotface")
+        suffix = None
+        if getattr(feat, "kind", None) == "pattern":
+            if getattr(feat, "pattern", None) == "bolt_circle" and feat.bcd is not None:
+                suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
+            elif getattr(feat, "pattern", None) == "grid" and feat.rows and feat.cols:
+                suffix = f"({feat.rows}×{feat.cols})"
+
+        token_w: list[float] = []
+        count = getattr(feat, "count", None)
+        if count and count > 1:
+            token_w.append(_text_width(f"{count}×", font_size))
+        token_w.append(sym_w)  # ⌀ symbol
+        token_w.append(_text_width(f"{_fmt(bore)}{_tol_suffix(_tol(group), draft)}", font_size))
+        if depth is None:
+            token_w.append(_text_width("THRU", font_size))
+        else:
+            token_w.append(sym_w)  # depth symbol
+            token_w.append(_text_width(_fmt(depth), font_size))
+        if cbore_dia is not None:
+            token_w.append(sym_w)  # counterbore/spotface symbol
+            token_w.append(sym_w)  # ⌀
+            token_w.append(_text_width(_fmt(cbore_dia), font_size))
+            if cbore_depth is not None:
+                token_w.append(sym_w)  # depth symbol
+                token_w.append(_text_width(_fmt(cbore_depth), font_size))
+        if suffix is not None:
+            token_w.append(_text_width(suffix, font_size))
+
+        n = len(token_w)
+        max_w = max(max_w, sum(token_w) + max(n - 1, 0) * gap + pad_around_text)
+    return max_w
+
+
 @dataclass
 class StripDepths:
     """Annotation strip depths (page-mm) computed before view positions are fixed.
@@ -358,6 +433,7 @@ def _measure_strips(
     font_size: float = _FONT_SIZE,
     arrow_length: float = 2.7,
     pad_around_text: float = 2.0,
+    declared_bore_callout_width: float = 0.0,
 ) -> StripDepths:
     """Compute annotation strip depths from hole geometry (Pass 1 of #131).
 
@@ -365,8 +441,11 @@ def _measure_strips(
     page-mm constant, so there is no circularity with choose_scale().
     *arrow_length* and *pad_around_text* should come from ``draft_preset(...)``.
     """
-    bore_depth = _est_bore_callout_width(
-        holes, font_size, patterns=patterns, pad_around_text=pad_around_text
+    bore_depth = max(
+        _est_bore_callout_width(
+            holes, font_size, patterns=patterns, pad_around_text=pad_around_text
+        ),
+        declared_bore_callout_width,
     )
     # Add elbow clearance and leader-to-label gap so gap_fv_sv fully contains
     # the composed leader: elbow_dx (= draft.arrow_length) + gap

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -172,6 +172,22 @@ class TestSheetTolerance:
             self._steplen_tol(dwg, n) is None for n in dwg._named if n.startswith("m_steplen")
         )
 
+    def test_toleranced_hole_callout_participates_in_layout_sizing(self):
+        # #450: a Sheet-authored bore tolerance widens the HoleCallout. Layout
+        # sizing must reserve that declared footprint before the plan/side/iso
+        # blocks are placed; otherwise the real callout is later dropped from the
+        # iso-bounded plan strip even though a wider corridor would fit.
+        plate = Box(120, 90, 8)
+        part = plate - (Pos(0, 0, 4) * Cylinder(4, 8))
+
+        s = Sheet(part)
+        s.envelope(plate)
+        s.hole(diameter=8, at=(0, 0, 4), axis="z").tolerance(0.1)
+        dwg = s.build()
+
+        assert any(n.startswith("hc_plan") for n in dwg._named)
+        assert "callout_dropped" not in {i.code for i in dwg.lint()}
+
 
 class TestToleranceHandle:
     def test_hole_tolerance_survives_feature_replacement(self):


### PR DESCRIPTION
## Summary

Fixes #450 by making layout/page selection reserve declared Sheet hole-callout footprints, including authored bore tolerances, before the plan/side/iso blocks are placed.

## Root Cause

`build_drawing(..., model=..., decorations=...)` passed Sheet tolerance decorations to assembly/rendering, but `_analyse` did not receive them. The strip/page estimator therefore sized corridors from detected geometry only, while rendering later built a wider declared `HoleCallout` (`ø8 ±0.1 THRU`) and dropped it from the iso-bounded plan strip.

## Changes

- Thread `decorations` into `_analyse`.
- Build a lightweight declared layout model during analysis so planned dimensions include authored tolerances.
- Add a layout-layer planned callout width estimator and include it in strip depth sizing.
- Add a regression test for the #450 repro.

## Validation

- `uv run pytest tests/test_tolerances.py -q`
- `uv run pytest tests/test_tolerances.py tests/test_make_drawing.py::TestAutoHoleAnnotations -q`
- `uv run pytest tests/test_sheet_emit.py tests/test_render_seam.py -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
