### PR TITLE
test(#635): strict placement golden for the #638/#639 refactors

### DIFF
--- a/tests/refactor_golden/bracket_section.json
+++ b/tests/refactor_golden/bracket_section.json
@@ -1,0 +1,389 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        125.4,
+        98.5,
+        133.4,
+        118.6
+      ],
+      "label": "20",
+      "label_bbox": [
+        130.3,
+        106.9,
+        132.5,
+        110.1
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        80.4,
+        167.2,
+        140.0,
+        169.8
+      ],
+      "label": "",
+      "label_bbox": [
+        126.1,
+        167.2,
+        140.0,
+        169.8
+      ],
+      "name": "hc_plan0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        92.4,
+        173.1,
+        140.7,
+        176.8
+      ],
+      "label": "",
+      "label_bbox": [
+        126.1,
+        174.2,
+        140.7,
+        176.8
+      ],
+      "name": "hc_plan1",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        71.4,
+        163.5,
+        81.4,
+        173.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm0",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        79.4,
+        166.5,
+        93.4,
+        180.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm1",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        142.8,
+        86.5,
+        202.9,
+        94.5
+      ],
+      "label": "60",
+      "label_bbox": [
+        171.2,
+        87.4,
+        174.5,
+        89.6
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        31.4,
+        126.5,
+        121.5,
+        134.5
+      ],
+      "label": "90",
+      "label_bbox": [
+        74.8,
+        127.4,
+        78.0,
+        129.6
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        31.4,
+        170.5,
+        76.5,
+        210.5
+      ],
+      "label": "45",
+      "label_bbox": [
+        52.3,
+        207.4,
+        55.6,
+        209.6
+      ],
+      "name": "m_locx0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        31.4,
+        175.5,
+        86.5,
+        220.0
+      ],
+      "label": "55",
+      "label_bbox": [
+        57.3,
+        216.9,
+        60.5,
+        219.1
+      ],
+      "name": "m_locx1",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        142.8,
+        120.5,
+        172.9,
+        130.5
+      ],
+      "label": "30",
+      "label_bbox": [
+        156.2,
+        127.4,
+        159.5,
+        129.6
+      ],
+      "name": "m_locy0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        142.8,
+        120.5,
+        177.9,
+        140.0
+      ],
+      "label": "35",
+      "label_bbox": [
+        158.7,
+        136.9,
+        162.0,
+        139.1
+      ],
+      "name": "m_locy1",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        230.7,
+        155.0,
+        255.0,
+        157.7
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        230.7,
+        155.0,
+        255.0,
+        157.7
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        23.6,
+        176.7,
+        25.2,
+        178.7
+      ],
+      "label": "A",
+      "label_bbox": [
+        23.6,
+        176.7,
+        25.2,
+        178.7
+      ],
+      "name": "section_a_left",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        127.6,
+        176.7,
+        129.2,
+        178.7
+      ],
+      "label": "A",
+      "label_bbox": [
+        127.6,
+        176.7,
+        129.2,
+        178.7
+      ],
+      "name": "section_a_right",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        26.5,
+        166.8,
+        28.3,
+        173.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "section_arrow_left",
+      "type": "Compound",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        124.5,
+        166.8,
+        126.3,
+        173.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "section_arrow_right",
+      "type": "Compound",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        248.0,
+        90.4,
+        267.6,
+        92.6
+      ],
+      "label": "SECTION A\u2013A",
+      "label_bbox": [
+        248.0,
+        90.4,
+        267.6,
+        92.6
+      ],
+      "name": "section_caption",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        212.8,
+        98.5,
+        302.8,
+        118.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "section_hatch",
+      "type": "Compound",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        27.4,
+        173.4,
+        125.4,
+        173.6
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "section_line",
+      "type": "Centerline",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        27.4,
+        166.8,
+        27.4,
+        173.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "section_wing_left",
+      "type": "Compound",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        125.4,
+        166.8,
+        125.4,
+        173.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "section_wing_right",
+      "type": "Compound",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        258.9,
+        10.9,
+        409.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 22,
+  "views": {
+    "front": [
+      31.4,
+      98.5,
+      121.4,
+      118.5
+    ],
+    "iso": [
+      173.9,
+      162.3,
+      311.8,
+      263.2
+    ],
+    "plan": [
+      31.4,
+      138.5,
+      121.4,
+      198.5
+    ],
+    "section_aa": [
+      212.8,
+      98.5,
+      302.8,
+      118.5
+    ],
+    "side": [
+      142.8,
+      98.5,
+      202.8,
+      118.5
+    ]
+  }
+}

--- a/tests/refactor_golden/centered_rebate.json
+++ b/tests/refactor_golden/centered_rebate.json
@@ -1,0 +1,171 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        122.0,
+        93.5,
+        136.5,
+        123.6
+      ],
+      "label": "30",
+      "label_bbox": [
+        133.4,
+        106.9,
+        135.6,
+        110.1
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        146.5,
+        125.5,
+        166.6,
+        135.5
+      ],
+      "label": "20",
+      "label_bbox": [
+        154.9,
+        132.4,
+        158.1,
+        134.6
+      ],
+      "name": "dim_shoulder_y0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        146.5,
+        125.5,
+        186.6,
+        145.0
+      ],
+      "label": "40",
+      "label_bbox": [
+        164.8,
+        141.9,
+        168.2,
+        144.1
+      ],
+      "name": "dim_shoulder_y1",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        114.0,
+        93.5,
+        122.0,
+        108.6
+      ],
+      "label": "15",
+      "label_bbox": [
+        118.9,
+        99.4,
+        121.1,
+        102.6
+      ],
+      "name": "dim_step_0",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        146.5,
+        81.5,
+        206.6,
+        89.5
+      ],
+      "label": "60",
+      "label_bbox": [
+        174.9,
+        82.4,
+        178.1,
+        84.6
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.0,
+        131.5,
+        110.1,
+        139.5
+      ],
+      "label": "80",
+      "label_bbox": [
+        68.4,
+        132.4,
+        71.6,
+        134.6
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        306.1,
+        116.1,
+        330.4,
+        118.8
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        306.1,
+        116.1,
+        330.4,
+        118.8
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        258.9,
+        10.9,
+        409.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 8,
+  "views": {
+    "front": [
+      30.0,
+      93.5,
+      110.0,
+      123.5
+    ],
+    "iso": [
+      253.9,
+      123.4,
+      382.6,
+      229.6
+    ],
+    "plan": [
+      30.0,
+      143.5,
+      110.0,
+      203.5
+    ],
+    "side": [
+      146.5,
+      93.5,
+      206.5,
+      123.5
+    ]
+  }
+}

--- a/tests/refactor_golden/chamfered.json
+++ b/tests/refactor_golden/chamfered.json
@@ -1,0 +1,135 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        124.0,
+        98.5,
+        132.0,
+        118.6
+      ],
+      "label": "20",
+      "label_bbox": [
+        128.9,
+        106.9,
+        131.1,
+        110.1
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        114.0,
+        192.5,
+        133.8,
+        201.4
+      ],
+      "label": "C12",
+      "label_bbox": [
+        128.8,
+        199.3,
+        133.8,
+        201.4
+      ],
+      "name": "m_chamfer_z0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        140.0,
+        86.5,
+        200.1,
+        94.5
+      ],
+      "label": "60",
+      "label_bbox": [
+        168.4,
+        87.4,
+        171.6,
+        89.6
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.0,
+        126.5,
+        120.1,
+        134.5
+      ],
+      "label": "90",
+      "label_bbox": [
+        73.4,
+        127.4,
+        76.6,
+        129.6
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        302.8,
+        118.7,
+        327.2,
+        121.4
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        302.8,
+        118.7,
+        327.2,
+        121.4
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        258.9,
+        10.9,
+        409.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 6,
+  "views": {
+    "front": [
+      30.0,
+      98.5,
+      120.0,
+      118.5
+    ],
+    "iso": [
+      246.1,
+      126.1,
+      372.9,
+      226.9
+    ],
+    "plan": [
+      30.0,
+      138.5,
+      120.0,
+      198.5
+    ],
+    "side": [
+      140.0,
+      98.5,
+      200.0,
+      118.5
+    ]
+  }
+}

--- a/tests/refactor_golden/filleted.json
+++ b/tests/refactor_golden/filleted.json
@@ -1,0 +1,135 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        124.0,
+        98.5,
+        132.0,
+        118.6
+      ],
+      "label": "20",
+      "label_bbox": [
+        128.9,
+        106.9,
+        131.1,
+        110.1
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        140.0,
+        86.5,
+        200.1,
+        94.5
+      ],
+      "label": "60",
+      "label_bbox": [
+        168.4,
+        87.4,
+        171.6,
+        89.6
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.0,
+        126.5,
+        120.1,
+        134.5
+      ],
+      "label": "90",
+      "label_bbox": [
+        73.4,
+        127.4,
+        76.6,
+        129.6
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        117.7,
+        196.2,
+        135.4,
+        205.4
+      ],
+      "label": "R8",
+      "label_bbox": [
+        132.2,
+        203.2,
+        135.4,
+        205.4
+      ],
+      "name": "m_fillet_z0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        302.8,
+        118.7,
+        327.2,
+        121.4
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        302.8,
+        118.7,
+        327.2,
+        121.4
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        258.9,
+        10.9,
+        409.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 6,
+  "views": {
+    "front": [
+      30.0,
+      98.5,
+      120.0,
+      118.5
+    ],
+    "iso": [
+      246.1,
+      126.1,
+      379.6,
+      226.9
+    ],
+    "plan": [
+      30.0,
+      138.5,
+      120.0,
+      198.5
+    ],
+    "side": [
+      140.0,
+      98.5,
+      200.0,
+      118.5
+    ]
+  }
+}

--- a/tests/refactor_golden/flange_dense.json
+++ b/tests/refactor_golden/flange_dense.json
@@ -1,0 +1,288 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        78.0,
+        133.4,
+        138.1,
+        193.6
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "bc_plan0",
+      "type": "CenterlineCircle",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        108.0,
+        83.5,
+        108.1,
+        103.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "centerline_front",
+      "type": "Centerline",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        251.0,
+        83.5,
+        251.2,
+        103.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "centerline_side",
+      "type": "Centerline",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        157.1,
+        88.5,
+        165.1,
+        98.6
+      ],
+      "label": "10",
+      "label_bbox": [
+        162.0,
+        91.9,
+        164.1,
+        95.1
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        63.0,
+        102.5,
+        153.1,
+        110.5
+      ],
+      "label": "\u00f890",
+      "label_bbox": [
+        105.5,
+        107.4,
+        110.6,
+        109.6
+      ],
+      "name": "dim_od",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        140.6,
+        153.2,
+        201.4,
+        162.0
+      ],
+      "label": "",
+      "label_bbox": [
+        155.1,
+        153.2,
+        201.4,
+        155.8
+      ],
+      "name": "hc_plan0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        44.0,
+        92.4,
+        100.1,
+        94.6
+      ],
+      "label": "\u00f816",
+      "label_bbox": [
+        44.0,
+        92.4,
+        49.1,
+        94.6
+      ],
+      "name": "ldr_z0",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        79.8,
+        141.9,
+        87.8,
+        149.9
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm0",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        113.3,
+        131.0,
+        121.3,
+        139.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm1",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        79.8,
+        177.1,
+        87.8,
+        185.1
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm2",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        134.1,
+        159.5,
+        142.1,
+        167.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm3",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        113.3,
+        188.0,
+        121.3,
+        196.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm4",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        99.1,
+        154.5,
+        117.1,
+        172.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm5",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        63.0,
+        165.5,
+        108.1,
+        220.5
+      ],
+      "label": "45",
+      "label_bbox": [
+        83.9,
+        217.4,
+        87.2,
+        219.6
+      ],
+      "name": "m_locx0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        206.1,
+        100.5,
+        251.2,
+        110.5
+      ],
+      "label": "45",
+      "label_bbox": [
+        227.0,
+        107.4,
+        230.3,
+        109.6
+      ],
+      "name": "m_locy0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        279.4,
+        156.3,
+        303.7,
+        159.0
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        279.4,
+        156.3,
+        303.7,
+        159.0
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        258.9,
+        10.9,
+        409.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 17,
+  "views": {
+    "front": [
+      63.1,
+      88.5,
+      153.1,
+      98.5
+    ],
+    "iso": [
+      233.0,
+      163.7,
+      350.0,
+      241.8
+    ],
+    "plan": [
+      63.1,
+      118.5,
+      153.1,
+      208.5
+    ],
+    "side": [
+      206.1,
+      88.5,
+      296.1,
+      98.5
+    ]
+  }
+}

--- a/tests/refactor_golden/grooved_shaft.json
+++ b/tests/refactor_golden/grooved_shaft.json
@@ -1,0 +1,149 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        39.9,
+        50.0,
+        40.1,
+        120.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "centerline_front",
+      "type": "Centerline",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        112.9,
+        50.0,
+        113.1,
+        120.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "centerline_side",
+      "type": "Centerline",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.0,
+        119.0,
+        50.1,
+        127.0
+      ],
+      "label": "\u00f820",
+      "label_bbox": [
+        37.5,
+        123.9,
+        42.5,
+        126.1
+      ],
+      "name": "dim_od",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        40.0,
+        70.0,
+        84.0,
+        91.7
+      ],
+      "label": "4 WIDE \u00d7 \u00f814",
+      "label_bbox": [
+        62.6,
+        89.5,
+        84.0,
+        91.7
+      ],
+      "name": "m_groove_z0",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        40.0,
+        100.0,
+        83.9,
+        121.7
+      ],
+      "label": "4 WIDE \u00d7 \u00f816",
+      "label_bbox": [
+        62.6,
+        119.5,
+        83.9,
+        121.7
+      ],
+      "name": "m_groove_z1",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        202.8,
+        86.3,
+        227.2,
+        89.0
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        202.8,
+        86.3,
+        227.2,
+        89.0
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        165.9,
+        10.9,
+        286.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [
+    [
+      "warning",
+      "step_dim_dropped",
+      "step-length chain dropped: turned shoulders too closely spaced to dimension at this scale (use a detail view)"
+    ]
+  ],
+  "item_count": 7,
+  "views": {
+    "front": [
+      30.0,
+      55.0,
+      50.0,
+      115.0
+    ],
+    "iso": [
+      202.0,
+      93.7,
+      228.0,
+      172.3
+    ],
+    "plan": [
+      30.0,
+      135.0,
+      50.0,
+      155.0
+    ],
+    "side": [
+      103.0,
+      55.0,
+      123.0,
+      115.0
+    ]
+  }
+}

--- a/tests/refactor_golden/hex_bar.json
+++ b/tests/refactor_golden/hex_bar.json
@@ -1,0 +1,117 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        71.2,
+        45.0,
+        79.2,
+        105.1
+      ],
+      "label": "30",
+      "label_bbox": [
+        76.1,
+        73.4,
+        78.3,
+        76.6
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        87.2,
+        33.0,
+        127.3,
+        41.0
+      ],
+      "label": "20",
+      "label_bbox": [
+        105.6,
+        33.9,
+        108.8,
+        36.1
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        15.8,
+        114.6,
+        39.3,
+        128.9
+      ],
+      "label": "18.6 A/F",
+      "label_bbox": [
+        15.8,
+        114.6,
+        29.8,
+        117.2
+      ],
+      "name": "m_flat_z0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        204.9,
+        78.9,
+        229.3,
+        81.6
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        204.9,
+        78.9,
+        229.3,
+        81.6
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        165.9,
+        10.9,
+        286.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 5,
+  "views": {
+    "front": [
+      30.0,
+      45.0,
+      67.2,
+      105.0
+    ],
+    "iso": [
+      191.3,
+      86.2,
+      242.9,
+      179.8
+    ],
+    "plan": [
+      30.0,
+      125.0,
+      67.2,
+      165.0
+    ],
+    "side": [
+      87.2,
+      45.0,
+      127.2,
+      105.0
+    ]
+  }
+}

--- a/tests/refactor_golden/holed_slot.json
+++ b/tests/refactor_golden/holed_slot.json
@@ -1,0 +1,300 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        99.2,
+        65.0,
+        107.2,
+        85.1
+      ],
+      "label": "20",
+      "label_bbox": [
+        104.2,
+        73.4,
+        106.3,
+        76.6
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        88.2,
+        137.7,
+        115.8,
+        140.3
+      ],
+      "label": "",
+      "label_bbox": [
+        97.2,
+        137.7,
+        115.8,
+        140.3
+      ],
+      "name": "hc_plan0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        69.2,
+        107.0,
+        77.2,
+        115.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm0",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        51.2,
+        135.0,
+        59.2,
+        143.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm1",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        81.2,
+        135.0,
+        89.2,
+        143.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm2",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        120.4,
+        53.0,
+        160.5,
+        61.0
+      ],
+      "label": "40",
+      "label_bbox": [
+        138.8,
+        53.9,
+        142.2,
+        56.1
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        35.2,
+        93.0,
+        95.3,
+        101.0
+      ],
+      "label": "60",
+      "label_bbox": [
+        63.6,
+        93.9,
+        66.9,
+        96.1
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        35.2,
+        141.0,
+        55.3,
+        166.5
+      ],
+      "label": "20",
+      "label_bbox": [
+        43.6,
+        163.4,
+        46.9,
+        165.6
+      ],
+      "name": "m_locx0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        35.2,
+        113.0,
+        73.3,
+        176.0
+      ],
+      "label": "38",
+      "label_bbox": [
+        52.6,
+        172.9,
+        55.9,
+        175.1
+      ],
+      "name": "m_locx1",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        35.2,
+        141.0,
+        85.3,
+        185.5
+      ],
+      "label": "50",
+      "label_bbox": [
+        58.6,
+        182.4,
+        61.8,
+        184.6
+      ],
+      "name": "m_locx2",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        115.1,
+        87.0,
+        131.9,
+        97.0
+      ],
+      "label": "6",
+      "label_bbox": [
+        122.8,
+        93.9,
+        124.2,
+        96.1
+      ],
+      "name": "m_locy0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        120.4,
+        87.0,
+        154.5,
+        106.5
+      ],
+      "label": "34",
+      "label_bbox": [
+        135.8,
+        103.4,
+        139.2,
+        105.6
+      ],
+      "name": "m_locy1",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        55.2,
+        131.0,
+        75.3,
+        157.0
+      ],
+      "label": "20",
+      "label_bbox": [
+        63.6,
+        153.9,
+        66.9,
+        156.1
+      ],
+      "name": "m_slot0_length",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        77.2,
+        121.0,
+        107.2,
+        129.1
+      ],
+      "label": "8",
+      "label_bbox": [
+        104.2,
+        124.3,
+        106.3,
+        125.7
+      ],
+      "name": "m_slot0_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        221.6,
+        88.5,
+        245.9,
+        91.2
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        221.6,
+        88.5,
+        245.9,
+        91.2
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        165.9,
+        10.9,
+        286.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 16,
+  "views": {
+    "front": [
+      35.2,
+      65.0,
+      95.2,
+      85.0
+    ],
+    "iso": [
+      187.8,
+      95.8,
+      279.7,
+      170.2
+    ],
+    "plan": [
+      35.2,
+      105.0,
+      95.2,
+      145.0
+    ],
+    "side": [
+      120.5,
+      65.0,
+      160.5,
+      85.0
+    ]
+  }
+}

--- a/tests/refactor_golden/pocketed.json
+++ b/tests/refactor_golden/pocketed.json
@@ -1,0 +1,202 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        114.7,
+        55.0,
+        122.7,
+        75.1
+      ],
+      "label": "20",
+      "label_bbox": [
+        119.6,
+        63.4,
+        121.8,
+        66.6
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        14.9,
+        108.7,
+        47.7,
+        111.3
+      ],
+      "label": "",
+      "label_bbox": [
+        14.9,
+        108.7,
+        28.7,
+        111.3
+      ],
+      "name": "hc_plan0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        46.7,
+        106.0,
+        54.7,
+        114.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm0",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        131.4,
+        43.0,
+        191.5,
+        51.0
+      ],
+      "label": "60",
+      "label_bbox": [
+        159.8,
+        43.9,
+        163.0,
+        46.1
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.7,
+        83.0,
+        110.8,
+        91.0
+      ],
+      "label": "80",
+      "label_bbox": [
+        69.1,
+        83.9,
+        72.3,
+        86.1
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        30.7,
+        112.0,
+        50.8,
+        167.0
+      ],
+      "label": "20",
+      "label_bbox": [
+        39.1,
+        163.9,
+        42.3,
+        166.1
+      ],
+      "name": "m_locx0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        131.4,
+        77.0,
+        146.5,
+        87.0
+      ],
+      "label": "15",
+      "label_bbox": [
+        137.3,
+        83.9,
+        140.5,
+        86.1
+      ],
+      "name": "m_locy0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        70.7,
+        135.0,
+        133.5,
+        166.7
+      ],
+      "label": "20 \u00d7 30 \u00d7 15 DEEP",
+      "label_bbox": [
+        103.3,
+        164.5,
+        133.5,
+        166.7
+      ],
+      "name": "m_pocket_yx0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        196.7,
+        92.9,
+        221.0,
+        95.6
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        196.7,
+        92.9,
+        221.0,
+        95.6
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        165.9,
+        10.9,
+        286.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 10,
+  "views": {
+    "front": [
+      30.7,
+      55.0,
+      110.7,
+      75.0
+    ],
+    "iso": [
+      145.2,
+      100.3,
+      272.5,
+      194.7
+    ],
+    "plan": [
+      30.7,
+      95.0,
+      110.7,
+      155.0
+    ],
+    "side": [
+      131.4,
+      55.0,
+      191.4,
+      75.0
+    ]
+  }
+}

--- a/tests/refactor_golden/prismatic_ladder.json
+++ b/tests/refactor_golden/prismatic_ladder.json
@@ -1,0 +1,153 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        122.0,
+        93.5,
+        136.5,
+        123.6
+      ],
+      "label": "30",
+      "label_bbox": [
+        133.4,
+        106.9,
+        135.6,
+        110.1
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        146.5,
+        125.5,
+        166.6,
+        135.5
+      ],
+      "label": "20",
+      "label_bbox": [
+        154.9,
+        132.4,
+        158.1,
+        134.6
+      ],
+      "name": "dim_shoulder_y0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        114.0,
+        93.5,
+        122.0,
+        108.6
+      ],
+      "label": "15",
+      "label_bbox": [
+        118.9,
+        99.4,
+        121.1,
+        102.6
+      ],
+      "name": "dim_step_0",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        146.5,
+        81.5,
+        206.6,
+        89.5
+      ],
+      "label": "60",
+      "label_bbox": [
+        174.9,
+        82.4,
+        178.1,
+        84.6
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.0,
+        131.5,
+        110.1,
+        139.5
+      ],
+      "label": "80",
+      "label_bbox": [
+        68.4,
+        132.4,
+        71.6,
+        134.6
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        306.1,
+        116.1,
+        330.4,
+        118.8
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        306.1,
+        116.1,
+        330.4,
+        118.8
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        258.9,
+        10.9,
+        409.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 7,
+  "views": {
+    "front": [
+      30.0,
+      93.5,
+      110.0,
+      123.5
+    ],
+    "iso": [
+      253.9,
+      123.4,
+      382.6,
+      229.6
+    ],
+    "plan": [
+      30.0,
+      143.5,
+      110.0,
+      203.5
+    ],
+    "side": [
+      146.5,
+      93.5,
+      206.5,
+      123.5
+    ]
+  }
+}

--- a/tests/refactor_golden/side_drilled.json
+++ b/tests/refactor_golden/side_drilled.json
@@ -1,0 +1,184 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        94.7,
+        60.0,
+        102.7,
+        90.1
+      ],
+      "label": "30",
+      "label_bbox": [
+        99.6,
+        73.4,
+        101.8,
+        76.6
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        111.4,
+        48.0,
+        131.5,
+        56.0
+      ],
+      "label": "20",
+      "label_bbox": [
+        119.8,
+        48.9,
+        123.0,
+        51.1
+      ],
+      "name": "dim_loc_side_y2000",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        153.4,
+        60.0,
+        183.4,
+        83.1
+      ],
+      "label": "23",
+      "label_bbox": [
+        180.3,
+        69.9,
+        182.5,
+        73.1
+      ],
+      "name": "dim_loc_side_z2300",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        134.1,
+        72.7,
+        167.2,
+        81.8
+      ],
+      "label": "",
+      "label_bbox": [
+        153.4,
+        72.7,
+        167.2,
+        75.3
+      ],
+      "name": "hc_side0",
+      "type": "Leader",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        127.4,
+        79.0,
+        135.4,
+        87.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm0",
+      "type": "CenterMark",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        111.4,
+        37.5,
+        151.5,
+        56.0
+      ],
+      "label": "40",
+      "label_bbox": [
+        129.7,
+        38.4,
+        133.1,
+        40.6
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.7,
+        98.0,
+        90.8,
+        106.0
+      ],
+      "label": "60",
+      "label_bbox": [
+        59.1,
+        98.9,
+        62.3,
+        101.1
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        217.0,
+        83.2,
+        241.4,
+        85.9
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        217.0,
+        83.2,
+        241.4,
+        85.9
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        165.9,
+        10.9,
+        286.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 9,
+  "views": {
+    "front": [
+      30.7,
+      60.0,
+      90.7,
+      90.0
+    ],
+    "iso": [
+      183.2,
+      90.5,
+      275.2,
+      175.5
+    ],
+    "plan": [
+      30.7,
+      110.0,
+      90.7,
+      150.0
+    ],
+    "side": [
+      111.4,
+      60.0,
+      151.4,
+      90.0
+    ]
+  }
+}

--- a/tests/refactor_golden/turned_stepped.json
+++ b/tests/refactor_golden/turned_stepped.json
@@ -1,0 +1,197 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        41.9,
+        58.0,
+        42.1,
+        108.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "centerline_front",
+      "type": "Centerline",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        118.9,
+        58.0,
+        119.1,
+        108.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "centerline_side",
+      "type": "Centerline",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        30.0,
+        107.0,
+        54.1,
+        115.0
+      ],
+      "label": "\u00f824",
+      "label_bbox": [
+        39.4,
+        111.9,
+        44.6,
+        114.1
+      ],
+      "name": "dim_od",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        15.9,
+        84.9,
+        34.0,
+        87.1
+      ],
+      "label": "\u00f816",
+      "label_bbox": [
+        15.9,
+        84.9,
+        21.0,
+        87.1
+      ],
+      "name": "m_dia_z0",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        15.9,
+        96.9,
+        37.0,
+        99.1
+      ],
+      "label": "\u00f810",
+      "label_bbox": [
+        15.9,
+        96.9,
+        21.0,
+        99.1
+      ],
+      "name": "m_dia_z1",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        56.0,
+        63.0,
+        67.0,
+        79.1
+      ],
+      "label": "16",
+      "label_bbox": [
+        63.9,
+        69.4,
+        66.1,
+        72.6
+      ],
+      "name": "m_steplen0",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        56.0,
+        79.0,
+        67.0,
+        93.1
+      ],
+      "label": "14",
+      "label_bbox": [
+        64.0,
+        84.3,
+        66.0,
+        87.7
+      ],
+      "name": "m_steplen1",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        56.0,
+        93.0,
+        67.0,
+        103.1
+      ],
+      "label": "10",
+      "label_bbox": [
+        63.9,
+        96.4,
+        66.1,
+        99.6
+      ],
+      "name": "m_steplen2",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        206.8,
+        95.4,
+        231.2,
+        98.1
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        206.8,
+        95.4,
+        231.2,
+        98.1
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        165.9,
+        10.9,
+        286.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 10,
+  "views": {
+    "front": [
+      30.0,
+      63.0,
+      54.0,
+      103.0
+    ],
+    "iso": [
+      203.4,
+      102.8,
+      234.6,
+      158.0
+    ],
+    "plan": [
+      30.0,
+      123.0,
+      54.0,
+      147.0
+    ],
+    "side": [
+      107.0,
+      63.0,
+      131.0,
+      103.0
+    ]
+  }
+}

--- a/tests/test_refactor_golden.py
+++ b/tests/test_refactor_golden.py
@@ -1,0 +1,218 @@
+"""Strict placement golden for the #638/#639 hotspot-split refactors (epic #635).
+
+These refactors (`render_pmi`, `_annotate_holes`, `finalize`, the #639 PlacementContext
+threading) are **behaviour-preserving** — the output must not change at all. This gate is a
+stronger, wider counterpart to the retired byte-exact golden (ADR 0007) and the ADR-0009
+`test_layout_snapshot`: it snapshots the FULL placement signature of a corpus chosen to
+exercise every path the split touches — machined-feature leader callouts (chamfer/fillet/
+flat/pocket/groove), off-axis hole locations, prismatic height ladders + step positions,
+sections, turned diameters, dense-hole table escalation — and also the **build-issue set**
+(drops/escalations), which a placement-only snapshot misses but the drop logic in
+`_annotate_holes`/`render_pmi` is load-bearing on.
+
+Precision: the 0.1 mm + 1e-6-bias quantisation proven cross-platform-stable for the ADR-0009
+snapshot (ADR 0006 pinned fonts). A raw byte/SVG digest is deliberately NOT used — a refactor
+that reorders floating-point sums shifts a value ~1 ULP with no real placement change, which a
+byte digest false-fails on; 0.1 mm catches the ~mm drift a wrong projector/sign/order causes
+while surviving that noise.
+
+**Throwaway:** delete this file and `tests/refactor_golden/` once #638 + #639 land.
+
+Re-bless intentionally (there should be NO intentional change during these refactors):
+    DRAFTWRIGHT_UPDATE_GOLDEN=1 uv run pytest tests/test_refactor_golden.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from build123d import Axis, Box, Cylinder, Pos, Rot, Rotation, chamfer, fillet
+
+from draftwright import build_drawing
+
+_GOLDEN_DIR = Path(__file__).parent / "refactor_golden"
+
+
+# --- corpus: fast parts exercising the #638/#639 code paths ------------------------------
+
+
+def _chamfered():
+    # A single corner chamfer → render_chamfers leader callout.
+    plate = Box(90, 60, 20)
+    e = plate.edges().filter_by(Axis.Z).sort_by(lambda e: e.center().X + e.center().Y)[-1]
+    return chamfer(e, 12)
+
+
+def _filleted():
+    # A single corner fillet → render_fillets leader callout.
+    plate = Box(90, 60, 20)
+    e = plate.edges().filter_by(Axis.Z).sort_by(lambda e: e.center().X + e.center().Y)[-1]
+    return fillet(e, 8)
+
+
+def _hex_bar():
+    # Six flats 60° apart on round stock → render_flats "A/F" callout.
+    bar = Cylinder(10, 30)
+    for k in range(6):
+        bar = bar - Rot(0, 0, 60 * k) * Pos(10.3, 0, 0) * Box(2, 40, 40)
+    return bar
+
+
+def _grooved_shaft():
+    # Two annular grooves on one shaft → render_grooves callouts + turned diameters/lengths.
+    shaft = Cylinder(10, 60)
+    shaft -= Pos(0, 0, 15) * (Cylinder(10, 4) - Cylinder(8, 4))
+    shaft -= Pos(0, 0, -15) * (Cylinder(10, 4) - Cylinder(7, 4))
+    return shaft
+
+
+def _pocketed():
+    # A blind pocket + a through hole → render_pockets callout + _annotate_holes.
+    return Box(80, 60, 20) - Pos(0, 10, 5) * Box(30, 20, 20) - Pos(-20, -15, 0) * Cylinder(3, 30)
+
+
+def _side_drilled():
+    # Radial (X-axis) through-holes at two heights → _locate_off_axis_holes (side/below).
+    part = Box(60, 40, 30)
+    for z in (8, 20):
+        part -= Pos(0, 0, z) * Rotation(0, 90, 0) * Cylinder(3, 80)
+    return part
+
+
+def _prismatic_ladder():
+    # An asymmetric step → height ladder + a step-position (shoulder) dim.
+    return Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15)
+
+
+def _centered_rebate():
+    # A central channel → two shoulders, both positions dimensioned.
+    return Box(80, 60, 30) - Pos(0, 0, 7.5) * Box(80, 20, 15)
+
+
+def _bracket_section():
+    # Central bore + offset counterbore → plan callouts + section A-A.
+    return Box(90, 60, 20) - Cylinder(4, 20) - Pos(10, 5, -7) * Cylinder(6, 6)
+
+
+def _turned_stepped():
+    # Z-turned stepped cylinder → step diameters + axial length chain.
+    from build123d import Align
+
+    base = (Align.CENTER, Align.CENTER, Align.MIN)
+    s = Cylinder(12, 16, align=base)
+    s += Pos(0, 0, 16) * Cylinder(8, 14, align=base)
+    s += Pos(0, 0, 30) * Cylinder(5, 10, align=base)
+    return s
+
+
+def _flange_dense():
+    # A bolt circle → dense plan holes escalate to the hole TABLE + balloon ring.
+    import math
+
+    flange = Cylinder(radius=45, height=10) - Cylinder(radius=8, height=10)
+    for i in range(5):
+        ang = math.radians(72 * i)
+        flange -= Pos(30 * math.cos(ang), 30 * math.sin(ang), 0) * Cylinder(3, 10)
+    return flange
+
+
+def _holed_slot():
+    # A hole whose X-location coincides with a slot edge → the #345 corridor dedup path.
+    from build123d import BuildPart, Hole, Locations, Mode
+
+    with BuildPart() as p:
+        Box(60, 40, 20)
+        Box(20, 8, 30, mode=Mode.SUBTRACT)
+        with Locations((-10, 14, 0), (20, 14, 0), (8, -14, 0)):
+            Hole(3, depth=20)
+    return p.part
+
+
+CORPUS = {
+    "chamfered": _chamfered,
+    "filleted": _filleted,
+    "hex_bar": _hex_bar,
+    "grooved_shaft": _grooved_shaft,
+    "pocketed": _pocketed,
+    "side_drilled": _side_drilled,
+    "prismatic_ladder": _prismatic_ladder,
+    "centered_rebate": _centered_rebate,
+    "bracket_section": _bracket_section,
+    "turned_stepped": _turned_stepped,
+    "flange_dense": _flange_dense,
+    "holed_slot": _holed_slot,
+}
+
+
+# --- signature ---------------------------------------------------------------------------
+
+
+def _round_bbox(box):
+    # 0.1 mm grid + 1e-6 bias: stable under a refactor's FP-reordering, sensitive to real drift.
+    if box is None:
+        return None
+    return [round(float(v) + 1e-6, 1) for v in box]
+
+
+def _geom_box(o):
+    try:
+        b = o.bounding_box()
+        return (b.min.X, b.min.Y, b.max.X, b.max.Y)
+    except Exception:
+        return None
+
+
+def _signature(dwg) -> dict:
+    annotations = sorted(
+        (
+            {
+                "name": name,
+                "view": dwg.view_of(name),
+                "type": type(o).__name__,
+                "label": getattr(o, "label", "") or "",
+                "label_bbox": _round_bbox(getattr(o, "label_bbox", None)),
+                "geom_bbox": _round_bbox(_geom_box(o)),
+            }
+            for name, o in dwg.iter_annotations()
+        ),
+        key=lambda a: a["name"],
+    )
+    views = {}
+    for vname, shapes in dwg.views.items():
+        vis = shapes[0] if isinstance(shapes, (tuple, list)) else shapes
+        views[vname] = _round_bbox(_geom_box(vis))
+    # Build issues (drops / escalations / warnings) — the drop logic in _annotate_holes and
+    # render_pmi is load-bearing and a placement-only snapshot would miss a change to it.
+    # Lists, not tuples: JSON has no tuple type, so tuples would fail the round-trip compare.
+    issues = sorted([i.severity, i.code, i.message] for i in dwg._build_issues)
+    return {
+        "views": views,
+        "annotations": annotations,
+        "item_count": len(dwg.items),
+        "build_issues": issues,
+    }
+
+
+@pytest.mark.parametrize("name", list(CORPUS))
+def test_refactor_golden(name):
+    dwg = build_drawing(CORPUS[name]())
+    sig = _signature(dwg)
+    golden = _GOLDEN_DIR / f"{name}.json"
+
+    if os.environ.get("DRAFTWRIGHT_UPDATE_GOLDEN"):
+        _GOLDEN_DIR.mkdir(exist_ok=True)
+        golden.write_text(json.dumps(sig, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return
+
+    assert golden.exists(), (
+        f"no golden for {name!r}; generate with "
+        f"DRAFTWRIGHT_UPDATE_GOLDEN=1 uv run pytest tests/test_refactor_golden.py"
+    )
+    expected = json.loads(golden.read_text(encoding="utf-8"))
+    assert sig == expected, (
+        f"placement/issue drift for {name!r}. The #638/#639 refactors must be byte-for-byte "
+        f"behaviour-preserving — this is a real regression, NOT to be re-blessed away."
+    )


### PR DESCRIPTION
Part of consolidation epic #635. A safety net for the upcoming **behaviour-preserving** hotspot-split refactors (#638 `render_pmi`/`_annotate_holes`/`finalize`, #639 PlacementContext), which must not change output at all.

## What

A dedicated golden gate — a stronger, wider counterpart to the ADR-0009 `test_layout_snapshot` — over a 12-part corpus chosen to exercise every path the split touches: machined-feature leader callouts (chamfer/fillet/flat/pocket/groove), off-axis hole locations, prismatic height ladders + step positions, sections, turned diameters, dense-hole table escalation, and the #345 corridor-dedup path. It snapshots the full placement signature **and** the build-issue set (drops/escalations) — the latter is where `_annotate_holes`/`render_pmi` drop logic is load-bearing and a placement-only snapshot is blind.

## Precision — why not a byte digest

Deliberately the **0.1 mm + 1e-6-bias** quantisation proven cross-platform-stable for the ADR-0009 snapshot, **not** a raw SVG/byte digest. A pure refactor that reorders floating-point sums shifts a value ~1 ULP with no real placement change; a byte digest false-fails on that (the reason the ADR-0007 byte golden was retired). 0.1 mm catches the ~mm drift a wrong projector/sign/order causes while surviving that noise. `render_pmi` PMI is already covered by `test_pmi`, so the slow CTC01 STEP fixture stays out of this gate.

## Lifecycle

Throwaway — delete `tests/test_refactor_golden.py` + `tests/refactor_golden/` once #638 and #639 land. Should merge **before** those refactors so they're guarded. Regenerate only for an intentional change: `DRAFTWRIGHT_UPDATE_GOLDEN=1`.

Additive (test + fixtures only); no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)