### PR TITLE
chore(#705): prune production-dead code left by closed migrations

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1,8 +1,8 @@
 """Shared annotation-placement helpers (#138 / ADR 0005, P5).
 
 Page-box geometry the passes share: an annotation's bbox (`_anno_box`), the
-set of already-placed boxes a candidate must not overprint (`_occupied_boxes`),
-and an AABB overlap test (`_box_hits`). Bottom of the annotations DAG.
+complete strip occupancy (`strip_obstacles`), and an AABB overlap test
+(`_box_hits`). Bottom of the annotations DAG.
 """
 
 from __future__ import annotations
@@ -72,21 +72,6 @@ def _anno_box(o):
         return (b.min.X, b.min.Y, b.max.X, b.max.Y)
     except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
         return None
-
-
-def _occupied_boxes(dwg):
-    """Boxes of already-placed annotations a location dim must not overprint:
-    every label-bearing annotation (hole callouts, other dims) plus the section
-    hatch.  Bare centrelines/leaders are excluded — those legitimately cross a
-    dimension and lint does not flag them."""
-    boxes = []
-    for name, o in dwg.iter_annotations():
-        if getattr(o, "label_bbox", None) is None and name != "section_hatch":
-            continue
-        bb = _anno_box(o)
-        if bb is not None:
-            boxes.append(bb)
-    return boxes
 
 
 def _geom_box(o):
@@ -309,8 +294,8 @@ def strip_obstacles(dwg, view=None, *, crossable=()):
     consumer may legitimately overlap — e.g. a location dim crosses a centre line
     but a leader does not; see :data:`CROSSABLE_TYPES`).
 
-    Unlike :func:`_occupied_boxes` (label boxes only, with bare centrelines
-    excluded), this captures the geometry a label box hides — leader shafts and
+    Unlike the retired label-box-only ``_occupied_boxes`` (which excluded bare
+    centrelines), this captures the geometry a label box hides — leader shafts and
     arrow tips, dimension witness/extension lines, centrelines, and the section
     hatch. That hidden geometry is the 'invisible occupant' class behind the
     recurring strip overlaps (#133/#225/#305): a placer that consults only label
@@ -321,7 +306,7 @@ def strip_obstacles(dwg, view=None, *, crossable=()):
     strip placer must still avoid — and drops only the *other* ortho views' blocks
     (which compose-then-pack keeps disjoint, ADR 0004). The section hatch
     (``view_of`` ``None``) is therefore present in every per-view query, the way
-    :func:`_occupied_boxes` special-cased it; restricting it to ``view=None`` would
+    ``_occupied_boxes`` special-cased it; restricting it to ``view=None`` would
     re-open the very blind spot this closes.
 
     Boxes are AABBs ``(x0, y0, x1, y1)`` (use with :func:`_box_hits`) — intentionally

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -65,7 +65,6 @@ from draftwright.annotations._common import (
     _box_hits,
     _geom_box,
     carve_free_position,
-    carve_free_segments,
     dim_footprint,
     place_strip_candidates,
     register_corridor,
@@ -815,9 +814,9 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
     # Place what fits; drop the smallest ø first, never the whole column (#298).
     survivors, ys = _place_what_fits(specs, 1, min_gap, fy0 + half_h, fy1 - half_h)
     # Full-footprint occupancy (leader shafts, witness/extension lines, hatch) — NOT
-    # the label-box-only `_occupied_boxes`, which is blind to a bore callout's leader
-    # SHAFT, so a ø label could silently overprint it (the #133/#225/#305 invisible-
-    # occupant class, #358). Centre lines stay crossable (a diameter dim may cross one).
+    # a label-box-only view, which is blind to a bore callout's leader SHAFT, so a
+    # ø label could silently overprint it (the #133/#225/#305 invisible-occupant
+    # class, #358). Centre lines stay crossable (a diameter dim may cross one).
     occupied = strip_obstacles(dwg, view="front", crossable=CROSSABLE_TYPES)
     placed = 0
     for i, ((tip, dia, label, feat), ly) in enumerate(zip(survivors, ys, strict=True)):
@@ -914,39 +913,6 @@ def env_dim_placed(pd) -> bool:
     decision, shared with the orchestrator's side-below tier reservation so the two
     can never drift (#316 review)."""
     return pd is not None and not pd.suppressed and pd.param.span is not None
-
-
-def _envelope_tier(dwg, strip, view, size):
-    """The page-coord at which an envelope dim of *size* stacks OUTSIDE every placed
-    obstacle in *view* on *strip* — the outermost free tier that fits, placed at its
-    inner (view-facing) edge — or None if no free tier fits.
-
-    Cursor-free (ADR 0009 carve), unlike the ``Strip.allocate`` it replaces: the
-    envelope dim lands beyond the feature/location dims already placed on this strip
-    (they become obstacles here), giving the ISO 'overall dim outermost' stack **by
-    construction**. That is enforced here by choosing the *outermost* fitting free
-    segment — NOT merely the one nearest the view, which would land the envelope
-    inside any obstacle sitting in a middle/outer tier (a callout label, a leader
-    shaft) whenever an inner tier happened to be free, inverting the stack. The old
-    ``allocate`` gave the right order only because an earlier pass had advanced a
-    shared cursor; that coupling inverted the moment the location pass moved to
-    ``plan_strip`` (#321), which never advances the cursor. Reading obstacle boxes
-    decouples the two passes. The current renderer queues envelope dims into the shared
-    corridor instead; #133 mandatory-dim starvation is guarded by envelope priority.
-
-    Assumes a below/above strip (Y stacking axis) — the only strips ``render_envelope``
-    uses; a left/right strip would need the X interval of each obstacle box."""
-    lo, hi, inner = strip_free_span(strip)
-    obst = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-    segs = carve_free_segments(lo, hi, [(b[1], b[3]) for b in obst], strip.spacing)
-    # Fit tolerant of float error at the reservation boundary (#133): the guaranteed
-    # segment is exactly `size` wide in the saturated worst case.
-    fitting = [s for s in segs if s[1] - s[0] >= size - 1e-9]
-    if not fitting:
-        return None
-    if inner == hi:  # below/left: outermost = smallest coords; place at seg inner (hi) edge
-        return min(fitting, key=lambda s: s[0])[1]
-    return max(fitting, key=lambda s: s[1])[0]  # above/right: outermost = largest coords
 
 
 def _chamfer_label(ch) -> str:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -124,9 +124,9 @@ def add_feature_callout(
     centre = dwg.at(view, *max(members, key=lambda m: dwg.at(view, *m)[0]))[:2]
 
     if view == "front":  # below the view (matches the auto-pass's front-callout side)
-        zones = getattr(a, "fv_zones", None) if a is not None else None
-        strip = getattr(zones, "below", None) if zones is not None else None
-        elbow_y = vy0 - max(tier, 0.6 * getattr(a, "DIM_PAD", 12.0))
+        zones = a.fv_zones if a is not None else None
+        strip = zones.below if zones is not None else None
+        elbow_y = vy0 - max(tier, 0.6 * (a.DIM_PAD if a is not None else 12.0))
         if strip is not None:
             coord = carve_free_position(
                 dwg, strip, view, "y", tier, (centre[0], centre[0] + gap + w)
@@ -138,11 +138,9 @@ def add_feature_callout(
         tside = "right" if centre[0] + gap + w <= room_right else "left"
     else:  # plan / side → to the right of the view
         zones = (
-            getattr(a, {"plan": "pv_zones", "side": "sv_zones"}[view], None)
-            if a is not None
-            else None
+            getattr(a, {"plan": "pv_zones", "side": "sv_zones"}[view]) if a is not None else None
         )
-        strip = getattr(zones, "right", None) if zones is not None else None
+        strip = zones.right if zones is not None else None
         elbow_x = vx1 + gap
         if strip is not None:
             coord = carve_free_position(
@@ -286,7 +284,7 @@ def add_feature_location(
             names.append(
                 _place(
                     "plan",
-                    getattr(a.pv_zones, "above", None),
+                    a.pv_zones.above,
                     PX(dx),
                     PX(rx),
                     PY(ry),
@@ -302,7 +300,7 @@ def add_feature_location(
             names.append(
                 _place(
                     "side",
-                    getattr(a.sv_zones, "above", None),
+                    a.sv_zones.above,
                     SX(dy),
                     SX(ry),
                     SZ(a.bb.max.Z),

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -61,21 +61,9 @@ from draftwright.projection import (
     _project_iso,
 )
 
-_TB_W = 150.0
-# Minimum acceptable projected view dimension (page-mm).  Below this, annotation
-# geometry (leader wires, centre marks, bore callout elbows) can degenerate and
-# cause OCCT Standard_DomainError / SIGABRT (#129).
-
-
-# ---------------------------------------------------------------------------
-# SVG post-processing
-# ---------------------------------------------------------------------------
-
-
-# Equidistance tolerance (page-mm) for accepting a sampled silhouette spline as
-# a circle about a known projected axis.  Loose enough to swallow HLR's spline
-# approximation error, tight enough not to round a genuinely off-axis curve.
-
+# A view centre must move by more than this (mm) for the measure-and-repack
+# pass to re-assemble.  Below it, the estimate already matched the measured
+# footprint and pass 1 stands (the common, non-ballooned case).
 _REPACK_TOL = 0.75
 _REPACK_MAX_ITER = 3
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -87,21 +87,6 @@ from draftwright.recognition import analyse_cylinders
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing
 
-_TB_W = 150.0
-# Minimum acceptable projected view dimension (page-mm).  Below this, annotation
-# geometry (leader wires, centre marks, bore callout elbows) can degenerate and
-# cause OCCT Standard_DomainError / SIGABRT (#129).
-
-
-# ---------------------------------------------------------------------------
-# SVG post-processing
-# ---------------------------------------------------------------------------
-
-
-# Equidistance tolerance (page-mm) for accepting a sampled silhouette spline as
-# a circle about a known projected axis.  Loose enough to swallow HLR's spline
-# approximation error, tight enough not to round a genuinely off-axis curve.
-
 
 def _build_table(rows, draft, block_cols=None):
     """Build a generic data-table annotation at the origin (bottom-left ``(0, 0)``).
@@ -568,25 +553,9 @@ class Drawing:
         self._coverage._dropped_callout_diams = value
 
     # -- coverage state operations (used by the annotation passes) ------------
-    def _cover_pattern(self, callout_name, holes):
-        """Record that placed *callout_name* documents *holes* (#92)."""
-        self._coverage.cover_pattern(callout_name, holes)
-
-    def _is_hole_patterned(self, hole) -> bool:
-        """Is *hole* already documented by a placed pattern callout?"""
-        return self._coverage.is_hole_patterned(hole)
-
-    def _cover_scattered_hole_doc(self, name) -> None:
-        """Record that placed *name* is a scattered hole callout / location dim (#351 PR-4c)."""
-        self._coverage.cover_scattered_hole_doc(name)
-
     def _is_scattered_hole_doc(self, name) -> bool:
         """Is *name* a placed scattered hole callout / location dim?"""
         return self._coverage.is_scattered_hole_doc(name)
-
-    def _reset_dropped_callout_diams(self):
-        """Clear dropped-diameter tracking (top of :func:`_auto_annotate`)."""
-        self._coverage.reset_dropped()
 
     def _drop_callout_diam(self, diam):
         """Record a diameter dropped by the per-view callout cap."""
@@ -1562,7 +1531,7 @@ class Drawing:
         # render_locations narrows the side-above strip's outer_limit IN PLACE on the shared
         # Analysis (from_model.py) — the one Analysis field a replay mutates. Capture + restore it
         # too, else a raised drain leaves the retry solving against a stale cap (#647 review).
-        sv_above = getattr(getattr(a, "sv_zones", None), "above", None) if a is not None else None
+        sv_above = a.sv_zones.above if a is not None else None
         sv_above_limit = sv_above.outer_limit if sv_above is not None else None
         deferred, self._defer_intents = self._defer_intents, False  # replay must place
         try:
@@ -2155,16 +2124,6 @@ class Drawing:
         dropped feature is never silent."""
         self._registry.record_issue(LintIssue(severity=severity, code=code, message=message))
 
-    def _reset_build_issues(self):
-        """Clear build-time issues — called at the top of :func:`_auto_annotate`
-        so re-annotation does not accumulate them."""
-        self._registry.reset_issues()
-
-    def _drop_build_issues(self, *codes):
-        """Drop recorded build issues whose code is in *codes* (a fallback that
-        restored tentatively-dropped annotations un-records their drop)."""
-        self._registry.drop_issues(codes)
-
     # -- repair ---------------------------------------------------------------
     def repair(self, max_iter: int = 3):
         """Close the lint→repair loop: act on violations, don't only report them.
@@ -2497,8 +2456,3 @@ class Drawing:
         for ann in self.items:
             label = getattr(ann, "label", "") or type(ann).__name__
             _export_shape(exporter, ann, "dims", f"annotation {label!r}")
-
-
-# A view centre must move by more than this (mm) for the measure-and-repack
-# pass to re-assemble.  Below it, the estimate already matched the measured
-# footprint and pass 1 stands (the common, non-ballooned case).

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -557,10 +557,6 @@ class Drawing:
         """Is *name* a placed scattered hole callout / location dim?"""
         return self._coverage.is_scattered_hole_doc(name)
 
-    def _drop_callout_diam(self, diam):
-        """Record a diameter dropped by the per-view callout cap."""
-        self._coverage.drop_diam(diam)
-
     # -- views ----------------------------------------------------------------
     def add_view(self, name, shape, camera, up, position, *, look_at=None, scaled=False):
         """Project ``shape`` from ``camera`` and place it at ``position``.

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -85,49 +85,12 @@ def _solve_strip_1d(naturals, min_gap, lo, hi):
     *naturals* must be sorted ascending; each solved value is bounded to
     ``[lo, hi]`` and adjacent values are at least *min_gap* apart. Delegates to
     the deterministic minimum-total-leader-length PAVA solve
-    (:func:`_solve_strip_1d_pava`) — the uniform-gap special case of
-    :func:`_solve_strip_1d_var` — which retired the earlier Cassowary
+    (:func:`_solve_strip_1d_pava`), which retired the earlier Cassowary
     (kiwisolver) constraint-satisfaction solve (its arbitrary feasible vertex
     was replaced by the L1-optimal, dependency-free placement)."""
     if not naturals:
         return []
     return _solve_strip_1d_pava(naturals, [min_gap] * (len(naturals) - 1), lo, hi)
-
-
-def _greedy_strip_1d_var(naturals, gaps, lo, hi, *, prefix=False):
-    """Greedy 1D placement with **per-pair** gaps (ADR 0003 phase 3a, #81).
-
-    ``gaps[i]`` is the minimum ``naturals[i+1] - naturals[i]`` separation;
-    ``len(gaps) == max(len(naturals) - 1, 0)``. Otherwise identical to
-    :func:`_greedy_strip_1d` (its uniform special case is ``gaps = [g]*(n-1)``).
-    """
-    result: list = []
-    for i, nat in enumerate(naturals):
-        floor = lo if i == 0 else result[-1] + gaps[i - 1]
-        v = max(floor, nat)
-        if v > hi:
-            if prefix:
-                break
-            return None
-        result.append(v)
-    return result
-
-
-def _solve_strip_1d_var(naturals, gaps, lo, hi):
-    """1D placement with **per-pair** gaps (ADR 0003 phase 3a, #81).
-
-    Like :func:`_solve_strip_1d`, but the required separation between adjacent
-    items is ``gaps[i]`` rather than one uniform value — used when heterogeneous
-    items (e.g. a deep step-dim slot next to a shallow height slot) share one
-    strip (see :attr:`StripCandidate.size`).
-    ``len(gaps)`` must be ``max(len(naturals) - 1, 0)``.
-
-    Delegates to :func:`_solve_strip_1d_pava` — same contract (``None`` when
-    provably infeasible), but the L1-optimal, deterministic, dependency-free
-    placement that retired the Cassowary (kiwisolver) satisfaction solve."""
-    if not naturals:
-        return []
-    return _solve_strip_1d_pava(naturals, gaps, lo, hi)
 
 
 _ANCHOR_WEIGHT = 1.0e6
@@ -180,7 +143,7 @@ def _solve_strip_1d_pava(naturals, gaps, lo, hi, weights=None):
     that dwarfs the others (``_ANCHOR_WEIGHT``) makes that point win every pool
     median, pinning it at its natural position while the rest flow around it.
 
-    Same contract as :func:`_solve_strip_1d_var`: *naturals* sorted ascending,
+    Same contract as :func:`_solve_strip_1d` (per-pair gaps): *naturals* sorted ascending,
     ``len(gaps) == max(len(naturals) - 1, 0)``, and returns ``None`` (never
     raises) when the fixed set is provably infeasible — the caller's
     drop-and-retry loop depends on that.

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -143,7 +143,7 @@ def _solve_strip_1d_pava(naturals, gaps, lo, hi, weights=None):
     that dwarfs the others (``_ANCHOR_WEIGHT``) makes that point win every pool
     median, pinning it at its natural position while the rest flow around it.
 
-    Same contract as :func:`_solve_strip_1d` (per-pair gaps): *naturals* sorted ascending,
+    Same contract as :func:`_solve_strip_1d`, but with per-pair *gaps*: *naturals* sorted ascending,
     ``len(gaps) == max(len(naturals) - 1, 0)``, and returns ``None`` (never
     raises) when the fixed set is provably infeasible — the caller's
     drop-and-retry loop depends on that.

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -10,10 +10,8 @@ import draftwright.layout as L
 from draftwright.layout import (
     _ANCHOR_WEIGHT,
     _greedy_strip_1d,
-    _greedy_strip_1d_var,
     _solve_strip_1d,
     _solve_strip_1d_pava,
-    _solve_strip_1d_var,
     fit_box,
 )
 
@@ -64,37 +62,6 @@ class TestGreedyStrip1d:
         assert out == [0, 8]
 
 
-class TestPerPairGaps:
-    """#81: per-pair gaps in the 1D primitive (heterogeneous slot depths)."""
-
-    def test_var_honours_each_pair_gap(self):
-        # All naturals at 0; gaps [4, 10] → packs to 0, 4, 14.
-        out = _solve_strip_1d_var([0.0, 0.0, 0.0], [4.0, 10.0], 0.0, 100.0)
-        assert out is not None
-        assert out[1] - out[0] >= 4.0 - 1e-9
-        assert out[2] - out[1] >= 10.0 - 1e-9
-
-    def test_var_matches_scalar_for_uniform_gaps(self):
-        # The uniform special case must reproduce the scalar primitive exactly.
-        naturals = [1.0, 1.0, 1.0, 1.0]
-        var = _solve_strip_1d_var(naturals, [3.0, 3.0, 3.0], 0.0, 100.0)
-        scalar = _solve_strip_1d(naturals, 3.0, 0.0, 100.0)
-        assert var == scalar
-
-    def test_var_infeasible_when_gaps_exceed_span(self):
-        # sum(gaps) = 14 > span 10 → None.
-        assert _solve_strip_1d_var([0.0, 0.0, 0.0], [4.0, 10.0], 0.0, 10.0) is None
-
-    def test_var_empty_and_single(self):
-        assert _solve_strip_1d_var([], [], 0.0, 10.0) == []
-        assert _solve_strip_1d_var([5.0], [], 0.0, 10.0) == [5.0]
-
-    def test_greedy_var_prefix_drops_overflow(self):
-        # gaps [4, 4]; span 6 fits only the first two → prefix stops before #3.
-        out = _greedy_strip_1d_var([0.0, 0.0, 0.0], [4.0, 4.0], 0.0, 6.0, prefix=True)
-        assert out == [0.0, 4.0]
-
-
 class TestSolveStrip1dPava:
     """P4b (#318, ADR 0009 Amendment 4): minimum-total-leader-length placement via
     weighted-median PAVA — the exact L1 optimum the earlier ``scipy.optimize.linprog``
@@ -113,7 +80,7 @@ class TestSolveStrip1dPava:
 
     def test_infeasible_returns_none(self):
         # sum(gaps) = 14 > span 10 → None, same provably-infeasible contract
-        # as _solve_strip_1d_var.
+        # as _solve_strip_1d.
         assert _solve_strip_1d_pava([0.0, 0.0, 0.0], [4.0, 10.0], 0.0, 10.0) is None
 
     def test_honours_bounds_and_gaps(self):

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -47,7 +47,6 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         ("from_model", "_bore_half_span"),
         ("from_model", "_diameter_column_left"),
         ("from_model", "_renderable_pmi_records"),
-        ("from_model", "_envelope_tier"),
         ("holes", "_legible_locations"),
         # Pass-level helpers exercised directly (candidates to retarget onto the ctx seam later).
         ("from_model", "_draw_step_chain"),

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -138,7 +138,7 @@ def test_rotational_bore_leaders_symmetric_when_room():
 
 
 def test_rotational_bore_leader_overflow_excluded_from_coverage():
-    # #374 review: a dropped bore must be registered via _drop_callout_diam so coverage lint does
+    # #374 review: a dropped bore must be registered via ctx.coverage.drop_diam so coverage lint does
     # not double-report it as feature_not_dimensioned on top of the callout_dropped warning.
     from build123d import Cylinder, Pos
 

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -2,7 +2,7 @@
 
 Grows with the boundary-labeling migration (tracking #320). P0b (#317): the
 complete per-strip occupancy model — `strip_obstacles` — that closes the
-`_occupied_boxes` blind spots behind #133/#225/#305. P0c (#317): the
+label-box-only blind spots behind #133/#225/#305. P0c (#317): the
 collect-then-solve seam — `StripCandidate` (a measured render-intent) + `plan_strip`
 (order = site order ⇒ crossing-free, then 1-D spacing). P2 (#322): `plan_strip`
 priority selection — drop the lowest-priority candidates until the rest fit, the
@@ -15,10 +15,7 @@ from __future__ import annotations
 from build123d import Box, BuildPart, Cylinder, Hole, Pos, Rotation
 
 from draftwright import build_drawing
-from draftwright.annotations._common import (
-    _occupied_boxes,
-    strip_obstacles,
-)
+from draftwright.annotations._common import strip_obstacles
 from draftwright.layout import StripCandidate, plan_strip
 
 
@@ -34,20 +31,19 @@ def _drive_screw_x():
     return Rotation(0, 90, 0) * p.part
 
 
-def test_strip_obstacles_captures_centreline_that_occupied_boxes_drops():
-    # _occupied_boxes excludes bare centrelines; the complete occupancy must not —
-    # a centreline through a callout's row is exactly the #305 blind spot.
+def test_strip_obstacles_captures_bare_centreline():
+    # A label-box-only occupancy misses bare centrelines; the complete occupancy
+    # must not — a centreline through a callout's row is exactly the #305 blind spot.
     dwg = build_drawing(_drive_screw_x())
     cl = dwg._named["centerline_front"]
     b = cl.bounding_box()
     cbox = (b.min.X, b.min.Y, b.max.X, b.max.Y)
 
     obst = strip_obstacles(dwg)
-    occ = _occupied_boxes(dwg)
 
     # #685 decomposed occupancy: the centreline arrives as stroke boxes (possibly
     # several pieces), not one exact hull — assert its midpoint and both ends are
-    # each inside some obstacle box, and none of them in _occupied_boxes.
+    # each inside some obstacle box.
     my = (cbox[1] + cbox[3]) / 2
     pts = [(cbox[0] + 0.5, my), ((cbox[0] + cbox[2]) / 2, my), (cbox[2] - 0.5, my)]
 
@@ -55,15 +51,12 @@ def test_strip_obstacles_captures_centreline_that_occupied_boxes_drops():
         return any(x[0] <= px <= x[2] and x[1] <= py <= x[3] for x in boxes)
 
     assert all(_holds(obst, *pt) for pt in pts), "centreline missing from strip_obstacles"
-    assert not any(_holds(occ, *pt) for pt in pts), (
-        "expected _occupied_boxes to exclude centrelines"
-    )
 
 
 def test_strip_obstacles_captures_full_leader_footprint_not_just_label():
-    # A bore callout's leader shaft extends well past its text box. _occupied_boxes
-    # records only the label box; strip_obstacles must record the full footprint,
-    # or a placer thinks the shaft's row is free (#133/#225).
+    # A bore callout's leader shaft extends well past its text box. A label-box-only
+    # occupancy records only the label box; strip_obstacles must record the full
+    # footprint, or a placer thinks the shaft's row is free (#133/#225).
     dwg = build_drawing(_drive_screw_x())
     name, leader = next((n, o) for n, o in dwg.iter_annotations() if n.startswith("hc_"))
 
@@ -74,7 +67,6 @@ def test_strip_obstacles_captures_full_leader_footprint_not_just_label():
     assert gb.min.X < lb[0] - 0.5 or gb.max.X > lb[2] + 0.5, "leader shaft not past its label?"
 
     obst = strip_obstacles(dwg)
-    occ = _occupied_boxes(dwg)
 
     # #685 decomposed occupancy: assert the shaft REGION beyond the label is covered —
     # some obstacle box must contain the leader's tip-side extreme, which the label
@@ -89,12 +81,6 @@ def test_strip_obstacles_captures_full_leader_footprint_not_just_label():
     assert all(_holds(obst, px, py) for px, py in seg_pts), (
         "leader stroke endpoints missing from strip_obstacles"
     )
-    # Negative check on a REAL shaft endpoint outside the label box (#688 r2):
-    # a diagonal shaft's hull midpoint need not lie on the shaft.
-    outside = next(
-        (px, py) for px, py in seg_pts if not (lb[0] <= px <= lb[2] and lb[1] <= py <= lb[3])
-    )
-    assert not _holds(occ, *outside), "label-only occupancy should not reach the shaft"
 
 
 def test_coaxial_bore_on_rotational_part_is_not_over_located():
@@ -219,8 +205,8 @@ def test_strip_obstacles_view_filter_drops_other_ortho_views():
 
 def test_strip_obstacles_keeps_section_hatch_in_every_per_view_query():
     # The section hatch is owned by no ortho view (view_of is None); a per-view
-    # strip solve must still avoid it — _occupied_boxes special-cased it by name,
-    # and restricting it to view=None would re-open that blind spot (review S1).
+    # strip solve must still avoid it — restricting it to view=None would
+    # re-open that blind spot (review S1).
     part = Box(80, 60, 20) - Cylinder(4, 20) - Pos(10, 5, -7) * Cylinder(6, 6)
     dwg = build_drawing(part)
     assert "section_hatch" in dwg._named and dwg.view_of("section_hatch") is None
@@ -423,8 +409,8 @@ def test_plan_strip_uses_per_pair_gaps_for_heterogeneous_sizes():
     # the same per-pair-gap rule #81 originally added for the (since-retired,
     # #547) LayoutSolver.solve_strip's heterogeneous Placeables. Exercises
     # plan_strip's own gap-list wiring (ordered[i]/[i+1] indexing, idx
-    # selection), not just the underlying _solve_strip_1d_var primitive (which
-    # is already covered elsewhere, in isolation).
+    # selection), not just the underlying PAVA primitive (which is already
+    # covered elsewhere, in isolation).
     cands = [
         StripCandidate("a", (0.0, 0.0), (6, 4), priority=0),
         StripCandidate("b", (0.0, 0.0), (6, 4), priority=0),
@@ -927,11 +913,11 @@ def test_plan_strip_rejects_duplicate_keys():
         plan_strip([_cand("a", 10), _cand("a", 20)], lo=0, hi=100, min_gap=5)
 
 
-# --- _envelope_tier: overall dim stacks OUTSIDE every obstacle (#321 P3a-envelope) ---
+# --- fake-dwg strip-occupancy queries (#321) ---
 
 
 def _fake_dwg(obstacles, view="side", types=None):
-    # Minimal dwg for strip_obstacles/_envelope_tier/corridor_blockers: named
+    # Minimal dwg for strip_obstacles/corridor_blockers: named
     # annotations exposing a bounding_box() and a single owning view. obstacles:
     # {name: (x0, y0, x1, y1)}; *types* optionally maps a name to its annotation
     # class name (default "_Obst") so corridor_blockers' type filter can be exercised.
@@ -1002,29 +988,6 @@ def test_side_hole_z_dim_is_kept_not_dropped_under_policy_b():
     dwg = build_drawing(CORPUS["side_drilled"]())
     names = {n for n, _ in dwg.iter_annotations()}
     assert any(n.startswith("dim_loc_") and "_z" in n for n in names), "Z location dim was dropped"
-
-
-def test_envelope_tier_stacks_outside_a_middle_tier_obstacle():
-    # A below strip (anchor 61, gap 10 → inner tier at 51, outer_limit 10). An obstacle
-    # sits in a MIDDLE tier [30,36] with the inner tier [40,51] left FREE. The overall
-    # dim must land OUTSIDE it (≤ 30 − spacing), not in the nearer-the-view free tier —
-    # picking the innermost free segment would invert the ISO stack (review #1).
-    from draftwright._core import Strip
-    from draftwright.annotations.from_model import _envelope_tier
-
-    strip = Strip(anchor=61.0, outer_limit=10.0, direction=-1.0)  # gap 10, spacing 2.5
-    dwg = _fake_dwg({"mid": (100.0, 30.0, 120.0, 36.0)})
-    pd = _envelope_tier(dwg, strip, "side", size=8.0)
-    assert pd is not None and pd <= 30.0, f"envelope inverted into inner tier: pd={pd}"
-
-
-def test_envelope_tier_uses_inner_tier_when_strip_is_clear():
-    # No obstacles → the overall dim takes the innermost tier (anchor − gap = 51).
-    from draftwright._core import Strip
-    from draftwright.annotations.from_model import _envelope_tier
-
-    strip = Strip(anchor=61.0, outer_limit=10.0, direction=-1.0)
-    assert _envelope_tier(_fake_dwg({}), strip, "side", size=8.0) == 51.0
 
 
 # --- unified above-corridor solve (ADR 0009 end state, #345/#346) -----------


### PR DESCRIPTION
Closes #705 — the 2026-07-18 audit's dead-weight list, one deletion PR (precedent: the #547 Placeable deletion).

## Deleted (all zero-production-caller, re-verified by grep on this head)
- **`from_model._envelope_tier`** + its two unit tests + its `test_private_test_imports` allowlist entry (the ratchet only shrinks).
- **`_common._occupied_boxes`** — the label-box-only occupancy behind the #133/#225/#305 defect class. Its two contrast tests keep their positive halves (they pin `strip_obstacles`' complete-occupancy contract) and lose only the dead negative checks.
- **`layout._solve_strip_1d_var` / `_greedy_strip_1d_var`** + their test class — `plan_strip` calls `_solve_strip_1d_pava` directly; per-pair-gap behaviour remains covered by the PAVA and `plan_strip` tests.
- **Six dead `Drawing` delegation shims** (`_cover_pattern`, `_is_hole_patterned`, `_cover_scattered_hole_doc`, `_reset_dropped_callout_diams`, `_reset_build_issues`, `_drop_build_issues`) — passes call `CoverageState`/registry directly since #164/#639. (`test_linting`'s similarly-named tests hit `CoverageState` directly and are untouched.)
- **P6 copy-split residue**: unreferenced `_TB_W = 150.0` in both `builder.py` and `drawing.py`, the empty "SVG post-processing" headers, the stray equidistance comment, and `drawing.py`'s stranded `_REPACK_TOL` comment — reunited with the constant in `builder.py`.
- `carve_free_segments` import in `from_model.py` (orphaned by the `_envelope_tier` deletion).

## Fail-loud getattr (the issue's last bullet)
Typed-`Analysis`/`ViewZones` sites (`holes.py:127–145/289/305`, `drawing.py:1565`) now use direct attribute access, so a field rename raises instead of silently substituting a divergent default (`12.0` vs the real `20.0`). **Deliberately left**: duck-typed `getattr` on user-suppliable feature/model objects (`feat.kind`/`feat.pattern`/`model.features`, ADR 0011 accepts loose sequences) and the dynamic-side fallbacks in `drawing.py:855/1025` — those defaults are load-bearing polymorphism, not dead defence.

## Verification
- ruff check / ruff format --check / mypy / codespell all clean.
- Targeted suites (layout, strip-layout, private-imports, linting, render-seam, encapsulation): 104 passed.
- Full fast tier `-n auto`: 1413 passed, 1 failed — the failure is the known pre-existing #710 `view_out_of_bounds` replay from the local Hypothesis DB (fails identically on main; CI draws fresh examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)