### PR TITLE
refactor(#588): source off-axis hole location dims from the IR (WP1 B3)

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -9,6 +9,7 @@ shared placement helpers come from annotations._common. Below annotate, no cycle
 from __future__ import annotations
 
 import math
+from typing import NamedTuple
 
 from build123d_drafting.helpers import (
     CenterlineCircle,
@@ -24,7 +25,6 @@ from draftwright._core import (
     _TB_H,
     Analysis,
     HoleRef,
-    _axis_letter,
     _dim,
     _fmt,
     _iso_bbox,
@@ -486,7 +486,31 @@ def _record_callout_drop(dwg, view, diam, reason, feat=None):
     dwg._escalations.append(Escalation(kind="callout", view=view, feature=feat, reason=reason))
 
 
-def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
+class _OffHole(NamedTuple):
+    """One side-drilled hole occurrence for the off-axis location pass — the IR fields
+    it reads (the axis letter + the member location), so no ``HoleRecord`` is needed
+    (ADR 0008; #584 WP1 B3)."""
+
+    axis: str
+    location: tuple
+
+
+def _ir_off_axis_holes(model) -> list[_OffHole]:
+    """Every loose x/y-axis (side-drilled) hole member in the IR, as :class:`_OffHole`.
+
+    Pattern members are separate ``PatternFeature``s (skipped), so patterned holes are
+    excluded by construction — matching the old ``h not in patterned`` filter without a
+    ``HoleRecord`` (ADR 0008; #584 WP1 B3). The turning-axis concentric filter is applied
+    by the caller that needs it."""
+    return [
+        _OffHole(f.frame.axis, pos)
+        for f in (model.features if model is not None else ())
+        if f.kind == "hole" and f.frame.axis in ("x", "y")
+        for pos in (f.members or (f.frame.origin,))
+    ]
+
+
+def _locate_off_axis_holes(dwg, a: Analysis, *, which):
     """Location dimensions for side-drilled holes (#133).
 
     An X-axis hole is a circle in the SIDE view (locate its Y below the view and
@@ -515,8 +539,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
       strips (#133).
     """
     draft = dwg.draft
-    all_holes = a.holes if holes_in is None else holes_in
-    patterned = {h for p in a.patterns for h in p.holes}
+    model = dwg._part_model
 
     def _coaxial(h):
         # The turning-axis bore of a rotational part is located by its centreline, not
@@ -526,7 +549,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
         # dims; coverage already credits the bore via its centre mark, so lint stays
         # clean. Non-rotational parts and genuine off-centre side-drilled holes keep
         # their dims (the a.od_axis + perpendicular-centre gates).
-        if not a.is_rotational or _axis_letter(h) != a.od_axis:
+        if not a.is_rotational or h.axis != a.od_axis:
             return False
         centre = (a.cx, a.cy, a.cz)
         return all(
@@ -535,11 +558,9 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
             if ax != a.od_axis
         )
 
-    off = [
-        h
-        for h in all_holes
-        if _axis_letter(h) in ("x", "y") and h not in patterned and not _coaxial(h)
-    ]
+    # Off-axis holes sourced from the IR (ADR 0008 Am6; #584 WP1 B3) — the turning-axis
+    # concentric bore excluded (located by its centreline, not a position dim).
+    off = [h for h in _ir_off_axis_holes(model) if not _coaxial(h)]
     if not off:
         return
     SX, SZ = a.proj.side_x, a.proj.side_z
@@ -634,7 +655,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
         cands = []
         order_y: dict = {}
         loc_by_name: dict = {}  # dim name -> contributing hole locations (for provenance)
-        for h in (h for h in off if _axis_letter(h) == "x"):
+        for h in (h for h in off if h.axis == "x"):
             yo = round(abs(h.location[1] - dy), 2)
             if yo * a.SCALE < 1.0:
                 continue
@@ -672,7 +693,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
     x_cands = []
     order_x: dict = {}
     x_loc_by_name: dict = {}
-    for h in (h for h in off if _axis_letter(h) == "y"):
+    for h in (h for h in off if h.axis == "y"):
         xo = round(abs(h.location[0] - dx), 2)
         if xo * a.SCALE < 1.0:
             continue
@@ -739,7 +760,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, holes_in=None, *, which):
 
         side_cand = (a.sv_zones.right, "side", (zr, SZ(dz), 0), (zr, SZ(hz), 0), zr)
         front_cand = (a.fv_zones.right, "front", (zrf, FZ(dz), 0), (zrf, FZ(hz), 0), zrf)
-        order = (side_cand, front_cand) if _axis_letter(h) == "x" else (front_cand, side_cand)
+        order = (side_cand, front_cand) if h.axis == "x" else (front_cand, side_cand)
         primary, *alternates = order
         strip, view, p_lo, p_hi, edge = primary
         primary_cand = _zc(view, p_lo, p_hi, edge)
@@ -1370,13 +1391,12 @@ def _annotate_holes(
         #    out along it has its callout text crossed by the centre mark / centreline
         #    (#305). Only a near-centre callout is close enough for the band to move.
         clr = draft.font_size + 3 * draft.pad_around_text  # clearance off a crossing line
-        patterned = {h for p in a.patterns for h in p.holes}
         off_axis_letter = {"side": "x", "front": "y"}.get(view)
         reserved_rows = (
             [
                 to_page(h.location)[1]
-                for h in a.holes
-                if _axis_letter(h) == off_axis_letter and h not in patterned
+                for h in _ir_off_axis_holes(dwg._part_model)
+                if h.axis == off_axis_letter
             ]
             if off_axis_letter
             else []

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -57,7 +57,6 @@ from draftwright.annotations.sections import (
     _reserve_section_row,
     _resolve_details,
     feature_hole_keys,
-    feature_holes_of,
 )
 from draftwright.model import (
     Frame,
@@ -239,17 +238,14 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # parts) — the IR gates callouts/furniture/sections on membership in this set, so no
     # recogniser Hole object crosses into the renderers (Amendment 6, #263/#207).
     # feature_hole_keys reads the IR (`_model.features`) — the single source shared with
-    # the section() add verb (#420 / #584 WP1). feature_holes (still record-typed) feeds
-    # only the off-axis side-drilled location pass below, which migrates in WP1 subsystem B.
+    # the section() add verb (#420 / #584 WP1) and the off-axis location pass, which now
+    # derives its own side-drilled holes from the IR too (subsystem B3).
     feature_keys = feature_hole_keys(_model, a)
-    feature_holes = feature_holes_of(a)
     # ADR 0011 #448: when the caller DECLARED the model (model=), a hole/pattern renders at
     # its declared position even where detection missed it — source the callout membership
     # set from the declared IR groups too, not only a.holes. A no-op for the detection-only
     # path (gated on the declared flag; and on a fully-detected declared part the declared
-    # keys already coincide with the detected ones). NOTE: off-axis side-drilled *location*
-    # dims (_locate_off_axis_holes below) still gate on detected holes — they need recogniser
-    # -Hole geometry (diameter/depth/bottom) a declared IR feature doesn't carry — a follow-up.
+    # keys already coincide with the detected ones).
     declared_keys: set = set()
     if getattr(dwg, "_model_declared", False):
         declared_keys = _declared_feature_keys(_groups, a)
@@ -267,13 +263,13 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (tests/test_layout_cleanliness.py) is exactly this accepted case.
     _section = plan_sections(_model, feature_keys)
     _reserve_section_row(dwg, a, _section)
-    if feature_holes or declared_keys:  # declared holes render even where detection missed them
+    if feature_keys:  # any hole/pattern member (declared holes render even where detection missed them)
         _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
     # through the existing above-view strips. Replaces the engine's _add_location_dims.
     render_locations(dwg, _model, a)
 
-    if a.cross_diams and a.is_rotational and not feature_holes:
+    if a.cross_diams and a.is_rotational and not feature_keys:
         _log.info(
             "Cross-hole ø%s detected but not annotated (requires section view)",
             _fmt(a.cross_diams[0]),
@@ -301,8 +297,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # the overall envelope depth. They now queue into the same batch; the envelope's
     # later subchain + mandatory priority keeps ISO outermost stacking and prevents
     # best-effort locations from starving the principal depth dimension (#477).
-    if feature_holes:
-        _locate_off_axis_holes(dwg, a, holes_in=feature_holes, which="across")
+    if feature_keys:
+        _locate_off_axis_holes(dwg, a, which="across")
 
     # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
     # queued into the shared corridor instead of claiming a post-hoc carve tier.
@@ -330,8 +326,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # candidates so below/right corridors solve them together with GD&T/PMI at the drain.
     # The front-right prismatic height ladder remains immediate because its later witness
     # bases depend on earlier placed tiers (#477).
-    if feature_holes:
-        _locate_off_axis_holes(dwg, a, holes_in=feature_holes, which="along")
+    if feature_keys:
+        _locate_off_axis_holes(dwg, a, which="along")
 
     # Non-cylindrical machined features: slots / reduced across-flats sections
     # (#135) — IR renderer, placed through the zone strips (shared infra). Runs

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -263,7 +263,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (tests/test_layout_cleanliness.py) is exactly this accepted case.
     _section = plan_sections(_model, feature_keys)
     _reserve_section_row(dwg, a, _section)
-    if feature_keys:  # any hole/pattern member (declared holes render even where detection missed them)
+    # Any hole/pattern member (declared holes render even where detection missed them).
+    if feature_keys:
         _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
     # through the existing above-view strips. Replaces the engine's _add_location_dims.

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -38,7 +38,6 @@ from draftwright._core import (
     Analysis,
     DetailRequest,
     HoleRef,
-    _axis_letter,
     _dim,
     _fmt,
     _iso_bbox,
@@ -50,27 +49,6 @@ from draftwright.annotations._common import strip_obstacles
 from draftwright.model import plan_sections
 
 _DETAIL_LETTERS = "ABCDEFGH"
-
-
-def _is_concentric_hole(h, a: Analysis) -> bool:
-    """True when *h* is an axial bore on the part centreline (turned base set)."""
-    if _axis_letter(h) != "z":
-        return False
-    return math.hypot(h.location[0] - a.cx, h.location[1] - a.cy) <= _CONCENTRIC_TOL_MM
-
-
-def feature_holes_of(a: Analysis) -> list:
-    """The feature holes the IR gates callouts / furniture / sections on — a turned
-    part's concentric axial bores (dimensioned by the centreline leaders) excluded,
-    every hole on a prismatic part kept.
-
-    Still recogniser-record-typed: the off-axis side-drilled *location* pass
-    (:func:`_locate_off_axis_holes`) reads per-hole diameter/depth/bottom the IR doesn't
-    yet carry on the declared path — migrating that is #584 WP1 subsystem B. The
-    membership *key* set has already moved to the IR (:func:`feature_hole_keys`)."""
-    if not a.is_rotational:
-        return list(a.holes)
-    return [h for h in a.holes if not _is_concentric_hole(h, a)]
 
 
 def feature_hole_keys(model, a: Analysis) -> set[HoleRef]:


### PR DESCRIPTION
Part of epic #584 WP1 — subsystem **B3** (off-axis / side-drilled hole location dims). Continues C→B→D→A (C=#593, B1+B2=#594 merged).

## The "gap" was illusory
The orchestrator comment claimed `_locate_off_axis_holes` needs recogniser-hole geometry (diameter/depth/bottom) the declared IR doesn't carry. Reading the code: the entire pass reads **only** the axis letter (`_axis_letter(h)`) and `h.location` — both already in the IR (`frame.axis` / `frame.origin`/members). So no IR extension was needed.

## What
- `_locate_off_axis_holes` (#133) and the matching `reserved_rows` guard in `_annotate_holes` now derive their off-axis holes from the IR via a new `_ir_off_axis_holes(model)` helper (+ `_OffHole` NamedTuple). Pattern members are separate `PatternFeature`s → patterned holes excluded by construction.
- Orchestrator: `feature_holes` truthiness gates → `feature_keys`; the two `_locate_off_axis_holes` calls drop `holes_in`.
- **Retires `feature_holes_of` + `_is_concentric_hole`** — the last record consumers on this path. `sections.py` and `holes.py` are now IR-clean for the hole set; `_axis_letter` is no longer imported in either (net −6 LOC).

## Verification
- The IR-derived off-axis set is **identical** to the old record set on a mixed side-drilled part (X + Y + Z holes).
- 160 + 154 focused tests (off-axis location, strip layout, section, layout-cleanliness) pass.
- ruff + mypy clean.

## Remaining WP1
- **B4** orchestrator hole-table tabulation (still passes records to the duck-typed balloon seam).
- **D** lint/coverage. **A** layout/sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)