### PR TITLE
refactor(#638): render_pmi axis matrix → per-axis config table + shared linear helper

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -19,6 +19,7 @@ once the holes epic landed (#251).
 from __future__ import annotations
 
 import math
+from typing import Any
 
 from build123d_drafting import DatumFeature, FeatureControlFrame, SurfaceFinish, TextBlock
 from build123d_drafting.helpers import Centerline, CenterMark, HoleCallout, Leader, TitleBlock
@@ -2138,6 +2139,38 @@ def render_pmi(dwg, model, a) -> int:
 
     _SLOT = 10.0  # mm — slot size for PMI dim lines in the strip
 
+    # Per-bore-axis ø/R placement as DATA (ADR 0008 orientation-as-data): each bore reads as a
+    # circle in ONE view, dimensioned across it in-plane when the page span fits the label, else
+    # led out to a shelf. This one table replaces three near-identical Z/X/Y blocks. `order` is
+    # the in-place above/below fallback; `leader_order` the narrow-bore one (Y historically
+    # prefers below first). `centre`/`span` project the circle centre and its ±half endpoints.
+    _bore: dict[str, dict[str, Any]] = {
+        "Z": {
+            "view": "plan",
+            "zones": {"above": a.pv_zones.above, "below": a.pv_zones.below},
+            "order": ("above", "below"),
+            "leader_order": ("above", "below"),
+            "centre": lambda cx, cy, cz: (PX(cx), PY(cy)),
+            "span": lambda cx, cy, cz, h: ((PX(cx - h), PY(cy), 0), (PX(cx + h), PY(cy), 0)),
+        },
+        "X": {
+            "view": "side",
+            "zones": {"above": a.sv_zones.above, "below": a.sv_zones.below},
+            "order": ("above", "below"),
+            "leader_order": ("above", "below"),
+            "centre": lambda cx, cy, cz: (SX(cy), SZ(cz)),
+            "span": lambda cx, cy, cz, h: ((SX(cy - h), SZ(cz), 0), (SX(cy + h), SZ(cz), 0)),
+        },
+        "Y": {
+            "view": "front",
+            "zones": {"above": a.fv_zones.above, "below": a.fv_zones.below},
+            "order": ("above", "below"),
+            "leader_order": ("below", "above"),
+            "centre": lambda cx, cy, cz: (FX(cx), FZ(cz)),
+            "span": lambda cx, cy, cz, h: ((FX(cx - h), FZ(cz), 0), (FX(cx + h), FZ(cz), 0)),
+        },
+    }
+
     def _bore_info(rec):
         """For Size_Diameter / Size_Radius records, return (bore_axis, cx, cy, cz).
 
@@ -2354,123 +2387,36 @@ def render_pmi(dwg, model, a) -> int:
             # narrow bores; bracket dims only when span fits the text.
             half_pg = half * a.SCALE  # bore radius on page (mm)
 
-            if bore_axis == "Z":
-                # Z-axis bore: circle visible in plan view.
-                if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
-                    p1 = (PX(cx_f - half), PY(cy_f), 0)
-                    p2 = (PX(cx_f + half), PY(cy_f), 0)
-                    placed = _queue_options(
-                        [
-                            _dim_spec(p1, p2, a.pv_zones.above, label, name_d, "plan", "above"),
-                            _dim_spec(p1, p2, a.pv_zones.below, label, name_d, "plan", "below"),
-                        ],
-                        ax,
-                        label,
-                        rec,
-                    )
-                else:
-                    placed = _queue_options(
-                        [
-                            _leader_spec(
-                                (PX(cx_f), PY(cy_f) + half_pg, 0),
-                                a.pv_zones.above,
-                                label,
-                                name_d,
-                                "plan",
-                                "above",
-                            ),
-                            _leader_spec(
-                                (PX(cx_f), PY(cy_f) - half_pg, 0),
-                                a.pv_zones.below,
-                                label,
-                                name_d,
-                                "plan",
-                                "below",
-                            ),
-                        ],
-                        ax,
-                        label,
-                        rec,
-                    )
-
-            elif bore_axis == "X":
-                # X-axis bore: circle visible in side view.
-                if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
-                    p1 = (SX(cy_f - half), SZ(cz_f), 0)
-                    p2 = (SX(cy_f + half), SZ(cz_f), 0)
-                    placed = _queue_options(
-                        [
-                            _dim_spec(p1, p2, a.sv_zones.above, label, name_d, "side", "above"),
-                            _dim_spec(p1, p2, a.sv_zones.below, label, name_d, "side", "below"),
-                        ],
-                        ax,
-                        label,
-                        rec,
-                    )
-                else:
-                    placed = _queue_options(
-                        [
-                            _leader_spec(
-                                (SX(cy_f), SZ(cz_f) + half_pg, 0),
-                                a.sv_zones.above,
-                                label,
-                                name_d,
-                                "side",
-                                "above",
-                            ),
-                            _leader_spec(
-                                (SX(cy_f), SZ(cz_f) - half_pg, 0),
-                                a.sv_zones.below,
-                                label,
-                                name_d,
-                                "side",
-                                "below",
-                            ),
-                        ],
-                        ax,
-                        label,
-                        rec,
-                    )
-
-            elif bore_axis == "Y":
-                # Y-axis bore: circle visible in front view as a circle.
-                if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
-                    p1 = (FX(cx_f - half), FZ(cz_f), 0)
-                    p2 = (FX(cx_f + half), FZ(cz_f), 0)
-                    placed = _queue_options(
-                        [
-                            _dim_spec(p1, p2, a.fv_zones.above, label, name_d, "front", "above"),
-                            _dim_spec(p1, p2, a.fv_zones.below, label, name_d, "front", "below"),
-                        ],
-                        ax,
-                        label,
-                        rec,
-                    )
-                else:
-                    # Narrow Y-axis bore historically prefers below, then above.
-                    placed = _queue_options(
-                        [
-                            _leader_spec(
-                                (FX(cx_f), FZ(cz_f) - half_pg, 0),
-                                a.fv_zones.below,
-                                label,
-                                name_d,
-                                "front",
-                                "below",
-                            ),
-                            _leader_spec(
-                                (FX(cx_f), FZ(cz_f) + half_pg, 0),
-                                a.fv_zones.above,
-                                label,
-                                name_d,
-                                "front",
-                                "above",
-                            ),
-                        ],
-                        ax,
-                        label,
-                        rec,
-                    )
+            cfg = _bore[bore_axis]
+            u, v = cfg["centre"](cx_f, cy_f, cz_f)
+            if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
+                p1, p2 = cfg["span"](cx_f, cy_f, cz_f, half)
+                placed = _queue_options(
+                    [
+                        _dim_spec(p1, p2, cfg["zones"][s], label, name_d, cfg["view"], s)
+                        for s in cfg["order"]
+                    ],
+                    ax,
+                    label,
+                    rec,
+                )
+            else:
+                placed = _queue_options(
+                    [
+                        _leader_spec(
+                            (u, v + (half_pg if s == "above" else -half_pg), 0),
+                            cfg["zones"][s],
+                            label,
+                            name_d,
+                            cfg["view"],
+                            s,
+                        )
+                        for s in cfg["leader_order"]
+                    ],
+                    ax,
+                    label,
+                    rec,
+                )
 
         elif ax == "X":
             wp = _witness_from_bbox(rec, "front")

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2356,6 +2356,42 @@ def render_pmi(dwg, model, a) -> int:
         )
         return True
 
+    def _front_linear(rec, ax, label, name, primary, secondary, center):
+        """An X- or Z-dominant linear PMI dim in the FRONT view (the two share one shape): the
+        witness spans the ref bbox; place ``[primary, secondary]`` when the perpendicular
+        midpoint sits on the primary side of the view centre, else fall back to ``[secondary]``
+        alone. Returns True/False placed, or ``None`` for a degenerate (no-witness) reference
+        so the caller can report it as a validation failure."""
+        wp = _witness_from_bbox(rec, "front")
+        if wp is None:
+            return None
+        p1, p2, avg = wp
+        zones = {
+            "above": a.fv_zones.above,
+            "below": a.fv_zones.below,
+            "right": a.fv_zones.right,
+            "left": a.fv_zones.left,
+        }
+        placed = False
+        if avg >= center:
+            placed = _queue_options(
+                [
+                    _dim_spec(p1, p2, zones[primary], label, name, "front", primary),
+                    _dim_spec(p1, p2, zones[secondary], label, name, "front", secondary),
+                ],
+                ax,
+                label,
+                rec,
+            )
+        if not placed:
+            placed = _queue_options(
+                [_dim_spec(p1, p2, zones[secondary], label, name, "front", secondary)],
+                ax,
+                label,
+                rec,
+            )
+        return placed
+
     queued = 0
     for idx, rec in enumerate(usable):
         ax = rec.dominant_axis
@@ -2419,54 +2455,18 @@ def render_pmi(dwg, model, a) -> int:
                 )
 
         elif ax == "X":
-            wp = _witness_from_bbox(rec, "front")
-            if wp is None:
+            placed = _front_linear(rec, ax, label, name_x, "above", "below", a.FV_Y)
+            if placed is None:
                 _log.debug("PMI dim[%d] X: degenerate reference", idx)
                 _record_pmi_unrenderable(dwg, label, rec)
                 continue
-            p1, p2, avg_pz = wp
-            if avg_pz >= a.FV_Y:
-                placed = _queue_options(
-                    [
-                        _dim_spec(p1, p2, a.fv_zones.above, label, name_x, "front", "above"),
-                        _dim_spec(p1, p2, a.fv_zones.below, label, name_x, "front", "below"),
-                    ],
-                    ax,
-                    label,
-                    rec,
-                )
-            if not placed:
-                placed = _queue_options(
-                    [_dim_spec(p1, p2, a.fv_zones.below, label, name_x, "front", "below")],
-                    ax,
-                    label,
-                    rec,
-                )
 
         elif ax == "Z":
-            wp = _witness_from_bbox(rec, "front")
-            if wp is None:
+            placed = _front_linear(rec, ax, label, name_z, "right", "left", a.FV_X)
+            if placed is None:
                 _log.debug("PMI dim[%d] Z: degenerate reference", idx)
                 _record_pmi_unrenderable(dwg, label, rec)
                 continue
-            p1, p2, avg_px = wp
-            if avg_px >= a.FV_X:
-                placed = _queue_options(
-                    [
-                        _dim_spec(p1, p2, a.fv_zones.right, label, name_z, "front", "right"),
-                        _dim_spec(p1, p2, a.fv_zones.left, label, name_z, "front", "left"),
-                    ],
-                    ax,
-                    label,
-                    rec,
-                )
-            if not placed:
-                placed = _queue_options(
-                    [_dim_spec(p1, p2, a.fv_zones.left, label, name_z, "front", "left")],
-                    ax,
-                    label,
-                    rec,
-                )
 
         elif ax == "Y":
             # A degenerate reference (no witness in EITHER candidate view) is a validation

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2423,36 +2423,40 @@ def render_pmi(dwg, model, a) -> int:
             # narrow bores; bracket dims only when span fits the text.
             half_pg = half * a.SCALE  # bore radius on page (mm)
 
-            cfg = _bore[bore_axis]
-            u, v = cfg["centre"](cx_f, cy_f, cz_f)
-            if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
-                p1, p2 = cfg["span"](cx_f, cy_f, cz_f, half)
-                placed = _queue_options(
-                    [
-                        _dim_spec(p1, p2, cfg["zones"][s], label, name_d, cfg["view"], s)
-                        for s in cfg["order"]
-                    ],
-                    ax,
-                    label,
-                    rec,
-                )
-            else:
-                placed = _queue_options(
-                    [
-                        _leader_spec(
-                            (u, v + (half_pg if s == "above" else -half_pg), 0),
-                            cfg["zones"][s],
-                            label,
-                            name_d,
-                            cfg["view"],
-                            s,
-                        )
-                        for s in cfg["leader_order"]
-                    ],
-                    ax,
-                    label,
-                    rec,
-                )
+            # An unresolved bore axis (dominant_axis is an unrestricted string) matches no
+            # config — leave placed=False and fall through to the bottom drop, exactly as the
+            # old Z/X/Y if-chain did (never a KeyError crash).
+            cfg = _bore.get(bore_axis)
+            if cfg is not None:
+                u, v = cfg["centre"](cx_f, cy_f, cz_f)
+                if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
+                    p1, p2 = cfg["span"](cx_f, cy_f, cz_f, half)
+                    placed = _queue_options(
+                        [
+                            _dim_spec(p1, p2, cfg["zones"][s], label, name_d, cfg["view"], s)
+                            for s in cfg["order"]
+                        ],
+                        ax,
+                        label,
+                        rec,
+                    )
+                else:
+                    placed = _queue_options(
+                        [
+                            _leader_spec(
+                                (u, v + (half_pg if s == "above" else -half_pg), 0),
+                                cfg["zones"][s],
+                                label,
+                                name_d,
+                                cfg["view"],
+                                s,
+                            )
+                            for s in cfg["leader_order"]
+                        ],
+                        ax,
+                        label,
+                        rec,
+                    )
 
         elif ax == "X":
             placed = _front_linear(rec, ax, label, name_x, "above", "below", a.FV_Y)

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -211,3 +211,32 @@ def test_build_pmi_features_mirrors_detection():
             for f in authored
         )
     assert build_pmi_features(None, bbox) == []  # None/empty → no features
+
+
+def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
+    # #638 review: the bore ø/R placement became a `_bore[axis]` table lookup. A diameter
+    # record whose dominant_axis doesn't resolve to X/Y/Z must still drop gracefully — as the
+    # old Z/X/Y if-chain did by falling through — not KeyError-crash the whole build.
+    from types import SimpleNamespace
+
+    from build123d import Box
+
+    from draftwright import build_drawing
+    from draftwright.annotations.from_model import render_pmi
+    from draftwright.model import AuthoredDimension
+    from draftwright.model.ir import Frame
+
+    dwg = build_drawing(Box(40, 30, 20), number="X")
+    bogus = AuthoredDimension(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        dimension_kind="diameter",
+        value=5.0,
+        label="ø5",
+        dominant_axis="Q",  # not X/Y/Z → matches no bore config
+        ref_bbox=(0.0, 0.0, 0.0, 5.0, 1.0, 1.0),
+        ref_pts=((0.0, 0.0, 0.0), (5.0, 0.0, 0.0)),
+    )
+    model = SimpleNamespace(features=[bogus])
+    n = render_pmi(dwg, model, dwg._analysis)  # must not raise
+    assert n == 0
+    assert any(i.code == "pmi_dropped" for i in dwg._build_issues)  # graceful drop recorded


### PR DESCRIPTION
Part of consolidation epic #635 (Phase 3, #638). First increment on the `render_pmi` hotspot: turn its axis matrix into data.

## What

`render_pmi`'s placement was ~12 near-identical blocks — the ADR 0008 "orientation is data, not code branches" smell. This collapses the regular ones:

- **Bore ø/R matrix** (Z/X/Y × in-place-dim vs narrow-bore-leader, ~117 lines) → one `_bore` per-axis config table (view / above+below zones / in-place `order` / narrow `leader_order` / projected `centre` + `span`) + a single dispatch. Preserves every detail — including that a Y bore's *in-place* fallback is above→below while its *leader* order is below→above ("historically prefers below"), kept as two separate order tuples.
- **X/Z linear dims** → one `_front_linear` helper (they're the same front-view gate→primary/secondary→fallback shape). Y stays inline — it's a genuinely different two-view (side→plan) algorithm.

## Not yet (follow-up)

`render_pmi` is 470 → 415 lines. Getting it under the ~150-line acceptance needs promoting the six nested helpers (`_bore_info`/`_witness_from_bbox`/`_dim_spec`/`_leader_spec`/`_place_one`/`_queue_options`) to module level — mechanical param-threading, deferred to a focused follow-up so this PR stays the substantive matrix-as-data change. `_annotate_holes` and `finalize` (the other two #638 hotspots) are separate PRs. #638 stays open.

## Test

No output change intended. Full fast tier + PMI + snapshot + render-seam + sheet-emit suites green; **no snapshot re-bless**. ruff / ruff format / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
