### PR TITLE
refactor(#588): position-key the coverage patterned set; reframe lint as ground-truth (WP1 D)

### DIFF
--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -21,6 +21,23 @@
   `detect.py` adapter protocol (typed per-record converters, not one universal
   converter) (ADR 0013). Amendment 6 (no recognition object crosses the boundary) is
   preserved.
+- **Amendment 8** (2026-07-13, epic #584 WP1): Amendment 6 is enforced across the
+  **render** path — the hole/pattern/boss recognition records no longer survive into the
+  annotation/table/section/callout renderers. `annotations/` (sections, hole callouts,
+  the hole table + balloons, the off-axis location dims, the scattered-hole tabulation)
+  now reads the IR (`model.features`); the only place records cross is the sanctioned
+  `build_part_model` boundary itself. **Two paths deliberately keep reading recognition
+  records, and this is correct — not a boundary violation:**
+  1. **lint / coverage** (`linting/coverage.py`) validates the drawing against
+     **recognised geometry** ("is every feature that physically *exists* dimensioned?").
+     That ground-truth check must read recognition, not the IR: sourcing coverage from the
+     dimensioning *plan* would be circular — a feature the planner omitted would never be
+     flagged. `linting/` also stays a leaf (no `model` import) by design. Coverage reading
+     recognition is the check working, not a leak.
+  2. **pre-IR layout/sizing** (`sheet.py` estimators) reads records *before* IR
+     construction, to pick `(scale, page)` during `_analyse`. This is a **pre**-IR pass,
+     not a post-IR render leak; the detected IR does not exist yet at that point. Whether
+     to build the IR earlier and feed these estimators is tracked as WP1 subsystem A.
 
 ## Current decision (as amended, 2026-07-12)
 

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -293,7 +293,10 @@ def lint_location_coverage(
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     if patterns is None:
         patterns = recognise_hole_patterns(holes)
-    patterned = {id(h) for pat in patterns for h in pat.holes}
+    # Position-keyed (HoleRef), not id()-keyed: the old identity set only worked because
+    # recognise_hole_patterns reuses the same HoleRecord objects; a position key is robust
+    # to any hole source and matches the rest of the engine's patterned-membership tests.
+    patterned = {HoleRef.of(h.location) for pat in patterns for h in pat.holes}
 
     marks: dict[str, list] = {}
     dim_verts: dict[str, list] = {}
@@ -323,7 +326,7 @@ def lint_location_coverage(
         perp = [(c, q) for ax, c, q in zip("xyz", (x, y, z), centre) if ax != axis]
         coaxial = all(abs(c - q) <= 1.0 for c, q in perp)
         if (
-            id(h) not in patterned
+            HoleRef.of(h.location) not in patterned
             and not coaxial
             and not any(
                 abs(vx - px) <= tol or abs(vy - py) <= tol for vx, vy in dim_verts.get(view, ())


### PR DESCRIPTION
Part of epic #584 WP1 — subsystem **D** (lint/coverage). Two parts, one of them a deliberate *non*-migration.

## D1 — robustness (the code change)
`lint_location_coverage`'s patterned-membership set was **`id()`-keyed**, which only worked because `recognise_hole_patterns` happens to reuse the same `HoleRecord` objects. Replaced with **`HoleRef` position keys** — robust to any hole source and consistent with the rest of the engine's patterned-membership tests (sections, `_declared_feature_keys`, `_is_hole_patterned`). Verified `id`/`HoleRef` membership agrees on every hole for a bolt-circle + loose-hole part.

## D2 — deliberately NOT migrated (ADR 0008 Amendment 8)
Sourcing coverage from the IR would be **architecturally wrong**, so this PR documents it instead of doing it:
- Coverage validates *"is every feature that physically **exists** dimensioned?"* against **recognised geometry (ground truth)**. Reading the IR (the dimensioning *plan*) would be **circular** — a feature the planner omitted would never be flagged. Coverage reading recognition is the check *working*, not a leak.
- `linting/` also stays a **leaf** (no `model` import) by design.
- The audit's IR-boundary acceptance targets the *annotation / sheet / planner / renderer / layout* path (now clean after B/C) — **linting is not in that list**.

Amendment 8 also records that the render path (annotations) is now IR-clean, and that the pre-IR `sheet.py` sizing estimators (subsystem **A**) are a *pre*-IR pass, not a post-IR leak.

## Verification
- 193 lint/coverage/location/centre-mark tests pass; all four lint checks clean.

## Remaining WP1
- **A** — pre-IR layout/sizing (`sheet.py`). Then update ADR 0008 status to "boundary complete (with the two documented carve-outs)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)