### PR TITLE
refactor(#590): split _analyse and finalize into named sub-steps (WP5)

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -14,7 +14,7 @@ import logging
 import math
 import warnings
 from collections.abc import Callable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 
 from build123d import Compound, Shape
 from build123d_drafting.helpers import draft_preset
@@ -329,6 +329,135 @@ def _solids_body(part, src: str = "part"):
     return body
 
 
+@dataclass(frozen=True)
+class _GeomClass:
+    """Cylinder inventory + OD/rotational classification, the first analysis sub-step (#590)."""
+
+    z_cyls: list
+    cross_cyls: list
+    z_diams: list
+    cross_diams: list
+    od_diam: float | None
+    od_axis: str
+    is_rotational: bool
+
+
+def _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz) -> _GeomClass:
+    """Analyse *part*'s cylinders and classify its OD / rotational orientation (#590 split of
+    :func:`_analyse`). Partial (fillet) faces are excluded — they would pollute the OD, the bore
+    leaders, and the rotational test alike (#81)."""
+    z_cyls, cross_cyls = analyse_cylinders(part)
+    full_z = full_cylinders(z_cyls)
+    z_diams = dedup_diams(full_z)
+    cross_diams = dedup_diams(full_cylinders(cross_cyls))
+
+    _log.info("Z-axis diameters: %s", z_diams)
+    if cross_diams:
+        _log.info("Cross-hole diams: %s", cross_diams)
+
+    od_cyl = max((c for c in full_z if c["external"]), key=lambda c: c["diameter"], default=None)
+    od_diam = None
+    if od_cyl:
+        # Snap to the dedup_diams representative so comparisons against z_diams entries
+        # (bore-leader exclusion, labels) are exact even if the cylinder records ever carry
+        # unrounded OCCT diameters (#86)
+        raw_od = od_cyl["diameter"]
+        od_diam = min(z_diams, key=lambda d: abs(d - raw_od))
+    od_axis_offset = (
+        math.hypot(od_cyl["axis_xyz"][0] - cx, od_cyl["axis_xyz"][1] - cy) if od_cyl else 0.0
+    )
+    is_rotational = _is_rotational(x_size, y_size, od_diam, od_axis_offset)
+    od_axis = "z"
+    if not is_rotational:
+        # Fallback: a *horizontal* (X/Y) round body — its OD is a cross-axis cylinder
+        # filling the square envelope perpendicular to that axis (#222). The Z check
+        # above is untouched, so vertical parts classify exactly as before; this only
+        # fires when Z-rotational fails and a cross-axis round body is present.
+        sizes = {"x": x_size, "y": y_size, "z": z_size}
+        ctr = {"x": cx, "y": cy, "z": cz}
+        cross_full = full_cylinders(cross_cyls)
+        for ax in ("x", "y"):
+            ext = [c for c in cross_full if c.get("axis") == ax and c["external"]]
+            # #222 targets a *single-OD* round body. A stepped shaft (multiple distinct
+            # cross diameters) stays on the turned-diameter path, not the OD furniture.
+            if len({round(c["diameter"], 1) for c in ext}) != 1:
+                continue
+            oc = max(ext, key=lambda c: c["diameter"], default=None)
+            if oc is None:
+                continue
+            p0, p1 = (a for a in "xyz" if a != ax)
+            off = math.hypot(
+                oc["axis_xyz"]["xyz".index(p0)] - ctr[p0],
+                oc["axis_xyz"]["xyz".index(p1)] - ctr[p1],
+            )
+            if _is_rotational(sizes[p0], sizes[p1], oc["diameter"], off):
+                od_diam, od_axis_offset, od_axis, is_rotational = oc["diameter"], off, ax, True
+                break
+    if z_diams and not is_rotational:
+        _log.info("Part classified prismatic; skipping OD/centreline/bore annotations")
+    return _GeomClass(z_cyls, cross_cyls, z_diams, cross_diams, od_diam, od_axis, is_rotational)
+
+
+def _validate_explicit_scale(
+    scale,
+    SCALE,
+    x_size,
+    y_size,
+    z_size,
+    n_for_sizing,
+    page,
+    strips_i,
+    layout_section,
+    layout_table_sizes,
+) -> None:
+    """Enforce the two scale floors when the caller pinned an explicit *scale* (#489, #590 split
+    of :func:`_analyse`). An explicit scale is the user's call — honour it, subject to:
+      - ``_MIN_RENDER_MM``: a hard geometry limit; below it OCCT's annotation arcs degenerate
+        (Geom_TrimmedCurve U1==U2, ~1e-4 mm; 0.1 mm is a conservative floor). Reject with a clean
+        message — there is no meaningful drawing this small anyway.
+      - ``_MIN_VIEW_MM``: a legibility floor; below it annotations crowd but the drawing is valid,
+        so honour the scale with a warning. This floor does NOT bound the auto scale
+        (``choose_scale`` is a pure geometric page fit), so a warning is only useful when a
+        legible page-fitting scale actually exists — i.e. the auto scale is itself legible."""
+    if scale is None:
+        return
+    min_dim = min(x_size, y_size, z_size)
+    min_view = min_dim * SCALE
+    if min_view < _MIN_RENDER_MM:
+        safe = _MIN_RENDER_MM / min_dim
+        raise ValueError(
+            f"scale {SCALE!r} projects the smallest part dimension "
+            f"({min_dim:.0f} mm) to {min_view:.3g} mm — the drawing geometry degenerates "
+            f"below {_MIN_RENDER_MM:g} mm (OCCT arc construction fails). "
+            f"Use scale ≥ {safe:.3g} or omit the scale for automatic selection."
+        )
+    auto_scale, _, _, _ = choose_scale(
+        x_size,
+        y_size,
+        z_size,
+        n_steps=n_for_sizing,
+        scale=None,
+        page=page,
+        strips=strips_i,
+        section=layout_section,
+        table_sizes=layout_table_sizes,
+    )
+    # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
+    # legible) but the requested scale is below the floor. A part illegible at every
+    # page-fitting scale can't be helped by a bigger one, so nagging there would be false.
+    if min_view < _MIN_VIEW_MM <= auto_scale * min_dim:
+        safe = _MIN_VIEW_MM / min_dim
+        # No stacklevel that reaches user code: this fires deep in _analyse, and the public
+        # entry points (make_drawing, Sheet.export, build_drawing) sit at different depths.
+        # The message is self-contained (names the scale, the projection, and the fix).
+        warnings.warn(
+            f"scale {SCALE!r} projects the smallest part dimension ({min_dim:.0f} mm) to "
+            f"{min_view:.1f} mm, below the {_MIN_VIEW_MM:.0f} mm legibility floor — "
+            f"annotations may crowd or overlap. Honouring the requested scale; use "
+            f"scale ≥ {safe:.3g} or omit the scale for an automatic legible fit."
+        )
+
+
 def _analyse(
     step_file,
     title,
@@ -375,57 +504,10 @@ def _analyse(
 
     _log.info("Loaded %s  bbox: %.2f × %.2f × %.2f mm", src, x_size, y_size, z_size)
 
-    z_cyls, cross_cyls = analyse_cylinders(part)
-    # Partial (fillet) faces are not features: they would pollute the OD,
-    # the bore leaders, and the rotational classification alike (#81)
-    full_z = full_cylinders(z_cyls)
-    z_diams = dedup_diams(full_z)
-    cross_diams = dedup_diams(full_cylinders(cross_cyls))
-
-    _log.info("Z-axis diameters: %s", z_diams)
-    if cross_diams:
-        _log.info("Cross-hole diams: %s", cross_diams)
-
-    od_cyl = max((c for c in full_z if c["external"]), key=lambda c: c["diameter"], default=None)
-    od_diam = None
-    if od_cyl:
-        # Snap to the dedup_diams representative so comparisons against
-        # z_diams entries (bore-leader exclusion, labels) are exact even if
-        # the cylinder records ever carry unrounded OCCT diameters (#86)
-        raw_od = od_cyl["diameter"]
-        od_diam = min(z_diams, key=lambda d: abs(d - raw_od))
-    od_axis_offset = (
-        math.hypot(od_cyl["axis_xyz"][0] - cx, od_cyl["axis_xyz"][1] - cy) if od_cyl else 0.0
-    )
-    is_rotational = _is_rotational(x_size, y_size, od_diam, od_axis_offset)
-    od_axis = "z"
-    if not is_rotational:
-        # Fallback: a *horizontal* (X/Y) round body — its OD is a cross-axis cylinder
-        # filling the square envelope perpendicular to that axis (#222). The Z check
-        # above is untouched, so vertical parts classify exactly as before; this only
-        # fires when Z-rotational fails and a cross-axis round body is present.
-        sizes = {"x": x_size, "y": y_size, "z": z_size}
-        ctr = {"x": cx, "y": cy, "z": cz}
-        cross_full = full_cylinders(cross_cyls)
-        for ax in ("x", "y"):
-            ext = [c for c in cross_full if c.get("axis") == ax and c["external"]]
-            # #222 targets a *single-OD* round body. A stepped shaft (multiple distinct
-            # cross diameters) stays on the turned-diameter path, not the OD furniture.
-            if len({round(c["diameter"], 1) for c in ext}) != 1:
-                continue
-            oc = max(ext, key=lambda c: c["diameter"], default=None)
-            if oc is None:
-                continue
-            p0, p1 = (a for a in "xyz" if a != ax)
-            off = math.hypot(
-                oc["axis_xyz"]["xyz".index(p0)] - ctr[p0],
-                oc["axis_xyz"]["xyz".index(p1)] - ctr[p1],
-            )
-            if _is_rotational(sizes[p0], sizes[p1], oc["diameter"], off):
-                od_diam, od_axis_offset, od_axis, is_rotational = oc["diameter"], off, ax, True
-                break
-    if z_diams and not is_rotational:
-        _log.info("Part classified prismatic; skipping OD/centreline/bore annotations")
+    _gc = _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz)
+    z_cyls, cross_cyls = _gc.z_cyls, _gc.cross_cyls
+    z_diams, cross_diams = _gc.z_diams, _gc.cross_diams
+    od_diam, od_axis, is_rotational = _gc.od_diam, _gc.od_axis, _gc.is_rotational
 
     # Step Z-levels feed both the step-height ladder and the page-sizing step
     # count. For a vertical (Z-axis) turned part, take them from the unified
@@ -530,50 +612,18 @@ def _analyse(
         _pick_for_step_count,
         lambda scale_i: len(_legible_steps(step_zs, bb.min.Z, scale_i)[0]),
     )
-    if scale is not None:
-        # An explicit scale is the user's call — honour it (#489). Two floors apply:
-        #  - _MIN_RENDER_MM: a hard geometry limit; below it OCCT's annotation arcs degenerate
-        #    (Geom_TrimmedCurve U1==U2, ~1e-4 mm empirically — 0.1 mm is a conservative floor).
-        #    Reject with a clean message; there is no meaningful drawing this small anyway.
-        #  - _MIN_VIEW_MM: a legibility floor; below it annotations crowd but the drawing is
-        #    valid, so honour the scale with a warning. This floor does NOT bound the auto scale
-        #    (choose_scale is a pure geometric page fit), so a warning is only useful when a
-        #    legible page-fitting scale actually exists — i.e. the auto scale is itself legible.
-        min_dim = min(x_size, y_size, z_size)
-        min_view = min_dim * SCALE
-        if min_view < _MIN_RENDER_MM:
-            safe = _MIN_RENDER_MM / min_dim
-            raise ValueError(
-                f"scale {SCALE!r} projects the smallest part dimension "
-                f"({min_dim:.0f} mm) to {min_view:.3g} mm — the drawing geometry degenerates "
-                f"below {_MIN_RENDER_MM:g} mm (OCCT arc construction fails). "
-                f"Use scale ≥ {safe:.3g} or omit the scale for automatic selection."
-            )
-        auto_scale, _, _, _ = choose_scale(
-            x_size,
-            y_size,
-            z_size,
-            n_steps=n_for_sizing,
-            scale=None,
-            page=page,
-            strips=strips_i,
-            section=layout_section,
-            table_sizes=layout_table_sizes,
-        )
-        # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
-        # legible) but the requested scale is below the floor. A part illegible at every
-        # page-fitting scale can't be helped by a bigger one, so nagging there would be false.
-        if min_view < _MIN_VIEW_MM <= auto_scale * min_dim:
-            safe = _MIN_VIEW_MM / min_dim
-            # No stacklevel that reaches user code: this fires deep in _analyse, and the public
-            # entry points (make_drawing, Sheet.export, build_drawing) sit at different depths.
-            # The message is self-contained (names the scale, the projection, and the fix).
-            warnings.warn(
-                f"scale {SCALE!r} projects the smallest part dimension ({min_dim:.0f} mm) to "
-                f"{min_view:.1f} mm, below the {_MIN_VIEW_MM:.0f} mm legibility floor — "
-                f"annotations may crowd or overlap. Honouring the requested scale; use "
-                f"scale ≥ {safe:.3g} or omit the scale for an automatic legible fit."
-            )
+    _validate_explicit_scale(
+        scale,
+        SCALE,
+        x_size,
+        y_size,
+        z_size,
+        n_for_sizing,
+        page,
+        strips_i,
+        layout_section,
+        layout_table_sizes,
+    )
     DIM_PAD = _DIM_PAD
     margin = _MARGIN
     # Refine: apply the same legibility gate _auto_annotate uses for dim_step.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -336,6 +336,34 @@ def _ir_hole_groups(model, target_axis: str) -> list[tuple]:
     return groups
 
 
+@dataclass(frozen=True)
+class _IntentRouting:
+    """How :meth:`Drawing.finalize` routes each recorded intent to an auto-pass solver (#426).
+
+    The classification half of finalize (#590 split): pure comprehensions over the recorded
+    intents deciding which route each takes. ``section`` is the pre-planned section (or None);
+    the ``*_ids`` are ``id()`` sets of the intents on each route; the ``only_*``/``*_feats`` are
+    the feature sets the routed renderers receive.
+    """
+
+    section: object
+    corridor_ids: set
+    callout_ids: set
+    dia_ids: set
+    len_ids: set
+    slot_ids: set
+    height_ladder_ids: set
+    step_position_ids: set
+    explicit_envelope_height: bool
+    user_dim_ids: set
+    only_loc: set
+    pinned_loc: set
+    only_callout: set
+    only_dia: set
+    only_len: set
+    slot_feats: set
+
+
 class Drawing:
     """A composable technical drawing — the editable form of :func:`make_drawing`.
 
@@ -1180,80 +1208,14 @@ class Drawing:
             self._defer_intents = prev
         self.finalize()
 
-    def finalize(self) -> None:
-        """Drain the recorded placement intents (#426).
+    def _classify_intents(self, model, a, routable) -> _IntentRouting:
+        """Classify the recorded placement intents by route — the classification half of
+        :meth:`finalize` (#590 split). Pure comprehensions over ``self._intents`` (no placement,
+        no mutation) deciding which auto-pass solver each intent drains through; the drain half
+        of finalize consumes the returned :class:`_IntentRouting`."""
+        from draftwright.annotations.sections import feature_hole_keys
+        from draftwright.model import PartModel, plan_sections
 
-        When the drawing was built in **deferred** mode (``_defer_intents``), the add
-        verbs recorded :class:`~draftwright.intents.Intent`\\s instead of placing. This
-        drains them, routing what it can through the auto-pass's own solvers:
-
-        * **(A)** live-replays furniture, non-slot dimensions, and axes-restricted locates
-          (in recorded order, pop-after-success);
-        * **(reserve, Phase 3b)** if a ``section`` was recorded, its cutting-plane row is
-          reserved first so the callout carve sees it as an obstacle (Coupling A);
-        * **(B1, Phase 3a)** hole/pattern ø **callouts** through ``_annotate_holes`` — the
-          real priority-drop / central-bore-anchoring solve;
-        * **(B2, Phase 2a+2b)** both-axes **locations** (``render_locations``) and
-          **slots** (``render_slots``) through the SHARED corridor + one ``drain_corridors``
-          — one crossing-free, deduped, monotone ladder (a slot position coincident with a
-          hole location collapses to one dim, #345);
-        * **(B3, Phase 4a)** X/Z-turned step/boss ø **diameters** through ``render_diameters``
-          — the row-below / column-left set-solve;
-        * **(B3b, Phase 4b)** a turned shaft's step-length **chain** through
-          ``render_step_lengths`` — the unified chain / ``N× v`` collapse / staggered tiers;
-        * **(C)** the ``section`` renders last (its room check clears the side view's right);
-        * **(D, Phase 4c)** dense-scattered plan holes escalate to the hole **table** + balloon
-          ring via ``_maybe_tabulate_holes`` — last, so it sees the section + title block as
-          obstacles. The density gate counts *all* analysis holes, so this is a full-
-          reconstruction escalation (a partial hand-edit still tabulates the full count, #434);
-          ``_escalations`` is cleared after so a repeat batch can't re-fire the fixed-name table.
-
-        A slot records two size dims (``slot_width``/``slot_length``) on one feature; routing
-        the feature also regenerates its model-derived datum **position** dim, so finalize
-        places a *superset* of the recorded slot intents (auto-pass parity by design —
-        commenting one of a slot's two lines still routes the feature). An unsupported-axis
-        (Y-turned) step/boss callout live-replays, so it surfaces the same ValueError the
-        live verb raises. Only ``only``-set routing is used here; the auto-pass path is
-        untouched.
-
-        Idempotent (draining empties the list; a repeat call — or ``export()`` then
-        ``export_pdf()`` — no-ops) and a no-op when nothing was recorded (the live/auto-pass
-        path), so ``export()`` calls it unconditionally. **Resilient:** a live-replayed
-        intent is removed only after it places, so a verb that raises surfaces the error
-        and leaves the rest recorded. A record → finalize → record-more → finalize
-        sequence drains each batch (#428 review).
-        """
-        if not self._intents:
-            return
-        from draftwright.annotations._common import drain_corridors
-        from draftwright.annotations.from_model import (
-            render_diameters,
-            render_height_ladder,
-            render_locations,
-            render_slots,
-            render_step_lengths,
-            render_step_positions,
-        )
-        from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
-        from draftwright.annotations.orchestrator import _maybe_tabulate_holes
-        from draftwright.annotations.sections import (
-            _add_section_view,
-            _reserve_section_row,
-            feature_hole_keys,
-        )
-        from draftwright.model import PartModel, plan_dimensions, plan_sections
-
-        # Corridor state the auto-pass creates in _auto_annotate S0 but a detect-only build
-        # lacks — render_locations/_annotate_holes/drain_corridors register/read here.
-        if not hasattr(self, "_corridor_batch"):
-            self._corridor_batch: dict = {}
-        if not hasattr(self, "_escalations"):
-            self._escalations: list = []
-        if not hasattr(self, "_detail_requests"):
-            self._detail_requests: list = []
-
-        model, a = self._part_model, self._analysis
-        routable = model is not None and a is not None
         # The section plan (if a section was recorded) — the ONE plan reserved before the
         # callout carve sees its row (Coupling A) and rendered last (Phase 3b).
         _section = None
@@ -1388,6 +1350,107 @@ class Drawing:
         only_dia = {it.feature for it in self._intents if id(it) in dia_ids}
         only_len = {it.feature for it in self._intents if id(it) in len_ids}
         slot_feats = {it.feature for it in self._intents if id(it) in slot_ids}
+        return _IntentRouting(
+            section=_section,
+            corridor_ids=corridor_ids,
+            callout_ids=callout_ids,
+            dia_ids=dia_ids,
+            len_ids=len_ids,
+            slot_ids=slot_ids,
+            height_ladder_ids=height_ladder_ids,
+            step_position_ids=step_position_ids,
+            explicit_envelope_height=explicit_envelope_height,
+            user_dim_ids=user_dim_ids,
+            only_loc=only_loc,
+            pinned_loc=pinned_loc,
+            only_callout=only_callout,
+            only_dia=only_dia,
+            only_len=only_len,
+            slot_feats=slot_feats,
+        )
+
+    def finalize(self) -> None:
+        """Drain the recorded placement intents (#426).
+
+        When the drawing was built in **deferred** mode (``_defer_intents``), the add
+        verbs recorded :class:`~draftwright.intents.Intent`\\s instead of placing. This
+        drains them, routing what it can through the auto-pass's own solvers:
+
+        * **(A)** live-replays furniture, non-slot dimensions, and axes-restricted locates
+          (in recorded order, pop-after-success);
+        * **(reserve, Phase 3b)** if a ``section`` was recorded, its cutting-plane row is
+          reserved first so the callout carve sees it as an obstacle (Coupling A);
+        * **(B1, Phase 3a)** hole/pattern ø **callouts** through ``_annotate_holes`` — the
+          real priority-drop / central-bore-anchoring solve;
+        * **(B2, Phase 2a+2b)** both-axes **locations** (``render_locations``) and
+          **slots** (``render_slots``) through the SHARED corridor + one ``drain_corridors``
+          — one crossing-free, deduped, monotone ladder (a slot position coincident with a
+          hole location collapses to one dim, #345);
+        * **(B3, Phase 4a)** X/Z-turned step/boss ø **diameters** through ``render_diameters``
+          — the row-below / column-left set-solve;
+        * **(B3b, Phase 4b)** a turned shaft's step-length **chain** through
+          ``render_step_lengths`` — the unified chain / ``N× v`` collapse / staggered tiers;
+        * **(C)** the ``section`` renders last (its room check clears the side view's right);
+        * **(D, Phase 4c)** dense-scattered plan holes escalate to the hole **table** + balloon
+          ring via ``_maybe_tabulate_holes`` — last, so it sees the section + title block as
+          obstacles. The density gate counts *all* analysis holes, so this is a full-
+          reconstruction escalation (a partial hand-edit still tabulates the full count, #434);
+          ``_escalations`` is cleared after so a repeat batch can't re-fire the fixed-name table.
+
+        A slot records two size dims (``slot_width``/``slot_length``) on one feature; routing
+        the feature also regenerates its model-derived datum **position** dim, so finalize
+        places a *superset* of the recorded slot intents (auto-pass parity by design —
+        commenting one of a slot's two lines still routes the feature). An unsupported-axis
+        (Y-turned) step/boss callout live-replays, so it surfaces the same ValueError the
+        live verb raises. Only ``only``-set routing is used here; the auto-pass path is
+        untouched.
+
+        Idempotent (draining empties the list; a repeat call — or ``export()`` then
+        ``export_pdf()`` — no-ops) and a no-op when nothing was recorded (the live/auto-pass
+        path), so ``export()`` calls it unconditionally. **Resilient:** a live-replayed
+        intent is removed only after it places, so a verb that raises surfaces the error
+        and leaves the rest recorded. A record → finalize → record-more → finalize
+        sequence drains each batch (#428 review).
+        """
+        if not self._intents:
+            return
+        from draftwright.annotations._common import drain_corridors
+        from draftwright.annotations.from_model import (
+            render_diameters,
+            render_height_ladder,
+            render_locations,
+            render_slots,
+            render_step_lengths,
+            render_step_positions,
+        )
+        from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
+        from draftwright.annotations.orchestrator import _maybe_tabulate_holes
+        from draftwright.annotations.sections import (
+            _add_section_view,
+            _reserve_section_row,
+            feature_hole_keys,
+        )
+        from draftwright.model import PartModel, plan_dimensions
+
+        # Corridor state the auto-pass creates in _auto_annotate S0 but a detect-only build
+        # lacks — render_locations/_annotate_holes/drain_corridors register/read here.
+        if not hasattr(self, "_corridor_batch"):
+            self._corridor_batch: dict = {}
+        if not hasattr(self, "_escalations"):
+            self._escalations: list = []
+        if not hasattr(self, "_detail_requests"):
+            self._detail_requests: list = []
+
+        model, a = self._part_model, self._analysis
+        routable = model is not None and a is not None
+        r = self._classify_intents(model, a, routable)
+        _section = r.section
+        corridor_ids, callout_ids, dia_ids = r.corridor_ids, r.callout_ids, r.dia_ids
+        len_ids, slot_ids = r.len_ids, r.slot_ids
+        height_ladder_ids, step_position_ids = r.height_ladder_ids, r.step_position_ids
+        explicit_envelope_height, user_dim_ids = r.explicit_envelope_height, r.user_dim_ids
+        only_loc, pinned_loc, only_callout = r.only_loc, r.pinned_loc, r.only_callout
+        only_dia, only_len, slot_feats = r.only_dia, r.only_len, r.slot_feats
 
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:


### PR DESCRIPTION
Closes #590

The final #584 work package (WP5) — cosmetic decomposition of the two genuinely-oversized orchestrators. **No layout-behaviour change** (snapshot-stable), per the issue.

## `analysis.py` — `_analyse`
Extracted two named, cohesive helpers (~90 lines of logic moved out):
- **`_classify_geometry`** — cylinder inventory (`analyse_cylinders` + `dedup_diams`) + OD / rotational-vs-prismatic classification, returning a `_GeomClass`.
- **`_validate_explicit_scale`** — the two explicit-scale floors (`_MIN_RENDER_MM` reject / `_MIN_VIEW_MM` warn, #489).

## `drawing.py` — `Drawing.finalize`
Split the ~180-line method into:
- **`_classify_intents`** — the intent→route classification (~130 lines of **pure comprehensions**, no placement/mutation) returning an `_IntentRouting` bundle.
- the **drain phase**, which is **byte-identical** — it unpacks the bundle into the same local names, so the delicate #426 record-then-finalize replay (the `--script` / `Sheet` reconstruction path) is untouched.

## Why it's safe
The extracted blocks are side-effect-free and cohesive; the risky drain phase never changed. Verified behaviour-preserving:
- Snapshot + emit round-trip + finalize suites: **268 passed, 1 skipped**.
- Classification identical on turned / prismatic / horizontal-round parts (smoke-checked `is_rotational`/`od_axis`/`od_diam`/`SCALE`).

The other four functions #584 originally named as oversized are explicitly out of scope (they're 32–47 lines — the original claim was overstated, per #590).

🤖 Generated with [Claude Code](https://claude.com/claude-code)