### PR TITLE
feat(#607): recognise arc-bounded slot walls in curved stock (148e)

### DIFF
--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -15,9 +15,12 @@ recess rather than some other facing-wall feature with three predicates a naive
 1. **Facing walls** — two axis-aligned planar faces with anti-parallel outward
    normals each pointing *towards* the other.  The part's own outer faces face
    *away*, so this excludes them without any "is this an outer face" heuristic.
-2. **Rectangular walls** — both walls are bounded by straight (LINE) edges only.
-   A turned groove / circlip recess has *annular* walls (CIRCLE edges); this
-   rejects them (otherwise a stepped shaft's groove reads as a slot).
+2. **Slot walls** — both walls are bounded by straight (LINE) and/or circular-arc
+   (CIRCLE) edges, with at least one straight edge (:func:`_is_wall`).  A rectangular
+   wall (all LINE) qualifies; so does a wall a slot cut into round stock clips into an
+   arc + a straight floor/chord (#148e).  A turned groove / circlip recess has a *pure
+   annular* wall — CIRCLE edges only, no straight edge — so it is still rejected
+   (otherwise a stepped shaft's groove reads as a slot).
 3. **Through vs blind** — whether a planar floor caps the cut.  A blind pocket
    (or the floored gap between two bosses) has a floor face spanning the
    footprint; a through-slot does not.  ``_has_floor`` is the sole split between
@@ -173,7 +176,21 @@ class _Face:
     normal: tuple
     axis: str
     bb: object
-    rect: bool  # bounded by straight (LINE) edges only
+    wall: bool  # a valid slot wall: LINE/CIRCLE edges, at least one straight LINE (#148e)
+
+
+def _is_wall(face) -> bool:
+    """True when *face* can be a slot wall: bounded only by straight (LINE) or circular-arc
+    (CIRCLE) edges, with **at least one** straight edge. A fully rectangular wall qualifies
+    (all LINE); a slot cut into round stock has a wall clipped by the OD into an arc + a
+    straight floor/chord, which now qualifies too (#148e). A turned groove / circlip recess
+    has a *pure annular* wall — CIRCLE edges only, no straight edge — so it is still rejected
+    (else a stepped shaft's groove reads as a slot); a freeform (spline/ellipse) face is
+    rejected outright."""
+    types = [e.geom_type for e in face.edges()]
+    if not types or any(t not in (GeomType.LINE, GeomType.CIRCLE) for t in types):
+        return False
+    return any(t == GeomType.LINE for t in types)
 
 
 def _planar_faces(part):
@@ -186,8 +203,7 @@ def _planar_faces(part):
         axis = _dominant_axis(nrm)
         if axis is None:
             continue
-        rect = all(e.geom_type == GeomType.LINE for e in face.edges())
-        faces.append(_Face(nrm, axis, face.bounding_box(), rect))
+        faces.append(_Face(nrm, axis, face.bounding_box(), _is_wall(face)))
     return faces
 
 
@@ -319,7 +335,7 @@ def recognise_slots(part) -> list[Slot]:
     # O(n^2) pairing runs within each axis instead of across all planar faces.
     by_axis: dict[str, list[_Face]] = {}
     for f in faces:
-        if f.rect:
+        if f.wall:
             by_axis.setdefault(f.axis, []).append(f)
     candidates: list[Slot] = []
     for walls in by_axis.values():
@@ -556,7 +572,7 @@ def recognise_pockets(part) -> list[Pocket]:
     part_ext = {a: getattr(pbb.size, "XYZ"[_AXES[a]]) for a in "xyz"}
     by_axis: dict[str, list[_Face]] = {}
     for f in faces:
-        if f.rect:
+        if f.wall:
             by_axis.setdefault(f.axis, []).append(f)
     candidates: list[Pocket] = []
     for walls in by_axis.values():

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -16,11 +16,12 @@ recess rather than some other facing-wall feature with three predicates a naive
    normals each pointing *towards* the other.  The part's own outer faces face
    *away*, so this excludes them without any "is this an outer face" heuristic.
 2. **Slot walls** — both walls are bounded by straight (LINE) and/or circular-arc
-   (CIRCLE) edges, with at least one straight edge (:func:`_is_wall`).  A rectangular
-   wall (all LINE) qualifies; so does a wall a slot cut into round stock clips into an
-   arc + a straight floor/chord (#148e).  A turned groove / circlip recess has a *pure
-   annular* wall — CIRCLE edges only, no straight edge — so it is still rejected
-   (otherwise a stepped shaft's groove reads as a slot).
+   (CIRCLE) edges, with at least one straight edge and **at most one arc**
+   (:func:`_is_wall`).  A rectangular wall (all LINE) qualifies; so does a wall a slot
+   cut into round stock clips into a single arc + a straight floor/chord (#148e).  A
+   turned groove / circlip recess has an *annular* wall bounded by *two* concentric arcs
+   (OD + floor), so the one-arc cap rejects it — even when a keyway / flat notches a
+   straight edge into the annulus (otherwise a keyed shaft's groove reads as a slot).
 3. **Through vs blind** — whether a planar floor caps the cut.  A blind pocket
    (or the floored gap between two bosses) has a floor face spanning the
    footprint; a through-slot does not.  ``_has_floor`` is the sole split between
@@ -181,16 +182,22 @@ class _Face:
 
 def _is_wall(face) -> bool:
     """True when *face* can be a slot wall: bounded only by straight (LINE) or circular-arc
-    (CIRCLE) edges, with **at least one** straight edge. A fully rectangular wall qualifies
-    (all LINE); a slot cut into round stock has a wall clipped by the OD into an arc + a
-    straight floor/chord, which now qualifies too (#148e). A turned groove / circlip recess
-    has a *pure annular* wall — CIRCLE edges only, no straight edge — so it is still rejected
-    (else a stepped shaft's groove reads as a slot); a freeform (spline/ellipse) face is
-    rejected outright."""
+    (CIRCLE) edges, with **at least one** straight edge and **at most one** arc. A fully
+    rectangular wall qualifies (all LINE); a slot cut into round stock has a wall the OD clips
+    into a *single* arc + a straight floor/chord, which now qualifies too (#148e).
+
+    A turned groove / circlip recess is still rejected — its annular wall is a washer bounded
+    by *two* concentric arcs (the outer OD + the inner floor circle), so the ``<= 1`` arc cap
+    excludes it. That cap holds even when a keyway / flat / cross-hole notches a straight edge
+    into the annulus (which defeated an "all edges must be straight" test — #148e review): the
+    two concentric arcs survive, so a keyed groove never reads as a slot. A freeform
+    (spline/ellipse) face is rejected outright."""
     types = [e.geom_type for e in face.edges()]
     if not types or any(t not in (GeomType.LINE, GeomType.CIRCLE) for t in types):
         return False
-    return any(t == GeomType.LINE for t in types)
+    n_line = sum(1 for t in types if t == GeomType.LINE)
+    n_circle = sum(1 for t in types if t == GeomType.CIRCLE)
+    return n_line >= 1 and n_circle <= 1
 
 
 def _planar_faces(part):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -23,7 +23,12 @@ from draftwright.analysis import (
 from draftwright.drawing import analyse_cylinders
 from draftwright.export import _export_shape
 from draftwright.make_drawing import generate_script, lint_feature_coverage
-from draftwright.recognition import Slot, recognise_face_levels, recognise_slots
+from draftwright.recognition import (
+    Slot,
+    recognise_face_levels,
+    recognise_pockets,
+    recognise_slots,
+)
 from draftwright.sheet import StripDepths, _fits, choose_scale
 
 _skip_011 = pytest.mark.skipif(B123D_GE_011, reason=SKIP_011)
@@ -6987,6 +6992,34 @@ class TestFindSlots:
         # circlip groove reads as a slot — the #146 review false positive).
         part = Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(7, 4))
         assert recognise_slots(part) == []
+
+    def test_arc_walled_slot_in_round_stock_recognised(self):
+        # #148e: a slot milled into a curved surface has walls the OD clips into an
+        # arc + a straight floor/chord. The relaxed wall test (LINE/CIRCLE with at
+        # least one straight edge) now recognises it, where the old rectangular-only
+        # test — which requires every edge to be a straight LINE — missed it.
+        bar = Rotation(0, 90, 0) * Cylinder(20, 80)  # X-axis round bar
+        part = bar - Pos(0, 0, 14) * Box(6, 24, 12)  # enclosed slot milled into the top
+        (p,) = recognise_pockets(part)
+        assert p.width == 6.0
+        assert p.width_axis == "x"  # width runs ALONG the bar axis → arc-clipped walls
+        assert p.length == 24.0
+
+    def test_arc_wall_relaxation_still_excludes_grooves(self):
+        # The relaxation must NOT admit a turned groove's pure-annular wall (CIRCLE
+        # edges only, no straight edge) as a slot/pocket wall (#148e) — the very
+        # distinction the relaxed test preserves.
+        part = Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(8, 4))
+        assert recognise_slots(part) == []
+        assert recognise_pockets(part) == []
+
+    def test_transverse_notch_spanning_bar_is_not_a_slot(self):
+        # A notch cut fully ACROSS a round bar exits both sides of the OD — an open
+        # feature spanning the part, rejected by the span cap even with arc walls (#148e).
+        bar = Rotation(0, 90, 0) * Cylinder(15, 60)
+        part = bar - Pos(0, 0, 9) * Box(6, 40, 20)
+        assert recognise_slots(part) == []
+        assert recognise_pockets(part) == []
 
     def test_gap_between_bosses_is_not_a_slot(self):
         # The floored channel between two raised bosses has facing rectangular

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7021,6 +7021,20 @@ class TestFindSlots:
         assert recognise_slots(part) == []
         assert recognise_pockets(part) == []
 
+    def test_keyed_groove_does_not_leak_as_a_slot(self):
+        # A circlip groove crossed by a wrench flat / keyway notches a straight edge into
+        # each annular wall, so a "one straight edge" test would wrongly admit it and the
+        # groove would double-report as both a groove AND a phantom slot on a flanged shaft
+        # (the span cap can't save it). The annular wall keeps its TWO concentric arcs (OD +
+        # floor), so the one-arc cap rejects it (#148e review).
+        part = (
+            (Box(60, 60, 8) + Pos(0, 0, 34) * Cylinder(10, 60))
+            - Pos(0, 0, 34) * (Cylinder(10, 6) - Cylinder(7, 6))
+            - Pos(9, 0, 34) * Box(6, 30, 60)
+        )
+        assert recognise_slots(part) == []
+        assert recognise_pockets(part) == []
+
     def test_gap_between_bosses_is_not_a_slot(self):
         # The floored channel between two raised bosses has facing rectangular
         # walls but is not a cut slot — the floor (the base plate) rejects it.


### PR DESCRIPTION
Closes #607

Part of the #148 machined-feature epic. Broadens the slot recogniser to accept **arc-bounded walls** — slots/pockets milled into curved stock, whose walls the OD clips into an arc + a straight floor/chord.

## The change
`_planar_faces` classified a face as a slot-wall candidate only if **every** edge was a straight `LINE`. That rejected any wall a cylinder clips into an arc. The new `_is_wall` predicate accepts a wall bounded by `LINE` and/or `CIRCLE` edges **with at least one straight edge**.

## Why this is safe against grooves
The old rectangular-only test doubled as the guard that stops a turned **groove's** annular wall from being read as a slot. That still holds: a groove wall is a **pure annulus** — `CIRCLE` edges only, no straight edge — so `_is_wall` rejects it. Verified: `test_arc_wall_relaxation_still_excludes_grooves` (both `recognise_slots` and `recognise_pockets`), and the pre-existing `test_turned_groove_is_not_a_slot` still passes.

## Scope, honestly
Investigation showed much of the "curved stock" space **already worked**: a wall *parallel* to the stock axis meets the OD in straight generator **lines**, so slots across round bars, keyways, and pockets in cylinder tops were already recognised. The genuine gap is a slot whose **width axis runs along the stock axis**, so its walls are *perpendicular* to the axis and clipped into true arcs — an **enclosed blind** slot/pocket in curved stock. (A *through* slot across a round bar spans the full diameter and stays out of scope as an open feature, per the existing span cap.)

No new feature type: the existing Slot/Pocket `recognise + render + declare + emit` surfaces round-trip the arc-walled case unchanged (all-three-surfaces per epic #574).

## Split out
The obround/radiused-end **length** finding (reports flat-wall length, not overall) is a separate dimensioning concern — filed as #613, not bundled here.

## Tests
Arc-walled pocket in a round bar recognised (w×len×depth); groove excluded under the relaxation; full-span transverse notch still rejected. Full fast tier: no regressions from the wider candidate set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)