### PR TITLE
refactor: recogniser records + conform turned/face-level recognisers (#568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ unchanged (byte-identical); only import paths and callable signatures change.
   `feature_diameters`) keeps its names.
 - **`recognise_step_shoulders` now returns `list[StepShoulder]`** (a frozen dataclass)
   instead of raw `(axis, position)` tuples; `levels` is keyword-only.
+- **Recognition record classes renamed to avoid clashing with the IR `Feature` types:**
+  `draftwright.recognition.HoleFeature` → `HoleRecord`, `BossFeature` → `BossRecord`
+  (the IR `draftwright.model.ir.HoleFeature`/`BossFeature` are unchanged).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ unchanged (byte-identical); only import paths and callable signatures change.
   `feature_diameters`) keeps its names.
 - **`recognise_step_shoulders` now returns `list[StepShoulder]`** (a frozen dataclass)
   instead of raw `(axis, position)` tuples; `levels` is keyword-only.
+- **`recognise_turned_steps` now returns `list[TurnedStep]`** (empty for a non-turned
+  part) instead of `TurnedProfile | None`. `TurnedStep` gained an `axis` field (each step
+  is now a self-contained record); `TurnedProfile` remains only as a pipeline aggregate
+  (`TurnedProfile.from_steps(steps)`), no longer a recogniser return.
+- **`recognise_face_levels` now returns `list[FaceLevel]`** (a frozen `FaceLevel(z)`
+  record) instead of `list[float]`.
 - **Recognition record classes renamed to avoid clashing with the IR `Feature` types:**
   `draftwright.recognition.HoleFeature` → `HoleRecord`, `BossFeature` → `BossRecord`
   (the IR `draftwright.model.ir.HoleFeature`/`BossFeature` are unchanged).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,11 @@ No lower module imports an upper one.
   helpers). Every feature recogniser follows the **uniform contract** (ADR 0013 / #568,
   spelled out in `recognition/__init__.py`): `recognise_<feature>(part, *, <injected
   inventory>) -> list[<frozen-dataclass record>]` — British `recognise_` verb,
-  keyword-only args (deps injected by the caller, never re-recognised), deterministic
-  output. Normally a list of records; a **scalar/singular** feature may return
-  `list[<scalar>]` (`recognise_face_levels`) or `<Structure> | None`
-  (`recognise_turned_steps`) where a record would be ceremony (ADR 0013 Amendment 1).
-  `_features.py` (vendored from `build123d_drafting.features`; the
+  keyword-only args (deps injected by the caller, never re-recognised), a deterministic
+  list of records. Where a record first looks too thin (a face level, a turned step) the
+  fix is the record — `recognise_face_levels -> list[FaceLevel]`, `recognise_turned_steps
+  -> list[TurnedStep]` (each step carries its `axis`; `TurnedProfile` survives only as a
+  pipeline aggregate). `_features.py` (vendored from `build123d_drafting.features`; the
   hole/boss/pattern recognisers — `recognise_holes`/`recognise_bosses`/
   `recognise_hole_patterns` + the feature/pattern types; plus the cylinder-analysis
   *substrate* `analyse_cylinders`/`feature_diameters`/`full_cylinders`, which keep their

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,11 @@ No lower module imports an upper one.
   helpers). Every feature recogniser follows the **uniform contract** (ADR 0013 / #568,
   spelled out in `recognition/__init__.py`): `recognise_<feature>(part, *, <injected
   inventory>) -> list[<frozen-dataclass record>]` — British `recognise_` verb,
-  keyword-only args (deps injected by the caller, never re-recognised), a deterministic
-  list of records. `_features.py` (vendored from `build123d_drafting.features`; the
+  keyword-only args (deps injected by the caller, never re-recognised), deterministic
+  output. Normally a list of records; a **scalar/singular** feature may return
+  `list[<scalar>]` (`recognise_face_levels`) or `<Structure> | None`
+  (`recognise_turned_steps`) where a record would be ceremony (ADR 0013 Amendment 1).
+  `_features.py` (vendored from `build123d_drafting.features`; the
   hole/boss/pattern recognisers — `recognise_holes`/`recognise_bosses`/
   `recognise_hole_patterns` + the feature/pattern types; plus the cylinder-analysis
   *substrate* `analyse_cylinders`/`feature_diameters`/`full_cylinders`, which keep their

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -8,6 +8,11 @@
   shared package `b123d-recognisers` (§1) is a **secondary, deferred deployment**
   (**Phase 2**, gated on a second committed consumer). **The consistency is the point;
   the package is one optional way to ship it.**
+- **Amendment 1** (2026-07-12): §2's absolute "always `list[record]`, no
+  `Optional`-singular, no bare `list`" is **corrected** — it was over-strict. A
+  recogniser whose feature is inherently scalar/singular (`recognise_face_levels ->
+  list[float]`, `recognise_turned_steps -> TurnedProfile | None`) legitimately returns
+  that shape; forcing a record is ceremony. See *Amendment 1*.
 - **Date:** 2026-07-12
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -132,8 +137,12 @@ recognise_<feature>(part, **tuning) -> list[<Feature>Record]
 ```
 
 - verb `recognise_` (not `find_`/`analyse_`); one naming rule;
-- always a `list` of typed frozen dataclass records (no `Optional`-singular, no bare
-  `list`); empty when absent;
+- returns a **deterministic** result: normally a `list` of typed frozen dataclass
+  records (empty when absent). **Corrected by Amendment 1:** a recogniser whose feature
+  is inherently **scalar or singular** may instead return `list[<scalar>]` or
+  `<Structure> | None` where wrapping it in a record would be pure ceremony — the
+  original absolute "no `Optional`-singular, no bare `list`" was over-strict (it was
+  written knowing `recognise_turned_steps` was a counter-example);
 - `part` first, then **keyword-only** args: tuning knobs *and* injected shared
   inventory. A *base* feature (holes, chamfers, fillets, bosses, cylinders) derives
   only from `part`. A *derived* feature takes the canonical inventory it depends on
@@ -331,3 +340,30 @@ copy onto the shared source.
 - Sibling: `pzfreo/build123d-mcp` `tools/recognizers/` (the "repatriate later"
   package this ADR formalises the target for).
 - Roadmap: [`docs/plans/0013-shared-recognisers-roadmap.md`](../plans/0013-shared-recognisers-roadmap.md).
+
+## Amendment 1 (2026-07-12) — scalar/singular recognisers are an accepted shape (corrects §2)
+
+§2 as originally written asserted an **absolute** return contract: "always a `list` of
+typed frozen dataclass records (no `Optional`-singular, no bare `list`)". That was
+**over-strict, and written knowing of a counter-example.** At the time this ADR was
+authored, `recognise_turned_steps` already returned `TurnedProfile | None` and was
+flagged (here and in the #570 review) as "a genuine design call — is a turned profile
+even a `list[record]` recogniser?". The ADR nonetheless pinned the absolute rule and
+assumed the awkward cases would be *retyped to conform* under #568. Implementing #568
+showed that assumption was wrong:
+
+- `recognise_turned_steps -> TurnedProfile | None` is a **singular** whole-part
+  structure (its `.steps`/`.axis`/overall are consumed together). A `list` of 0-or-1
+  profiles is semantically wrong, and returning `list[TurnedStep]` would drop the
+  profile-level data consumers need.
+- `recognise_face_levels -> list[float]` is a **scalar** list — a face level *is* a Z
+  coordinate; its sole consumer wants the scalars, and a `FaceLevel(z)` wrapper adds
+  nothing.
+
+**Decision:** the contract accepts a **scalar or singular** return shape
+(`list[<scalar>]` / `<Structure> | None`) where wrapping in a record would be pure
+ceremony. The uniform *intent* (British verb, keyword-only signatures, deterministic,
+geometry-only, no recognition object crossing the IR boundary) stands; only the absolute
+"always `list[record]`" is relaxed. This is recorded honestly as a **correction of an
+over-specified original rule**, not a neutral refinement — the lesson being not to pin an
+absolute contract rule in an ADR while already holding a known exception.

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -8,11 +8,6 @@
   shared package `b123d-recognisers` (§1) is a **secondary, deferred deployment**
   (**Phase 2**, gated on a second committed consumer). **The consistency is the point;
   the package is one optional way to ship it.**
-- **Amendment 1** (2026-07-12): §2's absolute "always `list[record]`, no
-  `Optional`-singular, no bare `list`" is **corrected** — it was over-strict. A
-  recogniser whose feature is inherently scalar/singular (`recognise_face_levels ->
-  list[float]`, `recognise_turned_steps -> TurnedProfile | None`) legitimately returns
-  that shape; forcing a record is ceremony. See *Amendment 1*.
 - **Date:** 2026-07-12
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -137,12 +132,10 @@ recognise_<feature>(part, **tuning) -> list[<Feature>Record]
 ```
 
 - verb `recognise_` (not `find_`/`analyse_`); one naming rule;
-- returns a **deterministic** result: normally a `list` of typed frozen dataclass
-  records (empty when absent). **Corrected by Amendment 1:** a recogniser whose feature
-  is inherently **scalar or singular** may instead return `list[<scalar>]` or
-  `<Structure> | None` where wrapping it in a record would be pure ceremony — the
-  original absolute "no `Optional`-singular, no bare `list`" was over-strict (it was
-  written knowing `recognise_turned_steps` was a counter-example);
+- always a `list` of typed frozen dataclass records (no `Optional`-singular, no bare
+  `list`); empty when absent. Where a recogniser's record first looks "too thin" for a
+  list (a face level, a turned step), the fix is the **record** (make it self-contained —
+  `TurnedStep` carries its `axis`), not an exception to the rule;
 - `part` first, then **keyword-only** args: tuning knobs *and* injected shared
   inventory. A *base* feature (holes, chamfers, fillets, bosses, cylinders) derives
   only from `part`. A *derived* feature takes the canonical inventory it depends on
@@ -340,30 +333,3 @@ copy onto the shared source.
 - Sibling: `pzfreo/build123d-mcp` `tools/recognizers/` (the "repatriate later"
   package this ADR formalises the target for).
 - Roadmap: [`docs/plans/0013-shared-recognisers-roadmap.md`](../plans/0013-shared-recognisers-roadmap.md).
-
-## Amendment 1 (2026-07-12) — scalar/singular recognisers are an accepted shape (corrects §2)
-
-§2 as originally written asserted an **absolute** return contract: "always a `list` of
-typed frozen dataclass records (no `Optional`-singular, no bare `list`)". That was
-**over-strict, and written knowing of a counter-example.** At the time this ADR was
-authored, `recognise_turned_steps` already returned `TurnedProfile | None` and was
-flagged (here and in the #570 review) as "a genuine design call — is a turned profile
-even a `list[record]` recogniser?". The ADR nonetheless pinned the absolute rule and
-assumed the awkward cases would be *retyped to conform* under #568. Implementing #568
-showed that assumption was wrong:
-
-- `recognise_turned_steps -> TurnedProfile | None` is a **singular** whole-part
-  structure (its `.steps`/`.axis`/overall are consumed together). A `list` of 0-or-1
-  profiles is semantically wrong, and returning `list[TurnedStep]` would drop the
-  profile-level data consumers need.
-- `recognise_face_levels -> list[float]` is a **scalar** list — a face level *is* a Z
-  coordinate; its sole consumer wants the scalars, and a `FaceLevel(z)` wrapper adds
-  nothing.
-
-**Decision:** the contract accepts a **scalar or singular** return shape
-(`list[<scalar>]` / `<Structure> | None`) where wrapping in a record would be pure
-ceremony. The uniform *intent* (British verb, keyword-only signatures, deterministic,
-geometry-only, no recognition object crossing the IR boundary) stands; only the absolute
-"always `list[record]`" is relaxed. This is recorded honestly as a **correction of an
-over-specified original rule**, not a neutral refinement — the lesson being not to pin an
-absolute contract rule in an ADR while already holding a known exception.

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -35,6 +35,7 @@ from draftwright._core import (
 from draftwright.model.ir import Datum, PartModel, StepFeature
 from draftwright.model.planner import plan_dimensions
 from draftwright.recognition import (
+    TurnedProfile,
     analyse_cylinders,
     full_cylinders,
     recognise_bosses,
@@ -424,11 +425,11 @@ def _analyse(
     # recognise_face_levels admitted it). Prismatic and other parts keep the
     # general face-level scan, which recognise_turned_steps cannot replace (no
     # cylinders → no profile).
-    _turned = recognise_turned_steps(part)
+    _turned = TurnedProfile.from_steps(recognise_turned_steps(part))
     if _turned is not None and _turned.axis == "z":
         step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
     else:
-        face_zs = recognise_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)
+        face_zs = [fl.z for fl in recognise_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)]
         step_zs = [z for z in face_zs if z > bb.min.Z + 0.6 and z < bb.max.Z - 0.6]
 
     # Pass 1 (two-pass layout, #131): measure annotation strip depths before

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -27,6 +27,7 @@ from build123d_drafting.helpers import CenterMark, Dimension, TitleBlock
 from draftwright._core import _DIAM_RE, _END_ON, HoleRef, _axis_letter, _fmt, _xyz
 from draftwright.linting.issues import LintIssue
 from draftwright.recognition import (
+    TurnedProfile,
     analyse_cylinders,
     feature_diameters,
     recognise_hole_patterns,
@@ -435,7 +436,7 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     valid ``prof=None`` (non-turned part).
     """
     if prof is _UNSET:
-        prof = recognise_turned_steps(part)
+        prof = TurnedProfile.from_steps(recognise_turned_steps(part))
     if prof is None or prof.axis == "y":
         return []
     if assembly is None:

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -39,6 +39,7 @@ from draftwright.recognition import (
     HoleSpec,
     LinearArray,
     RectGrid,
+    TurnedProfile,
     recognise_bosses,
     recognise_chamfers,
     recognise_hole_patterns,
@@ -250,7 +251,7 @@ def build_part_model(
 
     # Turned profile → step segments; else external bosses → diameters.
     if prof is _UNSET:
-        prof = recognise_turned_steps(part)
+        prof = TurnedProfile.from_steps(recognise_turned_steps(part))
     orientation = prof.axis if prof is not None else None
     if prof is not None:
         idx = "xyz".index(prof.axis)

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -29,15 +29,20 @@ build123d types leak out — they are the future ``b123d-recognisers`` surface, 
 Phase 2, and ``detect.py`` adapts a record into the dimensioning IR with no recognition
 object crossing that boundary, ADR 0008 Am6).
 
-**State of this contract (this is the naming + signature step, #568 step 0).** Naming and
-the keyword-only signatures hold for *every* recogniser now. What does **not** yet hold,
-tracked by #568:
+Two recognisers legitimately return a **scalar / singular** shape rather than a list of
+records — forcing a record there would be ceremony with no consumer benefit:
 
-- **Return shape** — ``recognise_turned_steps`` returns ``TurnedProfile | None`` (genuinely
-  a single 0-or-1 profile — whether it is even a ``list[record]`` recogniser is an open
-  design call) and ``recognise_face_levels`` returns ``list[float]`` (not yet a record).
-- **Record idiom** — the vendored ``_features.py`` records (``HoleFeature``/``BossFeature``/…)
-  predate the ``…Record`` naming and clash by name with the IR ``Feature`` types.
+- ``recognise_face_levels(part, *, ...) -> list[float]`` — a face level *is* a Z
+  coordinate; its one consumer wants the scalars, and a ``FaceLevel(z)`` wrapper would add
+  nothing.
+- ``recognise_turned_steps(part) -> TurnedProfile | None`` — a turned profile is a single
+  whole-part structure (its ``.steps``/``.axis`` are consumed together), not a list of
+  independent features; ``list`` of 0-or-1 would be awkward.
+
+These are accepted shapes, not debt. Record class names avoid the IR ``Feature`` types:
+the vendored records are ``HoleRecord`` / ``BossRecord`` (not ``HoleFeature`` /
+``BossFeature`` — those are the IR types), keeping ``from draftwright.recognition import
+HoleRecord`` unambiguous against ``from draftwright.model.ir import HoleFeature``.
 
 ``analyse_cylinders`` / ``full_cylinders`` / ``feature_diameters`` are **not** recognisers
 under this contract — they are cylinder-analysis *substrate* (a tuple of dicts / a diameter
@@ -48,9 +53,9 @@ from __future__ import annotations
 
 from draftwright.recognition._features import (
     BoltCircle,
-    BossFeature,
+    BossRecord,
     CounterBore,
-    HoleFeature,
+    HoleRecord,
     HoleSpec,
     LinearArray,
     RectGrid,
@@ -74,9 +79,9 @@ from draftwright.recognition.turned import TurnedProfile, TurnedStep, recognise_
 __all__ = [
     "BoltCircle",
     "Chamfer",
-    "BossFeature",
+    "BossRecord",
     "CounterBore",
-    "HoleFeature",
+    "HoleRecord",
     "HoleSpec",
     "LinearArray",
     "Plate",

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -24,25 +24,27 @@ A *feature* recogniser takes one of two shapes:
   single inventory arg is unambiguous and stays positional.
 
 Common to both: a **British** ``recognise_`` verb (not ``find_``/``analyse_``); a
-**deterministic ``list`` of frozen-dataclass records**; **geometry-only records** (no
+**deterministic ``list`` of frozen-dataclass records** (empty when absent — never
+``Optional``-singular, never a bare ``list`` of primitives); **geometry-only records** (no
 build123d types leak out — they are the future ``b123d-recognisers`` surface, ADR 0013
 Phase 2, and ``detect.py`` adapts a record into the dimensioning IR with no recognition
 object crossing that boundary, ADR 0008 Am6).
 
-Two recognisers legitimately return a **scalar / singular** shape rather than a list of
-records — forcing a record there would be ceremony with no consumer benefit:
+The contract holds for **every** recogniser, including the two that once strained it —
+their records were simply the wrong shape (#568):
 
-- ``recognise_face_levels(part, *, ...) -> list[float]`` — a face level *is* a Z
-  coordinate; its one consumer wants the scalars, and a ``FaceLevel(z)`` wrapper would add
-  nothing.
-- ``recognise_turned_steps(part) -> TurnedProfile | None`` — a turned profile is a single
-  whole-part structure (its ``.steps``/``.axis`` are consumed together), not a list of
-  independent features; ``list`` of 0-or-1 would be awkward.
+- ``recognise_face_levels -> list[FaceLevel]`` (was ``list[float]``) — a level is now a
+  ``FaceLevel(z)`` record.
+- ``recognise_turned_steps -> list[TurnedStep]`` (was ``TurnedProfile | None``) — each
+  ``TurnedStep`` now carries its ``axis``, so it is a self-contained record and the old
+  ``TurnedProfile`` wrapper is no longer the return. ``TurnedProfile`` survives only as a
+  **pipeline aggregate** (``TurnedProfile.from_steps``) for consumers that want axis +
+  shoulders as a unit — it is not a recogniser return.
 
-These are accepted shapes, not debt. Record class names avoid the IR ``Feature`` types:
-the vendored records are ``HoleRecord`` / ``BossRecord`` (not ``HoleFeature`` /
-``BossFeature`` — those are the IR types), keeping ``from draftwright.recognition import
-HoleRecord`` unambiguous against ``from draftwright.model.ir import HoleFeature``.
+Record class names avoid the IR ``Feature`` types: the vendored records are ``HoleRecord``
+/ ``BossRecord`` (not ``HoleFeature`` / ``BossFeature`` — those are the IR types), keeping
+``from draftwright.recognition import HoleRecord`` unambiguous against ``from
+draftwright.model.ir import HoleFeature``.
 
 ``analyse_cylinders`` / ``full_cylinders`` / ``feature_diameters`` are **not** recognisers
 under this contract — they are cylinder-analysis *substrate* (a tuple of dicts / a diameter
@@ -68,6 +70,7 @@ from draftwright.recognition._features import (
 )
 from draftwright.recognition.chamfers import Chamfer, recognise_chamfers
 from draftwright.recognition.levels import (
+    FaceLevel,
     StepShoulder,
     recognise_face_levels,
     recognise_step_shoulders,
@@ -81,6 +84,7 @@ __all__ = [
     "Chamfer",
     "BossRecord",
     "CounterBore",
+    "FaceLevel",
     "HoleRecord",
     "HoleSpec",
     "LinearArray",

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -8,8 +8,8 @@ Imported via the package surface, :mod:`draftwright.recognition`.
 Recognises drilled-hole and boss features from a solid's cylindrical faces:
 
     from draftwright.recognition import recognise_holes, recognise_bosses
-    holes = recognise_holes(part)    # list[HoleFeature]
-    bosses = recognise_bosses(part)  # list[BossFeature]
+    holes = recognise_holes(part)    # list[HoleRecord]
+    bosses = recognise_bosses(part)  # list[BossRecord]
 
 A *hole* is a contiguous coaxial stack of internal full cylinders — the
 drilled bore plus optional counterbore and spotface steps — with its bottom
@@ -209,7 +209,7 @@ class CounterBore:
 
 
 @dataclass(frozen=True)
-class HoleFeature:
+class HoleRecord:
     """A drilled hole: the bore plus optional counterbore/spotface steps.
 
     ``axis`` is the drilling direction (unit vector pointing from the opening
@@ -231,7 +231,7 @@ class HoleFeature:
 
 
 @dataclass(frozen=True)
-class BossFeature:
+class BossRecord:
     """An external cylindrical boss (including a turned part's OD).
 
     ``axis`` points from the base toward the free end, ``location`` is the
@@ -466,8 +466,8 @@ def _merge_stacks(stacks, edge_faces, cache=None):
     return merged
 
 
-def recognise_holes(part, *, cyls=None) -> list[HoleFeature]:
-    """Recognise drilled holes on *part* (see :class:`HoleFeature`).
+def recognise_holes(part, *, cyls=None) -> list[HoleRecord]:
+    """Recognise drilled holes on *part* (see :class:`HoleRecord`).
 
     Coaxial internal cylinders are grouped into stacks — drill + optional
     counterbore + optional spotface become one hole, and a bore interrupted
@@ -555,7 +555,7 @@ def recognise_holes(part, *, cyls=None) -> list[HoleFeature]:
         else:
             depth = max(s["s_hi"] for s in deep_segs) - min(s["s_lo"] for s in bore_segs)
         holes.append(
-            HoleFeature(
+            HoleRecord(
                 axis=_unit(tuple(-c for c in d) if from_hi else d),
                 location=_axis_point(opening_seg, opening_s),
                 diameter=bore["diameter"],
@@ -568,9 +568,9 @@ def recognise_holes(part, *, cyls=None) -> list[HoleFeature]:
     return holes
 
 
-def recognise_bosses(part, *, cyls=None) -> list[BossFeature]:
+def recognise_bosses(part, *, cyls=None) -> list[BossRecord]:
     """Recognise external cylindrical bosses on *part* (one
-    :class:`BossFeature` per coaxial external cylinder segment, including a
+    :class:`BossRecord` per coaxial external cylinder segment, including a
     turned part's OD — callers wanting only local bosses can filter on
     diameter against the part envelope).
 
@@ -594,7 +594,7 @@ def recognise_bosses(part, *, cyls=None) -> list[BossFeature]:
         # default to the high end when both or neither are open.
         from_hi = not (lo_state == "open" and hi_state != "open")
         bosses.append(
-            BossFeature(
+            BossRecord(
                 axis=_unit(d if from_hi else tuple(-c for c in d)),
                 location=_axis_point(seg, seg["s_hi"] if from_hi else seg["s_lo"]),
                 diameter=seg["diameter"],
@@ -736,8 +736,8 @@ class HoleSpec:
     spotface: CounterBore | None
 
     @classmethod
-    def from_hole(cls, hole: HoleFeature) -> "HoleSpec":
-        """The :class:`HoleSpec` for *hole* (a :class:`HoleFeature`)."""
+    def from_hole(cls, hole: HoleRecord) -> "HoleSpec":
+        """The :class:`HoleSpec` for *hole* (a :class:`HoleRecord`)."""
         depth = None if hole.bottom == "through" else hole.depth
         axis = tuple(0.0 if abs(c) < 1e-6 else round(c, 6) for c in hole.axis)
         return cls(axis, hole.diameter, depth, hole.bottom, hole.cbore, hole.spotface)
@@ -988,7 +988,7 @@ def _rect_grid(members, pts):
 
 def recognise_hole_patterns(holes) -> list:
     """Recognise :class:`BoltCircle`, :class:`LinearArray`, and
-    :class:`RectGrid` patterns among *holes* (``HoleFeature`` records, e.g.
+    :class:`RectGrid` patterns among *holes* (``HoleRecord`` records, e.g.
     from :func:`recognise_holes`).
 
     Holes are grouped by machining spec and drilling axis, then each group is

--- a/src/draftwright/recognition/levels.py
+++ b/src/draftwright/recognition/levels.py
@@ -20,6 +20,15 @@ from OCP.GProp import GProp_GProps
 
 
 @dataclass(frozen=True, order=True)
+class FaceLevel:
+    """A recognised horizontal face level — its Z coordinate. A prismatic part's step
+    heights are dimensioned from these. ``order=True`` so the recogniser returns a
+    deterministically sorted list."""
+
+    z: float
+
+
+@dataclass(frozen=True, order=True)
 class StepShoulder:
     """A recognised step/rebate shoulder (#555). ``axis`` is the riser's normal axis
     ("x"/"y"); ``position`` is the world coord of the shoulder along it. ``order=True``
@@ -29,8 +38,11 @@ class StepShoulder:
     position: float
 
 
-def recognise_face_levels(part, *, tol: float = 0.5, min_area_frac: float = 0.0) -> list:
-    """Return sorted unique Z-coords of horizontal (normal≈±Z) planar faces.
+def recognise_face_levels(
+    part, *, tol: float = 0.5, min_area_frac: float = 0.0
+) -> list[FaceLevel]:
+    """Return the sorted unique horizontal (normal≈±Z) face levels as :class:`FaceLevel`
+    records — one per distinct Z of a horizontal planar face.
 
     Uses tol-bucket deduplication but returns the actual face Z, not the rounded
     bucket centre, so dimension labels match the true geometry.
@@ -59,8 +71,10 @@ def recognise_face_levels(part, *, tol: float = 0.5, min_area_frac: float = 0.0)
         bb = part.bounding_box()
         footprint = (bb.max.X - bb.min.X) * (bb.max.Y - bb.min.Y)
         threshold = min_area_frac * footprint
-        return sorted(z for key, z in buckets.items() if areas.get(key, 0.0) >= threshold)
-    return sorted(buckets.values())
+        return sorted(
+            FaceLevel(z) for key, z in buckets.items() if areas.get(key, 0.0) >= threshold
+        )
+    return sorted(FaceLevel(z) for z in buckets.values())
 
 
 def recognise_step_shoulders(

--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -85,10 +85,19 @@ class TurnedProfile:
 
     @classmethod
     def from_steps(cls, steps) -> TurnedProfile | None:
-        """Aggregate a recogniser's ``list[TurnedStep]`` (all coaxial), or ``None`` if
-        empty (a non-turned part)."""
+        """Aggregate a recogniser's ``list[TurnedStep]`` into a profile, or ``None`` if
+        empty (a non-turned part). The steps must be **coaxial** — a mixed-axis input is a
+        programming error and raises (it would otherwise silently pick one axis and
+        misrepresent the rest). Steps are sorted by ``lo`` so ``shoulders`` is correct
+        regardless of input order; contiguity / non-overlap is a caller precondition (the
+        recogniser guarantees it — this aggregate does not re-validate spans)."""
         steps = tuple(steps)
-        return cls(axis=steps[0].axis, steps=steps) if steps else None
+        if not steps:
+            return None
+        axes = {s.axis for s in steps}
+        if len(axes) != 1:
+            raise ValueError(f"turned steps are not coaxial: got axes {sorted(axes)}")
+        return cls(axis=next(iter(axes)), steps=tuple(sorted(steps, key=lambda s: s.lo)))
 
     @property
     def shoulders(self) -> tuple[float, ...]:

--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -57,8 +57,12 @@ _OD_FILL_MIN = 0.6
 
 @dataclass(frozen=True)
 class TurnedStep:
-    """One axial segment of a stepped shaft, between two shoulders (or ends)."""
+    """One axial segment of a stepped shaft, between two shoulders (or ends). ``axis`` is
+    the turning axis ("x"/"y"/"z") the segment is coaxial about — carried on the step so
+    it is a **self-contained record**: ``lo``/``hi``/``diameter`` are only interpretable
+    given the axis they are measured along."""
 
+    axis: str  # "x" / "y" / "z"
     lo: float
     hi: float
     diameter: float  # the external OD over this segment
@@ -70,10 +74,21 @@ class TurnedStep:
 
 @dataclass(frozen=True)
 class TurnedProfile:
-    """The axial step breakdown of a turned part along its turning ``axis``."""
+    """The turned-shaft **aggregate** for the annotation pipeline — the coaxial ``steps``
+    plus their shared ``axis`` and derived shoulders. **Not a recogniser return**
+    (:func:`recognise_turned_steps` returns ``list[TurnedStep]`` per ADR 0013 §2); built
+    from that list via :meth:`from_steps` for consumers that want axis + shoulders as a
+    unit."""
 
     axis: str  # "x" / "y" / "z"
     steps: tuple[TurnedStep, ...]
+
+    @classmethod
+    def from_steps(cls, steps) -> TurnedProfile | None:
+        """Aggregate a recogniser's ``list[TurnedStep]`` (all coaxial), or ``None`` if
+        empty (a non-turned part)."""
+        steps = tuple(steps)
+        return cls(axis=steps[0].axis, steps=steps) if steps else None
 
     @property
     def shoulders(self) -> tuple[float, ...]:
@@ -83,20 +98,22 @@ class TurnedProfile:
         return (*(s.lo for s in self.steps), self.steps[-1].hi)
 
 
-def recognise_turned_steps(part) -> TurnedProfile | None:
-    """Recognise the axial steps of a stepped turned ``part``, or ``None``.
+def recognise_turned_steps(part) -> list[TurnedStep]:
+    """Recognise the axial steps of a stepped turned ``part``.
 
-    Returns ``None`` for a non-turned part, a plain (single-diameter) cylinder,
-    or anything with fewer than two steps — nothing to dimension axially.
+    Returns ``[]`` for a non-turned part, a plain (single-diameter) cylinder, or
+    anything with fewer than two steps — nothing to dimension axially. Each
+    :class:`TurnedStep` carries the turning ``axis``; aggregate them with
+    :meth:`TurnedProfile.from_steps` if the axis/shoulders unit is wanted.
     """
     z_cyls, cross_cyls = analyse_cylinders(part)
     ext = [c for c in (*z_cyls, *cross_cyls) if c.get("external")]
     if not ext:
-        return None
+        return []
     axis, _ = Counter(c["axis"] for c in ext).most_common(1)[0]
     bands = [c for c in ext if c["axis"] == axis]
     if len({round(c["diameter"], 2) for c in bands}) < 2:
-        return None  # one OD → not a stepped turned part
+        return []  # one OD → not a stepped turned part
     idx = "xyz".index(axis)
 
     # A genuine turned shaft is a body of revolution about *axis*: its OD silhouette
@@ -113,7 +130,7 @@ def recognise_turned_steps(part) -> TurnedProfile | None:
         or max_od < _OD_FILL_MIN * cross
         or abs(perp[0] - perp[1]) > _SQUARENESS_TOL * cross
     ):
-        return None
+        return []
 
     def local_od(pos: float) -> float:
         radii = [
@@ -144,22 +161,23 @@ def recognise_turned_steps(part) -> TurnedProfile | None:
 
     planes = sorted(shoulders)
     if len(planes) < 3:  # fewer than two steps
-        return None
+        return []
     # A segment whose midpoint has no external band over it (`local_od` → 0) is a
     # gap between disconnected bands, not a real step — drop it so it never renders
     # as a phantom ø0 diameter (#279).
-    steps = tuple(
+    steps = [
         s
         for i in range(len(planes) - 1)
         if (
             s := TurnedStep(
+                axis=axis,
                 lo=planes[i],
                 hi=planes[i + 1],
                 diameter=2 * local_od((planes[i] + planes[i + 1]) / 2),
             )
         ).diameter
         > 0
-    )
+    ]
     if len(steps) < 2:  # fewer than two real steps → nothing to dimension axially
-        return None
-    return TurnedProfile(axis=axis, steps=steps)
+        return []
+    return steps

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2718,8 +2718,8 @@ def test_analyse_face_levels_box():
     box = Box(30, 20, 10)
     levels = recognise_face_levels(box)
     # Box centred at origin has Z faces at -5 and +5
-    assert any(abs(z - (-5.0)) < 0.1 for z in levels)
-    assert any(abs(z - 5.0) < 0.1 for z in levels)
+    assert any(abs(fl.z - (-5.0)) < 0.1 for fl in levels)
+    assert any(abs(fl.z - 5.0) < 0.1 for fl in levels)
 
 
 @pytest.mark.timeout(60)
@@ -2743,14 +2743,14 @@ def test_analyse_face_levels_area_filter_drops_tiny_faces():
 
     # Without the filter the tiny face shows up as a phantom level.
     unfiltered = recognise_face_levels(part)
-    assert any(abs(z - 7.0) < 0.1 for z in unfiltered)
+    assert any(abs(fl.z - 7.0) < 0.1 for fl in unfiltered)
 
     # With a 1%-of-footprint threshold (6 mm²) the 1 mm² face is dropped,
     # leaving only the real slab faces.
     filtered = recognise_face_levels(part, min_area_frac=0.01)
-    assert not any(abs(z - 7.0) < 0.1 for z in filtered)
-    assert any(abs(z - 5.0) < 0.1 for z in filtered)
-    assert any(abs(z - (-5.0)) < 0.1 for z in filtered)
+    assert not any(abs(fl.z - 7.0) < 0.1 for fl in filtered)
+    assert any(abs(fl.z - 5.0) < 0.1 for fl in filtered)
+    assert any(abs(fl.z - (-5.0)) < 0.1 for fl in filtered)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -23,9 +23,9 @@ from build123d import (
 )
 
 from draftwright.recognition import (
-    BossFeature,
+    BossRecord,
     CounterBore,
-    HoleFeature,
+    HoleRecord,
     HoleSpec,
     analyse_cylinders,
     feature_diameters,
@@ -49,7 +49,7 @@ class TestFindHoles:
     def test_plain_through_hole(self):
         holes = recognise_holes(Box(60, 60, 20) - Cylinder(5, 20))
         assert holes == [
-            HoleFeature(
+            HoleRecord(
                 axis=(0.0, 0.0, -1.0),
                 location=(0.0, 0.0, 10.0),
                 diameter=10.0,
@@ -448,7 +448,7 @@ class TestFindBosses:
     def test_boss_on_plate(self):
         part = Box(60, 60, 10) + Pos(0, 0, 5 + 4) * Cylinder(12, 8)
         assert recognise_bosses(part) == [
-            BossFeature(
+            BossRecord(
                 axis=(0.0, 0.0, 1.0),
                 location=(0.0, 0.0, 13.0),
                 diameter=24.0,
@@ -704,10 +704,10 @@ class TestFindHolePatterns:
         # LinearArray: endpoints are the farthest-apart pair, not a
         # lexicographic sort that a tiny jitter can reorder (mis-measuring the
         # span and pitch).
-        from draftwright.recognition import HoleFeature, LinearArray, recognise_hole_patterns
+        from draftwright.recognition import HoleRecord, LinearArray, recognise_hole_patterns
 
         holes = [
-            HoleFeature(
+            HoleRecord(
                 axis=(0.0, 0.0, -1.0),
                 location=(x, 1e-4 * ((i % 2) * 2 - 1), 0.0),
                 diameter=5.0,

--- a/tests/test_turned_steps.py
+++ b/tests/test_turned_steps.py
@@ -23,35 +23,41 @@ def _shaft_x(*sections):
     return Rotation(0, 90, 0) * solid
 
 
-def _lengths(profile: TurnedProfile):
-    return sorted(round(s.length, 2) for s in profile.steps)
+def _lengths(steps):
+    return sorted(round(s.length, 2) for s in steps)
 
 
 class TestFindTurnedSteps:
     def test_two_step_shaft(self):
-        prof = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
-        assert prof is not None
-        assert prof.axis == "x"
-        assert _lengths(prof) == [30.0, 40.0]
+        steps = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
+        assert steps
+        assert _lengths(steps) == [30.0, 40.0]
+
+    def test_each_step_is_a_self_contained_record_carrying_its_axis(self):
+        # The shape fix (#568): a TurnedStep carries its turning axis, so it is
+        # interpretable on its own — no TurnedProfile wrapper needed for that.
+        steps = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
+        assert steps
+        assert all(s.axis == "x" for s in steps)
 
     def test_three_step_shaft(self):
-        prof = recognise_turned_steps(_shaft_x((20, 10), (14, 10), (8, 10)))
-        assert prof is not None
-        assert _lengths(prof) == [10.0, 10.0, 10.0]
+        steps = recognise_turned_steps(_shaft_x((20, 10), (14, 10), (8, 10)))
+        assert steps
+        assert _lengths(steps) == [10.0, 10.0, 10.0]
 
     def test_steps_tile_the_axis_and_sum_to_overall(self):
-        prof = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
+        steps = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
         # contiguous: each step's hi is the next step's lo
-        for a, b in zip(prof.steps, prof.steps[1:]):
+        for a, b in zip(steps, steps[1:]):
             assert a.hi == pytest.approx(b.lo)
-        assert sum(s.length for s in prof.steps) == pytest.approx(70.0)
+        assert sum(s.length for s in steps) == pytest.approx(70.0)
 
     def test_axial_bore_is_ignored(self):
         # A through-bore down the centre must not add a step or shift shoulders.
         shaft = _shaft_x((30, 40), (16, 30)) - Rotation(0, 90, 0) * Cylinder(4, 200)
-        prof = recognise_turned_steps(shaft)
-        assert prof is not None
-        assert _lengths(prof) == [30.0, 40.0]
+        steps = recognise_turned_steps(shaft)
+        assert steps
+        assert _lengths(steps) == [30.0, 40.0]
 
     def test_chamfered_shoulders_keep_true_lengths(self):
         # Chamfer the shoulder edges; the step lengths must stay shoulder-to-
@@ -62,17 +68,19 @@ class TestFindTurnedSteps:
             shaft = shaft.chamfer(0.8, None, edges)
         except Exception:
             pytest.skip("chamfer not constructible on this fixture")
-        prof = recognise_turned_steps(shaft)
-        assert prof is not None
-        assert _lengths(prof) == [30.0, 40.0]
+        steps = recognise_turned_steps(shaft)
+        assert steps
+        assert _lengths(steps) == [30.0, 40.0]
 
     def test_diameter_per_step(self):
-        prof = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
-        by_len = {round(s.length): round(s.diameter) for s in prof.steps}
+        steps = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
+        by_len = {round(s.length): round(s.diameter) for s in steps}
         assert by_len == {40: 30, 30: 16}
 
-    def test_shoulders_property(self):
-        prof = recognise_turned_steps(_shaft_x((30, 40), (16, 30)))
+    def test_shoulders_aggregate(self):
+        # `shoulders` is a TurnedProfile-aggregate concern, built from the steps.
+        prof = TurnedProfile.from_steps(recognise_turned_steps(_shaft_x((30, 40), (16, 30))))
+        assert prof is not None and prof.axis == "x"
         sh = prof.shoulders
         assert len(sh) == 3
         assert list(sh) == sorted(sh)  # sorted shoulder positions
@@ -80,8 +88,9 @@ class TestFindTurnedSteps:
         diffs = sorted(round(b - a, 2) for a, b in zip(sh, sh[1:]))
         assert diffs == [30.0, 40.0]
 
-    def test_plain_cylinder_is_none(self):
-        assert recognise_turned_steps(Cylinder(15, 40)) is None
+    def test_plain_cylinder_is_empty(self):
+        assert recognise_turned_steps(Cylinder(15, 40)) == []
+        assert TurnedProfile.from_steps(recognise_turned_steps(Cylinder(15, 40))) is None
 
-    def test_prismatic_box_is_none(self):
-        assert recognise_turned_steps(Box(40, 40, 10)) is None
+    def test_prismatic_box_is_empty(self):
+        assert recognise_turned_steps(Box(40, 40, 10)) == []

--- a/tests/test_turned_steps.py
+++ b/tests/test_turned_steps.py
@@ -8,7 +8,7 @@ orientation that is not flagged Z-rotational), mirroring _x_stepped_shaft.
 import pytest
 from build123d import Box, Cylinder, GeomType, Pos, Rotation
 
-from draftwright.recognition import TurnedProfile, recognise_turned_steps
+from draftwright.recognition import TurnedProfile, TurnedStep, recognise_turned_steps
 
 
 def _shaft_x(*sections):
@@ -94,3 +94,25 @@ class TestFindTurnedSteps:
 
     def test_prismatic_box_is_empty(self):
         assert recognise_turned_steps(Box(40, 40, 10)) == []
+
+
+class TestTurnedProfileFromSteps:
+    """The aggregate is now a public boundary (was invariant-by-construction), so it
+    guards the invariant that would silently corrupt its axis/shoulders."""
+
+    def test_empty_is_none(self):
+        assert TurnedProfile.from_steps([]) is None
+
+    def test_rejects_mixed_axes(self):
+        # A mixed-axis input is a programming error — fail loud, don't silently
+        # pick steps[0].axis and misrepresent the rest.
+        steps = [TurnedStep("x", 0, 10, 20), TurnedStep("y", 10, 20, 16)]
+        with pytest.raises(ValueError):
+            TurnedProfile.from_steps(steps)
+
+    def test_sorts_by_lo_so_shoulders_are_ordered(self):
+        # Out-of-order coaxial steps must still yield sorted shoulders.
+        steps = [TurnedStep("x", 40, 70, 16), TurnedStep("x", 0, 40, 30)]
+        prof = TurnedProfile.from_steps(steps)
+        assert prof is not None and prof.axis == "x"
+        assert list(prof.shoulders) == [0.0, 40.0, 70.0]


### PR DESCRIPTION
## What

**Step 1 of the recogniser contract** (#568): finish making the recogniser layer conform to ADR 0013 §2 (`recognise_<feature>(part, *, …) -> list[<record>]`), with **zero exceptions**.

## Changes

- **Name-clash fix.** Renamed the recognition records that collided with the IR `Feature` types → `HoleRecord`/`BossRecord` (IR types unchanged).
- **`recognise_turned_steps -> list[TurnedStep]`** (was `TurnedProfile | None`; `[]` for a non-turned part). Root fix was the **record shape**: `TurnedStep` gained an `axis` field, so a step is self-contained. `TurnedProfile` survives only as a **pipeline aggregate** (`TurnedProfile.from_steps`, which rejects mixed axes + sorts) — `detect`/`analysis`/`coverage` wrap the list via it, so the `a.prof` pipeline is byte-identical.
- **`recognise_face_levels -> list[FaceLevel]`** (was `list[float]`).

## Why conform (not relax the ADR)

An earlier revision blessed the two stragglers as scalar/singular exceptions. Review + maintainer call: **ADR §2 is right; the records were the wrong shape.** Fixed the records instead — ADR 0013 §2 stands unamended.

## Notes

- **No drawing-output change** (`test_layout_snapshot` byte-identical incl. turned fixtures; e2e/part_model green).
- Part of the **0.3.0 breaking bucket** — CHANGELOG updated.

## Verification

`ruff` + `mypy` clean; `test_recognition`, `test_turned_steps` (incl. new `from_steps` adversarial tests), `test_layout_snapshot`, `test_e2e_standards`, `test_part_model`, `-m smoke` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
