### PR TITLE
feat(#578): step-position emit + declare surfaces (epic #574 back-fill)

### DIFF
--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 # none of these names, so they stay sub-second instead of paying for the kernel
 # on every TAB press (#313). Each name maps to the submodule that provides it.
 _LAZY = {
-    "recognise_face_levels": "draftwright.analysis",
+    "recognise_face_levels": "draftwright.recognition",
     "dedup_diams": "draftwright.analysis",
     "build_drawing": "draftwright.builder",
     "generate_script": "draftwright.builder",
@@ -72,12 +72,13 @@ _sys.modules[__name__].__class__ = _DraftwrightModule
 
 
 if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel cost
-    from draftwright.analysis import dedup_diams, recognise_face_levels
+    from draftwright.analysis import dedup_diams
     from draftwright.builder import build_drawing, generate_script, make_drawing
     from draftwright.drawing import Drawing, FeatureInfo
     from draftwright.export import fix_svg_page_size
     from draftwright.linting import lint_feature_coverage
     from draftwright.pmi import PmiRecord, extract_pmi
+    from draftwright.recognition import recognise_face_levels
     from draftwright.sheet import choose_scale
     from draftwright.sheet_dsl import Sheet
 

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -39,11 +39,11 @@ from draftwright.recognition import (
     analyse_cylinders,
     full_cylinders,
     recognise_bosses,
-    recognise_face_levels,
     recognise_hole_patterns,
     recognise_holes,
     recognise_slots,
     recognise_turned_steps,
+    step_level_zs,
 )
 from draftwright.sheet import (
     StripDepths,
@@ -273,11 +273,6 @@ def _converge_step_sizing(
 # value-label footprint (one glyph height + clearance) — enough to tell two
 # stacked step dims apart, without dropping genuinely-distinct shoulders.
 
-# A horizontal face counts as a real step only if its area is at least this
-# fraction of the part's plan footprint (x_size × y_size). Filters out tiny
-# faces from engraved text/numbers that are not steps (staircase.step review).
-_STEP_MIN_AREA_FRAC = 0.01
-
 # Minimum page-mm separation between two *consecutive* hole-location dimensions
 # along one axis. Stacked location dims sit on separate tiers, so their value
 # labels never collide (the tier pitch handles that); the legibility limit is the
@@ -429,8 +424,7 @@ def _analyse(
     if _turned is not None and _turned.axis == "z":
         step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
     else:
-        face_zs = [fl.z for fl in recognise_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)]
-        step_zs = [z for z in face_zs if z > bb.min.Z + 0.6 and z < bb.max.Z - 0.6]
+        step_zs = step_level_zs(part)  # shared area-filtered extraction (#578 review)
 
     # Pass 1 (two-pass layout, #131): measure annotation strip depths before
     # view positions are fixed.  font_size=3.0 is a fixed page-mm constant so

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -34,6 +34,7 @@ from draftwright.model.declare import (
     plate,
     slot,
     step,
+    step_level,
 )
 from draftwright.model.detect import build_part_model, build_pmi_features
 from draftwright.model.ir import (
@@ -100,6 +101,7 @@ __all__ = [
     "plate",
     "slot",
     "step",
+    "step_level",
     "display",
     "SectionPlan",
     "plan_dimensions",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -444,43 +444,53 @@ def plate(obj=None, *, axis=None, lo=None, hi=None, u=None, v=None) -> PlateFeat
 
 def _read_step_levels(
     obj,
-) -> tuple[float, tuple[float, ...], tuple[tuple[str, float], ...], Point]:
+) -> tuple[float, tuple[float, ...], tuple[tuple[str, float], ...], Point, Point]:
     """Read a prismatic height ladder off a part: ``base`` (bbox min Z), the interior step
-    ``levels`` (horizontal face levels strictly between base and top), the step ``shoulders``
-    (in-plane ``(axis, position)`` risers — only for a single-level rebate, mirroring
-    ``model/detect.py``), and the ``datum`` (bbox min corner the positions measure from)."""
-    from draftwright.recognition import recognise_face_levels, recognise_step_shoulders
+    ``levels`` (the shared area-filtered :func:`recognition.step_level_zs` — so the object
+    flavour reads exactly the levels ``analysis.py``/``detect.py`` do, not phantom incidental
+    faces, #578 review), the step ``shoulders`` (in-plane ``(axis, position)`` risers — only
+    for a single-level rebate, mirroring ``model/detect.py``), the ``datum`` (bbox min corner
+    the positions measure from) and ``at`` (the frame anchor — bbox centre X/Y at ``base``,
+    matching ``detect.py`` so an object round-trips to the same IR)."""
+    from draftwright.recognition import recognise_step_shoulders, step_level_zs
 
     bb = obj.bounding_box()
     base = round(bb.min.Z, 3)
-    top = round(bb.max.Z, 3)
-    levels = tuple(
-        z for z in (round(lvl.z, 3) for lvl in recognise_face_levels(obj)) if base < z < top
-    )
+    levels = tuple(sorted(round(z, 3) for z in step_level_zs(obj)))
     shoulders = (
         tuple((s.axis, s.position) for s in recognise_step_shoulders(obj, levels=list(levels)))
         if len(levels) == 1
         else ()
     )
-    return base, levels, shoulders, (round(bb.min.X, 3), round(bb.min.Y, 3), base)
+    c = bb.center()
+    return (
+        base,
+        levels,
+        shoulders,
+        (round(bb.min.X, 3), round(bb.min.Y, 3), base),
+        (round(c.X, 3), round(c.Y, 3), base),
+    )
 
 
 def step_level(
-    obj=None, *, base=None, levels=None, shoulders=None, datum=None
+    obj=None, *, base=None, levels=None, shoulders=None, datum=None, at=None
 ) -> StepLevelFeature:
     """A prismatic height ladder + step-position shoulders (#555/#578) — a rebated / stepped
     block. Either ``step_level(part)`` — ``base``, the interior ``levels``, the ``(axis,
-    position)`` ``shoulders`` and the ``datum`` read off the part — or explicit
-    ``step_level(base=0, levels=(10,), shoulders=(("x", 30),))``. ``levels`` are the interior
-    step Z-coords (each above ``base``); a ``shoulder`` is *where* a step changes height, its
-    position measured from ``datum`` along a horizontal ``axis`` (x/y). An object supplies
+    position)`` ``shoulders``, the ``datum`` and the frame anchor ``at`` read off the part — or
+    explicit ``step_level(base=0, levels=(10,), shoulders=(("x", 30),))``. ``levels`` are the
+    interior step Z-coords (unique, strictly increasing, each above ``base``); a ``shoulder`` is
+    *where* a step changes height, its position measured from ``datum`` along a horizontal
+    ``axis`` (x/y). ``at`` is the IR frame origin (like every sibling constructor); it defaults
+    to the ``datum`` X/Y at ``base`` and is inert for step rendering. An object supplies
     *defaults*; any explicit keyword overrides that field (#451)."""
     if obj is not None:
-        r_base, r_levels, r_shoulders, r_datum = _read_step_levels(obj)
+        r_base, r_levels, r_shoulders, r_datum, r_at = _read_step_levels(obj)
         base = r_base if base is None else base
         levels = r_levels if levels is None else levels
         shoulders = r_shoulders if shoulders is None else shoulders
         datum = r_datum if datum is None else datum
+        at = r_at if at is None else at
     if datum is None:
         datum = (0.0, 0.0, 0.0)
     if shoulders is None:
@@ -498,7 +508,17 @@ def step_level(
         if not z > base:
             raise ValueError(f"step_level() level {z} must be above base {base}")
     levels = tuple(sorted(levels))
+    # Levels are a correlated ladder: a duplicate or non-increasing level double-dimensions a
+    # rung and skews the shoulder-suppression count — reject rather than silently accept (#578).
+    for lo, hi in zip(levels, levels[1:]):
+        if not hi > lo:
+            raise ValueError(
+                f"step_level() levels must be unique and strictly increasing: {levels}"
+            )
     _require_point("datum", datum)
+    if at is None:
+        at = (datum[0], datum[1], base)
+    _require_point("at", at)
     norm_shoulders = []
     for sh in shoulders:
         if not (isinstance(sh, (tuple, list)) and len(sh) == 2):
@@ -515,7 +535,7 @@ def step_level(
             raise ValueError(f"step_level() shoulder position must be a number (got {p!r})")
         norm_shoulders.append((ax, float(p)))
     return StepLevelFeature(
-        frame=Frame(origin=(datum[0], datum[1], base), axis="z"),
+        frame=Frame(origin=(at[0], at[1], at[2]), axis="z"),
         base=base,
         levels=levels,
         shoulders=tuple(norm_shoulders),

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -43,6 +43,7 @@ from draftwright.model.ir import (
     Point,
     SlotFeature,
     StepFeature,
+    StepLevelFeature,
 )
 
 # Fractional tolerance below which a slot object's two longest bbox spans count as "near-equal",
@@ -438,6 +439,87 @@ def plate(obj=None, *, axis=None, lo=None, hi=None, u=None, v=None) -> PlateFeat
         hi=hi,
         u=u,
         v=v,
+    )
+
+
+def _read_step_levels(
+    obj,
+) -> tuple[float, tuple[float, ...], tuple[tuple[str, float], ...], Point]:
+    """Read a prismatic height ladder off a part: ``base`` (bbox min Z), the interior step
+    ``levels`` (horizontal face levels strictly between base and top), the step ``shoulders``
+    (in-plane ``(axis, position)`` risers — only for a single-level rebate, mirroring
+    ``model/detect.py``), and the ``datum`` (bbox min corner the positions measure from)."""
+    from draftwright.recognition import recognise_face_levels, recognise_step_shoulders
+
+    bb = obj.bounding_box()
+    base = round(bb.min.Z, 3)
+    top = round(bb.max.Z, 3)
+    levels = tuple(
+        z for z in (round(lvl.z, 3) for lvl in recognise_face_levels(obj)) if base < z < top
+    )
+    shoulders = (
+        tuple((s.axis, s.position) for s in recognise_step_shoulders(obj, levels=list(levels)))
+        if len(levels) == 1
+        else ()
+    )
+    return base, levels, shoulders, (round(bb.min.X, 3), round(bb.min.Y, 3), base)
+
+
+def step_level(
+    obj=None, *, base=None, levels=None, shoulders=None, datum=None
+) -> StepLevelFeature:
+    """A prismatic height ladder + step-position shoulders (#555/#578) — a rebated / stepped
+    block. Either ``step_level(part)`` — ``base``, the interior ``levels``, the ``(axis,
+    position)`` ``shoulders`` and the ``datum`` read off the part — or explicit
+    ``step_level(base=0, levels=(10,), shoulders=(("x", 30),))``. ``levels`` are the interior
+    step Z-coords (each above ``base``); a ``shoulder`` is *where* a step changes height, its
+    position measured from ``datum`` along a horizontal ``axis`` (x/y). An object supplies
+    *defaults*; any explicit keyword overrides that field (#451)."""
+    if obj is not None:
+        r_base, r_levels, r_shoulders, r_datum = _read_step_levels(obj)
+        base = r_base if base is None else base
+        levels = r_levels if levels is None else levels
+        shoulders = r_shoulders if shoulders is None else shoulders
+        datum = r_datum if datum is None else datum
+    if datum is None:
+        datum = (0.0, 0.0, 0.0)
+    if shoulders is None:
+        shoulders = ()
+    if base is None or levels is None:
+        raise ValueError("step_level() needs a part, or explicit base= and levels=")
+    if not (isinstance(base, (int, float)) and not isinstance(base, bool) and math.isfinite(base)):
+        raise ValueError(f"step_level() base must be a number (got {base!r})")
+    levels = tuple(levels)
+    if not levels:
+        raise ValueError("step_level() needs at least one step level above the base")
+    for z in levels:
+        if not (isinstance(z, (int, float)) and not isinstance(z, bool) and math.isfinite(z)):
+            raise ValueError(f"step_level() level must be a number (got {z!r})")
+        if not z > base:
+            raise ValueError(f"step_level() level {z} must be above base {base}")
+    levels = tuple(sorted(levels))
+    _require_point("datum", datum)
+    norm_shoulders = []
+    for sh in shoulders:
+        if not (isinstance(sh, (tuple, list)) and len(sh) == 2):
+            raise ValueError(
+                f"step_level() shoulder must be an (axis, position) pair (got {sh!r})"
+            )
+        ax = _norm_axis(sh[0])
+        if ax == "z":  # a shoulder POSITION is horizontal; Z is the height, not a position
+            raise ValueError(
+                "step_level() shoulder axis must be 'x' or 'y' (a horizontal position)"
+            )
+        p = sh[1]
+        if not (isinstance(p, (int, float)) and not isinstance(p, bool) and math.isfinite(p)):
+            raise ValueError(f"step_level() shoulder position must be a number (got {p!r})")
+        norm_shoulders.append((ax, float(p)))
+    return StepLevelFeature(
+        frame=Frame(origin=(datum[0], datum[1], base), axis="z"),
+        base=base,
+        levels=levels,
+        shoulders=tuple(norm_shoulders),
+        datum=(datum[0], datum[1], datum[2]),
     )
 
 

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -75,6 +75,7 @@ from draftwright.recognition.levels import (
     StepShoulder,
     recognise_face_levels,
     recognise_step_shoulders,
+    step_level_zs,
 )
 from draftwright.recognition.plates import Plate, recognise_plates
 from draftwright.recognition.slots import Slot, recognise_slots
@@ -99,6 +100,7 @@ __all__ = [
     "analyse_cylinders",
     "recognise_face_levels",
     "recognise_step_shoulders",
+    "step_level_zs",
     "feature_diameters",
     "recognise_bosses",
     "recognise_chamfers",

--- a/src/draftwright/recognition/levels.py
+++ b/src/draftwright/recognition/levels.py
@@ -77,6 +77,26 @@ def recognise_face_levels(
     return sorted(FaceLevel(z) for z in buckets.values())
 
 
+# Minimum horizontal-face area (as a fraction of the plan footprint) for a Z level to count
+# as a genuine prismatic step — drops an incidental tiny face (a blind-pocket floor, a small
+# pad top) that would otherwise read as a phantom step rung (#578 review / staircase.step).
+_STEP_MIN_AREA_FRAC = 0.01
+
+
+def step_level_zs(part, *, tol: float = 0.6) -> list[float]:
+    """The interior prismatic step Z-levels: the area-filtered horizontal face levels strictly
+    inside the part height (``base + tol < z < top - tol``). The single source of truth for the
+    step-height ladder (``analysis.py``) and the ``declare.step_level`` object flavour — using
+    the raw, unfiltered :func:`recognise_face_levels` in one and this gate in the other let a
+    tiny incidental face leak in as a phantom level, diverging the two paths (#578 review)."""
+    bb = part.bounding_box()
+    return [
+        fl.z
+        for fl in recognise_face_levels(part, min_area_frac=_STEP_MIN_AREA_FRAC)
+        if bb.min.Z + tol < fl.z < bb.max.Z - tol
+    ]
+
+
 def recognise_step_shoulders(
     part, *, levels, min_area_frac: float = 0.15, tol: float = 0.5
 ) -> list[StepShoulder]:

--- a/src/draftwright/sheet_dsl.py
+++ b/src/draftwright/sheet_dsl.py
@@ -56,6 +56,7 @@ from draftwright.model import pattern as _pattern
 from draftwright.model import plate as _plate
 from draftwright.model import slot as _slot
 from draftwright.model import step as _step
+from draftwright.model import step_level as _step_level
 from draftwright.model.declare import (
     _norm_axis,
     _read_cylinder,
@@ -544,6 +545,15 @@ class Sheet:
         lo=0, hi=4, u=10, v=5)``. Only a *multi-plate* part dimensions plates (a single slab is
         the envelope)."""
         self._features.append(_plate(obj, **kw))
+        return self
+
+    def step_level(self, obj=None, **kw) -> Sheet:
+        """Declare a prismatic height ladder + step-position shoulders (a rebated / stepped
+        block) — ``sheet.step_level(part)`` reads ``base`` / interior ``levels`` / the ``(axis,
+        position)`` ``shoulders`` / ``datum`` off the part, or explicit ``sheet.step_level(base=0,
+        levels=(10,), shoulders=(("x", 30),))``. A shoulder locates *where* a step changes
+        height along a horizontal axis, so a stepped block is fully constrained (#555/#578)."""
+        self._features.append(_step_level(obj, **kw))
         return self
 
     def pattern(self, member, **kw) -> Sheet:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -146,7 +146,7 @@ def _feature_line(f) -> str:
         _sh = "(" + ", ".join(_items) + ("," if len(_items) == 1 else "") + ")"
         return (
             f"sheet.step_level(base={_n(f.base)}, levels={_tuple_arg(f.levels)}, "
-            f"shoulders={_sh}, datum={_pt(f.datum)})"
+            f"shoulders={_sh}, datum={_pt(f.datum)}, at={_pt(f.frame.origin)})"
             "   # prismatic height ladder + shoulder position(s)"
         )
     if k == "hole":

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -140,15 +140,14 @@ def _feature_line(f) -> str:
             f"))   # envelope {_n(f.width)} × {_n(f.height)} × {_n(f.depth)}"
         )
     if k == "step_level":
-        # Carry shoulders + datum (#555) so the declared model still constrains the step
-        # POSITION, not just its heights.
-        _sh = "".join(f"({a!r}, {_n(p)}), " for a, p in f.shoulders)
+        # Carry shoulders + datum (#555/#578) so the declared model still constrains the step
+        # POSITION, not just its heights. The fluent verb rebuilds the frame from base+datum.
+        _items = [f"({a!r}, {_n(p)})" for a, p in f.shoulders]
+        _sh = "(" + ", ".join(_items) + ("," if len(_items) == 1 else "") + ")"
         return (
-            "sheet.add(StepLevelFeature("
-            f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
-            f"base={_n(f.base)}, levels={_tuple_arg(f.levels)}, "
-            f"shoulders=({_sh}), datum={_pt(f.datum)}"
-            "))   # prismatic height ladder + shoulder position(s)"
+            f"sheet.step_level(base={_n(f.base)}, levels={_tuple_arg(f.levels)}, "
+            f"shoulders={_sh}, datum={_pt(f.datum)})"
+            "   # prismatic height ladder + shoulder position(s)"
         )
     if k == "hole":
         return _hole_line(f)
@@ -250,8 +249,6 @@ def emit_sheet_script(
         model_imports.add("hole")
     if any(f.kind == "envelope" for f in model.features):
         model_imports.update(["EnvelopeFeature", "Frame"])
-    if any(f.kind == "step_level" for f in model.features):
-        model_imports.update(["Frame", "StepLevelFeature"])
     if any(f.kind == "pmi" for f in model.features):
         model_imports.update(["Frame", "PmiFeature"])
     # Only carry an aspect into the emitted constructor when it differs from build_drawing's

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -20,6 +20,7 @@ from draftwright.model import (
     PlateFeature,
     SlotFeature,
     StepFeature,
+    StepLevelFeature,
     boss,
     chamfer,
     envelope,
@@ -28,6 +29,7 @@ from draftwright.model import (
     plate,
     slot,
     step,
+    step_level,
 )
 from draftwright.sheet_dsl import _parse_scale
 
@@ -412,6 +414,51 @@ class TestPlate:
     def test_rejects_nonpositive_thickness(self):
         with pytest.raises(ValueError, match="hi > lo"):
             plate(axis="z", lo=4, hi=4, u=0, v=0)
+
+
+class TestStepLevel:
+    """#578: declare a prismatic height ladder + step-position shoulders — the emit +
+    declare surfaces for #555 (recognition landed there)."""
+
+    # A rebated block: base slab Z∈[-5,5], a raised step (x∈[-40,0]) rising from Z=5.
+    def _stepped(self):
+        return Box(80, 40, 10) + Pos(-20, 0, 10) * Box(40, 40, 12)
+
+    def test_reads_ladder_off_the_part(self):
+        f = step_level(self._stepped())
+        assert isinstance(f, StepLevelFeature)
+        assert f.base == pytest.approx(-5.0)
+        assert f.levels == pytest.approx((5.0,))  # interior level (base<z<top)
+        assert f.shoulders == (("x", 0.0),)  # single-level rebate → riser position read
+        assert f.datum == pytest.approx((-40.0, -20.0, -5.0))
+
+    def test_explicit_step_level(self):
+        f = step_level(base=0, levels=(10,), shoulders=(("X", 30),), datum=(0, 0, 0))
+        assert f.base == 0 and f.levels == (10,)
+        assert f.shoulders == (("x", 30.0),)  # axis normalised to lowercase
+
+    def test_declared_step_renders_shoulder_and_height(self):
+        # The step POSITION lands as dim_shoulder_x0 (40 = 0 − −40) alongside the height
+        # ladder — assert the dim actually renders and lint is clean, not just that the
+        # model echoes back (detection is skipped for a declared model).
+        part = self._stepped()
+        dwg = build_drawing(part, model=[step_level(part)], number="X")
+        assert dwg._named["dim_shoulder_x0"].label == "40"
+        assert "dim_height" in dwg._named
+        assert [i for i in dwg.lint() if i.severity != "info"] == []
+
+    def test_needs_base_and_levels(self):
+        with pytest.raises(ValueError, match="base= and levels="):
+            step_level(base=0)  # no levels
+
+    def test_rejects_level_below_base(self):
+        with pytest.raises(ValueError, match="above base"):
+            step_level(base=10, levels=(5,))
+
+    def test_rejects_z_shoulder_axis(self):
+        # A shoulder POSITION is horizontal; Z is the height, not a position.
+        with pytest.raises(ValueError, match="'x' or 'y'"):
+            step_level(base=0, levels=(10,), shoulders=(("z", 5),))
 
 
 class TestExplicitOverridesObject:

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -431,6 +431,22 @@ class TestStepLevel:
         assert f.levels == pytest.approx((5.0,))  # interior level (base<z<top)
         assert f.shoulders == (("x", 0.0),)  # single-level rebate → riser position read
         assert f.datum == pytest.approx((-40.0, -20.0, -5.0))
+        assert f.frame.origin == pytest.approx(
+            (0.0, 0.0, -5.0)
+        )  # bbox centre X/Y — matches detect
+
+    def test_object_flavour_matches_detection(self):
+        # #578 review: the object flavour must read the SAME area-filtered levels detection
+        # does — a tiny incidental face must not leak in as a phantom level (which would both
+        # add a spurious height rung AND, via len(levels)>1, suppress the shoulder dim).
+        from draftwright.builder import detect_part_model
+
+        # single-step rebate + a tiny 3×3 pad (top area 9 ≪ 1% of the 3200 footprint)
+        part = self._stepped() + Pos(35, 15, 7) * Box(3, 3, 4)
+        f = step_level(part)
+        det = next(x for x in detect_part_model(part).features if x.kind == "step_level")
+        assert f.levels == (5.0,) and f.shoulders == (("x", 0.0),)  # NOT (5.0, 9.0), ()
+        assert (f.levels, f.shoulders) == (det.levels, det.shoulders)  # parity with detection
 
     def test_explicit_step_level(self):
         f = step_level(base=0, levels=(10,), shoulders=(("X", 30),), datum=(0, 0, 0))
@@ -438,12 +454,19 @@ class TestStepLevel:
         assert f.shoulders == (("x", 30.0),)  # axis normalised to lowercase
 
     def test_declared_step_renders_shoulder_and_height(self):
-        # The step POSITION lands as dim_shoulder_x0 (40 = 0 − −40) alongside the height
-        # ladder — assert the dim actually renders and lint is clean, not just that the
-        # model echoes back (detection is skipped for a declared model).
+        # The step POSITION lands as dim_shoulder_x0 alongside the height ladder — assert
+        # the dim renders with the SAME value detection computes (position − datum) in the
+        # plan view, not just that the model echoes back (detection is skipped for a
+        # declared model). Cross-checking the declared render against the detect-path math
+        # catches a datum/axis/sign slip a hard-coded literal would miss.
+        from draftwright.builder import detect_part_model
+
         part = self._stepped()
+        det = next(x for x in detect_part_model(part).features if x.kind == "step_level")
+        expected = str(int(det.shoulders[0][1] - det.datum[0]))
         dwg = build_drawing(part, model=[step_level(part)], number="X")
-        assert dwg._named["dim_shoulder_x0"].label == "40"
+        assert dwg._named["dim_shoulder_x0"].label == expected
+        assert dwg.view_of("dim_shoulder_x0") == "plan"
         assert "dim_height" in dwg._named
         assert [i for i in dwg.lint() if i.severity != "info"] == []
 
@@ -454,6 +477,11 @@ class TestStepLevel:
     def test_rejects_level_below_base(self):
         with pytest.raises(ValueError, match="above base"):
             step_level(base=10, levels=(5,))
+
+    def test_rejects_duplicate_levels(self):
+        # #578 review: a duplicate / non-increasing level double-dimensions a rung.
+        with pytest.raises(ValueError, match="strictly increasing"):
+            step_level(base=0, levels=(10, 10))
 
     def test_rejects_z_shoulder_axis(self):
         # A shoulder POSITION is horizontal; Z is the height, not a position.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -19,12 +19,11 @@ from draftwright.analysis import (
     _converge_step_sizing,
     _is_rotational,
     dedup_diams,
-    recognise_face_levels,
 )
 from draftwright.drawing import analyse_cylinders
 from draftwright.export import _export_shape
 from draftwright.make_drawing import generate_script, lint_feature_coverage
-from draftwright.recognition import Slot, recognise_slots
+from draftwright.recognition import Slot, recognise_face_levels, recognise_slots
 from draftwright.sheet import StripDepths, _fits, choose_scale
 
 _skip_011 = pytest.mark.skipif(B123D_GE_011, reason=SKIP_011)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -317,6 +317,31 @@ class TestEmit:
         assert "levels=(5,)" in line
         ast.parse(src)
 
+    def test_step_level_round_trips_the_full_feature(self):
+        # #578 review: EXECUTE the emitted fluent verb (not just substring-check it) and
+        # assert the re-declared StepLevelFeature is identical to the detected one — base,
+        # levels, shoulders, datum AND frame.origin (carried via at=), so the round trip is
+        # lossless, not merely syntactically valid.
+        from draftwright import Sheet
+
+        part = Box(80, 40, 10) + Pos(-20, 0, 10) * Box(40, 40, 12)
+        model = detect_part_model(part)
+        src = _script_for(part)
+        line = next(ln for ln in src.splitlines() if "sheet.step_level(" in ln).split("#")[0]
+        sheet = Sheet(part, title="T", number="N")
+        exec(compile(line, "<emit>", "exec"), {"sheet": sheet})
+        got = sheet._features[-1]
+        det = next(f for f in model.features if f.kind == "step_level")
+        assert (got.base, got.levels, got.shoulders, got.datum) == (
+            det.base,
+            det.levels,
+            det.shoulders,
+            det.datum,
+        )
+        assert tuple(round(c, 3) for c in got.frame.origin) == tuple(
+            round(c, 3) for c in det.frame.origin
+        )
+
     @pytest.mark.skipif(not _PMI_AVAILABLE, reason="OCP GDT support not available")
     def test_ap242_script_keeps_side_hole_z_location_on_side_ladder(self, tmp_path):
         py = generate_sheet_script(str(AP242_CTC01), out=str(tmp_path / "ctc01"), pmi="annotate")

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -84,12 +84,12 @@ class TestEmit:
         assert "# authored_dimension" not in src
         assert "source='ap242_pmi'" in src
         assert "sheet.add(PmiFeature(" in src
-        assert "sheet.add(StepLevelFeature(" in src
+        assert "sheet.step_level(" in src  # #578: fluent verb, no StepLevelFeature import
         import_line = next(
             ln for ln in src.splitlines() if ln.startswith("from draftwright.model")
         )
         assert "Frame" in import_line and "PmiFeature" in import_line
-        assert "StepLevelFeature" in import_line
+        assert "StepLevelFeature" not in import_line
 
     def test_sheet_dimension_declares_renderable_authored_dimension(self, tmp_path):
         from draftwright import Sheet
@@ -294,14 +294,28 @@ class TestEmit:
         )
         assert "cbore=(" in line  # on the member hole(...) template
 
-    def test_step_level_emits_as_ir_fallback(self):
-        # A counterbored plate carries a step_level (horizontal face levels). It must
-        # round-trip as an explicit IR fallback so the generated script preserves the
-        # front-right height ladder occupancy that other dimensions negotiate against.
+    def test_step_level_emits_fluent_verb(self):
+        # A counterbored plate carries a step_level (horizontal face levels). #578: it
+        # round-trips through the fluent sheet.step_level(...) verb (carrying levels +
+        # shoulders + datum) — no StepLevelFeature/Frame import — so the generated script
+        # preserves the front-right height ladder occupancy other dimensions negotiate against.
         part = Box(100, 70, 24) - Pos(0, 0, 0) * Cylinder(9, 40) - Pos(0, 0, 8) * Cylinder(15, 20)
         src = _script_for(part)
-        assert "sheet.add(StepLevelFeature(" in src
+        assert "sheet.step_level(" in src
+        assert "sheet.add(StepLevelFeature(" not in src
         assert "# step_level" not in src
+        ast.parse(src)
+
+    def test_step_level_emits_shoulder_positions(self):
+        # #578: a single-level rebate carries a step-position shoulder; the emit must carry
+        # a non-empty shoulders=(...) so the round-trip constrains the step POSITION, not
+        # just its heights. The base slab top is Z=5; the raised step rises from x=0.
+        part = Box(80, 40, 10) + Pos(-20, 0, 10) * Box(40, 40, 12)
+        src = _script_for(part)
+        line = next(ln for ln in src.splitlines() if "sheet.step_level(" in ln)
+        assert "shoulders=(('x', 0),)" in line  # the riser position rides the emit
+        assert "levels=(5,)" in line
+        ast.parse(src)
 
     @pytest.mark.skipif(not _PMI_AVAILABLE, reason="OCP GDT support not available")
     def test_ap242_script_keeps_side_hole_z_location_on_side_ladder(self, tmp_path):


### PR DESCRIPTION
Closes #578. **Final** epic-#574 back-fill — the prismatic step-position feature (recognition + shoulder dims landed in #555) now round-trips through all three ADR-0011 surfaces.

## What
- **declare** — `declare.step_level()` + `_read_step_levels()`: object flavour reads `base` / interior `levels` / `(axis, position)` `shoulders` / `datum` off a part via the existing recognisers (mirrors `model/detect.py`); explicit flavour authors from scratch. Validates level-above-base; rejects a Z shoulder axis (a *position* is horizontal, not the height).
- **model/__init__** — re-export `step_level`.
- **Sheet.step_level** fluent verb.
- **emit** — `step_level` now emits the fluent `sheet.step_level(...)` verb (carrying `levels` + `shoulders` + `datum`) instead of the raw `sheet.add(StepLevelFeature(...))` form, dropping the `StepLevelFeature`/`Frame` import from generated scripts — matching the chamfer (#576) / plate (#577) / countersink (#575) pattern.

Two existing emit tests updated from the raw-add assertion to the fluent verb.

## Verification
- New `TestStepLevel` (object read, explicit, render-lands-`dim_shoulder_x0`+lint-clean, validation) + `test_step_level_emits_shoulder_positions` / `test_step_level_emits_fluent_verb`.
- Round-trip: rebated block `Box(80,40,10)+Pos(-20,0,10)*Box(40,40,12)` → detect → emit `sheet.step_level(base=-5, levels=(5,), shoulders=(('x', 0),), datum=(-40,-20,-5))` → re-declare → renders `dim_shoulder_x0`=40 + `dim_height`, lint clean.
- ruff + mypy clean; `test_sheet_emit.py` + `test_make_drawing.py` (638) green.

Epic #574 checklist complete after this: chamfer ✅ countersink ✅ plate ✅ step-position ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)