### PR TITLE
docs(#696): sweep stale status claims across CLAUDE.md, ADR headers, and module docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,10 @@ entry. Keep `_LAYERS` and this section in step.
   `sheet_dsl` alias shim remains for one release).
 - **`sheet_emit.py`** — the Sheet-script emitter behind `--script --style sheet`:
   generates an editable `Sheet` script from a detected model. Facade tier;
-  imports `builder` downward — the old builder/cli/sheet_emit lazy-import cycle
-  is gone; the one remaining upward edge is the sanctioned `builder._cli` compat
-  shim (#523, rescoped).
+  imports `builder` downward at module level, but `builder`'s lazy `_cli` shim
+  still closes a builder→cli→sheet_emit lazy-import cycle (the `builder→cli`
+  edge is the one `_LAZY_UPWARD_EXEMPT` entry) — breaking it is tracked by
+  #523 (open).
 - **`score.py`** — `feature_census` (#148f/#608): a standalone
   recognition-completeness measurement tool; depends only on `recognition/` +
   build123d, and nothing in the engine imports it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,9 @@ It sits on top of two Apache 2.0 libraries:
 ## Architecture
 
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
-top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, the `linting/` and
-`recognition/` subpackages) → `_core.py` → stage modules (`export.py`,
+top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
+`fits.py`, `intents.py`, the `linting/` and `recognition/` subpackages) →
+`_core.py` → stage modules (`export.py`,
 `repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
 `model/` IR subpackage, the `annotations/` subpackage) → `builder.py` → the
 user-facing surfaces: the `make_drawing.py` / `annotate.py` compat facades, the
@@ -37,7 +38,7 @@ cycle-breakers (`builder`↔`cli`); the one type-only upward reference
 (`_core`→`compose.StripDepths`, under `TYPE_CHECKING`) is an explicit allowlist
 entry. Keep `_LAYERS` and this section in step.
 
-- **`make_drawing.py`** — thin compat facade (~17 lines) re-exporting the public
+- **`make_drawing.py`** — thin compat facade (~20 lines) re-exporting the public
   surface (`Drawing`, `build_drawing`, `make_drawing`, `generate_script`, `_cli`,
   `FeatureInfo`, `fix_svg_page_size`, `lint_feature_coverage`) so existing imports
   and the `draftwright` CLI entry point keep working. The engine lives in:
@@ -63,9 +64,10 @@ entry. Keep `_LAYERS` and this section in step.
   **`annotations/`** subpackage (#164 / ADR 0005, P5):
   - **`annotations/orchestrator.py`** — `_auto_annotate`, the single entry point
     (called by `build_drawing`); classifies the part and drives the render passes
-    + title block. End state (ADR 0008) is `build model → plan → render`; a little
-    inline engine code (some envelope/step-ladder placement) remains here pending
-    the last convergence steps.
+    + title block. End state (ADR 0008) is `build model → plan → render`; some
+    inline engine code remains — chiefly `_maybe_tabulate_holes` (the
+    hole-table/balloon escalation resolver) and the iso right-strip
+    outer-limit tightening — pending the last convergence steps.
   - **`annotations/from_model.py`** — the **IR render layer** (largest annotations
     module): turns the planner's `DimensionGroup`/render-intents into placed
     dimensions/callouts/centre marks/section triggers. This is where the turned,
@@ -76,8 +78,10 @@ entry. Keep `_LAYERS` and this section in step.
     (incl. side-drilled #133), pitch/grid dims, slots (the largest *pass*).
   - **`annotations/sections.py`** — section A–A + detail views (ISO 128-44 arrows,
     ISO 128-50 hatching).
-  - **`annotations/_common.py`** — shared placement helpers (`_anno_box`,
-    `_occupied_boxes`, `_box_hits`) at the bottom of the annotations DAG.
+  - **`annotations/_common.py`** — the ADR 0009 corridor-solve engine
+    (`CorridorCandidate`, `solve_corridor`, `register_corridor`/`drain_corridors`,
+    `place_strip_candidates`, `PlacementContext`) plus the shared bbox helpers
+    (`_anno_box`, `_box_hits`), at the bottom of the annotations DAG.
   Submodules import only down or sideways — `_core`/`layout`/`analysis`/
   `projection`/the `model/` IR/`linting.structural`/third-party, never
   `annotate`/`make_drawing`/`drawing` (the drawing is duck-typed as `dwg`) — so
@@ -89,7 +93,15 @@ entry. Keep `_LAYERS` and this section in step.
 - **`layout.py`** — the constraint-based layout engine (ADR 0003): the deterministic
   1D PAVA strip solve (`_solve_strip_1d_pava`, plus `plan_strip`/`StripCandidate`,
   the ADR 0009 collect-then-solve entry point) and the 2D free-rectangle placer
-  (`place_box`/`fit_box`). Sits *below* the domain API.
+  (`fit_box`). Sits *below* the domain API.
+- **`_geometry.py`** — model-neutral geometry primitives (`_xyz`, `HoleRef`,
+  `_axis_letter`, `_END_ON`); the DAG's bottom leaf (guarded by
+  `test_geometry_is_a_leaf`) so the IR waist uses them without importing `_core`.
+- **`fits.py`** — the ISO 286 fit tables (`fit_deviation`, `FitClass`; ADR 0011
+  P2a.2): a rank-0 leaf consumed by `_core`, `model/ir` and `sheet`.
+- **`intents.py`** — the deferred-placement "low IR" behind `Drawing.finalize()`
+  (#426): a dependency-free leaf recording edit-verb intents for the recompose
+  (deliberately stringly-typed in its Phase-1 form).
 - **`registry.py`** — `AnnotationRegistry`: the single owner of annotation
   identity/ownership/pins/build-issues (#138 / ADR 0005, Step 2). `Drawing`
   delegates here and keeps the render list; `_named`/`_anno_view`/`_pinned`/
@@ -97,8 +109,8 @@ entry. Keep `_LAYERS` and this section in step.
 - **`linting/`** — the lint subpackage (#138 / ADR 0005; ADR 0007: draftwright
   owns linting): `coverage.py` (`lint_feature_coverage` + `CoverageState`),
   `structural.py` (geometry/standards checks), `issues.py` (the `LintIssue` type),
-  `suggest.py` (`_suggest_fix`, #29 snippets). Depends only on `_core` +
-  build123d_drafting. `_QUOTED_RE` (a lint-message label regex shared with the
+  `suggest.py` (`_suggest_fix`, #29 snippets). Depends only on `_core`,
+  `recognition/` (typed hole records in `coverage.py`) + build123d_drafting. `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
 - **`model/`** — the ADR 0008 IR waist: `ir.py` (the `Feature`/`DimParameter`/
   `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
@@ -112,6 +124,11 @@ entry. Keep `_LAYERS` and this section in step.
   (`choose_scale`, `ViewBlock`, zone/strip depths). Née `sheet.py`; renamed
   (#640) so the layout engine stops shadowing the user-facing `Sheet` facade
   (which now owns the `sheet.py` name).
+- **`analysis.py`** — the `_analyse` stage: solid classification, the one-shot
+  feature-inventory detection (ADR 0008 Am5), view sizing, and the strip/zone
+  model (`fv_zones`/`pv_zones`/`sv_zones`) that ADR 0009 placement reads.
+- **`projection.py`** — HLR projection and view-coordinate transforms
+  (`_assemble`'s geometry half; #161).
 - **`sheet.py`** — the fluent declarative **`Sheet`** facade (ADR 0011):
   feature verbs (`hole`/`boss`/`slot`/…), aspect verbs (`.tolerance`/`.fit`/
   `.finish`), GD&T (`datum`/`control`). Facade tier: builds a `PartModel` via
@@ -120,7 +137,12 @@ entry. Keep `_LAYERS` and this section in step.
   `sheet_dsl` alias shim remains for one release).
 - **`sheet_emit.py`** — the Sheet-script emitter behind `--script --style sheet`:
   generates an editable `Sheet` script from a detected model. Facade tier;
-  #523 tracks breaking its lazy-import cycle with `builder`/`cli`.
+  imports `builder` downward — the old builder/cli/sheet_emit lazy-import cycle
+  is gone; the one remaining upward edge is the sanctioned `builder._cli` compat
+  shim (#523, rescoped).
+- **`score.py`** — `feature_census` (#148f/#608): a standalone
+  recognition-completeness measurement tool; depends only on `recognition/` +
+  build123d, and nothing in the engine imports it.
 - **`recognition/`** — feature recognition (ADR 0007: draftwright owns it, not
   helpers). Every feature recogniser follows the **uniform contract** (ADR 0013 / #568,
   spelled out in `recognition/__init__.py`): `recognise_<feature>(part, *, <injected
@@ -134,10 +156,13 @@ entry. Keep `_LAYERS` and this section in step.
   `recognise_hole_patterns` + the feature/pattern types; plus the cylinder-analysis
   *substrate* `analyse_cylinders`/`feature_diameters`/`full_cylinders`, which keep their
   names — a tuple-of-dicts / diameter query, not `list[record]` recognisers),
-  `slots.py` (the milled-slot recogniser, #135), `turned.py` (`recognise_turned_steps`
-  — turned-shaft shoulders, OD-silhouette filtered), and `levels.py`
-  (`recognise_face_levels` prismatic horizontal face levels + `recognise_step_shoulders`
-  → `StepShoulder`, #191/#555). Bottom of the DAG: depends only on build123d/OCP. Import
+  `slots.py` (the milled-slot + pocket recognisers, #135/#148), `turned.py`
+  (`recognise_turned_steps` — turned-shaft shoulders, OD-silhouette filtered),
+  `levels.py` (`recognise_face_levels` prismatic horizontal face levels +
+  `recognise_step_shoulders` → `StepShoulder`, #191/#555), the #148-epic
+  recognisers `chamfers.py`/`fillets.py`/`flats.py`/`grooves.py`/`plates.py`/
+  `countersinks.py`, and `_record.py` (the shared frozen-`Record` mixin,
+  `.to_dict()`). Bottom of the DAG: depends only on build123d/OCP. Import
   via the package surface.
 - **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
   cross-platform layout (ADR 0006).
@@ -201,12 +226,13 @@ Current ADRs:
   bus; annotation identity/pins/build-issues moved to `registry.py`, coverage
   state to `linting/`, build context (`Analysis`, edge cache) into the pipeline.
   Stages split into `builder`/`analysis`/`compose` (née `sheet`, #640)/`projection`/`linting/`/`repair`/
-  `export`/`annotations/` (all #160–#166 landed; `make_drawing.py` 3,907 → ~17
+  `export`/`annotations/` (all #160–#166 landed; `make_drawing.py` 3,907 → ~20
   facade). `layout.py` unchanged. **Roadmap:** `docs/plans/138-module-split-roadmap.md`.
-  One deferred follow-up remains: full build-context threading off `Drawing`
-  (§2), tracked by **#639** (consolidation epic #635). (The other —
-  `annotations/envelope.py` — was overtaken by ADR 0008: the envelope pass
-  converged into `annotations/from_model.py` instead.)
+  Both deferred follow-ups are resolved: the §2 build-context threading closed
+  via **#639** (epic #635 — one typed `BuildState`, empty-allowlist ratchet), and
+  `annotations/envelope.py` was overtaken by ADR 0008 (the envelope pass
+  converged into `annotations/from_model.py` instead). §4's compat-alias exit is
+  tracked by **#699**.
 - **0006** — **Accepted** (#149): deterministic cross-platform layout via bundled,
   path-pinned fonts. Layout depends on measured text width; resolving a font *name*
   (`"Arial"`) substitutes a different font on Linux, drifting the whole sheet ~1 mm.
@@ -231,10 +257,11 @@ Current ADRs:
   select → assign → order(=feature order ⇒ crossing-free) → space. Removes the
   invisible-occupant collision class (#133/#225/#305) by construction; the inner
   per-view layer to 0004's outer block packing; consumes 0008's render-intents.
-  **Remaining migration:** a handful of render passes (plates, height ladder,
-  step positions, some hole helpers) still place via the solver-invisible
-  `carve_free_position` — tracked by **#636** (consolidation epic #635); the
-  by-construction guarantee holds only once those join the solve.
+  **Migration complete** (#636 closed, epic #635): every auto-pass strip
+  occupant joins the solve, so the by-construction guarantee holds; the
+  remaining `carve_free_position` callers are explicit exemptions (post-drain
+  fallthroughs, manual post-build verbs, the diagonal pitch fallback) pinned by
+  the fail-closed `tests/test_carve_free_position_callers.py`.
   Research: `docs/research/annotation-placement-boundary-labeling.md`. Roadmap:
   `docs/plans/strip-layout-boundary-labeling-roadmap.md`.
 - **0010** — **Accepted** (decision; work pending): **annotation provenance seam**.
@@ -270,6 +297,14 @@ Current ADRs:
   once; pin is the escape valve so the user never fights the solver. `place_dim()` is now
   the deprecated raw-coordinate escape hatch. The #477 below/right fold-in landed as a
   dependency.
+- **0013** — **Accepted** (#568; Phase 1 in progress): the **uniform recogniser
+  contract** — `recognise_<feature>(part, *, <injected deps>) -> list[<frozen
+  record>]` (plus the part-less *derived* shape, e.g.
+  `recognise_hole_patterns(holes)`), mechanically enforced by
+  `tests/test_recogniser_contract.py`. The shared `b123d-recognisers` package is
+  the deferred Phase-2 deployment (gated on a second committed consumer).
+  Remaining Phase 1: the typed `detect.py` adapter registry (roadmap item 1c).
+  Roadmap: `docs/plans/0013-shared-recognisers-roadmap.md`.
 
 ## Dependencies
 

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -86,12 +86,14 @@ same iterate-and-fix laps — with no fluency in draftwright internals required.
 
 ## Current state vs target
 
-- **Exists:** the engine, `lint()` / `lint_summary()` (the critique), and the
-  deterministic gains that minimise iteration.
-- **Roadmap (mostly unbuilt):** the domain-semantic edit API (#25–28), per-issue
-  suggestions (#29), and the lint→repair loop (#30). Until these land, the
-  "domain-fix" step falls back to the DSL — the path ADR 0001 deprecates — so
-  building this layer is the work that makes the loop real.
+*(Refreshed 2026-07-18 — the original "mostly unbuilt" roadmap here long predated
+the build-out.)* The loop is **built**: the domain-semantic edit API (#25–28 —
+`dimension()`/`callout()`/`locate()`/`drop()` on the model, ADR 0010/0012),
+per-issue suggestions (#29, `linting/suggest.py`), and the deterministic
+lint→repair loop (#30, `repair.py`, with `Drawing.repair()` as the thin
+wrapper) all shipped. Repair remains the *safety net*, not the primary
+placement mechanism — ADR 0009's collect-then-solve is the structural cure for
+the collision classes repair used to mop up.
 
 ## Related
 

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -87,8 +87,10 @@ same iterate-and-fix laps — with no fluency in draftwright internals required.
 ## Current state vs target
 
 *(Refreshed 2026-07-18 — the original "mostly unbuilt" roadmap here long predated
-the build-out.)* The loop is **built**: the domain-semantic edit API (#25–28 —
-`dimension()`/`callout()`/`locate()`/`drop()` on the model, ADR 0010/0012),
+the build-out.)* The loop is **built**: the read/query API (#25–28 — `place_dim()`/
+`features()`/`annotations()`/`view_bounds()`) plus the domain-semantic edit
+verbs (`dimension()`/`callout()`/`locate()`/`drop()`, shipped under the
+ADR 0010/0012 editable-surface work),
 per-issue suggestions (#29, `linting/suggest.py`), and the deterministic
 lint→repair loop (#30, `repair.py`, with `Drawing.repair()` as the thin
 wrapper) all shipped. Repair remains the *safety net*, not the primary

--- a/docs/adr/0003-constraint-based-layout.md
+++ b/docs/adr/0003-constraint-based-layout.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted (core implemented; the unifying *global 2-D* solve stays
   deferred — #94; amended 2026-07-10 — see Correction). The 1-D strip solve,
-  `place_box`/`fit_box`, and pins (#89) have shipped — the concrete carrier is
+  `fit_box`, and pins (#89) have shipped — the concrete carrier is
   `StripCandidate`/`plan_strip`/`CorridorCandidate`, not the original
   `Placeable`/`LayoutSolver` model, which was retired (#547). The **assignment
   layer** and **escalation ladder** for per-view strip placement are made
@@ -200,8 +200,8 @@ never be needed.** This is a deliberate scope correction, not an omission.
 
 ## Current state vs target
 
-- **Exists:** the deterministic 1D strip solve (`_solve_strip_1d_pava`) and 2D
-  `fit_box`/`place_box` free-rectangle placer, in `layout.py`; `plan_strip`/
+- **Exists:** the deterministic 1D strip solve (`_solve_strip_1d_pava`) and the
+  2D `fit_box` free-rectangle placer, in `layout.py`; `plan_strip`/
   `StripCandidate` (ADR 0009 collect-then-solve) and `solve_corridor`/
   `CorridorCandidate` (`annotations/_common.py`) as the production strip-
   placement path hole callouts, turned diameters, and every other strip
@@ -231,9 +231,11 @@ entrenching `plan_strip` as the real path.
 By 2026-07-10, `Placeable`/`LayoutSolver` had no caller anywhere in `src/`
 outside their own tests. Rather than leave a fully-tested, zero-consumer class
 in the tree as a standing (and, per the above, actively misleading) claim about
-what production code does, it was deleted (#547). `fit_box`/`place_box` — the
-2D free-rectangle placer, the one part of the original surface every consumer
+what production code does, it was deleted (#547). `fit_box` — the 2D
+free-rectangle placer, the one part of the original surface every consumer
 actually shares (tables, GD&T) — is unaffected and remains in `layout.py`.
+(The `place_box` wrapper name went with `LayoutSolver`; read `place_box`
+elsewhere in this document as `fit_box`, its surviving carrier.)
 
 This does not change the ADR's decision (constraint-based, deterministic,
 two-layer layout); it corrects which concrete types realise it. Read

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -1,6 +1,7 @@
 # ADR 0004 — Compose-then-pack: views as blocks carrying their annotation footprint
 
-- **Status:** Accepted (2026-06-19; amended 2026-06-20 and 2026-07-09 — see Amendments)
+- **Status:** Accepted (2026-06-19; amended 2026-06-20, 2026-07-09 and
+  2026-07-18 — see Amendments)
 - **Date:** 2026-06-19
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -125,7 +126,7 @@ above where OCCT's annotation arcs actually degenerate (`Geom_TrimmedCurve U1==U
   view-local space.
 - The **page-level packing stays fixed-topology** (plan above front sharing X;
   side beside front sharing Y; iso and table in free rectangles via
-  `place_box` / `fit_box`). It is **not** the full global 2D solve deferred in
+  `fit_box`). It is **not** the full global 2D solve deferred in
   #94, which we keep deferred — most "2D freedom" is forbidden by projection
   alignment, and a global non-overlap solve is disjunctive/NP-hard and
   non-deterministic. Fixed-topology + composed footprints + local free-rect
@@ -238,7 +239,7 @@ Decisions:
 This ADR names its anchors by their *current* location: `_analyse`,
 `StripDepths`, `ViewBlock`, `_repack`, `choose_scale` in `make_drawing.py`, and
 `_auto_annotate` in `annotate.py`. [ADR 0005](0005-pipeline-architecture-and-state-ownership.md)
-(Accepted, in progress) relocates these **without changing this decision** —
+(Accepted; the split is complete) relocated these **without changing this decision** —
 sheet planning/compose-then-pack to `sheet.py` (#162; since renamed `compose.py`, #640), projection/`_assemble` to
 `projection.py` (#161) / `builder.py` (#165), `_analyse` to `analysis.py` (#163),
 annotation sequencing to `annotations/orchestrator.py` (#164). Refresh the anchor
@@ -260,3 +261,26 @@ blocks, free-rectangle placement for furniture, and a fixed-point measure/repack
 loop. That is the intended architecture from this ADR, not a temporary halfway
 state. Remaining open issues are targeted hardening, coverage, detail-view
 capability, and manual-intent integration work.
+
+## Amendment (2026-07-18) — reconciling the absolute wording with the as-built loop
+
+Two of this ADR's absolutes read stricter than the accepted implementation; the
+code is right, and the text is hereby reconciled rather than left to mislead:
+
+1. **"The prediction problem disappears" (Decision rule 1) — prediction survives
+   as the pass-1 seed.** The composer's scale/page fitness still runs a-priori
+   estimators (`_will_balloon`, the `_est_*_depth` family in `compose.py`) to
+   seed the first compose; the **measure-and-repack fixed-point loop**
+   (`builder._repack_to_fixed_point`) is the corrective that makes the final
+   footprint the *actual* laid-out extent. Escalation authority did move to the
+   per-instance layout (the 2026-07-09 amendment); the estimators remain as
+   seeds, backstopped — not decision-makers. Retiring them entirely is possible
+   future convergence, not the current state.
+2. **"Geometry is built only once" / "never bbox-measured OCC geometry" — the
+   search is box-math; the measured pass reads built annotations.** The
+   `(scale, page)` *search* reasons purely over page-mm boxes (the O(n²)
+   perf motive this rule encodes). After a full build, the bounded repack loop
+   (≤ `_REPACK_MAX_ITER` extra `_assemble` runs) and the out-of-bounds check
+   (`_annotations_out_of_bounds`) deliberately measure the *built* annotations'
+   real bounding boxes — O(n) per bounded iteration, matching what lint tests.
+   The rule constrains the fitness search, not the post-build verification.

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -1,7 +1,8 @@
 # ADR 0005 — Compiler-pipeline module boundaries and single-owner build state
 
-- **Status:** Accepted (module split complete; one follow-up remains — see the
-  2026-07-15 note below)
+- **Status:** Accepted (module split complete; the deferred follow-ups are
+  closed — see the 2026-07-15 status note below; §4's compat-alias exit
+  criterion is tracked by #699)
 - **Date:** 2026-06-27
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Progress:** Execution roadmap with per-phase tracking issues:

--- a/docs/adr/0006-deterministic-layout-via-bundled-fonts.md
+++ b/docs/adr/0006-deterministic-layout-via-bundled-fonts.md
@@ -55,8 +55,11 @@ commercial distribution. It can return later as an opt-in, user-supplied font.
 
 **Positive**
 - Layout is **deterministic across Linux / macOS / Windows** — drawings are
-  reproducible, and the ADR-0005 golden gate now pins a **real part** (CTC-01),
-  closing its deferred real-part-coverage limitation.
+  reproducible. (At the time, this let the ADR-0005 golden gate pin a real part,
+  CTC-01; that byte-exact golden harness was later **retired** — ADR 0005 §3 /
+  ADR 0007 — and regression coverage now rests on the geometry-level and
+  `test_e2e_standards` suites. Determinism remains the point: identical layout
+  on every platform.)
 - Fixes the silent **typeface-substitution** bug (consistent IBM Plex everywhere),
   and removes the proprietary-Arial default.
 

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -17,10 +17,12 @@
 - **Supersedes the original 0008** ("unified feature model") with a concrete
   architecture. Step 1 (unify Z step recognition, #191/#193) stands.
 - **Amendment 7** (2026-07-12): the "one inventory" waist is now two tiers — a
-  shared *geometric* recognition record feeding the *dimensioning* IR through a uniform
-  `detect.py` adapter protocol (typed per-record converters, not one universal
-  converter) (ADR 0013). Amendment 6 (no recognition object crosses the boundary) is
-  preserved.
+  shared *geometric* recognition record feeding the *dimensioning* IR through
+  `detect.py` (ADR 0013). The record tier is landed; the uniform adapter
+  protocol there (typed per-record converters, not one universal converter) is
+  **decided but pending** — ADR 0013 Phase 1 / roadmap item 1c; `detect.py`
+  today remains bespoke per-feature translators. Amendment 6 (no recognition
+  object crosses the boundary) is preserved.
 - **Amendment 8** (2026-07-13, epic #584 WP1): Amendment 6 is enforced across the
   **render** path — the hole/pattern/boss recognition records no longer survive into the
   annotation/table/section/callout renderers. `annotations/` (sections, hole callouts,
@@ -37,7 +39,7 @@
     flagged. `linting/` also stays a leaf (no `model` import) by design. Coverage reading
     recognition is the check working, not a leak.
 
-## Current decision (as amended, 2026-07-12)
+## Current decision (as amended, 2026-07-13)
 
 *The part-drawing engine is a **compiler**.* detectors → a **Feature / DimParameter IR**
 (`PartModel`) → a dimensioning **planner** → **render-intents** → the shared
@@ -46,9 +48,13 @@ detected once** (`_analyse`); the orchestrator is **build model → plan → ren
 Orientation / feature-kind are *data in the IR*, not code branches. The migration is
 **complete — one path**: each step deleted the per-feature engine pass it replaced (not
 reproduce-and-swap, not two permanent paths — Am 2/3). The IR↔infra boundary is
-**IR-typed** — no recognition object crosses it (Am 6). The waist is now **two tiers**
-(Am 7): a shared **geometric recognition record** feeds the dimensioning IR through a
-uniform `detect.py` adapter protocol (a typed registry of per-record converters).
+**IR-typed** — no recognition object crosses it (Am 6), with one sanctioned exception:
+**lint/coverage reads recognised geometry, not the IR** (Am 8) — ground-truth
+validation sourced from the plan would be circular. The waist is now **two tiers**
+(Am 7): a shared **geometric recognition record** feeds the dimensioning IR through
+`detect.py`; the uniform adapter protocol there (a typed registry of per-record
+converters) is decided but **not yet built** — ADR 0013 Phase 1 (roadmap 1c) tracks
+it, and `detect.py` today remains bespoke per-feature translators.
 
 *The amendments below are the reasoning trail (contract refinement → out-grow strategy →
 one-path convergence → IR/infra boundary → one-inventory foundation → IR-typed interface →

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted (2026-06-30)
 - **Deciders:** Paul Fremantle (pzfreo)
 
-## Current decision (as amended, 2026-07-12)
+## Current decision (as amended, 2026-07-18)
 
 Annotation placement within each view's strips is a **collect-then-solve boundary-labeling**
 stage, not place-as-you-go. Per view: **collect** every strip occupant (plus fixed
@@ -23,30 +23,27 @@ leader geometry → the L1/PAVA min-leader solve → band-aware then shared-carv
 one-solve-across-passes → real footprints + GD&T → solver consolidation) — read them for
 the* why, *not to reconstruct the current state.*
 
-**Remaining migration (tracked by #636 / consolidation epic #635).**
-Amendment 8 consolidated PMI, front-view callouts, and the pitch fallback. #636
-then migrated the two 0.3.0 features that had regressed onto the solver-invisible
-single-position carve (`carve_free_position`) — **`render_plates` (#559)** and
-**`render_step_positions` (#555)** now register `CorridorCandidate`s that co-solve
-with the locations sharing their strips — and added a fail-closed guard test
-(`tests/test_carve_free_position_callers.py`) so the legacy path can no longer
-silently attract new callers. Until the remaining sites join the solve, the
-"invisible-occupant collision class removed **by construction**" claim above holds
-only for the migrated passes.
+**Migration complete (#636 closed 2026-07-16; consolidation epic #635).**
+Amendment 8 consolidated PMI, front-view callouts, and the pitch fallback; #636
+then migrated `render_plates` (#559), `render_step_positions` (#555) and finally
+`render_height_ladder` onto corridor candidates (see the dated 2026-07-17/18
+notes at the end of this file). **The "invisible-occupant collision class removed
+by construction" claim above now holds for every auto-pass strip occupant.** A
+fail-closed guard test (`tests/test_carve_free_position_callers.py`) pins the
+remaining `carve_free_position` callers, each an explicit exemption:
 
-The carve callers still allowed in `annotations/` (the guard-test allowlist):
-
-- **Permanent exemption** — `_place_pitch_dim`'s diagonal fallback (`holes.py`):
-  searches an arbitrary outward vector, so its dim cannot occupy a 1-D axis-aligned
-  strip tier and cannot be a solve candidate at all (Amendment 8's decision).
-- **Pending migration (#636)**, each with a genuine design fork deferred to its own
-  PR: `render_height_ladder` (the leapfrog witness cursor — a collect-then-solve
-  pass must rebuild the chain from solved positions), `render_gdt`'s PMI
-  alternate-strip fallback (runs inside a candidate's `on_drop`, i.e. after its
-  strip has already drained — needs a two-side candidate, not a post-hoc carve),
-  and the detect-only verbs `add_feature_callout` / `add_feature_location` (a
-  detect-only build has no shared corridor batch to register into — cousins of the
-  ADR 0012-exempt `place_dim`).
+- **`_place_pitch_dim`'s diagonal fallback** (`holes.py`) — permanent
+  (Amendment 8's decision): it searches an arbitrary outward vector, so its dim
+  cannot occupy a 1-D axis-aligned strip tier and cannot be a solve candidate
+  at all.
+- **The `render_gdt` and `render_plates` post-drain fallthroughs**
+  (`from_model.py`) — primary placement *is* a corridor candidate; the carve
+  runs only in a `ctx.post_drain`-deferred drop fallthrough, after every
+  corridor has drained (so it cannot preempt a sibling's reserved corner).
+- **The manual post-build verbs `add_feature_callout` / `add_feature_location`**
+  (`holes.py`) — a single user-driven annotation onto a *finished* sheet (the
+  #426 manual-edit half): every occupant is already placed and there is no
+  shared drain to join. Cousins of the ADR 0012-exempt `place_dim`.
 
 A new carve caller in `annotations/` fails the guard test; a genuine new exemption
 must be recorded in this note first.

--- a/docs/adr/0010-annotation-provenance-seam.md
+++ b/docs/adr/0010-annotation-provenance-seam.md
@@ -153,8 +153,9 @@ the `origin`-back-link mechanism dropped as unnecessary).
   single owner of annotation identity/ownership; provenance is the new axis, and its
   sink.
 - [ADR 0008](0008-unified-feature-model-and-dimensioning-planner.md) — the IR/planner
-  intent boundary is where the seam lives. (`origin` survives only on the GD&T
-  *aspect* features as a targeting handle — see Amendment 2; the universal
+  intent boundary is where the seam lives. (`origin` survives only on the
+  *aspect* features — `ControlFrame`/`DatumRef`/`Finish`/`Note` — as a
+  targeting handle; see Amendment 2. The universal
   back-link on IR feature types was never needed and was not built.)
 - [ADR 0009](0009-boundary-labeling-strip-placement.md) — the corridor placer is a
   layer that must carry the intent through to its deferred add.

--- a/docs/adr/0010-annotation-provenance-seam.md
+++ b/docs/adr/0010-annotation-provenance-seam.md
@@ -153,7 +153,9 @@ the `origin`-back-link mechanism dropped as unnecessary).
   single owner of annotation identity/ownership; provenance is the new axis, and its
   sink.
 - [ADR 0008](0008-unified-feature-model-and-dimensioning-planner.md) — the IR/planner
-  intent boundary is where the seam lives; `origin` extends the IR feature types.
+  intent boundary is where the seam lives. (`origin` survives only on the GD&T
+  *aspect* features as a targeting handle — see Amendment 2; the universal
+  back-link on IR feature types was never needed and was not built.)
 - [ADR 0009](0009-boundary-labeling-strip-placement.md) — the corridor placer is a
   layer that must carry the intent through to its deferred add.
 - Issues: #398 (edit-by-feature), #400 (expanded semantic script), #388 (finalize).

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -6,7 +6,7 @@
   → `DimParameter.tolerance`) and **P2a.2 fit-class** (`.fit("H7")` → ISO 286 deviation,
   `draftwright/fits.py`, riding the same `tolerance` field as a `FitClass` marker) landed;
   **P2b GD&T+finish** (#478) and **P2c aspect verbs** (`sheet.datum`/`.control`/`.finish`,
-  #480/#482) landed 2026-07-06/07; only **P2d PMI-sourced auto-GD&T** (#62) remains
+  #480/#482) landed 2026-07-06; only **P2d PMI-sourced auto-GD&T** (#62) remains
   pending per the #446 roadmap. Phase 2
   execution plan:
   [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -5,7 +5,9 @@
   toleranced dimensions** (±/limit on a diameter/step/hole, via a `decorations=` side-layer
   → `DimParameter.tolerance`) and **P2a.2 fit-class** (`.fit("H7")` → ISO 286 deviation,
   `draftwright/fits.py`, riding the same `tolerance` field as a `FitClass` marker) landed;
-  P2b GD&T+finish / P2c aspect verbs / P2d PMI still pending per the #446 roadmap. Phase 2
+  **P2b GD&T+finish** (#478) and **P2c aspect verbs** (`sheet.datum`/`.control`/`.finish`,
+  #480/#482) landed 2026-07-06/07; only **P2d PMI-sourced auto-GD&T** (#62) remains
+  pending per the #446 roadmap. Phase 2
   execution plan:
   [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
   **Amendment 1** (2026-07-05): the three authoring modes + the **mode-3 generation surface**

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -22,6 +22,14 @@ JSON-serializable (no build123d type leaks); (c) **codespell-enforced** — wire
 CI lint job. The recogniser-signature shape (part + keyword-only) is asserted by the same
 contract test.
 
+**Amendment 2 (2026-07-18) — the *derived* shape is part-less.** §2's derived-feature
+example (`recognise_patterns(part, *, holes)`) predates the implementation. A derived
+recogniser is a pure function of already-recognised records and never touches the
+solid, so `part` would be a dead argument. The sanctioned derived shape is
+`recognise_hole_patterns(holes)` — the inventory positional, no `part` — exactly as
+`recognition/__init__.py` documents and `tests/test_recogniser_contract.py` enforces.
+The base-feature shape (`part` first, keyword-only tuning/deps) is unchanged.
+
 ## Context
 
 Two findings, one from inside draftwright and one from a sibling project, meet here.

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1,11 +1,14 @@
 """Shared low-level primitives for the draftwright drawing engine.
 
-This module sits below :mod:`draftwright.make_drawing` and
-:mod:`draftwright.annotate`: it holds the data structures and small helpers
-both layers depend on (the :class:`Analysis` namespace and its field types,
-the dimension/format helpers, and the layout constants).  It imports only from
-:mod:`draftwright.layout` and third-party libraries -- never from
-``make_drawing`` -- so the module graph stays a DAG (#98 Phase C).
+This module sits below the stage modules (``analysis``/``projection``/
+``compose``/``annotations/``/``export``/``repair`` — its real consumers since
+the ADR 0005 split): it holds the data structures and small helpers they all
+depend on (the :class:`Analysis` namespace and its field types, the
+dimension/format helpers, and the layout constants).  It imports only from the
+leaf tier (:mod:`draftwright.layout`, :mod:`draftwright._geometry`,
+:mod:`draftwright.fits`, :mod:`draftwright.fonts`) and third-party libraries —
+never upward — so the module graph stays a DAG (machine-enforced by
+``tests/test_import_boundaries.py``).
 """
 
 from __future__ import annotations
@@ -565,9 +568,11 @@ class Analysis:
     pmi_mode: str
     # The PartModel built by _analyse's pre-scale sizing pass (#584 WP1 A) — stored so
     # the render path reuses it instead of re-running the detectors (ADR 0008 Amdt 5:
-    # one inventory, detected once; #602). Typed `object` because model/ sits above
-    # _core in the DAG. None when the caller declared a model (ADR 0011) or on a
-    # manually-built Analysis — consumers fall back to build_model(a).
+    # one inventory, detected once; #602). Typed `object` to keep _core free of a
+    # runtime model/ import (model/ sits BELOW _core in _LAYERS, so a typed
+    # `PartModel | None` is legal — a possible tightening). None when the caller
+    # declared a model (ADR 0011) or on a manually-built Analysis — consumers fall
+    # back to build_model(a).
     model: object | None = None
 
 

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -760,7 +760,7 @@ def _analyse(
         fv_hh=fv_hh,
         pv_hh=pv_hh,
         sv_hw=sv_hw,
-        # Strip / zone layout model (Phase 1 — regions defined, not yet used)
+        # Strip / zone layout model — the per-view strips ADR 0009 placement reads
         fv_zones=fv_zones,
         pv_zones=pv_zones,
         sv_zones=sv_zones,

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -61,8 +61,9 @@ class Escalation:
 def _anno_box(o):
     """Page-space bbox ``(x0, y0, x1, y1)`` of an annotation — its text
     ``label_bbox`` if it has one, else its geometric bounding box; ``None`` if
-    neither resolves.  Local mirror of ``make_drawing._anno_bbox`` (annotate sits
-    below make_drawing, so it cannot import from it)."""
+    neither resolves.  Twin of ``compose._anno_bbox`` (annotations sits above
+    compose in the DAG, so the mirror is deliberate — consolidation tracked by
+    #700)."""
     lb = getattr(o, "label_bbox", None)
     if lb is not None:
         return lb

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -26,8 +26,8 @@ What actually lives here today:
   production-facing collect-then-solve entry point built on top of it
   (selection, ordering, anchoring); the lower-level
   `_solve_strip_1d`/`_greedy_strip_1d` primitives are unit-tested in isolation
-  and consumed directly by the balloon-spread and diameter-row passes (via the
-  `_core` aliases). Keep-out-band avoidance
+  and consumed directly by the balloon-spread pass (imported from here) and
+  the diameter-row pass (via the `_core` aliases). Keep-out-band avoidance
   (a callout must not sit on a centre-line or a location-dim row) briefly lived
   as a `plan_strip`-internal banded solve (ADR 0009 Amendment 5, #318); that had
   a cross-segment correctness gap (#381), so Amendment 9 retired it in favour of

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -25,16 +25,17 @@ What actually lives here today:
   once PAVA gave the exact L1 placement). :func:`plan_strip` is the
   production-facing collect-then-solve entry point built on top of it
   (selection, ordering, anchoring); the lower-level
-  `_solve_strip_1d*`/`_greedy_strip_1d*` functions are unit-tested in
-  isolation and used by `plan_strip`'s anchored solve. Keep-out-band avoidance
+  `_solve_strip_1d`/`_greedy_strip_1d` primitives are unit-tested in isolation
+  and consumed directly by the balloon-spread and diameter-row passes (via the
+  `_core` aliases). Keep-out-band avoidance
   (a callout must not sit on a centre-line or a location-dim row) briefly lived
   as a `plan_strip`-internal banded solve (ADR 0009 Amendment 5, #318); that had
   a cross-segment correctness gap (#381), so Amendment 9 retired it in favour of
   the caller carving bands into the same obstacle segmentation it already uses
   (`holes.py`) — `plan_strip` itself no longer knows about bands.
-- :func:`fit_box` (+ the thin ``place_box`` naming used at call sites) — the 2D
-  free-rectangle placer for tables/GD&T frames/BOM blocks (#93), the one part
-  of the original `LayoutSolver` surface that is genuinely shared.
+- :func:`fit_box` — the 2D free-rectangle placer for tables/GD&T frames/BOM
+  blocks (#93), the one part of the original `LayoutSolver` surface that is
+  genuinely shared.
 
 Global 2D non-overlap (the disjunctive constraint ADR 0003 notes is
 non-linear) stays deferred (#94) and may never be needed — see that ADR's
@@ -266,8 +267,9 @@ class StripCandidate:
             :func:`_solve_strip_1d_pava`, so it stays a spacing hint, not a hard
             pin (an anchored candidate can still be *dropped* when over capacity).
 
-    An ``eligible_sides`` field joins when the multi-side *assign* step lands
-    (P2, #322); the P0 seam places on a single, caller-chosen strip.
+    Candidates place on a single, caller-chosen strip; side *assignment* stays
+    with the caller (the multi-side generalisation was considered in P2/#322
+    and not needed — passes pick the strip before solving).
     """
 
     key: str
@@ -294,8 +296,10 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
     keeps leaders crossing-free when the sites have **distinct** strip-axis
     coordinates. Sites that share that coordinate are ordered deterministically by
     ``key``; that tie-break is *not* crossing-optimal (it doesn't see the
-    perpendicular coordinate that decides those crossings) — resolving ties
-    crossing-optimally is the P4 assign/order step (#318). Then spaces the labels
+    perpendicular coordinate that decides those crossings) — P4 (#318, closed)
+    delivered the min-leader PAVA spacing solve instead, and crossing-optimal
+    tie-resolution remains a possible refinement should a real part force it.
+    Then spaces the labels
     within ``[lo, hi]``, at least *min_gap* apart, via the per-pair solve
     described below.
 

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -5,13 +5,14 @@ A stable intermediate representation (`PartModel` of `Feature` objects exposing
 recognition heuristics) and a *dimensioning planner* (back-end). The narrow waist
 that lets new shapes be new types, not new branches.
 
-**Status:** wired into `build_drawing` in production (ADR 0008 convergence,
-in progress). `build_part_model` is built once per build from `_analyse`'s single
-feature inventory (Amendment 5) and consumed by the renderers in
-`annotations/from_model.py` (turned step lengths/diameters, centre marks, envelope
-width/depth, slots) and by the lint coverage checks. Remaining engine passes
-(holes, sections, PMI, the prismatic step-ladder) are migrating onto it — see
-`docs/plans/0008-convergence-roadmap.md`.
+**Status:** the ADR 0008 convergence is **complete — one path** (2026-06-30).
+`build_part_model` runs once per build from `_analyse`'s single feature
+inventory (Amendment 5); every render pass consumes the IR — the
+`annotations/from_model.py` renderers (turned/diameters, centre marks,
+envelope, step lengths, height ladder, PMI, GD&T, …), the hole/section passes
+(`annotations/holes.py` / `sections.py` via `plan_dimensions` /
+`plan_sections`), and page/scale sizing (Amendment 8). Coverage lint alone
+reads recognised geometry, by design (ground truth, not the plan).
 
 - :mod:`.ir` — the IR: `DimParameter`, `Datum`, `Frame`, the `Feature` protocol,
   the concrete feature types, and `PartModel`.

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -7,7 +7,8 @@ line per feature — that the user edits / comments-out / extends, then re-runs.
 **Detected input only writes numbers (the part-seam form, ADR 0011 Amdt 1 decision).** For a STEP
 file or a recovered solid the number *is* the ground truth, so a detected value is honest. We never
 fabricate a build123d part to chase a number-free layer — a synthesised solid silently drops what
-detection didn't model (chamfers, fillets, turned profiles) yet reads as authoritative. A caller who
+detection didn't model (a misread band, a thread's true form, an unrecognised relief) yet reads as
+authoritative. A caller who
 *has* the objects (mode 3b) wires their real part into the seam and swaps the number lines for
 ``sheet.hole(obj)`` references — the emitter's numbers are a starting point, not a ceiling.
 


### PR DESCRIPTION
Fixes the stale-status documentation debt from the 2026-07-18 architecture audit (#696). No behaviour changes — CLAUDE.md, 10 ADRs, and 6 module docstrings only.

**What was wrong:** the #635/#636/#639 close-outs (and several earlier ones) never reached the docs. CLAUDE.md contradicted itself on ADR 0005 §2/#639 and denied the ADR 0009 by-construction guarantee that now holds; ADR 0011 claimed landed P2b/P2c work was pending; ADR 0008 stated an unbuilt adapter protocol as current fact; ADR 0002's state section called the shipped repair loop "mostly unbuilt"; four documents referenced the deleted `place_box`.

**Highlights** (full checklist in #696):
- CLAUDE.md: closed-state fixes + the architecture map gains its missing modules (`_geometry`, `fits`, `intents`, `score`, `analysis`, `projection`, the six #148 recognisers, `_record`) and the missing ADR 0013 entry; `_common.py` described as the corridor-solve engine. (An adversarial fact-check of the sweep itself caught five inaccuracies — including an incorrect claim that the #523 lazy-import cycle was gone — fixed in the follow-up commit.)
- ADR 0009's Current-decision header now matches its own 2026-07-18 close-out note and the real carve-caller allowlist; ADR 0008's header marks the detect.py adapter protocol decided-but-pending (ADR 0013 1c) and carries the Am 8 lint/coverage exception.
- ADR 0004 gains a reconciliation amendment: the pass-1 prediction seeds survive (backstopped by measure-repack), and the box-math rule constrains the fitness search, not post-build verification.
- ADR 0013 Amendment 2 blesses the part-less derived recogniser shape (`recognise_hole_patterns(holes)`) the code and contract test already enforce.
- Module docstrings: `model/__init__` no longer says the ADR 0008 migration is in progress; `layout.py` stops citing closed issues as future work; `analysis.py` zones comment un-falsified; `_core` documents its real consumers and import list.

Gate: ruff check ✓, ruff format --check ✓, mypy ✓, codespell ✓, smoke tier 47/47 ✓.

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)