### PR TITLE
feat: recognise and call out countersunk holes (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ contract (ADR 0013 / #568). These are *deliberate* breaks with **no compatibilit
 aliases**, so this must ship in a **minor bump (0.3.0), not a patch**. Drawing output is
 unchanged (byte-identical); only import paths and callable signatures change.
 
+### Added
+
+- **Countersink callouts (#558).** A countersunk hole is now recognised and called out
+  `Ø6 THRU ⌵ Ø14 × 90°` (major-Ø + included angle), the way counterbores already get
+  `⊔ Ø.. ↧..`. New `recognise_countersinks(part) -> list[CounterSink]` recogniser
+  (geometry-mirrored with `build123d-mcp` for the shared `b123d-recognisers` package);
+  the countersink rides on `HoleRecord`/`HoleFeature` so grouping and the callout-width
+  layout estimate account for it.
+
 ### Changed
 
 - **Feature recognisers renamed `find_`/`analyse_` → `recognise_`** and their

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -148,10 +148,11 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
         depth=f(spec["depth"]),
         cbore_dia=f(spec["cbore_dia"]),
         cbore_depth=f(spec["cbore_depth"]),
-        csink_dia=f(spec["csink_dia"]),
+        csink_dia=f(spec.get("csink_dia")),
         # Every value crosses as a _fmt string (the #261 invariant) — a raw float renders
         # "90.0°" and, worse, mismatches the width estimators' `_fmt` (they'd under-reserve).
-        csink_angle=f(spec["csink_angle"]),
+        # `.get()`: hand-built specs (tolerance/fit tests) omit csk keys.
+        csink_angle=f(spec.get("csink_angle")),
         suffix=spec["suffix"],
         draft=draft,
     )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -110,6 +110,8 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
         # counterbore precedence, spotface fallback — the engine's mapping
         "cbore_dia": _first(group, "diameter", "counterbore", "spotface"),
         "cbore_depth": _first(group, "depth", "counterbore", "spotface"),
+        "csink_dia": _first(group, "diameter", "countersink"),
+        "csink_angle": _first(group, "angle", "countersink"),
         "suffix": suffix,
         "tolerance": bore_tol,  # P2a: ± on the bore ⌀, baked into the callout string below
     }
@@ -146,6 +148,8 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
         depth=f(spec["depth"]),
         cbore_dia=f(spec["cbore_dia"]),
         cbore_depth=f(spec["cbore_depth"]),
+        csink_dia=f(spec["csink_dia"]),
+        csink_angle=spec["csink_angle"],
         suffix=spec["suffix"],
         draft=draft,
     )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -149,7 +149,9 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
         cbore_dia=f(spec["cbore_dia"]),
         cbore_depth=f(spec["cbore_depth"]),
         csink_dia=f(spec["csink_dia"]),
-        csink_angle=spec["csink_angle"],
+        # Every value crosses as a _fmt string (the #261 invariant) — a raw float renders
+        # "90.0°" and, worse, mismatches the width estimators' `_fmt` (they'd under-reserve).
+        csink_angle=f(spec["csink_angle"]),
         suffix=spec["suffix"],
         draft=draft,
     )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -52,9 +52,9 @@ from draftwright.recognition import (
 
 
 def _member_hole(h, frame: Frame, members: tuple = (), count: int = 1) -> HoleFeature:
-    """A recogniser hole → an IR `HoleFeature` (bore + counterbore/spotface). When
-    *h* represents a machining-spec group of identical holes, *members* are their
-    locations and *count* their number."""
+    """A recogniser hole → an IR `HoleFeature` (bore + counterbore/spotface/countersink).
+    When *h* represents a machining-spec group of identical holes, *members* are their
+    locations and *count* their number. The countersink rides on the HoleRecord (#558)."""
     return HoleFeature(
         frame=frame,
         diameter=h.diameter,
@@ -64,6 +64,7 @@ def _member_hole(h, frame: Frame, members: tuple = (), count: int = 1) -> HoleFe
         members=members,
         cbore=(h.cbore.diameter, h.cbore.depth) if h.cbore else None,
         spotface=(h.spotface.diameter, h.spotface.depth) if h.spotface else None,
+        csink=(h.csink.major_diameter, h.csink.included_angle) if h.csink else None,
     )
 
 
@@ -217,7 +218,8 @@ def build_part_model(
         features.append(_pattern_feature(pat, members))
     # Un-patterned holes: group by machining spec so identical holes share one
     # count× callout (the engine's grouped-callout rule); HoleSpec keys on the
-    # snapped axis too, so opposite-face drillings stay distinct.
+    # snapped axis and the countersink too, so opposite-face drillings and csk-vs-plain
+    # holes stay distinct.
     spec_groups: dict = {}
     for h in holes:
         if id(h) in patterned:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -129,6 +129,9 @@ class HoleFeature:
     members: tuple[Point, ...] = ()
     cbore: tuple[float, float] | None = None
     spotface: tuple[float, float] | None = None
+    # A countersink (flat-head screw seat): ``(major_diameter, included_angle°)`` or
+    # ``None`` — plain tuple, the IR stays decoupled from the recogniser's type (#558).
+    csink: tuple[float, float] | None = None
     kind: ClassVar[str] = "hole"
 
     def parameters(self) -> list[DimParameter]:
@@ -144,6 +147,10 @@ class HoleFeature:
             sd, sdp = self.spotface
             ps.append(DimParameter("diameter", "spotface", sd))
             ps.append(DimParameter("depth", "spotface", sdp))
+        if self.csink is not None:
+            csd, csa = self.csink
+            ps.append(DimParameter("diameter", "countersink", csd))
+            ps.append(DimParameter("angle", "countersink", csa))
         return ps
 
     def references(self) -> list[Datum]:

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -69,6 +69,7 @@ from draftwright.recognition._features import (
     recognise_holes,
 )
 from draftwright.recognition.chamfers import Chamfer, recognise_chamfers
+from draftwright.recognition.countersinks import CounterSink, recognise_countersinks
 from draftwright.recognition.levels import (
     FaceLevel,
     StepShoulder,
@@ -84,6 +85,7 @@ __all__ = [
     "Chamfer",
     "BossRecord",
     "CounterBore",
+    "CounterSink",
     "FaceLevel",
     "HoleRecord",
     "HoleSpec",
@@ -100,6 +102,7 @@ __all__ = [
     "feature_diameters",
     "recognise_bosses",
     "recognise_chamfers",
+    "recognise_countersinks",
     "recognise_hole_patterns",
     "recognise_holes",
     "recognise_plates",

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -474,20 +474,24 @@ def _merge_stacks(stacks, edge_faces, cache=None):
 
 _CSK_DIA_TOL = 0.2  # mm — countersink drill ⌀ vs bore ⌀
 _CSK_COAX_TOL = 0.2  # mm — countersink opening off the bore axis line
+_CSK_MOUTH_TOL = 0.5  # mm — countersink must sit at the bore's mouth, not deep inside
 
 
 def _csink_for_hole(h: HoleRecord, csinks: list[CounterSink]) -> CounterSink | None:
-    """The countersink coaxial with hole *h* — parallel axis, opening on the bore's axis
-    line, matching drill ⌀ — or None (#558)."""
+    """The countersink at hole *h*'s mouth, or None (#558). Requires: opening on the
+    bore's axis *line* (perp), the csk facing the **same way** as the bore (``same_dir`` —
+    so a coaxial hole drilled from the *opposite* face is not mis-matched), the csk on the
+    **mouth side** of the bore opening (``t`` ≤ tol, not deep inside), and matching drill ⌀."""
     hx = h.axis
     for cs in csinks:
         v = tuple(cs.location[i] - h.location[i] for i in range(3))
         t = sum(v[i] * hx[i] for i in range(3))
         perp = math.hypot(*(v[i] - t * hx[i] for i in range(3)))
-        parallel = abs(sum(hx[i] * cs.axis[i] for i in range(3))) > 1 - 1e-3
+        same_dir = sum(hx[i] * cs.axis[i] for i in range(3)) > 1 - 1e-3
         if (
-            parallel
+            same_dir
             and perp <= _CSK_COAX_TOL
+            and t <= _CSK_MOUTH_TOL
             and abs(cs.drill_diameter - h.diameter) <= _CSK_DIA_TOL
         ):
             return cs

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -29,7 +29,7 @@ This module also hosts the low-level cylinder analysis that
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.GeomAbs import (
@@ -40,6 +40,8 @@ from OCP.GeomAbs import (
     GeomAbs_Torus,
 )
 from OCP.TopAbs import TopAbs_Orientation
+
+from draftwright.recognition.countersinks import CounterSink, recognise_countersinks
 
 # Cylinder patches around one axis spanning half a turn or less in total are
 # not holes or bosses: quarter-turn patches are edge blends (fillets/rounds)
@@ -228,6 +230,10 @@ class HoleRecord:
     bottom: str
     cbore: CounterBore | None = None
     spotface: CounterBore | None = None
+    # A countersink (flat-head seat) coaxial with the bore, or None (#558). Composed
+    # from the standalone :func:`recognise_countersinks` so the hole's spec/grouping and
+    # the callout-width estimate all see it.
+    csink: CounterSink | None = None
 
 
 @dataclass(frozen=True)
@@ -466,6 +472,28 @@ def _merge_stacks(stacks, edge_faces, cache=None):
     return merged
 
 
+_CSK_DIA_TOL = 0.2  # mm — countersink drill ⌀ vs bore ⌀
+_CSK_COAX_TOL = 0.2  # mm — countersink opening off the bore axis line
+
+
+def _csink_for_hole(h: HoleRecord, csinks: list[CounterSink]) -> CounterSink | None:
+    """The countersink coaxial with hole *h* — parallel axis, opening on the bore's axis
+    line, matching drill ⌀ — or None (#558)."""
+    hx = h.axis
+    for cs in csinks:
+        v = tuple(cs.location[i] - h.location[i] for i in range(3))
+        t = sum(v[i] * hx[i] for i in range(3))
+        perp = math.hypot(*(v[i] - t * hx[i] for i in range(3)))
+        parallel = abs(sum(hx[i] * cs.axis[i] for i in range(3))) > 1 - 1e-3
+        if (
+            parallel
+            and perp <= _CSK_COAX_TOL
+            and abs(cs.drill_diameter - h.diameter) <= _CSK_DIA_TOL
+        ):
+            return cs
+    return None
+
+
 def recognise_holes(part, *, cyls=None) -> list[HoleRecord]:
     """Recognise drilled holes on *part* (see :class:`HoleRecord`).
 
@@ -565,6 +593,15 @@ def recognise_holes(part, *, cyls=None) -> list[HoleRecord]:
                 spotface=spotface,
             )
         )
+    # Compose countersinks (#558): a coaxial cone flaring from the bore is a hole
+    # attribute (like a counterbore), so it rides on the HoleRecord — HoleSpec grouping
+    # and the callout-width estimate then see it for free.
+    csinks = recognise_countersinks(part)
+    if csinks:
+        holes = [
+            (replace(h, csink=cs) if (cs := _csink_for_hole(h, csinks)) is not None else h)
+            for h in holes
+        ]
     return holes
 
 
@@ -734,13 +771,17 @@ class HoleSpec:
     bottom: str
     cbore: CounterBore | None
     spotface: CounterBore | None
+    # The countersink's *size* only — ``(major_diameter, included_angle)`` — never its
+    # location, so identical countersunk holes at different positions share one spec (#558).
+    csink: tuple[float, float] | None = None
 
     @classmethod
     def from_hole(cls, hole: HoleRecord) -> "HoleSpec":
         """The :class:`HoleSpec` for *hole* (a :class:`HoleRecord`)."""
         depth = None if hole.bottom == "through" else hole.depth
         axis = tuple(0.0 if abs(c) < 1e-6 else round(c, 6) for c in hole.axis)
-        return cls(axis, hole.diameter, depth, hole.bottom, hole.cbore, hole.spotface)
+        csink = (hole.csink.major_diameter, hole.csink.included_angle) if hole.csink else None
+        return cls(axis, hole.diameter, depth, hole.bottom, hole.cbore, hole.spotface, csink)
 
 
 def _spec_key(h):

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -478,22 +478,25 @@ _CSK_MOUTH_TOL = 0.5  # mm — countersink must sit at the bore's mouth, not dee
 
 
 def _csink_for_hole(h: HoleRecord, csinks: list[CounterSink]) -> CounterSink | None:
-    """The countersink at hole *h*'s mouth, or None (#558). Requires: opening on the
-    bore's axis *line* (perp), the csk facing the **same way** as the bore (``same_dir`` —
-    so a coaxial hole drilled from the *opposite* face is not mis-matched), the csk on the
-    **mouth side** of the bore opening (``t`` ≤ tol, not deep inside), and matching drill ⌀."""
+    """The countersink seated on hole *h*, or None (#558). A countersink belongs to the
+    hole when its **minor circle** — where the cone meets the drilled bore — sits coaxially
+    at one of the hole's bore *ends*: the opening (``s`` ≈ 0) or, for a through hole (open
+    at both faces), the far end (``s`` ≈ depth). Keying on the minor-at-a-bore-end (not the
+    opening face, nor the axis direction) makes association independent of which end
+    ``recognise_holes`` happened to call the opening, and still excludes a *separate*
+    coaxial hole on the opposite face — whose own bore ends are elsewhere."""
     hx = h.axis
+    through = h.bottom == "through"
     for cs in csinks:
-        v = tuple(cs.location[i] - h.location[i] for i in range(3))
-        t = sum(v[i] * hx[i] for i in range(3))
-        perp = math.hypot(*(v[i] - t * hx[i] for i in range(3)))
-        same_dir = sum(hx[i] * cs.axis[i] for i in range(3)) > 1 - 1e-3
-        if (
-            same_dir
-            and perp <= _CSK_COAX_TOL
-            and t <= _CSK_MOUTH_TOL
-            and abs(cs.drill_diameter - h.diameter) <= _CSK_DIA_TOL
-        ):
+        # The cone's minor circle: the opening (major) advanced by the cone depth along the
+        # csk axis, i.e. where the countersink meets the drilled bore.
+        m = tuple(cs.location[i] + cs.depth * cs.axis[i] for i in range(3))
+        v = tuple(m[i] - h.location[i] for i in range(3))
+        s = sum(v[i] * hx[i] for i in range(3))
+        perp = math.hypot(*(v[i] - s * hx[i] for i in range(3)))
+        if perp > _CSK_COAX_TOL or abs(cs.drill_diameter - h.diameter) > _CSK_DIA_TOL:
+            continue
+        if abs(s) <= _CSK_MOUTH_TOL or (through and abs(s - h.depth) <= _CSK_MOUTH_TOL):
             return cs
     return None
 

--- a/src/draftwright/recognition/countersinks.py
+++ b/src/draftwright/recognition/countersinks.py
@@ -1,0 +1,119 @@
+"""countersinks — countersink recognition for drilled holes (ADR 0007, #558).
+
+``recognise_countersinks`` recovers the countersinks a plain hole recogniser reports as
+mere openings: an internal **cone** that flares from a drilled bore (the minor circle)
+out to a larger opening (the major circle), coaxial with a **cylinder** of the drill
+radius. That is exactly a countersink for a flat-head screw. Keying on it — a cone with
+two distinct-radius circular edges whose smaller radius matches a coaxial drilled
+cylinder — excludes drill-point cones (a single circle + apex, not flared) and external
+edge chamfers (no coaxial bore).
+
+Geometry-mirrored with ``pzfreo/build123d-mcp``'s ``recognise_countersinks`` so the pair
+can converge in the shared ``b123d-recognisers`` package (ADR 0013). Bottom of the
+recognition DAG: depends only on build123d/OCP.
+
+Heuristic limits (``recognised`` tier): a small lead-in / deburr chamfer at a hole mouth
+is geometrically a shallow countersink and also registers (its small ``major_diameter`` /
+``depth`` make that visible); a near-flat cone above ``_MAX_INCLUDED_ANGLE`` (a draft /
+relief) is excluded; a countersink clipped by another feature (its edges no longer full
+circles) is missed.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from build123d import GeomType
+
+_TOL = 0.05  # mm — dimension match tolerance (matches the other feature matchers)
+_COAXIAL_TOL = 0.1  # mm — how far the opening may sit off the drill's axis line
+# Real countersinks are ≤120° included (60/82/90/100/120 standards); a near-flat cone is
+# a draft/relief/washer face, not a countersink. 160° keeps every real countersink with
+# margin while excluding drafts (~176–178° included).
+_MAX_INCLUDED_ANGLE = 160.0
+
+
+@dataclass(frozen=True)
+class CounterSink:
+    """A recognised countersink. ``axis`` points from the wide opening into the part;
+    ``location`` is the opening (major-circle) centre; ``major_diameter`` the outer rim,
+    ``drill_diameter`` the bore it sits on; ``included_angle`` the full cone angle
+    (degrees); ``depth`` the axial cone depth. Fields mirror the shared-package record."""
+
+    axis: tuple[float, float, float]
+    location: tuple[float, float, float]
+    major_diameter: float
+    drill_diameter: float
+    included_angle: float
+    depth: float
+
+
+def _parallel(a, b) -> bool:
+    return bool(abs(a[0] * b[0] + a[1] * b[1] + a[2] * b[2]) > 1 - 1e-3)
+
+
+def _dist_to_line(pt, line_pt, line_dir) -> float:
+    v = (pt[0] - line_pt[0], pt[1] - line_pt[1], pt[2] - line_pt[2])
+    t = v[0] * line_dir[0] + v[1] * line_dir[1] + v[2] * line_dir[2]
+    perp = (v[0] - t * line_dir[0], v[1] - t * line_dir[1], v[2] - t * line_dir[2])
+    return math.sqrt(perp[0] ** 2 + perp[1] ** 2 + perp[2] ** 2)
+
+
+def recognise_countersinks(part) -> list[CounterSink]:
+    """Recognise the countersinks of *part* (see module docstring). One
+    :class:`CounterSink` per qualifying cone, sorted deterministically; empty when the
+    part has none."""
+    from OCP.BRepAdaptor import BRepAdaptor_Surface
+
+    cyls = []
+    for cy in part.faces().filter_by(GeomType.CYLINDER):
+        ax = BRepAdaptor_Surface(cy.wrapped).Cylinder().Axis()
+        p, d = ax.Location(), ax.Direction()
+        cyls.append((cy.radius, (p.X(), p.Y(), p.Z()), (d.X(), d.Y(), d.Z())))
+
+    out: list[CounterSink] = []
+    for f in part.faces().filter_by(GeomType.CONE):
+        circles = sorted(f.edges().filter_by(GeomType.CIRCLE), key=lambda e: e.radius)
+        if len(circles) < 2:
+            continue  # drill-point cone (one circle + apex) or degenerate
+        minor_e, major_e = circles[0], circles[-1]
+        minor_r, major_r = minor_e.radius, major_e.radius
+        if major_r - minor_r < _TOL:
+            continue  # not flared — not a countersink
+        cone = BRepAdaptor_Surface(f.wrapped).Cone()
+        included_angle = round(2 * abs(math.degrees(cone.SemiAngle())), 2)
+        if included_angle > _MAX_INCLUDED_ANGLE:
+            continue  # a near-flat cone is a draft/relief/washer face, not a countersink
+        opening = major_e.arc_center
+        opening_pt = (opening.X, opening.Y, opening.Z)
+        mc = minor_e.arc_center
+        minor_pt = (mc.X, mc.Y, mc.Z)
+        # Axis points INTO the part: from the wide opening toward the drilled bore.
+        # (Deterministic — don't trust OCP's cone-axis sign across constructions.)
+        av = (
+            minor_pt[0] - opening_pt[0],
+            minor_pt[1] - opening_pt[1],
+            minor_pt[2] - opening_pt[2],
+        )
+        alen = math.sqrt(av[0] ** 2 + av[1] ** 2 + av[2] ** 2) or 1.0
+        axis = (av[0] / alen, av[1] / alen, av[2] / alen)
+        # A countersink sits on a drilled bore: a coaxial cylinder of the minor radius.
+        if not any(
+            abs(r - minor_r) <= _TOL
+            and _parallel(axis, ld)
+            and _dist_to_line(opening_pt, lp, ld) <= _COAXIAL_TOL
+            for r, lp, ld in cyls
+        ):
+            continue
+        out.append(
+            CounterSink(
+                axis=(round(axis[0], 4), round(axis[1], 4), round(axis[2], 4)),
+                location=tuple(round(v, 4) for v in opening_pt),
+                major_diameter=round(2 * major_r, 4),
+                drill_diameter=round(2 * minor_r, 4),
+                included_angle=included_angle,
+                depth=round(alen, 4),
+            )
+        )
+    return sorted(out, key=lambda c: (c.location, c.major_diameter))

--- a/src/draftwright/recognition/countersinks.py
+++ b/src/draftwright/recognition/countersinks.py
@@ -18,13 +18,20 @@ excludes it — a screw seat flares to roughly twice the bore, an edge break bar
 it; a near-flat cone above ``_MAX_INCLUDED_ANGLE`` (a draft / relief) is excluded; a
 countersink clipped by another feature (its edges no longer full circles) is missed.
 
-Known limitations (standalone recogniser; no effect on draftwright drawings, which only
-call out a countersink attached to a recognised bore): an **external transition chamfer**
-between two coaxial cylinders (e.g. a stepped shaft) also presents a flared cone coaxial
-with a cylinder and can register — an internal/external face-orientation check would
-exclude it (deferred to the shared ``b123d-recognisers`` extraction); a through hole
-countersunk on **both** faces yields two coaxial countersinks (each associates to the bore
-independently, but the single ``HoleRecord.csink`` slot records only one).
+Known limitations (edge geometries; the common one-face countersink is exact):
+
+- an **external transition chamfer** between two coaxial cylinders (e.g. a stepped
+  shaft) presents a flared cone coaxial with a cylinder and can register in the
+  standalone recogniser — harmless in draftwright drawings (``_csink_for_hole`` only
+  attaches a countersink to a recognised internal bore, and a shaft has none); an
+  internal/external face-orientation check would exclude it (deferred to the shared
+  ``b123d-recognisers`` extraction);
+- a **DIN 332 lathe centre-drill** (a 60° cone flaring from a small pilot bore) is
+  geometrically near-indistinguishable from a small countersink and can register;
+- a through hole countersunk on **both** faces yields two coaxial countersinks, but the
+  single ``HoleRecord.csink`` slot records only one — so it under-reports, and (since
+  ``HoleSpec`` keys the csink on size only) a both-face hole can group with a one-face
+  hole of the same size. A two-slot csink model would be needed to draw both seats.
 """
 
 from __future__ import annotations

--- a/src/draftwright/recognition/countersinks.py
+++ b/src/draftwright/recognition/countersinks.py
@@ -12,11 +12,19 @@ Geometry-mirrored with ``pzfreo/build123d-mcp``'s ``recognise_countersinks`` so 
 can converge in the shared ``b123d-recognisers`` package (ADR 0013). Bottom of the
 recognition DAG: depends only on build123d/OCP.
 
-Heuristic limits (``recognised`` tier): a small lead-in / deburr chamfer at a hole mouth
-is geometrically a shallow countersink and also registers (its small ``major_diameter`` /
-``depth`` make that visible); a near-flat cone above ``_MAX_INCLUDED_ANGLE`` (a draft /
-relief) is excluded; a countersink clipped by another feature (its edges no longer full
-circles) is missed.
+Heuristic limits (``recognised`` tier): an edge-break / deburr / lead-in chamfer at a hole
+mouth is geometrically a shallow countersink, so a **flare-ratio floor** (``_MIN_MAJOR_RATIO``)
+excludes it — a screw seat flares to roughly twice the bore, an edge break barely widens
+it; a near-flat cone above ``_MAX_INCLUDED_ANGLE`` (a draft / relief) is excluded; a
+countersink clipped by another feature (its edges no longer full circles) is missed.
+
+Known limitations (standalone recogniser; no effect on draftwright drawings, which only
+call out a countersink attached to a recognised bore): an **external transition chamfer**
+between two coaxial cylinders (e.g. a stepped shaft) also presents a flared cone coaxial
+with a cylinder and can register — an internal/external face-orientation check would
+exclude it (deferred to the shared ``b123d-recognisers`` extraction); a through hole
+countersunk on **both** faces yields two coaxial countersinks (each associates to the bore
+independently, but the single ``HoleRecord.csink`` slot records only one).
 """
 
 from __future__ import annotations
@@ -32,6 +40,11 @@ _COAXIAL_TOL = 0.1  # mm — how far the opening may sit off the drill's axis li
 # a draft/relief/washer face, not a countersink. 160° keeps every real countersink with
 # margin while excluding drafts (~176–178° included).
 _MAX_INCLUDED_ANGLE = 160.0
+# A screw seat flares to roughly twice the bore (a flat-head sits in it); an edge-break /
+# deburr / lead-in chamfer on a hole mouth is the same *shape* but barely wider than the
+# bore. Require the major to reach this multiple of the drill radius to exclude those —
+# else every chamfered hole mouth would be called out as a countersink (#558 review).
+_MIN_MAJOR_RATIO = 1.5
 
 
 @dataclass(frozen=True)
@@ -66,6 +79,10 @@ def recognise_countersinks(part) -> list[CounterSink]:
     part has none."""
     from OCP.BRepAdaptor import BRepAdaptor_Surface
 
+    cones = list(part.faces().filter_by(GeomType.CONE))
+    if not cones:
+        return []  # no cones → no countersinks; skip the cylinder scan (perf, #558 review)
+
     cyls = []
     for cy in part.faces().filter_by(GeomType.CYLINDER):
         ax = BRepAdaptor_Surface(cy.wrapped).Cylinder().Axis()
@@ -73,14 +90,14 @@ def recognise_countersinks(part) -> list[CounterSink]:
         cyls.append((cy.radius, (p.X(), p.Y(), p.Z()), (d.X(), d.Y(), d.Z())))
 
     out: list[CounterSink] = []
-    for f in part.faces().filter_by(GeomType.CONE):
+    for f in cones:
         circles = sorted(f.edges().filter_by(GeomType.CIRCLE), key=lambda e: e.radius)
         if len(circles) < 2:
             continue  # drill-point cone (one circle + apex) or degenerate
         minor_e, major_e = circles[0], circles[-1]
         minor_r, major_r = minor_e.radius, major_e.radius
-        if major_r - minor_r < _TOL:
-            continue  # not flared — not a countersink
+        if major_r < _MIN_MAJOR_RATIO * minor_r:
+            continue  # too little flare — an edge break / deburr, not a screw seat
         cone = BRepAdaptor_Surface(f.wrapped).Cone()
         included_angle = round(2 * abs(math.degrees(cone.SemiAngle())), 2)
         if included_angle > _MAX_INCLUDED_ANGLE:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -324,6 +324,11 @@ def _est_bore_callout_width(
             if step.depth:
                 token_w.append(sym_w)  # depth symbol
                 token_w.append(_text_width(_fmt(step.depth), h_fs))
+        if rep.csink is not None:
+            token_w.append(sym_w)  # countersink symbol
+            token_w.append(sym_w)  # ⌀
+            token_w.append(_text_width(_fmt(rep.csink.major_diameter), h_fs))
+            token_w.append(_text_width(f"× {_fmt(rep.csink.included_angle)}°", h_fs))
 
         # Pattern callout suffix ("EQ SP ON ø… BC" / "(r×c)"), when this spec
         # group is recognised as a pattern.
@@ -404,6 +409,14 @@ def _est_planned_bore_callout_width(
             if cbore_depth is not None:
                 token_w.append(sym_w)  # depth symbol
                 token_w.append(_text_width(_fmt(cbore_depth), font_size))
+        csink_dia = _first(group, "diameter", "countersink")
+        if csink_dia is not None:
+            token_w.append(sym_w)  # countersink symbol
+            token_w.append(sym_w)  # ⌀
+            token_w.append(_text_width(_fmt(csink_dia), font_size))
+            csink_angle = _first(group, "angle", "countersink")
+            if csink_angle is not None:
+                token_w.append(_text_width(f"× {_fmt(csink_angle)}°", font_size))
         if suffix is not None:
             token_w.append(_text_width(suffix, font_size))
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -426,6 +426,69 @@ class TestChamferCallout:
         assert _chamfer_label(chamfers[0]) == "C2.5"
 
 
+class TestCountersinkCallout:
+    """#558: a countersunk hole was called out as a plain THRU hole — no major-Ø /
+    included-angle. It must now carry a csk callout (⌵ Ø14 × 90°), like a counterbore."""
+
+    @staticmethod
+    def _csk_plate():
+        # The issue's repro: Ø6 through + a 90° csk flaring to Ø14 at the top face.
+        from build123d import Cone
+
+        plate = Box(90, 60, 12)
+        for x, y in [(-30, -15), (5, 12), (30, -8)]:
+            plate -= Pos(x, y, 0) * Cylinder(3, 12)
+            plate -= Pos(x, y, 4) * Cone(3, 7, 4)
+        return plate
+
+    def test_countersink_recognised(self):
+        from draftwright.recognition import recognise_countersinks
+
+        cs = recognise_countersinks(self._csk_plate())
+        assert len(cs) == 3
+        for c in cs:
+            assert abs(c.major_diameter - 14.0) < 0.1
+            assert abs(c.drill_diameter - 6.0) < 0.1
+            assert abs(c.included_angle - 90.0) < 0.5
+
+    def test_countersunk_hole_carries_csink_in_ir(self):
+        # Recovered as a HoleFeature.csink = (major_diameter, angle), grouped 3×.
+        dwg = build_drawing(self._csk_plate(), number="X")
+        holes = [f for f in dwg.model().features if f.kind == "hole"]
+        assert len(holes) == 1 and holes[0].count == 3
+        assert holes[0].csink is not None
+        maj, ang = holes[0].csink
+        assert abs(maj - 14.0) < 0.1 and abs(ang - 90.0) < 0.5
+
+    def test_countersink_callout_is_placed_not_dropped(self):
+        # The wider csk callout must reserve room in the layout estimate and place —
+        # NOT drop like it did before the estimator learned about countersinks.
+        dwg = build_drawing(self._csk_plate(), number="X")
+        assert not any(
+            getattr(i, "code", None) == "callout_dropped" for i in dwg._build_issues
+        )
+        leaders = [dwg._named[n] for n in dwg._named if n.startswith("hc_")]
+        assert leaders, "no hole callout placed"
+        # The placed callout covers both the bore (6) and the csk major (14).
+        assert any(14.0 in ldr.covers_diameters for ldr in leaders)
+
+    def test_plain_hole_has_no_countersink(self):
+        plate = Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(3, 12)
+        holes = [f for f in build_drawing(plate, number="X").model().features if f.kind == "hole"]
+        assert holes and holes[0].csink is None
+
+    def test_counterbore_is_not_a_countersink(self):
+        # A ⌀18 counterbore (a cylindrical recess) must not register as a countersink.
+        plate = Box(90, 60, 12)
+        plate -= Pos(0, 0, 0) * Cylinder(3, 12)
+        plate -= Pos(0, 0, 3) * Cylinder(9, 6)
+        from draftwright.recognition import recognise_countersinks
+
+        assert recognise_countersinks(plate) == []
+        holes = [f for f in build_drawing(plate, number="X").model().features if f.kind == "hole"]
+        assert holes and holes[0].csink is None and holes[0].cbore is not None
+
+
 class TestStepSizingConvergence:
     def test_step_sizing_converges_past_the_old_three_pass_limit(self):
         measure_calls = []

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -464,9 +464,7 @@ class TestCountersinkCallout:
         # The wider csk callout must reserve room in the layout estimate and place —
         # NOT drop like it did before the estimator learned about countersinks.
         dwg = build_drawing(self._csk_plate(), number="X")
-        assert not any(
-            getattr(i, "code", None) == "callout_dropped" for i in dwg._build_issues
-        )
+        assert not any(getattr(i, "code", None) == "callout_dropped" for i in dwg._build_issues)
         leaders = [dwg._named[n] for n in dwg._named if n.startswith("hc_")]
         assert leaders, "no hole callout placed"
         # The placed callout covers both the bore (6) and the csk major (14).
@@ -487,6 +485,59 @@ class TestCountersinkCallout:
         assert recognise_countersinks(plate) == []
         holes = [f for f in build_drawing(plate, number="X").model().features if f.kind == "hole"]
         assert holes and holes[0].csink is None and holes[0].cbore is not None
+
+    def test_deburr_mouth_chamfer_is_not_a_countersink(self):
+        # #558 review (BLOCKER): a 0.5 mm edge-break / deburr at a hole mouth is the same
+        # cone shape as a shallow csk — the flare-ratio floor must exclude it, else every
+        # chamfered hole mouth gets a spurious csk callout.
+        from build123d import Axis, chamfer
+
+        from draftwright.recognition import recognise_countersinks, recognise_holes
+
+        plate = Box(30, 30, 10) - Pos(0, 0, 0) * Cylinder(3, 20)
+        edge = plate.edges().filter_by(Axis.Z).group_by(lambda e: e.center().Z)[-1]
+        plate = chamfer(edge, 0.5)
+        assert recognise_countersinks(plate) == []
+        assert recognise_holes(plate)[0].csink is None
+
+    def test_opposite_face_coaxial_hole_is_not_mis_associated(self):
+        # #558 review (BLOCKER): a countersink must attach only to the bore at its mouth,
+        # facing the same way — NOT to a coaxial hole drilled from the opposite face.
+        from build123d import Cone
+
+        from draftwright.recognition import recognise_holes
+
+        p = Box(40, 40, 30)
+        p -= Pos(0, 0, 9) * Cylinder(3, 12)  # top hole, opening at z=15
+        p -= Pos(0, 0, 13) * Cone(3, 7, 4)  # csk at the top face
+        p -= Pos(0, 0, -9) * Cylinder(3, 12)  # coaxial bottom hole, same bore, NO csk
+        by_open = {round(h.location[2]): h for h in recognise_holes(p)}
+        top = max(by_open)  # the top (csk) hole
+        assert by_open[top].csink is not None
+        assert by_open[min(by_open)].csink is None  # the opposite-face hole stays plain
+
+    def test_callout_angle_is_formatted_not_raw_float(self):
+        # #558 review (BLOCKER): the angle must cross as a _fmt string so it renders
+        # "× 90°" (not "× 90.0°") AND matches the width estimators — a raw float renders
+        # wider and would re-drop the callout.
+        from build123d_drafting import HoleCallout
+
+        from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
+        from draftwright.model.planner import plan_dimensions
+
+        dwg = build_drawing(self._csk_plate(), number="X")
+        m = dwg.model()
+        hole = next(f for f in m.features if f.kind == "hole")
+        g = next(gg for gg in plan_dimensions(m) if getattr(gg, "feature", None) is hole)
+        built = callout_from_spec(hole_callout_spec(g), dwg.draft, 3)
+        ref_str = HoleCallout(
+            "6", count=3, through=True, csink_dia="14", csink_angle="90", draft=dwg.draft
+        )
+        ref_float = HoleCallout(
+            "6", count=3, through=True, csink_dia="14", csink_angle=90.0, draft=dwg.draft
+        )
+        assert abs(built.callout_width - ref_str.callout_width) < 0.05  # "× 90°"
+        assert abs(built.callout_width - ref_float.callout_width) > 1.0  # not "× 90.0°"
 
 
 class TestStepSizingConvergence:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -516,6 +516,18 @@ class TestCountersinkCallout:
         assert by_open[top].csink is not None
         assert by_open[min(by_open)].csink is None  # the opposite-face hole stays plain
 
+    def test_through_hole_countersink_is_orientation_independent(self):
+        # #558 review round 2 (BLOCKER): a through hole is open at both faces, so
+        # recognise_holes may call either end the "opening". The countersink must attach
+        # regardless of which — a Z-flip must not drop it to plain THRU.
+        from build123d import Rotation
+
+        from draftwright.recognition import recognise_holes
+
+        flipped = Rotation(180, 0, 0) * self._csk_plate()
+        holes = [h for h in recognise_holes(flipped) if h.csink is not None]
+        assert len(holes) == 3  # all three csk holes keep their countersink after the flip
+
     def test_callout_angle_is_formatted_not_raw_float(self):
         # #558 review (BLOCKER): the angle must cross as a _fmt string so it renders
         # "× 90°" (not "× 90.0°") AND matches the width estimators — a raw float renders


### PR DESCRIPTION
## What

Closes #558. A countersunk hole was **drawn** but **called out as a plain `THRU` hole** — no major-Ø / included angle. It now gets a csk callout `Ø6 THRU ⌵ Ø14 × 90°`, the way a counterbore gets `⊔ Ø.. ↧..`.

## How

- **New `recognise_countersinks(part) -> list[CounterSink]`** (`recognition/countersinks.py`): an internal cone flaring from a coaxial drilled bore. **Geometry mirrored with `build123d-mcp`**'s recogniser so the pair can converge in the shared `b123d-recognisers` package — this is the **ADR-0013 pilot**. Conforms to the recogniser contract.
- **The countersink rides on `HoleRecord`/`HoleFeature`** (composed in `recognise_holes`, like a counterbore), so `HoleSpec` grouping (keyed on csk *size*, not location, so identical csk holes still group into `3×`), the IR callout, and the layout width estimate all see it.
- **Fixed a real drop:** the wider csk callout was dropped ("no room beside the view") because `sheet.py`'s callout-width estimator handled counterbores but **not** countersinks — so the page/strip under-reserved (cbore placed, csk dropped). Estimator now includes csk. On the repro the 3 holes form one placed `3× Ø6 THRU ⌵ Ø14 × 90°` callout.

## Tests / verification

5 acceptance/edge tests (recognition; IR `csink`; **placed-not-dropped**; plain-hole and counterbore negatives). **No drawing-output change for non-csk parts** — `test_layout_snapshot` byte-identical. Full `test_make_drawing` (567), recognition, part_model, e2e, turned, smoke all green; ruff + mypy clean.

Additive feature; rides in the same **0.3.0** line — CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)