### PR TITLE
docs: ADR 0013 — b123d-recognisers shared geometry-only recognition package

### DIFF
--- a/docs/adr/0007-own-recognition-and-linting.md
+++ b/docs/adr/0007-own-recognition-and-linting.md
@@ -1,7 +1,11 @@
 # ADR 0007 — draftwright owns feature recognition and linting; helpers becomes the rendering library
 
 - **Status:** Accepted (recognition + linting vendored; `recognition/` and
-  `linting/` are the live homes; the golden harness was retired here)
+  `linting/` are the live homes; the golden harness was retired here).
+  **Amendment 1** (2026-07-12): the long-term home for *recognition* sharpens — it
+  becomes an extraction-ready, Apache-clean subpackage destined for a standalone
+  shared package `b123d-recognisers` (ADR 0013). helpers stays render-only; the
+  render-vs-reason boundary is unchanged.
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -161,3 +165,26 @@ The provenance note (§3) is for honesty, not legal necessity.
 - Trigger: turned-part axial step-length dimensioning (the drive-screw gap —
   every diameter dimensioned, no shoulder locatable; `find_bosses` length
   semantics wrong for the consumer).
+
+## Amendment 1 — recognition's long-term home is a shared package (2026-07-12)
+
+ADR 0013 refines where *recognition* ultimately lives, without reversing this ADR.
+
+This ADR's reasoning — "recognition is *reasoning*; it belongs with the reasoner,
+not the *rendering* library (helpers)" — was answered by vendoring recognition into
+draftwright. A second consumer has since appeared: `pzfreo/build123d-mcp` needs the
+same recognisers to **edit** solids it did not build (recover feature intent from
+geometry), and is duplicating them (a countersink recogniser, and a fork onto the
+now-deprecated helpers `find_holes`). That changes the calculus this ADR did not
+anticipate: recognition is no longer draftwright-specific.
+
+The refinement (ADR 0013): recognition's long-term home is a **standalone,
+Apache-licensed, geometry-only package `b123d-recognisers`**, not helpers and not
+permanently-internal draftwright code. This is **not** a reversal — 0007's boundary was
+"not in the *rendering* library", and `b123d-recognisers` is a *recognition* library, a
+different thing; helpers stays render-only. Sequencing keeps this ADR's anti-cross-repo-
+release principle intact: **Phase 1** makes draftwright's `recognition/` uniform and
+extraction-ready but stays internal (no new external dependency, no release wall);
+**Phase 2** extracts to the package only when a second consumer commits. mcp is a slow
+follower — not coupled until it chooses to adopt. Linting is untouched by ADR 0013 and
+remains draftwright-owned per this ADR.

--- a/docs/adr/0007-own-recognition-and-linting.md
+++ b/docs/adr/0007-own-recognition-and-linting.md
@@ -3,9 +3,10 @@
 - **Status:** Accepted (recognition + linting vendored; `recognition/` and
   `linting/` are the live homes; the golden harness was retired here).
   **Amendment 1** (2026-07-12): the long-term home for *recognition* sharpens — it
-  becomes an extraction-ready, Apache-clean subpackage destined for a standalone
-  shared package `b123d-recognisers` (ADR 0013). helpers stays render-only; the
-  render-vs-reason boundary is unchanged.
+  becomes an extraction-ready subpackage (dependency-self-contained; still AGPL as
+  draftwright code per §4) destined for the standalone Apache package
+  `b123d-recognisers` (ADR 0013). helpers stays render-only; the render-vs-reason
+  boundary is unchanged.
 - **Date:** 2026-06-28
 - **Deciders:** Paul Fremantle (pzfreo)
 

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -16,6 +16,10 @@
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Supersedes the original 0008** ("unified feature model") with a concrete
   architecture. Step 1 (unify Z step recognition, #191/#193) stands.
+- **Amendment 7** (2026-07-12): the "one inventory" waist is now two tiers — a
+  shared *geometric* recognition record feeding the *dimensioning* IR through a thin
+  uniform `detect.py` seam (ADR 0013). Amendment 6 (no recognition object crosses the
+  boundary) is preserved.
 
 ## Context
 
@@ -413,3 +417,26 @@ debt.*
 - The drive-screw thread (ADR 0007 PR-C) that made the accretion obvious.
 - Prototype: `src/draftwright/model/` (`ir`, `detect`, `planner`),
   `tests/test_part_model.py`.
+
+## Amendment 7 (2026-07-12) — the intake becomes a uniform lower tier (ADR 0013)
+
+This ADR got the **waist** right (a uniform IR `Feature` inventory) but left the
+**intake** — the recognisers that feed it — un-contracted: mixed `find_`/`analyse_`
+naming, `list` vs `Optional`-singular vs bare-`list` returns, and per-feature bespoke
+`detect.py` translators that mirror each recognition dataclass into an IR `Feature`
+(duplicating fields and logic). ADR 0013 pulls the intake up to the waist's standard.
+
+The waist is now **two tiers**:
+
+- a **shared, geometry-only recognition record** (the lower tier — points/axes/radii/
+  angles, `.to_dict()`, no build123d types out), produced by uniform
+  `recognise_<feature>(part) -> list[Record]` recognisers; and
+- draftwright's **dimensioning IR `Feature`** (the upper tier, this ADR's inventory),
+
+joined by **one thin uniform `detect.py` seam** (record → `Feature`), replacing the
+per-feature translators. This *strengthens* Amendment 6: no recognition *object*
+crosses the boundary — the geometric record is a decoupled fact-sheet the seam adapts,
+not a recogniser's internal type. The IR `Feature` Protocol stays draftwright-side; the
+lower tier is destined for the standalone `b123d-recognisers` package (ADR 0013, Phase
+2). Also folds in the `callout()`-on-`ChamferFeature` crack: label formatting lives
+uniformly in the dimensioning tier, never on the geometric record.

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -17,9 +17,10 @@
 - **Supersedes the original 0008** ("unified feature model") with a concrete
   architecture. Step 1 (unify Z step recognition, #191/#193) stands.
 - **Amendment 7** (2026-07-12): the "one inventory" waist is now two tiers — a
-  shared *geometric* recognition record feeding the *dimensioning* IR through a thin
-  uniform `detect.py` seam (ADR 0013). Amendment 6 (no recognition object crosses the
-  boundary) is preserved.
+  shared *geometric* recognition record feeding the *dimensioning* IR through a uniform
+  `detect.py` adapter protocol (typed per-record converters, not one universal
+  converter) (ADR 0013). Amendment 6 (no recognition object crosses the boundary) is
+  preserved.
 
 ## Context
 
@@ -433,8 +434,12 @@ The waist is now **two tiers**:
   `recognise_<feature>(part) -> list[Record]` recognisers; and
 - draftwright's **dimensioning IR `Feature`** (the upper tier, this ADR's inventory),
 
-joined by **one thin uniform `detect.py` seam** (record → `Feature`), replacing the
-per-feature translators. This *strengthens* Amendment 6: no recognition *object*
+joined by a **uniform `detect.py` adapter protocol** — a typed registry of per-record
+converters (record → `Feature`) dispatched one way. This is *not* one universal
+converter: hole→`HoleFeature` and chamfer→`ChamferFeature` carry different `DimParameter`
+semantics, so the per-type mapping is irreducible; what the protocol removes is the
+ad-hoc, each-different bespoke translators of today. It *strengthens* Amendment 6: no
+recognition *object*
 crosses the boundary — the geometric record is a decoupled fact-sheet the seam adapts,
 not a recogniser's internal type. The IR `Feature` Protocol stays draftwright-side; the
 lower tier is destined for the standalone `b123d-recognisers` package (ADR 0013, Phase

--- a/docs/adr/0013-shared-recognition-package.md
+++ b/docs/adr/0013-shared-recognition-package.md
@@ -1,0 +1,289 @@
+# ADR 0013 — `b123d-recognisers`: a shared, geometry-only feature-recognition package
+
+- **Status:** Accepted (direction). **Phase 1** (draftwright-internal: uniform,
+  extraction-ready `recognition/`) **in progress**; **Phase 2** (extraction to the
+  standalone `b123d-recognisers` package) **deferred**, gated on a second committed
+  consumer. Subsumes #568 (uniform recogniser pattern).
+- **Date:** 2026-07-12
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+Two findings, one from inside draftwright and one from a sibling project, meet here.
+
+**1. The recogniser layer has drifted; the feature layer has not.** draftwright's
+IR `Feature` types (`model/ir.py`) are uniform and enforced: every one is a frozen
+dataclass conforming to the `Feature` Protocol (`kind: ClassVar[str]`, `frame`,
+`parameters() -> list[DimParameter]`, `references() -> list[Datum]`). That is ADR
+0008's "one inventory" waist, and it holds. The **recognisers that feed it do not**.
+They have accreted with no shared contract:
+
+- **naming** — `find_chamfers` / `find_plates` / `find_holes` / `find_slots` vs
+  `analyse_cylinders` / `analyse_face_levels`. Two verbs, no rule.
+- **return shape** — most return `list[SomeDataclass]`, but `find_turned_steps`
+  returns `TurnedProfile | None` (singular-optional) and the vendored
+  `_features.py` recognisers return bare untyped `-> list`.
+- **signature** — some take just `part`; others take tuning knobs (`tol`,
+  `max_leg_frac`, `min_area_frac`); others take precomputed inputs (`cyls=`,
+  `levels`, `holes`).
+- **provenance** — `_features.py` (holes/bosses/cylinders) is vendored from
+  build123d-drafting in an older untyped style (ADR 0007); the native recognisers
+  (chamfers, plates, slots, turned, levels) use typed frozen dataclasses. Two
+  authoring styles coexist.
+- **structural duplication** — each recogniser has its own dataclass (`Chamfer`,
+  `Plate`, `Slot`…) that `detect.py` hand-translates into a mirror IR `Feature`.
+  Fields and logic get duplicated across the two layers; the dead `equal_leg`
+  removed from `recognition.Chamfer` during #560 review was exactly this — defined
+  on both the recognition dataclass and `ChamferFeature`, only the latter used.
+
+The asymmetry is the insight: ADR 0008 got the *waist* right and the *intake*
+wrong. #568 was filed to pull the intake up to the standard the features already
+meet.
+
+**2. A second project independently needs the same recognisers.**
+`pzfreo/build123d-mcp` gives an LLM CAD "eyes". Modelling is fine — the LLM builds
+with build123d and *knows* the features it created. **Editing** is where recognisers
+come in: to edit a solid the LLM did not just build (imported, or handed over), the
+tool must recover feature intent from geometry. mcp has already started: a
+`tools/recognizers/` package whose `__init__` says, verbatim, it is "kept
+self-contained (build123d/OCP only, no session coupling in the pure recognizer
+functions) so they can be repatriated into a shared permissive recognition package
+later without a rewrite." It contains a `recognise_countersinks(part)` written
+because the external hole recogniser reports countersinks as plain openings.
+
+The duplication is **live, not hypothetical**:
+
+- draftwright's **#558 (countersunk hole)** is next-but-one in the current
+  dimensioning batch — a second countersink recogniser, same geometry (a cone
+  flaring from a coaxial bore), being written in the same month.
+- mcp's `find_features.py` still wraps the **deprecated** `build123d_drafting.find_holes`
+  / `find_bosses` — the very helpers recognisers ADR 0007 moved draftwright *away*
+  from (draftwright vendored its own copy into `_features.py`). Holes/bosses have
+  already forked: mcp on the old helpers copy, draftwright on its vendored copy.
+
+**Why build123d does not already solve this.** build123d has the *vocabulary*
+(`Hole`, `CounterBoreHole`, `CounterSinkHole`, `chamfer()`, `fillet()`, `Slot*`) but
+as *construction operations*, not a persistent feature model. It is procedural: it
+runs the op, mutates the B-rep, and discards the recipe. The resulting `Solid` is
+dumb faces and edges — no "this is a countersink" tag survives. Parametric CAD keeps
+a feature tree; build123d does not. That discard is precisely why recognisers exist:
+to recover the intent build123d threw away. The one case where intent survives is
+when the caller still holds the build-time Python objects — which is ADR 0011's
+declare-path (`build_drawing(part, model=…)` skips recognition). Recognisers are the
+*fallback* for when the recipe is gone: imported STEP, or a bare solid. mcp's editing
+case and draftwright's STEP-import case are the same fallback.
+
+So features can reach the IR from **three provenances**: recognition-from-BRep (this
+ADR), caller declaration (ADR 0011), and STEP AP242 PMI (`pmi.py`). One feature
+model, three sources.
+
+## Decision
+
+### 1. The target: a shared, geometry-only recognition package `b123d-recognisers`
+
+The eventual home for BRep feature recognition is a standalone package:
+
+- **Name** `b123d-recognisers` (dist), `b123d_recognisers` (import). Deliberately
+  informal — a recogniser toolbox, not a framework.
+- **License Apache-2.0.** Forced by the consumers: mcp is Apache and cannot depend
+  on AGPL; draftwright (AGPL) depends on Apache freely, not the reverse.
+- **Input: a build123d object; BRep-powered inside; geometry-only output.** The
+  recognisers already are this — build123d for traversal (`.faces()`,
+  `filter_by(GeomType…)`, `.bounding_box()`), raw OCP for the hard predicates
+  (`BRepAdaptor_Surface`, `BRepClass3d_SolidClassifier`). Identity, input and
+  vocabulary are build123d (the round-trip: build with `Hole`, recognise a `hole`);
+  the *implementation* drops to BRep where it must. See *Alternatives* for why not
+  brep-pure.
+- **Output records are plain geometry** — points, axes, radii, angles; **no
+  build123d types leak into the output**, so downstream consumers are decoupled from
+  build123d in what they receive. Each record carries `.to_dict()` for JSON
+  (mcp's need) and stays a typed frozen dataclass (draftwright's need).
+- **Scope: measurement records, not reconstructable construction ops.** A recogniser
+  reports *what is there* (a countersink: opening ⌀, drill ⌀, included angle, depth,
+  axis, location). It never rebuilds a build123d object or recovers a feature tree.
+  mcp's LLM does the reconstruction from the record; draftwright dimensions from it.
+  This keeps every parametric-CAD hard problem (feature ordering, dependency, the
+  original sketch) *out of scope*.
+- **British spelling throughout** (`recognise_*`), **codespell-enforced** so the
+  convention does not depend on anyone remembering it.
+
+### 2. A uniform recogniser contract (this is #568)
+
+Every recogniser, shared or not, conforms to one shape:
+
+```
+recognise_<feature>(part, **tuning) -> list[<Feature>Record]
+```
+
+- verb `recognise_` (not `find_`/`analyse_`); one naming rule;
+- always a `list` of typed frozen dataclass records (no `Optional`-singular, no bare
+  `list`); empty when absent;
+- `part` first, optional keyword tuning after; **no precomputed-input coupling** in
+  the public signature (a recogniser that needs cylinders computes them, or takes
+  them as an optional keyword with a default);
+- **pure** — build123d/OCP only, no session, no drawing, no dimensioning types.
+
+### 3. Two-layer decoration
+
+The shared record is the **geometric** feature; each consumer **decorates** it with
+its own domain concerns:
+
+- **draftwright** adapts the geometric record → its dimensioning IR (`Feature` with
+  `parameters()`/`references()`). `detect.py` shrinks from per-feature bespoke
+  translators to **one thin uniform adapter**, because the input is now uniform.
+- **mcp** serialises the record to JSON for the LLM to reason over when editing.
+
+Same countersink, different decoration: mcp wants a measurement record; draftwright
+wants `HoleFeature` + `DimParameter`s. The *shared* layer is the geometry both agree
+on.
+
+### 4. Governance boundary — what is shared vs what stays home
+
+**The shared package is geometry-only. Domain interpretation stays per-consumer.**
+That line is what stops it accreting the union of two wishlists.
+
+- **Seed set (shareable, overlapping):** holes, bosses, cylinders, patterns,
+  countersink, chamfer, fillet.
+- **Stays home until proven shareable:** draftwright's dimensioning-flavoured
+  Plate / Envelope / StepLevel / Turned recognisers; mcp's editing-specific
+  `locate`. A recogniser is promoted to the shared package only when a second
+  consumer actually wants it — never speculatively.
+
+### 5. Sequencing — Phase 1 now (internal), Phase 2 deferred (extraction)
+
+With mcp a slow follower (§6), `b123d-recognisers` would have exactly **one**
+consumer today. Standing up a separate repo + CI + PyPI release for a single consumer
+is premature — extract on the *second committed* consumer, not the first.
+
+- **Phase 1 — now, inside draftwright (no repo, no external dependency, no mcp
+  coupling).** Make `recognition/` the uniform (§2), geometry-only, Apache-clean,
+  **extraction-ready** subpackage: apply the §2 contract, introduce geometry-only
+  records *below* the IR, collapse `detect.py`'s bespoke translators into one uniform
+  adapter (§3), and fix the callout-crack (§7). Keep the subpackage self-contained
+  (build123d/OCP only, no AGPL-only coupling) so a later lift-out is a mechanical
+  internal→package import swap. This mirrors exactly the "repatriate later" note mcp
+  already wrote on *its* `recognizers/` package. **Phase 1 delivers #568's value on
+  its own, independent of whether Phase 2 ever happens.**
+- **Phase 2 — deferred, gated on a second committed consumer.** Spin the standalone
+  Apache repo; publish `0.1.0` to PyPI once (so external users resolve a real dep);
+  wire both consumers via **uv `[tool.uv.sources]`** — an editable local path
+  (`{ path = "../b123d-recognisers", editable = true }`) or pinned git rev during
+  co-development, flipping to a plain `b123d-recognisers>=0.1` PyPI spec only when
+  cutting a release. That "dev against a local checkout, release against PyPI"
+  workflow keeps day-to-day velocity unchanged from single-repo work. Migrate one
+  recogniser per PR, driven by the next issue that touches it — never a
+  stop-the-world migration.
+
+**Pilots:** #558 (countersink) is written now to the §2 contract with geometry
+mirroring mcp's `recognise_countersinks`, so it is liftable unchanged; #561 (fillet)
+is the second, and the first recogniser authored to the contract from birth rather
+than retrofitted.
+
+### 6. mcp is a designated slow follower
+
+mcp is more mature, has more users, and its editing feature is a side-shot. It takes
+**no dependency on `b123d-recognisers` now**; it keeps its current recognisers
+(helpers-based `find_holes`, its own `countersink.py`) untouched and adopts the shared
+package **later, at its own cadence and risk**. draftwright is the lead adopter and
+absorbs the interface-churn risk on behalf of a codebase with fewer users. When mcp
+does follow, it retires its deprecated `find_holes` usage and its local countersink
+copy onto the shared source.
+
+### 7. Licensing and the callout crack
+
+- **Relicense file-by-file, not big-bang.** draftwright's *native* recognisers
+  (chamfers.py, plates.py, slots.py, turned.py) are AGPL new code; `_features.py` is
+  vendored-from-Apache-helpers and already clean. As each recogniser migrates in
+  Phase 2, its file is relicensed to Apache — a one-line header change; pzfreo owns
+  the copyright. The countersink seed is lifted from mcp's *already-Apache*
+  `countersink.py`, so the pilot needs no relicense.
+- **Fix the `callout()` crack as part of Phase 1.** `callout()` currently lives only
+  on `ChamferFeature` (added in #560); every other feature leaves label formatting to
+  the planner/`DimParameter`. Decide it *once*: callout formatting lives uniformly in
+  the dimensioning layer (planner/IR), not accreted per-feature. Geometric records in
+  the shared package carry no callout — formatting is a draftwright dimensioning
+  concern, not a geometry fact.
+
+## Consequences
+
+- **The intake reaches the standard the features already meet.** One recogniser
+  contract; `detect.py` becomes a thin uniform seam; the recognition-dataclass ↔ IR
+  mirroring duplication is removed.
+- **The live countersink duplication is resolved at the pilot,** and mcp's fork onto
+  the deprecated helpers `find_holes` gets a reconciliation path (when it follows).
+- **draftwright takes no new dependency in Phase 1** — recognition stays internal but
+  shaped for extraction. Extraction becomes a mechanical import swap when justified.
+- **The shared surface is small and low-churn by construction** (geometry only;
+  dimensioning and editing churn stay in the consumers), so the three-repo
+  coordination tax Phase 2 introduces is naturally bounded.
+
+## Risks
+
+- **Interface not yet validated by two consumers.** Deferring extraction (Phase 2
+  gate) is the mitigation: the contract proves itself in draftwright first; mcp
+  stress-tests it only when it chooses to follow.
+- **Phase 1 could stall at "extraction-ready" forever.** Acceptable: Phase 1 *is*
+  #568 and delivers value alone. Phase 2 is a bonus unlocked by a second consumer,
+  not a debt.
+- **Relicensing.** File-by-file relicense of AGPL-native recognisers to Apache is
+  deliberate and must be explicit per file; pzfreo owns the copyright, so it is a
+  header change, not a legal negotiation.
+- **Slow-follower drift.** While mcp stays on the old helpers recognisers, holes/bosses
+  remain forked. Accepted: mcp's larger user base makes stability worth more than DRY
+  until it chooses to reconcile.
+
+## Alternatives considered
+
+- **Brep-pure recognisers (input `TopoDS_Shape`, OCP-only).** More fundamental, bigger
+  theoretical audience (any OCC tool). Rejected: both real consumers feed build123d
+  objects (even STEP imports arrive build123d-wrapped); going brep-pure means
+  rewriting traversal against raw `TopExp`/`TopoDS`/`BRep_Tool` — *more* code, more
+  fragile, against "lightweight"; and it forfeits the build123d vocabulary round-trip.
+  The one real argument (depend on stable OCP, not churny build123d) evaporates because
+  both consumers pin build123d anyway. Escape hatch kept: geometry-only output plus a
+  one-line input normalise (`getattr(part, "wrapped", part)`) leaves the door open to a
+  brep consumer *if one ever appears*, without building for it now.
+- **Extract the package now (Phase 2 immediately).** Rejected: one committed consumer;
+  premature repo/CI/PyPI overhead; locks the interface before a second consumer tests
+  it.
+- **Keep duplicating per project.** Rejected: the duplication is live (countersink) and
+  compounding (holes/bosses already forked).
+- **Put recognition (back) into build123d-drafting-helpers.** Rejected: ADR 0007
+  deliberately moved recognition *out* of helpers because helpers is the *rendering*
+  library. A shared *recognition* package is a different thing; helpers stays
+  render-only.
+- **Reconstructable construction ops (round-trip to editable build123d code).**
+  Rejected as out of scope: mcp's LLM reconstructs from a measurement record; it does
+  not need the lib to rebuild objects. Full feature-tree recovery could be a later
+  provenance layer, not part of this ADR.
+
+## Impact on other ADRs
+
+- **0007** (draftwright owns recognition + lint) — **amended** (Amendment 1): the
+  long-term home for recognition sharpens from "vendored inside draftwright" to "an
+  extraction-ready, Apache-clean subpackage destined for the standalone
+  `b123d-recognisers` package"; helpers stays render-only; mcp is a slow follower. Not
+  a reversal — 0007's point was "not in the *rendering* library", and it still is not.
+- **0008** (the Feature/DimParameter IR waist) — **amended** (Amendment 7): the "one
+  inventory" waist is now two tiers — a shared *geometric* recognition record (lower)
+  feeding draftwright's *dimensioning* IR (upper) through a thin uniform `detect.py`
+  seam. The IR `Feature` Protocol stays draftwright-side; no recognition object crosses
+  the boundary (Amendment 6 preserved — the geometric record is not a recognition
+  *object*, it is a decoupled geometry fact-sheet the seam adapts).
+- **0011** (IR as public input) — unaffected in decision; noted: recognition output now
+  anchors on build123d construction vocabulary, matching 0011 P0's object→feature
+  constructors, giving a build ↔ recognise ↔ dimension round-trip on one vocabulary.
+- **0005** (pipeline DAG) — unchanged: `recognition/` stays the bottom layer (build123d
+  only, below `_core`); Phase 2 turns it into an external dependency at the same DAG
+  position.
+- **0010** (annotation provenance) — unaffected.
+
+## Related
+
+- ADR 0007 (own recognition), 0008 (the IR waist), 0011 (IR as input), 0001 (declare/
+  detect converge at the IR).
+- Issues: #568 (uniform recogniser pattern — subsumed by Phase 1), #558 (countersink
+  pilot), #561 (fillet — second pilot).
+- Sibling: `pzfreo/build123d-mcp` `tools/recognizers/` (the "repatriate later"
+  package this ADR formalises the target for).
+- Roadmap: [`docs/plans/0013-shared-recognisers-roadmap.md`](../plans/0013-shared-recognisers-roadmap.md).

--- a/docs/adr/0013-shared-recognition-package.md
+++ b/docs/adr/0013-shared-recognition-package.md
@@ -213,19 +213,15 @@ copy onto the shared source.
   recognisers (chamfers.py, plates.py, slots.py, turned.py) as new AGPL code, and even
   `_features.py` which, though vendored from Apache helpers, became AGPL inside
   draftwright (ADR 0007 §4). The target package is Apache, so extraction candidates
-  must be (re)licensed. pzfreo owns the copyright, so this is a header change, not a
-  negotiation — but it is a **deliberate, tracked step**. Two ways, choose per the
-  review of this ADR:
-  - **(a) Dual-license candidates during Phase 1** — add an SPDX
-    `Apache-2.0 OR AGPL-3.0` header to each recogniser *as a pilot touches it*
-    (#558 countersink, #561 fillet, then the rest incrementally). Phase 2 extraction
-    then carries no licensing work at all — genuinely turnkey. *Recommended.*
-  - **(b) Relicense at the Phase 2 gate** — leave files AGPL through Phase 1 and
-    relicense file-by-file when extracting. Simpler now, but makes extraction a
-    licensing event, so it is an explicit **gate**, not "mechanical".
-
-  The countersink seed is lifted from mcp's *already-Apache* `countersink.py`, so the
-  pilot's *shared-package* copy needs no relicense regardless.
+  must be relicensed. **Decision: relicense at the Phase 2 gate.** Files stay AGPL
+  through Phase 1; when a recogniser is extracted its file header is relicensed to
+  Apache — a one-line change (pzfreo owns the copyright), but a **deliberate, tracked
+  step**, so extraction is an explicit licensing **gate**, not a purely "mechanical"
+  move. (The alternative — dual-licensing each file `Apache-2.0 OR AGPL-3.0` during
+  Phase 1 to make Phase 2 turnkey — was considered and not taken; keeping Phase 1
+  licensing untouched is simpler and the relicense is cheap at the gate.) The
+  countersink seed is lifted from mcp's *already-Apache* `countersink.py`, so the
+  shared-package copy of that one needs no relicense regardless.
 - **Fix the `callout()` crack as part of Phase 1.** `callout()` currently lives only
   on `ChamferFeature` (added in #560); every other feature leaves label formatting to
   the planner/`DimParameter`. Decide it *once*: callout formatting lives uniformly in

--- a/docs/adr/0013-shared-recognition-package.md
+++ b/docs/adr/0013-shared-recognition-package.md
@@ -118,9 +118,17 @@ recognise_<feature>(part, **tuning) -> list[<Feature>Record]
 - verb `recognise_` (not `find_`/`analyse_`); one naming rule;
 - always a `list` of typed frozen dataclass records (no `Optional`-singular, no bare
   `list`); empty when absent;
-- `part` first, optional keyword tuning after; **no precomputed-input coupling** in
-  the public signature (a recogniser that needs cylinders computes them, or takes
-  them as an optional keyword with a default);
+- `part` first, then **keyword-only** args: tuning knobs *and* injected shared
+  inventory. A *base* feature (holes, chamfers, fillets, bosses, cylinders) derives
+  only from `part`. A *derived* feature takes the canonical inventory it depends on
+  by keyword — `recognise_patterns(part, *, holes)`, `recognise_step_shoulders(part,
+  *, levels)`. **Dependency injection stays; the recogniser never re-recognises a
+  dependency internally.** ADR 0008 Amendment 5 mandates one inventory detected once;
+  recomputing holes inside `recognise_patterns` would produce a *second*, possibly
+  divergent hole set and break pattern grouping (which relies on shared hole member
+  identity). The orchestrator owns the single inventory and threads it. What the
+  contract forbids is *inconsistent* signatures (positional precomputed inputs, ad-hoc
+  ordering), not injection itself.
 - **pure** — build123d/OCP only, no session, no drawing, no dimensioning types.
 
 ### 3. Two-layer decoration
@@ -129,8 +137,14 @@ The shared record is the **geometric** feature; each consumer **decorates** it w
 its own domain concerns:
 
 - **draftwright** adapts the geometric record → its dimensioning IR (`Feature` with
-  `parameters()`/`references()`). `detect.py` shrinks from per-feature bespoke
-  translators to **one thin uniform adapter**, because the input is now uniform.
+  `parameters()`/`references()`). This is **not** one universal converter: a
+  hole→`HoleFeature` (bore/cbore/spotface + `DimParameter` semantics) is genuinely
+  different from a chamfer→`ChamferFeature`, so a per-record-type conversion is
+  irreducible. What `detect.py` gains is a **uniform adapter protocol — a typed
+  registry of per-record converters** dispatched one way — replacing today's ad-hoc,
+  each-different bespoke translators. Normalization removes the *inconsistency* and
+  the recognition-dataclass ↔ IR-`Feature` mirroring duplication, not the per-type
+  mapping.
 - **mcp** serialises the record to JSON for the LLM to reason over when editing.
 
 Same countersink, different decoration: mcp wants a measurement record; draftwright
@@ -156,14 +170,17 @@ consumer today. Standing up a separate repo + CI + PyPI release for a single con
 is premature — extract on the *second committed* consumer, not the first.
 
 - **Phase 1 — now, inside draftwright (no repo, no external dependency, no mcp
-  coupling).** Make `recognition/` the uniform (§2), geometry-only, Apache-clean,
+  coupling).** Make `recognition/` the uniform (§2), geometry-only,
   **extraction-ready** subpackage: apply the §2 contract, introduce geometry-only
-  records *below* the IR, collapse `detect.py`'s bespoke translators into one uniform
-  adapter (§3), and fix the callout-crack (§7). Keep the subpackage self-contained
-  (build123d/OCP only, no AGPL-only coupling) so a later lift-out is a mechanical
-  internal→package import swap. This mirrors exactly the "repatriate later" note mcp
-  already wrote on *its* `recognizers/` package. **Phase 1 delivers #568's value on
-  its own, independent of whether Phase 2 ever happens.**
+  records *below* the IR, replace `detect.py`'s bespoke translators with the uniform
+  adapter protocol (§3), and fix the callout-crack (§7). "Extraction-ready" is a
+  **dependency** claim, not a licensing one: keep the subpackage self-contained
+  (build123d/OCP only, no upward coupling) so the *code* lift-out is a mechanical
+  internal→package import swap. **Licensing is a separate axis** — the files are AGPL
+  as draftwright code today (ADR 0007 §4); Apache licensing is handled per §7, not by
+  self-containment. This mirrors exactly the "repatriate later" note mcp already wrote
+  on *its* `recognizers/` package. **Phase 1 delivers #568's value on its own,
+  independent of whether Phase 2 ever happens.**
 - **Phase 2 — deferred, gated on a second committed consumer.** Spin the standalone
   Apache repo; publish `0.1.0` to PyPI once (so external users resolve a real dep);
   wire both consumers via **uv `[tool.uv.sources]`** — an editable local path
@@ -191,12 +208,24 @@ copy onto the shared source.
 
 ### 7. Licensing and the callout crack
 
-- **Relicense file-by-file, not big-bang.** draftwright's *native* recognisers
-  (chamfers.py, plates.py, slots.py, turned.py) are AGPL new code; `_features.py` is
-  vendored-from-Apache-helpers and already clean. As each recogniser migrates in
-  Phase 2, its file is relicensed to Apache — a one-line header change; pzfreo owns
-  the copyright. The countersink seed is lifted from mcp's *already-Apache*
-  `countersink.py`, so the pilot needs no relicense.
+- **Licensing is an explicit act, not a side effect of self-containment.** Every
+  file in `recognition/` is **AGPL as a draftwright file today** — the native
+  recognisers (chamfers.py, plates.py, slots.py, turned.py) as new AGPL code, and even
+  `_features.py` which, though vendored from Apache helpers, became AGPL inside
+  draftwright (ADR 0007 §4). The target package is Apache, so extraction candidates
+  must be (re)licensed. pzfreo owns the copyright, so this is a header change, not a
+  negotiation — but it is a **deliberate, tracked step**. Two ways, choose per the
+  review of this ADR:
+  - **(a) Dual-license candidates during Phase 1** — add an SPDX
+    `Apache-2.0 OR AGPL-3.0` header to each recogniser *as a pilot touches it*
+    (#558 countersink, #561 fillet, then the rest incrementally). Phase 2 extraction
+    then carries no licensing work at all — genuinely turnkey. *Recommended.*
+  - **(b) Relicense at the Phase 2 gate** — leave files AGPL through Phase 1 and
+    relicense file-by-file when extracting. Simpler now, but makes extraction a
+    licensing event, so it is an explicit **gate**, not "mechanical".
+
+  The countersink seed is lifted from mcp's *already-Apache* `countersink.py`, so the
+  pilot's *shared-package* copy needs no relicense regardless.
 - **Fix the `callout()` crack as part of Phase 1.** `callout()` currently lives only
   on `ChamferFeature` (added in #560); every other feature leaves label formatting to
   the planner/`DimParameter`. Decide it *once*: callout formatting lives uniformly in
@@ -207,12 +236,14 @@ copy onto the shared source.
 ## Consequences
 
 - **The intake reaches the standard the features already meet.** One recogniser
-  contract; `detect.py` becomes a thin uniform seam; the recognition-dataclass ↔ IR
-  mirroring duplication is removed.
+  contract; `detect.py` becomes a uniform adapter protocol (a typed registry of
+  per-record converters — the per-type mapping stays, its ad-hoc inconsistency goes);
+  the recognition-dataclass ↔ IR mirroring duplication is removed.
 - **The live countersink duplication is resolved at the pilot,** and mcp's fork onto
   the deprecated helpers `find_holes` gets a reconciliation path (when it follows).
 - **draftwright takes no new dependency in Phase 1** — recognition stays internal but
-  shaped for extraction. Extraction becomes a mechanical import swap when justified.
+  shaped for extraction. The extraction *code* move is a mechanical import swap when
+  justified; its *licensing* is handled per §7.
 - **The shared surface is small and low-churn by construction** (geometry only;
   dimensioning and editing churn stay in the consumers), so the three-repo
   coordination tax Phase 2 introduces is naturally bounded.
@@ -261,13 +292,14 @@ copy onto the shared source.
 
 - **0007** (draftwright owns recognition + lint) — **amended** (Amendment 1): the
   long-term home for recognition sharpens from "vendored inside draftwright" to "an
-  extraction-ready, Apache-clean subpackage destined for the standalone
-  `b123d-recognisers` package"; helpers stays render-only; mcp is a slow follower. Not
+  extraction-ready subpackage (dependency-self-contained; licensing per §7) destined
+  for the standalone `b123d-recognisers` package"; helpers stays render-only; mcp is a
+  slow follower. Not
   a reversal — 0007's point was "not in the *rendering* library", and it still is not.
 - **0008** (the Feature/DimParameter IR waist) — **amended** (Amendment 7): the "one
   inventory" waist is now two tiers — a shared *geometric* recognition record (lower)
-  feeding draftwright's *dimensioning* IR (upper) through a thin uniform `detect.py`
-  seam. The IR `Feature` Protocol stays draftwright-side; no recognition object crosses
+  feeding draftwright's *dimensioning* IR (upper) through a uniform `detect.py` adapter
+  protocol. The IR `Feature` Protocol stays draftwright-side; no recognition object crosses
   the boundary (Amendment 6 preserved — the geometric record is not a recognition
   *object*, it is a decoupled geometry fact-sheet the seam adapts).
 - **0011** (IR as public input) — unaffected in decision; noted: recognition output now

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -1,15 +1,22 @@
-# ADR 0013 — `b123d-recognisers`: a shared, geometry-only feature-recognition package
+# ADR 0013 — A uniform recogniser/feature contract (with `b123d-recognisers` as its deferred shared deployment)
 
-- **Status:** Accepted (direction). **Phase 1** (draftwright-internal: uniform,
-  extraction-ready `recognition/`) **in progress**; **Phase 2** (extraction to the
-  standalone `b123d-recognisers` package) **deferred**, gated on a second committed
-  consumer. Subsumes #568 (uniform recogniser pattern).
+- **Status:** Accepted. **The primary decision is a uniform, geometry-only
+  recogniser/feature contract** (§2 + the two-layer model §3; subsumes #568) — the
+  recogniser *intake* pulled up to the standard the IR `Feature` inventory already
+  meets (ADR 0008). It is delivered inside draftwright now (**Phase 1, in progress**)
+  and is worth doing for draftwright alone. Extracting that contract to a standalone
+  shared package `b123d-recognisers` (§1) is a **secondary, deferred deployment**
+  (**Phase 2**, gated on a second committed consumer). **The consistency is the point;
+  the package is one optional way to ship it.**
 - **Date:** 2026-07-12
 - **Deciders:** Paul Fremantle (pzfreo)
 
 ## Context
 
 Two findings, one from inside draftwright and one from a sibling project, meet here.
+The **first is the reason** (draftwright's own recogniser intake is inconsistent and
+should be fixed regardless); the **second is the opportunity** (a sibling project needs
+the same recognisers, so the fix is worth extracting once it has proven out).
 
 **1. The recogniser layer has drifted; the feature layer has not.** draftwright's
 IR `Feature` types (`model/ir.py`) are uniform and enforced: every one is a frozen
@@ -79,7 +86,16 @@ model, three sources.
 
 ## Decision
 
-### 1. The target: a shared, geometry-only recognition package `b123d-recognisers`
+**Read in priority order.** The load-bearing decision is the **uniform
+recogniser/feature contract (§2)** and the **two-layer model (§3)** — they make the
+recogniser intake as consistent as the IR `Feature` inventory already is (ADR 0008),
+and they stand on their own (Phase 1 / #568) *even if the shared package never ships*.
+Consistency is the goal; it is not contingent on extraction. The **shared package
+(§1)** is the *deployment* of that consistency to a second consumer — important, but
+secondary, deferred, and gated (§5). Sections are numbered for stable cross-referencing,
+not by priority; §2/§3 are the decision, §1/§5/§6 are how and when it travels.
+
+### 1. The shared package `b123d-recognisers` (the deferred deployment)
 
 The eventual home for BRep feature recognition is a standalone package:
 
@@ -107,9 +123,9 @@ The eventual home for BRep feature recognition is a standalone package:
 - **British spelling throughout** (`recognise_*`), **codespell-enforced** so the
   convention does not depend on anyone remembering it.
 
-### 2. A uniform recogniser contract (this is #568)
+### 2. The uniform recogniser/feature contract — the primary decision (subsumes #568)
 
-Every recogniser, shared or not, conforms to one shape:
+This is the point of the ADR. Every recogniser, shared or not, conforms to one shape:
 
 ```
 recognise_<feature>(part, **tuning) -> list[<Feature>Record]

--- a/docs/plans/0013-shared-recognisers-roadmap.md
+++ b/docs/plans/0013-shared-recognisers-roadmap.md
@@ -1,0 +1,70 @@
+# 0013 — `b123d-recognisers` roadmap (uniform recognition, extraction-ready)
+
+Execution plan for [ADR 0013](../adr/0013-shared-recognition-package.md). Two phases:
+make `recognition/` uniform and extraction-ready **now** (Phase 1 = #568); extract to
+the standalone Apache package **later**, gated on a second committed consumer (Phase 2).
+mcp is a slow follower — not coupled in either phase until it chooses to adopt.
+
+## Phase 1 — uniform, geometry-only, extraction-ready `recognition/` (now)
+
+Delivers #568's value standalone. No new repo, no external dependency, no mcp coupling.
+
+- **1a — the contract.** Adopt one recogniser shape (ADR 0013 §2):
+  `recognise_<feature>(part, **tuning) -> list[<Feature>Record]`. Rename existing
+  entry points onto `recognise_*` (from `find_*`/`analyse_*`); return typed frozen
+  dataclass lists (retire `TurnedProfile | None` singular-optional and the bare
+  untyped `-> list` in `_features.py`); drop precomputed-input coupling from public
+  signatures. British spelling; add **codespell** to CI with the convention pinned.
+- **1b — geometry-only records + `.to_dict()`.** Give each recogniser a plain-geometry
+  record (points/axes/radii/angles, no build123d types in the output) carrying
+  `.to_dict()`. These sit *below* the IR — they are the future shared-package surface.
+- **1c — one uniform `detect.py` seam.** Collapse the per-feature bespoke translators
+  into a single adapter from geometry-record → IR `Feature`. Remove the
+  recognition-dataclass ↔ IR mirroring duplication (the `equal_leg`-on-both class).
+- **1d — the `callout()` crack.** Move callout formatting off `ChamferFeature` into the
+  dimensioning layer (planner/IR) uniformly; geometric records carry no callout.
+- **Keep `recognition/` self-contained** — build123d/OCP only, no AGPL-only coupling —
+  so Phase 2 is a mechanical import swap.
+
+### Pilots (drive Phase 1 from real work, not a big-bang rewrite)
+
+- **#558 (countersink)** — written to the §2 contract now, geometry mirroring mcp's
+  `recognise_countersinks`, so it lifts to the package unchanged. First customer.
+- **#561 (fillet)** — second pilot; first recogniser authored to the contract from
+  birth. build123d's `fillet()` anchors the vocabulary.
+
+Migrate the remaining seed-set recognisers (holes, bosses, cylinders, patterns,
+chamfer) onto the contract **incrementally**, one per PR, as issues touch them — not
+as a forced sweep.
+
+## Phase 2 — extract to `b123d-recognisers` (deferred; gated on a 2nd consumer)
+
+Trigger: a second consumer commits to depend (in practice, mcp deciding to follow, or
+another tool appearing). Until then, do not spin the repo.
+
+- **2a — stand up the repo.** New Apache-2.0 `b123d-recognisers`; move the seed-set
+  recognisers + their geometry records + their tests (the geometric counter-examples —
+  gusset/ramp/hex-prism etc. — are geometry truths and belong here). Fast CI (build123d/
+  OCP only). Relicense each migrated file to Apache in its header (pzfreo owns
+  copyright); countersink seeds from mcp's already-Apache code.
+- **2b — publish + wire.** `0.1.0` to PyPI once. draftwright declares
+  `b123d-recognisers>=0.1`; during co-development both use `[tool.uv.sources]`
+  (editable path or pinned git rev), flipping to the PyPI spec for releases.
+- **2c — migrate draftwright imports** to the package (internal→package swap); the
+  uniform `detect.py` seam is unchanged.
+- **2d — governance.** Only seed-set (shareable) recognisers live in the package;
+  domain-flavoured ones (Plate/Envelope/StepLevel/Turned; mcp's `locate`) stay home
+  until a second consumer wants them.
+
+## mcp (slow follower — not on the critical path)
+
+When and only when mcp chooses to adopt: replace its deprecated
+`build123d_drafting.find_holes`/`find_bosses` usage and its local `countersink.py`
+with `b123d-recognisers`; keep its thin `find_*(session, name)` MCP wrappers over the
+shared pure functions. No timeline; mcp's user base makes stability worth more than DRY
+until it decides.
+
+## Out of scope
+
+Reconstructable construction ops / feature-tree recovery (a possible later provenance
+layer); brep-pure recognisers (see ADR 0013 *Alternatives*).

--- a/docs/plans/0013-shared-recognisers-roadmap.md
+++ b/docs/plans/0013-shared-recognisers-roadmap.md
@@ -10,21 +10,28 @@ mcp is a slow follower — not coupled in either phase until it chooses to adopt
 Delivers #568's value standalone. No new repo, no external dependency, no mcp coupling.
 
 - **1a — the contract.** Adopt one recogniser shape (ADR 0013 §2):
-  `recognise_<feature>(part, **tuning) -> list[<Feature>Record]`. Rename existing
-  entry points onto `recognise_*` (from `find_*`/`analyse_*`); return typed frozen
-  dataclass lists (retire `TurnedProfile | None` singular-optional and the bare
-  untyped `-> list` in `_features.py`); drop precomputed-input coupling from public
-  signatures. British spelling; add **codespell** to CI with the convention pinned.
+  `recognise_<feature>(part, *, ...) -> list[<Feature>Record]`. Rename existing entry
+  points onto `recognise_*` (from `find_*`/`analyse_*`); return typed frozen dataclass
+  lists (retire `TurnedProfile | None` singular-optional and the bare untyped
+  `-> list` in `_features.py`). **Keep dependency injection** for derived features
+  (`recognise_patterns(part, *, holes)`, `recognise_step_shoulders(part, *, levels)`) —
+  make it *keyword-only and typed*, not remove it; the orchestrator threads the single
+  shared inventory (ADR 0008 Am5), recognisers never re-recognise a dependency. British
+  spelling; add **codespell** to CI with the convention pinned.
 - **1b — geometry-only records + `.to_dict()`.** Give each recogniser a plain-geometry
   record (points/axes/radii/angles, no build123d types in the output) carrying
   `.to_dict()`. These sit *below* the IR — they are the future shared-package surface.
-- **1c — one uniform `detect.py` seam.** Collapse the per-feature bespoke translators
-  into a single adapter from geometry-record → IR `Feature`. Remove the
-  recognition-dataclass ↔ IR mirroring duplication (the `equal_leg`-on-both class).
+- **1c — a uniform `detect.py` adapter protocol.** Replace the ad-hoc per-feature
+  translators with a typed registry of per-record converters (geometry-record →
+  IR `Feature`) dispatched one way — the per-type mapping stays (hole→`HoleFeature`
+  ≠ chamfer→`ChamferFeature`), its inconsistency goes. Remove the recognition-dataclass
+  ↔ IR mirroring duplication (the `equal_leg`-on-both class).
 - **1d — the `callout()` crack.** Move callout formatting off `ChamferFeature` into the
   dimensioning layer (planner/IR) uniformly; geometric records carry no callout.
-- **Keep `recognition/` self-contained** — build123d/OCP only, no AGPL-only coupling —
-  so Phase 2 is a mechanical import swap.
+- **Keep `recognition/` dependency-self-contained** — build123d/OCP only, no upward
+  coupling — so Phase 2's *code* move is a mechanical import swap. Licensing is a
+  separate axis (ADR 0013 §7): either dual-license each recogniser
+  (`Apache-2.0 OR AGPL-3.0`) as a pilot touches it, or relicense at the Phase 2 gate.
 
 ### Pilots (drive Phase 1 from real work, not a big-bang rewrite)
 
@@ -45,8 +52,9 @@ another tool appearing). Until then, do not spin the repo.
 - **2a — stand up the repo.** New Apache-2.0 `b123d-recognisers`; move the seed-set
   recognisers + their geometry records + their tests (the geometric counter-examples —
   gusset/ramp/hex-prism etc. — are geometry truths and belong here). Fast CI (build123d/
-  OCP only). Relicense each migrated file to Apache in its header (pzfreo owns
-  copyright); countersink seeds from mcp's already-Apache code.
+  OCP only). Licensing: if Phase-1 option (a) was taken (files dual-licensed as touched),
+  there is nothing to do here; otherwise relicense each migrated file to Apache in its
+  header (pzfreo owns copyright). Countersink seeds from mcp's already-Apache code.
 - **2b — publish + wire.** `0.1.0` to PyPI once. draftwright declares
   `b123d-recognisers>=0.1`; during co-development both use `[tool.uv.sources]`
   (editable path or pinned git rev), flipping to the PyPI spec for releases.

--- a/docs/plans/0013-shared-recognisers-roadmap.md
+++ b/docs/plans/0013-shared-recognisers-roadmap.md
@@ -1,6 +1,6 @@
 # 0013 — `b123d-recognisers` roadmap (uniform recognition, extraction-ready)
 
-Execution plan for [ADR 0013](../adr/0013-shared-recognition-package.md). Two phases:
+Execution plan for [ADR 0013](../adr/0013-uniform-recognition-and-shared-package.md). Two phases:
 make `recognition/` uniform and extraction-ready **now** (Phase 1 = #568); extract to
 the standalone Apache package **later**, gated on a second committed consumer (Phase 2).
 mcp is a slow follower — not coupled in either phase until it chooses to adopt.

--- a/docs/plans/0013-shared-recognisers-roadmap.md
+++ b/docs/plans/0013-shared-recognisers-roadmap.md
@@ -30,8 +30,8 @@ Delivers #568's value standalone. No new repo, no external dependency, no mcp co
   dimensioning layer (planner/IR) uniformly; geometric records carry no callout.
 - **Keep `recognition/` dependency-self-contained** — build123d/OCP only, no upward
   coupling — so Phase 2's *code* move is a mechanical import swap. Licensing is a
-  separate axis (ADR 0013 §7): either dual-license each recogniser
-  (`Apache-2.0 OR AGPL-3.0`) as a pilot touches it, or relicense at the Phase 2 gate.
+  separate axis (ADR 0013 §7): files stay AGPL through Phase 1 and are relicensed to
+  Apache at the Phase 2 gate (file-by-file, pzfreo owns copyright).
 
 ### Pilots (drive Phase 1 from real work, not a big-bang rewrite)
 
@@ -52,9 +52,9 @@ another tool appearing). Until then, do not spin the repo.
 - **2a — stand up the repo.** New Apache-2.0 `b123d-recognisers`; move the seed-set
   recognisers + their geometry records + their tests (the geometric counter-examples —
   gusset/ramp/hex-prism etc. — are geometry truths and belong here). Fast CI (build123d/
-  OCP only). Licensing: if Phase-1 option (a) was taken (files dual-licensed as touched),
-  there is nothing to do here; otherwise relicense each migrated file to Apache in its
-  header (pzfreo owns copyright). Countersink seeds from mcp's already-Apache code.
+  OCP only). Licensing (the Phase 2 gate, ADR 0013 §7): relicense each migrated file to
+  Apache in its header (pzfreo owns copyright). Countersink seeds from mcp's
+  already-Apache code, so it needs no relicense.
 - **2b — publish + wire.** `0.1.0` to PyPI once. draftwright declares
   `b123d-recognisers>=0.1`; during co-development both use `[tool.uv.sources]`
   (editable path or pinned git rev), flipping to the PyPI spec for releases.


### PR DESCRIPTION
## What

A new ADR + roadmap + two amendments recording the direction for a **shared feature-recognition package**, `b123d-recognisers`. Docs-only — no code, per the agreed pause to get the ADR level right before building more.

## Why

Reviewing recogniser/feature consistency (prompted by #560) surfaced an asymmetry:

- The IR `Feature` layer (`model/ir.py`) is **uniform and enforced** (the `Feature` Protocol). ADR 0008's "one inventory" waist holds.
- The **recogniser intake has drifted**: mixed `find_`/`analyse_` naming, `list` vs `Optional`-singular vs bare-`list` returns, per-feature bespoke `detect.py` translators, and recognition-dataclass ↔ IR-`Feature` duplication (the dead `equal_leg` removed in #560 review was exactly this).

Separately, **`build123d-mcp` independently needs the same recognisers** — to *edit* solids it did not build, it must recover feature intent from geometry. It is duplicating them live (a countersink recogniser; a fork onto the now-deprecated helpers `find_holes`). build123d has the *vocabulary* (`Hole`/`CounterSinkHole`/`chamfer`/`fillet`) but not a persistent feature model — it's procedural and discards the recipe, which is *why* recognisers exist.

## Decision (ADR 0013, Accepted — direction)

- **`b123d-recognisers`** — standalone, **Apache-2.0**, build123d-input, BRep-powered, **geometry-only output**, **measurement-record** scope (the LLM reconstructs; the lib never rebuilds objects). British spelling, codespell-enforced.
- **Uniform recogniser contract** `recognise_<feature>(part, **tuning) -> list[<Feature>Record]` — subsumes #568.
- **Two-layer decoration**: shared geometric record → per-consumer domain layer (draftwright dimensioning IR via a thin uniform `detect.py` seam; mcp measurement JSON).
- **Geometry-only governance boundary**; seed set = holes/bosses/cylinders/patterns/countersink/chamfer/fillet.
- **Sequencing** (mcp = designated slow follower, not coupled now):
  - **Phase 1 (now, internal):** make `recognition/` uniform + extraction-ready. No repo, no external dependency, no mcp coupling. Delivers #568 alone.
  - **Phase 2 (deferred, gated on a 2nd committed consumer):** extract to the package via `uv` sources, one recogniser per PR.
- **Pilots:** #558 (countersink), #561 (fillet).

## Amendments

- **0007** — recognition's long-term home sharpens to the shared package (not a reversal: helpers stays render-only; a *recognition* lib is a different thing).
- **0008** — the one-inventory waist is now two tiers (geometric record → dimensioning IR via a thin uniform seam); folds in the `callout()`-on-`ChamferFeature` crack.

## Not in this PR

No code. mcp is untouched. Extraction (Phase 2) is deferred. The `recognition/` cleanup (Phase 1 / #568) lands later as its own work, with #558/#561 as the driving pilots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)