### PR TITLE
refactor(#638): _annotate_holes — promote all pure helpers, flatten 5-level nesting

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1221,6 +1221,135 @@ def _probe_box(s, edge, side, to_page, elbow_dx, draft, scale):
     return _geom_box(leader)
 
 
+class _StripCtx(NamedTuple):
+    """The plan/side-view strip geometry a callout carve reads — the vars the carve helpers
+    closed over inside _annotate_holes (#638). LOCAL placement geometry for one strip; distinct
+    from the #639 Drawing build-state context."""
+
+    edge: float
+    min_gap: float
+    y_min: float
+    y_max: float
+    a: object
+    to_page: object
+    view_cx: float
+    view_cy: float
+    draft: object
+
+
+def _seg_order(ny, segs):
+    """Segments nearest-to-farthest from *ny* — the containing segment (if any) first, else by
+    edge distance; ties (equidistant between two segments) break on segment start for
+    determinism. Promoted out of _annotate_holes (#638; pure)."""
+
+    def _dist(seg):
+        lo, hi = seg
+        return (0.0, lo) if lo <= ny <= hi else (min(abs(ny - lo), abs(ny - hi)), lo)
+
+    return sorted(segs, key=_dist)
+
+
+def _carve_and_place(cands_in, intervals, key_prefix_local, ctx: _StripCtx, *, allow_snap=True):
+    """Carve ``[ctx.y_min, ctx.y_max]`` around keep-out *intervals* and place each candidate in
+    the nearest free segment that fits (GLOBAL over-capacity selection). Returns
+    ``({id(cand): y}, {id(cand)} dropped)`` — keyed by the IDENTITY of the passed *cands_in*
+    tuples, so a caller must pass the same objects (not equivalents). Promoted out of
+    _annotate_holes (#638; pure)."""
+    segs = carve_free_segments(ctx.y_min, ctx.y_max, intervals, 0.0)
+    if not segs:
+        if not allow_snap:
+            # bands+obstacles combined leave no free segment — unlike a
+            # band-only strip (below), this has no single-pass escape that
+            # is safe to trust: a snap chosen to clear ONE blocking
+            # interval isn't rechecked against the others, so it can still
+            # land inside a different one (a real drawing-level obstacle,
+            # e.g. the section cutting-plane letter, unlike a band, is
+            # exactly the kind of thing that produces a visible overlap,
+            # not just a theoretical one). Returning nothing here (instead
+            # of a wrong position) defers every candidate cleanly to the
+            # bands-only baseline below, matching what a fully-obstacle-
+            # blocked carve already did before this helper existed.
+            return {}, set()
+
+        # *intervals* covers [y_min, y_max] entirely — a band wider than
+        # the whole strip (a shallow view, e.g. the `dshape` side strip).
+        # Rather than drop a real callout to honour it (policy B), snap
+        # each natural to the strip edge farthest from the row (the same
+        # minimal-residual choice the old `_coaxial_lift`/
+        # `_snap_out_of_bands` fallback made) and solve once over the
+        # whole, still-unavoidable range.
+        def _snap(ny):
+            p = ny
+            for a0, b0 in intervals:
+                if a0 < p < b0:
+                    p = b0 if (ctx.y_max - ny) >= (ny - ctx.y_min) else a0
+            return min(max(p, ctx.y_min), ctx.y_max)
+
+        cands = [
+            StripCandidate(
+                key=f"{key_prefix_local}{j:04d}",
+                anchor=(ctx.edge, _snap(s[4])),
+                size=(s[2].callout_width, ctx.min_gap),
+                priority=s[1],
+                anchored=_is_central(s, ctx.a, ctx.to_page, ctx.view_cx, ctx.view_cy, ctx.draft),
+            )
+            for j, s in enumerate(cands_in)
+        ]
+        res = plan_strip(cands, ctx.y_min, ctx.y_max, ctx.min_gap)
+        by_key = {c.key: s for c, s in zip(cands, cands_in, strict=True)}
+        return (
+            {id(by_key[k]): y for k, y in res.placed.items()},
+            {id(by_key[k]) for k in res.dropped},
+        )
+
+    def _cand(s, j):
+        return StripCandidate(
+            key=f"{key_prefix_local}{j:04d}",
+            anchor=(ctx.edge, s[4]),
+            size=(s[2].callout_width, ctx.min_gap),
+            priority=s[1],  # bore diameter — largest wins over-capacity (D3)
+            anchored=_is_central(s, ctx.a, ctx.to_page, ctx.view_cx, ctx.view_cy, ctx.draft),
+        )
+
+    # Selection (ADR 0009 P2) must be GLOBAL across every carved segment,
+    # not per-segment — a candidate that overflows its nearest segment may
+    # still fit a farther one with spare room (#381: the retired banded-DP
+    # tried this but approximated feasibility by placed-count alone, which
+    # lost track of *where* things were placed; this instead re-runs the
+    # real per-segment solve on each trial, so it can't reintroduce that
+    # bug). Process candidates highest-priority-first so a segment already
+    # holding only >= priority members can, on overflow, only ever be
+    # asked to drop the newcomer being tried — never evict a prior
+    # commitment — which is exactly what "trial has zero drops" verifies
+    # below: on a rare priority TIE it's conservative (rejects rather than
+    # risking evicting an existing member), never wrong.
+    order = sorted(cands_in, key=lambda s: (-s[1], s[4]))
+    members: dict = {seg: [] for seg in segs}
+    dropped_ids: set = set()
+    for s in order:
+        for seg in _seg_order(s[4], segs):
+            trial = members[seg] + [s]
+            cands = [_cand(m, j) for j, m in enumerate(trial)]
+            res = plan_strip(cands, seg[0], seg[1], ctx.min_gap)
+            if not res.dropped:
+                members[seg] = trial
+                break
+        else:
+            dropped_ids.add(id(s))
+
+    y_by_id: dict = {}
+    for seg, mem in members.items():
+        if not mem:
+            continue
+        cands = [_cand(m, j) for j, m in enumerate(mem)]
+        res = plan_strip(cands, seg[0], seg[1], ctx.min_gap)
+        by_key = {c.key: m for c, m in zip(cands, mem, strict=True)}
+        for k, y in res.placed.items():
+            y_by_id[id(by_key[k])] = y
+        dropped_ids.update(id(by_key[k]) for k in res.dropped)
+    return y_by_id, dropped_ids
+
+
 def _annotate_holes(
     dwg, a: Analysis, view_of_axis, groups, feature_keys, *, only=None, place_furniture=True
 ):
@@ -1529,6 +1658,8 @@ def _annotate_holes(
             if not queue:
                 return start_i
 
+            ctx = _StripCtx(edge, min_gap, y_min, y_max, a, to_page, view_cx, view_cy, draft)
+
             # Carve [y_min, y_max] around a set of keep-out intervals, assign each
             # candidate to its nearest free segment, then solve each segment
             # independently with the plain PAVA solve — the ONE carve+assign+solve
@@ -1538,120 +1669,13 @@ def _annotate_holes(
             # to its own band-free segment never needs cross-segment reasoning to
             # stay off a reserved row. *intervals* must already carry their own
             # clearance (pre-inflated) — this carves with `pad=0`.
-            def _carve_and_place(cands_in, intervals, key_prefix_local, *, allow_snap=True):
-                segs = carve_free_segments(y_min, y_max, intervals, 0.0)
-                if not segs:
-                    if not allow_snap:
-                        # bands+obstacles combined leave no free segment — unlike a
-                        # band-only strip (below), this has no single-pass escape that
-                        # is safe to trust: a snap chosen to clear ONE blocking
-                        # interval isn't rechecked against the others, so it can still
-                        # land inside a different one (a real drawing-level obstacle,
-                        # e.g. the section cutting-plane letter, unlike a band, is
-                        # exactly the kind of thing that produces a visible overlap,
-                        # not just a theoretical one). Returning nothing here (instead
-                        # of a wrong position) defers every candidate cleanly to the
-                        # bands-only baseline below, matching what a fully-obstacle-
-                        # blocked carve already did before this helper existed.
-                        return {}, set()
-
-                    # *intervals* covers [y_min, y_max] entirely — a band wider than
-                    # the whole strip (a shallow view, e.g. the `dshape` side strip).
-                    # Rather than drop a real callout to honour it (policy B), snap
-                    # each natural to the strip edge farthest from the row (the same
-                    # minimal-residual choice the old `_coaxial_lift`/
-                    # `_snap_out_of_bands` fallback made) and solve once over the
-                    # whole, still-unavoidable range.
-                    def _snap(ny):
-                        p = ny
-                        for a0, b0 in intervals:
-                            if a0 < p < b0:
-                                p = b0 if (y_max - ny) >= (ny - y_min) else a0
-                        return min(max(p, y_min), y_max)
-
-                    cands = [
-                        StripCandidate(
-                            key=f"{key_prefix_local}{j:04d}",
-                            anchor=(edge, _snap(s[4])),
-                            size=(s[2].callout_width, min_gap),
-                            priority=s[1],
-                            anchored=_is_central(s, a, to_page, view_cx, view_cy, draft),
-                        )
-                        for j, s in enumerate(cands_in)
-                    ]
-                    res = plan_strip(cands, y_min, y_max, min_gap)
-                    by_key = {c.key: s for c, s in zip(cands, cands_in, strict=True)}
-                    return (
-                        {id(by_key[k]): y for k, y in res.placed.items()},
-                        {id(by_key[k]) for k in res.dropped},
-                    )
-
-                def _seg_order(ny):
-                    """Segments nearest-to-farthest from *ny* — the containing
-                    segment (if any) first, else by edge distance; ties (equidistant
-                    between two segments) break on segment start for determinism."""
-
-                    def _dist(seg):
-                        lo, hi = seg
-                        return (
-                            (0.0, lo) if lo <= ny <= hi else (min(abs(ny - lo), abs(ny - hi)), lo)
-                        )
-
-                    return sorted(segs, key=_dist)
-
-                def _cand(s, j):
-                    return StripCandidate(
-                        key=f"{key_prefix_local}{j:04d}",
-                        anchor=(edge, s[4]),
-                        size=(s[2].callout_width, min_gap),
-                        priority=s[1],  # bore diameter — largest wins over-capacity (D3)
-                        anchored=_is_central(s, a, to_page, view_cx, view_cy, draft),
-                    )
-
-                # Selection (ADR 0009 P2) must be GLOBAL across every carved segment,
-                # not per-segment — a candidate that overflows its nearest segment may
-                # still fit a farther one with spare room (#381: the retired banded-DP
-                # tried this but approximated feasibility by placed-count alone, which
-                # lost track of *where* things were placed; this instead re-runs the
-                # real per-segment solve on each trial, so it can't reintroduce that
-                # bug). Process candidates highest-priority-first so a segment already
-                # holding only >= priority members can, on overflow, only ever be
-                # asked to drop the newcomer being tried — never evict a prior
-                # commitment — which is exactly what "trial has zero drops" verifies
-                # below: on a rare priority TIE it's conservative (rejects rather than
-                # risking evicting an existing member), never wrong.
-                order = sorted(cands_in, key=lambda s: (-s[1], s[4]))
-                members: dict = {seg: [] for seg in segs}
-                dropped_ids: set = set()
-                for s in order:
-                    for seg in _seg_order(s[4]):
-                        trial = members[seg] + [s]
-                        cands = [_cand(m, j) for j, m in enumerate(trial)]
-                        res = plan_strip(cands, seg[0], seg[1], min_gap)
-                        if not res.dropped:
-                            members[seg] = trial
-                            break
-                    else:
-                        dropped_ids.add(id(s))
-
-                y_by_id: dict = {}
-                for seg, mem in members.items():
-                    if not mem:
-                        continue
-                    cands = [_cand(m, j) for j, m in enumerate(mem)]
-                    res = plan_strip(cands, seg[0], seg[1], min_gap)
-                    by_key = {c.key: m for c, m in zip(cands, mem, strict=True)}
-                    for k, y in res.placed.items():
-                        y_by_id[id(by_key[k])] = y
-                    dropped_ids.update(id(by_key[k]) for k in res.dropped)
-                return y_by_id, dropped_ids
 
             # Baseline: bands only, ignoring drawing-level obstacles entirely —
             # every candidate pulled toward its own natural Y, respecting only
             # min_gap from its queue siblings and the keep-out rows. Used below
             # as the "cost of NOT avoiding [obstacles]" reference a carve-based
             # relocation must beat to be worth taking.
-            base_y, base_dropped = _carve_and_place(queue, band_intervals, key_prefix)
+            base_y, base_dropped = _carve_and_place(queue, band_intervals, key_prefix, ctx)
 
             # Carve around drawing-level obstacles this column's leaders would
             # cross too (e.g. the section cutting-plane arrow — #351 P5 strand
@@ -1680,7 +1704,7 @@ def _annotate_holes(
                 (max(y_min, o[1] - min_gap), min(y_max, o[3] + min_gap)) for o in occupied
             ]
             seg_y, _seg_dropped = _carve_and_place(
-                queue, band_intervals + obstacle_intervals, key_prefix, allow_snap=False
+                queue, band_intervals + obstacle_intervals, key_prefix, ctx, allow_snap=False
             )
 
             # Decide per candidate: take the carve-aware (obstacle-avoiding)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1157,6 +1157,70 @@ def _leader_hits(leader, tip, elbow, side, obstacles):
     return _box_hits(label_box, obstacles)
 
 
+def _rim_tip(centre, elbow, dia, scale):
+    """Pull the tip from the hole centre to its circumference (bore *dia* mm). Promoted out of
+    _annotate_holes (#638; pure) — *scale* was the closed-over ``a.SCALE``."""
+    r = dia * scale / 2
+    dx, dy = elbow[0] - centre[0], elbow[1] - centre[1]
+    norm = math.hypot(dx, dy)
+    if norm <= r:
+        return centre
+    return (centre[0] + dx / norm * r, centre[1] + dy / norm * r)
+
+
+def _build_leader_at(s, edge, side, y, to_page, elbow_dx, draft, scale):
+    """The Leader a callout would draw for queue entry *s* at elbow-Y *y* — built but not
+    placed, so its footprint can be checked before committing (ADR 0009 P5 strand 3). Returns
+    ``(leader, tip, elbow)``. Promoted (#638; pure)."""
+    _locs, dia, callout, _feat, _ny, rep = s
+    centre = to_page(rep)
+    if side == "right":
+        elbow = (edge + elbow_dx, y)
+        tip = _rim_tip(centre, elbow, dia, scale)
+        tip = (min(tip[0], edge - draft.arrow_length), tip[1])
+    else:
+        elbow = (edge - elbow_dx, y)
+        tip = _rim_tip(centre, elbow, dia, scale)
+        tip = (max(tip[0], edge + draft.arrow_length), tip[1])
+    leader = Leader(
+        tip=(tip[0], tip[1], 0),
+        elbow=(elbow[0], elbow[1], 0),
+        label="",
+        draft=draft,
+        text_side=side,
+        callout=callout,
+    )
+    return leader, tip, elbow
+
+
+def _is_central(s, a, to_page, view_cx, view_cy, draft):
+    """The coaxial hole whose callout belongs *on* the view-centre row, and so is anchored there
+    (ADR 0009 Amendment 4) — the exact minimum-leader spacing solve can't then slide it off
+    centre on a tie. Prismatic parts only: on a turned/rotational round view the centre-line
+    itself runs through this row, so the coaxial bore is pushed OFF it (the ``forbidden``
+    centreline band) — anchoring is gated off exactly when the centreline band is on (ADR 0009
+    Amendment 5, P4c). ``s[5]`` is the representative hole location. Promoted (#638; pure)."""
+    rep = s[5]
+    if rep is None or a.is_rotational or a.prof is not None:
+        return False
+    cx, cy = to_page(rep)
+    tol = draft.font_size
+    return abs(cx - view_cx) < tol and abs(cy - view_cy) < tol
+
+
+def _probe_box(s, edge, side, to_page, elbow_dx, draft, scale):
+    """Probe a queued candidate's leader footprint up front (before it's chosen for placement),
+    so a degenerate geometry (a hole essentially coincident with the strip edge) gets a
+    defensive catch, matching _geom_box's "not every annotation bbox-es cleanly" idiom. Returns
+    the box or ``None``. Promoted (#638; pure)."""
+    try:
+        leader, _, _ = _build_leader_at(s, edge, side, s[4], to_page, elbow_dx, draft, scale)
+    except Exception as exc:  # noqa: BLE001 — geometry construction raises broadly
+        _log.debug("plan/side %s strip: probe leader failed (%s); omitted", side, exc)
+        return None
+    return _geom_box(leader)
+
+
 def _annotate_holes(
     dwg, a: Analysis, view_of_axis, groups, feature_keys, *, only=None, place_furniture=True
 ):
@@ -1245,15 +1309,6 @@ def _annotate_holes(
         _feat_of_callout[id(callout)] = feat  # provenance (#408)
         by_view.setdefault(view, []).append((locs, dia, callout, pat))
 
-    def _rim_tip(centre, elbow, dia):
-        """Pull the tip from the hole centre to its circumference (bore *dia* mm)."""
-        r = dia * a.SCALE / 2
-        dx, dy = elbow[0] - centre[0], elbow[1] - centre[1]
-        norm = math.hypot(dx, dy)
-        if norm <= r:
-            return centre
-        return (centre[0] + dx / norm * r, centre[1] + dy / norm * r)
-
     def _hc_name(view, i):
         # The auto-pass (only is None) numbers callouts positionally hc_{view}{i} — the
         # historical byte-identical scheme. The #426 finalize path (only set) may run after
@@ -1313,7 +1368,7 @@ def _annotate_holes(
                     _callout=callout,
                 ):
                     elbow = (_centre[0], pos)
-                    tip = _rim_tip(_centre, elbow, _dia)
+                    tip = _rim_tip(_centre, elbow, _dia, a.SCALE)
                     return Leader(
                         tip=(tip[0], tip[1], 0),
                         elbow=(elbow[0], elbow[1], 0),
@@ -1470,52 +1525,6 @@ def _annotate_holes(
         # cannot hold every callout, the smallest-bore features drop first so the most
         # significant survive (the same "largest wins" policy the front-view shaft rows
         # already use, line 638). Ties (equal bore) fall back to key = natural-Y order.
-        def _build_leader_at(s, edge, side, y):
-            """The Leader `_add` would draw for queue entry *s* at elbow-Y *y* —
-            built but not placed, so its footprint can be checked before
-            committing (ADR 0009 P5 strand 3). Returns ``(leader, tip, elbow)``."""
-            _locs, dia, callout, _feat, _ny, rep = s
-            centre = to_page(rep)
-            if side == "right":
-                elbow = (edge + elbow_dx, y)
-                tip = _rim_tip(centre, elbow, dia)
-                tip = (min(tip[0], edge - draft.arrow_length), tip[1])
-            else:
-                elbow = (edge - elbow_dx, y)
-                tip = _rim_tip(centre, elbow, dia)
-                tip = (max(tip[0], edge + draft.arrow_length), tip[1])
-            leader = Leader(
-                tip=(tip[0], tip[1], 0),
-                elbow=(elbow[0], elbow[1], 0),
-                label="",
-                draft=draft,
-                text_side=side,
-                callout=callout,
-            )
-            return leader, tip, elbow
-
-        def _is_central(s):
-            """The coaxial hole whose callout belongs *on* the view-centre row, and
-            so is anchored there (ADR 0009 Amendment 4) — the exact minimum-leader
-            spacing solve can't then slide it off centre on a tie (the equal-cost
-            placements differ only in *which* callout absorbs the shift, and for a
-            central feature that must not be the central one).
-
-            Prismatic parts only: on a turned/rotational round view the centre-line
-            *itself* runs through this row, so the coaxial bore must be pushed
-            **off** it (the ``forbidden`` centreline band) — the opposite of
-            anchoring. The two are mutually exclusive by part class, so anchoring
-            is gated off exactly when the centreline band is on (ADR 0009
-            Amendment 5, P4c). ``s[5]`` is the callout's representative hole
-            location (``None`` only for a left-queue entry with no left edge, which
-            never happens for a placed callout)."""
-            rep = s[5]
-            if rep is None or a.is_rotational or a.prof is not None:
-                return False
-            cx, cy = to_page(rep)
-            tol = draft.font_size
-            return abs(cx - view_cx) < tol and abs(cy - view_cy) < tol
-
         def _place_queue(queue, edge, side, key_prefix, start_i):
             if not queue:
                 return start_i
@@ -1566,7 +1575,7 @@ def _annotate_holes(
                             anchor=(edge, _snap(s[4])),
                             size=(s[2].callout_width, min_gap),
                             priority=s[1],
-                            anchored=_is_central(s),
+                            anchored=_is_central(s, a, to_page, view_cx, view_cy, draft),
                         )
                         for j, s in enumerate(cands_in)
                     ]
@@ -1596,7 +1605,7 @@ def _annotate_holes(
                         anchor=(edge, s[4]),
                         size=(s[2].callout_width, min_gap),
                         priority=s[1],  # bore diameter — largest wins over-capacity (D3)
-                        anchored=_is_central(s),
+                        anchored=_is_central(s, a, to_page, view_cx, view_cy, draft),
                     )
 
                 # Selection (ADR 0009 P2) must be GLOBAL across every carved segment,
@@ -1652,22 +1661,11 @@ def _annotate_holes(
             # position-dependent geometry (it runs from the fixed hole location
             # to the elbow), so probing everyone at one far-away Y badly
             # misjudges it.
-            def _probe_box(s):
-                # Unlike the old code (which only ever built a Leader for a
-                # candidate already chosen for placement), this probes EVERY
-                # queued candidate up front, including ones that may end up
-                # dropped — so a degenerate geometry unreachable before now
-                # (e.g. a hole essentially coincident with the strip edge) gets
-                # a defensive catch here too, matching _geom_box's own
-                # established "not every annotation bbox-es cleanly" idiom.
-                try:
-                    leader, _, _ = _build_leader_at(s, edge, side, s[4])
-                except Exception as exc:  # noqa: BLE001 — geometry construction raises broadly
-                    _log.debug("plan/side %s strip: probe leader failed (%s); omitted", side, exc)
-                    return None
-                return _geom_box(leader)
-
-            probe_boxes = [b for s in queue if (b := _probe_box(s)) is not None]
+            probe_boxes = [
+                b
+                for s in queue
+                if (b := _probe_box(s, edge, side, to_page, elbow_dx, draft, a.SCALE)) is not None
+            ]
             occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
             if probe_boxes:
                 band_lo = min(b[0] for b in probe_boxes)
@@ -1715,7 +1713,9 @@ def _annotate_holes(
                 else:
                     dropped.append(s)
                     continue
-                leader, tip, elbow = _build_leader_at(s, edge, side, y)
+                leader, tip, elbow = _build_leader_at(
+                    s, edge, side, y, to_page, elbow_dx, draft, a.SCALE
+                )
                 if _leader_hits(leader, tip, elbow, side, occupied):
                     crossing.append((s, y, leader))
                 else:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1212,7 +1212,7 @@ def _probe_box(s, edge, side, to_page, elbow_dx, draft, scale):
     """Probe a queued candidate's leader footprint up front (before it's chosen for placement),
     so a degenerate geometry (a hole essentially coincident with the strip edge) gets a
     defensive catch, matching _geom_box's "not every annotation bbox-es cleanly" idiom. Returns
-    the box or ``None``. Promoted (#638; pure)."""
+    the box or ``None``. Promoted (#638; side-effect-free bar a debug log on failure)."""
     try:
         leader, _, _ = _build_leader_at(s, edge, side, s[4], to_page, elbow_dx, draft, scale)
     except Exception as exc:  # noqa: BLE001 — geometry construction raises broadly


### PR DESCRIPTION
Part of #638 (split the complexity hotspots). Continues the `_annotate_holes` de-nest after the D1 warm-up (#655): promotes **every remaining pure helper** out of the ~640-line function, in two commits.

## Commit 1 — leader-geometry helpers
Promote `_rim_tip` / `_is_central` / `_build_leader_at` / `_probe_box` (all pure) to module level, threading their closed-over vars as explicit params (bottom-up, so each callee is already promoted). Bodies verbatim.

## Commit 2 — the carve cluster (kills the 5-level nesting)
Promote the deep placement chain — `_annotate_holes → _place_queue → _carve_and_place → _seg_order → _dist` (5 levels) — to module level, flattening to **≤2**:
- `_carve_and_place` and `_seg_order` (with `_dist` one level inside it) → module level; `_snap`/`_cand` stay one level inside `_carve_and_place`.
- The ~9 closed-over strip-geometry vars ride in one local **`_StripCtx` NamedTuple**, built once per `_place_queue` call — safer than a 10-positional-param signature, and more readable. It's LOCAL strip geometry, deliberately distinct from the #639 Drawing build-state context (which is held for review).
- **Hazard preserved:** `_carve_and_place` returns `{id(cand): y}` dicts; both call sites pass the *same* `queue` object, so identity is stable by construction.

## Test
Behaviour-preserving. Golden byte-identical after each commit; **full fast tier 1375 passed** (run locally because this touches the carve *fallback* branches — obstacle-carve, snap-out-of-bands — the golden corpus doesn't all exercise). ruff / format / mypy / codespell clean.

Remaining for a later PR: the stateful `_place_queue` split (collect→carve→emit) + `_hc_name` naming — the last, higher-risk piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)