### PR TITLE
refactor(#588): source drawing.features() + the hole table from the IR (WP1 B1+B2)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -13,6 +13,7 @@ import contextlib
 import math
 import warnings
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from build123d import (
     Align,
@@ -40,7 +41,6 @@ from draftwright._core import (
     _STRIP_GAP,
     _STRIP_SPACING,
     Analysis,
-    _axis_letter,
     _dim,
     _fmt,
     _log,
@@ -78,10 +78,7 @@ from draftwright.projection import (
     _exactify_silhouettes,
     _raw_view_projector,
 )
-from draftwright.recognition import (
-    HoleSpec,
-    analyse_cylinders,
-)
+from draftwright.recognition import analyse_cylinders
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing
 
@@ -306,6 +303,34 @@ class FeatureInfo:
     through: bool
     depth: float | None
     count: int
+
+
+class _HoleInstance(NamedTuple):
+    """One hole occurrence for the table / balloon renderers — the IR fields those
+    passes read (``location`` + ``diameter`` for a balloon, ``through``/``depth`` for a
+    table row), so no ``HoleRecord`` is needed (ADR 0008; #584 WP1). Duck-compatible
+    with the recogniser record the orchestrator's balloon path still passes."""
+
+    location: tuple
+    diameter: float
+    through: bool
+    depth: float | None
+
+
+def _ir_hole_groups(model, target_axis: str) -> list[tuple]:
+    """``(spec, [member positions])`` groups of *model*'s holes on *target_axis*.
+
+    One group per IR hole/pattern feature — the spec-grouping + pattern recognition
+    detection already did, so no ``HoleRecord``/``HoleSpec`` re-grouping is needed
+    (ADR 0008 Am6; #584 WP1). ``spec`` is the representative ``HoleFeature`` (carries
+    diameter / through / depth); ``positions`` are its member centres."""
+    groups: list[tuple] = []
+    for f in model.features:
+        if f.kind == "hole" and f.frame.axis == target_axis:
+            groups.append((f, list(f.members) or [f.frame.origin]))
+        elif f.kind == "pattern" and f.member.frame.axis == target_axis:
+            groups.append((f.member, list(f.members) or [f.member.frame.origin]))
+    return groups
 
 
 class Drawing:
@@ -606,26 +631,20 @@ class Drawing:
         if view not in self._coords:
             return []
 
-        def _to_page(h):
-            return self._coords[view].pp(*h.location)
-
-        groups: dict = {}
-        for h in a.holes:
-            if _axis_letter(h) != target_axis:
-                continue
-            groups.setdefault(HoleSpec.from_hole(h), []).append(h)
+        model = self._part_model
+        if model is None:
+            return []
 
         result = []
-        for group in groups.values():
-            rep = group[0]
+        for spec, positions in _ir_hole_groups(model, target_axis):
             result.append(
                 FeatureInfo(
                     type="hole",
-                    page_pos=_to_page(rep),
-                    diameter=rep.diameter,
-                    through=rep.bottom == "through",
-                    depth=None if rep.bottom == "through" else rep.depth,
-                    count=len(group),
+                    page_pos=self._coords[view].pp(*positions[0]),
+                    diameter=spec.diameter,
+                    through=spec.through,
+                    depth=None if spec.through else spec.depth,
+                    count=len(positions),
                 )
             )
         return result
@@ -1570,17 +1589,21 @@ class Drawing:
     def _hole_spec_groups(self, view):
         """Ordered ``(tag, [holes])`` spec-groups of *view*'s holes (tags A, B,
         …). The shared basis for the hole table's rows and its balloons, so the
-        TAG column and the balloon glyphs line up."""
-        a = self._analysis
+        TAG column and the balloon glyphs line up.
+
+        Sourced from the IR (``model.features``), so each group is one hole/pattern
+        feature — a pattern and same-spec loose holes are distinct groups (ADR 0008;
+        #584 WP1). Each ``holes`` element is a :class:`_HoleInstance` carrying the
+        location + shared spec the table/balloon renderers read."""
+        model = self._part_model
         target = {"plan": "z", "front": "y", "side": "x"}.get(view)
-        if a is None or target is None or view not in self._coords:
+        if model is None or target is None or view not in self._coords:
             return []
 
-        groups: dict = {}
-        for h in a.holes:
-            if _axis_letter(h) == target:
-                groups.setdefault(HoleSpec.from_hole(h), []).append(h)
-        glist = list(groups.values())
+        glist = [
+            [_HoleInstance(pos, spec.diameter, spec.through, spec.depth) for pos in positions]
+            for spec, positions in _ir_hole_groups(model, target)
+        ]
         return list(zip(_tag_sequence(len(glist)), glist, strict=True))
 
     def _add_balloons(self, view, specs):
@@ -1825,7 +1848,7 @@ class Drawing:
         diams = []
         for tag, holes in groups:
             h = holes[0]
-            depth = "THRU" if h.bottom == "through" else (_fmt(h.depth) if h.depth else "")
+            depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
             rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(len(holes))))
             diams.append(h.diameter)
         table = self.add_table(rows, prefer=prefer, name=name or f"hole_table_{view}")

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -318,18 +318,21 @@ class _HoleInstance(NamedTuple):
 
 
 def _ir_hole_groups(model, target_axis: str) -> list[tuple]:
-    """``(spec, [member positions])`` groups of *model*'s holes on *target_axis*.
+    """``(spec, [member positions], count)`` groups of *model*'s holes on *target_axis*.
 
     One group per IR hole/pattern feature — the spec-grouping + pattern recognition
     detection already did, so no ``HoleRecord``/``HoleSpec`` re-grouping is needed
     (ADR 0008 Am6; #584 WP1). ``spec`` is the representative ``HoleFeature`` (carries
-    diameter / through / depth); ``positions`` are its member centres."""
+    diameter / through / depth); ``positions`` are its member centres (drive balloon
+    placement); ``count`` is the feature's own count (the table QTY / FeatureInfo.count).
+    They coincide on the detected path (``members`` is fully populated); ``count`` stays
+    faithful for a declared feature whose ``members`` are unspecified (ADR 0011)."""
     groups: list[tuple] = []
     for f in model.features:
         if f.kind == "hole" and f.frame.axis == target_axis:
-            groups.append((f, list(f.members) or [f.frame.origin]))
+            groups.append((f, list(f.members) or [f.frame.origin], f.count))
         elif f.kind == "pattern" and f.member.frame.axis == target_axis:
-            groups.append((f.member, list(f.members) or [f.member.frame.origin]))
+            groups.append((f.member, list(f.members) or [f.member.frame.origin], f.count))
     return groups
 
 
@@ -636,7 +639,7 @@ class Drawing:
             return []
 
         result = []
-        for spec, positions in _ir_hole_groups(model, target_axis):
+        for spec, positions, count in _ir_hole_groups(model, target_axis):
             result.append(
                 FeatureInfo(
                     type="hole",
@@ -644,7 +647,7 @@ class Drawing:
                     diameter=spec.diameter,
                     through=spec.through,
                     depth=None if spec.through else spec.depth,
-                    count=len(positions),
+                    count=count,
                 )
             )
         return result
@@ -1587,24 +1590,31 @@ class Drawing:
         return self.add(table.locate(Location((pos[0], pos[1], 0))), name)
 
     def _hole_spec_groups(self, view):
-        """Ordered ``(tag, [holes])`` spec-groups of *view*'s holes (tags A, B,
+        """Ordered ``(tag, [holes], count)`` spec-groups of *view*'s holes (tags A, B,
         …). The shared basis for the hole table's rows and its balloons, so the
         TAG column and the balloon glyphs line up.
 
         Sourced from the IR (``model.features``), so each group is one hole/pattern
         feature — a pattern and same-spec loose holes are distinct groups (ADR 0008;
-        #584 WP1). Each ``holes`` element is a :class:`_HoleInstance` carrying the
-        location + shared spec the table/balloon renderers read."""
+        #584 WP1). Each ``holes`` element is a :class:`_HoleInstance` (one per member
+        position, driving a balloon); ``count`` is the feature's declared/detected count
+        for the table QTY — equal to ``len(holes)`` on the detected path."""
         model = self._part_model
         target = {"plan": "z", "front": "y", "side": "x"}.get(view)
         if model is None or target is None or view not in self._coords:
             return []
 
         glist = [
-            [_HoleInstance(pos, spec.diameter, spec.through, spec.depth) for pos in positions]
-            for spec, positions in _ir_hole_groups(model, target)
+            (
+                [_HoleInstance(pos, spec.diameter, spec.through, spec.depth) for pos in positions],
+                count,
+            )
+            for spec, positions, count in _ir_hole_groups(model, target)
         ]
-        return list(zip(_tag_sequence(len(glist)), glist, strict=True))
+        return [
+            (tag, holes, count)
+            for tag, (holes, count) in zip(_tag_sequence(len(glist)), glist, strict=True)
+        ]
 
     def _add_balloons(self, view, specs):
         """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
@@ -1846,10 +1856,10 @@ class Drawing:
             return None
         rows = [("TAG", "⌀", "DEPTH", "QTY")]
         diams = []
-        for tag, holes in groups:
+        for tag, holes, count in groups:
             h = holes[0]
             depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
-            rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(len(holes))))
+            rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(count)))
             diams.append(h.diameter)
         table = self.add_table(rows, prefer=prefer, name=name or f"hole_table_{view}")
         if table is None:
@@ -1859,7 +1869,7 @@ class Drawing:
         if balloons:
             self._add_balloons(
                 view,
-                [(tag, j, h) for tag, holes in groups for j, h in enumerate(holes)],
+                [(tag, j, h) for tag, holes, _count in groups for j, h in enumerate(holes)],
             )
         return table
 

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -58,6 +58,23 @@ class TestConstructors:
         f = hole(diameter=6, at=(0, 0, 0), axis="z", cbore=(10, 3), count=4)
         assert f.cbore == (10, 3) and f.count == 4
 
+    def test_declared_hole_count_is_faithful_in_features(self):
+        # #584 WP1 B2 review: features()/the hole table QTY read the feature's own
+        # count, not len(members) — a declared count-N hole with unspecified members
+        # (only pattern() auto-populates them) must still report N, not 1.
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        part = Box(80, 60, 12) - Pos(20, 10, 0) * Cylinder(3, 12)
+        dwg = build_drawing(
+            part,
+            model=[hole(diameter=6, at=(20, 10, 0), axis="z", through=True, count=3)],
+            number="X",
+        )
+        (feat,) = dwg.features("plan")
+        assert feat.diameter == 6 and feat.count == 3
+
     def test_read_cylinder_diameter_is_face_radius(self):
         c = Pos(0, 0, 0) * Cylinder(3, 8)
         r = max(fc.radius for fc in c.faces().filter_by(GeomType.CYLINDER))

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6604,6 +6604,22 @@ class TestFeatures:
         assert feats[10.0].count == 4
         assert feats[6.0].count == 1
 
+    def test_pattern_and_loose_same_spec_holes_are_separate_groups(self):
+        # #584 WP1 (B2): features()/the hole table source grouping from the IR, so a
+        # recognised pattern and same-spec LOOSE holes are DISTINCT groups (the pattern
+        # keeps its bolt-circle callout) — not one flat spec-group. Six ø6 on a bolt
+        # circle + two loose ø6 → a count-6 pattern group AND a count-2 loose group,
+        # not one count-8 group.
+        part = Box(140, 140, 12)
+        for i in range(6):
+            ang = math.radians(60 * i + 15)
+            part -= Pos(30 * math.cos(ang), 30 * math.sin(ang), 0) * Cylinder(3, 12)
+        part -= Pos(-60, -60, 0) * Cylinder(3, 12)
+        part -= Pos(60, 60, 0) * Cylinder(3, 12)
+        dwg = build_drawing(part, number="X")
+        six = sorted(f.count for f in dwg.features("plan") if f.diameter == 6.0)
+        assert six == [2, 6]  # two ø6 groups, not one merged count-8
+
     def test_page_pos_is_in_plan_view_coordinate_range(self):
         dwg = build_drawing(_holed_plate())
         a = dwg._analysis


### PR DESCRIPTION
Part of epic #584 WP1 — subsystems **B1** (public `features()` API) + **B2** (hole table + balloons). Continues the C→B→D→A sub-split (C merged in #593).

## What
`Drawing.features()` and `_hole_spec_groups` now derive from the **IR** (`model.features`) instead of grouping `Analysis.holes` by `HoleSpec.from_hole`. `drawing.py` no longer imports any recogniser hole record type — only `analyse_cylinders` (cylinder substrate, a separate lower-level concern).

## How
- New `_ir_hole_groups(model, axis)` yields one `(spec, positions)` group per IR hole/pattern feature (detection already did the spec-grouping + pattern recognition — no re-grouping needed).
- A tiny `_HoleInstance` NamedTuple carries `location` + the group's shared `diameter`/`through`/`depth` for the table + balloon renderers.
- The balloon seam (`_add_balloons`/`_render_balloon`) stays **duck-typed** on `.location`/`.diameter`, so the orchestrator's balloon path (subsystem B4) and record-passing tests keep working — **deferred, not touched**.

## Accepted behaviour change (you approved this as more-correct)
Grouping is now **pattern-separated**: a recognised pattern and same-spec **loose** holes are distinct groups/rows. E.g. a ø6 bolt-circle ×6 plus two loose ø6 → a count-6 pattern group **and** a count-2 loose group, not one flat count-8. Locked in by a new test (`test_pattern_and_loose_same_spec_holes_are_separate_groups`), since byte-golden was retired (ADR 0007).

## Deferred (documented)
- Subsystem **B3** — the off-axis `_locate_off_axis_holes` path (the genuine declared-model IR gap) stays on records.
- Subsystem **D** — the lint/coverage `a.holes` read (drawing.py:1994).

## Verification
- 143 features/hole-table/balloon tests + the full `TestFeatures` class pass.
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)