### PR TITLE
docs(#697): ADRs 0014/0015 supersede the outgrown 0009/0008

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,25 +263,10 @@ Current ADRs:
   was **retired** here — byte-exact digests are friction during deliberate output
   evolution; regression coverage rests on the geometry-level + `test_e2e_standards`
   suites. See ADR 0005 §3's retirement note.)
-- **0008** — **Accepted, migration complete** (one path, 2026-06-30): the
-  part-drawing **compiler** — detectors → a Feature/DimParameter **IR/PartModel**
-  → a dimensioning **planner** → render-intents → the shared layout/projection/
-  export infra. One feature inventory, detected once; orientation/feature-kind are
-  *data in the IR*, not code branches. Roadmaps: `docs/plans/0008-*-roadmap.md`.
-- **0009** — **Accepted, largely implemented** (Amendments 1–9; supersedes/
-  subsumes #150): **collect-then-solve** per-strip annotation placement
-  (boundary labeling). Strip passes stop placing-as-they-go;
-  every strip occupant is collected as a candidate and one solve per strip does
-  select → assign → order(=feature order ⇒ crossing-free) → space. Removes the
-  invisible-occupant collision class (#133/#225/#305) by construction; the inner
-  per-view layer to 0004's outer block packing; consumes 0008's render-intents.
-  **Migration complete** (#636 closed, epic #635): every auto-pass strip
-  occupant joins the solve, so the by-construction guarantee holds; the
-  remaining `carve_free_position` callers are explicit exemptions (post-drain
-  fallthroughs, manual post-build verbs, the diagonal pitch fallback) pinned by
-  the fail-closed `tests/test_carve_free_position_callers.py`.
-  Research: `docs/research/annotation-placement-boundary-labeling.md`. Roadmap:
-  `docs/plans/strip-layout-boundary-labeling-roadmap.md`.
+- **0008** — **Superseded by 0015** (#697): the compiler-convergence why-trail,
+  frozen. Read 0015 for current state.
+- **0009** — **Superseded by 0014** (#697): the collect-then-solve why-trail
+  (9 amendments), frozen. Read 0014 for current state.
 - **0010** — **Accepted** (decision; work pending): **annotation provenance seam**.
   The editable-surface epic needs "which annotations did this feature/intent
   produce?" (for `drop`/`dimension`/`finalize`/the #400 emitter). Rather than
@@ -323,6 +308,19 @@ Current ADRs:
   the deferred Phase-2 deployment (gated on a second committed consumer).
   Remaining Phase 1: the typed `detect.py` adapter registry (roadmap item 1c).
   Roadmap: `docs/plans/0013-shared-recognisers-roadmap.md`.
+- **0014** — **Accepted** (supersedes 0009, #697): **collect-then-solve
+  annotation placement as built** — collect every strip occupant as a
+  candidate; one solve per strip (select → order(=feature order ⇒
+  crossing-free) → space, the PAVA L1 solve); post-#636 the guarantee holds for
+  every auto-pass occupant, with the `carve_free_position` exemptions pinned
+  fail-closed. Includes the strip/zone/corridor glossary and the
+  StripCandidate↔CorridorCandidate layering.
+- **0015** — **Accepted** (supersedes 0008, #697): **the part-drawing compiler
+  as built** — detectors + declared features → the one PartModel waist (two
+  tiers, ADR 0013) → planner → render-intents → shared infra; with the
+  **honest planner-coverage split** (which kinds flow through `plan_dimensions`
+  vs bypass it — convergence tracked by #698) and the lint/coverage carve-out
+  stated properly. New feature kinds must take the planner path.
 
 ## Dependencies
 

--- a/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
+++ b/docs/adr/0008-unified-feature-model-and-dimensioning-planner.md
@@ -1,6 +1,12 @@
 # ADR 0008 — The part-drawing compiler: a Feature/DimParameter IR and a dimensioning planner
 
-- **Status:** Accepted — **migration complete; one path** (2026-06-30). The
+- **Status:** **Superseded by [ADR 0015](0015-part-drawing-compiler-as-built.md)**
+  (2026-07-18, #697). After 8 amendments — two of which existed only as status
+  bullets, and a "Current decision" section predating the last of them — 0015
+  restates the compiler shape as-built in one clean pass (including the honest
+  planner-coverage split, #698). This file is **frozen** as the historical
+  why-trail — do not amend it further; changes go to 0015.
+- **Original status:** Accepted — **migration complete; one path** (2026-06-30). The
   correctness-judged strangler converged on ONE feature→dimension path (Amendment 3),
   which *feeds* the engine's shared layout/table/section/projection/export
   infrastructure rather than reabsorbing it (Amendment 4), **through an IR-typed

--- a/docs/adr/0009-boundary-labeling-strip-placement.md
+++ b/docs/adr/0009-boundary-labeling-strip-placement.md
@@ -1,7 +1,12 @@
 # ADR 0009 — Boundary labeling: collect-then-solve per-strip annotation placement
 
-- **Status:** Accepted (2026-06-30)
+- **Status:** **Superseded by [ADR 0014](0014-collect-then-solve-annotation-placement.md)**
+  (2026-07-18, #697). After 9 amendments + 2 dated notes this record's instructed
+  reading path (header first) yielded stale state; 0014 restates the current
+  collect-then-solve decision in one clean pass. This file is **frozen** as the
+  historical why-trail — do not amend it further; changes go to 0014.
 - **Deciders:** Paul Fremantle (pzfreo)
+- **Originally accepted:** 2026-06-30
 
 ## Current decision (as amended, 2026-07-18)
 

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -1,0 +1,218 @@
+# ADR 0014 — Collect-then-solve annotation placement (as built)
+
+- **Status:** Accepted (2026-07-18). **Supersedes
+  [ADR 0009](0009-boundary-labeling-strip-placement.md)** (#697): after 9
+  amendments + 2 dated notes, 0009 no longer functioned as a decision record —
+  its base Decision text described a solver that was later retired and a phase
+  that shipped differently. This ADR states the collect-then-solve placement
+  model **as it exists in the code today**, in one pass. 0009 is frozen as the
+  historical why-trail; read it for *why* each piece evolved, never for current
+  state. Changes go here.
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context (short — the full story is 0009's)
+
+A recurring defect class (#133/#225/#305: the "invisible occupant" — one strip,
+several placers, no shared occupancy model) motivated a control-flow inversion:
+render passes stop committing geometry as they run, and instead **collect**
+every strip occupant as a candidate so **one solve per strip** places the whole
+set. This is boundary labeling (Bekos et al. 2007); the research backing is
+[`research/annotation-placement-boundary-labeling.md`](../research/annotation-placement-boundary-labeling.md).
+The migration is complete (#636, epic #635): the guarantee below now holds for
+every automatic-pass strip occupant **by construction**.
+
+## Decision — the model as built
+
+Per view, per strip: **collect → solve → emit.**
+
+- **Collect.** Each render pass measures its render-intents (ADR 0008 / ADR
+  0015) into candidates and *registers* them — `register_corridor` queues a
+  `CorridorCandidate` into the run's `PlacementContext.corridor_batch`
+  (`annotations/_common.py`), keyed by `(view, side)` — instead of calling
+  `dwg.add(...)` mid-flight. Failures are first-class `Escalation` objects on
+  `ctx.escalations` (kind/view/feature/reason/remedies), resolved by one
+  resolver pass (`_maybe_tabulate_holes`, `annotations/orchestrator.py`) — not
+  stringly-typed lint greps.
+- **Solve.** `drain_corridors` runs once, after every corridor-feeding pass has
+  registered, and executes one `solve_corridor` per strip:
+  - **Select** — dedup coincident spans by `(dedup, precedence)` (the
+    higher-precedence measurement survives; a dropped winner promotes its top
+    loser); over capacity, `plan_strip` (`layout.py`) drops the lowest
+    `(priority, key)` — a ranked selection, not an arrival-order drop.
+  - **Assign** — the original multi-side assign step was evaluated (P2/#322)
+    and **not needed**: each pass picks its candidate's strip before solving,
+    with alternate-side fallthroughs in `on_drop` callbacks. What survives as
+    assignment is (a) segment assignment within a carved strip
+    (`carve_free_segments` + innermost-first fill in
+    `place_strip_candidates`), and (b) the balloon pass's genuinely global
+    band assignment — a deterministic min-cost max-flow solve
+    (`_assign_balloon_bands`, `layout.py`, #516).
+  - **Order** — label order along the strip = site/feature order (candidates
+    sort by anchor coordinate, ties by key), so leaders are **crossing-free by
+    construction**; corridor candidates additionally carry an `order` key
+    segregating size dims from the monotonic datum-location ladder (#346).
+  - **Space** — the deterministic minimum-total-leader-length **L1 solve**:
+    `_solve_strip_1d_pava` (`layout.py`), weighted-median PAVA with per-pair
+    gaps, a global box clamp, and a fixed *lower-median* tie convention —
+    deterministic by construction (ADR 0001), pure standard library.
+    **Anchoring** (`StripCandidate.anchored` → `_ANCHOR_WEIGHT`) pins a
+    candidate at its natural position while the rest flow around it; it is a
+    spacing hint, not a drop immunity.
+- **Emit.** `place_strip_candidates` carves the strip around the *complete*
+  occupancy (`strip_obstacles` — full rendered footprints, decomposed per
+  stroke since #685, not label boxes), evaluates candidates on analytical or
+  probe footprints (`dim_footprint`, #602 — no OCC build per probe), then
+  builds each survivor **once** and re-validates its real box (corridor
+  blockers, the `forbid` title-block box, out-of-band obstacles) — a
+  prediction miss degrades to a later-segment retry, never a collision.
+  Feature provenance is recorded at this drain seam
+  (`CorridorCandidate.feature` → `dwg.add(..., feature=)`, ADR 0010).
+
+**One stage order, two entry paths.** `_PASS_SEQUENCE`
+(`annotations/orchestrator.py`, #699 slice b) is the single canonical stage
+tuple; both `_auto_annotate` and the finalize drain (`Drawing._drain_intents`)
+hand their stage dicts to the shared `run_stages` executor, so neither path can
+run a stage the sequence does not name, nor in a private order. The `"drain"`
+stage is `drain_and_reconcile` — `drain_corridors` followed by
+`reconcile_witness_labels` (#690, label shifts for witness crossings) — shared
+verbatim by both paths. `drain_corridors` also coordinates view corners:
+before each strip solves, the innermost-tier footprints of not-yet-drained
+same-view siblings' **force** candidates join its obstacles, and `on_drop`
+fallthroughs are deferred via `ctx.post_drain` until every strip has drained.
+
+**Policy B** (two-precedent pattern, ratified 2026-07-02 — 0009 Amendment 2):
+when avoiding an occupant would cost more than a bounded relocation, keep the
+annotation at its natural position and accept a visible, logged crossing —
+never an unbounded search, never a silent drop of a real annotation for a
+placement reason alone. Realised as `force=True` candidates (a second
+`place_strip_candidates` pass that skips the corridor check) and the permanent
+`BENIGN`/`SPACE-CONSTRAINED` entries in `tests/test_layout_cleanliness.py`'s
+`_KNOWN_OVERLAPS` (only `PENDING` entries are debt).
+
+## The by-construction guarantee and its exemptions
+
+Every automatic-pass strip occupant is a candidate in the shared solve, so the
+invisible-occupant collision class cannot recur — *provided* no pass regresses
+onto the solver-invisible single-position carve (`carve_free_position`,
+`annotations/_common.py`). A **fail-closed guard**
+(`tests/test_carve_free_position_callers.py`, `_ALLOWED_CALLERS`) pins the
+only permitted callers; any new caller anywhere under `annotations/` trips it.
+The current allowlist, each an explicit exemption:
+
+- **`_place_pitch_dim`** (`holes.py`) — *permanent*: the pitch fallback
+  searches an arbitrary diagonal outward vector, so its dim cannot occupy a
+  1-D axis-aligned strip tier and cannot be a solve candidate at all.
+- **`render_gdt`** and **`render_plates`** (`from_model.py`) — primary
+  placement *is* a corridor candidate; the carve runs only in a
+  `ctx.post_drain`-deferred drop fallthrough, after every corridor has drained
+  (so it cannot preempt a sibling's reserved corner).
+- **`add_feature_callout`** / **`add_feature_location`** (`holes.py`) — manual
+  post-build verbs: a single user-driven annotation onto a *finished* sheet,
+  where every occupant is already placed and there is no shared drain to join
+  (the #426 manual-edit half; cousins of the ADR 0012-exempt `place_dim`).
+
+A genuine new exemption must be recorded **in this list first**, then added to
+the allowlist (the guard's failure message cites the ADR 0009 note this
+section replaces).
+
+## Glossary — one concept, three names
+
+- **Strip** — the geometric record: `_core.Strip`, a 1-D annotation band
+  adjacent to a view (`anchor`/`outer_limit`/`direction`/`gap`/`spacing`).
+  The mutable `allocate` cursor is retired (#150); placers read its bounds via
+  `strip_free_span` and carve.
+- **Zone** — the per-view grouping of strips: `_core.ViewZones`
+  (`right`/`above`/`below`/`left`), instantiated by `analysis.py` as
+  `fv_zones`/`pv_zones`/`sv_zones`. "Zone" names the collection, "strip" the
+  individual band — same objects, two vantage points.
+- **Corridor** — a strip viewed as a *shared solve domain across passes*: the
+  `(view, side)`-keyed batch in `PlacementContext.corridor_batch`. The name
+  entered with the first cross-pass unification (#345/#346, 0009 Amendment 6)
+  and stuck for the register/drain machinery. Caution: `corridor_blockers`
+  uses the same word for a different thing — the 2-D *witness corridor* a
+  right/below dim occupies between the view edge and its dim line, which the
+  1-D strip carve cannot represent and which is checked separately.
+
+Two candidate types, layered — the outer wraps the inner:
+
+- **`StripCandidate`** (`layout.py`) — the geometry-only solver input: `key`,
+  `anchor`, `size`, `priority`, `anchored`. It *is* a measured render-intent:
+  the collect step (in `annotations/`, which may depend on the IR) projects
+  intent → page geometry and hands the solver only that, so `layout.py` stays
+  a leaf with no IR dependency. A few passes build these directly (the
+  concentric-bore leader stack in `from_model.py`).
+- **`CorridorCandidate`** (`annotations/_common.py`) — the rich render-intent
+  carrier for the cross-pass corridors: a `build(pos) → Dimension` closure,
+  the ladder `order` key, `dedup`/`precedence`, `priority`,
+  `anchored`/`natural` (how ADR 0012 pinned edits join), `force` (policy B),
+  `feature` provenance, real `size` footprint (wide occupants — a ~24×6 mm
+  GD&T frame — reserve their true extent, #61), the `forbid` box, the
+  analytical `footprint`, and `on_place`/`on_drop` callbacks carrying each
+  pass's own bookkeeping.
+
+The boundary: `solve_corridor` → `place_strip_candidates` constructs
+per-segment `StripCandidate`s → `plan_strip` → `_solve_strip_1d_pava`. Above
+that line the code knows the drawing, closures, and lint; from `plan_strip`
+down it knows only numbers.
+
+## Dropped from 0009, deliberately
+
+- **The solver-library evaluation** (0009 Amendment 3's 10-row table): the
+  history in one line — the original Cassowary/`kiwisolver`
+  constraint-satisfaction solve and its `scipy.optimize.linprog` replacement
+  were *both* retired (non-unique L1 optima broke cross-platform determinism
+  on day one) for the dependency-free weighted-median PAVA that shipped
+  (`_solve_strip_1d_pava`). Neither `kiwisolver` nor `scipy` is a dependency.
+  0009 Amendments 3–4 hold the full evaluation and post-mortem.
+- **The banded-PAVA DP** (0009 Amendment 5): retired by Amendment 9 (#381).
+  `plan_strip` has no keep-out-band parameter; a reserved row (centre-line,
+  location-dim extension) is an ordinary interval in the caller's
+  `carve_free_segments` carve, like any other obstacle.
+- **Rotted line references.** 0009 cited `holes.py` line numbers that no
+  longer resolve. This ADR cites files and symbol/test names only.
+- **The amendment trail.** The nine amendments and the migration phase issues
+  (#317–#323, #351, #318, #345/#346, #61, #524, #381, #636) stay in 0009 as
+  the why-trail; this ADR does not restate them.
+
+## Relationships
+
+- **ADR 0001 / 0002** — determinism is why the solve is an exact, explainable
+  algorithm ("label *i* sits here because order + min-gap + shortest leader"),
+  never a metaheuristic; repair stays a peephole safety net (it no longer
+  touches `annotation_overlap`).
+- **ADR 0003** (still Accepted) — the constraint-based inner-layout frame this
+  ADR realises for the strips. The carrier is `StripCandidate`/`plan_strip`,
+  not 0003's original `Placeable`/`LayoutSolver` (deleted unused, #547 — see
+  0003's 2026-07-10 correction); the deferred global 2-D solve (#94) remains
+  deferred.
+- **ADR 0004** — the **outer** layer: compose-then-pack keeps view blocks
+  disjoint; this ADR is the **inner** per-view layer whose deterministic
+  annotation boxes are exactly the block footprints 0004 packs.
+- **ADR 0008 / [ADR 0015](0015-part-drawing-compiler-as-built.md)** — the
+  planner's render-intents are what the collect phase measures into
+  candidates; 0015 restates that compiler shape (superseding 0008 in the same
+  #697 sweep).
+- **ADR 0010** — provenance is recorded once at the drain seam
+  (`CorridorCandidate.feature`), not tagged through every pass.
+- **ADR 0012** — the user-edit layer **on this same solve**: `dimension(...,
+  pin=, priority=)` intents become corridor candidates (`anchored=pin`), re-run
+  by `Drawing.finalize()` through the same `_PASS_SEQUENCE`/drain. Not
+  restated here — 0012 is current.
+- Roadmap: [`plans/strip-layout-boundary-labeling-roadmap.md`](../plans/strip-layout-boundary-labeling-roadmap.md);
+  research note as above. Guard tests:
+  `tests/test_carve_free_position_callers.py`,
+  `tests/test_layout_cleanliness.py`.
+
+## Consequences (standing, not aspirational)
+
+- The invisible-occupant collision class is removed by construction; the
+  fail-closed guard keeps it removed.
+- Deterministic, explainable, dependency-free placement; over-capacity is a
+  priority-ranked selection with first-class escalation, not an arrival-order
+  drop.
+- Honest edges that remain: placement is per-view (cross-view contention rests
+  on ADR 0004); AABB occupancy is deliberately conservative for diagonal
+  leaders (the precise `_geometry._segment_crosses_box` test covers leader
+  shafts); and a perpendicular-axis conflict — a witness line crossing a
+  fixed-height label — is outside the 1-D tier solve's reach, handled by the
+  post-drain `reconcile_witness_labels` shift (#690).

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -48,9 +48,12 @@ Per view, per strip: **collect → solve → emit.**
     band assignment — a deterministic min-cost max-flow solve
     (`_assign_balloon_bands`, `layout.py`, #516).
   - **Order** — label order along the strip = site/feature order (candidates
-    sort by anchor coordinate, ties by key), so leaders are **crossing-free by
-    construction**; corridor candidates additionally carry an `order` key
-    segregating size dims from the monotonic datum-location ladder (#346).
+    sort by anchor coordinate), so leaders between **distinct** strip-axis
+    coordinates are **crossing-free by construction**; coincident sites
+    tie-break by key for determinism, which is not crossing-optimal
+    (`plan_strip`'s own docstring carries the same qualifier). Corridor
+    candidates additionally carry an `order` key segregating size dims from
+    the monotonic datum-location ladder (#346).
   - **Space** — the deterministic minimum-total-leader-length **L1 solve**:
     `_solve_strip_1d_pava` (`layout.py`), weighted-median PAVA with per-pair
     gaps, a global box clamp, and a fixed *lower-median* tie convention —
@@ -91,10 +94,12 @@ placement reason alone. Realised as `force=True` candidates (a second
 
 ## The by-construction guarantee and its exemptions
 
-Every automatic-pass strip occupant is a candidate in the shared solve, so the
-invisible-occupant collision class cannot recur — *provided* no pass regresses
-onto the solver-invisible single-position carve (`carve_free_position`,
-`annotations/_common.py`). A **fail-closed guard**
+Every **non-exempt** automatic-pass strip occupant is a candidate in the shared
+solve; the exempt placements below run only *after* the drain (or off the strip
+axes entirely), so they see the completed occupancy rather than racing it. That
+is what removes the invisible-occupant collision class — *provided* no pass
+regresses onto the solver-invisible single-position carve
+(`carve_free_position`, `annotations/_common.py`). A **fail-closed guard**
 (`tests/test_carve_free_position_callers.py`, `_ALLOWED_CALLERS`) pins the
 only permitted callers; any new caller anywhere under `annotations/` trips it.
 The current allowlist, each an explicit exemption:

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -1,0 +1,195 @@
+# ADR 0015 — The part-drawing compiler, as built
+
+- **Status:** Accepted. **Supersedes [ADR 0008](0008-unified-feature-model-and-dimensioning-planner.md).**
+- **Date:** 2026-07-18
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Why a superseding ADR
+
+ADR 0008 accumulated eight amendments; the last two exist only as status-header
+bullets, and the header's "Current decision" summary has had to be re-synced
+against the trail more than once (#696/#697). Per the project rule (past ~3–4
+amendments, supersede), this ADR restates the compiler architecture **as it is
+actually built today** — including where the code has *not* yet converged on
+0008's stated end state — in one clean pass. 0008 is marked Superseded; its
+amendment trail remains the historical record of *how* the shape was reached
+(contract refinement → out-grow strategy → one-path convergence → IR/infra
+boundary → one inventory → IR-typed interface → two-tier waist → the lint
+carve-out). Nothing in that trail is re-litigated here.
+
+## The compiler shape
+
+The part-drawing engine is a **compiler**:
+
+```
+  recognisers (recognition/)          declared features (model/declare.py)
+        │  geometry-only records            │  ADR 0011: the caller supplies
+        │  (ADR 0013 contract)              │  the features it already knows
+        ▼                                   ▼
+  model/detect.py ──────────────► PART MODEL — the IR waist ◄──────────────
+        adapters: record → Feature   (model/ir.py: Feature / DimParameter /
+                                      Datum / PartModel; frozen dataclasses)
+                                            │
+  dimensioning planner (model/planner.py)   │  plan_dimensions → DimensionGroup
+  plan_locations / plan_sections            │  per feature; convention + view +
+                                            ▼  model-level suppression + datum
+  render-intents → the IR render layer (annotations/from_model.py, holes.py)
+                                            │
+  shared layout / projection / export  (ADR 0014 placement, ADR 0004 pack,
+                                        projection.py, export.py — fed, never absorbed)
+```
+
+The load-bearing properties, all live in the code today:
+
+1. **One feature inventory, detected once — regardless of `auto_dims`.**
+   `analysis._analyse` runs the recognisers once and builds the `PartModel` up
+   front, so **page/scale sizing reads the same feature model the renderers do**
+   (`sizing_model` → `plan_dimensions` feeds the `compose.py` estimators;
+   detected and declared parts share one sizing path). `builder._assemble`
+   attaches that model to the `Drawing` *before* the `auto_dims` gate, so
+   `dwg.model()` and the feature-edit verbs work even in manual mode; the
+   orchestrator (`annotations/orchestrator.py`) reads the attached model rather
+   than rebuilding, and `builder.detect_part_model` exposes the same
+   detect-only path as a cheap seed (`Sheet.from_part`).
+2. **Orientation and feature kind are data in the IR**, never code branches in
+   the back-end: `Feature.frame` carries the axis; the planner derives a
+   group's view from it by one rule (`_END_ON`), so X and Z are symmetric.
+   (One residue: `planner._group_view` special-cases `kind == "step"` → front —
+   flagged in #698.)
+3. **The waist is two tiers.** The lower tier is the geometry-only recognition
+   record produced under the uniform `recognise_<feature>` contract (ADR 0013);
+   the upper tier is the dimensioning IR `Feature`. They are joined by the
+   `model/detect.py` adapters. The typed per-record **adapter registry** there
+   is decided but pending — that is **ADR 0013 Phase 1, roadmap item 1c**, not
+   this ADR; `detect.py` today remains bespoke per-feature translators. No
+   recognition object crosses the boundary in either state.
+4. **Two front doors, one waist.** Detection (`model/detect.py`, from
+   `recognition/`) and declaration (`model/declare.py`, ADR 0011:
+   `hole`/`boss`/`step`/… constructors that read a feature's size off the
+   build123d object, or take explicit values) both emit the **same** IR
+   `Feature` types into the same `PartModel`. Everything downstream is
+   producer-blind.
+5. **The IR→infrastructure boundary is IR-typed** (0008 Am 6, kept): shared
+   services take model-space locations, `DimParameter`s, feature kinds, and
+   frozen value keys (`HoleRef`), enforced by their signatures. The shared
+   layout/table/section/projection/export machinery is *fed* by render-intents,
+   never reabsorbed (0008 Am 4, kept).
+
+## The planner, honestly: what flows through it and what bypasses it
+
+0008 §3 claimed "one rule set over DimParameters … uniformly". As built, that
+centralisation covers a **core, not the whole surface** — the 2026-07-18 audit
+finding, tracked as **#698**. `orchestrator._auto_annotate` calls
+`plan_dimensions` exactly once and threads the `DimensionGroup`s to every
+renderer that reads them; but a majority of feature kinds are rendered by
+passes that take the `model` and format raw feature fields directly, ignoring
+the groups the orchestrator computed for them.
+
+**Planner-fed today** (the renderer consumes `DimensionGroup`s from
+`plan_dimensions`, or another planner entry point):
+
+| Feature kind(s) | Renderer (annotations/) | Planner entry |
+| --- | --- | --- |
+| holes / patterns (bore, counterbore, spotface, thread, BCD, pitch) | `holes._annotate_holes` (+ centre marks via `from_model.render_centermarks`) | `plan_dimensions` |
+| hole / pattern locations | `from_model.render_locations` | `plan_locations` (refs + datum) |
+| turned diameters (ø leaders, row/column) | `from_model.render_diameters` | `plan_dimensions` |
+| boss diameters | `from_model.render_boss_diameters` | `plan_dimensions` |
+| envelope (overall W/D/L, with model-level suppression) | `from_model.render_envelope` | `plan_dimensions` |
+| turned step lengths (the chain) | `from_model.render_step_lengths` | `plan_dimensions` |
+| section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |
+
+**Planner-bypassing today** (the renderer takes `model`, re-filters
+`model.features` by kind, and formats raw fields — its computed
+`DimensionGroup`s are discarded):
+
+- `render_slots`, `render_chamfers`, `render_fillets`, `render_flats`,
+  `render_pockets`, `render_grooves`, `render_plates`, `render_rotational`
+  (OD/centreline/bore furniture), `render_pmi` — all in
+  `annotations/from_model.py`.
+- `render_height_ladder` and `render_step_positions` are also model-routed,
+  **by design**: `StepLevelFeature` carries correlated sets that must never be
+  flattened into independent dims, so group-per-feature is the wrong shape for
+  them. Their model-routing is sanctioned, not debt.
+- `render_gdt` is model-routed and **out of the planner's scope by design**:
+  `ControlFrame`/`DatumRef`/`Finish` (ADR 0011 P2b) are placement intents, not
+  `DimParameter`-bearing features — there is nothing for `plan_dimensions` to
+  plan.
+
+**Why the bypass list matters** (from #698, adversarially verified): the
+planner is where authored decorations fold onto the parameter
+(`plan_dimensions` merges `model.decorations` into `DimParameter.tolerance`),
+so a bypassed kind silently drops an authored tolerance — the exact #629 bug
+class already fixed for bosses, latent in the bypassed passes. And ISO 129
+no-double-dimensioning/suppression rules currently have no single home
+(`detect.py` exclusions, `planner._suppression`, per-renderer collapses).
+`_CONVENTION` in `planner.py` has entries only for the planner-fed roles.
+
+**The convergence tracker is #698** — extend `_CONVENTION` +
+`plan_dimensions` kind-by-kind (chamfer, fillet, flat, groove, pocket, plate,
+slots first) and convert each renderer to consume its group, pulling the
+scattered suppression rules into the planner as each kind migrates. This ADR
+deliberately does **not** claim that work done; it records the split so the
+ADR stays true while #698 proceeds. New feature kinds must take the planner
+path, not add to the bypass list.
+
+## The lint/coverage carve-out
+
+0008's Amendment 8 established this but never gave it a body; stated properly:
+
+**One path deliberately keeps reading recognised geometry instead of the IR,
+and that is correct — not a boundary violation.** `linting/coverage.py`
+(`lint_feature_coverage`) answers "is every feature that physically *exists*
+dimensioned?". It runs the recognisers itself (`recognise_holes`,
+`recognise_turned_steps`, `analyse_cylinders`, …) for the ground truth, and
+reads the **placed drawing** (dimension witness endpoints, callout labels —
+`_dim_vertices`) for what was actually drawn — never a build-time side
+channel, and never the plan. Sourcing coverage from the dimensioning plan
+would be circular: a feature the planner (or a bypassing renderer) omitted
+would never be flagged. Coverage reading recognition is the check *working*.
+Structurally, `linting/` stays a leaf with **no `draftwright.model` import**
+(machine-checked by `tests/test_import_boundaries.py`), so the carve-out
+cannot silently widen into IR coupling. The only other place recognition
+records cross is the sanctioned `build_part_model` boundary itself.
+
+## What this ADR does not restate
+
+- **ADR 0011** — the IR as a *public input* (declare features, `model=`, the
+  `Sheet` façade, tolerance/fit/GD&T aspects). 0015 only records that
+  declaration is the second front door into the same waist.
+- **ADR 0013** — the uniform recogniser contract and the pending typed
+  adapter registry in `detect.py` (Phase 1 item 1c), plus the deferred shared
+  `b123d-recognisers` package. The intake tier's rules live there.
+- **ADR 0014** — placement (superseding ADR 0009's collect-then-solve strip
+  record). The planner emits *intents*; how they are placed is entirely 0014's
+  concern (as 0004 owns the outer pack).
+
+## Consequences
+
+- New shapes remain **new `Feature` types + a detector and/or declare
+  constructor**, never new back-end branches — with the added, explicit rule
+  that their rendering goes through `plan_dimensions` (#698), so the planner's
+  coverage grows instead of shrinking.
+- The duplicate-recogniser and orientation-gate bug classes stay designed out
+  (one inventory, axis-as-data).
+- The ADR now matches the code: readers get the real planner coverage and the
+  real state of the adapter protocol, instead of 0008's aspirational
+  "migration complete — one rule set".
+
+## Supersession
+
+ADR 0008 is **Superseded by this ADR**. Its status header, decision text, and
+Amendments 1–8 are frozen as the historical record of the convergence; consult
+them for the *why* trail (strategy pivots, the retired equivalence gates, the
+boundary decisions), not for current state. Step 1 of the original 0008
+(unified Z step recognition, #191/#193) stands.
+
+## Related
+
+- #697 — the audit item mandating this supersession (and ADR 0014's).
+- #698 — the planner-bypass audit finding; the convergence epic this ADR's
+  coverage table tracks.
+- #699 — the one canonical `_PASS_SEQUENCE` shared by the auto-pass and
+  `finalize()` (orchestrator `run_stages`), which orders the passes named
+  above.
+- `docs/plans/0008-convergence-roadmap.md` — the historical migration plan of
+  record under 0008.

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -67,8 +67,14 @@ The load-bearing properties, all live in the code today:
    `recognition/`) and declaration (`model/declare.py`, ADR 0011:
    `hole`/`boss`/`step`/… constructors that read a feature's size off the
    build123d object, or take explicit values) both emit the **same** IR
-   `Feature` types into the same `PartModel`. Everything downstream is
-   producer-blind.
+   `Feature` types into the same `PartModel`, so no renderer branches on
+   feature *types* by producer. Downstream is not fully producer-**blind**,
+   though: one declared-provenance flag survives — `builder.build_drawing`
+   synthesises rotational/PMI features for a caller-declared model (a declared
+   turned shaft must render with the same furniture detection produces, #472)
+   and records `model_declared`, which the orchestrator reads to widen the
+   hole-callout membership set to declared positions detection missed
+   (ADR 0011 #448). The flag gates *parity behaviours*, not divergent paths.
 5. **The IR→infrastructure boundary is IR-typed** (0008 Am 6, kept): shared
    services take model-space locations, `DimParameter`s, feature kinds, and
    frozen value keys (`HoleRef`), enforced by their signatures. The shared
@@ -146,8 +152,10 @@ reads the **placed drawing** (dimension witness endpoints, callout labels —
 channel, and never the plan. Sourcing coverage from the dimensioning plan
 would be circular: a feature the planner (or a bypassing renderer) omitted
 would never be flagged. Coverage reading recognition is the check *working*.
-Structurally, `linting/` stays a leaf with **no `draftwright.model` import**
-(machine-checked by `tests/test_import_boundaries.py`), so the carve-out
+Structurally, `linting/` has **no `draftwright.model` import** — machine-checked
+by the dedicated `test_linting_does_not_import_model` guard in
+`tests/test_import_boundaries.py` (the general layer rule alone would permit
+linting→model, so the carve-out gets its own fail-closed assertion) — so it
 cannot silently widen into IR coupling. The only other place recognition
 records cross is the sanctioned `build_part_model` boundary itself.
 

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -460,3 +460,18 @@ def test_geometry_is_a_leaf():
     submodules, relative = _draftwright_imports(_SRC / "_geometry.py")
     assert submodules == set()
     assert relative == []
+
+
+def test_linting_does_not_import_model():
+    """``linting/`` must not import ``draftwright.model`` (ADR 0015's lint/coverage
+    carve-out): coverage reads recognised geometry + the placed drawing for ground
+    truth, never the dimensioning IR — sourcing coverage from the plan would be
+    circular (a feature the planner omitted would never be flagged). The general
+    `_LAYERS` DAG rule alone would PERMIT linting→model (model ranks below), so
+    this dedicated assertion pins the carve-out (#697 review)."""
+    for path in sorted((_SRC / "linting").glob("*.py")):
+        submodules, _ = _draftwright_imports(path)
+        assert "model" not in submodules, (
+            f"{path.name} imports draftwright.model — the lint/coverage carve-out "
+            "(ADR 0015) forbids IR coupling in linting/"
+        )


### PR DESCRIPTION
Closes #697 (2026-07-18 audit).

## What

- **ADR 0014 — collect-then-solve annotation placement (as built)**, superseding 0009 (843 lines / 9 amendments / 2 dated notes). One clean pass of the current model: collect → solve (select/order/space with the actual symbols — `register_corridor`/`solve_corridor`/`plan_strip`/`_solve_strip_1d_pava`) → emit; the post-#636 by-construction guarantee with the *real* current `carve_free_position` exemption list; the audit-requested **glossary** (strip/zone/corridor — one concept, three names, plus the `corridor_blockers` false-friend) and the `StripCandidate`↔`CorridorCandidate` layering with the exact wrap chain; the reversed Amendment-3 solver evaluation compressed to one line. File+symbol references only — no line numbers to rot.
- **ADR 0015 — the part-drawing compiler, as built**, superseding 0008 (8 amendments, two body-less). The two-front-door waist (detect + declare), the five load-bearing properties verified against code, and the **honest planner-coverage split**: 8 kinds planner-fed, 9 bypassing (`render_slots`/`chamfers`/`fillets`/`flats`/`pockets`/`grooves`/`plates`/`rotational`/`pmi`), 3 model-routed *by design* (`height_ladder`/`step_positions` correlated sets; `gdt` has no DimParameters) — with #698 as the convergence tracker and the explicit rule that new kinds take the planner path. Also gives 0008's Amendment 8 (the lint/coverage carve-out) the body it never had.
- 0008/0009 marked **Superseded**, frozen as why-trails with forward pointers; CLAUDE.md's ADR list updated (0008/0009 collapsed to pointers; 0014/0015 added).

## Judgment calls

- The issue's 4th checkbox ("consider normalising the status-field format corpus-wide") is **deliberately not done**: cosmetic churn across ten stable files, real review cost, no behavioural payoff.
- Both drafts were verified claim-by-claim against current code; notable stale-in-0009 findings (Cassowary named in the base Decision, the never-shipped multi-side assign step, `dwg._escalations`, the PMI-after-drain claim) are corrected in 0014 rather than patched into the frozen 0009.
- One claim in the issue itself was stale: 0008's "Current decision" on main is dated 2026-07-13 *with* the Am 8 carve-out sentence; what was genuinely missing was a body for Am 8 — 0015 supplies it.

## Verification

Docs-only + CLAUDE.md: codespell clean across docs/adr/ and CLAUDE.md; smoke tier 42 passed (no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)