### PR TITLE
refactor(#588): source the scattered-hole tabulation from the IR (WP1 B4)

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -24,7 +24,6 @@ from draftwright._core import (
     Analysis,
     HoleRef,
     _add_title_block,
-    _axis_letter,
     _fmt,
     _iso_bbox,
     _log,
@@ -422,11 +421,15 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     # recognised pattern are documented by their grouped ``n× ⌀`` callout +
     # pattern dimension, so they must not become table rows or per-hole balloons
     # (#92).  Excluding them is also what keeps a densely-but-regularly drilled
-    # part (e.g. NIST CTC-02) off the 61-row escalation (#111).
+    # part (e.g. NIST CTC-02) off the 61-row escalation (#111). Sourced from the IR —
+    # a loose z-axis HoleFeature is by construction not a pattern member, so no
+    # HoleRecord crosses here (ADR 0008 Am6; #584 WP1 B4).
+    _model = dwg._part_model
     holes = [
-        h
-        for h in a.holes
-        if _axis_letter(h) == "z" and not dwg._is_hole_patterned(HoleRef.of(h.location))
+        SimpleNamespace(location=pos, diameter=f.diameter)
+        for f in (_model.features if _model is not None else ())
+        if f.kind == "hole" and f.frame.axis == "z"
+        for pos in (f.members or (f.frame.origin,))
     ]
     # A chart is warranted only for a *genuinely* dense plan view — a part that
     # merely dropped one too-close location ref keeps its individual dims (the


### PR DESCRIPTION
Part of epic #584 WP1 — subsystem **B4** (orchestrator hole-table tabulation). Completes the **B** group (C=#593, B1+B2=#594, B3=#595 merged).

## What
`_maybe_tabulate_holes`' scattered plan-view hole list (the dense-part hole chart + per-hole balloons, #93) now derives from the IR (`model.features`) instead of `Analysis.holes`. The pattern-balloon path in the same function already used the IR — only the scattered list still read records.

## How
- The scattered set = loose z-axis `HoleFeature` member positions. A loose HoleFeature is by construction **not** a pattern member, so the old `_is_hole_patterned` exclusion is implicit; no `HoleRecord`/`HoleRef`/`_axis_letter` needed.
- Built as `SimpleNamespace(location, diameter)` — matching the existing pattern-spec style; the table + duck-typed balloon seam read only `.location`/`.diameter`.

## Verification
- The IR scattered set is **identical** to the old record set on a dense 10-hole plate.
- 124 tabulation/table/balloon/pattern tests pass; all four lint checks clean.

## Milestone
The whole **`annotations/` layer is now IR-clean** for the hole set. The only remaining `a.holes`/`a.patterns` read in the orchestrator is the sanctioned `build_model` → `build_part_model` boundary (records → IR — where they're *supposed* to cross).

## Remaining WP1
- **D** lint/coverage (`coverage.py`, `drawing.py:1994`). **A** layout/sizing (`sheet.py`, the pre-IR estimators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)