### PR TITLE
fix: clear pitch-dim labels off centerlines/bolt-circles at creation time (#129)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # 3.13+. Mirrors pzfreo/build123d-mcp's dependency handling.
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
-    "build123d-drafting-helpers>=0.13.0",
+    "build123d-drafting-helpers>=0.13.1",
     "numpy>=1.24",
     "reportlab>=4.0",
     "svglib>=1.5",

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -104,81 +104,72 @@ per-consumer choice, passed as ``crossable`` to :func:`strip_obstacles`."""
 
 
 def clear_label_of_centerlines(label_bbox, centerlines, gap):
-    """Cumulative ``label_offset_x`` so *label_bbox* clears every crossing
-    centre-line-family annotation in *centerlines* (#129) — both a turned part's
-    thin vertical/horizontal axis :class:`Centerline` and a bolt-circle's wide
-    :class:`CenterlineCircle`. Mirrors the overlap test
-    :func:`draftwright.linting.structural.lint_drawing` itself uses
-    (``label_centerline_overlap``): a thin line (extent < 0.1 mm in one axis) is
-    cleared past its midpoint by half the label width + *gap*; a wide bbox
-    (patterns/circles) is cleared past its nearer edge, and only when the two
-    boxes would actually overlap by more than 0.5 mm in **both** axes (the same
-    threshold the lint check flags). A thin **horizontal** line can't be cleared
-    by an X shift alone, so it is left to the lint/repair safety net.
+    """``label_offset_x`` so *label_bbox* clears every crossing centre-line-family
+    annotation in *centerlines* (#129) — both a turned part's thin vertical/
+    horizontal axis :class:`Centerline` and a bolt-circle's wide
+    :class:`CenterlineCircle`.
 
-    With more than one centre line, clearing the nearest-edge shift for one can
-    re-cross another already cleared — so this re-scans from scratch after every
-    single shift (a bounded fixed-point iteration, not a one-pass walk) rather
-    than compounding shifts blindly. This is a local search, not a joint solve:
-    when two centre lines sit closer together than the label needs to clear both
-    (rare — the two documented #129 sources, a part's one turning-axis line and a
-    pattern's own bolt circle, aren't normally that close), it can oscillate
-    between their two nearest edges and never find the single "go around both"
-    position that does exist further out; the iteration cap then returns
-    whichever total the last pass left it at (residual overlaps still surface via
-    lint, same safety net as the thin-horizontal-line case above)."""
+    Two steps. First, decide whether the label's UNSHIFTED position is already
+    fine: a crossing only counts past 0.5 mm of depth (a thin line, off its
+    midpoint) or overlap (a wide bbox) — the same threshold
+    :func:`draftwright.linting.structural.lint_drawing`'s
+    ``label_centerline_overlap`` flags — so a marginal graze the lint would not
+    flag leaves the label untouched. If nothing crosses by that measure, return
+    0.0 without moving anything.
+
+    Otherwise, every centre line the label's row (Y-extent) genuinely reaches —
+    *regardless of its own individual X depth* — becomes one forbidden interval
+    for the label's LEFT edge (`x`: the label occupies `[x, x+width]`, so it
+    clears a crossing's `[c0, c1]` by *gap* exactly when `x` is outside
+    `(c0-gap-width, c1+gap)`), carved from a generous span via
+    :func:`carve_free_segments` — the same occupancy-carve primitive this
+    module's other placers use for the dimension *line* itself. Including every
+    reachable centre line here, not just the ones individually past the 0.5 mm
+    threshold, matters: once the label is going to move at all, a centre line
+    it barely grazed at the ORIGINAL position can end up squarely inside the
+    NEW one — this joint carve accounts for all of them in one pass, so moving
+    to clear one can never expose a violation against another (the bug class
+    an earlier per-centre-line local-search design had, #129 second review). A
+    thin **horizontal** line can't be cleared by an X shift at all, so it is
+    excluded and left to the lint/repair safety net."""
     if label_bbox is None:
         return 0.0
     lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
+    label_w = lmax_x - lmin_x
     extents = []
+    natural_violation = False
     for cl in centerlines:
         if not getattr(cl, "is_centerline", False):
             continue
         try:
-            extents.append(_centerline_extent(cl))
+            cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl)
         except Exception:
             continue
-    total = 0.0
-    # 2x + 2 rather than a tight len(extents)+1: a converging case can legitimately
-    # need every one of len(extents)+1 passes (verified — 2 centrelines can take 3),
-    # which leaves no spare pass to confirm a full scan found nothing left to clear;
-    # the extra margin makes that confirmation pass affordable (still O(n^2) worst
-    # case on a handful of centrelines, not a real cost).
-    for _ in range(2 * len(extents) + 2):
-        eff_lmin_x, eff_lmax_x = lmin_x + total, lmax_x + total
-        shift = 0.0
-        for cl_min_x, cl_min_y, cl_max_x, cl_max_y in extents:
-            cl_w, cl_h = cl_max_x - cl_min_x, cl_max_y - cl_min_y
-            if cl_h < 0.1:
-                continue  # a horizontal line's clash can't be fixed by an X shift
-            oy = min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y)
-            if oy <= 0.5:
-                continue  # no real vertical overlap — matches the lint's own oy>0.5 gate
-            if cl_w < 0.1:
-                cl_x = (cl_min_x + cl_max_x) / 2.0
-                ox = (
-                    min(cl_x - eff_lmin_x, eff_lmax_x - cl_x)
-                    if eff_lmin_x < cl_x < eff_lmax_x
-                    else 0.0
-                )
-                if ox <= 0.5:
-                    continue  # matches the lint's own ox>0.5 gate for a thin line
-                half_w = (lmax_x - lmin_x) / 2.0
-                eff_cx = (eff_lmin_x + eff_lmax_x) / 2.0
-                shift_right = cl_x + half_w + gap - eff_cx
-                shift_left = cl_x - half_w - gap - eff_cx
-            else:
-                ox = min(eff_lmax_x, cl_max_x) - max(eff_lmin_x, cl_min_x)
-                if ox <= 0.5:
-                    continue
-                shift_right = (cl_max_x + gap) - eff_lmin_x
-                shift_left = (cl_min_x - gap) - eff_lmax_x
-            shift = shift_right if abs(shift_right) <= abs(shift_left) else shift_left
-            break
-        if shift == 0.0:
-            break
-        total += shift
-    return total
+        if cl_max_y - cl_min_y < 0.1:
+            continue  # a horizontal line's clash can't be fixed by an X shift
+        oy = min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y)
+        if oy <= 0.5:
+            continue  # no real vertical overlap — matches the lint's own oy>0.5 gate
+        extents.append((cl_min_x, cl_max_x))
+        if cl_max_x - cl_min_x < 0.1:
+            cl_x = (cl_min_x + cl_max_x) / 2.0
+            ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
+        else:
+            ox = min(lmax_x, cl_max_x) - max(lmin_x, cl_min_x)
+        natural_violation = natural_violation or ox > 0.5
+    if not natural_violation:
+        return 0.0  # already clear enough that the lint would not flag it
+    forbidden = [(cl_min_x - gap - label_w, cl_max_x + gap) for cl_min_x, cl_max_x in extents]
+    # A span this wide beyond every forbidden edge is free even if every interval
+    # merged into one contiguous run (their combined width can never exceed the
+    # sum of the individual widths) — carve_free_segments is therefore guaranteed
+    # a non-empty result; no defensive empty-result fallback needed.
+    total_w = sum(f1 - f0 for f0, f1 in forbidden) + label_w + 10.0
+    lo = min([lmin_x, *(f0 for f0, _ in forbidden)]) - total_w
+    hi = max([lmax_x, *(f1 for _, f1 in forbidden)]) + total_w
+    segs = carve_free_segments(lo, hi, forbidden, 0.0)
+    target_x = min((min(max(lmin_x, s0), s1) for s0, s1 in segs), key=lambda x: abs(x - lmin_x))
+    return target_x - lmin_x
 
 
 def strip_obstacles(dwg, view=None, *, crossable=()):

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from build123d_drafting.helpers import Dimension, SafeDimension
 
 from draftwright.layout import StripCandidate, plan_strip
+from draftwright.linting.structural import _centerline_extent
 
 _log = logging.getLogger(__name__)
 
@@ -102,23 +103,6 @@ and centre marks. A **leader**, by contrast, must avoid them (#305) — so this 
 per-consumer choice, passed as ``crossable`` to :func:`strip_obstacles`."""
 
 
-def _centerline_extent(cl):
-    """``(min_x, min_y, max_x, max_y)`` for a centre-line-family annotation.
-
-    Prefers the zero-width ``.segments`` (the true centre line) so a thin-faced
-    centreline still reads as a zero-width vertical/horizontal line; falls back
-    to the rendered ``.bounding_box()`` (which is line_width wide). A
-    :class:`CenterlineCircle`'s bbox is a full-diameter square, not zero-width in
-    either axis — callers must handle that case separately from the thin-line one."""
-    segs = getattr(cl, "segments", None)
-    if segs:
-        xs = [p[0] for s in segs for p in s]
-        ys = [p[1] for s in segs for p in s]
-        return (min(xs), min(ys), max(xs), max(ys))
-    bb = cl.bounding_box()
-    return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
-
-
 def clear_label_of_centerlines(label_bbox, centerlines, gap):
     """Cumulative ``label_offset_x`` so *label_bbox* clears every crossing
     centre-line-family annotation in *centerlines* (#129) — both a turned part's
@@ -130,38 +114,60 @@ def clear_label_of_centerlines(label_bbox, centerlines, gap):
     (patterns/circles) is cleared past its nearer edge, and only when the two
     boxes would actually overlap by more than 0.5 mm in **both** axes (the same
     threshold the lint check flags). A thin **horizontal** line can't be cleared
-    by an X shift alone, so it is left to the lint/repair safety net."""
+    by an X shift alone, so it is left to the lint/repair safety net.
+
+    With more than one centre line, clearing the nearest-edge shift for one can
+    re-cross another already cleared — so this re-scans from scratch after every
+    single shift (a bounded fixed-point iteration, not a one-pass walk) rather
+    than compounding shifts blindly. This is a local search, not a joint solve:
+    when two centre lines sit closer together than the label needs to clear both
+    (rare — the two documented #129 sources, a part's one turning-axis line and a
+    pattern's own bolt circle, aren't normally that close), it can oscillate
+    between their two nearest edges and never find the single "go around both"
+    position that does exist further out; the iteration cap then returns
+    whichever total the last pass left it at (residual overlaps still surface via
+    lint, same safety net as the thin-horizontal-line case above)."""
     if label_bbox is None:
         return 0.0
     lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
-    total = 0.0
+    extents = []
     for cl in centerlines:
         if not getattr(cl, "is_centerline", False):
             continue
         try:
-            cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl)
+            extents.append(_centerline_extent(cl))
         except Exception:
             continue
-        cl_w, cl_h = cl_max_x - cl_min_x, cl_max_y - cl_min_y
-        if cl_h < 0.1:
-            continue  # a horizontal line's clash can't be fixed by an X shift
+    total = 0.0
+    for _ in range(len(extents) + 1):
         eff_lmin_x, eff_lmax_x = lmin_x + total, lmax_x + total
-        if cl_w < 0.1:
-            cl_x = (cl_min_x + cl_max_x) / 2.0
-            if not (eff_lmin_x < cl_x < eff_lmax_x):
-                continue
-            half_w = (lmax_x - lmin_x) / 2.0
-            eff_cx = (eff_lmin_x + eff_lmax_x) / 2.0
-            shift_right = cl_x + half_w + gap - eff_cx
-            shift_left = cl_x - half_w - gap - eff_cx
-        else:
-            ox = min(eff_lmax_x, cl_max_x) - max(eff_lmin_x, cl_min_x)
+        shift = 0.0
+        for cl_min_x, cl_min_y, cl_max_x, cl_max_y in extents:
+            cl_w, cl_h = cl_max_x - cl_min_x, cl_max_y - cl_min_y
+            if cl_h < 0.1:
+                continue  # a horizontal line's clash can't be fixed by an X shift
             oy = min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y)
-            if ox <= 0.5 or oy <= 0.5:
-                continue
-            shift_right = (cl_max_x + gap) - eff_lmin_x
-            shift_left = (cl_min_x - gap) - eff_lmax_x
-        total += shift_right if abs(shift_right) <= abs(shift_left) else shift_left
+            if oy <= 0.5:
+                continue  # no real vertical overlap — matches the lint's own oy>0.5 gate
+            if cl_w < 0.1:
+                cl_x = (cl_min_x + cl_max_x) / 2.0
+                if not (eff_lmin_x < cl_x < eff_lmax_x):
+                    continue
+                half_w = (lmax_x - lmin_x) / 2.0
+                eff_cx = (eff_lmin_x + eff_lmax_x) / 2.0
+                shift_right = cl_x + half_w + gap - eff_cx
+                shift_left = cl_x - half_w - gap - eff_cx
+            else:
+                ox = min(eff_lmax_x, cl_max_x) - max(eff_lmin_x, cl_min_x)
+                if ox <= 0.5:
+                    continue
+                shift_right = (cl_max_x + gap) - eff_lmin_x
+                shift_left = (cl_min_x - gap) - eff_lmax_x
+            shift = shift_right if abs(shift_right) <= abs(shift_left) else shift_left
+            break
+        if shift == 0.0:
+            break
+        total += shift
     return total
 
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -139,7 +139,12 @@ def clear_label_of_centerlines(label_bbox, centerlines, gap):
         except Exception:
             continue
     total = 0.0
-    for _ in range(len(extents) + 1):
+    # 2x + 2 rather than a tight len(extents)+1: a converging case can legitimately
+    # need every one of len(extents)+1 passes (verified — 2 centrelines can take 3),
+    # which leaves no spare pass to confirm a full scan found nothing left to clear;
+    # the extra margin makes that confirmation pass affordable (still O(n^2) worst
+    # case on a handful of centrelines, not a real cost).
+    for _ in range(2 * len(extents) + 2):
         eff_lmin_x, eff_lmax_x = lmin_x + total, lmax_x + total
         shift = 0.0
         for cl_min_x, cl_min_y, cl_max_x, cl_max_y in extents:
@@ -151,8 +156,13 @@ def clear_label_of_centerlines(label_bbox, centerlines, gap):
                 continue  # no real vertical overlap — matches the lint's own oy>0.5 gate
             if cl_w < 0.1:
                 cl_x = (cl_min_x + cl_max_x) / 2.0
-                if not (eff_lmin_x < cl_x < eff_lmax_x):
-                    continue
+                ox = (
+                    min(cl_x - eff_lmin_x, eff_lmax_x - cl_x)
+                    if eff_lmin_x < cl_x < eff_lmax_x
+                    else 0.0
+                )
+                if ox <= 0.5:
+                    continue  # matches the lint's own ox>0.5 gate for a thin line
                 half_w = (lmax_x - lmin_x) / 2.0
                 eff_cx = (eff_lmin_x + eff_lmax_x) / 2.0
                 shift_right = cl_x + half_w + gap - eff_cx
@@ -295,6 +305,21 @@ def _box_hits(bb, boxes):
         if min(bb[2], c[2]) > max(bb[0], c[0]) and min(bb[3], c[3]) > max(bb[1], c[1]):
             return True
     return False
+
+
+def box_within_page_and_clear(bb, page_box, obstacles) -> bool:
+    """True when ``bb`` is fully inside *page_box* and hits none of *obstacles*
+    (:func:`_box_hits`) — the safety check a shifted label must pass before a
+    caller accepts it over an unshifted fallback (#129 review: this was inline
+    in ``holes.py``'s ``_clear_and_validate`` and untestable in isolation)."""
+    return (
+        bb is not None
+        and bb[0] >= page_box[0]
+        and bb[1] >= page_box[1]
+        and bb[2] <= page_box[2]
+        and bb[3] <= page_box[3]
+        and not _box_hits(bb, obstacles)
+    )
 
 
 def _segment_hits_box(p1, p2, box) -> bool:

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -102,6 +102,69 @@ and centre marks. A **leader**, by contrast, must avoid them (#305) — so this 
 per-consumer choice, passed as ``crossable`` to :func:`strip_obstacles`."""
 
 
+def _centerline_extent(cl):
+    """``(min_x, min_y, max_x, max_y)`` for a centre-line-family annotation.
+
+    Prefers the zero-width ``.segments`` (the true centre line) so a thin-faced
+    centreline still reads as a zero-width vertical/horizontal line; falls back
+    to the rendered ``.bounding_box()`` (which is line_width wide). A
+    :class:`CenterlineCircle`'s bbox is a full-diameter square, not zero-width in
+    either axis — callers must handle that case separately from the thin-line one."""
+    segs = getattr(cl, "segments", None)
+    if segs:
+        xs = [p[0] for s in segs for p in s]
+        ys = [p[1] for s in segs for p in s]
+        return (min(xs), min(ys), max(xs), max(ys))
+    bb = cl.bounding_box()
+    return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+
+
+def clear_label_of_centerlines(label_bbox, centerlines, gap):
+    """Cumulative ``label_offset_x`` so *label_bbox* clears every crossing
+    centre-line-family annotation in *centerlines* (#129) — both a turned part's
+    thin vertical/horizontal axis :class:`Centerline` and a bolt-circle's wide
+    :class:`CenterlineCircle`. Mirrors the overlap test
+    :func:`draftwright.linting.structural.lint_drawing` itself uses
+    (``label_centerline_overlap``): a thin line (extent < 0.1 mm in one axis) is
+    cleared past its midpoint by half the label width + *gap*; a wide bbox
+    (patterns/circles) is cleared past its nearer edge, and only when the two
+    boxes would actually overlap by more than 0.5 mm in **both** axes (the same
+    threshold the lint check flags). A thin **horizontal** line can't be cleared
+    by an X shift alone, so it is left to the lint/repair safety net."""
+    if label_bbox is None:
+        return 0.0
+    lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
+    total = 0.0
+    for cl in centerlines:
+        if not getattr(cl, "is_centerline", False):
+            continue
+        try:
+            cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl)
+        except Exception:
+            continue
+        cl_w, cl_h = cl_max_x - cl_min_x, cl_max_y - cl_min_y
+        if cl_h < 0.1:
+            continue  # a horizontal line's clash can't be fixed by an X shift
+        eff_lmin_x, eff_lmax_x = lmin_x + total, lmax_x + total
+        if cl_w < 0.1:
+            cl_x = (cl_min_x + cl_max_x) / 2.0
+            if not (eff_lmin_x < cl_x < eff_lmax_x):
+                continue
+            half_w = (lmax_x - lmin_x) / 2.0
+            eff_cx = (eff_lmin_x + eff_lmax_x) / 2.0
+            shift_right = cl_x + half_w + gap - eff_cx
+            shift_left = cl_x - half_w - gap - eff_cx
+        else:
+            ox = min(eff_lmax_x, cl_max_x) - max(eff_lmin_x, cl_min_x)
+            oy = min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y)
+            if ox <= 0.5 or oy <= 0.5:
+                continue
+            shift_right = (cl_max_x + gap) - eff_lmin_x
+            shift_left = (cl_min_x - gap) - eff_lmax_x
+        total += shift_right if abs(shift_right) <= abs(shift_left) else shift_left
+    return total
+
+
 def strip_obstacles(dwg, view=None, *, crossable=()):
     """The COMPLETE occupancy for strip placement (ADR 0009): every placed
     annotation's full rendered footprint, optionally restricted to *view*, minus

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -39,6 +39,7 @@ from draftwright.annotations._common import (
     _segment_hits_box,
     carve_free_position,
     carve_free_segments,
+    clear_label_of_centerlines,
     place_strip_candidates,
     register_corridor,
     strip_obstacles,
@@ -940,7 +941,7 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
         side, reach = max(cands, key=lambda c: c[0][0] * pref[0] + c[0][1] * pref[1])
     fallback_sides = [(side, reach)] + [c for c in cands if c[0] != side]
 
-    def _make(off, side_vec=side):
+    def _make(off, side_vec=side, label_offset_x=0.0):
         return _dim(
             (p1[0], p1[1], 0),
             (p2[0], p2[1], 0),
@@ -948,10 +949,23 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
             off,
             dwg.draft,
             label=f"{n - 1}× {_fmt(pitch)}",
+            label_offset_x=label_offset_x,
         )
 
+    def _clear(off, side_vec):
+        # Nudge the LABEL (not the line — a dim line crossing a centre line is
+        # fine, ISO 128) off any centre line / bolt-circle it would otherwise
+        # overlap (#129): a turned part's axis Centerline, or a pattern's
+        # CenterlineCircle, both already placed before pitch dims render.
+        dim = _make(off, side_vec)
+        centerlines = [
+            o for _, o in dwg.annotations_in_view(view) if getattr(o, "is_centerline", False)
+        ]
+        lox = clear_label_of_centerlines(dim.label_bbox, centerlines, gap=1.0)
+        return _make(off, side_vec, label_offset_x=lox) if lox else dim
+
     def _place(off, side_vec=side):
-        dwg.add(_make(off, side_vec), name, view=view, feature=feature)
+        dwg.add(_clear(off, side_vec), name, view=view, feature=feature)
 
     # Place onto the zone strip for the chosen side (#374): each side is its own strip, so the
     # obstacle-aware carve stacks this dim clear of placed content — where an arbitrary-direction
@@ -1034,6 +1048,20 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
                 continue
             if _box_hits(bb, obstacles):
                 continue
+            # Prefer the centre-line-cleared label (#129), but only if it still clears
+            # the page and every real obstacle — the shift moves label ink only, not
+            # the line, yet must be re-checked since it can widen the footprint.
+            cleared = _clear(offset, side_vec)
+            cbb = _geom_box(cleared)
+            if (
+                cbb is not None
+                and cbb[0] >= page_box[0]
+                and cbb[1] >= page_box[1]
+                and cbb[2] <= page_box[2]
+                and cbb[3] <= page_box[3]
+                and not _box_hits(cbb, obstacles)
+            ):
+                probe = cleared
             dwg.add(probe, name, view=view, feature=feature)
             return
     _log.info("Pitch dimension for the %s× %s array skipped (no room)", n, _fmt(pitch))

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -37,6 +37,7 @@ from draftwright.annotations._common import (
     _box_hits,
     _geom_box,
     _segment_hits_box,
+    box_within_page_and_clear,
     carve_free_position,
     carve_free_segments,
     clear_label_of_centerlines,
@@ -987,15 +988,7 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
         cleared, unshifted = _clear(off, side_vec, dim)
         if cleared is unshifted:
             return unshifted  # no shift applied — nothing to validate
-        lbb = cleared.label_bbox
-        if (
-            lbb is not None
-            and lbb[0] >= page_box[0]
-            and lbb[1] >= page_box[1]
-            and lbb[2] <= page_box[2]
-            and lbb[3] <= page_box[3]
-            and not _box_hits(lbb, obstacles)
-        ):
+        if box_within_page_and_clear(cleared.label_bbox, page_box, obstacles):
             return cleared
         return unshifted
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -970,7 +970,9 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
         centerlines = [
             o for _, o in dwg.annotations_in_view(view) if getattr(o, "is_centerline", False)
         ]
-        lox = clear_label_of_centerlines(dim.label_bbox, centerlines, gap=1.0)
+        lox = clear_label_of_centerlines(
+            dim.label_bbox, centerlines, gap=dwg.draft.pad_around_text
+        )
         if not lox:
             return dim, dim
         return _make(off, side_vec, label_offset_x=lox), dim

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -952,20 +952,62 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
             label_offset_x=label_offset_x,
         )
 
-    def _clear(off, side_vec):
+    def _clear(off, side_vec, dim=None):
         # Nudge the LABEL (not the line — a dim line crossing a centre line is
-        # fine, ISO 128) off any centre line / bolt-circle it would otherwise
-        # overlap (#129): a turned part's axis Centerline, or a pattern's
-        # CenterlineCircle, both already placed before pitch dims render.
-        dim = _make(off, side_vec)
+        # fine, ISO 128) off any centre line / bolt-circle already placed in this
+        # view (#129): a turned part's axis Centerline, or a pattern's own
+        # CenterlineCircle. Not a complete guarantee — furniture for OTHER
+        # patterns sharing this view may render after this dim, so a sibling
+        # pattern's CenterlineCircle can still be missed; #129 only covers the
+        # cases verified reachable (this dim's own pattern + any turned-axis line).
+        # Returns (final, unshifted): `_make` builds real OCC geometry (a boolean
+        # fuse per dim, #129 review — a production part hit a 120s single-op
+        # timeout after this went from one build to three per placement), so a
+        # caller that already has the unshifted dim passes it in as `dim` rather
+        # than have it rebuilt here.
+        dim = dim if dim is not None else _make(off, side_vec)
         centerlines = [
             o for _, o in dwg.annotations_in_view(view) if getattr(o, "is_centerline", False)
         ]
         lox = clear_label_of_centerlines(dim.label_bbox, centerlines, gap=1.0)
-        return _make(off, side_vec, label_offset_x=lox) if lox else dim
+        if not lox:
+            return dim, dim
+        return _make(off, side_vec, label_offset_x=lox), dim
+
+    def _clear_and_validate(off, side_vec, page_box, obstacles, dim=None):
+        # The clearing shift moves label ink only — the dimension LINE (p1..p2, the
+        # bulk of _geom_box's footprint) is unchanged and was never gated against
+        # `obstacles` on this path in the first place (the strip carve's own
+        # occupancy model is what makes the line's tier safe, a coarser guarantee
+        # `_box_hits` doesn't share — checking the full geometry here rejected valid
+        # shifts whenever the line's own extension routing already crossed another
+        # dim's, which is normal and unrelated to the label). So re-check only the
+        # LABEL's own bbox — the thing that actually moved — against the page and
+        # every real obstacle, falling back to the unshifted dim otherwise.
+        cleared, unshifted = _clear(off, side_vec, dim)
+        if cleared is unshifted:
+            return unshifted  # no shift applied — nothing to validate
+        lbb = cleared.label_bbox
+        if (
+            lbb is not None
+            and lbb[0] >= page_box[0]
+            and lbb[1] >= page_box[1]
+            and lbb[2] <= page_box[2]
+            and lbb[3] <= page_box[3]
+            and not _box_hits(lbb, obstacles)
+        ):
+            return cleared
+        return unshifted
 
     def _place(off, side_vec=side):
-        dwg.add(_clear(off, side_vec), name, view=view, feature=feature)
+        page_box = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
+        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+        dwg.add(
+            _clear_and_validate(off, side_vec, page_box, obstacles),
+            name,
+            view=view,
+            feature=feature,
+        )
 
     # Place onto the zone strip for the chosen side (#374): each side is its own strip, so the
     # obstacle-aware carve stacks this dim clear of placed content — where an arbitrary-direction
@@ -1048,21 +1090,12 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
                 continue
             if _box_hits(bb, obstacles):
                 continue
-            # Prefer the centre-line-cleared label (#129), but only if it still clears
-            # the page and every real obstacle — the shift moves label ink only, not
-            # the line, yet must be re-checked since it can widen the footprint.
-            cleared = _clear(offset, side_vec)
-            cbb = _geom_box(cleared)
-            if (
-                cbb is not None
-                and cbb[0] >= page_box[0]
-                and cbb[1] >= page_box[1]
-                and cbb[2] <= page_box[2]
-                and cbb[3] <= page_box[3]
-                and not _box_hits(cbb, obstacles)
-            ):
-                probe = cleared
-            dwg.add(probe, name, view=view, feature=feature)
+            dwg.add(
+                _clear_and_validate(offset, side_vec, page_box, obstacles, probe),
+                name,
+                view=view,
+                feature=feature,
+            )
             return
     _log.info("Pitch dimension for the %s× %s array skipped (no room)", n, _fmt(pitch))
 

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1244,12 +1244,11 @@ def test_clear_label_of_centerlines_clears_two_well_separated_centerlines():
 
 def test_clear_label_of_centerlines_recovers_from_a_cascading_re_violation():
     # #129 second review: the "well separated" case above never actually exercises the
-    # re-crossing bug the multi-pass fix targets, since the two centrelines there never
-    # interact — the old single-pass algorithm passes it unchanged. This case genuinely
-    # distinguishes them: clearing cl1(x=0) alone lands the label on cl2(x=6); the OLD
-    # single forward pass then clears cl2 and stops, leaving cl1 re-violated (verified:
-    # the old algorithm returns -5.0 here, which still overlaps cl1). The new bounded
-    # re-scan keeps going and finds 7.0, which clears both.
+    # re-crossing bug a naive per-centreline local search has, since the two centrelines
+    # there never interact. This case genuinely distinguishes them: clearing cl1(x=0)
+    # alone lands the label on cl2(x=6). A single forward pass that clears cl2 and stops
+    # would leave cl1 re-violated; the joint carve (#129 third review — every reachable
+    # centreline is carved out in one pass, not walked one at a time) clears both.
     from draftwright.annotations._common import clear_label_of_centerlines
 
     cl1 = _FakeCenterline(0, -100, 0, 100)
@@ -1260,20 +1259,22 @@ def test_clear_label_of_centerlines_recovers_from_a_cascading_re_violation():
     assert not (lo < 6 < hi), "still overlaps the second centerline"
 
 
-def test_clear_label_of_centerlines_degrades_safely_on_a_tight_squeeze():
-    # #129 second review: the docstring documents that two centrelines closer together
-    # than the label needs to clear both can defeat this local search (it can oscillate
-    # rather than find the "go around both" position further out) — but nothing verified
-    # that documented degradation is actually SAFE (bounded, finite, doesn't crash) rather
-    # than just asserted in prose. label width 10 vs a 9mm gap between the centrelines is
-    # geometrically infeasible for ANY single-side clearance, by construction.
+def test_clear_label_of_centerlines_solves_a_tight_squeeze():
+    # #129 third review: a per-centreline local search (nearest-edge, one at a time) could
+    # defeat itself when two centrelines sit closer together than the label needs to clear
+    # both — label width 10 vs a 9mm gap between the centrelines here is exactly that case,
+    # with no position that clears both by hugging either one individually. The joint carve
+    # (clear_label_of_centerlines routes through carve_free_segments, exactly like the
+    # dimension LINE's own placement elsewhere in this module) finds the "go around both"
+    # position that does exist further out — this is now solved, not just bounded/safe.
     from draftwright.annotations._common import clear_label_of_centerlines
 
     cl1 = _FakeCenterline(5, -100, 5, 100)
     cl2 = _FakeCenterline(14, -100, 14, 100)
     total = clear_label_of_centerlines((0, 0, 10, 10), [cl1, cl2], gap=1)
-    assert isinstance(total, float)
-    assert abs(total) < 1000, f"expected a bounded best-effort result, got {total}"
+    lo, hi = total, 10 + total
+    assert not (lo < 5 < hi), "still overlaps the first centerline"
+    assert not (lo < 14 < hi), "still overlaps the second centerline"
 
 
 def test_box_within_page_and_clear_rejects_a_shift_that_hits_an_obstacle():

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1100,3 +1100,56 @@ def test_corridor_orders_location_ladder_monotonically():
     assert tiers == sorted(tiers) or tiers == sorted(tiers, reverse=True), (
         f"location ladder not monotonic by span (interleaved, #346): {sorted(rungs)}"
     )
+
+
+def _pitch_dim_over_centerline(centerline_obj, centerline_name):
+    # Shared #129 repro: a plate whose 2-hole pitch dim naturally centres its label at
+    # plan_x(0) — then a centre-line-family annotation is placed exactly there, in the
+    # strip the dim will land in, before `_place_pitch_dim` runs (mirrors real render
+    # order: centre marks/circles are placed before pitch dims). Returns the placed
+    # dim and the (now-cleared) lint issues against that one centerline.
+    from build123d import Box, Cylinder, Pos
+
+    from draftwright.annotations.holes import _place_pitch_dim, build_view_of_axis
+    from draftwright.linting.structural import _lint_centerline_dim_overlap
+
+    part = Box(100, 50, 10)
+    for x in (-30, 30):
+        part = part - Pos(x, 0, 0) * Cylinder(3, 10)
+    dwg = build_drawing(part)
+    a = dwg._analysis
+    view, to_page = build_view_of_axis(a)["z"]
+    dwg.add(centerline_obj, centerline_name, view="plan")
+    _place_pitch_dim(dwg, a, "plan", (-30, 0, 0), (30, 0, 0), 2, 60, to_page, "test_pitch")
+    dim = dwg.get_annotation("test_pitch")
+    cl = dwg.get_annotation(centerline_name)
+    issues = []
+    _lint_centerline_dim_overlap(dim, cl, issues)
+    return dim, issues
+
+
+def test_pitch_dim_label_clears_a_thin_vertical_centerline():
+    # #129: a turned part's axis Centerline (drawn full-height through the view, e.g.
+    # `render_rotational`'s centerline_front/side) sits right where a symmetric 2-hole
+    # pitch dim's label would naturally centre. `_place_pitch_dim` must offset the label
+    # off it at creation time, not rely on the lint→repair loop.
+    from build123d_drafting import Centerline
+
+    part_cx = 85.1919925875  # a.proj.plan_x(0) for the Box(100,50,10) fixture below
+    cl = Centerline((part_cx, 150, 0), (part_cx, 300, 0))
+    dim, issues = _pitch_dim_over_centerline(cl, "test_centerline")
+    assert dim._dw_spec.kwargs.get("label_offset_x", 0.0) != 0.0, "label was not shifted"
+    assert issues == [], f"label still overlaps the centerline: {[i.message for i in issues]}"
+
+
+def test_pitch_dim_label_clears_a_bolt_circle_centerline():
+    # #129 (broader scope): a bolt-circle pattern's CenterlineCircle is wide, not a thin
+    # line — `_compute_label_offset_x`-style midpoint logic alone doesn't cover it. The
+    # same creation-time clearing must also push the label past the circle's nearer edge.
+    from build123d_drafting import CenterlineCircle
+
+    part_cx = 85.1919925875
+    cl = CenterlineCircle((part_cx, 222.5), 30)
+    dim, issues = _pitch_dim_over_centerline(cl, "test_circle")
+    assert dim._dw_spec.kwargs.get("label_offset_x", 0.0) != 0.0, "label was not shifted"
+    assert issues == [], f"label still overlaps the bolt circle: {[i.message for i in issues]}"

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1227,19 +1227,46 @@ def test_clear_label_of_centerlines_requires_real_depth_not_just_containment():
     assert got == 0.0
 
 
-def test_clear_label_of_centerlines_clears_two_well_separated_centerlines():
-    # #129 review: a single forward pass over multiple centerlines could clear one and
-    # silently re-cross an earlier one already cleared. With two centerlines far enough
-    # apart that a position clearing both exists, the result must clear both — not just
-    # whichever was processed last.
+def test_clear_label_of_centerlines_merges_adjacent_forbidden_intervals():
+    # #129 fourth review: the joint carve routes through carve_free_segments, which only
+    # merges forbidden intervals that actually touch/overlap — two close-together
+    # centerlines (5 and 8) produce overlapping forbidden zones that must merge into ONE
+    # block, while a third, distant one (50) stays separate and must not disturb the
+    # result. Exercises the interval-merge path a 2-centerline case can't distinguish from
+    # a correct implementation (superseded the old "two well separated centerlines" case,
+    # which no longer stresses anything a harder test doesn't already cover).
     from draftwright.annotations._common import clear_label_of_centerlines
 
-    cl1 = _FakeCenterline(3, -10, 3, 20)
-    cl2 = _FakeCenterline(43, -10, 43, 20)
-    total = clear_label_of_centerlines((0, 0, 10, 10), [cl1, cl2], gap=1)
+    cl1 = _FakeCenterline(5, -100, 5, 100)
+    cl2 = _FakeCenterline(8, -100, 8, 100)
+    cl3 = _FakeCenterline(50, -100, 50, 100)
+    total = clear_label_of_centerlines((0, 0, 10, 10), [cl1, cl2, cl3], gap=1)
     lo, hi = total, 10 + total
-    assert not (lo < 3 < hi), "still overlaps the first centerline"
-    assert not (lo < 43 < hi), "still overlaps the second centerline"
+    assert not (lo < 5 < hi), "still overlaps the first (merged-block) centerline"
+    assert not (lo < 8 < hi), "still overlaps the second (merged-block) centerline"
+    assert not (lo < 50 < hi), "still overlaps the distant, separate centerline"
+
+
+def test_clear_label_of_centerlines_folds_in_a_centerline_that_only_grazed_the_natural_position():
+    # #129 fourth review: the docstring's core claim about why every reachable centerline
+    # is carved (not just the ones individually past the 0.5mm natural-position threshold)
+    # is that a centerline with ZERO overlap at the natural position can still end up
+    # inside the position a shift lands on. Proven here: with only cl_v, the nearest clear
+    # position is -6.0 (verified below); placing cl_graze exactly where that landing spot
+    # would be (and nowhere near the natural [0,10] position, so it contributes nothing to
+    # the natural-violation check) must change the outcome to a position clearing both.
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    cl_v = _FakeCenterline(5, -100, 5, 100)
+    solo = clear_label_of_centerlines((0, 0, 10, 10), [cl_v], gap=1)
+    assert solo == -6.0, f"solo-centerline baseline drifted (was -6.0), got {solo}"
+
+    cl_graze = _FakeCenterline(-3, -100, -3, 100)  # inside [-6, 4], outside natural [0, 10]
+    both = clear_label_of_centerlines((0, 0, 10, 10), [cl_v, cl_graze], gap=1)
+    assert both != solo, "the graze centerline was not folded into the forbidden set"
+    lo, hi = both, 10 + both
+    assert not (lo < 5 < hi), "still overlaps cl_v"
+    assert not (lo < -3 < hi), "still overlaps the folded-in graze centerline"
 
 
 def test_clear_label_of_centerlines_recovers_from_a_cascading_re_violation():

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1102,12 +1102,14 @@ def test_corridor_orders_location_ladder_monotonically():
     )
 
 
-def _pitch_dim_over_centerline(centerline_obj, centerline_name):
+def _pitch_dim_over_centerline(centerline_factory, centerline_name):
     # Shared #129 repro: a plate whose 2-hole pitch dim naturally centres its label at
-    # plan_x(0) — then a centre-line-family annotation is placed exactly there, in the
-    # strip the dim will land in, before `_place_pitch_dim` runs (mirrors real render
-    # order: centre marks/circles are placed before pitch dims). Returns the placed
-    # dim and the (now-cleared) lint issues against that one centerline.
+    # plan_x(0) — then a centre-line-family annotation is placed exactly there (computed
+    # live via a.proj.plan_x(0), not a hardcoded page coordinate, so this stays correct if
+    # unrelated layout/margin/scale logic ever shifts it), in the strip the dim will land
+    # in, before `_place_pitch_dim` runs (mirrors real render order: centre marks/circles
+    # are placed before pitch dims). Returns the placed dim and the (now-cleared) lint
+    # issues against that one centerline.
     from build123d import Box, Cylinder, Pos
 
     from draftwright.annotations.holes import _place_pitch_dim, build_view_of_axis
@@ -1119,7 +1121,8 @@ def _pitch_dim_over_centerline(centerline_obj, centerline_name):
     dwg = build_drawing(part)
     a = dwg._analysis
     view, to_page = build_view_of_axis(a)["z"]
-    dwg.add(centerline_obj, centerline_name, view="plan")
+    part_cx = a.proj.plan_x(0)
+    dwg.add(centerline_factory(part_cx), centerline_name, view="plan")
     _place_pitch_dim(dwg, a, "plan", (-30, 0, 0), (30, 0, 0), 2, 60, to_page, "test_pitch")
     dim = dwg.get_annotation("test_pitch")
     cl = dwg.get_annotation(centerline_name)
@@ -1135,9 +1138,9 @@ def test_pitch_dim_label_clears_a_thin_vertical_centerline():
     # off it at creation time, not rely on the lint→repair loop.
     from build123d_drafting import Centerline
 
-    part_cx = 85.1919925875  # a.proj.plan_x(0) for the Box(100,50,10) fixture below
-    cl = Centerline((part_cx, 150, 0), (part_cx, 300, 0))
-    dim, issues = _pitch_dim_over_centerline(cl, "test_centerline")
+    dim, issues = _pitch_dim_over_centerline(
+        lambda cx: Centerline((cx, 150, 0), (cx, 300, 0)), "test_centerline"
+    )
     assert dim._dw_spec.kwargs.get("label_offset_x", 0.0) != 0.0, "label was not shifted"
     assert issues == [], f"label still overlaps the centerline: {[i.message for i in issues]}"
 
@@ -1148,8 +1151,75 @@ def test_pitch_dim_label_clears_a_bolt_circle_centerline():
     # same creation-time clearing must also push the label past the circle's nearer edge.
     from build123d_drafting import CenterlineCircle
 
-    part_cx = 85.1919925875
-    cl = CenterlineCircle((part_cx, 222.5), 30)
-    dim, issues = _pitch_dim_over_centerline(cl, "test_circle")
+    dim, issues = _pitch_dim_over_centerline(
+        lambda cx: CenterlineCircle((cx, 222.5), 30), "test_circle"
+    )
     assert dim._dw_spec.kwargs.get("label_offset_x", 0.0) != 0.0, "label was not shifted"
     assert issues == [], f"label still overlaps the bolt circle: {[i.message for i in issues]}"
+
+
+class _FakeCenterline:
+    # A minimal is_centerline-family stand-in for direct clear_label_of_centerlines()
+    # unit tests below — controls the extent exactly (no build123d geometry needed),
+    # matching the codebase's existing formula-level test pattern (e.g.
+    # test_carve_free_segments_*).
+    def __init__(self, x0, y0, x1, y1):
+        self.is_centerline = True
+        self.segments = [((x0, y0), (x1, y1))]
+
+
+def test_clear_label_of_centerlines_picks_the_nearer_side_not_just_any_clearing_side():
+    # #129 review: a purely-symmetric repro (centreline dead-centre on the label) can't
+    # tell a correct minimal-distance shift from a same-magnitude wrong-direction one — both
+    # clear equally well. Use an OFF-CENTRE thin line so the two directions have different
+    # magnitudes, and assert the exact expected minimal shift (not just "some shift").
+    import pytest
+
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    # label x in [0,20] (half-width 10, centred at 10); thin vertical line at x=5, gap=2.
+    # shift_right = 5+10+2-10 = 7 (clears past the line's right side); shift_left = -17
+    # (clears past its left side) — right is nearer, so 7.0 is the only correct answer.
+    got = clear_label_of_centerlines((0, 0, 20, 10), [_FakeCenterline(5, -100, 5, 100)], gap=2)
+    assert got == pytest.approx(7.0)
+
+
+def test_clear_label_of_centerlines_picks_the_nearer_edge_of_a_wide_bbox():
+    # Same direction-sensitivity check for the CenterlineCircle/wide-bbox branch.
+    import pytest
+
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    # label x in [0,20]; wide bbox spans x in [8,40] (a bolt circle straddling the label's
+    # right portion). Clearing past its left edge (8) is much nearer than past its right
+    # edge (40), so the only correct answer is the left-edge shift.
+    got = clear_label_of_centerlines((0, 0, 20, 10), [_FakeCenterline(8, -50, 40, 50)], gap=2)
+    assert got == pytest.approx(-14.0)
+
+
+def test_clear_label_of_centerlines_requires_real_y_overlap():
+    # #129 review: the thin-line branch used to shift on X-containment alone, without
+    # checking the label's Y-range actually overlaps the line's Y-extent — unlike the
+    # lint check it mirrors. A centreline nowhere near the label vertically must not
+    # trigger any shift.
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    got = clear_label_of_centerlines(
+        (10, 10, 30, 20), [_FakeCenterline(15, 1000, 15, 1100)], gap=1
+    )
+    assert got == 0.0
+
+
+def test_clear_label_of_centerlines_clears_two_well_separated_centerlines():
+    # #129 review: a single forward pass over multiple centerlines could clear one and
+    # silently re-cross an earlier one already cleared. With two centerlines far enough
+    # apart that a position clearing both exists, the result must clear both — not just
+    # whichever was processed last.
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    cl1 = _FakeCenterline(3, -10, 3, 20)
+    cl2 = _FakeCenterline(43, -10, 43, 20)
+    total = clear_label_of_centerlines((0, 0, 10, 10), [cl1, cl2], gap=1)
+    lo, hi = total, 10 + total
+    assert not (lo < 3 < hi), "still overlaps the first centerline"
+    assert not (lo < 43 < hi), "still overlaps the second centerline"

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1210,6 +1210,23 @@ def test_clear_label_of_centerlines_requires_real_y_overlap():
     assert got == 0.0
 
 
+def test_clear_label_of_centerlines_requires_real_depth_not_just_containment():
+    # #129 second review: the thin-line branch shifted on bare X-containment, with no
+    # minimum-depth requirement — unlike the wide-bbox branch (ox<=0.5: continue) and the
+    # lint check both branches are meant to mirror. A marginal (<=0.5mm) containment must
+    # not trigger a shift — especially since a shift here can land the label ON a SECOND,
+    # previously-clear centreline, creating a worse violation than doing nothing.
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    # cl1 is only 0.2mm inside the label (not a real lint violation); cl2 doesn't overlap
+    # the label at all originally. Before the fix this returned 1.2 (shifting onto cl2).
+    lbb = (-0.2, 0, 3.8, 10)
+    cl1 = _FakeCenterline(0, -100, 0, 100)
+    cl2 = _FakeCenterline(4.0, -100, 4.0, 100)
+    got = clear_label_of_centerlines(lbb, [cl1, cl2], gap=1)
+    assert got == 0.0
+
+
 def test_clear_label_of_centerlines_clears_two_well_separated_centerlines():
     # #129 review: a single forward pass over multiple centerlines could clear one and
     # silently re-cross an earlier one already cleared. With two centerlines far enough
@@ -1223,3 +1240,55 @@ def test_clear_label_of_centerlines_clears_two_well_separated_centerlines():
     lo, hi = total, 10 + total
     assert not (lo < 3 < hi), "still overlaps the first centerline"
     assert not (lo < 43 < hi), "still overlaps the second centerline"
+
+
+def test_clear_label_of_centerlines_recovers_from_a_cascading_re_violation():
+    # #129 second review: the "well separated" case above never actually exercises the
+    # re-crossing bug the multi-pass fix targets, since the two centrelines there never
+    # interact — the old single-pass algorithm passes it unchanged. This case genuinely
+    # distinguishes them: clearing cl1(x=0) alone lands the label on cl2(x=6); the OLD
+    # single forward pass then clears cl2 and stops, leaving cl1 re-violated (verified:
+    # the old algorithm returns -5.0 here, which still overlaps cl1). The new bounded
+    # re-scan keeps going and finds 7.0, which clears both.
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    cl1 = _FakeCenterline(0, -100, 0, 100)
+    cl2 = _FakeCenterline(6, -100, 6, 100)
+    total = clear_label_of_centerlines((0, 0, 10, 10), [cl1, cl2], gap=1)
+    lo, hi = total, 10 + total
+    assert not (lo < 0 < hi), "still overlaps the first centerline (the old-algorithm bug)"
+    assert not (lo < 6 < hi), "still overlaps the second centerline"
+
+
+def test_clear_label_of_centerlines_degrades_safely_on_a_tight_squeeze():
+    # #129 second review: the docstring documents that two centrelines closer together
+    # than the label needs to clear both can defeat this local search (it can oscillate
+    # rather than find the "go around both" position further out) — but nothing verified
+    # that documented degradation is actually SAFE (bounded, finite, doesn't crash) rather
+    # than just asserted in prose. label width 10 vs a 9mm gap between the centrelines is
+    # geometrically infeasible for ANY single-side clearance, by construction.
+    from draftwright.annotations._common import clear_label_of_centerlines
+
+    cl1 = _FakeCenterline(5, -100, 5, 100)
+    cl2 = _FakeCenterline(14, -100, 14, 100)
+    total = clear_label_of_centerlines((0, 0, 10, 10), [cl1, cl2], gap=1)
+    assert isinstance(total, float)
+    assert abs(total) < 1000, f"expected a bounded best-effort result, got {total}"
+
+
+def test_box_within_page_and_clear_rejects_a_shift_that_hits_an_obstacle():
+    # #129 second review: holes.py's _clear_and_validate falls back to the unshifted dim
+    # when a shift would leave the page or hit a real obstacle, but that closure is not
+    # independently callable — nothing exercised the rejection branch. The check itself
+    # is a small pure predicate (box_within_page_and_clear), factored out for exactly this.
+    from draftwright.annotations._common import box_within_page_and_clear
+
+    page_box = (0, 0, 100, 100)
+    obstacles = [(40, 40, 60, 60)]
+    assert box_within_page_and_clear((10, 10, 20, 20), page_box, obstacles), "clear box rejected"
+    assert not box_within_page_and_clear((45, 45, 55, 55), page_box, obstacles), (
+        "obstacle-hitting box accepted"
+    )
+    assert not box_within_page_and_clear((-5, 10, 5, 20), page_box, obstacles), (
+        "off-page box accepted"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -142,15 +142,15 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.13.0"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/6b/c33c8f3aeb31984e3c8734b943a7ddce1b94c1b7397e0a0bc753636c04b5/build123d_drafting_helpers-0.13.0.tar.gz", hash = "sha256:3202612609f76f1cdc5b41263d8d1e929b3c52ffb7046f08fabb811fbf0423ea", size = 343336, upload-time = "2026-06-27T08:43:58.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/22/fb9562b73ff68bc6131d8202ffc95b0e89085c8c4e2f89055cca9e214955/build123d_drafting_helpers-0.13.1.tar.gz", hash = "sha256:373b8f6f39e0b0588664f60ede7c4ea72c291744d9451ff97ad02b0757ac4237", size = 341527, upload-time = "2026-07-11T07:14:34.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/e6/b20ad04c7d2d57bdaede8d129578522caa9d50ed176a4bbcf4b3f74822b0/build123d_drafting_helpers-0.13.0-py3-none-any.whl", hash = "sha256:61968f588c953ebfcc819e9e06f78147e381cb1bcd41cb54282ce2544efc5083", size = 284337, upload-time = "2026-06-27T08:43:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/71/13/38f7426c15e4dd962f2cd1cda4c59ebf9a5b5bf9d4374a3bcb416b1d476f/build123d_drafting_helpers-0.13.1-py3-none-any.whl", hash = "sha256:c73f3271111676849bc8fb151c6f182027c3a0e457ad15f5648be72d07ebf86b", size = 283958, upload-time = "2026-07-11T07:14:33.14Z" },
 ]
 
 [[package]]
@@ -693,7 +693,7 @@ dev = [
 requires-dist = [
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.13.0" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.13.1" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "svglib", specifier = ">=1.5" },


### PR DESCRIPTION
## Summary
- `_place_pitch_dim` (LinearArray + RectGrid pitch dims) now offsets its label off any already-placed centre-line-family annotation in its view — at creation time, per ADR 0002 (repair is a safety net, not the primary placement mechanism), superseding the #119 repair-loop approach that #129 documented as broken.
- New `clear_label_of_centerlines()` (`annotations/_common.py`) mirrors the lint's own `label_centerline_overlap` test exactly and handles **both** shapes: a thin vertical/horizontal `Centerline` (turned-part axis line) and a wide `CenterlineCircle` (bolt-circle pattern) — broader than the issue's originally-suggested `helpers._compute_label_offset_x`, which only covers the thin-line case.
- Verified against real geometry both directions (fails without the fix, passes with it) — not just the formula in isolation.

## Out of scope
CTC-02 still shows `label_centerline_overlap` warnings after this fix. Traced to a *different*, unrelated collision: a pitch-dim label against a hole-table balloon marker (`Compound`, which unexpectedly also carries `is_centerline=True`). Not something #129 covers; flagging for a possible follow-up issue rather than expanding scope here.

## Test plan
- [x] `tests/test_strip_layout.py` — 52/52 (2 new regression tests, both verified to fail with the fix reverted)
- [x] `tests/test_layout_cleanliness.py` — 20/20
- [x] `tests/test_layout_snapshot.py` — 10/10 (byte-identical, no shift in the 9-part corpus)
- [x] `ruff format --check`, `ruff check`, `mypy` — clean
- [ ] CI (3×3 OS/Python matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)