### PR TITLE
refactor(#639 + #647): explicit PlacementContext + transactional finalize

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -388,7 +388,8 @@ def _largest_empty_rect(drawable, obstacles, *, warn: bool = True):
 @dataclass
 class DetailRequest:
     """A renderer's request for an enlarged detail of a region it could not draw
-    legibly at sheet scale (#307). Renderers append these to ``dwg._detail_requests``
+    legibly at sheet scale (#307). Renderers append these to the run's
+    ``PlacementContext.detail_requests``
     instead of building bespoke detail views; ``_resolve_details`` resolves them all
     through one generic detailer (crop → project → place → caption → marker), then
     calls ``redraw`` to draw the feature's own dims inside the placed detail view.

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -22,7 +22,8 @@ _log = logging.getLogger(__name__)
 class Escalation:
     """A first-class "could not place this here" signal (ADR 0009 Amendment 1, P5-strand-2).
 
-    Placers *collect* one of these into ``dwg._escalations`` at the point of failure —
+    Placers *collect* one of these into the run's ``PlacementContext.escalations`` at the point
+    of failure —
     instead of recording a stringly-typed ``*_dropped`` lint code and letting the escalators
     grep for it — and one later resolver pass groups them by ``(view, feature-or-pattern)``,
     picks a remedy per group (ISO pattern-grouped balloon / table / detail / drop), and emits
@@ -519,42 +520,44 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
                 _promote_losers(c)
 
 
-def register_corridor(dwg, key, strip, view, axis, tier, cand):
+@dataclass
+class PlacementContext:
+    """The per-run placement scratch a build's passes share, threaded to them explicitly instead
+    of hung on the ``Drawing`` result object (ADR 0005 §2, #639): the corridor batch
+    (:func:`register_corridor`/:func:`drain_corridors`), the escalation list (ADR 0009 Amdt 1,
+    #351), and the enlarged-detail request list (#307).
+
+    All three are per-run — both entry paths (:func:`_auto_annotate` and ``Drawing.finalize``)
+    make a fresh one each build and discard it after draining/consuming. The corridor batch is a
+    pure function of the still-present intents; escalations/detail-requests need no cross-retry
+    persistence either, because finalize is transactional (#647): a raised drain rolls the drawing
+    back and the retry re-runs from a clean slate, re-generating them."""
+
+    corridor_batch: dict = field(default_factory=dict)
+    escalations: list = field(default_factory=list)
+    detail_requests: list = field(default_factory=list)
+
+
+def register_corridor(ctx, key, strip, view, axis, tier, cand):
     """Queue a :class:`CorridorCandidate` under a shared corridor *key* so one
     :func:`drain_corridors` places the whole cross-pass set together (ADR 0009 end state).
     The first registration for a key fixes its ``(strip, view, axis)``; mixed producers on
     the same corridor use the largest requested tier so spacing is not registration-order
     dependent."""
-    b = dwg._corridor_batch.setdefault(
+    b = ctx.corridor_batch.setdefault(
         key, {"strip": strip, "view": view, "axis": axis, "tier": tier, "cands": []}
     )
     b["tier"] = max(b["tier"], tier)
     b["cands"].append(cand)
 
 
-def init_placement_scratch(dwg) -> None:
-    """Seed a FRESH set of the per-run placement scratch containers a build's passes share — the
-    corridor batch (:func:`register_corridor`/:func:`drain_corridors`), the escalation list (ADR
-    0009 Amdt 1, #351), and the enlarged-detail request list (#307). The single owner both entry
-    paths call (#638), replacing the two hand-rolled copies that had drifted.
-
-    All three are per-run: both the auto-pass and the record→finalize path start from a clean
-    slate. The corridor batch is a pure function of the still-present intents (#639); escalations/
-    detail-requests need no cross-retry persistence either, because finalize is transactional — a
-    raised drain rolls the drawing back and the retry re-runs from a clean slate (#647), so it
-    re-generates them (this reverts the #659 create-if-absent workaround the pre-#647 finalize
-    needed)."""
-    dwg._corridor_batch = {}
-    dwg._escalations = []
-    dwg._detail_requests = []
-
-
-def drain_corridors(dwg):
+def drain_corridors(ctx, dwg):
     """Solve every registered corridor (one :func:`solve_corridor` per strip), then clear
-    the batch. Called once, after all corridor-feeding passes have registered."""
-    for b in dwg._corridor_batch.values():
+    the batch. Called once, after all corridor-feeding passes have registered. Takes both the
+    scratch *ctx* (the batch) and *dwg* (the drawing :func:`solve_corridor` places onto)."""
+    for b in ctx.corridor_batch.values():
         solve_corridor(dwg, b["strip"], b["view"], b["axis"], b["cands"], b["tier"])
-    dwg._corridor_batch = {}
+    ctx.corridor_batch = {}
 
 
 def place_strip_candidates(

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -532,28 +532,21 @@ def register_corridor(dwg, key, strip, view, axis, tier, cand):
     b["cands"].append(cand)
 
 
-def init_placement_scratch(dwg, *, reset: bool) -> None:
-    """Seed the per-run placement scratch containers a build's passes share — the corridor batch
-    (:func:`register_corridor`/:func:`drain_corridors`), the escalation list (ADR 0009 Amdt 1,
-    #351), and the enlarged-detail request list (#307). The single owner both entry paths call
-    (#638), replacing the two hand-rolled copies that had drifted.
+def init_placement_scratch(dwg) -> None:
+    """Seed a FRESH set of the per-run placement scratch containers a build's passes share — the
+    corridor batch (:func:`register_corridor`/:func:`drain_corridors`), the escalation list (ADR
+    0009 Amdt 1, #351), and the enlarged-detail request list (#307). The single owner both entry
+    paths call (#638), replacing the two hand-rolled copies that had drifted.
 
-    The corridor batch is ALWAYS fresh: it is a pure function of the still-present intents (#639),
-    so a raised drain leaves the intents recorded and a retry rebuilds it — no leftover to
-    preserve. Escalations/detail-requests are NOT so lucky: B1 records a callout-drop escalation
-    and drops the producing callout intent *before* the fallible drain, so they can't be rebuilt
-    on a retry. ``reset=True`` (the auto-pass) clears them each run; ``reset=False`` (finalize)
-    creates-if-absent so a B1 escalation survives a raised B2 drain to the retry's hole-table
-    pass (#659 review)."""
+    All three are per-run: both the auto-pass and the record→finalize path start from a clean
+    slate. The corridor batch is a pure function of the still-present intents (#639); escalations/
+    detail-requests need no cross-retry persistence either, because finalize is transactional — a
+    raised drain rolls the drawing back and the retry re-runs from a clean slate (#647), so it
+    re-generates them (this reverts the #659 create-if-absent workaround the pre-#647 finalize
+    needed)."""
     dwg._corridor_batch = {}
-    if reset:
-        dwg._escalations = []
-        dwg._detail_requests = []
-        return
-    if not hasattr(dwg, "_escalations"):
-        dwg._escalations = []
-    if not hasattr(dwg, "_detail_requests"):
-        dwg._detail_requests = []
+    dwg._escalations = []
+    dwg._detail_requests = []
 
 
 def drain_corridors(dwg):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -163,7 +163,7 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
     )
 
 
-def _record_slot_drop(dwg, kind, idx, view, feat):
+def _record_slot_drop(ctx, dwg, kind, idx, view, feat):
     """Record a slot dim the layout could not place (#135).
 
     Info severity — a dim with no clear room is dropped as "place what fits",
@@ -177,12 +177,12 @@ def _record_slot_drop(dwg, kind, idx, view, feat):
         "slot_dim_dropped",
         f"slot{idx} {kind} dim not placed (no room beside the {view})",
     )
-    dwg._escalations.append(
+    ctx.escalations.append(
         Escalation(kind="slot", view=view, feature=feat, reason=f"no room beside the {view}")
     )
 
 
-def render_slots(dwg, model, a, *, only=None) -> int:
+def render_slots(dwg, model, a, *, ctx, only=None) -> int:
     """Dimension milled slots from the IR — width (the defining size, across
     ``width_axis``) + length (along ``long_axis``) + a position dim from the part
     datum, in the view the two axes span. Places through the engine's zone strips
@@ -292,10 +292,10 @@ def render_slots(dwg, model, a, *, only=None) -> int:
                         features={cname: _feat},
                     ):
                         return  # placed on the below strip
-                    _record_slot_drop(dwg, _dw, idx, vw[0], _feat)
+                    _record_slot_drop(ctx, dwg, _dw, idx, vw[0], _feat)
 
                 register_corridor(
-                    dwg,
+                    ctx,
                     (vw[0], "above"),
                     zn.above,
                     vw[0],
@@ -343,13 +343,13 @@ def render_slots(dwg, model, a, *, only=None) -> int:
         ):
             count += 1
         else:
-            _record_slot_drop(dwg, "width", i, name, s)
+            _record_slot_drop(ctx, dwg, "width", i, name, s)
         if _place(
             s.long_axis, s.lo, s.hi, s.w_center - half, s.w_center + half, s.length, "length"
         ):
             count += 1
         else:
-            _record_slot_drop(dwg, "length", i, name, s)
+            _record_slot_drop(ctx, dwg, "length", i, name, s)
         datum = _bb(s.long_axis, False)
         if (s.lo - datum) * a.SCALE >= 1.0:
             if _place(
@@ -364,7 +364,7 @@ def render_slots(dwg, model, a, *, only=None) -> int:
             ):
                 count += 1
             else:
-                _record_slot_drop(dwg, "position", i, name, s)
+                _record_slot_drop(ctx, dwg, "position", i, name, s)
     return count
 
 
@@ -384,6 +384,7 @@ _MIN_INPLACE_BORE_HALF_MM = 4.0
 
 def _location_candidate(
     dwg,
+    ctx,
     name,
     *,
     view,
@@ -409,7 +410,7 @@ def _location_candidate(
         dwg._record_build_issue(
             "warning", "location_ref_dropped", f"{nm} not placed (no room above the {edge})"
         )
-        dwg._escalations.append(Escalation("location", view, nm, "strip_full"))
+        ctx.escalations.append(Escalation("location", view, nm, "strip_full"))
 
     return CorridorCandidate(
         name=name,
@@ -426,7 +427,7 @@ def _location_candidate(
     )
 
 
-def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
+def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
     """Baseline X/Y hole-location dims from the IR (#238). The planner decides the
     intent (`plan_locations`: which refs, from which datum); this renderer owns the
     layout (Amendment 4) — X dims tier above the plan view, Y dims above the side
@@ -501,7 +502,7 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
             f"{_n_x_close} X location dim(s) too closely spaced to dimension legibly "
             "(use a detail view)",
         )
-        dwg._escalations.append(Escalation("location", "plan", None, "illegible"))
+        ctx.escalations.append(Escalation("location", "plan", None, "illegible"))
     _kept_x_set = set(_kept_x)
     x_refs = [r for r in x_refs if r[0] not in _x_drawable or r[0] in _kept_x_set]
     # Register X-location dims into the shared plan-above corridor (ADR 0009 end state,
@@ -519,7 +520,7 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
         # dimension and annotations_of never over-claims it (review #406, ADR 0010).
         _xfeat = None if any(abs(o[0] - rx) < 0.5 and o[2] != feat for o in refs) else feat
         register_corridor(
-            dwg,
+            ctx,
             ("plan", "above"),
             a.pv_zones.above,
             "plan",
@@ -527,6 +528,7 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
             tier,
             _location_candidate(
                 dwg,
+                ctx,
                 _loc_name("m_locx", i),
                 view="plan",
                 span_key=(round(PX(datum_x), 1), round(PX(rx), 1)),
@@ -565,7 +567,7 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
             f"{_n_y_close} Y location dim(s) too closely spaced to dimension legibly "
             "(use a detail view)",
         )
-        dwg._escalations.append(Escalation("location", "side", None, "illegible"))
+        ctx.escalations.append(Escalation("location", "side", None, "illegible"))
     _kept_y_set = set(_kept_y)
     y_refs = [r for r in y_refs if r[1] not in _y_drawable or r[1] in _kept_y_set]
     # Cap the side-above strip below the iso view so Y-location dims never run under it
@@ -580,7 +582,7 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
         # Shared-Y location dim → unowned (see the X loop; review #406).
         _yfeat = None if any(abs(o[1] - ry) < 0.5 and o[2] != feat for o in refs) else feat
         register_corridor(
-            dwg,
+            ctx,
             ("side", "above"),
             a.sv_zones.above,
             "side",
@@ -588,6 +590,7 @@ def render_locations(dwg, model, a, *, only=None, pinned=None) -> int:
             tier,
             _location_candidate(
                 dwg,
+                ctx,
                 _loc_name("m_locy", i),
                 view="side",
                 span_key=(round(SX(datum_y), 1), round(SX(ry), 1)),
@@ -1271,7 +1274,7 @@ def render_boss_diameters(dwg, groups, a) -> int:
     return n
 
 
-def render_plates(dwg, model, a) -> int:
+def render_plates(dwg, model, a, *, ctx) -> int:
     """Plate/wall thicknesses (#559): the thin extent of each recognised slab
     (`PlateFeature`), placed in the view where its thin axis is characteristic — a Z
     plate (horizontal slab) as a vertical dim left of the front elevation, a Y plate
@@ -1331,7 +1334,7 @@ def render_plates(dwg, model, a) -> int:
         # is physically full — the same outcome the prior solver-invisible carve gave, but now
         # co-solved with the locations/steps that share this strip.
         register_corridor(
-            dwg,
+            ctx,
             (view, side),
             strip,
             view,
@@ -1351,7 +1354,7 @@ def render_plates(dwg, model, a) -> int:
     return n
 
 
-def render_envelope(dwg, groups, a) -> int:
+def render_envelope(dwg, groups, a, *, ctx) -> int:
     """Overall width (plan, below) + depth (side, below) envelope dims via the IR,
     registered into the same below-strip corridor as feature/location/GD&T/PMI candidates.
     The overall dims use the last ladder subchain so they stack outermost by construction,
@@ -1366,7 +1369,7 @@ def render_envelope(dwg, groups, a) -> int:
 
     def _queue(name, strip, view, tier, distance, build):
         register_corridor(
-            dwg,
+            ctx,
             (view, "below"),
             strip,
             view,
@@ -1561,7 +1564,7 @@ def _next_steplen_start(dwg, prefix: str = "m_steplen") -> int:
     return max(idxs) + 1 if idxs else 0
 
 
-def render_step_lengths(dwg, groups, *, only=None) -> int:
+def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     """Unified turned step-length chain (ADR 0008 #223): each `StepFeature`'s length
     span projects into the front view and joins the chain that tiles the turning axis
     so every shoulder is located. X-turned → horizontal chain above the view;
@@ -1628,7 +1631,7 @@ def render_step_lengths(dwg, groups, *, only=None) -> int:
                     hsegs = [(dwg.at(view, *a), dwg.at(view, *b), v, t) for a, b, v, t in _hw]
                     return _draw_step_chain(dwg, view, hsegs, f"dim_{view}_steplen", detail_scale)
 
-                dwg._detail_requests.append(
+                ctx.detail_requests.append(
                     DetailRequest(
                         axis="x",
                         lo=hlo,
@@ -1676,7 +1679,7 @@ def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):
     return n, mean_rise
 
 
-def render_height_ladder(dwg, model, a, *, include_overall: bool = True) -> int:
+def render_height_ladder(dwg, model, a, *, ctx, include_overall: bool = True) -> int:
     """Front-view right ladder: prismatic step heights (from `StepLevelFeature`)
     stacked inner→outer, then the overall height outermost — through `fv_zones.right`,
     preserving the leapfrog witness cursor (#237). Replaces the engine's inline
@@ -1733,7 +1736,7 @@ def render_height_ladder(dwg, model, a, *, include_overall: bool = True) -> int:
             # gate, which previously could queue a spurious detail even when the uniform-
             # staircase branch above already fully documented the part with one
             # representative dim (a real bug this routing fixes as a side effect).
-            dwg._escalations.append(
+            ctx.escalations.append(
                 Escalation(kind="step", view="front", feature=step, reason="illegible")
             )
         for col, z in enumerate(kept):
@@ -1801,7 +1804,7 @@ def render_height_ladder(dwg, model, a, *, include_overall: bool = True) -> int:
     return n
 
 
-def render_step_positions(dwg, model, a) -> int:
+def render_step_positions(dwg, model, a, *, ctx) -> int:
     """Prismatic step POSITIONS (#555): where each shoulder sits along its axis,
     dimensioned from the part datum so a stepped block is fully constrained (the step
     heights alone leave the shoulder location implicit — two geometries draw the same
@@ -1854,7 +1857,7 @@ def render_step_positions(dwg, model, a) -> int:
         # duplicate to collapse, and deduping would only couple the shoulder to the hole's
         # lifecycle for no benefit.
         register_corridor(
-            dwg,
+            ctx,
             (view, "above"),
             strip,
             view,
@@ -2030,7 +2033,7 @@ def render_rotational(dwg, model, a) -> int:
     return n
 
 
-def _record_pmi_drop(dwg, ax, label, rec):
+def _record_pmi_drop(ctx, dwg, ax, label, rec):
     """Record a PMI dim the layout could not place (#208).
 
     Previously silent (#351 PR-4a) — a PMI dim that found no strip space just
@@ -2052,7 +2055,7 @@ def _record_pmi_drop(dwg, ax, label, rec):
     dwg._record_build_issue(
         "warning", "pmi_dropped", f"PMI {label!r} not placed (no room beside the {view})"
     )
-    dwg._escalations.append(
+    ctx.escalations.append(
         Escalation(kind="pmi", view=view, feature=rec, reason="no room beside the view")
     )
 
@@ -2102,7 +2105,7 @@ def _renderable_pmi_records(records):
     ]
 
 
-def render_pmi(dwg, model, a) -> int:
+def render_pmi(dwg, model, a, *, ctx) -> int:
     """Render imported authored dimensions from concept IR as first-class candidates.
 
     AP242 dimensional PMI lowers to ``AuthoredDimension``; unsupported raw PMI fallback
@@ -2332,10 +2335,10 @@ def render_pmi(dwg, model, a) -> int:
                         alt["side"],
                     )
                     return
-            _record_pmi_drop(dwg, _ax, _label, _rec)
+            _record_pmi_drop(ctx, dwg, _ax, _label, _rec)
 
         register_corridor(
-            dwg,
+            ctx,
             (primary["view"], primary["side"]),
             primary["strip"],
             primary["view"],
@@ -2517,7 +2520,7 @@ def render_pmi(dwg, model, a) -> int:
             queued += 1
         else:
             _log.info("PMI dim[%d] %s %.3g → no viable strip", idx, ax, rec.value)
-            _record_pmi_drop(dwg, ax, label, rec)
+            _record_pmi_drop(ctx, dwg, ax, label, rec)
 
     _log.info("PMI annotate: %d/%d dims queued", queued, len(usable))
     return queued
@@ -2562,7 +2565,7 @@ def _gdt_glyph(item, draft):
     return SurfaceFinish(item.ra, position=(0.0, 0.0), draft=draft)
 
 
-def render_gdt(dwg, model, a) -> int:
+def render_gdt(dwg, model, a, *, ctx) -> int:
     """Place declared GD&T frames / datum symbols / surface finishes (#61) as first-class
     ADR 0009 corridor candidates — registered into the SAME strip the feature's dimensions
     use, BEFORE ``drain_corridors``, so one solve orders and spaces them crossing-free with
@@ -2680,7 +2683,7 @@ def render_gdt(dwg, model, a) -> int:
             )
 
         register_corridor(
-            dwg,
+            ctx,
             (item.view, item.side),
             strip,
             item.view,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -460,7 +460,7 @@ def _legible_locations(positions, scale):
     return kept, n_too_close
 
 
-def _record_callout_drop(dwg, view, diam, reason, feat=None):
+def _record_callout_drop(ctx, dwg, view, diam, reason, feat=None):
     """Record a hole callout the layout could not place (#36).
 
     A warning (the drawing is incomplete, not invalid), whose diameter is
@@ -482,7 +482,7 @@ def _record_callout_drop(dwg, view, diam, reason, feat=None):
     # First-class escalation object alongside the lint code (ADR 0009 Amdt 1, #351 PR-2).
     # The resolver (`_maybe_tabulate_holes`) triggers on these; the lint code stays for
     # coverage. 1:1 with the code emit, so the object trigger is byte-identical.
-    dwg._escalations.append(Escalation(kind="callout", view=view, feature=feat, reason=reason))
+    ctx.escalations.append(Escalation(kind="callout", view=view, feature=feat, reason=reason))
 
 
 class _OffHole(NamedTuple):
@@ -542,6 +542,7 @@ def _off_axis_emit(dwg, tier, strip, view, axis, cands, force=False, features=No
 
 def _off_axis_queue(
     dwg,
+    ctx,
     tier,
     strip,
     view,
@@ -564,7 +565,7 @@ def _off_axis_queue(
         return
     for i, (name, build) in enumerate(cands):
         register_corridor(
-            dwg,
+            ctx,
             (view, side),
             strip,
             view,
@@ -591,7 +592,7 @@ def _off_axis_owner(dwg, hole_locs):
     return next(iter(feats)) if len(feats) == 1 else None
 
 
-def _locate_across(dwg, a: Analysis, off):
+def _locate_across(dwg, ctx, a: Analysis, off):
     """The "across" phase (#133): an X-axis hole's Y position below the SIDE view, queued
     with the envelope so the overall depth dim stacks outside it (ISO order). Confined to the
     side view: a Y-axis hole's X position contends the FRONT-below strip with the
@@ -627,6 +628,7 @@ def _locate_across(dwg, a: Analysis, off):
     feats = {nm: _off_axis_owner(dwg, locs) for nm, locs in loc_by_name.items()}
     _off_axis_queue(
         dwg,
+        ctx,
         tier,
         a.sv_zones.below,
         "side",
@@ -639,7 +641,7 @@ def _locate_across(dwg, a: Analysis, off):
     )
 
 
-def _locate_along_planar(dwg, a: Analysis, off):
+def _locate_along_planar(dwg, ctx, a: Analysis, off):
     """The "along" phase's planar dim: a Y-axis hole's X position below the FRONT view, placed
     after the envelope + turned-diameter passes so it never evicts those from the contended
     front-below strip (#133). Promoted (#638)."""
@@ -673,6 +675,7 @@ def _locate_along_planar(dwg, a: Analysis, off):
     x_feats = {nm: _off_axis_owner(dwg, locs) for nm, locs in x_loc_by_name.items()}
     _off_axis_queue(
         dwg,
+        ctx,
         tier,
         a.fv_zones.below,
         "front",
@@ -685,7 +688,7 @@ def _locate_along_planar(dwg, a: Analysis, off):
     )
 
 
-def _locate_along_z(dwg, a: Analysis, off):
+def _locate_along_z(dwg, ctx, a: Analysis, off):
     """The "along" phase's height dim: a hole's height (Z) is visible to the RIGHT of both the
     side and the front view. Neither right strip is universally free, so try the natural strip
     first, then RELOCATE to the other view if a bore-callout leader sits in the natural
@@ -750,6 +753,7 @@ def _locate_along_z(dwg, a: Analysis, off):
 
         _off_axis_queue(
             dwg,
+            ctx,
             tier,
             strip,
             view,
@@ -763,7 +767,7 @@ def _locate_along_z(dwg, a: Analysis, off):
         )
 
 
-def _locate_off_axis_holes(dwg, a: Analysis, *, which):
+def _locate_off_axis_holes(dwg, ctx, a: Analysis, *, which):
     """Location dimensions for side-drilled holes (#133).
 
     An X-axis hole is a circle in the SIDE view (locate its Y below the view and
@@ -806,10 +810,10 @@ def _locate_off_axis_holes(dwg, a: Analysis, *, which):
     if not off:
         return
     if which == "across":
-        _locate_across(dwg, a, off)
+        _locate_across(dwg, ctx, a, off)
         return
-    _locate_along_planar(dwg, a, off)
-    _locate_along_z(dwg, a, off)
+    _locate_along_planar(dwg, ctx, a, off)
+    _locate_along_z(dwg, ctx, a, off)
 
 
 def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_page):
@@ -1371,7 +1375,7 @@ def _carve_and_place(cands_in, intervals, key_prefix_local, ctx: _StripCtx, *, a
 
 
 def _annotate_holes(
-    dwg, a: Analysis, view_of_axis, groups, feature_keys, *, only=None, place_furniture=True
+    dwg, a: Analysis, view_of_axis, groups, feature_keys, *, ctx, only=None, place_furniture=True
 ):
     """Leader-attached HoleCallouts, one per distinct hole spec per view (#91).
 
@@ -1504,7 +1508,7 @@ def _annotate_holes(
                     side = "left"
                 else:
                     _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
-                    _record_callout_drop(dwg, view, dia, "no room beside the view", feat)
+                    _record_callout_drop(ctx, dwg, view, dia, "no room beside the view", feat)
                     continue
 
                 name = _hc_name(view, i)
@@ -1550,7 +1554,7 @@ def _annotate_holes(
                 if name in left_names:
                     dia, feat = meta[name]
                     _log.info("Hole callout ø%s skipped (front strip full)", _fmt(dia))
-                    _record_callout_drop(dwg, view, dia, "front strip full", feat)
+                    _record_callout_drop(ctx, dwg, view, dia, "front strip full", feat)
                     continue
                 if place_furniture:  # #426: finalize's furniture() replay owns furniture
                     idx, feat = furniture[name]
@@ -1647,7 +1651,7 @@ def _annotate_holes(
 
             if not can_right and not can_left:
                 _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
-                _record_callout_drop(dwg, view, dia, "no room beside the view", feat)
+                _record_callout_drop(ctx, dwg, view, dia, "no room beside the view", feat)
                 continue
 
             # Natural Y is the bore's own row; keep-out-band avoidance is now
@@ -1678,7 +1682,7 @@ def _annotate_holes(
             if not queue:
                 return start_i
 
-            ctx = _StripCtx(edge, min_gap, y_min, y_max, a, to_page, view_cx, view_cy, draft)
+            sctx = _StripCtx(edge, min_gap, y_min, y_max, a, to_page, view_cx, view_cy, draft)
 
             # Carve [y_min, y_max] around a set of keep-out intervals, assign each
             # candidate to its nearest free segment, then solve each segment
@@ -1695,7 +1699,7 @@ def _annotate_holes(
             # min_gap from its queue siblings and the keep-out rows. Used below
             # as the "cost of NOT avoiding [obstacles]" reference a carve-based
             # relocation must beat to be worth taking.
-            base_y, base_dropped = _carve_and_place(queue, band_intervals, key_prefix, ctx)
+            base_y, base_dropped = _carve_and_place(queue, band_intervals, key_prefix, sctx)
 
             # Carve around drawing-level obstacles this column's leaders would
             # cross too (e.g. the section cutting-plane arrow — #351 P5 strand
@@ -1724,7 +1728,7 @@ def _annotate_holes(
                 (max(y_min, o[1] - min_gap), min(y_max, o[3] + min_gap)) for o in occupied
             ]
             seg_y, _seg_dropped = _carve_and_place(
-                queue, band_intervals + obstacle_intervals, key_prefix, ctx, allow_snap=False
+                queue, band_intervals + obstacle_intervals, key_prefix, sctx, allow_snap=False
             )
 
             # Decide per candidate: take the carve-aware (obstacle-avoiding)
@@ -1773,7 +1777,7 @@ def _annotate_holes(
                     len(queue),
                 )
                 for s in dropped:
-                    _record_callout_drop(dwg, view, s[1], f"{side} strip full", s[3])
+                    _record_callout_drop(ctx, dwg, view, s[1], f"{side} strip full", s[3])
             if crossing:
                 _log.info(
                     "plan/side %s strip: %d bore callout(s) placed despite crossing an "

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -30,7 +30,7 @@ from draftwright._core import (
     _tag_sequence,
 )
 from draftwright.analysis import _sizing_bores
-from draftwright.annotations._common import drain_corridors, init_placement_scratch
+from draftwright.annotations._common import PlacementContext, drain_corridors
 from draftwright.annotations.from_model import (
     render_boss_diameters,
     render_centermarks,
@@ -166,10 +166,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # not accumulate duplicate drop records.
     dwg._reset_build_issues()
     dwg._reset_dropped_callout_diams()
-    # Per-run placement scratch (detail requests / escalations / corridor batch) — reset each
-    # auto-pass; the single owner is init_placement_scratch (#638). The corridor batch is
-    # drained once at the end (drain_corridors, #345/#346).
-    init_placement_scratch(dwg)
+    # Per-run placement scratch (detail requests / escalations / corridor batch), threaded to the
+    # passes instead of hung on the Drawing (ADR 0005 §2, #639). Fresh each auto-pass; the corridor
+    # batch is drained once at the end (drain_corridors, #345/#346).
+    ctx = PlacementContext()
 
     # Tighten right-strip outer_limits to the actual iso view left edge now
     # that the iso has been projected and fitted.  Always apply so that any
@@ -257,10 +257,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     _reserve_section_row(dwg, a, _section)
     # Any hole/pattern member (declared holes render even where detection missed them).
     if feature_keys:
-        _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys)
+        _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys, ctx=ctx)
     # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
     # through the existing above-view strips. Replaces the engine's _add_location_dims.
-    render_locations(dwg, _model, a)
+    render_locations(dwg, _model, a, ctx=ctx)
 
     if a.cross_diams and a.is_rotational and not feature_keys:
         _log.info(
@@ -272,16 +272,16 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # through fv_zones.right preserving the leapfrog cursor (#237). Replaces the inline
     # dim_step_* + dim_height; the turned step-length chain (render_step_lengths) handles
     # turned parts, and a Z-turned overall height is suppressed there (ISO 129).
-    render_height_ladder(dwg, _model, a)
+    render_height_ladder(dwg, _model, a, ctx=ctx)
 
     # Plate/wall thicknesses on a multi-plate prismatic (#559): the thin extent of each
     # recognised slab, placed in the view where its thin axis is visible. A single flat
     # plate has none (its thickness IS the envelope height).
-    render_plates(dwg, _model, a)
+    render_plates(dwg, _model, a, ctx=ctx)
 
     # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a
     # stepped block is fully constrained (the heights alone leave the shoulder implicit).
-    render_step_positions(dwg, _model, a)
+    render_step_positions(dwg, _model, a, ctx=ctx)
 
     # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.
     render_chamfers(dwg, _model, a)
@@ -296,17 +296,17 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # later subchain + mandatory priority keeps ISO outermost stacking and prevents
     # best-effort locations from starving the principal depth dimension (#477).
     if feature_keys:
-        _locate_off_axis_holes(dwg, a, which="across")
+        _locate_off_axis_holes(dwg, ctx, a, which="across")
 
     # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
     # queued into the shared corridor instead of claiming a post-hoc carve tier.
     # Suppression (square footprint / X-turned width) is the planner's decision (#250).
-    render_envelope(dwg, _groups, a)
+    render_envelope(dwg, _groups, a, ctx=ctx)
 
     # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))
     # — resolved with every other detail request below (#307).
     if detail_view:
-        _request_prismatic_detail(dwg, a)
+        _request_prismatic_detail(dwg, a, ctx=ctx)
 
     # Turned-part dimensions via the IR (ADR 0008 convergence). The model is built
     # once and fed to both renderers (#229 — no per-pass rebuild):
@@ -322,35 +322,35 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     render_boss_diameters(dwg, _groups, a)
     render_diameters(dwg, _groups)
     if a.prof is not None:
-        render_step_lengths(dwg, _groups)
+        render_step_lengths(dwg, _groups, ctx=ctx)
 
     # Side-drilled (X/Y-axis) hole HEIGHT locations — queued after the mandatory envelope
     # candidates so below/right corridors solve them together with GD&T/PMI at the drain.
     # The front-right prismatic height ladder remains immediate because its later witness
     # bases depend on earlier placed tiers (#477).
     if feature_keys:
-        _locate_off_axis_holes(dwg, a, which="along")
+        _locate_off_axis_holes(dwg, ctx, a, which="along")
 
     # Non-cylindrical machined features: slots / reduced across-flats sections
     # (#135) — IR renderer, placed through the zone strips (shared infra). Runs
     # after every hole/diameter pass so it claims strip space last.
-    render_slots(dwg, _model, a)
+    render_slots(dwg, _model, a, ctx=ctx)
 
     # Declared GD&T frames / datum symbols / surface finishes (ADR 0011 §4, #61) and
     # authored STEP PMI dims (#393) register into the same strips as first-class
     # candidates BEFORE the drain, so the one solve orders and spaces them crossing-free
     # with locations/slots rather than consuming leftovers as first-fit placements.
-    render_gdt(dwg, _model, a)
+    render_gdt(dwg, _model, a, ctx=ctx)
     if a.pmi_mode == "annotate" or (
         getattr(dwg, "_model_declared", False)
         and any(f.kind in ("authored_dimension", "pmi") for f in _model.features)
     ):
-        render_pmi(dwg, _model, a)
+        render_pmi(dwg, _model, a, ctx=ctx)
 
     # Now every corridor feeder pass has registered; solve each shared strip once
     # (ADR 0009 end state, #345/#346/#393) — dedup coincident spans, order the ladder —
     # BEFORE the section/detail views so they see the placed ladder as an obstacle.
-    drain_corridors(dwg)
+    drain_corridors(ctx, dwg)
 
     # Turned/circlip-groove callouts (#148c): {width} WIDE × ø{dia} via a leader off each
     # groove. A groove is a secondary leader-callout on a turned shaft — exactly where the
@@ -370,22 +370,20 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Resolve every queued enlarged-detail request (#307) — prismatic step bands and
     # crowded turned heads alike — through the one generic detailer, now that all
     # views and main-view annotations are placed (so the detail avoids them).
-    _resolve_details(dwg, a)
+    _resolve_details(dwg, a, ctx=ctx)
 
     _add_title_block(dwg, a)
 
     # Escalate to a hole table when the plan view is too dense to dimension
     # every hole — runs last so the table avoids every placed annotation
     # including the title block (#93).
-    _maybe_tabulate_holes(dwg, a)
-    # Don't leave the consumed escalations on the drawing: a later deferred edit
-    # (`build_drawing(part)` then `with dwg.deferred(): …`) would otherwise inherit
-    # them and re-fire finalize's leg D against stale drops, relocating the table
-    # (#440). Nothing reads _escalations after the table pass.
-    dwg._escalations = []
+    _maybe_tabulate_holes(dwg, a, ctx=ctx)
+    # The escalations live only on this per-run ctx (#639), discarded when _auto_annotate
+    # returns — so nothing carries stale drops into a later deferred edit (#440), and there is
+    # no drawing-level list to clear.
 
 
-def _maybe_tabulate_holes(dwg, a: Analysis):
+def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
     """Escalate to a per-instance hole table + balloons when the plan view is too
     dense to dimension every hole individually (#93); a dropped ISO pattern
     callout gets one grouped balloon of its own (#351 PR-3, ADR 0009 Amdt 1
@@ -411,9 +409,8 @@ def _maybe_tabulate_holes(dwg, a: Analysis):
     # Trigger on the first-class Escalation objects the hole placers collect (ADR 0009
     # Amdt 1, #351 PR-2), not by grepping the `*_dropped` lint strings. Byte-identical:
     # a "callout"/"location" Escalation is emitted 1:1 with each callout_dropped/
-    # location_ref_dropped code. `getattr` default guards the auto_dims=False path (which
-    # skips this whole pass anyway). The lint codes stay as the coverage surface.
-    escalations = getattr(dwg, "_escalations", ())
+    # location_ref_dropped code. The lint codes stay as the coverage surface.
+    escalations = ctx.escalations
     if not any(e.kind in ("callout", "location") for e in escalations):
         return
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -169,7 +169,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Per-run placement scratch (detail requests / escalations / corridor batch) — reset each
     # auto-pass; the single owner is init_placement_scratch (#638). The corridor batch is
     # drained once at the end (drain_corridors, #345/#346).
-    init_placement_scratch(dwg, reset=True)
+    init_placement_scratch(dwg)
 
     # Tighten right-strip outer_limits to the actual iso view left edge now
     # that the iso has been projected and fitted.  Always apply so that any

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -549,14 +549,14 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
     return True
 
 
-def _resolve_details(dwg, a: Analysis) -> None:
+def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
     """Resolve every queued :class:`DetailRequest` (#307) through the one generic
     detailer, lettering DETAIL A/B/… On a placement bail-out nothing is drawn for that
     request — the main view already carries the located head/block inline, so lint
     reports any un-located interior rather than coverage being silently lost. Clears
     the queue."""
-    reqs = list(getattr(dwg, "_detail_requests", ()) or ())
-    dwg._detail_requests = []
+    reqs = list(ctx.detail_requests)
+    ctx.detail_requests = []
     n_placed = 0  # letters advance only on a successful placement — no A/B gaps (#307 review)
     for req in reqs:
         if n_placed >= len(_DETAIL_LETTERS):
@@ -567,7 +567,7 @@ def _resolve_details(dwg, a: Analysis) -> None:
             n_placed += 1
 
 
-def _request_prismatic_detail(dwg, a: Analysis) -> None:
+def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
     """Queue a detail of a prismatic part's crowded step-height band (#42), routed
     through the unified pipeline (#307).
 
@@ -593,9 +593,7 @@ def _request_prismatic_detail(dwg, a: Analysis) -> None:
     enlarged scale."""
     if len(a.step_zs) < 2:
         return
-    if not any(
-        e.kind == "step" and e.reason == "illegible" for e in getattr(dwg, "_escalations", ())
-    ):
+    if not any(e.kind == "step" and e.reason == "illegible" for e in ctx.escalations):
         return
     z0, z1 = min(a.step_zs), max(a.step_zs)
     pad = 0.08 * (z1 - z0) + 1.0
@@ -640,7 +638,7 @@ def _request_prismatic_detail(dwg, a: Analysis) -> None:
                 _log.info("detail step dim %d skipped (%s)", i, exc)
         return placed
 
-    dwg._detail_requests.append(
+    ctx.detail_requests.append(
         DetailRequest(
             axis="z",
             lo=band_lo,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1466,6 +1466,11 @@ class Drawing:
         views_snap = dict(self.views)
         coords_snap = dict(self._coords)
         coverage_snap = self._coverage.snapshot()
+        # render_locations narrows the side-above strip's outer_limit IN PLACE on the shared
+        # Analysis (from_model.py) — the one Analysis field a replay mutates. Capture + restore it
+        # too, else a raised drain leaves the retry solving against a stale cap (#647 review).
+        sv_above = getattr(getattr(a, "sv_zones", None), "above", None) if a is not None else None
+        sv_above_limit = sv_above.outer_limit if sv_above is not None else None
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
             # Reserve the section's cutting-plane row BEFORE the callout carve so the carve
@@ -1601,6 +1606,8 @@ class Drawing:
             self.views = views_snap
             self._coords = coords_snap
             self._coverage.restore(coverage_snap)
+            if sv_above is not None:
+                sv_above.outer_limit = sv_above_limit
             self._view_edge_cache.clear()
             raise
         finally:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1445,11 +1445,10 @@ class Drawing:
 
         # Fresh corridor scratch for this finalize — the auto-pass seeds it in _auto_annotate but
         # a detect-only build lacks it; render_locations/_annotate_holes/drain_corridors
-        # register/read here. The batch is rebuilt from the current intents each call (#639), so a
-        # raised drain strands nothing — the intents survive and a retry re-registers. Escalations/
-        # detail-requests create-if-absent (reset=False): a B1 escalation whose callout intent is
-        # already dropped can't be rebuilt, so it must survive a raised B2 drain to the retry (#659).
-        init_placement_scratch(self, reset=False)
+        # register/read here. All three are per-run: finalize is transactional (#647), so a raised
+        # drain rolls the drawing back and the retry re-runs from a clean slate, re-generating the
+        # batch (from the surviving intents) and any escalations — no cross-call persistence needed.
+        init_placement_scratch(self)
 
         model, a = self._part_model, self._analysis
         routable = model is not None and a is not None
@@ -1462,6 +1461,17 @@ class Drawing:
         only_loc, pinned_loc, only_callout = r.only_loc, r.pinned_loc, r.only_callout
         only_dia, only_len, slot_feats = r.only_dia, r.only_len, r.slot_feats
 
+        # (#647) Finalize is transactional: snapshot every collection it mutates so a raise
+        # part-way (a corridor solve, a replayed verb) rolls the drawing back to its pre-finalize
+        # state — a retry then starts from a clean slate and re-runs, rather than operating against
+        # half-committed annotations/intents (the duplicate-corridor / partial-commit defects
+        # #647 describes). The registry owns identity (named/view/feature/pins); items/intents/
+        # views/build-issues are the rest; the edge cache is recomputable so it is just cleared.
+        reg_snap = self._registry.snapshot()
+        issues_snap = list(self._build_issues)
+        items_snap = list(self.items)
+        intents_snap = list(self._intents)
+        views_snap = dict(self.views)
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
             # Reserve the section's cutting-plane row BEFORE the callout carve so the carve
@@ -1583,6 +1593,15 @@ class Drawing:
                 assert a is not None
                 _maybe_tabulate_holes(self, a)
                 self._escalations = []
+        except Exception:
+            # (#647) Roll back a partial finalize so a corrected retry starts clean.
+            self._registry.restore(reg_snap)
+            self._build_issues = issues_snap
+            self.items = items_snap
+            self._intents = intents_snap
+            self.views = views_snap
+            self._view_edge_cache.clear()
+            raise
         finally:
             self._defer_intents = deferred
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1457,12 +1457,15 @@ class Drawing:
         # state — a retry then starts from a clean slate and re-runs, rather than operating against
         # half-committed annotations/intents (the duplicate-corridor / partial-commit defects
         # #647 describes). The registry owns identity (named/view/feature/pins); items/intents/
-        # views/build-issues are the rest; the edge cache is recomputable so it is just cleared.
+        # views/build-issues/coverage/coords are the rest (a section view adds to BOTH views and
+        # _coords; the passes mutate coverage); the edge cache is recomputable so it is just cleared.
         reg_snap = self._registry.snapshot()
         issues_snap = list(self._build_issues)
         items_snap = list(self.items)
         intents_snap = list(self._intents)
         views_snap = dict(self.views)
+        coords_snap = dict(self._coords)
+        coverage_snap = self._coverage.snapshot()
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
             # Reserve the section's cutting-plane row BEFORE the callout carve so the carve
@@ -1586,13 +1589,18 @@ class Drawing:
             if routable:
                 assert a is not None
                 _maybe_tabulate_holes(self, a, ctx=ctx)
-        except Exception:
+        except BaseException:
             # (#647) Roll back a partial finalize so a corrected retry starts clean.
+            # BaseException (not just Exception) so a KeyboardInterrupt/SystemExit mid-drain
+            # still restores the drawing before propagating — the transaction is all-or-nothing
+            # on *any* raise, matching the guarantee this block advertises.
             self._registry.restore(reg_snap)
             self._build_issues = issues_snap
             self.items = items_snap
             self._intents = intents_snap
             self.views = views_snap
+            self._coords = coords_snap
+            self._coverage.restore(coverage_snap)
             self._view_edge_cache.clear()
             raise
         finally:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -393,12 +393,6 @@ class Drawing:
     first :meth:`lint` otherwise).
     """
 
-    # Per-run placement scratch — created by _common.init_placement_scratch (auto-pass or
-    # finalize, #638), not in __init__; declared here so mypy knows their types.
-    _corridor_batch: dict
-    _escalations: list
-    _detail_requests: list
-
     def __init__(
         self,
         *,
@@ -923,7 +917,7 @@ class Drawing:
             )
         return matches[0], chosen, p1, p2
 
-    def _queue_dimension_intent(self, it, a, *, used_names=None) -> bool:
+    def _queue_dimension_intent(self, it, a, *, ctx, used_names=None) -> bool:
         """Queue a pinned/prioritized feature dimension into a shared corridor."""
         from draftwright.annotations._common import CorridorCandidate, register_corridor
 
@@ -991,7 +985,7 @@ class Drawing:
         if it.kwargs.get("pin"):
             priority = max(priority, 100.0)
         register_corridor(
-            self,
+            ctx,
             (view, side),
             strip,
             view,
@@ -1401,7 +1395,7 @@ class Drawing:
           ring via ``_maybe_tabulate_holes`` — last, so it sees the section + title block as
           obstacles. The density gate counts *all* analysis holes, so this is a full-
           reconstruction escalation (a partial hand-edit still tabulates the full count, #434);
-          ``_escalations`` is cleared after so a repeat batch can't re-fire the fixed-name table.
+          The escalations live only on the per-run ctx, so a repeat batch starts clean (#639).
 
         A slot records two size dims (``slot_width``/``slot_length``) on one feature; routing
         the feature also regenerates its model-derived datum **position** dim, so finalize
@@ -1418,14 +1412,12 @@ class Drawing:
         and leaves the rest recorded. A record → finalize → record-more → finalize
         sequence drains each batch (#428 review).
         """
-        # A populated _corridor_batch left by a prior finalize whose drain raised must still
-        # drain: the step-position pass (A0b) drops its intent the moment it registers, so a
-        # retry can reach here with no intents but pending candidates — early-returning then
-        # would strand them permanently (#636 review). _corridor_batch is created lower down,
-        # so a first call (no attr yet) still short-circuits on empty intents as before.
+        # Nothing recorded → nothing to replay (the live/auto-pass path). The corridor batch is
+        # a per-run local built below from these intents (#639), so an empty intent list has no
+        # pending placement work to strand.
         if not self._intents:
             return
-        from draftwright.annotations._common import drain_corridors, init_placement_scratch
+        from draftwright.annotations._common import PlacementContext, drain_corridors
         from draftwright.annotations.from_model import (
             render_diameters,
             render_height_ladder,
@@ -1443,12 +1435,11 @@ class Drawing:
         )
         from draftwright.model import PartModel, plan_dimensions
 
-        # Fresh corridor scratch for this finalize — the auto-pass seeds it in _auto_annotate but
-        # a detect-only build lacks it; render_locations/_annotate_holes/drain_corridors
-        # register/read here. All three are per-run: finalize is transactional (#647), so a raised
-        # drain rolls the drawing back and the retry re-runs from a clean slate, re-generating the
-        # batch (from the surviving intents) and any escalations — no cross-call persistence needed.
-        init_placement_scratch(self)
+        # Fresh per-run placement scratch, threaded to the passes rather than hung on the drawing
+        # (ADR 0005 §2, #639): render_locations/_annotate_holes/drain_corridors register/read here.
+        # A local — finalize is transactional (#647), so a raised drain rolls the drawing back and
+        # the retry re-runs from a clean slate with a new ctx; no cross-call persistence needed.
+        ctx = PlacementContext()
 
         model, a = self._part_model, self._analysis
         routable = model is not None and a is not None
@@ -1485,7 +1476,9 @@ class Drawing:
             # from starving the correlated step rungs.
             if height_ladder_ids:
                 assert a is not None and isinstance(model, PartModel)
-                render_height_ladder(self, model, a, include_overall=not explicit_envelope_height)
+                render_height_ladder(
+                    self, model, a, ctx=ctx, include_overall=not explicit_envelope_height
+                )
             self._intents = [it for it in self._intents if id(it) not in height_ladder_ids]
             # (A0b) prismatic step positions through the auto-pass renderer (all shoulders).
             # This only REGISTERS corridor candidates; they place at the B2 drain. Their intents
@@ -1494,7 +1487,7 @@ class Drawing:
             # a pure function of the still-present intents, so it needs no persistence, #639).
             if step_position_ids:
                 assert a is not None and isinstance(model, PartModel)
-                render_step_positions(self, model, a)
+                render_step_positions(self, model, a, ctx=ctx)
             # (A) live-replay every intent EXCEPT the routed callouts/locates and section
             #     (furniture, step/boss callouts, dimensions, axes-restricted locates).
             i = 0
@@ -1526,6 +1519,7 @@ class Drawing:
                     build_view_of_axis(a),
                     plan_dimensions(model),
                     feature_hole_keys(model, a),
+                    ctx=ctx,
                     only=only_callout,
                     place_furniture=False,
                 )
@@ -1545,15 +1539,15 @@ class Drawing:
             if only_loc or slot_feats or user_dim_ids or step_position_ids:
                 assert a is not None and isinstance(model, PartModel)  # either ⟹ routable
                 if only_loc:
-                    render_locations(self, model, a, only=only_loc, pinned=pinned_loc)
+                    render_locations(self, model, a, ctx=ctx, only=only_loc, pinned=pinned_loc)
                 if slot_feats:
-                    render_slots(self, model, a, only=slot_feats)
+                    render_slots(self, model, a, ctx=ctx, only=slot_feats)
                 used_dim_names: set[str] = set()
                 for it in self._intents:
                     if id(it) in user_dim_ids:
-                        if self._queue_dimension_intent(it, a, used_names=used_dim_names):
+                        if self._queue_dimension_intent(it, a, ctx=ctx, used_names=used_dim_names):
                             queued_dim_ids.add(id(it))
-                drain_corridors(self)
+                drain_corridors(ctx, self)
             self._intents = [
                 it
                 for it in self._intents
@@ -1569,7 +1563,7 @@ class Drawing:
             #       staggered tiers) — auto-pass S11b, after diameters, before section.
             if only_len:
                 assert a is not None and isinstance(model, PartModel)  # only_len ⟹ routable
-                render_step_lengths(self, plan_dimensions(model), only=only_len)
+                render_step_lengths(self, plan_dimensions(model), ctx=ctx, only=only_len)
             self._intents = [it for it in self._intents if id(it) not in len_ids]
             # (C) render the section LAST, reusing the reserved plan (its room check clears
             #     everything right of the side view; _add_section_view clears the reservation).
@@ -1581,18 +1575,17 @@ class Drawing:
             # (D, Phase 4c) dense-scattered plan-view holes escalate to the hole TABLE +
             #     balloon ring — LAST, mirroring the auto-pass (_maybe_tabulate_holes runs
             #     last in _auto_annotate) so the resolver sees the section + title block as
-            #     obstacles. It reads _escalations (the callout/location drops B1/B2 collected)
+            #     obstacles. It reads ctx.escalations (the callout/location drops B1/B2 collected)
             #     and the scattered-hole coverage recorded at the hole emit site even under
             #     place_furniture=False (#426 Ph4c) to find + replace the plan callouts. The
             #     density gate counts ALL analysis holes (a.holes), so this is a FULL-
             #     reconstruction escalation: a partial hand-edit that drops some callout() lines
             #     still tabulates the full count (documented full-reconstruction scope, #434).
-            #     Clear _escalations after so a repeat finalize batch can't re-fire against stale
-            #     drops and collide on the fixed name hole_table_plan.
+            #     The escalations live only on this per-run ctx (#639), discarded when finalize
+            #     returns — no drawing-level list to clear or leak into a later edit (#440).
             if routable:
                 assert a is not None
-                _maybe_tabulate_holes(self, a)
-                self._escalations = []
+                _maybe_tabulate_holes(self, a, ctx=ctx)
         except Exception:
             # (#647) Roll back a partial finalize so a corrected retry starts clean.
             self._registry.restore(reg_snap)

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -149,6 +149,27 @@ class CoverageState:
         """Diameters dropped by the cap (passed to lint_feature_coverage)."""
         return self._dropped_callout_diams
 
+    # -- transactional snapshot (#647) ----------------------------------------
+
+    def snapshot(self) -> tuple:
+        """Capture the mutable coverage collections so finalize's transaction can
+        roll a partial mutation back on a raise (#647) — the passes it replays
+        mutate coverage (drop_diam / cover_scattered_hole_doc / cover_pattern)."""
+        return (
+            set(self._pattern_callouts),
+            set(self._patterned_holes),
+            set(self._scattered_hole_docs),
+            list(self._dropped_callout_diams),
+        )
+
+    def restore(self, snap: tuple) -> None:
+        """Restore the collections captured by :meth:`snapshot`."""
+        pc, ph, shd, dropped = snap
+        self._pattern_callouts = set(pc)
+        self._patterned_holes = set(ph)
+        self._scattered_hole_docs = set(shd)
+        self._dropped_callout_diams = list(dropped)
+
 
 def lint_feature_coverage(
     part,

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -215,10 +215,10 @@ def test_dense_scattered_reconstruction_rebuilds_the_hole_table():
     auto = build_drawing(part)
     assert "hole_table_plan" in auto.annotations(), "fixture must escalate in the auto-pass"
     auto_codes = {i.code for i in auto.lint() if i.severity in ("warning", "error")}
-    # #440: the escalating build must not leave its consumed escalations on the drawing —
-    # else a later `with dwg.deferred(): …` edit would inherit them and re-fire leg D,
-    # relocating the table. (Here the build collected callout/location drops before tabulating.)
-    assert auto._escalations == []
+    # #440/#639: the escalating build must not leak its consumed escalations into a later
+    # `with dwg.deferred(): …` edit (which would re-fire leg D and relocate the table). Since
+    # #639 the escalations live on a per-run PlacementContext, discarded when the build returns
+    # — the leak is now impossible by construction (no drawing attribute to assert against).
 
     dwg = build_drawing(part, auto_dims=False)
     with dwg.deferred():
@@ -231,7 +231,7 @@ def test_dense_scattered_reconstruction_rebuilds_the_hole_table():
     assert snap(dwg) == snap(auto)  # same table + balloon tags, no orphaned callouts
     assert not [n for n in dwg.annotations() if n.startswith("hc_plan")]  # no duplicate callouts
     assert dwg._intents == []  # drained
-    assert dwg._escalations == []  # leg D cleared the consumed escalations (retry-safe)
+    # (#639) Escalations live on the per-run PlacementContext — no cross-run leak to assert.
     # Lint no worse than the auto-pass (the epic's soft-acceptance bar): the reconstruction
     # introduces NO warning/error code the auto-pass doesn't already have — no new
     # callout_dropped / location_ref_dropped / table_dropped. (It is a strict subset here:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -320,6 +320,30 @@ class TestStepPosition:
         dwg.finalize()  # clean retry — the shoulder position places exactly once (no duplicate)
         assert len([n for n in dwg._named if n.startswith("dim_shoulder")]) == 1
 
+    def test_finalize_rolls_back_a_narrowed_analysis_bound(self, monkeypatch):
+        # #647 review: render_locations narrows a.sv_zones.above.outer_limit IN PLACE on the
+        # shared Analysis. A raise after that narrowing must restore it — else a corrected retry
+        # solves a side-above dim against a stale cap (the one Analysis field a replay mutates).
+        # Inject the in-place narrowing at the drain, then raise, and assert the bound is restored.
+        from draftwright.annotations import _common
+
+        part = Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15)  # step → the B2 drain runs
+        dwg = build_drawing(part, auto_dims=False)
+        step = next(f for f in dwg.model().features if f.kind == "step_level")
+        dwg._defer_intents = True
+        dwg.dimension(step, "length", role="step_position")
+        strip = dwg._analysis.sv_zones.above
+        limit_before = strip.outer_limit
+
+        def _boom(ctx, d):
+            strip.outer_limit = limit_before - 50.0  # mimic render_locations' in-place narrowing
+            raise RuntimeError("injected drain failure")
+
+        monkeypatch.setattr(_common, "drain_corridors", _boom)
+        with pytest.raises(RuntimeError):
+            dwg.finalize()
+        assert dwg._analysis.sv_zones.above.outer_limit == limit_before  # restored (#647 review)
+
     def test_centered_rebate_dimensions_both_shoulders(self):
         # A symmetric central channel has TWO shoulders; both positions must be given
         # (20 and 40 from the front datum), else the channel is under-constrained.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -278,8 +278,9 @@ class TestStepPosition:
         # #647: finalize is transactional. A drain that raises AFTER an earlier stage already
         # committed annotations must not leave them behind — else a retry re-runs the source
         # intents and duplicates the measurement (the m_locx0 + m_locx1 defect). The rollback
-        # restores _named/items/_intents to the pre-finalize state, so a clean retry places each
-        # dimension exactly once.
+        # restores _named/items/_intents AND the coverage bookkeeping to the pre-finalize state
+        # (the B1 callout records scattered-hole coverage; leaving it mutated would make a later
+        # lint() false-clean, #647 review), so a clean retry places each dimension exactly once.
         from draftwright.annotations import _common
 
         # A step positioned in B2's drain, plus an off-centre hole whose callout live-places in
@@ -295,6 +296,7 @@ class TestStepPosition:
         dwg.dimension(step, "length", role="step_position")  # drained in B2
         names_before, items_before = set(dwg._named), len(dwg.items)
         intents_before = len(dwg._intents)
+        coverage_before = dwg._coverage.snapshot()
 
         calls = {"n": 0}
         real = _common.drain_corridors
@@ -312,6 +314,7 @@ class TestStepPosition:
         assert set(dwg._named) == names_before
         assert len(dwg.items) == items_before
         assert len(dwg._intents) == intents_before
+        assert dwg._coverage.snapshot() == coverage_before  # coverage restored (#647 review)
 
         monkeypatch.undo()
         dwg.finalize()  # clean retry — the shoulder position places exactly once (no duplicate)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -244,11 +244,9 @@ class TestStepPosition:
         assert placed == ["20"]
 
     def test_finalize_retries_when_the_drain_itself_raised(self, monkeypatch):
-        # #639: the corridor batch is TRANSIENT — a pure function of the still-recorded intents,
-        # not persistent state. A0b registers the step candidates but drops their intent only
-        # after the drain, so if drain_corridors ITSELF raises (step-only, no other intents), the
-        # step-position INTENT survives; a retry rebuilds the batch from it and drains — no
-        # stranded state to preserve (this replaced the earlier batch-persistence retry-safety).
+        # #647: finalize is transactional. If drain_corridors raises (step-only, no other
+        # intents), the rollback restores the pre-finalize state — so the step-position INTENT is
+        # back on the drawing and a clean retry re-runs from it and drains.
         from draftwright.annotations import _common
 
         part = Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15)  # step only, no holes
@@ -269,33 +267,56 @@ class TestStepPosition:
         monkeypatch.setattr(_common, "drain_corridors", _boom)
         with pytest.raises(RuntimeError):
             dwg.finalize()  # A0b registered the candidates; the drain then raises
-        # The step-position INTENT survives (dropped only on drain success) — the source of truth
-        # a retry rebuilds from; nothing is stranded.
+        # The rollback restored the step-position INTENT; a retry re-runs from it and drains.
         assert any(it.kwargs.get("role") == "step_position" for it in dwg._intents)
         dwg.finalize()  # retry: re-registers from the surviving intent and drains
         placed = sorted(dwg._named[n].label for n in dwg._named if n.startswith("dim_shoulder"))
         assert placed == ["20"]
 
-    def test_scratch_reset_flag_preserves_unrebuildable_escalations(self):
-        # #659 review: the corridor batch is always fresh (rebuilt from intents), but escalations
-        # are NOT rebuildable — B1 records a callout-drop escalation and drops the producing callout
-        # intent BEFORE the fallible B2 drain. So on a finalize retry (reset=False) a pre-existing
-        # escalation must SURVIVE (create-if-absent) to reach the retry's hole-table pass; only the
-        # auto-pass (reset=True) clears it. The batch resets either way.
-        from types import SimpleNamespace
+    def test_finalize_rolls_back_a_partial_commit(self, monkeypatch):
+        # #647: finalize is transactional. A drain that raises AFTER an earlier stage already
+        # committed annotations must not leave them behind — else a retry re-runs the source
+        # intents and duplicates the measurement (the m_locx0 + m_locx1 defect). The rollback
+        # restores _named/items/_intents to the pre-finalize state, so a clean retry places each
+        # dimension exactly once.
+        from draftwright.annotations import _common
 
-        from draftwright.annotations._common import Escalation, init_placement_scratch
-
-        esc = Escalation(kind="callout", view="front", feature=None, reason="strip_full")
-        dwg = SimpleNamespace(
-            _corridor_batch={"stale": object()}, _escalations=[esc], _detail_requests=["d"]
+        # A step positioned in B2's drain, plus an off-centre hole whose callout live-places in
+        # leg B1 — so an annotation is COMMITTED before the B2 drain raises, and must roll back.
+        part = (
+            Box(80, 60, 30)
+            - Pos(0, -20, 7.5) * Box(80, 20, 15)
+            - Pos(20, 15, 0) * Cylinder(3, 30)
         )
-        init_placement_scratch(dwg, reset=False)  # finalize: preserve escalations/details
-        assert dwg._corridor_batch == {}  # batch always fresh
-        assert dwg._escalations == [esc] and dwg._detail_requests == ["d"]  # survive the retry
+        dwg = build_drawing(part, auto_dims=False)
+        step = next(f for f in dwg.model().features if f.kind == "step_level")
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        dwg._defer_intents = True
+        dwg.callout(hole)  # commits in leg B1, before the B2 drain
+        dwg.dimension(step, "length", role="step_position")  # drained in B2
+        names_before, items_before = set(dwg._named), len(dwg.items)
+        intents_before = len(dwg._intents)
 
-        init_placement_scratch(dwg, reset=True)  # auto-pass: clean slate
-        assert dwg._corridor_batch == {} and dwg._escalations == [] and dwg._detail_requests == []
+        calls = {"n": 0}
+        real = _common.drain_corridors
+
+        def _boom(d):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("injected drain failure")
+            return real(d)
+
+        monkeypatch.setattr(_common, "drain_corridors", _boom)
+        with pytest.raises(RuntimeError):
+            dwg.finalize()
+        # Rolled back to exactly the pre-finalize state — the B1 callout is gone again.
+        assert set(dwg._named) == names_before
+        assert len(dwg.items) == items_before
+        assert len(dwg._intents) == intents_before
+
+        monkeypatch.undo()
+        dwg.finalize()  # clean retry — the shoulder position places exactly once (no duplicate)
+        assert len([n for n in dwg._named if n.startswith("dim_shoulder")]) == 1
 
     def test_centered_rebate_dimensions_both_shoulders(self):
         # A symmetric central channel has TWO shoulders; both positions must be given

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -208,10 +208,10 @@ class TestStepPosition:
         assert placed == ["20"]  # the shoulder position survives the recompose
 
     def test_finalize_drains_step_positions_after_a_mid_replay_raise(self, monkeypatch):
-        # #636 review: A0b registers the step-position corridor candidates and drops their
-        # intents BEFORE the fallible callout phase. If that phase raises and finalize() is
-        # retried, the recomputed step_position_ids is empty — so the drain must key off the
-        # pending corridor batch, not the intent set, or the candidates strand and vanish.
+        # #636/#647: A0b registers the step-position corridor candidates and drops their
+        # intents before the fallible B1 callout phase. If that phase raises, finalize's
+        # transactional rollback (#647) restores the step-position intent — so a retry
+        # re-registers from it and drains, rather than stranding the candidates.
         from draftwright.annotations import holes as _holes_mod
 
         part = (
@@ -235,11 +235,12 @@ class TestStepPosition:
 
         monkeypatch.setattr(_holes_mod, "_annotate_holes", _boom)
         with pytest.raises(RuntimeError):
-            dwg.finalize()  # A0b registered the step candidates; B1 raises → batch stranded
-        assert dwg._corridor_batch  # candidates persist, not yet drained
+            dwg.finalize()  # A0b registered the step candidates; B1 raises → rollback
+        # The rollback restored the step-position INTENT; nothing was committed.
+        assert any(it.kwargs.get("role") == "step_position" for it in dwg._intents)
         assert not [n for n in dwg._named if n.startswith("dim_shoulder")]
 
-        dwg.finalize()  # retry: step_position_ids is now empty, but the batch still drains
+        dwg.finalize()  # retry: re-registers from the surviving intent and drains
         placed = sorted(dwg._named[n].label for n in dwg._named if n.startswith("dim_shoulder"))
         assert placed == ["20"]
 
@@ -258,11 +259,11 @@ class TestStepPosition:
         real = _common.drain_corridors
         calls = {"n": 0}
 
-        def _boom(d):
+        def _boom(ctx, d):
             calls["n"] += 1
             if calls["n"] == 1:
                 raise RuntimeError("injected drain failure")
-            return real(d)
+            return real(ctx, d)
 
         monkeypatch.setattr(_common, "drain_corridors", _boom)
         with pytest.raises(RuntimeError):
@@ -284,9 +285,7 @@ class TestStepPosition:
         # A step positioned in B2's drain, plus an off-centre hole whose callout live-places in
         # leg B1 — so an annotation is COMMITTED before the B2 drain raises, and must roll back.
         part = (
-            Box(80, 60, 30)
-            - Pos(0, -20, 7.5) * Box(80, 20, 15)
-            - Pos(20, 15, 0) * Cylinder(3, 30)
+            Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15) - Pos(20, 15, 0) * Cylinder(3, 30)
         )
         dwg = build_drawing(part, auto_dims=False)
         step = next(f for f in dwg.model().features if f.kind == "step_level")
@@ -300,11 +299,11 @@ class TestStepPosition:
         calls = {"n": 0}
         real = _common.drain_corridors
 
-        def _boom(d):
+        def _boom(ctx, d):
             calls["n"] += 1
             if calls["n"] == 1:
                 raise RuntimeError("injected drain failure")
-            return real(d)
+            return real(ctx, d)
 
         monkeypatch.setattr(_common, "drain_corridors", _boom)
         with pytest.raises(RuntimeError):
@@ -5518,7 +5517,7 @@ class TestDetailView:
         # "step"/"illegible" Escalation render_height_ladder emits instead.
         from types import SimpleNamespace
 
-        from draftwright.annotations._common import Escalation
+        from draftwright.annotations._common import Escalation, PlacementContext
         from draftwright.annotations.sections import _request_prismatic_detail
 
         a = SimpleNamespace(
@@ -5526,16 +5525,15 @@ class TestDetailView:
             bb=SimpleNamespace(min=SimpleNamespace(Z=0.0), max=SimpleNamespace(Z=2.0)),
             SCALE=1.0,
         )
-        no_escalation = SimpleNamespace(_escalations=[], _detail_requests=[])
-        _request_prismatic_detail(no_escalation, a)
-        assert no_escalation._detail_requests == []
+        no_escalation = PlacementContext()
+        _request_prismatic_detail(None, a, ctx=no_escalation)
+        assert no_escalation.detail_requests == []
 
-        with_escalation = SimpleNamespace(
-            _escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")],
-            _detail_requests=[],
+        with_escalation = PlacementContext(
+            escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")],
         )
-        _request_prismatic_detail(with_escalation, a)
-        assert len(with_escalation._detail_requests) == 1
+        _request_prismatic_detail(None, a, ctx=with_escalation)
+        assert len(with_escalation.detail_requests) == 1
 
     def test_plain_part_gets_no_detail_view(self):
         dwg = build_drawing(Box(60, 40, 20))
@@ -6632,7 +6630,8 @@ class TestFeatureEdits:
                     dwg.locate(f)
         assert docs(dwg) == docs(auto)  # coverage restored under place_furniture=False
         assert dwg._intents == []  # drained
-        assert dwg._escalations == []  # leg D ran + cleared them for retry safety
+        # (#639) Escalations live on the per-run PlacementContext, discarded when finalize
+        # returns — no cross-run leak to assert against on the drawing.
 
     @staticmethod
     def _hc_ys(d):
@@ -8882,19 +8881,21 @@ class TestPatternGroupBalloon:
         )
 
     def test_dropped_pattern_gets_one_grouped_balloon(self):
-        from draftwright.annotations._common import Escalation
+        from draftwright.annotations._common import Escalation, PlacementContext
         from draftwright.annotations.orchestrator import _maybe_tabulate_holes
 
         dwg = build_drawing(_multi_hole_plate())  # sparse — density gate stays shut
         before = set(dwg.annotations())
         feat = self._fake_pattern(count=6, diameter=5.0)
-        dwg._escalations.append(
-            Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
+        ctx = PlacementContext(
+            escalations=[
+                Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
+            ]
         )
         # Mirror what _record_callout_drop does in production, so clearing it below
         # actually exercises the resolve path rather than trivially passing.
         dwg._record_build_issue("warning", "callout_dropped", "synthetic plan-view drop")
-        _maybe_tabulate_holes(dwg, dwg._analysis)
+        _maybe_tabulate_holes(dwg, dwg._analysis, ctx=ctx)
 
         assert "hole_table_plan" not in dwg.annotations()  # density gate untouched
         new_balloons = [
@@ -8905,7 +8906,7 @@ class TestPatternGroupBalloon:
         assert "callout_dropped" not in {i.code for i in dwg.lint()}  # resolved, not just hidden
 
     def test_multiple_dropped_patterns_get_distinct_non_overlapping_balloons(self):
-        from draftwright.annotations._common import Escalation
+        from draftwright.annotations._common import Escalation, PlacementContext
         from draftwright.annotations.orchestrator import _maybe_tabulate_holes
 
         dwg = build_drawing(_multi_hole_plate())
@@ -8913,11 +8914,12 @@ class TestPatternGroupBalloon:
             self._fake_pattern(count=4, diameter=3.0, origin=(-15.0, -8.0, 0.0)),
             self._fake_pattern(count=6, diameter=5.0, origin=(15.0, 8.0, 0.0)),
         ]
+        ctx = PlacementContext()
         for feat in feats:
-            dwg._escalations.append(
+            ctx.escalations.append(
                 Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
             )
-        _maybe_tabulate_holes(dwg, dwg._analysis)
+        _maybe_tabulate_holes(dwg, dwg._analysis, ctx=ctx)
 
         balloons = [n for n in dwg.annotations() if n.startswith("balloon_plan_")]
         assert {n.split("_")[2] for n in balloons} == {"4×A", "6×B"}
@@ -8934,16 +8936,18 @@ class TestPatternGroupBalloon:
     def test_unresolved_pattern_in_other_view_keeps_the_drop_lint(self):
         # A pattern drop the resolver does not cover (a non-plan view) must not
         # have its callout_dropped warning silently cleared.
-        from draftwright.annotations._common import Escalation
+        from draftwright.annotations._common import Escalation, PlacementContext
         from draftwright.annotations.orchestrator import _maybe_tabulate_holes
 
         dwg = build_drawing(_multi_hole_plate())
         feat = self._fake_pattern(count=3, diameter=4.0)
-        dwg._escalations.append(
-            Escalation(kind="callout", view="front", feature=feat, reason="front strip full")
+        ctx = PlacementContext(
+            escalations=[
+                Escalation(kind="callout", view="front", feature=feat, reason="front strip full")
+            ]
         )
         dwg._record_build_issue("warning", "callout_dropped", "synthetic front-view drop")
-        _maybe_tabulate_holes(dwg, dwg._analysis)
+        _maybe_tabulate_holes(dwg, dwg._analysis, ctx=ctx)
 
         assert not any(n.startswith("balloon_") for n in dwg.annotations())
         assert "callout_dropped" in {i.code for i in dwg.lint()}

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -222,6 +222,7 @@ def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
     from build123d import Box
 
     from draftwright import build_drawing
+    from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.from_model import render_pmi
     from draftwright.model import AuthoredDimension
     from draftwright.model.ir import Frame
@@ -237,6 +238,6 @@ def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
         ref_pts=((0.0, 0.0, 0.0), (5.0, 0.0, 0.0)),
     )
     model = SimpleNamespace(features=[bogus])
-    n = render_pmi(dwg, model, dwg._analysis)  # must not raise
+    n = render_pmi(dwg, model, dwg._analysis, ctx=PlacementContext())  # must not raise
     assert n == 0
     assert any(i.code == "pmi_dropped" for i in dwg._build_issues)  # graceful drop recorded

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -200,16 +200,17 @@ def test_strip_obstacles_keeps_section_hatch_in_every_per_view_query():
 
 def test_record_callout_drop_emits_a_callout_escalation():
     # PR-2 routing: a dropped hole callout emits a first-class Escalation into
-    # dwg._escalations (which the tabulation resolver now triggers on), alongside the
+    # ctx.escalations (which the tabulation resolver now triggers on), alongside the
     # `callout_dropped` lint code (kept for coverage). 1:1 with the code → byte-identical.
     # PR-3 (#351): `feature` now carries the dropped group's IR feature (a PatternFeature
     # when it's a fully-surviving recognised pattern, else None) rather than the diameter —
     # the resolver groups pattern balloons on it.
+    from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.holes import _record_callout_drop
 
     class _Dwg:
         def __init__(s):
-            s._escalations, s._codes, s._dropped = [], [], []
+            s._codes, s._dropped = [], []
 
         def _drop_callout_diam(s, d):
             s._dropped.append(d)
@@ -217,38 +218,42 @@ def test_record_callout_drop_emits_a_callout_escalation():
         def _record_build_issue(s, sev, code, msg):
             s._codes.append(code)
 
+    ctx = PlacementContext()
     d = _Dwg()
-    _record_callout_drop(d, "plan", 6.0, "no room beside the view")
+    _record_callout_drop(ctx, d, "plan", 6.0, "no room beside the view")
     assert d._codes == ["callout_dropped"] and d._dropped == [6.0]
-    assert len(d._escalations) == 1
-    e = d._escalations[0]
+    assert len(ctx.escalations) == 1
+    e = ctx.escalations[0]
     assert e.kind == "callout" and e.view == "plan" and e.feature is None
 
+    ctx2 = PlacementContext()
     d2 = _Dwg()
     sentinel = object()
-    _record_callout_drop(d2, "plan", 6.0, "no room beside the view", sentinel)
-    assert d2._escalations[0].feature is sentinel
+    _record_callout_drop(ctx2, d2, "plan", 6.0, "no room beside the view", sentinel)
+    assert ctx2.escalations[0].feature is sentinel
 
 
 def test_record_slot_drop_emits_a_slot_escalation():
     # #351 PR-4a: a dropped slot dim (width/length/position) emits a first-class
     # "slot" Escalation alongside the existing slot_dim_dropped lint code — purely
     # additive, no resolver consumes it yet (slots have no natural grouping remedy).
+    from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.from_model import _record_slot_drop
 
     class _Dwg:
         def __init__(s):
-            s._escalations, s._codes = [], []
+            s._codes = []
 
         def _record_build_issue(s, sev, code, msg):
             s._codes.append((sev, code))
 
+    ctx = PlacementContext()
     d = _Dwg()
     sentinel = object()
-    _record_slot_drop(d, "width", 0, "plan", sentinel)
+    _record_slot_drop(ctx, d, "width", 0, "plan", sentinel)
     assert d._codes == [("info", "slot_dim_dropped")]
-    assert len(d._escalations) == 1
-    e = d._escalations[0]
+    assert len(ctx.escalations) == 1
+    e = ctx.escalations[0]
     assert e.kind == "slot" and e.view == "plan" and e.feature is sentinel
 
 
@@ -257,34 +262,38 @@ def test_record_pmi_drop_emits_a_pmi_escalation():
     # code at all). Now records pmi_dropped + a first-class "pmi" Escalation.
     from types import SimpleNamespace
 
+    from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.from_model import _record_pmi_drop
 
     class _Dwg:
         def __init__(s):
-            s._escalations, s._codes = [], []
+            s._codes = []
 
         def _record_build_issue(s, sev, code, msg):
             s._codes.append((sev, code))
 
+    ctx = PlacementContext()
     d = _Dwg()
     rec = SimpleNamespace(pmi_kind="linear")
-    _record_pmi_drop(d, "X", "12.0", rec)
+    _record_pmi_drop(ctx, d, "X", "12.0", rec)
     assert d._codes == [("warning", "pmi_dropped")]
-    assert len(d._escalations) == 1
-    e = d._escalations[0]
+    assert len(ctx.escalations) == 1
+    e = ctx.escalations[0]
     assert e.kind == "pmi" and e.view == "front" and e.feature is rec
 
+    ctx2 = PlacementContext()
     d2 = _Dwg()
-    _record_pmi_drop(d2, "Y", "12.0", SimpleNamespace(pmi_kind="linear"))
-    assert d2._escalations[0].view == "side"
+    _record_pmi_drop(ctx2, d2, "Y", "12.0", SimpleNamespace(pmi_kind="linear"))
+    assert ctx2.escalations[0].view == "side"
 
     # A bore diameter/radius uses a DIFFERENT view table (the view where the bore
     # appears as a circle) from linear dims — conflating the two mislabelled every
     # dropped bore diameter/radius (caught by review, #351 PR-4a).
     for ax, want_view in (("Z", "plan"), ("X", "side"), ("Y", "front")):
+        ctx3 = PlacementContext()
         d3 = _Dwg()
-        _record_pmi_drop(d3, ax, "ø12.0", SimpleNamespace(pmi_kind="diameter"))
-        assert d3._escalations[0].view == want_view, ax
+        _record_pmi_drop(ctx3, d3, ax, "ø12.0", SimpleNamespace(pmi_kind="diameter"))
+        assert ctx3.escalations[0].view == want_view, ax
 
 
 def test_escalation_is_a_frozen_value_with_default_remedies():
@@ -301,13 +310,6 @@ def test_escalation_is_a_frozen_value_with_default_remedies():
     assert e2.view is None and e2.remedies == ("table", "drop")
     with pytest.raises(dataclasses.FrozenInstanceError):  # immutable value object
         e.kind = "x"
-
-
-def test_build_initialises_empty_escalations_collector():
-    # Scaffolding only: the collector exists and starts empty; no placer emits into it
-    # yet, so the build stays behaviour-preserving.
-    dwg = build_drawing(Box(40, 30, 10))
-    assert dwg._escalations == []
 
 
 # --- plan_strip: the collect-then-solve seam (pure geometry, no OCC) --------
@@ -667,9 +669,11 @@ def test_place_strip_candidates_priority_survives_key_order():
 def test_register_corridor_uses_largest_tier_across_producers():
     # #477: below/right corridors now collect candidates from mixed producers
     # (locations, envelope, GD&T/PMI). Spacing must not depend on which pass registers first.
-    from types import SimpleNamespace
-
-    from draftwright.annotations._common import CorridorCandidate, register_corridor
+    from draftwright.annotations._common import (
+        CorridorCandidate,
+        PlacementContext,
+        register_corridor,
+    )
 
     def _cand(name):
         return CorridorCandidate(
@@ -680,16 +684,16 @@ def test_register_corridor_uses_largest_tier_across_producers():
             on_drop=lambda _nm: None,
         )
 
-    dwg = SimpleNamespace(_corridor_batch={})
+    ctx = PlacementContext()
     key = ("side", "below")
-    register_corridor(dwg, key, object(), "side", "y", 4.0, _cand("small"))
-    register_corridor(dwg, key, object(), "side", "y", 9.0, _cand("large"))
-    assert dwg._corridor_batch[key]["tier"] == 9.0
+    register_corridor(ctx, key, object(), "side", "y", 4.0, _cand("small"))
+    register_corridor(ctx, key, object(), "side", "y", 9.0, _cand("large"))
+    assert ctx.corridor_batch[key]["tier"] == 9.0
 
-    dwg = SimpleNamespace(_corridor_batch={})
-    register_corridor(dwg, key, object(), "side", "y", 9.0, _cand("large"))
-    register_corridor(dwg, key, object(), "side", "y", 4.0, _cand("small"))
-    assert dwg._corridor_batch[key]["tier"] == 9.0
+    ctx = PlacementContext()
+    register_corridor(ctx, key, object(), "side", "y", 9.0, _cand("large"))
+    register_corridor(ctx, key, object(), "side", "y", 4.0, _cand("small"))
+    assert ctx.corridor_batch[key]["tier"] == 9.0
 
 
 def test_place_strip_candidates_refills_after_late_forbid_rejection():


### PR DESCRIPTION
Bundles two coupled changes from the #635 consolidation epic. They ship together because #647 is what makes #639 clean.

## #647 — `finalize()` is transactional (commit 1, `d83ba2a`)

`finalize()` now snapshots every collection it mutates (registry via its existing `snapshot()`/`restore()`, plus `items`/`_intents`/`views`/`_build_issues`) and **rolls back on any raise**, so a corrected retry starts from a clean slate. Previously a mid-drain exception could leave a half-committed drawing (the `m_locx0 + m_locx1` duplicate-measurement class).

- `drawing.py`: snapshot before the deferred drain; restore + `raise` in an `except` before `finally`.
- Reverts the #659 create-if-absent scratch workaround — with rollback, escalations/details no longer need to survive a retry.

## #639 — explicit `PlacementContext`; retire `Drawing` as the build-state bus (commit 2, `f53eac7`)

ADR 0005 §2. The per-run placement scratch (corridor batch, escalations, detail-requests) no longer hangs on `Drawing`. A `PlacementContext` dataclass is created fresh at each engine entry point (auto-pass orchestrator and `finalize()`) and threaded explicitly to every render pass as `ctx`. **`Drawing` now holds zero placement scratch.**

Why it's clean *now*: #647 made escalations/details genuinely per-run (they can't need to survive a retry), so all three scratch types live on a discarded per-run local instead of the drawing.

- `_common.py`: add `PlacementContext`; `register_corridor`/`drain_corridors` take `ctx`; `init_placement_scratch` deleted.
- `from_model.py`/`holes.py`/`sections.py`: thread `ctx` to every pass + the `_record_*_drop` helpers.
- `holes.py`: rename the `_StripCtx` local in `_place_queue` to `sctx` — it was shadowing the threaded `ctx` parameter, so a dropped callout recorded its escalation on the strip context (caught by the crowded-plate e2e).
- `orchestrator.py`/`drawing.py`: `ctx = PlacementContext()` per run; drop the `_escalations` clears and the `Drawing` class-level scratch fields.

## Behaviour / testing

- **Byte-identical** auto-pass output (refactor golden green — the threading is behaviour-preserving).
- Full fast tier green (1374 passed; the one failure was a test-side `render_pmi` signature drift, now fixed).
- Test updates track the new signatures. Two assertions on `dwg._escalations`/`dwg._corridor_batch` were removed: the no-cross-run-leak invariant is now **structural** (a fresh per-run ctx can't leak). The mid-replay + collector tests are reworked to the post-#647 rollback model rather than dropping coverage.
- Four lint checks (ruff check + format + mypy + codespell) clean.

Closes #647. Advances #639 (P4 of epic #635).

🤖 Generated with [Claude Code](https://claude.com/claude-code)