### PR TITLE
perf(#602): probe pitch-dim fallback offsets with analytical footprints

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -107,8 +107,8 @@ _QUOTED_RE = re.compile(r"'([^']*)'")
 
 
 @functools.lru_cache(maxsize=512)
-def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> float:
-    """Measured rendered width (page-mm) of *text* at *font_size*.
+def _text_size(text: str, font_size: float, font_path: str = PLEX_MONO) -> tuple[float, float]:
+    """Measured rendered (width, height) (page-mm) of *text* at *font_size*.
 
     Uses build123d's ``Text`` — the same primitive ``Dimension``/``HoleCallout``
     stroke their labels with — so callout-width estimates use real glyph metrics
@@ -120,18 +120,20 @@ def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> floa
     recur across holes and the rasterisation is the costly part.
     """
     if not text:
-        return 0.0
-    return (
-        Text(
-            txt=text,
-            font_size=font_size,
-            font_path=font_path,
-            align=(Align.CENTER, Align.CENTER),
-            mode=Mode.PRIVATE,
-        )
-        .bounding_box()
-        .size.X
-    )
+        return (0.0, 0.0)
+    bb = Text(
+        txt=text,
+        font_size=font_size,
+        font_path=font_path,
+        align=(Align.CENTER, Align.CENTER),
+        mode=Mode.PRIVATE,
+    ).bounding_box()
+    return (bb.size.X, bb.size.Y)
+
+
+def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> float:
+    """Measured rendered width (page-mm) of *text* — see :func:`_text_size`."""
+    return _text_size(text, font_size, font_path)[0]
 
 
 # Cheap mean glyph advance as a fraction of the em (font size), for label-width ESTIMATES in

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -107,7 +107,9 @@ _QUOTED_RE = re.compile(r"'([^']*)'")
 
 
 @functools.lru_cache(maxsize=512)
-def _text_size(text: str, font_size: float, font_path: str = PLEX_MONO) -> tuple[float, float]:
+def _text_size(
+    text: str, font_size: float, font_path: str | None = PLEX_MONO, font: str = "Arial"
+) -> tuple[float, float]:
     """Measured rendered (width, height) (page-mm) of *text* at *font_size*.
 
     Uses build123d's ``Text`` — the same primitive ``Dimension``/``HoleCallout``
@@ -116,14 +118,17 @@ def _text_size(text: str, font_size: float, font_path: str = PLEX_MONO) -> tuple
     (``font_path``), not a system font *name*: name resolution substitutes a
     different font on Linux, which makes this estimate — and the layout it feeds —
     platform-variant (#149). The default is the same face the annotations render
-    with, so estimate and render agree.  Cached because the same numeric labels
-    recur across holes and the rasterisation is the costly part.
+    with, so estimate and render agree.  *font* only matters when a caller opts out
+    of path-pinning (``font_path=None``) — then the *name* resolves through the OS
+    font stack, exactly as the renderer would.  Cached because the same numeric
+    labels recur across holes and the rasterisation is the costly part.
     """
     if not text:
         return (0.0, 0.0)
     bb = Text(
         txt=text,
         font_size=font_size,
+        font=font,
         font_path=font_path,
         align=(Align.CENTER, Align.CENTER),
         mode=Mode.PRIVATE,

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -11,8 +11,9 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-from build123d_drafting.helpers import Dimension, SafeDimension
+from build123d_drafting.helpers import DEFAULT_FONT_PATH, Dimension, SafeDimension
 
+from draftwright._core import _text_size
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import _centerline_extent
@@ -98,6 +99,54 @@ def _geom_box(o):
     except Exception as exc:  # noqa: BLE001 — not every annotation bbox-es cleanly
         _log.debug("strip occupancy: %s did not bbox (%s); omitted", type(o).__name__, exc)
         return None
+
+
+def dim_footprint(p1, p2, side, distance, draft, label):
+    """Analytical page-mm AABB ``(x0, y0, x1, y1)`` of the :class:`Dimension` that
+    ``_dim(p1, p2, side, distance, draft, label=label)`` would build — WITHOUT
+    constructing any OCC geometry (#602: a rejected candidate must not pay the
+    rendering cost).
+
+    Mirrors ``helpers.Dimension`` / build123d ``ExtensionLine``: each extension line
+    is the object→dimension-line segment *translated* ``extension_gap`` along itself,
+    so it spans ``p + side·gap`` → ``p + side·(distance + gap)`` — starting ``gap``
+    clear of the object and overshooting the dimension line by the same ``gap``. The
+    measured label is centred on the line's midpoint with its extents swapped for a
+    vertical measured segment (the label is rotated); everything strokes at
+    ``line_width``. Arrows lie along the dimension line inside the extension-line
+    overshoot (at preset sizes), so they add nothing to the hull. The estimate is
+    metrically exact for the inline-label case; callers accepting a candidate off
+    this footprint must still build the real geometry once and re-validate its box
+    (the #602 validation fallback) so a mismatch (e.g. an externally relocated
+    label) degrades to a wasted probe, never a collision.
+    """
+    sx, sy = side[0], side[1]
+    off = abs(distance)
+    gap = draft.extension_gap
+    dxp, dyp = p2[0] - p1[0], p2[1] - p1[1]
+    w, h = _text_size(label, draft.font_size, getattr(draft, "font_path", DEFAULT_FONT_PATH))
+    hx, hy = (h / 2.0, w / 2.0) if abs(dyp) > abs(dxp) else (w / 2.0, h / 2.0)
+    lcx = (p1[0] + p2[0]) / 2.0 + sx * off
+    lcy = (p1[1] + p2[1]) / 2.0 + sy * off
+    far = off + gap
+    xs = (
+        p1[0] + sx * gap,
+        p2[0] + sx * gap,
+        p1[0] + sx * far,
+        p2[0] + sx * far,
+        lcx - hx,
+        lcx + hx,
+    )
+    ys = (
+        p1[1] + sy * gap,
+        p2[1] + sy * gap,
+        p1[1] + sy * far,
+        p2[1] + sy * far,
+        lcy - hy,
+        lcy + hy,
+    )
+    pad = draft.line_width / 2.0
+    return (min(xs) - pad, min(ys) - pad, max(xs) + pad, max(ys) + pad)
 
 
 CROSSABLE_TYPES = frozenset({"Centerline", "CenterlineCircle", "CenterMark"})

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -124,7 +124,15 @@ def dim_footprint(p1, p2, side, distance, draft, label):
     off = abs(distance)
     gap = draft.extension_gap
     dxp, dyp = p2[0] - p1[0], p2[1] - p1[1]
-    w, h = _text_size(label, draft.font_size, getattr(draft, "font_path", DEFAULT_FONT_PATH))
+    # Mirror the renderer's font resolution exactly (helpers._font_path): the pinned
+    # font *file* when set, else the helpers default; an explicit font_path=None means
+    # name-based resolution of draft.font — so pass the name through too.
+    w, h = _text_size(
+        label,
+        draft.font_size,
+        getattr(draft, "font_path", DEFAULT_FONT_PATH),
+        getattr(draft, "font", "Arial"),
+    )
     hx, hy = (h / 2.0, w / 2.0) if abs(dyp) > abs(dxp) else (w / 2.0, h / 2.0)
     lcx = (p1[0] + p2[0]) / 2.0 + sx * off
     lcy = (p1[1] + p2[1]) / 2.0 + sy * off

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -44,6 +44,7 @@ from draftwright.annotations._common import (
     carve_free_position,
     carve_free_segments,
     clear_label_of_centerlines,
+    dim_footprint,
     place_strip_candidates,
     register_corridor,
     strip_obstacles,
@@ -981,6 +982,8 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
         side, reach = max(cands, key=lambda c: c[0][0] * pref[0] + c[0][1] * pref[1])
     fallback_sides = [(side, reach)] + [c for c in cands if c[0] != side]
 
+    label = f"{n - 1}× {_fmt(pitch)}"
+
     def _make(off, side_vec=side, label_offset_x=0.0):
         return _dim(
             (p1[0], p1[1], 0),
@@ -988,7 +991,7 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
             side_vec,
             off,
             dwg.draft,
-            label=f"{n - 1}× {_fmt(pitch)}",
+            label=label,
             label_offset_x=label_offset_x,
         )
 
@@ -1115,10 +1118,11 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
                 ):
                     break
                 continue
-            probe = _make(offset, side_vec)
-            bb = _geom_box(probe)
-            if bb is None:
-                continue
+            # Analytical footprint, not built geometry (#602): a rejected offset must not
+            # pay the ~0.4 s OCC boolean-fuse cost of a full Dimension build.
+            bb = dim_footprint(
+                (p1[0], p1[1], 0), (p2[0], p2[1], 0), side_vec, offset, dwg.draft, label
+            )
             if (
                 bb[0] < page_box[0]
                 or bb[1] < page_box[1]
@@ -1127,6 +1131,20 @@ def _place_pitch_dim(dwg, a: Analysis, view, loc1, loc2, n, pitch, to_page, name
             ):
                 continue
             if _box_hits(bb, obstacles):
+                continue
+            # Analytically clear — build the real geometry ONCE and re-validate its true
+            # box (the #602 validation fallback): a footprint/geometry mismatch degrades
+            # to a wasted probe and the loop resumes, never a collision.
+            probe = _make(offset, side_vec)
+            real = _geom_box(probe)
+            if (
+                real is None
+                or real[0] < page_box[0]
+                or real[1] < page_box[1]
+                or real[2] > page_box[2]
+                or real[3] > page_box[3]
+                or _box_hits(real, obstacles)
+            ):
                 continue
             dwg.add(
                 _clear_and_validate(offset, side_vec, page_box, obstacles, probe),

--- a/tests/refactor_golden/grid_plate.json
+++ b/tests/refactor_golden/grid_plate.json
@@ -1,0 +1,474 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        168.4,
+        93.5,
+        176.4,
+        103.6
+      ],
+      "label": "10",
+      "label_bbox": [
+        173.3,
+        96.9,
+        175.5,
+        100.1
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        32.4,
+        143.5,
+        127.4,
+        179.6
+      ],
+      "label": "2\u00d7 18",
+      "label_bbox": [
+        33.3,
+        157.2,
+        35.5,
+        165.8
+      ],
+      "name": "dim_pitch_plan0_0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        129.3,
+        145.5,
+        149.4,
+        215.5
+      ],
+      "label": "1\u00d7 20",
+      "label_bbox": [
+        135.0,
+        212.4,
+        143.7,
+        214.6
+      ],
+      "name": "dim_pitch_plan0_1",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        59.3,
+        150.5,
+        89.4,
+        215.5
+      ],
+      "label": "2\u00d7 15",
+      "label_bbox": [
+        70.1,
+        212.4,
+        78.7,
+        214.6
+      ],
+      "name": "dim_pitch_plan1_0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        153.4,
+        142.2,
+        194.0,
+        144.8
+      ],
+      "label": "",
+      "label_bbox": [
+        166.4,
+        142.2,
+        194.0,
+        144.8
+      ],
+      "name": "hc_plan0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        14.8,
+        147.2,
+        56.9,
+        149.8
+      ],
+      "label": "",
+      "label_bbox": [
+        14.8,
+        147.2,
+        42.4,
+        149.8
+      ],
+      "name": "hc_plan1",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        55.9,
+        145.0,
+        62.9,
+        152.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm0",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        70.9,
+        145.0,
+        77.9,
+        152.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm1",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        144.4,
+        138.5,
+        154.4,
+        148.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm10",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        124.4,
+        156.5,
+        134.4,
+        166.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm11",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        144.4,
+        156.5,
+        154.4,
+        166.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm12",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        124.4,
+        174.5,
+        134.4,
+        184.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm13",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        144.4,
+        174.5,
+        154.4,
+        184.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm14",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        85.9,
+        145.0,
+        92.9,
+        152.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm2",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        55.9,
+        160.0,
+        62.9,
+        167.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm3",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        70.9,
+        160.0,
+        77.9,
+        167.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm4",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        85.9,
+        160.0,
+        92.9,
+        167.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm5",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        55.9,
+        175.0,
+        62.9,
+        182.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm6",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        70.9,
+        175.0,
+        77.9,
+        182.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm7",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        85.9,
+        175.0,
+        92.9,
+        182.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm8",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        124.4,
+        138.5,
+        134.4,
+        148.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm9",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        198.7,
+        81.5,
+        278.8,
+        89.5
+      ],
+      "label": "80",
+      "label_bbox": [
+        237.1,
+        82.4,
+        240.4,
+        84.6
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        44.3,
+        111.5,
+        164.4,
+        119.5
+      ],
+      "label": "120",
+      "label_bbox": [
+        101.8,
+        112.4,
+        106.9,
+        114.6
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        44.3,
+        150.5,
+        59.4,
+        227.0
+      ],
+      "label": "15",
+      "label_bbox": [
+        50.2,
+        223.9,
+        53.5,
+        226.1
+      ],
+      "name": "m_locx0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        44.3,
+        145.5,
+        129.4,
+        238.5
+      ],
+      "label": "85",
+      "label_bbox": [
+        85.3,
+        235.4,
+        88.5,
+        237.6
+      ],
+      "name": "m_locx1",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        198.7,
+        105.5,
+        218.8,
+        115.5
+      ],
+      "label": "20",
+      "label_bbox": [
+        207.1,
+        112.4,
+        210.4,
+        114.6
+      ],
+      "name": "m_locy0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        198.7,
+        105.5,
+        223.8,
+        125.0
+      ],
+      "label": "25",
+      "label_bbox": [
+        209.6,
+        121.9,
+        212.8,
+        124.1
+      ],
+      "name": "m_locy1",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        285.0,
+        139.5,
+        309.4,
+        142.2
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        285.0,
+        139.5,
+        309.4,
+        142.2
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        258.9,
+        10.9,
+        409.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [],
+  "item_count": 29,
+  "views": {
+    "front": [
+      44.4,
+      93.5,
+      164.4,
+      103.5
+    ],
+    "iso": [
+      205.3,
+      146.9,
+      389.1,
+      263.6
+    ],
+    "plan": [
+      44.4,
+      123.5,
+      164.4,
+      203.5
+    ],
+    "side": [
+      198.7,
+      93.5,
+      278.7,
+      103.5
+    ]
+  }
+}

--- a/tests/test_pitch_dim_footprint.py
+++ b/tests/test_pitch_dim_footprint.py
@@ -1,0 +1,87 @@
+"""#602: the pitch-dim fallback probes with analytical footprints, not built geometry.
+
+Two guards on the perf fix:
+
+1. ``dim_footprint`` must stay metrically faithful to the real ``Dimension`` bbox —
+   the probe loop's accept/reject decisions ride on it, so a drifting estimate either
+   reintroduces per-probe OCC builds (via constant validation failures) or shifts
+   placements. Tolerance 0.15 mm: the estimate is exact except for a deliberate
+   uniform ``line_width/2`` stroke pad (±0.05 mm at preset weights).
+
+2. The grid benchmark part must place its pitch dims in a *bounded* number of
+   ``Dimension`` constructions — the issue's acceptance criterion ("prefer asserting
+   geometry-construction counts over flaky wall-clock limits"). Pre-#602 this part
+   built 88 dimensions for 4 placed pitch dims; the bound allows the accept build,
+   the optional centre-line label-shift rebuild, and one validation-fallback retry
+   per placed dim.
+
+The label-wider-than-the-line case (helpers relocates the label externally) is a
+documented footprint mismatch: the estimate under-covers, the accept-time validation
+build rejects, and the loop resumes — correctness holds, one probe is wasted. It is
+deliberately not asserted tight here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box, Cylinder, Pos
+from build123d_drafting import draft_preset
+
+from draftwright import build_drawing
+from draftwright._core import _dim
+from draftwright.annotations._common import _geom_box, dim_footprint
+
+
+@pytest.mark.parametrize(
+    ("p1", "p2", "side", "distance", "label"),
+    [
+        pytest.param((10, 20, 0), (40, 20, 0), (0, -1, 0), 15, "2× 15", id="horiz-below"),
+        pytest.param((10, 20, 0), (40, 20, 0), (0, 1, 0), 22.5, "4× 7.5", id="horiz-above"),
+        pytest.param((30, 10, 0), (30, 60, 0), (-1, 0, 0), 18, "2× 25", id="vert-left"),
+        pytest.param((30, 10, 0), (30, 60, 0), (1, 0, 0), 40, "3× 16.7", id="vert-right"),
+        pytest.param((10, 10, 0), (40, 30, 0), (-0.5547, 0.83205, 0), 20, "2× 18", id="diagonal"),
+    ],
+)
+def test_dim_footprint_matches_real_geometry(p1, p2, side, distance, label):
+    draft = draft_preset(font_size=3.5, decimal_precision=1)
+    real = _geom_box(_dim(p1, p2, side, distance, draft, label=label))
+    est = dim_footprint(p1, p2, side, distance, draft, label)
+    assert real is not None
+    assert max(abs(e - r) for e, r in zip(est, real)) <= 0.15
+
+
+def _grid_plate():
+    # The #602 benchmark part (same as the refactor-golden fixture): 15 holes in two
+    # regular grids, whose pitch dims exhaust the strip carve and exercise the
+    # bounded-offset fallback.
+    plate = Box(120, 80, 10)
+    for i in range(3):
+        for j in range(3):
+            plate -= Pos(-45 + i * 15, -15 + j * 15, 0) * Cylinder(2.5, 10)
+    for i in range(2):
+        for j in range(3):
+            plate -= Pos(25 + i * 20, -20 + j * 18, 0) * Cylinder(4, 10)
+    return plate
+
+
+def test_grid_pitch_dim_constructions_bounded(monkeypatch):
+    from draftwright.annotations import holes
+
+    pitch_builds = 0
+    real_dim = holes._dim
+
+    def counting_dim(p1, p2, side, distance, draft, **kwargs):
+        nonlocal pitch_builds
+        if "× " in (kwargs.get("label") or ""):
+            pitch_builds += 1
+        return real_dim(p1, p2, side, distance, draft, **kwargs)
+
+    monkeypatch.setattr(holes, "_dim", counting_dim)
+    dwg = build_drawing(_grid_plate())
+
+    placed = [name for name, _ in dwg.iter_annotations() if name.startswith("dim_pitch_")]
+    assert placed, "fixture no longer places pitch dims — the guard lost its subject"
+    assert pitch_builds <= 3 * len(placed), (
+        f"{pitch_builds} Dimension builds for {len(placed)} placed pitch dims — the "
+        f"#602 footprint probe regressed to constructing geometry for rejected offsets"
+    )

--- a/tests/test_pitch_dim_footprint.py
+++ b/tests/test_pitch_dim_footprint.py
@@ -50,6 +50,17 @@ def test_dim_footprint_matches_real_geometry(p1, p2, side, distance, label):
     assert max(abs(e - r) for e, r in zip(est, real)) <= 0.15
 
 
+def test_dim_footprint_matches_name_resolved_font():
+    # font_path=None opts out of path-pinning: the renderer resolves the font *name*
+    # through the OS stack, and the footprint must measure with the same resolution
+    # (est and real go through the same fallback, so they agree on any platform).
+    draft = draft_preset(font_size=3.5, decimal_precision=1, font_path=None)
+    real = _geom_box(_dim((10, 20, 0), (40, 20, 0), (0, -1, 0), 15, draft, label="2× 15"))
+    est = dim_footprint((10, 20, 0), (40, 20, 0), (0, -1, 0), 15, draft, "2× 15")
+    assert real is not None
+    assert max(abs(e - r) for e, r in zip(est, real)) <= 0.15
+
+
 def _grid_plate():
     # The #602 benchmark part (same as the refactor-golden fixture): 15 holes in two
     # regular grids, whose pitch dims exhaust the strip carve and exercise the
@@ -65,18 +76,21 @@ def _grid_plate():
 
 
 def test_grid_pitch_dim_constructions_bounded(monkeypatch):
-    from draftwright.annotations import holes
+    # Count at the construction site (_core.Dimension, which every _dim call resolves
+    # at call time) rather than white-box patching annotations/ internals — the
+    # test_private_test_imports ratchet forbids new private imports from holes.
+    import draftwright._core as core
 
     pitch_builds = 0
-    real_dim = holes._dim
+    real_dimension = core.Dimension
 
-    def counting_dim(p1, p2, side, distance, draft, **kwargs):
+    def counting_dimension(p1, p2, side, distance, draft, **kwargs):
         nonlocal pitch_builds
         if "× " in (kwargs.get("label") or ""):
             pitch_builds += 1
-        return real_dim(p1, p2, side, distance, draft, **kwargs)
+        return real_dimension(p1, p2, side, distance, draft, **kwargs)
 
-    monkeypatch.setattr(holes, "_dim", counting_dim)
+    monkeypatch.setattr(core, "Dimension", counting_dimension)
     dwg = build_drawing(_grid_plate())
 
     placed = [name for name, _ in dwg.iter_annotations() if name.startswith("dim_pitch_")]

--- a/tests/test_refactor_golden.py
+++ b/tests/test_refactor_golden.py
@@ -17,7 +17,9 @@ that reorders floating-point sums shifts a value ~1 ULP with no real placement c
 byte digest false-fails on; 0.1 mm catches the ~mm drift a wrong projector/sign/order causes
 while surviving that noise.
 
-**Throwaway:** delete this file and `tests/refactor_golden/` once #638 + #639 land.
+Originally a throwaway gate for #638 + #639; retained as the deviation gate for the #602
+performance work — perf refactors (placement-footprint separation, caching) are exactly the
+behaviour-preserving class this corpus polices, so it stays until that epic concludes.
 
 Re-bless intentionally (there should be NO intentional change during these refactors):
     DRAFTWRIGHT_UPDATE_GOLDEN=1 uv run pytest tests/test_refactor_golden.py
@@ -120,6 +122,20 @@ def _flange_dense():
     return flange
 
 
+def _grid_plate():
+    # The #602 benchmark: a plate with 15 holes in two regular grid patterns → grid pitch
+    # dims through _place_pitch_dim's bounded-offset fallback (the perf hotspot: the strip
+    # carve finds no free tier, so every candidate offset is footprint-tested).
+    plate = Box(120, 80, 10)
+    for i in range(3):
+        for j in range(3):
+            plate -= Pos(-45 + i * 15, -15 + j * 15, 0) * Cylinder(2.5, 10)
+    for i in range(2):
+        for j in range(3):
+            plate -= Pos(25 + i * 20, -20 + j * 18, 0) * Cylinder(4, 10)
+    return plate
+
+
 def _holed_slot():
     # A hole whose X-location coincides with a slot edge → the #345 corridor dedup path.
     from build123d import BuildPart, Hole, Locations, Mode
@@ -144,6 +160,7 @@ CORPUS = {
     "bracket_section": _bracket_section,
     "turned_stepped": _turned_stepped,
     "flange_dense": _flange_dense,
+    "grid_plate": _grid_plate,
     "holed_slot": _holed_slot,
 }
 


### PR DESCRIPTION
## Summary

First PR of the #602 queue: the bounded-offset fallback in `_place_pitch_dim` built a **full Dimension** (an OCC boolean fuse, ~0.4 s) for every candidate offset, so rejected probes paid nearly the full rendering cost — 88 builds for 4 placed pitch dims on the #602 grid benchmark.

Probes now use `dim_footprint` (`annotations/_common.py`): the analytical page-mm AABB of the Dimension `_dim` would build — extension lines translated by `extension_gap` (they overshoot the dimension line by the same gap — measured, not assumed), the label box via the pinned-font `_text_size` metrics (ADR 0006), stroke pad. Calibrated to **±0.05 mm** of real geometry for axis-aligned and diagonal dims. The accepted candidate is still built once and its real box re-validated (the issue's sanctioned validation fallback), so a footprint mismatch — e.g. helpers relocating a label wider than its line — degrades to a wasted probe, never a collision.

## Numbers (grid benchmark, 15 holes / two grids)

| | before | after |
|---|---:|---:|
| `build_drawing` total | 40.1 s | **7.9 s** |
| `_add_grid_pitch_dims` | 33.2 s | **1.3 s** |
| Dimension builds for 4 pitch dims | 88 | ≤ 12 (count-gated) |

## Correctness

- **Refactor-golden corpus passes unchanged** (13 fixtures incl. the new `grid_plate`, 0.1 mm grid) — placement is identical. The corpus gains the #602 benchmark part (baseline blessed from unmodified main *before* the fix, commit 1) and the harness docstring is amended: no longer throwaway, it is the perf-iteration deviation gate.
- New `tests/test_pitch_dim_footprint.py`: footprint-vs-real calibration across dim orientations + a geometry-construction-count regression test (the issue's 'counts, not wall-clock' criterion).
- Smoke tier, four lint checks green locally; full fast tier = CI.

## ADR fit

- Extends **ADR 0004**'s footprints-are-box-layouts-never-measured-geometry principle from the outer compose to the inner probe loop — on-pattern, no new architecture.
- `_place_pitch_dim` is the **ADR 0009 Amendment 8 permanent carve exemption** (a diagonal dim cannot occupy a 1-D strip tier), so optimising the fallback in place is the end-state for this site, not a #636 stopgap. No new `carve_free_position` callers; the caller-allowlist guard is untouched.
- `dim_footprint` sits at the bottom of the annotations DAG (`_common`), importing only `_core` — and is shaped for reuse by the next queue item (`place_strip_candidates` measure/build separation).

Part of #602 (does not close it — the queue continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)