### PR TITLE
fix(#629): thread planned diameter tolerance into boss ø callout

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1221,11 +1221,14 @@ def render_grooves(dwg, model, a) -> int:
     return n
 
 
-def render_boss_diameters(dwg, model, a) -> int:
+def render_boss_diameters(dwg, groups, a) -> int:
     """ø leaders for a PRISMATIC part's bosses (#629). A boss reads as a circle looking down its
     axis, so its diameter is called out with a leader to that circle in the view normal to the
     axis — a Z boss in the plan, X in the side, Y in the front — free to exit into clear margin
     (``_ray_exit_dist``), like a pocket/groove.
+
+    The ⌀ + its tolerance/fit come from the planner's ``DimParameter`` (as in ``render_diameters``),
+    never raw geometry — formatting ``b.diameter`` directly dropped an authored diameter tolerance.
 
     A *turned* part keeps the diameter row/column (``render_diameters``): there the boss ø sits
     in the OD stack. The turned column-left strip, applied to a prismatic boss, strands its ø
@@ -1238,13 +1241,20 @@ def render_boss_diameters(dwg, model, a) -> int:
         return 0
     draft = dwg.draft
     view_of = {"z": "plan", "x": "side", "y": "front"}  # the view looking down the boss axis
-    bosses = [f for f in model.features if f.kind == "boss"]
+    boss_groups = [g for g in groups if g.feature_kind == "boss"]
     mentioned = _mentioned_diameters(dwg)
     page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
     reach = draft.font_size + 6 * draft.pad_around_text
     n = 0
-    for bi, b in enumerate(sorted(bosses, key=lambda f: (f.frame.axis, f.frame.origin))):
-        dia = b.diameter
+    for bi, g in enumerate(
+        sorted(boss_groups, key=lambda g: (g.feature.frame.axis, g.feature.frame.origin))
+    ):
+        b = g.feature
+        dpd = next((pd for pd in g.dims if pd.param.kind == "diameter"), None)
+        if dpd is None:
+            continue
+        dia = dpd.param.value
+        dtol = dpd.param.tolerance
         if any(abs(dia - m) <= 0.15 for m in mentioned):
             continue  # a coincident bore / step already carries this ø
         view = view_of.get(b.frame.axis)
@@ -1256,7 +1266,7 @@ def render_boss_diameters(dwg, model, a) -> int:
         x0, y0, x1, y1 = vb
         center = dwg.at(view, *b.frame.origin)
         r_page = dia / 2 * a.SCALE  # the boss circle radius in page units
-        label_str = f"ø{_fmt(dia)}"
+        label_str = f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}"
         obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
         placed = False
         for dx, dy in _POCKET_LEAD_DIRS:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -322,7 +322,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Prismatic bosses get a plan-view ø leader BEFORE the turned row/column solve, which then
     # sees the ø as 'mentioned' and skips it (#629 — the column-left strip strands a boss ø when
     # tight, even on a half-empty sheet). No-op on turned parts (they keep the OD stack).
-    render_boss_diameters(dwg, _model, a)
+    render_boss_diameters(dwg, _groups, a)
     render_diameters(dwg, _groups)
     if a.prof is not None:
         render_step_lengths(dwg, _groups)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7933,6 +7933,18 @@ class TestPrismaticBossDiameter:
         assert any(o.label == "ø28" for o in dwg._named.values() if getattr(o, "label", None))
         assert dwg.lint_summary()["by_code"].get("feature_not_dimensioned", 0) == 0
 
+    def test_boss_diameter_carries_authored_tolerance(self):
+        # The pass must consume the planner's DimParameter (value + tolerance/fit), not raw
+        # geometry — formatting b.diameter directly dropped an authored ⌀ tolerance, and then
+        # blocked render_diameters via `mentioned`, losing it silently (gpt-5.6-sol review).
+        from draftwright import Sheet
+
+        s = Sheet.from_part(Box(90, 64, 38) + Pos(0, 0, 24) * Cylinder(14, 10))
+        s.of(Pos(0, 0, 24) * Cylinder(14, 10)).tolerance(0.0, 0.1)  # tolerance the boss ⌀28
+        dwg = s.build()
+        labels = [o.label for n, o in dwg._named.items() if n.startswith("m_bossdia_")]
+        assert labels and any("0.1" in str(lbl) for lbl in labels), labels
+
     def test_turned_part_boss_stays_in_the_column(self):
         # A rotational shaft's step/OD diameters keep the m_dia column — render_boss_diameters
         # is a prismatic-only pass and must not fire on a turned body.


### PR DESCRIPTION
## Problem

A Codex `gpt-5.6-sol` (xhigh) adversarial review of the merged #629 fix (PR #643)
found a regression: `render_boss_diameters` formatted a prismatic boss's ø leader
as `ø{_fmt(dia)}` **directly from raw geometry** (`b.diameter`), dropping any
user-authored diameter **tolerance** or **fit-class**. Worse, the callout still
recorded its diameter in `_mentioned_diameters`, so the downstream
`render_diameters` pass — which *would* have emitted the tolerance — skipped it as
already-mentioned. The tolerance disappeared entirely.

## Fix

Consume the planner's `DimParameter` instead of raw geometry, mirroring
`render_diameters`:

- Iterate the boss `DimensionGroup`s, read `dia = param.value` and
  `dtol = param.tolerance` off each group's diameter `DimParameter`.
- Format the label with `_tol_suffix(dtol, draft)` (tolerance **and** fit-class
  ride the same field).
- A boss with no authored tolerance is unchanged: `_tol_suffix(None, …)` → `""`.

Signature changes `render_boss_diameters(dwg, model, a)` →
`(dwg, groups, a)`; the orchestrator already holds `_groups` at the call site.

This is the ADR 0008 "consume render-intents, not raw geometry" principle applied
to the one pass that had regressed from it.

## Test

`test_boss_diameter_carries_authored_tolerance` — a `Sheet` boss with
`.tolerance(0.0, 0.1)` now emits a `m_bossdia_*` label carrying `0.1`.

## Scope

Surgical: 3 files, +28 −6. No-op for bosses without an authored tolerance.

Follow-up to #629 / #643. Unrelated pre-existing suite flake tracked in #644.