### PR TITLE
feat(#577): plate emit + declare surfaces (epic #574 back-fill)

### DIFF
--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -31,6 +31,7 @@ from draftwright.model.declare import (
     hole,
     note,
     pattern,
+    plate,
     slot,
     step,
 )
@@ -96,6 +97,7 @@ __all__ = [
     "hole",
     "note",
     "pattern",
+    "plate",
     "slot",
     "step",
     "display",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -39,6 +39,7 @@ from draftwright.model.ir import (
     HoleFeature,
     Note,
     PatternFeature,
+    PlateFeature,
     Point,
     SlotFeature,
     StepFeature,
@@ -385,6 +386,58 @@ def chamfer(
         )
     return ChamferFeature(
         frame=Frame(origin=at, axis=axis), axis=axis, leg1=hi, leg2=lo, angle=angle
+    )
+
+
+def _read_plate(obj) -> tuple[str, float, float, float, float]:
+    """Read a thin slab off its bounding box: the thin (thickness) axis is the smallest span;
+    ``lo``/``hi`` its extent along that axis; ``u``/``v`` the slab centre on the other two axes
+    (in axis order). The slab is present material, so the bbox reads it directly."""
+    bb = obj.bounding_box()
+    sizes = [bb.size.X, bb.size.Y, bb.size.Z]
+    i = min(range(3), key=lambda k: sizes[k])
+    oi = [j for j in range(3) if j != i]
+    span = ((bb.min.X, bb.max.X), (bb.min.Y, bb.max.Y), (bb.min.Z, bb.max.Z))
+    c = (bb.center().X, bb.center().Y, bb.center().Z)
+    return (
+        "xyz"[i],
+        round(span[i][0], 4),
+        round(span[i][1], 4),
+        round(c[oi[0]], 4),
+        round(c[oi[1]], 4),
+    )
+
+
+def plate(obj=None, *, axis=None, lo=None, hi=None, u=None, v=None) -> PlateFeature:
+    """A thin slab's thickness (#559/#577) — a base plate, an upright wall, a rib. Either
+    ``plate(slab_box)`` — the thin axis, its ``lo``/``hi`` extent, and the ``u``/``v`` slab
+    centre read off the object's bbox — or explicit ``plate(axis="z", lo=0, hi=4, u=10, v=5)``.
+    ``hi - lo`` is the thickness; ``u``/``v`` locate the thickness dim on the other two axes
+    (in axis order). An object supplies *defaults*; any explicit keyword overrides (#451)."""
+    if obj is not None:
+        r_axis, r_lo, r_hi, r_u, r_v = _read_plate(obj)
+        axis = r_axis if axis is None else axis
+        lo = r_lo if lo is None else lo
+        hi = r_hi if hi is None else hi
+        u = r_u if u is None else u
+        v = r_v if v is None else v
+    if None in (axis, lo, hi, u, v):
+        raise ValueError("plate() needs a slab object, or explicit axis=, lo=, hi=, u= and v=")
+    axis = _norm_axis(axis)
+    if not hi > lo:
+        raise ValueError(f"plate() needs hi > lo (a positive thickness); got lo={lo}, hi={hi}")
+    i = "xyz".index(axis)
+    oi = [j for j in range(3) if j != i]
+    origin = [0.0, 0.0, 0.0]
+    origin[i] = (lo + hi) / 2
+    origin[oi[0]], origin[oi[1]] = u, v
+    return PlateFeature(
+        frame=Frame(origin=(origin[0], origin[1], origin[2]), axis=axis),
+        axis=axis,
+        lo=lo,
+        hi=hi,
+        u=u,
+        v=v,
     )
 
 

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -53,6 +53,7 @@ from draftwright.model import finish as _declare_finish
 from draftwright.model import hole as _hole
 from draftwright.model import note as _declare_note
 from draftwright.model import pattern as _pattern
+from draftwright.model import plate as _plate
 from draftwright.model import slot as _slot
 from draftwright.model import step as _step
 from draftwright.model.declare import (
@@ -535,6 +536,14 @@ class Sheet:
         ``sheet.chamfer(axis="z", leg=6, at=(x, y, z))``. ``leg`` = equal-leg 45° (``C{leg}``);
         ``leg1``/``leg2`` = asymmetric."""
         self._features.append(_chamfer(obj, **kw))
+        return self
+
+    def plate(self, obj=None, **kw) -> Sheet:
+        """Declare a thin slab's thickness (a base plate / wall / rib) — ``sheet.plate(slab_box)``
+        reads the thin axis + extent + centre off the slab, or explicit ``sheet.plate(axis="z",
+        lo=0, hi=4, u=10, v=5)``. Only a *multi-plate* part dimensions plates (a single slab is
+        the envelope)."""
+        self._features.append(_plate(obj, **kw))
         return self
 
     def pattern(self, member, **kw) -> Sheet:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -189,6 +189,10 @@ def _feature_line(f) -> str:
             f'sheet.chamfer(axis="{f.axis}", leg1={_n(f.leg1)}, leg2={_n(f.leg2)}, '
             f"angle={_n(f.angle)}, at={_pt(f.frame.origin)})"
         )
+    if k == "plate":
+        return (
+            f'sheet.plate(axis="{f.axis}", lo={_n(f.lo)}, hi={_n(f.hi)}, u={_n(f.u)}, v={_n(f.v)})'
+        )
     # Kinds with no declarative verb yet: flag inline so they aren't silently lost. The auto-pass
     # over the declared model still draws rotational furniture faithfully (#472).
     return f"# {k} @ {_pt(f.frame.origin)} — no declarative verb yet; drawn by the auto-pass"

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -17,6 +17,7 @@ from draftwright.model import (
     HoleFeature,
     PartModel,
     PatternFeature,
+    PlateFeature,
     SlotFeature,
     StepFeature,
     boss,
@@ -24,6 +25,7 @@ from draftwright.model import (
     envelope,
     hole,
     pattern,
+    plate,
     slot,
     step,
 )
@@ -372,6 +374,36 @@ class TestCountersink:
         # #582 review: an included angle >= 180° is not a real cone.
         with pytest.raises(ValueError, match="180"):
             hole(diameter=6, at=(0, 0, 0), axis="z", csink=(14, 200))
+
+
+class TestPlate:
+    """#577: declare a thin slab's thickness — the third ADR-0011 surface for #559."""
+
+    def test_reads_thin_axis_and_extent_off_the_slab(self):
+        from draftwright.model.declare import _read_plate
+
+        axis, lo, hi, u, v = _read_plate(Box(80, 50, 8))  # thinnest span = Z (8)
+        assert axis == "z" and hi - lo == pytest.approx(8.0)
+
+    def test_explicit_plate(self):
+        f = plate(axis="z", lo=0, hi=4, u=10, v=5)
+        assert isinstance(f, PlateFeature)
+        assert f.axis == "z" and f.hi - f.lo == pytest.approx(4.0) and (f.u, f.v) == (10, 5)
+
+    def test_declared_plates_render_thickness_dims(self):
+        # An L-bracket declared as two plates renders both thickness dims.
+        lbr = Box(80, 50, 8) + Pos(-36, 0, 29) * Box(8, 50, 50)
+        model = [plate(Box(80, 50, 8)), plate(axis="x", lo=-40, hi=-32, u=0, v=27)]
+        dwg = build_drawing(lbr, model=model, number="X")
+        assert len([f for f in dwg.model().features if f.kind == "plate"]) == 2
+
+    def test_needs_object_or_explicit(self):
+        with pytest.raises(ValueError):
+            plate(axis="z", lo=0)  # missing hi / u / v
+
+    def test_rejects_nonpositive_thickness(self):
+        with pytest.raises(ValueError, match="hi > lo"):
+            plate(axis="z", lo=4, hi=4, u=0, v=0)
 
 
 class TestExplicitOverridesObject:

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -382,8 +382,11 @@ class TestPlate:
     def test_reads_thin_axis_and_extent_off_the_slab(self):
         from draftwright.model.declare import _read_plate
 
-        axis, lo, hi, u, v = _read_plate(Box(80, 50, 8))  # thinnest span = Z (8)
+        # Off the origin so u/v (the slab centre on the two NON-thin axes, in axis order)
+        # are non-zero and a u/v swap or a min/max-vs-centre bug can't hide.
+        axis, lo, hi, u, v = _read_plate(Pos(12, 7, 0) * Box(80, 50, 8))  # thinnest span = Z (8)
         assert axis == "z" and hi - lo == pytest.approx(8.0)
+        assert (u, v) == pytest.approx((12.0, 7.0))  # u=X-centre, v=Y-centre (axis order)
 
     def test_explicit_plate(self):
         f = plate(axis="z", lo=0, hi=4, u=10, v=5)
@@ -391,11 +394,16 @@ class TestPlate:
         assert f.axis == "z" and f.hi - f.lo == pytest.approx(4.0) and (f.u, f.v) == (10, 5)
 
     def test_declared_plates_render_thickness_dims(self):
-        # An L-bracket declared as two plates renders both thickness dims.
+        # An L-bracket declared as two plates renders both thickness dims — assert the
+        # dims actually LAND (named + labelled + lint-clean), not just that the model
+        # echoes back what we handed it (detection is skipped for a declared model).
         lbr = Box(80, 50, 8) + Pos(-36, 0, 29) * Box(8, 50, 50)
         model = [plate(Box(80, 50, 8)), plate(axis="x", lo=-40, hi=-32, u=0, v=27)]
         dwg = build_drawing(lbr, model=model, number="X")
-        assert len([f for f in dwg.model().features if f.kind == "plate"]) == 2
+        plate_dims = {n: dwg._named[n].label for n in dwg._named if n.startswith("dim_plate")}
+        assert sorted(plate_dims) == ["dim_plate_x0", "dim_plate_z0"]  # both slabs dimensioned
+        assert sorted(plate_dims.values()) == ["8", "8"]  # each 8 thick
+        assert [i for i in dwg.lint() if i.severity != "info"] == []
 
     def test_needs_object_or_explicit(self):
         with pytest.raises(ValueError):

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -205,6 +205,13 @@ class TestEmit:
         assert pat and "csink=(14" in pat[0]
         ast.parse(src)
 
+    def test_plate_emits_the_plate_verb(self):
+        # #577: a multi-plate part emits sheet.plate(...) per slab (was dropped).
+        part = Box(80, 50, 8) + Pos(-36, 0, 29) * Box(8, 50, 50)  # base plate + upright wall
+        src = _script_for(part)
+        assert src.count("sheet.plate(") == 2
+        ast.parse(src)
+
     def test_chamfer_emits_the_chamfer_verb(self):
         # #576: a detected chamfer emits `sheet.chamfer(...)` (was a "no declarative verb yet"
         # comment) — the emit surface for #560.

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -210,6 +210,11 @@ class TestEmit:
         part = Box(80, 50, 8) + Pos(-36, 0, 29) * Box(8, 50, 50)  # base plate + upright wall
         src = _script_for(part)
         assert src.count("sheet.plate(") == 2
+        # Assert the emitted fields, not just the verb count — a swapped axis/lo/hi/u/v
+        # would still parse and count 2. The base slab is a Z plate lo=-4 hi=4; the
+        # upright wall is an X plate lo=-40 hi=-32.
+        assert 'sheet.plate(axis="z", lo=-4, hi=4,' in src
+        assert 'sheet.plate(axis="x", lo=-40, hi=-32,' in src
         ast.parse(src)
 
     def test_chamfer_emits_the_chamfer_verb(self):


### PR DESCRIPTION
Closes #577.

Adds the two missing ADR-0011 authoring surfaces for the prismatic **plate** feature (recognition landed in #559): **declare** and **emit**. Third of four epic-#574 back-fills, following the declare+emit pattern proven on chamfer (#576) and countersink (#575).

## What
- **declare** — `declare.plate()` + `_read_plate()`: thin axis = smallest bbox span; `lo`/`hi` the extent along it; `u`/`v` the centre on the other two axes. Object flavour reads the slab; explicit flavour (`plate(axis=, lo=, hi=, u=, v=)`) for parametric callers. Rejects `hi <= lo`.
- **model/__init__** — re-export `plate`.
- **Sheet.plate** verb — appends a `PlateFeature` to the declared model.
- **emit** — `sheet_emit._feature_line`: `if k == "plate"` case, one `sheet.plate(...)` line per slab so a multi-plate part round-trips.

## Verification
- New `TestPlate` (declare read, explicit, render, validation) + `test_plate_emits_the_plate_verb` (L-bracket emits 2 `sheet.plate(` lines, `ast.parse` clean).
- ruff + mypy clean; targeted declare/emit/snapshot suites green.
- Manual round-trip: L-bracket `Box(80,50,8)+Pos(-36,0,29)*Box(8,50,50)` → 2 plates detected, emits `sheet.plate(axis="x", ...)` + `sheet.plate(axis="z", ...)`, declared plates render 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)