### PR TITLE
fix(#622): anchor fillet leaders on the radius surface, not the bbox centre

### DIFF
--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -396,9 +396,9 @@ def chamfer(
 
 def _read_fillet_face(face) -> tuple[str, float, Point]:
     """Read a fillet off its **cylindrical blend face**: the axis (the edge the fillet runs
-    along), the radius (the cylinder radius), and a point **on the round** (the face centre —
-    the ``R`` leader's tip). Agrees with the recogniser (recognition/fillets.py) in the two
-    in-plane (placement) coordinates; the along-edge coordinate is view depth."""
+    along), the radius (the cylinder radius), and a point **on the round** (mid angular/axial of
+    the trimmed face — the ``R`` leader's tip). Agrees with the recogniser (recognition/fillets.py)
+    in the two in-plane (placement) coordinates; the along-edge coordinate is view depth."""
     from OCP.BRepAdaptor import BRepAdaptor_Surface
     from OCP.GeomAbs import GeomAbs_Cylinder
 
@@ -415,18 +415,20 @@ def _read_fillet_face(face) -> tuple[str, float, Point]:
             "fillet(face=...): the round must run along one principal axis; use axis=, radius=, at="
         )
     edge_i = max(range(3), key=lambda i: comp[i])
-    # The bbox centre of the face, NOT face.center() (the surface centroid): the recogniser
-    # anchors on the bbox centre (recognition/fillets.py), so this keeps a declared fillet's
-    # leader tip byte-identical to the detected one's in the two in-plane coordinates.
-    bb = face.bounding_box()
-    c = (0.5 * (bb.min.X + bb.max.X), 0.5 * (bb.min.Y + bb.max.Y), 0.5 * (bb.min.Z + bb.max.Z))
+    # Anchor on the curved radius surface itself — a point at the middle of the trimmed face's
+    # angular (U) and axial (V) parameter spans — NOT the bbox centre, which sits off the round
+    # near the virtual sharp corner (#622). Evaluated exactly as recognition/fillets.py does, so
+    # a declared fillet's leader tip is identical to the detected one's.
+    u_mid = 0.5 * (s.FirstUParameter() + s.LastUParameter())
+    v_mid = 0.5 * (s.FirstVParameter() + s.LastVParameter())
+    p = s.Value(u_mid, v_mid)
     return (
         "xyz"[edge_i],
         round(s.Cylinder().Radius(), 3),
         (
-            round(c[0], 4),
-            round(c[1], 4),
-            round(c[2], 4),
+            round(p.X(), 4),
+            round(p.Y(), 4),
+            round(p.Z(), 4),
         ),
     )
 

--- a/src/draftwright/recognition/fillets.py
+++ b/src/draftwright/recognition/fillets.py
@@ -144,7 +144,10 @@ def recognise_fillets(
         # off the surface (#622). Evaluate a point at the middle of the trimmed face's angular
         # (U) and axial (V) parameter spans; the adaptor's bounds are the FACE's trimmed range
         # (already gated below a full turn above), so a periodic seam is handled by using those
-        # bounds directly rather than the raw 0..2π surface range.
+        # bounds directly rather than the raw 0..2π surface range. On-face for the ordinary
+        # quarter-round edge blend (a UV-rectangular patch); a fillet whose UV region is punched
+        # by an interior hole through its centre could still land mid-UV in that void — rare, and
+        # no worse than the bbox centre it replaces (review).
         u_mid = 0.5 * (s.FirstUParameter() + s.LastUParameter())
         v_mid = 0.5 * (s.FirstVParameter() + s.LastVParameter())
         p = s.Value(u_mid, v_mid)

--- a/src/draftwright/recognition/fillets.py
+++ b/src/draftwright/recognition/fillets.py
@@ -139,11 +139,20 @@ def recognise_fillets(
         if clsf.State() == TopAbs_IN:
             continue  # concave corner — an internal round / slot-wall blend, not an edge fillet
 
+        # Anchor the leader on the curved radius surface itself, not the face bounding-box
+        # centre — that centre sits near the arc's centre of curvature / virtual sharp corner,
+        # off the surface (#622). Evaluate a point at the middle of the trimmed face's angular
+        # (U) and axial (V) parameter spans; the adaptor's bounds are the FACE's trimmed range
+        # (already gated below a full turn above), so a periodic seam is handled by using those
+        # bounds directly rather than the raw 0..2π surface range.
+        u_mid = 0.5 * (s.FirstUParameter() + s.LastUParameter())
+        v_mid = 0.5 * (s.FirstVParameter() + s.LastVParameter())
+        p = s.Value(u_mid, v_mid)
         out.append(
             Fillet(
                 axis="xyz"[edge_i],
                 radius=round(radius, 3),
-                at=(round(fc[0], 3), round(fc[1], 3), round(fc[2], 3)),
+                at=(round(p.X(), 3), round(p.Y(), 3), round(p.Z(), 3)),
             )
         )
     return sorted(out, key=lambda c: (c.axis, c.at))

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -430,10 +430,42 @@ class TestFillet:
         det = next(
             x for x in build_drawing(solid, number="X").model().features if x.kind == "fillet"
         )
-        # Exact in-plane parity: declare reads the same bbox-centre anchor the recogniser does
+        # Exact in-plane parity: declare reads the same on-round anchor the recogniser does — a
+        # point at mid angular/axial of the trimmed face (#622), not the off-surface bbox centre
         # (the along-edge Z coord is view depth, so it need not match).
         assert f.frame.origin[0] == pytest.approx(det.frame.origin[0], abs=0.01)
         assert f.frame.origin[1] == pytest.approx(det.frame.origin[1], abs=0.01)
+        from build123d import Vertex
+
+        assert Vertex(*f.frame.origin).distance_to(solid) < 0.05  # declared anchor on the round
+
+    def test_anchor_lies_on_the_radius_surface_not_the_virtual_corner(self):
+        # #622: the R leader must terminate on the curved radius surface, not the face bbox
+        # centre — which sits in the removed-wedge void near the arc's centre of curvature /
+        # virtual sharp corner, OFF the solid (~0.71R away). Cover X/Y/Z edge axes + off-origin,
+        # and the grouped case (every equal-R member anchored on its own round).
+        from build123d import Axis, Pos, Vertex
+        from build123d import fillet as bd_fillet
+
+        from draftwright.recognition import recognise_fillets
+
+        z = bd_fillet(Box(60, 40, 30).edges().filter_by(Axis.Z).sort_by(Axis.X)[-1], 5)
+        cases = {
+            "z": z,
+            "x": bd_fillet(Box(60, 40, 30).edges().filter_by(Axis.X).sort_by(Axis.Z)[-1], 5),
+            "y": bd_fillet(Box(60, 40, 30).edges().filter_by(Axis.Y).sort_by(Axis.Z)[-1], 5),
+            "off-origin": Pos(100, 50, 20) * z,
+        }
+        for label, part in cases.items():
+            (fl,) = recognise_fillets(part)
+            assert Vertex(*fl.at).distance_to(part) < 0.05, (
+                f"{label}: anchor off the round surface"
+            )
+        # grouped: all four vertical edges rounded → four members, each on its own round.
+        grouped = bd_fillet(Box(60, 40, 30).edges().filter_by(Axis.Z), 5)
+        members = recognise_fillets(grouped)
+        assert len(members) == 4
+        assert all(Vertex(*m.at).distance_to(grouped) < 0.05 for m in members)
 
     def test_recognises_external_fillet(self):
         dwg = build_drawing(self._filleted(3), number="X")


### PR DESCRIPTION
Closes #622

`recognise_fillets` stored the fillet face's **bounding-box centre** as the R-leader anchor. For a quarter-cylinder edge fillet that centre lies near the arc's centre of curvature / virtual sharp corner — **off the round** (~0.71R from the axis, not R), so the R callout points *inside* the corner rather than at the rounded surface.

## Fix
Evaluate an actual point **on the trimmed cylindrical surface**: the middle of the face's angular (U) and axial (V) parameter spans, `s.Value(u_mid, v_mid)`. The adaptor's bounds are the *face's* trimmed range (the recogniser already gates below a full turn), so a periodic seam is handled by using those bounds directly. `declare._read_fillet_face` gets the **same** evaluation — it previously deliberately mirrored the old bbox centre, so detected and declared fillets stay identical, now on the corrected on-round point.

## Tests
The anchor lies on the round (distance-to-solid ≈ 0, vs ~0.71R off for the bbox centre) across **X/Y/Z** edge axes, an **off-origin** part, and **every member of a grouped n× R** callout; declare's anchor matches and is on the round.

Recogniser + declare only; the anchor flows through `FilletFeature.frame` to `render_fillets` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)