### PR TITLE
refactor(#638): single owner for the per-run placement scratch init

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -532,6 +532,29 @@ def register_corridor(dwg, key, strip, view, axis, tier, cand):
     b["cands"].append(cand)
 
 
+def init_placement_scratch(dwg, *, reset: bool) -> None:
+    """Seed the per-run placement scratch containers a build's passes share — the corridor
+    batch (:func:`register_corridor`/:func:`drain_corridors`), the escalation list (ADR 0009
+    Amdt 1, #351), and the enlarged-detail request list (#307). The single owner both entry
+    paths call (#638), replacing the two hand-rolled copies that had drifted.
+
+    ``reset=True`` (the auto-pass, :func:`_auto_annotate`) clears them each run — the pass is
+    idempotent. ``reset=False`` (the record→finalize path, #426) creates-if-absent only, so it
+    never wipes a ``_corridor_batch`` left populated by a prior finalize whose drain raised;
+    that leftover must still drain (#636 retry-safety)."""
+    if reset:
+        dwg._corridor_batch = {}
+        dwg._escalations = []
+        dwg._detail_requests = []
+        return
+    if not hasattr(dwg, "_corridor_batch"):
+        dwg._corridor_batch = {}
+    if not hasattr(dwg, "_escalations"):
+        dwg._escalations = []
+    if not hasattr(dwg, "_detail_requests"):
+        dwg._detail_requests = []
+
+
 def drain_corridors(dwg):
     """Solve every registered corridor (one :func:`solve_corridor` per strip), then clear
     the batch. Called once, after all corridor-feeding passes have registered."""

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -30,7 +30,7 @@ from draftwright._core import (
     _tag_sequence,
 )
 from draftwright.analysis import _sizing_bores
-from draftwright.annotations._common import drain_corridors
+from draftwright.annotations._common import drain_corridors, init_placement_scratch
 from draftwright.annotations.from_model import (
     render_boss_diameters,
     render_centermarks,
@@ -166,9 +166,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # not accumulate duplicate drop records.
     dwg._reset_build_issues()
     dwg._reset_dropped_callout_diams()
-    dwg._detail_requests = []  # renderers queue enlarged-detail requests here (#307)
-    dwg._escalations = []  # placers collect Escalation objects here (ADR 0009 Amdt 1, #351)
-    dwg._corridor_batch = {}  # passes register CorridorCandidates here; one drain solves each strip (#345/#346)
+    # Per-run placement scratch (detail requests / escalations / corridor batch) — reset each
+    # auto-pass; the single owner is init_placement_scratch (#638). The corridor batch is
+    # drained once at the end (drain_corridors, #345/#346).
+    init_placement_scratch(dwg, reset=True)
 
     # Tighten right-strip outer_limits to the actual iso view left edge now
     # that the iso has been projected and fitted.  Always apply so that any

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -393,6 +393,12 @@ class Drawing:
     first :meth:`lint` otherwise).
     """
 
+    # Per-run placement scratch — created by _common.init_placement_scratch (auto-pass or
+    # finalize, #638), not in __init__; declared here so mypy knows their types.
+    _corridor_batch: dict
+    _escalations: list
+    _detail_requests: list
+
     def __init__(
         self,
         *,
@@ -1419,7 +1425,7 @@ class Drawing:
         # so a first call (no attr yet) still short-circuits on empty intents as before.
         if not self._intents and not getattr(self, "_corridor_batch", None):
             return
-        from draftwright.annotations._common import drain_corridors
+        from draftwright.annotations._common import drain_corridors, init_placement_scratch
         from draftwright.annotations.from_model import (
             render_diameters,
             render_height_ladder,
@@ -1437,14 +1443,10 @@ class Drawing:
         )
         from draftwright.model import PartModel, plan_dimensions
 
-        # Corridor state the auto-pass creates in _auto_annotate S0 but a detect-only build
-        # lacks — render_locations/_annotate_holes/drain_corridors register/read here.
-        if not hasattr(self, "_corridor_batch"):
-            self._corridor_batch: dict = {}
-        if not hasattr(self, "_escalations"):
-            self._escalations: list = []
-        if not hasattr(self, "_detail_requests"):
-            self._detail_requests: list = []
+        # Corridor state the auto-pass creates in _auto_annotate but a detect-only build lacks —
+        # render_locations/_annotate_holes/drain_corridors register/read here. reset=False keeps
+        # a _corridor_batch left by a prior finalize whose drain raised (#636 retry-safety).
+        init_placement_scratch(self, reset=False)
 
         model, a = self._part_model, self._analysis
         routable = model is not None and a is not None


### PR DESCRIPTION
Part of #638 (split the complexity hotspots — the `finalize` corridor-init duplication the issue calls out at ~line 1437).

## What

`_auto_annotate` (orchestrator ~169) and `Drawing.finalize` (~1442) each hand-rolled the seeding of the three per-run placement scratch containers — `_corridor_batch` / `_escalations` / `_detail_requests` — and the two copies had **drifted**: the auto-pass resets them each run, while finalize creates-if-absent so it never wipes a `_corridor_batch` left by a prior finalize whose drain raised (the #636 retry-safety).

One owner, `_common.init_placement_scratch(dwg, *, reset)`, keeps **both** semantics behind the flag (`reset=True` auto-pass, `reset=False` finalize). Class-level annotations on `Drawing` declare the scratch attrs' types now that the annotated inits moved out.

## Safety

No behaviour change. Verified byte-identical by the **refactor golden** (the new #635 gate, 12 parts through the full auto-pass), the finalize/deferred + step suites, and the full fast tier (**1375 passed**). The reset-flag preserves the exact #636 stranded-batch retry contract — the one thing a naive single-init helper would have broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)