### PR TITLE
refactor(#637): one leader-callout pass; name the magic constants; dedup helpers

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import math
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -133,7 +134,38 @@ def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> floa
     )
 
 
+# Cheap mean glyph advance as a fraction of the em (font size), for label-width ESTIMATES in
+# the diameter row/column capacity checks. Plex Mono is monospaced at ~0.6 em, padded a touch.
+# The exact metric is `_text_width()` above (measured per string), which the corridor/label
+# placers use; these capacity gates only need a close bound, not the metric, so they trade
+# exactness for not rasterising a text layout per candidate. The two may diverge for unusually
+# wide/narrow glyph runs.
+_EST_CHAR_WIDTH_EM = 0.62
+
+
 _CONCENTRIC_TOL_MM = 0.5
+
+
+def _first_free_index(prefix: str, taken) -> int:
+    """The lowest ``j`` for which ``f"{prefix}{j}"`` is not in *taken* (a set or any container
+    supporting ``in``). The shared kernel of the first-free annotation-name allocators
+    (``_loc_name``/``_uniq``/``_hc_name``) — used where reusing a freed gap is fine. NOTE: the
+    step-length / diameter runs deliberately use ``max+1`` instead (``_next_start`` /
+    ``_next_steplen_start``), because a contiguous run started at a gap below an occupied index
+    would wrap onto it (#432); don't fold those onto this."""
+    j = 0
+    while f"{prefix}{j}" in taken:
+        j += 1
+    return j
+
+
+def _concentric_with_axis(a, x: float, y: float) -> bool:
+    """True when the page/world point ``(x, y)`` lies on the rotational part's turned axis
+    (within :data:`_CONCENTRIC_TOL_MM`). A bore/pattern centred on the axis needs no location
+    dim — its position is the axis — so several passes filter such refs; this is the single
+    radial test they share (the perpendicular-plane distance to the axis centre ``(a.cx,
+    a.cy)``). Callers still gate on ``a.is_rotational`` / role / axis as their context needs."""
+    return math.hypot(x - a.cx, y - a.cy) <= _CONCENTRIC_TOL_MM
 
 
 def _dim(p1, p2, side, distance, draft, **kwargs):
@@ -159,6 +191,9 @@ def _dim(p1, p2, side, distance, draft, **kwargs):
 # extension-line origins) and subsequent parallel lines stack tighter and uniform (#347).
 _STRIP_GAP = 10.0  # clearance between the view outline and the first dimension line
 _STRIP_SPACING = 2.5  # clear gap between successive parallel dimension lines (beyond the label)
+# Small lift (page-mm) of an overall/envelope witness line off the projected silhouette edge,
+# so its extension line reads as distinct from the outline rather than sitting on top of it.
+_WITNESS_LIFT_MM = 2.0
 
 
 @dataclass

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -24,17 +24,20 @@ from build123d_drafting import DatumFeature, FeatureControlFrame, SurfaceFinish,
 from build123d_drafting.helpers import Centerline, CenterMark, HoleCallout, Leader, TitleBlock
 
 from draftwright._core import (
-    _CONCENTRIC_TOL_MM,
     _DIAM_RE,
     _END_ON,
+    _EST_CHAR_WIDTH_EM,
     _MARGIN,
     _MIN_STEP_SEP_MM,
     _SLOT_DIM_DEPTH,
     _SLOT_DIM_HEIGHT,
     _SLOT_DIM_STEP,
     _SLOT_DIM_WIDTH,
+    _WITNESS_LIFT_MM,
     DetailRequest,
+    _concentric_with_axis,
     _dim,
+    _first_free_index,
     _fmt,
     _greedy_strip_ys,
     _iso_bbox,
@@ -372,6 +375,11 @@ _LOC_SUBCHAIN = 1
 _OVERALL_SUBCHAIN = 2
 _MANDATORY_OVERALL_PRIORITY = 100.0
 
+# Minimum half of a bore's PAGE-projected diameter (mm) for its ø dim to fit across the circle
+# in-plane; below this the circle is too small to letter inside, so the callout leaders out
+# instead. Applied per bore-axis view (plan/side/front).
+_MIN_INPLACE_BORE_HALF_MM = 4.0
+
 
 def _location_candidate(
     dwg,
@@ -451,11 +459,7 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
         # centreline, not a position dim (matches the engine's feature_holes
         # filter). A pattern ref (role "location_pattern" — e.g. a bolt-circle
         # centre) is NOT filtered, even on the axis.
-        if (
-            pd.param.role == "location"
-            and a.is_rotational
-            and math.hypot(rx - a.cx, ry - a.cy) <= _CONCENTRIC_TOL_MM
-        ):
+        if pd.param.role == "location" and a.is_rotational and _concentric_with_axis(a, rx, ry):
             continue
         refs.append((rx, ry, pd.feature))  # carry the source feature for provenance (ADR 0010)
     if not refs:
@@ -473,11 +477,9 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
     def _loc_name(prefix: str, i: int) -> str:
         if _loc_used is None:
             return f"{prefix}{i}"  # auto-pass: unchanged, byte-identical
-        j = 0
-        while f"{prefix}{j}" in _loc_used:
-            j += 1
-        _loc_used.add(f"{prefix}{j}")
-        return f"{prefix}{j}"
+        name = f"{prefix}{_first_free_index(prefix, _loc_used)}"
+        _loc_used.add(name)
+        return name
 
     # --- X locations: tier above the plan view ---
     PX, PY = a.proj.plan_x, a.proj.plan_y
@@ -686,7 +688,7 @@ def _diameter_row_below(dwg, items, start: int = 0) -> int:
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
         specs.append((tip, dia, f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}", feat))
-    half_w = max(len(label) for _, _, label, _ in specs) * draft.font_size * 0.62 / 2
+    half_w = max(len(label) for _, _, label, _ in specs) * draft.font_size * _EST_CHAR_WIDTH_EM / 2
     min_gap = 2 * half_w + 2 * draft.pad_around_text
     # Place what fits; drop the smallest ø first, never the whole row (#298).
     survivors, xs = _place_what_fits(specs, 0, min_gap, fx0 + half_w, fx1 - half_w)
@@ -712,7 +714,7 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
     label_w = (
         max(len(f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}") for _, dia, _, dtol in items)
         * draft.font_size
-        * 0.62
+        * _EST_CHAR_WIDTH_EM
     )
     elbow_x = fx0 - (draft.font_size + 2 * draft.pad_around_text)
     if elbow_x - label_w < _MARGIN:
@@ -1384,7 +1386,7 @@ def render_envelope(dwg, groups, a) -> int:
     if env_dim_placed(width):
         (x0, y0, z0), (x1, _, _) = width.param.span
         p1, p2 = dwg.at("plan", x0, y0, z0), dwg.at("plan", x1, y0, z0)
-        witness = p1[1] - 2
+        witness = p1[1] - _WITNESS_LIFT_MM
         _queue(
             "m_env_width",
             a.pv_zones.below,
@@ -1405,7 +1407,7 @@ def render_envelope(dwg, groups, a) -> int:
     if env_dim_placed(depth):
         (x0, y0, z0), (_, y1, _) = depth.param.span
         p1, p2 = dwg.at("side", x0, y0, z0), dwg.at("side", x0, y1, z0)
-        witness = p1[1] - 2
+        witness = p1[1] - _WITNESS_LIFT_MM
         _queue(
             "m_env_depth",
             a.sv_zones.below,
@@ -1483,7 +1485,7 @@ def _draw_step_chain(
         tiers = [0] * len(segs)
         if horizontal:
             cw = [
-                ((pa[0] + pb[0]) / 2, len(_fmt(v)) * draft.font_size * 0.62)
+                ((pa[0] + pb[0]) / 2, len(_fmt(v)) * draft.font_size * _EST_CHAR_WIDTH_EM)
                 for pa, pb, v, *_ in segs
             ]
 
@@ -2354,7 +2356,7 @@ def render_pmi(dwg, model, a) -> int:
 
             if bore_axis == "Z":
                 # Z-axis bore: circle visible in plan view.
-                if half_pg >= 4.0:
+                if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
                     p1 = (PX(cx_f - half), PY(cy_f), 0)
                     p2 = (PX(cx_f + half), PY(cy_f), 0)
                     placed = _queue_options(
@@ -2393,7 +2395,7 @@ def render_pmi(dwg, model, a) -> int:
 
             elif bore_axis == "X":
                 # X-axis bore: circle visible in side view.
-                if half_pg >= 4.0:
+                if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
                     p1 = (SX(cy_f - half), SZ(cz_f), 0)
                     p2 = (SX(cy_f + half), SZ(cz_f), 0)
                     placed = _queue_options(
@@ -2432,7 +2434,7 @@ def render_pmi(dwg, model, a) -> int:
 
             elif bore_axis == "Y":
                 # Y-axis bore: circle visible in front view as a circle.
-                if half_pg >= 4.0:
+                if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
                     p1 = (FX(cx_f - half), FZ(cz_f), 0)
                     p2 = (FX(cx_f + half), FZ(cz_f), 0)
                     placed = _queue_options(

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -871,16 +871,90 @@ def _chamfer_label(ch) -> str:
     return f"{_fmt(ch.leg1)} × {_fmt(ch.angle)}°"
 
 
+# ── Shared machined-feature leader-callout pass (#637) ──────────────────────────────────
+# render_chamfers/_fillets/_flats/_pockets/_grooves were the same function five times: pick
+# the view an edge/face reads in, lead a diagonal Leader out to a label, and keep it only if
+# the LABEL lands in clear margin. They now share one pass and differ only in their label,
+# their tip/lead geometry (corner-diagonal vs mid-face radial), and their view map — a sixth
+# feature kind is a new thin adapter (or a table row), never a sixth copy.
+
+
+def _leader_callout_reach(draft) -> float:
+    """Outward leader length past the tip (label→elbow) for a machined-feature callout: one
+    line height plus six text-pads. Shared so all five callout passes reach the same distance
+    into the margin."""
+    return float(draft.font_size + 6 * draft.pad_around_text)
+
+
+def _label_lands_clear(ldr, obstacles, silhouette, page) -> bool:
+    """True when a leader's LABEL box sits in clear margin: off other annotations
+    (*obstacles*), off the part *silhouette* (the leader line may cross into the view, its
+    text may not), and inside the *page* margin box. The single accept test the five callout
+    passes share (was the identical six-line guard, copied five times)."""
+    label = getattr(ldr, "label_bbox", None) or _anno_box(ldr)
+    if label is None:
+        return False
+    return not (
+        _box_hits(label, obstacles)
+        or _box_hits(label, [silhouette])
+        or label[0] < page[0]
+        or label[1] < page[1]
+        or label[2] > page[2]
+        or label[3] > page[3]
+    )
+
+
+def _corner_candidates(dwg, view, vb, members, reach):
+    """Lead candidates for a corner-sitting feature (chamfer/fillet/flat): from each member's
+    projected origin, a diagonal from the view centre out through the corner, *reach* beyond
+    the tip — a corner clears the silhouette this way. Yields ``(tip, elbow, member)`` in the
+    given member order (nearest-clear wins in the pass); a single-feature callout passes a
+    one-element *members*."""
+    x0, y0, x1, y1 = vb
+    cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
+    for m in members:
+        tip = dwg.at(view, *m.frame.origin)
+        dx, dy = tip[0] - cx, tip[1] - cy
+        d = math.hypot(dx, dy) or 1.0
+        elbow = (tip[0] + dx / d * reach, tip[1] + dy / d * reach, 0)
+        yield (tip, elbow, m)
+
+
+def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code) -> int:
+    """Place one machined-feature leader callout per job (#637). A *job* is
+    ``(name, view, vb, label, candidates)`` where *candidates* yields ``(tip, elbow,
+    feature)`` lead positions to try in order. Places the first Leader whose label lands clear
+    (:func:`_label_lands_clear`), attributed to that candidate's feature; if none of a job's
+    candidates land, records ``<noun> callout … not placed`` as ``<drop_code>`` lint (never a
+    silent drop). Obstacles are recomputed per job so a callout placed earlier is avoided.
+    Returns the count placed."""
+    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
+    n = 0
+    for name, view, vb, label, candidates in jobs:
+        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+        for tip, elbow, feature in candidates:
+            ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label, draft=dwg.draft)
+            if _label_lands_clear(ldr, obstacles, vb, page):
+                dwg.add(ldr, name, view=view, feature=feature)
+                n += 1
+                break
+        else:
+            dwg._record_build_issue(
+                "warning", drop_code, f"{noun} callout {label} not placed (no clear room)"
+            )
+    return n
+
+
 def render_chamfers(dwg, model, a) -> int:
     """Chamfer callouts (#560): a leader from each recognised chamfer face to its
     ``C{leg}`` / ``{leg}×{angle}°`` label, in the view normal to the chamfered edge (a Z
     edge reads in the plan, an X edge in the side, a Y edge in the front). The leader runs
     diagonally OUT of the corner the chamfer sits on into clear margin, and is dropped
     (lint, not silently) if it would overprint placed geometry. Returns the count placed."""
-    draft = dwg.draft
+    reach = _leader_callout_reach(dwg.draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
     chamfers = [f for f in model.features if f.kind == "chamfer"]
-    n = 0
+    jobs = []
     for i, ch in enumerate(sorted(chamfers, key=lambda f: (f.axis, f.frame.origin))):
         view = view_of.get(ch.axis)
         if view is None:
@@ -888,43 +962,16 @@ def render_chamfers(dwg, model, a) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
-        x0, y0, x1, y1 = vb
-        ox, oy, oz = ch.frame.origin
-        tip = dwg.at(view, ox, oy, oz)
-        # Lead diagonally outward from the view centre through the chamfer corner into
-        # the margin; a chamfer sits on a corner, so this clears the part silhouette.
-        cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
-        dx, dy = tip[0] - cx, tip[1] - cy
-        d = math.hypot(dx, dy) or 1.0
-        reach = draft.font_size + 6 * draft.pad_around_text
-        elbow = (tip[0] + dx / d * reach, tip[1] + dy / d * reach, 0)
-        ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=_chamfer_label(ch), draft=draft)
-        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-        # The LABEL must land in clear margin: outside the view silhouette (a leader may
-        # cross into the view but its text must not sit over the part), off other
-        # annotations, and on-page. Checked on the label box, not the whole leader.
-        label = getattr(ldr, "label_bbox", None) or _anno_box(ldr)
-        page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
-        if (
-            label is None
-            or _box_hits(label, obstacles)
-            or _box_hits(label, [(x0, y0, x1, y1)])  # over the part silhouette
-            or (
-                label[0] < page[0]
-                or label[1] < page[1]
-                or label[2] > page[2]
-                or label[3] > page[3]
+        jobs.append(
+            (
+                f"m_chamfer_{ch.axis}{i}",
+                view,
+                vb,
+                _chamfer_label(ch),
+                _corner_candidates(dwg, view, vb, [ch], reach),
             )
-        ):
-            dwg._record_build_issue(
-                "warning",
-                "chamfer_dropped",
-                f"chamfer callout {_chamfer_label(ch)} not placed (no clear room)",
-            )
-            continue
-        dwg.add(ldr, f"m_chamfer_{ch.axis}{i}", view=view, feature=ch)
-        n += 1
-    return n
+        )
+    return _leader_callout_pass(dwg, a, jobs, noun="chamfer", drop_code="chamfer_dropped")
 
 
 def _fillet_label(radius, count) -> str:
@@ -940,14 +987,13 @@ def render_fillets(dwg, model, a) -> int:
     the same edge axis share ONE ``n× R`` callout (#561 acceptance), placed in the view
     normal to the rounded edge, led diagonally out of the corner into clear margin, and
     dropped (lint, not silently) if it would overprint placed geometry. Returns the count."""
-    draft = dwg.draft
+    reach = _leader_callout_reach(dwg.draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
     fillets = [f for f in model.features if f.kind == "fillet"]
     groups: dict = {}
     for fl in fillets:
         groups.setdefault((fl.axis, round(fl.radius, 3)), []).append(fl)
-    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
-    n = 0
+    jobs = []
     for gi, ((axis, radius), members) in enumerate(sorted(groups.items())):
         view = view_of.get(axis)
         if view is None:
@@ -955,44 +1001,20 @@ def render_fillets(dwg, model, a) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
-        x0, y0, x1, y1 = vb
-        cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
-        label_str = _fillet_label(radius, len(members))
-        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-        # One grouped ``n× R`` callout, but its leader may anchor at ANY of the equal
-        # fillets — try each corner (nearest-to-clear-margin first) until the label lands
-        # in clear room, so the group is not dropped just because its first corner leads
-        # into an occupied region (a neighbouring view / dim strip).
-        reach = draft.font_size + 6 * draft.pad_around_text
-        placed = False
-        for fl in sorted(members, key=lambda f: f.frame.origin):
-            tip = dwg.at(view, *fl.frame.origin)
-            dx, dy = tip[0] - cx, tip[1] - cy
-            d = math.hypot(dx, dy) or 1.0
-            elbow = (tip[0] + dx / d * reach, tip[1] + dy / d * reach, 0)
-            ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label_str, draft=draft)
-            label = getattr(ldr, "label_bbox", None) or _anno_box(ldr)
-            if (
-                label is None
-                or _box_hits(label, obstacles)
-                or _box_hits(label, [(x0, y0, x1, y1)])  # over the part silhouette
-                or label[0] < page[0]
-                or label[1] < page[1]
-                or label[2] > page[2]
-                or label[3] > page[3]
-            ):
-                continue
-            dwg.add(ldr, f"m_fillet_{axis}{gi}", view=view, feature=fl)
-            n += 1
-            placed = True
-            break
-        if not placed:
-            dwg._record_build_issue(
-                "warning",
-                "fillet_dropped",
-                f"fillet callout {label_str} not placed (no clear room)",
+        # One grouped ``n× R`` callout, but its leader may anchor at ANY of the equal fillets
+        # — _corner_candidates tries each corner (nearest-clear first) so the group is not
+        # dropped just because its first corner leads into an occupied region.
+        ordered = sorted(members, key=lambda f: f.frame.origin)
+        jobs.append(
+            (
+                f"m_fillet_{axis}{gi}",
+                view,
+                vb,
+                _fillet_label(radius, len(members)),
+                _corner_candidates(dwg, view, vb, ordered, reach),
             )
-    return n
+        )
+    return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped")
 
 
 def _flat_label(across) -> str:
@@ -1008,14 +1030,13 @@ def render_flats(dwg, model, a) -> int:
     Flats sharing an axis and across-flats size — the faces of a double-D or hex — share ONE
     callout. The leader runs diagonally out of the flat into clear margin, and is dropped
     (lint, not silently) if it would overprint placed geometry. Returns the count placed."""
-    draft = dwg.draft
+    reach = _leader_callout_reach(dwg.draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
     flats = [f for f in model.features if f.kind == "flat"]
     groups: dict = {}
     for fl in flats:
         groups.setdefault((fl.axis, round(fl.across, 3)), []).append(fl)
-    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
-    n = 0
+    jobs = []
     for gi, ((axis, across), members) in enumerate(sorted(groups.items())):
         view = view_of.get(axis)
         if view is None:
@@ -1023,40 +1044,17 @@ def render_flats(dwg, model, a) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
-        x0, y0, x1, y1 = vb
-        cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
-        label_str = _flat_label(across)
-        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-        reach = draft.font_size + 6 * draft.pad_around_text
-        placed = False
-        for fl in sorted(members, key=lambda f: f.frame.origin):
-            tip = dwg.at(view, *fl.frame.origin)
-            dx, dy = tip[0] - cx, tip[1] - cy
-            d = math.hypot(dx, dy) or 1.0
-            elbow = (tip[0] + dx / d * reach, tip[1] + dy / d * reach, 0)
-            ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label_str, draft=draft)
-            label = getattr(ldr, "label_bbox", None) or _anno_box(ldr)
-            if (
-                label is None
-                or _box_hits(label, obstacles)
-                or _box_hits(label, [(x0, y0, x1, y1)])  # over the part silhouette
-                or label[0] < page[0]
-                or label[1] < page[1]
-                or label[2] > page[2]
-                or label[3] > page[3]
-            ):
-                continue
-            dwg.add(ldr, f"m_flat_{axis}{gi}", view=view, feature=fl)
-            n += 1
-            placed = True
-            break
-        if not placed:
-            dwg._record_build_issue(
-                "warning",
-                "flat_dropped",
-                f"flat callout {label_str} not placed (no clear room)",
+        ordered = sorted(members, key=lambda f: f.frame.origin)
+        jobs.append(
+            (
+                f"m_flat_{axis}{gi}",
+                view,
+                vb,
+                _flat_label(across),
+                _corner_candidates(dwg, view, vb, ordered, reach),
             )
-    return n
+        )
+    return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped")
 
 
 def _groove_label(width, diameter) -> str:
@@ -1106,6 +1104,22 @@ _POCKET_LEAD_DIRS = (
 )
 
 
+def _radial_candidates(dwg, view, vb, feature, reach):
+    """Lead candidates for a mid-face feature (pocket/groove): from the feature's projected
+    origin, one candidate per :data:`_POCKET_LEAD_DIRS` direction — exit the silhouette along
+    it (:func:`_ray_exit_dist`) then *reach* on into the margin, so even a centre-of-view
+    feature clears the part. Yields ``(tip, elbow, feature)`` (same feature each time;
+    nearest-clear wins in the pass)."""
+    x0, y0, x1, y1 = vb
+    tip = dwg.at(view, *feature.frame.origin)
+    for dx, dy in _POCKET_LEAD_DIRS:
+        d = math.hypot(dx, dy)
+        ux, uy = dx / d, dy / d
+        exit_d = _ray_exit_dist(tip[0], tip[1], ux, uy, (x0, y0, x1, y1))
+        elbow = (tip[0] + ux * (exit_d + reach), tip[1] + uy * (exit_d + reach), 0)
+        yield (tip, elbow, feature)
+
+
 def render_pockets(dwg, model, a) -> int:
     """Blind-recess callouts (#148a): a leader from each floored slot/pocket to its
     ``W × L × D DEEP`` label, in the view normal to the recess opening (a Z-depth pocket
@@ -1113,12 +1127,10 @@ def render_pockets(dwg, model, a) -> int:
     mid-face, so — unlike a corner chamfer — the leader is tried toward each margin
     direction (nearest clear wins) and the callout is dropped (lint, not silently) if none
     lands in clear room. Returns the count placed."""
-    draft = dwg.draft
+    reach = _leader_callout_reach(dwg.draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
     pockets = [f for f in model.features if f.kind == "pocket"]
-    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
-    reach = draft.font_size + 6 * draft.pad_around_text
-    n = 0
+    jobs = []
     for i, pk in enumerate(sorted(pockets, key=lambda f: (f.width_axis, f.frame.origin))):
         view = view_of.get(pk.depth_axis)
         if view is None:
@@ -1126,41 +1138,16 @@ def render_pockets(dwg, model, a) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
-        x0, y0, x1, y1 = vb
-        tip = dwg.at(view, *pk.frame.origin)
-        label_str = _pocket_label(pk)
-        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-        placed = False
-        for dx, dy in _POCKET_LEAD_DIRS:
-            d = math.hypot(dx, dy)
-            ux, uy = dx / d, dy / d
-            # Exit the view silhouette along this direction, then reach on into the margin —
-            # so the label clears the part even for a pocket at the view centre.
-            exit_d = _ray_exit_dist(tip[0], tip[1], ux, uy, (x0, y0, x1, y1))
-            elbow = (tip[0] + ux * (exit_d + reach), tip[1] + uy * (exit_d + reach), 0)
-            ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label_str, draft=draft)
-            label = getattr(ldr, "label_bbox", None) or _anno_box(ldr)
-            if (
-                label is None
-                or _box_hits(label, obstacles)
-                or _box_hits(label, [(x0, y0, x1, y1)])  # over the part silhouette
-                or label[0] < page[0]
-                or label[1] < page[1]
-                or label[2] > page[2]
-                or label[3] > page[3]
-            ):
-                continue
-            dwg.add(ldr, f"m_pocket_{pk.width_axis}{pk.long_axis}{i}", view=view, feature=pk)
-            n += 1
-            placed = True
-            break
-        if not placed:
-            dwg._record_build_issue(
-                "warning",
-                "pocket_dropped",
-                f"pocket callout {label_str} not placed (no clear room)",
+        jobs.append(
+            (
+                f"m_pocket_{pk.width_axis}{pk.long_axis}{i}",
+                view,
+                vb,
+                _pocket_label(pk),
+                _radial_candidates(dwg, view, vb, pk, reach),
             )
-    return n
+        )
+    return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped")
 
 
 def render_grooves(dwg, model, a) -> int:
@@ -1173,12 +1160,10 @@ def render_grooves(dwg, model, a) -> int:
     dimensioned). The groove sits on the axis, so the leader exits the silhouette
     (``_ray_exit_dist``) toward each margin (nearest clear wins) and is dropped (lint, not
     silently) if none lands clear. Returns the count placed."""
-    draft = dwg.draft
+    reach = _leader_callout_reach(dwg.draft)
     view_of = {"z": "front", "x": "front", "y": "side"}
     grooves = [f for f in model.features if f.kind == "groove"]
-    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
-    reach = draft.font_size + 6 * draft.pad_around_text
-    n = 0
+    jobs = []
     for gi, gr in enumerate(sorted(grooves, key=lambda f: (f.axis, f.frame.origin))):
         view = view_of.get(gr.axis)
         if view is None:
@@ -1186,39 +1171,16 @@ def render_grooves(dwg, model, a) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
-        x0, y0, x1, y1 = vb
-        label_str = _groove_label(gr.width, gr.diameter)
-        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-        tip = dwg.at(view, *gr.frame.origin)
-        placed = False
-        for dx, dy in _POCKET_LEAD_DIRS:
-            d = math.hypot(dx, dy)
-            ux, uy = dx / d, dy / d
-            exit_d = _ray_exit_dist(tip[0], tip[1], ux, uy, (x0, y0, x1, y1))
-            elbow = (tip[0] + ux * (exit_d + reach), tip[1] + uy * (exit_d + reach), 0)
-            ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label_str, draft=draft)
-            label = getattr(ldr, "label_bbox", None) or _anno_box(ldr)
-            if (
-                label is None
-                or _box_hits(label, obstacles)
-                or _box_hits(label, [(x0, y0, x1, y1)])  # over the part silhouette
-                or label[0] < page[0]
-                or label[1] < page[1]
-                or label[2] > page[2]
-                or label[3] > page[3]
-            ):
-                continue
-            dwg.add(ldr, f"m_groove_{gr.axis}{gi}", view=view, feature=gr)
-            n += 1
-            placed = True
-            break
-        if not placed:
-            dwg._record_build_issue(
-                "warning",
-                "groove_dropped",
-                f"groove callout {label_str} not placed (no clear room)",
+        jobs.append(
+            (
+                f"m_groove_{gr.axis}{gi}",
+                view,
+                vb,
+                _groove_label(gr.width, gr.diameter),
+                _radial_candidates(dwg, view, vb, gr, reach),
             )
-    return n
+        )
+    return _leader_callout_pass(dwg, a, jobs, noun="groove", drop_code="groove_dropped")
 
 
 def render_boss_diameters(dwg, groups, a) -> int:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -23,9 +23,12 @@ from draftwright._core import (
     _MIN_LOC_SEP_MM,
     _TB_CLEAR,
     _TB_H,
+    _WITNESS_LIFT_MM,
     Analysis,
     HoleRef,
+    _concentric_with_axis,
     _dim,
+    _first_free_index,
     _fmt,
     _iso_bbox,
     _log,
@@ -55,6 +58,11 @@ from draftwright.layout import StripCandidate, plan_strip
 from draftwright.model import plan_dimensions
 from draftwright.model.ir import HoleFeature, PatternFeature
 from draftwright.model.planner import plan_locations
+
+# |cos| threshold for treating a view's side vector as axis-aligned (≈ within 1.6° of an
+# axis) when choosing the strip a hole-location row stacks against — above it the side is
+# "horizontal" / "vertical" enough to pick the left/right vs above/below strip cleanly.
+_AXIS_ALIGN_COS = 0.9996
 
 
 def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | None = None) -> str:
@@ -236,12 +244,7 @@ def add_feature_location(
     SX, SZ = a.proj.side_x, a.proj.side_z
 
     def _uniq(prefix: str) -> str:
-        j = 0
-        nm = f"{prefix}{j}"
-        while nm in dwg._named:
-            j += 1
-            nm = f"{prefix}{j}"
-        return nm
+        return f"{prefix}{_first_free_index(prefix, dwg._named)}"
 
     def _place(view: str, strip, p1, p2, baseline, label: str) -> str:
         perp = (min(p1, p2), max(p1, p2))
@@ -271,11 +274,7 @@ def add_feature_location(
         rx, ry = pd.param.span[1][0], pd.param.span[1][1]
         # A rotational part's on-axis *hole* is located by the centreline, not a
         # position dim (matches render_locations); a pattern ref is never filtered.
-        if (
-            pd.param.role == "location"
-            and a.is_rotational
-            and math.hypot(rx - a.cx, ry - a.cy) <= _CONCENTRIC_TOL_MM
-        ):
+        if pd.param.role == "location" and a.is_rotational and _concentric_with_axis(a, rx, ry):
             continue
         # Coincident X (or Y) across this feature's own members → one dim, not a stack
         # of identical position dims (matches render_locations' x_refs/y_refs dedup).
@@ -650,7 +649,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, *, which):
     # turned-diameter ø-row, so it stays in the "along" phase (after the diameter pass),
     # preserving the #133 priority.
     if which == "across":
-        yw = SZ(dz) - 2
+        yw = SZ(dz) - _WITNESS_LIFT_MM
         seen_y: set = set()
         cands = []
         order_y: dict = {}
@@ -688,7 +687,7 @@ def _locate_off_axis_holes(dwg, a: Analysis, *, which):
 
     # "along" phase (after the envelope + turned-diameter passes): a Y-axis hole's X
     # position below the FRONT view, then every hole's height (Z) to the right.
-    xw = FZ(dz) - 2
+    xw = FZ(dz) - _WITNESS_LIFT_MM
     seen_x: set = set()
     x_cands = []
     order_x: dict = {}
@@ -1041,7 +1040,9 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
     sx, sy = side[0], side[1]
     strip = axis = perp = None
     witness = sgn = 0.0
-    if abs(sx) > 0.9996:  # horizontal side ⟂ a vertical row → left/right strip, stacks along x
+    if (
+        abs(sx) > _AXIS_ALIGN_COS
+    ):  # horizontal side ⟂ a vertical row → left/right strip, stacks along x
         strip, axis, perp, witness, sgn = (
             (zones.right if sx > 0 else zones.left),
             "x",
@@ -1049,7 +1050,9 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
             mid[0],
             math.copysign(1.0, sx),
         )
-    elif abs(sy) > 0.9996:  # vertical side ⟂ a horizontal row → above/below strip, stacks along y
+    elif (
+        abs(sy) > _AXIS_ALIGN_COS
+    ):  # vertical side ⟂ a horizontal row → above/below strip, stacks along y
         strip, axis, perp, witness, sgn = (
             (zones.above if sy > 0 else zones.below),
             "y",
@@ -1237,10 +1240,8 @@ def _annotate_holes(
         # index to avoid Drawing.add silently replacing an earlier callout (#430 review).
         if only is None:
             return f"hc_{view}{i}"
-        j = 0
-        while f"hc_{view}{j}" in _hc_used:
-            j += 1
-        name = f"hc_{view}{j}"
+        prefix = f"hc_{view}"
+        name = f"{prefix}{_first_free_index(prefix, _hc_used)}"
         _hc_used.add(name)
         return name
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -19,11 +19,11 @@ import math
 from types import SimpleNamespace
 
 from draftwright._core import (
-    _CONCENTRIC_TOL_MM,
     _TABULATE_MIN_HOLES,
     Analysis,
     HoleRef,
     _add_title_block,
+    _concentric_with_axis,
     _fmt,
     _iso_bbox,
     _log,
@@ -154,11 +154,7 @@ def _declared_feature_keys(groups, a: Analysis) -> set:
         if not isinstance(feat, HoleFeature | PatternFeature):
             continue
         for m in feat.members or (g.anchor,):
-            if (
-                a.is_rotational
-                and feat.frame.axis == "z"
-                and math.hypot(m[0] - a.cx, m[1] - a.cy) <= _CONCENTRIC_TOL_MM
-            ):
+            if a.is_rotational and feat.frame.axis == "z" and _concentric_with_axis(a, m[0], m[1]):
                 continue
             keys.add(HoleRef.of(m))
     return keys


### PR DESCRIPTION
Part of consolidation epic #635 (Phase 2). Addresses parts 1–3 of #637; **part 4 (dedup-policy unification, the #345-adjacent one) is split to a focused follow-up** so the risky change isn't buried in a refactor.

## Leader-callout dedup (the headline)

`render_chamfers` / `render_fillets` / `render_flats` / `render_pockets` / `render_grooves` were the same function five times — the identical six-line label-clear guard copied five times, plus five copies of the try-candidates→place-or-drop loop and the `font_size + 6*pad` reach.

Extracted:
- `_leader_callout_pass(dwg, a, jobs, noun=, drop_code=)` — the one place/drop loop.
- `_label_lands_clear(...)` — the single accept test.
- `_leader_callout_reach(draft)`, `_corner_candidates(...)` (corner-diagonal), `_radial_candidates(...)` (mid-face 8-way ray-exit).

The five renderers are now thin adapters (label / view-map / name / candidate strategy). A grouped callout attributes the placed leader to the member whose corner landed. A sixth feature kind is a new adapter (or a table row), not a sixth copy.

## Named constants (byte-identical, pure literal→name)

- `_EST_CHAR_WIDTH_EM` (0.62) → `_core`, beside its exact counterpart `_text_width`; **`grep -c "0.62" from_model.py` → 0**.
- `_WITNESS_LIFT_MM` (2.0) → `_core`; the bare `±2` witness-line nudges share it.
- `_MIN_INPLACE_BORE_HALF_MM` (4.0), `_AXIS_ALIGN_COS` (0.9996).

## Shared helpers

- `_core._concentric_with_axis(a, x, y)` — the radial "on the turned axis" test the location filters in from_model / holes / orchestrator each inlined.
- `_core._first_free_index(prefix, taken)` — the first-free name kernel behind `_loc_name` / `_uniq` / `_hc_name`. The `max+1` run allocators (`_next_start` / `_next_steplen_start`) are **deliberately not folded on** — a run started at a gap below an occupied index would wrap onto it (#432).

## Not in this PR

- **Part 4** — the two dedup bases in tension (0.5 mm radius vs 0.1 rounding) the code itself warns can resurrect #345. Split to a follow-up.
- The two "within 10%" staircase detectors — logic-level reconciliation, deferred with part 4.

## Test

No output change intended. Full fast tier **1355 passed, 4 skipped**; snapshot clean; e2e-standards + chamfer/flat/groove callout suites green; ruff / ruff format / mypy / codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
