### PR TITLE
refactor(#639): route build-issue + coverage onto PlacementContext (phase 3 / stage C)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import Any
 
 from build123d_drafting.helpers import Dimension, SafeDimension
 
 from draftwright.layout import StripCandidate, plan_strip
+from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import _centerline_extent
 
 _log = logging.getLogger(__name__)
@@ -522,8 +524,10 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
 
 @dataclass
 class PlacementContext:
-    """The per-run placement scratch a build's passes share, threaded to them explicitly instead
-    of hung on the ``Drawing`` result object (ADR 0005 §2, #639): the corridor batch
+    """The per-run placement scratch a build's passes share — plus references to the drawing's
+    build-state stores (the ``registry`` build-issue sink + ``coverage`` bookkeeping) — threaded
+    to the passes explicitly instead of hung on the ``Drawing`` result object (ADR 0005 §2, #639):
+    the corridor batch
     (:func:`register_corridor`/:func:`drain_corridors`), the escalation list (ADR 0009 Amdt 1,
     #351), and the enlarged-detail request list (#307).
 
@@ -536,6 +540,22 @@ class PlacementContext:
     corridor_batch: dict = field(default_factory=dict)
     escalations: list = field(default_factory=list)
     detail_requests: list = field(default_factory=list)
+    # The drawing's build-state stores, referenced (not owned) by the run's passes (#639).
+    # Duck-typed as ``Any`` — matching the untyped ``Drawing._record_build_issue`` they replace —
+    # so mypy does not reject the delegating calls below.
+    registry: Any = None  # the drawing's AnnotationRegistry: build-issue sink + names
+    coverage: Any = None  # the drawing's CoverageState
+
+    def record_issue(self, severity, code, message) -> None:
+        """Record a build-time lint issue on the run's registry (#639). Replaces the passes'
+        old `dwg._record_build_issue`."""
+        self.registry.record_issue(LintIssue(severity=severity, code=code, message=message))
+
+    def reset_issues(self) -> None:
+        self.registry.reset_issues()
+
+    def drop_issues(self, *codes) -> None:
+        self.registry.drop_issues(codes)
 
 
 def register_corridor(ctx, key, strip, view, axis, tier, cand):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -172,7 +172,7 @@ def _record_slot_drop(ctx, dwg, kind, idx, view, feat):
     no natural grouping remedy like a recognised hole pattern, so no resolver
     consumes this yet — purely additive.
     """
-    dwg._record_build_issue(
+    ctx.record_issue(
         "info",
         "slot_dim_dropped",
         f"slot{idx} {kind} dim not placed (no room beside the {view})",
@@ -401,13 +401,13 @@ def _location_candidate(
     it; only a physically full strip drops (``location_ref_dropped`` → hole-table escalate)."""
 
     def _placed(nm):
-        dwg._cover_scattered_hole_doc(nm)
+        ctx.coverage.cover_scattered_hole_doc(nm)
         if pinned:
             dwg.pin(nm)
 
     def _drop(nm):
         edge = "plan view" if view == "plan" else "side view"
-        dwg._record_build_issue(
+        ctx.record_issue(
             "warning", "location_ref_dropped", f"{nm} not placed (no room above the {edge})"
         )
         ctx.escalations.append(Escalation("location", view, nm, "strip_full"))
@@ -496,7 +496,7 @@ def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
     _x_drawable = {r[0] for r in x_refs if abs(r[0] - datum_x) * a.SCALE >= 1.0}
     _kept_x, _n_x_close = _legible_locations(_x_drawable, a.SCALE)
     if _n_x_close:
-        dwg._record_build_issue(
+        ctx.record_issue(
             "warning",
             "location_ref_dropped",
             f"{_n_x_close} X location dim(s) too closely spaced to dimension legibly "
@@ -561,7 +561,7 @@ def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
     _y_drawable = {r[1] for r in y_refs if abs(r[1] - datum_y) * a.SCALE >= 1.0}
     _kept_y, _n_y_close = _legible_locations(_y_drawable, a.SCALE)
     if _n_y_close:
-        dwg._record_build_issue(
+        ctx.record_issue(
             "warning",
             "location_ref_dropped",
             f"{_n_y_close} Y location dim(s) too closely spaced to dimension legibly "
@@ -926,7 +926,7 @@ def _corner_candidates(dwg, view, vb, members, reach):
         yield (tip, elbow, m)
 
 
-def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code) -> int:
+def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx) -> int:
     """Place one machined-feature leader callout per job (#637). A *job* is
     ``(name, view, vb, label, candidates)`` where *candidates* yields ``(tip, elbow,
     feature)`` lead positions to try in order. Places the first Leader whose label lands clear
@@ -945,13 +945,13 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code) -> int:
                 n += 1
                 break
         else:
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning", drop_code, f"{noun} callout {label} not placed (no clear room)"
             )
     return n
 
 
-def render_chamfers(dwg, model, a) -> int:
+def render_chamfers(dwg, model, a, *, ctx) -> int:
     """Chamfer callouts (#560): a leader from each recognised chamfer face to its
     ``C{leg}`` / ``{leg}×{angle}°`` label, in the view normal to the chamfered edge (a Z
     edge reads in the plan, an X edge in the side, a Y edge in the front). The leader runs
@@ -977,7 +977,7 @@ def render_chamfers(dwg, model, a) -> int:
                 _corner_candidates(dwg, view, vb, [ch], reach),
             )
         )
-    return _leader_callout_pass(dwg, a, jobs, noun="chamfer", drop_code="chamfer_dropped")
+    return _leader_callout_pass(dwg, a, jobs, noun="chamfer", drop_code="chamfer_dropped", ctx=ctx)
 
 
 def _fillet_label(radius, count) -> str:
@@ -987,7 +987,7 @@ def _fillet_label(radius, count) -> str:
     return f"{count}× {r}" if count > 1 else r
 
 
-def render_fillets(dwg, model, a) -> int:
+def render_fillets(dwg, model, a, *, ctx) -> int:
     """Fillet radius callouts (#561): a leader from an external edge fillet to its
     ``R{radius}`` label — the arc analog of :func:`render_chamfers`. Equal-radius fillets on
     the same edge axis share ONE ``n× R`` callout (#561 acceptance), placed in the view
@@ -1020,7 +1020,7 @@ def render_fillets(dwg, model, a) -> int:
                 _corner_candidates(dwg, view, vb, ordered, reach),
             )
         )
-    return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped")
+    return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped", ctx=ctx)
 
 
 def _flat_label(across) -> str:
@@ -1030,7 +1030,7 @@ def _flat_label(across) -> str:
     return f"{_fmt(across)} A/F"
 
 
-def render_flats(dwg, model, a) -> int:
+def render_flats(dwg, model, a, *, ctx) -> int:
     """Machined-flat callouts (#148b): a leader from a flat truncating round stock to its
     ``{across} A/F`` label, in the view down the stock axis (a Z-axis bar reads in the plan).
     Flats sharing an axis and across-flats size — the faces of a double-D or hex — share ONE
@@ -1060,7 +1060,7 @@ def render_flats(dwg, model, a) -> int:
                 _corner_candidates(dwg, view, vb, ordered, reach),
             )
         )
-    return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped")
+    return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped", ctx=ctx)
 
 
 def _groove_label(width, diameter) -> str:
@@ -1126,7 +1126,7 @@ def _radial_candidates(dwg, view, vb, feature, reach):
         yield (tip, elbow, feature)
 
 
-def render_pockets(dwg, model, a) -> int:
+def render_pockets(dwg, model, a, *, ctx) -> int:
     """Blind-recess callouts (#148a): a leader from each floored slot/pocket to its
     ``W × L × D DEEP`` label, in the view normal to the recess opening (a Z-depth pocket
     reads in the plan, an X-depth in the side, a Y-depth in the front). A pocket sits
@@ -1153,10 +1153,10 @@ def render_pockets(dwg, model, a) -> int:
                 _radial_candidates(dwg, view, vb, pk, reach),
             )
         )
-    return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped")
+    return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped", ctx=ctx)
 
 
-def render_grooves(dwg, model, a) -> int:
+def render_grooves(dwg, model, a, *, ctx) -> int:
     """Turned/circlip-groove callouts (#148c): a leader from each annular groove in round
     stock to its ``{width} WIDE × ø{diameter}`` label. The groove's width is *axial*, so the
     callout lands in the **profile** view (the one showing the stock axis in-plane, where the
@@ -1186,10 +1186,10 @@ def render_grooves(dwg, model, a) -> int:
                 _radial_candidates(dwg, view, vb, gr, reach),
             )
         )
-    return _leader_callout_pass(dwg, a, jobs, noun="groove", drop_code="groove_dropped")
+    return _leader_callout_pass(dwg, a, jobs, noun="groove", drop_code="groove_dropped", ctx=ctx)
 
 
-def render_boss_diameters(dwg, groups, a) -> int:
+def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
     """ø leaders for a PRISMATIC part's bosses (#629). A boss reads as a circle looking down its
     axis, so its diameter is called out with a leader to that circle in the view normal to the
     axis — a Z boss in the plan, X in the side, Y in the front — free to exit into clear margin
@@ -1266,7 +1266,7 @@ def render_boss_diameters(dwg, groups, a) -> int:
             placed = True
             break
         if not placed:
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning",
                 "boss_dia_dropped",
                 f"boss ø{_fmt(dia)} callout not placed (no clear room)",
@@ -1323,7 +1323,7 @@ def render_plates(dwg, model, a, *, ctx) -> int:
             return _dim(pa, pb, side, pos - edge, draft, label=_fmt(val))
 
         def _drop(nm, val=val, view=view, stack=stack):
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning",
                 "plate_thickness_dropped",
                 f"plate thickness {_fmt(val)} not dimensioned ({view} {stack}-strip full)",
@@ -1431,7 +1431,7 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
     return n
 
 
-def _record_step_chain_drop(dwg, why: str) -> None:
+def _record_step_chain_drop(dwg, why: str, *, ctx) -> None:
     """Record the ``step_dim_dropped`` lint warning when a turned step-length chain
     is dropped whole (#362). These drops were silent (debug log only) — the user got
     a drawing with no step-length dimensioning and no signal. Mirrors
@@ -1440,7 +1440,7 @@ def _record_step_chain_drop(dwg, why: str) -> None:
     ``_request_prismatic_detail`` (sections.py), which would redraw *prismatic*
     height-above-base dims for a *turned* chain — the wrong semantics #351 PR-4b
     removed. A Z-turned-appropriate detail-view remedy is a tracked follow-up."""
-    dwg._record_build_issue(
+    ctx.record_issue(
         "warning",
         "step_dim_dropped",
         f"step-length chain dropped: {why} at this scale (use a detail view)",
@@ -1448,7 +1448,7 @@ def _record_step_chain_drop(dwg, why: str) -> None:
 
 
 def _draw_step_chain(
-    dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True, *, start=0
+    dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True, *, ctx, start=0
 ) -> int:
     """Place a turned step-length chain in *view* from *segs* — each ``(pa, pb,
     value)`` already projected to *view*'s page coords, in axis order. Orientation is
@@ -1506,14 +1506,16 @@ def _draw_step_chain(
             else:
                 _log.info("step-length chain skipped: too dense even when staggered")
                 _record_step_chain_drop(
-                    dwg, "shoulders too dense to dimension even when staggered"
+                    dwg, "shoulders too dense to dimension even when staggered", ctx=ctx
                 )
                 return 0
         else:
             shoulder_ys = sorted({c for pa, pb, *_ in segs for c in (pa[1], pb[1])})
             if any(b - a < tier_step for a, b in zip(shoulder_ys, shoulder_ys[1:])):
                 _log.info("step-length chain skipped: shoulders too close to dimension")
-                _record_step_chain_drop(dwg, "turned shoulders too closely spaced to dimension")
+                _record_step_chain_drop(
+                    dwg, "turned shoulders too closely spaced to dimension", ctx=ctx
+                )
                 return 0
 
         candidates = []
@@ -1538,7 +1540,7 @@ def _draw_step_chain(
         if box is not None and not (
             page[0] <= box[0] and box[2] <= page[2] and page[1] <= box[1] and box[3] <= page[3]
         ):
-            _record_step_chain_drop(dwg, "a dimension would fall off the drawable page")
+            _record_step_chain_drop(dwg, "a dimension would fall off the drawable page", ctx=ctx)
             return 0
     for name, dim in candidates:
         if detail_scale is not None:
@@ -1629,7 +1631,9 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
                 def _redraw(dwg, view, detail_scale, _hw=ra):
                     # View-scoped name prefix so two detail views never collide (#307 review).
                     hsegs = [(dwg.at(view, *a), dwg.at(view, *b), v, t) for a, b, v, t in _hw]
-                    return _draw_step_chain(dwg, view, hsegs, f"dim_{view}_steplen", detail_scale)
+                    return _draw_step_chain(
+                        dwg, view, hsegs, f"dim_{view}_steplen", detail_scale, ctx=ctx
+                    )
 
                 ctx.detail_requests.append(
                     DetailRequest(
@@ -1649,10 +1653,10 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
             # The chain now mixes head-block(s) with real steps — never collapse it to a
             # uniform "N× v" representative (a block is not a repeated step, #307 review).
             return _draw_step_chain(
-                dwg, "front", main, "m_steplen", allow_collapse=False, start=start
+                dwg, "front", main, "m_steplen", allow_collapse=False, ctx=ctx, start=start
             )
 
-    return _draw_step_chain(dwg, "front", fsegs, "m_steplen", start=start)
+    return _draw_step_chain(dwg, "front", fsegs, "m_steplen", ctx=ctx, start=start)
 
 
 def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):
@@ -1716,7 +1720,7 @@ def render_height_ladder(dwg, model, a, *, ctx, include_overall: bool = True) ->
             right_ladder = px
             n += 1
         else:
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "error",
                 "placement_unsatisfiable",
                 "representative step-height dimension dropped (front-view right strip full)",
@@ -1724,7 +1728,7 @@ def render_height_ladder(dwg, model, a, *, ctx, include_overall: bool = True) ->
     elif levels:
         kept, n_close = _legible_steps(levels, a.bb.min.Z, a.SCALE)
         if n_close:
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning",
                 "step_dim_dropped",
                 f"{n_close} step height(s) too closely spaced to dimension at this scale "
@@ -1743,7 +1747,7 @@ def render_height_ladder(dwg, model, a, *, ctx, include_overall: bool = True) ->
             perp = tuple(sorted((FZ(a.bb.min.Z), FZ(z))))
             px = carve_free_position(dwg, a.fv_zones.right, "front", "x", _SLOT_DIM_STEP, perp)
             if px is None:
-                dwg._record_build_issue(
+                ctx.record_issue(
                     "error",
                     "placement_unsatisfiable",
                     f"{len(kept) - col} step-height dimension(s) dropped "
@@ -1842,7 +1846,7 @@ def render_step_positions(dwg, model, a, *, ctx) -> int:
             )
 
         def _drop(nm, val=val, view=view):
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning",
                 "step_position_dropped",
                 f"step position {_fmt(val)} not dimensioned ({view} above-strip full)",
@@ -1877,7 +1881,7 @@ def render_step_positions(dwg, model, a, *, ctx) -> int:
     return n
 
 
-def render_rotational(dwg, model, a) -> int:
+def render_rotational(dwg, model, a, *, ctx) -> int:
     """Rotational furniture from the IR `RotationalFeature` (#237): the OD dim (above
     the front view), the rotation-axis centrelines (front + side), and the concentric
     bore leaders stacked to the left of the front view. Replaces the engine's inline
@@ -1961,11 +1965,11 @@ def render_rotational(dwg, model, a) -> int:
                     n += 1
                 dropped = [d for i, d in enumerate(rot.bores) if placed.get(f"{i:03d}") is None]
                 for d in dropped:
-                    dwg._drop_callout_diam(
+                    ctx.coverage.drop_diam(
                         d
                     )  # exclude from coverage — else double-reported (#374 rev)
                 if dropped:
-                    dwg._record_build_issue(
+                    ctx.record_issue(
                         "warning",
                         "callout_dropped",
                         f"{len(dropped)} concentric-bore diameter(s) {dropped} not annotated "
@@ -2052,7 +2056,7 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
         view = {"Z": "plan", "X": "side", "Y": "front"}.get(ax, "front")
     else:
         view = "front" if ax in ("X", "Z") else "side"
-    dwg._record_build_issue(
+    ctx.record_issue(
         "warning", "pmi_dropped", f"PMI {label!r} not placed (no room beside the {view})"
     )
     ctx.escalations.append(
@@ -2060,13 +2064,13 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
     )
 
 
-def _record_pmi_unrenderable(dwg, label, rec):
+def _record_pmi_unrenderable(dwg, label, rec, *, ctx):
     """Record an authored dimension whose reference geometry can't form a witness (fewer
     than two distinct reference points, or a sub-legible span). Distinct from
     ``pmi_dropped`` (a *placement* failure): this is a *validation* failure, so a caller
     sees a specific reason instead of a misleading "no room" — an authored dim is only
     ``pmi_dropped`` after a real candidate reaches the corridor solver and cannot fit (#562)."""
-    dwg._record_build_issue(
+    ctx.record_issue(
         "warning",
         "authored_dim_degenerate",
         f"authored dimension {label!r} has degenerate reference geometry (needs two "
@@ -2465,14 +2469,14 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
             placed = _front_linear(rec, ax, label, name_x, "above", "below", a.FV_Y)
             if placed is None:
                 _log.debug("PMI dim[%d] X: degenerate reference", idx)
-                _record_pmi_unrenderable(dwg, label, rec)
+                _record_pmi_unrenderable(dwg, label, rec, ctx=ctx)
                 continue
 
         elif ax == "Z":
             placed = _front_linear(rec, ax, label, name_z, "right", "left", a.FV_X)
             if placed is None:
                 _log.debug("PMI dim[%d] Z: degenerate reference", idx)
-                _record_pmi_unrenderable(dwg, label, rec)
+                _record_pmi_unrenderable(dwg, label, rec, ctx=ctx)
                 continue
 
         elif ax == "Y":
@@ -2481,7 +2485,7 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
             # only fires when a real candidate reached the solver (#562).
             if _witness_from_bbox(rec, "side") is None and _witness_from_bbox(rec, "plan") is None:
                 _log.debug("PMI dim[%d] Y: degenerate reference", idx)
-                _record_pmi_unrenderable(dwg, label, rec)
+                _record_pmi_unrenderable(dwg, label, rec, ctx=ctx)
                 continue
             # Try side view (Y maps to SX horizontal).
             wp = _witness_from_bbox(rec, "side")
@@ -2596,7 +2600,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
         name = f"m_gdt{i}"
         vk = views.get(item.view)
         if vk is None or item.side not in ("above", "below", "left", "right"):
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning", "gdt_dropped", f"{name}: bad target {item.view!r}/{item.side!r}"
             )
             continue
@@ -2615,7 +2619,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
         try:
             gb = _gdt_glyph(item, draft).bounding_box().size
         except Exception as e:  # noqa: BLE001 — any glyph-spec error drops one item, not the build
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning", "gdt_dropped", f"{name}: cannot render ({type(e).__name__}: {e})"
             )
             continue
@@ -2676,7 +2680,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                     if not _box_hits(_anno_box(dim), (_tb,)):  # clear of the title block
                         dwg.add(dim, nm, view=_v, feature=_feat)  # placed on the alternate side
                         return
-            dwg._record_build_issue(
+            ctx.record_issue(
                 "warning",
                 "gdt_dropped",
                 f"{nm} not placed (no room in the {_v} {_s} strip or its opposite)",

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -311,7 +311,7 @@ def add_feature_location(
     return names
 
 
-def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None) -> list[str]:
+def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None, ctx) -> list[str]:
     """Add a hole/pattern's non-dimensional **sheet furniture** — the #419 ``furniture()``
     add verb (symmetric with :meth:`Drawing.drop`).
 
@@ -366,7 +366,7 @@ def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None) ->
             for nm in dwg._named
         ):
             j += 1
-        _add_furniture(dwg, a, view, j, feature, lambda loc: dwg.at(view, *loc))
+        _add_furniture(dwg, a, view, j, feature, lambda loc: dwg.at(view, *loc), ctx=ctx)
 
     return sorted(set(dwg.annotations()) - before)
 
@@ -468,8 +468,8 @@ def _record_callout_drop(ctx, dwg, view, diam, reason, feat=None):
     else ``None`` — carried on the Escalation so the resolver can group by pattern
     identity (#351 PR-3).
     """
-    dwg._drop_callout_diam(diam)
-    dwg._record_build_issue(
+    ctx.coverage.drop_diam(diam)
+    ctx.record_issue(
         "warning",
         "callout_dropped",
         f"hole callout ø{_fmt(diam)} dropped from the {view} view ({reason})",
@@ -504,7 +504,7 @@ def _ir_off_axis_holes(model) -> list[_OffHole]:
     ]
 
 
-def _off_axis_drop(dwg, axis, view):
+def _off_axis_drop(dwg, axis, view, *, ctx):
     # Recorded at INFO under a code DISTINCT from the plan path's
     # ``location_ref_dropped`` (which is a warning). Two reasons:
     #  - Severity: a best-effort off-axis location dim that did not fit is not
@@ -518,7 +518,7 @@ def _off_axis_drop(dwg, axis, view):
     #    view, so it gets its own code.
     # (The plan path's primary top-view positions are expected on every
     # drawing, so a drop there stays a warning.) Promoted (#638).
-    dwg._record_build_issue(
+    ctx.record_issue(
         "info",
         "off_axis_location_dropped",
         f"{axis} location dim for a {view}-view hole not placed (no room beside the view)",
@@ -631,7 +631,7 @@ def _locate_across(dwg, ctx, a: Analysis, off):
         "y",
         cands,
         features=feats,
-        on_drop=lambda _nm: _off_axis_drop(dwg, "y", "side"),
+        on_drop=lambda _nm: _off_axis_drop(dwg, "y", "side", ctx=ctx),
         order_key=lambda nm, _i: order_y.get(nm, _i),
     )
 
@@ -678,7 +678,7 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
         "y",
         x_cands,
         features=x_feats,
-        on_drop=lambda _nm: _off_axis_drop(dwg, "x", "front"),
+        on_drop=lambda _nm: _off_axis_drop(dwg, "x", "front", ctx=ctx),
         order_key=lambda nm, _i: order_x.get(nm, _i),
     )
 
@@ -744,7 +744,7 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
             if _off_axis_emit(
                 dwg, tier, p_strip, p_view, "x", [_cand], force=True, features=_feature_map(p_view)
             ):
-                _off_axis_drop(dwg, "Z", p_view)
+                _off_axis_drop(dwg, "Z", p_view, ctx=ctx)
 
         _off_axis_queue(
             dwg,
@@ -811,7 +811,7 @@ def _locate_off_axis_holes(dwg, ctx, a: Analysis, *, which):
     _locate_along_z(dwg, ctx, a, off)
 
 
-def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_page):
+def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_page, *, ctx):
     """Pattern sheet furniture, added once its callout is placed (#92). Driven by the
     IR `PatternFeature` *feat* (members / bcd / pitch / grid), not a recogniser
     `Pattern` — ADR 0008 Amendment 6. Plain (unpatterned) plan callouts carry no
@@ -823,7 +823,7 @@ def _add_furniture(dwg, a: Analysis, view, j, feat: PatternFeature | None, to_pa
     # Remember the bore-callout name AND the holes it documents (by position), so a
     # later hole-table escalation leaves the grouped pattern callout standing and
     # tabulates only the holes no *placed* pattern callout covers (#92).
-    dwg._cover_pattern(f"hc_{view}{j}", [HoleRef.of(m) for m in members])
+    ctx.coverage.cover_pattern(f"hc_{view}{j}", [HoleRef.of(m) for m in members])
     if feat.pattern == "bolt_circle":
         assert feat.bcd is not None  # a bolt circle always carries its BCD
         cx = sum(to_page(m)[0] for m in members) / len(members)
@@ -1553,7 +1553,7 @@ def _annotate_holes(
                     continue
                 if place_furniture:  # #426: finalize's furniture() replay owns furniture
                     idx, feat = furniture[name]
-                    _add_furniture(dwg, a, view, idx, feat, to_page)
+                    _add_furniture(dwg, a, view, idx, feat, to_page, ctx=ctx)
             continue
 
         # plan / side: two-pass leader placement.
@@ -1795,9 +1795,9 @@ def _annotate_holes(
                 # _maybe_tabulate_holes find + replace it (#426 Ph4c). Coverage-only, so the
                 # auto-pass (place_furniture=True) set is unchanged → byte-identical.
                 if view == "plan" and feat is None:
-                    dwg._cover_scattered_hole_doc(name)
+                    ctx.coverage.cover_scattered_hole_doc(name)
                 if place_furniture:  # #426: finalize's furniture() replay owns furniture
-                    _add_furniture(dwg, a, view, i, feat, to_page)
+                    _add_furniture(dwg, a, view, i, feat, to_page, ctx=ctx)
                 i += 1
             return i
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -162,14 +162,15 @@ def _declared_feature_keys(groups, a: Analysis) -> set:
 
 def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     """Add the standard automatic dimensions, centrelines, and title block."""
+    # Per-run placement scratch (detail requests / escalations / corridor batch) + references to
+    # the drawing's build-state stores (registry/coverage), threaded to the passes instead of hung
+    # on the Drawing (ADR 0005 §2, #639). Fresh each auto-pass; the corridor batch is drained once
+    # at the end (drain_corridors, #345/#346).
+    ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
     # Idempotent: clear build-time lint state so a second annotation pass does
     # not accumulate duplicate drop records.
-    dwg._reset_build_issues()
-    dwg._reset_dropped_callout_diams()
-    # Per-run placement scratch (detail requests / escalations / corridor batch), threaded to the
-    # passes instead of hung on the Drawing (ADR 0005 §2, #639). Fresh each auto-pass; the corridor
-    # batch is drained once at the end (drain_corridors, #345/#346).
-    ctx = PlacementContext()
+    ctx.reset_issues()
+    ctx.coverage.reset_dropped()
 
     # Tighten right-strip outer_limits to the actual iso view left edge now
     # that the iso has been projected and fitted.  Always apply so that any
@@ -212,7 +213,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     # Rotational furniture — OD dim + axis centrelines + concentric bore leaders — IR
     # renderer (#237), placed early like the engine's inline block it replaces.
-    render_rotational(dwg, _model, a)
+    render_rotational(dwg, _model, a, ctx=ctx)
 
     # Centre marks for every hole (all part classes) — IR renderer.
     render_centermarks(dwg, _groups)
@@ -284,12 +285,12 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     render_step_positions(dwg, _model, a, ctx=ctx)
 
     # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.
-    render_chamfers(dwg, _model, a)
-    render_fillets(dwg, _model, a)
+    render_chamfers(dwg, _model, a, ctx=ctx)
+    render_fillets(dwg, _model, a, ctx=ctx)
     # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.
-    render_flats(dwg, _model, a)
+    render_flats(dwg, _model, a, ctx=ctx)
     # Blind-recess callouts (#148a): W × L × D DEEP via a leader off each floored pocket.
-    render_pockets(dwg, _model, a)
+    render_pockets(dwg, _model, a, ctx=ctx)
 
     # Side-drilled holes' in-plane (side-below) locations share the below corridor with
     # the overall envelope depth. They now queue into the same batch; the envelope's
@@ -319,7 +320,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Prismatic bosses get a plan-view ø leader BEFORE the turned row/column solve, which then
     # sees the ø as 'mentioned' and skips it (#629 — the column-left strip strands a boss ø when
     # tight, even on a half-empty sheet). No-op on turned parts (they keep the OD stack).
-    render_boss_diameters(dwg, _groups, a)
+    render_boss_diameters(dwg, _groups, a, ctx=ctx)
     render_diameters(dwg, _groups)
     if a.prof is not None:
         render_step_lengths(dwg, _groups, ctx=ctx)
@@ -357,7 +358,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # primary turned-length chain runs — so it places into remaining clear room only after
     # the corridor drain has finalised the diameter/step-length furniture (else its room
     # check can't see the not-yet-drained length dims and collides, #148c crowded-shaft).
-    render_grooves(dwg, _model, a)
+    render_grooves(dwg, _model, a, ctx=ctx)
 
     # The section view renders after the corridor-drained furniture exists, so
     # its full strip_obstacles room check can see side callouts, envelope dims,
@@ -482,7 +483,9 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
         # Structured coverage state (registered at placement time, #351 PR-4c), not
         # an annotation-name-prefix grep — the last stringly-typed inference this
         # resolver relied on (ADR 0009 Amdt 1).
-        replaced = {n: o for n, o in list(dwg.iter_annotations()) if dwg._is_scattered_hole_doc(n)}
+        replaced = {
+            n: o for n, o in list(dwg.iter_annotations()) if ctx.coverage.is_scattered_hole_doc(n)
+        }
         replaced_view = {n: dwg.view_of(n) for n in replaced}
         for n in replaced:
             dwg.remove(n)
@@ -495,14 +498,14 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
             )
             if table is not None:
                 break
-        dwg._drop_build_issues("table_dropped")
+        ctx.drop_issues("table_dropped")
         if table is None:
             # Even wrapped it will not fit — restore the callouts/dims and keep the
             # drop lint, so the sheet is never left with neither. The pattern
             # balloons below are unaffected — nothing of theirs was removed.
             for n, obj in replaced.items():
                 dwg.add(obj, n, view=replaced_view.get(n))
-            dwg._record_build_issue("warning", "table_dropped", "hole table did not fit the sheet")
+            ctx.record_issue("warning", "table_dropped", "hole table did not fit the sheet")
         else:
             # One entry per hole (with repeats) so the coverage *count* check sees
             # that the table documents every instance, not just each distinct
@@ -516,7 +519,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
             # pattern balloon sharing this resolver's combined band can still drop
             # (review follow-up: this used to clear callout_dropped wholesale here,
             # masking a dropped pattern balloon).
-            dwg._drop_build_issues("location_ref_dropped")
+            ctx.drop_issues("location_ref_dropped")
 
     balloon_specs = scattered_specs + pattern_specs
     placed_names: set = set()
@@ -552,4 +555,4 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
 
     unresolved = [e for e in escalations if e.kind == "callout" and not _resolved(e)]
     if not unresolved:
-        dwg._drop_build_issues("callout_dropped")
+        ctx.drop_issues("callout_dropped")

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -496,6 +496,16 @@ class Drawing:
     def _build_issues(self, value) -> None:
         self._registry._build_issues = value
 
+    @property
+    def registry(self):
+        """The AnnotationRegistry (identity/build-issue store) — the build handle the passes' PlacementContext references (#639)."""
+        return self._registry
+
+    @property
+    def coverage(self):
+        """The CoverageState — referenced by the run's PlacementContext (#639)."""
+        return self._coverage
+
     # -- coverage state (compat accessors, ADR 0005 §4) -----------------------
     # The CoverageState owner holds these three; exposed as their live containers
     # so code reading dwg._pattern_callouts / _patterned_holes /
@@ -1136,9 +1146,13 @@ class Drawing:
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
             self._intents.append(Intent("furniture", feature, {"view": view}))
             return []
+        from draftwright.annotations._common import PlacementContext
         from draftwright.annotations.holes import add_feature_furniture
 
-        return add_feature_furniture(self, feature, self._part_model, self._analysis, view=view)
+        ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
+        return add_feature_furniture(
+            self, feature, self._part_model, self._analysis, view=view, ctx=ctx
+        )
 
     def section(self) -> list[str]:
         """Add the automatic full **section A–A** (#420) — the section half of the
@@ -1448,7 +1462,7 @@ class Drawing:
         # (ADR 0005 §2, #639): render_locations/_annotate_holes/drain_corridors register/read here.
         # A local — finalize is transactional (#647), so a raised drain rolls the drawing back and
         # the retry re-runs from a clean slate with a new ctx; no cross-call persistence needed.
-        ctx = PlacementContext()
+        ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
 
         model, a = self._part_model, self._analysis
         routable = model is not None and a is not None

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -36,17 +36,9 @@ _DWG_PRIVATE_READ_ALLOW: frozenset[str] = frozenset(
     {
         "_add_balloons",  # balloon-render helper the hole pass calls back through
         "_coords",  # cached per-view projected coordinates
-        "_cover_pattern",  # coverage bookkeeping for pattern callouts
-        "_cover_scattered_hole_doc",  # coverage bookkeeping for scattered-hole doc
-        "_drop_build_issues",  # drop-verb build-issue bookkeeping
-        "_drop_callout_diam",  # drop-verb dropped-diameter bookkeeping
         "_feature_of_hole_at",  # feature lookup by hole location
-        "_is_scattered_hole_doc",  # coverage predicate for scattered-hole doc
         "_named",  # the name→annotation index (free-name probing)
         "_part_model",  # the built PartModel (read; write now via attach_part_model, #639)
-        "_record_build_issue",  # build-issue sink
-        "_reset_build_issues",  # build-issue reset
-        "_reset_dropped_callout_diams",  # dropped-diameter reset
         "_model_declared",  # whether the model was declared (vs detected) — getattr probe
     }
 )

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8957,9 +8957,11 @@ class TestPatternGroupBalloon:
         before = set(dwg.annotations())
         feat = self._fake_pattern(count=6, diameter=5.0)
         ctx = PlacementContext(
+            registry=dwg.registry,
+            coverage=dwg.coverage,
             escalations=[
                 Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
-            ]
+            ],
         )
         # Mirror what _record_callout_drop does in production, so clearing it below
         # actually exercises the resolve path rather than trivially passing.
@@ -8983,7 +8985,7 @@ class TestPatternGroupBalloon:
             self._fake_pattern(count=4, diameter=3.0, origin=(-15.0, -8.0, 0.0)),
             self._fake_pattern(count=6, diameter=5.0, origin=(15.0, 8.0, 0.0)),
         ]
-        ctx = PlacementContext()
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
         for feat in feats:
             ctx.escalations.append(
                 Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
@@ -9011,9 +9013,11 @@ class TestPatternGroupBalloon:
         dwg = build_drawing(_multi_hole_plate())
         feat = self._fake_pattern(count=3, diameter=4.0)
         ctx = PlacementContext(
+            registry=dwg.registry,
+            coverage=dwg.coverage,
             escalations=[
                 Escalation(kind="callout", view="front", feature=feat, reason="front strip full")
-            ]
+            ],
         )
         dwg._record_build_issue("warning", "callout_dropped", "synthetic front-view drop")
         _maybe_tabulate_holes(dwg, dwg._analysis, ctx=ctx)

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -238,6 +238,9 @@ def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
         ref_pts=((0.0, 0.0, 0.0), (5.0, 0.0, 0.0)),
     )
     model = SimpleNamespace(features=[bogus])
-    n = render_pmi(dwg, model, dwg._analysis, ctx=PlacementContext())  # must not raise
+    # The pmi_dropped lint now routes through the ctx's registry/coverage (#639); wire them to
+    # the drawing's so the drop lands on dwg's build issues.
+    ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+    n = render_pmi(dwg, model, dwg._analysis, ctx=ctx)  # must not raise
     assert n == 0
     assert any(i.code == "pmi_dropped" for i in dwg._build_issues)  # graceful drop recorded

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -148,9 +148,13 @@ class TestStepChainDrop:
         return _Dwg()
 
     def test_crowded_vertical_chain_records_the_drop(self):
+        from draftwright.annotations._common import PlacementContext
         from draftwright.annotations.from_model import _draw_step_chain
+        from draftwright.registry import AnnotationRegistry
 
         dwg = self._stub_dwg()
+        # The drop lint routes through the ctx's registry now (#639), not the drawing.
+        ctx = PlacementContext(registry=AnnotationRegistry())
         # Vertical (chain-to-the-right) segs whose shoulder Ys are 0.1 mm apart —
         # far below tier_step (= font_size + 2*pad = 4). Values differ so the
         # uniform-collapse path is not taken. The chain is dropped whole.
@@ -158,10 +162,11 @@ class TestStepChainDrop:
             ((80.0, 10.0, 0), (80.0, 10.1, 0), 5.0),
             ((80.0, 10.1, 0), (80.0, 10.2, 0), 8.0),
         ]
-        placed = _draw_step_chain(dwg, "front", segs, "m_steplen")
+        placed = _draw_step_chain(dwg, "front", segs, "m_steplen", ctx=ctx)
         assert placed == 0
-        codes = [code for _sev, code, _msg in dwg.issues]
+        codes = [i.code for i in ctx.registry._build_issues]
         assert "step_dim_dropped" in codes, "silent drop no longer allowed (#362)"
+        assert ctx.escalations == []  # _record_step_chain_drop records lint only, no Escalation
 
 
 class TestDiameterColumnOccupancy:

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -207,29 +207,22 @@ def test_record_callout_drop_emits_a_callout_escalation():
     # the resolver groups pattern balloons on it.
     from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.holes import _record_callout_drop
+    from draftwright.linting.coverage import CoverageState
+    from draftwright.registry import AnnotationRegistry
 
-    class _Dwg:
-        def __init__(s):
-            s._codes, s._dropped = [], []
-
-        def _drop_callout_diam(s, d):
-            s._dropped.append(d)
-
-        def _record_build_issue(s, sev, code, msg):
-            s._codes.append(code)
-
-    ctx = PlacementContext()
-    d = _Dwg()
-    _record_callout_drop(ctx, d, "plan", 6.0, "no room beside the view")
-    assert d._codes == ["callout_dropped"] and d._dropped == [6.0]
+    # The build-issue + dropped-diameter bookkeeping now routes through the ctx's registry/
+    # coverage (#639), not the drawing — so the dwg arg is inert here.
+    ctx = PlacementContext(registry=AnnotationRegistry(), coverage=CoverageState())
+    _record_callout_drop(ctx, object(), "plan", 6.0, "no room beside the view")
+    assert [i.code for i in ctx.registry._build_issues] == ["callout_dropped"]
+    assert ctx.coverage.dropped_diams == [6.0]
     assert len(ctx.escalations) == 1
     e = ctx.escalations[0]
     assert e.kind == "callout" and e.view == "plan" and e.feature is None
 
-    ctx2 = PlacementContext()
-    d2 = _Dwg()
+    ctx2 = PlacementContext(registry=AnnotationRegistry(), coverage=CoverageState())
     sentinel = object()
-    _record_callout_drop(ctx2, d2, "plan", 6.0, "no room beside the view", sentinel)
+    _record_callout_drop(ctx2, object(), "plan", 6.0, "no room beside the view", sentinel)
     assert ctx2.escalations[0].feature is sentinel
 
 
@@ -239,19 +232,14 @@ def test_record_slot_drop_emits_a_slot_escalation():
     # additive, no resolver consumes it yet (slots have no natural grouping remedy).
     from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.from_model import _record_slot_drop
+    from draftwright.registry import AnnotationRegistry
 
-    class _Dwg:
-        def __init__(s):
-            s._codes = []
-
-        def _record_build_issue(s, sev, code, msg):
-            s._codes.append((sev, code))
-
-    ctx = PlacementContext()
-    d = _Dwg()
+    ctx = PlacementContext(registry=AnnotationRegistry())
     sentinel = object()
-    _record_slot_drop(ctx, d, "width", 0, "plan", sentinel)
-    assert d._codes == [("info", "slot_dim_dropped")]
+    _record_slot_drop(ctx, object(), "width", 0, "plan", sentinel)
+    assert [(i.severity, i.code) for i in ctx.registry._build_issues] == [
+        ("info", "slot_dim_dropped")
+    ]
     assert len(ctx.escalations) == 1
     e = ctx.escalations[0]
     assert e.kind == "slot" and e.view == "plan" and e.feature is sentinel
@@ -264,35 +252,28 @@ def test_record_pmi_drop_emits_a_pmi_escalation():
 
     from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.from_model import _record_pmi_drop
+    from draftwright.registry import AnnotationRegistry
 
-    class _Dwg:
-        def __init__(s):
-            s._codes = []
-
-        def _record_build_issue(s, sev, code, msg):
-            s._codes.append((sev, code))
-
-    ctx = PlacementContext()
-    d = _Dwg()
+    ctx = PlacementContext(registry=AnnotationRegistry())
     rec = SimpleNamespace(pmi_kind="linear")
-    _record_pmi_drop(ctx, d, "X", "12.0", rec)
-    assert d._codes == [("warning", "pmi_dropped")]
+    _record_pmi_drop(ctx, object(), "X", "12.0", rec)
+    assert [(i.severity, i.code) for i in ctx.registry._build_issues] == [
+        ("warning", "pmi_dropped")
+    ]
     assert len(ctx.escalations) == 1
     e = ctx.escalations[0]
     assert e.kind == "pmi" and e.view == "front" and e.feature is rec
 
-    ctx2 = PlacementContext()
-    d2 = _Dwg()
-    _record_pmi_drop(ctx2, d2, "Y", "12.0", SimpleNamespace(pmi_kind="linear"))
+    ctx2 = PlacementContext(registry=AnnotationRegistry())
+    _record_pmi_drop(ctx2, object(), "Y", "12.0", SimpleNamespace(pmi_kind="linear"))
     assert ctx2.escalations[0].view == "side"
 
     # A bore diameter/radius uses a DIFFERENT view table (the view where the bore
     # appears as a circle) from linear dims — conflating the two mislabelled every
     # dropped bore diameter/radius (caught by review, #351 PR-4a).
     for ax, want_view in (("Z", "plan"), ("X", "side"), ("Y", "front")):
-        ctx3 = PlacementContext()
-        d3 = _Dwg()
-        _record_pmi_drop(ctx3, d3, ax, "ø12.0", SimpleNamespace(pmi_kind="diameter"))
+        ctx3 = PlacementContext(registry=AnnotationRegistry())
+        _record_pmi_drop(ctx3, object(), ax, "ø12.0", SimpleNamespace(pmi_kind="diameter"))
         assert ctx3.escalations[0].view == want_view, ax
 
 


### PR DESCRIPTION
**#639 phase 3, stage C** (ADR 0005 §2). First of two staged PRs that finish #639 — driving the annotation layer's `dwg._private` read-allowlist to **zero** (approach A: literal zero, full decouple).

Phases 1–2 (#660/#662) moved the placement scratch off `Drawing` and killed the model/analysis probing. This routes the two remaining **build-state** concerns — build-issue recording + coverage bookkeeping — onto the threaded `PlacementContext`, so passes depend on the context, not the drawing's internals (the #639 "testable seam").

## Changes
- **`PlacementContext`** gains `registry` + `coverage` refs and a thin API: `record_issue` / `reset_issues` / `drop_issues` (forward to the registry, which owns build-issues per ADR 0005). Coverage goes through `ctx.coverage.*`.
- **`Drawing`** exposes read-only `registry`/`coverage` properties so the orchestrator wires the ctx without a private reach; both entry points (orchestrator, `finalize`) populate them.
- Threaded `ctx` into the helpers that lacked it (leader-callout renderers, turned/boss/step-chain drops, furniture) and routed **all 8** build-issue/coverage reaches.
- The encapsulation read-allowlist (`test_drawing_encapsulation.py`) drops those 8; the **6 remaining** (`_named`/`_part_model`/`_coords`/`_feature_of_hole_at`/`_add_balloons`/`_model_declared`) are **stage D (639d)**.

## Verification
- **Byte-identical** (refactor golden — the correctness gate — 12 passed).
- Encapsulation (write/probe/shrinking-allowlist), edit-path, strip, pmi, render-seam suites green; `test_make_drawing` + `test_linting` = 627 passed.
- Four lint checks clean.

Advances #639 (P4 of epic #635). Stage D drives the allowlist to empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)