### PR TITLE
chore: bump version to 0.3.3.dev0 after release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.3.2.dev0"
+version = "0.3.3.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.3.2.dev0"
+version = "0.3.3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
Post-v0.3.2 dev version bump (the v0.3.1→0.3.2.dev0 pattern, eeb6c3e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)