### PR TITLE
fix(#604): collapse cross-slot arms into whole channels (148d)

### DIFF
--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -31,7 +31,7 @@ import math
 from dataclasses import dataclass
 from typing import TypeVar
 
-from build123d import GeomType
+from build123d import GeomType, Vector
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.GeomAbs import GeomAbs_Plane
 from OCP.TopAbs import TopAbs_Orientation
@@ -326,7 +326,7 @@ def recognise_slots(part) -> list[Slot]:
                 if s is not None and not _has_floor(faces, s):
                     candidates.append(s)
     # Recombine arms of a crossing channel split by the intersection (#604).
-    return _collapse_collinear(_merge(candidates))
+    return _collapse_collinear(_merge(candidates), part)
 
 
 def _same_channel_line(a: Slot, b: Slot):
@@ -352,45 +352,36 @@ def _same_channel_line(a: Slot, b: Slot):
     return gap if gap[1] - gap[0] > 0 else None
 
 
-def _gap_bridged(gap, arm: Slot, slots: list[Slot]) -> bool:
-    """True when a crossing channel spans ``gap`` *at this arm's location* — the
-    evidence the gap between two collinear arms is void, not solid material.
+def _gap_is_void(gap, arm: Slot, part) -> bool:
+    """True when the gap between two collinear arms is empty space — the crossing
+    void of an intersecting channel — rather than solid stock.
 
-    The crossing channel runs across the arm: its ``width_axis`` is the arm's
-    ``long_axis`` and its ``long_axis`` the arm's ``width_axis``; its wall
-    separation matches the gap's size and its centreline the gap's centre.  It
-    must also *reach* the arm — a perpendicular slot elsewhere on the part whose
-    centreline and width merely happen to match the gap would otherwise fuse two
-    collinear slots across solid stock (#610 review).  A symmetric cross splits
-    the crossing channel too, so its run is unioned across *all* its matching
-    arms; that union must cover this arm's centreline and overlap it in depth."""
-    g_center = (gap[0] + gap[1]) / 2
-    g_size = gap[1] - gap[0]
-    crossers = [
-        p
-        for p in slots
-        if p.width_axis == arm.long_axis
-        and p.long_axis == arm.width_axis
-        and abs(p.w_center - g_center) <= _MERGE_TOL
-        and abs(p.width - g_size) <= _MERGE_TOL
-        and max(p.d_lo, arm.d_lo) < min(p.d_hi, arm.d_hi)
-    ]
-    if not crossers:
-        return False
-    run_lo = min(p.lo for p in crossers)
-    run_hi = max(p.hi for p in crossers)
-    return run_lo - _MERGE_TOL <= arm.w_center <= run_hi + _MERGE_TOL
+    Tested directly by sampling the gap's centre point against the solid, which is
+    robust where reasoning from the neighbouring slots' metadata is not: a
+    symmetric or off-centre cross, a T-junction, or a pinwheel of separate slots
+    around a solid hub all reduce to "is the point between the arms material?".
+    The sample sits at the gap centre along the run, on the arms' centreline
+    across it, and at mid-depth — interior to whichever region (void or solid) it
+    falls in, so it is never ambiguous on a wall."""
+    coord = {
+        arm.long_axis: (gap[0] + gap[1]) / 2,
+        arm.width_axis: arm.w_center,
+        arm.depth_axis: (arm.d_lo + arm.d_hi) / 2,
+    }
+    point = Vector(coord["x"], coord["y"], coord["z"])
+    return not any(s.is_inside(point) for s in part.solids())
 
 
-def _collapse_collinear(slots: list[Slot]) -> list[Slot]:
+def _collapse_collinear(slots: list[Slot], part) -> list[Slot]:
     """Recombine slot arms split by a crossing channel into whole channels (#604).
 
     A ``+`` of two intersecting through-channels is milled as one continuous slot
     each, but the central intersection removes the middle of both channels' walls,
     so the wall scan yields two collinear arm-slots per channel (four total).
-    Union collinear co-axial arms whose gap a perpendicular channel bridges, and
-    span each group into a single slot running its full length.  Arms with a solid
-    bridge between them (no crossing channel) are left as separate features."""
+    Union collinear co-axial arms whose gap is void (a crossing channel passes
+    between them), and span each group into a single slot running its full length.
+    Arms separated by solid material — two genuinely distinct slots — are left as
+    separate features."""
     parent = list(range(len(slots)))
 
     def find(i: int) -> int:
@@ -402,7 +393,7 @@ def _collapse_collinear(slots: list[Slot]) -> list[Slot]:
     for i in range(len(slots)):
         for j in range(i + 1, len(slots)):
             gap = _same_channel_line(slots[i], slots[j])
-            if gap is not None and _gap_bridged(gap, slots[i], slots):
+            if gap is not None and _gap_is_void(gap, slots[i], part):
                 parent[find(i)] = find(j)
 
     groups: dict[int, list[Slot]] = {}

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -31,7 +31,7 @@ import math
 from dataclasses import dataclass
 from typing import TypeVar
 
-from build123d import GeomType, Vector
+from build123d import Box, GeomType, Pos
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.GeomAbs import GeomAbs_Plane
 from OCP.TopAbs import TopAbs_Orientation
@@ -53,6 +53,11 @@ _MERGE_TOL = 0.5
 # covers at least _FLOOR_COVER_FRAC of the slot footprint on each in-plane axis.
 _FLOOR_TOL = 0.3
 _FLOOR_COVER_FRAC = 0.5
+# The gap between two collinear arms counts as void (a crossing channel runs
+# through it) when the intersection of the inset gap box with the solid is at most
+# this fraction of the box — a channel carves it to ~0, a hole/solid leaves more.
+_VOID_INSET = 0.1
+_VOID_VOL_FRAC = 0.01
 
 
 @dataclass(frozen=True)
@@ -353,23 +358,35 @@ def _same_channel_line(a: Slot, b: Slot):
 
 
 def _gap_is_void(gap, arm: Slot, part) -> bool:
-    """True when the gap between two collinear arms is empty space — the crossing
-    void of an intersecting channel — rather than solid stock.
+    """True when the *whole* gap between two collinear arms is empty space — a
+    crossing channel of matching cross-section runs through it — rather than solid
+    stock or merely pierced by an incidental void.
 
-    Tested directly by sampling the gap's centre point against the solid, which is
-    robust where reasoning from the neighbouring slots' metadata is not: a
-    symmetric or off-centre cross, a T-junction, or a pinwheel of separate slots
-    around a solid hub all reduce to "is the point between the arms material?".
-    The sample sits at the gap centre along the run, on the arms' centreline
-    across it, and at mid-depth — interior to whichever region (void or solid) it
-    falls in, so it is never ambiguous on a wall."""
-    coord = {
-        arm.long_axis: (gap[0] + gap[1]) / 2,
-        arm.width_axis: arm.w_center,
-        arm.depth_axis: (arm.d_lo + arm.d_hi) / 2,
+    The gap region is the box of its full run (along ``long_axis``) × the arm's
+    width × the arm's depth, inset slightly off the arm walls to avoid
+    coincident-face noise.  A crossing channel carves this box away entirely, so
+    its intersection with the solid is (near) zero volume.  A solid bridge fills
+    it; a small unrelated hole between two aligned slots leaves the box corners
+    solid — both keep a substantial intersection, so the arms stay separate.
+    Testing the whole box (not a single sample point) is what distinguishes a
+    channel from an incidental hole at the gap centre (#610 re-reviews)."""
+    span = {
+        arm.long_axis: (gap[0], gap[1]),
+        arm.width_axis: (arm.w_center - arm.width / 2, arm.w_center + arm.width / 2),
+        arm.depth_axis: (arm.d_lo, arm.d_hi),
     }
-    point = Vector(coord["x"], coord["y"], coord["z"])
-    return not any(s.is_inside(point) for s in part.solids())
+    size, centre = {}, {}
+    for ax, (lo, hi) in span.items():
+        inset = min(_VOID_INSET, (hi - lo) / 4)
+        size[ax] = (hi - lo) - 2 * inset
+        centre[ax] = (lo + hi) / 2
+    if min(size.values()) <= 0:
+        return False
+    probe = Pos(centre["x"], centre["y"], centre["z"]) * Box(size["x"], size["y"], size["z"])
+    inter = part.intersect(probe)
+    box_vol = size["x"] * size["y"] * size["z"]
+    inter_vol = inter.volume if inter is not None else 0.0
+    return bool(inter_vol <= _VOID_VOL_FRAC * box_vol)
 
 
 def _collapse_collinear(slots: list[Slot], part) -> list[Slot]:

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -325,7 +325,100 @@ def recognise_slots(part) -> list[Slot]:
                 # between bosses) is capped by a floor and is out of scope (#148).
                 if s is not None and not _has_floor(faces, s):
                     candidates.append(s)
-    return _merge(candidates)
+    # Recombine arms of a crossing channel split by the intersection (#604).
+    return _collapse_collinear(_merge(candidates))
+
+
+def _same_channel_line(a: Slot, b: Slot):
+    """When ``a`` and ``b`` are collinear co-axial slot *arms* — same wall plane
+    (width axis, centreline, width and depth extent) but disjoint along their run
+    — return the gap ``(g_lo, g_hi)`` between them along ``long_axis``; else None.
+
+    Two arms of one channel that a crossing cut has split (#604) share every
+    dimension but their run; two genuinely parallel slots have different
+    centrelines (``w_center``) and never reach here."""
+    if a.width_axis != b.width_axis or a.long_axis != b.long_axis:
+        return None
+    if abs(a.w_center - b.w_center) > _MERGE_TOL or abs(a.width - b.width) > _MERGE_TOL:
+        return None
+    if abs(a.d_lo - b.d_lo) > _MERGE_TOL or abs(a.d_hi - b.d_hi) > _MERGE_TOL:
+        return None
+    if a.hi <= b.lo:
+        gap = (a.hi, b.lo)
+    elif b.hi <= a.lo:
+        gap = (b.hi, a.lo)
+    else:
+        return None  # overlapping along the run — not two disjoint arms
+    return gap if gap[1] - gap[0] > 0 else None
+
+
+def _gap_bridged(gap, long_axis: str, slots: list[Slot]) -> bool:
+    """True when a perpendicular channel exactly spans ``gap`` along ``long_axis``
+    — the evidence the gap between two collinear arms is a crossing slot (void),
+    not solid material.  The crossing channel's width runs along ``long_axis``
+    (``width_axis == long_axis``); its centreline and width match the gap's centre
+    and size.  A symmetric cross splits *both* channels, so the bridging arm need
+    not span this channel's centreline — matching the gap is what identifies it,
+    and a solid bridge has no such channel to match."""
+    g_center = (gap[0] + gap[1]) / 2
+    g_size = gap[1] - gap[0]
+    return any(
+        p.width_axis == long_axis
+        and abs(p.w_center - g_center) <= _MERGE_TOL
+        and abs(p.width - g_size) <= _MERGE_TOL
+        for p in slots
+    )
+
+
+def _collapse_collinear(slots: list[Slot]) -> list[Slot]:
+    """Recombine slot arms split by a crossing channel into whole channels (#604).
+
+    A ``+`` of two intersecting through-channels is milled as one continuous slot
+    each, but the central intersection removes the middle of both channels' walls,
+    so the wall scan yields two collinear arm-slots per channel (four total).
+    Union collinear co-axial arms whose gap a perpendicular channel bridges, and
+    span each group into a single slot running its full length.  Arms with a solid
+    bridge between them (no crossing channel) are left as separate features."""
+    parent = list(range(len(slots)))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(len(slots)):
+        for j in range(i + 1, len(slots)):
+            gap = _same_channel_line(slots[i], slots[j])
+            if gap is not None and _gap_bridged(gap, slots[i].long_axis, slots):
+                parent[find(i)] = find(j)
+
+    groups: dict[int, list[Slot]] = {}
+    for idx, s in enumerate(slots):
+        groups.setdefault(find(idx), []).append(s)
+
+    out: list[Slot] = []
+    for members in groups.values():
+        if len(members) == 1:
+            out.append(members[0])
+            continue
+        base = members[0]
+        lo = min(m.lo for m in members)
+        hi = max(m.hi for m in members)
+        out.append(
+            Slot(
+                width_axis=base.width_axis,
+                long_axis=base.long_axis,
+                width=base.width,
+                length=round(hi - lo, 2),
+                w_center=base.w_center,
+                lo=round(lo, 2),
+                hi=round(hi, 2),
+                d_lo=base.d_lo,
+                d_hi=base.d_hi,
+            )
+        )
+    return sorted(out, key=lambda c: (c.width, _region_center(c)))
 
 
 def _region_center(s: Slot | Pocket):

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -369,7 +369,14 @@ def _gap_is_void(gap, arm: Slot, part) -> bool:
     it; a small unrelated hole between two aligned slots leaves the box corners
     solid — both keep a substantial intersection, so the arms stay separate.
     Testing the whole box (not a single sample point) is what distinguishes a
-    channel from an incidental hole at the gap centre (#610 re-reviews)."""
+    channel from an incidental hole at the gap centre (#610 re-reviews).
+
+    Known limitation: a wide *enclosed* void (a square window/pocket) flush with
+    the arm ends also empties the box and so fuses the arms.  This is a continuum
+    with the accepted symmetric-cross case — which likewise leaves the merged
+    slot wall-less where the crossing channel passes — and distinguishing a
+    narrow crossing channel from a wide window is an aspect-ratio judgement with
+    no clean line; #604's scope is intersecting *channels*, so it is left as-is."""
     span = {
         arm.long_axis: (gap[0], gap[1]),
         arm.width_axis: (arm.w_center - arm.width / 2, arm.w_center + arm.width / 2),
@@ -384,8 +391,15 @@ def _gap_is_void(gap, arm: Slot, part) -> bool:
         return False
     probe = Pos(centre["x"], centre["y"], centre["z"]) * Box(size["x"], size["y"], size["z"])
     inter = part.intersect(probe)
+    # ``intersect`` returns None (empty), a single shape with ``.volume`` (older
+    # build123d), or a ShapeList of shapes (newer build123d) — sum either way.
+    if inter is None:
+        inter_vol = 0.0
+    elif hasattr(inter, "volume"):
+        inter_vol = inter.volume
+    else:
+        inter_vol = sum(s.volume for s in inter)
     box_vol = size["x"] * size["y"] * size["z"]
-    inter_vol = inter.volume if inter is not None else 0.0
     return bool(inter_vol <= _VOID_VOL_FRAC * box_vol)
 
 

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -352,22 +352,34 @@ def _same_channel_line(a: Slot, b: Slot):
     return gap if gap[1] - gap[0] > 0 else None
 
 
-def _gap_bridged(gap, long_axis: str, slots: list[Slot]) -> bool:
-    """True when a perpendicular channel exactly spans ``gap`` along ``long_axis``
-    — the evidence the gap between two collinear arms is a crossing slot (void),
-    not solid material.  The crossing channel's width runs along ``long_axis``
-    (``width_axis == long_axis``); its centreline and width match the gap's centre
-    and size.  A symmetric cross splits *both* channels, so the bridging arm need
-    not span this channel's centreline — matching the gap is what identifies it,
-    and a solid bridge has no such channel to match."""
+def _gap_bridged(gap, arm: Slot, slots: list[Slot]) -> bool:
+    """True when a crossing channel spans ``gap`` *at this arm's location* — the
+    evidence the gap between two collinear arms is void, not solid material.
+
+    The crossing channel runs across the arm: its ``width_axis`` is the arm's
+    ``long_axis`` and its ``long_axis`` the arm's ``width_axis``; its wall
+    separation matches the gap's size and its centreline the gap's centre.  It
+    must also *reach* the arm — a perpendicular slot elsewhere on the part whose
+    centreline and width merely happen to match the gap would otherwise fuse two
+    collinear slots across solid stock (#610 review).  A symmetric cross splits
+    the crossing channel too, so its run is unioned across *all* its matching
+    arms; that union must cover this arm's centreline and overlap it in depth."""
     g_center = (gap[0] + gap[1]) / 2
     g_size = gap[1] - gap[0]
-    return any(
-        p.width_axis == long_axis
+    crossers = [
+        p
+        for p in slots
+        if p.width_axis == arm.long_axis
+        and p.long_axis == arm.width_axis
         and abs(p.w_center - g_center) <= _MERGE_TOL
         and abs(p.width - g_size) <= _MERGE_TOL
-        for p in slots
-    )
+        and max(p.d_lo, arm.d_lo) < min(p.d_hi, arm.d_hi)
+    ]
+    if not crossers:
+        return False
+    run_lo = min(p.lo for p in crossers)
+    run_hi = max(p.hi for p in crossers)
+    return run_lo - _MERGE_TOL <= arm.w_center <= run_hi + _MERGE_TOL
 
 
 def _collapse_collinear(slots: list[Slot]) -> list[Slot]:
@@ -390,7 +402,7 @@ def _collapse_collinear(slots: list[Slot]) -> list[Slot]:
     for i in range(len(slots)):
         for j in range(i + 1, len(slots)):
             gap = _same_channel_line(slots[i], slots[j])
-            if gap is not None and _gap_bridged(gap, slots[i].long_axis, slots):
+            if gap is not None and _gap_bridged(gap, slots[i], slots):
                 parent[find(i)] = find(j)
 
     groups: dict[int, list[Slot]] = {}

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6767,6 +6767,35 @@ class TestFindSlots:
         assert s.width == 4.0
         assert s.long_axis == "x"  # not z, despite z-extent ≈ x-extent locally
 
+    def test_cross_slot_collapses_to_two_channels(self):
+        # A + of two intersecting through-channels: the central intersection
+        # splits each channel's walls, so the raw scan finds FOUR arm-slots. The
+        # collinear-collapse must recombine them into the TWO channels, each
+        # spanning its full length (#148d). Thin plate so the arm length exceeds
+        # the (through) thickness, else the depth axis is mistaken for length.
+        part = Box(80, 60, 10) - Box(50, 12, 20) - Box(14, 44, 20)
+        slots = recognise_slots(part)
+        assert len(slots) == 2
+        by_long = {s.long_axis: s for s in slots}
+        assert by_long["x"].width == 12.0
+        assert by_long["x"].length == 50.0  # the full x-channel, not a 18mm arm
+        assert (by_long["x"].lo, by_long["x"].hi) == (-25.0, 25.0)
+        assert by_long["y"].width == 14.0
+        assert by_long["y"].length == 44.0  # the full y-channel, not a 16mm arm
+        assert (by_long["y"].lo, by_long["y"].hi) == (-22.0, 22.0)
+
+    def test_collinear_slots_with_solid_bridge_stay_separate(self):
+        # Two collinear slots on the SAME centreline but separated by solid
+        # material (no crossing channel bridging the gap) are distinct features.
+        # The collapse must span arms only when a perpendicular channel fills the
+        # gap — here it does not, so both slots survive (#148d guard).
+        part = (
+            Box(120, 40, 10) - Pos(-35, 0, 0) * Box(40, 12, 20) - Pos(35, 0, 0) * Box(40, 12, 20)
+        )
+        slots = recognise_slots(part)
+        assert len(slots) == 2
+        assert all(s.length == 40.0 for s in slots)  # not merged into one 110mm run
+
     def test_slot_is_frozen_dataclass(self):
         s = recognise_slots(Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20))[0]
         assert isinstance(s, Slot)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6817,9 +6817,8 @@ class TestFindSlots:
         # Four disjoint slots arranged around a SOLID central hub: two collinear
         # x-arms and two collinear y-arms, each opposed pair straddling — but not
         # reaching — the hub. Reasoning only from the neighbouring slots' extents
-        # would fuse each opposed pair across the hub; the void is tested directly
-        # at the gap centre (solid hub -> not void -> not merged), so all four
-        # survive (#610 re-review).
+        # would fuse each opposed pair across the hub; the gap box over the solid
+        # hub is not void, so it is not merged and all four survive (#610 re-review).
         from build123d import Align
 
         def cut(xlo, xhi, ylo, yhi):
@@ -6835,6 +6834,24 @@ class TestFindSlots:
             - cut(40, 60, 60, 90)
         )
         assert len(recognise_slots(part)) == 4  # solid hub keeps all four apart
+
+    def test_incidental_hole_between_aligned_slots_does_not_fuse_them(self):
+        # Two separate collinear slots on a shared centreline with an unrelated
+        # through-hole centred between them (a natural mounting-hole layout).  The
+        # hole makes the gap CENTRE void, but the gap box is mostly solid, so the
+        # slots must stay separate — a crossing channel would carve the whole box,
+        # a hole only pierces it (#610 re-review).
+        from build123d import Cylinder
+
+        part = (
+            Box(120, 40, 10)
+            - Pos(-35, 0, 0) * Box(40, 12, 20)
+            - Pos(35, 0, 0) * Box(40, 12, 20)
+            - Cylinder(4, 30)
+        )
+        slots = recognise_slots(part)
+        assert len(slots) == 2  # not fused into one 110mm slot by the hole
+        assert all(s.length == 40.0 for s in slots)
 
     def test_slot_is_frozen_dataclass(self):
         s = recognise_slots(Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20))[0]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6813,6 +6813,29 @@ class TestFindSlots:
         assert len(slots) == 3  # two 40mm x-arms + one y-channel, none merged
         assert sorted(s.length for s in slots) == [40.0, 40.0, 40.0]
 
+    def test_pinwheel_of_slots_around_a_solid_hub_stays_four(self):
+        # Four disjoint slots arranged around a SOLID central hub: two collinear
+        # x-arms and two collinear y-arms, each opposed pair straddling — but not
+        # reaching — the hub. Reasoning only from the neighbouring slots' extents
+        # would fuse each opposed pair across the hub; the void is tested directly
+        # at the gap centre (solid hub -> not void -> not merged), so all four
+        # survive (#610 re-review).
+        from build123d import Align
+
+        def cut(xlo, xhi, ylo, yhi):
+            return Pos(xlo, ylo, -5) * Box(
+                xhi - xlo, yhi - ylo, 20, align=(Align.MIN, Align.MIN, Align.MIN)
+            )
+
+        part = (
+            Box(100, 100, 10, align=(Align.MIN, Align.MIN, Align.MIN))
+            - cut(10, 40, 47, 53)
+            - cut(60, 90, 47, 53)
+            - cut(40, 60, 10, 40)
+            - cut(40, 60, 60, 90)
+        )
+        assert len(recognise_slots(part)) == 4  # solid hub keeps all four apart
+
     def test_slot_is_frozen_dataclass(self):
         s = recognise_slots(Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20))[0]
         assert isinstance(s, Slot)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6796,6 +6796,23 @@ class TestFindSlots:
         assert len(slots) == 2
         assert all(s.length == 40.0 for s in slots)  # not merged into one 110mm run
 
+    def test_arms_not_fused_by_a_channel_that_misses_their_centreline(self):
+        # The bridging channel must actually REACH the arms, not merely match the
+        # gap's centre and width.  Two collinear x-arms on centreline y=0 with a
+        # SOLID gap, plus a perpendicular channel displaced to y∈[10,50] whose
+        # x-centre and x-width coincide with the gap but which never crosses y=0.
+        # Position-blind bridging would fuse the arms across solid stock (#610
+        # review); the run-overlap check keeps all three slots distinct.
+        part = (
+            Box(120, 100, 10)
+            - Pos(-35, 0, 0) * Box(40, 12, 20)
+            - Pos(35, 0, 0) * Box(40, 12, 20)
+            - Pos(0, 30, 0) * Box(30, 40, 20)
+        )
+        slots = recognise_slots(part)
+        assert len(slots) == 3  # two 40mm x-arms + one y-channel, none merged
+        assert sorted(s.length for s in slots) == [40.0, 40.0, 40.0]
+
     def test_slot_is_frozen_dataclass(self):
         s = recognise_slots(Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20))[0]
         assert isinstance(s, Slot)


### PR DESCRIPTION
Closes #604 (child of epic #148).

## Problem
A `+` of two intersecting through-channels was reported as **4** arm-slots.
The central intersection removes the middle of each channel's walls, so the
wall scan finds two collinear arm-slots per channel and the pair-merge never
recombined them.

## Fix
`recognise_slots` runs a **collinear-collapse** pass after the existing pair
merge. Two co-axial arms that share wall plane, centreline, width and depth
extent but are disjoint along their run are unioned into one full-length slot
**when a perpendicular channel exactly spans the gap** between them — the
evidence the gap is a crossing void, not solid material. A symmetric cross
splits *both* channels at the same point, so the bridging arm need not span
this channel's centreline; matching the gap's centre and size identifies it,
and a solid bridge has no such channel to match.

## Scope / architectural fit
A recogniser **count fix**, not a new feature. Slots already round-trip all
three ADR-0011 surfaces (recognise + emit + declare), so the corrected count
flows through detect → IR → render/emit unchanged — verified: the cross part
builds **lint-clean with 2 slot groups** (`m_slot0`, `m_slot1`). No IR/emit/
declare changes needed.

## Guards (no over-merge — verified identical to `main`)
- single through-slot → 1
- parallel slots (different centreline) → unchanged
- **collinear slots with a solid bridge** (no crossing channel) → stay 2

## Tests
- `test_cross_slot_collapses_to_two_channels` — the `+`, 2 channels each full length
- `test_collinear_slots_with_solid_bridge_stay_separate` — the guard

## Acceptance
A cross-slot part reports **2** slots each spanning its full channel; existing
single/parallel slots unchanged. ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)