### PR TITLE
refactor(#586): extract model-neutral primitives out of _core into a leaf (WP2)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -31,6 +31,11 @@ from build123d_drafting.helpers import (
     format_drawing_scale,
 )
 
+# The model-neutral geometry primitives (`_END_ON`, `_xyz`, `HoleRef`, `_axis_letter`)
+# now live in the leaf `draftwright._geometry` so the IR waist (`model/`) can use them
+# without importing this stage-level grab-bag (ADR 0008; #584 WP2). Re-exported here for
+# the above-`_core` consumers (annotations/sheet/drawing/linting) that already import them.
+from draftwright._geometry import _END_ON, HoleRef, _axis_letter, _xyz  # noqa: F401
 from draftwright.fits import FitClass
 from draftwright.fonts import PLEX_MONO, PLEX_SANS_CONDENSED
 from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
@@ -42,39 +47,6 @@ _MARGIN = 10.0
 
 
 _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for clearance
-
-# The orthographic view a feature is dimensioned end-on in — the view normal to its
-# axis. Single source of truth shared by the planner (view choice) and the lint
-# coverage checks (where to look for a feature's dims). Orientation is data.
-_END_ON = {"x": "side", "y": "front", "z": "plan"}
-
-
-def _xyz(loc) -> tuple[float, float, float]:
-    """A build123d ``Vector`` (has ``.X/.Y/.Z``) or an ``(x, y, z)`` sequence → an
-    ``(x, y, z)`` float tuple. Shared by the detectors and the lint coverage checks
-    so the Vector-unpacking idiom lives in one place."""
-    if hasattr(loc, "X"):
-        return (loc.X, loc.Y, loc.Z)
-    x, y, z = loc
-    return (float(x), float(y), float(z))
-
-
-@dataclass(frozen=True)
-class HoleRef:
-    """A position-keyed reference to a hole — the IR-typed value the cover / hole-table
-    bookkeeping matches on, so the shared escalation never needs a recogniser ``Hole``
-    object (ADR 0008 Amendment 6). Built from any location via :meth:`of` (rounded, so
-    two references at the same position compare equal)."""
-
-    x: float
-    y: float
-    z: float
-
-    @classmethod
-    def of(cls, loc) -> HoleRef:
-        x, y, z = _xyz(loc)
-        return cls(round(x, 3), round(y, 3), round(z, 3))
-
 
 _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built with this
 
@@ -159,14 +131,6 @@ def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> floa
         .bounding_box()
         .size.X
     )
-
-
-def _axis_letter(obj) -> str:
-    """Letter (``"x"``/``"y"``/``"z"``) of ``obj.axis``'s dominant component.
-
-    ``obj`` is anything carrying an ``.axis`` 3-vector (a hole or a boss).
-    """
-    return max(zip("xyz", obj.axis, strict=True), key=lambda t: abs(t[1]))[0]
 
 
 _CONCENTRIC_TOL_MM = 0.5

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -1,0 +1,50 @@
+"""Model-neutral geometry primitives — the leaf below both ``_core`` and ``model``.
+
+These four helpers read an axis / coordinate / position off a build123d object
+(or the IR) and carry no drawing, layout or page knowledge. They live here, not
+in :mod:`draftwright._core`, so the IR waist (:mod:`draftwright.model`) can use
+them without importing the stage-level drawing grab-bag (ADR 0008; #584 WP2).
+This module imports nothing from ``draftwright`` — it is the bottom of the DAG.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Axis letter -> the orthographic view a feature on that axis reads end-on in.
+_END_ON = {"x": "side", "y": "front", "z": "plan"}
+
+
+def _xyz(loc) -> tuple[float, float, float]:
+    """A build123d ``Vector`` (has ``.X/.Y/.Z``) or an ``(x, y, z)`` sequence → an
+    ``(x, y, z)`` float tuple. Shared by the detectors and the lint coverage checks
+    so the Vector-unpacking idiom lives in one place."""
+    if hasattr(loc, "X"):
+        return (loc.X, loc.Y, loc.Z)
+    x, y, z = loc
+    return (float(x), float(y), float(z))
+
+
+@dataclass(frozen=True)
+class HoleRef:
+    """A position-keyed reference to a hole — the IR-typed value the cover / hole-table
+    bookkeeping matches on, so the shared escalation never needs a recogniser ``Hole``
+    object (ADR 0008 Amendment 6). Built from any location via :meth:`of` (rounded, so
+    two references at the same position compare equal)."""
+
+    x: float
+    y: float
+    z: float
+
+    @classmethod
+    def of(cls, loc) -> HoleRef:
+        x, y, z = _xyz(loc)
+        return cls(round(x, 3), round(y, 3), round(z, 3))
+
+
+def _axis_letter(obj) -> str:
+    """Letter (``"x"``/``"y"``/``"z"``) of ``obj.axis``'s dominant component.
+
+    ``obj`` is anything carrying an ``.axis`` 3-vector (a hole or a boss).
+    """
+    return max(zip("xyz", obj.axis, strict=True), key=lambda t: abs(t[1]))[0]

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -14,7 +14,7 @@ for any part.
 
 from __future__ import annotations
 
-from draftwright._core import _axis_letter, _xyz
+from draftwright._geometry import _axis_letter, _xyz
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
     AuthoredDimension,

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 
-from draftwright._core import _END_ON, HoleRef
+from draftwright._geometry import _END_ON, HoleRef
 from draftwright.model.ir import (
     Datum,
     DimParameter,

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -2,12 +2,19 @@
 
 The IR waist (:mod:`draftwright.model`) is the neutral middle of the compiler
 hourglass — it must not reach *up* into the stage-level drawing/layout modules
-(``_core``, ``analysis``, ``sheet``, the annotation/render layers, …). It may
-only depend on leaf modules (``_geometry``, ``fits``, ``recognition``, ``layout``).
+(``_core``, ``analysis``, ``sheet``, ``linting``, the annotation/render layers, …).
+It may only depend on leaf modules (``_geometry``, ``fits``, ``recognition``,
+``layout``, ``fonts``) and its own subpackage.
 
 This is what #584 WP2 fixed by extracting the model-neutral primitives
 (``_END_ON``/``_xyz``/``HoleRef``/``_axis_letter``) out of ``_core`` into the leaf
 ``_geometry``. The test fails if the inversion returns.
+
+The guard is a **fail-closed allowlist**: any draftwright submodule a ``model/``
+file imports must be in :data:`_MODEL_MAY_IMPORT`, so a future upper-layer import
+(e.g. ``linting``, which itself imports ``_core``) trips the test even though it is
+not literally a drawing/layout stage. Relative imports are rejected outright — the
+codebase is 100%-absolute, and a relative import would slip past the resolver.
 """
 
 from __future__ import annotations
@@ -15,59 +22,93 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-_MODEL_DIR = Path(__file__).resolve().parent.parent / "src" / "draftwright" / "model"
+_SRC = Path(__file__).resolve().parent.parent / "src" / "draftwright"
+_MODEL_DIR = _SRC / "model"
 
-# Stage-level / upper drawing+layout modules the IR waist must never import.
-_FORBIDDEN = {
-    "_core",
-    "analysis",
-    "annotate",
-    "annotations",
-    "builder",
-    "cli",
-    "drawing",
-    "export",
-    "make_drawing",
-    "projection",
-    "registry",
-    "repair",
-    "sheet",
-    "sheet_dsl",
-    "sheet_emit",
+# The only draftwright submodules the IR waist may depend on: leaf modules that
+# sit below it in the DAG, plus its own subpackage. Fail-closed — anything else
+# (a stage module, or a leaf like `linting` that transitively pulls in `_core`)
+# is a boundary violation.
+_MODEL_MAY_IMPORT = {
+    "_geometry",
+    "fits",
+    "fonts",
+    "layout",
+    "model",
+    "recognition",
 }
 
 
-def _imported_draftwright_submodules(path: Path) -> set[str]:
-    """The top-level ``draftwright.<name>`` submodules imported by one source file."""
+def _draftwright_imports(path: Path) -> tuple[set[str], list[str]]:
+    """The top-level ``draftwright.<name>`` submodules a source file imports, and any
+    relative imports it uses (which the resolver deliberately refuses to interpret)."""
     tree = ast.parse(path.read_text(), filename=str(path))
-    names: set[str] = set()
+    submodules: set[str] = set()
+    relative: list[str] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module:
-            parts = node.module.split(".")
-            if parts[0] == "draftwright" and len(parts) > 1:
-                names.add(parts[1])
+        if isinstance(node, ast.ImportFrom):
+            if node.level > 0:
+                relative.append(node.module or "(bare relative import)")
+            elif node.module:
+                parts = node.module.split(".")
+                if parts[0] == "draftwright" and len(parts) > 1:
+                    submodules.add(parts[1])
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 parts = alias.name.split(".")
                 if parts[0] == "draftwright" and len(parts) > 1:
-                    names.add(parts[1])
-    return names
+                    submodules.add(parts[1])
+    return submodules, relative
 
 
-def test_model_does_not_import_upper_layers():
-    """No file under ``model/`` imports a stage-level drawing/layout module."""
+def test_model_imports_only_allowed_leaves():
+    """No file under ``model/`` imports outside the leaf allowlist (fail-closed)."""
     offenders: dict[str, set[str]] = {}
+    relatives: dict[str, list[str]] = {}
     for path in sorted(_MODEL_DIR.glob("*.py")):
-        bad = _imported_draftwright_submodules(path) & _FORBIDDEN
+        submodules, relative = _draftwright_imports(path)
+        bad = submodules - _MODEL_MAY_IMPORT
         if bad:
             offenders[path.name] = bad
+        if relative:
+            relatives[path.name] = relative
     assert not offenders, (
-        "model/ (the IR waist) must not import stage-level drawing/layout modules "
-        f"(ADR 0008; #584 WP2): {offenders}"
+        "model/ (the IR waist) may only import leaf modules "
+        f"{sorted(_MODEL_MAY_IMPORT)} (ADR 0008; #584 WP2). Disallowed: {offenders}"
     )
+    assert not relatives, (
+        "model/ must use absolute imports so the boundary guard can resolve them "
+        f"(#584 WP2). Relative imports found: {relatives}"
+    )
+
+
+def test_guard_catches_absolute_and_relative_forbidden_imports():
+    """The extractor is not a tautology: it flags every form a regression could take."""
+    src = (
+        "from draftwright._core import HoleRef\n"
+        "import draftwright.sheet\n"
+        "from .._core import _xyz\n"
+        "from .. import analysis\n"
+    )
+    tree = ast.parse(src)
+    # Reuse the same logic against synthetic source.
+    submodules: set[str] = set()
+    relative: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.level > 0:
+                relative.append(node.module or "(bare)")
+            elif node.module:
+                submodules.add(node.module.split(".")[1])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                submodules.add(alias.name.split(".")[1])
+    assert submodules == {"_core", "sheet"}  # both absolute forms caught
+    assert len(relative) == 2  # both relative forms flagged, not silently missed
 
 
 def test_geometry_is_a_leaf():
     """``_geometry`` is the bottom of the DAG — it imports nothing from draftwright."""
-    path = _MODEL_DIR.parent / "_geometry.py"
-    assert _imported_draftwright_submodules(path) == set()
+    submodules, relative = _draftwright_imports(_SRC / "_geometry.py")
+    assert submodules == set()
+    assert relative == []

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -1,0 +1,73 @@
+"""Import-boundary guards (ADR 0008; #584 WP2).
+
+The IR waist (:mod:`draftwright.model`) is the neutral middle of the compiler
+hourglass — it must not reach *up* into the stage-level drawing/layout modules
+(``_core``, ``analysis``, ``sheet``, the annotation/render layers, …). It may
+only depend on leaf modules (``_geometry``, ``fits``, ``recognition``, ``layout``).
+
+This is what #584 WP2 fixed by extracting the model-neutral primitives
+(``_END_ON``/``_xyz``/``HoleRef``/``_axis_letter``) out of ``_core`` into the leaf
+``_geometry``. The test fails if the inversion returns.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_MODEL_DIR = Path(__file__).resolve().parent.parent / "src" / "draftwright" / "model"
+
+# Stage-level / upper drawing+layout modules the IR waist must never import.
+_FORBIDDEN = {
+    "_core",
+    "analysis",
+    "annotate",
+    "annotations",
+    "builder",
+    "cli",
+    "drawing",
+    "export",
+    "make_drawing",
+    "projection",
+    "registry",
+    "repair",
+    "sheet",
+    "sheet_dsl",
+    "sheet_emit",
+}
+
+
+def _imported_draftwright_submodules(path: Path) -> set[str]:
+    """The top-level ``draftwright.<name>`` submodules imported by one source file."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            parts = node.module.split(".")
+            if parts[0] == "draftwright" and len(parts) > 1:
+                names.add(parts[1])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                parts = alias.name.split(".")
+                if parts[0] == "draftwright" and len(parts) > 1:
+                    names.add(parts[1])
+    return names
+
+
+def test_model_does_not_import_upper_layers():
+    """No file under ``model/`` imports a stage-level drawing/layout module."""
+    offenders: dict[str, set[str]] = {}
+    for path in sorted(_MODEL_DIR.glob("*.py")):
+        bad = _imported_draftwright_submodules(path) & _FORBIDDEN
+        if bad:
+            offenders[path.name] = bad
+    assert not offenders, (
+        "model/ (the IR waist) must not import stage-level drawing/layout modules "
+        f"(ADR 0008; #584 WP2): {offenders}"
+    )
+
+
+def test_geometry_is_a_leaf():
+    """``_geometry`` is the bottom of the DAG — it imports nothing from draftwright."""
+    path = _MODEL_DIR.parent / "_geometry.py"
+    assert _imported_draftwright_submodules(path) == set()


### PR DESCRIPTION
Closes #586 · epic #584 WP2

## What
Restores dependency direction: `model/planner.py` and `model/detect.py` imported four model-neutral primitives (`_END_ON`, `HoleRef`, `_axis_letter`, `_xyz`) from `_core` — a stage-level drawing/layout grab-bag. That's the IR waist reaching *up* into drawing infra; ADR 0008 intends `model/` to be the neutral middle of the hourglass.

## How
- **New leaf `draftwright/_geometry.py`** holds the four self-contained primitives. It imports nothing from `draftwright` — the bottom of the DAG.
- **`_core.py` re-exports** them, so the legitimately-above-`_core` consumers (annotations / sheet / drawing / linting) are untouched — surgical, minimal churn.
- **`model/detect.py` + `model/planner.py`** now import from `_geometry`; **`model/` no longer imports `_core` at all**.
- **New guard test `tests/test_import_boundaries.py`** fails if any `model/*` file imports a stage-level module (`_core`, `analysis`, `sheet`, …), so the inversion can't silently return. Also asserts `_geometry` is a true leaf.

## Verification
- Pure move + re-export — no behaviour change.
- ruff + mypy clean.
- 764 tests across the affected suites (model / declare / linting / make_drawing / strip_layout / import-boundaries) pass unchanged.

## Architectural fit
First of the sequenced #584 packages — smallest and mechanical, and it adds the import-boundary guard that WP1/WP3 rely on. No ADR amendment needed: this *realises* ADR 0008's stated waist intent rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)