### PR TITLE
feat(export): unified export(formats=…) API + PNG raster export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **PNG raster export** — `--format png` on the CLI, or `Drawing.export(formats=("png",))`.
+  Rendered SVG → PDF → PNG via **pypdfium2** (Apache-2.0, Google PDFium BSD-3) + **Pillow**
+  (HPND) — both permissively licensed and pure-wheel, so PNG works cross-platform with **no
+  native cairo** (ADR 0006) and keeps the render path dual-license-friendly. `dpi=` sets the
+  raster resolution.
+
+### Changed
+
+- **Unified export API** — `Drawing.export(out, *, formats=("pdf",)) → {format: path}` is now
+  the single entry point over `svg`/`dxf`/`pdf`/`png`; it returns a dict and internally handles
+  the SVG→PDF→PNG intermediate chain (writing/cleaning up intermediates it wasn't asked to keep).
+  The CLI `--format` gains `png`.
+
+### Deprecated
+
+- `Drawing.export_pdf()` — use `export(formats=("pdf",))["pdf"]`; the method now warns.
+- The legacy `export(svg=, dxf=)` boolean keywords and their `(svg_path, dxf_path)` tuple return
+  — kept for back-compat; prefer `formats=[...]` (the dict API).
+
 ## v0.3.0 — 2026-07-14
 
 **Breaking — feature-recogniser API renamed** (ADR 0013 / #568): *deliberate* breaks with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,12 +139,15 @@ entry. Keep `_LAYERS` and this section in step.
   via the package surface.
 - **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
   cross-platform layout (ADR 0006).
-- **`export.py`** — SVG/DXF/PDF export + post-processing (page-size fix,
+- **`export.py`** — SVG/DXF/PDF/PNG export + post-processing (page-size fix,
   attribution hyperlink/metadata, DXF metadata, arc sanitisation, element-wise
-  shape-export degradation, pure-Python PDF render via svglib + reportlab — no
-  native cairo, #288). The first **module-split** step of
-  #138 (ADR 0005): `Drawing.export()` / `export_pdf()` stay as thin wrappers.
-  Sits below `make_drawing.py`, above `_core.py`.
+  shape-export degradation). The render chain is **SVG → PDF → PNG**: PDF via
+  svglib + reportlab (`_render_pdf`, #288), PNG via **pypdfium2 + Pillow**
+  (`_render_png`) — both pure-wheel, **no native cairo** and permissively
+  licensed (BSD/Apache/HPND, dual-license-clean). The unified
+  `Drawing.export(out, *, formats=("pdf",)) → {format: path}` is the front door
+  (the legacy `svg=`/`dxf=` tuple form + `export_pdf` are back-compat/deprecated
+  wrappers). Sits below `make_drawing.py`, above `_core.py`.
 - **`repair.py`** — the deterministic lint→repair loop (#30 / ADR 0002): the
   re-place helpers (`_find_dim`/`_replace_dim`/`_repair_*`/`repair_drawing`) take
   the drawing duck-typed as `dwg`; `Drawing.repair()` stays a thin wrapper.
@@ -270,6 +273,10 @@ Current ADRs:
 
 - `build123d-drafting-helpers>=0.13.0` (Apache 2.0)
 - `build123d>=0.9.0` (Apache 2.0)
+- Export render chain: `reportlab` (BSD) + `svglib` (LGPL) for PDF; `pypdfium2`
+  (Apache-2.0, wrapping Google PDFium BSD-3) + `pillow` (HPND) for PNG. All
+  pure-wheel (no native cairo) and — except svglib's weak-copyleft LGPL — permissive,
+  so the render path stays dual-license-friendly.
 
 The 1D strip solve (`layout.py`) is the dependency-free minimum-total-leader-length
 **PAVA** algorithm (`_solve_strip_1d_pava`, ADR 0009 Amdt 4); the earlier Cassowary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ dependencies = [
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.13.1",
     "numpy>=1.24",
+    # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
+    # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system
+    # deps — so PNG works cross-platform without cairo (ADR 0006) and stays dual-license-clean.
+    "pillow>=10",
+    "pypdfium2>=4",
     "reportlab>=4.0",
     "svglib>=1.5",
     "typer>=0.12",

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -23,12 +23,12 @@ app = typer.Typer(
     # source-panel traceback buries clean domain errors (e.g. "could not read STEP
     # file") in developer noise.
     pretty_exceptions_enable=False,
-    help="Zero-AI STEP -> technical drawing (PDF by default; SVG/DXF via --format, "
+    help="Zero-AI STEP -> technical drawing (PDF by default; SVG/DXF/PNG via --format, "
     "or an editable .py script).",
 )
 
-# Output formats the --format selector understands ('all' expands to all three).
-_FORMATS = ("pdf", "svg", "dxf")
+# Output formats the --format selector understands ('all' expands to all four).
+_FORMATS = ("pdf", "svg", "dxf", "png")
 
 
 class PmiMode(str, Enum):
@@ -61,15 +61,9 @@ def _parse_formats(value: str) -> list[str]:
 
 
 def _emit(dwg, formats: list[str]) -> list[str]:
-    """Write the requested formats and return their paths in *formats* order.
-    PDF renders from an on-disk SVG, so the SVG is written to drive the PDF even
-    when it wasn't itself requested — and removed again afterwards."""
-    want = {f: f in formats for f in _FORMATS}
-    svg_path, dxf_path = dwg.export(svg=want["svg"] or want["pdf"], dxf=want["dxf"])
-    pdf_path = dwg.export_pdf() if want["pdf"] else None
-    if want["pdf"] and not want["svg"] and svg_path is not None:
-        os.remove(svg_path)  # temp SVG, written only to render the PDF
-    paths = {"pdf": pdf_path, "svg": svg_path, "dxf": dxf_path}
+    """Write the requested formats and return their paths in *formats* order. ``export`` handles
+    the SVG→PDF→PNG intermediate chain and removes any it wasn't asked to keep."""
+    paths = dwg.export(formats=formats)
     return [paths[f] for f in formats]
 
 
@@ -134,7 +128,7 @@ def main(
         "pdf",
         "--format",
         "-f",
-        help="Comma-list of output formats: pdf, svg, dxf (or 'all'). E.g. --format pdf,dxf",
+        help="Comma-list of output formats: pdf, svg, dxf, png (or 'all'). E.g. --format pdf,png",
     ),
     verbose: bool = typer.Option(
         False,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import contextlib
 import math
+import os
 import warnings
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -51,6 +52,7 @@ from draftwright.annotations._common import carve_free_position, strip_obstacles
 from draftwright.export import (
     _export_shape,
     _render_pdf,
+    _render_png,
     add_svg_hyperlink,
     add_svg_metadata,
     fix_svg_page_size,
@@ -2266,18 +2268,11 @@ class Drawing:
             ],
         }
 
-    def export(self, out=None, *, svg=True, dxf=True) -> tuple[str | None, str | None]:
-        """Lint, then write the requested vector formats. Returns
-        ``(svg_path, dxf_path)`` — each is ``None`` when that format is skipped.
-        Both default on (the unchanged one-shot behaviour; the CLI's ``--format``
-        selector is the only caller that turns one off)."""
-        self.finalize()  # #426: drain any recorded intents before export (no-op if none)
-        out = out if out is not None else self.out
-        for _ext in (".svg", ".dxf"):
-            if out.endswith(_ext):
-                out = out[: -len(_ext)]
-                break
+    # The output formats export() understands. PDF renders from the SVG, PNG from the PDF —
+    # so requesting pdf/png writes the SVG (and pdf) as intermediates, cleaned up if not asked for.
+    _EXPORT_FORMATS = ("svg", "dxf", "pdf", "png")
 
+    def _lint_and_log(self) -> None:
         issues = self.lint()
         if issues:
             _log.warning("Lint issues:")
@@ -2286,75 +2281,120 @@ class Drawing:
         else:
             _log.info("Lint: OK")
 
+    def _write_svg(self, out: str) -> str:
+        """Write the SVG (part/hidden/dims layers, page-size fix, arc sanitise, hyperlink +
+        metadata) and return its path. The PDF and PNG renders both read this SVG."""
         blk = Color(0, 0, 0)
         grey = Color(0.5, 0.5, 0.5)
         blue = Color(0, 0.2, 0.7)
+        svg_exp = ExportSVG(margin=10)
+        svg_exp.add_layer("part", line_color=blk, line_weight=0.5)
+        svg_exp.add_layer("hidden", line_color=grey, line_weight=0.25, line_type=LineType.HIDDEN)
+        svg_exp.add_layer("dims", line_color=blue, fill_color=blue, line_weight=0.05)
+        self._add_shapes(svg_exp)
+        svg_path = out + ".svg"
+        svg_exp.write(svg_path)
+        fix_svg_page_size(svg_path, self.page_w, self.page_h)
+        n_arcs = sanitize_svg_arcs(svg_path)
+        if n_arcs:
+            _log.info("Rewrote %d degenerate (near-zero-radius) arc(s) as line segments", n_arcs)
+        link_rect = getattr(self, "_draftwright_link_rect", None)
+        if link_rect is not None:
+            add_svg_hyperlink(svg_path, link_rect)
+        add_svg_metadata(svg_path)
+        _log.info("SVG → %s", svg_path)
+        return svg_path
 
-        svg_path = None
-        if svg:
-            svg_exp = ExportSVG(margin=10)
-            svg_exp.add_layer("part", line_color=blk, line_weight=0.5)
-            svg_exp.add_layer(
-                "hidden", line_color=grey, line_weight=0.25, line_type=LineType.HIDDEN
+    def _write_dxf(self, out: str) -> str:
+        """Write the DXF (part/hidden/dims layers + metadata) and return its path."""
+        dxf_exp = ExportDXF()
+        dxf_exp.add_layer("part", line_weight=0.5)
+        dxf_exp.add_layer("hidden", line_weight=0.25)
+        dxf_exp.add_layer("dims", line_weight=0.05)
+        self._add_shapes(dxf_exp)
+        set_dxf_metadata(dxf_exp)
+        dxf_path = out + ".dxf"
+        dxf_exp.write(dxf_path)
+        _log.info("DXF → %s", dxf_path)
+        return dxf_path
+
+    def export(
+        self, out=None, *, formats=None, svg=None, dxf=None, dpi: int = 150
+    ) -> dict[str, str] | tuple[str | None, str | None]:
+        """Lint, then write the requested output *formats*; return ``{format: path}``.
+
+        *formats* is a format name or an iterable from ``("svg", "dxf", "pdf", "png")``
+        (default ``("pdf",)``). PDF renders from the SVG and PNG from the PDF, so the SVG/PDF are
+        written as intermediates and removed when not themselves requested. *dpi* sets the PNG
+        raster resolution.
+
+        Legacy (kept for back-compat): the boolean ``svg=``/``dxf=`` keywords — and calling
+        ``export()`` with no ``formats`` — select those two vector formats and return the old
+        ``(svg_path, dxf_path)`` tuple. Prefer ``formats=[...]`` (the dict API); ``export_pdf`` is
+        likewise superseded by ``export(formats=("pdf",))`` and now warns.
+        """
+        self.finalize()  # #426: drain any recorded intents before export (no-op if none)
+        out = out if out is not None else self.out
+        for _ext in self._EXPORT_FORMATS:
+            if out.endswith("." + _ext):
+                out = out[: -(len(_ext) + 1)]
+                break
+        self._lint_and_log()
+
+        # --- legacy path: svg=/dxf= keywords → the old (svg, dxf) tuple (back-compat) ---
+        if formats is None:
+            svg_path = self._write_svg(out) if (svg is None or svg) else None
+            dxf_path = self._write_dxf(out) if (dxf is None or dxf) else None
+            self.svg_path, self.dxf_path = svg_path, dxf_path
+            return svg_path, dxf_path
+
+        # --- formats=... → {format: path} (requested order) ---
+        want = [formats] if isinstance(formats, str) else [f.lower() for f in formats]
+        unknown = [f for f in want if f not in self._EXPORT_FORMATS]
+        if unknown:
+            raise ValueError(
+                f"unknown export format(s) {unknown}; choose from {self._EXPORT_FORMATS}"
             )
-            svg_exp.add_layer("dims", line_color=blue, fill_color=blue, line_weight=0.05)
-            self._add_shapes(svg_exp)
-            svg_path = out + ".svg"
-            svg_exp.write(svg_path)
-            fix_svg_page_size(svg_path, self.page_w, self.page_h)
-            n_arcs = sanitize_svg_arcs(svg_path)
-            if n_arcs:
-                _log.info(
-                    "Rewrote %d degenerate (near-zero-radius) arc(s) as line segments", n_arcs
-                )
-            link_rect = getattr(self, "_draftwright_link_rect", None)
-            if link_rect is not None:
-                add_svg_hyperlink(svg_path, link_rect)
-            add_svg_metadata(svg_path)
-            _log.info("SVG → %s", svg_path)
-
-        dxf_path = None
-        if dxf:
-            dxf_exp = ExportDXF()
-            dxf_exp.add_layer("part", line_weight=0.5)
-            dxf_exp.add_layer("hidden", line_weight=0.25)
-            dxf_exp.add_layer("dims", line_weight=0.05)
-            self._add_shapes(dxf_exp)
-            set_dxf_metadata(dxf_exp)
-            dxf_path = out + ".dxf"
-            dxf_exp.write(dxf_path)
-            _log.info("DXF → %s", dxf_path)
-
+        want_set = set(want)
+        paths: dict[str, str] = {}
+        svg_path = self._write_svg(out) if (want_set & {"svg", "pdf", "png"}) else None
         self.svg_path = svg_path
-        self.dxf_path = dxf_path
-        return svg_path, dxf_path
+        if "dxf" in want_set:
+            self.dxf_path = paths["dxf"] = self._write_dxf(out)
+        pdf_path = None
+        if want_set & {"pdf", "png"}:
+            assert svg_path is not None
+            pdf_path = out + ".pdf"
+            _render_pdf(svg_path, pdf_path, getattr(self, "_draftwright_link_rect", None))
+            _log.info("PDF → %s", pdf_path)
+        if "png" in want_set:
+            assert pdf_path is not None
+            paths["png"] = out + ".png"
+            _render_png(pdf_path, paths["png"], dpi=dpi)
+            _log.info("PNG → %s", paths["png"])
+        if "pdf" in want_set:
+            paths["pdf"] = pdf_path  # type: ignore[assignment]
+        if "svg" in want_set:
+            paths["svg"] = svg_path  # type: ignore[assignment]
+        # Drop intermediates that weren't themselves requested.
+        if svg_path is not None and "svg" not in want_set:
+            os.remove(svg_path)
+            self.svg_path = None
+        if pdf_path is not None and "pdf" not in want_set:
+            os.remove(pdf_path)
+        return {f: paths[f] for f in want}
 
     def export_pdf(self, out=None) -> str:
-        """Write a PDF rendered from the SVG (via ``svglib`` + ``reportlab``, both
-        core dependencies — pure Python, no native cairo, so PDF works on every
-        platform).  Calls :meth:`export` first if the SVG hasn't been written yet.
-        Returns the PDF path.
-
-        The PDF carries a 'generated by draftwright' Creator metadata field and,
-        over the title-block URL row, a clickable hyperlink to the project (a
-        real PDF link annotation — the SVG ``<a>`` element is not understood by
-        the PDF renderer, so it is added here via reportlab)."""
-        try:
-            import reportlab  # noqa: F401  (import-guard; the real work is in _render_pdf)
-            import svglib  # noqa: F401
-        except ImportError as exc:
-            raise ImportError(
-                "PDF export requires svglib + reportlab (core dependencies); reinstall draftwright"
-            ) from exc
-
-        svg_path = getattr(self, "svg_path", None)
-        if svg_path is None:
-            svg_path, _ = self.export(out=out)
-        assert svg_path is not None  # export() writes the SVG by default
-        pdf_path = svg_path[:-4] + ".pdf" if svg_path.endswith(".svg") else svg_path + ".pdf"
-        _render_pdf(svg_path, pdf_path, getattr(self, "_draftwright_link_rect", None))
-        _log.info("PDF → %s", pdf_path)
-        return pdf_path
+        """Deprecated — use ``export(out, formats=("pdf",))["pdf"]``. Renders a PDF (svglib +
+        reportlab) with the draftwright metadata + clickable title-block link."""
+        warnings.warn(
+            "Drawing.export_pdf() is deprecated; use export(formats=('pdf',))['pdf'].",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        paths = self.export(out, formats=("pdf",))
+        assert isinstance(paths, dict)  # formats=... always returns the {format: path} dict
+        return paths["pdf"]
 
     def _add_shapes(self, exporter):
         """Add every view layer and annotation to *exporter* with error context."""

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import math
 import os
+import tempfile
 import warnings
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -2349,39 +2350,56 @@ class Drawing:
             return svg_path, dxf_path
 
         # --- formats=... → {format: path} (requested order) ---
-        want = [formats] if isinstance(formats, str) else [f.lower() for f in formats]
+        want = [formats.lower()] if isinstance(formats, str) else [f.lower() for f in formats]
         unknown = [f for f in want if f not in self._EXPORT_FORMATS]
         if unknown:
             raise ValueError(
                 f"unknown export format(s) {unknown}; choose from {self._EXPORT_FORMATS}"
             )
+        if "png" in want and dpi <= 0:
+            raise ValueError(f"png export needs dpi > 0, got {dpi}")
         want_set = set(want)
         paths: dict[str, str] = {}
-        svg_path = self._write_svg(out) if (want_set & {"svg", "pdf", "png"}) else None
-        self.svg_path = svg_path
-        if "dxf" in want_set:
-            self.dxf_path = paths["dxf"] = self._write_dxf(out)
-        pdf_path = None
-        if want_set & {"pdf", "png"}:
-            assert svg_path is not None
-            pdf_path = out + ".pdf"
-            _render_pdf(svg_path, pdf_path, getattr(self, "_draftwright_link_rect", None))
-            _log.info("PDF → %s", pdf_path)
-        if "png" in want_set:
-            assert pdf_path is not None
-            paths["png"] = out + ".png"
-            _render_png(pdf_path, paths["png"], dpi=dpi)
-            _log.info("PNG → %s", paths["png"])
-        if "pdf" in want_set:
-            paths["pdf"] = pdf_path  # type: ignore[assignment]
-        if "svg" in want_set:
-            paths["svg"] = svg_path  # type: ignore[assignment]
-        # Drop intermediates that weren't themselves requested.
-        if svg_path is not None and "svg" not in want_set:
-            os.remove(svg_path)
-            self.svg_path = None
-        if pdf_path is not None and "pdf" not in want_set:
-            os.remove(pdf_path)
+        # Intermediates — the SVG behind a PDF/PNG, the PDF behind a PNG — go to a temp dir when
+        # not themselves requested, NEVER the user's <out>.svg/.pdf. Otherwise a later
+        # `export(out, formats="png")` would overwrite then delete an <out>.svg/.pdf an earlier
+        # export wrote (#677 review). The temp dir + its contents are removed when the stack closes.
+        with contextlib.ExitStack() as stack:
+            tmpdir: str | None = None
+
+            def _intermediate_stem() -> str:
+                nonlocal tmpdir
+                if tmpdir is None:
+                    tmpdir = stack.enter_context(
+                        tempfile.TemporaryDirectory(prefix="draftwright-export-")
+                    )
+                return os.path.join(tmpdir, "intermediate")
+
+            svg_path = None
+            if want_set & {"svg", "pdf", "png"}:
+                svg_path = self._write_svg(out if "svg" in want_set else _intermediate_stem())
+            self.svg_path = svg_path if "svg" in want_set else None
+            if "svg" in want_set:
+                paths["svg"] = svg_path  # type: ignore[assignment]
+
+            self.dxf_path = None
+            if "dxf" in want_set:
+                self.dxf_path = paths["dxf"] = self._write_dxf(out)
+
+            pdf_path = None
+            if want_set & {"pdf", "png"}:
+                assert svg_path is not None
+                pdf_path = (out if "pdf" in want_set else _intermediate_stem()) + ".pdf"
+                _render_pdf(svg_path, pdf_path, getattr(self, "_draftwright_link_rect", None))
+                _log.info("PDF → %s", pdf_path)
+                if "pdf" in want_set:
+                    paths["pdf"] = pdf_path
+
+            if "png" in want_set:
+                assert pdf_path is not None
+                paths["png"] = out + ".png"
+                _render_png(pdf_path, paths["png"], dpi=dpi)
+                _log.info("PNG → %s", paths["png"])
         return {f: paths[f] for f in want}
 
     def export_pdf(self, out=None) -> str:

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -195,6 +195,27 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None) -> None:
         renderPDF.drawToFile(drawing, pdf_path)
 
 
+def _render_png(pdf_path: str, png_path: str, *, dpi: int = 150) -> None:
+    """Rasterise *pdf_path* (page 1) to *png_path* at *dpi*, via pypdfium2 (Google PDFium,
+    BSD-3-Clause) + Pillow (HPND) — both permissively licensed, pre-built wheels with NO native
+    system deps, so PNG works cross-platform without cairo (ADR 0006). The PNG rides on the PDF
+    render, so the raster matches the vector output exactly."""
+    try:
+        import pypdfium2 as pdfium
+    except ImportError as exc:  # pragma: no cover — packaging guard
+        raise ImportError(
+            "PNG export requires pypdfium2 + Pillow (core dependencies); reinstall draftwright"
+        ) from exc
+
+    pdf = pdfium.PdfDocument(pdf_path)
+    try:
+        page = pdf[0]
+        bitmap = page.render(scale=dpi / 72.0)  # PDF user space is 72 dpi
+        bitmap.to_pil().save(png_path)  # PIL encodes the PNG
+    finally:
+        pdf.close()
+
+
 def _elements(shape):
     """Decompose *shape* for export retry: faces plus any loose edges."""
     faces = list(shape.faces())

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9118,6 +9118,19 @@ class TestExportFormats:
         # the SVG + PDF written only to render the PNG are removed
         assert not (tmp_path / "p.svg").exists() and not (tmp_path / "p.pdf").exists()
 
+    def test_png_export_does_not_clobber_existing_outputs(self, tmp_path):
+        # #677 review (blocking): a later png-only export to the same stem must NOT overwrite
+        # then delete an SVG/PDF an earlier export wrote — intermediates go to a temp dir.
+        dwg = build_drawing(Box(60, 40, 20))
+        stem = str(tmp_path / "part")
+        dwg.export(stem, formats=("svg", "pdf"))
+        svg, pdf = tmp_path / "part.svg", tmp_path / "part.pdf"
+        svg_bytes, pdf_bytes = svg.read_bytes(), pdf.read_bytes()
+        dwg.export(stem, formats="png")  # must not touch the existing svg/pdf
+        assert (tmp_path / "part.png").exists()
+        assert svg.exists() and svg.read_bytes() == svg_bytes  # untouched, not deleted
+        assert pdf.exists() and pdf.read_bytes() == pdf_bytes
+
     def test_export_png_dpi_scales_the_raster(self, tmp_path):
         dwg = build_drawing(Box(60, 40, 20))
         lo = Path(dwg.export(str(tmp_path / "lo"), formats="png", dpi=72)["png"]).stat().st_size
@@ -9128,6 +9141,18 @@ class TestExportFormats:
         dwg = build_drawing(Box(30, 20, 10))
         with pytest.raises(ValueError, match="unknown export format"):
             dwg.export(str(tmp_path / "x"), formats=("svg", "jpeg"))
+
+    def test_export_format_is_case_insensitive(self, tmp_path):
+        # #677 review: a single-string format must normalise like an iterable one.
+        dwg = build_drawing(Box(30, 20, 10))
+        assert set(dwg.export(str(tmp_path / "u"), formats="PNG")) == {"png"}
+        assert set(dwg.export(str(tmp_path / "v"), formats=("SVG", "Dxf"))) == {"svg", "dxf"}
+
+    def test_export_png_zero_dpi_raises(self, tmp_path):
+        # #677 review: reject dpi<=0 before writing, so no intermediates are stranded.
+        dwg = build_drawing(Box(30, 20, 10))
+        with pytest.raises(ValueError, match="dpi > 0"):
+            dwg.export(str(tmp_path / "z"), formats="png", dpi=0)
 
     def test_export_pdf_is_deprecated_but_still_works(self, tmp_path):
         dwg = build_drawing(Box(30, 20, 10))

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3067,10 +3067,15 @@ class TestFormatSelector:
 
         assert _parse_formats("dxf, pdf ,dxf") == ["dxf", "pdf"]
 
-    def test_parse_all_expands_to_three(self):
+    def test_parse_all_expands_to_all_four(self):
         from draftwright.cli import _parse_formats
 
-        assert _parse_formats("all") == ["pdf", "svg", "dxf"]
+        assert _parse_formats("all") == ["pdf", "svg", "dxf", "png"]
+
+    def test_parse_png(self):
+        from draftwright.cli import _parse_formats
+
+        assert _parse_formats("png,pdf") == ["png", "pdf"]
 
     def test_parse_unknown_format_raises(self):
         import typer
@@ -3089,67 +3094,43 @@ class TestFormatSelector:
             _parse_formats(" , ")
 
     class _FakeDwg:
-        """Records export() calls and writes real placeholder files so _emit's
-        temp-SVG cleanup can be observed."""
+        """Records the export(formats=) call and writes a placeholder per requested format, so
+        _emit's pass-through + ordering can be checked without a real render (the SVG→PDF→PNG
+        intermediate handling now lives inside Drawing.export, not _emit)."""
 
         def __init__(self, tmp):
             self.tmp = tmp
             self.calls = []
-            self.svg_path = None
 
-        def export(self, *, svg=True, dxf=True):
-            self.calls.append(("export", svg, dxf))
-            sp = str(self.tmp / "o.svg") if svg else None
-            dp = str(self.tmp / "o.dxf") if dxf else None
-            for p in (sp, dp):
-                if p:
-                    open(p, "w").close()
-            self.svg_path = sp
-            return sp, dp
+        def export(self, *, formats):
+            self.calls.append(("export", tuple(formats)))
+            paths = {}
+            for f in formats:
+                p = str(self.tmp / f"o.{f}")
+                open(p, "w").close()
+                paths[f] = p
+            return paths
 
-        def export_pdf(self):
-            self.calls.append(("export_pdf",))
-            pp = str(self.tmp / "o.pdf")
-            open(pp, "w").close()
-            return pp
-
-    def test_emit_pdf_only_discards_temp_svg(self, tmp_path):
+    def test_emit_delegates_to_export_and_orders_paths(self, tmp_path):
         from draftwright.cli import _emit
 
         dwg = self._FakeDwg(tmp_path)
-        out = _emit(dwg, ["pdf"])
+        out = _emit(dwg, ["pdf", "png", "dxf"])
 
-        assert out == [str(tmp_path / "o.pdf")]
-        # SVG was written to drive the PDF, then removed; DXF never written.
-        assert dwg.calls == [("export", True, False), ("export_pdf",)]
-        assert not (tmp_path / "o.svg").exists()
-        assert not (tmp_path / "o.dxf").exists()
-        assert (tmp_path / "o.pdf").exists()
-
-    def test_emit_svg_dxf_skips_pdf(self, tmp_path):
-        from draftwright.cli import _emit
-
-        dwg = self._FakeDwg(tmp_path)
-        out = _emit(dwg, ["svg", "dxf"])
-
-        assert out == [str(tmp_path / "o.svg"), str(tmp_path / "o.dxf")]
-        assert dwg.calls == [("export", True, True)]
-        assert (tmp_path / "o.svg").exists()
-        assert (tmp_path / "o.dxf").exists()
-
-    def test_emit_all_keeps_requested_svg(self, tmp_path):
-        from draftwright.cli import _emit
-
-        dwg = self._FakeDwg(tmp_path)
-        out = _emit(dwg, ["pdf", "svg", "dxf"])
-
+        # One export(formats=) call with the formats passed straight through; paths in order.
+        assert dwg.calls == [("export", ("pdf", "png", "dxf"))]
         assert out == [
             str(tmp_path / "o.pdf"),
-            str(tmp_path / "o.svg"),
+            str(tmp_path / "o.png"),
             str(tmp_path / "o.dxf"),
         ]
-        # SVG requested → kept, not discarded.
-        assert (tmp_path / "o.svg").exists()
+
+    def test_emit_png_only(self, tmp_path):
+        from draftwright.cli import _emit
+
+        dwg = self._FakeDwg(tmp_path)
+        assert _emit(dwg, ["png"]) == [str(tmp_path / "o.png")]
+        assert dwg.calls == [("export", ("png",))]
 
 
 # ---------------------------------------------------------------------------
@@ -9115,3 +9096,41 @@ class TestDraftwrightAttribution:
             if b"/URI" in chunk and b"pzfreo" in chunk:
                 found = True
         assert found, "PDF must embed a clickable draftwright URI link annotation"
+
+
+class TestExportFormats:
+    """The unified export(formats=...) → {format: path} API + PNG raster export
+    (permissive pypdfium2 + Pillow; SVG→PDF→PNG, no native cairo)."""
+
+    def test_export_returns_dict_of_requested_paths(self, tmp_path):
+        dwg = build_drawing(Box(60, 40, 20))
+        paths = dwg.export(str(tmp_path / "d"), formats=("svg", "dxf", "pdf", "png"))
+        assert set(paths) == {"svg", "dxf", "pdf", "png"}
+        for fmt, p in paths.items():
+            assert Path(p).exists() and Path(p).stat().st_size > 0, fmt
+            assert p.endswith("." + fmt)
+
+    def test_export_png_is_valid_and_cleans_intermediates(self, tmp_path):
+        dwg = build_drawing(Box(60, 40, 20))
+        paths = dwg.export(str(tmp_path / "p"), formats="png")  # single-format string accepted
+        assert set(paths) == {"png"}
+        assert Path(paths["png"]).read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic
+        # the SVG + PDF written only to render the PNG are removed
+        assert not (tmp_path / "p.svg").exists() and not (tmp_path / "p.pdf").exists()
+
+    def test_export_png_dpi_scales_the_raster(self, tmp_path):
+        dwg = build_drawing(Box(60, 40, 20))
+        lo = Path(dwg.export(str(tmp_path / "lo"), formats="png", dpi=72)["png"]).stat().st_size
+        hi = Path(dwg.export(str(tmp_path / "hi"), formats="png", dpi=220)["png"]).stat().st_size
+        assert hi > lo  # more pixels → a larger file
+
+    def test_export_unknown_format_raises(self, tmp_path):
+        dwg = build_drawing(Box(30, 20, 10))
+        with pytest.raises(ValueError, match="unknown export format"):
+            dwg.export(str(tmp_path / "x"), formats=("svg", "jpeg"))
+
+    def test_export_pdf_is_deprecated_but_still_works(self, tmp_path):
+        dwg = build_drawing(Box(30, 20, 10))
+        with pytest.warns(DeprecationWarning, match="export_pdf"):
+            pdf = dwg.export_pdf(str(tmp_path / "old"))
+        assert Path(pdf).exists() and pdf.endswith(".pdf")

--- a/uv.lock
+++ b/uv.lock
@@ -683,6 +683,8 @@ dependencies = [
     { name = "build123d-drafting-helpers" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "pypdfium2" },
     { name = "reportlab" },
     { name = "svglib" },
     { name = "typer" },
@@ -706,6 +708,8 @@ requires-dist = [
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.13.1" },
     { name = "numpy", specifier = ">=1.24" },
+    { name = "pillow", specifier = ">=10" },
+    { name = "pypdfium2", specifier = ">=4" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "svglib", specifier = ">=1.5" },
     { name = "typer", specifier = ">=0.12" },
@@ -2059,6 +2063,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypdfium2"
+version = "5.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/a1/9653cdb69b8dfeff943d4ddb977ae402a44410d27009bfc11990bfc931e3/pypdfium2-5.12.0.tar.gz", hash = "sha256:f5b6cad86ade60230e5227a2910874ed080e71906e37dda6ee0201cc2aade02f", size = 274345, upload-time = "2026-07-15T18:57:32.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/4b/effaf6b343f33be7b51967af490d94ca51964a390ee57746df36abcda1fc/pypdfium2-5.12.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:63fe3d188f2eaf922ac2e884c0a6ce5f4ad1ab5f69c0e9d833c0ae7e21f7ead4", size = 3392271, upload-time = "2026-07-15T18:56:58.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/57/df410bca545cc891980aca4411f49072652069281c07060427ef79074ccb/pypdfium2-5.12.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:4491120c7692f36725e972d98034c5d9da1678a9d4b4f1be8f107590e204b124", size = 2848773, upload-time = "2026-07-15T18:57:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2b/d78887e09f179b667fa837e2da021583db77f14d2afd116975c4a37498ae/pypdfium2-5.12.0-py3-none-macosx_13_0_arm64.whl", hash = "sha256:8839c297ef66ac605c56d4b7b0e228d76f3f2d549c3909053d90b56170d6fce7", size = 3480241, upload-time = "2026-07-15T18:57:02.534Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ea/13e8d1d47bc822ba5269ca5e5844e45fc256ed0f11f70c79c4a184d377bb/pypdfium2-5.12.0-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:24aa4fe48671d9cac0bc2315e1f42078229fae3f0b8c955bcec9293bddef73b5", size = 3643487, upload-time = "2026-07-15T18:57:04.121Z" },
+    { url = "https://files.pythonhosted.org/packages/60/05/e682c4fb369cda2dcc80e9aeba195e2cbdc3bc0518968acb516fc370b14f/pypdfium2-5.12.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b2466efdbe783a3b55c64161d507427545cdad798c61ec8b62b30220d865af8", size = 3649729, upload-time = "2026-07-15T18:57:05.635Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/19/2d6b80ea4ab4d9f1b0d32342eddcc1231f850956b3d89b036945b703df3d/pypdfium2-5.12.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2f8c6c26ddf249fd709aa65614c0d787a50d52bb05462dcf93a1004ae8b048b3", size = 3380824, upload-time = "2026-07-15T18:57:07.156Z" },
+    { url = "https://files.pythonhosted.org/packages/73/80/d0b3f3735cd88e65d59b3ba6ce1e0c4ca154b904b47415f8c2edce38a37d/pypdfium2-5.12.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cbb84ddd3eccb0a12926ccf7f93e6be7ca582a53ea22a94f51f5bb242009e77b", size = 3777199, upload-time = "2026-07-15T18:57:08.709Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9d/0a16d1b46b46f75ae1d3744bf71f6b41cc764a25016fd1d56b7d98a5b0fc/pypdfium2-5.12.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a545b841101fa240ae4fc4fd6e78004208ba024d98586bb808e845a470a784a1", size = 4186081, upload-time = "2026-07-15T18:57:10.187Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fd/e5ee6e1751478fd61860f3e28b3424f75322a88db2a7ecb930985004743a/pypdfium2-5.12.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09c48c1b2a27d5a6fd40be2a97ea8850dd05b562d9524d699075f34f4ef80646", size = 3701728, upload-time = "2026-07-15T18:57:11.971Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c7/e4aef7e93b2cf1bce0db53a1d469fee9dd33cf2ae2f353c544b450c1c873/pypdfium2-5.12.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e0edc4887d8fa74d27d66f1736198a3467501a825941daf3284377fc86d6fa6b", size = 4030402, upload-time = "2026-07-15T18:57:13.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/92/aedd6c6dd05dd1b13c3269423d13cae51ab4e2f97741abdd6e4573065cf2/pypdfium2-5.12.0-py3-none-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34ec1ce19359fde13e3a7e7ef99d30c297d1e8800d98f75a2e57029461f43824", size = 3994410, upload-time = "2026-07-15T18:57:15.167Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6a/00478443b4df55de679dbaf1a9498f156af7a9bd5cf3286df97efe4dd5f4/pypdfium2-5.12.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9ef73afb4fa04eb97cda76626eb4102239b37b01ff2825623fd57c370aec58ae", size = 4993683, upload-time = "2026-07-15T18:57:16.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3d/2102ee6cad0fcf1a1702cd0ff29f02e2ad5f20fa3a4efafd512cf016700c/pypdfium2-5.12.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:77d470e8af5b119948aa7d98115caf27c8a0beedc1b20cd61f2b3a6096a79eac", size = 4534554, upload-time = "2026-07-15T18:57:18.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b2/61cd47ceeceab185fcc4d69796545b19c44de160fce29595b9c51fd5869f/pypdfium2-5.12.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:660bc2e747cca345f0c511642d1651816707ba286e53213173089e83ad202959", size = 5237676, upload-time = "2026-07-15T18:57:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ae/1b2bca0ef024e66550f55110f3d8998e2761a352c0666acc2b89c340e8b8/pypdfium2-5.12.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:32814f0998ec3b00304c9e0f55cc153dc8e82df3f406697ea2415739c0f72023", size = 5143022, upload-time = "2026-07-15T18:57:21.405Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/27/2e83beacb830e9c2234994e552402113fd5b1efd549e6f8299ef44857f8a/pypdfium2-5.12.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:0c7734b36f7869121716870d4b4b1fa4f508bcb212b20906de77524c21eddc46", size = 4647043, upload-time = "2026-07-15T18:57:22.869Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f8/24882b1557effb74741633eff3b88458553bb886262a8df2f7ac3450e731/pypdfium2-5.12.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:0eab7bf39df7dcc4e3ab4f92471ddf29f44819ab25f3ef1b53acca87adb60dc2", size = 5088744, upload-time = "2026-07-15T18:57:24.542Z" },
+    { url = "https://files.pythonhosted.org/packages/50/72/ecff3c30a9e7d850c59999521c551d14c605b86dac950d8e69078a2161e8/pypdfium2-5.12.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:aba721a6574c1874763c886bd74c24fa890d8b2f55725c279b7cefd550bd1794", size = 5049688, upload-time = "2026-07-15T18:57:26.013Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c0/8853f64109fe1fe4315ea6aef1153a3a3e9315181ee258c6dc35f957bc02/pypdfium2-5.12.0-py3-none-win32.whl", hash = "sha256:34d0e9d96a269e5b6053d8f6904f61be746e1c92bf6e9807880a906c6c255d2f", size = 3725463, upload-time = "2026-07-15T18:57:27.628Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7d/8e1a264591e950d04d5b511d5d248358118c4f4c0fe4b4c8640eda00bada/pypdfium2-5.12.0-py3-none-win_amd64.whl", hash = "sha256:03ea532d7d15b4893ad94c0ac6ee908a8e7308452f4a7ebe847f27fd19db59b9", size = 3859843, upload-time = "2026-07-15T18:57:29.114Z" },
+    { url = "https://files.pythonhosted.org/packages/29/94/0869674bf591886e6a389c9c9502f54abef3bb34d4db919088ddbe4332bb/pypdfium2-5.12.0-py3-none-win_arm64.whl", hash = "sha256:8bd5047e967b945cd17feedb3611da6d277826cac13eece3080d08df161f53f3", size = 3674601, upload-time = "2026-07-15T18:57:30.667Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cleans up the ad-hoc export surface and adds **PNG** (key for AI-based interactions).

## API
- **`Drawing.export(out, *, formats=("pdf",), dpi=150) → {format: path}`** — one entry point over `svg`/`dxf`/`pdf`/`png`, returns a dict, and internally handles the **SVG → PDF → PNG** intermediate chain (writing/removing intermediates it wasn't asked to keep). `formats` accepts a single name or an iterable.
- **CLI `--format` gains `png`** (`all` now expands to all four); `_emit` collapses to a single `export(formats=…)` call — the old temp-SVG-write-then-delete dance is gone.

## PNG rasteriser — permissive, no cairo
SVG → PDF → PNG via **pypdfium2** (Apache-2.0, wrapping Google PDFium BSD-3) + **Pillow** (HPND) — both permissively licensed and pure-wheel, so PNG works cross-platform with **no native cairo** (ADR 0006) and keeps the render path **dual-license-clean**. (reportlab-native `renderPM` was ruled out — its wheels here lack the `_rl_renderPM` accelerator and fall back to demanding cairo.)

## Deprecation (staged, as discussed)
- `export_pdf()` now **warns** → use `export(formats=("pdf",))["pdf"]`.
- The legacy `export(svg=, dxf=)` boolean/tuple form is **kept working** and marked legacy in the docstring (no runtime warning yet). Hard-deprecating it + migrating first-party callers (`make_drawing`/`Sheet`/the script emitters) is a deliberate **follow-up** to keep this PR focused.

## Licence note
Audited: all new deps are permissive (BSD/Apache/HPND). Existing `svglib` is **LGPL-3.0** (weak-copyleft, already in the tree for PDF) — flagged in the CHANGELOG/CLAUDE.md; purging it is a separate job.

## Verification
- New `TestExportFormats`: dict return for all four formats, PNG validity (magic bytes) + intermediate cleanup, `dpi` scaling, unknown-format `ValueError`, `export_pdf` deprecation warning. `TestFormatSelector` updated to the new `_emit` + `png`.
- Four lint checks clean; e2e / pmi / sheet_emit sweep green; `uv.lock` synced; CLAUDE.md + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)