### PR TITLE
refactor(#704): facade-tier cleanup — curated exports, authored_dimension, shared single-face reads, score as enforced leaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@
   tuple. **Breaking** for callers unpacking that tuple: use
   `sheet.export(stem, formats=("svg", "dxf"))` and read the dict.
 
+### Added
+
+- **`draftwright.model.authored_dimension`** (#704): the IR constructor behind
+  `Sheet.dimension()`, extracted so `build_drawing(model=…)` callers can author
+  a pre-measured drafting dimension without the `Sheet` façade.
+
+### Removed
+
+- **Three orphaned root exports** (#704): `draftwright.recognise_face_levels`
+  (one recogniser of ~12 — incoherent as a top-level surface; import it from
+  `draftwright.recognition`), `draftwright.dedup_diams` (an analysis internal),
+  and `draftwright.fix_svg_page_size` (still available from `draftwright.export`
+  and the `draftwright.make_drawing` facade). None had any internal or test
+  consumer via the root API.
+
 ### Deprecated
 
 - **`draftwright.sheet_dsl`** (belated announcement — the alias shim shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@
   `Sheet.dimension()`, extracted so `build_drawing(model=…)` callers can author
   a pre-measured drafting dimension without the `Sheet` façade.
 
+### Fixed
+
+- **`model.chamfer(face=…)` rejects a non-planar face** (#704): the declared
+  front-end silently accepted a curved face (`normal_at()` does not fail on
+  one) and read garbage legs off it — e.g. a fillet or countersink face became
+  a bogus `ChamferFeature`. It now raises the documented `ValueError`, using
+  the recogniser's own planarity gate (`classify_bevel`), so declared and
+  detected chamfers classify identically by construction.
+
 ### Removed
 
 - **Three orphaned root exports** (#704): `draftwright.recognise_face_levels`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,8 @@ entry. Keep `_LAYERS` and this section in step.
   #523 (open).
 - **`score.py`** — `feature_census` (#148f/#608): a standalone
   recognition-completeness measurement tool; depends only on `recognition/` +
-  build123d, and nothing in the engine imports it.
+  build123d, and nothing in the engine imports it. Ranked 0 in `_LAYERS` (#704),
+  so that leaf status is machine-enforced.
 - **`recognition/`** — feature recognition (ADR 0007: draftwright owns it, not
   helpers). Every feature recogniser follows the **uniform contract** (ADR 0013 / #568,
   spelled out in `recognition/__init__.py`): `recognise_<feature>(part, *, <injected

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -23,15 +23,12 @@ from typing import TYPE_CHECKING
 # none of these names, so they stay sub-second instead of paying for the kernel
 # on every TAB press (#313). Each name maps to the submodule that provides it.
 _LAZY = {
-    "recognise_face_levels": "draftwright.recognition",
-    "dedup_diams": "draftwright.analysis",
     "build_drawing": "draftwright.builder",
     "generate_script": "draftwright.builder",
     "make_drawing": "draftwright.builder",
     "Drawing": "draftwright.drawing",
     "FeatureInfo": "draftwright.drawing",
     "Sheet": "draftwright.sheet",
-    "fix_svg_page_size": "draftwright.export",
     "lint_feature_coverage": "draftwright.linting",
     "PmiRecord": "draftwright.pmi",
     "extract_pmi": "draftwright.pmi",
@@ -72,14 +69,11 @@ _sys.modules[__name__].__class__ = _DraftwrightModule
 
 
 if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel cost
-    from draftwright.analysis import dedup_diams
     from draftwright.builder import build_drawing, generate_script, make_drawing
     from draftwright.compose import choose_scale
     from draftwright.drawing import Drawing, FeatureInfo
-    from draftwright.export import fix_svg_page_size
     from draftwright.linting import lint_feature_coverage
     from draftwright.pmi import PmiRecord, extract_pmi
-    from draftwright.recognition import recognise_face_levels
     from draftwright.sheet import Sheet
 
 
@@ -95,12 +89,9 @@ __all__ = [
     "FeatureInfo",
     "PmiRecord",
     "Sheet",
-    "recognise_face_levels",
     "build_drawing",
     "choose_scale",
-    "dedup_diams",
     "extract_pmi",
-    "fix_svg_page_size",
     "generate_script",
     "lint_feature_coverage",
     "make_drawing",

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -36,7 +36,11 @@ from draftwright._core import (
     _tb_width,
 )
 from draftwright.analysis import _analyse
-from draftwright.annotate import _auto_annotate, build_model, build_rotational_feature
+from draftwright.annotations.orchestrator import (
+    _auto_annotate,
+    build_model,
+    build_rotational_feature,
+)
 from draftwright.annotations.sections import feature_hole_keys
 from draftwright.compose import (
     ViewBlock,

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -23,6 +23,7 @@ reads recognised geometry, by design (ground truth, not the plan).
 from __future__ import annotations
 
 from draftwright.model.declare import (
+    authored_dimension,
     boss,
     chamfer,
     control_frame,
@@ -100,6 +101,7 @@ __all__ = [
     "StepFeature",
     "PlateFeature",
     "StepLevelFeature",
+    "authored_dimension",
     "build_part_model",
     "build_pmi_features",
     "boss",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -28,6 +28,8 @@ import math
 import warnings
 
 from draftwright.model.ir import (
+    AUTHORED_DIMENSION_KINDS,
+    AuthoredDimension,
     BossFeature,
     ChamferFeature,
     ControlFrame,
@@ -258,23 +260,24 @@ def hole(
 def read_countersink(cone) -> tuple[float, float]:
     """``(major_diameter, included_angle°)`` of a countersink **cone** tool — the larger rim ⌀
     and the full cone angle, read off its conical **face** (not a removed edge, #576 lesson).
-    Mirrors :func:`recognition.recognise_countersinks`' cone geometry."""
+    The cone geometry is the recogniser's own
+    :func:`~draftwright.recognition.countersinks.cone_rims` (#704), so a declared
+    countersink reads identically to a detected one by construction."""
     from build123d import GeomType
-    from OCP.BRepAdaptor import BRepAdaptor_Surface
+
+    from draftwright.recognition import cone_rims
 
     faces = cone.faces().filter_by(GeomType.CONE)
     if not faces:
         raise ValueError("countersink(cone=...) needs a conical tool (a build123d Cone)")
-    f = faces[0]
-    circles = f.edges().filter_by(GeomType.CIRCLE)
-    if len(circles) < 2:
+    rims = cone_rims(faces[0])
+    if rims is None:
         raise ValueError(
             "countersink(cone=...) needs a flared cone with two distinct-radius rims; a "
             "single-rim drill-point cone is not a countersink"
         )
-    major = 2 * max(e.radius for e in circles)
-    semi = abs(BRepAdaptor_Surface(f.wrapped).Cone().SemiAngle())
-    return round(major, 4), round(2 * math.degrees(semi), 2)
+    _minor_e, major_e, included = rims
+    return round(2 * major_e.radius, 4), included
 
 
 def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:
@@ -323,29 +326,26 @@ def step(obj=None, *, diameter=None, length=None, at=None, axis=None, span=None)
 def _read_chamfer_face(face) -> tuple[str, float, float, Point]:
     """Read a chamfer off its **oblique planar bevel face**: the axis (the edge the chamfer
     runs along), the two legs (the face's in-plane extents), and a point **on the bevel** (the
-    face centre — not the removed sharp corner). The leader point agrees with the recogniser
-    (recognition/chamfers.py) in the two **in-plane** (placement) coordinates; the along-edge
-    coordinate is view depth, so it need not match exactly."""
+    face centre — not the removed sharp corner). The classification + leg geometry is the
+    recogniser's own :func:`~draftwright.recognition.chamfers.classify_bevel` (#704), so a
+    declared chamfer reads identically to a detected one by construction; only the
+    user-facing error messages live here."""
+    from draftwright.recognition import BevelReject, classify_bevel
+
     try:
-        nrm = face.normal_at()
-    except Exception:  # noqa: BLE001 — a degenerate/non-planar face has no clean normal
+        edge_i, _nv, _span, hi, lo = classify_bevel(face)
+    except BevelReject as e:
+        if e.reason == "aligned":
+            raise ValueError(
+                "chamfer(face=...) needs an OBLIQUE planar face (the bevel); an axis-aligned "
+                "face is not a chamfer — declare with axis=, leg=, at= instead"
+            ) from None
+        if e.reason == "compound":
+            raise ValueError(
+                "chamfer(face=...): the bevel must run along one principal axis; "
+                "use axis=, leg=, at="
+            ) from None
         raise ValueError("chamfer(face=...) needs an oblique planar bevel face") from None
-    nv = (nrm.X, nrm.Y, nrm.Z)
-    if max(abs(c) for c in nv) > 0.99:
-        raise ValueError(
-            "chamfer(face=...) needs an OBLIQUE planar face (the bevel); an axis-aligned "
-            "face is not a chamfer — declare with axis=, leg=, at= instead"
-        )
-    edge_i = next((i for i in range(3) if abs(nv[i]) < 0.05), None)
-    if edge_i is None:  # oblique on all three axes → a compound corner bevel
-        raise ValueError(
-            "chamfer(face=...): the bevel must run along one principal axis; use axis=, leg=, at="
-        )
-    oi = [j for j in range(3) if j != edge_i]
-    bb = face.bounding_box()
-    span = ((bb.min.X, bb.max.X), (bb.min.Y, bb.max.Y), (bb.min.Z, bb.max.Z))
-    hi = max(span[oi[0]][1] - span[oi[0]][0], span[oi[1]][1] - span[oi[1]][0])
-    lo = min(span[oi[0]][1] - span[oi[0]][0], span[oi[1]][1] - span[oi[1]][0])
     c = face.center()
     # No angle: it is always derivable from the legs, so returning it would let a leg-only
     # override leave a stale, contradicting angle (#580 review). chamfer() derives it.
@@ -415,20 +415,19 @@ def _read_fillet_face(face) -> tuple[str, float, Point]:
             "fillet(face=...): the round must run along one principal axis; use axis=, radius=, at="
         )
     edge_i = max(range(3), key=lambda i: comp[i])
-    # Anchor on the curved radius surface itself — a point at the middle of the trimmed face's
-    # angular (U) and axial (V) parameter spans — NOT the bbox centre, which sits off the round
-    # near the virtual sharp corner (#622). Evaluated exactly as recognition/fillets.py does, so
-    # a declared fillet's leader tip is identical to the detected one's.
-    u_mid = 0.5 * (s.FirstUParameter() + s.LastUParameter())
-    v_mid = 0.5 * (s.FirstVParameter() + s.LastVParameter())
-    p = s.Value(u_mid, v_mid)
+    # Anchor on the curved radius surface itself — the recogniser's own fillet_anchor
+    # (#622 lesson: never the bbox centre), so a declared fillet's leader tip is
+    # identical to the detected one's by construction (#704).
+    from draftwright.recognition import fillet_anchor
+
+    p = fillet_anchor(s)
     return (
         "xyz"[edge_i],
         round(s.Cylinder().Radius(), 3),
         (
-            round(p.X(), 4),
-            round(p.Y(), 4),
-            round(p.Z(), 4),
+            round(p[0], 4),
+            round(p[1], 4),
+            round(p[2], 4),
         ),
     )
 
@@ -509,11 +508,11 @@ def _read_groove_face(face) -> tuple[str, float, float, Point]:
     axis_i = max(range(3), key=lambda i: comp[i])
     bb = face.bounding_box()
     span = ((bb.min.X, bb.max.X), (bb.min.Y, bb.max.Y), (bb.min.Z, bb.max.Z))[axis_i]
-    c = (
-        0.5 * (bb.min.X + bb.max.X),
-        0.5 * (bb.min.Y + bb.max.Y),
-        0.5 * (bb.min.Z + bb.max.Z),
-    )
+    # The leader tip is the recogniser's own floor_face_anchor (#704), so a declared
+    # groove anchors identically to a detected one by construction.
+    from draftwright.recognition import floor_face_anchor
+
+    c = floor_face_anchor(face)
     return (
         "xyz"[axis_i],
         round(span[1] - span[0], 3),
@@ -1233,4 +1232,70 @@ def control_frame(
         diameter=bool(diameter),
         modifier=modifier,
         origin=origin,
+    )
+
+
+def _point3(name: str, p) -> Point:
+    vals = tuple(float(c) for c in p)
+    if len(vals) != 3:
+        raise ValueError(f"dimension() {name} must be a 3-tuple")
+    return (vals[0], vals[1], vals[2])
+
+
+def authored_dimension(
+    *,
+    kind: str,
+    value: float,
+    label: str,
+    dominant_axis: str,
+    ref_pts,
+    ref_bbox=None,
+    at=None,
+    axis: str | None = None,
+    upper_tol: float | None = None,
+    lower_tol: float | None = None,
+    source: str = "sheet",
+    source_kind: str | None = None,
+) -> AuthoredDimension:
+    """A pre-authored drafting dimension from explicit measured values — the IR constructor
+    behind :meth:`Sheet.dimension` (#704: extracted so ``build_drawing(model=…)`` callers can
+    author one without the façade). Validates the kind against
+    :data:`~draftwright.model.ir.AUTHORED_DIMENSION_KINDS`, needs ≥2 ``ref_pts``, and derives
+    ``at`` (the ``ref_bbox`` centre, else the ``ref_pts`` centroid) when not given."""
+    _require_positive(value=value)
+    dim_kind = str(kind).lower()
+    if dim_kind not in AUTHORED_DIMENSION_KINDS:
+        allowed = ", ".join(sorted(AUTHORED_DIMENSION_KINDS))
+        raise ValueError(f"dimension() kind must be one of: {allowed}")
+    pts = tuple(_point3("ref_pts item", p) for p in ref_pts)
+    if len(pts) < 2:
+        raise ValueError("dimension() needs at least two ref_pts")
+    bbox = None if ref_bbox is None else tuple(float(c) for c in ref_bbox)
+    if bbox is not None and len(bbox) != 6:
+        raise ValueError("dimension() ref_bbox must be a 6-tuple")
+    dom = str(dominant_axis).upper()
+    if dom not in ("X", "Y", "Z"):
+        if not (dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None):
+            raise ValueError("dimension() dominant_axis must be X, Y, or Z")
+    if at is None:
+        if bbox is not None:
+            x0, y0, z0, x1, y1, z1 = bbox
+            at = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
+        else:
+            n = len(pts)
+            at = tuple(sum(p[i] for p in pts) / n for i in range(3))
+    origin = _point3("at", at)
+    ax = _norm_axis(axis or (dom.lower() if dom in ("X", "Y", "Z") else "z"))
+    return AuthoredDimension(
+        frame=Frame(origin, ax),
+        dimension_kind=dim_kind,
+        value=float(value),
+        label=str(label),
+        dominant_axis=dom,
+        upper_tol=upper_tol,
+        lower_tol=lower_tol,
+        ref_bbox=bbox,
+        ref_pts=pts,
+        source=source,
+        source_kind=source_kind or dim_kind,
     )

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -68,11 +68,16 @@ from draftwright.recognition._features import (
     recognise_hole_patterns,
     recognise_holes,
 )
-from draftwright.recognition.chamfers import Chamfer, recognise_chamfers
-from draftwright.recognition.countersinks import CounterSink, recognise_countersinks
-from draftwright.recognition.fillets import Fillet, recognise_fillets
+from draftwright.recognition.chamfers import (
+    BevelReject,
+    Chamfer,
+    classify_bevel,
+    recognise_chamfers,
+)
+from draftwright.recognition.countersinks import CounterSink, cone_rims, recognise_countersinks
+from draftwright.recognition.fillets import Fillet, fillet_anchor, recognise_fillets
 from draftwright.recognition.flats import Flat, recognise_flats
-from draftwright.recognition.grooves import Groove, recognise_grooves
+from draftwright.recognition.grooves import Groove, floor_face_anchor, recognise_grooves
 from draftwright.recognition.levels import (
     FaceLevel,
     StepShoulder,
@@ -104,7 +109,12 @@ __all__ = [
     "StepShoulder",
     "TurnedProfile",
     "TurnedStep",
+    "BevelReject",
     "analyse_cylinders",
+    "classify_bevel",
+    "cone_rims",
+    "fillet_anchor",
+    "floor_face_anchor",
     "recognise_face_levels",
     "recognise_step_shoulders",
     "step_level_zs",

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -48,7 +48,11 @@ draftwright.model.ir import HoleFeature``.
 
 ``analyse_cylinders`` / ``full_cylinders`` / ``feature_diameters`` are **not** recognisers
 under this contract — they are cylinder-analysis *substrate* (a tuple of dicts / a diameter
-query), and deliberately keep their names.
+query), and deliberately keep their names. Likewise the **shared single-face reads**
+(``classify_bevel``/``BevelReject``, ``fillet_anchor``, ``cone_rims``,
+``floor_face_anchor``, ``step_level_zs``, #704): helpers shared with the declared
+front-end (``model/declare``), not recognisers — they traffic in build123d/OCP objects,
+so a future ADR 0013 Phase-2 package extraction would keep them internal, not surface.
 """
 
 from __future__ import annotations

--- a/src/draftwright/recognition/chamfers.py
+++ b/src/draftwright/recognition/chamfers.py
@@ -129,13 +129,14 @@ def recognise_chamfers(part, *, tol: float = 0.5, max_leg_frac: float = 0.45) ->
         fw = f.wrapped
         # The shared single-face read (classification thresholds + legs = the face's OWN
         # in-plane bbox extents, not measured against a possibly distant outermost wall).
+        # (The old extra skew gate on the in-plane normal components was unreachable — a
+        # unit normal with two components < 0.05 forces the third > 0.99, which "aligned"
+        # already rejects — so it was dropped when the thresholds moved, #704 review.)
         try:
-            edge_i, nv, span, leg_hi, leg_lo = classify_bevel(f)
+            edge_i, _nv, span, leg_hi, leg_lo = classify_bevel(f)
         except BevelReject:
             continue
         oi = [j for j in (0, 1, 2) if j != edge_i]
-        if abs(nv[oi[0]]) < 0.05 or abs(nv[oi[1]]) < 0.05:
-            continue
         fc = {i: 0.5 * (span[i][0] + span[i][1]) for i in (0, 1, 2)}  # face centre
         if leg_lo < tol:
             continue

--- a/src/draftwright/recognition/chamfers.py
+++ b/src/draftwright/recognition/chamfers.py
@@ -59,6 +59,44 @@ class Chamfer(Record):
     at: tuple[float, float, float]
 
 
+class BevelReject(ValueError):
+    """*face* is not a single-axis oblique planar bevel; ``reason`` says why:
+    ``"nonplanar"``, ``"degenerate"`` (no clean normal), ``"aligned"`` (axis-aligned or a
+    shallow draft angle — a real face, not a chamfer), or ``"compound"`` (oblique on all
+    three axes — a corner bevel, out of scope)."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+def classify_bevel(face):
+    """The single-face oblique-bevel read shared by :func:`recognise_chamfers` and the
+    declared front-end (``model/declare._read_chamfer_face``) — one home for the
+    normal→axis classification thresholds and the leg geometry (#704). Returns
+    ``(edge_i, nv, span, leg_hi, leg_lo)``: the along-edge axis index, the unit normal,
+    per-axis ``(lo, hi)`` bbox spans, and the two in-plane leg lengths (unrounded,
+    ``leg_hi >= leg_lo``). Raises :class:`BevelReject` when the face is not one."""
+    if BRepAdaptor_Surface(face.wrapped).GetType() != GeomAbs_Plane:
+        raise BevelReject("nonplanar")
+    try:
+        nvec = face.normal_at()
+    except Exception:  # noqa: BLE001 — a degenerate face has no clean normal
+        raise BevelReject("degenerate") from None
+    nv = (nvec.X, nvec.Y, nvec.Z)
+    if max(abs(c) for c in nv) > 0.99:
+        raise BevelReject("aligned")
+    edge_i = next((i for i in (0, 1, 2) if abs(nv[i]) < 0.05), None)
+    if edge_i is None:
+        raise BevelReject("compound")
+    oi = [j for j in (0, 1, 2) if j != edge_i]
+    fb = face.bounding_box()
+    span = {0: (fb.min.X, fb.max.X), 1: (fb.min.Y, fb.max.Y), 2: (fb.min.Z, fb.max.Z)}
+    leg_u = span[oi[0]][1] - span[oi[0]][0]
+    leg_v = span[oi[1]][1] - span[oi[1]][0]
+    return edge_i, nv, span, max(leg_u, leg_v), min(leg_u, leg_v)
+
+
 def _axis_aligned_axis(face_wrapped) -> tuple[int, float] | None:
     """The axis a planar face's normal aligns with and that plane's fixed coordinate along
     it, or None if the face is not planar or not axis-aligned. Sign-agnostic (only
@@ -89,32 +127,19 @@ def recognise_chamfers(part, *, tol: float = 0.5, max_leg_frac: float = 0.45) ->
     out: list[Chamfer] = []
     for f in all_faces:
         fw = f.wrapped
-        s = BRepAdaptor_Surface(fw)
-        if s.GetType() != GeomAbs_Plane:
-            continue
+        # The shared single-face read (classification thresholds + legs = the face's OWN
+        # in-plane bbox extents, not measured against a possibly distant outermost wall).
         try:
-            nvec = f.normal_at()
-        except Exception:  # noqa: BLE001 — a degenerate face has no clean normal
+            edge_i, nv, span, leg_hi, leg_lo = classify_bevel(f)
+        except BevelReject:
             continue
-        nv = (nvec.X, nvec.Y, nvec.Z)
-        if max(abs(c) for c in nv) > 0.99:
-            continue  # axis-aligned (a real face) or a shallow draft angle — not a chamfer
-        edge_i = next((i for i in (0, 1, 2) if abs(nv[i]) < 0.05), None)
-        if edge_i is None:
-            continue  # a compound corner bevel (oblique on all axes) — out of scope
         oi = [j for j in (0, 1, 2) if j != edge_i]
         if abs(nv[oi[0]]) < 0.05 or abs(nv[oi[1]]) < 0.05:
             continue
-        # Legs = the chamfer face's OWN in-plane bbox extents — read from the face itself,
-        # not measured against a (possibly distant) outermost wall.
-        fb = f.bounding_box()
-        span = {0: (fb.min.X, fb.max.X), 1: (fb.min.Y, fb.max.Y), 2: (fb.min.Z, fb.max.Z)}
         fc = {i: 0.5 * (span[i][0] + span[i][1]) for i in (0, 1, 2)}  # face centre
-        leg_u = span[oi[0]][1] - span[oi[0]][0]
-        leg_v = span[oi[1]][1] - span[oi[1]][0]
-        if leg_u < tol or leg_v < tol:
+        if leg_lo < tol:
             continue
-        if max(leg_u, leg_v) > max_leg_frac * max(ext.values()):
+        if leg_hi > max_leg_frac * max(ext.values()):
             continue  # a ramp/wedge spanning a large fraction of the part — not an edge break
         # Must bridge two axis-aligned faces on distinct in-plane axes (a chamfer replaces
         # a sharp 90° edge). A hex side abuts oblique faces. Record each neighbour plane's
@@ -157,12 +182,12 @@ def recognise_chamfers(part, *, tol: float = 0.5, max_leg_frac: float = 0.45) ->
         # of the convex planar bevel lies on the face; this also matches declare's
         # _read_chamfer_face, so detected and declared chamfers anchor identically.
         fctr = f.center()
-        angle = math.degrees(math.atan2(min(leg_u, leg_v), max(leg_u, leg_v)))
+        angle = math.degrees(math.atan2(leg_lo, leg_hi))
         out.append(
             Chamfer(
                 axis="xyz"[edge_i],
-                leg1=round(max(leg_u, leg_v), 3),
-                leg2=round(min(leg_u, leg_v), 3),
+                leg1=round(leg_hi, 3),
+                leg2=round(leg_lo, 3),
                 angle=round(angle, 2),
                 at=(round(fctr.X, 3), round(fctr.Y, 3), round(fctr.Z, 3)),
             )

--- a/src/draftwright/recognition/countersinks.py
+++ b/src/draftwright/recognition/countersinks.py
@@ -71,6 +71,22 @@ class CounterSink(Record):
     depth: float
 
 
+def cone_rims(face):
+    """``(minor_edge, major_edge, included_angle°)`` of a conical *face* — its two circular
+    rims (smallest- and largest-radius) and the full cone angle (2 dp) — or ``None`` when
+    the cone has fewer than two circular rims (a drill-point cone / degenerate). The
+    single-face cone read shared by :func:`recognise_countersinks` and the declared
+    front-end (``model/declare.read_countersink``), #704."""
+    from OCP.BRepAdaptor import BRepAdaptor_Surface
+
+    circles = sorted(face.edges().filter_by(GeomType.CIRCLE), key=lambda e: e.radius)
+    if len(circles) < 2:
+        return None
+    cone = BRepAdaptor_Surface(face.wrapped).Cone()
+    included = round(2 * abs(math.degrees(cone.SemiAngle())), 2)
+    return circles[0], circles[-1], included
+
+
 def _parallel(a, b) -> bool:
     return bool(abs(a[0] * b[0] + a[1] * b[1] + a[2] * b[2]) > 1 - 1e-3)
 
@@ -100,15 +116,13 @@ def recognise_countersinks(part) -> list[CounterSink]:
 
     out: list[CounterSink] = []
     for f in cones:
-        circles = sorted(f.edges().filter_by(GeomType.CIRCLE), key=lambda e: e.radius)
-        if len(circles) < 2:
+        rims = cone_rims(f)  # the shared single-face cone read (#704)
+        if rims is None:
             continue  # drill-point cone (one circle + apex) or degenerate
-        minor_e, major_e = circles[0], circles[-1]
+        minor_e, major_e, included_angle = rims
         minor_r, major_r = minor_e.radius, major_e.radius
         if major_r < _MIN_MAJOR_RATIO * minor_r:
             continue  # too little flare — an edge break / deburr, not a screw seat
-        cone = BRepAdaptor_Surface(f.wrapped).Cone()
-        included_angle = round(2 * abs(math.degrees(cone.SemiAngle())), 2)
         if included_angle > _MAX_INCLUDED_ANGLE:
             continue  # a near-flat cone is a draft/relief/washer face, not a countersink
         opening = major_e.arc_center

--- a/src/draftwright/recognition/fillets.py
+++ b/src/draftwright/recognition/fillets.py
@@ -56,6 +56,19 @@ class Fillet(Record):
     at: tuple[float, float, float]
 
 
+def fillet_anchor(s) -> tuple[float, float, float]:
+    """A leader-tip point **on** the trimmed cylindrical blend face *s* (a
+    ``BRepAdaptor_Surface``) — the middle of its angular (U) and axial (V) parameter spans.
+    Never the bbox centre, which sits off the round near the virtual sharp corner (#622).
+    The one implementation shared by :func:`recognise_fillets` and the declared front-end
+    (``model/declare._read_fillet_face``), so a declared fillet's leader tip is identical
+    to the detected one's (#704)."""
+    u_mid = 0.5 * (s.FirstUParameter() + s.LastUParameter())
+    v_mid = 0.5 * (s.FirstVParameter() + s.LastVParameter())
+    p = s.Value(u_mid, v_mid)
+    return (p.X(), p.Y(), p.Z())
+
+
 def _axis_aligned_axis(face_wrapped) -> tuple[int, float] | None:
     """``(axis_index, coordinate)`` of a planar axis-aligned face — the plane's axis and
     where it sits — or None if the face is not planar or not axis-aligned. Sign-agnostic
@@ -151,23 +164,20 @@ def recognise_fillets(
         if clsf.State() == TopAbs_IN:
             continue  # concave corner — an internal round / slot-wall blend, not an edge fillet
 
-        # Anchor the leader on the curved radius surface itself, not the face bounding-box
-        # centre — that centre sits near the arc's centre of curvature / virtual sharp corner,
-        # off the surface (#622). Evaluate a point at the middle of the trimmed face's angular
-        # (U) and axial (V) parameter spans; the adaptor's bounds are the FACE's trimmed range
-        # (already gated below a full turn above), so a periodic seam is handled by using those
-        # bounds directly rather than the raw 0..2π surface range. On-face for the ordinary
-        # quarter-round edge blend (a UV-rectangular patch); a fillet whose UV region is punched
-        # by an interior hole through its centre could still land mid-UV in that void — rare, and
-        # no worse than the bbox centre it replaces (review).
-        u_mid = 0.5 * (s.FirstUParameter() + s.LastUParameter())
-        v_mid = 0.5 * (s.FirstVParameter() + s.LastVParameter())
-        p = s.Value(u_mid, v_mid)
+        # Anchor the leader on the curved radius surface itself via the shared
+        # fillet_anchor (#622 lesson, one implementation with declare's front-end, #704).
+        # The adaptor's bounds are the FACE's trimmed range (already gated below a full
+        # turn above), so a periodic seam is handled by using those bounds directly rather
+        # than the raw 0..2π surface range. On-face for the ordinary quarter-round edge
+        # blend (a UV-rectangular patch); a fillet whose UV region is punched by an
+        # interior hole through its centre could still land mid-UV in that void — rare,
+        # and no worse than the bbox centre it replaces (review).
+        p = fillet_anchor(s)
         out.append(
             Fillet(
                 axis="xyz"[edge_i],
                 radius=round(radius, 3),
-                at=(round(p.X(), 3), round(p.Y(), 3), round(p.Z(), 3)),
+                at=(round(p[0], 3), round(p[1], 3), round(p[2], 3)),
             )
         )
     return sorted(out, key=lambda c: (c.axis, c.at))

--- a/src/draftwright/recognition/grooves.py
+++ b/src/draftwright/recognition/grooves.py
@@ -74,6 +74,20 @@ class Groove(Record):
     at: tuple[float, float, float]
 
 
+def floor_face_anchor(face) -> tuple[float, float, float]:
+    """The groove leader-tip anchor: the **bbox centre** of the floor face (the reduced-OD
+    band), unrounded. The one anchor contract shared by :func:`recognise_grooves` and the
+    declared front-end (``model/declare._read_groove_face``), #704 — the substrates differ
+    (band dicts from ``analyse_cylinders`` vs a single user-supplied face), but the leader
+    tip must not."""
+    bb = face.bounding_box()
+    return (
+        0.5 * (bb.min.X + bb.max.X),
+        0.5 * (bb.min.Y + bb.max.Y),
+        0.5 * (bb.min.Z + bb.max.Z),
+    )
+
+
 def recognise_grooves(part, *, cyls=None) -> list[Groove]:
     """Recognise the turned grooves of *part* (see module docstring). Returns one
     :class:`Groove` per external band whose OD is a strict local minimum between two
@@ -118,12 +132,8 @@ def recognise_grooves(part, *, cyls=None) -> list[Groove]:
             wider_wall = max(prev["s_hi"] - prev["s_lo"], nxt["s_hi"] - nxt["s_lo"])
             if cur_w >= wider_wall - _WIDTH_MARGIN:
                 continue
-            bb = cur["face"].bounding_box()
-            at = (
-                round(0.5 * (bb.min.X + bb.max.X), 3),
-                round(0.5 * (bb.min.Y + bb.max.Y), 3),
-                round(0.5 * (bb.min.Z + bb.max.Z), 3),
-            )
+            cx, cy, cz = floor_face_anchor(cur["face"])
+            at = (round(cx, 3), round(cy, 3), round(cz, 3))
             out.append(
                 Groove(
                     axis=cur["axis"],

--- a/src/draftwright/score.py
+++ b/src/draftwright/score.py
@@ -22,7 +22,8 @@ below 1.0 permanently (exactly the #158 reason ``feature_diameters`` avoids that
 census is the one honest signal, so that is all this reports.
 
 Bottom of the DAG beside the recognisers: depends only on :mod:`draftwright.recognition` +
-build123d, and nothing in the engine imports it.
+build123d, and nothing in the engine imports it. Ranked 0 in the machine-enforced DAG
+(``tests/test_import_boundaries.py``), so importing the engine from here fails CI (#704).
 """
 
 from __future__ import annotations

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -48,7 +48,8 @@ from dataclasses import replace
 from draftwright.analysis import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
-from draftwright.model import AuthoredDimension, Feature, Frame
+from draftwright.model import Feature
+from draftwright.model import authored_dimension as _authored_dimension
 from draftwright.model import boss as _boss
 from draftwright.model import chamfer as _chamfer
 from draftwright.model import control_frame as _declare_control
@@ -75,14 +76,6 @@ from draftwright.model.declare import (
 )
 from draftwright.model.declare import read_bore_step as _read_bore_step
 from draftwright.model.declare import read_countersink as _read_countersink
-from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, Point
-
-
-def _point3(name: str, p) -> Point:
-    vals = tuple(float(c) for c in p)
-    if len(vals) != 3:
-        raise ValueError(f"dimension() {name} must be a 3-tuple")
-    return (vals[0], vals[1], vals[2])
 
 
 def _parse_datums(to) -> tuple[str, ...]:
@@ -419,44 +412,23 @@ class Sheet:
         may call the record PMI, but the editable script declares a dimension category, value,
         label, referenced model points, and optional structured tolerances. For ordinary
         geometry-backed edits prefer feature handles such as ``sheet.hole(...).tolerance(...)``.
+        Delegates to :func:`draftwright.model.declare.authored_dimension` (#704), so
+        ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
-        _require_positive(value=value)
-        dim_kind = str(kind).lower()
-        if dim_kind not in AUTHORED_DIMENSION_KINDS:
-            allowed = ", ".join(sorted(AUTHORED_DIMENSION_KINDS))
-            raise ValueError(f"dimension() kind must be one of: {allowed}")
-        pts = tuple(_point3("ref_pts item", p) for p in ref_pts)
-        if len(pts) < 2:
-            raise ValueError("dimension() needs at least two ref_pts")
-        bbox = None if ref_bbox is None else tuple(float(c) for c in ref_bbox)
-        if bbox is not None and len(bbox) != 6:
-            raise ValueError("dimension() ref_bbox must be a 6-tuple")
-        dom = str(dominant_axis).upper()
-        if dom not in ("X", "Y", "Z"):
-            if not (dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None):
-                raise ValueError("dimension() dominant_axis must be X, Y, or Z")
-        if at is None:
-            if bbox is not None:
-                x0, y0, z0, x1, y1, z1 = bbox
-                at = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
-            else:
-                n = len(pts)
-                at = tuple(sum(p[i] for p in pts) / n for i in range(3))
-        origin = _point3("at", at)
-        ax = _norm_axis(axis or (dom.lower() if dom in ("X", "Y", "Z") else "z"))
         self._features.append(
-            AuthoredDimension(
-                frame=Frame(origin, ax),
-                dimension_kind=dim_kind,
-                value=float(value),
-                label=str(label),
-                dominant_axis=dom,
+            _authored_dimension(
+                kind=kind,
+                value=value,
+                label=label,
+                dominant_axis=dominant_axis,
+                ref_pts=ref_pts,
+                ref_bbox=ref_bbox,
+                at=at,
+                axis=axis,
                 upper_tol=upper_tol,
                 lower_tol=lower_tol,
-                ref_bbox=bbox,
-                ref_pts=pts,
                 source=source,
-                source_kind=source_kind or dim_kind,
+                source_kind=source_kind,
             )
         )
         return self

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1428,3 +1428,38 @@ class TestSheetDslShim:
         assert "Sheet" in dir(shim)
         public = {n for n in dir(sheet) if not n.startswith("_")}
         assert public <= set(shim.__all__)
+
+
+class TestAuthoredDimension:
+    """``model.authored_dimension`` — the IR constructor behind ``Sheet.dimension`` (#704),
+    so ``build_drawing(model=…)`` callers can author one without the façade."""
+
+    _KW = dict(
+        kind="linear",
+        value=40,
+        label="40",
+        dominant_axis="X",
+        ref_bbox=(-20, -10, -5, 20, 10, 5),
+        ref_pts=[(-20, 0, 0), (20, 0, 0)],
+        upper_tol=0.1,
+        lower_tol=0.0,
+    )
+
+    def test_matches_the_sheet_facade_feature(self):
+        # The façade must append EXACTLY the feature the constructor builds — the
+        # frozen-dataclass equality pins the delegation against re-inlining drift.
+        from draftwright.model import authored_dimension
+        from draftwright.sheet import Sheet
+
+        sheet = Sheet(Box(40, 20, 10), title="P")
+        sheet.dimension(**self._KW)
+        via_facade = next(f for f in sheet.features if f.kind == "authored_dimension")
+        assert authored_dimension(**self._KW) == via_facade
+
+    def test_validates_without_the_facade(self):
+        from draftwright.model import authored_dimension
+
+        with pytest.raises(ValueError, match="kind must be one of"):
+            authored_dimension(**{**self._KW, "kind": "liner"})
+        with pytest.raises(ValueError, match="at least two ref_pts"):
+            authored_dimension(**{**self._KW, "ref_pts": [(0, 0, 0)]})

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -62,6 +62,7 @@ _LAYERS: dict[str, int] = {
     "registry": 0,
     "intents": 0,
     "recognition": 0,
+    "score": 0,  # census over recognition/ only — a leaf beside the recognisers (#704)
     "model": 0,  # the ADR 0008 IR waist — depends only on rank-0 leaves (guarded below too)
     # 1 — the shared drawing/layout primitives
     "_core": 1,
@@ -87,7 +88,6 @@ _LAYERS: dict[str, int] = {
     "sheet_dsl": 7,  # frozen deprecation shim — re-exports the sheet facade (renamed, #640)
     "sheet_emit": 7,
     "cli": 7,
-    "score": 7,
     # 8 — the package root: the public API surface, above everything
     "__init__": 8,
 }


### PR DESCRIPTION
Resolves the five grouped facade-tier findings from the 2026-07-18 architecture audit (#704).

## 1. Root exports curated
`draftwright.__init__` drops three orphans with **zero consumers via the root API** (verified across src/tests/docs/examples): `recognise_face_levels` (one recogniser of ~12 — incoherent as public surface; still importable from `draftwright.recognition`), `dedup_diams` (an analysis internal), `fix_svg_page_size` (still on `draftwright.export` + the `make_drawing` facade). Removed from `_LAZY`, the `TYPE_CHECKING` block and `__all__`; CHANGELOG **Removed** entry added. Straight removal rather than a deprecation shim: pre-0.4, no consumers found anywhere, and each release hardens them further.

## 2. `model.authored_dimension()` extracted
`Sheet.dimension()` was a ~60-line inline IR constructor — the only verb not backed by a `model/declare` constructor, so `build_drawing(model=…)` callers couldn't author one. The validation + construction now lives in `declare.authored_dimension()` (exported from `draftwright.model`); the façade verb delegates. New `TestAuthoredDimension` pins **frozen-dataclass equality** between the constructor's feature and the one the façade appends (guards against re-inlining drift), plus façade-free validation.

## 3. builder → orchestrator, directly
`builder.py` imported the engine's own orchestrator through the *external-compat* `annotate` shim, hiding the true `builder→annotations` edge. It now imports `annotations.orchestrator` directly; `annotate.py` is purely for external callers. DAG guard passes (rank 6 → 4 is downward).

## 4. Shared single-face reads (the `step_level_zs` / #578 precedent)
The four declare/recogniser parallel geometry reads — coupled only by comments — now share one implementation each, living beside the recogniser and exported from the `recognition` package surface:
- **`chamfers.classify_bevel`** (+ typed `BevelReject`): the normal→axis classification thresholds + leg geometry. **The recogniser loop consumes it too**; declare's `_read_chamfer_face` maps reject reasons to its user-facing messages.
- **`fillets.fillet_anchor`**: the #622 mid-U/V on-face anchor — both sides call it, so a declared fillet's leader tip is identical to a detected one by construction.
- **`countersinks.cone_rims`**: rim circles + included angle; recogniser and `declare.read_countersink` both consume it.
- **`grooves.floor_face_anchor`**: the bbox-centre leader-tip contract. The *rest* of the groove read deliberately stays split — the recogniser works on `analyse_cylinders` band dicts, declare on a single user-supplied face; only the anchor is a shared contract.

One deliberate strictness fix: `_read_chamfer_face` now cleanly rejects a **non-planar** face (`classify_bevel` checks `GeomAbs_Plane`; the old declare path just hoped `normal_at()` would fail). All chamfer/fillet/groove/countersink/declare round-trip suites pass unchanged.

## 5. `score` is an enforced leaf
Its docstring claimed "bottom of the DAG" while `_LAYERS` ranked it 7 (user-facing), legally allowing whole-engine imports. Moved to **rank 0** — the boundary suite passes, confirming it genuinely only imports `recognition/`. The claim is now machine-enforced.

## Verification
- Lint ×4 clean (ruff check, ruff format --check, mypy, codespell).
- Targeted: 345 passed (chamfer/fillet/groove/countersink/declare/emit/pmi/score selections); guard suites (`test_recogniser_contract`, `test_import_boundaries`, `test_private_test_imports`) green.
- Full fast tier: **1416 passed**; the 1 failure is the known pre-existing #710 Hypothesis local-DB replay (`test_generated_part_has_no_layout_collisions`), identical on main — CI draws fresh examples and is unaffected.

The issue's "related" notes (sheet's five private declare-helper imports; the `_read_step` positivity-guard comment) are observations, not extracted here — `_require_positive` *is* already the shared guard; restructuring the private-import surface wasn't part of the ask.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)