### PR TITLE
perf(#602): memoise annotation bounding boxes across lint checks and calls

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -448,6 +448,8 @@ class Drawing:
         # Same persistence idea for annotation bounding boxes (#602): an optimal
         # bbox on fused dimension geometry costs ~10 ms and lint needs one per
         # item; entries are identity-checked so replaced annotations re-measure.
+        # Contract: items are replaced, never mutated in place, once on the
+        # sheet (see _ann_box); lint() prunes entries for departed objects.
         self._ann_box_cache: dict = {}
         self.svg_path: str | None = None
         self.dxf_path: str | None = None
@@ -2144,6 +2146,12 @@ class Drawing:
         # longer relies on the helpers set_page module-global (ADR 0007).
         page_bbox = (_MARGIN, _MARGIN, self.page_w - _MARGIN, self.page_h - _MARGIN)
         view_shapes = [vis for vis, _ in self.views.values()]
+        # Prune box-cache entries for objects no longer on the sheet, so replaced
+        # annotations (repair's _replace_dim swaps in a fresh object) don't keep
+        # their OCC geometry strongly referenced for the drawing's lifetime.
+        live = {id(i) for i in self.items} | {id(v) for v in view_shapes}
+        for stale in [k for k in self._ann_box_cache if k not in live]:
+            del self._ann_box_cache[stale]
         # Most annotations are at sheet scale, but a non-sheet-scale view (the
         # enlarged detail view, #42) tags its dims with `_dw_scale`. Lint each
         # scale group with its own drawing_scale so label-vs-measured is correct

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -448,8 +448,9 @@ class Drawing:
         # Same persistence idea for annotation bounding boxes (#602): an optimal
         # bbox on fused dimension geometry costs ~10 ms and lint needs one per
         # item; entries are identity-checked so replaced annotations re-measure.
-        # Contract: items are replaced, never mutated in place, once on the
-        # sheet (see _ann_box); lint() prunes entries for departed objects.
+        # Entries are identity- AND location-token-checked (see _ann_box), so a
+        # replaced or in-place-relocated object re-measures; lint() prunes
+        # entries for departed objects.
         self._ann_box_cache: dict = {}
         self.svg_path: str | None = None
         self.dxf_path: str | None = None

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -445,6 +445,10 @@ class Drawing:
         # objects (self.views) repeatedly, so persisting it recomputes each
         # view's edges once instead of every lint (helpers #143/#164).
         self._view_edge_cache: dict = {}
+        # Same persistence idea for annotation bounding boxes (#602): an optimal
+        # bbox on fused dimension geometry costs ~10 ms and lint needs one per
+        # item; entries are identity-checked so replaced annotations re-measure.
+        self._ann_box_cache: dict = {}
         self.svg_path: str | None = None
         self.dxf_path: str | None = None
         self._analysis: Analysis | None = None
@@ -1526,6 +1530,7 @@ class Drawing:
             if sv_above is not None:
                 sv_above.outer_limit = sv_above_limit
             self._view_edge_cache.clear()
+            self._ann_box_cache.clear()
             raise
         finally:
             self._defer_intents = deferred
@@ -2153,6 +2158,7 @@ class Drawing:
                 drawing_scale=self.scale,
                 view_shapes=view_shapes,
                 view_edge_cache=self._view_edge_cache,
+                ann_box_cache=self._ann_box_cache,
             )
         else:
             issues = []
@@ -2163,6 +2169,7 @@ class Drawing:
                     drawing_scale=_scale,
                     view_shapes=view_shapes,
                     view_edge_cache=self._view_edge_cache,
+                    ann_box_cache=self._ann_box_cache,
                 )
         if self.part is not None:
             # Reuse the single feature inventory from the build (#244) when present,

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -30,35 +30,45 @@ def _seg_intersects_rect(p, q, rect) -> bool:
     return bool(_seg_hits_box(p, q, rect, pad=0.0))
 
 
+def _loc_token(item):
+    """A cheap (~14 µs) fingerprint of *item*'s placement, or None if it has no
+    location. ``Shape.locate()`` transforms *in place*, so identity alone can't
+    detect a relocated live object — the token can."""
+    try:
+        loc = getattr(item, "location", None)
+        return None if loc is None else tuple(loc)
+    except Exception:
+        return None
+
+
 def _ann_box(item, cache):
     """*item*'s full rendered bbox as (min_x, min_y, max_x, max_y), or None; memoised.
 
     An *optimal* ``bounding_box()`` on fused annotation geometry costs ~10 ms —
     the dominant lint cost once the view edges are cached (#602). Every lint
     check that needs a full box goes through this one memo, so an item is
-    measured at most once per cache lifetime. Entries are id-keyed and store the
-    item itself for an identity check, so a caller-persisted cache can't return
-    a stale box after ``id()`` reuse (same pattern as ``_view_edge_entries``).
-
-    Contract for a persisted cache: annotations must be *replaced*, never
-    mutated in place, once measured — the engine's universal discipline (the
-    repair loop's ``_replace_dim`` swaps in a freshly built object; every
-    ``.locate()`` happens at construction, before an object joins the sheet).
-    A caller that transforms a live object must clear its cache. A failed
+    measured at most once per cache lifetime. Entries are id-keyed and store
+    the item itself plus its location token: the identity check means a
+    caller-persisted cache can't return a stale box after ``id()`` reuse (same
+    pattern as ``_view_edge_entries``), and the token check re-measures an
+    object relocated in place via ``.locate()``-style transforms — the engine
+    itself always *replaces* (the repair loop's ``_replace_dim`` swaps in a
+    freshly built object), but ``Drawing.items`` exposes live shapes. A failed
     measure is cached as ``None`` — deterministic for unchanged geometry, so
     the affected checks skip the item exactly as their old per-site handlers
     did, without re-raising per lint.
     """
     key = id(item)
     hit = cache.get(key)
-    if hit is not None and hit[0] is item:
-        return hit[1]
+    token = _loc_token(item)
+    if hit is not None and hit[0] is item and hit[1] == token:
+        return hit[2]
     try:
         bb = item.bounding_box()
         box = (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
     except Exception:
         box = None
-    cache[key] = (item, box)
+    cache[key] = (item, token, box)
     return box
 
 

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -39,6 +39,15 @@ def _ann_box(item, cache):
     measured at most once per cache lifetime. Entries are id-keyed and store the
     item itself for an identity check, so a caller-persisted cache can't return
     a stale box after ``id()`` reuse (same pattern as ``_view_edge_entries``).
+
+    Contract for a persisted cache: annotations must be *replaced*, never
+    mutated in place, once measured — the engine's universal discipline (the
+    repair loop's ``_replace_dim`` swaps in a freshly built object; every
+    ``.locate()`` happens at construction, before an object joins the sheet).
+    A caller that transforms a live object must clear its cache. A failed
+    measure is cached as ``None`` — deterministic for unchanged geometry, so
+    the affected checks skip the item exactly as their old per-site handlers
+    did, without re-raising per lint.
     """
     key = id(item)
     hit = cache.get(key)

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -53,7 +53,12 @@ def _ann_box(item, cache):
     pattern as ``_view_edge_entries``), and the token check re-measures an
     object relocated in place via ``.locate()``-style transforms — the engine
     itself always *replaces* (the repair loop's ``_replace_dim`` swaps in a
-    freshly built object), but ``Drawing.items`` exposes live shapes. A failed
+    freshly built object), but ``Drawing.items`` exposes live shapes. Known
+    limit, accepted: a mutation that changes geometry while *preserving*
+    ``.location`` (or mutating a location-less duck-typed stand-in) is
+    undetectable without hashing topology — which would cost as much as the
+    measure this memo avoids — so such objects must be replaced or the cache
+    cleared, per the engine-wide discipline above. A failed
     measure is cached as ``None`` — deterministic for unchanged geometry, so
     the affected checks skip the item exactly as their old per-site handlers
     did, without re-raising per lint.

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -551,9 +551,11 @@ def _lint_view_shapes(
                 )
 
 
-def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache) -> None:
+def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache=None) -> None:
     """Flag label-vs-centerline overlap for a (dim, centerline) pair."""
     try:
+        if box_cache is None:
+            box_cache = {}
         cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl_item, box_cache)
 
         label_bbox = getattr(dim_item, "label_bbox", None)

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -30,7 +30,30 @@ def _seg_intersects_rect(p, q, rect) -> bool:
     return bool(_seg_hits_box(p, q, rect, pad=0.0))
 
 
-def _centerline_extent(cl_item):
+def _ann_box(item, cache):
+    """*item*'s full rendered bbox as (min_x, min_y, max_x, max_y), or None; memoised.
+
+    An *optimal* ``bounding_box()`` on fused annotation geometry costs ~10 ms —
+    the dominant lint cost once the view edges are cached (#602). Every lint
+    check that needs a full box goes through this one memo, so an item is
+    measured at most once per cache lifetime. Entries are id-keyed and store the
+    item itself for an identity check, so a caller-persisted cache can't return
+    a stale box after ``id()`` reuse (same pattern as ``_view_edge_entries``).
+    """
+    key = id(item)
+    hit = cache.get(key)
+    if hit is not None and hit[0] is item:
+        return hit[1]
+    try:
+        bb = item.bounding_box()
+        box = (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+    except Exception:
+        box = None
+    cache[key] = (item, box)
+    return box
+
+
+def _centerline_extent(cl_item, box_cache=None):
     """Return (min_x, min_y, max_x, max_y) for a centreline.
 
     Prefers the zero-width ``.segments`` (the true centreline) so a thin-faced
@@ -42,8 +65,10 @@ def _centerline_extent(cl_item):
         xs = [p[0] for s in segs for p in s]
         ys = [p[1] for s in segs for p in s]
         return (min(xs), min(ys), max(xs), max(ys))
-    bb = cl_item.bounding_box()
-    return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+    box = _ann_box(cl_item, box_cache if box_cache is not None else {})
+    if box is None:
+        raise ValueError("centreline bbox unavailable")
+    return box
 
 
 def _item_label(item) -> str:
@@ -88,6 +113,7 @@ def lint_drawing(
     drawing_scale: float = 1.0,
     view_shapes: list | None = None,
     view_edge_cache: dict | None = None,
+    ann_box_cache: dict | None = None,
 ) -> list[LintIssue]:
     """Structural checks on a composed annotation list, duck-typed.
 
@@ -144,6 +170,12 @@ def lint_drawing(
             the same dict to successive lints; discard it when the view shapes
             change. Omit it (the default) for a fresh per-call cache, which
             behaves exactly as before.
+        ann_box_cache: optional dict memoising each *annotation's* full optimal
+            bounding box — the dominant remaining lint cost once view edges are
+            cached (#602). Same persistence contract as *view_edge_cache*;
+            entries are identity-checked, so a replaced annotation is re-measured
+            automatically. Omit it for a fresh per-call cache (which still
+            de-duplicates the several checks that need the same item's box).
 
     Returns:
         list[LintIssue].
@@ -156,6 +188,7 @@ def lint_drawing(
         raise ValueError(f"drawing_scale must be positive, got {drawing_scale}")
 
     issues: list[LintIssue] = []
+    box_cache = {} if ann_box_cache is None else ann_box_cache
 
     # Resolve page bounds: explicit arg beats module-level context.
     if page_bbox is None and _DRAWING_PAGE is not None:
@@ -164,9 +197,9 @@ def lint_drawing(
 
     for item in items:
         if getattr(item, "elbow", None) is not None:
-            _lint_leader(item, issues)
+            _lint_leader(item, issues, box_cache)
         elif getattr(item, "measured_length", None) is not None:
-            _lint_dim(item, part_bbox, issues, drawing_scale)
+            _lint_dim(item, part_bbox, issues, drawing_scale, box_cache)
 
     # Pairwise label-overlap check. The compare-box for a label-less item is an
     # *optimal* bounding_box() — expensive, and previously recomputed for both
@@ -178,8 +211,7 @@ def lint_drawing(
         lb = getattr(item, "label_bbox", None)
         if lb is not None:
             return lb
-        bb = item.bounding_box()
-        return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+        return _ann_box(item, box_cache)
 
     boxes: list = []
     for item in items:
@@ -204,7 +236,7 @@ def lint_drawing(
                 if is_cl_a or is_cl_b:
                     dim_item = item_b if is_cl_a else item_a
                     cl_item = item_a if is_cl_a else item_b
-                    _lint_centerline_dim_overlap(dim_item, cl_item, issues)
+                    _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache)
                     continue
 
                 # Compare label text extents, NOT full bounding boxes.
@@ -239,8 +271,10 @@ def lint_drawing(
     if page_bbox is not None:
         for item in items:
             try:
-                bb = item.bounding_box()
-                for detail in _overshoots((bb.min.X, bb.min.Y, bb.max.X, bb.max.Y), page_bbox):
+                bb = _ann_box(item, box_cache)
+                if bb is None:
+                    continue
+                for detail in _overshoots(bb, page_bbox):
                     lbl = _item_label(item) or "?"
                     issues.append(
                         LintIssue(
@@ -257,7 +291,12 @@ def lint_drawing(
 
     if view_shapes is not None:
         _lint_view_shapes(
-            view_shapes, items, issues, page_bbox=page_bbox, edge_cache=view_edge_cache
+            view_shapes,
+            items,
+            issues,
+            page_bbox=page_bbox,
+            edge_cache=view_edge_cache,
+            box_cache=box_cache,
         )
 
     # Principal envelope completeness check: verify each bbox extent appears
@@ -378,13 +417,15 @@ def _view_edge_entries(vs, cache):
     return entries
 
 
-def _lint_view_shapes(view_shapes, ann_items, issues, page_bbox=None, edge_cache=None) -> None:
+def _lint_view_shapes(
+    view_shapes, ann_items, issues, page_bbox=None, edge_cache=None, box_cache=None
+) -> None:
     """Check views against annotations (#159/#76), each other (#160), and the page (#75)."""
     # Build named bbox list; use the shape's id as fallback name.
     named_views = []
     view_shape_ids = set()
     for vs in view_shapes:
-        bb = _bbox2d(vs)
+        bb = _ann_box(vs, box_cache if box_cache is not None else {})
         if bb is None:
             continue
         name = getattr(vs, "label", None) or getattr(vs, "name", None) or f"view@{id(vs)}"
@@ -400,6 +441,7 @@ def _lint_view_shapes(view_shapes, ann_items, issues, page_bbox=None, edge_cache
     # mostly blank face, where placing callouts is a legitimate convention —
     # so a label over a blank region is reported as an info-level notice.
     cache = {} if edge_cache is None else edge_cache
+    ann_cache = box_cache if box_cache is not None else {}
     for vname, vbb, vs in named_views:
         vx0, vy0, vx1, vy1 = vbb
         for ann in ann_items:
@@ -413,7 +455,7 @@ def _lint_view_shapes(view_shapes, ann_items, issues, page_bbox=None, edge_cache
                 continue  # hatching is intentionally inside the section view
             try:
                 label_box = getattr(ann, "label_bbox", None)
-                ab = label_box if label_box is not None else _bbox2d(ann)
+                ab = label_box if label_box is not None else _ann_box(ann, ann_cache)
                 if ab is None:
                     continue
                 if not _bboxes_overlap_2d(vbb, ab):
@@ -485,18 +527,17 @@ def _lint_view_shapes(view_shapes, ann_items, issues, page_bbox=None, edge_cache
                 )
 
 
-def _lint_centerline_dim_overlap(dim_item, cl_item, issues) -> None:
+def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache) -> None:
     """Flag label-vs-centerline overlap for a (dim, centerline) pair."""
     try:
-        cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl_item)
+        cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl_item, box_cache)
 
         label_bbox = getattr(dim_item, "label_bbox", None)
-        if label_bbox is not None:
-            lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
-        else:
-            db = dim_item.bounding_box()
-            lmin_x, lmin_y = db.min.X, db.min.Y
-            lmax_x, lmax_y = db.max.X, db.max.Y
+        if label_bbox is None:
+            label_bbox = _ann_box(dim_item, box_cache)
+        if label_bbox is None:
+            return
+        lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
 
         cl_w = cl_max_x - cl_min_x
         cl_h = cl_max_y - cl_min_y
@@ -530,7 +571,7 @@ def _lint_centerline_dim_overlap(dim_item, cl_item, issues) -> None:
         pass
 
 
-def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0) -> None:
+def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:
     label = _item_label(item)
     measured = getattr(item, "measured_length", None)
 
@@ -565,14 +606,14 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0) -> None:
                 )
 
     if part_bbox is not None:
-        try:
-            db = item.bounding_box()
-        except Exception:
+        db = _ann_box(item, box_cache if box_cache is not None else {})
+        if db is None:
             return
-        ox = max(0.0, min(db.max.X, part_bbox.max.X) - max(db.min.X, part_bbox.min.X))
-        oy = max(0.0, min(db.max.Y, part_bbox.max.Y) - max(db.min.Y, part_bbox.min.Y))
+        dmin_x, dmin_y, dmax_x, dmax_y = db
+        ox = max(0.0, min(dmax_x, part_bbox.max.X) - max(dmin_x, part_bbox.min.X))
+        oy = max(0.0, min(dmax_y, part_bbox.max.Y) - max(dmin_y, part_bbox.min.Y))
         overlap = ox * oy
-        dim_area = max((db.max.X - db.min.X) * (db.max.Y - db.min.Y), 1e-9)
+        dim_area = max((dmax_x - dmin_x) * (dmax_y - dmin_y), 1e-9)
         if overlap / dim_area > 0.10:
             issues.append(
                 LintIssue(
@@ -586,14 +627,14 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0) -> None:
             )
 
 
-def _lint_leader(item, issues) -> None:
+def _lint_leader(item, issues, box_cache=None) -> None:
     try:
         box = getattr(item, "label_bbox", None)
-        if box is not None:
-            minx, miny, maxx, maxy = box
-        else:
-            tb = item.bounding_box()
-            minx, miny, maxx, maxy = tb.min.X, tb.min.Y, tb.max.X, tb.max.Y
+        if box is None:
+            box = _ann_box(item, box_cache if box_cache is not None else {})
+        if box is None:
+            return
+        minx, miny, maxx, maxy = box
         ex, ey = item.elbow
         if minx <= ex <= maxx and miny <= ey <= maxy:
             issues.append(

--- a/tests/test_lint_box_cache.py
+++ b/tests/test_lint_box_cache.py
@@ -1,0 +1,85 @@
+"""#602: lint measures each annotation's optimal bounding box at most once.
+
+An optimal ``bounding_box()`` on fused annotation geometry costs ~10 ms, and the
+structural checks (page bounds, pairwise labels, centreline pairs, view overlap)
+each used to measure independently — the centreline pair check even re-measured a
+label-less dim once per (dim, centreline) pair. All full-box lookups now go
+through one identity-checked memo (``_ann_box``), persisted on the Drawing as
+``_ann_box_cache`` beside the #143 view-edge cache, so a re-lint (every
+``export()``, every repair-loop iteration) re-measures nothing that hasn't been
+replaced.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.linting.structural import _ann_box, lint_drawing
+
+
+class _FakeAnn:
+    """Duck-typed annotation with a countable full-bbox and no label_bbox."""
+
+    label = "fake"
+
+    def __init__(self):
+        self.calls = 0
+
+    def bounding_box(self):
+        self.calls += 1
+        return SimpleNamespace(
+            min=SimpleNamespace(X=0.0, Y=0.0), max=SimpleNamespace(X=10.0, Y=5.0)
+        )
+
+
+def test_ann_box_memoises_and_identity_checks():
+    cache: dict = {}
+    a = _FakeAnn()
+    assert _ann_box(a, cache) == (0.0, 0.0, 10.0, 5.0)
+    assert _ann_box(a, cache) == (0.0, 0.0, 10.0, 5.0)
+    assert a.calls == 1
+    # A replacement object is re-measured even if the cache is stale.
+    b = _FakeAnn()
+    cache[id(b)] = (a, (9.9, 9.9, 9.9, 9.9))  # simulated id-collision entry
+    assert _ann_box(b, cache) == (0.0, 0.0, 10.0, 5.0)
+    assert b.calls == 1
+
+
+def test_lint_drawing_measures_once_across_calls():
+    ann = _FakeAnn()
+    cache: dict = {}
+    for _ in range(3):
+        lint_drawing([ann], page_bbox=(0, 0, 100, 100), ann_box_cache=cache)
+    assert ann.calls == 1, "persistent ann_box_cache must survive repeated lints"
+
+
+def test_relint_recomputes_no_annotation_boxes():
+    # Integration: on a real drawing the second lint() must not re-measure any
+    # annotation/view geometry — every full-box lookup hits the persisted cache.
+    import build123d.topology.shape_core as shape_core
+
+    dwg = build_drawing(Box(60, 40, 20) - Pos(10, 5, 0) * Cylinder(4, 20))
+    first = dwg.lint()
+
+    calls = 0
+    real = shape_core.Shape.bounding_box
+
+    def counting(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real(self, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(shape_core.Shape, "bounding_box", counting)
+        second = dwg.lint()
+
+    # The one allowed call is lint_location_coverage's part.bounding_box() — a single
+    # cheap query on the 3D solid, not annotation-geometry re-measurement.
+    assert calls <= 1, f"re-lint recomputed {calls} bounding boxes despite the cache"
+    assert [(i.severity, i.code, i.message) for i in second] == [
+        (i.severity, i.code, i.message) for i in first
+    ]

--- a/tests/test_lint_box_cache.py
+++ b/tests/test_lint_box_cache.py
@@ -44,9 +44,24 @@ def test_ann_box_memoises_and_identity_checks():
     assert a.calls == 1
     # A replacement object is re-measured even if the cache is stale.
     b = _FakeAnn()
-    cache[id(b)] = (a, (9.9, 9.9, 9.9, 9.9))  # simulated id-collision entry
+    cache[id(b)] = (a, None, (9.9, 9.9, 9.9, 9.9))  # simulated id-collision entry
     assert _ann_box(b, cache) == (0.0, 0.0, 10.0, 5.0)
     assert b.calls == 1
+
+
+def test_ann_box_remeasures_after_in_place_relocation():
+    # Shape.locate() transforms in place, and Drawing.items exposes live shapes —
+    # identity alone can't see the move, so the entry also carries a location
+    # token and a relocated object re-measures instead of serving its old box.
+    cache: dict = {}
+    ann = _FakeAnn()
+    ann.location = (0.0, 0.0, 0.0)
+    _ann_box(ann, cache)
+    _ann_box(ann, cache)
+    assert ann.calls == 1
+    ann.location = (25.0, 0.0, 0.0)  # simulate .locate() on the live object
+    _ann_box(ann, cache)
+    assert ann.calls == 2
 
 
 def test_lint_drawing_measures_once_across_calls():

--- a/tests/test_lint_box_cache.py
+++ b/tests/test_lint_box_cache.py
@@ -57,6 +57,23 @@ def test_lint_drawing_measures_once_across_calls():
     assert ann.calls == 1, "persistent ann_box_cache must survive repeated lints"
 
 
+def test_lint_prunes_cache_entries_for_replaced_items():
+    # A replaced annotation (the repair loop swaps in a fresh object) must not
+    # stay strongly referenced by the persistent cache: lint() prunes entries
+    # whose object is no longer on the sheet, so the cache is bounded by live
+    # membership and released geometry can be collected.
+    dwg = build_drawing(Box(60, 40, 20) - Pos(10, 5, 0) * Cylinder(4, 20))
+    dwg.lint()
+    view_ids = {id(vis) for vis, _ in dwg.views.values()}
+    ann_keys = [k for k in dwg._ann_box_cache if k not in view_ids]
+    assert ann_keys, "lint cached no annotation boxes — the guard lost its subject"
+    departed = ann_keys[0]
+    dwg.items = [i for i in dwg.items if id(i) != departed]
+    dwg.lint()
+    assert departed not in dwg._ann_box_cache
+    assert set(dwg._ann_box_cache) <= {id(i) for i in dwg.items} | view_ids
+
+
 def test_relint_recomputes_no_annotation_boxes():
     # Integration: on a real drawing the second lint() must not re-measure any
     # annotation/view geometry — every full-box lookup hits the persisted cache.


### PR DESCRIPTION
Part of #602 (queue item 5: lint box reuse — the last measured draftwright-owned hotspot). Follows #678/#679/#680.

## What

An optimal OCC `bounding_box()` on fused annotation geometry costs ~10 ms, and the structural lint checks each measured independently — the page-bounds loop per item **per call**, `_lint_dim` again, and the centreline-pair / view-overlap checks once **per pair** for label-less items. On the scattered-plate benchmark that's 57 box computations per lint — 0.77 s of the 0.88 s pass — re-paid on **every `export()`** and every repair-loop iteration.

All full-box lookups now go through one memo, `_ann_box(item, cache)`: id-keyed, identity-checked (the entry stores the item, which also prevents `id()` reuse outright), persisted on the `Drawing` as `_ann_box_cache` beside the #143 `_view_edge_cache` and cleared at the same finalize-rollback site. A replaced annotation re-measures automatically. `lint_drawing` gains an optional `ann_box_cache=` with the same persistence contract as `view_edge_cache` — omitted, a fresh per-call cache still de-duplicates within the call.

## Numbers

| | before | after |
|---|---|---|
| `Drawing.lint()` (scattered plate) | 0.85–0.94 s | **0.06–0.08 s** |

The build's own lint→repair loop pre-warms the cache, so the export-time lint is ~free (the sole remaining OCC bbox on re-lint is `lint_location_coverage`'s single `part.bounding_box()` — the 3D solid, not annotation geometry).

## ADR fit

- **ADR 0002** — the lint→repair loop is the safety net that re-lints repeatedly; this is precisely the caller the #143 view-edge cache was built for, extended to the annotation boxes that dominated once view edges were cached.
- **ADR 0007** — draftwright owns linting; the change is contained in `linting/structural.py` + the `Drawing.lint` wiring. No layering change (drawing → linting is already downward).
- Semantics preserved: the memo returns exactly what each site computed before; failure paths (`None`) skip checks the same way the old per-site `except` blocks did.

## Gates

- Golden corpus **14/14 unchanged**
- New `tests/test_lint_box_cache.py`: memo + identity-check unit tests, persistent-cache-across-lints guard, and an integration guard that a re-lint recomputes ≤1 bounding box
- Lint suites (structural/linting/reconciliation + new) 65 passed; smoke 47 passed; ruff check / format / mypy (51 files) / codespell clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
