### PR TITLE
Iterate measure-repack to a fixed point

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -77,6 +77,7 @@ _TB_W = 150.0
 # approximation error, tight enough not to round a genuinely off-axis curve.
 
 _REPACK_TOL = 0.75
+_REPACK_MAX_ITER = 3
 
 
 def _cross_view_overlaps(dwg, a) -> int:
@@ -345,6 +346,15 @@ def _repack_candidates(a, scale, page):
     return list(_LADDER)
 
 
+def _needs_repack(dwg, a) -> bool:
+    """True when the measured drawing still needs a compose-then-pack pass."""
+    return (
+        _cross_view_overlaps(dwg, a) != 0
+        or _annotation_view_overlaps(dwg, a) != 0
+        or _annotations_out_of_bounds(dwg, a)
+    )
+
+
 def _repack(
     a, dwg, out, assembly, detail_view, scale=None, page=None, model=None, decorations=None
 ):
@@ -360,11 +370,7 @@ def _repack(
     byte-identical) or when the repack would change nothing (same sheet/scale and
     no view actually moves).
     """
-    if (
-        _cross_view_overlaps(dwg, a) == 0
-        and _annotation_view_overlaps(dwg, a) == 0
-        and not _annotations_out_of_bounds(dwg, a)
-    ):
+    if not _needs_repack(dwg, a):
         return None
     blocks = _measure_blocks(dwg, a)
 
@@ -485,6 +491,40 @@ def _repack(
     return a2, dwg2
 
 
+def _repack_to_fixed_point(
+    a, dwg, out, assembly, detail_view, scale=None, page=None, model=None, decorations=None
+):
+    """Iterate measure→repack→assemble until stable or bounded (#302)."""
+    cur_a, cur_dwg = a, dwg
+    for i in range(_REPACK_MAX_ITER):
+        repacked = _repack(
+            cur_a,
+            cur_dwg,
+            out,
+            assembly,
+            detail_view,
+            scale=scale,
+            page=page,
+            model=model,
+            decorations=decorations,
+        )
+        if repacked is None:
+            if _needs_repack(cur_dwg, cur_a):
+                _log.warning(
+                    "measure-repack: stalled after %d iteration(s) with residual layout triggers",
+                    i,
+                )
+            return (cur_a, cur_dwg) if i else None
+        cur_a, cur_dwg = repacked
+
+    if _needs_repack(cur_dwg, cur_a):
+        _log.warning(
+            "measure-repack: reached iteration limit (%d) with residual layout triggers",
+            _REPACK_MAX_ITER,
+        )
+    return cur_a, cur_dwg
+
+
 def build_drawing(
     step_file: str | Path | Shape,
     out: str | None = None,
@@ -570,7 +610,7 @@ def build_drawing(
     # measure ≈ estimate, so they skip pass 2 and stand byte-identical.
     dwg = _assemble(a, out, assembly, detail_view, auto_dims, model=model, decorations=decorations)
     if auto_dims:
-        repacked = _repack(
+        repacked = _repack_to_fixed_point(
             a,
             dwg,
             out,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1576,6 +1576,77 @@ class TestComposeThenPackRepack:
         cands = _repack_candidates(a, 2.0, "A3")
         assert len(cands) == 1 and cands[0][0] == 2.0
 
+    def test_repack_to_fixed_point_iterates_until_stable(self, monkeypatch):
+        from types import SimpleNamespace
+
+        import draftwright.builder as builder
+
+        a0, d0 = SimpleNamespace(pass_id=0), SimpleNamespace(pass_id=0)
+        a1, d1 = SimpleNamespace(pass_id=1), SimpleNamespace(pass_id=1)
+        a2, d2 = SimpleNamespace(pass_id=2), SimpleNamespace(pass_id=2)
+        returns = [(a1, d1), (a2, d2), None]
+        calls = []
+
+        def fake_repack(a, dwg, *args, **kwargs):
+            calls.append((a.pass_id, dwg.pass_id))
+            return returns.pop(0)
+
+        monkeypatch.setattr(builder, "_repack", fake_repack)
+        monkeypatch.setattr(builder, "_needs_repack", lambda dwg, a: False)
+
+        out = builder._repack_to_fixed_point(a0, d0, "out", None, False)
+
+        assert out == (a2, d2)
+        assert calls == [(0, 0), (1, 1), (2, 2)]
+
+    def test_repack_to_fixed_point_warns_at_iteration_limit(self, monkeypatch, caplog):
+        from types import SimpleNamespace
+
+        import draftwright.builder as builder
+
+        calls = []
+
+        def fake_repack(a, dwg, *args, **kwargs):
+            calls.append((a.pass_id, dwg.pass_id))
+            pass_id = len(calls)
+            return SimpleNamespace(pass_id=pass_id), SimpleNamespace(pass_id=pass_id)
+
+        monkeypatch.setattr(builder, "_repack", fake_repack)
+        monkeypatch.setattr(builder, "_needs_repack", lambda dwg, a: True)
+
+        with caplog.at_level(logging.WARNING):
+            out_a, out_dwg = builder._repack_to_fixed_point(
+                SimpleNamespace(pass_id=0),
+                SimpleNamespace(pass_id=0),
+                "out",
+                None,
+                False,
+            )
+
+        assert len(calls) == builder._REPACK_MAX_ITER
+        assert out_a.pass_id == out_dwg.pass_id == builder._REPACK_MAX_ITER
+        assert "reached iteration limit" in caplog.text
+
+    def test_repack_to_fixed_point_warns_on_stalled_trigger(self, monkeypatch, caplog):
+        from types import SimpleNamespace
+
+        import draftwright.builder as builder
+
+        monkeypatch.setattr(builder, "_repack", lambda *args, **kwargs: None)
+        monkeypatch.setattr(builder, "_needs_repack", lambda dwg, a: True)
+
+        with caplog.at_level(logging.WARNING):
+            out = builder._repack_to_fixed_point(
+                SimpleNamespace(pass_id=0),
+                SimpleNamespace(pass_id=0),
+                "out",
+                None,
+                False,
+            )
+
+        assert out is None
+        assert "stalled after 0 iteration" in caplog.text
+
     @pytest.mark.timeout(120)
     def test_repack_honours_pinned_scale_on_oversized_part(self):
         # #350 review: when no candidate fits the measured layout, the repack backstop


### PR DESCRIPTION
## Summary

- factor repack trigger checks into `_needs_repack(...)`
- add `_repack_to_fixed_point(...)`, a bounded measure→repack→assemble loop
- route `build_drawing(...)` through the fixed-point loop before repair
- warn when repack stalls with residual triggers or reaches the iteration cap without clearing them

## Scope

Closes #302.

## Validation

- `uv run pytest tests/test_make_drawing.py::TestComposeThenPackRepack -q`
- `uv run pytest tests/test_make_drawing.py -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
