### PR TITLE
feat(#729): route plate dimensions through the planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,19 +32,23 @@
 
 ### Fixed
 
-- **Authored fillet, flat, groove and pocket tolerances now render**
-  (#725/#726/#727/#728 / #698): the four leader-callout kinds join `_CONVENTION`
-  and their renderers (`render_fillets`/`render_flats`/`render_grooves`/
-  `render_pockets`) consume the planner's `DimensionGroup`s, binding each
+- **Authored fillet, flat, groove, pocket and plate tolerances now render**
+  (#725/#726/#727/#728/#729 / #698): the four leader-callout kinds join
+  `_CONVENTION` and their renderers (`render_fillets`/`render_flats`/
+  `render_grooves`/`render_pockets`) — and the plate-thickness linear pass
+  (`render_plates`, riding `_CONVENTION`'s `"linear"` default) — consume the
+  planner's `DimensionGroup`s, binding each
   planned dim explicitly by `(role, kind)` — so a `decorations`-authored ± /
   limit tolerance reaches the placed callout (`R8 ±0.1`, `17 ±0.2 A/F`,
-  `4 ±0.1 WIDE × ø16 ±0.5`, `18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP`; on a
-  multi-value label each suffix rides its own number). Previously all four
+  `4 ±0.1 WIDE × ø16 ±0.5`, `18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP`, a `10 ±0.1`
+  thickness dim; on a
+  multi-value label each suffix rides its own number). Previously all five
   passes formatted raw feature fields and silently dropped it — the latent #629
   bug class the ADR 0015 bypass list documents. The fillet `n× R` and flat
   double-D/hex collapses stay render-side (first-authored tolerance wins, the
   `render_diameters` precedent); a pocket's three values share one authored
-  tolerance (all kind `"length"`). Untolerated labels/views are unchanged.
+  tolerance (all kind `"length"`). Untolerated labels/views/placement are
+  unchanged.
 - **Authored chamfer tolerances now render** (#724 / #698): `render_chamfers`
   consumes the planner's `DimensionGroup` (chamfer joins `_CONVENTION` as a
   leader), so a `decorations`-authored ± / limit tolerance on a chamfer leg

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -107,13 +107,14 @@ the groups the orchestrator computed for them.
 | flats ({across} A/F leader, #726) | `from_model.render_flats` | `plan_dimensions` |
 | grooves ({width} WIDE × ø{diameter} leader, #727) | `from_model.render_grooves` | `plan_dimensions` |
 | pockets (W × L × D DEEP leader, #728) | `from_model.render_pockets` | `plan_dimensions` |
+| plates (thickness linear dim, #729) | `from_model.render_plates` | `plan_dimensions` |
 | section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |
 
 **Planner-bypassing today** (the renderer takes `model`, re-filters
 `model.features` by kind, and formats raw fields — its computed
 `DimensionGroup`s are discarded):
 
-- `render_slots`, `render_plates`, `render_rotational`
+- `render_slots`, `render_rotational`
   (OD/centreline/bore furniture), `render_pmi` — all in
   `annotations/from_model.py`.
 - `render_height_ladder` and `render_step_positions` are also model-routed,
@@ -136,7 +137,8 @@ no-double-dimensioning/suppression rules currently have no single home
 
 **The convergence tracker is #698** — extend `_CONVENTION` +
 `plan_dimensions` kind-by-kind (chamfer landed first, #724; fillet/flat/
-groove/pocket followed, #725–#728; plate, slots next) and convert each
+groove/pocket followed, #725–#728; plate, #729 — the first *linear*-convention
+migration, no `_CONVENTION` entry needed; slots next) and convert each
 renderer to consume its
 group, pulling the
 scattered suppression rules into the planner as each kind migrates. This ADR

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1428,7 +1428,7 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
     )
 
 
-def render_plates(dwg, model, a, *, ctx) -> int:
+def render_plates(dwg, groups, a, *, ctx) -> int:
     """Plate/wall thicknesses (#559): the thin extent of each recognised slab
     (`PlateFeature`), placed in the view where its thin axis is characteristic — a Z
     plate (horizontal slab) as a vertical dim left of the front elevation, a Y plate
@@ -1436,14 +1436,31 @@ def render_plates(dwg, model, a, *, ctx) -> int:
     shows it edge-on, an X plate below the front view. Base and wall land in different
     views so the two legs of a multi-plate prismatic read as distinct features rather
     than the overall envelope. A slab whose strip is full is dropped with a lint code
-    (like the step ladder), not silently. Returns the count placed."""
+    (like the step ladder), not silently. Returns the count placed.
+
+    Planner-fed (#729 / #698): the thickness VALUE + its tolerance come from the
+    planner's ``DimParameter``, bound explicitly by ``(role, kind)`` —
+    ``("thickness", "length")`` — never ``dims[0]``. Formatting ``pl.hi - pl.lo``
+    directly dropped an authored tolerance (the #629 class). Placement mechanics
+    (strips, tier stacking, the allowlisted carve fallthrough) are untouched. The
+    pass KEEPS its own axis→view map: ``g.view`` is ``_END_ON`` (z→plan / y→front /
+    x→side), not the edge-on profile view a thickness dim reads in (z→front-left,
+    y→side-above, x→front-below)."""
     draft = dwg.draft
     tier = draft.font_size + 2 * draft.pad_around_text
-    plates = [f for f in model.features if f.kind == "plate"]
+    plate_groups = [g for g in groups if g.feature_kind == "plate"]
     n = 0
     counts: dict = {"x": 0, "y": 0, "z": 0}
-    for pl in sorted(plates, key=lambda f: (f.axis, f.lo, f.hi)):
-        val = pl.hi - pl.lo
+    for g in sorted(plate_groups, key=lambda g: (g.feature.axis, g.feature.lo, g.feature.hi)):
+        pl = g.feature
+        pd = next(
+            (d for d in g.dims if (d.param.role, d.param.kind) == ("thickness", "length")),
+            None,
+        )
+        if pd is None or pd.suppressed:
+            continue
+        val = pd.param.value
+        lbl = _fmt(val) + _tol_suffix(pd.param.tolerance, draft)
         i = counts[pl.axis]
         counts[pl.axis] += 1
         if pl.axis == "z":
@@ -1502,22 +1519,22 @@ def render_plates(dwg, model, a, *, ctx) -> int:
             alt = None
         name = f"dim_plate_{pl.axis}{i}"
 
-        def _build(pos, pa=pa, pb=pb, side=side, edge=edge, val=val):
-            return _dim(pa, pb, side, pos - edge, draft, label=_fmt(val))
+        def _build(pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl):
+            return _dim(pa, pb, side, pos - edge, draft, label=lbl)
 
-        def _foot(pos, pa=pa, pb=pb, side=side, edge=edge, val=val):
-            return dim_footprint(pa, pb, side, pos - edge, draft, _fmt(val))
+        def _foot(pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl):
+            return dim_footprint(pa, pb, side, pos - edge, draft, lbl)
 
-        def _drop(nm, val=val, view=view, stack=stack, alt=alt, feat=pl):  # noqa: B008
+        def _drop(nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=pl):  # noqa: B008
             # Opposite-strip fallthrough (mirrors the GD&T #481 pattern), DEFERRED to
             # ctx.post_drain so it runs after EVERY corridor has drained (#684 review):
             # a mid-drain carve could occupy a corner a later sibling's force candidate
             # needs; post-drain, carve_free_position sees all placed annotations.
-            def _retry(nm=nm, val=val, view=view, stack=stack, alt=alt, feat=feat):
+            def _retry(nm=nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=feat):
                 for view2, side2, strip2, axis2, qa, qb, edge2 in alt or ():
                     if strip2 is None:
                         continue
-                    foot0 = dim_footprint(qa, qb, side2, tier, draft, _fmt(val))
+                    foot0 = dim_footprint(qa, qb, side2, tier, draft, lbl)
                     perp = (foot0[1], foot0[3]) if axis2 == "x" else (foot0[0], foot0[2])
                     pos = carve_free_position(dwg, strip2, view2, axis2, tier, perp)
                     if pos is not None:
@@ -1526,7 +1543,7 @@ def render_plates(dwg, model, a, *, ctx) -> int:
                         # against live obstacles + the page before adding (the same
                         # contract as the corridor's validation fallback). A miss
                         # tries the next alternate.
-                        dim = _dim(qa, qb, side2, pos - edge2, draft, label=_fmt(val))
+                        dim = _dim(qa, qb, side2, pos - edge2, draft, label=lbl)
                         real = _geom_box(dim)
                         page = (_MARGIN, _MARGIN, a.PAGE_W - _MARGIN, a.PAGE_H - _MARGIN)
                         if real is None or (

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -361,7 +361,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Plate/wall thicknesses on a multi-plate prismatic (#559): the thin extent of each
         # recognised slab, placed in the view where its thin axis is visible. A single flat
         # plate has none (its thickness IS the envelope height).
-        render_plates(dwg, _model, a, ctx=ctx)
+        # Planner-fed (#729): consumes the DimensionGroups so an authored tolerance renders.
+        render_plates(dwg, _groups, a, ctx=ctx)
 
     def _s_step_positions():
         # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -57,6 +57,8 @@ _CONVENTION = {
     ("pocket_width", "length"): "leader",
     ("pocket_length", "length"): "leader",
     ("pocket_depth", "length"): "leader",
+    # A plate thickness ("thickness", "length") is a linear Dimension — the default —
+    # so it needs no entry here; render_plates is planner-fed regardless (#729).
 }
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -57,8 +57,11 @@ _CONVENTION = {
     ("pocket_width", "length"): "leader",
     ("pocket_length", "length"): "leader",
     ("pocket_depth", "length"): "leader",
-    # A plate thickness ("thickness", "length") is a linear Dimension — the default —
-    # so it needs no entry here; render_plates is planner-fed regardless (#729).
+    # A plate thickness is a linear Dimension. That IS the table default, but the
+    # entry is explicit anyway (#744 review): this table is the one convention
+    # registry, and a planner-fed kind relying on the implicit default would erode
+    # that — unknown pairs should eventually fail loudly, not silently go linear.
+    ("thickness", "length"): "linear",
 }
 
 

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -626,6 +626,41 @@ class TestPlateTolerance:
         ]
         assert labels == ["8 ±0.1"], labels
 
+    def test_tolerance_survives_the_post_drain_carve_fallthrough(self):
+        # #744 review: when the primary corridor candidate DROPS, the deferred carve
+        # retry rebuilds the dim from its own captured label — the tolerance must ride
+        # along, not be reconstructed from the raw value. Drive the fallthrough
+        # deterministically: register via render_plates, fire the candidate's on_drop
+        # (what the solve does on a full strip), then run the deferred post_drain
+        # retries — the relocated dim must still read "8 ±0.1".
+        from draftwright.annotations._common import PlacementContext
+        from draftwright.annotations.from_model import render_plates
+
+        pl = self._plate_feature()
+        dwg = build_drawing(
+            self._flat_plate(),
+            model=[pl],
+            decorations={(pl, "length"): 0.1},
+            number="X",
+            auto_dims=False,
+        )
+        (g,) = [g for g in plan_dimensions(dwg.model()) if g.feature_kind == "plate"]
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        assert render_plates(dwg, [g], dwg._analysis, ctx=ctx) == 1
+        (cand,) = [
+            c
+            for b in ctx.corridor_batch.values()
+            for c in b["cands"]
+            if c.name.startswith("dim_plate")
+        ]
+        cand.on_drop(cand.name)  # the solve's full-strip signal
+        for cb in ctx.post_drain:  # the deferred opposite-strip retries
+            cb()
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("dim_plate")
+        ]
+        assert labels == ["8 ±0.1"], labels
+
     def test_untolerated_plate_label_unchanged(self):
         # No decoration → the planner path is byte-identical to the old raw-field label.
         pl = self._plate_feature()

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -17,7 +17,7 @@ from build123d_drafting.helpers import draft_preset
 from draftwright import Sheet, build_drawing
 from draftwright._core import _tol_suffix
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.model import PartModel, chamfer, fillet, flat, groove, hole, pocket, step
+from draftwright.model import PartModel, chamfer, fillet, flat, groove, hole, plate, pocket, step
 from draftwright.model.planner import plan_dimensions
 
 
@@ -174,6 +174,26 @@ class TestPlannerDecorations:
             assert pd.convention == "leader"
             assert pd.param.tolerance == 0.2
             assert not pd.suppressed
+
+    def test_plate_dim_is_linear_with_folded_tolerance(self):
+        # #729: the plate thickness routes through the planner — convention "linear"
+        # (the _CONVENTION default; the first non-leader kind migration, so no table
+        # entry), with an authored decoration folded onto DimParameter.tolerance
+        # (kind "length").
+        pl = plate(axis="z", lo=-4, hi=4, u=0, v=0)
+        model = PartModel(
+            bbox=Box(80, 50, 8).bounding_box(),
+            orientation=None,
+            features=[pl],
+            decorations={(pl, "length"): 0.1},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "plate")
+        (pd,) = g.dims
+        assert (pd.param.role, pd.param.kind) == ("thickness", "length")
+        assert pd.convention == "linear"
+        assert pd.param.value == 8.0  # hi - lo — exactly what the renderer displays
+        assert pd.param.tolerance == 0.1
+        assert not pd.suppressed
 
 
 class TestCalloutRendering:
@@ -573,6 +593,75 @@ class TestPocketTolerance:
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_pocket")
         ]
         assert labels == ["7 × 30 × 5 DEEP"], labels
+
+
+class TestPlateTolerance:
+    """#729 (the #629 class, latent): a plate's authored thickness tolerance must render
+    on the placed linear dim — the pass now consumes the planner's DimensionGroups,
+    binding the dim explicitly by (role, kind) == ("thickness", "length"). Only the
+    VALUE and TOLERANCE source changed; the strip/tier placement mechanics (including
+    the allowlisted carve fallthrough) are untouched."""
+
+    @staticmethod
+    def _flat_plate():
+        return Box(80, 50, 8)
+
+    @staticmethod
+    def _plate_feature():
+        return plate(axis="z", lo=-4, hi=4, u=0, v=0)
+
+    def test_authored_plate_tolerance_renders_on_dim(self):
+        # Declared model (ADR 0011): detection's ≥2-axis scope guard doesn't apply, so a
+        # single declared slab renders its thickness dim; the decoration keys on
+        # (feature, "length").
+        pl = self._plate_feature()
+        dwg = build_drawing(
+            self._flat_plate(),
+            model=[pl],
+            decorations={(pl, "length"): 0.1},
+            number="X",
+        )
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("dim_plate")
+        ]
+        assert labels == ["8 ±0.1"], labels
+
+    def test_untolerated_plate_label_unchanged(self):
+        # No decoration → the planner path is byte-identical to the old raw-field label.
+        pl = self._plate_feature()
+        dwg = build_drawing(self._flat_plate(), model=[pl], number="X")
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("dim_plate")
+        ]
+        assert labels == ["8"], labels
+
+    def test_renderer_displays_the_planned_value_not_the_raw_fields(self):
+        # #698 binding proof (the #724 decoy shape): the renderer must be
+        # planner-AUTHORITATIVE — the displayed thickness is pd.param.value, bound by
+        # (role, kind), never dims[0]. Feed render_plates a hand-built group with a decoy
+        # first dim and a planned value deliberately different from the feature's raw
+        # hi - lo, and assert the placed dim shows the planned value. Unlike the leader
+        # passes, render_plates registers corridor candidates, so the batch is drained
+        # before reading the label.
+        from dataclasses import replace
+
+        from draftwright.annotations._common import PlacementContext, drain_corridors
+        from draftwright.annotations.from_model import render_plates
+
+        pl = self._plate_feature()
+        dwg = build_drawing(self._flat_plate(), model=[pl], number="X", auto_dims=False)
+        (g,) = [g for g in plan_dimensions(dwg.model()) if g.feature_kind == "plate"]
+        (pd,) = g.dims
+        decoy = replace(pd, param=replace(pd.param, role="decoy", value=99.0))
+        planned = replace(pd, param=replace(pd.param, value=7.0))  # ≠ pl.hi - pl.lo == 8
+        g2 = replace(g, dims=(decoy, planned))
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        assert render_plates(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        drain_corridors(ctx, dwg)
+        labels = [
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("dim_plate")
+        ]
+        assert labels == ["7"], labels
 
 
 class TestToleranceHandle:


### PR DESCRIPTION
Epic #698, kind 6 of 7 — the first *linear*-convention migration. Closes #729.

## What

- `render_plates` binds its dim explicitly by `("thickness", "length")` and threads `pd.param.value` + `_tol_suffix(pd.param.tolerance)` through the build/footprint/carve-fallthrough closures — closing the latent #629-class tolerance drop for plate thicknesses. Placement mechanics untouched (per-axis strip tiers, and the allowlisted `carve_free_position` post-drain fallthrough stays exactly as pinned).
- **No `_CONVENTION` entry, deliberately**: plate's linear convention is the table's default (the leader kinds needed entries only because "leader" is non-default) — documented in the table comment and ADR 0015.
- **View verdict: kept the pass's own map** — `g.view` (`_END_ON`) is provably wrong for plates on all three axes (the pass places in the edge-on profile views: z→front-left, y→side-above, x→front-below); commented in the renderer.
- `parameters()`-vs-rendered consistency verified: both compute `hi − lo`; the swap is value-preserving, pinned by a planner unit test.
- 4 new tests (planner unit, end-to-end authored tolerance `["8 ±0.1"]`, untolerated pin, decoy/planned-value with corridor drain); ADR 0015 table + CHANGELOG updated.

## Verification (re-run after rebase onto main incl. #742/#743)

- Guards 81 passed pre-rebase, goldens/import/carve guards re-run green post-rebase; targeted selection 83 passed
- Full fast tier (pre-rebase): **1444 passed**, 3 skipped; lint ×4 clean; goldens: no shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)