### PR TITLE
refactor(#700): one home per duplicated helper family

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,9 @@ entry. Keep `_LAYERS` and this section in step.
     ISO 128-50 hatching).
   - **`annotations/_common.py`** — the ADR 0009 corridor-solve engine
     (`CorridorCandidate`, `solve_corridor`, `register_corridor`/`drain_corridors`,
-    `place_strip_candidates`, `PlacementContext`) plus the shared bbox helpers
-    (`_anno_box`, `_box_hits`), at the bottom of the annotations DAG.
+    `place_strip_candidates`, `PlacementContext`) plus `_box_hits`, at the
+    bottom of the annotations DAG. (The bbox/segment primitives it delegates to
+    live in `_core`/`_geometry` since #700.)
   Submodules import only down or sideways — `_core`/`layout`/`analysis`/
   `projection`/the `model/` IR/`linting.structural`/third-party, never
   `annotate`/`make_drawing`/`drawing` (the drawing is duck-typed as `dwg`) — so
@@ -95,8 +96,10 @@ entry. Keep `_LAYERS` and this section in step.
   the ADR 0009 collect-then-solve entry point) and the 2D free-rectangle placer
   (`fit_box`). Sits *below* the domain API.
 - **`_geometry.py`** — model-neutral geometry primitives (`_xyz`, `HoleRef`,
-  `_axis_letter`, `_END_ON`); the DAG's bottom leaf (guarded by
-  `test_geometry_is_a_leaf`) so the IR waist uses them without importing `_core`.
+  `_axis_letter`, `_END_ON`) plus the #700 shared page-plane maths (`_fmt`,
+  `_boxes_overlap`, the two segment/box tests); the DAG's bottom leaf (guarded
+  by `test_geometry_is_a_leaf`) so the IR waist uses them without importing
+  `_core`.
 - **`fits.py`** — the ISO 286 fit tables (`fit_deviation`, `FitClass`; ADR 0011
   P2a.2): a rank-0 leaf consumed by `_core`, `model/ir` and `sheet`.
 - **`intents.py`** — the deferred-placement "low IR" behind `Drawing.finalize()`

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -280,7 +280,8 @@ made this concrete and costly: a plain AABB collision check caused **5 real
 regressions** on ordinary fixtures with no actual crossing, because a callout's
 diagonal shaft merely *near* an obstacle registered as blocked.
 
-The fix, `_segment_hits_box` (`annotations/_common.py`) — a precise
+The fix, `_segment_hits_box` (`annotations/_common.py`; since #700
+`_geometry._segment_crosses_box`) — a precise
 line-segment-vs-AABB intersection test, used for the diagonal shaft portion of
 a leader only (the elbow→label shelf+text stays an ordinary AABB check, since
 it genuinely is axis-aligned) — is a **direct, reusable building block for P4**

--- a/docs/plans/strip-layout-boundary-labeling-roadmap.md
+++ b/docs/plans/strip-layout-boundary-labeling-roadmap.md
@@ -109,7 +109,8 @@ Updated 2026-07-08.
     the `bracket` fixture's PENDING overlap (`hc_plan0`/`section_arrow_right`) is fixed —
     `_annotate_holes`'s plan/side hole-callout placer (`holes.py`) now consults
     `strip_obstacles` (it never had, predating the P0–P3 carve migration), with a new
-    precise line-segment-vs-box intersection test (`_segment_hits_box`, `_common.py`) for
+    precise line-segment-vs-box intersection test (`_segment_hits_box`, `_common.py`;
+    since #700 `_geometry._segment_crosses_box`) for
     the diagonal leader shaft — a plain AABB check over-claims a diagonal's empty
     triangle and caused 5 real regressions before the precise geometry landed. Plus
     **policy B** (user, 2026-07-02): a callout is only relocated to avoid an obstacle

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -39,7 +39,7 @@ from build123d_drafting.helpers import (
 # now live in the leaf `draftwright._geometry` so the IR waist (`model/`) can use them
 # without importing this stage-level grab-bag (ADR 0008; #584 WP2). Re-exported here for
 # the above-`_core` consumers (annotations/sheet/drawing/linting) that already import them.
-from draftwright._geometry import _END_ON, HoleRef, _axis_letter, _xyz  # noqa: F401
+from draftwright._geometry import _END_ON, HoleRef, _axis_letter, _fmt, _xyz  # noqa: F401
 from draftwright.fits import FitClass
 from draftwright.fonts import PLEX_MONO, PLEX_SANS_CONDENSED
 from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
@@ -58,10 +58,79 @@ _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built 
 _TB_H = 35.0
 
 
-def _fmt(v: float) -> str:
-    """Format a float as integer string if whole, otherwise 1 dp."""
-    r = round(v)
-    return str(r) if abs(v - r) < 1e-6 else f"{v:.1f}"
+def _shape_box2d(shape):
+    """``(x0, y0, x1, y1)`` page-plane bbox of a build123d shape, or ``None`` on
+    failure — the one home of the bounding-box-read idiom (#700; the memoised /
+    logging variants in ``linting.structural`` and ``annotations._common`` layer
+    their policies over the same read)."""
+    try:
+        bb = shape.bounding_box()
+        return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
+    except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+        return None
+
+
+def _anno_box(o):
+    """Page-space bbox ``(x0, y0, x1, y1)`` of an annotation — its text
+    ``label_bbox`` if it has one, else its geometric bounding box; ``None`` if
+    neither resolves (logged at debug: a silently un-bbox-able annotation drops
+    out of overlap counts and measured footprints, #121). The one copy behind
+    ``annotations._common`` and ``compose`` (#700)."""
+    lb = getattr(o, "label_bbox", None)
+    if lb is not None:
+        return lb
+    box = _shape_box2d(o)
+    if box is None:
+        _log.debug("annotation %r has no resolvable bbox", type(o).__name__)
+    return box
+
+
+def _wrap_rows(header, data, ncols):
+    """Reshape *data* rows into *ncols* side-by-side blocks (a wider, shorter
+    table), each block headed by *header* — so a long hole chart fits the page.
+    Shared by the annotation pass and the compose-time footprint estimate (#700).
+    """
+    per = math.ceil(len(data) / ncols)
+    blank = ("",) * len(header)
+    wide = [tuple(header) * ncols]
+    for r in range(per):
+        row: tuple = ()
+        for c in range(ncols):
+            idx = c * per + r
+            row += data[idx] if idx < len(data) else blank
+        wide.append(row)
+    return wide
+
+
+def _table_metrics(rows, font_size, pad_around_text, block_cols=None):
+    """The sizing model of a data table: per-column left/right edges (page-mm,
+    block gaps inserted), total width/height, row height and effective block
+    width, as ``(lefts, rights, total_w, total_h, row_h, bc)``.
+
+    The ONE place table geometry is computed (#700): ``drawing._build_table``
+    draws from it and ``compose._est_table_size`` estimates from it, so the
+    ADR 0004 ``table_fits`` fitness check can never desynchronise from what
+    renders (the drift ADR 0004 names as the failure mode to guard against).
+    """
+    fs = font_size
+    pad = pad_around_text
+    row_h = fs + 2 * pad
+    ncol = len(rows[0])
+    # Only treat as multi-block when block_cols evenly divides the row width.
+    bc = block_cols if (block_cols and ncol % block_cols == 0 and block_cols < ncol) else ncol
+    block_gap = 3 * pad  # whitespace between side-by-side blocks
+    col_w = [
+        max(max(_text_width(str(r[c]), fs) for r in rows) + 2 * pad, fs * 2.5) for c in range(ncol)
+    ]
+    # Per-column left/right edges, inserting block_gap before each new block.
+    lefts, rights, cursor = [], [], 0.0
+    for c in range(ncol):
+        if c > 0 and c % bc == 0:
+            cursor += block_gap
+        lefts.append(cursor)
+        cursor += col_w[c]
+        rights.append(cursor)
+    return lefts, rights, cursor, row_h * len(rows), row_h, bc
 
 
 def _tol_suffix(tolerance, draft) -> str:

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -64,7 +64,10 @@ def _fmt(v: float) -> str:
 def _boxes_overlap(a, b) -> bool:
     """True when two ``(x0, y0, x1, y1)`` AABBs overlap (strict: a touch is not
     an overlap). The one pairwise test behind both the placement-side
-    ``_box_hits`` and the lint-side overlap checks (#700)."""
+    ``_box_hits`` and the lint-side overlap checks (#700). Nuance: a degenerate
+    (zero-width/height) box strictly inside the other counts as overlapping
+    here, where the pre-#700 ``_box_hits`` form said no — the conservative
+    direction for obstacle tests (rejects, never overprints)."""
     return bool(a[0] < b[2] and a[2] > b[0] and a[1] < b[3] and a[3] > b[1])
 
 

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -1,10 +1,12 @@
 """Model-neutral geometry primitives — the leaf below both ``_core`` and ``model``.
 
-These four helpers read an axis / coordinate / position off a build123d object
-(or the IR) and carry no drawing, layout or page knowledge. They live here, not
-in :mod:`draftwright._core`, so the IR waist (:mod:`draftwright.model`) can use
-them without importing the stage-level drawing grab-bag (ADR 0008; #584 WP2).
-This module imports nothing from ``draftwright`` — it is the bottom of the DAG.
+These helpers read an axis / coordinate / position off a build123d object (or
+the IR), or do pure page-plane maths (AABB overlap, segment/box intersection,
+number formatting — the #700 shared home), and carry no drawing, layout or page
+knowledge. They live here, not in :mod:`draftwright._core`, so the IR waist
+(:mod:`draftwright.model`) can use them without importing the stage-level
+drawing grab-bag (ADR 0008; #584 WP2). This module imports nothing from
+``draftwright`` — it is the bottom of the DAG.
 """
 
 from __future__ import annotations
@@ -48,3 +50,90 @@ def _axis_letter(obj) -> str:
     ``obj`` is anything carrying an ``.axis`` 3-vector (a hole or a boss).
     """
     return max(zip("xyz", obj.axis, strict=True), key=lambda t: abs(t[1]))[0]
+
+
+def _fmt(v: float) -> str:
+    """Format a float as integer string if whole, otherwise 1 dp. The one number
+    formatter the IR (:mod:`draftwright.model.ir`) and the drawing layers
+    (:mod:`draftwright._core`) share (#700 — the two copies had already begun to
+    drift on ``-0``)."""
+    r = round(v)
+    return str(r) if abs(v - r) < 1e-6 else f"{v:.1f}"
+
+
+def _boxes_overlap(a, b) -> bool:
+    """True when two ``(x0, y0, x1, y1)`` AABBs overlap (strict: a touch is not
+    an overlap). The one pairwise test behind both the placement-side
+    ``_box_hits`` and the lint-side overlap checks (#700)."""
+    return bool(a[0] < b[2] and a[2] > b[0] and a[1] < b[3] and a[3] > b[1])
+
+
+def _segment_crosses_box(p1, p2, box) -> bool:
+    """True when line segment *p1*-*p2* intersects axis-aligned *box*
+    ``(x0, y0, x1, y1)`` — the precise counterpart of ``_box_hits`` for a
+    genuinely diagonal shaft (ADR 0009 P4/#318, #305: "a diagonal leader's box
+    over-claims its empty triangle"). Boxing an angled segment for a coarse
+    reject is correct and cheap; boxing it for the final accept/reject decision
+    over-avoids free space a real diagonal never crosses. Endpoint-in-box and
+    the 4 edge-crossing cases (a standard segment/AABB test).
+
+    The crossing test uses strict inequality deliberately, not an inclusive
+    ``<= 0`` — an inclusive test also treats a segment merely COLLINEAR with
+    one of the box's (infinite) edge lines as a hit, regardless of whether it
+    is anywhere near the box along that line (verified: a vertical segment at
+    ``x == box.x0`` but far outside ``[y0, y1]`` false-hits under `<=`). That
+    false-positive class is common (any axis-aligned shaft sharing an X or Y
+    coordinate with an edge), unlike the strict form's own known gap — a
+    segment passing exactly through two opposite corners is a measure-zero
+    event for the continuous, non-integer leader positions this computes over
+    (review finding, #351 P5 strand 3: tried the inclusive form, reverted).
+
+    Its sibling :func:`_segment_clips_box` is the *inclusive* (Liang–Barsky)
+    form lint uses — boundary semantics differ by design; pick per the caller's
+    false-positive tolerance (#700)."""
+    x0, y0, x1, y1 = box
+
+    def _inside(p):
+        return x0 <= p[0] <= x1 and y0 <= p[1] <= y1
+
+    if _inside(p1) or _inside(p2):
+        return True
+
+    def _cross(o, a, b):
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    def _seg_seg(a1, a2, b1, b2):
+        d1, d2 = _cross(b1, b2, a1), _cross(b1, b2, a2)
+        d3, d4 = _cross(a1, a2, b1), _cross(a1, a2, b2)
+        return ((d1 > 0 and d2 < 0) or (d1 < 0 and d2 > 0)) and (
+            (d3 > 0 and d4 < 0) or (d3 < 0 and d4 > 0)
+        )
+
+    corners = ((x0, y0), (x1, y0), (x1, y1), (x0, y1))
+    return any(_seg_seg(p1, p2, corners[i], corners[(i + 1) % 4]) for i in range(4))
+
+
+def _segment_clips_box(p, q, box, pad=0.0) -> bool:
+    """Liang–Barsky: does segment *p*→*q* intersect the *pad*-inflated AABB
+    *box*? Inclusive at the boundary (a touch is a hit) — the tolerant form the
+    lint checks use; :func:`_segment_crosses_box` is the strict placement-side
+    sibling (#700)."""
+    minx, miny, maxx, maxy = box[0] - pad, box[1] - pad, box[2] + pad, box[3] + pad
+    x0, y0 = p
+    dx, dy = q[0] - x0, q[1] - y0
+    t0, t1 = 0.0, 1.0
+    for pp, qq in ((-dx, x0 - minx), (dx, maxx - x0), (-dy, y0 - miny), (dy, maxy - y0)):
+        if abs(pp) < 1e-12:
+            if qq < 0:
+                return False
+        else:
+            r = qq / pp
+            if pp < 0:
+                if r > t1:
+                    return False
+                t0 = max(t0, r)
+            else:
+                if r < t0:
+                    return False
+                t1 = min(t1, r)
+    return t0 <= t1

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -14,7 +14,8 @@ from typing import Any
 
 from build123d_drafting.helpers import DEFAULT_FONT_PATH, Dimension, SafeDimension
 
-from draftwright._core import _text_size
+from draftwright._core import _anno_box, _text_size  # noqa: F401 — _anno_box re-exported (#700)
+from draftwright._geometry import _boxes_overlap, _segment_crosses_box  # noqa: F401
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import _centerline_extent
@@ -56,22 +57,6 @@ class Escalation:
     feature: object
     reason: str
     remedies: tuple[str, ...] = field(default_factory=tuple)
-
-
-def _anno_box(o):
-    """Page-space bbox ``(x0, y0, x1, y1)`` of an annotation — its text
-    ``label_bbox`` if it has one, else its geometric bounding box; ``None`` if
-    neither resolves.  Twin of ``compose._anno_bbox`` (annotations sits above
-    compose in the DAG, so the mirror is deliberate — consolidation tracked by
-    #700)."""
-    lb = getattr(o, "label_bbox", None)
-    if lb is not None:
-        return lb
-    try:
-        b = o.bounding_box()
-        return (b.min.X, b.min.Y, b.max.X, b.max.Y)
-    except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
-        return None
 
 
 def _geom_box(o):
@@ -402,16 +387,12 @@ def corridor_blockers(dwg, view):
 
 
 def _box_hits(bb, boxes):
-    """True when ``bb`` overlaps any box in ``boxes`` (strict AABB test). Slightly
-    more conservative than the within-view label lint (which tolerates a 0.5 mm
-    sliver): a touch counts as a hit, so a candidate never overprints — at worst
-    it is dropped a hair early."""
-    if bb is None:
-        return False
-    for c in boxes:
-        if min(bb[2], c[2]) > max(bb[0], c[0]) and min(bb[3], c[3]) > max(bb[1], c[1]):
-            return True
-    return False
+    """True when ``bb`` overlaps any box in ``boxes`` (strict AABB test,
+    :func:`draftwright._geometry._boxes_overlap`). Slightly more conservative
+    than the within-view label lint (which tolerates a 0.5 mm sliver): a touch
+    does not count as an overlap, so a candidate never overprints — at worst it
+    is dropped a hair early."""
+    return bb is not None and any(_boxes_overlap(bb, c) for c in boxes)
 
 
 def box_within_page_and_clear(bb, page_box, obstacles) -> bool:
@@ -427,47 +408,6 @@ def box_within_page_and_clear(bb, page_box, obstacles) -> bool:
         and bb[3] <= page_box[3]
         and not _box_hits(bb, obstacles)
     )
-
-
-def _segment_hits_box(p1, p2, box) -> bool:
-    """True when line segment *p1*-*p2* intersects axis-aligned *box*
-    ``(x0, y0, x1, y1)`` — the precise counterpart of :func:`_box_hits` for a
-    genuinely diagonal shaft (ADR 0009 P4/#318, #305: "a diagonal leader's box
-    over-claims its empty triangle"). Boxing an angled segment for a coarse
-    reject is correct and cheap; boxing it for the final accept/reject decision
-    over-avoids free space a real diagonal never crosses. Endpoint-in-box and
-    the 4 edge-crossing cases (a standard segment/AABB test).
-
-    The crossing test uses strict inequality deliberately, not an inclusive
-    ``<= 0`` — an inclusive test also treats a segment merely COLLINEAR with
-    one of the box's (infinite) edge lines as a hit, regardless of whether it
-    is anywhere near the box along that line (verified: a vertical segment at
-    ``x == box.x0`` but far outside ``[y0, y1]`` false-hits under `<=`). That
-    false-positive class is common (any axis-aligned shaft sharing an X or Y
-    coordinate with an edge), unlike the strict form's own known gap — a
-    segment passing exactly through two opposite corners is a measure-zero
-    event for the continuous, non-integer leader positions this computes over
-    (review finding, #351 P5 strand 3: tried the inclusive form, reverted)."""
-    x0, y0, x1, y1 = box
-
-    def _inside(p):
-        return x0 <= p[0] <= x1 and y0 <= p[1] <= y1
-
-    if _inside(p1) or _inside(p2):
-        return True
-
-    def _cross(o, a, b):
-        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
-
-    def _seg_seg(a1, a2, b1, b2):
-        d1, d2 = _cross(b1, b2, a1), _cross(b1, b2, a2)
-        d3, d4 = _cross(a1, a2, b1), _cross(a1, a2, b2)
-        return ((d1 > 0 and d2 < 0) or (d1 < 0 and d2 > 0)) and (
-            (d3 > 0 and d4 < 0) or (d3 < 0 and d4 > 0)
-        )
-
-    corners = ((x0, y0), (x1, y0), (x1, y1), (x0, y1))
-    return any(_seg_seg(p1, p2, corners[i], corners[(i + 1) % 4]) for i in range(4))
 
 
 @dataclass

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -940,16 +940,24 @@ def _leader_callout_reach(draft) -> float:
     return float(draft.font_size + 6 * draft.pad_around_text)
 
 
-def _label_lands_clear(ldr, obstacles, silhouette, page) -> bool:
+def _label_lands_clear(ldr, obstacles, silhouette, page, *, geom_clear=False) -> bool:
     """True when a leader's LABEL box sits in clear margin: off other annotations
     (*obstacles*), off the part *silhouette* (the leader line may cross into the view, its
-    text may not), and inside the *page* margin box. The single accept test the five callout
-    passes share (was the identical six-line guard, copied five times)."""
-    label = getattr(ldr, "label_bbox", None) or _anno_box(ldr)
-    if label is None:
+    text may not), and inside the *page* margin box. The single accept test the callout
+    passes share (was the identical six-line guard, copied five times).
+
+    With *geom_clear* the obstacle test uses the FULL ``_geom_box`` footprint (shaft +
+    arrow + label) instead of the label box — the shaft is the invisible occupant a
+    label-only box hides (#133/#305/#358), so a rim-anchored boss ø leader must clear
+    the other callouts/witnesses along its whole length (#629/#700). The silhouette/
+    page checks stay on the label box, since such a shaft legitimately starts inside
+    the view."""
+    geom = _geom_box(ldr) if geom_clear else None
+    label = getattr(ldr, "label_bbox", None) or (geom if geom_clear else _anno_box(ldr))
+    if label is None or (geom_clear and geom is None):
         return False
     return not (
-        _box_hits(label, obstacles)
+        _box_hits(geom if geom_clear else label, obstacles)
         or _box_hits(label, [silhouette])
         or label[0] < page[0]
         or label[1] < page[1]
@@ -974,21 +982,21 @@ def _corner_candidates(dwg, view, vb, members, reach):
         yield (tip, elbow, m)
 
 
-def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx) -> int:
+def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False) -> int:
     """Place one machined-feature leader callout per job (#637). A *job* is
     ``(name, view, vb, label, candidates)`` where *candidates* yields ``(tip, elbow,
     feature)`` lead positions to try in order. Places the first Leader whose label lands clear
-    (:func:`_label_lands_clear`), attributed to that candidate's feature; if none of a job's
-    candidates land, records ``<noun> callout … not placed`` as ``<drop_code>`` lint (never a
-    silent drop). Obstacles are recomputed per job so a callout placed earlier is avoided.
-    Returns the count placed."""
+    (:func:`_label_lands_clear`, with *geom_clear* passed through), attributed to that
+    candidate's feature; if none of a job's candidates land, records ``<noun> callout … not
+    placed`` as ``<drop_code>`` lint (never a silent drop). Obstacles are recomputed per job
+    so a callout placed earlier is avoided. Returns the count placed."""
     page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
     n = 0
     for name, view, vb, label, candidates in jobs:
         obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
         for tip, elbow, feature in candidates:
             ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label, draft=dwg.draft)
-            if _label_lands_clear(ldr, obstacles, vb, page):
+            if _label_lands_clear(ldr, obstacles, vb, page, geom_clear=geom_clear):
                 dwg.add(ldr, name, view=view, feature=feature)
                 n += 1
                 break
@@ -1158,17 +1166,20 @@ _POCKET_LEAD_DIRS = (
 )
 
 
-def _radial_candidates(dwg, view, vb, feature, reach):
-    """Lead candidates for a mid-face feature (pocket/groove): from the feature's projected
-    origin, one candidate per :data:`_POCKET_LEAD_DIRS` direction — exit the silhouette along
-    it (:func:`_ray_exit_dist`) then *reach* on into the margin, so even a centre-of-view
-    feature clears the part. Yields ``(tip, elbow, feature)`` (same feature each time;
-    nearest-clear wins in the pass)."""
+def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0):
+    """Lead candidates for a mid-face feature (pocket/groove/boss ø): from the feature's
+    projected origin, one candidate per :data:`_POCKET_LEAD_DIRS` direction — exit the
+    silhouette along it (:func:`_ray_exit_dist`) then *reach* on into the margin, so even
+    a centre-of-view feature clears the part. A non-zero *rim* (page units) advances the
+    arrow tip that far along the lead direction, so a boss ø leader's arrowhead lands on
+    the boss circle rather than its centre (#629/#700). Yields ``(tip, elbow, feature)``
+    (same feature each time; nearest-clear wins in the pass)."""
     x0, y0, x1, y1 = vb
-    tip = dwg.at(view, *feature.frame.origin)
+    origin = dwg.at(view, *feature.frame.origin)
     for dx, dy in _POCKET_LEAD_DIRS:
         d = math.hypot(dx, dy)
         ux, uy = dx / d, dy / d
+        tip = (origin[0] + ux * rim, origin[1] + uy * rim)
         exit_d = _ray_exit_dist(tip[0], tip[1], ux, uy, (x0, y0, x1, y1))
         elbow = (tip[0] + ux * (exit_d + reach), tip[1] + uy * (exit_d + reach), 0)
         yield (tip, elbow, feature)
@@ -1250,7 +1261,11 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
     in the OD stack. The turned column-left strip, applied to a prismatic boss, strands its ø
     whenever that narrow strip is tight — dropping the callout even on a half-empty sheet (#629).
     Run BEFORE ``render_diameters`` so a placed boss ø is 'mentioned' and not re-placed. A boss
-    whose ø a coincident feature already carries is skipped; an unplaceable one drops lint-visibly."""
+    whose ø a coincident feature already carries is skipped; an unplaceable one drops lint-visibly.
+
+    Placement rides the shared :func:`_leader_callout_pass` adapter (#700 — never a sixth copy
+    of the ray-exit loop, #637): rim-anchored :func:`_radial_candidates`, accepted with
+    ``geom_clear`` (the full shaft, not just the label, must clear other annotations)."""
     if a.is_rotational or a.prof is not None:
         # A turned profile means round stock — a band emitted as a boss (#298) belongs in the
         # OD diameter row/column, not an end-on plan leader. Only true prismatic parts qualify.
@@ -1259,9 +1274,8 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
     view_of = {"z": "plan", "x": "side", "y": "front"}  # the view looking down the boss axis
     boss_groups = [g for g in groups if g.feature_kind == "boss"]
     mentioned = _mentioned_diameters(dwg)
-    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
     reach = draft.font_size + 6 * draft.pad_around_text
-    n = 0
+    jobs = []
     for bi, g in enumerate(
         sorted(boss_groups, key=lambda g: (g.feature.frame.axis, g.feature.frame.origin))
     ):
@@ -1279,47 +1293,19 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
-        x0, y0, x1, y1 = vb
-        center = dwg.at(view, *b.frame.origin)
-        r_page = dia / 2 * a.SCALE  # the boss circle radius in page units
-        label_str = f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}"
-        obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-        placed = False
-        for dx, dy in _POCKET_LEAD_DIRS:
-            d = math.hypot(dx, dy)
-            ux, uy = dx / d, dy / d
-            arrow = (center[0] + ux * r_page, center[1] + uy * r_page)  # arrowhead on the rim
-            exit_d = _ray_exit_dist(center[0], center[1], ux, uy, (x0, y0, x1, y1))
-            elbow = (center[0] + ux * (exit_d + reach), center[1] + uy * (exit_d + reach), 0)
-            ldr = Leader(tip=(arrow[0], arrow[1], 0), elbow=elbow, label=label_str, draft=draft)
-            # _geom_box is the FULL footprint (shaft + arrow + label); the shaft is the invisible
-            # occupant a label-only box hides (#133/#305/#358), so it — not _anno_box — is what
-            # must clear the other callouts/witnesses. The silhouette/page checks use the label
-            # box, since the shaft legitimately starts at the boss rim inside the view.
-            geom = _geom_box(ldr)
-            label = getattr(ldr, "label_bbox", None) or geom
-            if (
-                geom is None
-                or label is None
-                or _box_hits(geom, obstacles)  # shaft or label crosses a callout/witness
-                or _box_hits(label, [(x0, y0, x1, y1)])  # label over the part silhouette
-                or label[0] < page[0]
-                or label[1] < page[1]
-                or label[2] > page[2]
-                or label[3] > page[3]
-            ):
-                continue
-            dwg.add(ldr, f"m_bossdia_{b.frame.axis}{bi}", view=view, feature=b)
-            n += 1
-            placed = True
-            break
-        if not placed:
-            ctx.record_issue(
-                "warning",
-                "boss_dia_dropped",
-                f"boss ø{_fmt(dia)} callout not placed (no clear room)",
+        jobs.append(
+            (
+                f"m_bossdia_{b.frame.axis}{bi}",
+                view,
+                vb,
+                f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}",
+                # arrowhead on the boss circle's rim, not its centre
+                _radial_candidates(dwg, view, vb, b, reach, rim=dia / 2 * a.SCALE),
             )
-    return n
+        )
+    return _leader_callout_pass(
+        dwg, a, jobs, noun="boss", drop_code="boss_dia_dropped", ctx=ctx, geom_clear=True
+    )
 
 
 def render_plates(dwg, model, a, *, ctx) -> int:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -39,7 +39,7 @@ from draftwright.annotations._common import (
     Escalation,
     _box_hits,
     _geom_box,
-    _segment_hits_box,
+    _segment_crosses_box,
     box_within_page_and_clear,
     carve_free_position,
     carve_free_segments,
@@ -1176,13 +1176,13 @@ def _needs_section(feat: HoleFeature | PatternFeature):
 
 def _leader_hits(leader, tip, elbow, side, obstacles):
     """True when *leader*'s rendered footprint truly overlaps any *obstacles* box — split into
-    the diagonal tip→elbow SHAFT (checked precisely via `_segment_hits_box`, since its AABB
+    the diagonal tip→elbow SHAFT (checked precisely via `_segment_crosses_box`, since its AABB
     over-claims the empty triangle it doesn't occupy — #305) and the elbow→label shelf+text
     (axis-aligned, so the coarse AABB check there is already exact). Promoted (#638; pure)."""
     full_box = _geom_box(leader)
     if full_box is None or not _box_hits(full_box, obstacles):
         return False  # fast reject: nowhere near any obstacle
-    if any(_segment_hits_box(tip, elbow, o) for o in obstacles):
+    if any(_segment_crosses_box(tip, elbow, o) for o in obstacles):
         return True
     label_box = (
         (elbow[0], full_box[1], full_box[2], full_box[3])

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -15,7 +15,6 @@ bore set, side-drilled locations, the hole table) + the section/PMI passes.
 
 from __future__ import annotations
 
-import math
 from types import SimpleNamespace
 
 from draftwright._core import (
@@ -28,6 +27,7 @@ from draftwright._core import (
     _iso_bbox,
     _log,
     _tag_sequence,
+    _wrap_rows,  # noqa: F401 — re-exported via the annotate facade (#700: one copy, in _core)
 )
 from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import PlacementContext, drain_corridors
@@ -73,22 +73,6 @@ from draftwright.model import (
     plan_sections,
 )
 from draftwright.repair import reconcile_witness_labels
-
-
-def _wrap_rows(header, data, ncols):
-    """Reshape *data* rows into *ncols* side-by-side blocks (a wider, shorter
-    table), each block headed by *header* — so a long hole chart fits the page.
-    """
-    per = math.ceil(len(data) / ncols)
-    blank = ("",) * len(header)
-    wide = [tuple(header) * ncols]
-    for r in range(per):
-        row: tuple = ()
-        for c in range(ncols):
-            idx = c * per + r
-            row += data[idx] if idx < len(data) else blank
-        wide.append(row)
-    return wide
 
 
 def _concentric_bore_diams(a: Analysis) -> list:

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -16,7 +16,6 @@ measure-and-repack pass (`_repack`, coupled to `_assemble`) stays in the builder
 from __future__ import annotations
 
 import logging
-import math
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -41,13 +40,16 @@ from draftwright._core import (
     _TB_H,
     Strip,
     ViewZones,
+    _anno_box,
     _fmt,
     _largest_empty_rect,
     _parse_page,
+    _table_metrics,
     _tag_sequence,
     _tb_width,
     _text_width,
     _tol_suffix,
+    _wrap_rows,
 )
 from draftwright.layout import fit_box
 
@@ -144,39 +146,19 @@ def _will_balloon(model) -> bool:
     return bool(covered < 0.8 * total)
 
 
-def _wrap_table_rows(header, data, ncols):
-    """Local mirror of the hole-table row wrapping used by the annotation pass."""
-
-    per = math.ceil(len(data) / ncols)
-    blank = ("",) * len(header)
-    wide = [tuple(header) * ncols]
-    for r in range(per):
-        row: tuple = ()
-        for c in range(ncols):
-            idx = c * per + r
-            row += data[idx] if idx < len(data) else blank
-        wide.append(row)
-    return wide
-
-
 def _est_table_size(
     rows, font_size: float = _FONT_SIZE, pad_around_text: float = 2.0, block_cols=None
 ):
-    """Table footprint estimate matching ``drawing._build_table``'s sizing model."""
+    """Table footprint estimate — ``drawing._build_table``'s sizing, from the
+    shared :func:`draftwright._core._table_metrics` so the ADR 0004
+    ``table_fits`` fitness check can never desynchronise from what renders
+    (#700; pinned by ``test_sheet_tables``)."""
 
     if not rows:
         return None
-    fs = font_size
-    pad = pad_around_text
-    row_h = fs + 2 * pad
-    ncol = len(rows[0])
-    bc = block_cols if (block_cols and ncol % block_cols == 0 and block_cols < ncol) else ncol
-    block_gap = 3 * pad
-    col_w = [
-        max(max(_text_width(str(r[c]), fs) for r in rows) + 2 * pad, fs * 2.5) for c in range(ncol)
-    ]
-    total_w = sum(col_w) + (max(ncol // bc - 1, 0) * block_gap)
-    total_h = row_h * len(rows)
+    _lefts, _rights, total_w, total_h, _row_h, _bc = _table_metrics(
+        rows, font_size, pad_around_text, block_cols
+    )
     return (total_w, total_h)
 
 
@@ -215,7 +197,7 @@ def _est_hole_table_sizes(
         for ncols in (1, 2, 3, 4)
         if (
             size := _est_table_size(
-                _wrap_table_rows(header, data, ncols), font_size, pad_around_text, len(header)
+                _wrap_rows(header, data, ncols), font_size, pad_around_text, len(header)
             )
         )
         is not None
@@ -632,23 +614,6 @@ def _view_geom(a) -> dict:
     }
 
 
-def _anno_bbox(o):
-    """Page-space bbox of an annotation: its text ``label_bbox`` if it has one,
-    else its geometric bounding box; ``None`` if neither resolves."""
-    lb = getattr(o, "label_bbox", None)
-    if lb is not None:
-        return lb
-    try:
-        b = o.bounding_box()
-        return (b.min.X, b.min.Y, b.max.X, b.max.Y)
-    except Exception as exc:  # noqa: BLE001 — not every annotation bbox-es cleanly
-        # Fails open: an un-bbox-able annotation drops out of the overlap count and
-        # the measured footprint. Surface it so a silently-missed repack trigger is
-        # debuggable rather than invisible (#121).
-        _log.debug("annotation %r has no resolvable bbox: %s", type(o).__name__, exc)
-        return None
-
-
 def _attribute_annotations(dwg, a):
     """Yield ``(name, view, bbox, is_label)`` for every annotation OWNED by an
     orthographic view, per the view recorded at creation (``dwg.view_of``).
@@ -666,7 +631,7 @@ def _attribute_annotations(dwg, a):
         if view not in ("front", "plan", "side"):
             continue
         label = getattr(o, "label_bbox", None)
-        bb = label if label is not None else _anno_bbox(o)
+        bb = label if label is not None else _anno_box(o)
         if bb is None:
             continue
         yield name, view, bb, label is not None

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -47,8 +47,8 @@ from draftwright._core import (
     _dim,
     _fmt,
     _log,
+    _table_metrics,
     _tag_sequence,
-    _text_width,
 )
 from draftwright.annotations._common import carve_free_position, strip_obstacles
 from draftwright.export import (
@@ -104,25 +104,11 @@ def _build_table(rows, draft, block_cols=None):
     than one run-on grid.
     """
     fs = draft.font_size
-    pad = draft.pad_around_text
-    row_h = fs + 2 * pad
     ncol = len(rows[0])
-    # Only treat as multi-block when block_cols evenly divides the row width.
-    bc = block_cols if (block_cols and ncol % block_cols == 0 and block_cols < ncol) else ncol
-    block_gap = 3 * pad  # whitespace between side-by-side blocks
-    col_w = [
-        max(max(_text_width(str(r[c]), fs) for r in rows) + 2 * pad, fs * 2.5) for c in range(ncol)
-    ]
-    # Per-column left/right edges, inserting block_gap before each new block.
-    lefts, rights, cursor = [], [], 0.0
-    for c in range(ncol):
-        if c > 0 and c % bc == 0:
-            cursor += block_gap
-        lefts.append(cursor)
-        cursor += col_w[c]
-        rights.append(cursor)
-    total_w = cursor
-    total_h = row_h * len(rows)
+    # One sizing model, shared with compose's footprint estimate (#700).
+    lefts, rights, total_w, total_h, row_h, bc = _table_metrics(
+        rows, fs, draft.pad_around_text, block_cols
+    )
     ys = [i * row_h for i in range(len(rows) + 1)]
     children = []
     for b in range(ncol // bc):  # one bordered grid per block

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -15,6 +15,8 @@ import re
 
 from build123d import GeomType
 
+from draftwright._core import _shape_box2d
+from draftwright._geometry import _boxes_overlap, _segment_clips_box
 from draftwright.linting.issues import LintIssue
 
 _log = logging.getLogger(__name__)
@@ -27,10 +29,10 @@ _DRAWING_PAGE = None
 def _seg_intersects_rect(p, q, rect) -> bool:
     """True if segment p→q intersects the (min_x, min_y, max_x, max_y) rect.
 
-    Thin wrapper over :func:`_seg_hits_box` (the same Liang–Barsky clip) with no
-    padding, kept for call-site readability.
+    Thin wrapper over :func:`draftwright._geometry._segment_clips_box` (the
+    Liang–Barsky clip) with no padding, kept for call-site readability.
     """
-    return bool(_seg_hits_box(p, q, rect, pad=0.0))
+    return bool(_segment_clips_box(p, q, rect, pad=0.0))
 
 
 def _loc_token(item):
@@ -387,22 +389,6 @@ def lint_drawing(
     return issues
 
 
-def _bbox2d(shape):
-    """Return (minx, miny, maxx, maxy) for a build123d shape, or None on failure."""
-    try:
-        bb = shape.bounding_box()
-        return bb.min.X, bb.min.Y, bb.max.X, bb.max.Y
-    except Exception:
-        return None
-
-
-def _bboxes_overlap_2d(a, b) -> bool:
-    """True if two (minx, miny, maxx, maxy) rectangles overlap in XY."""
-    ax0, ay0, ax1, ay1 = a
-    bx0, by0, bx1, by1 = b
-    return bool(ax0 < bx1 and ax1 > bx0 and ay0 < by1 and ay1 > by0)
-
-
 def _overshoots(bb, bounds) -> list[str]:
     """Sides where (min_x, min_y, max_x, max_y) *bb* spills past *bounds*, as text."""
     bx0, by0, bx1, by1 = bounds
@@ -430,7 +416,7 @@ def _edges_intersect_rect(edge_entries, rect) -> bool:
         try:
             if eb is None:
                 return True  # unanalysable edge — count as a hit
-            if not _bboxes_overlap_2d(eb, rect):
+            if not _boxes_overlap(eb, rect):
                 continue
             if e.geom_type == GeomType.LINE:
                 s, t = e.start_point(), e.end_point()
@@ -461,7 +447,7 @@ def _view_edge_entries(vs, cache):
     if hit is not None and hit[0] is vs:
         return hit[1]
     try:
-        entries: list | None = [(e, _bbox2d(e)) for e in vs.edges()]
+        entries: list | None = [(e, _shape_box2d(e)) for e in vs.edges()]
     except Exception:
         entries = None
     cache[key] = (vs, entries)
@@ -510,7 +496,7 @@ def _lint_view_shapes(
             ab = label_box if label_box is not None else _ann_box(ann, ann_cache)
             if ab is None:
                 continue
-            if not _bboxes_overlap_2d(vbb, ab):
+            if not _boxes_overlap(vbb, ab):
                 continue
             albl = getattr(ann, "label", None) or getattr(ann, "name", None) or type(ann).__name__
             what = "label of annotation" if label_box is not None else "annotation"
@@ -544,7 +530,7 @@ def _lint_view_shapes(
         ax0, ay0, ax1, ay1 = abb
         for bname, bbb, _ in named_views[i + 1 :]:
             bx0, by0, bx1, by1 = bbb
-            if _bboxes_overlap_2d(abb, bbb):
+            if _boxes_overlap(abb, bbb):
                 issues.append(
                     LintIssue(
                         severity="warning",
@@ -715,26 +701,3 @@ def _lint_leader(item, issues, box_cache=None) -> None:
                 code="leader_line_through_text",
             )
         )
-
-
-def _seg_hits_box(p, q, box, pad=0.2):
-    """Liang–Barsky: does segment p->q intersect the padded AABB box?"""
-    minx, miny, maxx, maxy = box[0] - pad, box[1] - pad, box[2] + pad, box[3] + pad
-    x0, y0 = p
-    dx, dy = q[0] - x0, q[1] - y0
-    t0, t1 = 0.0, 1.0
-    for pp, qq in ((-dx, x0 - minx), (dx, maxx - x0), (-dy, y0 - miny), (dy, maxy - y0)):
-        if abs(pp) < 1e-12:
-            if qq < 0:
-                return False
-        else:
-            r = qq / pp
-            if pp < 0:
-                if r > t1:
-                    return False
-                t0 = max(t0, r)
-            else:
-                if r < t0:
-                    return False
-                t1 = min(t1, r)
-    return t0 <= t1

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, runtime_checkable
 
+from draftwright._geometry import _fmt
+
 if TYPE_CHECKING:
     from draftwright.fits import FitClass
 
@@ -79,10 +81,6 @@ class DimParameter:
     # renders its own class-code / deviation suffix; ``None`` when untoleranced. Set by the
     # planner from the caller's ``decorations`` — geometry never supplies it.
     tolerance: float | tuple[float, float] | FitClass | None = None
-
-
-def _fmt(v: float) -> str:
-    return f"{v:.0f}" if abs(v - round(v)) < 1e-6 else f"{v:.1f}"
 
 
 def display(p: DimParameter) -> str:

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -115,6 +115,27 @@ def test_a_dropped_table_frees_its_name():
     assert any(i.code == "table_dropped" for i in dwg._build_issues)  # the drop is still recorded
 
 
+def test_estimated_table_size_matches_rendered():
+    # #700: compose's table_fits fitness check (ADR 0004) sizes tables via
+    # _est_table_size; the annotation pass renders them via _build_table. Both now
+    # draw from the one _core._table_metrics — this pins estimator == rendered, the
+    # exact drift ADR 0004 names as the failure mode to guard against.
+    from draftwright._core import _FONT_SIZE, _wrap_rows, draft_preset
+    from draftwright.compose import _est_table_size
+    from draftwright.drawing import _build_table
+
+    draft = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
+    header = ("TAG", "ø", "X", "Y")
+    data = [(f"A{i}", f"ø{3 + i}.5", str(10 * i), str(5 * i)) for i in range(5)]
+    for ncols in (1, 2, 3):
+        rows = _wrap_rows(header, data, ncols)
+        table = _build_table(rows, draft, block_cols=len(header))
+        est = _est_table_size(rows, draft.font_size, draft.pad_around_text, len(header))
+        assert est == pytest.approx(table.table_size), (
+            f"ncols={ncols}: estimated footprint {est} != rendered {table.table_size}"
+        )
+
+
 def test_model_inspection_ignores_tables():
     # model() is the cheap no-render inspection path — tables are render-time, so declaring one
     # must not affect the IR model or raise.


### PR DESCRIPTION
Closes #700 — the audit's duplicated-helper family, consolidated to one home per helper (net −276/+277, but the + is mostly docstrings on the shared homes).

## What moved where
- **`_geometry.py` (rank-0 leaf)**: `_fmt` (the `_core`/`model/ir` copies had already begun to drift on `-0`; `_core`'s `str(round(v))` form is canonical), `_boxes_overlap` (now behind both `_common._box_hits` and structural's three pairwise checks — their strictness was identical), and the two segment/AABB tests: `_segment_crosses_box` (strict, the placement-side corridor accept) and `_segment_clips_box` (inclusive Liang–Barsky, the lint side; unused `pad=0.2` default dropped to `0.0`). Kept as **two functions** deliberately: their boundary semantics differ by design and the #351 strand-3 review already tried and reverted a unification — the docstrings now cross-reference each other so the next reader picks knowingly.
- **`_core.py`**: `_anno_box` (the `_common`/`compose._anno_bbox` twins were byte-near-identical; the merged copy keeps compose's debug log), `_shape_box2d` (née `structural._bbox2d`), `_wrap_rows` (orchestrator's copy was byte-identical to `compose._wrap_table_rows`; the `annotate` facade re-export chain is preserved), and **`_table_metrics`** — the one table-sizing model. `drawing._build_table` now draws from it and `compose._est_table_size` estimates from it, so the ADR 0004 `table_fits` fitness check can never desynchronise from what renders.
- **Boss ø fold (#637's "never a sixth copy")**: `render_boss_diameters` now rides the shared `_leader_callout_pass`/`_radial_candidates` adapter — `rim=` advances the arrowhead onto the boss circle, `geom_clear=` preserves its deliberately stricter full-shaft obstacle test (elbow maths verified algebraically identical: `rim + (exit−rim) + reach = exit + reach`).

## New pinning test
`test_sheet_tables.py::test_estimated_table_size_matches_rendered` — estimator == rendered `table_size` across 1–3 wrap columns, the exact drift ADR 0004 names as the failure mode to guard against (previously untested).

## Deliberately left / split out
The large per-axis render mirrors (`render_locations` X/Y, `_diameter_row_below` vs `_diameter_column_left`, `render_rotational` z/x/y) are **#714** — layout-affecting refactors that deserve their own review. The memoised `_ann_box` and logging `_geom_box` keep their bodies: their caching/logging policies are the function, only the raw read idiom was consolidated.

## Verification
- ruff check / format / mypy / codespell clean.
- Targeted: 82 boss/pocket/groove/chamfer/fillet/flat/table selections + 284 lint/strip/declare/footprint tests, all passing.
- Full fast tier `-n auto`: **1414 passed**, 1 failed = the known pre-existing #710 local Hypothesis replay (fails identically on main; CI draws fresh examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)