### PR TITLE
Route strip sizing through annotation boxes

### DIFF
--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -435,28 +435,23 @@ def _measure_strips(
     pad_around_text: float = 2.0,
     declared_bore_callout_width: float = 0.0,
 ) -> StripDepths:
-    """Compute annotation strip depths from hole geometry (Pass 1 of #131).
+    """Compute annotation strip depths from composed annotation boxes (Pass 1 of #131).
 
     All annotation sizes are scale-independent because font_size is a fixed
     page-mm constant, so there is no circularity with choose_scale().
     *arrow_length* and *pad_around_text* should come from ``draft_preset(...)``.
     """
-    bore_depth = max(
-        _est_bore_callout_width(
-            holes, font_size, patterns=patterns, pad_around_text=pad_around_text
-        ),
-        declared_bore_callout_width,
+    return _footprint_from_boxes(
+        _compose_anno_boxes(
+            holes,
+            patterns,
+            n_steps,
+            font_size=font_size,
+            arrow_length=arrow_length,
+            pad_around_text=pad_around_text,
+            declared_bore_callout_width=declared_bore_callout_width,
+        )
     )
-    # Add elbow clearance and leader-to-label gap so gap_fv_sv fully contains
-    # the composed leader: elbow_dx (= draft.arrow_length) + gap
-    # (= draft.pad_around_text), always present.
-    if bore_depth > 0:
-        bore_depth += pad_around_text + arrow_length
-    right = max(_est_right_strip_depth(n_steps), bore_depth)
-    left = max(_DIM_PAD, bore_depth)
-    top = _est_pv_above_depth(holes, patterns, font_size, pad_around_text)
-    pv_halo = _est_plan_halo(font_size) if _will_balloon(holes, patterns) else 0.0
-    return StripDepths(right=right, left=left, top=top, pv_halo=pv_halo)
 
 
 @dataclass(frozen=True)
@@ -488,17 +483,21 @@ def _compose_anno_boxes(
     font_size: float = _FONT_SIZE,
     arrow_length: float = 2.7,
     pad_around_text: float = 2.0,
+    declared_bore_callout_width: float = 0.0,
 ) -> list[AnnoBox]:
     """Compose a drawing's annotation bands as ``AnnoBox`` boxes (#112, Step 4a).
 
-    Mirrors ``_measure_strips`` exactly, but emits each contributing band as a
-    box rather than folding them into three scalars up front.
-    ``_footprint_from_boxes`` reduces these back to the identical
-    ``StripDepths``.
+    This is the annotation-footprint authority for scale/page layout. Each
+    contributing furniture band is emitted as a box; ``_measure_strips`` only
+    reduces these boxes to the legacy ``StripDepths`` shape. Declared-model
+    callout widths flow through the same box path as detected geometry (#540).
     """
     boxes = [AnnoBox("right", _est_right_strip_depth(n_steps))]  # FV right dim ladder
-    bore_depth = _est_bore_callout_width(
-        holes, font_size, patterns=patterns, pad_around_text=pad_around_text
+    bore_depth = max(
+        _est_bore_callout_width(
+            holes, font_size, patterns=patterns, pad_around_text=pad_around_text
+        ),
+        declared_bore_callout_width,
     )
     if bore_depth > 0:
         # elbow clearance + leader-to-label gap, as in _measure_strips

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -862,13 +862,9 @@ class TestComposeAnnoBoxes:
         from draftwright.builder import _FONT_SIZE, draft_preset
         from draftwright.sheet import _compose_anno_boxes, _footprint_from_boxes, _measure_strips
 
-        # The composer must reproduce StripDepths exactly for ANY clearance
-        # args (#112, Step 4b): the bore-band elbow+gap overhead
-        # (arrow_length + pad_around_text) is added identically on both paths,
-        # so byte-identity cannot depend on the values. We test the function
-        # defaults, the production draft preset (which today equals the
-        # defaults — a forward-guard if it ever diverges), and a deliberately
-        # divergent set that actually exercises a different overhead.
+        # The composer is the footprint authority (#112): _measure_strips is only
+        # a compatibility reducer around these boxes. Exercise defaults, the
+        # production draft preset, and deliberately divergent clearance values.
         preset = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
         arg_sets = (
             {},
@@ -879,6 +875,43 @@ class TestComposeAnnoBoxes:
             composed = _footprint_from_boxes(_compose_anno_boxes(holes, patterns, n_steps, **kw))
             scalar = _measure_strips(holes, patterns, n_steps, bb, **kw)
             assert composed == scalar, (label, n_steps, kw)
+
+    def test_declared_bore_width_flows_through_boxes(self):
+        # #540: declared Sheet/IR callouts can be wider than detected geometry
+        # because authored tolerances live on the planned dimensions. That width
+        # must be represented as an annotation box, not as a scalar-only side
+        # channel in _measure_strips.
+        from draftwright.builder import _FONT_SIZE, draft_preset
+        from draftwright.recognition import find_hole_patterns, find_holes
+        from draftwright.sheet import _compose_anno_boxes, _footprint_from_boxes, _measure_strips
+
+        part = Box(60, 40, 12) - Pos(0, 0, 6) * Cylinder(3, 12)
+        holes = find_holes(part)
+        patterns = find_hole_patterns(holes)
+        bb = part.bounding_box()
+        draft = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
+        declared_width = 55.0
+        expected_bore_depth = declared_width + draft.pad_around_text + draft.arrow_length
+
+        boxes = _compose_anno_boxes(
+            holes,
+            patterns,
+            0,
+            arrow_length=draft.arrow_length,
+            pad_around_text=draft.pad_around_text,
+            declared_bore_callout_width=declared_width,
+        )
+        assert expected_bore_depth in [b.depth for b in boxes if b.side == "right"]
+        assert expected_bore_depth in [b.depth for b in boxes if b.side == "left"]
+        assert _footprint_from_boxes(boxes) == _measure_strips(
+            holes,
+            patterns,
+            0,
+            bb,
+            arrow_length=draft.arrow_length,
+            pad_around_text=draft.pad_around_text,
+            declared_bore_callout_width=declared_width,
+        )
 
     def test_matches_for_plain_part(self):
         from draftwright.recognition import find_hole_patterns, find_holes
@@ -937,8 +970,8 @@ class TestComposeAnnoBoxesCorpus:
     """Step 4b (#112): de-risk the 4c reservation switch by proving the AnnoBox
     composer is a faithful drop-in for _measure_strips across the full part
     archetype corpus, and by pinning the per-side box *structure* that 4c will
-    consume. Pure validation — nothing yet uses the composer for layout, so the
-    rendered output is byte-identical."""
+    consume. The strip estimate now reduces these boxes, so byte-identity here
+    guards the active layout path."""
 
     @staticmethod
     def _corpus():


### PR DESCRIPTION
## Summary

- make `_measure_strips` reduce composed `AnnoBox` footprints instead of owning separate scalar strip math
- thread declared/planned bore callout width through `_compose_anno_boxes`, so declared Sheet furniture uses the same footprint path as detected geometry
- add regression coverage that declared bore width appears as left/right annotation boxes and remains identical after reduction to `StripDepths`

## Scope

Advances #112 by making composed annotation boxes the authority for strip footprints. Closes #540.

## Validation

- `uv run pytest tests/test_make_drawing.py::TestComposeAnnoBoxes tests/test_make_drawing.py::TestComposeAnnoBoxesCorpus -q`
- `uv run pytest tests/test_tolerances.py::TestSheetTolerance::test_toleranced_hole_callout_participates_in_layout_sizing -q`
- `uv run pytest tests/test_make_drawing.py tests/test_tolerances.py -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
