### PR TITLE
test(#641): slot+coincident-hole fuzz strategy (gap-1 coverage extension)

### DIFF
--- a/tests/test_layout_hypothesis.py
+++ b/tests/test_layout_hypothesis.py
@@ -154,7 +154,38 @@ def _slot(draw):
     return part - cutter
 
 
-_PARTS = st.one_of(_box_holes(), _bolt_circle(), _grid(), _turned_steps(), _counterbore(), _slot())
+@st.composite
+def _slot_and_hole(draw):
+    """A box with a milled slot PLUS a hole whose X-location coincides with the slot's near edge
+    (parametrising the `_holed_slot` corpus part) — the mixed slot+coincident-hole extreme the
+    base corpus lacked (#301/#641 gap 1). Fuzzes the shared slot/location corridor solve + the
+    #345/#346 coincident-dim dedup over varied geometry. (Note: #345 itself is a knife-edge
+    value-binning *duplicate*, not a geometric collision, so reverting its guard produces a
+    redundant dim this tier's `_DEFECTS` collision invariant does not detect — verified; see the
+    #641 gap-1 closing note. The strategy's value is the coverage extension, not a #345 repro.)"""
+    w, d, h = draw(_f(55, 100)), draw(_f(40, 70)), draw(_f(12, 25))
+    part = Box(w, d, h)
+    slot_len = draw(_f(min(w, d) * 0.25, min(w, d) * 0.45))
+    slot_w = draw(_f(6, 12))
+    part -= Box(slot_len, slot_w, h + 4)  # centred slot along X → near edge at x = -slot_len/2
+    dia = draw(_f(3, 5))
+    x0 = -slot_len / 2  # the slot's near edge — the coincident hole's X-location matches it
+    y_off = slot_w / 2 + dia + 5  # clear of the slot walls
+    part -= Pos(x0, y_off, 0) * Cylinder(dia / 2, h + 4)  # coincident with the slot edge (#345)
+    x1 = draw(_f(x0 + 10, w / 2 - 8))  # a distinct-X second rung, so the ladder has real rungs
+    part -= Pos(x1, -y_off, 0) * Cylinder(dia / 2, h + 4)
+    return part
+
+
+_PARTS = st.one_of(
+    _box_holes(),
+    _bolt_circle(),
+    _grid(),
+    _turned_steps(),
+    _counterbore(),
+    _slot(),
+    _slot_and_hole(),
+)
 
 
 # Generous timeout: on a failure Hypothesis shrinks (many extra builds at ~3-6 s each), and


### PR DESCRIPTION
**#641 gap 1.** Adds `_slot_and_hole` to the Hypothesis layout tier — a box with a milled slot plus a hole whose X-location coincides with the slot's near edge (parametrising the `_holed_slot` corpus part) — the **mixed slot+coincident-hole extreme** the base corpus lacked (#301). Fuzzes the shared slot/location corridor solve + the #345/#346 coincident-dim dedup over varied geometry. Green on current code.

### On the "#345 shrunk counterexample" sub-clause — not delivered, by design
Verified empirically that #345 is **not** fuzzer-reproducible: it's a **knife-edge value-binning duplicate** (a span landing exactly on a 0.1 mm snap boundary — the guard's own rationale), and even when it fires the result is a **redundant dim, not a geometric collision** — so the tier's `_DEFECTS` (overlap/bounds) invariant can't detect it. Reverting the guard on `_holed_slot` → **lint clean, no duplicate**. Chasing a contrived collision-revert just to tick the sub-clause is box-ticking we've avoided; the strategy's real value is the coverage extension. Documented in the #641 close (acceptance sub-clause amended, plan (B), agreed with @pzfreo).

**gap 2** ("private-import allowlist that shrinks") is already satisfied by the #670 ratchet; its remaining entries are legitimate unit tests, not forced retargets.

Test-only. Fuzzer green (28 examples); four lint checks clean.

Closes #641 (P6 of epic #635) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)