### PR TITLE
feat(#587): enforce the ADR 0013 recogniser contract (WP3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Mypy
         run: uv run mypy src/draftwright/
 
+      - name: Codespell
+        run: uv run codespell src/ tests/ docs/
+
   test:
     strategy:
       fail-fast: false

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -11,6 +11,17 @@
 - **Date:** 2026-07-12
 - **Deciders:** Paul Fremantle (pzfreo)
 
+**Amendment 1 (2026-07-12, #584 WP3) — the contract is now mechanically enforced.**
+The three claims the #584 audit found asserted-but-unenforced are real as of this PR:
+(a) **no sibling re-recognition** — `recognise_holes` no longer calls
+`recognise_countersinks` internally; the caller (`analysis.py` / `detect.py`) owns the
+single inventory and injects `csinks=` (§2, ADR 0008 Am5); (b) **uniform serialization** —
+every record inherits a `Record` mixin giving `.to_dict()`, and a contract test
+(`tests/test_recogniser_contract.py`) proves each recogniser's records are frozen and
+JSON-serializable (no build123d type leaks); (c) **codespell-enforced** — wired into the
+CI lint job. The recogniser-signature shape (part + keyword-only) is asserted by the same
+contract test.
+
 ## Context
 
 Two findings, one from inside draftwright and one from a sibling project, meet here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ ignore = ["E501"]
 
 [dependency-groups]
 dev = [
+    "codespell>=2.3.0",
     "mypy>=2.1.0",
     "pytest>=8",
     "pytest-cov>=5",
@@ -118,6 +119,15 @@ dev = [
     "pytest-xdist>=3",
     "ruff>=0.4",
 ]
+
+[tool.codespell]
+# Spelling enforcement for the ADR 0013 contract (epic #584 WP3). Skips binary /
+# generated / vendored assets: STEP fixtures, the lockfile, fonts, git internals.
+skip = "*.stp,*.step,*.svg,*.dxf,*.pdf,uv.lock,.git,*.ttf,*.otf,src/draftwright/fonts/*"
+# Valid words/identifiers codespell's dictionary misflags (calibrated from a clean run):
+# `nd` a Dijkstra distance var, `tread` a real word (stair-tread faces), `accreting`
+# a real word, `testof` the `TestOf` class name, and the valid hyphenated re-* forms.
+ignore-words-list = "nd,tread,accreting,testof,re-using,re-declare,re-declared,re-declaring"
 
 [tool.uv]
 # On Python 3.13/3.14, build123d resolves to 0.11, whose OCP kernel is

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -39,6 +39,7 @@ from draftwright.recognition import (
     analyse_cylinders,
     full_cylinders,
     recognise_bosses,
+    recognise_countersinks,
     recognise_hole_patterns,
     recognise_holes,
     recognise_slots,
@@ -446,7 +447,7 @@ def _analyse(
         if layout_model is not None
         else 0.0
     )
-    holes = recognise_holes(part, cyls=(z_cyls, cross_cyls))
+    holes = recognise_holes(part, cyls=(z_cyls, cross_cyls), csinks=recognise_countersinks(part))
     patterns = recognise_hole_patterns(holes)
     bosses = recognise_bosses(
         part, cyls=(z_cyls, cross_cyls)

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -42,6 +42,7 @@ from draftwright.recognition import (
     TurnedProfile,
     recognise_bosses,
     recognise_chamfers,
+    recognise_countersinks,
     recognise_hole_patterns,
     recognise_holes,
     recognise_plates,
@@ -208,7 +209,7 @@ def build_part_model(
     # (count× member-diameter + pattern dims); its member holes are NOT also
     # emitted individually — the grouped-callout rule the engine uses.
     if holes is None:
-        holes = recognise_holes(part)
+        holes = recognise_holes(part, csinks=recognise_countersinks(part))
     if patterns is None:
         patterns = recognise_hole_patterns(holes)
     patterned: set[int] = set()

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -41,7 +41,8 @@ from OCP.GeomAbs import (
 )
 from OCP.TopAbs import TopAbs_Orientation
 
-from draftwright.recognition.countersinks import CounterSink, recognise_countersinks
+from draftwright.recognition._record import Record
+from draftwright.recognition.countersinks import CounterSink
 
 # Cylinder patches around one axis spanning half a turn or less in total are
 # not holes or bosses: quarter-turn patches are edge blends (fillets/rounds)
@@ -203,7 +204,7 @@ _full_cyls = full_cylinders
 
 
 @dataclass(frozen=True)
-class CounterBore:
+class CounterBore(Record):
     """A counterbore or spotface step of a hole: its diameter and axial depth."""
 
     diameter: float
@@ -211,7 +212,7 @@ class CounterBore:
 
 
 @dataclass(frozen=True)
-class HoleRecord:
+class HoleRecord(Record):
     """A drilled hole: the bore plus optional counterbore/spotface steps.
 
     ``axis`` is the drilling direction (unit vector pointing from the opening
@@ -237,7 +238,7 @@ class HoleRecord:
 
 
 @dataclass(frozen=True)
-class BossRecord:
+class BossRecord(Record):
     """An external cylindrical boss (including a turned part's OD).
 
     ``axis`` points from the base toward the free end, ``location`` is the
@@ -501,7 +502,7 @@ def _csink_for_hole(h: HoleRecord, csinks: list[CounterSink]) -> CounterSink | N
     return None
 
 
-def recognise_holes(part, *, cyls=None) -> list[HoleRecord]:
+def recognise_holes(part, *, cyls=None, csinks=None) -> list[HoleRecord]:
     """Recognise drilled holes on *part* (see :class:`HoleRecord`).
 
     Coaxial internal cylinders are grouped into stacks — drill + optional
@@ -513,6 +514,12 @@ def recognise_holes(part, *, cyls=None) -> list[HoleRecord]:
 
     Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to avoid
     re-scanning the solid (mirrors ``lint_feature_coverage``'s parameter).
+
+    Pass *csinks* — a precomputed ``recognise_countersinks(part)`` result — to
+    compose each countersink onto the hole it flares (#558). Per the ADR 0013
+    contract this recogniser does **not** recognise countersinks itself; the
+    caller owns the single inventory and injects it (``analysis.py`` / ``detect.py``).
+    With ``csinks=None`` the holes come back without countersink attribution.
     """
     z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     internal = [c for c in _full_cyls(z_cyls) + _full_cyls(cross_cyls) if not c["external"]]
@@ -600,10 +607,10 @@ def recognise_holes(part, *, cyls=None) -> list[HoleRecord]:
                 spotface=spotface,
             )
         )
-    # Compose countersinks (#558): a coaxial cone flaring from the bore is a hole
-    # attribute (like a counterbore), so it rides on the HoleRecord — HoleSpec grouping
-    # and the callout-width estimate then see it for free.
-    csinks = recognise_countersinks(part)
+    # Compose the injected countersinks (#558): a coaxial cone flaring from the bore is
+    # a hole attribute (like a counterbore), so it rides on the HoleRecord — HoleSpec
+    # grouping and the callout-width estimate then see it for free. The caller injects the
+    # inventory (ADR 0013 — no sibling re-recognition here).
     if csinks:
         holes = [
             (replace(h, csink=cs) if (cs := _csink_for_hole(h, csinks)) is not None else h)
@@ -698,7 +705,7 @@ _BC_SPACING_TOL = 0.04
 
 
 @dataclass(frozen=True)
-class BoltCircle:
+class BoltCircle(Record):
     """≥3 identical holes equally spaced on a circle.
 
     ``center`` is the world point at the holes' opening plane, ``diameter``
@@ -711,7 +718,7 @@ class BoltCircle:
 
 
 @dataclass(frozen=True)
-class LinearArray:
+class LinearArray(Record):
     """≥3 identical holes collinear at constant pitch.
 
     ``direction`` is the unit vector from the first hole toward the last
@@ -724,7 +731,7 @@ class LinearArray:
 
 
 @dataclass(frozen=True)
-class RectGrid:
+class RectGrid(Record):
     """A fully-populated rectangular grid of identical holes (an N×M lattice).
 
     ``rows``×``cols`` holes sit on a regular rectangular lattice with
@@ -753,7 +760,7 @@ def _pattern_tol(nominal: float) -> float:
 
 
 @dataclass(frozen=True)
-class HoleSpec:
+class HoleSpec(Record):
     """The machining spec shared by holes that are the *same drilled feature*.
 
     Two holes drilled with the same tool, in the same direction, with the same

--- a/src/draftwright/recognition/_record.py
+++ b/src/draftwright/recognition/_record.py
@@ -1,0 +1,28 @@
+"""The recognition-record base mixin (ADR 0013).
+
+Every feature-recognition record is a frozen, geometry-only dataclass — no
+build123d / OCP object leaks out (records are the future ``b123d-recognisers``
+surface, ADR 0013 Phase 2). This mixin gives them the one uniform serialization
+accessor the contract promises: :meth:`to_dict`, a plain nested dict of
+primitives (``dataclasses.asdict`` recurses into nested records and hole tuples).
+
+Leaf of the recognition DAG — imports only the stdlib.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+class Record:
+    """Mixin: a uniform ``.to_dict()`` for every recognition record (ADR 0013).
+
+    The record must be a dataclass; ``to_dict`` returns a nested dict of pure
+    primitives, so a leaked build123d type surfaces as a non-serializable value
+    the contract test catches.
+    """
+
+    def to_dict(self) -> dict:
+        # `self` is always a dataclass instance in practice (the mixin is only used
+        # on records); mypy can't see that through the plain-class base.
+        return dataclasses.asdict(self)  # type: ignore[call-overload,no-any-return]

--- a/src/draftwright/recognition/chamfers.py
+++ b/src/draftwright/recognition/chamfers.py
@@ -41,9 +41,11 @@ from OCP.GeomAbs import GeomAbs_Plane
 from OCP.gp import gp_Pnt
 from OCP.TopAbs import TopAbs_IN
 
+from draftwright.recognition._record import Record
+
 
 @dataclass(frozen=True)
-class Chamfer:
+class Chamfer(Record):
     """A recognised chamfer. ``axis`` is the chamfered edge's direction ("x"/"y"/"z");
     ``leg1``/``leg2`` are the cut depths into the two adjacent faces (equal for a 45°
     chamfer, ``leg1`` the larger); ``angle`` is the chamfer angle in degrees (45 for

--- a/src/draftwright/recognition/countersinks.py
+++ b/src/draftwright/recognition/countersinks.py
@@ -41,6 +41,8 @@ from dataclasses import dataclass
 
 from build123d import GeomType
 
+from draftwright.recognition._record import Record
+
 _TOL = 0.05  # mm — dimension match tolerance (matches the other feature matchers)
 _COAXIAL_TOL = 0.1  # mm — how far the opening may sit off the drill's axis line
 # Real countersinks are ≤120° included (60/82/90/100/120 standards); a near-flat cone is
@@ -55,7 +57,7 @@ _MIN_MAJOR_RATIO = 1.5
 
 
 @dataclass(frozen=True)
-class CounterSink:
+class CounterSink(Record):
     """A recognised countersink. ``axis`` points from the wide opening into the part;
     ``location`` is the opening (major-circle) centre; ``major_diameter`` the outer rim,
     ``drill_diameter`` the bore it sits on; ``included_angle`` the full cone angle

--- a/src/draftwright/recognition/levels.py
+++ b/src/draftwright/recognition/levels.py
@@ -18,9 +18,11 @@ from OCP.BRepGProp import BRepGProp
 from OCP.GeomAbs import GeomAbs_Plane
 from OCP.GProp import GProp_GProps
 
+from draftwright.recognition._record import Record
+
 
 @dataclass(frozen=True, order=True)
-class FaceLevel:
+class FaceLevel(Record):
     """A recognised horizontal face level — its Z coordinate. A prismatic part's step
     heights are dimensioned from these. ``order=True`` so the recogniser returns a
     deterministically sorted list."""
@@ -29,7 +31,7 @@ class FaceLevel:
 
 
 @dataclass(frozen=True, order=True)
-class StepShoulder:
+class StepShoulder(Record):
     """A recognised step/rebate shoulder (#555). ``axis`` is the riser's normal axis
     ("x"/"y"); ``position`` is the world coord of the shoulder along it. ``order=True``
     so recognisers can return a deterministically sorted list."""

--- a/src/draftwright/recognition/plates.py
+++ b/src/draftwright/recognition/plates.py
@@ -39,9 +39,11 @@ from OCP.BRepGProp import BRepGProp
 from OCP.GeomAbs import GeomAbs_Plane
 from OCP.GProp import GProp_GProps
 
+from draftwright.recognition._record import Record
+
 
 @dataclass(frozen=True)
-class Plate:
+class Plate(Record):
     """A recognised thin slab. ``axis`` is the thin (thickness) axis ("x"/"y"/"z");
     ``lo``/``hi`` are the slab's two bounding coords along it (``hi - lo`` is the
     thickness); ``u``/``v`` are the slab centre on the other two axes (in axis order),

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -34,6 +34,8 @@ from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.GeomAbs import GeomAbs_Plane
 from OCP.TopAbs import TopAbs_Orientation
 
+from draftwright.recognition._record import Record
+
 _AXES = {"x": 0, "y": 1, "z": 2}
 # A normal counts as axis-aligned when its dominant component is within this of
 # unit length — machined slot walls are square to the stock, so this is tight.
@@ -49,7 +51,7 @@ _FLOOR_COVER_FRAC = 0.5
 
 
 @dataclass(frozen=True)
-class Slot:
+class Slot(Record):
     """A milled slot / reduced across-flats section.
 
     A slot is bounded by two opposed parallel walls facing each other.  The

--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -34,6 +34,7 @@ from collections import Counter
 from dataclasses import dataclass
 
 from draftwright.recognition._features import analyse_cylinders
+from draftwright.recognition._record import Record
 
 # A face's axial position counts as on a band edge / its normal counts as
 # axis-aligned within these tolerances (mm / unit-vector component).
@@ -56,7 +57,7 @@ _OD_FILL_MIN = 0.6
 
 
 @dataclass(frozen=True)
-class TurnedStep:
+class TurnedStep(Record):
     """One axial segment of a stepped shaft, between two shoulders (or ends). ``axis`` is
     the turning axis ("x"/"y"/"z") the segment is coaxial about — carried on the step so
     it is a **self-contained record**: ``lo``/``hi``/``diameter`` are only interpretable
@@ -73,7 +74,7 @@ class TurnedStep:
 
 
 @dataclass(frozen=True)
-class TurnedProfile:
+class TurnedProfile(Record):
     """The turned-shaft **aggregate** for the annotation pipeline — the coaxial ``steps``
     plus their shared ``axis`` and derived shoulders. **Not a recogniser return**
     (:func:`recognise_turned_steps` returns ``list[TurnedStep]`` per ADR 0013 §2); built

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -147,7 +147,7 @@ def test_invalid_glyph_spec_drops_not_crashes():
     # with a gdt_dropped warning, NOT raise ValueError and take down the whole drawing.
     frame = ControlFrame(
         frame=Frame((0.0, 0.0, 0.0), "z"),
-        characteristic="postion",  # typo — helper raises "Unknown characteristic"
+        characteristic="postion",  # codespell:ignore postion — deliberate typo; helper raises "Unknown characteristic"
         tolerance="0.1",
         view="plan",
         side="above",

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -497,20 +497,22 @@ class TestCountersinkCallout:
         edge = plate.edges().filter_by(Axis.Z).group_by(lambda e: e.center().Z)[-1]
         plate = chamfer(edge, 0.5)
         assert recognise_countersinks(plate) == []
-        assert recognise_holes(plate)[0].csink is None
+        assert recognise_holes(plate, csinks=recognise_countersinks(plate))[0].csink is None
 
     def test_opposite_face_coaxial_hole_is_not_mis_associated(self):
         # #558 review (BLOCKER): a countersink must attach only to the bore at its mouth,
         # facing the same way — NOT to a coaxial hole drilled from the opposite face.
         from build123d import Cone
 
-        from draftwright.recognition import recognise_holes
+        from draftwright.recognition import recognise_countersinks, recognise_holes
 
         p = Box(40, 40, 30)
         p -= Pos(0, 0, 9) * Cylinder(3, 12)  # top hole, opening at z=15
         p -= Pos(0, 0, 13) * Cone(3, 7, 4)  # csk at the top face
         p -= Pos(0, 0, -9) * Cylinder(3, 12)  # coaxial bottom hole, same bore, NO csk
-        by_open = {round(h.location[2]): h for h in recognise_holes(p)}
+        by_open = {
+            round(h.location[2]): h for h in recognise_holes(p, csinks=recognise_countersinks(p))
+        }
         top = max(by_open)  # the top (csk) hole
         assert by_open[top].csink is not None
         assert by_open[min(by_open)].csink is None  # the opposite-face hole stays plain
@@ -521,10 +523,14 @@ class TestCountersinkCallout:
         # regardless of which — a Z-flip must not drop it to plain THRU.
         from build123d import Rotation
 
-        from draftwright.recognition import recognise_holes
+        from draftwright.recognition import recognise_countersinks, recognise_holes
 
         flipped = Rotation(180, 0, 0) * self._csk_plate()
-        holes = [h for h in recognise_holes(flipped) if h.csink is not None]
+        holes = [
+            h
+            for h in recognise_holes(flipped, csinks=recognise_countersinks(flipped))
+            if h.csink is not None
+        ]
         assert len(holes) == 3  # all three csk holes keep their countersink after the flip
 
     def test_callout_angle_is_formatted_not_raw_float(self):

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -18,9 +18,21 @@ import inspect
 import json
 
 import pytest
-from build123d import Box, Cylinder, Pos, Rot
+from build123d import Axis, Box, Cylinder, Pos, Rot, chamfer
 
 from draftwright.recognition import (
+    BoltCircle,
+    BossRecord,
+    Chamfer,
+    CounterSink,
+    FaceLevel,
+    HoleRecord,
+    LinearArray,
+    Plate,
+    RectGrid,
+    Slot,
+    StepShoulder,
+    TurnedStep,
     recognise_bosses,
     recognise_chamfers,
     recognise_countersinks,
@@ -33,6 +45,26 @@ from draftwright.recognition import (
     recognise_turned_steps,
 )
 from draftwright.recognition._record import Record
+
+# Every record class a recogniser returns. The coverage test asserts the drive-parts
+# below actually emit one of each — so a record type that silently stops being produced
+# (or a new recogniser added without contract coverage) fails the test loudly, rather
+# than slipping through a bare count. (CounterBore/HoleSpec/TurnedProfile are sub-records
+# / aggregates, not recogniser returns, so they are exercised nested, not listed here.)
+_EXPECTED_RECORD_TYPES = {
+    HoleRecord,
+    CounterSink,
+    BossRecord,
+    BoltCircle,
+    LinearArray,
+    RectGrid,
+    Chamfer,
+    Slot,
+    Plate,
+    FaceLevel,
+    StepShoulder,
+    TurnedStep,
+}
 
 
 def _csk_plate():
@@ -53,30 +85,62 @@ def _turned_shaft():
     return Rot(0, 90, 0) * (Cylinder(10, 30) + Pos(0, 0, 20) * Cylinder(6, 10))
 
 
+def _linear_array_plate():
+    part = Box(120, 40, 10)
+    for i in range(5):
+        part -= Pos(-40 + i * 20, 0, 0) * Cylinder(3, 10)
+    return part
+
+
+def _grid_plate(nx=3, ny=3, px=25, py=25):
+    part = Box(px * (nx + 1), py * (ny + 1), 10)
+    for i in range(nx):
+        for j in range(ny):
+            part -= Pos((i - (nx - 1) / 2) * px, (j - (ny - 1) / 2) * py, 0) * Cylinder(3, 10)
+    return part
+
+
+def _bolt_circle_plate(n=6, r=30):
+    from math import cos, radians, sin
+
+    part = Box(100, 100, 12)
+    for i in range(n):
+        a = radians(360 / n * i + 15.0)
+        part -= Pos(r * cos(a), r * sin(a), 0) * Cylinder(4, 12)
+    return part
+
+
+def _chamfered_box():
+    box = Box(30, 30, 30)
+    edge = box.edges().filter_by(Axis.Z).sort_by(Axis.X)[-1]
+    return chamfer(edge, 3)
+
+
+def _l_bracket():
+    return Box(80, 40, 8) + Pos(-36, 0, 24) * Box(8, 40, 40)
+
+
 def _records_from_recognisers():
-    """(name, record) pairs across every recogniser, on parts that trigger them."""
+    """(name, record) pairs across every recogniser, on parts that actually trigger them."""
     csk = _csk_plate()
     stepped = _stepped()
     holes = recognise_holes(csk, csinks=recognise_countersinks(csk))
-    bc = Box(80, 80, 10)
-    for i in range(6):
-        a = i * 60
-        from math import cos, radians, sin
-
-        bc -= Pos(25 * cos(radians(a)), 25 * sin(radians(a)), 0) * Cylinder(2, 10)
     slotted = Box(60, 40, 20) - Pos(0, 0, 0) * Box(30, 8, 20)
+    levels = [f.z for f in recognise_face_levels(stepped)]
 
     out: list[tuple[str, object]] = []
     for name, recs in [
         ("recognise_holes", holes),
         ("recognise_countersinks", recognise_countersinks(csk)),
         ("recognise_bosses", recognise_bosses(Cylinder(10, 20))),
-        ("recognise_hole_patterns", recognise_hole_patterns(recognise_holes(bc))),
-        ("recognise_chamfers", recognise_chamfers(Box(20, 20, 20))),  # may be empty
+        ("hole_patterns:bolt", recognise_hole_patterns(recognise_holes(_bolt_circle_plate()))),
+        ("hole_patterns:linear", recognise_hole_patterns(recognise_holes(_linear_array_plate()))),
+        ("hole_patterns:grid", recognise_hole_patterns(recognise_holes(_grid_plate()))),
+        ("recognise_chamfers", recognise_chamfers(_chamfered_box())),
         ("recognise_slots", recognise_slots(slotted)),
-        ("recognise_plates", recognise_plates(Box(80, 60, 4))),
+        ("recognise_plates", recognise_plates(_l_bracket())),
         ("recognise_face_levels", recognise_face_levels(stepped)),
-        ("recognise_step_shoulders", recognise_step_shoulders(stepped, levels=[10.0])),
+        ("recognise_step_shoulders", recognise_step_shoulders(stepped, levels=levels)),
         ("recognise_turned_steps", recognise_turned_steps(_turned_shaft())),
     ]:
         for r in recs:
@@ -87,8 +151,6 @@ def _records_from_recognisers():
 def test_records_are_frozen_and_json_serializable():
     """Every record from every recogniser is a frozen, JSON-serializable ``Record``."""
     records = _records_from_recognisers()
-    # Sanity: the drive-parts actually exercised a broad spread of recognisers.
-    assert len({name for name, _ in records}) >= 6
 
     for name, rec in records:
         assert isinstance(rec, Record), f"{name}: {type(rec).__name__} is not a Record"
@@ -99,6 +161,17 @@ def test_records_are_frozen_and_json_serializable():
         assert isinstance(d, dict)
         # The teeth: a leaked build123d/OCP object makes this raise.
         json.dumps(d)
+
+
+def test_every_record_type_is_actually_exercised():
+    """The drive-parts must emit *each* recogniser record type — no silent under-coverage.
+
+    Guards against the count-only trap: a record type whose drive-part stops producing it
+    (or a new record added without coverage) fails here instead of passing on a bare tally.
+    """
+    seen = {type(rec) for _, rec in _records_from_recognisers()}
+    missing = _EXPECTED_RECORD_TYPES - seen
+    assert not missing, f"contract test never exercised these record types: {missing}"
 
 
 def test_frozen_records_reject_mutation():

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -1,0 +1,140 @@
+"""ADR 0013 recogniser-contract tests.
+
+Enforces the uniform contract mechanically (epic #584 WP3):
+
+- **Immutable records** — every recogniser returns frozen dataclasses.
+- **Uniform serialization** — each record has ``.to_dict()`` (the :class:`Record`
+  mixin) that yields a *JSON-serializable* nested dict. This is the invariant with
+  teeth: a leaked build123d / OCP object would make ``json.dumps`` raise, so the
+  test proves the "geometry-only records, no build123d type leaks out" rule.
+- **Signature shape** — a part-based recogniser takes ``part`` then keyword-only
+  args; a derived recogniser takes a single positional inventory.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import json
+
+import pytest
+from build123d import Box, Cylinder, Pos, Rot
+
+from draftwright.recognition import (
+    recognise_bosses,
+    recognise_chamfers,
+    recognise_countersinks,
+    recognise_face_levels,
+    recognise_hole_patterns,
+    recognise_holes,
+    recognise_plates,
+    recognise_slots,
+    recognise_step_shoulders,
+    recognise_turned_steps,
+)
+from draftwright.recognition._record import Record
+
+
+def _csk_plate():
+    from build123d import Cone
+
+    plate = Box(90, 60, 12)
+    for x, y in [(-30, -15), (5, 12), (30, -8)]:
+        plate -= Pos(x, y, 0) * Cylinder(3, 12)
+        plate -= Pos(x, y, 4) * Cone(3, 7, 4)
+    return plate
+
+
+def _stepped():
+    return Box(80, 40, 10) + Pos(-20, 0, 10) * Box(40, 40, 12)
+
+
+def _turned_shaft():
+    return Rot(0, 90, 0) * (Cylinder(10, 30) + Pos(0, 0, 20) * Cylinder(6, 10))
+
+
+def _records_from_recognisers():
+    """(name, record) pairs across every recogniser, on parts that trigger them."""
+    csk = _csk_plate()
+    stepped = _stepped()
+    holes = recognise_holes(csk, csinks=recognise_countersinks(csk))
+    bc = Box(80, 80, 10)
+    for i in range(6):
+        a = i * 60
+        from math import cos, radians, sin
+
+        bc -= Pos(25 * cos(radians(a)), 25 * sin(radians(a)), 0) * Cylinder(2, 10)
+    slotted = Box(60, 40, 20) - Pos(0, 0, 0) * Box(30, 8, 20)
+
+    out: list[tuple[str, object]] = []
+    for name, recs in [
+        ("recognise_holes", holes),
+        ("recognise_countersinks", recognise_countersinks(csk)),
+        ("recognise_bosses", recognise_bosses(Cylinder(10, 20))),
+        ("recognise_hole_patterns", recognise_hole_patterns(recognise_holes(bc))),
+        ("recognise_chamfers", recognise_chamfers(Box(20, 20, 20))),  # may be empty
+        ("recognise_slots", recognise_slots(slotted)),
+        ("recognise_plates", recognise_plates(Box(80, 60, 4))),
+        ("recognise_face_levels", recognise_face_levels(stepped)),
+        ("recognise_step_shoulders", recognise_step_shoulders(stepped, levels=[10.0])),
+        ("recognise_turned_steps", recognise_turned_steps(_turned_shaft())),
+    ]:
+        for r in recs:
+            out.append((name, r))
+    return out
+
+
+def test_records_are_frozen_and_json_serializable():
+    """Every record from every recogniser is a frozen, JSON-serializable ``Record``."""
+    records = _records_from_recognisers()
+    # Sanity: the drive-parts actually exercised a broad spread of recognisers.
+    assert len({name for name, _ in records}) >= 6
+
+    for name, rec in records:
+        assert isinstance(rec, Record), f"{name}: {type(rec).__name__} is not a Record"
+        assert dataclasses.is_dataclass(rec) and rec.__dataclass_params__.frozen, (
+            f"{name}: {type(rec).__name__} must be a frozen dataclass"
+        )
+        d = rec.to_dict()
+        assert isinstance(d, dict)
+        # The teeth: a leaked build123d/OCP object makes this raise.
+        json.dumps(d)
+
+
+def test_frozen_records_reject_mutation():
+    """A record is immutable — assigning a field raises (frozen dataclass)."""
+    hole = recognise_holes(_csk_plate())[0]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        hole.diameter = 99.0  # type: ignore[misc]
+
+
+def test_part_based_recognisers_are_keyword_only_after_part():
+    """Part-based recognisers take ``part`` then keyword-only args (ADR 0013)."""
+    for fn in (
+        recognise_holes,
+        recognise_bosses,
+        recognise_countersinks,
+        recognise_chamfers,
+        recognise_slots,
+        recognise_plates,
+        recognise_face_levels,
+        recognise_step_shoulders,
+        recognise_turned_steps,
+    ):
+        params = list(inspect.signature(fn).parameters.values())
+        assert params[0].name == "part"
+        assert params[0].kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+        for p in params[1:]:
+            assert p.kind == inspect.Parameter.KEYWORD_ONLY, (
+                f"{fn.__name__}: '{p.name}' must be keyword-only (injected dep / tuning)"
+            )
+
+
+def test_derived_recogniser_takes_single_positional_inventory():
+    """A derived recogniser (``recognise_hole_patterns``) takes one positional arg."""
+    params = list(inspect.signature(recognise_hole_patterns).parameters.values())
+    assert params[0].name == "holes"
+    assert params[0].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD

--- a/uv.lock
+++ b/uv.lock
@@ -352,6 +352,15 @@ wheels = [
 ]
 
 [[package]]
+name = "codespell"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9d/1d0903dff693160f893ca6abcabad545088e7a2ee0a6deae7c24e958be69/codespell-2.4.2.tar.gz", hash = "sha256:3c33be9ae34543807f088aeb4832dfad8cb2dae38da61cac0a7045dd376cfdf3", size = 352058, upload-time = "2026-03-05T18:10:42.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/a1/52fa05533e95fe45bcc09bcf8a503874b1c08f221a4e35608017e0938f55/codespell-2.4.2-py3-none-any.whl", hash = "sha256:97e0c1060cf46bd1d5db89a936c98db8c2b804e1fdd4b5c645e82a1ec6b1f886", size = 353715, upload-time = "2026-03-05T18:10:41.398Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -681,6 +690,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "codespell" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -702,6 +712,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codespell", specifier = ">=2.3.0" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=5" },


### PR DESCRIPTION
Closes #587 · epic #584 WP3

Makes the three ADR 0013 claims the #584 audit found **asserted-but-unenforced** real.

## 1. No sibling re-recognition (§2, ADR 0008 Am5)
`recognise_holes` called `recognise_countersinks(part)` internally — a recogniser re-recognising a dependency. Now it takes an injected `csinks=`, and the caller (`analysis.py` / `detect.py`) owns the single inventory and threads it. `csinks=None` ⇒ holes without countersink attribution.
- Behaviour-identical on every `build_drawing`/`make_drawing` path (analysis + detect both inject).
- The two **direct**-recognition csink tests now inject the inventory — the association logic they verify (opposite-face exclusion, orientation-independence) is unchanged; only the call follows the new contract.

## 2. Uniform serialization + no-leak teeth
- New leaf `recognition/_record.py`: a `Record` mixin giving every record `.to_dict()` (nested primitives via `dataclasses.asdict`).
- New `tests/test_recogniser_contract.py`: proves each recogniser's records are **frozen** and **JSON-serializable** (a leaked build123d/OCP object makes `json.dumps` raise — that's the real invariant), and asserts the **part + keyword-only** signature shape.

## 3. codespell in CI
- `[tool.codespell]` config (skips STEP/font/binary assets; `ignore-words-list` calibrated from a clean run for valid words it misflags — `nd`, `tread`, `accreting`, the `TestOf` class, valid hyphenated `re-*`). The one **deliberate** typo in a negative test is inline-`# codespell:ignore`'d.
- Added to the CI `lint` job. Closes the #568 spelling-enforcement remainder.

ADR 0013 amended (Amendment 1) to record the contract is now mechanical.

## Verification
- 843 affected-suite tests pass (recognition, contract, make_drawing, part_model, declare, sheet_emit, linting).
- ruff + format + mypy + codespell all clean.

## Architectural fit
Third #584 package. Directly realises ADR 0013 §2/§4 + ADR 0008 Am5 (one inventory). No new coupling; `_record.py` is a stdlib-only leaf at the bottom of the recognition DAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)