### PR TITLE
docs: align ADRs with current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ entry. Keep `_LAYERS` and this section in step.
   - **`annotations/balloons.py`** — the leadered hole-balloon pass (#111/#516;
     moved down from `Drawing`, #699). `Drawing.add_balloons` is the public verb
     threading build state in; the band-assignment flow solver lives in `layout.py`.
-  - **`annotations/_common.py`** — the ADR 0009 corridor-solve engine
+  - **`annotations/_common.py`** — the ADR 0014 corridor-solve engine
     (`CorridorCandidate`, `solve_corridor`, `register_corridor`/`drain_corridors`,
     `place_strip_candidates`, `PlacementContext`) plus `_box_hits`, at the
     bottom of the annotations DAG. (The bbox/segment primitives it delegates to
@@ -102,9 +102,10 @@ entry. Keep `_LAYERS` and this section in step.
   the `Analysis` namespace and its field types (`_Projector`, `Strip`, `ViewZones`),
   the dimension/format helpers (`_dim`, `_fmt`, `_add_title_block`, …), and the
   page/slot/margin layout constants.
-- **`layout.py`** — the constraint-based layout engine (ADR 0003): the deterministic
+- **`layout.py`** — the deterministic placement primitives used by ADRs 0004/0014:
+  the deterministic
   1D PAVA strip solve (`_solve_strip_1d_pava`, plus `plan_strip`/`StripCandidate`,
-  the ADR 0009 collect-then-solve entry point), the 2D free-rectangle placer
+  the ADR 0014 collect-then-solve entry point), the 2D free-rectangle placer
   (`fit_box`), and the balloon band-assignment min-cost max-flow solve
   (`_assign_balloon_bands`, #516; here since #699 — solvers live in the solver
   layer). Sits *below* the domain API.
@@ -142,7 +143,7 @@ entry. Keep `_LAYERS` and this section in step.
   (which now owns the `sheet.py` name).
 - **`analysis.py`** — the `_analyse` stage: solid classification, the one-shot
   feature-inventory detection (ADR 0008 Am5), view sizing, and the strip/zone
-  model (`fv_zones`/`pv_zones`/`sv_zones`) that ADR 0009 placement reads.
+  model (`fv_zones`/`pv_zones`/`sv_zones`) that ADR 0014 placement reads.
 - **`projection.py`** — HLR projection and view-coordinate transforms
   (`_assemble`'s geometry half; #161).
 - **`sheet.py`** — the fluent declarative **`Sheet`** facade (ADR 0011):
@@ -229,8 +230,8 @@ Current ADRs:
 - **0001** — deterministic generation over an editable DSL.
 - **0002** — iterate via lint-critique and domain-repair (repair is a *safety
   net*, not the primary placement mechanism).
-- **0003** — constraint-based **inner** layout (the deterministic PAVA strip
-  solve in `layout.py`): placing one view's annotations within its own zones.
+- **0003** — **Retired**: historical universal-solver exploration. Its live
+  responsibilities are split between 0004 (outer layout) and 0014 (inner placement).
 - **0004** — **compose-then-pack** (Accepted; the **outer** layout): each view is
   a *block* = `view_rect(scale) + its annotation boxes`; choose `(scale, page)`
   by a monotone search whose fitness function is composing + packing the blocks
@@ -248,9 +249,10 @@ Current ADRs:
   facade). `layout.py` unchanged. **Roadmap:** `docs/plans/138-module-split-roadmap.md`.
   Both deferred follow-ups are resolved: the §2 build-context threading closed
   via **#639** (epic #635 — one typed `BuildState`, empty-allowlist ratchet), and
-  `annotations/envelope.py` was overtaken by ADR 0008 (the envelope pass
+  `annotations/envelope.py` was overtaken by the compiler convergence now
+  recorded in ADR 0015 (the envelope pass
   converged into `annotations/from_model.py` instead). §4's compat-alias exit is
-  tracked by **#699**.
+  tracked by **#720** for 0.4.0.
 - **0006** — **Accepted** (#149): deterministic cross-platform layout via bundled,
   path-pinned fonts. Layout depends on measured text width; resolving a font *name*
   (`"Arial"`) substitutes a different font on Linux, drifting the whole sheet ~1 mm.
@@ -267,15 +269,15 @@ Current ADRs:
   frozen. Read 0015 for current state.
 - **0009** — **Superseded by 0014** (#697): the collect-then-solve why-trail
   (9 amendments), frozen. Read 0014 for current state.
-- **0010** — **Accepted** (decision; work pending): **annotation provenance seam**.
+- **0010** — **Accepted; landed**: **annotation provenance seam**.
   The editable-surface epic needs "which annotations did this feature/intent
   produce?" (for `drop`/`dimension`/`finalize`/the #400 emitter). Rather than
   tagging each render pass (the link is lost at the corridor placer, the
   diameter-spec flattening, and the recognition→IR boundary), record
   `intent → [names]` **once** at the intent→render seam, with an `origin` back-link
-  on IR features. The registry's `_anno_feature` (#398b) is the sink; the seam is
-  the automatic populator. Re-plans #398c–e, enables #400.
-- **0011** — **Accepted** (Phase 0+1 + Phase 2 aspects landed; P2d PMI-source pending):
+  on every IR feature was rejected; aspect features retain targeting handles.
+  The render seam is the automatic populator and the contract is audit-tested.
+- **0011** — **Accepted** (core landed; #62/#462/#495 remain):
   **the IR as a public input** — declare features, don't only detect them.
   `build_drawing(part, model=…)` accepts a caller-supplied `PartModel`/`Sequence[Feature]`
   and **skips detection**; object→feature constructors
@@ -285,21 +287,21 @@ Current ADRs:
   "beautiful-Python" surface over the existing renderers. **Aspects geometry can't carry
   are now built:** tolerance/fit ride `DimParameter` (P2a/P2a.2); **GD&T + surface finish**
   are standalone IR features (`ControlFrame`/`DatumRef`/`Finish`, `model/ir.py`) placed as
-  first-class ADR 0009 corridor candidates by `render_gdt` (P2b #478), authored via
+  first-class ADR 0014 corridor candidates by `render_gdt` (P2b #478), authored via
   `sheet.datum`/`sheet.control(…).position(…)`/`.finish` whose target view+strip derive
   from the referenced feature/face (`declare.gdt_target`, P2c #480/#482). PMI-sourced
-  auto-GD&T is the last item (#62). Sidesteps #298 misdetection; complements #400 (read +
-  edit → now also input). Roadmap: `docs/plans/0011-phase2-aspects-roadmap.md`; #446/#445.
-- **0012** — **Accepted; landed** (2026-07-08, umbrella #511 closed — supersedes #396,
-  extends #388/#426): **user annotation edits are pinned, priority-ranked candidates in
-  the one global solve.** A `dimension(..., pin=, priority=)` edit records a
+  auto-GD&T remains #62; number-free aspects remain #462 and raw-cutter slot reading
+  remains #495. Sidesteps #298 misdetection; complements #400 (read + edit → now also
+  input). Roadmap: `docs/plans/0011-phase2-aspects-roadmap.md`; #446/#445.
+- **0012** — **Accepted; partially landed** (2026-07-08; corrected 2026-07-19):
+  user annotation edits are pinned, priority-ranked corridor candidates. A
+  `dimension(..., pin=, priority=)` edit records a
   scale-independent *dimension intent* on the model — **pin** = the solver's `anchored`/
   `_ANCHOR_WEIGHT` (stays put while the rest flow around it), **priority** =
-  `CorridorCandidate.priority` (#357) — placed by the **same** `solve_corridor` as the
-  auto dims, re-run by the recompose (`Drawing.finalize()`, #426). Edit freely, recompose
-  once; pin is the escape valve so the user never fights the solver. `place_dim()` is now
-  the deprecated raw-coordinate escape hatch. The #477 below/right fold-in landed as a
-  dependency.
+  `CorridorCandidate.priority` (#357). `Drawing.finalize()` drains only recorded
+  deferred intents through `_PASS_SEQUENCE`; it does not reconstruct auto candidates or
+  perform a global auto-plus-user recompose. `place_dim()` remains the deprecated raw-
+  coordinate escape hatch. Full recomposition/parity remains #426/#661/#707.
 - **0013** — **Accepted** (#568; Phase 1 in progress): the **uniform recogniser
   contract** — `recognise_<feature>(part, *, <injected deps>) -> list[<frozen
   record>]` (plus the part-less *derived* shape, e.g.

--- a/docs/adr/0001-deterministic-generation-over-editable-dsl.md
+++ b/docs/adr/0001-deterministic-generation-over-editable-dsl.md
@@ -118,16 +118,19 @@ rejected primitive dump (§3) nor a bespoke serialized DSL, but the **detected
   B-rep faces/edges (no tags/names), semantically poorer than authored objects;
   the detected model is uniform and semantic for both. (This is the concrete form
   of "get me from a STEP input to somewhere like if I had build123d objects.")
-- **Edit against the model, re-solve deterministically.** Tweaks reference feature
-  handles from `dwg.model()` (read half, #397) via a feature-targeted write API
-  (#398), and `finalize_drawing(dwg)` (#388) re-runs the ADR-0009 layout. No dead
-  coordinates; edits survive a re-draft — the property §3 rejected primitive dumps
-  for lacking. This surface has an optional **executable form** (#400): emit the
+- **Edit against the model, then deterministically drain recorded intents.**
+  Tweaks reference feature handles from `dwg.model()` (read half, #397) via a
+  feature-targeted write API (#398). `Drawing.finalize()` (#388) routes intents
+  recorded in deferred mode through the current ADR-0014 corridor machinery.
+  It does not rerun automatic annotation or guarantee a single
+  automatic-plus-user re-solve; ADR 0012 records that narrower landed contract.
+  This surface has an optional **executable form** (#400): emit the
   planner's per-feature intents as a readable, editable script of *semantic* calls
   (not page coordinates). That is a sanctioned narrowing of §3's "de-emphasise
   code generation" — code generation at the *intent* level dodges the dead-coordinate
-  failure §3 actually rejected — provided the emitter serializes the planner's real
-  intents (faithful by construction) and a round-trip test holds.
+  failure §3 actually rejected — provided the emitter serializes the planner's
+  real intents. Script/direct equality must be demonstrated per feature path
+  rather than assumed by construction; known gaps are tracked by #426/#661/#707.
 - **Topology is an optional accelerant, not a dependency.** When the caller
   authored the part (the b123d scenario) they may *also* reference a raw
   `Face`/`Edge`/tag (§4's "edit the solid" made concrete for annotation);

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -49,11 +49,13 @@ refinement model, with the lint system as the machine-readable critic.
 
 4. **Make the loop cheap to close.** Two mechanisms reduce the fix step to near
    review-only:
-   - **Per-issue `suggestion` (#29):** each lint issue carries a computed,
-     ready-to-apply domain-API call, so the caller reviews/applies rather than
-     invents.
-   - **lint→repair loop (#30):** computable suggestions are auto-applied; only
-     genuinely judgement-bearing issues reach the human/AI.
+   - **Per-issue `suggestion` (#29):** supported lint issues can carry a computed
+     domain-API call for a caller to review and apply. Suggestions are advisory;
+     they are not a general executable repair program.
+   - **lint→repair loop (#30):** automatic repair is deliberately allowlisted.
+     Today `repair.py` handles only the mechanically clear `dim_inside_part`
+     case; all other suggestions and judgement-bearing issues remain with the
+     caller.
 
 The loop is the API-side equivalent of the interactive laps: the engine gives the
 first lap free, lint gives the critique, and the domain API + repair loop give the
@@ -91,10 +93,12 @@ the build-out.)* The loop is **built**: the read/query API (#25–28 — `place_
 `features()`/`annotations()`/`view_bounds()`) plus the domain-semantic edit
 verbs (`dimension()`/`callout()`/`locate()`/`drop()`, shipped under the
 ADR 0010/0012 editable-surface work),
-per-issue suggestions (#29, `linting/suggest.py`), and the deterministic
-lint→repair loop (#30, `repair.py`, with `Drawing.repair()` as the thin
-wrapper) all shipped. Repair remains the *safety net*, not the primary
-placement mechanism — ADR 0009's collect-then-solve is the structural cure for
+per-issue advisory suggestions (#29, `linting/suggest.py`), and a narrow
+deterministic repair hook (#30, `repair.py`, with `Drawing.repair()` as the thin
+wrapper) all shipped. The hook currently repairs only `dim_inside_part` and
+does not execute arbitrary `Issue.suggestion` values. Repair remains the
+*safety net*, not the primary placement mechanism — ADR 0014's
+collect-then-solve contract is the structural cure for
 the collision classes repair used to mop up.
 
 ## Related

--- a/docs/adr/0003-constraint-based-layout.md
+++ b/docs/adr/0003-constraint-based-layout.md
@@ -1,13 +1,9 @@
 # ADR 0003 — Constraint-based layout: one solver for every placeable
 
-- **Status:** Accepted (core implemented; the unifying *global 2-D* solve stays
-  deferred — #94; amended 2026-07-10 — see Correction). The 1-D strip solve,
-  `fit_box`, and pins (#89) have shipped — the concrete carrier is
-  `StripCandidate`/`plan_strip`/`CorridorCandidate`, not the original
-  `Placeable`/`LayoutSolver` model, which was retired (#547). The **assignment
-  layer** and **escalation ladder** for per-view strip placement are made
-  concrete by [ADR 0009](0009-boundary-labeling-strip-placement.md)
-  (collect-then-solve boundary labeling).
+- **Status:** **Retired (2026-07-19). Superseded jointly by
+  [ADR 0004](0004-compose-then-pack-view-blocks.md) and
+  [ADR 0014](0014-collect-then-solve-annotation-placement.md).** See the final
+  amendment. Retained as the historical record of the solver exploration.
 - **Date:** 2026-06-18
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -252,10 +248,28 @@ Migration sections as the conceptual shape that was later realised by
 - [ADR 0005](0005-pipeline-architecture-and-state-ownership.md) — module
   boundaries and single-owner build state; `layout.py` is unchanged, but pin
   state moves to `registry.py`.
-- [ADR 0009](0009-boundary-labeling-strip-placement.md) — makes this ADR's
+- [ADR 0014](0014-collect-then-solve-annotation-placement.md) — makes this ADR's
   assignment layer and escalation ladder concrete for per-view strip placement
-  (collect-then-solve boundary labeling); the per-view inner layer to ADR 0004's
-  outer block packing.
+  (collect-then-solve annotation placement); the per-view inner layer to ADR
+  0004's outer block packing. It supersedes ADR 0009, which remains the
+  historical design record.
 - Issue #77 (external turned diameters — the first `Placeable`); the phased
   layout issues (protocol/solver → port callouts → port dims → tables/GD&T);
   #61/#62 (GD&T — beneficiaries of the unified placement).
+
+## Final amendment — retired, not deferred (2026-07-19)
+
+This ADR is no longer a current architecture contract.
+
+- Its proposed shared `Placeable`/`LayoutSolver` carrier was deleted in #547
+  after production placement converged on corridor candidates instead.
+- Its page-global free 2-D solve was explicitly closed as unnecessary in #94,
+  not left as deferred work. Projection alignment makes page topology mostly
+  fixed; ADR 0004's compose-then-pack model is the accepted outer layout.
+- ADR 0014 is the accepted inner annotation-placement contract: collect,
+  select, assign, and solve deterministic one-dimensional corridors, with
+  `fit_box` for bounded free-rectangle furniture placement.
+
+Read the Decision, Migration, and earlier Correction sections above as design
+history. For current implementation guidance, use ADR 0004 for view/page
+composition and ADR 0014 for annotation placement.

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -30,8 +30,9 @@ recurring class of failures (surfaced while making dense hole patterns legible,
   drawing (NIST CTC-02, ~60 balloons) sits at the CI timeout.
 
 Each symptom is a patch on the same flaw: annotations are second-class citizens
-placed post-hoc, competing for scraps. ADR 0003 settles how *annotations within
-a view* are placed (the `Placeable`/Cassowary inner layout). This ADR settles
+placed post-hoc, competing for scraps. ADR 0014 now settles how *annotations
+within a view* are placed (collect-then-solve corridors; retired ADR 0003 holds
+the earlier `Placeable`/Cassowary exploration). This ADR settles
 the layer around it: **how a view and its full annotation set are composed into
 one placeable block, and how those blocks are packed onto the page and scaled.**
 
@@ -220,7 +221,7 @@ Decisions:
 3. **Acceptance test = the inter-view overlap.** A step is correct when
    **plan-view labels do not overlap front-view dimensions** (and lint is clean)
    on the hard case (NIST CTC-02), *not* when output is unchanged.
-4. **Footprint stays a box layout** (page-mm rectangles via the ADR-0003 inner
+4. **Footprint stays a box layout** (page-mm rectangles via the ADR-0014 inner
    layout in view-local space) — never bbox-measured OCC geometry (the O(n²)
    `lint()` wall, ~110 s on CTC-02, is the standing evidence).
 5. **Tracked as #121.** The root cause is "annotations placed *after* views are

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -115,22 +115,20 @@ hard rejection is `_MIN_RENDER_MM` (0.1 mm) — a conservative geometry floor we
 above where OCCT's annotation arcs actually degenerate (`Geom_TrimmedCurve U1==U2`,
 ~1e-4 mm); there we raise a clean message rather than crash.
 
-### Relationship to ADR 0003 and the deferred 2D solve
+### Relationship to retired ADR 0003 and the rejected 2D solve
 
-- ADR 0003 governs the **inner** layout (placing a view's own annotations in its
-  zones via the `Placeable`/Cassowary system) — now made concrete by
-  [ADR 0009](0009-boundary-labeling-strip-placement.md) (collect-then-solve
-  boundary labeling per strip). This ADR governs the **outer** layout (composing
-  view+annotation blocks and packing them on the page). A block's footprint is
-  the deterministic bounding box that the ADR-0009 inner solve produces in
-  view-local space.
+- [ADR 0014](0014-collect-then-solve-annotation-placement.md) governs the
+  **inner** layout: collect-then-solve annotation placement per corridor. This
+  ADR governs the **outer** layout: composing view+annotation blocks and
+  packing them on the page. ADR 0003 is retained only as the retired historical
+  proposal that preceded these two concrete contracts.
 - The **page-level packing stays fixed-topology** (plan above front sharing X;
   side beside front sharing Y; iso and table in free rectangles via
-  `fit_box`). It is **not** the full global 2D solve deferred in
-  #94, which we keep deferred — most "2D freedom" is forbidden by projection
-  alignment, and a global non-overlap solve is disjunctive/NP-hard and
-  non-deterministic. Fixed-topology + composed footprints + local free-rect
-  placement is the right amount of structure.
+  `fit_box`). The full global 2D solve in #94 was closed as superseded and
+  unnecessary: most "2D freedom" is forbidden by projection alignment, while
+  a global non-overlap solve is disjunctive/NP-hard and risks nondeterminism.
+  Fixed-topology + composed footprints + local free-rect placement is the
+  accepted amount of structure.
 
 ### Implementation state (updated 2026-07-09)
 

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -1,11 +1,8 @@
 # ADR 0005 — Compiler-pipeline module boundaries and single-owner build state
 
-- **Status:** Accepted (module split complete; the deferred follow-ups are
-  closed — see the 2026-07-15 status note below; §4's compat-alias exit
-  prerequisites are met by #699 slice c — the seven aliases are tracked by
-  **#720** with removal target **0.4.0** and external call sites are
-  redirected to the public reads — with the deletion itself remaining #720's
-  0.4.0 work)
+- **Status:** Accepted; implemented. The lasting contract is summarized in the
+  2026-07-19 amendment. Compatibility-alias deletion remains tracked by #720
+  for 0.4.0.
 - **Date:** 2026-06-27
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Progress:** Execution roadmap with per-phase tracking issues:
@@ -84,7 +81,7 @@ draftwright/
   projection.py          # view projection, exact silhouettes, iso fitting (_assemble, _project_iso, _fit_iso_view)
   drawing.py             # Drawing public facade
   registry.py            # annotation identity/ownership/pins/build-issues (see §2)
-  linting.py             # lint_feature_coverage, suggestions, scoring, summary (ADR 0002)
+  linting/               # coverage, issues, structural lint, suggestions (ADR 0002)
   repair.py              # deterministic repair loop (ADR 0002)
   export.py              # SVG/DXF/PDF export + post-processing
   tables.py              # generic table construction/placement helpers
@@ -92,17 +89,20 @@ draftwright/
                          #    the one sizing model (#700/#699); PLACEMENT stayed a Drawing verb, add_table)
   annotations/
     orchestrator.py      # auto_annotate sequencing (_auto_annotate)
-    envelope.py          # OD/width/depth/height/step dims
+    _common.py           # shared annotation placement/rendering helpers
+    from_model.py        # IR planner/render passes, including envelope features
     holes.py             # hole callouts, location dims, hole-table escalation
-    turned.py            # turned-diameter leaders
     sections.py          # section/detail views
-    pmi.py               # PMI annotation placement
+    balloons.py          # balloon rendering and placement
   layout.py              # UNCHANGED — solver/placement abstraction (ADR 0003)
   _core.py               # shared primitives below builder/annotations (Analysis types, _dim/_fmt, layout constants)
 ```
 
-`layout.py` keeps its current responsibility exactly (ADR 0003); it stays the
-bottom of the DAG with `_core.py`.
+This is the landed module shape. The earlier proposal named standalone
+`envelope.py`, `turned.py`, and `pmi.py` modules; those responsibilities
+converged into `from_model.py` and the shared annotation modules instead.
+`layout.py` keeps its current responsibility (ADR 0003) near the bottom of the
+DAG with `_core.py`.
 
 ### 2. Build-time state gets explicit owners — three, not one god-object
 
@@ -291,3 +291,27 @@ Follows the issue (#138) sequence, with §3 added as Step 0:
   [ADR 0004](0004-compose-then-pack-view-blocks.md).
 
 **Amendment (2026-07-18) — §2 closed (#639):** `Drawing` is no longer the implicit state bus. The render passes take an explicit `PlacementContext` and make **zero** private `Drawing` reads (the `_DWG_PRIVATE_READ_ALLOW` ratchet is empty and fail-closed). The build context (`Analysis`, part model, lint geometry caches) lives in one typed `BuildState` on the drawing, filled at a single `builder._assemble` site and single-writer-guarded; it serves the Drawing's own methods (lint/finalize/repair/edit verbs) and the test surface — hosting its own state was never the §2 sin, passes reaching in was.
+
+## Amendment — current architecture contract (2026-07-19)
+
+The original migration plan, measurements, golden-harness discussion, module
+proposals, and prerequisite warnings above are retained as implementation
+history. They are not current work instructions. The lasting decision is:
+
+1. Compiler stages have explicit module homes: orchestration in `builder.py`,
+   analysis in `analysis.py`, outer layout in `compose.py`, projection in
+   `projection.py`, annotation passes in `annotations/`, lint in `linting/`,
+   repair in `repair.py`, and export in `export.py`.
+2. `Drawing` is the public editable object, not an implicit communication bus.
+   Render passes receive an explicit `PlacementContext`; their fail-closed
+   private-read allowlist is empty.
+3. Build artefacts are held in one typed `BuildState`, populated at the single
+   `builder._assemble` boundary. Annotation identity belongs to `Registry`, and
+   lint coverage belongs to `CoverageState`.
+4. Import direction and state encapsulation are executable contracts enforced
+   by `test_import_boundaries.py` and `test_drawing_encapsulation.py`.
+5. Seven private compatibility aliases remain only for the 0.4.0 transition;
+   #720 owns their deletion. They are not sanctioned extension points.
+
+This amendment is the reader's current entry point. The dated sections above
+explain how the package reached it.

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -1,8 +1,6 @@
 # ADR 0005 — Compiler-pipeline module boundaries and single-owner build state
 
-- **Status:** Accepted; implemented. The lasting contract is summarized in the
-  2026-07-19 amendment. Compatibility-alias deletion remains tracked by #720
-  for 0.4.0.
+- **Status:** Accepted; implemented, with compatibility-alias deletion tracked by #720 for 0.4.0.
 - **Date:** 2026-06-27
 - **Deciders:** Paul Fremantle (pzfreo)
 - **Progress:** Execution roadmap with per-phase tracking issues:
@@ -94,14 +92,14 @@ draftwright/
     holes.py             # hole callouts, location dims, hole-table escalation
     sections.py          # section/detail views
     balloons.py          # balloon rendering and placement
-  layout.py              # UNCHANGED — solver/placement abstraction (ADR 0003)
+  layout.py              # placement primitives consumed by ADRs 0004/0014
   _core.py               # shared primitives below builder/annotations (Analysis types, _dim/_fmt, layout constants)
 ```
 
-This is the landed module shape. The earlier proposal named standalone
+This is the landed shape of the modules this ADR proposed. The earlier proposal named standalone
 `envelope.py`, `turned.py`, and `pmi.py` modules; those responsibilities
 converged into `from_model.py` and the shared annotation modules instead.
-`layout.py` keeps its current responsibility (ADR 0003) near the bottom of the
+`layout.py` keeps its placement-primitives responsibility near the bottom of the
 DAG with `_core.py`.
 
 ### 2. Build-time state gets explicit owners — three, not one god-object
@@ -306,7 +304,8 @@ history. They are not current work instructions. The lasting decision is:
    Render passes receive an explicit `PlacementContext`; their fail-closed
    private-read allowlist is empty.
 3. Build artefacts are held in one typed `BuildState`, populated at the single
-   `builder._assemble` boundary. Annotation identity belongs to `Registry`, and
+   `builder._assemble` boundary. Annotation identity belongs to
+   `AnnotationRegistry`, and
    lint coverage belongs to `CoverageState`.
 4. Import direction and state encapsulation are executable contracts enforced
    by `test_import_boundaries.py` and `test_drawing_encapsulation.py`.

--- a/docs/adr/0010-annotation-provenance-seam.md
+++ b/docs/adr/0010-annotation-provenance-seam.md
@@ -32,7 +32,8 @@ layer boundaries before `dwg.add`:
 Tagging each pass in turn (398c, 398d, …) treats the symptom pass by pass. The common
 **root** is that there is no single seam recording, per planned intent, the annotation
 names it emitted. The planner already produces one `DimensionGroup` per feature
-(ADR 0008), and the render layer consumes groups and calls `dwg.add` — but the
+(ADR 0015, superseding ADR 0008), and the render layer consumes groups and calls
+`dwg.add` — but the
 `group → names` mapping is discarded at the moment it is known.
 
 ## Decision
@@ -152,7 +153,8 @@ the `origin`-back-link mechanism dropped as unnecessary).
 - [ADR 0005](0005-pipeline-architecture-and-state-ownership.md) — the registry is the
   single owner of annotation identity/ownership; provenance is the new axis, and its
   sink.
-- [ADR 0008](0008-unified-feature-model-and-dimensioning-planner.md) — the IR/planner
+- [ADR 0015](0015-part-drawing-compiler-as-built.md) — the current IR/planner
+  contract (superseding ADR 0008); the
   intent boundary is where the seam lives. (`origin` survives only on the
   *aspect* features — `ControlFrame`/`DatumRef`/`Finish`/`Note` — as a
   targeting handle; see Amendment 2. The universal

--- a/docs/adr/0010-annotation-provenance-seam.md
+++ b/docs/adr/0010-annotation-provenance-seam.md
@@ -157,6 +157,7 @@ the `origin`-back-link mechanism dropped as unnecessary).
   *aspect* features — `ControlFrame`/`DatumRef`/`Finish`/`Note` — as a
   targeting handle; see Amendment 2. The universal
   back-link on IR feature types was never needed and was not built.)
-- [ADR 0009](0009-boundary-labeling-strip-placement.md) — the corridor placer is a
+- [ADR 0014](0014-collect-then-solve-annotation-placement.md) — the current
+  corridor-placement contract (superseding ADR 0009) is a
   layer that must carry the intent through to its deferred add.
 - Issues: #398 (edit-by-feature), #400 (expanded semantic script), #388 (finalize).

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -1,13 +1,8 @@
 # ADR 0011 — The IR as a public input: declare features, don't only detect them
 
-- **Status:** Accepted; core public-input and `Sheet` façade landed. Aspect
-  rendering is mostly landed. Remaining scope is explicit: PMI-sourced
-  auto-GD&T (#62), number-free object-reading aspects (#462), and raw-cutter
-  slot reading (#495), under roadmap #446. See Amendment 2.
-  Phase 2
-  execution plan:
-  [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
-  **Amendment 1** (2026-07-05): the three authoring modes + the **mode-3 generation surface**
+- **Status:** Accepted; core landed, with #62/#462/#495 remaining under roadmap #446 (see Amendment 2).
+- **Phase 2 plan:** [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
+- **Amendment 1** (2026-07-05): the three authoring modes + the **mode-3 generation surface**
   (a declarative `Sheet`-DSL emitter, #461/#462/#463) — sequenced *before* P2b. Decided: for
   detected input, emit a **part-seam** with detected numbers; reconstruction deferred.
 - **Date:** 2026-07-05
@@ -16,7 +11,8 @@
 ## Context
 
 draftwright compiles a solid into a drawing through one waist: the **IR
-`PartModel`** — a list of frozen `Feature` dataclasses (ADR 0008). Everything
+`PartModel`** — a list of frozen `Feature` dataclasses (introduced by retired
+ADR 0008; current compiler contract: ADR 0015). Everything
 downstream of it — the planner, render-intents, the ADR-0009 layout, lint,
 export — reads *that*, never the raw solid. Today there is exactly **one producer**
 of the IR: **feature detection** (`recognition/` → `build_part_model`), which
@@ -268,7 +264,8 @@ generation surface is the differentiator; GD&T is additive rendering behind the 
 
 - **Extends ADR 0001 Amendment 1** (both inputs converge at the detected IR) — the
   caller is now a first-class *producer* of that IR, not only an editor of it.
-- **Builds on ADR 0008** (the unified feature model / dimensioning planner) — the
+- **Builds on ADR 0015** (which supersedes ADR 0008's unified feature-model
+  history) — the
   PartModel waist is exactly the seam that makes a single `model=` input possible with
   zero downstream change.
 - **Complements #400** (the editable surface): read (`dwg.model()`) + edit (verbs) +

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -1,13 +1,10 @@
 # ADR 0011 — The IR as a public input: declare features, don't only detect them
 
-- **Status:** Accepted — Phase 0 (the `model=` seam + object→feature constructors) and
-  Phase 1 (the `Sheet` façade) landed; Phase 2 (aspect renderers) underway: **P2a
-  toleranced dimensions** (±/limit on a diameter/step/hole, via a `decorations=` side-layer
-  → `DimParameter.tolerance`) and **P2a.2 fit-class** (`.fit("H7")` → ISO 286 deviation,
-  `draftwright/fits.py`, riding the same `tolerance` field as a `FitClass` marker) landed;
-  **P2b GD&T+finish** (#478) and **P2c aspect verbs** (`sheet.datum`/`.control`/`.finish`,
-  #480/#482) landed 2026-07-06; only **P2d PMI-sourced auto-GD&T** (#62) remains
-  pending per the #446 roadmap. Phase 2
+- **Status:** Accepted; core public-input and `Sheet` façade landed. Aspect
+  rendering is mostly landed. Remaining scope is explicit: PMI-sourced
+  auto-GD&T (#62), number-free object-reading aspects (#462), and raw-cutter
+  slot reading (#495), under roadmap #446. See Amendment 2.
+  Phase 2
   execution plan:
   [`docs/plans/0011-phase2-aspects-roadmap.md`](../plans/0011-phase2-aspects-roadmap.md).
   **Amendment 1** (2026-07-05): the three authoring modes + the **mode-3 generation surface**
@@ -276,3 +273,23 @@ generation surface is the differentiator; GD&T is additive rendering behind the 
   zero downstream change.
 - **Complements #400** (the editable surface): read (`dwg.model()`) + edit (verbs) +
   now **input** (`model=`).
+
+## Amendment 2 — current delivery boundary (2026-07-19)
+
+The `model=` seam, object-to-feature constructors, hybrid declaration, `Sheet`
+façade, tolerances/fits, finish, datum, and feature-control verbs have landed.
+That makes the public IR input a current contract.
+
+The ADR is not fully complete in every authoring mode:
+
+- #62 remains the PMI-to-automatic-GD&T ingestion path.
+- #462 remains the number-free object-reading surface for size-bearing aspects
+  such as counterbores and spotfaces.
+- #495 remains raw-cutter/intersection-based slot reading.
+- #707 separately tracks declarative script versus direct-output fidelity; this
+  ADR guarantees semantic input, not byte-identical rendering.
+
+The earlier phrase “only P2d remains” referred only to the aspect-renderer
+sequence and did not account for the still-open authoring-completeness work.
+This amendment is authoritative for delivery status; the original phases above
+remain the historical execution record.

--- a/docs/adr/0012-edits-as-pinned-priority-candidates-in-the-global-solve.md
+++ b/docs/adr/0012-edits-as-pinned-priority-candidates-in-the-global-solve.md
@@ -133,8 +133,8 @@ The recorded-intent mechanism shipped:
    It does **not** rerun `_auto_annotate`, reconstruct the automatic candidate
    population, or co-solve a later user edit with annotations already committed
    to the drawing. Existing annotations are obstacles for that drain. The
-   A/B1/B2/B3/C/D ordering in its docstring describes routing of the recorded
-   subsets; it is not one sheet-global solve.
+   `_PASS_SEQUENCE`-keyed drain describes routing of the recorded subsets; it
+   is not one sheet-global solve.
 4. **Below/right dependency (#477)** — closed 2026-07-08 as part of the
    broader "finish the ADR 0009 unification" umbrella; the below/right ladders
    are corridor registrants, so a user dim there co-solves.

--- a/docs/adr/0012-edits-as-pinned-priority-candidates-in-the-global-solve.md
+++ b/docs/adr/0012-edits-as-pinned-priority-candidates-in-the-global-solve.md
@@ -1,11 +1,11 @@
-# ADR 0012 — User annotation edits are pinned, priority-ranked candidates in the one global solve
+# ADR 0012 — User annotation edits are pinned, priority-ranked corridor candidates
 
-- **Status:** Accepted; landed (2026-07-08 — see Amendment 1). Supersedes #396,
-  extends #388/#426.
+- **Status:** Accepted; partially landed (2026-07-08; accuracy correction
+  2026-07-19 — see Amendment 1). Supersedes #396, extends #388/#426.
 - **Date:** 2026-07-07
 - **Deciders:** Paul Fremantle (pzfreo)
 
-## Context
+## Context at the time of the decision
 
 Two placement worlds exist today and do not meet:
 
@@ -32,7 +32,10 @@ sheet **can fit sub-optimally** (dims that the batch would have ordered, dropped
 priority, or deduped). That is the intended edit workflow, so the failure is real, not
 hypothetical.
 
-## Decision
+## Original decision and target
+
+The following records the target accepted on 2026-07-07. Read it with Amendment
+1 for the narrower behavior that actually landed.
 
 **A user annotation edit is a *dimension intent* carrying `(pin, priority)`, placed by the
 same global corridor solve as the automatic dimensions — not a raw single-slot poke.**
@@ -77,7 +80,7 @@ frozen imperative placement (never re-optimised) or an unconstrained re-solve (j
 - **Performance.** A full re-solve per edit is costly, so edits accumulate on the model and
   a *recompose runs the solve once* (`finalize_drawing`), rather than per `place_dim` call.
 
-## Consequences
+## Intended consequences
 
 - `dimension()` gains `pin=` and `priority=` and records a dimension intent on the model
   (in addition to, or in place of, the raw annotation). `place_dim()` is deprecated for
@@ -94,7 +97,7 @@ frozen imperative placement (never re-optimised) or an unconstrained re-solve (j
 - The **#477 below/right fold-in** is promoted from an open non-goal to a dependency (a
   user dim on a below/right strip needs those ladders in the corridor).
 
-## Phased work (tracking issue to follow)
+## Original phased work
 
 1. **Intent + knobs.** A scale-independent dimension-intent representation on the model;
    `pin=`/`priority=` on `dimension()` recording it. `place_dim()` remains raw-coordinate
@@ -108,11 +111,12 @@ frozen imperative placement (never re-optimised) or an unconstrained re-solve (j
 5. **Escape hatch.** Keep deprecated raw single-slot `place_dim` for arbitrary-page-coordinate,
    unsolved placement, clearly documented.
 
-## Amendment 1 — all five phases landed (2026-07-08)
+## Amendment 1 — recorded-intent corridor solving landed (2026-07-08; corrected 2026-07-19)
 
-**Status:** Accepted; fully landed. Umbrella **#511**, closed 2026-07-08.
+**Status:** Accepted; partially landed. Umbrella **#511** closed 2026-07-08,
+but the implementation is narrower than the original global-recompose proposal.
 
-All five phased-work items above shipped:
+The recorded-intent mechanism shipped:
 
 1. **Intent + knobs** — `Drawing.dimension(..., pin=, priority=)` records a
    scale-independent dimension intent (`draftwright/intents.py`) when the
@@ -124,10 +128,13 @@ All five phased-work items above shipped:
    (`annotations/_common.py`), `anchored=pin` and `priority=priority` carried
    straight through. Landed via #531 ("Add pinned locate candidates") and #532
    ("Route pinned dimension intents through corridor"), both merged 2026-07-08.
-3. **Recompose** — `Drawing.finalize()` is the realised recompose step; it is
-   idempotent and drains the full recorded intent set (auto features + user
-   edits) through the orchestration in one pass (see its docstring for the
-   full A/B1/B2/B3/C/D solver ordering it preserves).
+3. **Recorded-intent drain, not full recompose** — `Drawing.finalize()` is
+   idempotent and drains the intents recorded while the drawing is deferred.
+   It does **not** rerun `_auto_annotate`, reconstruct the automatic candidate
+   population, or co-solve a later user edit with annotations already committed
+   to the drawing. Existing annotations are obstacles for that drain. The
+   A/B1/B2/B3/C/D ordering in its docstring describes routing of the recorded
+   subsets; it is not one sheet-global solve.
 4. **Below/right dependency (#477)** — closed 2026-07-08 as part of the
    broader "finish the ADR 0009 unification" umbrella; the below/right ladders
    are corridor registrants, so a user dim there co-solves.
@@ -143,6 +150,34 @@ exit, and `export()`/`export_pdf()` call it unconditionally (a no-op once
 intents are drained) so a script that never opts into `deferred()` is
 unaffected.
 
-Found while auditing this ADR's status for accuracy (#548): the "work pending"
-status line had not been updated since the epic closed, understating that the
-core mechanism this ADR proposed is live.
+Consequently, the original **one global solve over automatic features plus user
+edits remains a target, not a landed guarantee**. Generated scripts can approach
+that target when they faithfully record the same semantic intents before
+finalization, but direct and script output are not guaranteed equal; detail-view
+reconstruction is a known example. Track full script/direct equality and
+automatic-plus-user recomposition in #426/#661/#707. ADR 0014 is the current
+placement contract; ADR 0009 is retained only as its historical predecessor.
+
+The 2026-07-19 correction replaces the earlier "fully landed" wording, which
+incorrectly equated draining recorded intents with reconstructing and solving
+the complete automatic-plus-user population.
+
+## Current contract summary (2026-07-19)
+
+For current callers, this ADR means only the following:
+
+1. Semantic edit verbs may record scale-independent intents while a drawing is
+   deferred.
+2. `Drawing.finalize()` drains those recorded intents deterministically through
+   corridor-specific routing, carrying pin and priority where supported.
+3. Finalization does not reconstruct automatic candidates and is not a global
+   automatic-plus-user recompose.
+4. Existing annotations therefore participate as obstacles, not as members of
+   the newly solved population.
+5. `Drawing.place_dim()` remains the raw, scale-frozen, unsolved escape hatch.
+6. Script/direct equality and full recomposition remain tracked by
+   #426/#661/#707.
+
+The original target and phased plan above are retained to show why the intent
+mechanism was introduced; this summary plus ADR 0014 describe the behavior that
+exists today.

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -1,13 +1,6 @@
 # ADR 0013 — A uniform recogniser/feature contract (with `b123d-recognisers` as its deferred shared deployment)
 
-- **Status:** Accepted. **The primary decision is a uniform, geometry-only
-  recogniser/feature contract** (§2 + the two-layer model §3; subsumes #568) — the
-  recogniser *intake* pulled up to the standard the IR `Feature` inventory already
-  meets (ADR 0008). It is delivered inside draftwright now (**Phase 1, in progress**)
-  and is worth doing for draftwright alone. Extracting that contract to a standalone
-  shared package `b123d-recognisers` (§1) is a **secondary, deferred deployment**
-  (**Phase 2**, gated on a second committed consumer). **The consistency is the point;
-  the package is one optional way to ship it.**
+- **Status:** Accepted; Phase 1 is in progress (the core contract is enforced, typed adapter registry pending), and Phase 2 package extraction is deferred.
 - **Date:** 2026-07-12
 - **Deciders:** Paul Fremantle (pzfreo)
 

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -198,11 +198,11 @@ down it knows only numbers.
   algorithm ("label *i* sits here because order + min-gap + shortest leader"),
   never a metaheuristic; repair stays a peephole safety net (it no longer
   touches `annotation_overlap`).
-- **ADR 0003** (still Accepted) — the constraint-based inner-layout frame this
-  ADR realises for the strips. The carrier is `StripCandidate`/`plan_strip`,
-  not 0003's original `Placeable`/`LayoutSolver` (deleted unused, #547 — see
-  0003's 2026-07-10 correction); the deferred global 2-D solve (#94) remains
-  deferred.
+- **ADR 0003** (retired) — the historical constraint-based inner-layout frame.
+  This ADR is its implemented successor for strips. The carrier is
+  `StripCandidate`/`plan_strip`, not 0003's deleted
+  `Placeable`/`LayoutSolver`. The page-global 2-D solve in #94 was closed as
+  superseded and unnecessary; ADR 0004 owns the fixed-topology outer layout.
 - **ADR 0004** — the **outer** layer: compose-then-pack keeps view blocks
   disjoint; this ADR is the **inner** per-view layer whose deterministic
   annotation boxes are exactly the block footprints 0004 packs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,28 +18,28 @@ architecture** table; open retired or superseded records only for design history
 
 ## Current architecture
 
-| ADR | Decision | Status | Representative guards |
-| --- | --- | --- | --- |
-| [0001](0001-deterministic-generation-over-editable-dsl.md) | Prefer deterministic generation and domain-semantic editing over a primitive editable-code DSL. | Accepted | `test_sheet_emit.py`, `test_make_drawing.py` |
-| [0002](0002-iterate-via-lint-critique-and-domain-repair.md) | Refine drawings through machine-readable lint and narrowly allowlisted domain repair. | Accepted | `test_linting.py`, `test_lint_structural.py`, `test_lint_reconciliation.py` |
-| [0004](0004-compose-then-pack-view-blocks.md) | Compose each view with its annotation footprint, then pack fixed-topology blocks. | Accepted | `test_layout.py`, `test_layout_cleanliness.py`, `test_refactor_golden.py` |
-| [0005](0005-pipeline-architecture-and-state-ownership.md) | Give compiler stages explicit module homes and build-time state explicit owners. | Accepted; implemented; compatibility aliases tracked by #720 | `test_import_boundaries.py`, `test_drawing_encapsulation.py`, `test_registry.py` |
-| [0006](0006-deterministic-layout-via-bundled-fonts.md) | Pin bundled font files so text measurement and layout are cross-platform deterministic. | Accepted | `test_refactor_golden.py`, `test_layout_cleanliness.py` |
-| [0007](0007-own-recognition-and-linting.md) | draftwright owns recognition and linting; helpers remains a rendering library. | Accepted | `test_import_boundaries.py`, `test_recognition.py`, `test_linting.py` |
-| [0010](0010-annotation-provenance-seam.md) | Record annotation provenance once at the render/add seam. | Accepted; landed | `test_render_seam.py`, `test_registry.py` |
-| [0011](0011-ir-as-public-input.md) | Accept the feature IR as public input through declarations and the `Sheet` façade. | Accepted; core landed; #62/#462/#495 remain | `test_declare.py`, `test_object_aspects.py`, `test_sheet_gdt.py` |
-| [0012](0012-edits-as-pinned-priority-candidates-in-the-global-solve.md) | Drain recorded semantic edits through corridor placement with pin and priority; full auto-plus-user recomposition is not landed. | Accepted; partially landed; #426/#661/#707 remain | `test_carve_free_position_callers.py`, `test_script_detail_parity.py`, `test_sheet_emit.py` |
-| [0013](0013-uniform-recognition-and-shared-package.md) | Enforce a uniform geometry-only recognizer contract internally; defer package extraction until there is a second consumer. | Accepted; internal contract landed; extraction deferred | `test_recogniser_contract.py`, `test_import_boundaries.py` |
-| [0014](0014-collect-then-solve-annotation-placement.md) | Collect, select, assign, and deterministically solve annotations per corridor before rendering. | Accepted; supersedes 0009 | `test_carve_free_position_callers.py`, `test_strip_layout.py`, `test_layout_property.py` |
-| [0015](0015-part-drawing-compiler-as-built.md) | Use one detected-or-declared feature IR and planner-fed dimension groups as the compiler waist. | Accepted; supersedes 0008 | `test_part_model.py`, `test_detect_once.py`, `test_import_boundaries.py` |
+| ADR | Title | Decision | Status | Representative guards |
+| --- | --- | --- | --- | --- |
+| [0001](0001-deterministic-generation-over-editable-dsl.md) | Deterministic generation and domain-semantic editing over a bespoke editable-code DSL | Prefer deterministic generation and domain-semantic editing over a primitive editable-code DSL. | Accepted | `test_sheet_emit.py`, `test_make_drawing.py` |
+| [0002](0002-iterate-via-lint-critique-and-domain-repair.md) | Iterate via lint critique and domain-semantic repair, not by editing generated code | Refine drawings through machine-readable lint and narrowly allowlisted domain repair. | Accepted | `test_linting.py`, `test_lint_structural.py`, `test_make_drawing.py` |
+| [0004](0004-compose-then-pack-view-blocks.md) | Compose-then-pack: views as blocks carrying their annotation footprint | Compose each view with its annotation footprint, then pack fixed-topology blocks. | Accepted | `test_layout.py`, `test_layout_cleanliness.py`, `test_refactor_golden.py` |
+| [0005](0005-pipeline-architecture-and-state-ownership.md) | Compiler-pipeline module boundaries and single-owner build state | Give compiler stages explicit module homes and build-time state explicit owners. | Accepted; implemented; compatibility aliases tracked by #720 | `test_import_boundaries.py`, `test_drawing_encapsulation.py`, `test_registry.py` |
+| [0006](0006-deterministic-layout-via-bundled-fonts.md) | Deterministic cross-platform layout via bundled, path-pinned fonts | Pin bundled font files so text measurement and layout are cross-platform deterministic. | Accepted | `test_refactor_golden.py`, `test_layout_cleanliness.py` |
+| [0007](0007-own-recognition-and-linting.md) | draftwright owns feature recognition and linting; helpers becomes the rendering library | draftwright owns recognition and linting; helpers remains a rendering library. | Accepted | `test_import_boundaries.py`, `test_recognition.py`, `test_linting.py` |
+| [0010](0010-annotation-provenance-seam.md) | Annotation provenance: record intent → annotation once, at the render seam | Record annotation provenance once at the render/add seam. | Accepted; landed | `test_render_seam.py`, `test_registry.py` |
+| [0011](0011-ir-as-public-input.md) | The IR as a public input: declare features, don't only detect them | Accept the feature IR as public input through declarations and the `Sheet` façade. | Accepted; core landed; #62/#462/#495 remain | `test_declare.py`, `test_object_aspects.py`, `test_sheet_gdt.py` |
+| [0012](0012-edits-as-pinned-priority-candidates-in-the-global-solve.md) | User annotation edits are pinned, priority-ranked corridor candidates | Drain recorded semantic edits through corridor placement with pin and priority. | Accepted; partially landed; full recomposition/parity remains #426/#661/#707 | `test_make_drawing.py`, `test_sheet_emit.py` |
+| [0013](0013-uniform-recognition-and-shared-package.md) | A uniform recogniser/feature contract (with `b123d-recognisers` as its deferred shared deployment) | Enforce a uniform geometry-only recogniser contract internally; defer package extraction until there is a second consumer. | Accepted; Phase 1 in progress; extraction deferred | `test_recogniser_contract.py`, `test_import_boundaries.py` |
+| [0014](0014-collect-then-solve-annotation-placement.md) | Collect-then-solve annotation placement (as built) | Collect, select, assign, and deterministically solve annotations per corridor before rendering. | Accepted; supersedes 0009 | `test_carve_free_position_callers.py`, `test_strip_layout.py`, `test_layout_property.py`, `test_import_boundaries.py` |
+| [0015](0015-part-drawing-compiler-as-built.md) | The part-drawing compiler, as built | Use one detected-or-declared feature IR and planner-fed dimension groups as the compiler waist. | Accepted; supersedes 0008 | `test_part_model.py`, `test_detect_once.py`, `test_import_boundaries.py` |
 
 ## Historical records
 
-| ADR | Historical decision | Status | Read instead |
-| --- | --- | --- | --- |
-| [0003](0003-constraint-based-layout.md) | Explored a universal `Placeable`/`LayoutSolver` and page-global constraint solve. | Retired; carrier deleted and #94 closed as unnecessary | [0004](0004-compose-then-pack-view-blocks.md) for outer layout and [0014](0014-collect-then-solve-annotation-placement.md) for inner placement |
-| [0008](0008-unified-feature-model-and-dimensioning-planner.md) | Introduced the feature/parameter IR and dimensioning-planner direction. | Superseded by 0015; frozen | [0015](0015-part-drawing-compiler-as-built.md) |
-| [0009](0009-boundary-labeling-strip-placement.md) | Developed collect-then-solve boundary-label placement through nine amendments. | Superseded by 0014; frozen | [0014](0014-collect-then-solve-annotation-placement.md) |
+| ADR | Title | Historical decision | Status | Read instead |
+| --- | --- | --- | --- | --- |
+| [0003](0003-constraint-based-layout.md) | Constraint-based layout: one solver for every placeable | Explored a universal `Placeable`/`LayoutSolver` and page-global constraint solve. | Retired; carrier deleted and #94 closed as unnecessary | [0004](0004-compose-then-pack-view-blocks.md) for outer layout and [0014](0014-collect-then-solve-annotation-placement.md) for inner placement |
+| [0008](0008-unified-feature-model-and-dimensioning-planner.md) | The part-drawing compiler: a Feature/DimParameter IR and a dimensioning planner | Introduced the feature/parameter IR and dimensioning-planner direction. | Superseded by 0015; frozen | [0015](0015-part-drawing-compiler-as-built.md) |
+| [0009](0009-boundary-labeling-strip-placement.md) | Boundary labeling: collect-then-solve per-strip annotation placement | Developed collect-then-solve boundary-label placement through nine amendments. | Superseded by 0014; frozen | [0014](0014-collect-then-solve-annotation-placement.md) |
 
 ## Reading paths
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,51 @@
+# Architecture decision records
+
+This is the front door to draftwright's ADR corpus. Start with the **Current
+architecture** table; open retired or superseded records only for design history.
+
+## Maintenance rules
+
+- Keep the status header to one load-bearing statement.
+- At roughly four amendments, write a successor ADR and freeze the old record.
+  The superseded file remains the historical why-trail; do not rewrite it.
+- Cite symbols and test names, never source line numbers.
+- If an invariant can be checked mechanically, guard it with a test. A claim
+  that something is machine-checked must name the real check.
+- Preserve reversals in the frozen record. The successor compresses each to one
+  line and points back to the history.
+- Update this index whenever an ADR is accepted, retired, or superseded, or when
+  its guarding test changes.
+
+## Current architecture
+
+| ADR | Decision | Status | Representative guards |
+| --- | --- | --- | --- |
+| [0001](0001-deterministic-generation-over-editable-dsl.md) | Prefer deterministic generation and domain-semantic editing over a primitive editable-code DSL. | Accepted | `test_sheet_emit.py`, `test_make_drawing.py` |
+| [0002](0002-iterate-via-lint-critique-and-domain-repair.md) | Refine drawings through machine-readable lint and narrowly allowlisted domain repair. | Accepted | `test_linting.py`, `test_lint_structural.py`, `test_lint_reconciliation.py` |
+| [0004](0004-compose-then-pack-view-blocks.md) | Compose each view with its annotation footprint, then pack fixed-topology blocks. | Accepted | `test_layout.py`, `test_layout_cleanliness.py`, `test_refactor_golden.py` |
+| [0005](0005-pipeline-architecture-and-state-ownership.md) | Give compiler stages explicit module homes and build-time state explicit owners. | Accepted; implemented; compatibility aliases tracked by #720 | `test_import_boundaries.py`, `test_drawing_encapsulation.py`, `test_registry.py` |
+| [0006](0006-deterministic-layout-via-bundled-fonts.md) | Pin bundled font files so text measurement and layout are cross-platform deterministic. | Accepted | `test_refactor_golden.py`, `test_layout_cleanliness.py` |
+| [0007](0007-own-recognition-and-linting.md) | draftwright owns recognition and linting; helpers remains a rendering library. | Accepted | `test_import_boundaries.py`, `test_recognition.py`, `test_linting.py` |
+| [0010](0010-annotation-provenance-seam.md) | Record annotation provenance once at the render/add seam. | Accepted; landed | `test_render_seam.py`, `test_registry.py` |
+| [0011](0011-ir-as-public-input.md) | Accept the feature IR as public input through declarations and the `Sheet` façade. | Accepted; core landed; #62/#462/#495 remain | `test_declare.py`, `test_object_aspects.py`, `test_sheet_gdt.py` |
+| [0012](0012-edits-as-pinned-priority-candidates-in-the-global-solve.md) | Drain recorded semantic edits through corridor placement with pin and priority; full auto-plus-user recomposition is not landed. | Accepted; partially landed; #426/#661/#707 remain | `test_carve_free_position_callers.py`, `test_script_detail_parity.py`, `test_sheet_emit.py` |
+| [0013](0013-uniform-recognition-and-shared-package.md) | Enforce a uniform geometry-only recognizer contract internally; defer package extraction until there is a second consumer. | Accepted; internal contract landed; extraction deferred | `test_recogniser_contract.py`, `test_import_boundaries.py` |
+| [0014](0014-collect-then-solve-annotation-placement.md) | Collect, select, assign, and deterministically solve annotations per corridor before rendering. | Accepted; supersedes 0009 | `test_carve_free_position_callers.py`, `test_strip_layout.py`, `test_layout_property.py` |
+| [0015](0015-part-drawing-compiler-as-built.md) | Use one detected-or-declared feature IR and planner-fed dimension groups as the compiler waist. | Accepted; supersedes 0008 | `test_part_model.py`, `test_detect_once.py`, `test_import_boundaries.py` |
+
+## Historical records
+
+| ADR | Historical decision | Status | Read instead |
+| --- | --- | --- | --- |
+| [0003](0003-constraint-based-layout.md) | Explored a universal `Placeable`/`LayoutSolver` and page-global constraint solve. | Retired; carrier deleted and #94 closed as unnecessary | [0004](0004-compose-then-pack-view-blocks.md) for outer layout and [0014](0014-collect-then-solve-annotation-placement.md) for inner placement |
+| [0008](0008-unified-feature-model-and-dimensioning-planner.md) | Introduced the feature/parameter IR and dimensioning-planner direction. | Superseded by 0015; frozen | [0015](0015-part-drawing-compiler-as-built.md) |
+| [0009](0009-boundary-labeling-strip-placement.md) | Developed collect-then-solve boundary-label placement through nine amendments. | Superseded by 0014; frozen | [0014](0014-collect-then-solve-annotation-placement.md) |
+
+## Reading paths
+
+- Compiler and state ownership: 0001 → 0005 → 0015.
+- Recognition and public declaration: 0007 → 0013 → 0011 → 0015.
+- Layout and placement: 0004 → 0014 → 0012.
+- Quality and correction: 0002, with provenance from 0010.
+
+Tracking issue: #745.

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -58,8 +58,9 @@ verification — detection happens once, three consumers read it.
 
 ## Layout
 
-- **Inner** (constraint-based, ADR 0003): a 1-D Cassowary strip solver spreads a
-  view's labels; a 2-D free-rectangle placer fits boxes in the view's zones.
+- **Inner** (collect-then-solve, ADR 0014): a dependency-free weighted-median
+  PAVA solver places labels in deterministic 1-D corridors; `fit_box` handles
+  bounded free-rectangle furniture placement. ADR 0003 is retired history.
 - **Outer** (compose-then-pack, ADR 0004): each view is a *block* = projected
   geometry + its annotation boxes; `(scale, page)` is chosen by a monotone search
   that packs the blocks **disjoint** — so cross-view overlap cannot occur.


### PR DESCRIPTION
## Summary

- add the #745 ADR index with current and historical reading paths, statuses, and representative guards
- correct ADR drift around finalization, repair scope, module ownership, and active placement references
- retire ADR 0003 through a final amendment while preserving its design history
- add current-contract amendments to ADRs 0005, 0011, and 0012

## Why

Several accepted ADRs described proposed behavior as fully landed or pointed readers to superseded architecture. The corpus also lacked a front door, making it difficult to distinguish current contracts from frozen history.

## Impact

Documentation only. Current architectural guidance now matches the implementation and links to executable guards. No production behavior changes.

## Validation

- `git diff --check`
- `uv run pytest -q tests/test_import_boundaries.py tests/test_drawing_encapsulation.py tests/test_carve_free_position_callers.py tests/test_recogniser_contract.py` (27 passed)

Closes #745.