### PR TITLE
refactor(#699): move engine logic out of the Drawing result object (slice a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ entry. Keep `_LAYERS` and this section in step.
     `--version` stay sub-second (#313). Entry point: `draftwright.cli:app`.
   - **`drawing.py`** — the `Drawing` result object (`.lint()`/`.add()`/`.place_dim()`/
     `.repair()`/`.export*()`; delegates identity to `registry`, coverage to `lint`)
-    plus `_build_table` and `FeatureInfo`. Sits below `builder` (which constructs it).
+    plus `FeatureInfo` (`_build_table` moved beside `_table_metrics` in `_core`, #699).
+    Sits below `builder` (which constructs it).
     *(The build context lives in ONE typed `BuildState` on `Drawing` (`_build`:
     analysis, part model, lint's geometry caches) — filled at a single site in
     `builder._assemble`, read through compat properties, single-writer-guarded
@@ -78,6 +79,9 @@ entry. Keep `_LAYERS` and this section in step.
     (incl. side-drilled #133), pitch/grid dims, slots (the largest *pass*).
   - **`annotations/sections.py`** — section A–A + detail views (ISO 128-44 arrows,
     ISO 128-50 hatching).
+  - **`annotations/balloons.py`** — the leadered hole-balloon pass (#111/#516;
+    moved down from `Drawing`, #699). `Drawing.add_balloons` is the public verb
+    threading build state in; the band-assignment flow solver lives in `layout.py`.
   - **`annotations/_common.py`** — the ADR 0009 corridor-solve engine
     (`CorridorCandidate`, `solve_corridor`, `register_corridor`/`drain_corridors`,
     `place_strip_candidates`, `PlacementContext`) plus `_box_hits`, at the
@@ -93,8 +97,10 @@ entry. Keep `_LAYERS` and this section in step.
   page/slot/margin layout constants.
 - **`layout.py`** — the constraint-based layout engine (ADR 0003): the deterministic
   1D PAVA strip solve (`_solve_strip_1d_pava`, plus `plan_strip`/`StripCandidate`,
-  the ADR 0009 collect-then-solve entry point) and the 2D free-rectangle placer
-  (`fit_box`). Sits *below* the domain API.
+  the ADR 0009 collect-then-solve entry point), the 2D free-rectangle placer
+  (`fit_box`), and the balloon band-assignment min-cost max-flow solve
+  (`_assign_balloon_bands`, #516; here since #699 — solvers live in the solver
+  layer). Sits *below* the domain API.
 - **`_geometry.py`** — model-neutral geometry primitives (`_xyz`, `HoleRef`,
   `_axis_letter`, `_END_ON`) plus the #700 shared page-plane maths (`_fmt`,
   `_boxes_overlap`, the two segment/box tests); the DAG's bottom leaf (guarded

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -85,6 +85,8 @@ draftwright/
   repair.py              # deterministic repair loop (ADR 0002)
   export.py              # SVG/DXF/PDF export + post-processing
   tables.py              # generic table construction/placement helpers
+                         #   (never created — table GEOMETRY converged into _core._table_metrics/_build_table,
+                         #    the one sizing model (#700/#699); PLACEMENT stayed a Drawing verb, add_table)
   annotations/
     orchestrator.py      # auto_annotate sequencing (_auto_annotate)
     envelope.py          # OD/width/depth/height/step dims

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from draftwright.compose import StripDepths
     from draftwright.recognition import TurnedProfile
 
-from build123d import Align, BoundBox, Location, Mode, Shape, Text
+from build123d import Align, BoundBox, Compound, Edge, Location, Mode, Shape, Text, Vector
 from build123d_drafting.helpers import (
     Dimension,
     TitleBlock,
@@ -131,6 +131,55 @@ def _table_metrics(rows, font_size, pad_around_text, block_cols=None):
         cursor += col_w[c]
         rights.append(cursor)
     return lefts, rights, cursor, row_h * len(rows), row_h, bc
+
+
+def _build_table(rows, draft, block_cols=None):
+    """Build a generic data-table annotation at the origin (bottom-left ``(0, 0)``).
+
+    *rows* is a list of equal-length string tuples; ``rows[0]`` is the header,
+    drawn at the top. Returns a :class:`Compound` of grid rules + cell text,
+    carrying ``.table_size = (w, h)`` so it can be positioned via
+    :func:`fit_box`. Column widths are sized to their content via real glyph
+    metrics (:func:`_text_width`). Generic — the hole table, and gear/BOM/
+    revision tables, all build through here.
+
+    When the rows are a wrapped chart of *block_cols*-wide side-by-side blocks
+    (see :func:`_wrap_rows`), each block is drawn as its own bordered grid with
+    a whitespace gap between them, so the blocks read as separate tables rather
+    than one run-on grid.
+    """
+    fs = draft.font_size
+    ncol = len(rows[0])
+    # One sizing model, shared with compose's footprint estimate (#700).
+    lefts, rights, total_w, total_h, row_h, bc = _table_metrics(
+        rows, fs, draft.pad_around_text, block_cols
+    )
+    ys = [i * row_h for i in range(len(rows) + 1)]
+    children = []
+    for b in range(ncol // bc):  # one bordered grid per block
+        cols = range(b * bc, b * bc + bc)
+        bl, br = lefts[b * bc], rights[b * bc + bc - 1]
+        for x in [lefts[c] for c in cols] + [br]:  # column rules + block edges
+            children.append(Edge.make_line(Vector(x, 0, 0), Vector(x, total_h, 0)))
+        for y in ys:  # horizontal rules stop at the block edge, not the gap
+            children.append(Edge.make_line(Vector(bl, y, 0), Vector(br, y, 0)))
+    for ri, row in enumerate(rows):  # rows[0] (header) sits at the top
+        cy = total_h - (ri + 0.5) * row_h
+        for ci, cell in enumerate(row):
+            if not str(cell):
+                continue
+            cx = (lefts[ci] + rights[ci]) / 2
+            text = Text(
+                txt=str(cell),
+                font_size=fs,
+                font_path=PLEX_MONO,
+                align=(Align.CENTER, Align.CENTER),
+                mode=Mode.PRIVATE,
+            ).locate(Location((cx, cy, 0)))
+            children.extend(text.faces())
+    table = Compound(children=children)
+    table.table_size = (total_w, total_h)
+    return table
 
 
 def _tol_suffix(tolerance, draft) -> str:

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -107,8 +107,8 @@ def _table_metrics(rows, font_size, pad_around_text, block_cols=None):
     block gaps inserted), total width/height, row height and effective block
     width, as ``(lefts, rights, total_w, total_h, row_h, bc)``.
 
-    The ONE place table geometry is computed (#700): ``drawing._build_table``
-    draws from it and ``compose._est_table_size`` estimates from it, so the
+    The ONE place table geometry is computed (#700): :func:`_build_table` (below,
+    since #699) draws from it and ``compose._est_table_size`` estimates from it, so the
     ADR 0004 ``table_fits`` fitness check can never desynchronise from what
     renders (the drift ADR 0004 names as the failure mode to guard against).
     """

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -1,0 +1,242 @@
+"""balloons — the leadered hole-balloon render pass (#111/#516).
+
+Moved down from the ``Drawing`` result object (#699): a render pass belongs in the
+render layer, not hosted above it — the orchestrator used to call *up* into
+``dwg.add_balloons`` by duck-typing. The band-assignment solver it drives
+(:func:`layout._assign_balloon_bands`, min-cost max-flow) lives in ``layout.py``
+with the other solvers (ADR 0003/0009). ``Drawing.add_balloons`` remains the
+public verb: an owner method that threads the build state into this pass.
+"""
+
+from __future__ import annotations
+
+import math
+
+from build123d import Align, Circle, Compound, Location, Mode, Text
+from build123d_drafting.helpers import Leader
+
+from draftwright._core import _STRIP_GAP, _STRIP_SPACING
+from draftwright.annotations._common import strip_obstacles
+from draftwright.fonts import PLEX_MONO
+from draftwright.layout import (
+    _assign_balloon_bands,
+    _greedy_strip_1d,
+    _solve_strip_1d,
+    _strip_capacity,
+)
+
+
+def render_balloons(dwg, a, view, specs, ctx):
+    """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
+    fitted into the halo the layout reserved around the view (#111).
+
+    Each hole is assigned to a reserved band — left, right, top or (when the
+    FV↔PV gap has room) bottom of the plan view — by a global
+    max-cardinality/min-cost assignment (:func:`layout._assign_balloon_bands`,
+    #516), and the balloons in each band are spread along it with the 1D strip
+    solver so none overlap, each pulled toward its hole's coordinate.  A
+    :class:`Leader` then runs from the hole rim to the glyph.  Because the
+    layout reserved this band before placing the views (:func:`_est_plan_halo`
+    / :func:`_will_balloon`), the balloons sit in clear space off the part and
+    no leader crosses a neighbouring view.
+
+    The drawing is duck-typed as *dwg* and touched only through its public
+    surface; build state rides *a* and *ctx* (ADR 0005 §2 / #639, #699).
+    """
+    pp = dwg.coords(view).pp
+    fs = dwg.draft.font_size
+    r = fs * 1.5  # circle comfortably larger than the glyph
+    standoff = _STRIP_GAP
+    gap = 2 * r + 2 * _STRIP_SPACING  # min centre-to-centre: balloon + padding both sides
+
+    # Plan-view page edges; the reserved bands sit just outside them.
+    pl, pr = a.PV_X - a.fv_hw, a.PV_X + a.fv_hw
+    pt, pb = a.PV_Y + a.pv_hh, a.PV_Y - a.pv_hh
+    sv_left = a.SV_X - a.sv_hw
+    margin, ph, pw = a.margin, a.PAGE_H, a.PAGE_W
+
+    # Stack the balloon ring *beyond* the annotations already placed around the
+    # plan view, not on top of them (#121). Measure the REAL depth every placed
+    # occupant extends into each band from its full rendered footprint — leader
+    # shafts, centreline geometry, tables, and bare extension lines included.
+    # This intentionally shares the same full-footprint occupancy source as
+    # corridor placement (#518), instead of re-growing a per-furniture allowlist.
+    top_dim = bot_dim = left_dim = right_dim = 0.0
+    for x0, y0, x1, y1 in strip_obstacles(dwg, view=view):
+        if x1 > pl and x0 < pr:  # spans the plan's width → top/bottom bands
+            if y1 > pt:
+                top_dim = max(top_dim, y1 - pt)
+            if y0 < pb:
+                bot_dim = max(bot_dim, pb - y0)
+        if y1 > pb and y0 < pt:  # spans the plan's height → left/right bands
+            if x0 < pl:
+                left_dim = max(left_dim, pl - x0)
+            if x1 > pr:
+                right_dim = max(right_dim, x1 - pr)
+
+    # A dense part can stack many pitch dims on one side (holes._place_pitch_dim
+    # pushes each successive one 10 mm further out, #92), so the measured depth
+    # can exceed the room between the view and the page edge. Clamp each band so
+    # its *ring itself* never lands off the drawable area (#349 follow-up) — the
+    # ring then sits at the margin and overlaps the far witness lines instead,
+    # which is only a tolerated warning (structural.py compares label_bbox, not
+    # the full bbox, for overlap), never the out_of_bounds error.
+    left_dim = min(left_dim, max(0.0, pl - standoff - 2 * r - margin))
+    right_dim = min(right_dim, max(0.0, pw - margin - pr - standoff - 2 * r))
+    top_dim = min(top_dim, max(0.0, ph - margin - pt - standoff - 2 * r))
+    bot_dim = min(bot_dim, max(0.0, pb - standoff - 2 * r - margin))
+
+    # A bottom band (below PV, beyond the overall-width dim) is usable only
+    # when the FV↔PV gap has room for the width dim *and* a balloon row;
+    # otherwise bottom-edge holes fall back to the nearest side/top band.
+    bottom_line = pb - bot_dim - standoff - r
+    has_bottom = pb - (a.FV_Y + a.fv_hh) > bot_dim + standoff + 2 * r
+
+    # left/right balloons vary in Y at a fixed X just outside the part; top
+    # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
+    # offset by its side's dim depth so the ring sits clear of the dims.
+    band_defs = {
+        "left": ("y", pl - left_dim - standoff - r, margin + r, ph - margin - r),
+        "right": ("y", pr + right_dim + standoff + r, margin + r, ph - margin - r),
+        "top": ("x", pt + top_dim + standoff + r, pl - standoff, sv_left - r),
+        "bottom": ("x", bottom_line, pl - standoff, sv_left - r),
+    }
+
+    # Globally assign holes across the usable reserved bands.  Nearest-band
+    # greedy could crowd one side and drop balloons while another side sat
+    # empty; the assignment maximises placed balloons first, then minimises
+    # leader distance to the ACTUAL post-depth band lines (#516).
+    members = []
+    choices_by_member = []
+    for tag, j, hole in specs:
+        cx, cy = pp(*hole.location)
+        choices = {
+            "left": abs(cx - band_defs["left"][1]),
+            "right": abs(band_defs["right"][1] - cx),
+            "top": abs(band_defs["top"][1] - cy),
+        }
+        if has_bottom:
+            choices["bottom"] = abs(cy - band_defs["bottom"][1])
+        members.append((tag, j, hole, cx, cy))
+        choices_by_member.append(choices)
+
+    capacities = {
+        name: (_strip_capacity(lo, hi, gap) if name != "bottom" or has_bottom else 0)
+        for name, (_axis, _line, lo, hi) in band_defs.items()
+    }
+    bands, dropped = _assign_balloon_bands(members, choices_by_member, capacities)
+    dropped += _place_band(
+        dwg,
+        view,
+        bands["left"],
+        *band_defs["left"],
+        gap,
+        fs,
+        r,
+        ctx,
+    )
+    dropped += _place_band(
+        dwg,
+        view,
+        bands["right"],
+        *band_defs["right"],
+        gap,
+        fs,
+        r,
+        ctx,
+    )
+    dropped += _place_band(
+        dwg,
+        view,
+        bands["top"],
+        *band_defs["top"],
+        gap,
+        fs,
+        r,
+        ctx,
+    )
+    dropped += _place_band(
+        dwg,
+        view,
+        bands["bottom"],
+        *band_defs["bottom"],
+        gap,
+        fs,
+        r,
+        ctx,
+    )
+    # A band too crowded to hold every balloon drops its tail (the strip solver's
+    # prefix fallback) — record it instead of letting the balloons vanish silently
+    # (review follow-up). The resolver keeps the callout_dropped lint for a pattern
+    # whose balloon did not land, so a missing pattern balloon is still a coverage gap.
+    if dropped:
+        ctx.record_issue(
+            "warning",
+            "balloon_dropped",
+            f"{dropped} balloon(s) could not fit their reserved band and were dropped",
+        )
+
+
+def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx) -> int:
+    """Spread *members* (``(tag, j, hole, cx, cy)``) along one reserved band
+    with the strip solver, then render a leadered balloon for each (#111).
+
+    *axis* is the band's free axis (``"y"`` for the left/right bands, ``"x"``
+    for the top); *line* is the fixed coordinate of the other axis.  Overflow
+    beyond ``[lo, hi]`` drops the tail rather than running balloons off-page.
+    Returns the number of members dropped, so the caller can surface it as lint
+    (a silently truncated balloon leaves a hole undocumented — the resolver
+    must know, review follow-up).
+    """
+    if not members:
+        return 0
+    k = 4 if axis == "y" else 3  # index of cy / cx in the member tuple
+    members.sort(key=lambda m: m[k])
+    naturals = [m[k] for m in members]
+    coords = (
+        _solve_strip_1d(naturals, gap, lo, hi)
+        or _greedy_strip_1d(naturals, gap, lo, hi)
+        or _greedy_strip_1d(naturals, gap, lo, hi, prefix=True)
+    )
+    for (tag, j, hole, cx, cy), c in zip(members, coords):
+        bx, by = (line, c) if axis == "y" else (c, line)
+        _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx)
+    return len(members) - len(coords)
+
+
+def _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx):
+    """Build and add one balloon glyph + leader at solved centre ``(bx, by)``
+    for hole ``(cx, cy)`` (#111)."""
+    loc = Location((bx, by, 0))
+    # The annotation layer fills closed paths, so a circle edge renders as a
+    # disc. A thin annular FACE fills as a ring — i.e. a circle outline.
+    ring_faces = [f.moved(loc) for f in (Circle(r) - Circle(r - 0.35)).faces()]
+    text = Text(
+        txt=tag,
+        font_size=fs,
+        font_path=PLEX_MONO,
+        align=(Align.CENTER, Align.CENTER),
+        mode=Mode.PRIVATE,
+    ).locate(loc)
+    parts = [*ring_faces, *text.faces()]
+    # Leader from the hole rim to the balloon's near edge — the glyph is the
+    # label, so label="".  Skipped when the balloon could not clear the hole
+    # (degenerate fallback), where a leader would be a stub through the ring.
+    dx, dy = bx - cx, by - cy
+    dist = math.hypot(dx, dy)
+    hole_r = hole.diameter * dwg.scale / 2
+    if dist > hole_r + r:
+        ux, uy = dx / dist, dy / dist
+        tip = (cx + ux * hole_r, cy + uy * hole_r, 0)
+        elbow = (bx - ux * r, by - uy * r, 0)
+        parts.append(Leader(tip, elbow, "", dwg.draft))
+    balloon = Compound(children=parts)
+    # Furniture that legitimately sits on the view geometry — exempt from the
+    # annotation-overlap / centreline lint, as the section arrows do.
+    balloon.is_centerline = True
+    dwg.add(
+        balloon,
+        f"balloon_{view}_{tag}_{j}",
+        view=view,
+        feature=ctx.feature_of_hole_at(hole.location),
+    )

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -31,6 +31,7 @@ from draftwright._core import (
 )
 from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import PlacementContext, drain_corridors
+from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.from_model import (
     render_boss_diameters,
     render_centermarks,
@@ -520,9 +521,10 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
     placed_names: set = set()
     if balloon_specs:
         # One call: the strip solver must see every band member together, or two
-        # independent _add_balloons calls could stack a pattern balloon on a
-        # per-hole one in the same band.
-        dwg.add_balloons("plan", balloon_specs)
+        # independent render_balloons calls could stack a pattern balloon on a
+        # per-hole one in the same band. Called sideways into the render layer
+        # (#699) — no longer an upward duck-typed dwg.add_balloons call.
+        render_balloons(dwg, a, "plan", balloon_specs, ctx)
         placed_names = {n for n, _ in dwg.iter_annotations()}
 
     # Clear `callout_dropped` only when EVERY dropped plan-view callout is now

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -149,7 +149,7 @@ def _will_balloon(model) -> bool:
 def _est_table_size(
     rows, font_size: float = _FONT_SIZE, pad_around_text: float = 2.0, block_cols=None
 ):
-    """Table footprint estimate — ``drawing._build_table``'s sizing, from the
+    """Table footprint estimate — ``_core._build_table``'s sizing, from the
     shared :func:`draftwright._core._table_metrics` so the ADR 0004
     ``table_fits`` fitness check can never desynchronise from what renders
     (#700; pinned by ``test_sheet_tables``)."""

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -19,21 +19,15 @@ from dataclasses import field as dataclasses_field
 from typing import NamedTuple
 
 from build123d import (
-    Align,
-    Circle,
     Color,
     Compound,
-    Edge,
     ExportDXF,
     ExportSVG,
     LineType,
     Location,
-    Mode,
-    Text,
     Vector,
 )
 from build123d_drafting.helpers import (
-    Leader,
     ViewCoordinates,
     annotate,
     view_axes,
@@ -41,16 +35,19 @@ from build123d_drafting.helpers import (
 
 from draftwright._core import (
     _MARGIN,
-    _STRIP_GAP,
-    _STRIP_SPACING,
     Analysis,
+    _build_table,
     _dim,
     _fmt,
     _log,
-    _table_metrics,
     _tag_sequence,
 )
-from draftwright.annotations._common import carve_free_position, strip_obstacles
+from draftwright.annotations._common import (
+    PlacementContext,
+    carve_free_position,
+    strip_obstacles,
+)
+from draftwright.annotations.balloons import render_balloons
 from draftwright.export import (
     _export_shape,
     _render_pdf,
@@ -62,13 +59,8 @@ from draftwright.export import (
     set_dxf_metadata,
     write_dxf,
 )
-from draftwright.fonts import PLEX_MONO
 from draftwright.intents import Intent
-from draftwright.layout import (
-    _greedy_strip_1d,
-    _solve_strip_1d,
-    fit_box,
-)
+from draftwright.layout import fit_box
 from draftwright.linting import (
     CoverageState,
     LintIssue,
@@ -86,153 +78,6 @@ from draftwright.projection import (
 from draftwright.recognition import analyse_cylinders
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing
-
-
-def _build_table(rows, draft, block_cols=None):
-    """Build a generic data-table annotation at the origin (bottom-left ``(0, 0)``).
-
-    *rows* is a list of equal-length string tuples; ``rows[0]`` is the header,
-    drawn at the top. Returns a :class:`Compound` of grid rules + cell text,
-    carrying ``.table_size = (w, h)`` so it can be positioned via
-    :func:`fit_box`. Column widths are sized to their content via real glyph
-    metrics (:func:`_text_width`). Generic — the hole table, and gear/BOM/
-    revision tables, all build through here.
-
-    When the rows are a wrapped chart of *block_cols*-wide side-by-side blocks
-    (see :func:`_wrap_rows`), each block is drawn as its own bordered grid with
-    a whitespace gap between them, so the blocks read as separate tables rather
-    than one run-on grid.
-    """
-    fs = draft.font_size
-    ncol = len(rows[0])
-    # One sizing model, shared with compose's footprint estimate (#700).
-    lefts, rights, total_w, total_h, row_h, bc = _table_metrics(
-        rows, fs, draft.pad_around_text, block_cols
-    )
-    ys = [i * row_h for i in range(len(rows) + 1)]
-    children = []
-    for b in range(ncol // bc):  # one bordered grid per block
-        cols = range(b * bc, b * bc + bc)
-        bl, br = lefts[b * bc], rights[b * bc + bc - 1]
-        for x in [lefts[c] for c in cols] + [br]:  # column rules + block edges
-            children.append(Edge.make_line(Vector(x, 0, 0), Vector(x, total_h, 0)))
-        for y in ys:  # horizontal rules stop at the block edge, not the gap
-            children.append(Edge.make_line(Vector(bl, y, 0), Vector(br, y, 0)))
-    for ri, row in enumerate(rows):  # rows[0] (header) sits at the top
-        cy = total_h - (ri + 0.5) * row_h
-        for ci, cell in enumerate(row):
-            if not str(cell):
-                continue
-            cx = (lefts[ci] + rights[ci]) / 2
-            text = Text(
-                txt=str(cell),
-                font_size=fs,
-                font_path=PLEX_MONO,
-                align=(Align.CENTER, Align.CENTER),
-                mode=Mode.PRIVATE,
-            ).locate(Location((cx, cy, 0)))
-            children.extend(text.faces())
-    table = Compound(children=children)
-    table.table_size = (total_w, total_h)
-    return table
-
-
-@dataclass
-class _FlowEdge:
-    to: int
-    rev: int
-    cap: int
-    cost: int
-
-
-def _strip_capacity(lo: float, hi: float, gap: float) -> int:
-    """Number of uniform balloon centres that can fit in ``[lo, hi]``."""
-
-    if hi < lo:
-        return 0
-    return int(math.floor((hi - lo) / gap + 1e-9)) + 1
-
-
-def _assign_balloon_bands(members, choices_by_member, capacities):
-    """Global max-cardinality/min-cost assignment of balloons to side bands (#516)."""
-
-    band_order = ("left", "right", "top", "bottom")
-    bands = [b for b in band_order if capacities.get(b, 0) > 0]
-    assigned: dict[str, list] = {b: [] for b in band_order}
-    if not members or not bands:
-        return assigned, len(members)
-
-    source = 0
-    member0 = 1
-    band0 = member0 + len(members)
-    sink = band0 + len(bands)
-    graph: list[list[_FlowEdge]] = [[] for _ in range(sink + 1)]
-
-    def add_edge(fr: int, to: int, cap: int, cost: int) -> _FlowEdge:
-        fwd = _FlowEdge(to, len(graph[to]), cap, cost)
-        rev = _FlowEdge(fr, len(graph[fr]), 0, -cost)
-        graph[fr].append(fwd)
-        graph[to].append(rev)
-        return fwd
-
-    used_edges: dict[tuple[int, str], _FlowEdge] = {}
-    for i, choices in enumerate(choices_by_member):
-        add_edge(source, member0 + i, 1, 0)
-        for j, band in enumerate(bands):
-            if band not in choices:
-                continue
-            # Costs are integerised for deterministic shortest paths; the tiny band
-            # ordinal keeps exact ties stable without changing real distance order.
-            cost = int(round(max(0.0, choices[band]) * 1000)) + band_order.index(band)
-            used_edges[(i, band)] = add_edge(member0 + i, band0 + j, 1, cost)
-    for j, band in enumerate(bands):
-        add_edge(band0 + j, sink, capacities[band], 0)
-
-    def shortest_path():
-        dist = [math.inf] * len(graph)
-        prev: list[tuple[int, int] | None] = [None] * len(graph)
-        in_queue = [False] * len(graph)
-        queue = [source]
-        dist[source] = 0
-        in_queue[source] = True
-        while queue:
-            v = queue.pop(0)
-            in_queue[v] = False
-            for ei, edge in enumerate(graph[v]):
-                if edge.cap <= 0:
-                    continue
-                nd = dist[v] + edge.cost
-                if nd >= dist[edge.to]:
-                    continue
-                dist[edge.to] = nd
-                prev[edge.to] = (v, ei)
-                if not in_queue[edge.to]:
-                    queue.append(edge.to)
-                    in_queue[edge.to] = True
-        return prev if prev[sink] is not None else None
-
-    max_flow = min(len(members), sum(capacities.get(b, 0) for b in bands))
-    flow = 0
-    while flow < max_flow and (prev := shortest_path()) is not None:
-        v = sink
-        while v != source:
-            pv, ei = prev[v]
-            edge = graph[pv][ei]
-            edge.cap -= 1
-            graph[v][edge.rev].cap += 1
-            v = pv
-        flow += 1
-
-    placed = 0
-    for i, member in enumerate(members):
-        for band in bands:
-            edge = used_edges.get((i, band))
-            if edge is not None and edge.cap == 0:
-                assigned[band].append(member)
-                placed += 1
-                break
-    return assigned, len(members) - placed
-
 
 # Codes that check standards/geometry correctness rather than pure page
 # layout. Grouped so a caller (and the #30 repair loop) can tell a wrong
@@ -455,9 +300,6 @@ class Drawing:
         # than it being detected — gates the model-driven hole/pattern render membership so a
         # declared hole draws even where detection missed it, no-op for the detected path (#448).
         self._model_declared: bool = False
-        # Lazy model-location → IR hole/pattern feature index (#408), so a balloon —
-        # which holds a recognition hole, not the IR feature — can attribute itself.
-        self._hole_feature_index: dict | None = None
         # Deferred placement intents (#426 Phase 1). When _defer_intents is True the add
         # verbs record an Intent instead of placing; finalize() drains them (Phase 1
         # replays through the live helpers). Default off → the live path is unchanged.
@@ -1810,222 +1652,19 @@ class Drawing:
         """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
         fitted into the halo the layout reserved around the view (#111).
 
-        Each hole is assigned to the nearest reserved band — left, right, or top
-        of the plan view (never the bottom: the front view abuts it there) — and
-        the balloons in each band are spread along it with the 1D strip solver so
-        none overlap, each pulled toward its hole's coordinate.  A :class:`Leader`
-        then runs from the hole rim to the glyph.  Because the layout reserved
-        this band before placing the views (:func:`_est_plan_halo` /
-        :func:`_will_balloon`), the balloons sit in clear space off the part and
-        no leader crosses a neighbouring view.
+        Public verb over the :mod:`draftwright.annotations.balloons` render pass
+        (#699: the pass lives in the render layer; this owner method threads the
+        build state in). Each hole is assigned to a reserved band — left, right,
+        top or bottom — by a global max-cardinality/min-cost assignment (#516),
+        each band is spread with the 1D strip solver, and a :class:`Leader` runs
+        from the hole rim to each glyph.
         """
-        a = self._analysis
-        if view not in self._coords or a is None:
+        if view not in self._coords or self._analysis is None:
             return
-        pp = self._coords[view].pp
-        fs = self.draft.font_size
-        r = fs * 1.5  # circle comfortably larger than the glyph
-        standoff = _STRIP_GAP
-        gap = 2 * r + 2 * _STRIP_SPACING  # min centre-to-centre: balloon + padding both sides
-
-        # Plan-view page edges; the reserved bands sit just outside them.
-        pl, pr = a.PV_X - a.fv_hw, a.PV_X + a.fv_hw
-        pt, pb = a.PV_Y + a.pv_hh, a.PV_Y - a.pv_hh
-        sv_left = a.SV_X - a.sv_hw
-        margin, ph, pw = a.margin, a.PAGE_H, a.PAGE_W
-
-        # Stack the balloon ring *beyond* the annotations already placed around the
-        # plan view, not on top of them (#121). Measure the REAL depth every placed
-        # occupant extends into each band from its full rendered footprint — leader
-        # shafts, centreline geometry, tables, and bare extension lines included.
-        # This intentionally shares the same full-footprint occupancy source as
-        # corridor placement (#518), instead of re-growing a per-furniture allowlist.
-        top_dim = bot_dim = left_dim = right_dim = 0.0
-        for x0, y0, x1, y1 in strip_obstacles(self, view=view):
-            if x1 > pl and x0 < pr:  # spans the plan's width → top/bottom bands
-                if y1 > pt:
-                    top_dim = max(top_dim, y1 - pt)
-                if y0 < pb:
-                    bot_dim = max(bot_dim, pb - y0)
-            if y1 > pb and y0 < pt:  # spans the plan's height → left/right bands
-                if x0 < pl:
-                    left_dim = max(left_dim, pl - x0)
-                if x1 > pr:
-                    right_dim = max(right_dim, x1 - pr)
-
-        # A dense part can stack many pitch dims on one side (holes._place_pitch_dim
-        # pushes each successive one 10 mm further out, #92), so the measured depth
-        # can exceed the room between the view and the page edge. Clamp each band so
-        # its *ring itself* never lands off the drawable area (#349 follow-up) — the
-        # ring then sits at the margin and overlaps the far witness lines instead,
-        # which is only a tolerated warning (structural.py compares label_bbox, not
-        # the full bbox, for overlap), never the out_of_bounds error.
-        left_dim = min(left_dim, max(0.0, pl - standoff - 2 * r - margin))
-        right_dim = min(right_dim, max(0.0, pw - margin - pr - standoff - 2 * r))
-        top_dim = min(top_dim, max(0.0, ph - margin - pt - standoff - 2 * r))
-        bot_dim = min(bot_dim, max(0.0, pb - standoff - 2 * r - margin))
-
-        # A bottom band (below PV, beyond the overall-width dim) is usable only
-        # when the FV↔PV gap has room for the width dim *and* a balloon row;
-        # otherwise bottom-edge holes fall back to the nearest side/top band.
-        bottom_line = pb - bot_dim - standoff - r
-        has_bottom = pb - (a.FV_Y + a.fv_hh) > bot_dim + standoff + 2 * r
-
-        # left/right balloons vary in Y at a fixed X just outside the part; top
-        # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
-        # offset by its side's dim depth so the ring sits clear of the dims.
-        band_defs = {
-            "left": ("y", pl - left_dim - standoff - r, margin + r, ph - margin - r),
-            "right": ("y", pr + right_dim + standoff + r, margin + r, ph - margin - r),
-            "top": ("x", pt + top_dim + standoff + r, pl - standoff, sv_left - r),
-            "bottom": ("x", bottom_line, pl - standoff, sv_left - r),
-        }
-
-        # Globally assign holes across the usable reserved bands.  Nearest-band
-        # greedy could crowd one side and drop balloons while another side sat
-        # empty; the assignment maximises placed balloons first, then minimises
-        # leader distance to the ACTUAL post-depth band lines (#516).
-        members = []
-        choices_by_member = []
-        for tag, j, hole in specs:
-            cx, cy = pp(*hole.location)
-            choices = {
-                "left": abs(cx - band_defs["left"][1]),
-                "right": abs(band_defs["right"][1] - cx),
-                "top": abs(band_defs["top"][1] - cy),
-            }
-            if has_bottom:
-                choices["bottom"] = abs(cy - band_defs["bottom"][1])
-            members.append((tag, j, hole, cx, cy))
-            choices_by_member.append(choices)
-
-        capacities = {
-            name: (_strip_capacity(lo, hi, gap) if name != "bottom" or has_bottom else 0)
-            for name, (_axis, _line, lo, hi) in band_defs.items()
-        }
-        bands, dropped = _assign_balloon_bands(members, choices_by_member, capacities)
-        dropped += self._place_band(
-            view,
-            bands["left"],
-            *band_defs["left"],
-            gap,
-            fs,
-            r,
+        ctx = PlacementContext(
+            registry=self._registry, coverage=self._coverage, part_model=self._part_model
         )
-        dropped += self._place_band(
-            view,
-            bands["right"],
-            *band_defs["right"],
-            gap,
-            fs,
-            r,
-        )
-        dropped += self._place_band(
-            view,
-            bands["top"],
-            *band_defs["top"],
-            gap,
-            fs,
-            r,
-        )
-        dropped += self._place_band(
-            view,
-            bands["bottom"],
-            *band_defs["bottom"],
-            gap,
-            fs,
-            r,
-        )
-        # A band too crowded to hold every balloon drops its tail (the strip solver's
-        # prefix fallback) — record it instead of letting the balloons vanish silently
-        # (review follow-up). The resolver keeps the callout_dropped lint for a pattern
-        # whose balloon did not land, so a missing pattern balloon is still a coverage gap.
-        if dropped:
-            self._record_build_issue(
-                "warning",
-                "balloon_dropped",
-                f"{dropped} balloon(s) could not fit their reserved band and were dropped",
-            )
-
-    def _place_band(self, view, members, axis, line, lo, hi, gap, fs, r) -> int:
-        """Spread *members* (``(tag, j, hole, cx, cy)``) along one reserved band
-        with the strip solver, then render a leadered balloon for each (#111).
-
-        *axis* is the band's free axis (``"y"`` for the left/right bands, ``"x"``
-        for the top); *line* is the fixed coordinate of the other axis.  Overflow
-        beyond ``[lo, hi]`` drops the tail rather than running balloons off-page.
-        Returns the number of members dropped, so the caller can surface it as lint
-        (a silently truncated balloon leaves a hole undocumented — the resolver
-        must know, review follow-up).
-        """
-        if not members:
-            return 0
-        k = 4 if axis == "y" else 3  # index of cy / cx in the member tuple
-        members.sort(key=lambda m: m[k])
-        naturals = [m[k] for m in members]
-        coords = (
-            _solve_strip_1d(naturals, gap, lo, hi)
-            or _greedy_strip_1d(naturals, gap, lo, hi)
-            or _greedy_strip_1d(naturals, gap, lo, hi, prefix=True)
-        )
-        for (tag, j, hole, cx, cy), c in zip(members, coords):
-            bx, by = (line, c) if axis == "y" else (c, line)
-            self._render_balloon(view, tag, j, hole, cx, cy, bx, by, fs, r)
-        return len(members) - len(coords)
-
-    def _feature_of_hole_at(self, location):
-        """The IR hole/pattern feature whose member sits at model-space *location*, or
-        ``None`` (#408). Attributes a balloon (which carries a recognition hole, not the
-        IR feature) to its feature so :meth:`drop` clears it. Cached — the model is fixed
-        after build."""
-        m = self._part_model
-        if m is None:
-            return None
-        if self._hole_feature_index is None:
-            idx: dict = {}
-            for f in getattr(m, "features", []):
-                if getattr(f, "kind", None) in ("hole", "pattern"):
-                    for loc in getattr(f, "members", None) or (f.frame.origin,):
-                        idx[tuple(round(c, 3) for c in loc)] = f
-            self._hole_feature_index = idx
-        return self._hole_feature_index.get(tuple(round(c, 3) for c in location))
-
-    def _render_balloon(self, view, tag, j, hole, cx, cy, bx, by, fs, r):
-        """Build and add one balloon glyph + leader at solved centre ``(bx, by)``
-        for hole ``(cx, cy)`` (#111)."""
-        loc = Location((bx, by, 0))
-        # The annotation layer fills closed paths, so a circle edge renders as a
-        # disc. A thin annular FACE fills as a ring — i.e. a circle outline.
-        ring_faces = [f.moved(loc) for f in (Circle(r) - Circle(r - 0.35)).faces()]
-        text = Text(
-            txt=tag,
-            font_size=fs,
-            font_path=PLEX_MONO,
-            align=(Align.CENTER, Align.CENTER),
-            mode=Mode.PRIVATE,
-        ).locate(loc)
-        parts = [*ring_faces, *text.faces()]
-        # Leader from the hole rim to the balloon's near edge — the glyph is the
-        # label, so label="".  Skipped when the balloon could not clear the hole
-        # (degenerate fallback), where a leader would be a stub through the ring.
-        dx, dy = bx - cx, by - cy
-        dist = math.hypot(dx, dy)
-        hole_r = hole.diameter * self.scale / 2
-        if dist > hole_r + r:
-            ux, uy = dx / dist, dy / dist
-            tip = (cx + ux * hole_r, cy + uy * hole_r, 0)
-            elbow = (bx - ux * r, by - uy * r, 0)
-            parts.append(Leader(tip, elbow, "", self.draft))
-        balloon = Compound(children=parts)
-        # Furniture that legitimately sits on the view geometry — exempt from the
-        # annotation-overlap / centreline lint, as the section arrows do.
-        balloon.is_centerline = True
-        self.add(
-            balloon,
-            f"balloon_{view}_{tag}_{j}",
-            view=view,
-            feature=self._feature_of_hole_at(hole.location),
-        )
+        render_balloons(self, self._analysis, view, specs, ctx)
 
     def _add_balloon(self, view, tag, j, hole):
         """Single-balloon convenience over :meth:`add_balloons` (#111)."""

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -44,6 +44,7 @@ non-linear) stays deferred (#94) and may never be needed — see that ADR's
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Literal, NamedTuple
 
@@ -196,6 +197,104 @@ def _solve_strip_1d_pava(naturals, gaps, lo, hi, weights=None):
 # ---------------------------------------------------------------------------
 # Collect-then-solve strip stage (ADR 0009)
 # ---------------------------------------------------------------------------
+
+
+# ── balloon band assignment (#516; moved from drawing.py, #699) ─────────────────────────
+@dataclass
+class _FlowEdge:
+    to: int
+    rev: int
+    cap: int
+    cost: int
+
+
+def _strip_capacity(lo: float, hi: float, gap: float) -> int:
+    """Number of uniform balloon centres that can fit in ``[lo, hi]``."""
+
+    if hi < lo:
+        return 0
+    return int(math.floor((hi - lo) / gap + 1e-9)) + 1
+
+
+def _assign_balloon_bands(members, choices_by_member, capacities):
+    """Global max-cardinality/min-cost assignment of balloons to side bands (#516)."""
+
+    band_order = ("left", "right", "top", "bottom")
+    bands = [b for b in band_order if capacities.get(b, 0) > 0]
+    assigned: dict[str, list] = {b: [] for b in band_order}
+    if not members or not bands:
+        return assigned, len(members)
+
+    source = 0
+    member0 = 1
+    band0 = member0 + len(members)
+    sink = band0 + len(bands)
+    graph: list[list[_FlowEdge]] = [[] for _ in range(sink + 1)]
+
+    def add_edge(fr: int, to: int, cap: int, cost: int) -> _FlowEdge:
+        fwd = _FlowEdge(to, len(graph[to]), cap, cost)
+        rev = _FlowEdge(fr, len(graph[fr]), 0, -cost)
+        graph[fr].append(fwd)
+        graph[to].append(rev)
+        return fwd
+
+    used_edges: dict[tuple[int, str], _FlowEdge] = {}
+    for i, choices in enumerate(choices_by_member):
+        add_edge(source, member0 + i, 1, 0)
+        for j, band in enumerate(bands):
+            if band not in choices:
+                continue
+            # Costs are integerised for deterministic shortest paths; the tiny band
+            # ordinal keeps exact ties stable without changing real distance order.
+            cost = int(round(max(0.0, choices[band]) * 1000)) + band_order.index(band)
+            used_edges[(i, band)] = add_edge(member0 + i, band0 + j, 1, cost)
+    for j, band in enumerate(bands):
+        add_edge(band0 + j, sink, capacities[band], 0)
+
+    def shortest_path():
+        dist = [math.inf] * len(graph)
+        prev: list[tuple[int, int] | None] = [None] * len(graph)
+        in_queue = [False] * len(graph)
+        queue = [source]
+        dist[source] = 0
+        in_queue[source] = True
+        while queue:
+            v = queue.pop(0)
+            in_queue[v] = False
+            for ei, edge in enumerate(graph[v]):
+                if edge.cap <= 0:
+                    continue
+                nd = dist[v] + edge.cost
+                if nd >= dist[edge.to]:
+                    continue
+                dist[edge.to] = nd
+                prev[edge.to] = (v, ei)
+                if not in_queue[edge.to]:
+                    queue.append(edge.to)
+                    in_queue[edge.to] = True
+        return prev if prev[sink] is not None else None
+
+    max_flow = min(len(members), sum(capacities.get(b, 0) for b in bands))
+    flow = 0
+    while flow < max_flow and (prev := shortest_path()) is not None:
+        v = sink
+        while v != source:
+            pv, ei = prev[v]
+            edge = graph[pv][ei]
+            edge.cap -= 1
+            graph[v][edge.rev].cap += 1
+            v = pv
+        flow += 1
+
+    placed = 0
+    for i, member in enumerate(members):
+        for band in bands:
+            edge = used_edges.get((i, band))
+            if edge is not None and edge.cap == 0:
+                assigned[band].append(member)
+                placed += 1
+                break
+    return assigned, len(members) - placed
 
 
 @dataclass(frozen=True)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1685,9 +1685,8 @@ class TestDepthEstimators:
         assert _est_right_strip_depth(3) == pytest.approx(69.5, abs=0.01)
 
     def test_right_depth_grows_per_step_uncapped(self):
-        from draftwright._core import _SLOT_DIM_STEP
+        from draftwright._core import _SLOT_DIM_STEP, _STRIP_SPACING
         from draftwright.compose import _est_right_strip_depth
-        from draftwright.drawing import _STRIP_SPACING
 
         # #36: no cap — each further step adds one slot + one spacing.
         assert _est_right_strip_depth(10) > _est_right_strip_depth(3)
@@ -1710,9 +1709,13 @@ class TestDepthEstimators:
         # _est_right_strip_depth(n) must reserve enough corridor for dim_height + n
         # dim_steps stacked from the view edge (gap, then `spacing` between dims) — the
         # cursor-free capacity condition the carve places into (ADR 0009 / #150).
-        from draftwright._core import _SLOT_DIM_HEIGHT, _SLOT_DIM_STEP, _STRIP_SPACING
+        from draftwright._core import (
+            _SLOT_DIM_HEIGHT,
+            _SLOT_DIM_STEP,
+            _STRIP_GAP,
+            _STRIP_SPACING,
+        )
         from draftwright.compose import _est_right_strip_depth
-        from draftwright.drawing import _STRIP_GAP
 
         for n_steps in (0, 1, 3):
             est = _est_right_strip_depth(n_steps)
@@ -1722,9 +1725,8 @@ class TestDepthEstimators:
 
     def test_pv_below_depth_fits_in_exact_corridor(self):
         # _est_pv_below_depth() must reserve enough for one dim_width from the view edge.
-        from draftwright._core import _SLOT_DIM_WIDTH
+        from draftwright._core import _SLOT_DIM_WIDTH, _STRIP_GAP
         from draftwright.compose import _est_pv_below_depth
-        from draftwright.drawing import _STRIP_GAP
 
         assert _STRIP_GAP + _SLOT_DIM_WIDTH <= _est_pv_below_depth() + 1e-9
 
@@ -6886,10 +6888,13 @@ class TestFeatureEdits:
 
     def test_balloon_is_owned_by_its_hole(self):
         # #408 C: a balloon (which carries a recognition hole) attributes to the IR feature.
+        from draftwright.annotations._common import PlacementContext
+
         dwg = build_drawing(_holed_plate())
         a = dwg._analysis
         hole_obj = a.holes[0]
-        feat = dwg._feature_of_hole_at(hole_obj.location)
+        # the attribution index lives on the run ctx (#639/#699); build one to query it
+        feat = PlacementContext(part_model=dwg.model()).feature_of_hole_at(hole_obj.location)
         assert feat is not None
         dwg._add_balloon("plan", "A", 0, hole_obj)
         bln = next(n for n in dwg.annotations() if n.startswith("balloon_"))
@@ -8621,21 +8626,23 @@ class TestHoleTable:
         dwg.add_hole_table("plan", balloons=False)
         assert not any(n.startswith("balloon_") for n in dwg.annotations())
 
-    def test_place_band_reports_dropped_overflow(self):
+    def test_place_band_reports_dropped_overflow(self, monkeypatch):
         # #1a review follow-up: a band too small for every balloon drops its tail
         # (the strip solver's prefix fallback) — _place_band must REPORT the dropped
-        # count so _add_balloons can surface it as `balloon_dropped` lint, instead of
-        # the balloons vanishing silently. 5 balloons needing a 10 mm gap in a 20 mm
-        # band fit only 3 (at 0, 10, 20); the other 2 are dropped and reported.
-        from types import SimpleNamespace
+        # count so render_balloons can surface it as `balloon_dropped` lint, instead
+        # of the balloons vanishing silently. 5 balloons needing a 10 mm gap in a
+        # 20 mm band fit only 3 (at 0, 10, 20); the other 2 are dropped and reported.
+        import draftwright.annotations.balloons as balloons
 
         rendered: list = []
-        stub = SimpleNamespace(_render_balloon=lambda *a: rendered.append(a))
+        monkeypatch.setattr(balloons, "_render_balloon", lambda *a: rendered.append(a))
         members = [("t", 0, object(), 0.0, float(i)) for i in range(5)]
-        dropped = Drawing._place_band(stub, "plan", members, "y", 50.0, 0.0, 20.0, 10.0, 3.0, 5.0)
+        dropped = balloons._place_band(
+            None, "plan", members, "y", 50.0, 0.0, 20.0, 10.0, 3.0, 5.0, None
+        )
         assert dropped == 2 and len(rendered) == 3
 
-    def test_balloon_ring_depth_uses_bare_obstacle_footprints(self):
+    def test_balloon_ring_depth_uses_bare_obstacle_footprints(self, monkeypatch):
         from types import SimpleNamespace
 
         from draftwright._core import _STRIP_GAP
@@ -8657,33 +8664,35 @@ class TestHoleTable:
         pt = a.PV_Y + a.pv_hh
         bare_obstacle = self._Boxed((35.0, pt + 2.0, 65.0, pt + 12.0))
 
-        def place_band(view, members, axis, line, lo, hi, gap, fs, r):
+        import draftwright.annotations.balloons as balloons
+
+        def place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx):
             calls.append((view, members, axis, line, lo, hi, gap, fs, r))
             return 0
 
+        monkeypatch.setattr(balloons, "_place_band", place_band)
+        coords = {"plan": SimpleNamespace(pp=lambda *_loc: (50.0, 58.0))}
         stub = SimpleNamespace(
-            _analysis=a,
-            _coords={"plan": SimpleNamespace(pp=lambda *_loc: (50.0, 58.0))},
+            coords=coords.__getitem__,
             draft=SimpleNamespace(font_size=3.0),
             iter_annotations=lambda: iter([("bare_obstacle", bare_obstacle)]),
             view_of=lambda _name: "plan",
-            _place_band=place_band,
-            _record_build_issue=lambda *_args: None,
         )
+        ctx = SimpleNamespace(record_issue=lambda *_args: None)
         hole = SimpleNamespace(location=(0.0, 0.0, 0.0), diameter=4.0)
 
-        Drawing.add_balloons(stub, "plan", [("A", 0, hole)])
+        balloons.render_balloons(stub, a, "plan", [("A", 0, hole)], ctx)
 
         top_call = next(call for call in calls if call[2] == "x" and call[1])
         _view, _members, _axis, line, *_rest, fs, r = top_call
         assert line == pytest.approx(pt + 12.0 + _STRIP_GAP + r)
         assert fs == 3.0
 
-    def test_balloon_assignment_rebalances_across_bands_before_dropping(self):
+    def test_balloon_assignment_rebalances_across_bands_before_dropping(self, monkeypatch):
         from types import SimpleNamespace
 
         from draftwright._core import _STRIP_GAP, _STRIP_SPACING
-        from draftwright.drawing import _strip_capacity
+        from draftwright.layout import _strip_capacity
 
         calls = []
         a = SimpleNamespace(
@@ -8700,23 +8709,25 @@ class TestHoleTable:
             fv_hh=5.0,
         )
 
-        def place_band(view, members, axis, line, lo, hi, gap, fs, r):
+        import draftwright.annotations.balloons as balloons
+
+        def place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx):
             calls.append((view, list(members), axis, line, lo, hi, gap, fs, r))
             return 0
 
+        monkeypatch.setattr(balloons, "_place_band", place_band)
+        coords = {"plan": SimpleNamespace(pp=lambda *_loc: (50.0, 58.0))}
         stub = SimpleNamespace(
-            _analysis=a,
-            _coords={"plan": SimpleNamespace(pp=lambda *_loc: (50.0, 58.0))},
+            coords=coords.__getitem__,
             draft=SimpleNamespace(font_size=3.0),
             iter_annotations=lambda: iter(()),
             view_of=lambda _name: "plan",
-            _place_band=place_band,
-            _record_build_issue=lambda *_args: None,
         )
+        ctx = SimpleNamespace(record_issue=lambda *_args: None)
         holes = [SimpleNamespace(location=(float(i), 0.0, 0.0), diameter=4.0) for i in range(6)]
 
-        Drawing.add_balloons(
-            stub, "plan", [(chr(ord("A") + i), 0, h) for i, h in enumerate(holes)]
+        balloons.render_balloons(
+            stub, a, "plan", [(chr(ord("A") + i), 0, h) for i, h in enumerate(holes)], ctx
         )
 
         fs = stub.draft.font_size
@@ -8729,7 +8740,9 @@ class TestHoleTable:
         assert len(top_members) == top_cap
         assert len(side_members) == len(holes) - top_cap
 
-    def test_balloon_assignment_cost_uses_actual_band_line_after_furniture_depth(self):
+    def test_balloon_assignment_cost_uses_actual_band_line_after_furniture_depth(
+        self, monkeypatch
+    ):
         from types import SimpleNamespace
 
         calls = []
@@ -8748,22 +8761,24 @@ class TestHoleTable:
         )
         right_obstacle = self._Boxed((71.0, 45.0, 115.0, 55.0))
 
-        def place_band(view, members, axis, line, lo, hi, gap, fs, r):
+        import draftwright.annotations.balloons as balloons
+
+        def place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx):
             calls.append((view, list(members), axis, line, lo, hi, gap, fs, r))
             return 0
 
+        monkeypatch.setattr(balloons, "_place_band", place_band)
+        coords = {"plan": SimpleNamespace(pp=lambda *_loc: (60.0, 50.0))}
         stub = SimpleNamespace(
-            _analysis=a,
-            _coords={"plan": SimpleNamespace(pp=lambda *_loc: (60.0, 50.0))},
+            coords=coords.__getitem__,
             draft=SimpleNamespace(font_size=3.0),
             iter_annotations=lambda: iter([("right_obstacle", right_obstacle)]),
             view_of=lambda _name: "plan",
-            _place_band=place_band,
-            _record_build_issue=lambda *_args: None,
         )
+        ctx = SimpleNamespace(record_issue=lambda *_args: None)
         hole = SimpleNamespace(location=(0.0, 0.0, 0.0), diameter=4.0)
 
-        Drawing.add_balloons(stub, "plan", [("A", 0, hole)])
+        balloons.render_balloons(stub, a, "plan", [("A", 0, hole)], ctx)
 
         left_members = next(call[1] for call in calls if call[2] == "y" and call[3] < a.PV_X)
         right_members = next(call[1] for call in calls if call[2] == "y" and call[3] > a.PV_X)
@@ -8829,7 +8844,7 @@ class TestHoleTable:
         assert Path(svg).stat().st_size > 0 and Path(dxf).stat().st_size > 0
 
     def test_table_geometry_is_deterministic(self):
-        from draftwright.drawing import _build_table
+        from draftwright._core import _build_table
 
         rows = [("TAG", "⌀", "QTY"), ("A", "ø10", "2")]
         a = build_drawing(Box(60, 40, 20)).draft

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -120,9 +120,8 @@ def test_estimated_table_size_matches_rendered():
     # _est_table_size; the annotation pass renders them via _build_table. Both now
     # draw from the one _core._table_metrics — this pins estimator == rendered, the
     # exact drift ADR 0004 names as the failure mode to guard against.
-    from draftwright._core import _FONT_SIZE, _wrap_rows, draft_preset
+    from draftwright._core import _FONT_SIZE, _build_table, _wrap_rows, draft_preset
     from draftwright.compose import _est_table_size
-    from draftwright.drawing import _build_table
 
     draft = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
     header = ("TAG", "ø", "X", "Y")


### PR DESCRIPTION
Slice (a) of #699 (drawing.py re-accretion). **Does not close #699** — slices b–d follow.

## What moved

| Logic | From | To | Why |
|---|---|---|---|
| `_FlowEdge` / `_strip_capacity` / `_assign_balloon_bands` (min-cost max-flow, #516) | `drawing.py` | `layout.py` | Solvers live in the solver layer (ADR 0003/0009) |
| Balloon render pass (`add_balloons` body, `_place_band`, `_render_balloon`) | `drawing.py` | new `annotations/balloons.py` | A render pass belongs in the render layer; the orchestrator used to call *up* into `dwg.add_balloons` by duck-typing — it now calls sideways into `render_balloons` |
| `_feature_of_hole_at` + `_hole_feature_index` | `drawing.py` | *(deleted)* | `PlacementContext.feature_of_hole_at` was already the one implementation — this was a duplicate |
| `_build_table` | `drawing.py` | `_core.py` (beside `_table_metrics`) | One table-sizing model (#700); ADR 0005 §1 annotated — the planned `tables.py` was never needed |

## Design

- `Drawing.add_balloons` stays the **public verb**: an owner method that builds a `PlacementContext` and threads the build state into the pass. No public API change.
- `annotations/balloons.py` touches the drawing only through its public surface (`coords`, `draft`, `scale`, `add`); build state rides `a` + `ctx`. The **#639 encapsulation ratchet stays at its empty allowlist**.
- All function bodies moved verbatim (asserted by the transform script); the only edits are `self` → `dwg` and `self._record_build_issue` → `ctx.record_issue`.

## Verification

- 4 lint checks clean (ruff check, ruff format, mypy, codespell)
- Guard suites: import boundaries (drawing→annotations.balloons is downward, rank 5→4), encapsulation ratchet, carve-callers — 19 passed
- Full fast tier: 1421 passed, 3 skipped; only failure is the known pre-existing #710 Hypothesis local-DB replay (identical on main)
- 5 balloon stub tests rewritten to target the module functions; 3 depth-estimator tests redirected from `drawing`'s incidental `_STRIP_GAP`/`_STRIP_SPACING` re-exports to `_core` (their true home)

🤖 Generated with [Claude Code](https://claude.com/claude-code)