### PR TITLE
refactor(#699): fix the state-bus residue writers, widen the guard (slice d)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,10 @@ entry. Keep `_LAYERS` and this section in step.
     analysis, part model, lint's geometry caches) — filled at a single site in
     `builder._assemble`, read through compat properties, single-writer-guarded
     by `test_drawing_encapsulation`. ADR 0005 §2 / #639 closed: `annotations/`
-    has zero private `Drawing` reads (empty allowlist ratchet).)*
+    has zero private `Drawing` reads (empty allowlist ratchet) — and since #699
+    slice d the state-bus guard covers the WHOLE engine: no module but
+    `drawing.py` touches `dwg._*` (rationale-carrying allowlist, builder's
+    fill site only).)*
 - **`annotate.py`** — thin compat facade re-exporting `_auto_annotate` (the
   orchestrator) from `annotations/`. The annotation passes were split into the
   **`annotations/`** subpackage (#164 / ADR 0005, P5):

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -752,18 +752,22 @@ def _title_block_box(dwg, a: Analysis):
 def _add_title_block(dwg, a: Analysis):
     """Add the title block annotation."""
     tb, cell = _make_title_block(dwg, a)
-    dwg.add(tb, "title_block")
 
     # Record that cell's page-space rectangle so export() can place a clickable
     # draftwright hyperlink over the "… / draftwright" author text. The build-frame
-    # cell corners are offset by the block's page location (bx, _TB_CLEAR).
+    # cell corners are offset by the block's page location (bx, _TB_CLEAR). The
+    # rect rides the title-block annotation itself (like ``covers_diameters`` /
+    # ``is_centerline`` riders), NOT an expando poked onto the drawing — the
+    # drawing is not the state bus (#699 slice d); export reads it back via
+    # ``get_annotation("title_block")``, so a removed block drops its link too.
     bx = a.PAGE_W - a.TB_W - _TB_CLEAR
-    dwg._draftwright_link_rect = (
+    tb.draftwright_link_rect = (
         bx + cell["min_x"],
         _TB_CLEAR + cell["min_y"],
         bx + cell["max_x"],
         _TB_CLEAR + cell["max_y"],
     )
+    dwg.add(tb, "title_block")
 
 
 def _iso_bbox(dwg):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2021,7 +2021,7 @@ class Drawing:
         n_arcs = sanitize_svg_arcs(svg_path)
         if n_arcs:
             _log.info("Rewrote %d degenerate (near-zero-radius) arc(s) as line segments", n_arcs)
-        link_rect = getattr(self, "_draftwright_link_rect", None)
+        link_rect = getattr(self.get_annotation("title_block"), "draftwright_link_rect", None)
         if link_rect is not None:
             add_svg_hyperlink(svg_path, link_rect)
         add_svg_metadata(svg_path)
@@ -2113,7 +2113,11 @@ class Drawing:
             if want_set & {"pdf", "png"}:
                 assert svg_path is not None
                 pdf_path = (out if "pdf" in want_set else _intermediate_stem()) + ".pdf"
-                _render_pdf(svg_path, pdf_path, getattr(self, "_draftwright_link_rect", None))
+                _render_pdf(
+                    svg_path,
+                    pdf_path,
+                    getattr(self.get_annotation("title_block"), "draftwright_link_rect", None),
+                )
                 _log.info("PDF → %s", pdf_path)
                 if "pdf" in want_set:
                     paths["pdf"] = pdf_path

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -292,7 +292,7 @@ def lint_location_coverage(
     gap left out of :func:`lint_feature_coverage` (#218).
 
     *dwg* is the drawing, duck-typed: it must offer ``at(view, x, y, z)`` projection,
-    a ``_named`` mapping, and ``_anno_view``. For each hole, project its centre into
+    ``iter_annotations()``, and ``view_of()``. For each hole, project its centre into
     the view normal to its axis (:data:`_END_ON`) and check the placed annotations:
 
     - **centre mark** — a ``CenterMark`` whose centre coincides with the projected
@@ -448,7 +448,7 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     (:func:`_axial_covered_from_drawing`), not a build-time side channel — so it
     judges any producer. A shortfall yields one ``axial_length_missing`` issue.
 
-    *dwg* is the drawing, duck-typed (needs ``at``/``_named``/``_anno_view``).
+    *dwg* is the drawing, duck-typed (needs ``at``/``annotations``/``view_of``).
 
     Covers **X- and Z-axis** turning: both are now located by the unified IR
     step-length chain (ADR 0008 #223), so a missing chain on either is a real gap
@@ -472,9 +472,7 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     # callout on the turning axis as covering its band — so a fully-dimensioned grooved shaft
     # (N−1 step lengths + the groove width) is not flagged (#628); a *dropped* groove callout
     # leaves its band uncovered, so a genuine gap still fires (reconcile rendered, not intent).
-    covered += sum(
-        1 for name in getattr(dwg, "_named", {}) if name.startswith(f"m_groove_{prof.axis}")
-    )
+    covered += sum(1 for name in dwg.annotations() if name.startswith(f"m_groove_{prof.axis}"))
     if covered >= n:
         return []
     return [

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -217,9 +217,13 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     # helpers (>=0.11) cannot project for the oblique iso (pp() needs the full
     # foreshortening basis). Rebuild from the raw viewport so dwg.at("iso", ...)
     # maps world points correctly — also covers an iso re-projected at a
-    # different scale than the sheet.
-    dwg._coords["iso"] = ViewCoordinates.from_viewport(
-        camera, (0, 0, 1), la, a.ISO_X, a.ISO_Y, a.cx, a.cy, a.cz, scale
+    # different scale than the sheet. Through the public override verb, not a
+    # direct _coords poke (#699 slice d).
+    dwg.set_view_coordinates(
+        "iso",
+        ViewCoordinates.from_viewport(
+            camera, (0, 0, 1), la, a.ISO_X, a.ISO_Y, a.cx, a.cy, a.cz, scale
+        ),
     )
 
 

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -27,7 +27,7 @@ def _find_dim(dwg, label):
     """
     # Identity-based, matching clear_annotations: "this specific object", not
     # build123d's geometric Shape equality.
-    pinned_ids = dwg._registry.pinned_object_ids()
+    pinned_ids = dwg.registry.pinned_object_ids()
     for o in dwg.items:
         if id(o) in pinned_ids:
             continue
@@ -42,7 +42,7 @@ def _replace_dim(dwg, old, new):
     if getattr(old, "_dw_scale", None) is not None:
         new._dw_scale = old._dw_scale
     dwg.items[dwg.items.index(old)] = new
-    dwg._registry.replace_object(old, new)
+    dwg.registry.replace_object(old, new)
 
 
 def _repair_dim_inside_part(dwg, issue) -> bool:
@@ -68,7 +68,7 @@ def repair_drawing(dwg, max_iter: int = 3):
         if not before:
             break
         snap_annotations = list(dwg.items)
-        snap_registry = dwg._registry.snapshot()
+        snap_registry = dwg.registry.snapshot()
         changed = False
         for issue in before:
             if issue.code not in _REPAIRABLE_CODES:
@@ -86,7 +86,7 @@ def repair_drawing(dwg, max_iter: int = 3):
         if len(dwg.lint()) > len(before):
             # The repairs net-worsened the sheet — undo this pass and stop.
             dwg.items[:] = snap_annotations
-            dwg._registry.restore(snap_registry)
+            dwg.registry.restore(snap_registry)
             break
     return dwg
 
@@ -128,7 +128,7 @@ def reconcile_witness_labels(dwg) -> int:
         return segs
 
     pad = 1.0  # keep-clear each side of a crossing stroke
-    pinned_ids = dwg._registry.pinned_object_ids()  # a pin is deliberate — never moved (#693 r1)
+    pinned_ids = dwg.registry.pinned_object_ids()  # a pin is deliberate — never moved (#693 r1)
     dims = [
         (name, o)
         for name, o in dwg.iter_annotations()

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -44,8 +44,10 @@ def _anno_sources() -> list[Path]:
 
 
 def _is_dwg(node: ast.AST) -> bool:
-    """Whether *node* is the bare ``dwg`` name (the duck-typed drawing)."""
-    return isinstance(node, ast.Name) and node.id == "dwg"
+    """Whether *node* is a bare conventional drawing-receiver name (``dwg``, or
+    ``drawing`` since the #699 slice-d whole-engine guard — a rename must not be
+    the evasion; see _DRAWING_RECEIVER_NAMES)."""
+    return isinstance(node, ast.Name) and node.id in _DRAWING_RECEIVER_NAMES
 
 
 def _dwg_private_writes(tree: ast.Module) -> list[tuple[int, str]]:
@@ -158,11 +160,16 @@ def test_write_guard_catches_every_mutation_form():
         'dwg._coords["iso"] = v',  # subscript mutation through a private (#699 slice d)
         'del dwg._coords["iso"]',
         'dwg._coords["iso"] += v',
+        "drawing._part_model = m",  # the rename evasion (#699 slice d, Codex review)
     ):
         writes = _dwg_private_writes(ast.parse(snippet))
         assert writes, f"guard missed a mutation form: {snippet!r}"
     # A pure read must NOT register as a write (else every read is a false positive).
     assert not _dwg_private_writes(ast.parse("use(dwg._named)"))
+    # The aliasing evasion is caught as the alias itself (#699 slice d, Codex review):
+    assert _drawing_aliases(ast.parse("d = dwg"))
+    assert _drawing_aliases(ast.parse("if (d := drawing): pass"))
+    assert not _drawing_aliases(ast.parse("d = other"))  # unrelated binds don't flag
 
 
 def test_no_build_context_probing():
@@ -210,9 +217,11 @@ def test_private_reads_are_a_documented_shrinking_allowlist():
 
 
 # The whole-engine guard's sanctioned exceptions (#699 slice d). Keys are file names
-# under src/draftwright/ (drawing.py itself — the owner — is exempt from the scan);
-# values are the private names that file may READ or WRITE on the duck-typed ``dwg``,
-# each with a rationale. May only shrink, like _DWG_PRIVATE_READ_ALLOW.
+# under src/draftwright/, keyed by _SRC-RELATIVE posix path (not basename — a future
+# nested builder.py must not inherit the root builder's exemption, Codex review);
+# drawing.py itself — the owner — is exempt from the scan. Values are the private
+# names that file may READ or WRITE on the duck-typed ``dwg``, each with a
+# rationale. May only shrink, like _DWG_PRIVATE_READ_ALLOW.
 _ENGINE_DWG_PRIVATE_ALLOW: dict[str, frozenset[str]] = {
     # builder._assemble is THE sanctioned build-state fill site (#639): it fills
     # dwg._build.analysis/part_model (a _build READ + field store, pinned exactly by
@@ -221,25 +230,61 @@ _ENGINE_DWG_PRIVATE_ALLOW: dict[str, frozenset[str]] = {
     "builder.py": frozenset({"_build", "_model_declared"}),
 }
 
+# The drawing-receiver naming convention the engine guard matches. The scan is
+# receiver-NAME based (static analysis cannot type a duck-typed parameter), so its
+# guarantee is exactly: no engine module touches ``<receiver>._<name>`` under these
+# conventional names, and no module REBINDS one of them (the aliasing check below
+# fail-closes the ``d = dwg; d._x`` evasion by flagging the alias itself). A
+# drawing passed in under a novel parameter name remains out of static reach —
+# review's job, as the annotations guard has always noted (Codex review, #699 d).
+_DRAWING_RECEIVER_NAMES = ("dwg", "drawing")
+
+
+def _drawing_aliases(tree: ast.Module) -> list[tuple[int, str]]:
+    """Every simple rebinding of a conventional drawing receiver —
+    ``x = dwg`` / ``x = drawing`` (plain or walrus) — as ``(lineno, alias)``.
+    Flagged wholesale in the engine guard: aliasing is the cheap evasion of a
+    receiver-name scan, so the alias itself is the offence."""
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        value = getattr(node, "value", None)
+        if (
+            isinstance(node, (ast.Assign, ast.NamedExpr))
+            and isinstance(value, ast.Name)
+            and value.id in _DRAWING_RECEIVER_NAMES
+        ):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for t in targets:
+                if isinstance(t, ast.Name):
+                    out.append((node.lineno, t.id))
+    return out
+
 
 def test_no_engine_module_touches_drawing_privates():
-    """#699 slice d: the state-bus guard, widened from ``annotations/`` to the WHOLE
+    """#699 slice d: the state-bus guard, widened from ``annotations/`` to the whole
     engine. No module under src/draftwright/ except ``drawing.py`` (the owner) may
-    read or mutate ``dwg._<name>`` privates on the duck-typed drawing — the audit
-    found the coupling class regrowing exactly where the #639 ratchet didn't police
-    (_core's link-rect expando, projection's ``_coords["iso"]`` poke, repair's
-    ``_registry`` reads). Fail-closed with a rationale-carrying allowlist."""
+    read or mutate ``dwg._<name>``/``drawing._<name>`` privates on the duck-typed
+    drawing — the audit found the coupling class regrowing exactly where the #639
+    ratchet didn't police (_core's link-rect expando, projection's
+    ``_coords["iso"]`` poke, repair's ``_registry`` reads). Fail-closed with a
+    rationale-carrying allowlist; rebinding a receiver name (``d = dwg``) is
+    itself an offence, so the scan can't be evaded by a one-line alias. The
+    residual static limit — a drawing arriving under a novel parameter name — is
+    documented at _DRAWING_RECEIVER_NAMES."""
     offenders: list[str] = []
     for path in sorted(_SRC.rglob("*.py")):
         if "__pycache__" in path.parts or path.name == "drawing.py":
             continue
-        allow = _ENGINE_DWG_PRIVATE_ALLOW.get(path.name, frozenset())
+        rel = path.relative_to(_SRC).as_posix()
+        allow = _ENGINE_DWG_PRIVATE_ALLOW.get(rel, frozenset())
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for lineno, attr in _dwg_private_writes(tree):
             if attr not in allow:
-                offenders.append(f"{path.relative_to(_SRC)}:{lineno}: dwg.{attr} mutated")
+                offenders.append(f"{rel}:{lineno}: dwg.{attr} mutated")
         for attr in sorted(_dwg_private_reads(tree) - allow):
-            offenders.append(f"{path.relative_to(_SRC)}: dwg.{attr} read")
+            offenders.append(f"{rel}: dwg.{attr} read")
+        for lineno, alias in _drawing_aliases(tree):
+            offenders.append(f"{rel}:{lineno}: drawing receiver rebound to {alias!r}")
     assert not offenders, (
         "Engine modules must not touch Drawing privates — the drawing is not the state "
         "bus (#699 slice d / ADR 0005 §2). Use the public surface (registry, "

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -65,6 +65,19 @@ def _dwg_private_writes(tree: ast.Module) -> list[tuple[int, str]]:
         ):
             out.append((node.lineno, node.attr))
         elif (
+            # Subscript mutation THROUGH a private: ``dwg._coords["iso"] = …`` /
+            # ``del dwg._x[k]``. The attribute itself is only ever in Load context
+            # here (the dict is loaded, then stored into), so the plain-attribute
+            # branch above misses it — the exact form projection.py used to poke
+            # the iso ViewCoordinates past ``set_view_coordinates`` (#699 slice d).
+            isinstance(node, ast.Subscript)
+            and isinstance(node.ctx, (ast.Store, ast.Del))
+            and isinstance(node.value, ast.Attribute)
+            and _is_dwg(node.value.value)
+            and node.value.attr.startswith("_")
+        ):
+            out.append((node.lineno, node.value.attr))
+        elif (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
             and node.func.id in ("setattr", "delattr")
@@ -142,6 +155,9 @@ def test_write_guard_catches_every_mutation_form():
         'setattr(dwg, "_part_model", m)',
         'delattr(dwg, "_part_model")',
         "(dwg._a, y) = pair",  # tuple-unpack target
+        'dwg._coords["iso"] = v',  # subscript mutation through a private (#699 slice d)
+        'del dwg._coords["iso"]',
+        'dwg._coords["iso"] += v',
     ):
         writes = _dwg_private_writes(ast.parse(snippet))
         assert writes, f"guard missed a mutation form: {snippet!r}"
@@ -190,6 +206,46 @@ def test_private_reads_are_a_documented_shrinking_allowlist():
     assert not stale, (
         "Allowlisted private read(s) no longer used — good, #639 is shrinking. Remove them "
         f"from _DWG_PRIVATE_READ_ALLOW to keep it honest: {sorted(stale)}"
+    )
+
+
+# The whole-engine guard's sanctioned exceptions (#699 slice d). Keys are file names
+# under src/draftwright/ (drawing.py itself — the owner — is exempt from the scan);
+# values are the private names that file may READ or WRITE on the duck-typed ``dwg``,
+# each with a rationale. May only shrink, like _DWG_PRIVATE_READ_ALLOW.
+_ENGINE_DWG_PRIVATE_ALLOW: dict[str, frozenset[str]] = {
+    # builder._assemble is THE sanctioned build-state fill site (#639): it fills
+    # dwg._build.analysis/part_model (a _build READ + field store, pinned exactly by
+    # test_build_state_has_a_single_construction_and_fill_site below) and sets the
+    # ADR 0011 #448 model-declared flag pending its move into BuildState.
+    "builder.py": frozenset({"_build", "_model_declared"}),
+}
+
+
+def test_no_engine_module_touches_drawing_privates():
+    """#699 slice d: the state-bus guard, widened from ``annotations/`` to the WHOLE
+    engine. No module under src/draftwright/ except ``drawing.py`` (the owner) may
+    read or mutate ``dwg._<name>`` privates on the duck-typed drawing — the audit
+    found the coupling class regrowing exactly where the #639 ratchet didn't police
+    (_core's link-rect expando, projection's ``_coords["iso"]`` poke, repair's
+    ``_registry`` reads). Fail-closed with a rationale-carrying allowlist."""
+    offenders: list[str] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        if "__pycache__" in path.parts or path.name == "drawing.py":
+            continue
+        allow = _ENGINE_DWG_PRIVATE_ALLOW.get(path.name, frozenset())
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for lineno, attr in _dwg_private_writes(tree):
+            if attr not in allow:
+                offenders.append(f"{path.relative_to(_SRC)}:{lineno}: dwg.{attr} mutated")
+        for attr in sorted(_dwg_private_reads(tree) - allow):
+            offenders.append(f"{path.relative_to(_SRC)}: dwg.{attr} read")
+    assert not offenders, (
+        "Engine modules must not touch Drawing privates — the drawing is not the state "
+        "bus (#699 slice d / ADR 0005 §2). Use the public surface (registry, "
+        "set_view_coordinates, annotation riders) or thread the value as a parameter; "
+        "a truly-needed exception goes in _ENGINE_DWG_PRIVATE_ALLOW with a rationale:\n  "
+        + "\n  ".join(offenders)
     )
 
 

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -169,6 +169,7 @@ def test_write_guard_catches_every_mutation_form():
     # The aliasing evasion is caught as the alias itself (#699 slice d, Codex review):
     assert _drawing_aliases(ast.parse("d = dwg"))
     assert _drawing_aliases(ast.parse("if (d := drawing): pass"))
+    assert _drawing_aliases(ast.parse("d: object = dwg"))  # annotated form (review r2)
     assert not _drawing_aliases(ast.parse("d = other"))  # unrelated binds don't flag
 
 
@@ -249,7 +250,7 @@ def _drawing_aliases(tree: ast.Module) -> list[tuple[int, str]]:
     for node in ast.walk(tree):
         value = getattr(node, "value", None)
         if (
-            isinstance(node, (ast.Assign, ast.NamedExpr))
+            isinstance(node, (ast.Assign, ast.AnnAssign, ast.NamedExpr))
             and isinstance(value, ast.Name)
             and value.id in _DRAWING_RECEIVER_NAMES
         ):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9140,8 +9140,9 @@ class TestDraftwrightAttribution:
         # against the placed block's bounding box so it catches drift if the rect
         # or the upstream TitleBlock layout ever diverge.
         dwg = build_drawing(Box(60, 40, 20))
-        x0, y0, x1, y1 = dwg._draftwright_link_rect
         tb = dwg.get_annotation("title_block")
+        # The rect rides the title-block annotation (#699 slice d), not the drawing.
+        x0, y0, x1, y1 = tb.draftwright_link_rect
         bb = tb.bounding_box()
         cell = tb.drawn_by_cell_bbox()  # build-frame; block min corner is at bb.min
         assert x1 == pytest.approx(bb.max.X, abs=0.5)  # flush to block right edge


### PR DESCRIPTION
Final slice of #699 — **Closes #699** (slices a #717, b #719, c #721 merged earlier today).

## The residues (audit §4 + one the guard found)

| Site | Was | Now |
|---|---|---|
| `repair.py` (5 sites) | `dwg._registry.…` | public `dwg.registry` |
| `projection.py` | `dwg._coords["iso"] = …` (bypassing the verb) | `dwg.set_view_coordinates("iso", …)` |
| `_core._add_title_block` | `dwg._draftwright_link_rect = …` expando, `getattr`-read in export | the rect rides the **title-block annotation** (`tb.draftwright_link_rect`, like the `covers_diameters`/`is_centerline` riders); export reads it via `get_annotation("title_block")`, so removing the block naturally drops its hyperlink |
| `linting/coverage.py` | `getattr(dwg, "_named", {})` — a 4th site the audit missed; the widened guard caught it | `dwg.annotations()` |

## The widened guard

`test_drawing_encapsulation.py` gains `test_no_engine_module_touches_drawing_privates`: every module under `src/draftwright/` **except `drawing.py`** is AST-scanned for `dwg._<name>` reads and writes, fail-closed, with a rationale-carrying allowlist containing only `builder.py`'s sanctioned build-state fill site (`_build` read + `_model_declared` write, ADR 0011 #448). The mutation detector is also extended to catch **subscript mutation through a private** (`dwg._x[k] = …` / `del dwg._x[k]` / `+=`) — the exact form projection.py used, which the old detector missed — with the new forms pinned in the guard's self-test.

No user-facing behaviour change (the link-rect read is identical for any drawing with a title block; a title-block-less drawing exports without a hyperlink, as before).

## Verification

- 4 lint checks clean; guard suites (incl. the new whole-engine check) pass
- Link-rect/export/coverage targeted selections: 29 + 75 passed
- Full fast tier: **1419 passed**, 3 skipped; only failure is the known pre-existing #710 Hypothesis local-DB replay (identical on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)