### PR TITLE
fix(#628): count rendered groove callouts in axial-length coverage

### DIFF
--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -446,6 +446,14 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
         assembly = len(part.solids()) > 1
     n = len(prof.steps)
     covered = _axial_covered_from_drawing(part, dwg, prof)
+    # A groove band's axial extent is dimensioned by its width callout, not a step length, so
+    # detect.py leaves it out of the step-length chain (#606). Count each *rendered* groove-width
+    # callout on the turning axis as covering its band — so a fully-dimensioned grooved shaft
+    # (N−1 step lengths + the groove width) is not flagged (#628); a *dropped* groove callout
+    # leaves its band uncovered, so a genuine gap still fires (reconcile rendered, not intent).
+    covered += sum(
+        1 for name in getattr(dwg, "_named", {}) if name.startswith(f"m_groove_{prof.axis}")
+    )
     if covered >= n:
         return []
     return [

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8047,6 +8047,25 @@ class TestTurnedLengths:
         dwg = build_drawing(Box(80, 60, 20))
         assert not any(n.startswith("m_steplen") for n in dwg._named)
 
+    def test_grooved_shaft_step_chain_not_flagged_axial_missing(self):
+        # A groove band is excluded from the step-length chain (#606) and dimensioned by its
+        # WIDTH callout instead. The axial-coverage lint counts prof.steps (which still includes
+        # the groove band), so it must credit the rendered groove-width callout as covering that
+        # band — else an otherwise fully-dimensioned grooved shaft false-fires axial_length_missing
+        # (#628, a regression from the #606 groove exclusion).
+        from build123d import Cylinder, Pos
+
+        shaft = (
+            Pos(0, 0, 7.5) * Cylinder(30, 15)
+            + Pos(0, 0, 32) * Cylinder(20, 34)
+            + Pos(0, 0, 53) * Cylinder(13, 8)  # ø26 local-minimum band → recognised as a groove
+            + Pos(0, 0, 74) * Cylinder(20, 34)
+            + Pos(0, 0, 107) * Cylinder(14, 32)
+        ) - Pos(0, 0, 61.5) * Cylinder(8, 123)
+        dwg = build_drawing(shaft, number="X")
+        assert any(n.startswith("m_groove") for n in dwg._named)  # the ø26 band IS a groove
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
+
     def test_chain_skips_gracefully_when_no_room(self):
         # Forced onto a too-small page, the chain must SKIP rather than run off the
         # page edge (the parity guard the diameter row has). Lint then reports the


### PR DESCRIPTION
Closes #628

A **regression from the #606 groove work.** A groove band is a local-minimum OD band that `recognise_turned_steps` sees as a step, but `detect.py` excludes it from the step-length chain (#606) — the groove is dimensioned by its **width** callout instead. `lint_axial_coverage` still counts `n = len(prof.steps)` (including the groove band) against the placed step-length dims, so a **fully-dimensioned** grooved shaft (N−1 step lengths + the groove width) false-fired `axial_length_missing`.

Repro from the issue: a 5-step shaft with a ø26 groove band renders `15 / 34 / 34 / 32` step lengths + `8 WIDE × ø26` (the band's axial extent) — every shoulder is locatable — yet lint warned "5 steps but only 4 lengths."

## Fix
Credit each **rendered** groove-width callout on the turning axis as covering its band (**reconcile rendered, not intent** — the #632/#633 theme): a fully-dimensioned grooved shaft is no longer flagged, while a *dropped* groove callout leaves its band uncovered so a genuine gap still fires.

## Tests
The #628 5-step grooved shaft lints clean (and the ø26 band *is* recognised as a groove); a crowded under-dimensioned shaft still reports `axial_length_missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)