### PR TITLE
fix(#562): render ref_pts-only authored dimensions (+ Z strip sizing)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1742,6 +1742,20 @@ def _record_pmi_drop(dwg, ax, label, rec):
     )
 
 
+def _record_pmi_unrenderable(dwg, label, rec):
+    """Record an authored dimension whose reference geometry can't form a witness (fewer
+    than two distinct reference points, or a sub-legible span). Distinct from
+    ``pmi_dropped`` (a *placement* failure): this is a *validation* failure, so a caller
+    sees a specific reason instead of a misleading "no room" — an authored dim is only
+    ``pmi_dropped`` after a real candidate reaches the corridor solver and cannot fit (#562)."""
+    dwg._record_build_issue(
+        "warning",
+        "authored_dim_degenerate",
+        f"authored dimension {label!r} has degenerate reference geometry (needs two "
+        "distinct reference points spanning a legible distance)",
+    )
+
+
 def _bore_half_span(pmi_kind: str, value: float) -> float:
     """Half the perpendicular span of a bore-size dim from the bore centroid — the
     distance to each witness base point. A ``"diameter"`` record stores the full
@@ -1842,10 +1856,20 @@ def render_pmi(dwg, model, a) -> int:
         Gives the correct span for linear dims where both ref faces are flush
         (e.g. two parallel faces of a slot or step).  Not suitable for bore
         diameters — use _bore_info instead.
+
+        When the record carries no ``ref_bbox`` (an authored ``Sheet.dimension()`` with
+        only ``ref_pts``, #562), the span is derived from the ref points — so a ref_pts-only
+        dimension renders instead of silently vanishing.
         """
         bb = rec.ref_bbox
         if bb is None:
-            return None
+            pts = rec.ref_pts
+            if not pts or len(pts) < 2:
+                return None
+            xs = [p[0] for p in pts]
+            ys = [p[1] for p in pts]
+            zs = [p[2] for p in pts]
+            bb = (min(xs), min(ys), min(zs), max(xs), max(ys), max(zs))
         xmin, ymin, zmin, xmax, ymax, zmax = bb
         ax = rec.dominant_axis
 
@@ -2137,7 +2161,8 @@ def render_pmi(dwg, model, a) -> int:
         elif ax == "X":
             wp = _witness_from_bbox(rec, "front")
             if wp is None:
-                _log.debug("PMI dim[%d] X: degenerate bbox", idx)
+                _log.debug("PMI dim[%d] X: degenerate reference", idx)
+                _record_pmi_unrenderable(dwg, label, rec)
                 continue
             p1, p2, avg_pz = wp
             if avg_pz >= a.FV_Y:
@@ -2161,7 +2186,8 @@ def render_pmi(dwg, model, a) -> int:
         elif ax == "Z":
             wp = _witness_from_bbox(rec, "front")
             if wp is None:
-                _log.debug("PMI dim[%d] Z: degenerate bbox", idx)
+                _log.debug("PMI dim[%d] Z: degenerate reference", idx)
+                _record_pmi_unrenderable(dwg, label, rec)
                 continue
             p1, p2, avg_px = wp
             if avg_px >= a.FV_X:
@@ -2183,6 +2209,13 @@ def render_pmi(dwg, model, a) -> int:
                 )
 
         elif ax == "Y":
+            # A degenerate reference (no witness in EITHER candidate view) is a validation
+            # failure, not a placement one — report it distinctly so the bottom "no room"
+            # only fires when a real candidate reached the solver (#562).
+            if _witness_from_bbox(rec, "side") is None and _witness_from_bbox(rec, "plan") is None:
+                _log.debug("PMI dim[%d] Y: degenerate reference", idx)
+                _record_pmi_unrenderable(dwg, label, rec)
+                continue
             # Try side view (Y maps to SX horizontal).
             wp = _witness_from_bbox(rec, "side")
             if wp is not None:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -388,6 +388,23 @@ def _compose_anno_boxes(
         bore_depth += pad_around_text + arrow_length
         boxes.append(AnnoBox("right", bore_depth))  # FV/PV right bore callouts
         boxes.append(AnnoBox("left", bore_depth))  # FV/PV left bore callouts
+    # Authored Z-axis linear dimensions (Sheet.dimension / AP242 PMI) render as height
+    # dims to the front LEFT/RIGHT strips (#562). The right strip already holds the
+    # envelope height + step ladder, but the left has only its _DIM_PAD floor, so an
+    # authored Z dim was queued and then dropped as "no room". Reserve a slot per authored
+    # Z dim on BOTH sides (they split by x position only at layout, so reserve
+    # conservatively) — enough depth for the corridor solve to place them.
+    z_authored = sum(
+        1
+        for f in model.features
+        if f.kind == "authored_dimension"
+        and f.dominant_axis == "Z"
+        and getattr(f, "dimension_kind", None) not in ("diameter", "radius", "angular")
+    )
+    if z_authored:
+        slot = _SLOT_DIM_STEP + _STRIP_SPACING
+        boxes.append(AnnoBox("right", _est_right_strip_depth(n_steps) + z_authored * slot))
+        boxes.append(AnnoBox("left", _STRIP_GAP + z_authored * slot))
     above = _est_pv_above_depth(model, font_size, pad_around_text)
     if above > 0:
         boxes.append(AnnoBox("above", above))  # tiered X-location dims above PV (#121)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -140,6 +140,52 @@ class TestEmit:
                 ref_bbox=(-20, -10, -5, 20, 10, 5),
             )
 
+    def test_refpts_only_linear_dim_renders_on_each_axis(self):
+        # #562: a linear Sheet.dimension() with two valid ref_pts and NO ref_bbox must
+        # render (the witness is derived from the ref points) — for X, Y, and Z. Z needs
+        # the front left/right strip reserved for authored height dims (the sizing fix).
+        from draftwright import Sheet
+
+        cases = {
+            "X": [(-40, -30, 0), (-30, -30, 0)],
+            "Y": [(-40, -30, 0), (-40, -20, 0)],
+            "Z": [(-38, -30, 5), (-38, -30, 15)],
+        }
+        for axis, ref_pts in cases.items():
+            sheet = Sheet(Box(80, 60, 40), title="P")
+            sheet.dimension(
+                kind="linear",
+                value=10,
+                label="10",
+                dominant_axis=axis,
+                ref_pts=ref_pts,
+                at=ref_pts[0],
+            )
+            dwg = sheet.build()
+            placed = [n for n in dwg._named if n.startswith("pmi_")]
+            assert placed, f"{axis}: ref_pts-only dim was not placed"
+            assert not any(i.code == "pmi_dropped" for i in dwg._build_issues), axis
+
+    def test_degenerate_refpts_reports_specific_code_not_no_room(self):
+        # #562: a genuinely unrenderable ref (two coincident points → no span) reports a
+        # specific validation code, NOT the misleading "no room" — the latter is reserved
+        # for a real candidate that reached the corridor solver and could not fit.
+        from draftwright import Sheet
+
+        sheet = Sheet(Box(80, 60, 40), title="P")
+        sheet.dimension(
+            kind="linear",
+            value=10,
+            label="10",
+            dominant_axis="Z",
+            ref_pts=[(-38, -30, 5), (-38, -30, 5)],
+            at=(-38, -30, 5),
+        )
+        dwg = sheet.build()
+        codes = {i.code for i in dwg._build_issues}
+        assert "authored_dim_degenerate" in codes
+        assert "pmi_dropped" not in codes
+
     def test_title_block_and_layout_aspects_emitted_when_set(self):
         # #474: non-default drawn_by/tolerance/scale/page ride the Sheet(...) constructor.
         ctor = next(


### PR DESCRIPTION
Closes #562. `Sheet.dimension()` accepted a linear dimension with `ref_pts` and **no** `ref_bbox`, but the renderer couldn't build a witness for it — so it was never queued and then reported the misleading `pmi_dropped: no room`. Three fixes:

## 1. Witness from `ref_pts` (the core bug)
`_witness_from_bbox` now derives the span bbox from the two `ref_pts` when `ref_bbox` is absent. **X and Y ref_pts-only dims now render.** (Existing AP242 records that carry a `ref_bbox` are untouched — only the `ref_bbox is None` branch changed.)

## 2. Z-axis strip sizing (the deeper cause)
With (1), the Z dim reached the corridor solver but was still dropped: authored Z dims render as height dims to the front **left/right** strips, and only the RIGHT strip was reserved (envelope height + step ladder) — the LEFT kept just its `_DIM_PAD` floor. `_compose_anno_boxes` now reserves a slot per authored Z dim on **both** sides, so `solve_corridor` has room. **Detected parts have no authored Z dims (`z_authored=0`), so their layout is unchanged** — the layout-snapshot suite is unaffected.

## 3. Specific validation message
A genuinely unrenderable reference (fewer than two distinct points / sub-legible span) now records **`authored_dim_degenerate`**, not `pmi_dropped`. The "no room" code is reserved for a real candidate that reached the solver and couldn't fit — fixing both the X/Z **silent** skip and the Y **misleading** "no room".

## Acceptance (all met)
- ✅ A linear `Sheet.dimension()` with two valid `ref_pts` and no `ref_bbox` renders + survives export.
- ✅ X, Y, **and Z** dominant-axis cases covered.
- ✅ `pmi_dropped: no room` only after a real candidate reaches the solver and can't fit.
- ✅ Degenerate references produce a specific validation/lint code.
- ✅ Existing `ref_bbox` records unchanged.

765 affected-suite tests pass (incl. the layout snapshots); four lint checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)