### PR TITLE
perf(#602): measure/plan/build separation for the corridor strip solve

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -120,6 +120,13 @@ def dim_footprint(p1, p2, side, distance, draft, label):
     (the #602 validation fallback) so a mismatch (e.g. an externally relocated
     label) degrades to a wasted probe, never a collision.
     """
+    if isinstance(side, str):  # mirror helpers._SIDE_VECTORS ("above"/"below"/"left"/"right")
+        side = {
+            "above": (0.0, 1.0, 0.0),
+            "below": (0.0, -1.0, 0.0),
+            "left": (-1.0, 0.0, 0.0),
+            "right": (1.0, 0.0, 0.0),
+        }[side]
     sx, sy = side[0], side[1]
     off = abs(distance)
     gap = draft.extension_gap
@@ -472,6 +479,11 @@ class CorridorCandidate:
     # the title block, which is placed after the corridor drain so the strip carve can't see
     # it (#481). ``None`` (every dim) skips the check → byte-identical.
     forbid: object | None = None
+    # Analytical ``pos -> (x0, y0, x1, y1)`` footprint of the geometry ``build(pos)``
+    # would produce (#602): lets the strip solve measure and evaluate this candidate
+    # without constructing OCC geometry at all (see :func:`dim_footprint`). ``None``
+    # falls back to one probe build at the strip edge + the box-shift model.
+    footprint: object | None = None
 
 
 def solve_corridor(dwg, strip, view, axis, cands, tier):
@@ -529,6 +541,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
     prio = {c.name: c.priority for c in kept if c.priority}  # over-capacity survival rank (#357)
     anchored = {c.name: c.anchored for c in kept if c.anchored}
     naturals = {c.name: c.natural for c in kept if c.natural is not None}
+    foots = {c.name: c.footprint for c in kept if c.footprint is not None}  # analytical (#602)
     left = {
         n
         for n, _ in place_strip_candidates(
@@ -544,6 +557,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
             priorities=prio,
             anchored=anchored,
             naturals=naturals,
+            footprints=foots,
         )
     }
     force_pairs = [(c.name, c.build) for c in kept if c.name in left and c.force]
@@ -558,6 +572,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier):
                 force_pairs,
                 tier,
                 force=True,
+                footprints=foots,
                 features=feats,
                 sizes=sizes,
                 forbid=forbid,
@@ -679,6 +694,7 @@ def place_strip_candidates(
     priorities=None,
     anchored=None,
     naturals=None,
+    footprints=None,
 ):
     """Collect-then-solve placement of location/feature dims on one strip (ADR 0009).
     The single shared strip placer that retires the ``Strip.allocate`` cursor (#150,
@@ -756,9 +772,36 @@ def place_strip_candidates(
     # obstacles out first. The perpendicular extent is independent of the tier position,
     # so a single probe build per candidate suffices; the corridor check below already
     # uses the full 2-D box, so it needs no such filter.
-    pbands = [
-        (b[perp], b[perp + 2]) for _n, build in cands if (b := _geom_box(build(lo))) is not None
-    ]
+    #
+    # That one probe build is also this call's entire MEASUREMENT step (#602): every
+    # candidate is a fixed feature-side anchor (witness origin / leader shaft end)
+    # plus a dim line that translates with the tier position, so its box at position
+    # ``pos`` is the probe box with the OUTWARD stacking-axis edge shifted by
+    # ``pos - lo`` — no further geometry is built to evaluate a position. The
+    # segment loop below re-solves and re-checks on these predicted boxes only;
+    # each finally-accepted candidate is built once and its real box re-validated
+    # (a prediction miss degrades to a later-segment retry, never a collision).
+    # A candidate with an analytical *footprints* entry (#602) needs no probe build at
+    # all — its box at any position is computed, not measured.
+    probe_boxes = {
+        name: (footprints[name](lo) if name in (footprints or {}) else _geom_box(build(lo)))
+        for name, build in cands
+    }
+    pbands = [(b[perp], b[perp + 2]) for b in probe_boxes.values() if b is not None]
+
+    def _predicted_box(name, pos):
+        fp = (footprints or {}).get(name)
+        if fp is not None:
+            return fp(pos)
+        pb = probe_boxes.get(name)
+        if pb is None:
+            return None
+        box = list(pb)
+        # The moving edge is the one AWAY from the view (`inner`); the feature-side
+        # edge is anchored geometry and stays put.
+        box[idx + 2 if inner == lo else idx] += pos - lo
+        return tuple(box)
+
     occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
     if pbands:
         band_lo, band_hi = min(p[0] for p in pbands), max(p[1] for p in pbands)
@@ -821,8 +864,15 @@ def place_strip_candidates(
             if pos is None:  # segment over its estimated capacity (shouldn't occur)
                 rejected.append((name, build))
                 continue
-            dim = build(pos)
-            if not force and _box_hits(_geom_box(dim), blockers):  # corridor crosses a leader
+            # Predicted box, not built geometry (#602): the refill loop re-evaluates
+            # every already-accepted candidate each iteration, so building here made
+            # the drain quadratic in OCC builds.
+            box = _predicted_box(name, pos)
+            if box is None:  # probe didn't bbox — measure the old way, once per check
+                box = _geom_box(build(pos))
+            if (
+                not force and box is not None and _box_hits(box, blockers)
+            ):  # corridor crosses a leader
                 rejected.append((name, build))
                 continue
             # A forbidden box (the title block, #481) is rejected even under force — it is
@@ -830,10 +880,10 @@ def place_strip_candidates(
             # must still not stack onto it. `forbid` maps names to their box (only GD&T sets it,
             # so dims are byte-identical). Returned unplaced → the caller's on_drop fallthrough.
             fb = (forbid or {}).get(name)
-            if fb is not None and _box_hits(_geom_box(dim), (fb,)):
+            if fb is not None and box is not None and _box_hits(box, (fb,)):
                 rejected.append((name, build))
                 continue
-            accepted.append(((name, build), dim))
+            accepted.append(((name, build), pos))
         return accepted, rejected
 
     for seg_lo, seg_hi in segs:
@@ -849,9 +899,25 @@ def place_strip_candidates(
             if vacancies <= 0 or not todo:
                 break
             fill, todo = _take_for_segment(todo, vacancies)
-            take = [nb for nb, _dim in accepted] + fill
+            take = [nb for nb, _pos in accepted] + fill
+        # Build each survivor ONCE at its solved position and re-validate the real box
+        # (the #602 validation fallback): a prediction miss is returned to the pool for
+        # the next segment — exactly where a same-segment rejection would have sent it.
+        placed = []
+        for (name, build), pos in accepted:
+            dim = build(pos)
+            real = _geom_box(dim)
+            if real is not None:
+                if not force and _box_hits(real, blockers):
+                    rejected_total.append((name, build))
+                    continue
+                fb = (forbid or {}).get(name)
+                if fb is not None and _box_hits(real, (fb,)):
+                    rejected_total.append((name, build))
+                    continue
+            placed.append((name, dim))
         todo = todo + rejected_total
-        for (name, _build), dim in accepted:
+        for name, dim in placed:
             # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
             # dims — `features` maps this batch's names to their source IR feature.
             dwg.add(dim, name, view=view, feature=(features or {}).get(name))

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -482,7 +482,13 @@ class CorridorCandidate:
     # Analytical ``pos -> (x0, y0, x1, y1)`` footprint of the geometry ``build(pos)``
     # would produce (#602): lets the strip solve measure and evaluate this candidate
     # without constructing OCC geometry at all (see :func:`dim_footprint`). ``None``
-    # falls back to one probe build at the strip edge + the box-shift model.
+    # falls back to one probe build at the strip edge + the box-shift model. CONTRACT:
+    # the footprint must be accurate — its PERPENDICULAR extent feeds the obstacle
+    # band filter, so an underestimate hides obstacles from the carve. The solve
+    # re-validates each built survivor against the blockers, the forbid box and the
+    # band-filtered-out obstacles, so a miss costs a wasted build and a retry, but
+    # keeping footprints truthful (``dim_footprint``, ±0.05 mm) is what keeps that
+    # fallback rare and the placement identical to the probe path.
     footprint: object | None = None
 
 
@@ -803,9 +809,19 @@ def place_strip_candidates(
         return tuple(box)
 
     occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+    # Obstacles OUTSIDE the batch's predicted perpendicular band are invisible to the
+    # carve below by design — but that makes the band prediction itself load-bearing: a
+    # candidate whose real geometry exceeds its predicted band could land on one with no
+    # check ever seeing it (review #679). Keep the filtered-out set: the post-build
+    # validation re-checks each survivor's REAL box against it. In-band overlaps are NOT
+    # validated — witness lines legitimately cross the boxes of dims stacked further in
+    # (ISO 129-1), which is exactly why the carve projects onto the stacking axis only.
+    out_of_band: list = []
     if pbands:
         band_lo, band_hi = min(p[0] for p in pbands), max(p[1] for p in pbands)
-        occupied = [b for b in occupied if b[perp] < band_hi and b[perp + 2] > band_lo]
+        in_band = [b for b in occupied if b[perp] < band_hi and b[perp + 2] > band_lo]
+        out_of_band = [b for b in occupied if not (b[perp] < band_hi and b[perp + 2] > band_lo)]
+        occupied = in_band
     blockers = () if force else corridor_blockers(dwg, view)
     segs = carve_free_segments(lo, hi, [(b[idx], b[idx + 2]) for b in occupied], pad)
     # Fill innermost-first (nearest the view), matching the old cursor's stack order.
@@ -913,6 +929,13 @@ def place_strip_candidates(
                     continue
                 fb = (forbid or {}).get(name)
                 if fb is not None and _box_hits(real, (fb,)):
+                    rejected_total.append((name, build))
+                    continue
+                # A survivor whose real geometry escaped the batch's predicted
+                # perpendicular band could overlap an obstacle the carve was never
+                # shown (review #679) — the one collision class the stacking-axis
+                # model cannot tolerate. Never fires while predictions are accurate.
+                if _box_hits(real, out_of_band):
                     rejected_total.append((name, build))
                     continue
             placed.append((name, dim))

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -58,6 +58,7 @@ from draftwright.annotations._common import (
     _geom_box,
     carve_free_position,
     carve_free_segments,
+    dim_footprint,
     place_strip_candidates,
     register_corridor,
     strip_free_span,
@@ -393,6 +394,7 @@ def _location_candidate(
     build,
     feature=None,
     pinned=False,
+    footprint=None,
 ):
     """A :class:`CorridorCandidate` for a datum-referenced hole/pattern location dim.
     Location dims outrank a coincident slot-position line in dedup (#345) and form the
@@ -424,6 +426,7 @@ def _location_candidate(
         priority=100.0 if pinned else 0.0,
         force=True,
         feature=feature,  # provenance (ADR 0010): the located hole/pattern
+        footprint=footprint,  # analytical measure — no probe build (#602)
     )
 
 
@@ -543,6 +546,14 @@ def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
                 ),
                 feature=_xfeat,
                 pinned=pin_ref,
+                footprint=lambda pos, _rx=rx, _ry=ry: dim_footprint(
+                    (PX(datum_x), PY(_ry), 0),
+                    (PX(_rx), PY(_ry), 0),
+                    "above",
+                    pos - PY(_ry),
+                    draft,
+                    _fmt(_rx - datum_x),
+                ),
             ),
         )
 
@@ -605,6 +616,14 @@ def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
                 ),
                 feature=_yfeat,
                 pinned=pin_ref,
+                footprint=lambda pos, _ry=ry: dim_footprint(
+                    (SX(datum_y), SZ(a.bb.max.Z), 0),
+                    (SX(_ry), SZ(a.bb.max.Z), 0),
+                    "above",
+                    pos - side_top,
+                    draft,
+                    _fmt(_ry - datum_y),
+                ),
             ),
         )
     return n
@@ -1322,6 +1341,9 @@ def render_plates(dwg, model, a, *, ctx) -> int:
         def _build(pos, pa=pa, pb=pb, side=side, edge=edge, val=val):
             return _dim(pa, pb, side, pos - edge, draft, label=_fmt(val))
 
+        def _foot(pos, pa=pa, pb=pb, side=side, edge=edge, val=val):
+            return dim_footprint(pa, pb, side, pos - edge, draft, _fmt(val))
+
         def _drop(nm, val=val, view=view, stack=stack):
             ctx.record_issue(
                 "warning",
@@ -1348,6 +1370,7 @@ def render_plates(dwg, model, a, *, ctx) -> int:
                 on_drop=_drop,
                 force=True,
                 feature=pl,
+                footprint=_foot,  # analytical measure — no probe build (#602)
             ),
         )
         n += 1
@@ -1367,7 +1390,7 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
         return 0
     n = 0
 
-    def _queue(name, strip, view, tier, distance, build):
+    def _queue(name, strip, view, tier, distance, build, footprint=None):
         register_corridor(
             ctx,
             (view, "below"),
@@ -1383,6 +1406,7 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
                 on_drop=lambda _nm: None,
                 priority=_MANDATORY_OVERALL_PRIORITY,
                 force=True,
+                footprint=footprint,  # analytical measure — no probe build (#602)
             ),
         )
 
@@ -1405,6 +1429,9 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
                 dwg.draft,
                 label=_fmt(_v),
             ),
+            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.param.value: dim_footprint(
+                (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _fmt(_v)
+            ),
         )
         n += 1
     depth = _env_pd(env, "depth")
@@ -1425,6 +1452,9 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
                 _w - pos,
                 dwg.draft,
                 label=_fmt(_v),
+            ),
+            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.param.value: dim_footprint(
+                (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _fmt(_v)
             ),
         )
         n += 1

--- a/tests/refactor_golden/scattered_plate.json
+++ b/tests/refactor_golden/scattered_plate.json
@@ -1,0 +1,649 @@
+{
+  "annotations": [
+    {
+      "geom_bbox": [
+        182.0,
+        149.0,
+        190.0,
+        161.1
+      ],
+      "label": "12",
+      "label_bbox": [
+        186.9,
+        153.4,
+        189.1,
+        156.6
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        171.0,
+        186.7,
+        198.5,
+        189.3
+      ],
+      "label": "",
+      "label_bbox": [
+        180.0,
+        186.7,
+        198.5,
+        189.3
+      ],
+      "name": "hc_plan0",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        150.5,
+        204.7,
+        198.5,
+        207.3
+      ],
+      "label": "",
+      "label_bbox": [
+        180.0,
+        204.7,
+        198.5,
+        207.3
+      ],
+      "name": "hc_plan1",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        168.0,
+        254.7,
+        200.3,
+        257.3
+      ],
+      "label": "",
+      "label_bbox": [
+        180.0,
+        254.7,
+        200.3,
+        257.3
+      ],
+      "name": "hc_plan2",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        17.4,
+        262.7,
+        44.0,
+        265.3
+      ],
+      "label": "",
+      "label_bbox": [
+        17.4,
+        262.7,
+        36.0,
+        265.3
+      ],
+      "name": "hc_plan3",
+      "type": "Leader",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        49.0,
+        192.0,
+        57.0,
+        200.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm0",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        114.0,
+        187.0,
+        122.0,
+        195.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm1",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        164.0,
+        184.0,
+        172.0,
+        192.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm2",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        84.5,
+        212.5,
+        91.5,
+        219.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm3",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        144.5,
+        202.5,
+        151.5,
+        209.5
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm4",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        63.0,
+        246.0,
+        73.0,
+        256.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm5",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        43.0,
+        259.0,
+        53.0,
+        269.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm6",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        128.0,
+        231.0,
+        138.0,
+        241.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm7",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        97.0,
+        255.0,
+        109.0,
+        267.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm8",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        157.0,
+        250.0,
+        169.0,
+        262.0
+      ],
+      "label": "",
+      "label_bbox": null,
+      "name": "m_cm9",
+      "type": "CenterMark",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        137.0,
+        295.1,
+        145.0
+      ],
+      "label": "90",
+      "label_bbox": [
+        248.4,
+        137.9,
+        251.7,
+        140.1
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        169.0,
+        178.1,
+        177.0
+      ],
+      "label": "140",
+      "label_bbox": [
+        105.5,
+        169.9,
+        110.5,
+        172.1
+      ],
+      "name": "m_env_width",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        266.0,
+        48.1,
+        283.0
+      ],
+      "label": "10",
+      "label_bbox": [
+        41.4,
+        279.9,
+        44.6,
+        282.1
+      ],
+      "name": "m_locx0",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        198.0,
+        53.1,
+        294.5
+      ],
+      "label": "15",
+      "label_bbox": [
+        43.9,
+        291.4,
+        47.1,
+        293.6
+      ],
+      "name": "m_locx1",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        253.0,
+        68.1,
+        304.0
+      ],
+      "label": "30",
+      "label_bbox": [
+        51.4,
+        300.9,
+        54.6,
+        303.1
+      ],
+      "name": "m_locx2",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        218.0,
+        88.1,
+        313.5
+      ],
+      "label": "50",
+      "label_bbox": [
+        61.4,
+        310.4,
+        64.6,
+        312.6
+      ],
+      "name": "m_locx3",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        263.0,
+        103.1,
+        323.0
+      ],
+      "label": "65",
+      "label_bbox": [
+        68.9,
+        319.9,
+        72.1,
+        322.1
+      ],
+      "name": "m_locx4",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        193.0,
+        118.1,
+        332.5
+      ],
+      "label": "80",
+      "label_bbox": [
+        76.4,
+        329.4,
+        79.6,
+        331.6
+      ],
+      "name": "m_locx5",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        238.0,
+        133.1,
+        342.0
+      ],
+      "label": "95",
+      "label_bbox": [
+        83.9,
+        338.9,
+        87.1,
+        341.1
+      ],
+      "name": "m_locx6",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        208.0,
+        148.1,
+        351.5
+      ],
+      "label": "110",
+      "label_bbox": [
+        90.5,
+        348.4,
+        95.5,
+        350.6
+      ],
+      "name": "m_locx7",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        258.0,
+        163.1,
+        361.0
+      ],
+      "label": "125",
+      "label_bbox": [
+        98.0,
+        357.9,
+        103.0,
+        360.1
+      ],
+      "name": "m_locx8",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        38.0,
+        190.0,
+        168.1,
+        370.5
+      ],
+      "label": "130",
+      "label_bbox": [
+        100.5,
+        367.4,
+        105.5,
+        369.6
+      ],
+      "name": "m_locx9",
+      "type": "Dimension",
+      "view": "plan"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        212.1,
+        173.0
+      ],
+      "label": "7",
+      "label_bbox": [
+        207.8,
+        170.0,
+        209.2,
+        172.0
+      ],
+      "name": "m_locy0",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        220.1,
+        182.5
+      ],
+      "label": "15",
+      "label_bbox": [
+        210.9,
+        179.4,
+        214.2,
+        181.6
+      ],
+      "name": "m_locy1",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        230.1,
+        192.0
+      ],
+      "label": "25",
+      "label_bbox": [
+        215.9,
+        188.9,
+        219.2,
+        191.1
+      ],
+      "name": "m_locy2",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        240.1,
+        201.5
+      ],
+      "label": "35",
+      "label_bbox": [
+        220.9,
+        198.4,
+        224.2,
+        200.6
+      ],
+      "name": "m_locy3",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        260.1,
+        211.0
+      ],
+      "label": "55",
+      "label_bbox": [
+        231.0,
+        207.9,
+        234.1,
+        210.1
+      ],
+      "name": "m_locy4",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        275.1,
+        220.5
+      ],
+      "label": "70",
+      "label_bbox": [
+        238.4,
+        217.4,
+        241.7,
+        219.6
+      ],
+      "name": "m_locy5",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        280.1,
+        230.0
+      ],
+      "label": "75",
+      "label_bbox": [
+        240.9,
+        226.9,
+        244.2,
+        229.1
+      ],
+      "name": "m_locy6",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        205.0,
+        163.0,
+        285.1,
+        239.5
+      ],
+      "label": "80",
+      "label_bbox": [
+        243.4,
+        236.4,
+        246.7,
+        238.6
+      ],
+      "name": "m_locy7",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
+        437.4,
+        163.3,
+        461.7,
+        165.9
+      ],
+      "label": "ISO VIEW (NTS)",
+      "label_bbox": [
+        437.4,
+        163.3,
+        461.7,
+        165.9
+      ],
+      "name": "note_iso_nts",
+      "type": "Note",
+      "view": null
+    },
+    {
+      "geom_bbox": [
+        432.9,
+        10.9,
+        583.1,
+        27.1
+      ],
+      "label": "DRAWING",
+      "label_bbox": null,
+      "name": "title_block",
+      "type": "TitleBlock",
+      "view": null
+    }
+  ],
+  "build_issues": [
+    [
+      "warning",
+      "location_ref_dropped",
+      "2 Y location dim(s) too closely spaced to dimension legibly (use a detail view)"
+    ]
+  ],
+  "item_count": 37,
+  "views": {
+    "front": [
+      38.0,
+      149.0,
+      178.0,
+      161.0
+    ],
+    "iso": [
+      343.8,
+      170.6,
+      555.2,
+      305.4
+    ],
+    "plan": [
+      38.0,
+      181.0,
+      178.0,
+      271.0
+    ],
+    "side": [
+      205.0,
+      149.0,
+      295.0,
+      161.0
+    ]
+  }
+}

--- a/tests/test_pitch_dim_footprint.py
+++ b/tests/test_pitch_dim_footprint.py
@@ -75,6 +75,57 @@ def _grid_plate():
     return plate
 
 
+def _scattered_plate():
+    # The #602 second benchmark (same as the refactor-golden fixture): ten holes, four
+    # diameters, no pattern → a large corridor-candidate set through
+    # place_strip_candidates' measure/plan/build seam.
+    plate = Box(140, 90, 12)
+    spots = [
+        (-55, -30, 3),
+        (-40, 25, 4),
+        (-20, -10, 2.5),
+        (-5, 35, 5),
+        (10, -35, 3),
+        (25, 10, 4),
+        (40, -20, 2.5),
+        (55, 30, 5),
+        (60, -38, 3),
+        (-60, 38, 4),
+    ]
+    for x, y, r in spots:
+        plate -= Pos(x, y, 0) * Cylinder(r, 12)
+    return plate
+
+
+def test_corridor_dim_constructions_bounded(monkeypatch):
+    # #602 queue item 2: corridor candidates are measured analytically (footprint
+    # callables) or by ONE probe build; evaluation runs on predicted boxes; a placed
+    # dim is built once. So total Dimension constructions must stay close to the
+    # PLACED count — before the seam this part built 59 for 21 placed (probe per
+    # candidate per pass + a rebuild per refill-loop iteration).
+    import draftwright._core as core
+
+    builds = 0
+    real_dimension = core.Dimension
+
+    def counting_dimension(p1, p2, side, distance, draft, **kwargs):
+        nonlocal builds
+        builds += 1
+        return real_dimension(p1, p2, side, distance, draft, **kwargs)
+
+    monkeypatch.setattr(core, "Dimension", counting_dimension)
+    dwg = build_drawing(_scattered_plate())
+
+    from build123d_drafting.helpers import Dimension
+
+    placed = [name for name, o in dwg.iter_annotations() if isinstance(o, Dimension)]
+    assert placed, "fixture no longer places dimensions — the guard lost its subject"
+    assert builds <= len(placed) + 5, (
+        f"{builds} Dimension builds for {len(placed)} placed — the #602 corridor "
+        f"measure/build separation regressed to probing or re-evaluating with built geometry"
+    )
+
+
 def test_grid_pitch_dim_constructions_bounded(monkeypatch):
     # Count at the construction site (_core.Dimension, which every _dim call resolves
     # at call time) rather than white-box patching annotations/ internals — the

--- a/tests/test_refactor_golden.py
+++ b/tests/test_refactor_golden.py
@@ -136,6 +136,27 @@ def _grid_plate():
     return plate
 
 
+def _scattered_plate():
+    # The #602 second benchmark: ten holes, four diameters, no regular pattern → a large
+    # corridor-candidate set through place_strip_candidates (the measure/build seam).
+    plate = Box(140, 90, 12)
+    spots = [
+        (-55, -30, 3),
+        (-40, 25, 4),
+        (-20, -10, 2.5),
+        (-5, 35, 5),
+        (10, -35, 3),
+        (25, 10, 4),
+        (40, -20, 2.5),
+        (55, 30, 5),
+        (60, -38, 3),
+        (-60, 38, 4),
+    ]
+    for x, y, r in spots:
+        plate -= Pos(x, y, 0) * Cylinder(r, 12)
+    return plate
+
+
 def _holed_slot():
     # A hole whose X-location coincides with a slot edge → the #345 corridor dedup path.
     from build123d import BuildPart, Hole, Locations, Mode
@@ -161,6 +182,7 @@ CORPUS = {
     "turned_stepped": _turned_stepped,
     "flange_dense": _flange_dense,
     "grid_plate": _grid_plate,
+    "scattered_plate": _scattered_plate,
     "holed_slot": _holed_slot,
 }
 


### PR DESCRIPTION
## Summary

Queue item 2 of #602. `place_strip_candidates` paid a full OCC Dimension build per candidate per evaluation: a probe build for the perpendicular band, a rebuild of **every already-accepted candidate** on each refill-loop iteration, and rebuilds again when rejected candidates rolled to later segments — 59 builds for 21 placed dims on the scattered-plate benchmark (21 s of a 25 s drawing).

This lands the issue's measure/plan/render boundary in the corridor solve:

- **Measure** — `CorridorCandidate` gains an optional analytical `footprint` callable (`pos → AABB`, threaded through `solve_corridor`). Without one, the single probe build at the strip edge doubles as the measurement via a box-shift model: every candidate is a fixed feature-side anchor plus a dim line that translates with the tier position, so its box at `pos` is the probe box with the outward edge shifted by `pos − lo`.
- **Plan** — `_evaluate_segment` runs corridor-blocker/forbid checks on predicted boxes only; no geometry inside the refill loop.
- **Build** — each survivor is built once at its solved position and its real box re-validated (the issue's sanctioned validation fallback); a prediction miss returns to the pool for the next segment, exactly where a same-segment rejection would have gone.

Footprints populated for the X/Y location dims (`_location_candidate`), plate-thickness dims, and envelope width/depth dims; the remaining candidate sites use probe+shift (one build, never one per evaluation). `dim_footprint` now also accepts the `'above'/'below'/'left'/'right'` side strings, mirroring `helpers._SIDE_VECTORS`.

## Numbers

| benchmark | before | after |
|---|---:|---:|
| scattered plate `build_drawing` | 24.8 s | **10.9 s** |
| — corridor drain | 21.3 s | 7.6 s |
| — Dimension builds / placed | 59 / 21 | **21 / 21** (zero waste, count-gated) |
| grid plate `build_drawing` | 9.8 s | 7.7 s |

Cumulative with #678: the grid plate is 40.1 s → 7.7 s.

## Correctness

- **14-fixture placement golden passes unchanged** (0.1 mm grid), including the new `scattered_plate` fixture blessed from unmodified main *before* the change (commit 1).
- New count-gated regression test: total Dimension constructions ≤ placed + 5 on the scattered plate (pre-change: 59 vs 21, fails).
- Smoke + targeted tests + the four lint checks green locally; full fast tier = CI.

## ADR fit

- The inner-layout counterpart of **ADR 0004**'s footprints-are-box-layouts-never-measured-geometry rule, applied inside **ADR 0009**'s collect-then-solve corridor. The footprint seam rides the existing `CorridorCandidate` collection — no new placement path, no new `carve_free_position` callers, allowlist untouched.
- Candidate sites keep owning their geometry (builder + footprint side by side), so the seam doesn't leak pass knowledge into `_common`.

Part of #602 (does not close it — export and lint items remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)