### PR TITLE
feat(#690): shift a label clear of a foreign crossing witness

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -72,6 +72,7 @@ from draftwright.model import (
     plan_dimensions,
     plan_sections,
 )
+from draftwright.repair import reconcile_witness_labels
 
 
 def _wrap_rows(header, data, ncols):
@@ -356,6 +357,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (ADR 0009 end state, #345/#346/#393) — dedup coincident spans, order the ladder —
     # BEFORE the section/detail views so they see the placed ladder as an obstacle.
     drain_corridors(ctx, dwg)
+    # (#690) Witness-crossing label reconciliation — after every corridor (and its
+    # deferred fallthroughs) has placed: shift any dim label a FOREIGN transverse
+    # stroke crosses, along its own line, via the repair machinery. Deterministic,
+    # runs in both build paths.
+    reconcile_witness_labels(dwg)
 
     # Turned/circlip-groove callouts (#148c): {width} WIDE × ø{dia} via a leader off each
     # groove. A groove is a secondary leader-callout on a turned shaft — exactly where the

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1560,6 +1560,7 @@ class Drawing:
             feature_hole_keys,
         )
         from draftwright.model import PartModel, plan_dimensions
+        from draftwright.repair import reconcile_witness_labels
 
         _section = r.section
         corridor_ids, callout_ids, dia_ids = r.corridor_ids, r.callout_ids, r.dia_ids
@@ -1652,6 +1653,8 @@ class Drawing:
                     if self._queue_dimension_intent(it, a, ctx=ctx, used_names=used_dim_names):
                         queued_dim_ids.add(id(it))
             drain_corridors(ctx, self)
+            # (#690) Same witness-crossing label reconciliation as the auto-pass drain.
+            reconcile_witness_labels(self)
         self._intents = [
             it
             for it in self._intents

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -128,10 +128,13 @@ def reconcile_witness_labels(dwg) -> int:
         return segs
 
     pad = 1.0  # keep-clear each side of a crossing stroke
+    pinned_ids = dwg._registry.pinned_object_ids()  # a pin is deliberate — never moved (#693 r1)
     dims = [
         (name, o)
         for name, o in dwg.iter_annotations()
-        if getattr(o, "_dw_spec", None) is not None and getattr(o, "label_bbox", None) is not None
+        if getattr(o, "_dw_spec", None) is not None
+        and getattr(o, "label_bbox", None) is not None
+        and id(o) not in pinned_ids
     ]
     shifted = 0
     for name, dim in dims:
@@ -143,29 +146,31 @@ def reconcile_witness_labels(dwg) -> int:
         span_lo, span_hi = sorted((s.p1[ax], s.p2[ax]))
         mid = (lb[ax] + lb[ax + 2]) / 2.0
         half = (lb[ax + 2] - lb[ax]) / 2.0
+        # Threats = EVERY axis-aligned transverse stroke whose fixed-axis extent
+        # reaches the label's band, across the WHOLE span — not just those crossing
+        # the label's current position (#693 r1: a shift must not land ON another
+        # witness further along the line). Diagonal strokes (leader shafts) are
+        # skipped: a single travel coordinate does not describe them, and moving a
+        # label off an AABB-midpoint guess produced false positives; they were
+        # never this pass's target class.
+        oth = 1 - ax
         threats = []
         for other, oo in dwg.iter_annotations():
             if other == name:
                 continue
             for seg in getattr(oo, "segments", None) or ():
                 (x0, y0), (x1, y1) = seg
-                sdx, sdy = x1 - x0, y1 - y0
-                # transverse to the label line only (parallel = stacked shafts, exempt)
-                if (abs(sdy) > abs(sdx)) == vertical:
+                sdx, sdy = abs(x1 - x0), abs(y1 - y0)
+                if min(sdx, sdy) > 0.1:  # diagonal — skip (see above)
                     continue
+                if (sdy > sdx) == vertical:
+                    continue  # parallel = stacked shafts, exempt
                 sb = (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
-                # A drawn stroke is a zero-thickness line: crossing = its constant
-                # coordinate strictly inside the label band on the label's travel
-                # axis, plus real overlap on the other axis (>0.5 mm, the lint
-                # threshold). An AABB two-axis test can never fire on a line box.
-                oth = 1 - ax
-                t = (sb[ax] + sb[ax + 2]) / 2.0
-                if (
-                    lb[ax] + 0.3 < t < lb[ax + 2] - 0.3
-                    and min(sb[oth + 2], lb[oth + 2]) - max(sb[oth], lb[oth]) > 0.5
-                ):
-                    threats.append(t)
-        if not threats:
+                if min(sb[oth + 2], lb[oth + 2]) - max(sb[oth], lb[oth]) > 0.5:
+                    threats.append((sb[ax] + sb[ax + 2]) / 2.0)
+        # Shift only a label that is CURRENTLY crossed; but block every threat as a
+        # destination, so the chosen spot cannot trade one crossing for another.
+        if not any(lb[ax] + 0.3 < t < lb[ax + 2] - 0.3 for t in threats):
             continue
         segs = _free_segments(
             span_lo, span_hi, [(t - pad - half, t + pad + half) for t in threats]

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -89,3 +89,99 @@ def repair_drawing(dwg, max_iter: int = 3):
             dwg._registry.restore(snap_registry)
             break
     return dwg
+
+
+def reconcile_witness_labels(dwg) -> int:
+    """Shift a dimension's label along its own line when ANOTHER dimension's
+    stroke crosses it (#690) — the perpendicular-axis conflict class tier
+    co-solving cannot fix (a location dim's witness must cross the whole strip
+    to reach its tier; any inner label at that height gets crossed wherever
+    the tiers land — the dshape ``dim_height`` case).
+
+    Runs as a deterministic late pipeline pass (both build paths call it after
+    every corridor has drained), using the repair machinery: offenders rebuild
+    once via :func:`_replace_dim` with the minimal clearing ``label_offset_x``.
+    Detection mirrors the cleanliness ratchet's decomposed model (#685): a
+    foreign drawn stroke (helpers ``.segments``) TRANSVERSE to the label's own
+    dim line, crossing its ``label_bbox`` by >0.5 mm on both axes. Parallel
+    strokes are the legitimate stacked-shaft pattern and never count. The shift
+    is clamped to the dimension's own span (a label pushed past its witness
+    ends reads as the neighbour's); an unshiftable label is left where it is —
+    unchanged output, and lint reports it exactly as before. Returns the count
+    shifted."""
+
+    def _free_segments(lo, hi, blocked):
+        # Local minimal interval-subtraction (repair sits below annotations/ in the
+        # DAG, so it cannot import the corridor carve; ~the same ten lines).
+        segs = [(lo, hi)]
+        for b_lo, b_hi in sorted(blocked):
+            nxt = []
+            for s_lo, s_hi in segs:
+                if b_hi <= s_lo or b_lo >= s_hi:
+                    nxt.append((s_lo, s_hi))
+                    continue
+                if b_lo > s_lo:
+                    nxt.append((s_lo, b_lo))
+                if b_hi < s_hi:
+                    nxt.append((b_hi, s_hi))
+            segs = nxt
+        return segs
+
+    pad = 1.0  # keep-clear each side of a crossing stroke
+    dims = [
+        (name, o)
+        for name, o in dwg.iter_annotations()
+        if getattr(o, "_dw_spec", None) is not None and getattr(o, "label_bbox", None) is not None
+    ]
+    shifted = 0
+    for name, dim in dims:
+        s = dim._dw_spec
+        lb = dim.label_bbox
+        dx, dy = s.p2[0] - s.p1[0], s.p2[1] - s.p1[1]
+        vertical = abs(dy) > abs(dx)  # the label travels along the dim line
+        ax = 1 if vertical else 0  # page axis the label moves along
+        span_lo, span_hi = sorted((s.p1[ax], s.p2[ax]))
+        mid = (lb[ax] + lb[ax + 2]) / 2.0
+        half = (lb[ax + 2] - lb[ax]) / 2.0
+        threats = []
+        for other, oo in dwg.iter_annotations():
+            if other == name:
+                continue
+            for seg in getattr(oo, "segments", None) or ():
+                (x0, y0), (x1, y1) = seg
+                sdx, sdy = x1 - x0, y1 - y0
+                # transverse to the label line only (parallel = stacked shafts, exempt)
+                if (abs(sdy) > abs(sdx)) == vertical:
+                    continue
+                sb = (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
+                # A drawn stroke is a zero-thickness line: crossing = its constant
+                # coordinate strictly inside the label band on the label's travel
+                # axis, plus real overlap on the other axis (>0.5 mm, the lint
+                # threshold). An AABB two-axis test can never fire on a line box.
+                oth = 1 - ax
+                t = (sb[ax] + sb[ax + 2]) / 2.0
+                if (
+                    lb[ax] + 0.3 < t < lb[ax + 2] - 0.3
+                    and min(sb[oth + 2], lb[oth + 2]) - max(sb[oth], lb[oth]) > 0.5
+                ):
+                    threats.append(t)
+        if not threats:
+            continue
+        segs = _free_segments(
+            span_lo, span_hi, [(t - pad - half, t + pad + half) for t in threats]
+        )
+        best = None
+        for g_lo, g_hi in segs:
+            if g_hi - g_lo < 2 * half:
+                continue
+            c = min(max(mid, g_lo + half), g_hi - half)
+            if best is None or abs(c - mid) < abs(best - mid):
+                best = c
+        if best is None or abs(best - mid) <= 0.05:
+            continue
+        off = best - mid
+        kwargs = dict(s.kwargs)
+        kwargs["label_offset_x"] = kwargs.get("label_offset_x", 0.0) + off
+        _replace_dim(dwg, dim, _dim(s.p1, s.p2, s.side, s.distance, s.draft, **kwargs))
+        shifted += 1
+    return shifted

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -141,6 +141,12 @@ def reconcile_witness_labels(dwg) -> int:
         s = dim._dw_spec
         lb = dim.label_bbox
         dx, dy = s.p2[0] - s.p1[0], s.p2[1] - s.p1[1]
+        if min(abs(dx), abs(dy)) > 0.1:
+            # A diagonal dim's label_offset_x moves BOTH page coordinates — the
+            # axis-aligned solve below cannot describe it (#693 r2). Skip, same
+            # tolerance as the stroke rule; the diagonal pitch fallback already
+            # places with its own clearance search.
+            continue
         vertical = abs(dy) > abs(dx)  # the label travels along the dim line
         ax = 1 if vertical else 0  # page axis the label moves along
         span_lo, span_hi = sorted((s.p1[ax], s.p2[ax]))

--- a/tests/test_layout_cleanliness.py
+++ b/tests/test_layout_cleanliness.py
@@ -71,12 +71,11 @@ _KNOWN_OVERLAPS: dict[str, set[frozenset[str]]] = {
     #  - POLICY-B ARROW CROSSINGS (bracket): hc_plan0's wide label straddles the
     #    thin section arrow on the plan centre row; hc_plan1's DIAGONAL shaft AABB
     #    clips the same arrow by <1 mm (the placer verifies the diagonal precisely).
-    # dshape's dim_height pair: the location dim's WITNESS must cross the whole
-    # right strip to reach its tier, and dim_height's label sits at a fixed height
-    # on that path — co-solving tiers (the #636 ladder migration) cannot separate a
-    # perpendicular-axis conflict. Remedy = label-offset shifting for witness
-    # crossings (the #129 centreline machinery generalised) — see the follow-up
-    # issue referenced in ADR 0009's migration note.
+    # dshape's dim_height pair, post-#690: the witness-through-label defect is
+    # FIXED (reconcile_witness_labels shifts the height label clear of the loc
+    # dim's crossing witness). The pair remains observed through their SHARED
+    # DATUM WITNESS (both anchor y=81, the common base edge) — the same BENIGN
+    # running-dimension corridor as plate_holes/holed_slot above.
     "bracket": {
         frozenset({"hc_plan0", "section_arrow_right"}),
         frozenset({"hc_plan1", "section_arrow_right"}),

--- a/tests/test_witness_label_reconciliation.py
+++ b/tests/test_witness_label_reconciliation.py
@@ -1,0 +1,56 @@
+"""#690: no dimension label is crossed by a FOREIGN transverse stroke after a build.
+
+The perpendicular-axis conflict class tier co-solving cannot fix: a location dim's
+witness must cross the whole strip to reach its tier, so any inner label at that
+height gets crossed wherever the tiers land. ``reconcile_witness_labels`` (repair.py)
+runs after every corridor drains and shifts the crossed label along its own dim line
+(the #129 remedy). The dshape fixture is the proven case: pre-#690 its height label
+sat directly on the z-location dim's witness.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from test_layout_cleanliness import CORPUS  # noqa: E402
+
+from draftwright import build_drawing  # noqa: E402
+from draftwright.repair import reconcile_witness_labels  # noqa: E402
+
+
+def _label_crossings(dwg):
+    hits = []
+    dims = [
+        (n, o)
+        for n, o in dwg.iter_annotations()
+        if getattr(o, "_dw_spec", None) is not None and getattr(o, "label_bbox", None) is not None
+    ]
+    for name, dim in dims:
+        s = dim._dw_spec
+        lb = dim.label_bbox
+        vertical = abs(s.p2[1] - s.p1[1]) > abs(s.p2[0] - s.p1[0])
+        ax = 1 if vertical else 0
+        oth = 1 - ax
+        for other, oo in dwg.iter_annotations():
+            if other == name:
+                continue
+            for (x0, y0), (x1, y1) in getattr(oo, "segments", None) or ():
+                if (abs(y1 - y0) > abs(x1 - x0)) == vertical:
+                    continue  # parallel: stacked shafts, not a crossing
+                sb = (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
+                t = (sb[ax] + sb[ax + 2]) / 2.0
+                if (
+                    lb[ax] + 0.3 < t < lb[ax + 2] - 0.3
+                    and min(sb[oth + 2], lb[oth + 2]) - max(sb[oth], lb[oth]) > 0.5
+                ):
+                    hits.append((name, other))
+    return hits
+
+
+def test_dshape_height_label_clears_the_location_witness():
+    dwg = build_drawing(CORPUS["dshape"]())
+    assert _label_crossings(dwg) == [], "a foreign transverse stroke crosses a dim label"
+    # Idempotent: nothing left to shift on a reconciled drawing.
+    assert reconcile_witness_labels(dwg) == 0


### PR DESCRIPTION
Closes #690. The perpendicular-axis conflict class tier co-solving cannot fix: a location dim's witness must cross the whole strip to reach its tier, so any inner-tier label at that height is crossed wherever the tiers land (the dshape `dim_height` case, PENDING since #685).

## What

`reconcile_witness_labels` (repair.py — the ADR 0002 machinery as a **deterministic late pipeline pass**, called by both build paths after every corridor drains and defers): for each spec-carrying dim whose label a **foreign transverse stroke** crosses — a zero-thickness-line test (constant coord strictly inside the label band + >0.5 mm overlap on the other axis; parallel strokes are the stacked-shaft pattern, exempt) — compute the minimal clearing `label_offset_x` along the dim's own line (interval carve over its span, clamped to it) and rebuild once via `_replace_dim`. Unshiftable labels stay put (unchanged output; lint reports as before).

Design note: an in-solve seam was prototyped and **dropped** — tracing showed the conflict pair is never co-solved (the dims arrive via different placement calls), so only a post-drain pass sees both; one mechanism at the right altitude.

## Results

- The dshape witness-through-label defect is **fixed** (label shifts ~2.4 mm clear; verified by the new regression test, which asserts the no-crossing property across the fixture and reconciliation idempotence).
- The dshape ratchet pair reclassifies honestly: what remains is the **shared-datum witness** (both dims anchor the same base edge — the BENIGN running-dimension corridor, same as plate_holes).
- Goldens **unchanged** (no golden-corpus part had a crossing).

## Gates

Full fast tier 1411 passed / 1 failed — the failure is the pre-existing #692 hypothesis-replay flake (reproduces identically on main). Ruff/format/mypy/codespell clean; DAG intact (repair imports only `_core`; the reconciler inlines its ten-line interval carve rather than importing the corridor's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
