### PR TITLE
fix(#629): plan-view leader for a prismatic boss's ø (not the turned column)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -51,6 +51,7 @@ from draftwright.annotations._common import (
     Escalation,
     _anno_box,
     _box_hits,
+    _geom_box,
     carve_free_position,
     carve_free_segments,
     place_strip_candidates,
@@ -1216,6 +1217,81 @@ def render_grooves(dwg, model, a) -> int:
                 "warning",
                 "groove_dropped",
                 f"groove callout {label_str} not placed (no clear room)",
+            )
+    return n
+
+
+def render_boss_diameters(dwg, model, a) -> int:
+    """ø leaders for a PRISMATIC part's bosses (#629). A boss reads as a circle looking down its
+    axis, so its diameter is called out with a leader to that circle in the view normal to the
+    axis — a Z boss in the plan, X in the side, Y in the front — free to exit into clear margin
+    (``_ray_exit_dist``), like a pocket/groove.
+
+    A *turned* part keeps the diameter row/column (``render_diameters``): there the boss ø sits
+    in the OD stack. The turned column-left strip, applied to a prismatic boss, strands its ø
+    whenever that narrow strip is tight — dropping the callout even on a half-empty sheet (#629).
+    Run BEFORE ``render_diameters`` so a placed boss ø is 'mentioned' and not re-placed. A boss
+    whose ø a coincident feature already carries is skipped; an unplaceable one drops lint-visibly."""
+    if a.is_rotational or a.prof is not None:
+        # A turned profile means round stock — a band emitted as a boss (#298) belongs in the
+        # OD diameter row/column, not an end-on plan leader. Only true prismatic parts qualify.
+        return 0
+    draft = dwg.draft
+    view_of = {"z": "plan", "x": "side", "y": "front"}  # the view looking down the boss axis
+    bosses = [f for f in model.features if f.kind == "boss"]
+    mentioned = _mentioned_diameters(dwg)
+    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
+    reach = draft.font_size + 6 * draft.pad_around_text
+    n = 0
+    for bi, b in enumerate(sorted(bosses, key=lambda f: (f.frame.axis, f.frame.origin))):
+        dia = b.diameter
+        if any(abs(dia - m) <= 0.15 for m in mentioned):
+            continue  # a coincident bore / step already carries this ø
+        view = view_of.get(b.frame.axis)
+        if view is None:
+            continue
+        vb = dwg.view_bounds(view)
+        if vb is None:
+            continue
+        x0, y0, x1, y1 = vb
+        center = dwg.at(view, *b.frame.origin)
+        r_page = dia / 2 * a.SCALE  # the boss circle radius in page units
+        label_str = f"ø{_fmt(dia)}"
+        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+        placed = False
+        for dx, dy in _POCKET_LEAD_DIRS:
+            d = math.hypot(dx, dy)
+            ux, uy = dx / d, dy / d
+            arrow = (center[0] + ux * r_page, center[1] + uy * r_page)  # arrowhead on the rim
+            exit_d = _ray_exit_dist(center[0], center[1], ux, uy, (x0, y0, x1, y1))
+            elbow = (center[0] + ux * (exit_d + reach), center[1] + uy * (exit_d + reach), 0)
+            ldr = Leader(tip=(arrow[0], arrow[1], 0), elbow=elbow, label=label_str, draft=draft)
+            # _geom_box is the FULL footprint (shaft + arrow + label); the shaft is the invisible
+            # occupant a label-only box hides (#133/#305/#358), so it — not _anno_box — is what
+            # must clear the other callouts/witnesses. The silhouette/page checks use the label
+            # box, since the shaft legitimately starts at the boss rim inside the view.
+            geom = _geom_box(ldr)
+            label = getattr(ldr, "label_bbox", None) or geom
+            if (
+                geom is None
+                or label is None
+                or _box_hits(geom, obstacles)  # shaft or label crosses a callout/witness
+                or _box_hits(label, [(x0, y0, x1, y1)])  # label over the part silhouette
+                or label[0] < page[0]
+                or label[1] < page[1]
+                or label[2] > page[2]
+                or label[3] > page[3]
+            ):
+                continue
+            dwg.add(ldr, f"m_bossdia_{b.frame.axis}{bi}", view=view, feature=b)
+            n += 1
+            placed = True
+            break
+        if not placed:
+            dwg._record_build_issue(
+                "warning",
+                "boss_dia_dropped",
+                f"boss ø{_fmt(dia)} callout not placed (no clear room)",
             )
     return n
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -32,6 +32,7 @@ from draftwright._core import (
 from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import drain_corridors
 from draftwright.annotations.from_model import (
+    render_boss_diameters,
     render_centermarks,
     render_chamfers,
     render_diameters,
@@ -318,6 +319,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     #    (#223). A crowded X-turned head queues an enlarged detail request (#304/#307)
     #    instead of cramming; the envelope dim along the turning axis was suppressed
     #    so the chain does not double-dimension the length.
+    # Prismatic bosses get a plan-view ø leader BEFORE the turned row/column solve, which then
+    # sees the ø as 'mentioned' and skips it (#629 — the column-left strip strands a boss ø when
+    # tight, even on a half-empty sheet). No-op on turned parts (they keep the OD stack).
+    render_boss_diameters(dwg, _model, a)
     render_diameters(dwg, _groups)
     if a.prof is not None:
         render_step_lengths(dwg, _groups)

--- a/tests/layout_snapshots/dshape.json
+++ b/tests/layout_snapshots/dshape.json
@@ -74,6 +74,24 @@
     },
     {
       "geom_bbox": [
+        116.3,
+        94.7,
+        130.5,
+        104.7
+      ],
+      "label": "\u00f88",
+      "label_bbox": [
+        116.3,
+        102.5,
+        119.6,
+        104.7
+      ],
+      "name": "m_bossdia_x0",
+      "type": "Leader",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
         131.9,
         84.7,
         140.5,
@@ -84,24 +102,6 @@
       "name": "m_cm0",
       "type": "CenterMark",
       "view": "side"
-    },
-    {
-      "geom_bbox": [
-        75.1,
-        68.9,
-        82.7,
-        81.0
-      ],
-      "label": "\u00f88",
-      "label_bbox": [
-        75.1,
-        68.9,
-        78.4,
-        71.1
-      ],
-      "name": "m_dia_x0",
-      "type": "Leader",
-      "view": "front"
     },
     {
       "geom_bbox": [

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7896,6 +7896,51 @@ def _x_stepped_shaft():
     return Rotation(0, 90, 0) * (Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(8, 30))
 
 
+class TestPrismaticBossDiameter:
+    """#629: a boss on a PRISMATIC part gets its ø as a plan-view leader to the boss
+    circle (names ``m_bossdia_*``), free to exit into clear margin — not the turned
+    column-left strip (``m_dia_z``), which strands the ø when that narrow strip is
+    tight even on a half-empty sheet. Turned parts keep the OD-stack column."""
+
+    @staticmethod
+    def _box_boss():
+        return Box(90, 64, 38) + Pos(0, 0, 24) * Cylinder(14, 10)
+
+    @staticmethod
+    def _shelled_cover():
+        # The #629 report: a shelled cover whose front view hugs the left margin, so
+        # the column-left ø strip has no room and the boss ø28 was dropped.
+        return (
+            Box(90, 64, 38)
+            - Pos(0, 0, -3) * Box(84, 58, 38)
+            + Pos(0, 0, 24) * Cylinder(14, 10)
+            - Pos(0, 0, 15) * Cylinder(6, 40)
+        )
+
+    def test_prismatic_boss_diameter_is_a_plan_leader(self):
+        dwg = build_drawing(self._box_boss())
+        # the boss ø routes to the plan-view leader path, not the turned column
+        assert any(n.startswith("m_bossdia_") for n in dwg._named)
+        boss = next(o for n, o in dwg._named.items() if n.startswith("m_bossdia_"))
+        assert boss.label == "ø28"
+        # and it is not ALSO emitted by the turned column (no double-dimensioning)
+        assert not any(o.label == "ø28" for n, o in dwg._named.items() if n.startswith("m_dia_z"))
+
+    def test_shelled_cover_boss_diameter_not_dropped(self):
+        # The regression: even forced onto A4 (scale 0.5, front view against the left
+        # margin) the boss ø28 places into the clear sheet, so it never lints uncovered.
+        dwg = build_drawing(self._shelled_cover(), page="A4")
+        assert any(o.label == "ø28" for o in dwg._named.values() if getattr(o, "label", None))
+        assert dwg.lint_summary()["by_code"].get("feature_not_dimensioned", 0) == 0
+
+    def test_turned_part_boss_stays_in_the_column(self):
+        # A rotational shaft's step/OD diameters keep the m_dia column — render_boss_diameters
+        # is a prismatic-only pass and must not fire on a turned body.
+        dwg = build_drawing(Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(10, 30))
+        assert not any(n.startswith("m_bossdia_") for n in dwg._named)
+        assert any(n.startswith("m_dia_z") for n in dwg._named)
+
+
 class TestTurnedDiameters:
     """#77/#131: external turned diameters get ø leader callouts. Migrated onto the
     IR renderer (from_model.render_diameters, names ``m_dia_*``) — one path, row


### PR DESCRIPTION
## The bug (#629)

A boss on a **prismatic** part had its diameter routed through the turned `_diameter_column_left` strip — a fixed narrow zone just left of the front view. When the front view hugs the left margin that strip has no room, so the whole column returns 0 and the boss ø is **dropped even on a half-empty sheet**.

The reported shelled cover reproduced it exactly: ⌀28 silently missing (`feature_not_dimensioned`) at A2, A3 and a forced A4 — with the entire right half of the sheet empty. The "no room" was never real; the ø was confined to the wrong zone.

**Before → after (forced A4, scale 0.5):** ⌀28 goes from dropped to a clean plan-view leader pointing at the boss's outer circle, up into the clear space above the plan view. The ⌀12 THRU bore callout stays on the inner circle; they don't fight.

## The fix

New `render_boss_diameters` pass: for a genuinely prismatic part it calls out each boss ø with a leader to the boss circle in the view normal to its axis (Z→plan, X→side, Y→front), free to exit into clear margin like a pocket/groove. It runs **before** `render_diameters`, which then sees the ø as already *mentioned* and skips it — no double-dimensioning, no change to the turned path.

- **Gated to prismatic parts.** No-op when the part is rotational or has a turned profile — a turned shaft, and round stock where a band is emitted as a boss (#298), keep the OD row/column.
- **Invisible-occupant safe.** The leader is checked against its FULL footprint (`_geom_box`, incl. the diagonal shaft), not the label box — so it can never overprint another callout/witness (#133/#305/#358). A label-only check let the shaft cross a side-hole callout on the `dshape` fixture; the full-footprint check tries other directions and finds a clear one (or drops lint-visibly).

## Tests

- New `TestPrismaticBossDiameter`: plan-leader placement + no double-dim; the shelled cover's ⌀28 not dropped even forced to A4; turned parts untouched (stay in the column).
- `dshape` layout snapshot re-blessed — the only corpus drift is the boss rename `m_dia_x0` → `m_bossdia_x0` and its reposition.
- Full fast tier: **1345 passed, 4 skipped, 0 failures**. All 4 lint checks clean.

## Scope note

This fixes the **auto-pass** drop (the reported bug). The ADR 0012 `finalize()` recompose preserves the plan-leader boss ø (verified — no drop, no double), so no divergence in the common path. Routing an explicit `callout(prismatic_boss)` edit through the plan-leader instead of the column is a possible follow-up, not needed for #629.

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)