### PR TITLE
refactor(#588): source section/callout membership keys from the IR (WP1 slice C)

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -56,6 +56,7 @@ from draftwright.annotations.sections import (
     _request_prismatic_detail,
     _reserve_section_row,
     _resolve_details,
+    feature_hole_keys,
     feature_holes_of,
 )
 from draftwright.model import (
@@ -234,12 +235,14 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # dimensioned by the ldr_z leaders, so they are excluded here to avoid a
     # duplicate hole callout; only the off-axis features get callouts.  On a
     # prismatic part every hole flows through unchanged.
-    # The surviving feature holes + their *positions* (concentric bores excluded on
-    # rotational parts) — the IR gates callouts/furniture/sections on membership in this
-    # set, so no recogniser Hole object crosses into the renderers (Amendment 6, #263/
-    # #207). feature_holes_of is the single source shared with the section() add verb (#420).
+    # The surviving feature holes' *positions* (concentric bores excluded on rotational
+    # parts) — the IR gates callouts/furniture/sections on membership in this set, so no
+    # recogniser Hole object crosses into the renderers (Amendment 6, #263/#207).
+    # feature_hole_keys reads the IR (`_model.features`) — the single source shared with
+    # the section() add verb (#420 / #584 WP1). feature_holes (still record-typed) feeds
+    # only the off-axis side-drilled location pass below, which migrates in WP1 subsystem B.
+    feature_keys = feature_hole_keys(_model, a)
     feature_holes = feature_holes_of(a)
-    feature_keys = {HoleRef.of(h.location) for h in feature_holes}
     # ADR 0011 #448: when the caller DECLARED the model (model=), a hole/pattern renders at
     # its declared position even where detection missed it — source the callout membership
     # set from the declared IR groups too, not only a.holes. A no-op for the detection-only

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -62,17 +62,43 @@ def _is_concentric_hole(h, a: Analysis) -> bool:
 def feature_holes_of(a: Analysis) -> list:
     """The feature holes the IR gates callouts / furniture / sections on — a turned
     part's concentric axial bores (dimensioned by the centreline leaders) excluded,
-    every hole on a prismatic part kept. The single source shared by ``_auto_annotate``
-    and the ``section()`` add verb so their trigger set cannot drift (#420)."""
+    every hole on a prismatic part kept.
+
+    Still recogniser-record-typed: the off-axis side-drilled *location* pass
+    (:func:`_locate_off_axis_holes`) reads per-hole diameter/depth/bottom the IR doesn't
+    yet carry on the declared path — migrating that is #584 WP1 subsystem B. The
+    membership *key* set has already moved to the IR (:func:`feature_hole_keys`)."""
     if not a.is_rotational:
         return list(a.holes)
     return [h for h in a.holes if not _is_concentric_hole(h, a)]
 
 
-def feature_hole_keys(a: Analysis) -> set[HoleRef]:
-    """The :class:`HoleRef` position keys of :func:`feature_holes_of` — the membership
-    set ``plan_sections`` gates a section trigger on (#420)."""
-    return {HoleRef.of(h.location) for h in feature_holes_of(a)}
+def feature_hole_keys(model, a: Analysis) -> set[HoleRef]:
+    """The :class:`HoleRef` position keys of the part's feature holes — the membership
+    set the callout/furniture passes and ``plan_sections`` gate on (#420).
+
+    Sourced from the **IR** (``model.features`` — the hole/pattern features detection or
+    a declared model produced), not recogniser records, so no ``HoleRecord`` crosses into
+    the renderers (ADR 0008 Am6 / #584 WP1). A turned part's concentric axial bores
+    (dimensioned by the centreline leaders, not a callout) are excluded; every other hole
+    — singleton or pattern member — is kept."""
+    keys: set[HoleRef] = set()
+    for f in model.features:
+        if f.kind == "hole":
+            axis, positions = f.frame.axis, (f.members or (f.frame.origin,))
+        elif f.kind == "pattern":
+            axis, positions = f.member.frame.axis, (f.members or (f.member.frame.origin,))
+        else:
+            continue
+        for pos in positions:
+            if (
+                a.is_rotational
+                and axis == "z"
+                and math.hypot(pos[0] - a.cx, pos[1] - a.cy) <= _CONCENTRIC_TOL_MM
+            ):
+                continue
+            keys.add(HoleRef.of(pos))
+    return keys
 
 
 def add_section(dwg) -> list[str]:
@@ -96,7 +122,7 @@ def add_section(dwg) -> list[str]:
     a = getattr(dwg, "_analysis", None)
     if a is None:
         raise ValueError("section(): no analysis — build the drawing first")
-    plan = plan_sections(model, feature_hole_keys(a))
+    plan = plan_sections(model, feature_hole_keys(model, a))
     if plan is None:
         return []  # no counterbore/spotface/blind Z-hole — no section warranted
     before = set(dwg.annotations())

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -792,7 +792,7 @@ def _feature_listing(a: Analysis) -> str:
         for p in feat.parameters():
             if p.span is not None or kind == "slot":  # a linear dim dimension() accepts
                 body.append(f'dwg.dimension(f, "{p.kind}", role="{p.role}")   # {display(p)}')
-    if plan_sections(model, feature_hole_keys(a)) is not None:
+    if plan_sections(model, feature_hole_keys(model, a)) is not None:
         body += [
             "",
             "# Section A–A (part-level; comment to drop the whole section)",

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1237,7 +1237,7 @@ class Drawing:
         _section = None
         if routable and any(it.kind == "section" for it in self._intents):
             assert a is not None and isinstance(model, PartModel)
-            _section = plan_sections(model, feature_hole_keys(a))
+            _section = plan_sections(model, feature_hole_keys(model, a))
         # Route through the auto-pass solvers when possible (else everything live-replays):
         #  - BOTH-axes locate → the ADR-0009 location corridor. An axes-restricted locate
         #    can't go through the per-feature filter, so it live-replays (#429).
@@ -1417,7 +1417,7 @@ class Drawing:
                     a,
                     build_view_of_axis(a),
                     plan_dimensions(model),
-                    feature_hole_keys(a),
+                    feature_hole_keys(model, a),
                     only=only_callout,
                     place_furniture=False,
                 )


### PR DESCRIPTION
Part of epic #584 WP1 (finish the recognition→IR boundary) — **subsystem C (sections)**, the first of the C→B→D→A sub-split.

## What
`feature_hole_keys` — the `HoleRef` membership set that `plan_sections` and the callout/furniture passes gate on — now derives from the **IR** (`model.features` hole/pattern features) instead of the recogniser `Analysis.holes`/`.patterns` records. No `HoleRecord` crosses into the section-trigger derivation (ADR 0008 Am6).

## How
- `feature_hole_keys(a)` → `feature_hole_keys(model, a)`: iterates `HoleFeature` / `PatternFeature` member positions (`members or (frame.origin,)`) applying the same rotational-concentric-bore filter.
- Callers pass `model`: `sections.add_section`, `builder`, `drawing` (×2), `orchestrator`.
- `feature_holes_of` (record-typed) is **kept** — it still feeds only the off-axis side-drilled location pass (`_locate_off_axis_holes`), which carries the declared-path IR gap and migrates in **subsystem B**.

## Verification
- **Key-set equivalence proven**: the IR keys are byte-identical to the old record path across prismatic / bolt-circle / linear-array / cbore-section-trigger / rotational-concentric parts.
- 219 affected-suite tests pass (make_drawing, declare, e2e_standards, sheet_of — filtered to section/hole/pattern/turned/rotational).
- ruff + mypy clean.

## Architectural fit
Incremental step toward ADR 0008's "recognition records don't survive past IR". Scoped deliberately narrow (membership keys only); the off-axis location path stays on records until subsystem B closes its declared-path gap. `sections.py` no longer imports any recognition record type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)