### PR TITLE
refactor(#639): finish — annotation layer reads ZERO Drawing privates (phase 3 / stage D)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -545,6 +545,33 @@ class PlacementContext:
     # so mypy does not reject the delegating calls below.
     registry: Any = None  # the drawing's AnnotationRegistry: build-issue sink + names
     coverage: Any = None  # the drawing's CoverageState
+    # The ensured PartModel (ADR 0008 IR) the run's passes read, threaded off the drawing so
+    # they no longer reach into ``dwg._part_model`` (#639). Both entry paths set it from the
+    # PUBLIC ``dwg.model()`` after the model is ensured/attached.
+    part_model: Any = None
+    # Whether the model was DECLARED (vs detected) — the ADR 0011 gate the orchestrator reads,
+    # threaded off ``getattr(dwg, "_model_declared")`` (#639).
+    model_declared: bool = False
+    # Per-run cache for :meth:`feature_of_hole_at` — the model is fixed after build, so a
+    # per-ctx (per-run) index is correct (mirrors the old ``Drawing._hole_feature_index``).
+    _hole_feature_index: Any = field(default=None, repr=False)
+
+    def feature_of_hole_at(self, location):
+        """The IR hole/pattern feature whose member sits at model-space *location*, or ``None``
+        (#408/#639). Attributes a balloon (which carries a recognition hole, not the IR feature)
+        to its feature so :meth:`Drawing.drop` clears it. Cached on the run's ctx — the model is
+        fixed after build."""
+        m = self.part_model
+        if m is None:
+            return None
+        if self._hole_feature_index is None:
+            idx: dict = {}
+            for f in getattr(m, "features", []):
+                if getattr(f, "kind", None) in ("hole", "pattern"):
+                    for loc in getattr(f, "members", None) or (f.frame.origin,):
+                        idx[tuple(round(c, 3) for c in loc)] = f
+            self._hole_feature_index = idx
+        return self._hole_feature_index.get(tuple(round(c, 3) for c in location))
 
     def record_issue(self, severity, code, message) -> None:
         """Record a build-time lint issue on the run's registry (#639). Replaces the passes'

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -474,7 +474,7 @@ def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
     # m_locx{i}, the historical byte-identical scheme. The finalize() path (only set) may
     # run AFTER live-replayed locate() dims already hold m_loc names, so there it allocates
     # the first FREE index to avoid Drawing.add silently replacing one (#429 review).
-    _loc_used = set(dwg._named) if only is not None else None
+    _loc_used = set(ctx.registry.names()) if only is not None else None
 
     def _loc_name(prefix: str, i: int) -> str:
         if _loc_used is None:
@@ -748,7 +748,7 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
     return placed
 
 
-def render_diameters(dwg, groups, tol: float = 0.15, *, only=None) -> int:
+def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
     """ø leaders for a turned part's external step/boss diameters, from the IR —
     one distinct callout per diameter, in a tidy row below the front view
     (X-turning) or a column to its left (Z-turning). Orientation is the feature
@@ -803,7 +803,7 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, only=None) -> int:
     def _next_start(prefix):
         idxs = [
             int(n[len(prefix) :])
-            for n in dwg._named
+            for n in ctx.registry.names()
             if n.startswith(prefix) and n[len(prefix) :].isdigit()
         ]
         return max(idxs) + 1 if idxs else 0
@@ -1549,12 +1549,12 @@ def _draw_step_chain(
     return len(candidates)
 
 
-def _next_steplen_start(dwg, prefix: str = "m_steplen") -> int:
+def _next_steplen_start(ctx, prefix: str = "m_steplen") -> int:
     """First free m_steplen index past the MAX existing one — the #426 finalize path names
     the chain as a contiguous run from one start, so it must clear every existing name (max+1,
     not first-free: a gap below an occupied index would let the run wrap onto it, #432)."""
     idxs: list[int] = []
-    for n in dwg._named:
+    for n in ctx.registry.names():
         if not n.startswith(prefix):
             continue
         rest = n[len(prefix) :]
@@ -1597,7 +1597,7 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     draft = dwg.draft
     # only=None (auto-pass) → start=0, historical m_steplen naming, byte-identical. The
     # finalize path (only set) starts past existing m_steplen names (#426 naming seam).
-    start = _next_steplen_start(dwg) if only is not None else 0
+    start = _next_steplen_start(ctx) if only is not None else 0
     fsegs = [(dwg.at("front", *a), dwg.at("front", *b), v, t) for a, b, v, t in rows]
     horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -66,7 +66,7 @@ _AXIS_ALIGN_COS = 0.9996
 
 
 def add_feature_callout(
-    dwg, feature, model, a, *, view: str | None = None, name: str | None = None
+    dwg, feature, model, a, *, view: str | None = None, name: str | None = None, ctx
 ) -> str:
     """Add a hole/pattern ø-depth **leader callout** for *feature* — the #414 add verb,
     the callout-mechanism half of the editable surface (symmetric with :meth:`Drawing.drop`).
@@ -155,7 +155,7 @@ def add_feature_callout(
     if name is None:
         i = 0
         name = f"hc_{view}0"
-        while name in dwg._named:
+        while name in ctx.registry:
             i += 1
             name = f"hc_{view}{i}"
     tip = _rim_tip(centre, elbow)
@@ -176,7 +176,7 @@ def add_feature_callout(
 
 
 def add_feature_location(
-    dwg, feature, model, a, *, axes: tuple[str, ...] | None = None, pin: bool = False
+    dwg, feature, model, a, *, axes: tuple[str, ...] | None = None, pin: bool = False, ctx
 ) -> list[str]:
     """Add datum-referenced **X/Y position dimensions** for a Z-axis hole/pattern —
     the #418 ``locate()`` add verb (symmetric with :meth:`Drawing.drop`).
@@ -242,7 +242,7 @@ def add_feature_location(
     SX, SZ = a.proj.side_x, a.proj.side_z
 
     def _uniq(prefix: str) -> str:
-        return f"{prefix}{_first_free_index(prefix, dwg._named)}"
+        return f"{prefix}{_first_free_index(prefix, ctx.registry)}"
 
     def _place(view: str, strip, p1, p2, baseline, label: str) -> str:
         perp = (min(p1, p2), max(p1, p2))
@@ -349,7 +349,7 @@ def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None, ct
     for loc in feature.members or (feature.frame.origin,):
         px, py, *_ = dwg.at(view, *loc)
         j = 0
-        while (nm := f"m_cm{j}") in dwg._named:
+        while (nm := f"m_cm{j}") in ctx.registry:
             j += 1
         dwg.add(CenterMark((px, py, 0), size, dwg.draft), nm, view=view, feature=feature)
 
@@ -363,7 +363,7 @@ def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None, ct
         while any(
             nm in (f"bc_{view}{j}", f"dim_pitch_{view}{j}")
             or nm.startswith(f"dim_pitch_{view}{j}_")
-            for nm in dwg._named
+            for nm in ctx.registry.names()
         ):
             j += 1
         _add_furniture(dwg, a, view, j, feature, lambda loc: dwg.at(view, *loc), ctx=ctx)
@@ -371,7 +371,7 @@ def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None, ct
     return sorted(set(dwg.annotations()) - before)
 
 
-def add_feature_diameter(dwg, feature, model) -> str:
+def add_feature_diameter(dwg, feature, model, *, ctx) -> str:
     """Add a turned **step/boss diameter** ø-leader — the #419 extension of the callout
     add verb to :class:`StepFeature` / :class:`BossFeature`.
 
@@ -415,7 +415,7 @@ def add_feature_diameter(dwg, feature, model) -> str:
     # collides on m_dia_x0/z0 and clobbers an existing leader (#419 review F1).
     prefix = "m_dia_x" if axis == "x" else "m_dia_z"
     start = 0
-    while f"{prefix}{start}" in dwg._named:
+    while f"{prefix}{start}" in ctx.registry:
         start += 1
     before = set(dwg.annotations())
     if axis == "x":
@@ -578,11 +578,11 @@ def _off_axis_queue(
         )
 
 
-def _off_axis_owner(dwg, hole_locs):
+def _off_axis_owner(ctx, hole_locs):
     # The IR hole feature owning a side-drilled location dim, or None when the dim's
     # offset is shared by >1 distinct feature (unowned, so drop can't over-strip a
     # sibling — mirrors the #398c shared-coordinate rule). Promoted (#638).
-    feats = {dwg._feature_of_hole_at(loc) for loc in hole_locs}
+    feats = {ctx.feature_of_hole_at(loc) for loc in hole_locs}
     feats.discard(None)
     return next(iter(feats)) if len(feats) == 1 else None
 
@@ -620,7 +620,7 @@ def _locate_across(dwg, ctx, a: Analysis, off):
                     ),
                 )
             )
-    feats = {nm: _off_axis_owner(dwg, locs) for nm, locs in loc_by_name.items()}
+    feats = {nm: _off_axis_owner(ctx, locs) for nm, locs in loc_by_name.items()}
     _off_axis_queue(
         dwg,
         ctx,
@@ -667,7 +667,7 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
                     ),
                 )
             )
-    x_feats = {nm: _off_axis_owner(dwg, locs) for nm, locs in x_loc_by_name.items()}
+    x_feats = {nm: _off_axis_owner(ctx, locs) for nm, locs in x_loc_by_name.items()}
     _off_axis_queue(
         dwg,
         ctx,
@@ -707,7 +707,7 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
             continue
         seen_z.add(zo)
         hz = h.location[2]
-        owner = _off_axis_owner(dwg, z_locs[zo])
+        owner = _off_axis_owner(ctx, z_locs[zo])
 
         def _zc(view, p_lo, p_hi, edge, _zo=zo):
             return (
@@ -780,7 +780,7 @@ def _locate_off_axis_holes(dwg, ctx, a: Analysis, *, which):
     ``across`` phase is `_locate_across`; the ``along`` phase is `_locate_along_planar`
     (a Y-hole's X) then `_locate_along_z` (every hole's height), split out at #638.
     """
-    model = dwg._part_model
+    model = ctx.part_model
 
     def _coaxial(h):
         # The turning-axis bore of a rotational part is located by its centreline, not
@@ -1469,7 +1469,7 @@ def _annotate_holes(
         _hc_used.add(name)
         return name
 
-    _hc_used = set(dwg._named)
+    _hc_used = set(ctx.registry.names())
 
     for view, view_groups in by_view.items():
         to_page = view_of_axis[{"plan": "z", "front": "y", "side": "x"}[view]][1]
@@ -1605,7 +1605,7 @@ def _annotate_holes(
         reserved_rows = (
             [
                 to_page(h.location)[1]
-                for h in _ir_off_axis_holes(dwg._part_model)
+                for h in _ir_off_axis_holes(ctx.part_model)
                 if h.axis == off_axis_letter
             ]
             if off_axis_letter

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -205,8 +205,12 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (:func:`build_model`, attached to the drawing before this pass) so the read surface
     # (dwg.model()) and feature edits work even in manual mode (#398); fall back to
     # building it here for any direct caller that skipped _assemble.
-    _model = dwg._part_model if dwg._part_model is not None else build_model(a)
+    _model = dwg.model() if dwg.model() is not None else build_model(a)
     dwg.attach_part_model(_model)
+    # Thread the ensured model + declared flag onto the run's ctx so every pass reads them from
+    # ctx, not the drawing's privates (#639). Set AFTER attach so ctx sees the ensured model.
+    ctx.part_model = _model
+    ctx.model_declared = dwg.model_declared
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them
     # (was recomputed per renderer, #275). One rule set over DimParameters, literally.
     _groups = plan_dimensions(_model)
@@ -240,7 +244,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # path (gated on the declared flag; and on a fully-detected declared part the declared
     # keys already coincide with the detected ones).
     declared_keys: set = set()
-    if getattr(dwg, "_model_declared", False):
+    if ctx.model_declared:
         declared_keys = _declared_feature_keys(_groups, a)
         feature_keys = feature_keys | declared_keys
     # Decide the section trigger + cut-plane row now (pure function of _model/
@@ -321,7 +325,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # sees the ø as 'mentioned' and skips it (#629 — the column-left strip strands a boss ø when
     # tight, even on a half-empty sheet). No-op on turned parts (they keep the OD stack).
     render_boss_diameters(dwg, _groups, a, ctx=ctx)
-    render_diameters(dwg, _groups)
+    render_diameters(dwg, _groups, ctx=ctx)
     if a.prof is not None:
         render_step_lengths(dwg, _groups, ctx=ctx)
 
@@ -343,7 +347,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # with locations/slots rather than consuming leftovers as first-fit placements.
     render_gdt(dwg, _model, a, ctx=ctx)
     if a.pmi_mode == "annotate" or (
-        getattr(dwg, "_model_declared", False)
+        ctx.model_declared
         and any(f.kind in ("authored_dimension", "pmi") for f in _model.features)
     ):
         render_pmi(dwg, _model, a, ctx=ctx)
@@ -431,7 +435,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
     # part (e.g. NIST CTC-02) off the 61-row escalation (#111). Sourced from the IR —
     # a loose z-axis HoleFeature is by construction not a pattern member, so no
     # HoleRecord crosses here (ADR 0008 Am6; #584 WP1 B4).
-    _model = dwg._part_model
+    _model = ctx.part_model
     holes = [
         SimpleNamespace(location=pos, diameter=f.diameter)
         for f in (_model.features if _model is not None else ())
@@ -527,7 +531,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
         # One call: the strip solver must see every band member together, or two
         # independent _add_balloons calls could stack a pattern balloon on a
         # per-hole one in the same band.
-        dwg._add_balloons("plan", balloon_specs)
+        dwg.add_balloons("plan", balloon_specs)
         placed_names = {n for n, _ in dwg.iter_annotations()}
 
     # Clear `callout_dropped` only when EVERY dropped plan-view callout is now

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -502,8 +502,9 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
     except Exception as exc:  # noqa: BLE001 — projection raises broadly on cast geometry
         _log.warning("Detail %s skipped (projection failed: %s)", letter, exc)
         return False
-    dwg._coords[view_name] = ViewCoordinates(
-        view_axes(camera, (0, 0, 1), la), DX, DY, dcx, dcy, dcz, detail_scale
+    dwg.set_view_coordinates(
+        view_name,
+        ViewCoordinates(view_axes(camera, (0, 0, 1), la), DX, DY, dcx, dcy, dcz, detail_scale),
     )
 
     # The feature draws its own dims inside the detail. If nothing legible lands even
@@ -512,7 +513,7 @@ def _render_detail(dwg, a: Analysis, req: DetailRequest, view_name: str, letter:
     # head/block inline, so lint reports any un-located interior) (#307 review).
     if not req.redraw(dwg, view_name, detail_scale):
         dwg.views.pop(view_name, None)
-        dwg._coords.pop(view_name, None)
+        dwg.drop_view_coordinates(view_name)
         _log.info("Detail %s skipped (no legible dims at the detail scale)", letter)
         return False
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -613,6 +613,14 @@ class Drawing:
         """Return the :class:`ViewCoordinates` for a named view."""
         return self._coords[view]
 
+    def set_view_coordinates(self, view, coords) -> None:
+        """Override a view's projected coordinates (a repositioned detail/section band, #307)."""
+        self._coords[view] = coords
+
+    def drop_view_coordinates(self, view) -> None:
+        """Remove a view's projected coordinates (a bailed detail/section, #307)."""
+        self._coords.pop(view, None)
+
     def at(self, view, x, y, z):
         """Map a world point to a page point ``(px, py, 0)`` in ``view``."""
         px, py = self._coords[view].pp(x, y, z)
@@ -716,6 +724,12 @@ class Drawing:
         """Attach the built PartModel so ``model()`` and feature edits see it. Lets the
         orchestrator hand the model back without an ``annotations/`` attribute write (#639)."""
         self._part_model = model
+
+    @property
+    def model_declared(self) -> bool:
+        """Whether this drawing's model was **declared** by the caller (ADR 0011) rather than
+        detected — the public read the annotation pass threads onto its PlacementContext (#639)."""
+        return self._model_declared
 
     def place_dim(
         self,
@@ -1121,12 +1135,14 @@ class Drawing:
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
             self._intents.append(Intent("callout", feature, {"view": view, "name": name}))
             return ""
+        from draftwright.annotations._common import PlacementContext
         from draftwright.annotations.holes import add_feature_callout, add_feature_diameter
 
+        ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
         if getattr(feature, "kind", None) in ("step", "boss"):
-            return add_feature_diameter(self, feature, self._part_model)
+            return add_feature_diameter(self, feature, self._part_model, ctx=ctx)
         return add_feature_callout(
-            self, feature, self._part_model, self._analysis, view=view, name=name
+            self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
         )
 
     def furniture(self, feature, *, view=None) -> list[str]:
@@ -1197,10 +1213,12 @@ class Drawing:
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
             self._intents.append(Intent("locate", feature, {"axes": axes, "pin": pin}))
             return []
+        from draftwright.annotations._common import PlacementContext
         from draftwright.annotations.holes import add_feature_location
 
+        ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
         return add_feature_location(
-            self, feature, self._part_model, self._analysis, axes=axes, pin=pin
+            self, feature, self._part_model, self._analysis, axes=axes, pin=pin, ctx=ctx
         )
 
     @contextlib.contextmanager
@@ -1462,7 +1480,12 @@ class Drawing:
         # (ADR 0005 §2, #639): render_locations/_annotate_holes/drain_corridors register/read here.
         # A local — finalize is transactional (#647), so a raised drain rolls the drawing back and
         # the retry re-runs from a clean slate with a new ctx; no cross-call persistence needed.
-        ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
+        ctx = PlacementContext(
+            registry=self._registry,
+            coverage=self._coverage,
+            part_model=self.model(),
+            model_declared=self.model_declared,
+        )
 
         model, a = self._part_model, self._analysis
         routable = model is not None and a is not None
@@ -1588,7 +1611,7 @@ class Drawing:
             #      column-left) — auto-pass S11b, after callouts/locations, before section.
             if only_dia:
                 assert a is not None and isinstance(model, PartModel)  # only_dia ⟹ routable
-                render_diameters(self, plan_dimensions(model), only=only_dia)
+                render_diameters(self, plan_dimensions(model), ctx=ctx, only=only_dia)
             self._intents = [it for it in self._intents if id(it) not in dia_ids]
             # (B3b) turned step-length CHAIN through render_step_lengths (N× collapse /
             #       staggered tiers) — auto-pass S11b, after diameters, before section.
@@ -1747,7 +1770,7 @@ class Drawing:
             for tag, (holes, count) in zip(_tag_sequence(len(glist)), glist, strict=True)
         ]
 
-    def _add_balloons(self, view, specs):
+    def add_balloons(self, view, specs):
         """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
         fitted into the halo the layout reserved around the view (#111).
 
@@ -1969,8 +1992,8 @@ class Drawing:
         )
 
     def _add_balloon(self, view, tag, j, hole):
-        """Single-balloon convenience over :meth:`_add_balloons` (#111)."""
-        self._add_balloons(view, [(tag, j, hole)])
+        """Single-balloon convenience over :meth:`add_balloons` (#111)."""
+        self.add_balloons(view, [(tag, j, hole)])
 
     def add_hole_table(self, view="plan", *, prefer="tr", name=None, balloons=True):
         """Add a hole table for *view*'s holes, placed in a free corner (#93).
@@ -1998,7 +2021,7 @@ class Drawing:
         # The table documents these diameters — let lint see that (#93).
         table.covers_diameters = tuple(diams)
         if balloons:
-            self._add_balloons(
+            self.add_balloons(
                 view,
                 [(tag, j, h) for tag, holes, _count in groups for j, h in enumerate(holes)],
             )

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -49,6 +49,11 @@ class AnnotationRegistry:
     def __contains__(self, name) -> bool:
         return name in self._named
 
+    def names(self) -> set:
+        """The set of registered annotation names — the free-name probe surface the render
+        passes read (#639, replacing their old ``dwg._named`` reach)."""
+        return set(self._named)
+
     def named(self, name):
         """The object registered under *name*, or ``None``."""
         return self._named.get(name)

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -30,18 +30,13 @@ _SRC = Path(__file__).resolve().parent.parent / "src" / "draftwright"
 _ANNO_DIR = _SRC / "annotations"
 
 # Distinct ``dwg._<name>`` private reads (attribute access + ``getattr(dwg, "_name", …)`` probes)
-# the annotations layer still relies on. This is the compat surface #639 will shrink to zero;
-# it may only SHRINK. One-line rationale per entry:
-_DWG_PRIVATE_READ_ALLOW: frozenset[str] = frozenset(
-    {
-        "_add_balloons",  # balloon-render helper the hole pass calls back through
-        "_coords",  # cached per-view projected coordinates
-        "_feature_of_hole_at",  # feature lookup by hole location
-        "_named",  # the name→annotation index (free-name probing)
-        "_part_model",  # the built PartModel (read; write now via attach_part_model, #639)
-        "_model_declared",  # whether the model was declared (vs detected) — getattr probe
-    }
-)
+# the annotations layer still relies on. #639 drove this to ZERO: the annotation render layer no
+# longer reads any Drawing private — the model/model-declared flag/hole-feature index ride the
+# per-run PlacementContext, the balloon render + view-coordinate mutations go through public
+# Drawing methods (``add_balloons``/``set_view_coordinates``/``drop_view_coordinates``), and the
+# name→annotation index is read through ``ctx.registry`` (``__contains__``/``names()``). The
+# allowlist may only SHRINK; it is now empty and must stay so.
+_DWG_PRIVATE_READ_ALLOW: frozenset[str] = frozenset()
 
 
 def _anno_sources() -> list[Path]:
@@ -154,18 +149,20 @@ def test_write_guard_catches_every_mutation_form():
     assert not _dwg_private_writes(ast.parse("use(dwg._named)"))
 
 
-def test_no_analysis_or_part_model_probing():
-    """No ``annotations/`` module probes ``getattr(dwg, "_analysis"/"_part_model", …)`` — the
-    model and analysis are threaded in as parameters now (#639)."""
+def test_no_build_context_probing():
+    """No ``annotations/`` module probes the drawing for build context via
+    ``getattr(dwg, "_analysis"/"_part_model"/"_model_declared", …)`` — the model, analysis, and
+    model-declared flag are all threaded in as parameters / on the PlacementContext now (#639)."""
     offenders: list[str] = []
     for path in _anno_sources():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for name in _dwg_getattr_probes(tree):
-            if name in ("_analysis", "_part_model"):
+            if name in ("_analysis", "_part_model", "_model_declared"):
                 offenders.append(f"{path.relative_to(_SRC)}: getattr(dwg, {name!r}, …)")
     assert not offenders, (
-        "annotations/ must not probe the drawing for the model/analysis — pass them in as "
-        "parameters (#639 / ADR 0005 §2):\n  " + "\n  ".join(offenders)
+        "annotations/ must not probe the drawing for the model/analysis/model-declared flag — "
+        "pass them in as parameters or on the PlacementContext (#639 / ADR 0005 §2):\n  "
+        + "\n  ".join(offenders)
     )
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8691,7 +8691,7 @@ class TestHoleTable:
         )
         hole = SimpleNamespace(location=(0.0, 0.0, 0.0), diameter=4.0)
 
-        Drawing._add_balloons(stub, "plan", [("A", 0, hole)])
+        Drawing.add_balloons(stub, "plan", [("A", 0, hole)])
 
         top_call = next(call for call in calls if call[2] == "x" and call[1])
         _view, _members, _axis, line, *_rest, fs, r = top_call
@@ -8734,7 +8734,7 @@ class TestHoleTable:
         )
         holes = [SimpleNamespace(location=(float(i), 0.0, 0.0), diameter=4.0) for i in range(6)]
 
-        Drawing._add_balloons(
+        Drawing.add_balloons(
             stub, "plan", [(chr(ord("A") + i), 0, h) for i, h in enumerate(holes)]
         )
 
@@ -8782,7 +8782,7 @@ class TestHoleTable:
         )
         hole = SimpleNamespace(location=(0.0, 0.0, 0.0), diameter=4.0)
 
-        Drawing._add_balloons(stub, "plan", [("A", 0, hole)])
+        Drawing.add_balloons(stub, "plan", [("A", 0, hole)])
 
         left_members = next(call[1] for call in calls if call[2] == "y" and call[3] < a.PV_X)
         right_members = next(call[1] for call in calls if call[2] == "y" and call[3] > a.PV_X)
@@ -8959,6 +8959,7 @@ class TestPatternGroupBalloon:
         ctx = PlacementContext(
             registry=dwg.registry,
             coverage=dwg.coverage,
+            part_model=dwg.model(),  # (#639) the tabulation resolver reads the model off ctx now
             escalations=[
                 Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
             ],
@@ -8985,7 +8986,9 @@ class TestPatternGroupBalloon:
             self._fake_pattern(count=4, diameter=3.0, origin=(-15.0, -8.0, 0.0)),
             self._fake_pattern(count=6, diameter=5.0, origin=(15.0, 8.0, 0.0)),
         ]
-        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        ctx = PlacementContext(
+            registry=dwg.registry, coverage=dwg.coverage, part_model=dwg.model()
+        )
         for feat in feats:
             ctx.escalations.append(
                 Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
@@ -9015,6 +9018,7 @@ class TestPatternGroupBalloon:
         ctx = PlacementContext(
             registry=dwg.registry,
             coverage=dwg.coverage,
+            part_model=dwg.model(),
             escalations=[
                 Escalation(kind="callout", view="front", feature=feat, reason="front strip full")
             ],


### PR DESCRIPTION
**Finishes #639** (ADR 0005 §2). The annotation layer's `dwg._private` read-allowlist is now **empty** (`frozenset()`) — `annotations/` no longer reaches into any `Drawing` private. `Drawing` = public renderer + result; `PlacementContext` = build state.

## The last 6 reaches, eliminated
- `dwg._part_model` → `ctx.part_model` (populated at both entry points via public `dwg.model()`).
- `dwg._coords[...]` **mutations** → public `Drawing.set_view_coordinates` / `drop_view_coordinates`.
- `dwg._feature_of_hole_at` → `ctx.feature_of_hole_at` (moved onto the context, per-run cached).
- `getattr(dwg, "_model_declared")` → `ctx.model_declared` (public `Drawing.model_declared` property).
- `dwg._named` → `ctx.registry` (membership via `__contains__`; new `AnnotationRegistry.names()`).
- `dwg._add_balloons` → public `Drawing.add_balloons` (a render method — now public API).

## New public surface
`Drawing.{set_view_coordinates, drop_view_coordinates, add_balloons, model_declared}`, `AnnotationRegistry.names()`, `PlacementContext.{part_model, model_declared, feature_of_hole_at}`. The encapsulation probe test also now forbids `getattr(dwg, "_model_declared")`.

## Verification
- **Byte-identical** (refactor golden, 12 corpus parts) — the correctness gate.
- Encapsulation suite green with the **empty** allowlist; four lint checks clean.
- Full `test_make_drawing.py` under xdist surfaced two **pre-existing flakes** (`test_pitch_dim_skipped_when_off_page`, `test_byte_identity_across_corpus`) — both **pass in isolation**, and the latter exercises only `compose.py` (untouched here), so neither is a 639d regression. Filing a separate flake issue.

Completes #639 (P4 of epic #635). Together with #660/#662/#667, the drawing is no longer the annotation layer's state bus — a machine-enforced bright line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)