### PR TITLE
docs: ADR 0009 Amendment 9 — retire the banded-PAVA DP (#381)

### DIFF
--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -475,9 +475,10 @@ centre-line band. `holes.py`'s *other* band source — `reserved_rows`, the
 off-axis holes' location-dim extension lines — is **not** gated by part class;
 it applies to prismatic parts too, independently of `_is_central`. A prismatic
 part with a genuinely central hole (anchored) and another off-axis hole on the
-same strip hits this DP gap today, in the un-carved baseline solve
-(`holes.py`'s `base_res`) — not a hypothetical future combination. See
-Amendment 9, which retires this DP rather than making it exact.
+same strip hit this DP gap in the un-carved baseline solve (`holes.py`'s
+pre-#381 `base_res`, since renamed `base_y` by Amendment 9 below) — not a
+hypothetical combination. See Amendment 9, which retires this DP rather than
+making it exact.
 
 Two supporting changes in `holes.py`:
 - **Bands built from the same causes** `_coaxial_lift` used — the off-axis
@@ -689,12 +690,16 @@ by part class as originally believed (see the Correction note on Amendment 5).
 **Decision.** Retire `_feasible_segments` and `_solve_strip_1d_pava_banded`.
 Express a keep-out band as an ordinary carve interval
 (`(centre - half_width, centre + half_width)`, `pad=0` since the clearance is
-already in the half-width) fed into the existing `carve_free_segments`. Route
-`holes.py`'s two `plan_strip(forbidden=...)` call sites through the same
-carve + nearest-segment-assign + per-segment `_solve_strip_1d_pava` path
-`place_strip_candidates` already uses for every other pass, instead of calling
-`plan_strip`'s `forbidden=` parameter directly. `plan_strip`'s `forbidden=`
-parameter and the banded solve path are removed once nothing calls them.
+already in the half-width) fed into the existing `carve_free_segments` — the
+same carve primitive `place_strip_candidates` already uses for every other
+pass, though its own segment-fill strategy (sort segments once by distance
+from the strip's inner edge, fill near-to-far via priority-capacity slicing)
+is not reused here; `holes.py`'s two `plan_strip(forbidden=...)` call sites
+instead route through a new per-candidate segment-assignment step (below)
+built specifically for this carve, then solve each assigned segment with
+per-segment `_solve_strip_1d_pava`, instead of calling `plan_strip`'s
+`forbidden=` parameter directly. `plan_strip`'s `forbidden=` parameter and the
+banded solve path are removed once nothing calls them.
 
 This resolves #381 by construction, not by making the DP exact: an anchored
 candidate assigned to its own obstacle-free segment never sees the band that
@@ -708,9 +713,9 @@ no way to declare a keep-out band; only `holes.py`'s two callers carve them.
 Making that available to every pass is a further, separate change, not part
 of #381.
 
-A first implementation used plain nearest-segment greedy assignment (matching
-`place_strip_candidates`'s existing quality bar) but an independent review
-found it capacity-oblivious: a candidate assigned to its nearest segment could
+A first implementation used plain nearest-segment greedy assignment — not
+actually `place_strip_candidates`'s own strategy (see the Decision above), but
+an independent review found it capacity-oblivious regardless: a candidate assigned to its nearest segment could
 be dropped there even when a farther segment had ample free room — a real
 regression against Policy B (never drop a real annotation to avoid a
 crossing/band) that the retired DP, for all its own bugs, did not have. The
@@ -733,6 +738,33 @@ Byte-identity is not preserved for the (narrow) cases where the DP's
 cross-segment optimum would have differed from greedy-assign's answer —
 acceptable under ADR 0004's standing byte-identity waiver (output may change;
 the invariant is lint-clean + no new overlaps).
+
+**Investigated, not fixed (2026-07-10, #381 follow-up).** Solving each carved
+segment independently raises an apparent second gap the trade-off above
+didn't name: `min_gap` itself is not enforced *across* a band, so two
+candidates assigned to the segments either side of a thin band could each sit
+at their own natural position even when those positions are less than
+`min_gap` apart — the old DP's single cross-segment solve used to catch this;
+independent per-segment solves can't see across the carve. A review raised
+this using the retired DP test's synthetic numbers (a 3 mm band, 10 mm
+`min_gap`); those numbers don't occur in `holes.py`. Its band half-width is
+`clr = font_size + 3·pad_around_text` and `min_gap = font_size +
+2·pad_around_text` (`holes.py` line ~1316/1078), so `clr - min_gap =
+pad_around_text`, always positive — a band's width (`2·clr`) always exceeds
+`min_gap`. `pad_around_text` is not a public parameter: `builder.py`'s
+`_assemble` always constructs `draft_preset(...)` without overriding it, so
+it is fixed at `2.0` on every real build. The same argument covers
+`obstacle_intervals` (pre-inflated by `min_gap` on each side already, so its
+occupied width is always >= `2·min_gap`) and the combined band+obstacle carve
+(`holes.py` line ~1628): `carve_free_segments` only merges intervals that
+touch or overlap, so the worst-case cross-segment gap always equals the width
+of the one occupied block separating two free segments, and every
+contributor to that block (band alone, obstacle alone, or both) already
+exceeds `min_gap` on its own. This failure mode is therefore unreachable
+through `holes.py`'s actual formulas, not merely untested; no code change was
+made. Documented here so a future change to the `clr`/`min_gap` formulas or
+to `pad_around_text`'s fixed value re-opens this as a live gap, not a
+resolved one.
 
 ## Related
 

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -658,7 +658,7 @@ segment refills from the remaining candidates before committing placements.
 
 ## Amendment 9 — Retire the banded-PAVA DP; fold keep-out bands into the shared carve (#381)
 
-**Status:** Accepted (decision, 2026-07-10); implementation pending, tracked in #381.
+**Status:** Accepted and implemented (2026-07-10, #381).
 
 **Problem.** Amendment 5 gave keep-out bands their own segmentation-and-solve
 mechanism (`_feasible_segments` + the cross-segment DP in
@@ -698,17 +698,41 @@ parameter and the banded solve path are removed once nothing calls them.
 
 This resolves #381 by construction, not by making the DP exact: an anchored
 candidate assigned to its own obstacle-free segment never sees the band that
-would have needed the DP's cross-segment reasoning to route around. It also
-makes row-avoidance available to every corridor-registered pass for free,
-closing the holes.py-only inconsistency above.
+would have needed the DP's cross-segment reasoning to route around. It unifies
+on the *one* carve primitive (`carve_free_segments`) every corridor pass
+already uses — but band **declaration** (`band_intervals`, built from
+`reserved_rows`/the centreline case) still lives entirely inside
+`holes.py`'s own `_place_queue`, not threaded through the shared
+`CorridorCandidate`/`solve_corridor` seam. A GD&T frame or PMI note still has
+no way to declare a keep-out band; only `holes.py`'s two callers carve them.
+Making that available to every pass is a further, separate change, not part
+of #381.
+
+A first implementation used plain nearest-segment greedy assignment (matching
+`place_strip_candidates`'s existing quality bar) but an independent review
+found it capacity-oblivious: a candidate assigned to its nearest segment could
+be dropped there even when a farther segment had ample free room — a real
+regression against Policy B (never drop a real annotation to avoid a
+crossing/band) that the retired DP, for all its own bugs, did not have. The
+shipped fix instead does **global, priority-ordered greedy assignment with
+live feasibility re-checks**: candidates are processed highest-priority-first;
+each tries its nearest segment, then progressively farther ones, accepting a
+segment only when re-running the real per-segment solve on the trial
+membership drops nobody. Because segments only ever gain higher-or-equal-
+priority members before a lower-priority one is tried, a segment's own
+drop-on-overflow can (outside a rare priority tie) only ever evict the
+candidate currently being tried, never a prior commitment — one pass, no
+cascading, and every feasibility check is the real solver rather than an
+approximate count, so it cannot reintroduce the DP's original bug.
 
 **Trade-off (the honest edge).** This gives up the DP's aim of an exact,
-provably cost-optimal cross-segment placement, in favour of the same
-nearest-segment greedy-assignment quality bar the rest of the corridor system
-already runs on, uncomplained-about. Byte-identity is not preserved for the
-(narrow) cases where the DP's cross-segment optimum would have differed from
-greedy-assign's answer — acceptable under ADR 0004's standing byte-identity
-waiver (output may change; the invariant is lint-clean + no new overlaps).
+provably cost-optimal cross-segment placement, in favour of a greedy
+(highest-priority-first, nearest-segment-first) assignment that is optimal
+per-candidate-in-order but not globally optimal across all orderings.
+Byte-identity is not preserved for the (narrow) cases where the DP's
+cross-segment optimum would have differed from greedy-assign's answer —
+acceptable under ADR 0004's standing byte-identity waiver (output may change;
+the invariant is lint-clean + no new overlaps).
 
 ## Related
 

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -470,6 +470,15 @@ co-occur in a placed strip: the centre-line band is gated to rotational parts,
 which don't anchor), so output is byte-identical; the exact fix — a Pareto
 frontier over `(cost, last_pos)` per count — is a tracked follow-up.
 
+**Correction (2026-07-10, #381):** "unreachable" above covers only the
+centre-line band. `holes.py`'s *other* band source — `reserved_rows`, the
+off-axis holes' location-dim extension lines — is **not** gated by part class;
+it applies to prismatic parts too, independently of `_is_central`. A prismatic
+part with a genuinely central hole (anchored) and another off-axis hole on the
+same strip hits this DP gap today, in the un-carved baseline solve
+(`holes.py`'s `base_res`) — not a hypothetical future combination. See
+Amendment 9, which retires this DP rather than making it exact.
+
 Two supporting changes in `holes.py`:
 - **Bands built from the same causes** `_coaxial_lift` used — the off-axis
   location-dim rows, plus the centre-line row on a turned/rotational view — and
@@ -647,6 +656,60 @@ but the fixed-step/count-stack residuals from the audit are gone. The review fol
 that is rejected late by `forbid`/corridor blockers does not waste a usable slot; the
 segment refills from the remaining candidates before committing placements.
 
+## Amendment 9 — Retire the banded-PAVA DP; fold keep-out bands into the shared carve (#381)
+
+**Status:** Accepted (decision, 2026-07-10); implementation pending, tracked in #381.
+
+**Problem.** Amendment 5 gave keep-out bands their own segmentation-and-solve
+mechanism (`_feasible_segments` + the cross-segment DP in
+`_solve_strip_1d_pava_banded`), separate from the general obstacle-avoidance
+path every other pass uses (`carve_free_segments` + nearest-segment greedy
+assignment + independent per-segment `_solve_strip_1d_pava`, in
+`place_strip_candidates`/`solve_corridor`). `holes.py` runs *both, nested*: it
+carves for real 2-D obstacles, then re-invokes the banded DP inside each carved
+segment for row-bands. No other pass gets row-avoidance at all — a GD&T frame
+or PMI note has no way to avoid a centre-line, not because it shouldn't, but
+because that avoidance only exists inside `holes.py`'s two direct call sites.
+
+This is exactly the failure mode this ADR's own Context section names as the
+reason it exists: a mechanism that doesn't share an occupancy model with the
+rest of the corridor system, landing as a point-fix for one pass's symptom
+(the old `_coaxial_lift` re-crowding bug) instead of a generalisation of the
+shared solve. `carve_free_segments(lo, hi, intervals, pad)` and
+`_feasible_segments(lo, hi, bands)` are structurally the same operation — both
+reduce `[lo, hi]` minus a set of intervals to a free-segment list — differing
+only in whether the clearance arrives as a separate `pad` or is pre-baked into
+each band's half-width. Two APIs for one operation.
+
+The cost of the duplication is now concrete, not just aesthetic: the DP has a
+real correctness gap (Amendment 5's follow-up, #381) that a corrected
+reachability read shows is live on ordinary prismatic parts today, not gated
+by part class as originally believed (see the Correction note on Amendment 5).
+
+**Decision.** Retire `_feasible_segments` and `_solve_strip_1d_pava_banded`.
+Express a keep-out band as an ordinary carve interval
+(`(centre - half_width, centre + half_width)`, `pad=0` since the clearance is
+already in the half-width) fed into the existing `carve_free_segments`. Route
+`holes.py`'s two `plan_strip(forbidden=...)` call sites through the same
+carve + nearest-segment-assign + per-segment `_solve_strip_1d_pava` path
+`place_strip_candidates` already uses for every other pass, instead of calling
+`plan_strip`'s `forbidden=` parameter directly. `plan_strip`'s `forbidden=`
+parameter and the banded solve path are removed once nothing calls them.
+
+This resolves #381 by construction, not by making the DP exact: an anchored
+candidate assigned to its own obstacle-free segment never sees the band that
+would have needed the DP's cross-segment reasoning to route around. It also
+makes row-avoidance available to every corridor-registered pass for free,
+closing the holes.py-only inconsistency above.
+
+**Trade-off (the honest edge).** This gives up the DP's aim of an exact,
+provably cost-optimal cross-segment placement, in favour of the same
+nearest-segment greedy-assignment quality bar the rest of the corridor system
+already runs on, uncomplained-about. Byte-identity is not preserved for the
+(narrow) cases where the DP's cross-segment optimum would have differed from
+greedy-assign's answer — acceptable under ADR 0004's standing byte-identity
+waiver (output may change; the invariant is lint-clean + no new overlaps).
+
 ## Related
 
 - [ADR 0001](0001-deterministic-generation-over-editable-dsl.md) — determinism;
@@ -666,4 +729,6 @@ segment refills from the remaining candidates before committing placements.
   original angled-leader-vs-centreline case Amendment 2's Finding 1 traces back
   to), #318 (P4 — the direct consumer of Amendment 2's `_segment_hits_box` and
   "policy B" findings, and the subject of Amendment 3), #366/#367 (Amendment
-  2's filed residual gaps), #524 (Amendment 8 solver-path consolidation).
+  2's filed residual gaps), #524 (Amendment 8 solver-path consolidation), #381
+  (banded-DP anchor-defeat gap; Amendment 9 retires the DP instead of fixing it
+  in place).

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -756,7 +756,7 @@ pad_around_text`, always positive — a band's width (`2·clr`) always exceeds
 it is fixed at `2.0` on every real build. The same argument covers
 `obstacle_intervals` (pre-inflated by `min_gap` on each side already, so its
 occupied width is always >= `2·min_gap`) and the combined band+obstacle carve
-(`holes.py` line ~1628): `carve_free_segments` only merges intervals that
+(`holes.py` lines ~1617-1622): `carve_free_segments` only merges intervals that
 touch or overlap, so the worst-case cross-segment gap always equals the width
 of the one occupied block separating two free segments, and every
 contributor to that block (band alone, obstacle alone, or both) already

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1296,10 +1296,11 @@ def _annotate_holes(
         view_cy = a.PV_Y if view == "plan" else a.SV_Y
 
         # Keep-out bands (ADR 0009 Amendment 5, P4c, #318) — the page rows a callout's
-        # "⌀… ↓…" text may not sit on, handed to `plan_strip(forbidden=...)` so the
-        # spacing solve avoids them by construction (retiring the old `_coaxial_lift`
-        # pre-solve nudge). Each is `(centre, half_width)`. Two causes, keyed on the
-        # crossing line, not the part's shape:
+        # "⌀… ↓…" text may not sit on, folded into `_place_queue`'s obstacle carve
+        # (ADR 0009 Amendment 9, #381) so the spacing solve avoids them by
+        # construction (retiring the old `_coaxial_lift` pre-solve nudge, and — since
+        # Amendment 9 — the separate banded-DP solve). Each is `(centre, half_width)`.
+        # Two causes, keyed on the crossing line, not the part's shape:
         #  - location-dim extension lines: the rows where `_locate_off_axis_holes`
         #    will draw the off-axis bores' height/offset dims. Computed from hole
         #    geometry (the callout carries no feature link; its own row equals its
@@ -1327,6 +1328,7 @@ def _annotate_holes(
         forbidden = [(r, clr) for r in reserved_rows]
         if a.is_rotational or a.prof is not None:
             forbidden.append((view_cy, clr))
+        band_intervals = [(c - h, c + h) for c, h in forbidden]
 
         # --- Pass 1: boundary assignment ---
         right_queue = []  # (locs, dia, callout, feat, natural_y, rep)
@@ -1454,33 +1456,103 @@ def _annotate_holes(
             if not queue:
                 return start_i
 
-            # Baseline: the single full-range solve the pre-#351-P5-strand-3 code
-            # always did, ignoring drawing-level obstacles entirely — every
-            # candidate pulled toward its own natural Y, respecting only min_gap
-            # from its queue siblings. Used below as the "cost of NOT avoiding"
-            # reference a carve-based relocation must beat to be worth taking.
-            base_cands = [
-                StripCandidate(
-                    key=f"{key_prefix}{j:04d}",
-                    anchor=(edge, s[4]),
-                    size=(s[2].callout_width, min_gap),
-                    priority=s[1],
-                    anchored=_is_central(s),
-                )
-                for j, s in enumerate(queue)
-            ]
-            base_res = plan_strip(base_cands, y_min, y_max, min_gap, forbidden=forbidden)
-            base_by_key = {c.key: s for c, s in zip(base_cands, queue, strict=True)}
-            base_y = {id(base_by_key[k]): y for k, y in base_res.placed.items()}
-            base_dropped = {id(base_by_key[k]) for k in base_res.dropped}
+            # Carve [y_min, y_max] around a set of keep-out intervals, assign each
+            # candidate to its nearest free segment, then solve each segment
+            # independently with the plain PAVA solve — the ONE carve+assign+solve
+            # mechanism, reused below both for the bands-only baseline and for
+            # bands+drawing-obstacles together (ADR 0009 Amendment 9, #381). This
+            # retires the separate banded-DP solve: an anchored candidate assigned
+            # to its own band-free segment never needs cross-segment reasoning to
+            # stay off a reserved row. *intervals* must already carry their own
+            # clearance (pre-inflated) — this carves with `pad=0`.
+            def _carve_and_place(cands_in, intervals, key_prefix_local):
+                segs = carve_free_segments(y_min, y_max, intervals, 0.0)
+                if not segs:
+                    # *intervals* covers [y_min, y_max] entirely — a band wider than
+                    # the whole strip (a shallow view, e.g. the `dshape` side strip).
+                    # Rather than drop a real callout to honour it (policy B), snap
+                    # each natural to the strip edge farthest from the row (the same
+                    # minimal-residual choice the old `_coaxial_lift`/
+                    # `_snap_out_of_bands` fallback made) and solve once over the
+                    # whole, still-unavoidable range.
+                    def _snap(ny):
+                        p = ny
+                        for a0, b0 in intervals:
+                            if a0 < p < b0:
+                                p = b0 if (y_max - ny) >= (ny - y_min) else a0
+                        return min(max(p, y_min), y_max)
 
-            # Carve [y_min, y_max] around drawing-level obstacles this column's
-            # leaders would cross (e.g. the section cutting-plane arrow — #351 P5
-            # strand 3): a Y-only solve can't see an obstacle it never measures,
-            # the textbook invisible-occupant defect. Probed at each candidate's
-            # OWN natural Y, not a shared reference — a callout's leader shaft is
-            # position-dependent geometry (it runs from the fixed hole location to
-            # the elbow), so probing everyone at one far-away Y badly misjudges it.
+                    cands = [
+                        StripCandidate(
+                            key=f"{key_prefix_local}{j:04d}",
+                            anchor=(edge, _snap(s[4])),
+                            size=(s[2].callout_width, min_gap),
+                            priority=s[1],
+                            anchored=_is_central(s),
+                        )
+                        for j, s in enumerate(cands_in)
+                    ]
+                    res = plan_strip(cands, y_min, y_max, min_gap)
+                    by_key = {c.key: s for c, s in zip(cands, cands_in, strict=True)}
+                    return (
+                        {id(by_key[k]): y for k, y in res.placed.items()},
+                        {id(by_key[k]) for k in res.dropped},
+                    )
+
+                def _nearest_seg(ny):
+                    for lo, hi in segs:
+                        if lo <= ny <= hi:
+                            return (lo, hi)
+                    return min(
+                        segs, key=lambda sg: min(abs(ny - sg[0]), abs(ny - sg[1])), default=None
+                    )
+
+                by_seg: dict = {seg: [] for seg in segs}
+                for s in cands_in:
+                    seg = _nearest_seg(s[4])
+                    if seg is not None:
+                        by_seg[seg].append(s)
+                # A candidate whose natural Y fell outside every free segment (the
+                # whole column blocked, or between two far-apart obstacles) is
+                # simply absent from `by_seg` — the final per-candidate loop below
+                # already falls back to the baseline position for it.
+                y_by_id: dict = {}
+                dropped_ids: set = set()
+                for (seg_lo, seg_hi), members in by_seg.items():
+                    if not members:
+                        continue
+                    cands = [
+                        StripCandidate(
+                            key=f"{key_prefix_local}{j:04d}",
+                            anchor=(edge, s[4]),
+                            size=(s[2].callout_width, min_gap),
+                            priority=s[1],  # bore diameter — largest wins over-capacity (D3)
+                            anchored=_is_central(s),
+                        )
+                        for j, s in enumerate(members)
+                    ]
+                    res = plan_strip(cands, seg_lo, seg_hi, min_gap)
+                    by_key = {c.key: s for c, s in zip(cands, members, strict=True)}
+                    for k, y in res.placed.items():
+                        y_by_id[id(by_key[k])] = y
+                    dropped_ids.update(id(by_key[k]) for k in res.dropped)
+                return y_by_id, dropped_ids
+
+            # Baseline: bands only, ignoring drawing-level obstacles entirely —
+            # every candidate pulled toward its own natural Y, respecting only
+            # min_gap from its queue siblings and the keep-out rows. Used below
+            # as the "cost of NOT avoiding [obstacles]" reference a carve-based
+            # relocation must beat to be worth taking.
+            base_y, base_dropped = _carve_and_place(queue, band_intervals, key_prefix)
+
+            # Carve around drawing-level obstacles this column's leaders would
+            # cross too (e.g. the section cutting-plane arrow — #351 P5 strand
+            # 3): a Y-only solve can't see an obstacle it never measures, the
+            # textbook invisible-occupant defect. Probed at each candidate's OWN
+            # natural Y, not a shared reference — a callout's leader shaft is
+            # position-dependent geometry (it runs from the fixed hole location
+            # to the elbow), so probing everyone at one far-away Y badly
+            # misjudges it.
             def _probe_box(s):
                 # Unlike the old code (which only ever built a Leader for a
                 # candidate already chosen for placement), this probes EVERY
@@ -1502,59 +1574,17 @@ def _annotate_holes(
                 band_lo = min(b[0] for b in probe_boxes)
                 band_hi = max(b[2] for b in probe_boxes)
                 occupied = [o for o in occupied if o[0] < band_hi and o[2] > band_lo]
-            segs = carve_free_segments(y_min, y_max, [(o[1], o[3]) for o in occupied], min_gap)
-
-            # Assign each candidate to the free segment nearest its natural Y
-            # (containing it if possible, else the closer boundary) — the
-            # multi-segment analogue of the single plan_strip call this replaces.
-            # In practice at most one obstacle (the section arrow) ever splits
-            # this column, so a per-segment solve stays close to the
-            # single-segment optimum while never overprinting the carved gap.
-            def _nearest_seg(ny):
-                for lo, hi in segs:
-                    if lo <= ny <= hi:
-                        return (lo, hi)
-                return min(
-                    segs, key=lambda sg: min(abs(ny - sg[0]), abs(ny - sg[1])), default=None
-                )
-
-            by_seg: dict = {seg: [] for seg in segs}
-            for s in queue:
-                seg = _nearest_seg(s[4])
-                if seg is not None:
-                    by_seg[seg].append(s)
-            # A candidate whose natural Y fell outside every free segment (the
-            # whole column blocked, or between two far-apart obstacles) is simply
-            # absent from `by_seg` — the final per-candidate loop below already
-            # falls back to the baseline position for it (no special "unassigned"
-            # bucket needed; `plan_strip`'s own dropped set, from a segment truly
-            # out of capacity, is likewise just absent from `seg_y` below).
-
-            seg_y: dict = {}  # id(s) -> elbow_y, from the carve-aware per-segment solves
-
-            def _solve_segment(cands_in, lo, hi, key_prefix_local):
-                cands = [
-                    StripCandidate(
-                        key=f"{key_prefix_local}{j:04d}",
-                        anchor=(edge, s[4]),
-                        size=(s[2].callout_width, min_gap),
-                        priority=s[1],  # bore diameter — largest wins over-capacity (D3)
-                        anchored=_is_central(s),
-                    )
-                    for j, s in enumerate(cands_in)
-                ]
-                res = plan_strip(cands, lo, hi, min_gap, forbidden=forbidden)
-                by_key = {c.key: s for c, s in zip(cands, cands_in, strict=True)}
-                for k, y in res.placed.items():
-                    seg_y[id(by_key[k])] = y
-
-            for (seg_lo, seg_hi), members in by_seg.items():
-                if members:
-                    _solve_segment(members, seg_lo, seg_hi, key_prefix)
-            # A candidate whose natural Y fell outside every free segment (the
-            # whole column blocked, or between two far-apart obstacles) never
-            # entered `by_seg` — it has no carve-aware position to compare below,
-            # so the baseline (with crossing accepted, policy B) is its only shot.
+            # Obstacles get their own min_gap clearance, pre-inflated here (same
+            # amount the old dedicated carve applied); bands already carry their
+            # clearance in `band_intervals`'s half-width. Combining both into one
+            # carve call needs each pre-inflated by its own amount, not a single
+            # shared pad, so `_carve_and_place` above always carves with `pad=0`.
+            obstacle_intervals = [
+                (max(y_min, o[1] - min_gap), min(y_max, o[3] + min_gap)) for o in occupied
+            ]
+            seg_y, _seg_dropped = _carve_and_place(
+                queue, band_intervals + obstacle_intervals, key_prefix
+            )
 
             # Decide per candidate: take the carve-aware (obstacle-avoiding)
             # position ONLY when a free one exists AND it doesn't cost much more

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1363,8 +1363,8 @@ def _annotate_holes(
                 _record_callout_drop(dwg, view, dia, "no room beside the view", feat)
                 continue
 
-            # Natural Y is the bore's own row; keep-out-band avoidance is now the
-            # solve's job (`forbidden`, below), not a pre-solve lift.
+            # Natural Y is the bore's own row; keep-out-band avoidance is now
+            # `_place_queue`'s carve (`band_intervals`, below), not a pre-solve lift.
             if can_right and (not can_left or d_right <= d_left):
                 right_queue.append((locs, dia, callout, feat, centre_r[1], rep_r))
             else:
@@ -1465,9 +1465,23 @@ def _annotate_holes(
             # to its own band-free segment never needs cross-segment reasoning to
             # stay off a reserved row. *intervals* must already carry their own
             # clearance (pre-inflated) — this carves with `pad=0`.
-            def _carve_and_place(cands_in, intervals, key_prefix_local):
+            def _carve_and_place(cands_in, intervals, key_prefix_local, *, allow_snap=True):
                 segs = carve_free_segments(y_min, y_max, intervals, 0.0)
                 if not segs:
+                    if not allow_snap:
+                        # bands+obstacles combined leave no free segment — unlike a
+                        # band-only strip (below), this has no single-pass escape that
+                        # is safe to trust: a snap chosen to clear ONE blocking
+                        # interval isn't rechecked against the others, so it can still
+                        # land inside a different one (a real drawing-level obstacle,
+                        # e.g. the section cutting-plane letter, unlike a band, is
+                        # exactly the kind of thing that produces a visible overlap,
+                        # not just a theoretical one). Returning nothing here (instead
+                        # of a wrong position) defers every candidate cleanly to the
+                        # bands-only baseline below, matching what a fully-obstacle-
+                        # blocked carve already did before this helper existed.
+                        return {}, set()
+
                     # *intervals* covers [y_min, y_max] entirely — a band wider than
                     # the whole strip (a shallow view, e.g. the `dshape` side strip).
                     # Rather than drop a real callout to honour it (policy B), snap
@@ -1499,40 +1513,61 @@ def _annotate_holes(
                         {id(by_key[k]) for k in res.dropped},
                     )
 
-                def _nearest_seg(ny):
-                    for lo, hi in segs:
-                        if lo <= ny <= hi:
-                            return (lo, hi)
-                    return min(
-                        segs, key=lambda sg: min(abs(ny - sg[0]), abs(ny - sg[1])), default=None
+                def _seg_order(ny):
+                    """Segments nearest-to-farthest from *ny* — the containing
+                    segment (if any) first, else by edge distance; ties (equidistant
+                    between two segments) break on segment start for determinism."""
+
+                    def _dist(seg):
+                        lo, hi = seg
+                        return (
+                            (0.0, lo) if lo <= ny <= hi else (min(abs(ny - lo), abs(ny - hi)), lo)
+                        )
+
+                    return sorted(segs, key=_dist)
+
+                def _cand(s, j):
+                    return StripCandidate(
+                        key=f"{key_prefix_local}{j:04d}",
+                        anchor=(edge, s[4]),
+                        size=(s[2].callout_width, min_gap),
+                        priority=s[1],  # bore diameter — largest wins over-capacity (D3)
+                        anchored=_is_central(s),
                     )
 
-                by_seg: dict = {seg: [] for seg in segs}
-                for s in cands_in:
-                    seg = _nearest_seg(s[4])
-                    if seg is not None:
-                        by_seg[seg].append(s)
-                # A candidate whose natural Y fell outside every free segment (the
-                # whole column blocked, or between two far-apart obstacles) is
-                # simply absent from `by_seg` — the final per-candidate loop below
-                # already falls back to the baseline position for it.
-                y_by_id: dict = {}
+                # Selection (ADR 0009 P2) must be GLOBAL across every carved segment,
+                # not per-segment — a candidate that overflows its nearest segment may
+                # still fit a farther one with spare room (#381: the retired banded-DP
+                # tried this but approximated feasibility by placed-count alone, which
+                # lost track of *where* things were placed; this instead re-runs the
+                # real per-segment solve on each trial, so it can't reintroduce that
+                # bug). Process candidates highest-priority-first so a segment already
+                # holding only >= priority members can, on overflow, only ever be
+                # asked to drop the newcomer being tried — never evict a prior
+                # commitment — which is exactly what "trial has zero drops" verifies
+                # below: on a rare priority TIE it's conservative (rejects rather than
+                # risking evicting an existing member), never wrong.
+                order = sorted(cands_in, key=lambda s: (-s[1], s[4]))
+                members: dict = {seg: [] for seg in segs}
                 dropped_ids: set = set()
-                for (seg_lo, seg_hi), members in by_seg.items():
-                    if not members:
+                for s in order:
+                    for seg in _seg_order(s[4]):
+                        trial = members[seg] + [s]
+                        cands = [_cand(m, j) for j, m in enumerate(trial)]
+                        res = plan_strip(cands, seg[0], seg[1], min_gap)
+                        if not res.dropped:
+                            members[seg] = trial
+                            break
+                    else:
+                        dropped_ids.add(id(s))
+
+                y_by_id: dict = {}
+                for seg, mem in members.items():
+                    if not mem:
                         continue
-                    cands = [
-                        StripCandidate(
-                            key=f"{key_prefix_local}{j:04d}",
-                            anchor=(edge, s[4]),
-                            size=(s[2].callout_width, min_gap),
-                            priority=s[1],  # bore diameter — largest wins over-capacity (D3)
-                            anchored=_is_central(s),
-                        )
-                        for j, s in enumerate(members)
-                    ]
-                    res = plan_strip(cands, seg_lo, seg_hi, min_gap)
-                    by_key = {c.key: s for c, s in zip(cands, members, strict=True)}
+                    cands = [_cand(m, j) for j, m in enumerate(mem)]
+                    res = plan_strip(cands, seg[0], seg[1], min_gap)
+                    by_key = {c.key: m for c, m in zip(cands, mem, strict=True)}
                     for k, y in res.placed.items():
                         y_by_id[id(by_key[k])] = y
                     dropped_ids.update(id(by_key[k]) for k in res.dropped)
@@ -1583,7 +1618,7 @@ def _annotate_holes(
                 (max(y_min, o[1] - min_gap), min(y_max, o[3] + min_gap)) for o in occupied
             ]
             seg_y, _seg_dropped = _carve_and_place(
-                queue, band_intervals + obstacle_intervals, key_prefix
+                queue, band_intervals + obstacle_intervals, key_prefix, allow_snap=False
             )
 
             # Decide per candidate: take the carve-aware (obstacle-avoiding)

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -24,9 +24,14 @@ What actually lives here today:
   solver (the earlier Cassowary/``kiwisolver`` satisfaction solve was retired
   once PAVA gave the exact L1 placement). :func:`plan_strip` is the
   production-facing collect-then-solve entry point built on top of it
-  (selection, ordering, anchoring, keep-out bands); the lower-level
+  (selection, ordering, anchoring); the lower-level
   `_solve_strip_1d*`/`_greedy_strip_1d*` functions are unit-tested in
-  isolation and used by `plan_strip`'s banded/anchored solve.
+  isolation and used by `plan_strip`'s anchored solve. Keep-out-band avoidance
+  (a callout must not sit on a centre-line or a location-dim row) briefly lived
+  as a `plan_strip`-internal banded solve (ADR 0009 Amendment 5, #318); that had
+  a cross-segment correctness gap (#381), so Amendment 9 retired it in favour of
+  the caller carving bands into the same obstacle segmentation it already uses
+  (`holes.py`) — `plan_strip` itself no longer knows about bands.
 - :func:`fit_box` (+ the thin ``place_box`` naming used at call sites) — the 2D
   free-rectangle placer for tables/GD&T frames/BOM blocks (#93), the one part
   of the original `LayoutSolver` surface that is genuinely shared.
@@ -224,136 +229,6 @@ def _solve_strip_1d_pava(naturals, gaps, lo, hi, weights=None):
     return positions
 
 
-def _feasible_segments(lo, hi, bands):
-    """The sub-intervals of ``[lo, hi]`` left after punching out the keep-out
-    *bands* (each an ``(band_lo, band_hi)`` pair). Overlapping/touching bands are
-    merged and clipped to ``[lo, hi]`` first; the returned ``(seg_lo, seg_hi)``
-    list is ascending and pairwise disjoint (empty when the bands cover
-    everything)."""
-    clipped: list[tuple[float, float]] = []
-    for b_lo, b_hi in sorted(bands):
-        b_lo, b_hi = max(b_lo, lo), min(b_hi, hi)
-        if b_hi <= b_lo:
-            continue
-        if clipped and b_lo <= clipped[-1][1]:
-            clipped[-1] = (clipped[-1][0], max(clipped[-1][1], b_hi))
-        else:
-            clipped.append((b_lo, b_hi))
-    segments: list[tuple[float, float]] = []
-    cursor = lo
-    for b_lo, b_hi in clipped:
-        if b_lo > cursor:
-            segments.append((cursor, b_lo))
-        cursor = max(cursor, b_hi)
-    if cursor < hi:
-        segments.append((cursor, hi))
-    return segments
-
-
-def _snap_out_of_bands(value, bands, lo, hi):
-    """Nudge *value* to the nearer edge of any keep-out band it lies inside, toward
-    the roomier half of ``[lo, hi]`` on a tie, then clamp to ``[lo, hi]``. Used only
-    for the shallow-strip fallback in :func:`_solve_strip_1d_pava_banded`: when a
-    strip is too thin to clear a band, this reproduces the old ``_coaxial_lift``
-    clamp — sit at the strip edge farthest from the row (minimal residual), rather
-    than dead-centre on it."""
-    p = value
-    for b_lo, b_hi in bands:
-        if b_lo < p < b_hi:
-            p = b_hi if (hi - value) >= (value - lo) else b_lo
-    return min(max(p, lo), hi)
-
-
-def _solve_strip_1d_pava_banded(naturals, gaps, lo, hi, weights, bands):
-    """Band-aware :func:`_solve_strip_1d_pava` (ADR 0009 Amendment 5, P4c, #318):
-    the same minimum-(weighted-)total-leader-length placement, but the labels should
-    also avoid the keep-out *bands* — the page rows a callout's text may not sit on
-    (a view centre-line, a location-dimension's extension line — #305/#321). This
-    retires the pre-solve ``_coaxial_lift`` nudge: reserved-row avoidance is now a
-    property the solve honours, not a fixed lift the spacing solve could later
-    re-crowd.
-
-    A band is a **non-convex** keep-out (stay above *or* below the row), which the
-    plain PAVA box cannot express. But the bands split ``[lo, hi]`` into disjoint
-    feasible **segments** (:func:`_feasible_segments`), and *within one segment* the
-    box is convex again — so the exact PAVA atom still applies. The labels keep
-    their fixed ascending order (crossing-free, established upstream), so they map to
-    the segments as **contiguous runs at non-decreasing segment indices**; a small
-    DP over ``(segment, labels-placed)`` searches for a low-cost such partition,
-    solving each run with :func:`_solve_strip_1d_pava` inside its segment. With no
-    bands it is exactly the plain solve (byte-identical). Deterministic: each run
-    solve is, and ties between equal-cost states break on the lexicographically
-    smaller position vector.
-
-    **Not globally optimal across ≥2 segments.** The DP keeps one representative
-    per labels-placed count, but a run's feasible room in a later segment depends
-    on the *last placed position*, not just the count — so a costlier prefix that
-    lowers the last label can unlock a cheaper suffix the DP won't find, and (the
-    reachable symptom) a band present alongside an ``anchored`` candidate can drag
-    the anchor off its natural. Unreachable on the corpus today (anchor and band
-    never co-occur in a placed strip — the centre-line band is gated to rotational
-    parts, where :func:`plan_strip`'s caller does not anchor), so output is
-    byte-identical; the exact fix (a Pareto frontier over ``(cost, last_pos)`` per
-    count) is tracked as a follow-up.
-
-    **Graceful degradation.** Avoidance is a strong preference, not a hard drop: a
-    band can be *wider than the whole strip* (a shallow view), leaving no segment to
-    hold the label. Rather than drop a real callout to honour the band (against
-    policy B — never drop a real annotation just to avoid a crossing), the DP-can't-
-    place case falls back to a plain solve toward band-edge-snapped naturals — the
-    label sits at the strip edge farthest from the row (minimal residual, as the old
-    lift did). A genuine over-capacity strip still returns ``None`` (the fallback
-    plain solve does), for the caller's drop-and-retry loop.
-    """
-    if weights is None:
-        weights = [1.0] * len(naturals)
-    if not bands:
-        return _solve_strip_1d_pava(naturals, gaps, lo, hi, weights)
-    if not naturals:
-        return []
-    n = len(naturals)
-    segments = _feasible_segments(lo, hi, bands)
-
-    # DP: best[k] = (cost, positions) to place labels[:k] using the segments seen so
-    # far. Each segment takes a contiguous run labels[k:j] (possibly empty), solved
-    # by the PAVA atom within the segment's convex box.
-    best: dict[int, tuple[float, list[float]]] = {0: (0.0, [])}
-    for seg_lo, seg_hi in segments:
-        nxt = dict(best)  # carry every state forward = put no labels in this segment
-        for k, (cost, pos) in best.items():
-            if k >= n:
-                continue  # all labels already placed in earlier segments → no run here
-            # Lower bound for this segment's run: the cross-segment min-gap to the
-            # last label placed in an earlier segment. Tighten seg_lo up to it (a
-            # still-convex box) rather than solving against raw seg_lo and rejecting
-            # a too-close result — rejecting would discard a valid, strictly-cheaper
-            # placement that a shift up would reach (parking a label on the band edge
-            # or forcing the fallback; #379 review).
-            run_lo = seg_lo if not pos else max(seg_lo, pos[-1] + gaps[k - 1])
-            for j in range(k + 1, n + 1):
-                sol = _solve_strip_1d_pava(
-                    naturals[k:j], gaps[k : j - 1], run_lo, seg_hi, weights[k:j]
-                )
-                if sol is None:
-                    break  # a longer run only needs more room → also infeasible
-                total = cost + sum(
-                    w * abs(p - nat)
-                    for p, nat, w in zip(sol, naturals[k:j], weights[k:j], strict=True)
-                )
-                cand = pos + sol
-                if j not in nxt or (total, cand) < (nxt[j][0], nxt[j][1]):
-                    nxt[j] = (total, cand)
-        best = nxt
-    if n in best:
-        return best[n][1]
-
-    # No band-avoiding placement fits every label → accept minimal band intrusion:
-    # solve toward naturals snapped to the nearer band edge (the shallow-strip
-    # fallback). Returns None only when the strip is genuinely over capacity.
-    snapped = [_snap_out_of_bands(nat, bands, lo, hi) for nat in naturals]
-    return _solve_strip_1d_pava(snapped, gaps, lo, hi, weights)
-
-
 # ---------------------------------------------------------------------------
 # Collect-then-solve strip stage (ADR 0009)
 # ---------------------------------------------------------------------------
@@ -412,7 +287,7 @@ class StripPlacement(NamedTuple):
     dropped: tuple
 
 
-def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y", forbidden=()):
+def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     """Collect-then-solve placement of *candidates* along one strip (ADR 0009).
 
     Orders the labels in **site order** along *axis* — placing them in site order
@@ -444,12 +319,12 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y", forbidden=()):
     row. Candidate *keys* must be unique (they key the result). Deterministic
     throughout.
 
-    **Keep-out bands (P4c, #318):** *forbidden* is an iterable of ``(centre,
-    half_width)`` rows the labels must avoid — a view centre-line or a location
-    dimension's extension line a callout's text may not sit on (#305/#321). It
-    routes the spacing through :func:`_solve_strip_1d_pava_banded`, so avoidance is
-    a property the solve honours (retiring the pre-solve ``_coaxial_lift`` nudge).
-    Empty (the default) → the plain solve, byte-for-byte.
+    No keep-out-band support: a caller that needs to avoid a reserved row (a
+    view centre-line, a location dimension's extension line — #305/#321) folds
+    it into its own obstacle carve and calls this once per free segment, the
+    same way it already handles any other 2-D obstacle (ADR 0009 Amendment 9,
+    #381, retiring a `plan_strip`-internal banded solve that had a cross-segment
+    correctness gap — see `annotations/holes.py`).
     """
     if not candidates:
         return StripPlacement({}, ())
@@ -468,8 +343,7 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y", forbidden=()):
             for i in range(len(ordered) - 1)
         ]
         weights = [_ANCHOR_WEIGHT if c.anchored else 1.0 for c in ordered]
-        bands = [(c - h, c + h) for c, h in forbidden]
-        positions = _solve_strip_1d_pava_banded(naturals, gaps, lo, hi, weights, bands)
+        positions = _solve_strip_1d_pava(naturals, gaps, lo, hi, weights)
         if positions is not None:
             placed = {c.key: p for c, p in zip(ordered, positions, strict=True)}
             return StripPlacement(placed, tuple(dropped))

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -9,13 +9,10 @@ import pytest
 import draftwright.layout as L
 from draftwright.layout import (
     _ANCHOR_WEIGHT,
-    _feasible_segments,
     _greedy_strip_1d,
     _greedy_strip_1d_var,
-    _snap_out_of_bands,
     _solve_strip_1d,
     _solve_strip_1d_pava,
-    _solve_strip_1d_pava_banded,
     _solve_strip_1d_var,
     fit_box,
 )
@@ -167,100 +164,6 @@ class TestSolveStrip1dPava:
         assert _solve_strip_1d_pava([100.0, 102.0], [7.0], 0.0, 200.0) == pytest.approx(
             [95.0, 102.0]
         )
-
-
-class TestFeasibleSegments:
-    """P4c (#318, ADR 0009 Amendment 5): ``[lo, hi]`` minus the keep-out bands."""
-
-    def test_no_bands_is_the_whole_strip(self):
-        assert _feasible_segments(0.0, 100.0, []) == [(0.0, 100.0)]
-
-    def test_single_interior_band_splits_in_two(self):
-        assert _feasible_segments(0.0, 100.0, [(40.0, 60.0)]) == [(0.0, 40.0), (60.0, 100.0)]
-
-    def test_edge_bands_clip_to_the_strip(self):
-        assert _feasible_segments(0.0, 100.0, [(-10.0, 10.0), (90.0, 110.0)]) == [(10.0, 90.0)]
-
-    def test_overlapping_bands_merge(self):
-        assert _feasible_segments(0.0, 100.0, [(30.0, 50.0), (45.0, 70.0)]) == [
-            (0.0, 30.0),
-            (70.0, 100.0),
-        ]
-
-    def test_band_covering_everything_leaves_no_segment(self):
-        assert _feasible_segments(40.0, 60.0, [(30.0, 70.0)]) == []
-
-
-class TestSolveStrip1dPavaBanded:
-    """P4c (#318, ADR 0009 Amendment 5): the min-leader PAVA solve made keep-out-
-    band aware (retiring the ``_coaxial_lift`` pre-solve nudge). Avoidance is by
-    construction where the strip has room, and degrades gracefully to minimal band
-    intrusion (not a drop) where it does not."""
-
-    def test_no_bands_is_byte_identical_to_the_plain_solve(self):
-        for naturals, gaps, lo, hi in [
-            ([10.0, 7.0, 4.0], [5.0, 5.0], -100.0, 100.0),
-            ([-5.0, -4.0], [3.0], 0.0, 100.0),
-            ([], [], 0.0, 10.0),
-        ]:
-            assert _solve_strip_1d_pava_banded(naturals, gaps, lo, hi, None, []) == (
-                _solve_strip_1d_pava(naturals, gaps, lo, hi)
-            )
-
-    def test_label_on_a_band_is_pushed_to_the_nearer_edge(self):
-        # natural 50 sits inside the band (45, 55); the room-available solve seats
-        # it at the nearer segment edge (45), not on the row.
-        assert _solve_strip_1d_pava_banded([50.0], [], 0.0, 100.0, None, [(45.0, 55.0)]) == (
-            pytest.approx([45.0])
-        )
-
-    def test_two_labels_already_clear_are_untouched(self):
-        # both naturals already sit outside a thin interior band → unchanged.
-        assert _solve_strip_1d_pava_banded(
-            [40.0, 60.0], [5.0], 0.0, 120.0, None, [(48.0, 52.0)]
-        ) == (pytest.approx([40.0, 60.0]))
-
-    def test_shallow_strip_degrades_to_minimal_intrusion_not_a_drop(self):
-        # The band (81, 99) is WIDER than the whole strip [82, 98] (the dshape side
-        # view): no band-clear position exists, so rather than drop a real callout
-        # the solve clamps to the strip edge farthest from the row — 98, an 8 mm
-        # residual, exactly what the old _coaxial_lift did. NOT None.
-        assert _solve_strip_1d_pava_banded([90.0], [], 82.0, 98.0, None, [(81.0, 99.0)]) == (
-            pytest.approx([98.0])
-        )
-
-    def test_cross_segment_gap_shifts_the_run_up_not_reject(self):
-        # #379 review regression: when the next segment's run at its natural would
-        # violate the cross-segment gap to the label already placed below the band,
-        # the run must be SHIFTED UP (its lower bound tightened) to the min-cost
-        # band-clear placement — not rejected outright (which parked the label on the
-        # band edge at higher cost). naturals [29, 34], gap 10, band (30,33): the
-        # optimum is [29, 39] (label 0 at its natural below, label 1 shifted up clear
-        # of the band), cost 5 — NOT [20, 30] (cost 13, label 1 on the 30 edge).
-        assert _solve_strip_1d_pava_banded(
-            [29.0, 34.0], [10.0], 0.0, 100.0, None, [(30.0, 33.0)]
-        ) == pytest.approx([29.0, 39.0])
-
-    def test_genuine_over_capacity_still_returns_none(self):
-        # Three labels needing 50 mm gaps can't fit an 80 mm strip regardless of
-        # bands → None, preserving the caller's drop-and-retry contract.
-        assert (
-            _solve_strip_1d_pava_banded(
-                [10.0, 20.0, 30.0], [50.0, 50.0], 0.0, 80.0, None, [(40.0, 45.0)]
-            )
-            is None
-        )
-
-    def test_deterministic_across_calls(self):
-        args = ([40.0, 50.0, 60.0], [4.0, 4.0], 0.0, 120.0, None, [(48.0, 58.0)])
-        assert _solve_strip_1d_pava_banded(*args) == _solve_strip_1d_pava_banded(*args)
-
-    def test_snap_out_of_bands_prefers_the_roomier_half(self):
-        # equidistant from both edges of a strip-engulfing band → toward the
-        # roomier half (up), then clamped: matches _coaxial_lift's old direction.
-        assert _snap_out_of_bands(90.0, [(81.0, 99.0)], 82.0, 98.0) == 98.0
-        # natural clear of every band is returned unchanged.
-        assert _snap_out_of_bands(30.0, [(45.0, 55.0)], 0.0, 100.0) == 30.0
 
 
 class TestFitBox:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3686,6 +3686,41 @@ class TestLocationDimsAndSection:
         assert [i for i in dwg.lint() if i.severity != "info"] == []
 
     @pytest.mark.timeout(120)
+    def test_side_drilled_callouts_survive_capacity_aware_carve(self):
+        # Each unpatterned side-drilled hole reserves its own row as a keep-out
+        # band (#318), so its callout is pushed off its own natural Y into the
+        # nearest carved segment. Four holes packed close enough together that
+        # their bands merge push the callout selection past a single tight
+        # segment: a per-segment-only assignment (the #381 regression) can drop
+        # one that overflows its nearest segment even though a farther segment
+        # has spare room — the global priority-ordered assignment must not.
+        part = Box(60, 40, 80)
+        for z, r in ((-20, 1.0), (-12, 1.2), (-4, 1.4), (20, 1.6)):
+            part -= Pos(0, 0, z) * Cylinder(r, 60, rotation=(0, 90, 0))
+        dwg = build_drawing(part)
+        assert len([n for n in dwg._named if n.startswith("hc_side")]) == 4
+        assert [i for i in dwg.lint() if i.severity != "info"] == []
+
+    @pytest.mark.timeout(120)
+    def test_fully_blocked_plan_strip_defers_instead_of_unsafe_snap(self):
+        # A stepped part whose bands+obstacles carve leaves the plan view's left
+        # strip with no free segment at all: unlike the band-only carve (which may
+        # safely snap to the nearest strip edge), a snap here isn't rechecked
+        # against every other blocking interval and can land inside a different
+        # one. The bands+obstacles call must defer cleanly to the bands-only
+        # baseline instead of snapping (distinct geometry from
+        # test_section_clears_the_step_dim_ladder, which exercises the same
+        # defer but wasn't written to assert it).
+        part = (
+            Box(44, 12, 44)
+            - Pos(11, 0, 22) * Box(22, 12, 44)
+            - Pos(-11, 0, 0) * Cylinder(3, 44)
+            - Pos(-11, 0, 18) * Cylinder(5, 8)
+        )
+        dwg = build_drawing(part)
+        assert [i for i in dwg.lint() if i.severity != "info"] == []
+
+    @pytest.mark.timeout(120)
     def test_linear_array_locates_its_nearest_member(self):
         # The baseline dim goes to the hole nearest the datum corner; the
         # pitch dim chains the rest outward.

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -437,6 +437,36 @@ def test_plan_strip_anchored_candidate_stays_on_its_natural():
     assert plain.placed["mid"] == pytest.approx(95.0)
 
 
+def test_carve_free_segments_merges_overlapping_intervals():
+    # Two overlapping keep-out intervals must merge into ONE blocked region
+    # before the free segments are computed, not be treated as independently
+    # subtractable (which would under-block the overlap). Equivalent to the
+    # retired `_feasible_segments`'s `test_overlapping_bands_merge`.
+    from draftwright.annotations._common import carve_free_segments
+
+    segs = carve_free_segments(0.0, 100.0, [(30.0, 50.0), (45.0, 70.0)], 0.0)
+    assert segs == [(0.0, 30.0), (70.0, 100.0)]
+
+
+def test_carve_free_segments_clips_intervals_at_the_strip_edge():
+    # An interval extending past [lo, hi] clips to the strip bounds rather than
+    # producing a free segment outside them. Equivalent to the retired
+    # `_feasible_segments`'s `test_edge_bands_clip_to_the_strip`.
+    from draftwright.annotations._common import carve_free_segments
+
+    segs = carve_free_segments(0.0, 100.0, [(-10.0, 10.0), (90.0, 110.0)], 0.0)
+    assert segs == [(10.0, 90.0)]
+
+
+def test_carve_free_segments_fully_covered_leaves_no_segment():
+    # An interval spanning the whole strip leaves zero free segments — the
+    # trigger for `holes.py`'s whole-range-blocked fallback. Equivalent to the
+    # retired `_feasible_segments`'s `test_band_covering_everything_leaves_no_segment`.
+    from draftwright.annotations._common import carve_free_segments
+
+    assert carve_free_segments(40.0, 60.0, [(30.0, 70.0)], 0.0) == []
+
+
 def test_carve_then_plan_strip_keeps_a_label_off_a_reserved_row():
     # ADR 0009 Amendment 9 (#381): `plan_strip` no longer knows about keep-out
     # bands itself — a caller carves the band out of the strip with the same

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -437,20 +437,55 @@ def test_plan_strip_anchored_candidate_stays_on_its_natural():
     assert plain.placed["mid"] == pytest.approx(95.0)
 
 
-def test_plan_strip_forbidden_band_keeps_a_label_off_the_row():
-    # P4c (#318, Amendment 5): a `forbidden` keep-out band (centre, half_width) is a
-    # row the label may not sit on (a centre-line / dim extension line). A callout
-    # whose natural is on the band is seated off it; one already clear stays put.
+def test_carve_then_plan_strip_keeps_a_label_off_a_reserved_row():
+    # ADR 0009 Amendment 9 (#381): `plan_strip` no longer knows about keep-out
+    # bands itself — a caller carves the band out of the strip with the same
+    # `carve_free_segments` every other obstacle already uses, then calls
+    # `plan_strip` once per free segment (see `annotations/holes.py`). A label
+    # whose natural sits on the band lands in the nearer free segment, at its
+    # edge; one already clear stays put.
     import pytest
 
-    res = plan_strip(
-        [_cand("on", 50), _cand("clear", 80)], lo=0, hi=100, min_gap=5, forbidden=[(50.0, 8.0)]
-    )
-    assert res.placed["on"] == pytest.approx(42.0), "on-row label not moved off the band"
-    assert res.placed["clear"] == pytest.approx(80.0), "already-clear label should not move"
+    from draftwright.annotations._common import carve_free_segments
+
+    segs = carve_free_segments(0.0, 100.0, [(42.0, 58.0)], 0.0)
+    assert segs == [(0.0, 42.0), (58.0, 100.0)]
+    on = plan_strip([_cand("on", 50)], lo=0.0, hi=42.0, min_gap=5)
+    assert on.placed["on"] == pytest.approx(42.0), "on-row label not moved off the band"
+    clear = plan_strip([_cand("clear", 80)], lo=58.0, hi=100.0, min_gap=5)
+    assert clear.placed["clear"] == pytest.approx(80.0), "already-clear label should not move"
     # Without the band the on-row label stays on its natural.
-    plain = plan_strip([_cand("on", 50), _cand("clear", 80)], lo=0, hi=100, min_gap=5)
+    plain = plan_strip([_cand("on", 50)], lo=0, hi=100, min_gap=5)
     assert plain.placed["on"] == pytest.approx(50.0)
+
+
+def test_carve_around_a_band_keeps_an_anchored_candidate_on_its_natural():
+    # #381: the retired banded-DP kept one representative per labels-placed
+    # count, so a band could drag an `anchored` candidate off its natural when
+    # a cheaper-looking prefix (from an unrelated candidate) won the DP's
+    # pruning. Carving the band out first and solving each free segment
+    # independently (Amendment 9) resolves this BY CONSTRUCTION: an anchored
+    # candidate assigned to its own band-free segment is never in the same
+    # solve as anything the band would have forced a trade-off against.
+    # naturals [29, 34], gap 10, band (30, 33) — the DP's own reachable
+    # regression case (docs/adr/0009 Amendment 5) — with label 1 anchored.
+    import pytest
+
+    from draftwright.annotations._common import carve_free_segments
+
+    segs = carve_free_segments(0.0, 100.0, [(30.0, 33.0)], 0.0)
+    assert segs == [(0.0, 30.0), (33.0, 100.0)]
+    below = plan_strip([StripCandidate("below", (0.0, 29.0), (6, 3))], lo=0.0, hi=30.0, min_gap=10)
+    above = plan_strip(
+        [StripCandidate("above", (0.0, 34.0), (6, 3), anchored=True)],
+        lo=33.0,
+        hi=100.0,
+        min_gap=10,
+    )
+    assert below.placed["below"] == pytest.approx(29.0)
+    assert above.placed["above"] == pytest.approx(34.0), (
+        "anchored candidate dragged off its natural"
+    )
 
 
 def test_plan_strip_min_gap_floors_a_pair_smaller_than_it():

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -527,6 +527,22 @@ def test_carve_free_segments_no_bands_is_the_whole_strip():
     assert carve_free_segments(0.0, 100.0, [], 0.0) == [(0.0, 100.0)]
 
 
+def test_holes_band_clearance_exceeds_min_gap_on_the_real_draft():
+    # Guards the invariant docs/adr/0009's "Investigated, not fixed" paragraph
+    # relies on to call the cross-segment min_gap violation unreachable: a
+    # band's half-width (clr) must exceed min_gap on the actual production
+    # draft (builder.py's _assemble draft_preset() call), or that paragraph's
+    # reachability argument is wrong.
+    from build123d_drafting.helpers import draft_preset
+
+    from draftwright._core import _FONT_SIZE
+
+    draft = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
+    clr = draft.font_size + 3 * draft.pad_around_text
+    min_gap = draft.font_size + 2 * draft.pad_around_text
+    assert clr > min_gap
+
+
 def test_plan_strip_min_gap_floors_a_pair_smaller_than_it():
     # A pair whose sizes are both below the caller's min_gap floor must still get
     # at least min_gap of separation — min_gap is a floor, not just a fallback.

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -518,6 +518,15 @@ def test_carve_around_a_band_keeps_an_anchored_candidate_on_its_natural():
     )
 
 
+def test_carve_free_segments_no_bands_is_the_whole_strip():
+    # Equivalent to the retired `_feasible_segments`'s
+    # `test_no_bands_is_the_whole_strip` — the base case the other three
+    # carried-over cases (merge/clip/fully-covered) sit alongside.
+    from draftwright.annotations._common import carve_free_segments
+
+    assert carve_free_segments(0.0, 100.0, [], 0.0) == [(0.0, 100.0)]
+
+
 def test_plan_strip_min_gap_floors_a_pair_smaller_than_it():
     # A pair whose sizes are both below the caller's min_gap floor must still get
     # at least min_gap of separation — min_gap is a floor, not just a fallback.


### PR DESCRIPTION
## Summary
- Corrects Amendment 5's reachability claim for #381: the DP's anchor-vs-band gap is not gated by part class the way it looked — `holes.py`'s `reserved_rows` band source applies to prismatic parts too, independently of `_is_central`. A plain prismatic part (central hole + a nearby off-axis hole) hits it today.
- Records the decision (ADR 0009 Amendment 9): retire `_feasible_segments`/`_solve_strip_1d_pava_banded`. Fold keep-out bands into the general `carve_free_segments` occupancy carve every other pass already uses.
- Full analysis also posted to #381.

## Implementation
- `layout.py`: deletes `_feasible_segments`, `_snap_out_of_bands`, `_solve_strip_1d_pava_banded`; `plan_strip` drops its `forbidden=` parameter.
- `annotations/holes.py`'s `_place_queue` gains `_carve_and_place`, which carves band (and, on the second pass, band+real-obstacle) intervals via `carve_free_segments`, then does **global, priority-ordered assignment with live feasibility re-checks**: candidates are tried highest-priority-first, nearest segment first, accepted only when re-running the real per-segment solve on the trial membership drops nobody. This fixes #381 by construction — an anchored candidate assigned to its own carved segment never competes with a band.
- New regression test reproduces the issue's own example directly.

## Review-driven fixes (independent adversarial review, post-push)
An independent review found the first version of this fix had two real regressions, both confirmed by CI (all 17 matrix jobs failed) and reproduced directly:
1. **Capacity-oblivious nearest-segment assignment** — a candidate could be dropped in its nearest segment even when a farther segment had spare room (a regression against Policy B). Fixed with the global priority-ordered assignment described above.
2. **An unsafe single-pass snap fallback** reachable from the combined bands+obstacles carve, not just the band-only case it was built for — it could still land a callout inside a different blocking interval (a real overlap, caught by `test_section_clears_the_step_dim_ladder`). The snap is now gated to the band-only baseline pass only; the combined pass returns nothing on total blockage and cleanly defers to baseline instead.

Also fixed: a stale comment referencing the removed `forbidden=` parameter, and two ADR 0009 Amendment 9 claims that didn't match what shipped (status line said "pending"; overstated how shared the row-avoidance carve is with other passes — band declaration is still `holes.py`-only, not threaded through the shared corridor seam).

**Known gap, not blocking:** the review flagged that the regression tests exercise `carve_free_segments`/`plan_strip` directly, not `holes.py`'s actual `_place_queue`/`_carve_and_place` integration end-to-end. A real-geometry integration test for the capacity-spillover case specifically was attempted but abandoned (pattern-detection collapse + OCC build cost made it an unreliable, slow test to construct) — the fix is verified instead by direct algorithm reproduction of the reviewer's exact scenario, plus the two real regression tests now green (`test_section_clears_the_step_dim_ladder`, `test_layout_snapshot[dshape]`).

## Test plan
- [x] `pytest -m smoke` + targeted `test_layout.py`/`test_strip_layout.py`/`test_layout_snapshot.py`/`test_make_drawing.py::TestLocationDimsAndSection` — all green
- [x] `ruff check`, `ruff format --check`, `mypy` all clean
- [ ] CI full matrix (pushed, pending)