### PR TITLE
feat(#730): route slot dimensions through the planner; derive the step group view (#731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,23 +32,26 @@
 
 ### Fixed
 
-- **Authored fillet, flat, groove, pocket and plate tolerances now render**
-  (#725/#726/#727/#728/#729 / #698): the four leader-callout kinds join
+- **Authored fillet, flat, groove, pocket, plate and slot tolerances now render**
+  (#725/#726/#727/#728/#729/#730 / #698): the four leader-callout kinds join
   `_CONVENTION` and their renderers (`render_fillets`/`render_flats`/
-  `render_grooves`/`render_pockets`) — and the plate-thickness linear pass
-  (`render_plates`, riding `_CONVENTION`'s `"linear"` default) — consume the
+  `render_grooves`/`render_pockets`) — and the plate-thickness and slot
+  width/length linear passes
+  (`render_plates`/`render_slots`, explicit `"linear"` entries) — consume the
   planner's `DimensionGroup`s, binding each
   planned dim explicitly by `(role, kind)` — so a `decorations`-authored ± /
   limit tolerance reaches the placed callout (`R8 ±0.1`, `17 ±0.2 A/F`,
   `4 ±0.1 WIDE × ø16 ±0.5`, `18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP`, a `10 ±0.1`
-  thickness dim; on a
-  multi-value label each suffix rides its own number). Previously all five
+  thickness dim, an `8 ±0.1` slot width; on a
+  multi-value label each suffix rides its own number). Previously all six
   passes formatted raw feature fields and silently dropped it — the latent #629
   bug class the ADR 0015 bypass list documents. The fillet `n× R` and flat
   double-D/hex collapses stay render-side (first-authored tolerance wins, the
-  `render_diameters` precedent); a pocket's three values share one authored
-  tolerance (all kind `"length"`). Untolerated labels/views/placement are
-  unchanged.
+  `render_diameters` precedent); a pocket's three values — and a slot's
+  width + length — share one authored
+  tolerance (all kind `"length"`). The slot's model-derived datum position dim
+  and its corridor/immediate placement mechanics are untouched. Untolerated
+  labels/views/placement are unchanged.
 - **Authored chamfer tolerances now render** (#724 / #698): `render_chamfers`
   consumes the planner's `DimensionGroup` (chamfer joins `_CONVENTION` as a
   leader), so a `decorations`-authored ± / limit tolerance on a chamfer leg

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -53,9 +53,11 @@ The load-bearing properties, all live in the code today:
    detect-only path as a cheap seed (`Sheet.from_part`).
 2. **Orientation and feature kind are data in the IR**, never code branches in
    the back-end: `Feature.frame` carries the axis; the planner derives a
-   group's view from it by one rule (`_END_ON`), so X and Z are symmetric.
-   (One residue: `planner._group_view` special-cases `kind == "step"` → front —
-   flagged in #698.)
+   group's view from it by one rule — `_END_ON` for a diameter callout,
+   `_PROFILE` (the in-plane containment rule: front is the x–z plane, so X and
+   Z both derive to front) for a turned step's length/OD — so X and Z are
+   symmetric. (The former residue — a hardcoded `kind == "step"` → front —
+   was replaced by that derivation in #731.)
 3. **The waist is two tiers.** The lower tier is the geometry-only recognition
    record produced under the uniform `recognise_<feature>` contract (ADR 0013);
    the upper tier is the dimensioning IR `Feature`. They are joined by the

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -108,14 +108,15 @@ the groups the orchestrator computed for them.
 | grooves ({width} WIDE × ø{diameter} leader, #727) | `from_model.render_grooves` | `plan_dimensions` |
 | pockets (W × L × D DEEP leader, #728) | `from_model.render_pockets` | `plan_dimensions` |
 | plates (thickness linear dim, #729) | `from_model.render_plates` | `plan_dimensions` |
+| slots (width/length linear dims, #730; the datum position dim stays model-derived — it is drawing state, not a feature parameter) | `from_model.render_slots` | `plan_dimensions` |
 | section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |
 
 **Planner-bypassing today** (the renderer takes `model`, re-filters
 `model.features` by kind, and formats raw fields — its computed
 `DimensionGroup`s are discarded):
 
-- `render_slots`, `render_rotational`
-  (OD/centreline/bore furniture), `render_pmi` — all in
+- `render_rotational`
+  (OD/centreline/bore furniture), `render_pmi` — both in
   `annotations/from_model.py`.
 - `render_height_ladder` and `render_step_positions` are also model-routed,
   **by design**: `StepLevelFeature` carries correlated sets that must never be
@@ -138,7 +139,7 @@ no-double-dimensioning/suppression rules currently have no single home
 **The convergence tracker is #698** — extend `_CONVENTION` +
 `plan_dimensions` kind-by-kind (chamfer landed first, #724; fillet/flat/
 groove/pocket followed, #725–#728; plate, #729 — the first *linear*-convention
-migration, no `_CONVENTION` entry needed; slots next) and convert each
+migration; slots, #730 — the mixed corridor/immediate pass) and convert each
 renderer to consume its
 group, pulling the
 scattered suppression rules into the planner as each kind migrates. This ADR

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -190,21 +190,35 @@ def _record_slot_drop(ctx, dwg, kind, idx, view, feat):
     )
 
 
-def render_slots(dwg, model, a, *, ctx, only=None) -> int:
+def render_slots(dwg, groups, a, *, ctx, only=None) -> int:
     """Dimension milled slots from the IR — width (the defining size, across
     ``width_axis``) + length (along ``long_axis``) + a position dim from the part
     datum, in the view the two axes span. Places through the engine's zone strips
     (shared infra, ADR 0008 Amend. 4); a dim with no clear room is dropped and
-    recorded at info severity (place-what-fits). Sources `SlotFeature`s from the
-    model; replaces the engine's `_annotate_slots`. Returns the count placed.
+    recorded at info severity (place-what-fits). Sources slot `DimensionGroup`s
+    from the plan; replaces the engine's `_annotate_slots`. Returns the count placed.
+
+    Planner-fed (#730 / #698): the width + length VALUES and their tolerances come
+    from the planner's ``DimParameter``s, bound explicitly by ``(role, kind)`` —
+    ``("slot_width", "length")`` / ``("slot_length", "length")`` — never positionally.
+    Formatting ``s.width``/``s.length`` directly dropped an authored tolerance (the
+    #629 class). Placement mechanics are untouched: which dims register into the
+    (view, "above") corridor vs place immediately, the ``on_drop`` below-strip
+    fallthrough, the position-vs-hole-location dedup key, and the witness geometry
+    (still the feature's raw fields) all behave as before. The datum POSITION dim
+    stays model-derived (datum → ``s.lo`` is drawing state, not a feature parameter
+    — `SlotFeature.parameters()` has no position param) and carries no tolerance.
+    The pass KEEPS its own axis→view map (the view the slot's two in-plane axes
+    span); ``g.view`` is ``_END_ON`` of the frame axis, which is not that view.
 
     ``only`` (a set of `SlotFeature`s, #426 Phase 2b) restricts placement to a recorded
     subset for ``finalize()``; ``only=None`` (the auto-pass) places all slots, byte-
     identically. Skips filtered slots **in place** so ``i`` stays the slot's model index
     (the ``m_slot{i}_*`` names must match the auto-pass — never re-enumerate a compacted
-    list)."""
-    slots = [f for f in model.features if f.kind == "slot"]
-    if not slots:
+    list; `plan_dimensions` emits one group per slot in model order, so enumerating the
+    slot groups preserves that index)."""
+    slot_groups = [g for g in groups if g.feature_kind == "slot"]
+    if not slot_groups:
         return 0
     draft = dwg.draft
     tier = draft.font_size + 2 * draft.pad_around_text
@@ -218,7 +232,8 @@ def render_slots(dwg, model, a, *, ctx, only=None) -> int:
         return getattr(a.bb.max if hi else a.bb.min, axis.upper())
 
     count = 0
-    for i, s in enumerate(slots):
+    for i, g in enumerate(slot_groups):
+        s = g.feature
         if only is not None and s not in only:
             continue  # #426 Ph2b: skip in place — i must stay the model index
         view = views[frozenset((s.width_axis, s.long_axis))]
@@ -230,9 +245,10 @@ def render_slots(dwg, model, a, *, ctx, only=None) -> int:
             p_hi,
             perp_lo,
             perp_hi,
-            label,
+            value,
             kind,
             anchor="center",
+            sfx="",
             vw=view,
             zn=zones,
             ha=h_axis,
@@ -240,6 +256,9 @@ def render_slots(dwg, model, a, *, ctx, only=None) -> int:
             vp=v_proj,
             idx=i,
         ):
+            # The rendered label: the PLANNED value + its pre-formatted tolerance suffix
+            # (#730 — planner-authoritative; sfx="" keeps untolerated labels byte-identical).
+            lbl = _fmt(value) + sfx
             # Raw (pre-snap) endpoints — the dedup key must share a basis with the
             # hole-location key (which uses the raw ref), else the ~0.05 mm snap gap can
             # push a coincident span into an adjacent 0.1 mm page bin and the #345
@@ -247,7 +266,7 @@ def render_slots(dwg, model, a, *, ctx, only=None) -> int:
             raw_lo, raw_hi = p_lo, p_hi
             # Snap the geometric span to the displayed (1-dp) value so drawn length
             # matches the label (else label-vs-measured lint trips).
-            disp = float(_fmt(label))
+            disp = float(_fmt(value))
             sgn = 1.0 if p_hi >= p_lo else -1.0
             if anchor == "center":
                 mid = (p_lo + p_hi) / 2
@@ -272,8 +291,8 @@ def render_slots(dwg, model, a, *, ctx, only=None) -> int:
                     e_lo, e_hi = (witness, meas_proj(p_lo), 0), (witness, meas_proj(p_hi), 0)
                 return (
                     cname,
-                    lambda pos, _el=e_lo, _eh=e_hi, _s=side, _w=witness: _dim(
-                        _el, _eh, _s, abs(pos - _w), draft, label=_fmt(label)
+                    lambda pos, _el=e_lo, _eh=e_hi, _s=side, _w=witness, _l=lbl: _dim(
+                        _el, _eh, _s, abs(pos - _w), draft, label=_l
                     ),
                 )
 
@@ -345,19 +364,39 @@ def render_slots(dwg, model, a, *, ctx, only=None) -> int:
                     return True
             return False
 
+        # Bind each planned dim explicitly by (role, kind) — never positionally (#730).
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        wpd = by_key.get(("slot_width", "length"))
+        lpd = by_key.get(("slot_length", "length"))
         half = s.width / 2
-        if _place(
-            s.width_axis, s.w_center - half, s.w_center + half, s.lo, s.hi, s.width, "width"
-        ):
-            count += 1
-        else:
-            _record_slot_drop(ctx, dwg, "width", i, name, s)
-        if _place(
-            s.long_axis, s.lo, s.hi, s.w_center - half, s.w_center + half, s.length, "length"
-        ):
-            count += 1
-        else:
-            _record_slot_drop(ctx, dwg, "length", i, name, s)
+        if wpd is not None and not wpd.suppressed:
+            if _place(
+                s.width_axis,
+                s.w_center - half,
+                s.w_center + half,
+                s.lo,
+                s.hi,
+                wpd.param.value,
+                "width",
+                sfx=_tol_suffix(wpd.param.tolerance, draft),
+            ):
+                count += 1
+            else:
+                _record_slot_drop(ctx, dwg, "width", i, name, s)
+        if lpd is not None and not lpd.suppressed:
+            if _place(
+                s.long_axis,
+                s.lo,
+                s.hi,
+                s.w_center - half,
+                s.w_center + half,
+                lpd.param.value,
+                "length",
+                sfx=_tol_suffix(lpd.param.tolerance, draft),
+            ):
+                count += 1
+            else:
+                _record_slot_drop(ctx, dwg, "length", i, name, s)
         datum = _bb(s.long_axis, False)
         if (s.lo - datum) * a.SCALE >= 1.0:
             if _place(

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -444,7 +444,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Non-cylindrical machined features: slots / reduced across-flats sections
         # (#135) — IR renderer, placed through the zone strips (shared infra). Runs
         # after every hole/diameter pass so it claims strip space last.
-        render_slots(dwg, _model, a, ctx=ctx)
+        # Planner-fed (#730): consumes the DimensionGroups so authored tolerances render.
+        render_slots(dwg, _groups, a, ctx=ctx)
 
     def _s_gdt():
         # Declared GD&T frames / datum symbols / surface finishes (ADR 0011 §4, #61)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1523,10 +1523,11 @@ class Drawing:
         def _s_slots():
             # Slots regenerate width + length + the model-derived datum position (a
             # superset of the recorded slot intents — auto-pass parity by design) and
-            # register into the shared corridor.
+            # register into the shared corridor. Planner-fed (#730): the width/length
+            # values + tolerances come from the plan, like the auto-pass.
             if r.slot_feats:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render_slots(self, model, a, ctx=ctx, only=r.slot_feats)
+                render_slots(self, plan_dimensions(model), a, ctx=ctx, only=r.slot_feats)
 
         def _s_user_dims():
             # User-authored pin/priority dimensions queue into the shared corridor as

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -113,14 +113,29 @@ class DimensionGroup:
         return self.feature.frame.origin
 
 
+# The PROFILE view per axis — the orthographic view whose page plane CONTAINS the
+# axis, so an axial length along it is measurable there (in its `_END_ON` view the
+# span is degenerate — a point). The front view is the x–z plane, so X- and Z-turned
+# axes both derive to "front" by that one containment rule (X/Z parity); a Y axis
+# lies in the side (y–z) plane — the same map the groove profile callouts use.
+_PROFILE = {"x": "front", "z": "front", "y": "side"}
+
+
 def _group_view(feature: Feature) -> str:
     """The single view a feature's callout lands on — derived from the feature's
     axis, never hardcoded, so X and Z are handled by the same rule (parity). A
-    turned step's length + OD read on the lengthwise (front) profile view; a
     diameter callout (hole / boss) reads on the view where the cylinder is end-on
-    (z→plan, x→side, y→front)."""
+    (z→plan, x→side, y→front). A turned step is the opposite case (#731): its
+    length + OD read where the turning axis lies IN-PLANE — `_PROFILE`, not
+    `_END_ON` — which derives to "front" for both X- and Z-turned steps because
+    the front view is the x–z plane. That matches the renderers per axis:
+    `render_step_lengths` draws the chain on the front view (X → horizontal
+    above, Z → vertical right) and `render_diameters` hangs its ø row/column off
+    the front view (X → row below, Z → column left). A Y-axis step derives to
+    its geometric profile ("side"); no step render pipeline consumes Y today
+    (`render_diameters` buckets x/z only)."""
     if feature.kind == "step":
-        return "front"
+        return _PROFILE.get(feature.frame.axis, "front")
     return _END_ON.get(feature.frame.axis, "plan")
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -62,6 +62,10 @@ _CONVENTION = {
     # registry, and a planner-fed kind relying on the implicit default would erode
     # that — unknown pairs should eventually fail loudly, not silently go linear.
     ("thickness", "length"): "linear",
+    # A slot's width + length are linear Dimensions with witness lines (#730) —
+    # again the table default, entered explicitly per the #744 review rule above.
+    ("slot_width", "length"): "linear",
+    ("slot_length", "length"): "linear",
 }
 
 

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -221,6 +221,30 @@ class TestPlanner:
         assert hole_view(z_hole) == "plan"  # Z hole seen end-on in plan
         assert hole_view(x_hole) == "side"  # X hole seen end-on in side — not 'plan'
 
+    def test_step_group_view_is_the_derived_profile_view(self):
+        # #731: a turned step's view is DERIVED from its frame axis by the profile
+        # (in-plane containment) rule, not hardcoded per kind. An axial length is
+        # degenerate in its end-on view; it reads where the axis lies IN the view
+        # plane — the front view is the x–z plane, so X- and Z-turned steps BOTH
+        # derive to "front" by one rule (exactly where render_step_lengths draws
+        # the chain — X horizontal above, Z vertical right — and render_diameters
+        # hangs the ø row below / column left, per axis). A Y-axis step derives to
+        # its geometric profile plane ("side", y–z); no step render pipeline
+        # consumes a Y step today.
+        def view_of(axis):
+            st = StepFeature(
+                frame=Frame((0, 0, 0), axis),
+                length=20.0,
+                diameter=8.0,
+                span=((0, 0, 0), (20, 0, 0)),
+            )
+            (g,) = plan_dimensions(PartModel(bbox=None, orientation=axis, features=[st]))
+            return g.view
+
+        assert view_of("x") == "front"  # x lies in the front (x–z) plane
+        assert view_of("z") == "front"  # z too — the same containment rule, X/Z parity
+        assert view_of("y") == "side"  # y's profile plane is the side (y–z) view
+
     def test_pattern_count_survives_the_planner(self):
         # The planned group must still expose the feature metadata (count, pattern)
         # so a renderer can emit "6× ø6", not just ø6 + ø50 (the narrow-waist gap

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -166,7 +166,7 @@ class TestPlannerDecorations:
         # #728: a pocket's width/length/depth are three distinct-ROLE params sharing kind
         # "length", and decorations key on (feature, kind) — so ONE authored length
         # tolerance folds onto ALL THREE values (documented behaviour; independent
-        # per-role tolerancing is an authoring-surface gap tracked under #698).
+        # per-role tolerancing is an authoring-surface gap, tracked by #746).
         pk = pocket(width=18, length=30, depth=5, long_axis="x", width_axis="y", lo=-15, hi=15)
         model = PartModel(
             bbox=Box(90, 60, 20).bounding_box(),
@@ -212,7 +212,7 @@ class TestPlannerDecorations:
         # (role, kind). Both share kind "length" and decorations key on (feature, kind),
         # so ONE authored length tolerance folds onto BOTH values (documented behaviour,
         # the pocket precedent; independent per-role tolerancing is an authoring-surface
-        # gap tracked under #698).
+        # gap, tracked by #746).
         sl = slot(width=8, length=20, long_axis="x", width_axis="y", lo=-10, hi=10, w_center=0)
         model = PartModel(
             bbox=Box(50, 30, 20).bounding_box(),

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -17,7 +17,18 @@ from build123d_drafting.helpers import draft_preset
 from draftwright import Sheet, build_drawing
 from draftwright._core import _tol_suffix
 from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
-from draftwright.model import PartModel, chamfer, fillet, flat, groove, hole, plate, pocket, step
+from draftwright.model import (
+    PartModel,
+    chamfer,
+    fillet,
+    flat,
+    groove,
+    hole,
+    plate,
+    pocket,
+    slot,
+    step,
+)
 from draftwright.model.planner import plan_dimensions
 
 
@@ -194,6 +205,30 @@ class TestPlannerDecorations:
         assert pd.param.value == 8.0  # hi - lo — exactly what the renderer displays
         assert pd.param.tolerance == 0.1
         assert not pd.suppressed
+
+    def test_slot_dims_are_linear_with_folded_tolerance(self):
+        # #730: a slot's width + length route through the planner — convention "linear"
+        # (explicit _CONVENTION entries per the #744 review rule), each bound by its
+        # (role, kind). Both share kind "length" and decorations key on (feature, kind),
+        # so ONE authored length tolerance folds onto BOTH values (documented behaviour,
+        # the pocket precedent; independent per-role tolerancing is an authoring-surface
+        # gap tracked under #698).
+        sl = slot(width=8, length=20, long_axis="x", width_axis="y", lo=-10, hi=10, w_center=0)
+        model = PartModel(
+            bbox=Box(50, 30, 20).bounding_box(),
+            orientation=None,
+            features=[sl],
+            decorations={(sl, "length"): 0.1},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "slot")
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        assert set(by_key) == {("slot_width", "length"), ("slot_length", "length")}
+        wpd = by_key[("slot_width", "length")]
+        lpd = by_key[("slot_length", "length")]
+        assert wpd.convention == "linear" and lpd.convention == "linear"
+        assert wpd.param.value == 8.0 and lpd.param.value == 20.0
+        assert wpd.param.tolerance == 0.1 and lpd.param.tolerance == 0.1
+        assert not wpd.suppressed and not lpd.suppressed
 
 
 class TestCalloutRendering:
@@ -697,6 +732,117 @@ class TestPlateTolerance:
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("dim_plate")
         ]
         assert labels == ["7"], labels
+
+
+class TestSlotTolerance:
+    """#730 (the #629 class, latent): a slot's authored width/length tolerances must
+    render on the placed linear dims — the pass now consumes the planner's
+    DimensionGroups, binding each dim explicitly by (role, kind) ==
+    ("slot_width"/"slot_length", "length"). Only the VALUE and TOLERANCE source
+    changed; the placement mechanics — corridor registration for the horizontal
+    plan/side dims, immediate strip placement for the rest, the below-strip on_drop
+    fallthrough, the position dedup key, and the model-derived datum position dim —
+    are untouched. (Sheet.slot returns Sheet, not a tolerance handle, so the
+    declared-model decorations path is the authoring surface, as for the siblings.)"""
+
+    @staticmethod
+    def _slotted_block():
+        return Box(50, 30, 20) - Box(20, 8, 30)  # enclosed through-slot (#135)
+
+    @staticmethod
+    def _slot_feature():
+        return slot(width=8, length=20, long_axis="x", width_axis="y", lo=-10, hi=10, w_center=0)
+
+    def test_authored_slot_tolerance_renders_on_dims(self):
+        # Declared model (ADR 0011); the decoration keys on (feature, "length"), which
+        # BOTH slot params share — so one authored tolerance rides both the width dim
+        # (immediate right/left placement) and the length dim (corridor-drained). The
+        # model-derived datum position dim has no parameter, so it stays untoleranced.
+        sl = self._slot_feature()
+        dwg = build_drawing(
+            self._slotted_block(),
+            model=[sl],
+            decorations={(sl, "length"): 0.1},
+            number="X",
+        )
+        labels = {
+            n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_slot")
+        }
+        assert labels == {
+            "m_slot0_width": "8 ±0.1",
+            "m_slot0_length": "20 ±0.1",
+            "m_slot0_pos": "15",
+        }, labels
+
+    def test_untolerated_slot_labels_unchanged(self):
+        # No decoration → the planner path is byte-identical to the old raw-field labels.
+        sl = self._slot_feature()
+        dwg = build_drawing(self._slotted_block(), model=[sl], number="X")
+        labels = {
+            n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_slot")
+        }
+        assert labels == {
+            "m_slot0_width": "8",
+            "m_slot0_length": "20",
+            "m_slot0_pos": "15",
+        }, labels
+
+    def test_tolerance_survives_the_below_strip_fallthrough(self):
+        # #744 review lesson, applied to the slot pass: when the corridor candidate
+        # DROPS, _below_or_drop rebuilds the dim from its own captured label — the
+        # tolerance must ride along, not be reconstructed from the raw field. Drive the
+        # fallthrough deterministically: register via render_slots, then fire the length
+        # candidate's on_drop (the solve's full-strip signal) — the relocated below-strip
+        # dim must still read "20 ±0.1".
+        from draftwright.annotations._common import PlacementContext
+        from draftwright.annotations.from_model import render_slots
+
+        sl = self._slot_feature()
+        dwg = build_drawing(
+            self._slotted_block(),
+            model=[sl],
+            decorations={(sl, "length"): 0.1},
+            number="X",
+            auto_dims=False,
+        )
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        assert render_slots(dwg, plan_dimensions(dwg.model()), dwg._analysis, ctx=ctx) == 3
+        (cand,) = [
+            c
+            for b in ctx.corridor_batch.values()
+            for c in b["cands"]
+            if c.name == "m_slot0_length"
+        ]
+        cand.on_drop(cand.name)  # the solve's full-strip signal
+        assert dwg.get_annotation("m_slot0_length").label == "20 ±0.1"
+
+    def test_renderer_displays_the_planned_values_not_the_raw_fields(self):
+        # #698 binding proof (the #724 decoy shape): the renderer must be
+        # planner-AUTHORITATIVE — each displayed value is its pd.param.value, bound by
+        # (role, kind), never positionally. Feed render_slots a hand-built group with a
+        # decoy first dim and planned width/length deliberately different from the raw
+        # feature fields; the width places immediately, the length via the corridor
+        # drain — both must show the planned value.
+        from dataclasses import replace
+
+        from draftwright.annotations._common import PlacementContext, drain_corridors
+        from draftwright.annotations.from_model import render_slots
+
+        sl = self._slot_feature()
+        dwg = build_drawing(self._slotted_block(), model=[sl], number="X", auto_dims=False)
+        (g,) = [g for g in plan_dimensions(dwg.model()) if g.feature_kind == "slot"]
+        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        wpd = by_key[("slot_width", "length")]
+        lpd = by_key[("slot_length", "length")]
+        decoy = replace(wpd, param=replace(wpd.param, role="decoy", value=99.0))
+        planned_w = replace(wpd, param=replace(wpd.param, value=7.0))  # ≠ sl.width == 8
+        planned_l = replace(lpd, param=replace(lpd.param, value=19.0))  # ≠ sl.length == 20
+        g2 = replace(g, dims=(decoy, planned_w, planned_l))
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+        assert render_slots(dwg, [g2], dwg._analysis, ctx=ctx) == 3
+        drain_corridors(ctx, dwg)
+        assert dwg.get_annotation("m_slot0_width").label == "7"
+        assert dwg.get_annotation("m_slot0_length").label == "19"
 
 
 class TestToleranceHandle:


### PR DESCRIPTION
The final PR of epic #698 — **closes #730, closes #731, closes #698**.

## Commit 1 — slot via planner (#730)

The largest bypass pass, and the one with structure: `render_slots` is MIXED (plan/side horizontal-axis dims register into the `(view, "above")` corridor; right/left and front dims place immediately; a `_below_or_drop` fallback). All of that is **preserved exactly** — corridor registration, subchain ordering, dedup keys, the model-derived untoleranced datum-position dim, and the finalize `only=` routing (role strings `slot_width`/`slot_length` untouched; the deferred-edit tests pass unchanged). Only the value/label source changed: explicit `(role, kind)` binding, planner-authoritative values, `_tol_suffix` riding every build closure including the below-strip retry (the plate-review lesson). Explicit `"linear"` `_CONVENTION` entries per the #744 review rule. One kind-keyed tolerance folds onto both width and length — the documented pocket precedent, now tracked by **#746** (role-keyed decorations) since this PR closes the epic that previously tracked it.

## Commit 2 — the step group view is derived (#731)

`_group_view`'s `kind == "step" → "front"` hardcode replaced by a real one-rule derivation: a step's length/OD read where the axis lies **in-plane** (`_PROFILE` — the groove pass's containment map), which yields front for both X- and Z-turned steps because the front view is the x–z plane. Verified against the actual renderers (`render_step_lengths` draws on front; `render_diameters` buckets x/z off front) and grep-verified that **no consumer reads a step group's `.view`** — zero rendered-output change; a Y-axis step now reports its true geometric profile. Pinned per-axis by a unit test.

## Verification

- Full battery green pre-rebase: guards 81, targeted 179, goldens 14 (zero shift), full fast tier **1452 passed, 0 failed** (even #710's hypothesis test passed)
- Re-verified post-rebase onto main (incl. #729/#743): targeted 179 + guards 36 + tolerances 47 green; lint clean

## Epic wrap

With this, all seven kind migrations (#724–#730) + the `_group_view` fix (#731) are done: every machined-feature kind now takes the planner path, each closing its latent silent-tolerance-drop on the way, and ADR 0015's coverage table reads planner-fed across the board. New-kind rule stands: the planner path is the paved road.

🤖 Generated with [Claude Code](https://claude.com/claude-code)