### PR TITLE
feat(#703): cyls= injection for turned/grooves/flats — one cylinder scan per build

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -517,7 +517,7 @@ def _analyse(
     # recognise_face_levels admitted it). Prismatic and other parts keep the
     # general face-level scan, which recognise_turned_steps cannot replace (no
     # cylinders → no profile).
-    _turned = TurnedProfile.from_steps(recognise_turned_steps(part))
+    _turned = TurnedProfile.from_steps(recognise_turned_steps(part, cyls=(z_cyls, cross_cyls)))
     if _turned is not None and _turned.axis == "z":
         step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
     else:
@@ -566,6 +566,7 @@ def _analyse(
             step_zs=step_zs,
             rotational=(od_diam, _bores, od_axis) if is_rotational else None,
             pmi=pmi_records,
+            cyls=(z_cyls, cross_cyls),
         )
     )
     sizing_groups = plan_dimensions(sizing_model)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -125,6 +125,7 @@ def build_model(a: Analysis):
         step_zs=a.step_zs,
         rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
         pmi=a.pmi,
+        cyls=a.cyls,
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -210,6 +210,7 @@ def build_part_model(
     step_zs=None,
     rotational=None,
     pmi=None,
+    cyls=None,
 ) -> PartModel:
     """Run the detectors and assemble the :class:`PartModel` IR for *part*.
 
@@ -222,7 +223,12 @@ def build_part_model(
     ``step_zs`` (prismatic horizontal face levels) and ``rotational`` (``(od, bores)``
     or ``None``) are *classification* inputs from `_analyse` — the IR can't derive
     them from geometry alone — feeding the prismatic step ladder (#237) and the
-    rotational OD/bore furniture (#237)."""
+    rotational OD/bore furniture (#237).
+
+    ``cyls`` is a precomputed ``analyse_cylinders(part)`` result threaded into every
+    cylinder-substrate recogniser called here (holes/bosses/turned/grooves/flats), so
+    the solid is scanned once per build (#703); omitted, each recogniser scans for
+    itself."""
     bbox = part.bounding_box()
     features: list[Feature] = []
 
@@ -230,7 +236,7 @@ def build_part_model(
     # (count× member-diameter + pattern dims); its member holes are NOT also
     # emitted individually — the grouped-callout rule the engine uses.
     if holes is None:
-        holes = recognise_holes(part, csinks=recognise_countersinks(part))
+        holes = recognise_holes(part, cyls=cyls, csinks=recognise_countersinks(part))
     if patterns is None:
         patterns = recognise_hole_patterns(holes)
     patterned: set[int] = set()
@@ -304,11 +310,11 @@ def build_part_model(
     # its two walls read as shoulders, so recognise_turned_steps also delimits it as a
     # middle "step". Emitting both a StepFeature and a GrooveFeature for one band would
     # double-dimension the floor ø (ISO 129) and break ADR 0008's one-band-one-owner waist.
-    grooves = recognise_grooves(part)
+    grooves = recognise_grooves(part, cyls=cyls)
 
     # Turned profile → step segments; else external bosses → diameters.
     if prof is _UNSET:
-        prof = TurnedProfile.from_steps(recognise_turned_steps(part))
+        prof = TurnedProfile.from_steps(recognise_turned_steps(part, cyls=cyls))
     orientation = prof.axis if prof is not None else None
     if prof is not None:
         idx = "xyz".index(prof.axis)
@@ -350,7 +356,7 @@ def build_part_model(
         # floor is likewise a narrow reduced band, but the groove callout already carries its
         # ø, so it is suppressed here (_boss_is_groove_floor) to avoid a duplicate boss ø.
         step_dias = [s.diameter for s in prof.steps]
-        raw_bosses = recognise_bosses(part) if bosses is None else bosses
+        raw_bosses = recognise_bosses(part, cyls=cyls) if bosses is None else bosses
         for b in _distinct_by_diameter(raw_bosses):
             if all(
                 abs(b.diameter - d) > _DIA_TOL for d in step_dias
@@ -362,7 +368,7 @@ def build_part_model(
                     )
                 )
     else:
-        raw_bosses = recognise_bosses(part) if bosses is None else bosses
+        raw_bosses = recognise_bosses(part, cyls=cyls) if bosses is None else bosses
         bosses_d = _distinct_by_diameter(raw_bosses)
         for b in bosses_d:
             # A grooved round body can still fail the turned-step squareness gate (e.g. a
@@ -485,7 +491,7 @@ def build_part_model(
     # rotational branch): a D-shaft / hex head IS round stock and classifies rotational,
     # yet its flat still needs a callout. The recogniser self-gates on OD adjacency, so a
     # part with no round stock yields none.
-    for flat in recognise_flats(part):
+    for flat in recognise_flats(part, cyls=cyls):
         at = flat.at
         features.append(
             FlatFeature(

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -1041,7 +1041,7 @@ def _rect_grid(members, pts):
     )
 
 
-def recognise_hole_patterns(holes) -> list:
+def recognise_hole_patterns(holes) -> list[BoltCircle | LinearArray | RectGrid]:
     """Recognise :class:`BoltCircle`, :class:`LinearArray`, and
     :class:`RectGrid` patterns among *holes* (``HoleRecord`` records, e.g.
     from :func:`recognise_holes`).

--- a/src/draftwright/recognition/flats.py
+++ b/src/draftwright/recognition/flats.py
@@ -101,11 +101,14 @@ class Flat(Record):
     at: tuple[float, float, float]
 
 
-def recognise_flats(part) -> list[Flat]:
+def recognise_flats(part, *, cyls=None) -> list[Flat]:
     """Recognise the machined flats of *part* (see module docstring). Returns one
     :class:`Flat` per qualifying planar face truncating round stock, sorted
-    deterministically. Empty when the part has no round stock or no flat."""
-    z_cyls, cross_cyls = analyse_cylinders(part)
+    deterministically. Empty when the part has no round stock or no flat.
+
+    Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to avoid
+    re-scanning the solid (mirrors ``recognise_holes``'s parameter, #703)."""
+    z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     ext = [c for c in (*z_cyls, *cross_cyls) if c.get("external")]
     if not ext:
         return []

--- a/src/draftwright/recognition/grooves.py
+++ b/src/draftwright/recognition/grooves.py
@@ -74,12 +74,15 @@ class Groove(Record):
     at: tuple[float, float, float]
 
 
-def recognise_grooves(part) -> list[Groove]:
+def recognise_grooves(part, *, cyls=None) -> list[Groove]:
     """Recognise the turned grooves of *part* (see module docstring). Returns one
     :class:`Groove` per external band whose OD is a strict local minimum between two
     contiguous larger bands on the same shaft, sorted deterministically. Empty when the
-    part has no round stock or no groove."""
-    z_cyls, cross_cyls = analyse_cylinders(part)
+    part has no round stock or no groove.
+
+    Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to avoid
+    re-scanning the solid (mirrors ``recognise_holes``'s parameter, #703)."""
+    z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     ext = [c for c in (*z_cyls, *cross_cyls) if c.get("external")]
     if not ext:
         return []

--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -108,15 +108,18 @@ class TurnedProfile(Record):
         return (*(s.lo for s in self.steps), self.steps[-1].hi)
 
 
-def recognise_turned_steps(part) -> list[TurnedStep]:
+def recognise_turned_steps(part, *, cyls=None) -> list[TurnedStep]:
     """Recognise the axial steps of a stepped turned ``part``.
 
     Returns ``[]`` for a non-turned part, a plain (single-diameter) cylinder, or
     anything with fewer than two steps — nothing to dimension axially. Each
     :class:`TurnedStep` carries the turning ``axis``; aggregate them with
     :meth:`TurnedProfile.from_steps` if the axis/shoulders unit is wanted.
+
+    Pass *cyls* — a precomputed ``analyse_cylinders(part)`` result — to avoid
+    re-scanning the solid (mirrors ``recognise_holes``'s parameter, #703).
     """
-    z_cyls, cross_cyls = analyse_cylinders(part)
+    z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     ext = [c for c in (*z_cyls, *cross_cyls) if c.get("external")]
     if not ext:
         return []

--- a/src/draftwright/score.py
+++ b/src/draftwright/score.py
@@ -28,6 +28,7 @@ build123d, and nothing in the engine imports it.
 from __future__ import annotations
 
 from draftwright.recognition import (
+    analyse_cylinders,
     recognise_bosses,
     recognise_chamfers,
     recognise_countersinks,
@@ -46,20 +47,22 @@ from draftwright.recognition import (
 def feature_census(part) -> dict[str, int]:
     """The count of recognised features per kind for *part* (see module docs).
 
-    Runs every feature recogniser once — injecting hole patterns from the recognised holes (the
-    one ADR 0013 dependency) — and returns ``{kind: count}`` with a stable, complete set of
+    Runs every feature recogniser once — injecting hole patterns from the recognised holes and
+    one shared cylinder scan into every substrate recogniser (#703) — and returns
+    ``{kind: count}`` with a stable, complete set of
     keys (a kind absent from the part reports ``0``, not a missing key). The prismatic
     *substrate* recognisers (face levels, step shoulders — #555) are excluded: they feed other
     recognisers rather than being distinct machined features, and their level-derivation belongs
     to the model layer, not a metric."""
-    holes = recognise_holes(part)
+    cyls = analyse_cylinders(part)
+    holes = recognise_holes(part, cyls=cyls)
     records: dict[str, list] = {
         "hole": holes,
         "hole_pattern": recognise_hole_patterns(holes),
-        "boss": recognise_bosses(part),
-        "step": recognise_turned_steps(part),
-        "groove": recognise_grooves(part),
-        "flat": recognise_flats(part),
+        "boss": recognise_bosses(part, cyls=cyls),
+        "step": recognise_turned_steps(part, cyls=cyls),
+        "groove": recognise_grooves(part, cyls=cyls),
+        "flat": recognise_flats(part, cyls=cyls),
         "slot": recognise_slots(part),
         "pocket": recognise_pockets(part),
         "chamfer": recognise_chamfers(part),

--- a/src/draftwright/score.py
+++ b/src/draftwright/score.py
@@ -53,7 +53,7 @@ def feature_census(part) -> dict[str, int]:
     recognisers rather than being distinct machined features, and their level-derivation belongs
     to the model layer, not a metric."""
     holes = recognise_holes(part)
-    records = {
+    records: dict[str, list] = {
         "hole": holes,
         "hole_pattern": recognise_hole_patterns(holes),
         "boss": recognise_bosses(part),

--- a/tests/test_detect_once.py
+++ b/tests/test_detect_once.py
@@ -66,6 +66,43 @@ def test_generate_script_detects_once(fillet_counter, tmp_path):
     )
 
 
+@pytest.fixture
+def cyls_counter(monkeypatch):
+    """Count ``analyse_cylinders`` scans everywhere the name is import-bound —
+    patching only ``_features`` would miss the recognisers' own bindings."""
+    import draftwright.analysis as analysis
+    import draftwright.drawing as drawing
+    import draftwright.recognition._features as _features
+    import draftwright.recognition.flats as flats
+    import draftwright.recognition.grooves as grooves
+    import draftwright.recognition.turned as turned
+
+    calls = {"n": 0}
+    real = _features.analyse_cylinders
+
+    def counting(part):
+        calls["n"] += 1
+        return real(part)
+
+    for mod in (_features, analysis, drawing, flats, grooves, turned):
+        monkeypatch.setattr(mod, "analyse_cylinders", counting)
+    return calls
+
+
+def test_cylinder_scan_runs_once_per_build(cyls_counter):
+    # #703: one analyse_cylinders scan per build, threaded to every substrate
+    # recogniser (holes/bosses/turned/grooves/flats) via ``cyls=``. Injection
+    # alone can't pin this — a recogniser that ignores ``cyls`` and self-scans,
+    # or a dropped call-site threading, returns identical records; only the
+    # scan count regresses.
+    dwg = build_drawing(_filleted())
+    dwg.lint()
+    assert cyls_counter["n"] == 1, (
+        f"analyse_cylinders ran {cyls_counter['n']}× in one build+lint — a recogniser "
+        f"or lint path is re-scanning instead of sharing the one Analysis scan (#703)"
+    )
+
+
 def test_declared_model_runs_no_detection(fillet_counter):
     # ADR 0011: a caller-declared model skips detection entirely — build_part_model is
     # never invoked (the sizing path uses the declared model; the builder coerces it),

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -37,6 +37,7 @@ from draftwright.recognition import (
     Slot,
     StepShoulder,
     TurnedStep,
+    analyse_cylinders,
     recognise_bosses,
     recognise_chamfers,
     recognise_countersinks,
@@ -233,6 +234,23 @@ def test_part_based_recognisers_are_keyword_only_after_part():
             assert p.kind == inspect.Parameter.KEYWORD_ONLY, (
                 f"{fn.__name__}: '{p.name}' must be keyword-only (injected dep / tuning)"
             )
+
+
+def test_cylinder_substrate_is_injectable():
+    """#703: the three turned-stock recognisers accept a precomputed
+    ``analyse_cylinders`` result (``cyls=``) and return identical records to a
+    self-scan — the caller owns the one scan (ADR 0013 §2 / ADR 0008 Am5),
+    mirroring ``recognise_holes``/``recognise_bosses``."""
+    dshaft = Cylinder(10, 30) - Pos(10, 0, 0) * Box(10, 40, 40)
+    grooved = Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(8, 4))
+    for fn, part in (
+        (recognise_turned_steps, _turned_shaft()),
+        (recognise_grooves, grooved),
+        (recognise_flats, dshaft),
+    ):
+        records = fn(part)
+        assert records, f"{fn.__name__}: fixture no longer triggers the recogniser"
+        assert fn(part, cyls=analyse_cylinders(part)) == records
 
 
 def test_derived_recogniser_takes_single_positional_inventory():


### PR DESCRIPTION
## Summary

Audit issue #703: `recognise_turned_steps`/`recognise_grooves`/`recognise_flats` each re-ran `analyse_cylinders(part)` internally with no injection seam — while `recognise_holes`/`recognise_bosses` take `cyls=` precisely to avoid re-scanning. That recreated the inconsistent-injection asymmetry ADR 0013 §2 removed, and meant **≥4 cylinder scans per build** against ADR 0008 Am5's one-scan spirit.

## Changes

- The three turned-stock recognisers gain keyword-only `cyls=None` (compute-if-absent), mirroring `recognise_holes`' parameter + docstring wording.
- `build_part_model` gains `cyls=` and threads it into every cylinder-substrate recogniser it calls (the holes/bosses fallbacks + turned/grooves/flats).
- `analysis.py` threads its single scan into the turned-step call and the sizing-model `build_part_model`; `orchestrator.build_model` threads `a.cyls`. **`detect.py` no longer calls `analyse_cylinders` at all** — one scan per build path.
- Verified none of the recognisers mutates the shared cylinder records, so sharing is safe.
- ADR 0013 hygiene ride-along (named in the issue): `recognise_hole_patterns`' bare `-> list` becomes `list[BoltCircle | LinearArray | RectGrid]`; `score.py`'s census dict gets a `dict[str, list]` annotation to keep mypy green with the union.

## Testing

- New contract test `test_cylinder_substrate_is_injectable`: injected results are record-identical to a self-scan for all three (fixtures asserted non-trivial).
- Contract 6 ✓, turned/detect-once 86 ✓, recognition+score 74 ✓, smoke 47 ✓.
- Lint gate: ruff check ✓, ruff format --check ✓, mypy ✓, codespell ✓.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)