### PR TITLE
feat(#698): route fillet, flat, groove, pocket dimensions through the planner (batch 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@
 
 ### Fixed
 
+- **Authored fillet, flat, groove and pocket tolerances now render**
+  (#725/#726/#727/#728 / #698): the four leader-callout kinds join `_CONVENTION`
+  and their renderers (`render_fillets`/`render_flats`/`render_grooves`/
+  `render_pockets`) consume the planner's `DimensionGroup`s, binding each
+  planned dim explicitly by `(role, kind)` — so a `decorations`-authored ± /
+  limit tolerance reaches the placed callout (`R8 ±0.1`, `17 ±0.2 A/F`,
+  `4 ±0.1 WIDE × ø16 ±0.5`, `18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP`; on a
+  multi-value label each suffix rides its own number). Previously all four
+  passes formatted raw feature fields and silently dropped it — the latent #629
+  bug class the ADR 0015 bypass list documents. The fillet `n× R` and flat
+  double-D/hex collapses stay render-side (first-authored tolerance wins, the
+  `render_diameters` precedent); a pocket's three values share one authored
+  tolerance (all kind `"length"`). Untolerated labels/views are unchanged.
 - **Authored chamfer tolerances now render** (#724 / #698): `render_chamfers`
   consumes the planner's `DimensionGroup` (chamfer joins `_CONVENTION` as a
   leader), so a `decorations`-authored ± / limit tolerance on a chamfer leg

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -103,14 +103,17 @@ the groups the orchestrator computed for them.
 | envelope (overall W/D/L, with model-level suppression) | `from_model.render_envelope` | `plan_dimensions` |
 | turned step lengths (the chain) | `from_model.render_step_lengths` | `plan_dimensions` |
 | chamfers (C{leg} / {leg}×{angle}° leader, #724) | `from_model.render_chamfers` | `plan_dimensions` |
+| fillets (R{radius} / n× R leader, #725) | `from_model.render_fillets` | `plan_dimensions` |
+| flats ({across} A/F leader, #726) | `from_model.render_flats` | `plan_dimensions` |
+| grooves ({width} WIDE × ø{diameter} leader, #727) | `from_model.render_grooves` | `plan_dimensions` |
+| pockets (W × L × D DEEP leader, #728) | `from_model.render_pockets` | `plan_dimensions` |
 | section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |
 
 **Planner-bypassing today** (the renderer takes `model`, re-filters
 `model.features` by kind, and formats raw fields — its computed
 `DimensionGroup`s are discarded):
 
-- `render_slots`, `render_fillets`, `render_flats`,
-  `render_pockets`, `render_grooves`, `render_plates`, `render_rotational`
+- `render_slots`, `render_plates`, `render_rotational`
   (OD/centreline/bore furniture), `render_pmi` — all in
   `annotations/from_model.py`.
 - `render_height_ladder` and `render_step_positions` are also model-routed,
@@ -132,8 +135,9 @@ no-double-dimensioning/suppression rules currently have no single home
 `_CONVENTION` in `planner.py` has entries only for the planner-fed roles.
 
 **The convergence tracker is #698** — extend `_CONVENTION` +
-`plan_dimensions` kind-by-kind (chamfer landed first, #724; fillet, flat,
-groove, pocket, plate, slots next) and convert each renderer to consume its
+`plan_dimensions` kind-by-kind (chamfer landed first, #724; fillet/flat/
+groove/pocket followed, #725–#728; plate, slots next) and convert each
+renderer to consume its
 group, pulling the
 scattered suppression rules into the planner as each kind migrates. This ADR
 deliberately does **not** claim that work done; it records the split so the

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1103,15 +1103,18 @@ def render_fillets(dwg, groups, a, *, ctx) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
+        # First-AUTHORED tolerance wins: scan `members` in planner/model order (the
+        # render_diameters precedent — Codex review), not the spatially-sorted
+        # `ordered`, whose winner would change if the geometry moved.
         tol = next(
-            (pd.param.tolerance for _, pd in ordered if pd.param.tolerance is not None), None
+            (pd.param.tolerance for _, pd in members if pd.param.tolerance is not None), None
         )
         jobs.append(
             (
                 f"m_fillet_{axis}{gi}",
                 view,
                 vb,
-                _fillet_label(ordered[0][1].param.value, len(ordered)) + _tol_suffix(tol, draft),
+                _fillet_label(members[0][1].param.value, len(ordered)) + _tol_suffix(tol, draft),
                 _corner_candidates(dwg, view, vb, [g.feature for g, _ in ordered], reach),
             )
         )
@@ -1160,15 +1163,17 @@ def render_flats(dwg, groups, a, *, ctx) -> int:
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
+        # First-AUTHORED tolerance wins (planner/model order, not spatial — see the
+        # fillet pass / render_diameters precedent, Codex review).
         tol = next(
-            (pd.param.tolerance for _, pd in ordered if pd.param.tolerance is not None), None
+            (pd.param.tolerance for _, pd in members if pd.param.tolerance is not None), None
         )
         jobs.append(
             (
                 f"m_flat_{axis}{gi}",
                 view,
                 vb,
-                _flat_label(ordered[0][1].param.value, _tol_suffix(tol, draft)),
+                _flat_label(members[0][1].param.value, _tol_suffix(tol, draft)),
                 _corner_candidates(dwg, view, vb, [g.feature for g, _ in ordered], reach),
             )
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1202,13 +1202,17 @@ def _ray_exit_dist(px, py, ux, uy, rect) -> float:
     return max(min([t for t in ts if t > 0], default=0.0), 0.0)
 
 
-def _pocket_label(pk) -> str:
-    """The pocket callout string: ``{width} × {length} × {depth} DEEP`` (#148a). The ISO
-    depth glyph (↧) is drawn as geometry by the helper's hole callouts, not as font text —
-    a plain :class:`Leader` label has no access to it, so this uses the font-safe ``DEEP``
-    word (the vendored Plex Mono lacks ↧). Formatting lives in the render layer (ADR
-    0013 §7)."""
-    return f"{_fmt(pk.width)} × {_fmt(pk.length)} × {_fmt(pk.depth)} DEEP"
+def _pocket_label(width, length, depth, wsfx="", lsfx="", dsfx="") -> str:
+    """The pocket callout string: ``{width} × {length} × {depth} DEEP`` (#148a). The values
+    are the PLANNED ones (``pd.param.value``, #728); *wsfx*/*lsfx*/*dsfx* are each value's
+    pre-formatted tolerance suffix, interleaved so a tolerance rides its own number. (All
+    three params share kind ``"length"``, so today one authored decoration folds onto all
+    three — the per-value suffixes render that honestly; independent tolerancing needs an
+    authoring-surface change, #698.) The ISO depth glyph (↧) is drawn as geometry by the
+    helper's hole callouts, not as font text — a plain :class:`Leader` label has no access
+    to it, so this uses the font-safe ``DEEP`` word (the vendored Plex Mono lacks ↧).
+    Formatting lives in the render layer (ADR 0013 §7)."""
+    return f"{_fmt(width)}{wsfx} × {_fmt(length)}{lsfx} × {_fmt(depth)}{dsfx} DEEP"
 
 
 # Unit lead directions tried (nearest-clear wins), diagonals first so a central pocket's
@@ -1244,18 +1248,38 @@ def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0):
         yield (tip, elbow, feature)
 
 
-def render_pockets(dwg, model, a, *, ctx) -> int:
+def render_pockets(dwg, groups, a, *, ctx) -> int:
     """Blind-recess callouts (#148a): a leader from each floored slot/pocket to its
     ``W × L × D DEEP`` label, in the view normal to the recess opening (a Z-depth pocket
     reads in the plan, an X-depth in the side, a Y-depth in the front). A pocket sits
     mid-face, so — unlike a corner chamfer — the leader is tried toward each margin
     direction (nearest clear wins) and the callout is dropped (lint, not silently) if none
-    lands in clear room. Returns the count placed."""
-    reach = _leader_callout_reach(dwg.draft)
+    lands in clear room. Returns the count placed.
+
+    Planner-fed (#728 / #698): the multi-parameter case — width, length AND depth in one
+    label — so EACH value + its tolerance is bound explicitly by its ``(role, kind)``
+    (``pocket_width``/``pocket_length``/``pocket_depth``, all kind ``"length"``), never
+    positionally, never ``dims[0]``. Formatting ``pk.width``… directly dropped an authored
+    tolerance (the #629 class). The pass KEEPS its own axis→view map: ``g.view`` keys on
+    the frame axis, which is the pocket's LONG axis, but the callout reads in the view
+    normal to the DEPTH axis — not identical, so the map stays."""
+    draft = dwg.draft
+    reach = _leader_callout_reach(draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
-    pockets = [f for f in model.features if f.kind == "pocket"]
+    pocket_groups = [g for g in groups if g.feature_kind == "pocket"]
     jobs = []
-    for i, pk in enumerate(sorted(pockets, key=lambda f: (f.width_axis, f.frame.origin))):
+    for i, g in enumerate(
+        sorted(pocket_groups, key=lambda g: (g.feature.width_axis, g.feature.frame.origin))
+    ):
+        pk = g.feature
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        wpd = by_key.get(("pocket_width", "length"))
+        lpd = by_key.get(("pocket_length", "length"))
+        dpd = by_key.get(("pocket_depth", "length"))
+        if wpd is None or lpd is None or dpd is None:
+            continue
+        if wpd.suppressed or lpd.suppressed or dpd.suppressed:
+            continue
         view = view_of.get(pk.depth_axis)
         if view is None:
             continue
@@ -1267,7 +1291,14 @@ def render_pockets(dwg, model, a, *, ctx) -> int:
                 f"m_pocket_{pk.width_axis}{pk.long_axis}{i}",
                 view,
                 vb,
-                _pocket_label(pk),
+                _pocket_label(
+                    wpd.param.value,
+                    lpd.param.value,
+                    dpd.param.value,
+                    wsfx=_tol_suffix(wpd.param.tolerance, draft),
+                    lsfx=_tol_suffix(lpd.param.tolerance, draft),
+                    dsfx=_tol_suffix(dpd.param.tolerance, draft),
+                ),
                 _radial_candidates(dwg, view, vb, pk, reach),
             )
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1064,37 +1064,55 @@ def _fillet_label(radius, count) -> str:
     return f"{count}× {r}" if count > 1 else r
 
 
-def render_fillets(dwg, model, a, *, ctx) -> int:
+def render_fillets(dwg, groups, a, *, ctx) -> int:
     """Fillet radius callouts (#561): a leader from an external edge fillet to its
     ``R{radius}`` label — the arc analog of :func:`render_chamfers`. Equal-radius fillets on
     the same edge axis share ONE ``n× R`` callout (#561 acceptance), placed in the view
     normal to the rounded edge, led diagonally out of the corner into clear margin, and
-    dropped (lint, not silently) if it would overprint placed geometry. Returns the count."""
-    reach = _leader_callout_reach(dwg.draft)
-    view_of = {"z": "plan", "x": "side", "y": "front"}
-    fillets = [f for f in model.features if f.kind == "fillet"]
-    groups: dict = {}
-    for fl in fillets:
-        groups.setdefault((fl.axis, round(fl.radius, 3)), []).append(fl)
+    dropped (lint, not silently) if it would overprint placed geometry. Returns the count.
+
+    Planner-fed (#725 / #698): the radius VALUE + its tolerance come from the planner's
+    ``DimParameter`` (as in ``render_chamfers``), bound explicitly by ``(role, kind)``,
+    never positionally — formatting ``fl.radius`` directly dropped an authored tolerance
+    (the #629 class). The equal-radius ``n× R`` COLLAPSE stays render-side (grouping by
+    ``(axis, value)`` here, as before) — planner-side grouping is a structural change,
+    explicitly out of scope for this migration (#698). Where grouped members' authored
+    tolerances differ, the first (member-order) authored one wins — the documented
+    ``render_diameters`` shared-ø precedent. ``g.view`` is safe: a FilletFeature's frame
+    axis IS its edge axis (both ``detect.py`` and ``declare.fillet`` build
+    ``Frame(…, axis)``), and ``_END_ON`` matches the pass's old z→plan / x→side /
+    y→front map exactly."""
+    draft = dwg.draft
+    reach = _leader_callout_reach(draft)
+    collapse: dict = {}
+    for g in (g for g in groups if g.feature_kind == "fillet"):
+        pd = next(
+            (d for d in g.dims if (d.param.role, d.param.kind) == ("fillet", "radius")),
+            None,
+        )
+        if pd is None or pd.suppressed:
+            continue
+        collapse.setdefault((g.feature.axis, round(pd.param.value, 3)), []).append((g, pd))
     jobs = []
-    for gi, ((axis, radius), members) in enumerate(sorted(groups.items())):
-        view = view_of.get(axis)
-        if view is None:
-            continue
-        vb = dwg.view_bounds(view)
-        if vb is None:
-            continue
+    for gi, ((axis, _radius), members) in enumerate(sorted(collapse.items())):
         # One grouped ``n× R`` callout, but its leader may anchor at ANY of the equal fillets
         # — _corner_candidates tries each corner (nearest-clear first) so the group is not
         # dropped just because its first corner leads into an occupied region.
-        ordered = sorted(members, key=lambda f: f.frame.origin)
+        ordered = sorted(members, key=lambda gp: gp[0].feature.frame.origin)
+        view = ordered[0][0].view
+        vb = dwg.view_bounds(view)
+        if vb is None:
+            continue
+        tol = next(
+            (pd.param.tolerance for _, pd in ordered if pd.param.tolerance is not None), None
+        )
         jobs.append(
             (
                 f"m_fillet_{axis}{gi}",
                 view,
                 vb,
-                _fillet_label(radius, len(members)),
-                _corner_candidates(dwg, view, vb, ordered, reach),
+                _fillet_label(ordered[0][1].param.value, len(ordered)) + _tol_suffix(tol, draft),
+                _corner_candidates(dwg, view, vb, [g.feature for g, _ in ordered], reach),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped", ctx=ctx)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1175,11 +1175,14 @@ def render_flats(dwg, groups, a, *, ctx) -> int:
     return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped", ctx=ctx)
 
 
-def _groove_label(width, diameter) -> str:
+def _groove_label(width, diameter, wsfx="", dsfx="") -> str:
     """The turned/circlip-groove callout string: ``{width} WIDE × ø{diameter}`` — the groove's
-    axial width and its floor diameter (#148c). Formatting lives in the render layer, not on
-    the IR feature (ADR 0013 §7)."""
-    return f"{_fmt(width)} WIDE × ø{_fmt(diameter)}"
+    axial width and its floor diameter (#148c). *width*/*diameter* are the PLANNED values
+    (``pd.param.value``, #727); *wsfx*/*dsfx* are each value's pre-formatted tolerance
+    suffix, interleaved so a tolerance rides its own number (``4 ±0.1 WIDE × ø16 ±0.05``) —
+    the two params carry independent tolerances (kinds "length"/"diameter"). Formatting
+    lives in the render layer, not on the IR feature (ADR 0013 §7)."""
+    return f"{_fmt(width)}{wsfx} WIDE × ø{_fmt(diameter)}{dsfx}"
 
 
 def _ray_exit_dist(px, py, ux, uy, rect) -> float:
@@ -1271,7 +1274,7 @@ def render_pockets(dwg, model, a, *, ctx) -> int:
     return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped", ctx=ctx)
 
 
-def render_grooves(dwg, model, a, *, ctx) -> int:
+def render_grooves(dwg, groups, a, *, ctx) -> int:
     """Turned/circlip-groove callouts (#148c): a leader from each annular groove in round
     stock to its ``{width} WIDE × ø{diameter}`` label. The groove's width is *axial*, so the
     callout lands in the **profile** view (the one showing the stock axis in-plane, where the
@@ -1280,12 +1283,32 @@ def render_grooves(dwg, model, a, *, ctx) -> int:
     collapsed by size — two identical grooves on one shaft or on parallel shafts must each be
     dimensioned). The groove sits on the axis, so the leader exits the silhouette
     (``_ray_exit_dist``) toward each margin (nearest clear wins) and is dropped (lint, not
-    silently) if none lands clear. Returns the count placed."""
-    reach = _leader_callout_reach(dwg.draft)
+    silently) if none lands clear. Returns the count placed.
+
+    Planner-fed (#727 / #698): a groove is the multi-parameter case — width AND floor ø in
+    one label — so EACH value + its tolerance is bound explicitly by its ``(role, kind)``
+    (``("groove", "length")`` / ``("groove", "diameter")``), never positionally, never
+    ``dims[0]``. Formatting ``gr.width``/``gr.diameter`` directly dropped an authored
+    tolerance (the #629 class). The pass KEEPS its own axis→view map: ``g.view`` is
+    ``_END_ON`` (end-on: z→plan), but a groove reads in the PROFILE view where its axial
+    width is visible — not provably identical, so the map stays."""
+    draft = dwg.draft
+    reach = _leader_callout_reach(draft)
     view_of = {"z": "front", "x": "front", "y": "side"}
-    grooves = [f for f in model.features if f.kind == "groove"]
+    groove_groups = [g for g in groups if g.feature_kind == "groove"]
     jobs = []
-    for gi, gr in enumerate(sorted(grooves, key=lambda f: (f.axis, f.frame.origin))):
+    for gi, g in enumerate(
+        sorted(groove_groups, key=lambda g: (g.feature.axis, g.feature.frame.origin))
+    ):
+        gr = g.feature
+        wpd = next(
+            (d for d in g.dims if (d.param.role, d.param.kind) == ("groove", "length")), None
+        )
+        dpd = next(
+            (d for d in g.dims if (d.param.role, d.param.kind) == ("groove", "diameter")), None
+        )
+        if wpd is None or dpd is None or wpd.suppressed or dpd.suppressed:
+            continue
         view = view_of.get(gr.axis)
         if view is None:
             continue
@@ -1297,7 +1320,12 @@ def render_grooves(dwg, model, a, *, ctx) -> int:
                 f"m_groove_{gr.axis}{gi}",
                 view,
                 vb,
-                _groove_label(gr.width, gr.diameter),
+                _groove_label(
+                    wpd.param.value,
+                    dpd.param.value,
+                    wsfx=_tol_suffix(wpd.param.tolerance, draft),
+                    dsfx=_tol_suffix(dpd.param.tolerance, draft),
+                ),
                 _radial_candidates(dwg, view, vb, gr, reach),
             )
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1118,41 +1118,58 @@ def render_fillets(dwg, groups, a, *, ctx) -> int:
     return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped", ctx=ctx)
 
 
-def _flat_label(across) -> str:
+def _flat_label(across, sfx="") -> str:
     """The machined-flat callout string: ``{across} A/F`` (across flats) — the standard
-    abbreviation for a spanner-flat / D / hex size (#148b). Formatting lives in the render
-    layer, not on the IR feature (ADR 0013 §7)."""
-    return f"{_fmt(across)} A/F"
+    abbreviation for a spanner-flat / D / hex size (#148b). *across* is the PLANNED value
+    (``pd.param.value``, #726); *sfx* is the pre-formatted tolerance suffix, interleaved
+    after the value (``17 ±0.2 A/F`` — the tolerance rides the number, not the ``A/F``
+    qualifier). Formatting lives in the render layer, not on the IR feature (ADR 0013 §7)."""
+    return f"{_fmt(across)}{sfx} A/F"
 
 
-def render_flats(dwg, model, a, *, ctx) -> int:
+def render_flats(dwg, groups, a, *, ctx) -> int:
     """Machined-flat callouts (#148b): a leader from a flat truncating round stock to its
     ``{across} A/F`` label, in the view down the stock axis (a Z-axis bar reads in the plan).
     Flats sharing an axis and across-flats size — the faces of a double-D or hex — share ONE
     callout. The leader runs diagonally out of the flat into clear margin, and is dropped
-    (lint, not silently) if it would overprint placed geometry. Returns the count placed."""
-    reach = _leader_callout_reach(dwg.draft)
-    view_of = {"z": "plan", "x": "side", "y": "front"}
-    flats = [f for f in model.features if f.kind == "flat"]
-    groups: dict = {}
-    for fl in flats:
-        groups.setdefault((fl.axis, round(fl.across, 3)), []).append(fl)
-    jobs = []
-    for gi, ((axis, across), members) in enumerate(sorted(groups.items())):
-        view = view_of.get(axis)
-        if view is None:
+    (lint, not silently) if it would overprint placed geometry. Returns the count placed.
+
+    Planner-fed (#726 / #698): the across-flats VALUE + its tolerance come from the
+    planner's ``DimParameter``, bound explicitly by ``(role, kind)`` — formatting
+    ``fl.across`` directly dropped an authored tolerance (the #629 class). The shared
+    double-D/hex collapse stays render-side (planner-side grouping out of scope, #698);
+    first-authored tolerance wins across grouped members (the ``render_diameters``
+    precedent). ``g.view`` is safe: a FlatFeature's frame axis IS its stock axis (both
+    ``detect.py`` and ``declare.flat`` build ``Frame(…, axis)``), and ``_END_ON`` matches
+    the pass's old z→plan / x→side / y→front map exactly."""
+    draft = dwg.draft
+    reach = _leader_callout_reach(draft)
+    collapse: dict = {}
+    for g in (g for g in groups if g.feature_kind == "flat"):
+        pd = next(
+            (d for d in g.dims if (d.param.role, d.param.kind) == ("flat", "length")),
+            None,
+        )
+        if pd is None or pd.suppressed:
             continue
+        collapse.setdefault((g.feature.axis, round(pd.param.value, 3)), []).append((g, pd))
+    jobs = []
+    for gi, ((axis, _across), members) in enumerate(sorted(collapse.items())):
+        ordered = sorted(members, key=lambda gp: gp[0].feature.frame.origin)
+        view = ordered[0][0].view
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
-        ordered = sorted(members, key=lambda f: f.frame.origin)
+        tol = next(
+            (pd.param.tolerance for _, pd in ordered if pd.param.tolerance is not None), None
+        )
         jobs.append(
             (
                 f"m_flat_{axis}{gi}",
                 view,
                 vb,
-                _flat_label(across),
-                _corner_candidates(dwg, view, vb, ordered, reach),
+                _flat_label(ordered[0][1].param.value, _tol_suffix(tol, draft)),
+                _corner_candidates(dwg, view, vb, [g.feature for g, _ in ordered], reach),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped", ctx=ctx)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -472,7 +472,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # room only after the corridor drain has finalised the diameter/step-length
         # furniture (else its room check can't see the not-yet-drained length dims and
         # collides, #148c crowded-shaft).
-        render_grooves(dwg, _model, a, ctx=ctx)
+        # Planner-fed (#727): consumes the DimensionGroups so authored tolerances render.
+        render_grooves(dwg, _groups, a, ctx=ctx)
 
     def _s_section():
         # The section view renders after the corridor-drained furniture exists, so

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -380,7 +380,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     def _s_flats():
         # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.
-        render_flats(dwg, _model, a, ctx=ctx)
+        # Planner-fed (#726): consumes the DimensionGroups so an authored tolerance renders.
+        render_flats(dwg, _groups, a, ctx=ctx)
 
     def _s_pockets():
         # Blind-recess callouts (#148a): W × L × D DEEP via a leader off each floored pocket.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -374,7 +374,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         render_chamfers(dwg, _groups, a, ctx=ctx)
 
     def _s_fillets():
-        render_fillets(dwg, _model, a, ctx=ctx)
+        # Fillet callouts (#561): R{radius} (grouped n× R) via a leader off each rounded edge.
+        # Planner-fed (#725): consumes the DimensionGroups so an authored tolerance renders.
+        render_fillets(dwg, _groups, a, ctx=ctx)
 
     def _s_flats():
         # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -385,7 +385,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     def _s_pockets():
         # Blind-recess callouts (#148a): W × L × D DEEP via a leader off each floored pocket.
-        render_pockets(dwg, _model, a, ctx=ctx)
+        # Planner-fed (#728): consumes the DimensionGroups so authored tolerances render.
+        render_pockets(dwg, _groups, a, ctx=ctx)
 
     def _s_off_axis_across():
         # Side-drilled holes' in-plane (side-below) locations share the below corridor with

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -50,6 +50,9 @@ _CONVENTION = {
     ("chamfer", "length"): "leader",  # C{leg} / {leg}×{angle}° leader callout (#724)
     ("fillet", "radius"): "leader",  # R{radius} (grouped n× R) leader callout (#725)
     ("flat", "length"): "leader",  # {across} A/F across-flats leader callout (#726)
+    # One groove callout carries BOTH params: {width} WIDE × ø{diameter} (#727)
+    ("groove", "length"): "leader",
+    ("groove", "diameter"): "leader",
 }
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -53,6 +53,10 @@ _CONVENTION = {
     # One groove callout carries BOTH params: {width} WIDE × ø{diameter} (#727)
     ("groove", "length"): "leader",
     ("groove", "diameter"): "leader",
+    # One pocket callout carries all THREE params: W × L × D DEEP (#728)
+    ("pocket_width", "length"): "leader",
+    ("pocket_length", "length"): "leader",
+    ("pocket_depth", "length"): "leader",
 }
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -48,6 +48,7 @@ _CONVENTION = {
     ("pitch", "length"): "pitch",  # linear-array pitch — distinct from a plain linear dim
     ("grid_pitch", "length"): "pitch",
     ("chamfer", "length"): "leader",  # C{leg} / {leg}×{angle}° leader callout (#724)
+    ("fillet", "radius"): "leader",  # R{radius} (grouped n× R) leader callout (#725)
 }
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -49,6 +49,7 @@ _CONVENTION = {
     ("grid_pitch", "length"): "pitch",
     ("chamfer", "length"): "leader",  # C{leg} / {leg}×{angle}° leader callout (#724)
     ("fillet", "radius"): "leader",  # R{radius} (grouped n× R) leader callout (#725)
+    ("flat", "length"): "leader",  # {across} A/F across-flats leader callout (#726)
 }
 
 

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -17,7 +17,7 @@ from build123d_drafting.helpers import draft_preset
 from draftwright import Sheet, build_drawing
 from draftwright._core import _tol_suffix
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.model import PartModel, chamfer, fillet, flat, groove, hole, step
+from draftwright.model import PartModel, chamfer, fillet, flat, groove, hole, pocket, step
 from draftwright.model.planner import plan_dimensions
 
 
@@ -150,6 +150,30 @@ class TestPlannerDecorations:
         assert wpd.param.tolerance == 0.1
         assert dpd.param.tolerance == 0.5
         assert not wpd.suppressed and not dpd.suppressed
+
+    def test_pocket_dims_are_leaders_one_length_tolerance_folds_onto_all_three(self):
+        # #728: a pocket's width/length/depth are three distinct-ROLE params sharing kind
+        # "length", and decorations key on (feature, kind) — so ONE authored length
+        # tolerance folds onto ALL THREE values (documented behaviour; independent
+        # per-role tolerancing is an authoring-surface gap tracked under #698).
+        pk = pocket(width=18, length=30, depth=5, long_axis="x", width_axis="y", lo=-15, hi=15)
+        model = PartModel(
+            bbox=Box(90, 60, 20).bounding_box(),
+            orientation=None,
+            features=[pk],
+            decorations={(pk, "length"): 0.2},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "pocket")
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        assert set(by_key) == {
+            ("pocket_width", "length"),
+            ("pocket_length", "length"),
+            ("pocket_depth", "length"),
+        }
+        for pd in by_key.values():
+            assert pd.convention == "leader"
+            assert pd.param.tolerance == 0.2
+            assert not pd.suppressed
 
 
 class TestCalloutRendering:
@@ -428,6 +452,79 @@ class TestGrooveTolerance:
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_groove")
         ]
         assert labels == ["4 WIDE × ø16"], labels
+
+
+class TestPocketTolerance:
+    """#728 (the #629 class, latent): a pocket's authored tolerance must render on the
+    placed W × L × D callout — the pass now consumes the planner's DimensionGroups,
+    binding EACH of the three params explicitly by (role, kind). All three share kind
+    "length", so one authored decoration suffixes all three values (see the planner
+    test); the decoy test below proves the explicit multi-param binding."""
+
+    @staticmethod
+    def _pocketed_plate():
+        # A blind 30 × 18 × 5 recess in the top face of a plate.
+        return Box(90, 60, 20) - Pos(0, 0, 7.5) * Box(30, 18, 5)
+
+    @staticmethod
+    def _pocket_feature():
+        return pocket(width=18, length=30, depth=5, long_axis="x", width_axis="y", lo=-15, hi=15)
+
+    def test_authored_pocket_tolerance_renders_on_callout(self):
+        pk = self._pocket_feature()
+        dwg = build_drawing(
+            self._pocketed_plate(),
+            model=[pk],
+            decorations={(pk, "length"): 0.2},
+            number="X",
+        )
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_pocket")
+        ]
+        assert labels == ["18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP"], labels
+
+    def test_untolerated_pocket_label_unchanged(self):
+        # No decoration → the planner path is byte-identical to the old raw-field label.
+        pk = self._pocket_feature()
+        dwg = build_drawing(self._pocketed_plate(), model=[pk], number="X")
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_pocket")
+        ]
+        assert labels == ["18 × 30 × 5 DEEP"], labels
+
+    def test_renderer_displays_the_planned_values_not_the_raw_fields(self):
+        # #698 multi-param binding proof (the #724 decoy shape): the renderer must be
+        # planner-AUTHORITATIVE — each displayed value is its pd.param.value, bound by
+        # (role, kind), never positionally. Feed render_pockets a hand-built group with a
+        # decoy first dim and a planned width deliberately different from the feature's
+        # raw field, and assert the label shows the planned value in the width slot.
+        from dataclasses import replace
+
+        from draftwright.annotations._common import PlacementContext
+        from draftwright.annotations.from_model import render_pockets
+
+        pk = self._pocket_feature()
+        dwg = build_drawing(self._pocketed_plate(), model=[pk], number="X", auto_dims=False)
+        (g,) = [g for g in plan_dimensions(dwg.model()) if g.feature_kind == "pocket"]
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        wpd = by_key[("pocket_width", "length")]
+        decoy = replace(wpd, param=replace(wpd.param, role="decoy", value=99.0))
+        planned_w = replace(wpd, param=replace(wpd.param, value=7.0))  # ≠ pk.width == 18
+        g2 = replace(
+            g,
+            dims=(
+                decoy,
+                planned_w,
+                by_key[("pocket_length", "length")],
+                by_key[("pocket_depth", "length")],
+            ),
+        )
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        assert render_pockets(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_pocket")
+        ]
+        assert labels == ["7 × 30 × 5 DEEP"], labels
 
 
 class TestToleranceHandle:

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -17,7 +17,7 @@ from build123d_drafting.helpers import draft_preset
 from draftwright import Sheet, build_drawing
 from draftwright._core import _tol_suffix
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.model import PartModel, chamfer, fillet, flat, hole, step
+from draftwright.model import PartModel, chamfer, fillet, flat, groove, hole, step
 from draftwright.model.planner import plan_dimensions
 
 
@@ -130,6 +130,26 @@ class TestPlannerDecorations:
         assert pd.param.tolerance == 0.2
         assert not pd.suppressed
         assert g.view == "plan"  # frame axis == stock axis; a Z-bar flat reads in the plan
+
+    def test_groove_dims_are_leaders_with_independent_tolerances(self):
+        # #727: the multi-param case — width (kind "length") and floor ø (kind "diameter")
+        # are distinct decoration keys, so the one groove callout carries BOTH, each with
+        # its own folded tolerance.
+        gr = groove(axis="z", width=4, diameter=16, at=(0, 0, 0))
+        model = PartModel(
+            bbox=Cylinder(10, 40).bounding_box(),
+            orientation=None,
+            features=[gr],
+            decorations={(gr, "length"): 0.1, (gr, "diameter"): 0.5},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "groove")
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        wpd = by_key[("groove", "length")]
+        dpd = by_key[("groove", "diameter")]
+        assert wpd.convention == "leader" and dpd.convention == "leader"
+        assert wpd.param.tolerance == 0.1
+        assert dpd.param.tolerance == 0.5
+        assert not wpd.suppressed and not dpd.suppressed
 
 
 class TestCalloutRendering:
@@ -374,6 +394,40 @@ class TestFlatTolerance:
         dwg = build_drawing(self._flatted_bar(), model=[fl], number="X")
         labels = [dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_flat")]
         assert labels == ["17 A/F"], labels
+
+
+class TestGrooveTolerance:
+    """#727 (the #629 class, latent): a groove's authored width/floor-ø tolerances must
+    render on the placed callout — the pass now consumes the planner's DimensionGroups,
+    binding EACH of the two params explicitly by (role, kind). Each tolerance suffix
+    interleaves after its own value."""
+
+    @staticmethod
+    def _grooved_shaft():
+        # Z round stock with one annular groove at mid-height (floor ø16, 4 wide).
+        return Cylinder(10, 40) - (Cylinder(10.5, 4) - Cylinder(8, 4))
+
+    def test_authored_groove_tolerances_render_on_callout(self):
+        gr = groove(axis="z", width=4, diameter=16, at=(0, 0, 0))
+        dwg = build_drawing(
+            self._grooved_shaft(),
+            model=[gr],
+            decorations={(gr, "length"): 0.1, (gr, "diameter"): 0.5},
+            number="X",
+        )
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_groove")
+        ]
+        assert labels == ["4 ±0.1 WIDE × ø16 ±0.5"], labels
+
+    def test_untolerated_groove_label_unchanged(self):
+        # No decoration → the planner path is byte-identical to the old raw-field label.
+        gr = groove(axis="z", width=4, diameter=16, at=(0, 0, 0))
+        dwg = build_drawing(self._grooved_shaft(), model=[gr], number="X")
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_groove")
+        ]
+        assert labels == ["4 WIDE × ø16"], labels
 
 
 class TestToleranceHandle:

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -17,7 +17,7 @@ from build123d_drafting.helpers import draft_preset
 from draftwright import Sheet, build_drawing
 from draftwright._core import _tol_suffix
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.model import PartModel, chamfer, fillet, hole, step
+from draftwright.model import PartModel, chamfer, fillet, flat, hole, step
 from draftwright.model.planner import plan_dimensions
 
 
@@ -113,6 +113,23 @@ class TestPlannerDecorations:
         assert pd.param.tolerance == 0.1
         assert not pd.suppressed
         assert g.view == "plan"  # frame axis == edge axis; a Z-edge fillet reads in the plan
+
+    def test_flat_dim_is_leader_with_folded_tolerance(self):
+        # #726: the across-flats size routes through the planner — convention "leader",
+        # with an authored decoration folded onto DimParameter.tolerance (kind "length").
+        fl = flat(axis="z", across=17, at=(7, 0, 0))
+        model = PartModel(
+            bbox=Cylinder(10, 30).bounding_box(),
+            orientation=None,
+            features=[fl],
+            decorations={(fl, "length"): 0.2},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "flat")
+        (pd,) = g.dims
+        assert pd.convention == "leader"
+        assert pd.param.tolerance == 0.2
+        assert not pd.suppressed
+        assert g.view == "plan"  # frame axis == stock axis; a Z-bar flat reads in the plan
 
 
 class TestCalloutRendering:
@@ -327,6 +344,36 @@ class TestFilletTolerance:
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_fillet")
         ]
         assert labels == ["R8"], labels
+
+
+class TestFlatTolerance:
+    """#726 (the #629 class, latent): a machined flat's authored across-flats tolerance
+    must render on the placed A/F callout — the pass now consumes the planner's
+    DimensionGroups. The suffix interleaves after the value (the tolerance rides the
+    number, not the A/F qualifier)."""
+
+    @staticmethod
+    def _flatted_bar():
+        # A D-shaft: Z round stock with one milled flat at x = 7 (across = 7 + 10 = 17).
+        return Cylinder(10, 30) - Pos(12, 0, 0) * Box(10, 40, 40)
+
+    def test_authored_flat_tolerance_renders_on_callout(self):
+        fl = flat(axis="z", across=17, at=(7, 0, 0))  # the flat face centre
+        dwg = build_drawing(
+            self._flatted_bar(),
+            model=[fl],
+            decorations={(fl, "length"): 0.2},
+            number="X",
+        )
+        labels = [dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_flat")]
+        assert labels == ["17 ±0.2 A/F"], labels
+
+    def test_untolerated_flat_label_unchanged(self):
+        # No decoration → the planner path is byte-identical to the old raw-field label.
+        fl = flat(axis="z", across=17, at=(7, 0, 0))
+        dwg = build_drawing(self._flatted_bar(), model=[fl], number="X")
+        labels = [dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_flat")]
+        assert labels == ["17 A/F"], labels
 
 
 class TestToleranceHandle:

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -11,12 +11,13 @@ precision (1 dp today), so tests use tolerances that survive 1 dp.
 
 from build123d import Axis, Box, Cylinder, Pos, Rot
 from build123d import chamfer as b3d_chamfer
+from build123d import fillet as b3d_fillet
 from build123d_drafting.helpers import draft_preset
 
 from draftwright import Sheet, build_drawing
 from draftwright._core import _tol_suffix
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.model import PartModel, chamfer, hole, step
+from draftwright.model import PartModel, chamfer, fillet, hole, step
 from draftwright.model.planner import plan_dimensions
 
 
@@ -95,6 +96,23 @@ class TestPlannerDecorations:
         assert pd.param.tolerance == 0.2
         assert not pd.suppressed
         assert g.view == "plan"  # frame axis == edge axis; a Z-edge chamfer reads in the plan
+
+    def test_fillet_dim_is_leader_with_folded_tolerance(self):
+        # #725: the fillet radius routes through the planner — convention "leader", with an
+        # authored decoration folded onto DimParameter.tolerance (keyed by kind "radius").
+        fl = fillet(axis="z", radius=8, at=(41, 26, 0))
+        model = PartModel(
+            bbox=Box(90, 60, 20).bounding_box(),
+            orientation=None,
+            features=[fl],
+            decorations={(fl, "radius"): 0.1},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "fillet")
+        (pd,) = g.dims
+        assert pd.convention == "leader"
+        assert pd.param.tolerance == 0.1
+        assert not pd.suppressed
+        assert g.view == "plan"  # frame axis == edge axis; a Z-edge fillet reads in the plan
 
 
 class TestCalloutRendering:
@@ -272,6 +290,43 @@ class TestChamferTolerance:
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_chamfer")
         ]
         assert labels == ["7 × 45°"], labels  # planned 7 ≠ leg2 12 → leg×angle form
+
+
+class TestFilletTolerance:
+    """#725 (the #629 class, latent): a fillet's authored tolerance must render on the
+    placed ``R`` callout — the pass now consumes the planner's DimensionGroups. The
+    equal-radius ``n×`` collapse stays render-side (#698: planner-side grouping out of
+    scope); the displayed radius + tolerance come from the members' planned dims."""
+
+    @staticmethod
+    def _filleted_plate():
+        plate = Box(90, 60, 20)
+        e = plate.edges().filter_by(Axis.Z).sort_by(lambda e: e.center().X + e.center().Y)[-1]
+        return b3d_fillet(e, 8)
+
+    def test_authored_fillet_tolerance_renders_on_callout(self):
+        # Declared model (ADR 0011): the caller holds the feature object, so the
+        # decoration keys on it — (feature, "radius") for a fillet.
+        fl = fillet(axis="z", radius=8, at=(41, 26, 0))  # on the rounded corner
+        dwg = build_drawing(
+            self._filleted_plate(),
+            model=[fl],
+            decorations={(fl, "radius"): 0.1},
+            number="X",
+        )
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_fillet")
+        ]
+        assert labels == ["R8 ±0.1"], labels
+
+    def test_untolerated_fillet_label_unchanged(self):
+        # No decoration → the planner path is byte-identical to the old raw-field label.
+        fl = fillet(axis="z", radius=8, at=(41, 26, 0))
+        dwg = build_drawing(self._filleted_plate(), model=[fl], number="X")
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_fillet")
+        ]
+        assert labels == ["R8"], labels
 
 
 class TestToleranceHandle:

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -389,6 +389,29 @@ class TestFilletTolerance:
         ]
         assert labels == ["R8"], labels
 
+    def test_collapse_conflicting_tolerances_first_authored_wins(self):
+        # #742 review: when equal-radius fillets with DIFFERENT authored tolerances share
+        # one n×R callout, the FIRST-AUTHORED tolerance wins (the render_diameters
+        # precedent) — never the spatially-first member, whose identity would change if
+        # the geometry moved. Author the (+,+)-corner fillet first with ±0.1; the
+        # (-,-)-corner one (which sorts spatially FIRST by frame.origin) second with
+        # ±0.5. Spatial-first-wins would show ±0.5; authored-first shows ±0.1.
+        plate = Box(90, 60, 20)
+        es = plate.edges().filter_by(Axis.Z).sort_by(lambda e: e.center().X + e.center().Y)
+        part = b3d_fillet([es[0], es[-1]], 8)
+        f_pp = fillet(axis="z", radius=8, at=(41, 26, 0))  # authored first
+        f_mm = fillet(axis="z", radius=8, at=(-41, -26, 0))  # spatially first
+        dwg = build_drawing(
+            part,
+            model=[f_pp, f_mm],
+            decorations={(f_pp, "radius"): 0.1, (f_mm, "radius"): 0.5},
+            number="X",
+        )
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_fillet")
+        ]
+        assert labels == ["2× R8 ±0.1"], labels
+
 
 class TestFlatTolerance:
     """#726 (the #629 class, latent): a machined flat's authored across-flats tolerance
@@ -452,6 +475,31 @@ class TestGrooveTolerance:
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_groove")
         ]
         assert labels == ["4 WIDE × ø16"], labels
+
+    def test_renderer_displays_the_planned_values_not_the_raw_fields(self):
+        # #742 review — the multi-param decoy proof for groove (the #724/#728 shape): the
+        # renderer must be planner-AUTHORITATIVE, binding width and floor ø each by
+        # (role, kind), never positionally. A decoy first dim plus a planned width
+        # deliberately different from the raw feature field must render the planned value.
+        from dataclasses import replace
+
+        from draftwright.annotations._common import PlacementContext
+        from draftwright.annotations.from_model import render_grooves
+
+        gr = groove(axis="z", width=4, diameter=16, at=(0, 0, 0))
+        dwg = build_drawing(self._grooved_shaft(), model=[gr], number="X", auto_dims=False)
+        (g,) = [g for g in plan_dimensions(dwg.model()) if g.feature_kind == "groove"]
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        wpd = by_key[("groove", "length")]
+        decoy = replace(wpd, param=replace(wpd.param, role="decoy", value=99.0))
+        planned_w = replace(wpd, param=replace(wpd.param, value=7.0))  # ≠ gr.width == 4
+        g2 = replace(g, dims=(decoy, planned_w, by_key[("groove", "diameter")]))
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        assert render_grooves(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_groove")
+        ]
+        assert labels == ["7 WIDE × ø16"], labels
 
 
 class TestPocketTolerance:


### PR DESCRIPTION
Batch 1 of epic #698, per the approved batching plan — four kinds, **one commit per kind** for bisectability and per-kind review. Closes #725, closes #726, closes #727, closes #728.

## What (the ratified #724 pattern, ×4)

Per kind: `_CONVENTION` entries; the renderer consumes `DimensionGroup`s binding each dim **explicitly by (role, kind)** (pocket and groove are the multi-param cases the #724 review flagged); displayed values are planner-authoritative (`pd.param.value`); tolerances via `_tol_suffix` — closing the latent #629-class drop for each kind. View selection: `g.view` adopted where provably identical to the pass's own map (fillet, flat — frame axis == edge/stock axis in both front doors); the pass's own map kept with a comment where genuinely different (groove reads the PROFILE view, pocket keys on `depth_axis`).

## Design calls (reported, not silent)

- **Fillet `n×R` collapse stays render-side** (planner-side grouping marked out of scope in-code); grouped tolerance = first-authored wins, the documented `render_diameters` precedent. Same for the flat collapse.
- **Multi-param tolerance rendering interleaves per value**: `4 ±0.1 WIDE × ø16 ±0.5`, `18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP`. **Authoring gap flagged and pinned by test**: a pocket's three params share kind `"length"`, so one authored tolerance necessarily folds onto all three values — tolerancing only the depth needs role-keyed decorations (left with #698, documented in `_pocket_label`).

## Verification

- 13 new tests (4 planner-unit, 4 end-to-end authored-tolerance, 4 untolerated pins, 1 pocket decoy/planned-value binding test)
- Goldens: **14 passed, zero shift** — untolerated output byte-identical by construction
- Guard suites (incl. `test_private_test_imports`): 81 passed; targeted selection: 159 passed
- Full fast tier: **1438 passed**, 3 skipped; only the known #710 Hypothesis replay
- lint ×4 clean; ADR 0015 coverage table updated (four kinds bypass → planner-fed); CHANGELOG Fixed entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)