### PR TITLE
fix(#613): report obround slots' overall length (+ recognise/declare parity)

### DIFF
--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -334,10 +334,12 @@ _END_RADIUS_TOL = 0.15
 
 
 def _cylinder_faces(part) -> list[tuple]:
-    """``(radius, axis_letter, axis_location, bbox)`` for each axis-aligned cylindrical face of
-    *part* — the candidate obround end caps (#613). ``axis_location`` is a point on the cylinder
-    axis; ``bbox`` bounds the face (used to confirm the cap spans the slot's depth, not some
-    unrelated cylinder at a different depth)."""
+    """``(radius, axis_letter, axis_location, bbox, concave)`` for each axis-aligned cylindrical
+    face of *part* — the candidate obround end caps (#613). ``axis_location`` is a point on the
+    cylinder axis; ``bbox`` bounds the face (used to confirm the cap spans the slot's depth, not
+    some unrelated cylinder at a different depth); ``concave`` is True when the face bounds a
+    *void* (its material-outward normal points inward, toward the axis) — a recess wall — rather
+    than added material (a boss/post). Mirrors ``_outward_normal``'s FORWARD/handedness test."""
     out = []
     for face in part.faces():
         surf = BRepAdaptor_Surface(face.wrapped)
@@ -349,27 +351,31 @@ def _cylinder_faces(part) -> list[tuple]:
         if axis is None:
             continue
         loc = cyl.Axis().Location()
-        out.append((cyl.Radius(), axis, (loc.X(), loc.Y(), loc.Z()), face.bounding_box()))
+        fwd = face.wrapped.Orientation() == TopAbs_Orientation.TopAbs_FORWARD
+        concave = fwd != cyl.Position().Direct()
+        out.append((cyl.Radius(), axis, (loc.X(), loc.Y(), loc.Z()), face.bounding_box(), concave))
     return out
 
 
 def _end_cap_at(caps: list[tuple], s: _R, coord: float) -> bool:
     """True when a semicircular obround end cap sits at ``coord`` along the long axis (#613): a
-    cylinder of radius ≈ ``s.width/2`` about the depth axis, on the slot centreline, **spanning
-    the slot's own depth extent** ``[d_lo, d_hi]``. The depth-extent test is what separates a
-    real end cap from an unrelated coaxial cylinder — a protruding boss or a blind hole drilled
-    from the far face — that merely happens to sit near the end on the centreline (review)."""
+    **concave** (void-bounding) cylinder of radius ≈ ``s.width/2`` about the depth axis, on the
+    slot centreline, **spanning the slot's own depth extent** ``[d_lo, d_hi]``. Two clauses
+    separate a real cap from a coaxial impostor at the same place: the depth-extent test rejects
+    a boss/hole at a *different* depth, and the concavity test rejects added material — a post or
+    boss protruding *into* the slot end at the slot's depth (both review false positives)."""
     r = s.width / 2
     li, wi, di = _AXES[s.long_axis], _AXES[s.width_axis], _AXES[s.depth_axis]
     dc = "XYZ"[di]
     return any(
-        abs(rad - r) <= _END_RADIUS_TOL
+        concave
+        and abs(rad - r) <= _END_RADIUS_TOL
         and ax == s.depth_axis
         and abs(loc[li] - coord) <= _MERGE_TOL
         and abs(loc[wi] - s.w_center) <= _MERGE_TOL
         and abs(getattr(bb.min, dc) - s.d_lo) <= _MERGE_TOL
         and abs(getattr(bb.max, dc) - s.d_hi) <= _MERGE_TOL
-        for rad, ax, loc, bb in caps
+        for rad, ax, loc, bb, concave in caps
     )
 
 

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -32,12 +32,12 @@ recess rather than some other facing-wall feature with three predicates a naive
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TypeVar
 
 from build123d import Box, GeomType, Pos
 from OCP.BRepAdaptor import BRepAdaptor_Surface
-from OCP.GeomAbs import GeomAbs_Plane
+from OCP.GeomAbs import GeomAbs_Cylinder, GeomAbs_Plane
 from OCP.TopAbs import TopAbs_Orientation
 
 from draftwright.recognition._record import Record
@@ -327,6 +327,68 @@ def _has_floor(faces, s: Slot) -> bool:
     )
 
 
+# A radiused-end (obround) slot has semicircular end caps whose radius is the slot's
+# half-width; a cylindrical face counts as such a cap when its radius is within this (mm) of
+# width/2. Tight, so a filleted-corner rectangular slot (small corner radii) is not extended.
+_END_RADIUS_TOL = 0.15
+
+
+def _cylinder_faces(part) -> list[tuple]:
+    """``(radius, axis_letter, axis_location)`` for each axis-aligned cylindrical face of *part*
+    — the candidate obround end caps (#613). ``axis_location`` is a point on the cylinder axis."""
+    out = []
+    for face in part.faces():
+        surf = BRepAdaptor_Surface(face.wrapped)
+        if surf.GetType() != GeomAbs_Cylinder:
+            continue
+        cyl = surf.Cylinder()
+        d = cyl.Axis().Direction()
+        axis = _dominant_axis((d.X(), d.Y(), d.Z()))
+        if axis is None:
+            continue
+        loc = cyl.Axis().Location()
+        out.append((cyl.Radius(), axis, (loc.X(), loc.Y(), loc.Z())))
+    return out
+
+
+def _end_cap_at(caps: list[tuple], s: _R, coord: float) -> bool:
+    """True when a semicircular obround end cap (a cylinder of radius ≈ ``s.width/2`` about the
+    depth axis, on the slot centreline) sits at ``coord`` along the long axis (#613)."""
+    r = s.width / 2
+    li, wi = _AXES[s.long_axis], _AXES[s.width_axis]
+    return any(
+        abs(rad - r) <= _END_RADIUS_TOL
+        and ax == s.depth_axis
+        and abs(loc[li] - coord) <= _MERGE_TOL
+        and abs(loc[wi] - s.w_center) <= _MERGE_TOL
+        for rad, ax, loc in caps
+    )
+
+
+def _extend_obround_ends(records: list[_R], part) -> list[_R]:
+    """Extend radiused-end (obround) slots/pockets to their **overall** length (#613).
+
+    The recogniser pairs the two flat side walls, so the raw ``lo``/``hi`` stop at the straight
+    portion — a slot with semicircular ends under-reports its length by the two end radii (each
+    ``width/2``). Where a semicircular end cap (:func:`_end_cap_at`) is present, push that end
+    out by the radius so ``length`` becomes the overall length. This also aligns detection with
+    ``declare.slot(obj)``, which already reads the overall length off the object bounding box.
+    A rectangular slot has no such caps and is returned unchanged."""
+    caps = _cylinder_faces(part)
+    if not caps:
+        return records
+    out: list[_R] = []
+    for s in records:
+        r = s.width / 2
+        lo = s.lo - r if _end_cap_at(caps, s, s.lo) else s.lo
+        hi = s.hi + r if _end_cap_at(caps, s, s.hi) else s.hi
+        if lo == s.lo and hi == s.hi:
+            out.append(s)
+        else:
+            out.append(replace(s, lo=round(lo, 2), hi=round(hi, 2), length=round(hi - lo, 2)))
+    return out
+
+
 def recognise_slots(part) -> list[Slot]:
     """Recognise enclosed through-slots with rectangular walls in *part*.
 
@@ -353,8 +415,9 @@ def recognise_slots(part) -> list[Slot]:
                 # between bosses) is capped by a floor and is out of scope (#148).
                 if s is not None and not _has_floor(faces, s):
                     candidates.append(s)
-    # Recombine arms of a crossing channel split by the intersection (#604).
-    return _collapse_collinear(_merge(candidates), part)
+    # Recombine arms of a crossing channel split by the intersection (#604), then extend any
+    # radiused-end (obround) slot to its overall length (#613).
+    return _extend_obround_ends(_collapse_collinear(_merge(candidates), part), part)
 
 
 def _same_channel_line(a: Slot, b: Slot):
@@ -588,4 +651,4 @@ def recognise_pockets(part) -> list[Pocket]:
                 p = _pocket_candidate(walls[i], walls[j], faces, part_ext)
                 if p is not None:
                     candidates.append(p)
-    return _merge(candidates)
+    return _extend_obround_ends(_merge(candidates), part)

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -334,8 +334,10 @@ _END_RADIUS_TOL = 0.15
 
 
 def _cylinder_faces(part) -> list[tuple]:
-    """``(radius, axis_letter, axis_location)`` for each axis-aligned cylindrical face of *part*
-    — the candidate obround end caps (#613). ``axis_location`` is a point on the cylinder axis."""
+    """``(radius, axis_letter, axis_location, bbox)`` for each axis-aligned cylindrical face of
+    *part* — the candidate obround end caps (#613). ``axis_location`` is a point on the cylinder
+    axis; ``bbox`` bounds the face (used to confirm the cap spans the slot's depth, not some
+    unrelated cylinder at a different depth)."""
     out = []
     for face in part.faces():
         surf = BRepAdaptor_Surface(face.wrapped)
@@ -347,21 +349,27 @@ def _cylinder_faces(part) -> list[tuple]:
         if axis is None:
             continue
         loc = cyl.Axis().Location()
-        out.append((cyl.Radius(), axis, (loc.X(), loc.Y(), loc.Z())))
+        out.append((cyl.Radius(), axis, (loc.X(), loc.Y(), loc.Z()), face.bounding_box()))
     return out
 
 
 def _end_cap_at(caps: list[tuple], s: _R, coord: float) -> bool:
-    """True when a semicircular obround end cap (a cylinder of radius ≈ ``s.width/2`` about the
-    depth axis, on the slot centreline) sits at ``coord`` along the long axis (#613)."""
+    """True when a semicircular obround end cap sits at ``coord`` along the long axis (#613): a
+    cylinder of radius ≈ ``s.width/2`` about the depth axis, on the slot centreline, **spanning
+    the slot's own depth extent** ``[d_lo, d_hi]``. The depth-extent test is what separates a
+    real end cap from an unrelated coaxial cylinder — a protruding boss or a blind hole drilled
+    from the far face — that merely happens to sit near the end on the centreline (review)."""
     r = s.width / 2
-    li, wi = _AXES[s.long_axis], _AXES[s.width_axis]
+    li, wi, di = _AXES[s.long_axis], _AXES[s.width_axis], _AXES[s.depth_axis]
+    dc = "XYZ"[di]
     return any(
         abs(rad - r) <= _END_RADIUS_TOL
         and ax == s.depth_axis
         and abs(loc[li] - coord) <= _MERGE_TOL
         and abs(loc[wi] - s.w_center) <= _MERGE_TOL
-        for rad, ax, loc in caps
+        and abs(getattr(bb.min, dc) - s.d_lo) <= _MERGE_TOL
+        and abs(getattr(bb.max, dc) - s.d_hi) <= _MERGE_TOL
+        for rad, ax, loc, bb in caps
     )
 
 
@@ -370,22 +378,29 @@ def _extend_obround_ends(records: list[_R], part) -> list[_R]:
 
     The recogniser pairs the two flat side walls, so the raw ``lo``/``hi`` stop at the straight
     portion — a slot with semicircular ends under-reports its length by the two end radii (each
-    ``width/2``). Where a semicircular end cap (:func:`_end_cap_at`) is present, push that end
-    out by the radius so ``length`` becomes the overall length. This also aligns detection with
-    ``declare.slot(obj)``, which already reads the overall length off the object bounding box.
-    A rectangular slot has no such caps and is returned unchanged."""
+    ``width/2``). A true obround is symmetric, so a slot is extended only when a semicircular end
+    cap (:func:`_end_cap_at`) is present at **both** ends; each end is then pushed out by the
+    radius, keeping the centre fixed. Requiring both ends (not one) avoids a lone coaxial
+    cylinder shifting a flat-ended slot's centre (review), and matches ``declare.slot(obj)``,
+    which reads the overall length off the object bounding box. Rectangular slots have no caps
+    and are returned unchanged."""
     caps = _cylinder_faces(part)
     if not caps:
         return records
     out: list[_R] = []
     for s in records:
         r = s.width / 2
-        lo = s.lo - r if _end_cap_at(caps, s, s.lo) else s.lo
-        hi = s.hi + r if _end_cap_at(caps, s, s.hi) else s.hi
-        if lo == s.lo and hi == s.hi:
-            out.append(s)
+        if _end_cap_at(caps, s, s.lo) and _end_cap_at(caps, s, s.hi):
+            out.append(
+                replace(
+                    s,
+                    lo=round(s.lo - r, 2),
+                    hi=round(s.hi + r, 2),
+                    length=round(s.hi - s.lo + 2 * r, 2),
+                )
+            )
         else:
-            out.append(replace(s, lo=round(lo, 2), hi=round(hi, 2), length=round(hi - lo, 2)))
+            out.append(s)
     return out
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7075,6 +7075,23 @@ class TestFindSlots:
         declared = declare_slot(cutter, depth_axis="z")
         assert s.length == declared.length == 30.0
 
+    def test_pivot_boss_at_slot_end_does_not_extend_length(self):
+        # A slotted lever with a cylindrical pivot boss (radius = width/2) protruding at one
+        # end must NOT be read as a radiused end: the boss sits at a different depth than the
+        # slot, and a true obround is symmetric (both ends). Flat length 22 stays 22 (#613 review).
+        part = Box(60, 30, 10) - Box(22, 8, 20) + Pos(11.3, 0, 5) * Cylinder(4, 10)
+        (s,) = recognise_slots(part)
+        assert s.length == 22.0
+        assert (s.lo, s.hi) == (-11.0, 11.0)
+
+    def test_coaxial_blind_hole_does_not_extend_pocket(self):
+        # A blind pocket with a separate blind hole (radius = width/2) drilled from the far
+        # face, coaxial with one pocket end but at a different depth (solid material between),
+        # must NOT extend the pocket length — the cap's depth extent must match the slot's (#613 review).
+        part = Box(60, 30, 20) - Pos(0, 0, 4) * Box(22, 8, 12) - Pos(11.2, 0, -10) * Cylinder(4, 8)
+        (p,) = recognise_pockets(part)
+        assert p.length == 22.0
+
     def test_gap_between_bosses_is_not_a_slot(self):
         # The floored channel between two raised bosses has facing rectangular
         # walls but is not a cut slot — the floor (the base plate) rejects it.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7092,6 +7092,22 @@ class TestFindSlots:
         (p,) = recognise_pockets(part)
         assert p.length == 22.0
 
+    def test_coaxial_posts_at_both_ends_do_not_extend_length(self):
+        # Symmetric coaxial POSTS (added material, radius = width/2) protruding into both slot
+        # ends at the slot's own depth pass the radius/axis/centreline/depth checks — but they
+        # are CONVEX (material inside the cylinder), not concave void caps. The concavity test
+        # must reject them so the flat-ended slot is not extended (#613 2nd-pass review).
+        part = (
+            (Box(60, 30, 10) - Box(30, 8, 20))
+            + Pos(15, 0, 0) * Cylinder(4, 10)
+            + Pos(-15, 0, 0) * Cylinder(4, 10)
+        )
+        (s,) = recognise_slots(part)
+        assert (
+            s.length == 30.0
+        )  # the flat span, NOT 38 (would be if wrongly extended by the posts)
+        assert (s.lo, s.hi) == (-15.0, 15.0)
+
     def test_gap_between_bosses_is_not_a_slot(self):
         # The floored channel between two raised bosses has facing rectangular
         # walls but is not a cut slot — the floor (the base plate) rejects it.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7035,6 +7035,46 @@ class TestFindSlots:
         assert recognise_slots(part) == []
         assert recognise_pockets(part) == []
 
+    def test_obround_slot_reports_overall_length(self):
+        # A radiused-end (obround) slot's flat side walls stop at the straight portion; its
+        # length must be the OVERALL length (flat + width, the two semicircular ends), not the
+        # flat-wall span (#613). Overall 30, width 8 → flat walls span 22; report 30.
+        from build123d import Plane, SlotOverall, extrude
+
+        part = Box(60, 30, 10) - extrude(Plane.XY * SlotOverall(30, 8), 10, both=True)
+        (s,) = recognise_slots(part)
+        assert s.width == 8.0
+        assert s.length == 30.0
+        assert (s.lo, s.hi) == (-15.0, 15.0)
+
+    def test_obround_pocket_reports_overall_length(self):
+        # The blind counterpart — a floored obround pocket likewise reports overall length (#613).
+        from build123d import Plane, SlotOverall, extrude
+
+        part = Box(60, 30, 20) - Pos(0, 0, 5) * extrude(Plane.XY * SlotOverall(30, 8), 12)
+        (p,) = recognise_pockets(part)
+        assert p.length == 30.0
+
+    def test_rectangular_slot_length_is_unchanged(self):
+        # A rectangular slot has no semicircular end caps, so the overall extension is inert —
+        # its length is its flat span, already the overall length (#613 must not regress it).
+        (s,) = recognise_slots(Box(60, 30, 10) - Box(30, 8, 20))
+        assert s.length == 30.0
+
+    def test_recognise_matches_declare_on_obround_length(self):
+        # #613 also removes a recognise/declare divergence: declare.slot(obj) reads the overall
+        # length off the object bbox (30), while recognise used to report the flat span (22).
+        # After the fix both agree on the overall length.
+        from build123d import Plane, SlotOverall, extrude
+
+        from draftwright.model import slot as declare_slot
+
+        cutter = extrude(Plane.XY * SlotOverall(30, 8), 10)
+        part = Box(60, 30, 10) - extrude(Plane.XY * SlotOverall(30, 8), 20, both=True)
+        (s,) = recognise_slots(part)
+        declared = declare_slot(cutter, depth_axis="z")
+        assert s.length == declared.length == 30.0
+
     def test_gap_between_bosses_is_not_a_slot(self):
         # The floored channel between two raised bosses has facing rectangular
         # walls but is not a cut slot — the floor (the base plate) rejects it.


### PR DESCRIPTION
Closes #613

A radiused-end (obround) slot is recognised by pairing its two **flat side walls**, so its raw length stopped at the straight portion — a 30-overall × 8-wide slot reported `length = 22` (the flat span), dropping the two semicircular ends (each radius = width/2).

## Fix
`recognise_slots` / `recognise_pockets` now detect the semicircular **end caps** — cylinder faces of radius ≈ width/2 about the depth axis, on the slot centreline at an end — and extend `lo`/`hi` so `length` is the **overall** length. Rectangular slots have no such caps and are unchanged (`_END_RADIUS_TOL` is tight, so a filleted-corner rectangle isn't extended either).

## Also fixes a recognise/declare divergence
`declare.slot(obj)` already reads the overall length off the object bbox (30), while `recognise_slots` reported the flat span (22) — detected and declared slots **disagreed** on the same geometry (an ADR 0011 one-inventory concern). They now agree.

## Scope
Recogniser-only — **no record field, no emit/declare signature change** (`length`/`lo`/`hi` are already carried by every surface, so all-three-surfaces is satisfied by the corrected value). The end-radius R = width/2 is implied by the obround shape shown in the view (ISO practice); a separate R callout is out of scope.

## Tests
Obround through + blind pocket report overall length; rectangular slot unchanged; `recognise == declare` on the same obround. Full snapshot + slot suites green (no output regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)