### PR TITLE
perf(#602): set the DXF viewport from the known page window, not an entity walk

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -59,6 +59,7 @@ from draftwright.export import (
     fix_svg_page_size,
     sanitize_svg_arcs,
     set_dxf_metadata,
+    write_dxf,
 )
 from draftwright.fonts import PLEX_MONO
 from draftwright.intents import Intent
@@ -2315,7 +2316,8 @@ class Drawing:
         self._add_shapes(dxf_exp)
         set_dxf_metadata(dxf_exp)
         dxf_path = out + ".dxf"
-        dxf_exp.write(dxf_path)
+        # #602: skip ExportDXF.write's O(entities) zoom.extents pass — the page window is known.
+        write_dxf(dxf_exp, dxf_path, self.page_w, self.page_h)
         _log.info("DXF → %s", dxf_path)
         return dxf_path
 

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -123,6 +123,33 @@ def set_dxf_metadata(dxf) -> None:
         pass
 
 
+def write_dxf(dxf, path: str, page_w: float, page_h: float) -> None:
+    """Write *dxf* with the viewport zoomed to the known page window.
+
+    ``ExportDXF.write`` resets the viewport via ``ezdxf.zoom.extents`` — a
+    pure-Python walk of every modelspace entity that re-flattens each spline,
+    costing seconds on a dimension-dense sheet (#602; build123d#382 tracks
+    exposing viewport control). The drawing already lives in page-mm
+    coordinates ``(0, 0)–(page_w, page_h)``, so set that single-window
+    viewport directly and save. Best-effort: falls back to ``dxf.write`` if
+    the exporter's ezdxf internals aren't reachable (mirrors
+    ``set_dxf_metadata``).
+    """
+    doc = getattr(dxf, "_document", None)
+    msp = getattr(dxf, "_modelspace", None)
+    if doc is None or msp is None:
+        dxf.write(path)
+        return
+    try:
+        from ezdxf import zoom
+
+        zoom.window(msp, (0.0, 0.0), (page_w, page_h))
+    except Exception:
+        dxf.write(path)
+        return
+    doc.saveas(path, fmt="asc")
+
+
 def sanitize_svg_arcs(svg_path: str) -> int:
     """Rewrite near-degenerate elliptical arcs as straight line segments.
 

--- a/tests/test_export_dxf_zoom.py
+++ b/tests/test_export_dxf_zoom.py
@@ -1,0 +1,65 @@
+"""#602: DXF export sets the viewport from the known page window, not an entity walk.
+
+``ExportDXF.write`` ends with ``ezdxf.zoom.extents`` — a pure-Python bbox pass over
+every modelspace entity that re-flattens each spline (~2 s on the scattered-plate
+benchmark, half the DXF export cost). draftwright places everything in page-mm, so
+``export.write_dxf`` sets the same single-window viewport directly from
+``(0, 0)–(page_w, page_h)`` and saves. These tests guard:
+
+1. the perf property — no ``zoom.extents`` call on the export path (a regression
+   silently reintroduces the O(entities) walk);
+2. output integrity — the file still loads, keeps its layers and metadata, and the
+   active viewport is centred on the page;
+3. the best-effort fallback when the exporter hides its ezdxf internals.
+"""
+
+from __future__ import annotations
+
+import ezdxf
+import ezdxf.zoom
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.export import write_dxf
+
+
+@pytest.fixture(scope="module")
+def dwg():
+    return build_drawing(Box(60, 40, 20) - Pos(10, 5, 0) * Cylinder(4, 20))
+
+
+def test_dxf_export_skips_entity_walk_zoom(dwg, tmp_path, monkeypatch):
+    def _no_walk(*args, **kwargs):
+        raise AssertionError("zoom.extents (O(entities) walk) called on the DXF export path")
+
+    monkeypatch.setattr(ezdxf.zoom, "extents", _no_walk)
+    path = dwg._write_dxf(str(tmp_path / "plate"))
+    doc = ezdxf.readfile(path)
+    assert len(list(doc.modelspace())) > 0
+
+
+def test_dxf_viewport_centred_on_page(dwg, tmp_path):
+    path = dwg._write_dxf(str(tmp_path / "plate"))
+    doc = ezdxf.readfile(path)
+    # write_dxf zooms to the page window → the active vport centre is the page centre.
+    (vport,) = doc.viewports.get("*Active")
+    cx, cy = vport.dxf.center.x, vport.dxf.center.y
+    assert cx == pytest.approx(dwg.page_w / 2)
+    assert cy == pytest.approx(dwg.page_h / 2)
+    # Layers and the set_dxf_metadata stamp survive the direct saveas.
+    assert {"part", "dims"} <= {layer.dxf.name for layer in doc.layers}
+    assert doc.header.custom_vars.get("GeneratedBy") == "draftwright"
+
+
+def test_write_dxf_falls_back_without_ezdxf_internals(tmp_path):
+    class Opaque:
+        def __init__(self):
+            self.wrote = None
+
+        def write(self, path):
+            self.wrote = path
+
+    exp = Opaque()
+    write_dxf(exp, str(tmp_path / "o.dxf"), 210.0, 297.0)
+    assert exp.wrote == str(tmp_path / "o.dxf")


### PR DESCRIPTION
Part of #602 (queue item: export cost). Follows #678/#679.

## What

`ExportDXF.write` hardcodes `ezdxf.zoom.extents` — a pure-Python bbox pass over every modelspace entity that re-flattens each spline — solely to set the initial viewport (build123d#382 tracks exposing viewport control upstream). On the scattered-plate benchmark this pass costs **2.1–2.7 s** of the ~4.4 s DXF export.

draftwright places everything in page-mm coordinates `(0,0)–(page_w,page_h)`, so the new `export.write_dxf` sets the same single-window viewport via `ezdxf.zoom.window` (<1 ms) and saves directly. Internals access is best-effort (`_document`/`_modelspace`, mirroring the existing `set_dxf_metadata` pattern) with a fallback to plain `exporter.write`.

## Numbers

Paired within-process A/B (`_write_dxf`, scattered plate, alternating old/new — controls for the box's timing drift):

| rep | old | new |
|-----|-----|-----|
| 0 | 5.30 s | 3.16 s |
| 1 | 5.91 s | 3.60 s |
| 2 | 7.02 s | 4.29 s |

~2.2–2.7 s saved per DXF export (~40%). Remaining DXF cost is build123d's edge→ezdxf conversion (~3 s) — upstream.

## Behaviour change

The DXF's initial viewport now frames the page window instead of the entity extents (near-identical in practice — the title block spans the page). Entities, layers, and metadata are unchanged; goldens don't read DXF and placement is untouched.

## ADR fit

- **ADR 0004** — this is the footprint principle applied to export: use the known page-mm layout, never re-measure geometry (`zoom.extents` is exactly a geometry re-measure).
- **ADR 0005** — `write_dxf` lives in `export.py` (the export stage's home), beside `set_dxf_metadata` whose best-effort internals pattern it mirrors; `drawing.py` already imports downward from `export.py`, no layering change.
- No new dependency: `ezdxf` is imported lazily (guaranteed present via build123d) with a fallback.

## Gates

- Golden corpus **14/14 unchanged**
- New `tests/test_export_dxf_zoom.py`: no-entity-walk guard (monkeypatched `zoom.extents` raises), viewport-centred-on-page + layers/metadata integrity via `ezdxf.readfile`, fallback path
- Smoke 47 passed; targeted export tests 21 passed; ruff check / format / mypy (51 files) / codespell clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
