### PR TITLE
fix(#701): lint checks no longer silence themselves — narrow guards, log every skip

### DIFF
--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -10,11 +10,14 @@ since draftwright threads the page extent directly (see ``Drawing.lint``).
 
 from __future__ import annotations
 
+import logging
 import re
 
 from build123d import GeomType
 
 from draftwright.linting.issues import LintIssue
+
+_log = logging.getLogger(__name__)
 
 # Inert: draftwright always passes page_bbox explicitly (the set_page global
 # coupling is severed, ADR 0007). Kept so the vendored body is a faithful copy.
@@ -71,7 +74,12 @@ def _ann_box(item, cache):
     try:
         bb = item.bounding_box()
         box = (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 — not every annotation bbox-es cleanly
+        # #701: cached once per item, so this logs once — a silently skipped item
+        # is the wrong failure mode for lint (same rationale as _common._geom_box).
+        _log.debug(
+            "lint: %s did not bbox (%s); box-dependent checks skip it", type(item).__name__, exc
+        )
         box = None
     cache[key] = (item, token, box)
     return box
@@ -101,6 +109,20 @@ def _item_label(item) -> str:
     — e.g. a vanilla build123d ``ExtensionLine`` that does not retain its
     constructor label."""
     return getattr(item, "label", "") or getattr(item, "_annotate_label", "") or ""
+
+
+def _label_bbox(item):
+    """``item.label_bbox`` or ``None`` — the one duck-typed read the lint checks
+    guard, so a raising property on a user-supplied item cannot kill lint. It is
+    logged, not swallowed (#701: a check that silently skips an item can silently
+    disable itself)."""
+    try:
+        return getattr(item, "label_bbox", None)
+    except Exception as exc:  # noqa: BLE001 — duck-typed items may misbehave
+        _log.warning(
+            "lint: unreadable label_bbox on %s (%s); item skipped", type(item).__name__, exc
+        )
+        return None
 
 
 def _label_value(label: str) -> float | None:
@@ -232,7 +254,7 @@ def lint_drawing(
     # result is identical. Centre lines are compared via _centerline_extent, not
     # this box, so they don't need one.
     def _label_box(item):
-        lb = getattr(item, "label_bbox", None)
+        lb = _label_bbox(item)
         if lb is not None:
             return lb
         return _ann_box(item, box_cache)
@@ -242,76 +264,71 @@ def lint_drawing(
         if getattr(item, "is_centerline", False):
             boxes.append(None)
             continue
-        try:
-            boxes.append(_label_box(item))
-        except Exception:
-            boxes.append(None)
+        boxes.append(_label_box(item))
 
+    # #701: the check body runs unguarded — the fragile duck-typed reads happened
+    # above (boxes) or inside the callee; a bug here must fail loudly, not silently
+    # disable the check forever.
     for i, item_a in enumerate(items):
         for j in range(i + 1, len(items)):
             item_b = items[j]
-            try:
-                is_cl_a = getattr(item_a, "is_centerline", False)
-                is_cl_b = getattr(item_b, "is_centerline", False)
+            is_cl_a = getattr(item_a, "is_centerline", False)
+            is_cl_b = getattr(item_b, "is_centerline", False)
 
-                if is_cl_a and is_cl_b:
-                    continue
+            if is_cl_a and is_cl_b:
+                continue
 
-                if is_cl_a or is_cl_b:
-                    dim_item = item_b if is_cl_a else item_a
-                    cl_item = item_a if is_cl_a else item_b
-                    _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache)
-                    continue
+            if is_cl_a or is_cl_b:
+                dim_item = item_b if is_cl_a else item_a
+                cl_item = item_a if is_cl_a else item_b
+                _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache)
+                continue
 
-                # Compare label text extents, NOT full bounding boxes.
-                # Full bbox includes witness lines which legitimately overlap for
-                # stacked dims (every inner bbox is a subset of the outer one).
-                # label_bbox is the keep-clear region around the value text — the
-                # thing that actually matters to a reader.
-                la_box = boxes[i]
-                lb_box = boxes[j]
-                if la_box is None or lb_box is None:
-                    continue
-                ox = max(0.0, min(la_box[2], lb_box[2]) - max(la_box[0], lb_box[0]))
-                oy = max(0.0, min(la_box[3], lb_box[3]) - max(la_box[1], lb_box[1]))
-                if ox > 0.5 and oy > 0.5:
-                    la = getattr(item_a, "label", "?")
-                    lb = getattr(item_b, "label", "?")
-                    issues.append(
-                        LintIssue(
-                            severity="warning",
-                            message=(
-                                f"labels '{la}' and '{lb}' overlap by "
-                                f"{ox:.1f}×{oy:.1f} mm — use label_offset_x or "
-                                f"increase dim offset to separate them"
-                            ),
-                            code="annotation_overlap",
-                        )
+            # Compare label text extents, NOT full bounding boxes.
+            # Full bbox includes witness lines which legitimately overlap for
+            # stacked dims (every inner bbox is a subset of the outer one).
+            # label_bbox is the keep-clear region around the value text — the
+            # thing that actually matters to a reader.
+            la_box = boxes[i]
+            lb_box = boxes[j]
+            if la_box is None or lb_box is None:
+                continue
+            ox = max(0.0, min(la_box[2], lb_box[2]) - max(la_box[0], lb_box[0]))
+            oy = max(0.0, min(la_box[3], lb_box[3]) - max(la_box[1], lb_box[1]))
+            if ox > 0.5 and oy > 0.5:
+                la = getattr(item_a, "label", "?")
+                lb = getattr(item_b, "label", "?")
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        message=(
+                            f"labels '{la}' and '{lb}' overlap by "
+                            f"{ox:.1f}×{oy:.1f} mm — use label_offset_x or "
+                            f"increase dim offset to separate them"
+                        ),
+                        code="annotation_overlap",
                     )
-            except Exception:
-                pass
+                )
 
     # Page-bounds check — annotations must stay within the drawable area.
+    # (#701: unguarded — _ann_box absorbs the fragile measure; the rest is arithmetic.)
     if page_bbox is not None:
         for item in items:
-            try:
-                bb = _ann_box(item, box_cache)
-                if bb is None:
-                    continue
-                for detail in _overshoots(bb, page_bbox):
-                    lbl = _item_label(item) or "?"
-                    issues.append(
-                        LintIssue(
-                            severity="error",
-                            message=(
-                                f"annotation '{lbl}' extends past drawable area "
-                                f"({detail}) — increase margin or reduce offset"
-                            ),
-                            code="annotation_out_of_bounds",
-                        )
+            bb = _ann_box(item, box_cache)
+            if bb is None:
+                continue
+            for detail in _overshoots(bb, page_bbox):
+                lbl = _item_label(item) or "?"
+                issues.append(
+                    LintIssue(
+                        severity="error",
+                        message=(
+                            f"annotation '{lbl}' extends past drawable area "
+                            f"({detail}) — increase margin or reduce offset"
+                        ),
+                        code="annotation_out_of_bounds",
                     )
-            except Exception:
-                pass
+                )
 
     if view_shapes is not None:
         _lint_view_shapes(
@@ -477,43 +494,40 @@ def _lint_view_shapes(
                 continue  # a datum target sits on the part face by definition
             if getattr(ann, "is_section_hatch", False):
                 continue  # hatching is intentionally inside the section view
-            try:
-                label_box = getattr(ann, "label_bbox", None)
-                ab = label_box if label_box is not None else _ann_box(ann, ann_cache)
-                if ab is None:
-                    continue
-                if not _bboxes_overlap_2d(vbb, ab):
-                    continue
-                albl = (
-                    getattr(ann, "label", None) or getattr(ann, "name", None) or type(ann).__name__
+            # #701: unguarded — _label_bbox/_ann_box/_view_edge_entries absorb the
+            # fragile reads; a bug in the check itself must fail loudly.
+            label_box = _label_bbox(ann)
+            ab = label_box if label_box is not None else _ann_box(ann, ann_cache)
+            if ab is None:
+                continue
+            if not _bboxes_overlap_2d(vbb, ab):
+                continue
+            albl = getattr(ann, "label", None) or getattr(ann, "name", None) or type(ann).__name__
+            what = "label of annotation" if label_box is not None else "annotation"
+            edges = _view_edge_entries(vs, cache)
+            if edges is None or _edges_intersect_rect(edges, ab):
+                issues.append(
+                    LintIssue(
+                        severity="warning",
+                        message=(
+                            f"view '{vname}' line-work overlaps {what} '{albl}' "
+                            f"— increase view spacing or move the annotation"
+                        ),
+                        code="view_annotation_overlap",
+                    )
                 )
-                what = "label of annotation" if label_box is not None else "annotation"
-                edges = _view_edge_entries(vs, cache)
-                if edges is None or _edges_intersect_rect(edges, ab):
-                    issues.append(
-                        LintIssue(
-                            severity="warning",
-                            message=(
-                                f"view '{vname}' line-work overlaps {what} '{albl}' "
-                                f"— increase view spacing or move the annotation"
-                            ),
-                            code="view_annotation_overlap",
-                        )
+            else:
+                issues.append(
+                    LintIssue(
+                        severity="info",
+                        message=(
+                            f"{what} '{albl}' lies inside view '{vname}' extents "
+                            f"[x={vx0:.1f}–{vx1:.1f}, y={vy0:.1f}–{vy1:.1f}] over a "
+                            f"blank region — legitimate for callouts on large faces"
+                        ),
+                        code="view_annotation_inside_extents",
                     )
-                else:
-                    issues.append(
-                        LintIssue(
-                            severity="info",
-                            message=(
-                                f"{what} '{albl}' lies inside view '{vname}' extents "
-                                f"[x={vx0:.1f}–{vx1:.1f}, y={vy0:.1f}–{vy1:.1f}] over a "
-                                f"blank region — legitimate for callouts on large faces"
-                            ),
-                            code="view_annotation_inside_extents",
-                        )
-                    )
-            except Exception:
-                pass
+                )
 
     # #160 — view shape vs view shape bounding box overlaps
     for i, (aname, abb, _) in enumerate(named_views):
@@ -552,49 +566,56 @@ def _lint_view_shapes(
 
 
 def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache=None) -> None:
-    """Flag label-vs-centerline overlap for a (dim, centerline) pair."""
+    """Flag label-vs-centerline overlap for a (dim, centerline) pair.
+
+    #701: only the centreline measure is guarded (malformed ``segments`` /
+    unmeasurable bbox on a duck-typed item) and the skip is logged; the overlap
+    arithmetic runs unguarded so a bug fails loudly instead of silently
+    disabling the check.
+    """
+    if box_cache is None:
+        box_cache = {}
     try:
-        if box_cache is None:
-            box_cache = {}
         cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl_item, box_cache)
+    except Exception as exc:  # noqa: BLE001 — duck-typed centreline may not measure
+        _log.debug("lint: centreline did not measure (%s); overlap check skips it", exc)
+        return
 
-        label_bbox = getattr(dim_item, "label_bbox", None)
-        if label_bbox is None:
-            label_bbox = _ann_box(dim_item, box_cache)
-        if label_bbox is None:
-            return
-        lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
+    label_bbox = _label_bbox(dim_item)
+    if label_bbox is None:
+        label_bbox = _ann_box(dim_item, box_cache)
+    if label_bbox is None:
+        return
+    lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
 
-        cl_w = cl_max_x - cl_min_x
-        cl_h = cl_max_y - cl_min_y
+    cl_w = cl_max_x - cl_min_x
+    cl_h = cl_max_y - cl_min_y
 
-        if cl_w < 0.1:
-            cl_x = (cl_min_x + cl_max_x) / 2.0
-            ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
-        else:
-            ox = max(0.0, min(lmax_x, cl_max_x) - max(lmin_x, cl_min_x))
+    if cl_w < 0.1:
+        cl_x = (cl_min_x + cl_max_x) / 2.0
+        ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
+    else:
+        ox = max(0.0, min(lmax_x, cl_max_x) - max(lmin_x, cl_min_x))
 
-        if cl_h < 0.1:
-            cl_y = (cl_min_y + cl_max_y) / 2.0
-            oy = min(cl_y - lmin_y, lmax_y - cl_y) if lmin_y < cl_y < lmax_y else 0.0
-        else:
-            oy = max(0.0, min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y))
+    if cl_h < 0.1:
+        cl_y = (cl_min_y + cl_max_y) / 2.0
+        oy = min(cl_y - lmin_y, lmax_y - cl_y) if lmin_y < cl_y < lmax_y else 0.0
+    else:
+        oy = max(0.0, min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y))
 
-        if ox > 0.5 and oy > 0.5:
-            dim_label = getattr(dim_item, "label", "?")
-            issues.append(
-                LintIssue(
-                    severity="warning",
-                    message=(
-                        f"label '{dim_label}' overlaps centerline by "
-                        f"{ox:.1f}×{oy:.1f} mm — use label_offset_x to shift "
-                        f"or increase dim offset to clear the centerline"
-                    ),
-                    code="label_centerline_overlap",
-                )
+    if ox > 0.5 and oy > 0.5:
+        dim_label = getattr(dim_item, "label", "?")
+        issues.append(
+            LintIssue(
+                severity="warning",
+                message=(
+                    f"label '{dim_label}' overlaps centerline by "
+                    f"{ox:.1f}×{oy:.1f} mm — use label_offset_x to shift "
+                    f"or increase dim offset to clear the centerline"
+                ),
+                code="label_centerline_overlap",
             )
-    except Exception:
-        pass
+        )
 
 
 def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:
@@ -654,29 +675,36 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
 
 
 def _lint_leader(item, issues, box_cache=None) -> None:
+    # #701: was a whole-body `except Exception: pass` — an internal bug silently
+    # disabled the check forever. Only the duck-typed reads are guarded now.
+    box = _label_bbox(item)
+    if box is None:
+        box = _ann_box(item, box_cache if box_cache is not None else {})
+    if box is None:
+        return
+    minx, miny, maxx, maxy = box
     try:
-        box = getattr(item, "label_bbox", None)
-        if box is None:
-            box = _ann_box(item, box_cache if box_cache is not None else {})
-        if box is None:
-            return
-        minx, miny, maxx, maxy = box
         ex, ey = item.elbow
-        if minx <= ex <= maxx and miny <= ey <= maxy:
-            issues.append(
-                LintIssue(
-                    severity="error",
-                    message=(
-                        f"Leader '{getattr(item, 'label', '?')}': elbow point "
-                        f"({ex:.2f}, {ey:.2f}) is inside the label bbox — leader "
-                        f"line passes through the text"
-                    ),
-                    location=item.elbow,
-                    code="leader_line_through_text",
-                )
+    except Exception as exc:  # noqa: BLE001 — duck-typed elbow may not unpack
+        _log.warning(
+            "lint: unreadable elbow on leader %r (%s); leader_line_through_text skipped",
+            _item_label(item) or "?",
+            exc,
+        )
+        return
+    if minx <= ex <= maxx and miny <= ey <= maxy:
+        issues.append(
+            LintIssue(
+                severity="error",
+                message=(
+                    f"Leader '{getattr(item, 'label', '?')}': elbow point "
+                    f"({ex:.2f}, {ey:.2f}) is inside the label bbox — leader "
+                    f"line passes through the text"
+                ),
+                location=item.elbow,
+                code="leader_line_through_text",
             )
-    except Exception:
-        pass
+        )
 
 
 def _seg_hits_box(p, q, box, pad=0.2):

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -111,17 +111,27 @@ def _item_label(item) -> str:
     return getattr(item, "label", "") or getattr(item, "_annotate_label", "") or ""
 
 
+# Items whose raising label_bbox was already warned about — several checks read the
+# same item's label_bbox (per centreline pair, per view), so an unmemoised warning
+# would flood the log O(n²) on one bad item (#711 review).
+_warned_label_bbox: set[int] = set()
+
+
 def _label_bbox(item):
-    """``item.label_bbox`` or ``None`` — the one duck-typed read the lint checks
-    guard, so a raising property on a user-supplied item cannot kill lint. It is
-    logged, not swallowed (#701: a check that silently skips an item can silently
-    disable itself)."""
+    """``item.label_bbox`` or ``None`` — a raising property on a user-supplied
+    duck-typed item cannot kill lint; it is logged (once per item), not swallowed
+    (#701: a check that silently skips an item can silently disable itself).
+    Known hole: a property that raises ``AttributeError`` *internally* is
+    indistinguishable from an absent attribute through ``getattr`` and reads as a
+    silent ``None``."""
     try:
         return getattr(item, "label_bbox", None)
     except Exception as exc:  # noqa: BLE001 — duck-typed items may misbehave
-        _log.warning(
-            "lint: unreadable label_bbox on %s (%s); item skipped", type(item).__name__, exc
-        )
+        if id(item) not in _warned_label_bbox:
+            _warned_label_bbox.add(id(item))
+            _log.warning(
+                "lint: unreadable label_bbox on %s (%s); item skipped", type(item).__name__, exc
+            )
         return None
 
 
@@ -208,7 +218,7 @@ def lint_drawing(
             features, surface-finish marks) are tested by the label-text
             extents only — witness lines, leader shafts, datum triangles, and
             finish marks may enter the view freely.  Shapes whose bounding box
-            cannot be computed are silently skipped.
+            cannot be computed are skipped (logged at debug, #701).
         view_edge_cache: optional dict, persisted by the caller across repeated
             ``lint_drawing`` calls on the *same* views, that memoises each view
             shape's per-edge bounding boxes — the dominant cost when a drawing
@@ -701,7 +711,7 @@ def _lint_leader(item, issues, box_cache=None) -> None:
                     f"({ex:.2f}, {ey:.2f}) is inside the label bbox — leader "
                     f"line passes through the text"
                 ),
-                location=item.elbow,
+                location=(ex, ey),
                 code="leader_line_through_text",
             )
         )

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -417,3 +417,47 @@ class TestLintViewShapes:
         view = self._make_box_shape(80, 10, 40, 30)
         codes = {i.code for i in lint_drawing([], view_shapes=[view])}
         assert "view_out_of_bounds" not in codes
+
+
+class TestLintSelfSilencing:
+    """#701: the check bodies run unguarded — only the fragile duck-typed reads
+    are caught, and every swallowed failure is logged, so a broken check fails
+    loudly instead of silently reporting nothing forever."""
+
+    def test_raising_label_bbox_is_logged_not_swallowed(self, caplog):
+        import logging
+
+        class BadLabelBbox:
+            elbow = (1.0, 1.0)  # leader-like → dispatched to _lint_leader
+
+            @property
+            def label_bbox(self):
+                raise RuntimeError("boom")
+
+        with caplog.at_level(logging.WARNING, logger="draftwright.linting.structural"):
+            issues = lint_drawing([BadLabelBbox()])
+        assert "unreadable label_bbox" in caplog.text
+        assert isinstance(issues, list)  # lint completed; the bad item was skipped
+
+    def test_broken_elbow_is_logged_not_swallowed(self, caplog):
+        import logging
+
+        item = SimpleNamespace(elbow=object(), label_bbox=(0.0, 0.0, 10.0, 5.0), label="L")
+        with caplog.at_level(logging.WARNING, logger="draftwright.linting.structural"):
+            issues = lint_drawing([item])
+        assert "unreadable elbow" in caplog.text
+        assert not any(i.code == "leader_line_through_text" for i in issues)
+
+    def test_leader_elbow_inside_label_still_flagged(self):
+        # the check itself still fires once the reads succeed
+        item = SimpleNamespace(elbow=(5.0, 2.0), label_bbox=(0.0, 0.0, 10.0, 5.0), label="L")
+        issues = lint_drawing([item])
+        assert any(i.code == "leader_line_through_text" for i in issues)
+
+    def test_internal_bug_fails_loudly_not_silently(self):
+        # a malformed 2-tuple label_bbox breaks the pairwise overlap arithmetic;
+        # pre-#701 the whole-body `except Exception: pass` hid it forever.
+        a = SimpleNamespace(label_bbox=(0.0, 0.0), label="A")
+        b = SimpleNamespace(label_bbox=(0.0, 0.0, 4.0, 4.0), label="B")
+        with pytest.raises(IndexError):
+            lint_drawing([a, b])

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -436,7 +436,8 @@ class TestLintSelfSilencing:
 
         with caplog.at_level(logging.WARNING, logger="draftwright.linting.structural"):
             issues = lint_drawing([BadLabelBbox()])
-        assert "unreadable label_bbox" in caplog.text
+        # several checks read the same item's label_bbox — warned exactly once (#711 review)
+        assert caplog.text.count("unreadable label_bbox") == 1
         assert isinstance(issues, list)  # lint completed; the bad item was skipped
 
     def test_broken_elbow_is_logged_not_swallowed(self, caplog):


### PR DESCRIPTION
## Summary

Audit issue #701: `linting/structural.py` wrapped five **entire check bodies** in `except Exception: pass` — the leader check, the centreline-overlap check, the pairwise label-overlap loop, the page-bounds loop, and the view-vs-annotation loop. Any internal bug silently disabled the check forever. Since ADR 0002 makes lint-critique the engine's primary correctness mechanism, a self-silencing lint layer is an architectural weak point.

## Changes

- **Narrow guards, logged skips** (the in-tree `_common._geom_box` pattern): a new `_label_bbox()` helper guards the raising-property read (warns + skips the item); `_ann_box` logs its measure failure (once — the `None` is cached); the centreline measure and leader-elbow unpack keep narrow, logged guards.
- **Check bodies run unguarded** — pure arithmetic + issue construction; an internal bug now fails loudly instead of vanishing.
- Untouched by design: the fail-loud guards in `_edges_intersect_rect`/`_view_edge_entries` (failure counts as a hit) and the narrow `_loc_token`/`_bbox2d` leaf guards.

## Testing

- 4 new tests (`TestLintSelfSilencing`): raising `label_bbox` logged+skipped, broken elbow logged+skipped, the leader check still fires, and a malformed-box internal bug now raises (pre-#701 it was swallowed).
- `test_lint_structural.py` 48 passed; **full fast tier: 1418 passed**, 1 failed — the failure is a **pre-existing fuzz-found layout bug** (`view_out_of_bounds`, 0.8 mm overflow) that fails identically on `main`; filed as #710.
- Lint gate: ruff check ✓, ruff format --check ✓, mypy ✓, codespell ✓.

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)