### PR TITLE
docs: current-decision TL;DRs for ADR 0008/0009 + architectural-fit assessment rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,21 @@ re-derive or contradict them. If a change conflicts with an ADR, amend the ADR
 in the same PR (status, reasoning, date) rather than silently diverging — and if
 a decision turns out wrong, record that too.
 
+**Assess architectural fit — always.** An issue, a PR, and a review are each
+incomplete until they weigh the change against the ADRs, not just its local
+correctness. Ask: does this feature round-trip **all** the surfaces its kind
+requires — recognise **+** emit **+** declare (ADR 0011 / epic #574; no
+recognition-only debt)? Does it fit the compiler pipeline and one-inventory waist
+(ADR 0008)? Does it conform to the recogniser contract (ADR 0013)? Does it sit
+where it belongs in the DAG, or re-introduce a coupling an ADR removed? A change
+that is locally correct but architecturally off-pattern *is* tech debt — call it
+out in the issue/PR/review, not after merge.
+
+When an ADR has grown unwieldy with amendments, read its **Current decision**
+header first (the amended state in one place); the amendments below are the *why*
+trail. Once an ADR passes ~3–4 amendments, prefer a new **superseding** ADR over
+amendment N+1.
+
 Current ADRs:
 - **0001** — deterministic generation over an editable DSL.
 - **0002** — iterate via lint-critique and domain-repair (repair is a *safety

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -22,6 +22,23 @@
   converter) (ADR 0013). Amendment 6 (no recognition object crosses the boundary) is
   preserved.
 
+## Current decision (as amended, 2026-07-12)
+
+*The part-drawing engine is a **compiler**.* detectors → a **Feature / DimParameter IR**
+(`PartModel`) → a dimensioning **planner** → **render-intents** → the shared
+layout / table / section / projection / export infrastructure. **One feature inventory,
+detected once** (`_analyse`); the orchestrator is **build model → plan → render**.
+Orientation / feature-kind are *data in the IR*, not code branches. The migration is
+**complete — one path**: each step deleted the per-feature engine pass it replaced (not
+reproduce-and-swap, not two permanent paths — Am 2/3). The IR↔infra boundary is
+**IR-typed** — no recognition object crosses it (Am 6). The waist is now **two tiers**
+(Am 7): a shared **geometric recognition record** feeds the dimensioning IR through a
+uniform `detect.py` adapter protocol (a typed registry of per-record converters).
+
+*The amendments below are the reasoning trail (contract refinement → out-grow strategy →
+one-path convergence → IR/infra boundary → one-inventory foundation → IR-typed interface →
+two-tier waist) — read them for the* why, *not to reconstruct the current state.*
+
 ## Context
 
 draftwright recognises a part's features and dimensions them. Both halves grew by

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -3,6 +3,26 @@
 - **Status:** Accepted (2026-06-30)
 - **Deciders:** Paul Fremantle (pzfreo)
 
+## Current decision (as amended, 2026-07-12)
+
+Annotation placement within each view's strips is a **collect-then-solve boundary-labeling**
+stage, not place-as-you-go. Per view: **collect** every strip occupant (plus fixed
+obstacles) as a geometry-only candidate; **solve** once per strip — *select* (priority;
+over-capacity → a first-class escalation), *assign* (side), *order* (= feature order ⇒
+leaders **crossing-free by construction**), *space* (a deterministic **PAVA**
+minimum-total-leader-length solve — kiwisolver/Cassowary retired, Am 3–4 — with
+central-hole **anchoring**); **emit**. Keep-out (centre-lines / bolt-circles) is a keep-out
+**band** folded into the **one shared `carve_free_segments` primitive** every pass uses —
+the separate banded-PAVA DP was **retired** (Am 9). Corridors are solved **once across
+passes** (Am 6); candidates carry real per-candidate footprints and GD&T frames are
+first-class candidates (Am 7). **Deterministic and explainable** ("label *i* sits here
+because order + min-gap + shortest-leader"), never a global metaheuristic.
+
+*The 9 amendments below are the solver's evolution trail (escalation objects → precise
+leader geometry → the L1/PAVA min-leader solve → band-aware then shared-carve keep-out →
+one-solve-across-passes → real footprints + GD&T → solver consolidation) — read them for
+the* why, *not to reconstruct the current state.*
+
 ## Context
 
 A run of layout fixes — #133 (locate side-drilled holes), #225 (locate *every*


### PR DESCRIPTION
## What

Two docs improvements you asked for:

1. **Current-decision TL;DRs.** ADR **0008** (7 amendments) and **0009** (9) had grown so amended that the *present* decision was scattered across the original + N amendments — a reader had to do amendment-archaeology to answer "what do we actually do now." Each now opens with a **"Current decision (as amended)"** header stating the present state in one place; the amendments stay below as the reasoning trail (the *why*).

2. **CLAUDE.md — "assess architectural fit, always."** Issues, PRs, and reviews must weigh a change against the ADRs, not just local correctness: does it round-trip **all** ADR-0011 surfaces (recognise + emit + declare — no recognition-only debt, epic #574), fit the ADR-0008 compiler waist, conform to the ADR-0013 recogniser contract, and sit right in the DAG? A locally-correct but off-pattern change *is* tech debt — flag it in the issue/PR/review, not after merge. Plus a rule: past ~3–4 amendments, prefer a **superseding** ADR over amendment N+1 (0009 is the cautionary tale).

Docs-only. No content deleted — the TL;DRs summarise, they don't replace the amendment history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)