### PR TITLE
docs: delete dead Placeable/LayoutSolver, fix stale ADR status lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,10 @@ No lower module imports an upper one.
   the `Analysis` namespace and its field types (`_Projector`, `Strip`, `ViewZones`),
   the dimension/format helpers (`_dim`, `_fmt`, `_add_title_block`, …), and the
   page/slot/margin layout constants.
-- **`layout.py`** — the constraint-based layout engine (ADR 0003): the `Placeable`
-  protocol and `LayoutSolver` (1D Cassowary strip solver `solve_strip`; 2D
-  free-rectangle placer `place_box`/`fit_box`). Sits *below* the domain API.
+- **`layout.py`** — the constraint-based layout engine (ADR 0003): the deterministic
+  1D PAVA strip solve (`_solve_strip_1d_pava`, plus `plan_strip`/`StripCandidate`,
+  the ADR 0009 collect-then-solve entry point) and the 2D free-rectangle placer
+  (`place_box`/`fit_box`). Sits *below* the domain API.
 - **`registry.py`** — `AnnotationRegistry`: the single owner of annotation
   identity/ownership/pins/build-issues (#138 / ADR 0005, Step 2). `Drawing`
   delegates here and keeps the render list; `_named`/`_anno_view`/`_pinned`/
@@ -122,8 +123,8 @@ Current ADRs:
 - **0001** — deterministic generation over an editable DSL.
 - **0002** — iterate via lint-critique and domain-repair (repair is a *safety
   net*, not the primary placement mechanism).
-- **0003** — constraint-based **inner** layout (`Placeable`/Cassowary in
-  `layout.py`): placing one view's annotations within its own zones.
+- **0003** — constraint-based **inner** layout (the deterministic PAVA strip
+  solve in `layout.py`): placing one view's annotations within its own zones.
 - **0004** — **compose-then-pack** (Accepted; the **outer** layout): each view is
   a *block* = `view_rect(scale) + its annotation boxes`; choose `(scale, page)`
   by a monotone search whose fitness function is composing + packing the blocks
@@ -191,17 +192,16 @@ Current ADRs:
   from the referenced feature/face (`declare.gdt_target`, P2c #480/#482). PMI-sourced
   auto-GD&T is the last item (#62). Sidesteps #298 misdetection; complements #400 (read +
   edit → now also input). Roadmap: `docs/plans/0011-phase2-aspects-roadmap.md`; #446/#445.
-- **0012** — **Accepted** (decision; work pending — supersedes #396, extends #388/#426):
-  **user annotation edits are pinned, priority-ranked candidates in the one global solve.**
-  A `dimension()`/`place_dim()` edit becomes a scale-independent *dimension intent* on the
-  model carrying `(pin, priority)` — **pin** = the solver's existing `anchored`/`_ANCHOR_WEIGHT`
-  (stays put while the rest flow around it), **priority** = the `StripCandidate.priority`
-  plumbed through the corridor in #357 — placed by the **same** `solve_corridor` as the auto
-  dims, re-run by a recompose (`finalize_drawing`, #388 P2). The layout algorithm already
-  supports it (`anchored`+`priority` exist); the missing part is representing an edit as an
-  intent + wiring it into the batch. Not per-`place_dim` re-solve (jarring) — edit freely,
-  recompose once; pin is the escape valve so the user never fights the solver. Promotes the
-  #477 below/right fold-in to a dependency. Umbrella: #511.
+- **0012** — **Accepted; landed** (2026-07-08, umbrella #511 closed — supersedes #396,
+  extends #388/#426): **user annotation edits are pinned, priority-ranked candidates in
+  the one global solve.** A `dimension(..., pin=, priority=)` edit records a
+  scale-independent *dimension intent* on the model — **pin** = the solver's `anchored`/
+  `_ANCHOR_WEIGHT` (stays put while the rest flow around it), **priority** =
+  `CorridorCandidate.priority` (#357) — placed by the **same** `solve_corridor` as the
+  auto dims, re-run by the recompose (`Drawing.finalize()`, #426). Edit freely, recompose
+  once; pin is the escape valve so the user never fights the solver. `place_dim()` is now
+  the deprecated raw-coordinate escape hatch. The #477 below/right fold-in landed as a
+  dependency.
 
 ## Dependencies
 

--- a/docs/adr/0003-constraint-based-layout.md
+++ b/docs/adr/0003-constraint-based-layout.md
@@ -1,11 +1,13 @@
 # ADR 0003 — Constraint-based layout: one solver for every placeable
 
 - **Status:** Accepted (core implemented; the unifying *global 2-D* solve stays
-  deferred — #94). The `Placeable`/`LayoutSolver` model, the 1-D strip solve,
-  `place_box`/`fit_box`, and pins (#89) have shipped. The **assignment layer**
-  and **escalation ladder** for per-view strip placement are made concrete by
-  [ADR 0009](0009-boundary-labeling-strip-placement.md) (collect-then-solve
-  boundary labeling).
+  deferred — #94; amended 2026-07-10 — see Correction). The 1-D strip solve,
+  `place_box`/`fit_box`, and pins (#89) have shipped — the concrete carrier is
+  `StripCandidate`/`plan_strip`/`CorridorCandidate`, not the original
+  `Placeable`/`LayoutSolver` model, which was retired (#547). The **assignment
+  layer** and **escalation ladder** for per-view strip placement are made
+  concrete by [ADR 0009](0009-boundary-labeling-strip-placement.md)
+  (collect-then-solve boundary labeling).
 - **Date:** 2026-06-18
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -141,21 +143,22 @@ required mitigations:
 - **Manual override must win.** When a human or AI places something explicitly
   ("put *this* label *here*"), the solver must treat it as a hard **pin** that
   survives every later re-solve and stays local — never re-derive over a
-  deliberate placement. _Partly landed (#89):_ `dwg.pin(name)` / `dwg.unpin(name)`
-  are the domain verbs, `Placeable.locked` is the solver-side flag, and
-  `repair()` already refuses to move a pinned annotation. _(The pin **state** now
-  lives in `registry.py` as its single owner per
-  [ADR 0005](0005-pipeline-architecture-and-state-ownership.md) (split complete);
-  the override contract here is unchanged, only its home.)_ **Still owed
-  by #82:**
-  the global 2D solve must honour `locked` (keep it at `natural`, solve the rest
-  around it). This remains a hard prerequisite for that solve, not a later nicety.
+  deliberate placement. _Landed, but not on the mechanism this ADR originally
+  named:_ `dwg.pin(name)` / `dwg.unpin(name)` are still the domain verbs and
+  `repair()` still refuses to move a pinned annotation, but the solver-side flag
+  is `StripCandidate.anchored`/`CorridorCandidate.anchored` (ADR 0009's
+  `_ANCHOR_WEIGHT`-dominated PAVA solve) — `Placeable.locked` never became the
+  live path and was deleted (#547; see the 2026-07-10 correction below). ADR
+  0012 generalises the same field into user `pin=`/`priority=` dimension intents
+  co-solved with the automatic ones.
 
-Keep `Placeable`/`LayoutSolver` an implementation detail: callers edit through
-the domain API (`place_dim`, `features`, `annotations`, lint→repair), never by
-constructing placeables. As long as that holds, the engine *improves*
-editability for AI (state intent, get a correct deconflicted placement) rather
-than eroding it.
+Keep the strip-placement machinery (`StripCandidate`/`plan_strip`/
+`CorridorCandidate`/`solve_corridor`, `layout.py`/`annotations/_common.py`) an
+implementation detail: callers edit through the domain API (`dimension`,
+`place_dim`, `features`, `annotations`, lint→repair), never by constructing
+candidates directly. As long as that holds, the engine *improves* editability
+for AI (state intent, get a correct deconflicted placement) rather than
+eroding it.
 
 **Neutral / follow-ups**
 - Performance: hundreds of variables is comfortable for Cassowary; watch the
@@ -197,12 +200,46 @@ never be needed.** This is a deliberate scope correction, not an omission.
 
 ## Current state vs target
 
-- **Exists:** the strip/zone allocator; `LayoutSolver` with 1D `solve_strip`
-  (+ per-pair gaps) and 2D `place_box`; `Placeable`/`locked`; pin/override
-  (#89); hole callouts + turned diameters on the solver; `repair()`.
+- **Exists:** the deterministic 1D strip solve (`_solve_strip_1d_pava`) and 2D
+  `fit_box`/`place_box` free-rectangle placer, in `layout.py`; `plan_strip`/
+  `StripCandidate` (ADR 0009 collect-then-solve) and `solve_corridor`/
+  `CorridorCandidate` (`annotations/_common.py`) as the production strip-
+  placement path hole callouts, turned diameters, and every other strip
+  annotation actually place through; pin/override (#89, realised as
+  `anchored`/`priority` on those candidates, generalised to user dimension
+  intents by ADR 0012); `repair()`.
 - **Target:** the escalation ladder + tables/balloons (#93) and GD&T (#61/#62)
   built on the above. The full global 2D solve (#94) remains deferred unless a
   real part forces it.
+
+## Correction (2026-07-10): `Placeable`/`LayoutSolver` retired, never became the shared path
+
+This ADR's original "Migration" plan (below) and its "Current state" table (both
+unedited above their date) described `Placeable`/`LayoutSolver` as the
+in-progress, then-landed, shared 1D placement surface — "hole callouts +
+turned diameters on the solver." That stopped being true partway through: when
+[ADR 0009](0009-boundary-labeling-strip-placement.md) added the collect-then-
+solve boundary-labeling model (selection, feature-ordered assignment, keep-out
+bands, anchoring), those capabilities were built as a **new**, sibling surface —
+`StripCandidate`/`plan_strip` — rather than as extensions to `LayoutSolver`.
+Every real placer (#80, #87, #90, and the later ADR 0009/0012 work) migrated
+onto that sibling instead. #150 tried to reverse this drift back onto
+`LayoutSolver` and was closed by #349 without doing so — #349's actual change
+(retiring the `Strip` cursor) was itself part of the ADR 0009 migration, further
+entrenching `plan_strip` as the real path.
+
+By 2026-07-10, `Placeable`/`LayoutSolver` had no caller anywhere in `src/`
+outside their own tests. Rather than leave a fully-tested, zero-consumer class
+in the tree as a standing (and, per the above, actively misleading) claim about
+what production code does, it was deleted (#547). `fit_box`/`place_box` — the
+2D free-rectangle placer, the one part of the original surface every consumer
+actually shares (tables, GD&T) — is unaffected and remains in `layout.py`.
+
+This does not change the ADR's decision (constraint-based, deterministic,
+two-layer layout); it corrects which concrete types realise it. Read
+"`Placeable`"/"`LayoutSolver`" elsewhere in this document's original Decision/
+Migration sections as the conceptual shape that was later realised by
+`StripCandidate`/`plan_strip`/`CorridorCandidate`/`solve_corridor` instead.
 
 ## Related
 

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -94,7 +94,9 @@ not a rewrite, and it is the disciplined version of the already-funded #150.
   feature-ordered side/zone assignment) and turns the **escalation ladder** from
   prose into the selection step's output. 0003's "global 2-D Cassowary solve"
   stays deferred (#94); this is the per-view inner layer 0003 always implied.
-  `Placeable` / `LayoutSolver` are reused unchanged in spirit.
+  The underlying 1-D solve (`layout.py`) is reused unchanged in spirit, though
+  the concrete carrier is `StripCandidate`/`plan_strip`, not 0003's original
+  `Placeable`/`LayoutSolver` — see ADR 0003's 2026-07-10 correction (#547).
 - **ADR 0004 (compose-then-pack).** Orthogonal and complementary. 0004 is the
   **outer** layer (each view is a block; pack blocks disjoint so cross-view
   overlap cannot occur). 0009 is the **inner** layer (place one view's

--- a/docs/adr/0012-edits-as-pinned-priority-candidates-in-the-global-solve.md
+++ b/docs/adr/0012-edits-as-pinned-priority-candidates-in-the-global-solve.md
@@ -1,6 +1,7 @@
 # ADR 0012 — User annotation edits are pinned, priority-ranked candidates in the one global solve
 
-- **Status:** Accepted (decision; work pending — supersedes #396, extends #388/#426)
+- **Status:** Accepted; landed (2026-07-08 — see Amendment 1). Supersedes #396,
+  extends #388/#426.
 - **Date:** 2026-07-07
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -106,3 +107,42 @@ frozen imperative placement (never re-optimised) or an unconstrained re-solve (j
    there co-solves (#477).
 5. **Escape hatch.** Keep deprecated raw single-slot `place_dim` for arbitrary-page-coordinate,
    unsolved placement, clearly documented.
+
+## Amendment 1 — all five phases landed (2026-07-08)
+
+**Status:** Accepted; fully landed. Umbrella **#511**, closed 2026-07-08.
+
+All five phased-work items above shipped:
+
+1. **Intent + knobs** — `Drawing.dimension(..., pin=, priority=)` records a
+   scale-independent dimension intent (`draftwright/intents.py`) when the
+   drawing is in deferred mode (`dwg.deferred()`/`dwg._defer_intents`).
+2. **Solve the intents** — `Drawing.finalize()` (not the module-level
+   `finalize_drawing(dwg)` named in the original proposal — see below) routes
+   recorded dimension intents through the same `CorridorCandidate`/
+   `solve_corridor`/`drain_corridors` machinery the auto-pass uses
+   (`annotations/_common.py`), `anchored=pin` and `priority=priority` carried
+   straight through. Landed via #531 ("Add pinned locate candidates") and #532
+   ("Route pinned dimension intents through corridor"), both merged 2026-07-08.
+3. **Recompose** — `Drawing.finalize()` is the realised recompose step; it is
+   idempotent and drains the full recorded intent set (auto features + user
+   edits) through the orchestration in one pass (see its docstring for the
+   full A/B1/B2/B3/C/D solver ordering it preserves).
+4. **Below/right dependency (#477)** — closed 2026-07-08 as part of the
+   broader "finish the ADR 0009 unification" umbrella; the below/right ladders
+   are corridor registrants, so a user dim there co-solves.
+5. **Escape hatch** — `Drawing.place_dim()` is marked deprecated in its own
+   docstring, pointing callers at `dimension(..., pin=True)` /
+   `locate(..., pin=True)`, and documents itself as the raw, unsolved,
+   scale-frozen fallback this phase called for.
+
+One naming correction from the original proposal: the recompose entry point is
+the `Drawing.finalize()` method, not a standalone `finalize_drawing(dwg)`
+function — the `deferred()` context manager (#426) calls it automatically on
+exit, and `export()`/`export_pdf()` call it unconditionally (a no-op once
+intents are drained) so a script that never opts into `deferred()` is
+unaffected.
+
+Found while auditing this ADR's status for accuracy (#548): the "work pending"
+status line had not been updated since the epic closed, understating that the
+core mechanism this ADR proposed is live.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2140,11 +2140,6 @@ class Drawing:
             _export_shape(exporter, ann, "dims", f"annotation {label!r}")
 
 
-# 1D strip placement now lives in draftwright.layout (ADR 0003 phase 1, #79).
-# These aliases keep the existing axis-specific callers and their tests working
-# while the primitive is axis-neutral; later phases route through LayoutSolver.
-
-
 # A view centre must move by more than this (mm) for the measure-and-repack
 # pass to re-assemble.  Below it, the estimate already matched the measured
 # footprint and pass 1 stands (the common, non-ballooned case).

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -1,27 +1,39 @@
-"""Constraint-based layout engine — phase 1 scaffolding (ADR 0003).
+"""Constraint-based layout primitives (ADR 0003): the deterministic 1D strip
+solve and the 2D free-rectangle box placer.
 
-This module holds the placement primitives that every annotation type will
-eventually share: a :class:`Placeable` value object describing what the solver
-may move, and a :class:`LayoutSolver` that places a set of placeables along one
-axis via a single 1D strip solve.
+ADR 0003 originally proposed a class-based surface for this — a
+:class:`Placeable` value object plus a :class:`LayoutSolver` that would
+accumulate placeables and solve them. That surface shipped (#79/#80) but never
+became the path production code actually used: hole callouts and turned
+diameters were ported onto a sibling implementation instead —
+:class:`StripCandidate`/:func:`plan_strip` (ADR 0009's collect-then-solve
+boundary labeling), later wrapped again by ``CorridorCandidate``/
+``solve_corridor`` in ``annotations/_common.py`` for strips shared across
+passes. By 2026-07-10 `Placeable`/`LayoutSolver` had no production caller left
+(only their own tests), so they were deleted (#547) rather than kept as unused
+scaffolding; the module docstring here previously undersold this by saying
+"nothing... constructs a Placeable yet," which had quietly stayed true for the
+wrong reason — the phases that were meant to change that shipped onto
+`plan_strip` instead.
 
-Phase 1 (issue #79) is *scaffolding only*: it generalises the existing 1D strip
-solver into the axis-neutral primitive ADR 0003 calls for and wraps it in the
-`Placeable`/`LayoutSolver` surface, but **nothing in the default drawing path
-constructs a Placeable yet** — the passes are migrated in later phases (#80–83).
-The 1D solve is the deterministic minimum-total-leader-length PAVA algorithm
-(:func:`_solve_strip_1d_pava`, ADR 0009 Amdt 4) — pure standard library, no
-third-party solver (the earlier Cassowary/``kiwisolver`` satisfaction solve was
-retired once PAVA gave the exact L1 placement), so it is unit-testable without
-building a drawing.
+What actually lives here today:
 
-Explicitly deferred to later phases (so the surface is honest about its limits):
-global 2D non-overlap (the disjunctive constraint ADR 0003 notes is non-linear),
-the assignment layer (which zone/side — the collect-then-solve carve,
-``place_strip_candidates`` in ``annotations/_common.py``, since #150/P3 retired
-``Strip.allocate``), the escalation ladder, leader-length minimisation, alignment
-groups, and connector crossing. The only solve phase 1 performs correctly is the
-1D strip solve.
+- The 1D strip-placement primitives, bottoming out in
+  :func:`_solve_strip_1d_pava` — the deterministic minimum-total-leader-length
+  PAVA algorithm (ADR 0009 Amdt 4), pure standard library, no third-party
+  solver (the earlier Cassowary/``kiwisolver`` satisfaction solve was retired
+  once PAVA gave the exact L1 placement). :func:`plan_strip` is the
+  production-facing collect-then-solve entry point built on top of it
+  (selection, ordering, anchoring, keep-out bands); the lower-level
+  `_solve_strip_1d*`/`_greedy_strip_1d*` functions are unit-tested in
+  isolation and used by `plan_strip`'s banded/anchored solve.
+- :func:`fit_box` (+ the thin ``place_box`` naming used at call sites) — the 2D
+  free-rectangle placer for tables/GD&T frames/BOM blocks (#93), the one part
+  of the original `LayoutSolver` surface that is genuinely shared.
+
+Global 2D non-overlap (the disjunctive constraint ADR 0003 notes is
+non-linear) stays deferred (#94) and may never be needed — see that ADR's
+2026-06-18 correction.
 """
 
 from __future__ import annotations
@@ -99,9 +111,9 @@ def _solve_strip_1d_var(naturals, gaps, lo, hi):
     """1D placement with **per-pair** gaps (ADR 0003 phase 3a, #81).
 
     Like :func:`_solve_strip_1d`, but the required separation between adjacent
-    items is ``gaps[i]`` rather than one uniform value — the capability the
-    ``Placeable.size`` field exists for, used when heterogeneous items (e.g. a
-    deep step-dim slot next to a shallow height slot) share one strip.
+    items is ``gaps[i]`` rather than one uniform value — used when heterogeneous
+    items (e.g. a deep step-dim slot next to a shallow height slot) share one
+    strip (see :attr:`StripCandidate.size`).
     ``len(gaps)`` must be ``max(len(naturals) - 1, 0)``.
 
     Delegates to :func:`_solve_strip_1d_pava` — same contract (``None`` when
@@ -420,10 +432,9 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y", forbidden=()):
 
     **Spacing (P4a, #318):** each adjacent pair's required gap is the larger of
     the two candidates' strip-axis extents (``size[idx]``), floored at the
-    caller's *min_gap* — the same "larger of the two neighbours' requirements"
-    rule :meth:`LayoutSolver.solve_strip` already uses for heterogeneous
-    ``Placeable``s, applied here to ``StripCandidate.size`` instead of an
-    explicit per-item ``min_gap`` field. *min_gap* is therefore a floor (minimum
+    caller's *min_gap* — the "larger of the two neighbours' requirements" rule
+    applied to ``StripCandidate.size`` instead of an explicit per-item
+    ``min_gap`` field. *min_gap* is therefore a floor (minimum
     clearance/padding regardless of label size), not the whole story; solved via
     :func:`_solve_strip_1d_pava` (P4b, ADR 0009 Amendment 4), which finds the
     *minimum-total-leader-length* placement rather than merely one that satisfies
@@ -443,7 +454,7 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y", forbidden=()):
     if not candidates:
         return StripPlacement({}, ())
     keys = [c.key for c in candidates]
-    if len(set(keys)) != len(keys):  # like LayoutSolver.register — never silently drop
+    if len(set(keys)) != len(keys):  # a collision would silently drop a candidate
         raise ValueError("plan_strip: candidate keys must be unique")
     idx = 1 if axis == "y" else 0
 
@@ -470,129 +481,8 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y", forbidden=()):
 
 
 # ---------------------------------------------------------------------------
-# Placeable protocol + solver
+# 2D free-rectangle box placement (ADR 0003, #93)
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class Placeable:
-    """One thing the layout solver may position — a dimension, leader, callout,
-    or (later) a table. A pass builds a ``Placeable`` *describing* its annotation;
-    the annotation object itself stays a plain build123d-drafting primitive.
-
-    Attributes:
-        key: stable identifier; drives deterministic variable ordering and keys
-            the solved-position result.
-        anchors: fixed points the annotation must connect to — a leader/callout
-            has one (its tip), a dimension two (its witness points), a table none.
-        size: ``(width, height)`` of the label/footprint, from text metrics; the
-            position is what the solver decides.
-        dof_axis: the axis the solver may slide this along (``"x"``/``"y"``), or
-            ``None`` if it is pinned (e.g. a corner-anchored table).
-        natural: preferred position on ``dof_axis`` (e.g. the tip's coordinate);
-            the solver pulls toward it with ``strong`` priority.
-        min_gap: required clearance to a neighbour on ``dof_axis`` (centre-to-
-            centre), derived from ``size`` plus padding.
-        group: alignment-group id; placeables sharing a group will share an
-            offset variable once alignment lands (phase 3, #81).
-        locked: when true the solver must keep this at ``natural`` and never
-            move it — a deliberate (human/AI) placement that wins over automatic
-            layout. The global solve (#82) honours this; the Drawing-level pin
-            verb (``dwg.pin`` / #89) is how callers set it.
-    """
-
-    key: str
-    anchors: tuple
-    size: tuple
-    dof_axis: Axis | None
-    natural: float
-    min_gap: float
-    group: str | None = None
-    locked: bool = False
-
-
-class LayoutSolver:
-    """Accumulates :class:`Placeable`s and places them as one constraint system.
-
-    Phase 1 (#79) implements exactly one solve — :meth:`solve_strip`, the 1D
-    strip case — over ``Placeable``s instead of raw float lists. Global 2D
-    non-overlap, the assignment layer, and escalation are later phases; no API
-    for them exists here, by design, so they cannot be misused early.
-    """
-
-    def __init__(self) -> None:
-        self._placeables: list[Placeable] = []
-        self._keys: set[str] = set()
-
-    def register(self, placeable: Placeable) -> None:
-        """Add a placeable to be solved.
-
-        Raises ``ValueError`` on a duplicate ``key`` — the key is the result
-        handle, so a collision would silently drop a placeable from the solved
-        map rather than fail visibly.
-        """
-        if placeable.key in self._keys:
-            raise ValueError(f"duplicate placeable key {placeable.key!r}")
-        self._keys.add(placeable.key)
-        self._placeables.append(placeable)
-
-    def solve_strip(
-        self, *, lo: float, hi: float, axis: Axis, greedy_fallback: bool = True
-    ) -> dict | None:
-        """Place every registered placeable with ``dof_axis == axis`` along that
-        axis, as one 1D strip solve within ``[lo, hi]``.
-
-        Returns ``{key: position}`` for the placed members (``{}`` when none have
-        this axis), or ``None`` when they cannot be made to fit. Members are
-        ordered by ``(natural, key)`` so the result is deterministic regardless
-        of registration order; a single ``min_gap`` (the largest any member
-        requires) separates neighbours.
-
-        When the exact 1D solve is infeasible and *greedy_fallback* is
-        true (the default), a greedy packing is tried before giving up. A caller
-        that does its own overflow handling (e.g. dropping a prefix and recording
-        it) passes ``greedy_fallback=False`` to get the exact-or-``None`` contract
-        of the bare 1D primitive, so its drop logic fires exactly when the solve
-        is full.
-        """
-        members = sorted(
-            (p for p in self._placeables if p.dof_axis == axis),
-            key=lambda p: (p.natural, p.key),
-        )
-        if not members:
-            return {}
-        naturals = [p.natural for p in members]
-        min_gaps = [p.min_gap for p in members]
-        if len(set(min_gaps)) <= 1:
-            # Uniform (or single) members — the scalar primitive (one min_gap for
-            # every pair), delegating like the heterogeneous branch to the PAVA solve.
-            gap = max(min_gaps)
-            positions = _solve_strip_1d(naturals, gap, lo, hi)
-            if positions is None and greedy_fallback:
-                positions = _greedy_strip_1d(naturals, gap, lo, hi)
-        else:
-            # Heterogeneous members — per-pair gaps so a larger member's
-            # clearance doesn't over-separate every pair (#81).
-            gaps = [max(min_gaps[i], min_gaps[i + 1]) for i in range(len(members) - 1)]
-            positions = _solve_strip_1d_var(naturals, gaps, lo, hi)
-            if positions is None and greedy_fallback:
-                positions = _greedy_strip_1d_var(naturals, gaps, lo, hi)
-        if positions is None:
-            return None
-        return {p.key: pos for p, pos in zip(members, positions, strict=True)}
-
-    def place_box(self, *, size, region, obstacles, prefer="br"):
-        """Place a rigid box (a table, a GD&T frame, a revision block) in a free
-        part of the page near a preferred corner (ADR 0003 phase 4b, #93).
-
-        The 2D analogue of :meth:`solve_strip`: returns the box's ``(x0, y0)``
-        page-mm position, or ``None`` if it does not fit. *size* is ``(w, h)``;
-        *region* and each *obstacle* are ``(x0, y0, x1, y1)`` boxes; *prefer* is
-        one of ``"bl" "br" "tl" "tr"`` — the region corner to sit nearest. This
-        is the reusable 2D-placement capability tables and (later) GD&T frames
-        and BOM/revision blocks share.
-        """
-        return fit_box(size, region, obstacles, prefer)
 
 
 def fit_box(size, region, obstacles, prefer="br"):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,7 +1,7 @@
-"""Tests for draftwright.layout — the ADR 0003 phase-1 scaffolding (#79).
+"""Tests for draftwright.layout — the ADR 0003 1D strip primitives + fit_box.
 
-These exercise the constraint primitive and solver in isolation, with no drawing
-build, which is the point of putting them in their own module.
+These exercise the placement primitives in isolation, with no drawing build,
+which is the point of putting them in their own module.
 """
 
 import pytest
@@ -9,8 +9,6 @@ import pytest
 import draftwright.layout as L
 from draftwright.layout import (
     _ANCHOR_WEIGHT,
-    LayoutSolver,
-    Placeable,
     _feasible_segments,
     _greedy_strip_1d,
     _greedy_strip_1d_var,
@@ -265,99 +263,6 @@ class TestSolveStrip1dPavaBanded:
         assert _snap_out_of_bands(30.0, [(45.0, 55.0)], 0.0, 100.0) == 30.0
 
 
-class TestLayoutSolver:
-    def _leader(self, key, natural, gap=5.0, axis="x"):
-        return Placeable(
-            key=key,
-            anchors=((natural, 0.0),),
-            size=(4.0, 2.0),
-            dof_axis=axis,
-            natural=natural,
-            min_gap=gap,
-        )
-
-    def test_solve_strip_places_axis_members_keyed_by_key(self):
-        s = LayoutSolver()
-        s.register(self._leader("a", 0))
-        s.register(self._leader("b", 1))
-        s.register(self._leader("c", 2))
-        out = s.solve_strip(lo=-50, hi=50, axis="x")
-        assert set(out) == {"a", "b", "c"}
-        xs = [out["a"], out["b"], out["c"]]
-        assert xs[1] - xs[0] >= 5 - 1e-9 and xs[2] - xs[1] >= 5 - 1e-9
-
-    def test_solve_strip_uses_per_pair_gaps_for_heterogeneous_members(self):
-        # Members with different min_gaps share a strip: each pair is separated
-        # by the larger of its two neighbours' gaps, not one global max (#81).
-        s = LayoutSolver()
-        s.register(self._leader("a", 0, gap=4))
-        s.register(self._leader("b", 0, gap=4))
-        s.register(self._leader("c", 0, gap=12))
-        out = s.solve_strip(lo=0, hi=100, axis="x")
-        xs = [out["a"], out["b"], out["c"]]
-        assert xs[1] - xs[0] == pytest.approx(4)  # max(4,4)
-        assert xs[2] - xs[1] == pytest.approx(12)  # max(4,12), not a global 12 on both
-
-    def test_uniform_members_take_the_scalar_path(self, monkeypatch):
-        # Byte-identical contract: uniform members must NOT touch the _var
-        # primitive's sum(gaps) arithmetic. Make _var explode and confirm a
-        # uniform solve still succeeds — proving it routed to the scalar path.
-        def _boom(*a, **k):
-            raise AssertionError("uniform members must use the scalar path")
-
-        monkeypatch.setattr(L, "_solve_strip_1d_var", _boom)
-        s = LayoutSolver()
-        s.register(self._leader("a", 0, gap=5))
-        s.register(self._leader("b", 10, gap=5))
-        assert set(s.solve_strip(lo=-50, hi=50, axis="x")) == {"a", "b"}
-
-    def test_solve_strip_ignores_other_axis_and_pinned(self):
-        s = LayoutSolver()
-        s.register(self._leader("x1", 0, axis="x"))
-        s.register(self._leader("y1", 0, axis="y"))
-        s.register(Placeable("pin", ((0, 0),), (4, 2), dof_axis=None, natural=0, min_gap=5))
-        out = s.solve_strip(lo=-50, hi=50, axis="x")
-        assert set(out) == {"x1"}
-
-    def test_solve_strip_no_members_returns_empty_dict(self):
-        s = LayoutSolver()
-        s.register(self._leader("y1", 0, axis="y"))
-        assert s.solve_strip(lo=0, hi=10, axis="x") == {}
-
-    def test_solve_strip_infeasible_returns_none(self):
-        s = LayoutSolver()
-        for i in range(5):
-            s.register(self._leader(f"k{i}", 0, gap=20))
-        assert s.solve_strip(lo=0, hi=10, axis="x") is None
-
-    def test_registration_order_does_not_change_result(self):
-        forward = LayoutSolver()
-        for k, n in [("a", 0), ("b", 3), ("c", 6)]:
-            forward.register(self._leader(k, n))
-        shuffled = LayoutSolver()
-        for k, n in [("c", 6), ("a", 0), ("b", 3)]:
-            shuffled.register(self._leader(k, n))
-        assert forward.solve_strip(lo=-50, hi=50, axis="x") == shuffled.solve_strip(
-            lo=-50, hi=50, axis="x"
-        )
-
-    def test_duplicate_key_is_rejected(self):
-        s = LayoutSolver()
-        s.register(self._leader("dup", 0))
-        with pytest.raises(ValueError, match="duplicate placeable key"):
-            s.register(self._leader("dup", 5))
-
-    def test_solve_strip_falls_back_to_greedy(self, monkeypatch):
-        # When the Cassowary solve yields None but a greedy placement fits,
-        # solve_strip must still return positions (the fallback branch).
-        monkeypatch.setattr(L, "_solve_strip_1d", lambda *a, **k: None)
-        s = LayoutSolver()
-        s.register(self._leader("a", 0))
-        s.register(self._leader("b", 0))
-        out = s.solve_strip(lo=0, hi=100, axis="x")
-        assert out == {"a": 0, "b": 5}
-
-
 class TestFitBox:
     """#93: 2D free-rectangle box placement (tables, GD&T frames, BOM)."""
 
@@ -385,13 +290,6 @@ class TestFitBox:
     def test_deterministic(self):
         args = ((20, 10), (0, 0, 100, 100), [(30, 30, 60, 60)], "br")
         assert fit_box(*args) == fit_box(*args)
-
-    def test_place_box_method_delegates(self):
-        s = LayoutSolver()
-        assert s.place_box(size=(20, 10), region=(0, 0, 100, 100), obstacles=[], prefer="bl") == (
-            0,
-            0,
-        )
 
     def test_interior_obstacle_is_avoided(self):
         # An obstacle floating in the interior must be cleared (exercises the

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6708,13 +6708,6 @@ class TestPin:
         assert dwg.pin("a") is dwg
         assert dwg.unpin("a") is dwg
 
-    def test_placeable_locked_defaults_false(self):
-        from draftwright.layout import Placeable
-
-        p = Placeable("k", ((0, 0),), (4, 2), "y", 0.0, 5.0)
-        assert p.locked is False
-        assert Placeable("k", ((0, 0),), (4, 2), "y", 0.0, 5.0, locked=True).locked is True
-
     def test_pinning_both_overlap_labels_is_a_noop(self):
         # Both deliberate → the engine respects both and leaves the overlap.
         dwg = self._two_overlapping()

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -402,10 +402,11 @@ def test_plan_strip_x_axis():
 def test_plan_strip_uses_per_pair_gaps_for_heterogeneous_sizes():
     # P4a (#318): candidates with different strip-axis sizes are spaced by the
     # LARGER of each pair's own size (or the floor min_gap), not one global gap —
-    # the same rule LayoutSolver.solve_strip already uses for heterogeneous
-    # Placeables (#81). Exercises plan_strip's own gap-list wiring (ordered[i]/
-    # [i+1] indexing, idx selection), not just the underlying _solve_strip_1d_var
-    # primitive (which is already covered elsewhere, in isolation).
+    # the same per-pair-gap rule #81 originally added for the (since-retired,
+    # #547) LayoutSolver.solve_strip's heterogeneous Placeables. Exercises
+    # plan_strip's own gap-list wiring (ordered[i]/[i+1] indexing, idx
+    # selection), not just the underlying _solve_strip_1d_var primitive (which
+    # is already covered elsewhere, in isolation).
     cands = [
         StripCandidate("a", (0.0, 0.0), (6, 4), priority=0),
         StripCandidate("b", (0.0, 0.0), (6, 4), priority=0),
@@ -808,8 +809,8 @@ def test_plan_strip_empty():
 
 
 def test_plan_strip_rejects_duplicate_keys():
-    # keys key the result — a silent overwrite would drop a candidate (cf.
-    # LayoutSolver.register, which also raises).
+    # keys key the result — a silent overwrite would drop a candidate (cf. the
+    # since-retired LayoutSolver.register, #547, which also raised).
     import pytest
 
     with pytest.raises(ValueError, match="unique"):


### PR DESCRIPTION
## Summary

- Deletes `Placeable`/`LayoutSolver` (`layout.py`) — ADR 0003's original class-based strip-placement surface. It had zero production callers: the real strip-placement path became `StripCandidate`/`plan_strip` (ADR 0009), later wrapped by `CorridorCandidate`/`solve_corridor`. Only the class's own tests exercised it.
- Fixes `layout.py`'s module docstring and ADR 0003/0009 to describe what's actually in production instead of the retired class. `fit_box`/`place_box` (the 2D free-rectangle placer) is unaffected.
- Fixes ADR 0012's status line, which still said "work pending" after its umbrella tracking issue (#511) closed with all five phases landed on 2026-07-08. Adds an amendment documenting what shipped and correcting one naming detail (`Drawing.finalize()`, not the originally-proposed `finalize_drawing(dwg)`).
- Removes an orphaned stale comment in `drawing.py` that referenced the deleted class.
- Updates `CLAUDE.md`'s architecture section to match.

Closes #547, closes #548.

## Test plan

- [x] `uv run pytest -m smoke` — 60 passed
- [x] `uv run pytest tests/test_layout.py tests/test_strip_layout.py -q` — 87 passed
- [x] `uv run pytest tests/test_make_drawing.py -k "pin" -q` — 18 passed
- [x] `ruff check` — clean
- [ ] CI full fast tier (3×3 OS/Python matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)