### PR TITLE
feat: declare + emit surfaces for countersinks (#575)

### DIFF
--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -107,6 +107,19 @@ def _require_pair_positive(name: str, pair) -> None:
     _positive(f"{name} depth", pair[1])
 
 
+def _require_csink(name: str, csink) -> None:
+    """A ``(major_diameter, included_angle)`` pair — both positive, the angle a real cone
+    (< 180°). The second slot is an ANGLE, not a depth, so it gets its own message."""
+    if csink is None:
+        return
+    if not (isinstance(csink, (tuple, list)) and len(csink) == 2):
+        raise ValueError(f"{name} must be a (major_diameter, included_angle) pair (got {csink!r})")
+    _positive(f"{name} major_diameter", csink[0])
+    _positive(f"{name} included_angle", csink[1])
+    if not csink[1] < 180:
+        raise ValueError(f"{name} included_angle must be < 180° (got {csink[1]})")
+
+
 def _bbox_axis_dia(obj) -> tuple[str, float, Point]:
     """Read an axis-aligned cylinder's (axis, diameter, centre) off its bounding box:
     the two near-equal spans are the diameter; the odd one out is the bore/OD axis."""
@@ -220,7 +233,7 @@ def hole(
     _require_positive(diameter=diameter, depth=depth)
     _require_pair_positive("cbore", cbore)
     _require_pair_positive("spotface", spotface)
-    _require_pair_positive("csink", csink)  # (major_diameter, included_angle), both positive
+    _require_csink("csink", csink)  # (major_diameter, included_angle)
     _require_point("at", at)
     _require_count("hole()", count)
     return HoleFeature(
@@ -248,8 +261,11 @@ def read_countersink(cone) -> tuple[float, float]:
         raise ValueError("countersink(cone=...) needs a conical tool (a build123d Cone)")
     f = faces[0]
     circles = f.edges().filter_by(GeomType.CIRCLE)
-    if not circles:
-        raise ValueError("countersink(cone=...): the cone has no circular rim to size")
+    if len(circles) < 2:
+        raise ValueError(
+            "countersink(cone=...) needs a flared cone with two distinct-radius rims; a "
+            "single-rim drill-point cone is not a countersink"
+        )
     major = 2 * max(e.radius for e in circles)
     semi = abs(BRepAdaptor_Surface(f.wrapped).Cone().SemiAngle())
     return round(major, 4), round(2 * math.degrees(semi), 2)

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -197,14 +197,16 @@ def hole(
     depth=None,
     cbore=None,
     spotface=None,
+    csink=None,
     count=1,
     members=(),
 ) -> HoleFeature:
     """A drilled hole. Either ``hole(tool_cylinder)`` — read ⌀ / axis / location off the
     build123d object you subtracted — or ``hole(diameter=6, at=(20, 10, 0), axis="z")``.
 
-    ``cbore`` / ``spotface`` are ``(diameter, depth)`` pairs; ``count`` + ``members``
-    describe a machining-spec group drawn as one ``count×`` callout.
+    ``cbore`` / ``spotface`` are ``(diameter, depth)`` pairs; ``csink`` is a
+    ``(major_diameter, included_angle)`` pair (a flat-head seat, callout ``⌵ Ø.. × ..°``);
+    ``count`` + ``members`` describe a machining-spec group drawn as one ``count×`` callout.
 
     An object supplies *defaults*; any explicit keyword overrides that field (#451)."""
     if obj is not None:
@@ -218,6 +220,7 @@ def hole(
     _require_positive(diameter=diameter, depth=depth)
     _require_pair_positive("cbore", cbore)
     _require_pair_positive("spotface", spotface)
+    _require_pair_positive("csink", csink)  # (major_diameter, included_angle), both positive
     _require_point("at", at)
     _require_count("hole()", count)
     return HoleFeature(
@@ -229,7 +232,27 @@ def hole(
         members=tuple(members),
         cbore=cbore,
         spotface=spotface,
+        csink=csink,
     )
+
+
+def read_countersink(cone) -> tuple[float, float]:
+    """``(major_diameter, included_angle°)`` of a countersink **cone** tool — the larger rim ⌀
+    and the full cone angle, read off its conical **face** (not a removed edge, #576 lesson).
+    Mirrors :func:`recognition.recognise_countersinks`' cone geometry."""
+    from build123d import GeomType
+    from OCP.BRepAdaptor import BRepAdaptor_Surface
+
+    faces = cone.faces().filter_by(GeomType.CONE)
+    if not faces:
+        raise ValueError("countersink(cone=...) needs a conical tool (a build123d Cone)")
+    f = faces[0]
+    circles = f.edges().filter_by(GeomType.CIRCLE)
+    if not circles:
+        raise ValueError("countersink(cone=...): the cone has no circular rim to size")
+    major = 2 * max(e.radius for e in circles)
+    semi = abs(BRepAdaptor_Surface(f.wrapped).Cone().SemiAngle())
+    return round(major, 4), round(2 * math.degrees(semi), 2)
 
 
 def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -55,7 +55,13 @@ from draftwright.model import note as _declare_note
 from draftwright.model import pattern as _pattern
 from draftwright.model import slot as _slot
 from draftwright.model import step as _step
-from draftwright.model.declare import _norm_axis, _read_cylinder, _require_positive, gdt_target
+from draftwright.model.declare import (
+    _norm_axis,
+    _read_cylinder,
+    _require_csink,
+    _require_positive,
+    gdt_target,
+)
 from draftwright.model.declare import read_bore_step as _read_bore_step
 from draftwright.model.declare import read_countersink as _read_countersink
 from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, Point
@@ -163,7 +169,7 @@ class _Hole:
             angle = r_angle if angle is None else angle
         if major is None or angle is None:
             raise ValueError("countersink() needs a cone tool, or explicit major= and angle=")
-        _require_positive(**{"countersink major": major, "countersink angle": angle})
+        _require_csink("countersink", (major, angle))
         return self._set(csink=(major, angle))
 
     def _read_step(self, kind, obj, diameter, depth) -> tuple[float, float]:

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -57,6 +57,7 @@ from draftwright.model import slot as _slot
 from draftwright.model import step as _step
 from draftwright.model.declare import _norm_axis, _read_cylinder, _require_positive, gdt_target
 from draftwright.model.declare import read_bore_step as _read_bore_step
+from draftwright.model.declare import read_countersink as _read_countersink
 from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, Point
 
 
@@ -148,6 +149,22 @@ class _Hole:
     ) -> _Hole:
         """A spotface on this hole — same as :meth:`cbore` but a shallow facing (#462)."""
         return self._set(spotface=self._read_step("spotface", obj, diameter, depth))
+
+    def countersink(
+        self, obj=None, *, major: float | None = None, angle: float | None = None
+    ) -> _Hole:
+        """A countersink on this hole (a flat-head screw seat, #575). ``.countersink(cone_tool)``
+        reads the major ⌀ + included angle off the build123d ``Cone`` you subtracted, or explicit
+        ``.countersink(major=14, angle=90)``. Renders ``⌵ Ø.. × ..°`` on the callout. An object
+        supplies defaults; explicit kwargs override (#451)."""
+        if obj is not None:
+            r_major, r_angle = _read_countersink(obj)
+            major = r_major if major is None else major
+            angle = r_angle if angle is None else angle
+        if major is None or angle is None:
+            raise ValueError("countersink() needs a cone tool, or explicit major= and angle=")
+        _require_positive(**{"countersink major": major, "countersink angle": angle})
+        return self._set(csink=(major, angle))
 
     def _read_step(self, kind, obj, diameter, depth) -> tuple[float, float]:
         if obj is not None:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -66,6 +66,8 @@ def _hole_line(f) -> str:
         kw.append(f"cbore=({_n(f.cbore[0])}, {_n(f.cbore[1])})")
     if f.spotface:
         kw.append(f"spotface=({_n(f.spotface[0])}, {_n(f.spotface[1])})")
+    if f.csink:
+        kw.append(f"csink=({_n(f.csink[0])}, {_n(f.csink[1])})")
     line = f"sheet.hole({', '.join(kw)})"
     if not f.through and f.depth is not None:
         line += f".depth({_n(f.depth)})"

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -76,13 +76,16 @@ def _hole_line(f) -> str:
 
 def _member_hole_str(m) -> str:
     """The ``hole(...)`` template for a pattern member — carries its ⌀ AND its
-    counterbore / spotface / blind-depth so a counterbored bolt circle keeps those
-    callouts on re-run (declare.hole takes depth=/through=/cbore=/spotface= kwargs)."""
+    counterbore / spotface / countersink / blind-depth so a counterbored or countersunk
+    bolt circle keeps those callouts on re-run (declare.hole takes depth=/through=/cbore=/
+    spotface=/csink= kwargs)."""
     kw = [f"diameter={_n(m.diameter)}", f"at={_pt(m.frame.origin)}", f'axis="{m.frame.axis}"']
     if m.cbore:
         kw.append(f"cbore=({_n(m.cbore[0])}, {_n(m.cbore[1])})")
     if m.spotface:
         kw.append(f"spotface=({_n(m.spotface[0])}, {_n(m.spotface[1])})")
+    if m.csink:
+        kw.append(f"csink=({_n(m.csink[0])}, {_n(m.csink[1])})")
     if not m.through and m.depth is not None:
         kw.append(f"depth={_n(m.depth)}")
         kw.append("through=False")

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -359,6 +359,20 @@ class TestCountersink:
         with pytest.raises(ValueError):
             s.hole(diameter=6, at=(0, 0, 0), axis="z").countersink()
 
+    def test_drill_point_cone_is_rejected(self):
+        # #582 review: a single-rim drill-point cone is not a countersink (mirror recogniser).
+        from build123d import Cone
+
+        from draftwright.model.declare import read_countersink
+
+        with pytest.raises(ValueError, match="flared cone"):
+            read_countersink(Cone(0, 5, 4))
+
+    def test_rejects_impossible_angle(self):
+        # #582 review: an included angle >= 180° is not a real cone.
+        with pytest.raises(ValueError, match="180"):
+            hole(diameter=6, at=(0, 0, 0), axis="z", csink=(14, 200))
+
 
 class TestExplicitOverridesObject:
     """#451: an object supplies DEFAULTS; each explicit keyword overrides that field

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -326,6 +326,40 @@ class TestChamfer:
         assert f.angle == pytest.approx(math.degrees(math.atan2(3, 6)), abs=1.0)
 
 
+class TestCountersink:
+    """#575: declare a countersink (flat-head seat) — the third ADR-0011 surface for #558."""
+
+    def test_reads_major_and_angle_off_the_cone(self):
+        from build123d import Cone
+
+        from draftwright.model.declare import read_countersink
+
+        maj, ang = read_countersink(Cone(3, 7, 4))  # ⌀6 drill flaring to ⌀14, 90° included
+        assert maj == pytest.approx(14.0) and ang == pytest.approx(90.0, abs=0.5)
+
+    def test_explicit_csink_renders_the_callout(self):
+        part = Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(3, 12)
+        dwg = build_drawing(
+            part, model=[hole(diameter=6, at=(0, 0, 6), axis="z", csink=(14, 90))], number="X"
+        )
+        leaders = [dwg._named[n] for n in dwg._named if n.startswith("hc_")]
+        assert leaders and any(14.0 in ldr.covers_diameters for ldr in leaders)
+
+    def test_fluent_countersink_reads_the_cone(self):
+        from build123d import Cone
+
+        part = Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(3, 12)
+        s = Sheet(part)
+        s.hole(diameter=6, at=(0, 0, 6), axis="z").countersink(Cone(3, 7, 4))
+        assert s._features[0].csink is not None
+        assert abs(s._features[0].csink[0] - 14) < 0.1 and abs(s._features[0].csink[1] - 90) < 0.5
+
+    def test_needs_cone_or_explicit(self):
+        s = Sheet(Box(10, 10, 10))
+        with pytest.raises(ValueError):
+            s.hole(diameter=6, at=(0, 0, 0), axis="z").countersink()
+
+
 class TestExplicitOverridesObject:
     """#451: an object supplies DEFAULTS; each explicit keyword overrides that field
     independently. The reliable escape hatch for tricky geometry (tubes, counterbores,

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -176,6 +176,19 @@ class TestEmit:
         # the whole emitted script must parse — a generated script that doesn't is useless
         ast.parse(_script_for(_plate()))
 
+    def test_countersink_rides_the_hole_line(self):
+        # #575: a detected countersunk hole emits csink=(major, angle) on the hole line
+        # (was dropped) — the emit surface for #558.
+        from build123d import Cone
+
+        part = Box(90, 60, 12)
+        for x, y in [(-30, -15), (5, 12), (30, -8)]:
+            part -= Pos(x, y, 0) * Cylinder(3, 12)
+            part -= Pos(x, y, 4) * Cone(3, 7, 4)
+        src = _script_for(part)
+        assert "csink=(14" in src
+        ast.parse(src)
+
     def test_chamfer_emits_the_chamfer_verb(self):
         # #576: a detected chamfer emits `sheet.chamfer(...)` (was a "no declarative verb yet"
         # comment) — the emit surface for #560.

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -189,6 +189,22 @@ class TestEmit:
         assert "csink=(14" in src
         ast.parse(src)
 
+    def test_countersunk_bolt_circle_keeps_csink_on_members(self):
+        # #582 review (BLOCKER): a countersunk PATTERN member must emit csink= (was dropped in
+        # _member_hole_str), else the bolt circle loses its ⌵ callout on re-run.
+        from build123d import Cone
+
+        part = Cylinder(40, 12)
+        for i in range(6):
+            a = i * math.pi / 3
+            c = Pos(25 * math.cos(a), 25 * math.sin(a), 0)
+            part -= c * Cylinder(3, 20)
+            part -= c * Pos(0, 0, 4) * Cone(3, 7, 4)
+        src = _script_for(part)
+        pat = [ln for ln in src.splitlines() if "sheet.pattern(hole(" in ln]
+        assert pat and "csink=(14" in pat[0]
+        ast.parse(src)
+
     def test_chamfer_emits_the_chamfer_verb(self):
         # #576: a detected chamfer emits `sheet.chamfer(...)` (was a "no declarative verb yet"
         # comment) — the emit surface for #560.


### PR DESCRIPTION
## What

Closes #575 (epic #574). Completes the **countersink** across all three ADR-0011 surfaces — recognition + callout landed in #558; this adds **declare** and **emit**. A countersink is a hole attribute, so it mirrors the existing `cbore` pattern exactly.

## How

- **Declare** — `hole(..., csink=(major, angle))` param; `sheet.hole(bore).countersink(cone_tool)` reads the major ⌀ + included angle off the cone's conical **face** (not a removed edge — the #576 lesson), or explicit `.countersink(major=14, angle=90)`. New `declare.read_countersink`. Object supplies defaults, explicit kwargs override (#451).
- **Emit** — `sheet_emit` rides `csink=(major, angle)` on the hole line, like `cbore`/`spotface` (previously dropped).

`major_diameter` and `angle` are **independent** inputs (unlike the chamfer angle), so there's no coupled-derivation footgun.

## Tests

Cone read → (14, 90); explicit declare renders `⌵ Ø14 × 90°`; fluent `.countersink(cone)`; validation; emit round-trip (`csink=(14, 90)` on the hole line, script parses). **Byte-identical for non-csk parts.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)