### PR TITLE
Finish ViewBlock layout authority

### DIFF
--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -903,7 +903,6 @@ def _layout_geometry(
     pv_hh = y_size * scale / 2
     sv_hw = y_size * scale / 2
 
-    pv_below = _est_pv_below_depth()
     est_blocks = _compose_view_blocks(
         x_size, y_size, z_size, scale, strips, n_steps, section=section
     )
@@ -941,18 +940,11 @@ def _layout_geometry(
     col_left = max(fv.left, pv.left)
     col_right = max(fv.right, pv.right)
 
-    # Bottom balloon band: rather than pushing the front view down (which would
-    # cascade into the iso/table and the scale choice), LIFT the plan view up
-    # into the empty top headroom above it — the front/side views, iso and title
-    # block stay anchored, so the table is undisturbed.  The lift is implicit:
-    # the vertical stack is centred with the BASE front↔plan gap (so FV/SV centre
-    # exactly as when halo = 0), while PV is positioned with the full ballooned
-    # gap, leaving it max(0, halo - pv_below) higher.  Byte-identical when
-    # halo = 0.  (#112, ADR 0004.)
-    # FV↔PV vertical gap = fv.top + pv.bottom (abutting → sum). The estimator path
-    # keeps its lift trick (centre on the base gap, place PV on the full gap);
-    # the measured path uses the real gap directly.
-    base_gap = (fv.top + pv.bottom) if blocks is not None else (fv.top + pv_below)
+    # FV↔PV vertical gap = fv.top + pv.bottom (abutting → sum). Estimated and
+    # measured paths now use the same block footprint semantics: if the plan
+    # view carries a bottom halo, that band is part of the stacked block layout
+    # rather than a special-case lift outside the ViewBlock model (#112).
+    base_gap = fv.top + pv.bottom
     total_h = 2 * margin + fv.bottom + 2 * fv.hh + base_gap + 2 * pv.hh + pv.top
     y_offset = max(0.0, (page_h - total_h) / 2)
 
@@ -975,9 +967,7 @@ def _layout_geometry(
     FV_X = margin + x_offset + col_left + fv.hw
     FV_Y = y_offset + margin + fv.bottom + fv.hh
     PV_X = FV_X
-    # PV uses the full (ballooned) front↔plan gap while FV/SV were centred with
-    # the base gap — so the plan view sits pv_lift higher: lifted into the
-    # headroom, front view anchored.
+    # PV abuts the front-view block: gap = front top band + plan bottom band.
     PV_Y = FV_Y + fv.hh + (fv.top + pv.bottom) + pv.hh
     # SV abuts the FV/PV column: gap = column right band + SV's own left band
     # (disjoint sum). Byte-identical to the old max(fv.right, sv.left) on the

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1120,6 +1120,32 @@ class TestComposeViewBlocks:
         assert args[:6] == (60.0, 40.0, 20.0, 1.0, strips, 2)
         assert kwargs == {"section": True}
 
+    def test_estimator_vertical_stack_is_centred_from_composed_blocks(self):
+        from draftwright._core import _MARGIN
+        from draftwright.sheet import _compose_view_blocks, _layout_geometry
+
+        page_h = 297.0
+        blocks = _compose_view_blocks(60.0, 40.0, 20.0, 1.0, None, n_steps=3)
+        g = _layout_geometry(
+            60.0,
+            40.0,
+            20.0,
+            1.0,
+            420.0,
+            page_h,
+            150.0,
+            None,
+            n_steps=3,
+            warn_no_iso=False,
+        )
+
+        fv, pv = blocks["front"], blocks["plan"]
+        block_stack_h = fv.bottom + 2 * fv.hh + fv.top + pv.bottom + 2 * pv.hh + pv.top
+        expected_y_offset = max(0.0, (page_h - 2 * _MARGIN - block_stack_h) / 2)
+        actual_y_offset = g.FV_Y - _MARGIN - fv.bottom - fv.hh
+
+        assert actual_y_offset == pytest.approx(expected_y_offset)
+
 
 # ---------------------------------------------------------------------------
 # Phase 3 (#118): dynamic FV→SV corridor

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1146,6 +1146,34 @@ class TestComposeViewBlocks:
 
         assert actual_y_offset == pytest.approx(expected_y_offset)
 
+    def test_estimator_vertical_stack_centres_ballooned_plan_block(self):
+        from draftwright._core import _MARGIN
+        from draftwright.sheet import StripDepths, _compose_view_blocks, _layout_geometry
+
+        page_h = 297.0
+        strips = StripDepths(right=10.0, left=12.0, top=20.0, pv_halo=30.0)
+        blocks = _compose_view_blocks(60.0, 40.0, 20.0, 1.0, strips, n_steps=3)
+        g = _layout_geometry(
+            60.0,
+            40.0,
+            20.0,
+            1.0,
+            420.0,
+            page_h,
+            150.0,
+            strips,
+            n_steps=3,
+            warn_no_iso=False,
+        )
+
+        fv, pv = blocks["front"], blocks["plan"]
+        block_stack_h = fv.bottom + 2 * fv.hh + fv.top + pv.bottom + 2 * pv.hh + pv.top
+        expected_y_offset = max(0.0, (page_h - 2 * _MARGIN - block_stack_h) / 2)
+        actual_y_offset = g.FV_Y - _MARGIN - fv.bottom - fv.hh
+
+        assert pv.bottom > 20.0
+        assert actual_y_offset == pytest.approx(expected_y_offset)
+
 
 # ---------------------------------------------------------------------------
 # Phase 3 (#118): dynamic FV→SV corridor


### PR DESCRIPTION
## Summary
- make FV/PV vertical centering use the same composed ViewBlock gap in estimated and measured layout paths
- remove the old estimator-only plan-view lift exception
- add a regression test that pins estimator centering to composed block footprints

Closes #112.

## Validation
- uv run pytest tests/test_make_drawing.py::TestComposeViewBlocks tests/test_make_drawing.py::TestDynamicCorridors tests/test_make_drawing.py::TestTwoPassLayout tests/test_make_drawing.py::TestComposeThenPackRepack -q
- uv run pytest tests/test_make_drawing.py -q
- uv run pytest -q
- uv run ruff check src/draftwright/sheet.py tests/test_make_drawing.py