### PR TITLE
refactor(#639): encapsulation boundary — stop annotations/ probing Drawing privates

### DIFF
--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -65,7 +65,9 @@ from draftwright.model.planner import plan_locations
 _AXIS_ALIGN_COS = 0.9996
 
 
-def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | None = None) -> str:
+def add_feature_callout(
+    dwg, feature, model, a, *, view: str | None = None, name: str | None = None
+) -> str:
     """Add a hole/pattern ø-depth **leader callout** for *feature* — the #414 add verb,
     the callout-mechanism half of the editable surface (symmetric with :meth:`Drawing.drop`).
 
@@ -80,7 +82,6 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
     Raises ``ValueError`` if the drawing has no detected model, *feature* is not in it, or
     the feature exposes no hole callout (use :meth:`dimension` for a linear param instead).
     """
-    model = getattr(dwg, "_part_model", None)
     if model is None:
         raise ValueError("callout(): no detected model — build the drawing first")
     if not any(f is feature for f in model.features):
@@ -96,7 +97,6 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
             f"{type(feature).__name__} exposes none — use dimension() for a linear param"
         )
     draft = dwg.draft
-    a = getattr(dwg, "_analysis", None)
     members = feature.members or (feature.frame.origin,)
     # count comes from the spec (== feat.count) — the same source the auto-pass's
     # bare path uses — not re-derived from len(members) (#414 review).
@@ -176,7 +176,7 @@ def add_feature_callout(dwg, feature, *, view: str | None = None, name: str | No
 
 
 def add_feature_location(
-    dwg, feature, *, axes: tuple[str, ...] | None = None, pin: bool = False
+    dwg, feature, model, a, *, axes: tuple[str, ...] | None = None, pin: bool = False
 ) -> list[str]:
     """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern —
     the #418 ``locate()`` add verb (symmetric with :meth:`Drawing.drop`).
@@ -201,7 +201,6 @@ def add_feature_location(
     by the auto-pass). A feature with no datum-referenced ref (a datum-less model, a
     concentric/on-datum bore, or a ref deduped against a sibling) returns ``[]``.
     """
-    model = getattr(dwg, "_part_model", None)
     if model is None:
         raise ValueError("locate(): no detected model — build the drawing first")
     if not any(f is feature for f in model.features):
@@ -219,7 +218,6 @@ def add_feature_location(
             "locate(): only Z-axis holes/patterns have plan location dims; a side-drilled "
             "bore is located by the auto-pass, not this verb"
         )
-    a = getattr(dwg, "_analysis", None)
     if a is None:
         raise ValueError("locate(): no analysis — build the drawing first")
     want = {"x", "y"} if axes is None else {ax.lower() for ax in axes}
@@ -313,7 +311,7 @@ def add_feature_location(
     return names
 
 
-def add_feature_furniture(dwg, feature, *, view: str | None = None) -> list[str]:
+def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None) -> list[str]:
     """Add a hole/pattern's non-dimensional **sheet furniture** — the #419 ``furniture()``
     add verb (symmetric with :meth:`Drawing.drop`).
 
@@ -328,7 +326,6 @@ def add_feature_furniture(dwg, feature, *, view: str | None = None) -> list[str]
     Raises ``ValueError`` if the drawing has no detected model/analysis, *feature* is not
     in it, or *feature* is not a hole/pattern (use :meth:`dimension` for a linear param).
     """
-    model = getattr(dwg, "_part_model", None)
     if model is None:
         raise ValueError("furniture(): no detected model — build the drawing first")
     if not any(f is feature for f in model.features):
@@ -341,7 +338,6 @@ def add_feature_furniture(dwg, feature, *, view: str | None = None) -> list[str]
             f"furniture() draws a hole/pattern's centre marks + pattern furniture; "
             f"{type(feature).__name__} exposes none — use dimension() for a linear param"
         )
-    a = getattr(dwg, "_analysis", None)
     if a is None:
         raise ValueError("furniture(): no analysis — build the drawing first")
     view = view or _END_ON[feature.frame.axis]
@@ -375,7 +371,7 @@ def add_feature_furniture(dwg, feature, *, view: str | None = None) -> list[str]
     return sorted(set(dwg.annotations()) - before)
 
 
-def add_feature_diameter(dwg, feature) -> str:
+def add_feature_diameter(dwg, feature, model) -> str:
     """Add a turned **step/boss diameter** ø-leader — the #419 extension of the callout
     add verb to :class:`StepFeature` / :class:`BossFeature`.
 
@@ -387,7 +383,6 @@ def add_feature_diameter(dwg, feature) -> str:
     Raises ``ValueError`` if the feature exposes no step/boss diameter, its turning axis
     is unsupported, or there is no room to place the leader.
     """
-    model = getattr(dwg, "_part_model", None)
     if model is None:
         raise ValueError("callout(): no detected model — build the drawing first")
     if not any(f is feature for f in model.features):

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -205,7 +205,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (dwg.model()) and feature edits work even in manual mode (#398); fall back to
     # building it here for any direct caller that skipped _assemble.
     _model = dwg._part_model if dwg._part_model is not None else build_model(a)
-    dwg._part_model = _model
+    dwg.attach_part_model(_model)
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them
     # (was recomputed per renderer, #275). One rule set over DimParameters, literally.
     _groups = plan_dimensions(_model)

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -79,7 +79,7 @@ def feature_hole_keys(model, a: Analysis) -> set[HoleRef]:
     return keys
 
 
-def add_section(dwg) -> list[str]:
+def add_section(dwg, model, a) -> list[str]:
     """Add the automatic full **section A–A** (ISO 128-44 arrows + ISO 128-50 hatch)
     — the #420 ``section()`` add verb.
 
@@ -94,10 +94,8 @@ def add_section(dwg) -> list[str]:
 
     Raises ``ValueError`` if the drawing has no detected model / analysis.
     """
-    model = getattr(dwg, "_part_model", None)
     if model is None:
         raise ValueError("section(): no detected model — build the drawing first")
-    a = getattr(dwg, "_analysis", None)
     if a is None:
         raise ValueError("section(): no analysis — build the drawing first")
     plan = plan_sections(model, feature_hole_keys(model, a))

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -702,6 +702,11 @@ class Drawing:
         """
         return self._part_model
 
+    def attach_part_model(self, model) -> None:
+        """Attach the built PartModel so ``model()`` and feature edits see it. Lets the
+        orchestrator hand the model back without an ``annotations/`` attribute write (#639)."""
+        self._part_model = model
+
     def place_dim(
         self,
         p1,
@@ -1109,8 +1114,10 @@ class Drawing:
         from draftwright.annotations.holes import add_feature_callout, add_feature_diameter
 
         if getattr(feature, "kind", None) in ("step", "boss"):
-            return add_feature_diameter(self, feature)
-        return add_feature_callout(self, feature, view=view, name=name)
+            return add_feature_diameter(self, feature, self._part_model)
+        return add_feature_callout(
+            self, feature, self._part_model, self._analysis, view=view, name=name
+        )
 
     def furniture(self, feature, *, view=None) -> list[str]:
         """Add a hole/pattern's non-dimensional **sheet furniture** (#419) — centre marks
@@ -1131,7 +1138,7 @@ class Drawing:
             return []
         from draftwright.annotations.holes import add_feature_furniture
 
-        return add_feature_furniture(self, feature, view=view)
+        return add_feature_furniture(self, feature, self._part_model, self._analysis, view=view)
 
     def section(self) -> list[str]:
         """Add the automatic full **section A–A** (#420) — the section half of the
@@ -1151,7 +1158,7 @@ class Drawing:
             return []
         from draftwright.annotations.sections import add_section
 
-        return add_section(self)
+        return add_section(self, self._part_model, self._analysis)
 
     def locate(self, feature, *, axes=None, pin=False) -> list[str]:
         """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern
@@ -1178,7 +1185,9 @@ class Drawing:
             return []
         from draftwright.annotations.holes import add_feature_location
 
-        return add_feature_location(self, feature, axes=axes, pin=pin)
+        return add_feature_location(
+            self, feature, self._part_model, self._analysis, axes=axes, pin=pin
+        )
 
     @contextlib.contextmanager
     def deferred(self):

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -61,18 +61,33 @@ def _is_dwg(node: ast.AST) -> bool:
     return isinstance(node, ast.Name) and node.id == "dwg"
 
 
-def _dwg_private_write_targets(tree: ast.Module) -> list[ast.Attribute]:
-    """Every ``dwg._<name> = …`` / ``dwg._<name>: T = …`` assignment target in the module."""
-    out: list[ast.Attribute] = []
+def _dwg_private_writes(tree: ast.Module) -> list[tuple[int, str]]:
+    """Every ``dwg._<name>`` MUTATION as ``(lineno, name)``. Detected by AST *context* rather
+    than by statement kind, so it catches plain/annotated/augmented assignment
+    (``dwg._x = …`` / ``dwg._x: T = …`` / ``dwg._x += …``) and ``del dwg._x`` uniformly (all
+    carry ``Store``/``Del`` context), plus constant-name ``setattr``/``delattr(dwg, "_x", …)``.
+    (Aliasing — ``a = dwg; a._x = …`` — is out of scope; no code does it and review would catch
+    it. Noted rather than solved, #639.)"""
+    out: list[tuple[int, str]] = []
     for node in ast.walk(tree):
-        targets: list[ast.expr] = []
-        if isinstance(node, ast.Assign):
-            targets = list(node.targets)
-        elif isinstance(node, ast.AnnAssign):
-            targets = [node.target]
-        for t in targets:
-            if isinstance(t, ast.Attribute) and _is_dwg(t.value) and t.attr.startswith("_"):
-                out.append(t)
+        if (
+            isinstance(node, ast.Attribute)
+            and _is_dwg(node.value)
+            and node.attr.startswith("_")
+            and isinstance(node.ctx, (ast.Store, ast.Del))
+        ):
+            out.append((node.lineno, node.attr))
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in ("setattr", "delattr")
+            and len(node.args) >= 2
+            and _is_dwg(node.args[0])
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+            and node.args[1].value.startswith("_")
+        ):
+            out.append((node.lineno, node.args[1].value))
     return out
 
 
@@ -96,16 +111,16 @@ def _dwg_getattr_probes(tree: ast.Module) -> list[str]:
 
 
 def _dwg_private_reads(tree: ast.Module) -> set[str]:
-    """Distinct ``dwg._<name>`` private reads: attribute accesses that are NOT an assignment
-    target, plus ``getattr(dwg, "_name", …)`` probes."""
-    write_targets = {id(t) for t in _dwg_private_write_targets(tree)}
+    """Distinct ``dwg._<name>`` private READS: attribute accesses in ``Load`` context (so a
+    write/delete target — ``Store``/``Del`` — is never miscounted as a read), plus
+    ``getattr(dwg, "_name", …)`` probes."""
     reads: set[str] = set()
     for node in ast.walk(tree):
         if (
             isinstance(node, ast.Attribute)
             and _is_dwg(node.value)
             and node.attr.startswith("_")
-            and id(node) not in write_targets
+            and isinstance(node.ctx, ast.Load)
         ):
             reads.add(node.attr)
     reads |= set(_dwg_getattr_probes(tree))
@@ -113,18 +128,38 @@ def _dwg_private_reads(tree: ast.Module) -> set[str]:
 
 
 def test_no_dwg_private_attribute_writes():
-    """No ``annotations/`` module assigns ``dwg._<name> = …`` (ADR 0005 §2 / #639): build state
-    flows in via parameters or a named method (``dwg.attach_part_model``), never a private poke."""
+    """No ``annotations/`` module mutates ``dwg._<name>`` (ADR 0005 §2 / #639): build state
+    flows in via parameters or a named method (``dwg.attach_part_model``), never a private poke.
+    Covers assignment / annotated / augmented / ``del`` / ``setattr`` / ``delattr`` forms."""
     offenders: list[str] = []
     for path in _anno_sources():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for t in _dwg_private_write_targets(tree):
-            offenders.append(f"{path.relative_to(_SRC)}:{t.lineno}: dwg.{t.attr} = …")
+        for lineno, attr in _dwg_private_writes(tree):
+            offenders.append(f"{path.relative_to(_SRC)}:{lineno}: dwg.{attr} mutated")
     assert not offenders, (
         "annotations/ must not write Drawing privates — the drawing is not the state bus "
         "(#639 / ADR 0005 §2). Thread the value in as a parameter or route it through a named "
         "Drawing method (e.g. attach_part_model):\n  " + "\n  ".join(offenders)
     )
+
+
+def test_write_guard_catches_every_mutation_form():
+    """Pin the guard itself: each way to mutate a ``dwg`` private is detected, so the
+    encapsulation check can't be evaded by reaching for ``setattr``/``+=``/``del`` (#662 review)."""
+    for snippet in (
+        "dwg._part_model = m",
+        "dwg._part_model: int = m",
+        "dwg._named += x",
+        "dwg._named |= x",
+        "del dwg._part_model",
+        'setattr(dwg, "_part_model", m)',
+        'delattr(dwg, "_part_model")',
+        "(dwg._a, y) = pair",  # tuple-unpack target
+    ):
+        writes = _dwg_private_writes(ast.parse(snippet))
+        assert writes, f"guard missed a mutation form: {snippet!r}"
+    # A pure read must NOT register as a write (else every read is a false positive).
+    assert not _dwg_private_writes(ast.parse("use(dwg._named)"))
 
 
 def test_no_analysis_or_part_model_probing():
@@ -146,7 +181,12 @@ def test_private_reads_are_a_documented_shrinking_allowlist():
     """Every distinct ``dwg._<name>`` private READ across annotations/ is in the documented
     allowlist — the compat surface #639 will shrink to zero. The allowlist may only SHRINK:
     removing a name (as its read is threaded through the API) is fine; adding one is a conscious
-    re-coupling that needs a one-line rationale in _DWG_PRIVATE_READ_ALLOW."""
+    re-coupling that needs a one-line rationale in _DWG_PRIVATE_READ_ALLOW.
+
+    Note (#662 review): this asserts current-state equality, not cross-revision monotonicity —
+    adding a read AND its allowlist entry in one change passes in-process. True shrink-only
+    enforcement would need CI to diff the allowlist against the base revision; here it rests on
+    the stale-entry assertion (below) + the allowlist growth being visible in review."""
     reads: set[str] = set()
     for path in _anno_sources():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -1,0 +1,164 @@
+"""Encapsulation guards — the ``annotations/`` render layer may not reach into ``Drawing``
+privates (#639 / ADR 0005 §2).
+
+ADR 0005 §2 says ``Drawing`` stops being the implicit state bus: the annotation passes take
+the drawing duck-typed as ``dwg`` and must not treat its private attributes as a shared
+back-channel. Two habits are now fail-closed by AST-walking every module under
+``src/draftwright/annotations/``:
+
+- **No private WRITES.** An ``annotations/`` module must never assign ``dwg._<name> = ...`` —
+  build state flows in through parameters or a named method (e.g. ``dwg.attach_part_model``),
+  never a poke at a private field (:func:`test_no_dwg_private_attribute_writes`).
+- **No model/analysis PROBING.** The build model and analysis are threaded as parameters, so
+  ``getattr(dwg, "_analysis"/"_part_model", ...)`` probes are gone
+  (:func:`test_no_analysis_or_part_model_probing`).
+
+What private *reads* remain is a documented, shrinking allowlist
+(:data:`_DWG_PRIVATE_READ_ALLOW`) — the compat surface #639 will drive to zero. The allowlist
+may only SHRINK: removing a name (as a read is threaded through the API) is fine; adding one is
+a conscious re-coupling that needs a rationale here (:func:`test_private_reads_are_a_documented_shrinking_allowlist`).
+
+Dependency-free (stdlib ``ast`` + ``pathlib``), matching test_import_boundaries.py.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "draftwright"
+_ANNO_DIR = _SRC / "annotations"
+
+# Distinct ``dwg._<name>`` private reads (attribute access + ``getattr(dwg, "_name", …)`` probes)
+# the annotations layer still relies on. This is the compat surface #639 will shrink to zero;
+# it may only SHRINK. One-line rationale per entry:
+_DWG_PRIVATE_READ_ALLOW: frozenset[str] = frozenset(
+    {
+        "_add_balloons",  # balloon-render helper the hole pass calls back through
+        "_coords",  # cached per-view projected coordinates
+        "_cover_pattern",  # coverage bookkeeping for pattern callouts
+        "_cover_scattered_hole_doc",  # coverage bookkeeping for scattered-hole doc
+        "_drop_build_issues",  # drop-verb build-issue bookkeeping
+        "_drop_callout_diam",  # drop-verb dropped-diameter bookkeeping
+        "_feature_of_hole_at",  # feature lookup by hole location
+        "_is_scattered_hole_doc",  # coverage predicate for scattered-hole doc
+        "_named",  # the name→annotation index (free-name probing)
+        "_part_model",  # the built PartModel (read; write now via attach_part_model, #639)
+        "_record_build_issue",  # build-issue sink
+        "_reset_build_issues",  # build-issue reset
+        "_reset_dropped_callout_diams",  # dropped-diameter reset
+        "_model_declared",  # whether the model was declared (vs detected) — getattr probe
+    }
+)
+
+
+def _anno_sources() -> list[Path]:
+    return [p for p in sorted(_ANNO_DIR.rglob("*.py")) if "__pycache__" not in p.parts]
+
+
+def _is_dwg(node: ast.AST) -> bool:
+    """Whether *node* is the bare ``dwg`` name (the duck-typed drawing)."""
+    return isinstance(node, ast.Name) and node.id == "dwg"
+
+
+def _dwg_private_write_targets(tree: ast.Module) -> list[ast.Attribute]:
+    """Every ``dwg._<name> = …`` / ``dwg._<name>: T = …`` assignment target in the module."""
+    out: list[ast.Attribute] = []
+    for node in ast.walk(tree):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for t in targets:
+            if isinstance(t, ast.Attribute) and _is_dwg(t.value) and t.attr.startswith("_"):
+                out.append(t)
+    return out
+
+
+def _dwg_getattr_probes(tree: ast.Module) -> list[str]:
+    """Private names probed via ``getattr(dwg, "_name", …)`` — 1st arg ``dwg``, 2nd a
+    constant string starting with ``_``."""
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and _is_dwg(node.args[0])
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+            and node.args[1].value.startswith("_")
+        ):
+            out.append(node.args[1].value)
+    return out
+
+
+def _dwg_private_reads(tree: ast.Module) -> set[str]:
+    """Distinct ``dwg._<name>`` private reads: attribute accesses that are NOT an assignment
+    target, plus ``getattr(dwg, "_name", …)`` probes."""
+    write_targets = {id(t) for t in _dwg_private_write_targets(tree)}
+    reads: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and _is_dwg(node.value)
+            and node.attr.startswith("_")
+            and id(node) not in write_targets
+        ):
+            reads.add(node.attr)
+    reads |= set(_dwg_getattr_probes(tree))
+    return reads
+
+
+def test_no_dwg_private_attribute_writes():
+    """No ``annotations/`` module assigns ``dwg._<name> = …`` (ADR 0005 §2 / #639): build state
+    flows in via parameters or a named method (``dwg.attach_part_model``), never a private poke."""
+    offenders: list[str] = []
+    for path in _anno_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for t in _dwg_private_write_targets(tree):
+            offenders.append(f"{path.relative_to(_SRC)}:{t.lineno}: dwg.{t.attr} = …")
+    assert not offenders, (
+        "annotations/ must not write Drawing privates — the drawing is not the state bus "
+        "(#639 / ADR 0005 §2). Thread the value in as a parameter or route it through a named "
+        "Drawing method (e.g. attach_part_model):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_no_analysis_or_part_model_probing():
+    """No ``annotations/`` module probes ``getattr(dwg, "_analysis"/"_part_model", …)`` — the
+    model and analysis are threaded in as parameters now (#639)."""
+    offenders: list[str] = []
+    for path in _anno_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for name in _dwg_getattr_probes(tree):
+            if name in ("_analysis", "_part_model"):
+                offenders.append(f"{path.relative_to(_SRC)}: getattr(dwg, {name!r}, …)")
+    assert not offenders, (
+        "annotations/ must not probe the drawing for the model/analysis — pass them in as "
+        "parameters (#639 / ADR 0005 §2):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_private_reads_are_a_documented_shrinking_allowlist():
+    """Every distinct ``dwg._<name>`` private READ across annotations/ is in the documented
+    allowlist — the compat surface #639 will shrink to zero. The allowlist may only SHRINK:
+    removing a name (as its read is threaded through the API) is fine; adding one is a conscious
+    re-coupling that needs a one-line rationale in _DWG_PRIVATE_READ_ALLOW."""
+    reads: set[str] = set()
+    for path in _anno_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        reads |= _dwg_private_reads(tree)
+    new = reads - _DWG_PRIVATE_READ_ALLOW
+    assert not new, (
+        "New Drawing-private read(s) in annotations/ — this allowlist may only SHRINK "
+        "(#639 / ADR 0005 §2). Prefer threading the value through a parameter or a named "
+        f"Drawing method; if a read is truly needed, add it with a rationale: {sorted(new)}"
+    )
+    stale = _DWG_PRIVATE_READ_ALLOW - reads
+    assert not stale, (
+        "Allowlisted private read(s) no longer used — good, #639 is shrinking. Remove them "
+        f"from _DWG_PRIVATE_READ_ALLOW to keep it honest: {sorted(stale)}"
+    )


### PR DESCRIPTION
**#639 phase 2** (ADR 0005 §2). Phase 1 (merged in #660) moved the per-run placement *scratch* off `Drawing`. This kills the remaining **model/analysis reach-through** and makes the leftover Drawing-private surface a **fail-closed, shrinking allowlist**.

## Changes
- **Declare-verbs take the model/analysis as params, not probes.** `add_feature_callout` / `add_feature_location` / `add_feature_furniture` / `add_feature_diameter` (holes.py) and `add_section` (sections.py) previously did `getattr(dwg, "_part_model"/"_analysis", None)`. They now receive `model` (and `a`) as required params; the `Drawing` verb methods pass `self._part_model` / `self._analysis`. **All None-checks and error messages are byte-for-byte unchanged** — the value is handed in rather than probed.
- **Zero `dwg._*` writes from `annotations/`.** The one `dwg._part_model = _model` write (orchestrator) routes through a new one-line `Drawing.attach_part_model()` method.
- **New `tests/test_drawing_encapsulation.py`** (AST-walk, mirrors `test_import_boundaries.py`):
  - `test_no_dwg_private_attribute_writes` — fail-closed on any `dwg._x = …`.
  - `test_no_analysis_or_part_model_probing` — fail-closed on `getattr(dwg, "_analysis"/"_part_model", …)`.
  - `test_private_reads_are_a_documented_shrinking_allowlist` — the remaining private *reads* (`_record_build_issue`, `_named`, coverage methods, the `_model_declared` probe) are pinned to `_DWG_PRIVATE_READ_ALLOW`, which may only **shrink** (a stale entry also fails, keeping it honest).

## Scope (deliberately not in this PR)
The churny remainder of #639 — folding build context (`Analysis`, edge cache, hole index) onto `PlacementContext`, and routing the 21 `dwg._record_build_issue` calls through the context/registry — is now the allowlist's explicit shrink list, for a follow-up phase. This PR delivers the **enforcement** + the cheap, safe reach-through removal.

## Verification
- Behaviour-preserving (the verbs read the same model/analysis).
- Edit-path (`TestFeatureEdits`), the new encapsulation suite, and the DAG import-boundary guard all green; four lint checks clean.

Advances #639 (P4 of epic #635).

🤖 Generated with [Claude Code](https://claude.com/claude-code)