### PR TITLE
feat(#724): route chamfer dimensions through the planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@
 
 ### Fixed
 
+- **Authored chamfer tolerances now render** (#724 / #698): `render_chamfers`
+  consumes the planner's `DimensionGroup` (chamfer joins `_CONVENTION` as a
+  leader), so a `decorations`-authored ± / limit tolerance on a chamfer leg
+  reaches the placed callout (`C12 ±0.2`). Previously the pass formatted raw
+  feature fields and silently dropped it — the latent #629 bug class the ADR
+  0015 bypass list documents. Untolerated chamfer labels/views are unchanged.
 - **`model.chamfer(face=…)` rejects a non-planar face** (#704): the declared
   front-end silently accepted a curved face (`normal_at()` does not fail on
   one) and read garbage legs off it — e.g. a fillet or countersink face became

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -102,13 +102,14 @@ the groups the orchestrator computed for them.
 | boss diameters | `from_model.render_boss_diameters` | `plan_dimensions` |
 | envelope (overall W/D/L, with model-level suppression) | `from_model.render_envelope` | `plan_dimensions` |
 | turned step lengths (the chain) | `from_model.render_step_lengths` | `plan_dimensions` |
+| chamfers (C{leg} / {leg}×{angle}° leader, #724) | `from_model.render_chamfers` | `plan_dimensions` |
 | section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |
 
 **Planner-bypassing today** (the renderer takes `model`, re-filters
 `model.features` by kind, and formats raw fields — its computed
 `DimensionGroup`s are discarded):
 
-- `render_slots`, `render_chamfers`, `render_fillets`, `render_flats`,
+- `render_slots`, `render_fillets`, `render_flats`,
   `render_pockets`, `render_grooves`, `render_plates`, `render_rotational`
   (OD/centreline/bore furniture), `render_pmi` — all in
   `annotations/from_model.py`.
@@ -131,8 +132,9 @@ no-double-dimensioning/suppression rules currently have no single home
 `_CONVENTION` in `planner.py` has entries only for the planner-fed roles.
 
 **The convergence tracker is #698** — extend `_CONVENTION` +
-`plan_dimensions` kind-by-kind (chamfer, fillet, flat, groove, pocket, plate,
-slots first) and convert each renderer to consume its group, pulling the
+`plan_dimensions` kind-by-kind (chamfer landed first, #724; fillet, flat,
+groove, pocket, plate, slots next) and convert each renderer to consume its
+group, pulling the
 scattered suppression rules into the planner as each kind migrates. This ADR
 deliberately does **not** claim that work done; it records the split so the
 ADR stays true while #698 proceeds. New feature kinds must take the planner

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -915,14 +915,16 @@ def env_dim_placed(pd) -> bool:
     return pd is not None and not pd.suppressed and pd.param.span is not None
 
 
-def _chamfer_label(ch) -> str:
+def _chamfer_label(leg, ch) -> str:
     """The chamfer callout string: ``C{leg}`` for an equal-leg 45° chamfer, else
-    ``{leg} × {angle}°`` (#560). Formatting lives in the render layer, not on the IR
-    feature — every other feature's label is formed by the planner/renderer too, so a
-    ``ChamferFeature`` stays pure data (ADR 0013 §7)."""
-    if abs(ch.leg1 - ch.leg2) < 0.05 and abs(ch.angle - 45.0) < 0.5:
-        return f"C{_fmt(ch.leg1)}"
-    return f"{_fmt(ch.leg1)} × {_fmt(ch.angle)}°"
+    ``{leg} × {angle}°`` (#560). *leg* is the PLANNED value (``pd.param.value`` —
+    the planner-authoritative number, #724 review); the feature supplies only the
+    geometric *form* discriminators (``leg2``/``angle``). Formatting lives in the
+    render layer, not on the IR feature — every other feature's label is formed by
+    the planner/renderer too, so a ``ChamferFeature`` stays pure data (ADR 0013 §7)."""
+    if abs(leg - ch.leg2) < 0.05 and abs(ch.angle - 45.0) < 0.5:
+        return f"C{_fmt(leg)}"
+    return f"{_fmt(leg)} × {_fmt(ch.angle)}°"
 
 
 # ── Shared machined-feature leader-callout pass (#637) ──────────────────────────────────
@@ -1014,11 +1016,12 @@ def render_chamfers(dwg, groups, a, *, ctx) -> int:
     diagonally OUT of the corner the chamfer sits on into clear margin, and is dropped
     (lint, not silently) if it would overprint placed geometry. Returns the count placed.
 
-    Planner-fed (#724 / #698): the leg + its tolerance come from the planner's
+    Planner-fed (#724 / #698): the leg VALUE + its tolerance come from the planner's
     ``DimParameter`` (as in ``render_boss_diameters``), never raw geometry — formatting
-    ``ch.leg1`` directly dropped an authored chamfer tolerance (the #629 class). The
-    C-vs-leg×angle *form* stays geometric (:func:`_chamfer_label` reads legs/angle off the
-    feature); ``g.view`` is safe because a ChamferFeature's frame axis IS its edge axis
+    ``ch.leg1`` directly dropped an authored chamfer tolerance (the #629 class). The dim
+    is bound explicitly by ``(role, kind)``, never positionally. Only the C-vs-leg×angle
+    *form* discriminators (``leg2``/``angle``) read off the feature;
+    ``g.view`` is safe because a ChamferFeature's frame axis IS its edge axis
     (both ``detect.py`` and ``declare.chamfer`` build ``Frame(…, ch.axis)``), and
     ``_END_ON`` matches the pass's old z→plan / x→side / y→front map exactly."""
     draft = dwg.draft
@@ -1029,8 +1032,14 @@ def render_chamfers(dwg, groups, a, *, ctx) -> int:
         sorted(chamfer_groups, key=lambda g: (g.feature.axis, g.feature.frame.origin))
     ):
         ch = g.feature
-        pd = g.dims[0]
-        if pd.suppressed:
+        # Bind the intended planned dim EXPLICITLY by (role, kind), never dims[0]
+        # (#724 review): the pattern the remaining #698 migrations copy must not
+        # silently grab the wrong dimension on a multi-parameter kind.
+        pd = next(
+            (d for d in g.dims if (d.param.role, d.param.kind) == ("chamfer", "length")),
+            None,
+        )
+        if pd is None or pd.suppressed:
             continue
         view = g.view
         vb = dwg.view_bounds(view)
@@ -1041,7 +1050,7 @@ def render_chamfers(dwg, groups, a, *, ctx) -> int:
                 f"m_chamfer_{ch.axis}{i}",
                 view,
                 vb,
-                _chamfer_label(ch) + _tol_suffix(pd.param.tolerance, draft),
+                _chamfer_label(pd.param.value, ch) + _tol_suffix(pd.param.tolerance, draft),
                 _corner_candidates(dwg, view, vb, [ch], reach),
             )
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1007,20 +1007,32 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
     return n
 
 
-def render_chamfers(dwg, model, a, *, ctx) -> int:
+def render_chamfers(dwg, groups, a, *, ctx) -> int:
     """Chamfer callouts (#560): a leader from each recognised chamfer face to its
     ``C{leg}`` / ``{leg}×{angle}°`` label, in the view normal to the chamfered edge (a Z
     edge reads in the plan, an X edge in the side, a Y edge in the front). The leader runs
     diagonally OUT of the corner the chamfer sits on into clear margin, and is dropped
-    (lint, not silently) if it would overprint placed geometry. Returns the count placed."""
-    reach = _leader_callout_reach(dwg.draft)
-    view_of = {"z": "plan", "x": "side", "y": "front"}
-    chamfers = [f for f in model.features if f.kind == "chamfer"]
+    (lint, not silently) if it would overprint placed geometry. Returns the count placed.
+
+    Planner-fed (#724 / #698): the leg + its tolerance come from the planner's
+    ``DimParameter`` (as in ``render_boss_diameters``), never raw geometry — formatting
+    ``ch.leg1`` directly dropped an authored chamfer tolerance (the #629 class). The
+    C-vs-leg×angle *form* stays geometric (:func:`_chamfer_label` reads legs/angle off the
+    feature); ``g.view`` is safe because a ChamferFeature's frame axis IS its edge axis
+    (both ``detect.py`` and ``declare.chamfer`` build ``Frame(…, ch.axis)``), and
+    ``_END_ON`` matches the pass's old z→plan / x→side / y→front map exactly."""
+    draft = dwg.draft
+    reach = _leader_callout_reach(draft)
+    chamfer_groups = [g for g in groups if g.feature_kind == "chamfer"]
     jobs = []
-    for i, ch in enumerate(sorted(chamfers, key=lambda f: (f.axis, f.frame.origin))):
-        view = view_of.get(ch.axis)
-        if view is None:
+    for i, g in enumerate(
+        sorted(chamfer_groups, key=lambda g: (g.feature.axis, g.feature.frame.origin))
+    ):
+        ch = g.feature
+        pd = g.dims[0]
+        if pd.suppressed:
             continue
+        view = g.view
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
@@ -1029,7 +1041,7 @@ def render_chamfers(dwg, model, a, *, ctx) -> int:
                 f"m_chamfer_{ch.axis}{i}",
                 view,
                 vb,
-                _chamfer_label(ch),
+                _chamfer_label(ch) + _tol_suffix(pd.param.tolerance, draft),
                 _corner_candidates(dwg, view, vb, [ch], reach),
             )
         )

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -364,7 +364,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     def _s_chamfers():
         # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.
-        render_chamfers(dwg, _model, a, ctx=ctx)
+        # Planner-fed (#724): consumes the DimensionGroups so an authored tolerance renders.
+        render_chamfers(dwg, _groups, a, ctx=ctx)
 
     def _s_fillets():
         render_fillets(dwg, _model, a, ctx=ctx)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -47,6 +47,7 @@ _CONVENTION = {
     ("bolt_circle", "diameter"): "leader",  # BCD (a pitch-circle diameter)
     ("pitch", "length"): "pitch",  # linear-array pitch — distinct from a plain linear dim
     ("grid_pitch", "length"): "pitch",
+    ("chamfer", "length"): "leader",  # C{leg} / {leg}×{angle}° leader callout (#724)
 }
 
 

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -347,7 +347,7 @@ class TestChamfer:
         part = Box(90, 60, 10) + Pos(0, 0, 10) * Box(50, 40, 10)
         dwg = build_drawing(part, model=[chamfer(axis="z", leg=6, at=(25, 20, 10))], number="X")
         chs = [f for f in dwg.model().features if f.kind == "chamfer"]
-        assert len(chs) == 1 and _chamfer_label(chs[0]) == "C6"
+        assert len(chs) == 1 and _chamfer_label(chs[0].leg1, chs[0]) == "C6"
 
     def test_needs_axis_at_and_leg(self):
         with pytest.raises(ValueError):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -578,7 +578,7 @@ class TestChamferCallout:
         dwg = build_drawing(chamfer(e, 6), number="X")
         chamfers = [f for f in dwg.model().features if f.kind == "chamfer"]
         assert len(chamfers) == 1
-        assert _chamfer_label(chamfers[0]) == "C6"
+        assert _chamfer_label(chamfers[0].leg1, chamfers[0]) == "C6"
 
     def test_hex_prism_side_faces_are_not_chamfers(self):
         # #560 review: a polygon prism's oblique sides are REAL faces, not chamfers — they
@@ -642,7 +642,7 @@ class TestChamferCallout:
         dwg = build_drawing(chamfer(e, 2.5), number="X")
         chamfers = [f for f in dwg.model().features if f.kind == "chamfer"]
         assert len(chamfers) == 1
-        assert _chamfer_label(chamfers[0]) == "C2.5"
+        assert _chamfer_label(chamfers[0].leg1, chamfers[0]) == "C2.5"
 
 
 class TestFlatCallout:

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -247,6 +247,32 @@ class TestChamferTolerance:
         ]
         assert labels == ["C12"], labels
 
+    def test_renderer_displays_the_planned_value_not_the_raw_field(self):
+        # #724 review: the renderer must be planner-AUTHORITATIVE — the displayed leg is
+        # pd.param.value, and the dim is bound by (role, kind), never dims[0]. Feed
+        # render_chamfers a hand-built group whose planned value deliberately differs
+        # from the feature's raw leg1 (and carries a decoy first dim) and assert the
+        # label shows the planned value. This is the seam the remaining #698 kind
+        # migrations copy.
+        from dataclasses import replace
+
+        from draftwright.annotations._common import PlacementContext
+        from draftwright.annotations.from_model import render_chamfers
+
+        ch = chamfer(axis="z", leg=12, at=(39, 24, 0))
+        dwg = build_drawing(self._chamfered_plate(), model=[ch], number="X", auto_dims=False)
+        (g,) = [g for g in plan_dimensions(dwg.model()) if g.feature_kind == "chamfer"]
+        (pd,) = g.dims
+        decoy = replace(pd, param=replace(pd.param, role="decoy", value=99.0))
+        planned = replace(pd, param=replace(pd.param, value=7.0))  # ≠ ch.leg1 == 12
+        g2 = replace(g, dims=(decoy, planned))
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        assert render_chamfers(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_chamfer")
+        ]
+        assert labels == ["7 × 45°"], labels  # planned 7 ≠ leg2 12 → leg×angle form
+
 
 class TestToleranceHandle:
     def test_hole_tolerance_survives_feature_replacement(self):

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -9,13 +9,14 @@ into the label string, matching what ``Dimension(tolerance=…)`` formats (helpe
 precision (1 dp today), so tests use tolerances that survive 1 dp.
 """
 
-from build123d import Box, Cylinder, Pos, Rot
+from build123d import Axis, Box, Cylinder, Pos, Rot
+from build123d import chamfer as b3d_chamfer
 from build123d_drafting.helpers import draft_preset
 
-from draftwright import Sheet
+from draftwright import Sheet, build_drawing
 from draftwright._core import _tol_suffix
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.model import PartModel, hole, step
+from draftwright.model import PartModel, chamfer, hole, step
 from draftwright.model.planner import plan_dimensions
 
 
@@ -77,6 +78,23 @@ class TestPlannerDecorations:
         model = PartModel(bbox=part.bounding_box(), orientation="x", features=[st])
         groups = plan_dimensions(model)
         assert all(pd.param.tolerance is None for pd in groups[0].dims)
+
+    def test_chamfer_dim_is_leader_with_folded_tolerance(self):
+        # #724: the chamfer leg routes through the planner — convention "leader", with an
+        # authored decoration folded onto DimParameter.tolerance like every planner-fed kind.
+        ch = chamfer(axis="z", leg=12, at=(39, 24, 0))
+        model = PartModel(
+            bbox=Box(90, 60, 20).bounding_box(),
+            orientation=None,
+            features=[ch],
+            decorations={(ch, "length"): 0.2},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "chamfer")
+        (pd,) = g.dims
+        assert pd.convention == "leader"
+        assert pd.param.tolerance == 0.2
+        assert not pd.suppressed
+        assert g.view == "plan"  # frame axis == edge axis; a Z-edge chamfer reads in the plan
 
 
 class TestCalloutRendering:
@@ -191,6 +209,43 @@ class TestSheetTolerance:
 
         assert any(n.startswith("hc_plan") for n in dwg.annotations())
         assert "callout_dropped" not in {i.code for i in dwg.lint()}
+
+
+class TestChamferTolerance:
+    """#724 (the #629 class, latent): a chamfer's authored tolerance must render on the
+    placed callout — the pass now consumes the planner's DimensionGroup, whose param
+    carries the folded decoration, instead of formatting raw feature fields."""
+
+    @staticmethod
+    def _chamfered_plate():
+        plate = Box(90, 60, 20)
+        e = plate.edges().filter_by(Axis.Z).sort_by(lambda e: e.center().X + e.center().Y)[-1]
+        return b3d_chamfer(e, 12)
+
+    def test_authored_chamfer_tolerance_renders_on_callout(self):
+        # Declared model (ADR 0011): the caller holds the feature object, so the
+        # decoration keys on it. (Sheet.chamfer returns the Sheet, not an aspect handle,
+        # so build_drawing(model=…, decorations=…) is the authoring surface here.)
+        ch = chamfer(axis="z", leg=12, at=(39, 24, 0))  # bevel midpoint of the cut corner
+        dwg = build_drawing(
+            self._chamfered_plate(),
+            model=[ch],
+            decorations={(ch, "length"): 0.2},
+            number="X",
+        )
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_chamfer")
+        ]
+        assert labels == ["C12 ±0.2"], labels
+
+    def test_untolerated_chamfer_label_unchanged(self):
+        # No decoration → the planner path is byte-identical to the old raw-field label.
+        ch = chamfer(axis="z", leg=12, at=(39, 24, 0))
+        dwg = build_drawing(self._chamfered_plate(), model=[ch], number="X")
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_chamfer")
+        ]
+        assert labels == ["C12"], labels
 
 
 class TestToleranceHandle:


### PR DESCRIPTION
Closes #724 — the first kind-migration child of epic #698 (ADR 0015's planner-coverage convergence). This PR sets the pattern for #725–#730.

## What

- `_CONVENTION` gains `("chamfer", "length"): "leader"`; `plan_dimensions` now plans chamfer groups whose dims carry the folded authored tolerance.
- `render_chamfers` consumes `DimensionGroup`s instead of re-filtering `model.features` — following the `render_boss_diameters` precedent ("never raw geometry"). The label's geometric form (`C{leg}` vs `{leg}×{angle}°`) still reads off the feature; the value's ± tolerance now comes from the planner's `DimParameter` via `_tol_suffix`.
- **The latent #629-class bug is fixed for chamfers**: an authored tolerance on a chamfer was silently dropped (the planner's decoration folding was unreachable); now it renders (`"C12 ±0.2"`), pinned by an end-to-end test through the declared-model path plus a planner unit test. Untolerated labels are byte-identical (also pinned).
- View selection now uses the planner's `g.view`: verified safe because both front doors construct `Frame(…, ch.axis)` (frame axis == edge axis by construction) and `_END_ON` matches the old per-pass map exactly — reasoning recorded in the renderer docstring.
- ADR 0015's coverage table updated (chamfer: bypass → planner-fed); CHANGELOG Fixed entry.

## Verification

- 4 lint checks clean; targeted `chamfer or tolerance or planner`: 69 passed; guard suites: 21 passed; smoke: 42
- Full fast tier: **1423 passed**, 3 skipped; only failure is the known pre-existing #710 Hypothesis local-DB replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)