### PR TITLE
refactor(#699): one canonical pass sequence for auto-pass and finalize (slice b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Changed
 
+- **`finalize()` drains in the auto-pass's order** (#699 slice b): both build
+  paths now execute the orchestrator's one canonical `_PASS_SEQUENCE` (via the
+  shared `run_stages`), removing the hand-mirrored second orchestration in
+  `Drawing._drain_intents`. For the deferred/finalize path this reorders two
+  things toward auto-pass parity: the turned diameter/step-length set-solves now
+  place *before* the corridor drain (matching the auto-pass's obstacle
+  visibility), and slots register after them. Recompose output may shift
+  accordingly; the auto-pass order is unchanged.
 - **`Sheet.export` speaks the modern export API** (#702): it now takes
   `formats=` (any of svg/dxf/pdf/png, default **PDF** — matching the CLI
   default) and `dpi=`, and returns the `{format: path}` dict. Previously it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@
 - **`finalize()` drains in the auto-pass's order** (#699 slice b): both build
   paths now execute the orchestrator's one canonical `_PASS_SEQUENCE` (via the
   shared `run_stages`), removing the hand-mirrored second orchestration in
-  `Drawing._drain_intents`. For the deferred/finalize path this reorders two
+  `Drawing._drain_intents`. For the deferred/finalize path this reorders three
   things toward auto-pass parity: the turned diameter/step-length set-solves now
   place *before* the corridor drain (matching the auto-pass's obstacle
-  visibility), and slots register after them. Recompose output may shift
-  accordingly; the auto-pass order is unchanged.
+  visibility); slots register after them; and the register-only height-ladder /
+  step-position stages register *after* locations — observable too, since
+  registration order decides corridor key-creation (= drain) order and
+  same-priority tie-breaks (Codex review; the new order is exactly the
+  auto-pass's). Recompose output may shift accordingly; the auto-pass order is
+  unchanged.
 - **`Sheet.export` speaks the modern export API** (#702): it now takes
   `formats=` (any of svg/dxf/pdf/png, default **PDF** — matching the CLI
   default) and `dpi=`, and returns the `{format: path}` dict. Previously it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,14 @@ entry. Keep `_LAYERS` and this section in step.
   **`annotations/`** subpackage (#164 / ADR 0005, P5):
   - **`annotations/orchestrator.py`** — `_auto_annotate`, the single entry point
     (called by `build_drawing`); classifies the part and drives the render passes
-    + title block. End state (ADR 0008) is `build model → plan → render`; some
-    inline engine code remains — chiefly `_maybe_tabulate_holes` (the
-    hole-table/balloon escalation resolver) and the iso right-strip
-    outer-limit tightening — pending the last convergence steps.
+    + title block. Owns **`_PASS_SEQUENCE`** — the ONE canonical stage order
+    (#699 slice b): `_auto_annotate` and `Drawing._drain_intents` (the finalize
+    drain) both hand name→thunk dicts to the shared `run_stages`, so the two
+    build paths cannot diverge in sequencing (the drain step itself is the
+    shared `drain_and_reconcile`). End state (ADR 0008) is
+    `build model → plan → render`; some inline engine code remains — chiefly
+    `_maybe_tabulate_holes` (the hole-table/balloon escalation resolver) and the
+    iso right-strip outer-limit tightening — pending the last convergence steps.
   - **`annotations/from_model.py`** — the **IR render layer** (largest annotations
     module): turns the planner's `DimensionGroup`/render-intents into placed
     dimensions/callouts/centre marks/section triggers. This is where the turned,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -30,7 +30,7 @@ from draftwright._core import (
     _wrap_rows,  # noqa: F401 — re-exported via the annotate facade (#700: one copy, in _core)
 )
 from draftwright.analysis import _sizing_bores
-from draftwright.annotations._common import PlacementContext, drain_corridors
+from draftwright.annotations._common import PlacementContext
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.from_model import (
     render_boss_diameters,
@@ -137,8 +137,12 @@ def run_stages(stages: dict, sequence: tuple[str, ...] = _PASS_SEQUENCE) -> None
 def drain_and_reconcile(ctx, dwg) -> None:
     """Solve every registered corridor once (ADR 0009 end state, #345/#346/#393),
     then reconcile witness-crossing labels (#690) — the drain step both build
-    paths share verbatim (#699 slice b)."""
-    drain_corridors(ctx, dwg)
+    paths share verbatim (#699 slice b). ``drain_corridors`` is resolved at call
+    time (as the pre-#699 function-level imports did), so the #647 transactional-
+    rollback tests can still inject a drain failure via ``_common``."""
+    from draftwright.annotations import _common
+
+    _common.drain_corridors(ctx, dwg)
     reconcile_witness_labels(dwg)
 
 
@@ -268,13 +272,6 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (was recomputed per renderer, #275). One rule set over DimParameters, literally.
     _groups = plan_dimensions(_model)
 
-    # Rotational furniture — OD dim + axis centrelines + concentric bore leaders — IR
-    # renderer (#237), placed early like the engine's inline block it replaces.
-    render_rotational(dwg, _model, a, ctx=ctx)
-
-    # Centre marks for every hole (all part classes) — IR renderer.
-    render_centermarks(dwg, _groups)
-
     # Hole callouts, location dims, and the section view fire on *feature
     # presence*, independent of the turned/prismatic class (#10): the
     # classification only selects the base set (OD+centreline+ldr_z vs envelope
@@ -301,146 +298,222 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         declared_keys = _declared_feature_keys(_groups, a)
         feature_keys = feature_keys | declared_keys
     # Decide the section trigger + cut-plane row now (pure function of _model/
-    # feature_keys, no placement dependency) and reserve its cutting-plane arrows'
-    # row BEFORE the plan-view hole callouts place (ADR 0009 P5 strand 3) — the
-    # section itself still renders last (its own room check clears everything else
-    # placed), this only gives the (now strip_obstacles-aware) callout carve a
-    # real obstacle to see and, where a cheap relocation exists, avoid — instead
-    # of an invisible one it could never even detect. When avoiding would cost a
-    # large relocation, policy B keeps the callout at its natural position and
-    # accepts the crossing rather than pay that cost or drop it (holes.py); the
-    # `bracket` fixture's known hc_plan0/section_arrow_right overlap
-    # (tests/test_layout_cleanliness.py) is exactly this accepted case.
+    # feature_keys, no placement dependency); the "reserve_section" stage reserves
+    # its row and the "section" stage renders it.
     _section = plan_sections(_model, feature_keys)
-    _reserve_section_row(dwg, a, _section)
-    # Any hole/pattern member (declared holes render even where detection missed them).
-    if feature_keys:
-        _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys, ctx=ctx)
-    # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
-    # through the existing above-view strips. Replaces the engine's _add_location_dims.
-    render_locations(dwg, _model, a, ctx=ctx)
 
-    if a.cross_diams and a.is_rotational and not feature_keys:
-        _log.info(
-            "Cross-hole ø%s detected but not annotated (requires section view)",
-            _fmt(a.cross_diams[0]),
-        )
+    # ── the stage thunks, run in _PASS_SEQUENCE order (#699 slice b) ─────────
+    def _s_rotational():
+        # Rotational furniture — OD dim + axis centrelines + concentric bore leaders — IR
+        # renderer (#237), placed early like the engine's inline block it replaces.
+        render_rotational(dwg, _model, a, ctx=ctx)
 
-    # Front-view right ladder: prismatic step heights + overall height — IR renderer,
-    # through fv_zones.right preserving the leapfrog cursor (#237). Replaces the inline
-    # dim_step_* + dim_height; the turned step-length chain (render_step_lengths) handles
-    # turned parts, and a Z-turned overall height is suppressed there (ISO 129).
-    render_height_ladder(dwg, _model, a, ctx=ctx)
+    def _s_centermarks():
+        # Centre marks for every hole (all part classes) — IR renderer.
+        render_centermarks(dwg, _groups)
 
-    # Plate/wall thicknesses on a multi-plate prismatic (#559): the thin extent of each
-    # recognised slab, placed in the view where its thin axis is visible. A single flat
-    # plate has none (its thickness IS the envelope height).
-    render_plates(dwg, _model, a, ctx=ctx)
+    def _s_reserve_section():
+        # Reserve the cutting-plane arrows' row BEFORE the plan-view hole callouts
+        # place (ADR 0009 P5 strand 3) — the section itself still renders last (its
+        # own room check clears everything else placed), this only gives the (now
+        # strip_obstacles-aware) callout carve a real obstacle to see and, where a
+        # cheap relocation exists, avoid — instead of an invisible one it could
+        # never even detect. When avoiding would cost a large relocation, policy B
+        # keeps the callout at its natural position and accepts the crossing rather
+        # than pay that cost or drop it (holes.py); the `bracket` fixture's known
+        # hc_plan0/section_arrow_right overlap (tests/test_layout_cleanliness.py)
+        # is exactly this accepted case.
+        _reserve_section_row(dwg, a, _section)
 
-    # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a
-    # stepped block is fully constrained (the heights alone leave the shoulder implicit).
-    render_step_positions(dwg, _model, a, ctx=ctx)
+    def _s_hole_callouts():
+        # Any hole/pattern member (declared holes render even where detection missed them).
+        if feature_keys:
+            _annotate_holes(dwg, a, view_of_axis, _groups, feature_keys, ctx=ctx)
 
-    # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.
-    render_chamfers(dwg, _model, a, ctx=ctx)
-    render_fillets(dwg, _model, a, ctx=ctx)
-    # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.
-    render_flats(dwg, _model, a, ctx=ctx)
-    # Blind-recess callouts (#148a): W × L × D DEEP via a leader off each floored pocket.
-    render_pockets(dwg, _model, a, ctx=ctx)
+    def _s_locations():
+        # Hole location dims — IR renderer (planner picks the refs + datum, #238); placed
+        # through the existing above-view strips. Replaces the engine's _add_location_dims.
+        render_locations(dwg, _model, a, ctx=ctx)
+        if a.cross_diams and a.is_rotational and not feature_keys:
+            _log.info(
+                "Cross-hole ø%s detected but not annotated (requires section view)",
+                _fmt(a.cross_diams[0]),
+            )
 
-    # Side-drilled holes' in-plane (side-below) locations share the below corridor with
-    # the overall envelope depth. They now queue into the same batch; the envelope's
-    # later subchain + mandatory priority keeps ISO outermost stacking and prevents
-    # best-effort locations from starving the principal depth dimension (#477).
-    if feature_keys:
-        _locate_off_axis_holes(dwg, ctx, a, which="across")
+    def _s_height_ladder():
+        # Front-view right ladder: prismatic step heights + overall height — IR renderer,
+        # through fv_zones.right preserving the leapfrog cursor (#237). Replaces the inline
+        # dim_step_* + dim_height; the turned step-length chain (render_step_lengths) handles
+        # turned parts, and a Z-turned overall height is suppressed there (ISO 129).
+        render_height_ladder(dwg, _model, a, ctx=ctx)
 
-    # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
-    # queued into the shared corridor instead of claiming a post-hoc carve tier.
-    # Suppression (square footprint / X-turned width) is the planner's decision (#250).
-    render_envelope(dwg, _groups, a, ctx=ctx)
+    def _s_plates():
+        # Plate/wall thicknesses on a multi-plate prismatic (#559): the thin extent of each
+        # recognised slab, placed in the view where its thin axis is visible. A single flat
+        # plate has none (its thickness IS the envelope height).
+        render_plates(dwg, _model, a, ctx=ctx)
 
-    # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))
-    # — resolved with every other detail request below (#307).
-    if detail_view:
-        _request_prismatic_detail(dwg, a, ctx=ctx)
+    def _s_step_positions():
+        # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a
+        # stepped block is fully constrained (the heights alone leave the shoulder implicit).
+        render_step_positions(dwg, _model, a, ctx=ctx)
 
-    # Turned-part dimensions via the IR (ADR 0008 convergence). The model is built
-    # once and fed to both renderers (#229 — no per-pass rebuild):
-    #  - diameters: ø leaders, row below (X) / column left (Z), one path by frame
-    #    axis. Replaces _annotate_turned_diameters.
-    #  - step lengths: the chain that locates every shoulder, X and Z from one path
-    #    (#223). A crowded X-turned head queues an enlarged detail request (#304/#307)
-    #    instead of cramming; the envelope dim along the turning axis was suppressed
-    #    so the chain does not double-dimension the length.
-    # Prismatic bosses get a plan-view ø leader BEFORE the turned row/column solve, which then
-    # sees the ø as 'mentioned' and skips it (#629 — the column-left strip strands a boss ø when
-    # tight, even on a half-empty sheet). No-op on turned parts (they keep the OD stack).
-    render_boss_diameters(dwg, _groups, a, ctx=ctx)
-    render_diameters(dwg, _groups, ctx=ctx)
-    if a.prof is not None:
-        render_step_lengths(dwg, _groups, ctx=ctx)
+    def _s_chamfers():
+        # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.
+        render_chamfers(dwg, _model, a, ctx=ctx)
 
-    # Side-drilled (X/Y-axis) hole HEIGHT locations — queued after the mandatory envelope
-    # candidates so below/right corridors solve them together with GD&T/PMI at the drain.
-    # The front-right prismatic height ladder remains immediate because its later witness
-    # bases depend on earlier placed tiers (#477).
-    if feature_keys:
-        _locate_off_axis_holes(dwg, ctx, a, which="along")
+    def _s_fillets():
+        render_fillets(dwg, _model, a, ctx=ctx)
 
-    # Non-cylindrical machined features: slots / reduced across-flats sections
-    # (#135) — IR renderer, placed through the zone strips (shared infra). Runs
-    # after every hole/diameter pass so it claims strip space last.
-    render_slots(dwg, _model, a, ctx=ctx)
+    def _s_flats():
+        # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.
+        render_flats(dwg, _model, a, ctx=ctx)
 
-    # Declared GD&T frames / datum symbols / surface finishes (ADR 0011 §4, #61) and
-    # authored STEP PMI dims (#393) register into the same strips as first-class
-    # candidates BEFORE the drain, so the one solve orders and spaces them crossing-free
-    # with locations/slots rather than consuming leftovers as first-fit placements.
-    render_gdt(dwg, _model, a, ctx=ctx)
-    if a.pmi_mode == "annotate" or (
-        ctx.model_declared
-        and any(f.kind in ("authored_dimension", "pmi") for f in _model.features)
-    ):
-        render_pmi(dwg, _model, a, ctx=ctx)
+    def _s_pockets():
+        # Blind-recess callouts (#148a): W × L × D DEEP via a leader off each floored pocket.
+        render_pockets(dwg, _model, a, ctx=ctx)
 
-    # Now every corridor feeder pass has registered; solve each shared strip once
-    # (ADR 0009 end state, #345/#346/#393) — dedup coincident spans, order the ladder —
-    # BEFORE the section/detail views so they see the placed ladder as an obstacle.
-    drain_corridors(ctx, dwg)
-    # (#690) Witness-crossing label reconciliation — after every corridor (and its
-    # deferred fallthroughs) has placed: shift any dim label a FOREIGN transverse
-    # stroke crosses, along its own line, via the repair machinery. Deterministic,
-    # runs in both build paths.
-    reconcile_witness_labels(dwg)
+    def _s_off_axis_across():
+        # Side-drilled holes' in-plane (side-below) locations share the below corridor with
+        # the overall envelope depth. They now queue into the same batch; the envelope's
+        # later subchain + mandatory priority keeps ISO outermost stacking and prevents
+        # best-effort locations from starving the principal depth dimension (#477).
+        if feature_keys:
+            _locate_off_axis_holes(dwg, ctx, a, which="across")
 
-    # Turned/circlip-groove callouts (#148c): {width} WIDE × ø{dia} via a leader off each
-    # groove. A groove is a secondary leader-callout on a turned shaft — exactly where the
-    # primary turned-length chain runs — so it places into remaining clear room only after
-    # the corridor drain has finalised the diameter/step-length furniture (else its room
-    # check can't see the not-yet-drained length dims and collides, #148c crowded-shaft).
-    render_grooves(dwg, _model, a, ctx=ctx)
+    def _s_envelope():
+        # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
+        # queued into the shared corridor instead of claiming a post-hoc carve tier.
+        # Suppression (square footprint / X-turned width) is the planner's decision (#250).
+        render_envelope(dwg, _groups, a, ctx=ctx)
 
-    # The section view renders after the corridor-drained furniture exists, so
-    # its full strip_obstacles room check can see side callouts, envelope dims,
-    # slots, GD&T/PMI, and drained ladder outputs as one occupancy set. Details
-    # still render after it and avoid the section view.
-    section = _section
-    if section is not None:
-        _add_section_view(dwg, a, section)
+    def _s_detail_request():
+        # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))
+        # — resolved with every other detail request in the "details" stage (#307).
+        if detail_view:
+            _request_prismatic_detail(dwg, a, ctx=ctx)
 
-    # Resolve every queued enlarged-detail request (#307) — prismatic step bands and
-    # crowded turned heads alike — through the one generic detailer, now that all
-    # views and main-view annotations are placed (so the detail avoids them).
-    _resolve_details(dwg, a, ctx=ctx)
+    def _s_boss_diameters():
+        # Prismatic bosses get a plan-view ø leader BEFORE the turned row/column solve,
+        # which then sees the ø as 'mentioned' and skips it (#629 — the column-left strip
+        # strands a boss ø when tight, even on a half-empty sheet). No-op on turned parts
+        # (they keep the OD stack).
+        render_boss_diameters(dwg, _groups, a, ctx=ctx)
 
-    _add_title_block(dwg, a)
+    def _s_diameters():
+        # Turned-part dimensions via the IR (ADR 0008 convergence). The model is built
+        # once and fed to both renderers (#229 — no per-pass rebuild): ø leaders, row
+        # below (X) / column left (Z), one path by frame axis. Replaces
+        # _annotate_turned_diameters.
+        render_diameters(dwg, _groups, ctx=ctx)
 
-    # Escalate to a hole table when the plan view is too dense to dimension
-    # every hole — runs last so the table avoids every placed annotation
-    # including the title block (#93).
-    _maybe_tabulate_holes(dwg, a, ctx=ctx)
+    def _s_step_lengths():
+        # The chain that locates every shoulder, X and Z from one path (#223). A crowded
+        # X-turned head queues an enlarged detail request (#304/#307) instead of
+        # cramming; the envelope dim along the turning axis was suppressed so the chain
+        # does not double-dimension the length.
+        if a.prof is not None:
+            render_step_lengths(dwg, _groups, ctx=ctx)
+
+    def _s_off_axis_along():
+        # Side-drilled (X/Y-axis) hole HEIGHT locations — queued after the mandatory
+        # envelope candidates so below/right corridors solve them together with GD&T/PMI
+        # at the drain. The front-right prismatic height ladder remains immediate because
+        # its later witness bases depend on earlier placed tiers (#477).
+        if feature_keys:
+            _locate_off_axis_holes(dwg, ctx, a, which="along")
+
+    def _s_slots():
+        # Non-cylindrical machined features: slots / reduced across-flats sections
+        # (#135) — IR renderer, placed through the zone strips (shared infra). Runs
+        # after every hole/diameter pass so it claims strip space last.
+        render_slots(dwg, _model, a, ctx=ctx)
+
+    def _s_gdt():
+        # Declared GD&T frames / datum symbols / surface finishes (ADR 0011 §4, #61)
+        # register into the same strips as first-class candidates BEFORE the drain, so
+        # the one solve orders and spaces them crossing-free with locations/slots rather
+        # than consuming leftovers as first-fit placements.
+        render_gdt(dwg, _model, a, ctx=ctx)
+
+    def _s_pmi():
+        # Authored STEP PMI dims (#393) — same pre-drain registration as GD&T above.
+        if a.pmi_mode == "annotate" or (
+            ctx.model_declared
+            and any(f.kind in ("authored_dimension", "pmi") for f in _model.features)
+        ):
+            render_pmi(dwg, _model, a, ctx=ctx)
+
+    def _s_drain():
+        # Now every corridor feeder pass has registered; solve each shared strip once
+        # (ADR 0009 end state) + the #690 label reconciliation — BEFORE the
+        # section/detail views so they see the placed ladder as an obstacle.
+        drain_and_reconcile(ctx, dwg)
+
+    def _s_grooves():
+        # Turned/circlip-groove callouts (#148c): {width} WIDE × ø{dia} via a leader off
+        # each groove. A groove is a secondary leader-callout on a turned shaft — exactly
+        # where the primary turned-length chain runs — so it places into remaining clear
+        # room only after the corridor drain has finalised the diameter/step-length
+        # furniture (else its room check can't see the not-yet-drained length dims and
+        # collides, #148c crowded-shaft).
+        render_grooves(dwg, _model, a, ctx=ctx)
+
+    def _s_section():
+        # The section view renders after the corridor-drained furniture exists, so
+        # its full strip_obstacles room check can see side callouts, envelope dims,
+        # slots, GD&T/PMI, and drained ladder outputs as one occupancy set. Details
+        # still render after it and avoid the section view.
+        if _section is not None:
+            _add_section_view(dwg, a, _section)
+
+    def _s_details():
+        # Resolve every queued enlarged-detail request (#307) — prismatic step bands and
+        # crowded turned heads alike — through the one generic detailer, now that all
+        # views and main-view annotations are placed (so the detail avoids them).
+        _resolve_details(dwg, a, ctx=ctx)
+
+    def _s_title_block():
+        _add_title_block(dwg, a)
+
+    def _s_tabulate():
+        # Escalate to a hole table when the plan view is too dense to dimension
+        # every hole — runs last so the table avoids every placed annotation
+        # including the title block (#93).
+        _maybe_tabulate_holes(dwg, a, ctx=ctx)
+
+    run_stages(
+        {
+            "rotational": _s_rotational,
+            "centermarks": _s_centermarks,
+            "reserve_section": _s_reserve_section,
+            "hole_callouts": _s_hole_callouts,
+            "locations": _s_locations,
+            "height_ladder": _s_height_ladder,
+            "plates": _s_plates,
+            "step_positions": _s_step_positions,
+            "chamfers": _s_chamfers,
+            "fillets": _s_fillets,
+            "flats": _s_flats,
+            "pockets": _s_pockets,
+            "off_axis_across": _s_off_axis_across,
+            "envelope": _s_envelope,
+            "detail_request": _s_detail_request,
+            "boss_diameters": _s_boss_diameters,
+            "diameters": _s_diameters,
+            "step_lengths": _s_step_lengths,
+            "off_axis_along": _s_off_axis_along,
+            "slots": _s_slots,
+            "gdt": _s_gdt,
+            "pmi": _s_pmi,
+            "drain": _s_drain,
+            "grooves": _s_grooves,
+            "section": _s_section,
+            "details": _s_details,
+            "title_block": _s_title_block,
+            "tabulate": _s_tabulate,
+        }
+    )
     # The escalations live only on this per-run ctx (#639), discarded when _auto_annotate
     # returns — so nothing carries stale drops into a later deferred edit (#440), and there is
     # no drawing-level list to clear.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -120,12 +120,16 @@ _PASS_SEQUENCE: tuple[str, ...] = (
 )
 
 
-def run_stages(stages: dict, sequence: tuple[str, ...] = _PASS_SEQUENCE) -> None:
-    """Run the *stages* a path implements in the canonical *sequence* order.
+def run_stages(stages: dict, sequence: tuple[str, ...] | None = None) -> None:
+    """Run the *stages* a path implements in the canonical *sequence* order
+    (``_PASS_SEQUENCE``, resolved at call time so a test/instrumentation rebinding
+    is honoured — Codex review).
 
     The shared executor of the one pass list (#699 slice b): both build paths hand
     their name→thunk dict here, so neither can run a stage the sequence does not
     name (assertion) nor in an order of its own."""
+    if sequence is None:
+        sequence = _PASS_SEQUENCE
     unknown = set(stages) - set(sequence)
     assert not unknown, f"stages not in _PASS_SEQUENCE: {sorted(unknown)}"
     for name in sequence:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -75,6 +75,72 @@ from draftwright.model import (
 )
 from draftwright.repair import reconcile_witness_labels
 
+# ── the ONE auto-pass stage sequence (#699 slice b) ──────────────────────────
+# The canonical order of the annotation stages. `_auto_annotate` executes it, and
+# `Drawing._drain_intents` (the finalize drain) walks the SAME tuple for its routed
+# subset — so a reordering here reorders BOTH build paths, and the hand-mirrored
+# "mirroring the auto-pass" divergence class is gone by construction. Stages a path
+# does not run are simply absent from its dict ("live_replay"/"user_dims" are
+# finalize-only; most render stages are auto-only); an unknown stage key is an
+# assertion error in both consumers. Order matters through four mechanisms (see
+# the #699 slice-b analysis): immediate placers read live occupancy at call time,
+# corridor drain order follows key-creation order, some registrations read strip
+# state, and post-drain fallbacks run in registration order.
+_PASS_SEQUENCE: tuple[str, ...] = (
+    "rotational",
+    "centermarks",
+    "reserve_section",
+    "live_replay",  # finalize-only: recorded verbs replay before the routed solves
+    "hole_callouts",
+    "locations",
+    "height_ladder",
+    "plates",
+    "step_positions",
+    "chamfers",
+    "fillets",
+    "flats",
+    "pockets",
+    "off_axis_across",
+    "envelope",
+    "detail_request",
+    "boss_diameters",  # documented invariant: before "diameters" (ø then 'mentioned')
+    "diameters",
+    "step_lengths",
+    "off_axis_along",
+    "slots",
+    "user_dims",  # finalize-only: pin/priority dims queue into the shared corridor
+    "gdt",
+    "pmi",
+    "drain",
+    "grooves",
+    "section",
+    "details",
+    "title_block",
+    "tabulate",
+)
+
+
+def run_stages(stages: dict, sequence: tuple[str, ...] = _PASS_SEQUENCE) -> None:
+    """Run the *stages* a path implements in the canonical *sequence* order.
+
+    The shared executor of the one pass list (#699 slice b): both build paths hand
+    their name→thunk dict here, so neither can run a stage the sequence does not
+    name (assertion) nor in an order of its own."""
+    unknown = set(stages) - set(sequence)
+    assert not unknown, f"stages not in _PASS_SEQUENCE: {sorted(unknown)}"
+    for name in sequence:
+        fn = stages.get(name)
+        if fn is not None:
+            fn()
+
+
+def drain_and_reconcile(ctx, dwg) -> None:
+    """Solve every registered corridor once (ADR 0009 end state, #345/#346/#393),
+    then reconcile witness-crossing labels (#690) — the drain step both build
+    paths share verbatim (#699 slice b)."""
+    drain_corridors(ctx, dwg)
+    reconcile_witness_labels(dwg)
+
 
 def _concentric_bore_diams(a: Analysis) -> list:
     """Distinct bore diameters on the rotation axis, in z_diams order (#10).

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1278,28 +1278,33 @@ class Drawing:
 
         When the drawing was built in **deferred** mode (``_defer_intents``), the add
         verbs recorded :class:`~draftwright.intents.Intent`\\s instead of placing. This
-        drains them, routing what it can through the auto-pass's own solvers:
+        drains them, routing what it can through the auto-pass's own solvers — in the
+        auto-pass's own ORDER: the drain stages are keyed by the orchestrator's canonical
+        ``_PASS_SEQUENCE`` and executed by the shared ``run_stages`` (#699 slice b), so
+        the two build paths cannot silently diverge in sequencing. The routed stages:
 
-        * **(A)** live-replays furniture, non-slot dimensions, and axes-restricted locates
-          (in recorded order, pop-after-success);
-        * **(reserve, Phase 3b)** if a ``section`` was recorded, its cutting-plane row is
-          reserved first so the callout carve sees it as an obstacle (Coupling A);
-        * **(B1, Phase 3a)** hole/pattern ø **callouts** through ``_annotate_holes`` — the
+        * **reserve_section** — a recorded ``section``'s cutting-plane row is reserved
+          first so the callout carve sees it as an obstacle (Coupling A);
+        * **live_replay** — furniture, non-routed dimensions, and axes-restricted locates
+          replay in recorded order (pop-after-success);
+        * **hole_callouts** — hole/pattern ø callouts through ``_annotate_holes`` — the
           real priority-drop / central-bore-anchoring solve;
-        * **(B2, Phase 2a+2b)** both-axes **locations** (``render_locations``) and
-          **slots** (``render_slots``) through the SHARED corridor + one ``drain_corridors``
-          — one crossing-free, deduped, monotone ladder (a slot position coincident with a
-          hole location collapses to one dim, #345);
-        * **(B3, Phase 4a)** X/Z-turned step/boss ø **diameters** through ``render_diameters``
-          — the row-below / column-left set-solve;
-        * **(B3b, Phase 4b)** a turned shaft's step-length **chain** through
-          ``render_step_lengths`` — the unified chain / ``N× v`` collapse / staggered tiers;
-        * **(C)** the ``section`` renders last (its room check clears the side view's right);
-        * **(D, Phase 4c)** dense-scattered plan holes escalate to the hole **table** + balloon
-          ring via ``_maybe_tabulate_holes`` — last, so it sees the section + title block as
-          obstacles. The density gate counts *all* analysis holes, so this is a full-
-          reconstruction escalation (a partial hand-edit still tabulates the full count, #434);
-          The escalations live only on the per-run ctx, so a repeat batch starts clean (#639).
+        * **locations / height_ladder / step_positions / slots / user_dims** — the
+          register-only stages queue into the SHARED corridor (a slot position coincident
+          with a hole location collapses to one dim, #345; pin/priority user dims join as
+          first-class candidates, ADR 0012);
+        * **diameters / step_lengths** — the X/Z-turned set-solves place immediately,
+          before the drain, exactly as the auto-pass runs them;
+        * **drain** — one ``drain_and_reconcile`` places every queued candidate
+          (crossing-free, deduped, monotone ladder) + the #690 label reconciliation;
+        * **section** — renders after the drained furniture exists (its room check clears
+          the side view's right);
+        * **tabulate** — dense-scattered plan holes escalate to the hole **table** +
+          balloon ring via ``_maybe_tabulate_holes`` — last, so it sees the section +
+          title block as obstacles. The density gate counts *all* analysis holes, so this
+          is a full-reconstruction escalation (a partial hand-edit still tabulates the
+          full count, #434); the escalations live only on the per-run ctx, so a repeat
+          batch starts clean (#639).
 
         A slot records two size dims (``slot_width``/``slot_length``) on one feature; routing
         the feature also regenerates its model-derived datum **position** dim, so finalize
@@ -1380,11 +1385,15 @@ class Drawing:
             self._defer_intents = deferred
 
     def _drain_intents(self, ctx, model, a, r) -> None:
-        """The mutating half of :meth:`finalize` (#638): the drain stages A0..D, extracted from
-        its #647 ``try:`` body verbatim (same passes/order/intent-pop/filters). ``r`` = the
-        :class:`_IntentRouting` from :meth:`_classify_intents`; finalize wraps this call in the
-        snapshot/rollback/finally, so a raise here still rolls the drawing back as before."""
-        from draftwright.annotations._common import drain_corridors
+        """The mutating half of :meth:`finalize` (#638): the drain stages, keyed by the
+        orchestrator's canonical ``_PASS_SEQUENCE`` and executed in ITS order via the shared
+        :func:`~draftwright.annotations.orchestrator.run_stages` (#699 slice b) — so the
+        finalize path can no longer silently diverge from the auto-pass sequencing (the
+        pre-#699 hand-mirrored order drained the corridor BEFORE diameters/step lengths and
+        registered the ladder before the callouts; both now follow the one list, giving the
+        auto-pass's obstacle visibility). ``r`` = the :class:`_IntentRouting` from
+        :meth:`_classify_intents`; finalize wraps this call in the snapshot/rollback/finally,
+        so a raise here still rolls the drawing back as before."""
         from draftwright.annotations.from_model import (
             render_diameters,
             render_height_ladder,
@@ -1394,148 +1403,201 @@ class Drawing:
             render_step_positions,
         )
         from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
-        from draftwright.annotations.orchestrator import _maybe_tabulate_holes
+        from draftwright.annotations.orchestrator import (
+            _maybe_tabulate_holes,
+            drain_and_reconcile,
+            run_stages,
+        )
         from draftwright.annotations.sections import (
             _add_section_view,
             _reserve_section_row,
             feature_hole_keys,
         )
         from draftwright.model import PartModel, plan_dimensions
-        from draftwright.repair import reconcile_witness_labels
 
-        _section = r.section
-        corridor_ids, callout_ids, dia_ids = r.corridor_ids, r.callout_ids, r.dia_ids
-        len_ids, slot_ids = r.len_ids, r.slot_ids
-        height_ladder_ids, step_position_ids = r.height_ladder_ids, r.step_position_ids
-        explicit_envelope_height, user_dim_ids = r.explicit_envelope_height, r.user_dim_ids
-        only_loc, pinned_loc, only_callout = r.only_loc, r.pinned_loc, r.only_callout
-        only_dia, only_len, slot_feats = r.only_dia, r.only_len, r.slot_feats
         routable = model is not None and a is not None
+        queued_dim_ids: set = set()
 
-        # Reserve the section's cutting-plane row BEFORE the callout carve so the carve
-        # sees it as an obstacle (Coupling A, ADR 0009 P5 strand 3); rendered last (leg C).
-        if _section is not None:
-            assert a is not None
-            _reserve_section_row(self, a, _section)
-        # A0 — prismatic step-height ladder through the auto-pass renderer, before
-        # generic live-replayed dimensions. The auto-pass places this ladder before
-        # envelope dimensions; doing the same here prevents generic envelope edits
-        # from starving the correlated step rungs.
-        if height_ladder_ids:
-            assert a is not None and isinstance(model, PartModel)
-            render_height_ladder(
-                self, model, a, ctx=ctx, include_overall=not explicit_envelope_height
+        def _s_reserve_section():
+            # Reserve the section's cutting-plane row BEFORE the callout carve so the
+            # carve sees it as an obstacle (Coupling A, ADR 0009 P5 strand 3); rendered
+            # last (the "section" stage).
+            if r.section is not None:
+                assert a is not None
+                _reserve_section_row(self, a, r.section)
+
+        def _s_live_replay():
+            # Live-replay every intent EXCEPT the routed callouts/locates and section
+            # (furniture, step/boss callouts, dimensions, axes-restricted locates).
+            routed = (
+                r.corridor_ids
+                | r.callout_ids
+                | r.dia_ids
+                | r.len_ids
+                | r.slot_ids
+                | r.height_ladder_ids
+                | r.step_position_ids
+                | r.user_dim_ids
             )
-        # (#636) A0 now only REGISTERS ladder candidates; they place at the B2 drain.
-        # Their intents drop there (with step positions), NOT here — a raise before the
-        # drain leaves them recorded so a retry rebuilds the batch (#639).
-        # A0b — prismatic step positions through the auto-pass renderer (all shoulders).
-        # This only REGISTERS corridor candidates; they place at the B2 drain. Their intents
-        # are dropped there (with locations/slots), NOT here — so a raise before the drain leaves
-        # them recorded and a retry rebuilds the batch from the still-present intents (#639).
-        if step_position_ids:
-            assert a is not None and isinstance(model, PartModel)
-            render_step_positions(self, model, a, ctx=ctx)
-        # A — live-replay every intent EXCEPT the routed callouts/locates and section
-        #     (furniture, step/boss callouts, dimensions, axes-restricted locates).
-        i = 0
-        while i < len(self._intents):
-            it = self._intents[i]
-            if (
-                it.kind == "section"
-                or id(it)
-                in corridor_ids
-                | callout_ids
-                | dia_ids
-                | len_ids
-                | slot_ids
-                | height_ladder_ids
-                | step_position_ids
-                | user_dim_ids
-            ):
-                i += 1
-                continue
-            self._replay_intent(it)  # resilient: a raise leaves the rest recorded
-            self._intents.pop(i)
-        # B1 — hole/pattern callouts through the REAL priority-drop/anchoring solve.
-        #      Furniture is owned by the replayed furniture() intents → place_furniture=False.
-        if only_callout:
-            assert a is not None and isinstance(model, PartModel)  # only_callout ⟹ routable
-            _annotate_holes(
-                self,
-                a,
-                build_view_of_axis(a),
-                plan_dimensions(model),
-                feature_hole_keys(model, a),
-                ctx=ctx,
-                only=only_callout,
-                place_furniture=False,
-            )
-        # Drop the placed callout intents NOW — before the fallible B2 — so a raise in
-        # B2 can't re-route (and, via first-free hc_ naming, duplicate) them on a retry.
-        self._intents = [it for it in self._intents if id(it) not in callout_ids]
-        # B2 — both-axes locations + slots (+ the A0b step positions) through the SHARED
-        #      location corridor — one crossing-free ladder, one drain (auto-pass registers
-        #      locations then slots, then a single drain_corridors, so a slot position
-        #      coincident with a hole location dedups, #345). step_position_ids gates the drain
-        #      too: A0b only *registered* the shoulder candidates, so this drain is what places
-        #      them. Their intents — like locations/slots — are dropped only AFTER the drain
-        #      succeeds, so a raise leaves them recorded for a clean retry (#639).
-        queued_dim_ids = set()
-        if only_loc or slot_feats or user_dim_ids or step_position_ids or height_ladder_ids:
-            assert a is not None and isinstance(model, PartModel)  # either ⟹ routable
-            if only_loc:
-                render_locations(self, model, a, ctx=ctx, only=only_loc, pinned=pinned_loc)
-            if slot_feats:
-                render_slots(self, model, a, ctx=ctx, only=slot_feats)
+            i = 0
+            while i < len(self._intents):
+                it = self._intents[i]
+                if it.kind == "section" or id(it) in routed:
+                    i += 1
+                    continue
+                self._replay_intent(it)  # resilient: a raise leaves the rest recorded
+                self._intents.pop(i)
+
+        def _s_hole_callouts():
+            # Hole/pattern callouts through the REAL priority-drop/anchoring solve.
+            # Furniture is owned by the replayed furniture() intents → place_furniture=False.
+            if r.only_callout:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                _annotate_holes(
+                    self,
+                    a,
+                    build_view_of_axis(a),
+                    plan_dimensions(model),
+                    feature_hole_keys(model, a),
+                    ctx=ctx,
+                    only=r.only_callout,
+                    place_furniture=False,
+                )
+            # Drop the placed callout intents NOW — before the fallible later stages — so
+            # a raise there can't re-route (and, via first-free hc_ naming, duplicate)
+            # them on a retry.
+            self._intents = [it for it in self._intents if id(it) not in r.callout_ids]
+
+        def _s_locations():
+            # Both-axes locations register into the SHARED location corridor with slots,
+            # step positions and the height ladder — one crossing-free ladder, one drain
+            # (the "drain" stage), so a slot position coincident with a hole location
+            # dedups (#345).
+            if r.only_loc:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render_locations(self, model, a, ctx=ctx, only=r.only_loc, pinned=r.pinned_loc)
+
+        def _s_height_ladder():
+            # Prismatic step-height ladder through the auto-pass renderer. (#636) This
+            # only REGISTERS ladder candidates; they place at the drain. Their intents
+            # drop there (with step positions), NOT here — a raise before the drain
+            # leaves them recorded so a retry rebuilds the batch (#639).
+            if r.height_ladder_ids:
+                assert a is not None and isinstance(model, PartModel)
+                render_height_ladder(
+                    self, model, a, ctx=ctx, include_overall=not r.explicit_envelope_height
+                )
+
+        def _s_step_positions():
+            # Prismatic step positions (all shoulders) — registration-only, like the
+            # ladder above; placed and dropped at the drain (#639).
+            if r.step_position_ids:
+                assert a is not None and isinstance(model, PartModel)
+                render_step_positions(self, model, a, ctx=ctx)
+
+        def _s_diameters():
+            # Step/boss ø diameters through render_diameters' set-solve (row-below /
+            # column-left) — placed immediately, before the corridor drain, exactly as
+            # the auto-pass runs it (#699 slice b — the old drain-first order gave the
+            # deferred path different obstacle visibility).
+            if r.only_dia:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render_diameters(self, plan_dimensions(model), ctx=ctx, only=r.only_dia)
+            self._intents = [it for it in self._intents if id(it) not in r.dia_ids]
+
+        def _s_step_lengths():
+            # Turned step-length CHAIN through render_step_lengths (N× collapse /
+            # staggered tiers) — after diameters, as in the auto-pass.
+            if r.only_len:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render_step_lengths(self, plan_dimensions(model), ctx=ctx, only=r.only_len)
+            self._intents = [it for it in self._intents if id(it) not in r.len_ids]
+
+        def _s_slots():
+            # Slots regenerate width + length + the model-derived datum position (a
+            # superset of the recorded slot intents — auto-pass parity by design) and
+            # register into the shared corridor.
+            if r.slot_feats:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render_slots(self, model, a, ctx=ctx, only=r.slot_feats)
+
+        def _s_user_dims():
+            # User-authored pin/priority dimensions queue into the shared corridor as
+            # first-class candidates (ADR 0012).
             used_dim_names: set[str] = set()
             for it in self._intents:
-                if id(it) in user_dim_ids:
+                if id(it) in r.user_dim_ids:
                     if self._queue_dimension_intent(it, a, ctx=ctx, used_names=used_dim_names):
                         queued_dim_ids.add(id(it))
-            drain_corridors(ctx, self)
-            # (#690) Same witness-crossing label reconciliation as the auto-pass drain.
-            reconcile_witness_labels(self)
-        self._intents = [
-            it
-            for it in self._intents
-            if id(it)
-            not in (
-                corridor_ids | slot_ids | queued_dim_ids | step_position_ids | height_ladder_ids
-            )
-        ]
-        # B3 — step/boss ø diameters through render_diameters' set-solve (row-below /
-        #      column-left) — auto-pass S11b, after callouts/locations, before section.
-        if only_dia:
-            assert a is not None and isinstance(model, PartModel)  # only_dia ⟹ routable
-            render_diameters(self, plan_dimensions(model), ctx=ctx, only=only_dia)
-        self._intents = [it for it in self._intents if id(it) not in dia_ids]
-        # B3b — turned step-length CHAIN through render_step_lengths (N× collapse /
-        #       staggered tiers) — auto-pass S11b, after diameters, before section.
-        if only_len:
-            assert a is not None and isinstance(model, PartModel)  # only_len ⟹ routable
-            render_step_lengths(self, plan_dimensions(model), ctx=ctx, only=only_len)
-        self._intents = [it for it in self._intents if id(it) not in len_ids]
-        # C — render the section LAST, reusing the reserved plan (its room check clears
-        #     everything right of the side view; _add_section_view clears the reservation).
-        #     A recorded section with no trigger (_section is None) is a no-op.
-        self._intents = [it for it in self._intents if it.kind != "section"]
-        if _section is not None:
-            assert a is not None
-            _add_section_view(self, a, _section)
-        # D — dense-scattered plan-view holes escalate to the hole TABLE + balloon ring
-        #     (Phase 4c) — LAST, mirroring the auto-pass (_maybe_tabulate_holes runs last in
-        #     _auto_annotate) so the resolver sees the section + title block as obstacles. It
-        #     reads ctx.escalations (the callout/location drops B1/B2 collected) and the
-        #     scattered-hole coverage recorded at the hole emit site even under
-        #     place_furniture=False (#426 Ph4c) to find + replace the plan callouts. The density
-        #     gate counts ALL analysis holes (a.holes), so this is a FULL-reconstruction
-        #     escalation: a partial hand-edit that drops some callout() lines still tabulates the
-        #     full count (documented full-reconstruction scope, #434); the escalations live only
-        #     on this per-run ctx (#639), discarded when finalize returns (#440).
-        if routable:
-            assert a is not None
-            _maybe_tabulate_holes(self, a, ctx=ctx)
+
+        def _s_drain():
+            # One drain places everything the register-only stages queued; the corridor-
+            # routed intents are dropped only AFTER it succeeds, so a raise leaves them
+            # recorded for a clean retry (#639). Includes the #690 label reconciliation,
+            # shared verbatim with the auto-pass (drain_and_reconcile).
+            if (
+                r.only_loc
+                or r.slot_feats
+                or r.user_dim_ids
+                or r.step_position_ids
+                or r.height_ladder_ids
+            ):
+                assert a is not None and isinstance(model, PartModel)  # either ⟹ routable
+                drain_and_reconcile(ctx, self)
+            self._intents = [
+                it
+                for it in self._intents
+                if id(it)
+                not in (
+                    r.corridor_ids
+                    | r.slot_ids
+                    | queued_dim_ids
+                    | r.step_position_ids
+                    | r.height_ladder_ids
+                )
+            ]
+
+        def _s_section():
+            # Render the section, reusing the reserved plan (its room check clears
+            # everything right of the side view; _add_section_view clears the
+            # reservation). A recorded section with no trigger (r.section is None) is a
+            # no-op.
+            self._intents = [it for it in self._intents if it.kind != "section"]
+            if r.section is not None:
+                assert a is not None
+                _add_section_view(self, a, r.section)
+
+        def _s_tabulate():
+            # Dense-scattered plan-view holes escalate to the hole TABLE + balloon ring —
+            # last, so the resolver sees the section + title block as obstacles. It reads
+            # ctx.escalations (the callout/location drops collected above) and the
+            # scattered-hole coverage recorded at the hole emit site even under
+            # place_furniture=False (#426 Ph4c) to find + replace the plan callouts. The
+            # density gate counts ALL analysis holes (a.holes), so this is a FULL-
+            # reconstruction escalation: a partial hand-edit that drops some callout()
+            # lines still tabulates the full count (#434); the escalations live only on
+            # this per-run ctx (#639), discarded when finalize returns (#440).
+            if routable:
+                assert a is not None
+                _maybe_tabulate_holes(self, a, ctx=ctx)
+
+        run_stages(
+            {
+                "reserve_section": _s_reserve_section,
+                "live_replay": _s_live_replay,
+                "hole_callouts": _s_hole_callouts,
+                "locations": _s_locations,
+                "height_ladder": _s_height_ladder,
+                "step_positions": _s_step_positions,
+                "diameters": _s_diameters,
+                "step_lengths": _s_step_lengths,
+                "slots": _s_slots,
+                "user_dims": _s_user_dims,
+                "drain": _s_drain,
+                "section": _s_section,
+                "tabulate": _s_tabulate,
+            }
+        )
 
     def _replay_intent(self, it: Intent) -> None:
         """Place one recorded intent by calling its live verb (#426 Phase 1)."""

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6453,6 +6453,36 @@ class TestFeatureEdits:
         assert dwg._named["user_width"]._dw_spec.distance == 12
         assert dwg._intents == []
 
+    def test_finalize_mixed_corridor_batch_places_each_exactly_once(self):
+        # #699 slice b (Codex review): the drain stages now run in the auto-pass's
+        # canonical _PASS_SEQUENCE order, which moved the register-only height-ladder /
+        # step-position stages AFTER locations. Registration order decides corridor
+        # KEY-creation order (= drain order) and same-priority tie-breaks, so the reorder
+        # is observable — pin the mixed-batch outcome: locations, a height rung, a
+        # shoulder position and a pinned user dimension all competing in one deferred
+        # batch must each place exactly once, with no error-severity lint and nothing
+        # left recorded.
+        part = (
+            Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15) - Pos(20, 15, 0) * Cylinder(3, 30)
+        )
+        dwg = build_drawing(part, auto_dims=False)
+        step = next(f for f in dwg.model().features if f.kind == "step_level")
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        env = next(f for f in dwg.model().features if f.kind == "envelope")
+        with dwg.deferred():
+            dwg.locate(hole)  # the locations corridor (plan/side above)
+            dwg.dimension(step, "length", role="step_height")  # the front-right ladder
+            dwg.dimension(step, "length", role="step_position")  # the shoulder corridor
+            dwg.dimension(  # a pinned user dim joins the same drain (ADR 0012)
+                env, "length", role="width", side="below", name="user_width", pin=True
+            )
+        assert dwg._intents == []  # every routed intent drained
+        assert len([n for n in dwg.annotations() if n.startswith("dim_shoulder")]) == 1
+        assert [n for n in dwg.annotations() if n.startswith("dim_step")]  # rung placed
+        assert {n for n in dwg.annotations_of(hole) if n.startswith("m_loc")}
+        assert "user_width" in dwg.annotations() and "user_width" in dwg._pinned
+        assert [i for i in dwg.lint() if i.severity == "error"] == []
+
     def test_deferred_dimension_generated_names_do_not_collide_in_one_batch(self):
         # #511 review: generated names must be reserved before the corridor drain. Otherwise
         # two same-kind dimensions recorded in one deferred batch both choose dim_length0 and


### PR DESCRIPTION
Slice (b) of #699 (drawing.py re-accretion — item 2: finalize as a second orchestrator). **Does not close #699** — slices c–d follow.

## The problem

`finalize()`'s drain reused the auto-pass render passes but re-encoded their *sequencing* by hand (reserve → A0 ladder → … → D tabulate), with comments admitting the mirroring. A reorder in `_auto_annotate` silently diverged `finalize()` — CLAUDE.md's "no second engine" held for passes but not orchestration.

## The change

- **`annotations/orchestrator.py`** now owns **`_PASS_SEQUENCE`** — one canonical tuple of stage names — plus the shared **`run_stages`** executor (both paths hand it a name→thunk dict; unknown names assert) and **`drain_and_reconcile`** (the drain+#690-reconcile step both paths previously spelled out separately, now shared verbatim; `drain_corridors` resolves at call time so the #647 rollback tests' failure injection via `_common` still works).
- **`_auto_annotate`** executes the list — same stages, same order, same code inside each thunk (comments preserved). **Zero behaviour change on the auto-pass path.**
- **`Drawing._drain_intents`** executes the same list with its routed subset. This reorders the deferred path **toward auto-pass parity**:
  - the turned diameter/step-length set-solves now place **before** the corridor drain (previously drain-first — the deferred path had *different obstacle visibility* than the auto-pass, exactly the divergence class the audit flagged);
  - slots register after them (as the auto-pass does);
  - the registration-only ladder/step-position stages move after the callouts — output-neutral, since the corridor solve orders candidates by feature order, not registration order (ADR 0009), and their post-#636 registration-only comments already said placement happens at the drain.
- All the transactional properties are preserved: intent-drop points ride inside their stages (callouts drop before later fallible stages; corridor-routed intents drop only after the drain succeeds), and finalize's #647 snapshot/rollback wrapper is untouched.
- CHANGELOG Changed entry for the deferred-path reorder; CLAUDE.md orchestrator bullet updated.

## Verification

- 4 lint checks clean (ruff check, ruff format, mypy, codespell)
- Guard suites (import boundaries / encapsulation ratchet / carve callers): 19 passed
- Deferred/finalize/balloon/table targeted selection: 139 passed; smoke: 42 passed
- Full fast tier: **1416 passed**, 3 skipped; only failure is the known pre-existing #710 Hypothesis local-DB replay (identical on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)