### PR TITLE
feat(#736): solve-trace mode — explain every strip placement decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,20 @@
 
 - **Solve-trace / explain mode** (#736, from the #733 post-mortem): opt-in
   observability for strip placement. `build_drawing(trace=…)` or
-  `DRAFTWRIGHT_TRACE=<path-or-dir>` writes ONE JSON file per build recording
-  every strip solve — corridor key, strip bounds, the candidate set, the
-  obstacles that carved the strip (with owning annotation names), the free
-  segments, and each candidate's outcome (placed / dropped-with-reason /
-  deduped / promoted / deferred-to-post-drain) — so "why did X drop" is one
-  `jq` query. A `placement_unsatisfiable` strip-full drop now also names the
-  top occupants in its lint message (`…strip full; occupied by: …`). Default
-  off; zero output change, nil cost when off.
+  `DRAFTWRIGHT_TRACE=<path-or-dir>` writes ONE JSON file per build (schema v2)
+  with two record types: `solves` — every corridor solve's key, strip bounds,
+  candidate set, the obstacles that carved the strip (with owning annotation
+  names), the free segments, and each candidate's outcome (placed /
+  dropped-with-reason / deduped / promoted / deferred-to-post-drain) — and
+  `pass_events` — the standalone strip passes plus the *immediate* placers
+  (post-drain machined-feature leader callouts, the turned diameter row/column
+  and step-length set-solves), each with per-item placed/dropped outcomes. So
+  "why did X drop" is one `jq` query (`.solves[].outcomes[]` /
+  `.pass_events[].items[]`). A `placement_unsatisfiable` strip-full drop now
+  also names the top occupants in its lint message (`…strip full; occupied
+  by: …`). Recording-only: an unwritable path logs a warning (never aborts a
+  build), writes are atomic, and the recorder joins `finalize()`'s #647
+  rollback. Default off; zero output change, nil cost when off.
 
 - **`draftwright.model.authored_dimension`** (#704): the IR constructor behind
   `Sheet.dimension()`, extracted so `build_drawing(model=…)` callers can author

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@
 
 ### Added
 
+- **Solve-trace / explain mode** (#736, from the #733 post-mortem): opt-in
+  observability for strip placement. `build_drawing(trace=…)` or
+  `DRAFTWRIGHT_TRACE=<path-or-dir>` writes ONE JSON file per build recording
+  every strip solve — corridor key, strip bounds, the candidate set, the
+  obstacles that carved the strip (with owning annotation names), the free
+  segments, and each candidate's outcome (placed / dropped-with-reason /
+  deduped / promoted / deferred-to-post-drain) — so "why did X drop" is one
+  `jq` query. A `placement_unsatisfiable` strip-full drop now also names the
+  top occupants in its lint message (`…strip full; occupied by: …`). Default
+  off; zero output change, nil cost when off.
+
 - **`draftwright.model.authored_dimension`** (#704): the IR constructor behind
   `Sheet.dimension()`, extracted so `build_drawing(model=…)` callers can author
   a pre-measured drafting dimension without the `Sheet` façade.

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -228,6 +228,14 @@ down it knows only numbers.
 - Deterministic, explainable, dependency-free placement; over-capacity is a
   priority-ranked selection with first-class escalation, not an arrival-order
   drop.
+- The explanation is **recordable** (#736, from the #733 post-mortem): the
+  opt-in solve trace — `build_drawing(trace=…)` or `DRAFTWRIGHT_TRACE=<path>` —
+  dumps one JSON file per build with every strip solve's candidates, carving
+  obstacles (named), free segments, and per-candidate outcomes
+  (`SolveTrace`, threaded as `PlacementContext.trace`; default off, nil cost),
+  and a `placement_unsatisfiable` strip-full drop names the occupants that
+  filled the strip. Diagnosing a drop is a `jq` query, not a custom-script
+  rebuild.
 - Honest edges that remain: placement is per-view (cross-view contention rests
   on ADR 0004); AABB occupancy is deliberately conservative for diagonal
   leaders (the precise `_geometry._segment_crosses_box` test covers leader

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -230,12 +230,20 @@ down it knows only numbers.
   drop.
 - The explanation is **recordable** (#736, from the #733 post-mortem): the
   opt-in solve trace — `build_drawing(trace=…)` or `DRAFTWRIGHT_TRACE=<path>` —
-  dumps one JSON file per build with every strip solve's candidates, carving
-  obstacles (named), free segments, and per-candidate outcomes
-  (`SolveTrace`, threaded as `PlacementContext.trace`; default off, nil cost),
-  and a `placement_unsatisfiable` strip-full drop names the occupants that
-  filled the strip. Diagnosing a drop is a `jq` query, not a custom-script
-  rebuild.
+  dumps one JSON file per build with two distinct record types: `solves` (each
+  corridor solve's candidates, carving obstacles (named), free segments, and
+  per-candidate outcomes) and `pass_events` (the standalone strip passes plus
+  the *immediate* placers — the post-drain machined-feature leader callouts and
+  the turned diameter/step-length set-solves — each with per-item
+  placed/dropped outcomes, so the pre-#734 drain-time occupants stay visible
+  post-drain). `SolveTrace` is threaded as `PlacementContext.trace` (default
+  off, nil cost), participates in `finalize()`'s #647 transaction
+  (snapshot/restore on rollback; the file is rewritten only after a successful
+  drain), and is recording-only — an unwritable path logs a warning, never
+  aborts a build. A `placement_unsatisfiable` strip-full drop names the
+  occupants that filled the strip. Diagnosing a drop is a `jq` query
+  (`.solves[].outcomes[]` for corridor dims, `.pass_events[].items[]` for the
+  rest), not a custom-script rebuild.
 - Honest edges that remain: placement is per-view (cross-view contention rests
   on ADR 0004); AABB occupancy is deliberately conservative for diagonal
   leaders (the precise `_geometry._segment_crosses_box` test covers leader

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -306,12 +306,17 @@ class SolveTrace:
             "pass_events": self.pass_events,
             "escalations": self.escalations,
         }
-        text = json.dumps(data, indent=1)
         tmp = self.path.with_name(self.path.name + ".tmp")
         try:
+            # Serialisation stays inside the guard (orchestrator review): in finalize
+            # the write runs within the #647 transaction, so a raising dumps() would
+            # roll back and ABORT a user's finalize over a recorder bug. The strict
+            # no-default dumps still fails tests visibly — the schema/determinism
+            # tests parse this file, and a skipped write leaves nothing to parse.
+            text = json.dumps(data, indent=1)
             tmp.write_text(text, encoding="utf-8")
             os.replace(tmp, self.path)
-        except OSError as exc:
+        except (OSError, TypeError, ValueError) as exc:
             _log.warning("trace: could not write %s: %s", self.path, exc)
 
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -343,28 +343,26 @@ class SolveTrace:
     @_never_aborts
     def write(self) -> None:
         """Dump the trace JSON to :attr:`path` (once per build; a successful finalize
-        re-writes). **Recording-only, so it must never abort a build**: an unwritable
-        path degrades to a logged warning, and the rewrite is atomic
-        (``<path>.tmp`` then :func:`os.replace`) so a reader never sees a torn file.
-        Serialisation is strict (no ``default=``): a non-JSON-native field is a
-        recorder bug and should fail tests visibly, not be papered over."""
+        re-writes). **Recording-only, so it must never abort a build** — with the two
+        documented degradations kept distinct (final review): an *unwritable path* is
+        environmental and possibly transient, so it warns per attempt WITHOUT
+        disarming (a later finalize rewrite may succeed); a *serialisation failure*
+        is an internal recorder bug, so the strict no-``default=`` ``dumps`` raises
+        past this method's ``OSError``-only guard into :func:`_never_aborts`, which
+        disarms permanently with one warning. The rewrite is atomic
+        (``<path>.tmp`` then :func:`os.replace`) so a reader never sees a torn file."""
         data = {
             "version": 2,
             "solves": self.solves,
             "pass_events": self.pass_events,
             "escalations": self.escalations,
         }
+        text = json.dumps(data, indent=1)  # recorder-bug failures → decorator disarm
         tmp = self.path.with_name(self.path.name + ".tmp")
         try:
-            # Serialisation stays inside the guard (orchestrator review): in finalize
-            # the write runs within the #647 transaction, so a raising dumps() would
-            # roll back and ABORT a user's finalize over a recorder bug. The strict
-            # no-default dumps still fails tests visibly — the schema/determinism
-            # tests parse this file, and a skipped write leaves nothing to parse.
-            text = json.dumps(data, indent=1)
             tmp.write_text(text, encoding="utf-8")
             os.replace(tmp, self.path)
-        except (OSError, TypeError, ValueError) as exc:
+        except OSError as exc:
             _log.warning("trace: could not write %s: %s", self.path, exc)
 
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -7,6 +7,7 @@ complete strip occupancy (`strip_obstacles`), and an AABB overlap test
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import math
@@ -62,6 +63,29 @@ class Escalation:
     remedies: tuple[str, ...] = field(default_factory=tuple)
 
 
+def _never_aborts(method):
+    """Recording can never abort a build (#736 review): any exception inside a
+    :class:`SolveTrace` recording method logs ONE warning, disarms the recorder
+    (sets ``_broken`` — every later guarded call no-ops), and returns ``None``.
+    A recorder bug degrades to "no trace", never a failed drawing/export. The
+    guard lives HERE, on the recorder, rather than at every hook site — the hooks
+    stay bare ``trace is None`` checks (nil cost off) and no call site can forget
+    the try/except."""
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if self._broken:
+            return None
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 — the whole point: never propagate
+            self._broken = True
+            _log.warning("trace: recorder failed, tracing disabled: %s", exc)
+            return None
+
+    return wrapper
+
+
 class SolveTrace:
     """The opt-in solve-trace recorder (#736): one JSON file per build explaining every
     strip placement decision — the #733 post-mortem's "why is this strip full" answer
@@ -88,7 +112,8 @@ class SolveTrace:
       with reasons, unplaced leftovers), and per-candidate ``outcomes`` (placed /
       dropped-with-reason / deduped / promoted / deferred-to-post-drain).
     * ``pass_events`` — everything placed OUTSIDE a corridor solve: the standalone
-      strip passes (slot fallthroughs, front hole callouts) and the *immediate*
+      strip passes (slot fallthroughs, front hole callouts, off-axis locations,
+      PMI fallbacks) and the *immediate*
       placers — the post-drain machined-feature leader callouts
       (chamfer/fillet/flat/pocket/groove/boss ø) and the turned diameter row/column
       and step-length set-solves. Each entry carries ``seq``/``phase``, a pass
@@ -103,9 +128,17 @@ class SolveTrace:
         jq '.solves[].outcomes[] | select(.name == "dim_height")' t.trace.json
         jq '.pass_events[] | select(.label == "pocket_callouts") | .items[]' t.trace.json
 
-    Recording-only: an unwritable path degrades to a logged warning (:meth:`write`
-    never aborts a build), and :meth:`snapshot`/:meth:`restore` let ``finalize()``'s
-    #647 transaction roll a failed drain's records back out of the trace.
+    Recording-only, so the recorder can never abort a build: every public recording
+    method is wrapped by :func:`_never_aborts` — an internal failure logs ONE
+    warning (``trace: recorder failed, tracing disabled``), disarms the recorder
+    (``_broken``), and every later call no-ops. **Disarm semantics are
+    partial-disable**: records made before the failure stay in memory and any file
+    already written stays on disk, but nothing further is recorded or written (a
+    disarmed :meth:`snapshot` returns the ``None`` sentinel, which :meth:`restore`
+    tolerates). Separately, an *unwritable path* degrades to a per-attempt logged
+    warning without disarming (:meth:`write`), and :meth:`snapshot`/:meth:`restore`
+    let ``finalize()``'s #647 transaction roll a failed drain's records back out of
+    the trace.
     """
 
     def __init__(self, path):
@@ -117,12 +150,14 @@ class SolveTrace:
         self._phase_n = 0
         self._seq = 0
         self._current: dict | None = None
+        self._broken = False  # set by _never_aborts on the first internal failure
 
     def _next_seq(self) -> int:
         """One global event counter across solves + pass_events (decision order)."""
         self._seq += 1
         return self._seq - 1
 
+    @_never_aborts
     def snapshot(self):
         """The trace's rollback point for finalize's #647 transaction: capture the
         record counts + phase/seq counters so :meth:`restore` can truncate a failed
@@ -137,8 +172,12 @@ class SolveTrace:
             self._phase_n,
         )
 
+    @_never_aborts
     def restore(self, snap) -> None:
-        """Roll the trace back to *snap* (see :meth:`snapshot`)."""
+        """Roll the trace back to *snap* (see :meth:`snapshot`). Tolerates the
+        ``None`` sentinel a disarmed/failed :meth:`snapshot` returns (no-op)."""
+        if snap is None:
+            return
         n_solves, n_events, n_esc, seq, phase, phase_n = snap
         del self.solves[n_solves:]
         del self.pass_events[n_events:]
@@ -148,6 +187,7 @@ class SolveTrace:
         self._phase_n = phase_n
         self._current = None
 
+    @_never_aborts
     def begin_phase(self, label) -> None:
         """Start a new annotate run (``auto``) / finalize drain (``finalize``); each
         run's solves are labelled ``<label>:<n>`` so a measure-and-repack build keeps
@@ -167,6 +207,7 @@ class SolveTrace:
             "spacing": strip.spacing,
         }
 
+    @_never_aborts
     def begin_solve(self, key, view, axis, tier, strip, cands) -> None:
         """Open a corridor-solve record (called by :func:`solve_corridor`)."""
         self._current = {
@@ -195,9 +236,11 @@ class SolveTrace:
         }
         self.solves.append(self._current)
 
+    @_never_aborts
     def end_solve(self) -> None:
         self._current = None
 
+    @_never_aborts
     def begin_pass(self, *, force, label=None, strip=None, view=None, axis=None) -> dict:
         """Open a placement-pass record (called by :func:`place_strip_candidates`) —
         nested under the open corridor solve, or a standalone ``pass_events`` entry
@@ -226,6 +269,7 @@ class SolveTrace:
             self.pass_events.append(rec)
         return rec
 
+    @_never_aborts
     def end_pass(self, rec) -> None:
         """Close a placement-pass record. For a standalone ``pass_events`` entry the
         per-candidate story is folded into ``items`` (the jq contract:
@@ -243,6 +287,7 @@ class SolveTrace:
             for n in rec.pop("unplaced")
         ]
 
+    @_never_aborts
     def pass_event(self, label, **fields) -> dict:
         """Open a ``pass_events`` record for an *immediate* placer (the #733 gap: the
         post-drain machined-feature callouts and the turned diameter/step-length
@@ -259,6 +304,7 @@ class SolveTrace:
         self.pass_events.append(rec)
         return rec
 
+    @_never_aborts
     def record_outcome(self, name, outcome, **extra) -> None:
         """Record a candidate's solve-level outcome; a ``placed`` outcome is enriched
         with its position and a reason-less ``dropped`` with the last recorded
@@ -280,6 +326,7 @@ class SolveTrace:
             rec["reason"] = reason
         self._current["outcomes"].append(rec)
 
+    @_never_aborts
     def record_escalations(self, escalations) -> None:
         """Snapshot the run's :class:`Escalation` list (called once per annotate run)."""
         for e in escalations:
@@ -293,6 +340,7 @@ class SolveTrace:
                 }
             )
 
+    @_never_aborts
     def write(self) -> None:
         """Dump the trace JSON to :attr:`path` (once per build; a successful finalize
         re-writes). **Recording-only, so it must never abort a build**: an unwritable

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -72,29 +73,80 @@ class SolveTrace:
     paths trace. **Default off, and off means nil cost**: every hook site is a plain
     ``trace is None`` check — no dict is ever built.
 
-    JSON shape (``version`` 1): ``{"version", "solves": [...], "escalations": [...]}``.
-    Each solve entry carries ``seq`` (the drain's batch order), ``phase``
-    (``auto:N``/``finalize:N`` — one per annotate run), ``corridor`` (the
-    ``[view, side]`` key, or ``null`` + ``label`` for a standalone strip pass),
-    ``view``/``axis``/``tier``, the ``strip`` bounds
-    (anchor/outer_limit/direction/gap/spacing), the full candidate set (name, order,
-    priority, size, force, anchored, dedup, precedence), the placement ``passes``
-    (per pass: the carved span, the in-band obstacles with their owning annotation
-    names, the free segments, placed positions, rejections with reasons, unplaced
-    leftovers), and per-candidate ``outcomes`` (placed / dropped-with-reason /
-    deduped / promoted / deferred-to-post-drain). ``jq`` answers "why did X drop"
-    in one query, e.g.::
+    JSON shape (``version`` 2): ``{"version", "solves": [...], "pass_events": [...],
+    "escalations": [...]}`` — two DISTINCT record types, not one masquerading as the
+    other:
+
+    * ``solves`` — the corridor solves. Each entry carries ``seq`` (a global event
+      counter shared with ``pass_events``, so the build's decision order is
+      reconstructable), ``phase`` (``auto:N``/``finalize:N`` — one per annotate run),
+      ``corridor`` (the ``[view, side]`` key), ``view``/``axis``/``tier``, the
+      ``strip`` bounds (anchor/outer_limit/direction/gap/spacing), the full candidate
+      set (name, order, priority, size, force, anchored, dedup, precedence), the
+      placement ``passes`` (per pass: the carved span, the in-band obstacles with
+      their owning annotation names, the free segments, placed positions, rejections
+      with reasons, unplaced leftovers), and per-candidate ``outcomes`` (placed /
+      dropped-with-reason / deduped / promoted / deferred-to-post-drain).
+    * ``pass_events`` — everything placed OUTSIDE a corridor solve: the standalone
+      strip passes (slot fallthroughs, front hole callouts) and the *immediate*
+      placers — the post-drain machined-feature leader callouts
+      (chamfer/fillet/flat/pocket/groove/boss ø) and the turned diameter row/column
+      and step-length set-solves. Each entry carries ``seq``/``phase``, a pass
+      ``label``, and ``items`` — one outcome dict per attempted annotation
+      (``placed`` with its position, or ``dropped`` with a reason). The #733 gap:
+      pre-#734 these callouts were the drain-time occupants; post-drain, their own
+      story must still be in the trace.
+
+    The ``jq`` contract: ``.solves[].outcomes[]`` for corridor dims,
+    ``.pass_events[].items[]`` for everything else::
 
         jq '.solves[].outcomes[] | select(.name == "dim_height")' t.trace.json
+        jq '.pass_events[] | select(.label == "pocket_callouts") | .items[]' t.trace.json
+
+    Recording-only: an unwritable path degrades to a logged warning (:meth:`write`
+    never aborts a build), and :meth:`snapshot`/:meth:`restore` let ``finalize()``'s
+    #647 transaction roll a failed drain's records back out of the trace.
     """
 
     def __init__(self, path):
         self.path = Path(path)
         self.solves: list[dict] = []
+        self.pass_events: list[dict] = []
         self.escalations: list[dict] = []
         self._phase = ""
         self._phase_n = 0
+        self._seq = 0
         self._current: dict | None = None
+
+    def _next_seq(self) -> int:
+        """One global event counter across solves + pass_events (decision order)."""
+        self._seq += 1
+        return self._seq - 1
+
+    def snapshot(self):
+        """The trace's rollback point for finalize's #647 transaction: capture the
+        record counts + phase/seq counters so :meth:`restore` can truncate a failed
+        drain's records — a rolled-back finalize must not leave trace entries
+        describing placements that no longer exist."""
+        return (
+            len(self.solves),
+            len(self.pass_events),
+            len(self.escalations),
+            self._seq,
+            self._phase,
+            self._phase_n,
+        )
+
+    def restore(self, snap) -> None:
+        """Roll the trace back to *snap* (see :meth:`snapshot`)."""
+        n_solves, n_events, n_esc, seq, phase, phase_n = snap
+        del self.solves[n_solves:]
+        del self.pass_events[n_events:]
+        del self.escalations[n_esc:]
+        self._seq = seq
+        self._phase = phase
+        self._phase_n = phase_n
+        self._current = None
 
     def begin_phase(self, label) -> None:
         """Start a new annotate run (``auto``) / finalize drain (``finalize``); each
@@ -118,7 +170,7 @@ class SolveTrace:
     def begin_solve(self, key, view, axis, tier, strip, cands) -> None:
         """Open a corridor-solve record (called by :func:`solve_corridor`)."""
         self._current = {
-            "seq": len(self.solves),
+            "seq": self._next_seq(),
             "phase": self._phase,
             "corridor": list(key) if key is not None else None,
             "view": view,
@@ -148,8 +200,8 @@ class SolveTrace:
 
     def begin_pass(self, *, force, label=None, strip=None, view=None, axis=None) -> dict:
         """Open a placement-pass record (called by :func:`place_strip_candidates`) —
-        nested under the open corridor solve, or a standalone solve entry (with
-        *label*) for a pass-local strip placement outside any corridor."""
+        nested under the open corridor solve, or a standalone ``pass_events`` entry
+        (with *label*) for a pass-local strip placement outside any corridor."""
         rec: dict = {
             "force": force,
             "obstacles": [],
@@ -161,20 +213,50 @@ class SolveTrace:
         if self._current is not None:
             self._current["passes"].append(rec)
         else:
-            self.solves.append(
-                {
-                    "seq": len(self.solves),
-                    "phase": self._phase,
-                    "corridor": None,
-                    "label": label,
-                    "view": view,
-                    "axis": axis,
-                    "strip": self._strip_rec(strip),
-                    "candidates": None,
-                    "passes": [rec],
-                    "outcomes": [],
-                }
-            )
+            rec = {
+                "seq": self._next_seq(),
+                "phase": self._phase,
+                "label": label,
+                "view": view,
+                "axis": axis,
+                "strip": self._strip_rec(strip),
+                **rec,
+                "items": [],
+            }
+            self.pass_events.append(rec)
+        return rec
+
+    def end_pass(self, rec) -> None:
+        """Close a placement-pass record. For a standalone ``pass_events`` entry the
+        per-candidate story is folded into ``items`` (the jq contract:
+        ``.pass_events[].items[]``): each placed candidate with its position, each
+        leftover as ``dropped`` with its last rejection reason (default
+        ``strip_full``). A pass nested under a corridor solve keeps its raw
+        placed/unplaced lists — the solve's ``outcomes`` carry the summary there."""
+        if "items" not in rec:
+            return
+        reasons = {e["name"]: e["reason"] for e in rec["rejected"]}
+        rec["items"] = [
+            {"name": e["name"], "outcome": "placed", "pos": e["pos"]} for e in rec.pop("placed")
+        ] + [
+            {"name": n, "outcome": "dropped", "reason": reasons.get(n, "strip_full")}
+            for n in rec.pop("unplaced")
+        ]
+
+    def pass_event(self, label, **fields) -> dict:
+        """Open a ``pass_events`` record for an *immediate* placer (the #733 gap: the
+        post-drain machined-feature callouts and the turned diameter/step-length
+        set-solves place outside any strip solve, but their story must be in the
+        trace too). Returns the record; the caller appends one outcome dict per
+        attempted annotation to ``rec["items"]``."""
+        rec = {
+            "seq": self._next_seq(),
+            "phase": self._phase,
+            "label": label,
+            **fields,
+            "items": [],
+        }
+        self.pass_events.append(rec)
         return rec
 
     def record_outcome(self, name, outcome, **extra) -> None:
@@ -212,9 +294,25 @@ class SolveTrace:
             )
 
     def write(self) -> None:
-        """Dump the trace JSON to :attr:`path` (once per build; finalize re-writes)."""
-        data = {"version": 1, "solves": self.solves, "escalations": self.escalations}
-        self.path.write_text(json.dumps(data, indent=1, default=str), encoding="utf-8")
+        """Dump the trace JSON to :attr:`path` (once per build; a successful finalize
+        re-writes). **Recording-only, so it must never abort a build**: an unwritable
+        path degrades to a logged warning, and the rewrite is atomic
+        (``<path>.tmp`` then :func:`os.replace`) so a reader never sees a torn file.
+        Serialisation is strict (no ``default=``): a non-JSON-native field is a
+        recorder bug and should fail tests visibly, not be papered over."""
+        data = {
+            "version": 2,
+            "solves": self.solves,
+            "pass_events": self.pass_events,
+            "escalations": self.escalations,
+        }
+        text = json.dumps(data, indent=1)
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        try:
+            tmp.write_text(text, encoding="utf-8")
+            os.replace(tmp, self.path)
+        except OSError as exc:
+            _log.warning("trace: could not write %s: %s", self.path, exc)
 
 
 def _geom_box(o):
@@ -1270,6 +1368,7 @@ def place_strip_candidates(
             dwg.add(dim, name, view=view, feature=(features or {}).get(name))
     if tp is not None:
         tp["unplaced"] = [n for n, _ in todo]
+        trace.end_pass(tp)  # folds a standalone pass's items; no-op when corridor-nested
     return todo
 
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -7,9 +7,11 @@ complete strip occupancy (`strip_obstacles`), and an AABB overlap test
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from build123d_drafting.helpers import DEFAULT_FONT_PATH, Dimension, SafeDimension
@@ -57,6 +59,162 @@ class Escalation:
     feature: object
     reason: str
     remedies: tuple[str, ...] = field(default_factory=tuple)
+
+
+class SolveTrace:
+    """The opt-in solve-trace recorder (#736): one JSON file per build explaining every
+    strip placement decision — the #733 post-mortem's "why is this strip full" answer
+    as a glance instead of a custom script.
+
+    Activated by ``build_drawing(trace=...)`` or the ``DRAFTWRIGHT_TRACE`` env var
+    (see :func:`draftwright.builder.build_drawing`); threaded onto each run's
+    :class:`PlacementContext` (``ctx.trace``) so both the auto-annotate and finalize
+    paths trace. **Default off, and off means nil cost**: every hook site is a plain
+    ``trace is None`` check — no dict is ever built.
+
+    JSON shape (``version`` 1): ``{"version", "solves": [...], "escalations": [...]}``.
+    Each solve entry carries ``seq`` (the drain's batch order), ``phase``
+    (``auto:N``/``finalize:N`` — one per annotate run), ``corridor`` (the
+    ``[view, side]`` key, or ``null`` + ``label`` for a standalone strip pass),
+    ``view``/``axis``/``tier``, the ``strip`` bounds
+    (anchor/outer_limit/direction/gap/spacing), the full candidate set (name, order,
+    priority, size, force, anchored, dedup, precedence), the placement ``passes``
+    (per pass: the carved span, the in-band obstacles with their owning annotation
+    names, the free segments, placed positions, rejections with reasons, unplaced
+    leftovers), and per-candidate ``outcomes`` (placed / dropped-with-reason /
+    deduped / promoted / deferred-to-post-drain). ``jq`` answers "why did X drop"
+    in one query, e.g.::
+
+        jq '.solves[].outcomes[] | select(.name == "dim_height")' t.trace.json
+    """
+
+    def __init__(self, path):
+        self.path = Path(path)
+        self.solves: list[dict] = []
+        self.escalations: list[dict] = []
+        self._phase = ""
+        self._phase_n = 0
+        self._current: dict | None = None
+
+    def begin_phase(self, label) -> None:
+        """Start a new annotate run (``auto``) / finalize drain (``finalize``); each
+        run's solves are labelled ``<label>:<n>`` so a measure-and-repack build keeps
+        its passes apart."""
+        self._phase_n += 1
+        self._phase = f"{label}:{self._phase_n}"
+
+    @staticmethod
+    def _strip_rec(strip):
+        if strip is None:
+            return None
+        return {
+            "anchor": strip.anchor,
+            "outer_limit": strip.outer_limit,
+            "direction": strip.direction,
+            "gap": strip.gap,
+            "spacing": strip.spacing,
+        }
+
+    def begin_solve(self, key, view, axis, tier, strip, cands) -> None:
+        """Open a corridor-solve record (called by :func:`solve_corridor`)."""
+        self._current = {
+            "seq": len(self.solves),
+            "phase": self._phase,
+            "corridor": list(key) if key is not None else None,
+            "view": view,
+            "axis": axis,
+            "tier": tier,
+            "strip": self._strip_rec(strip),
+            "candidates": [
+                {
+                    "name": c.name,
+                    "order": list(c.order),
+                    "priority": c.priority,
+                    "size": list(c.size) if c.size is not None else None,
+                    "force": c.force,
+                    "anchored": c.anchored,
+                    "dedup": list(c.dedup) if c.dedup is not None else None,
+                    "precedence": c.precedence,
+                }
+                for c in cands
+            ],
+            "passes": [],
+            "outcomes": [],
+        }
+        self.solves.append(self._current)
+
+    def end_solve(self) -> None:
+        self._current = None
+
+    def begin_pass(self, *, force, label=None, strip=None, view=None, axis=None) -> dict:
+        """Open a placement-pass record (called by :func:`place_strip_candidates`) —
+        nested under the open corridor solve, or a standalone solve entry (with
+        *label*) for a pass-local strip placement outside any corridor."""
+        rec: dict = {
+            "force": force,
+            "obstacles": [],
+            "free_segments": [],
+            "placed": [],
+            "rejected": [],
+            "unplaced": [],
+        }
+        if self._current is not None:
+            self._current["passes"].append(rec)
+        else:
+            self.solves.append(
+                {
+                    "seq": len(self.solves),
+                    "phase": self._phase,
+                    "corridor": None,
+                    "label": label,
+                    "view": view,
+                    "axis": axis,
+                    "strip": self._strip_rec(strip),
+                    "candidates": None,
+                    "passes": [rec],
+                    "outcomes": [],
+                }
+            )
+        return rec
+
+    def record_outcome(self, name, outcome, **extra) -> None:
+        """Record a candidate's solve-level outcome; a ``placed`` outcome is enriched
+        with its position and a reason-less ``dropped`` with the last recorded
+        rejection reason (default ``strip_full``) from this solve's passes."""
+        if self._current is None:
+            return
+        rec: dict = {"name": name, "outcome": outcome, **extra}
+        if outcome == "placed":
+            for p in self._current["passes"]:
+                for e in p["placed"]:
+                    if e["name"] == name:
+                        rec["pos"] = e["pos"]
+        elif outcome == "dropped" and "reason" not in rec:
+            reason = "strip_full"
+            for p in self._current["passes"]:
+                for e in p["rejected"]:
+                    if e["name"] == name:
+                        reason = e["reason"]
+            rec["reason"] = reason
+        self._current["outcomes"].append(rec)
+
+    def record_escalations(self, escalations) -> None:
+        """Snapshot the run's :class:`Escalation` list (called once per annotate run)."""
+        for e in escalations:
+            self.escalations.append(
+                {
+                    "phase": self._phase,
+                    "kind": e.kind,
+                    "view": e.view,
+                    "reason": e.reason,
+                    "feature": type(e.feature).__name__ if e.feature is not None else None,
+                }
+            )
+
+    def write(self) -> None:
+        """Dump the trace JSON to :attr:`path` (once per build; finalize re-writes)."""
+        data = {"version": 1, "solves": self.solves, "escalations": self.escalations}
+        self.path.write_text(json.dumps(data, indent=1, default=str), encoding="utf-8")
 
 
 def _geom_box(o):
@@ -272,12 +430,18 @@ def occupancy_boxes(o, stroke_pad=None):
 _STROKE_PAD = 1.2
 
 
-def strip_obstacles(dwg, view=None, *, crossable=()):
+def strip_obstacles(dwg, view=None, *, crossable=(), named=False):
     """The COMPLETE occupancy for strip placement (ADR 0009): every placed
     annotation's full rendered footprint, optionally restricted to *view*, minus
     any annotation whose type name is in *crossable* (things this particular
     consumer may legitimately overlap — e.g. a location dim crosses a centre line
     but a leader does not; see :data:`CROSSABLE_TYPES`).
+
+    With *named* (the #736 trace/diagnosis flavour) each box comes back as an
+    ``(owner-name, box)`` pair — the same boxes, tagged with the annotation name
+    they decompose from — so a trace or a "what filled this strip" message can
+    attribute the occupancy. Default off: the hot placement path carries bare
+    boxes, unchanged.
 
     Unlike the retired label-box-only ``_occupied_boxes`` (which excluded bare
     centrelines), this captures the geometry a label box hides — leader shafts and
@@ -304,7 +468,7 @@ def strip_obstacles(dwg, view=None, *, crossable=()):
     # Preset-aware stroke pad (#688 review): arrowheads scale with font_size.
     al = getattr(getattr(dwg, "draft", None), "arrow_length", None)
     pad = max(_STROKE_PAD, al / 2) if al else _STROKE_PAD
-    boxes = []
+    boxes: list = []
     for name, o in dwg.iter_annotations():
         if view is not None:
             owner = dwg.view_of(name)
@@ -312,8 +476,40 @@ def strip_obstacles(dwg, view=None, *, crossable=()):
                 continue  # owned by a different ortho view → its own (disjoint) block
         if type(o).__name__ in crossable:
             continue  # this consumer may cross it (centre lines/marks for a dim)
-        boxes.extend(occupancy_boxes(o, stroke_pad=pad))  # decomposed, not one hull (#685)
+        occ = occupancy_boxes(o, stroke_pad=pad)  # decomposed, not one hull (#685)
+        boxes.extend(((name, b) for b in occ) if named else occ)
     return boxes
+
+
+def strip_occupants(dwg, strip, view, axis, limit=3):
+    """The names of the annotations whose footprints occupy *strip*'s free span,
+    ranked by covered stacking-axis extent (largest first; ties by name) — the
+    "what filled this strip" answer the #736 enriched drop message and the solve
+    trace share. ``[]`` when the strip is absent or nothing overlaps it."""
+    if strip is None:
+        return []
+    lo, hi, _inner = strip_free_span(strip)
+    idx = 1 if axis == "y" else 0
+    cover: dict[str, float] = {}
+    for name, box in strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES, named=True):
+        ov = min(hi, box[idx + 2]) - max(lo, box[idx])
+        if ov > 0:
+            cover[name] = cover.get(name, 0.0) + ov
+    return sorted(cover, key=lambda n: (-cover[n], n))[:limit]
+
+
+def full_strip_message(base, dwg, strip, view, axis):
+    """Extend a ``"…strip full)"`` drop message with the top occupant names (#736):
+    ``"…strip full; occupied by: dim_a, ldr_b)"`` — so a placement_unsatisfiable
+    drop names what filled the strip instead of demanding a custom-script rebuild
+    (the #733 diagnosis). Returns *base* unchanged when no occupant is known."""
+    occ = strip_occupants(dwg, strip, view, axis)
+    if not occ:
+        return base
+    who = ", ".join(occ)
+    if base.endswith(")"):
+        return f"{base[:-1]}; occupied by: {who})"
+    return f"{base} (occupied by: {who})"
 
 
 def strip_free_span(strip):
@@ -481,15 +677,22 @@ class CorridorCandidate:
     footprint: object | None = None
 
 
-def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=()):
+def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, key=None, ctx=None):
     """One collect-then-solve over every :class:`CorridorCandidate` a shared strip
     accumulated across passes (ADR 0009 end state). Dedup → order → one non-force
     :func:`place_strip_candidates` pass → a force pass for the force-eligible leftovers →
     dispatch each candidate's ``on_place``/``on_drop``. This is what removes the duplicate
     span (#345) and the interleaved ladder (#346) by construction: a single solve sees the
-    full set, so coincident spans collapse and the order is one monotonic chain."""
+    full set, so coincident spans collapse and the order is one monotonic chain.
+
+    *key* (the corridor's ``(view, side)``) and *ctx* are threaded by
+    :func:`drain_corridors` for the opt-in solve trace (#736, ``ctx.trace``) — when
+    tracing is off (``ctx`` is ``None`` or carries no trace) both are inert."""
     if not cands:
         return
+    trace = None if ctx is None else ctx.trace
+    if trace is not None:
+        trace.begin_solve(key, view, axis, tier, strip, cands)
     # Dedup: keep the highest-precedence candidate per coincidence key (tie-break on name,
     # deterministic — ADR 0001). A displaced duplicate is a *loser*: while its winner is
     # drawn it is silently dropped (never starved, so firing its pass's drop lint would be a
@@ -515,19 +718,29 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=()):
     for group in losers.values():
         group.sort(key=lambda c: (-c.precedence, c.name))
     kept.sort(key=lambda c: c.order)
+    if trace is not None:  # record who lost each dedup group (a loser never starves)
+        for dk, group in losers.items():
+            for loser in group:
+                trace.record_outcome(loser.name, "deduped", winner=winners[dk].name)
 
     def _promote_losers(dropped_winner):
         # The winner did not place → hand its measurement to the best surviving loser
         # (e.g. the slot position's below-strip fallthrough), then stop.
         for loser in losers.get(dropped_winner.dedup, ()):
             loser.on_drop(loser.name)
+            if trace is not None:
+                trace.record_outcome(loser.name, "promoted")
             break
 
     if strip is None:  # no such strip on this drawing — every candidate drops
         for c in kept:
             c.on_drop(c.name)
+            if trace is not None:
+                trace.record_outcome(c.name, "dropped", reason="no_strip")
             if c.dedup is not None:
                 _promote_losers(c)
+        if trace is not None:
+            trace.end_solve()
         return
     pairs = [(c.name, c.build) for c in kept]
     feats = {c.name: c.feature for c in kept if c.feature is not None}  # provenance (ADR 0010)
@@ -554,6 +767,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=()):
             naturals=naturals,
             footprints=foots,
             corner_reserves=corner_reserves,
+            trace=trace,
         )
     }
     force_pairs = [(c.name, c.build) for c in kept if c.name in left and c.force]
@@ -576,6 +790,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=()):
                 priorities=prio,
                 anchored=anchored,
                 naturals=naturals,
+                trace=trace,
             )
         }
         if force_pairs
@@ -585,10 +800,19 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=()):
         placed = c.name not in left or (c.force and c.name not in still)
         if placed:
             c.on_place(c.name)  # placed in the corridor-respecting pass or the force pass
+            if trace is not None:
+                trace.record_outcome(c.name, "placed")
         else:
+            n_deferred = len(ctx.post_drain) if trace is not None else 0
             c.on_drop(c.name)  # dropped / not force-kept — the pass's drop handler runs
+            if trace is not None:  # did on_drop queue a post-drain fallthrough?
+                trace.record_outcome(
+                    c.name, "dropped", deferred_post_drain=len(ctx.post_drain) > n_deferred
+                )
             if c.dedup is not None:  # a deduped winner failed → promote its top loser
                 _promote_losers(c)
+    if trace is not None:
+        trace.end_solve()
 
 
 @dataclass
@@ -613,6 +837,11 @@ class PlacementContext:
     # drained (#684 review): a mid-drain carve could occupy space a later sibling
     # corridor's force candidate needs; deferral makes "post-drain" literally true.
     post_drain: list = field(default_factory=list)
+    # The opt-in solve-trace recorder (#736) — a :class:`SolveTrace` threaded off the
+    # drawing's build state by both entry paths, or ``None`` (the default: tracing off,
+    # every hook a bare None check). Ctx state, not a module global, so the finalize
+    # path traces exactly like the auto pass.
+    trace: Any = None
     # The drawing's build-state stores, referenced (not owned) by the run's passes (#639).
     # Duck-typed as ``Any`` — matching the untyped ``Drawing._record_build_issue`` they replace —
     # so mypy does not reject the delegating calls below.
@@ -689,10 +918,10 @@ def drain_corridors(ctx, dwg):
     dims that would otherwise drop rather than relocate — so best-effort occupants
     never lose capacity to it. Already-drained siblings need nothing: their dims are
     real obstacles via :func:`strip_obstacles`."""
-    batches = list(ctx.corridor_batch.values())
-    for i, b in enumerate(batches):
+    batches = list(ctx.corridor_batch.items())
+    for i, (key, b) in enumerate(batches):
         reserves = []
-        for sib in batches[i + 1 :]:
+        for _sk, sib in batches[i + 1 :]:
             if sib["view"] != b["view"] or sib["strip"] is None:
                 continue
             s = sib["strip"]
@@ -703,7 +932,15 @@ def drain_corridors(ctx, dwg):
                     if box is not None:
                         reserves.append(box)
         solve_corridor(
-            dwg, b["strip"], b["view"], b["axis"], b["cands"], b["tier"], corner_reserves=reserves
+            dwg,
+            b["strip"],
+            b["view"],
+            b["axis"],
+            b["cands"],
+            b["tier"],
+            corner_reserves=reserves,
+            key=key,  # corridor identity + trace threading (#736)
+            ctx=ctx,
         )
     ctx.corridor_batch = {}
     # Deferred fallthroughs (opposite-strip retries) run once every strip has drained,
@@ -730,6 +967,8 @@ def place_strip_candidates(
     naturals=None,
     footprints=None,
     corner_reserves=(),
+    trace=None,
+    trace_label=None,
 ):
     """Collect-then-solve placement of location/feature dims on one strip (ADR 0009).
     The single shared strip placer that retires the ``Strip.allocate`` cursor (#150,
@@ -769,9 +1008,21 @@ def place_strip_candidates(
     the dim cleanly: keep it on its natural view and accept the (same-feature) leader
     crossing rather than drop a real dimension (policy B). Candidates that find no strip
     tier AT ALL are still returned (a physically full strip — the caller records the
-    genuine drop)."""
+    genuine drop).
+
+    *trace* is the opt-in :class:`SolveTrace` recorder (#736), ``None`` (default) = off
+    with nil cost; :func:`solve_corridor` threads it for corridor solves, and a
+    standalone caller may pass ``trace=ctx.trace`` with a *trace_label* naming its
+    pass. The recorded pass carries the carved span, the in-band obstacles with their
+    owning annotation names, the free segments, per-candidate placements/rejections
+    (with reasons), and the unplaced leftovers."""
     if strip is None or not cands:
         return list(cands)
+    tp = (
+        trace.begin_pass(force=force, label=trace_label, strip=strip, view=view, axis=axis)
+        if trace is not None
+        else None
+    )
     lo, hi, inner = strip_free_span(strip)
     idx = 1 if axis == "y" else 0
 
@@ -837,7 +1088,13 @@ def place_strip_candidates(
         box[idx + 2 if inner == lo else idx] += pos - lo
         return tuple(box)
 
-    occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+    if tp is None:
+        occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+        owners = {}
+    else:  # tracing: same boxes, tagged with their owning annotation names (#736)
+        named = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES, named=True)
+        occupied = [b for _, b in named]
+        owners = {id(b): n for n, b in named}
     # Obstacles OUTSIDE the batch's predicted perpendicular band are invisible to the
     # carve below by design — but that makes the band prediction itself load-bearing: a
     # candidate whose real geometry exceeds its predicted band could land on one with no
@@ -864,6 +1121,15 @@ def place_strip_candidates(
     segs = carve_free_segments(lo, hi, [(b[idx], b[idx + 2]) for b in occupied], pad)
     # Fill innermost-first (nearest the view), matching the old cursor's stack order.
     segs.sort(key=lambda s: abs((s[0] if inner == lo else s[1]) - inner))
+    if tp is not None:  # the diagnosis payload: what carved this strip, and what's left
+        tp["span"] = [lo, hi]
+        tp["obstacles"] = [
+            # owner None = a corner reserve (a projection, not placed geometry)
+            {"owner": owners.get(id(b)), "box": list(b)}
+            for b in occupied
+        ]
+        tp["out_of_band"] = len(out_of_band)
+        tp["free_segments"] = [list(s) for s in segs]
     todo = list(cands)
 
     def _take_for_segment(items, n):
@@ -913,9 +1179,17 @@ def place_strip_candidates(
         res = plan_strip([sc for sc, _ in triples], seg_lo, seg_hi, pad, axis=axis)
         accepted = []
         rejected = []
+
+        def _reject(name, reason):  # trace-only (#736): why this candidate left this segment
+            if tp is not None:
+                tp["rejected"].append(
+                    {"name": name, "reason": reason, "segment": [seg_lo, seg_hi]}
+                )
+
         for sc, (name, build) in triples:
             pos = res.placed.get(sc.key)
             if pos is None:  # segment over its estimated capacity (shouldn't occur)
+                _reject(name, "over_capacity")
                 rejected.append((name, build))
                 continue
             # Predicted box, not built geometry (#602): the refill loop re-evaluates
@@ -927,6 +1201,7 @@ def place_strip_candidates(
             if (
                 not force and box is not None and _box_hits(box, blockers)
             ):  # corridor crosses a leader
+                _reject(name, "corridor_blocked")
                 rejected.append((name, build))
                 continue
             # A forbidden box (the title block, #481) is rejected even under force — it is
@@ -935,6 +1210,7 @@ def place_strip_candidates(
             # so dims are byte-identical). Returned unplaced → the caller's on_drop fallthrough.
             fb = (forbid or {}).get(name)
             if fb is not None and box is not None and _box_hits(box, (fb,)):
+                _reject(name, "forbid_box")
                 rejected.append((name, build))
                 continue
             accepted.append(((name, build), pos))
@@ -963,10 +1239,16 @@ def place_strip_candidates(
             real = _geom_box(dim)
             if real is not None:
                 if not force and _box_hits(real, blockers):
+                    if tp is not None:
+                        tp["rejected"].append(
+                            {"name": name, "reason": "real_box_corridor_blocked"}
+                        )
                     rejected_total.append((name, build))
                     continue
                 fb = (forbid or {}).get(name)
                 if fb is not None and _box_hits(real, (fb,)):
+                    if tp is not None:
+                        tp["rejected"].append({"name": name, "reason": "real_box_forbid"})
                     rejected_total.append((name, build))
                     continue
                 # A survivor whose real geometry escaped the batch's predicted
@@ -974,14 +1256,20 @@ def place_strip_candidates(
                 # shown (review #679) — the one collision class the stacking-axis
                 # model cannot tolerate. Never fires while predictions are accurate.
                 if _box_hits(real, out_of_band):
+                    if tp is not None:
+                        tp["rejected"].append({"name": name, "reason": "real_box_out_of_band"})
                     rejected_total.append((name, build))
                     continue
             placed.append((name, dim))
+            if tp is not None:
+                tp["placed"].append({"name": name, "pos": pos})
         todo = todo + rejected_total
         for name, dim in placed:
             # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
             # dims — `features` maps this batch's names to their source IR feature.
             dwg.add(dim, name, view=view, feature=(features or {}).get(name))
+    if tp is not None:
+        tp["unplaced"] = [n for n, _ in todo]
     return todo
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -742,14 +742,16 @@ def _place_what_fits(specs, axis: int, min_gap: float, lo: float, hi: float):
     return [], []
 
 
-def _diameter_row_below(dwg, items, start: int = 0) -> int:
+def _diameter_row_below(dwg, items, start: int = 0, trace=None) -> int:
     """ø-callout row BELOW the front view for X-turned step/boss diameters (#77).
     *items* is ``[(anchor, diameter), ...]``. The row is dropped clear of anything
     already below the profile; labels spread along page-x by the ADR-0003 strip
     solve. Skips (returns 0) if there is no room — the diameters then surface as
-    ``feature_not_dimensioned``."""
+    ``feature_not_dimensioned``. *trace* (#736): one ``pass_events`` record with a
+    placed/dropped item per callout."""
     if not items:
         return 0
+    ev = trace.pass_event("diameter_row_below", view="front") if trace is not None else None
     draft = dwg.draft
     fx0, fy0, fx1, _ = dwg.view_bounds("front")
     obstacle_bottom = fy0
@@ -762,6 +764,11 @@ def _diameter_row_below(dwg, items, start: int = 0) -> int:
             obstacle_bottom = min(obstacle_bottom, ob.min.Y)
     label_y = obstacle_bottom - (draft.font_size + 4 * draft.pad_around_text)
     if label_y < _MARGIN + draft.font_size:
+        if ev is not None:
+            ev["items"].extend(
+                {"label": f"ø{_fmt(d)}", "outcome": "dropped", "reason": "no_room_below"}
+                for _, d, _, _ in items
+            )
         return 0
     specs = []  # (tip_page, dia, label, feature), tip on the step's bottom silhouette
     for anchor, dia, feat, dtol in items:
@@ -827,6 +834,13 @@ def _diameter_row_below(dwg, items, start: int = 0) -> int:
         drop = min(range(len(survivors)), key=lambda i: survivors[i][1])
         survivors.pop(drop)
         survivors, xs = _place_what_fits(survivors, 0, min_gap, fx0 + half_w, fx1 - half_w)
+    if ev is not None:  # the specs the fit solve squeezed out (#298 smallest-first drops)
+        kept = {id(s) for s in survivors}
+        ev["items"].extend(
+            {"label": s[2], "outcome": "dropped", "reason": "squeezed_out"}
+            for s in specs
+            if id(s) not in kept
+        )
     for i, ((tip, dia, label, feat), lx) in enumerate(zip(survivors, xs, strict=True)):
         dwg.add(
             Leader(tip=(tip[0], tip[1], 0), elbow=(lx, label_y, 0), label=label, draft=draft),
@@ -834,16 +848,27 @@ def _diameter_row_below(dwg, items, start: int = 0) -> int:
             view="front",
             feature=feat,
         )
+        if ev is not None:
+            ev["items"].append(
+                {
+                    "name": f"m_dia_x{start + i}",
+                    "label": label,
+                    "outcome": "placed",
+                    "pos": [lx, label_y],
+                }
+            )
     return len(survivors)
 
 
-def _diameter_column_left(dwg, items, start: int = 0) -> int:
+def _diameter_column_left(dwg, items, start: int = 0, trace=None) -> int:
     """ø-callout column to the LEFT of the front view for Z-turned step/boss
     diameters (#131) — the page-Y mirror of the row-below. A per-label occupancy
     gate drops only a label that would overprint a bore leader / existing callout
-    sharing the left region (#144), never the whole column. Returns the count placed."""
+    sharing the left region (#144), never the whole column. Returns the count placed.
+    *trace* (#736): one ``pass_events`` record with a placed/dropped item per callout."""
     if not items:
         return 0
+    ev = trace.pass_event("diameter_column_left", view="front") if trace is not None else None
     draft = dwg.draft
     fx0, fy0, _, fy1 = dwg.view_bounds("front")
     label_w = (
@@ -853,6 +878,11 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
     )
     elbow_x = fx0 - (draft.font_size + 2 * draft.pad_around_text)
     if elbow_x - label_w < _MARGIN:
+        if ev is not None:
+            ev["items"].extend(
+                {"label": f"ø{_fmt(d)}", "outcome": "dropped", "reason": "no_room_left"}
+                for _, d, _, _ in items
+            )
         return 0
     specs = []  # (tip_page, dia, label, feature), tip on the step's left silhouette
     for anchor, dia, feat, dtol in items:
@@ -867,13 +897,33 @@ def _diameter_column_left(dwg, items, start: int = 0) -> int:
     # a label-box-only view, which is blind to a bore callout's leader SHAFT, so a
     # ø label could silently overprint it (the #133/#225/#305 invisible-occupant
     # class, #358). Centre lines stay crossable (a diameter dim may cross one).
+    if ev is not None:  # the specs the fit solve squeezed out (#298 smallest-first drops)
+        kept = {id(s) for s in survivors}
+        ev["items"].extend(
+            {"label": s[2], "outcome": "dropped", "reason": "squeezed_out"}
+            for s in specs
+            if id(s) not in kept
+        )
     occupied = strip_obstacles(dwg, view="front", crossable=CROSSABLE_TYPES)
     placed = 0
     for i, ((tip, dia, label, feat), ly) in enumerate(zip(survivors, ys, strict=True)):
         ldr = Leader(tip=(tip[0], tip[1], 0), elbow=(elbow_x, ly, 0), label=label, draft=draft)
         if _box_hits(_anno_box(ldr), occupied):
+            if ev is not None:
+                ev["items"].append(
+                    {"label": label, "outcome": "dropped", "reason": "label_occupied"}
+                )
             continue  # would overprint a bore leader / existing callout — drop just this one
         dwg.add(ldr, f"m_dia_z{start + i}", view="front", feature=feat)
+        if ev is not None:
+            ev["items"].append(
+                {
+                    "name": f"m_dia_z{start + i}",
+                    "label": label,
+                    "outcome": "placed",
+                    "pos": [elbow_x, ly],
+                }
+            )
         occupied.append(_anno_box(ldr))
         placed += 1
     return placed
@@ -941,9 +991,10 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
 
     start_x = _next_start("m_dia_x") if only is not None else 0
     start_z = _next_start("m_dia_z") if only is not None else 0
-    return _diameter_row_below(dwg, _items(row_buckets), start=start_x) + _diameter_column_left(
-        dwg, _items(col_buckets), start=start_z
-    )
+    trace = getattr(ctx, "trace", None)  # the immediate placers report to the trace too (#736)
+    return _diameter_row_below(
+        dwg, _items(row_buckets), start=start_x, trace=trace
+    ) + _diameter_column_left(dwg, _items(col_buckets), start=start_z, trace=trace)
 
 
 def _env_pd(group, role):
@@ -1041,21 +1092,56 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
     (:func:`_label_lands_clear`, with *geom_clear* passed through), attributed to that
     candidate's feature; if none of a job's candidates land, records ``<noun> callout … not
     placed`` as ``<drop_code>`` lint (never a silent drop). Obstacles are recomputed per job
-    so a callout placed earlier is avoided. Returns the count placed."""
+    so a callout placed earlier is avoided. Returns the count placed.
+
+    Traced (#736): with ``ctx.trace`` on, one ``pass_events`` record
+    (``<noun>_callouts``) carries a per-job item — name, view, label, candidates
+    tried, obstacle count, placed tip/elbow or the drop reason. Post-#734 these
+    callouts place after the drain, so without this the #733 story ("why did this
+    pocket callout land here / drop") would be invisible to the trace."""
+    trace = getattr(ctx, "trace", None)
+    ev = trace.pass_event(f"{noun}_callouts") if trace is not None and jobs else None
     page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
     n = 0
     for name, view, vb, label, candidates in jobs:
         obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
+        tried = 0
         for tip, elbow, feature in candidates:
+            tried += 1
             ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label, draft=dwg.draft)
             if _label_lands_clear(ldr, obstacles, vb, page, geom_clear=geom_clear):
                 dwg.add(ldr, name, view=view, feature=feature)
+                if ev is not None:
+                    ev["items"].append(
+                        {
+                            "name": name,
+                            "view": view,
+                            "label": label,
+                            "candidates_tried": tried,
+                            "obstacles": len(obstacles),
+                            "outcome": "placed",
+                            "tip": [tip[0], tip[1]],
+                            "elbow": [elbow[0], elbow[1]],
+                        }
+                    )
                 n += 1
                 break
         else:
             ctx.record_issue(
                 "warning", drop_code, f"{noun} callout {label} not placed (no clear room)"
             )
+            if ev is not None:
+                ev["items"].append(
+                    {
+                        "name": name,
+                        "view": view,
+                        "label": label,
+                        "candidates_tried": tried,
+                        "obstacles": len(obstacles),
+                        "outcome": "dropped",
+                        "reason": "no_clear_room",
+                    }
+                )
     return n
 
 
@@ -1766,6 +1852,8 @@ def _draw_step_chain(
     vb = dwg.view_bounds(view)
     if vb is None:
         return 0
+    trace = getattr(ctx, "trace", None)  # the immediate placers report to the trace too (#736)
+    ev = trace.pass_event("step_length_chain", view=view) if trace is not None else None
     x0, y0, x1, y1 = vb
     draft = dwg.draft
     gap = draft.font_size + 4 * draft.pad_around_text
@@ -1808,6 +1896,10 @@ def _draw_step_chain(
                 _record_step_chain_drop(
                     dwg, "shoulders too dense to dimension even when staggered", ctx=ctx
                 )
+                if ev is not None:
+                    ev["items"].append(
+                        {"name": name_prefix, "outcome": "dropped", "reason": "too_dense"}
+                    )
                 return 0
         else:
             shoulder_ys = sorted({c for pa, pb, *_ in segs for c in (pa[1], pb[1])})
@@ -1816,6 +1908,14 @@ def _draw_step_chain(
                 _record_step_chain_drop(
                     dwg, "turned shoulders too closely spaced to dimension", ctx=ctx
                 )
+                if ev is not None:
+                    ev["items"].append(
+                        {
+                            "name": name_prefix,
+                            "outcome": "dropped",
+                            "reason": "shoulders_too_close",
+                        }
+                    )
                 return 0
 
         candidates = []
@@ -1841,11 +1941,20 @@ def _draw_step_chain(
             page[0] <= box[0] and box[2] <= page[2] and page[1] <= box[1] and box[3] <= page[3]
         ):
             _record_step_chain_drop(dwg, "a dimension would fall off the drawable page", ctx=ctx)
+            if ev is not None:
+                ev["items"].append(
+                    {"name": name_prefix, "outcome": "dropped", "reason": "off_page"}
+                )
             return 0
     for name, dim in candidates:
         if detail_scale is not None:
             dim._dw_scale = detail_scale
         dwg.add(dim, name, view=view)
+        if ev is not None:
+            b = _anno_box(dim)
+            ev["items"].append(
+                {"name": name, "outcome": "placed", "box": list(b) if b is not None else None}
+            )
     return len(candidates)
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2676,7 +2676,9 @@ def _pmi_leader_spec(tip, strip, label, name, view, side, draft):
     }
 
 
-def _pmi_place_one(dwg, spec, rec):
+def _pmi_place_one(dwg, spec, rec, trace=None):
+    # *trace* (#736): a PMI dim's post-drop fallback is a standalone strip pass —
+    # traced as a pass_event like the other standalone placers.
     left = place_strip_candidates(
         dwg,
         spec["strip"],
@@ -2687,6 +2689,8 @@ def _pmi_place_one(dwg, spec, rec):
         force=True,
         features={spec["name"]: rec},
         priorities={spec["name"]: _PMI_CORRIDOR_PRIORITY},
+        trace=trace,
+        trace_label="pmi_fallback",
     )
     return not left
 
@@ -2699,7 +2703,7 @@ def _pmi_queue_options(dwg, ctx, options, ax, label, rec):
 
     def _drop(nm, _alts=alternates, _ax=ax, _label=label, _rec=rec):
         for alt in _alts:
-            if _pmi_place_one(dwg, alt, _rec):
+            if _pmi_place_one(dwg, alt, _rec, trace=ctx.trace):
                 _log.info(
                     "PMI dim %s placed on fallback %s/%s",
                     nm,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -66,6 +66,7 @@ from draftwright.annotations._common import (
     _geom_box,
     carve_free_position,
     dim_footprint,
+    full_strip_message,
     place_strip_candidates,
     register_corridor,
     strip_free_span,
@@ -317,6 +318,8 @@ def render_slots(dwg, groups, a, *, ctx, only=None) -> int:
                         [_cand_for("below", _bh)],
                         tier,
                         features={cname: _feat},
+                        trace=ctx.trace,
+                        trace_label="slot_below_fallthrough",
                     ):
                         return  # placed on the below strip
                     _record_slot_drop(ctx, dwg, _dw, idx, vw[0], _feat)
@@ -359,7 +362,15 @@ def render_slots(dwg, groups, a, *, ctx, only=None) -> int:
                     continue
                 axis = "y" if side in ("above", "below") else "x"
                 if not place_strip_candidates(
-                    dwg, strip, vw[0], axis, [_cand_for(side, hi)], tier, features={cname: s}
+                    dwg,
+                    strip,
+                    vw[0],
+                    axis,
+                    [_cand_for(side, hi)],
+                    tier,
+                    features={cname: s},
+                    trace=ctx.trace,
+                    trace_label=f"slot_{side}",
                 ):
                     return True
             return False
@@ -2080,7 +2091,10 @@ def render_height_ladder(dwg, model, a, *, ctx, include_overall: bool = True) ->
 
         def _drop(nm, drop_msg=drop_msg, name=name):
             solved.pop(name, None)
-            ctx.record_issue("error", "placement_unsatisfiable", drop_msg)
+            # Name what filled the strip (#736): the #733 diagnosis ("which occupants
+            # exhausted the front-right strip?") becomes a glance at the lint message.
+            msg = full_strip_message(drop_msg, dwg, a.fv_zones.right, "front", "x")
+            ctx.record_issue("error", "placement_unsatisfiable", msg)
 
         register_corridor(
             ctx,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1536,6 +1536,8 @@ def _place_front_callouts(
         features=features,
         priorities=priorities,
         forbid=forbid,
+        trace=ctx.trace,
+        trace_label="front_hole_callouts",
     )
     left_names = {name for name, _ in left}
     for name, _build in cands:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -524,13 +524,23 @@ def _off_axis_drop(dwg, axis, view, *, ctx):
     )
 
 
-def _off_axis_emit(dwg, tier, strip, view, axis, cands, force=False, features=None):
+def _off_axis_emit(dwg, tier, strip, view, axis, cands, force=False, features=None, trace=None):
     # The collect-then-solve strip placer lives in _common as the shared
     # place_strip_candidates (P3, retiring the Strip cursor #150); this thin wrapper
     # binds the pass's dwg + tier. *features* (name -> IR feature) attributes each dim
-    # for drop() (#408). Promoted (#638).
+    # for drop() (#408). Promoted (#638). *trace* (#736): a standalone strip pass —
+    # traced as a pass_event like the other standalone placers.
     return place_strip_candidates(
-        dwg, strip, view, axis, cands, tier, force=force, features=features
+        dwg,
+        strip,
+        view,
+        axis,
+        cands,
+        tier,
+        force=force,
+        features=features,
+        trace=trace,
+        trace_label="off_axis_locations",
     )
 
 
@@ -736,12 +746,27 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
             for alt_strip, alt_view, alt_p_lo, alt_p_hi, alt_edge in _alts:
                 alt = _zc(alt_view, alt_p_lo, alt_p_hi, alt_edge)
                 if not _off_axis_emit(
-                    dwg, tier, alt_strip, alt_view, "x", [alt], features=_feature_map(alt_view)
+                    dwg,
+                    tier,
+                    alt_strip,
+                    alt_view,
+                    "x",
+                    [alt],
+                    features=_feature_map(alt_view),
+                    trace=ctx.trace,
                 ):
                     return
             p_strip, p_view, _p_lo, _p_hi, _edge = _primary
             if _off_axis_emit(
-                dwg, tier, p_strip, p_view, "x", [_cand], force=True, features=_feature_map(p_view)
+                dwg,
+                tier,
+                p_strip,
+                p_view,
+                "x",
+                [_cand],
+                force=True,
+                features=_feature_map(p_view),
+                trace=ctx.trace,
             ):
                 _off_axis_drop(dwg, "Z", p_view, ctx=ctx)
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -233,7 +233,15 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # the drawing's build-state stores (registry/coverage), threaded to the passes instead of hung
     # on the Drawing (ADR 0005 §2, #639). Fresh each auto-pass; the corridor batch is drained once
     # at the end (drain_corridors, #345/#346).
-    ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
+    ctx = PlacementContext(
+        registry=dwg.registry,
+        coverage=dwg.coverage,
+        # The opt-in solve-trace recorder (#736), attached to the drawing's build state
+        # by the builder; getattr because dwg is duck-typed in tests. None = off.
+        trace=getattr(dwg, "solve_trace", None),
+    )
+    if ctx.trace is not None:
+        ctx.trace.begin_phase("auto")  # one phase per annotate run (repack re-runs this)
     # Idempotent: clear build-time lint state so a second annotation pass does
     # not accumulate duplicate drop records.
     ctx.reset_issues()
@@ -533,6 +541,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "tabulate": _s_tabulate,
         }
     )
+    if ctx.trace is not None:  # snapshot the run's escalations into the trace (#736)
+        ctx.trace.record_escalations(ctx.escalations)
     # The escalations live only on this per-run ctx (#639), discarded when _auto_annotate
     # returns — so nothing carries stale drops into a later deferred edit (#440), and there is
     # no drawing-level list to clear.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -9,6 +9,7 @@ stage modules -- never make_drawing -- so the graph stays a DAG.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
@@ -36,6 +37,7 @@ from draftwright._core import (
     _tb_width,
 )
 from draftwright.analysis import _analyse
+from draftwright.annotations._common import SolveTrace
 from draftwright.annotations.orchestrator import (
     _auto_annotate,
     build_model,
@@ -236,10 +238,14 @@ def detect_part_model(part, *, pmi="off") -> PartModel:
     return model
 
 
-def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=None) -> Drawing:
+def _assemble(
+    a, out, assembly, detail_view, auto_dims, model=None, decorations=None, trace=None
+) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
-    repacked analysis it is also pass 2 of the measure-and-repack loop (#121)."""
+    repacked analysis it is also pass 2 of the measure-and-repack loop (#121).
+    *trace* is the opt-in #736 solve-trace recorder (attached to the drawing's
+    build state so the annotate + finalize paths thread it), or ``None``."""
     cxs, cys, czs = a.cx * a.SCALE, a.cy * a.SCALE, a.cz * a.SCALE
     dist = a.bbox_max * a.SCALE + 100
 
@@ -294,6 +300,8 @@ def _assemble(a, out, assembly, detail_view, auto_dims, model=None, decorations=
     dwg._build.analysis = a
     dwg._build.part_model = pm
     dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
+    if trace is not None:  # opt-in solve trace (#736), threaded via a named method
+        dwg.attach_solve_trace(trace)
 
     part_s = a.part.scale(a.SCALE)
     dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)
@@ -354,7 +362,16 @@ def _needs_repack(dwg, a) -> bool:
 
 
 def _repack(
-    a, dwg, out, assembly, detail_view, scale=None, page=None, model=None, decorations=None
+    a,
+    dwg,
+    out,
+    assembly,
+    detail_view,
+    scale=None,
+    page=None,
+    model=None,
+    decorations=None,
+    trace=None,
 ):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
     when a view collides across views, pack the blocks disjoint — escalating the
@@ -484,13 +501,29 @@ def _repack(
         sv_zones=sv_zones,
     )
     dwg2 = _assemble(
-        a2, out, assembly, detail_view, auto_dims=True, model=model, decorations=decorations
+        a2,
+        out,
+        assembly,
+        detail_view,
+        auto_dims=True,
+        model=model,
+        decorations=decorations,
+        trace=trace,
     )
     return a2, dwg2
 
 
 def _repack_to_fixed_point(
-    a, dwg, out, assembly, detail_view, scale=None, page=None, model=None, decorations=None
+    a,
+    dwg,
+    out,
+    assembly,
+    detail_view,
+    scale=None,
+    page=None,
+    model=None,
+    decorations=None,
+    trace=None,
 ):
     """Iterate measure→repack→assemble until stable or bounded (#302)."""
     cur_a, cur_dwg = a, dwg
@@ -505,6 +538,7 @@ def _repack_to_fixed_point(
             page=page,
             model=model,
             decorations=decorations,
+            trace=trace,
         )
         if repacked is None:
             if _needs_repack(cur_dwg, cur_a):
@@ -523,6 +557,27 @@ def _repack_to_fixed_point(
     return cur_a, cur_dwg
 
 
+def _resolve_trace(trace, out) -> SolveTrace | None:
+    """Resolve :func:`build_drawing`'s ``trace`` option to a :class:`SolveTrace`
+    recorder, or ``None`` (off — the default). ``None`` consults the
+    ``DRAFTWRIGHT_TRACE`` env var; ``False`` forces off; ``True`` writes
+    ``<out>.trace.json`` beside the drawing; a path-or-directory writes there."""
+    if trace is False:
+        return None
+    if trace is None:
+        env = os.environ.get("DRAFTWRIGHT_TRACE", "")
+        if not env:
+            return None
+        trace = env
+    if trace is True:
+        path = Path(f"{out}.trace.json")
+    else:
+        path = Path(trace)
+        if path.is_dir():
+            path = path / f"{Path(out).name}.trace.json"
+    return SolveTrace(path)
+
+
 def build_drawing(
     step_file: str | Path | Shape,
     out: str | None = None,
@@ -539,6 +594,7 @@ def build_drawing(
     assembly: bool | None = None,
     model: Sequence[Feature] | PartModel | None = None,
     decorations: dict | None = None,
+    trace: str | Path | bool | None = None,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -575,6 +631,16 @@ def build_drawing(
             it (#448); the one remaining detection-dependent bit is the off-axis
             side-drilled hole *location* dim, which needs recogniser-Hole geometry a
             declared feature doesn't carry. See ADR 0011.)
+        trace: the opt-in **solve-trace / explain mode** (#736): record every strip
+            placement decision — per corridor solve, the candidate set, the obstacles
+            that carved the strip (with owning annotation names), the free segments,
+            and each candidate's outcome (placed/dropped-with-reason/deduped/
+            promoted) — as ONE JSON file per build. ``True`` writes
+            ``<out>.trace.json`` beside the drawing; a path writes there (a
+            directory gets ``<stem>.trace.json`` inside it). Default ``None``
+            consults the ``DRAFTWRIGHT_TRACE`` env var (same path-or-directory
+            semantics); ``False`` forces it off. **Zero output change**: tracing
+            never alters a placement decision, and off (the default) costs nothing.
 
     Returns:
         A :class:`Drawing` with the standard front/plan/side/iso views projected
@@ -587,6 +653,7 @@ def build_drawing(
             out = out[: -len(_ext)]
             break
     title = title or stem.replace("_", " ").upper()
+    tracer = _resolve_trace(trace, out)
 
     a = _analyse(
         step_file,
@@ -606,7 +673,16 @@ def build_drawing(
     # per-view footprints and re-pack the blocks disjoint if a view actually
     # moves (#121, ADR 0004 — "lay out, don't predict").  Non-ballooned parts
     # measure ≈ estimate, so they skip pass 2 and stand byte-identical.
-    dwg = _assemble(a, out, assembly, detail_view, auto_dims, model=model, decorations=decorations)
+    dwg = _assemble(
+        a,
+        out,
+        assembly,
+        detail_view,
+        auto_dims,
+        model=model,
+        decorations=decorations,
+        trace=tracer,
+    )
     if auto_dims:
         repacked = _repack_to_fixed_point(
             a,
@@ -618,6 +694,7 @@ def build_drawing(
             page=page,
             model=model,
             decorations=decorations,
+            trace=tracer,
         )
         if repacked is not None:
             a, dwg = repacked
@@ -627,6 +704,8 @@ def build_drawing(
         # A no-op on a clean sheet, so default-on costs nothing when there is
         # nothing to fix.
         dwg.repair()
+    if tracer is not None:  # one JSON per build; Drawing.finalize() re-writes it (#736)
+        tracer.write()
     return dwg
 
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -632,15 +632,26 @@ def build_drawing(
             side-drilled hole *location* dim, which needs recogniser-Hole geometry a
             declared feature doesn't carry. See ADR 0011.)
         trace: the opt-in **solve-trace / explain mode** (#736): record every strip
-            placement decision — per corridor solve, the candidate set, the obstacles
-            that carved the strip (with owning annotation names), the free segments,
-            and each candidate's outcome (placed/dropped-with-reason/deduped/
-            promoted) — as ONE JSON file per build. ``True`` writes
-            ``<out>.trace.json`` beside the drawing; a path writes there (a
-            directory gets ``<stem>.trace.json`` inside it). Default ``None``
-            consults the ``DRAFTWRIGHT_TRACE`` env var (same path-or-directory
-            semantics); ``False`` forces it off. **Zero output change**: tracing
-            never alters a placement decision, and off (the default) costs nothing.
+            placement decision as ONE JSON file per build (schema ``version`` 2),
+            with two record types. ``solves`` — the corridor solves: the candidate
+            set, the obstacles that carved the strip (with owning annotation names),
+            the free segments, and each candidate's outcome (placed/dropped-with-
+            reason/deduped/promoted). ``pass_events`` — everything placed outside a
+            corridor solve: the standalone strip passes plus the *immediate* placers
+            (the post-drain machined-feature leader callouts and the turned
+            diameter/step-length set-solves), each with per-item outcomes. The
+            ``jq`` contract — corridor dims vs everything else::
+
+                jq '.solves[].outcomes[] | select(.name == "dim_height")' t.trace.json
+                jq '.pass_events[] | select(.label == "pocket_callouts") | .items[]' t.trace.json
+
+            ``True`` writes ``<out>.trace.json`` beside the drawing; a path writes
+            there (a directory gets ``<stem>.trace.json`` inside it). Default
+            ``None`` consults the ``DRAFTWRIGHT_TRACE`` env var (same
+            path-or-directory semantics); ``False`` forces it off. **Zero output
+            change**: tracing never alters a placement decision, and off (the
+            default) costs nothing. Recording-only: an unwritable trace path logs a
+            warning and never aborts the build/export.
 
     Returns:
         A :class:`Drawing` with the standard front/plan/side/iso views projected

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -16,7 +16,7 @@ import tempfile
 import warnings
 from dataclasses import dataclass
 from dataclasses import field as dataclasses_field
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 from build123d import (
     Color,
@@ -198,6 +198,9 @@ class BuildState:
       (helpers #143/#164).
     - ``ann_box_cache`` — lint's annotation bounding boxes (#602): identity- AND
       location-token-checked entries (see ``_ann_box``), pruned by ``lint()``.
+    - ``trace`` — the opt-in solve-trace recorder (#736,
+      :class:`~draftwright.annotations._common.SolveTrace`), or ``None`` (default:
+      tracing off). Carried here so the finalize path traces like the auto pass.
 
     Builder fills it at one site; the compat properties on ``Drawing`` read
     through it, so ``dwg._analysis``-style test inspection keeps working.
@@ -207,6 +210,7 @@ class BuildState:
     part_model: object | None = None
     view_edge_cache: dict = dataclasses_field(default_factory=dict)
     ann_box_cache: dict = dataclasses_field(default_factory=dict)
+    trace: Any = None
 
     def clear_geometry_caches(self) -> None:
         """The one invalidation seam (finalize rollback): view edges + annotation
@@ -584,6 +588,18 @@ class Drawing:
         """Attach the built PartModel so ``model()`` and feature edits see it. Lets the
         orchestrator hand the model back without an ``annotations/`` attribute write (#639)."""
         self._build.part_model = model
+
+    @property
+    def solve_trace(self):
+        """The opt-in solve-trace recorder threaded through this build (#736), or
+        ``None`` (the default — tracing off). See ``build_drawing(trace=...)``."""
+        return self._build.trace
+
+    def attach_solve_trace(self, trace) -> None:
+        """Attach the #736 :class:`~draftwright.annotations._common.SolveTrace` recorder
+        so the annotate and finalize paths thread it onto their per-run
+        ``PlacementContext`` (build state flows through a named method, #639)."""
+        self._build.trace = trace
 
     @property
     def model_declared(self) -> bool:
@@ -1344,7 +1360,10 @@ class Drawing:
             coverage=self._coverage,
             part_model=self.model(),
             model_declared=self.model_declared,
+            trace=self._build.trace,  # the finalize drain traces too (#736)
         )
+        if ctx.trace is not None:
+            ctx.trace.begin_phase("finalize")
 
         model, a = self._part_model, self._analysis
         routable = model is not None and a is not None
@@ -1390,6 +1409,8 @@ class Drawing:
             raise
         finally:
             self._defer_intents = deferred
+        if ctx.trace is not None:  # re-write the trace with the finalize solves (#736)
+            ctx.trace.write()
 
     def _drain_intents(self, ctx, model, a, r) -> None:
         """The mutating half of :meth:`finalize` (#638): the drain stages, keyed by the

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1362,6 +1362,11 @@ class Drawing:
             model_declared=self.model_declared,
             trace=self._build.trace,  # the finalize drain traces too (#736)
         )
+        # The solve trace joins the transaction (#736 review): the recorder appends during
+        # the drain, so a rolled-back finalize must also truncate those records — else the
+        # trace (and a rewritten file) would describe placements that no longer exist.
+        # Snapshot BEFORE opening the finalize phase: the phase counter is trace state too.
+        trace_snap = ctx.trace.snapshot() if ctx.trace is not None else None
         if ctx.trace is not None:
             ctx.trace.begin_phase("finalize")
 
@@ -1405,11 +1410,15 @@ class Drawing:
             self._coverage.restore(coverage_snap)
             if sv_above is not None:
                 sv_above.outer_limit = sv_above_limit
+            if trace_snap is not None:  # roll the failed drain's records out of the trace
+                ctx.trace.restore(trace_snap)
             self._build.clear_geometry_caches()
             raise
         finally:
             self._defer_intents = deferred
-        if ctx.trace is not None:  # re-write the trace with the finalize solves (#736)
+        # Re-write the trace file only AFTER a successful drain (#736) — never mid-drain,
+        # so a rollback cannot leave a file describing rolled-back placements.
+        if ctx.trace is not None:
             ctx.trace.write()
 
     def _drain_intents(self, ctx, model, a, r) -> None:

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -344,7 +344,7 @@ def test_build_state_has_a_single_construction_and_fill_site():
                     # count too when the receiver is a _build attribute (#691 r2).
                     or (
                         node.args[1].value
-                        in ("analysis", "part_model", "view_edge_cache", "ann_box_cache")
+                        in ("analysis", "part_model", "view_edge_cache", "ann_box_cache", "trace")
                         and isinstance(node.args[0], ast.Attribute)
                         and node.args[0].attr == "_build"
                     )
@@ -356,5 +356,8 @@ def test_build_state_has_a_single_construction_and_fill_site():
 
     assert writers == {
         "builder.py": ["_build.analysis", "_build.part_model"],
-        "drawing.py": ["_build", "_build.analysis", "_build.part_model"],
+        # _build.trace: attach_solve_trace — the #736 solve-trace recorder rides
+        # BuildState like the rest of the build context (filled via the named
+        # method by builder._assemble; read by the annotate/finalize ctx threading).
+        "drawing.py": ["_build", "_build.analysis", "_build.part_model", "_build.trace"],
     }, writers

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -358,6 +358,10 @@ def test_build_state_has_a_single_construction_and_fill_site():
         "builder.py": ["_build.analysis", "_build.part_model"],
         # _build.trace: attach_solve_trace — the #736 solve-trace recorder rides
         # BuildState like the rest of the build context (filled via the named
-        # method by builder._assemble; read by the annotate/finalize ctx threading).
+        # method by builder._assemble — its ONLY caller; read by the annotate/
+        # finalize ctx threading). The recorder also participates in finalize()'s
+        # #647 transaction: finalize snapshots it beside the registry/coverage
+        # snapshots and restores it on rollback, so a failed drain leaves no
+        # trace records for placements that no longer exist.
         "drawing.py": ["_build", "_build.analysis", "_build.part_model", "_build.trace"],
     }, writers

--- a/tests/test_solve_trace.py
+++ b/tests/test_solve_trace.py
@@ -79,6 +79,32 @@ class TestTraceRecording:
             build_drawing(Box(60, 40, 20), out=str(tmp_path / stem), trace=True)
         assert (tmp_path / "a.trace.json").read_bytes() == (tmp_path / "b.trace.json").read_bytes()
 
+    def test_recorder_failure_disarms_and_never_aborts(self, tmp_path, caplog, monkeypatch):
+        # The never-aborts guarantee covers the recording HOOKS, not just write():
+        # every public recorder method is guarded (_never_aborts), so an internal
+        # failure mid-build logs ONE warning, disarms the recorder, and the build
+        # completes. Disarm semantics = partial-disable: whatever was recorded/
+        # written before the failure stays; nothing further is recorded or written.
+        from draftwright.annotations._common import SolveTrace
+
+        def _boom(strip):
+            raise RuntimeError("injected recorder failure")
+
+        # _strip_rec is internal to begin_solve/begin_pass — a genuine in-method
+        # failure the guard must swallow (the first corridor solve trips it).
+        monkeypatch.setattr(SolveTrace, "_strip_rec", staticmethod(_boom))
+        with caplog.at_level(logging.WARNING, logger="draftwright.annotations._common"):
+            dwg = _build_box(tmp_path, trace=True)
+        msgs = [r.getMessage() for r in caplog.records if "recorder failed" in r.getMessage()]
+        assert len(msgs) == 1, "ONE warning, then silence (disarmed)"
+        assert "tracing disabled" in msgs[0]
+        assert dwg.solve_trace is not None and dwg.solve_trace._broken
+        # Nothing was written after the disarm (it fired before the first write).
+        assert not (tmp_path / "t.trace.json").exists()
+        # A disarmed snapshot returns the sentinel and restore tolerates it.
+        assert dwg.solve_trace.snapshot() is None
+        dwg.solve_trace.restore(None)
+
     def test_unwritable_trace_path_never_aborts_the_build(self, tmp_path, caplog):
         # Recording-only: an unwritable path degrades to a warning — the build (and
         # any export after it) must complete untouched.
@@ -125,6 +151,26 @@ class TestPassEvents:
         assert chain["items"] and all(
             i["outcome"] in ("placed", "dropped") for i in chain["items"]
         )
+
+
+class TestTracedUntracedParity:
+    def test_tracing_never_changes_the_drawing(self, tmp_path):
+        # "Zero output change" is a contract, not a comment: tracing takes a different
+        # obstacle-construction branch (named (owner, box) records projected back to
+        # bare boxes), so pin trace=False vs trace=True to an identical drawing
+        # signature — names/types/labels/label+geom boxes/view boxes/item count/build
+        # issues (test_refactor_golden's fingerprint). The part exercises corridor
+        # solves (envelope dims) AND immediate leader callouts (chamfer + pocket).
+        from build123d import Axis
+        from build123d import chamfer as b3d_chamfer
+        from test_refactor_golden import _signature
+
+        plate = Box(90, 60, 20)
+        e = plate.edges().filter_by(Axis.Z).sort_by(lambda e: e.center().X + e.center().Y)[-1]
+        part = b3d_chamfer(e, 12) - Pos(0, 0, 7.5) * Box(30, 18, 5)
+        s_off = _signature(build_drawing(part, out=str(tmp_path / "off"), trace=False))
+        s_on = _signature(build_drawing(part, out=str(tmp_path / "on"), trace=True))
+        assert s_off == s_on
 
 
 class TestFinalizeTransaction:

--- a/tests/test_solve_trace.py
+++ b/tests/test_solve_trace.py
@@ -1,0 +1,125 @@
+"""Solve-trace / explain mode (#736): the opt-in per-build JSON strip-placement trace.
+
+Child 1 of #735 (the #733 post-mortem): diagnosing a "strip full" drop must be a
+glance — one JSON file per build plus a lint message that names the occupants —
+never a custom script and two slow CTC rebuilds. Tracing is default-OFF and must
+never change a placement decision (zero output risk; the golden corpus pins that).
+"""
+
+import json
+from types import SimpleNamespace
+
+from build123d import Box
+
+from draftwright import build_drawing
+from draftwright._core import Strip
+from draftwright.annotations._common import full_strip_message, strip_occupants
+
+
+def _build_box(tmp_path, **kw):
+    return build_drawing(Box(60, 40, 20), out=str(tmp_path / "t"), **kw)
+
+
+class TestTraceRecording:
+    def test_trace_kwarg_writes_one_json_per_build(self, tmp_path):
+        dwg = _build_box(tmp_path, trace=True)
+        path = tmp_path / "t.trace.json"
+        assert path.exists()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["version"] == 1
+        assert data["solves"], "at least one strip solve must be recorded"
+        # seq is the drain's batch order — the per-strip solve sequence.
+        assert [s["seq"] for s in data["solves"]] == list(range(len(data["solves"])))
+        by_corridor = {tuple(s["corridor"]): s for s in data["solves"] if s["corridor"]}
+        # A plain box registers its height ladder in the shared (front, right) corridor.
+        s = by_corridor[("front", "right")]
+        assert [c["name"] for c in s["candidates"]] == ["dim_height"]
+        cand = s["candidates"][0]
+        assert cand["force"] is True and cand["priority"] == 0
+        # The strip bounds are the diagnosis frame …
+        assert set(s["strip"]) == {"anchor", "outer_limit", "direction", "gap", "spacing"}
+        # … and each pass records the carve + per-candidate events.
+        p = s["passes"][0]
+        assert set(p) >= {"obstacles", "free_segments", "placed", "rejected", "unplaced", "span"}
+        assert p["free_segments"], "the carved free segments must be recorded"
+        # "Why did X place/drop" is one query over outcomes (the jq contract).
+        outcome = next(o for o in s["outcomes"] if o["name"] == "dim_height")
+        assert outcome["outcome"] == "placed"
+        assert outcome["pos"] == p["placed"][0]["pos"]
+        # The recorder rides the drawing's build state, so finalize() traces too.
+        assert dwg.solve_trace is not None
+
+    def test_env_var_directory_activates(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DRAFTWRIGHT_TRACE", str(tmp_path))
+        _build_box(tmp_path)
+        data = json.loads((tmp_path / "t.trace.json").read_text(encoding="utf-8"))
+        assert data["version"] == 1 and data["solves"]
+
+    def test_off_by_default_no_file_no_recorder(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DRAFTWRIGHT_TRACE", raising=False)
+        dwg = _build_box(tmp_path)
+        assert dwg.solve_trace is None, "tracing must be off by default (nil cost)"
+        assert not list(tmp_path.glob("**/*.trace.json"))
+
+
+class _Anno:
+    """A duck-typed placed annotation: a hull bbox only (no ``.segments``)."""
+
+    def __init__(self, x0, y0, x1, y1):
+        self._box = (x0, y0, x1, y1)
+
+    def bounding_box(self):
+        x0, y0, x1, y1 = self._box
+        return SimpleNamespace(min=SimpleNamespace(X=x0, Y=y0), max=SimpleNamespace(X=x1, Y=y1))
+
+
+class _Dwg:
+    """A duck-typed drawing exposing just the occupancy surface strip_occupants reads."""
+
+    draft = None
+
+    def __init__(self, annos):
+        self._annos = annos
+
+    def iter_annotations(self):
+        return list(self._annos.items())
+
+    def view_of(self, name):
+        return "front"
+
+
+class TestFullStripMessage:
+    """The #736 enriched placement_unsatisfiable message: name what filled the strip."""
+
+    def test_names_top_occupants_largest_first(self):
+        strip = Strip(anchor=90.0, outer_limit=140.0, direction=1.0)  # free span x=[100, 140]
+        dwg = _Dwg(
+            {
+                "ldr_big": _Anno(105, 0, 130, 10),  # covers 25 mm of the span
+                "dim_small": _Anno(110, 20, 112, 24),  # covers 2 mm
+                "dim_elsewhere": _Anno(0, 0, 50, 5),  # outside the span → not an occupant
+            }
+        )
+        assert strip_occupants(dwg, strip, "front", "x") == ["ldr_big", "dim_small"]
+        msg = full_strip_message(
+            "overall height dimension dropped (front-view right strip full)",
+            dwg,
+            strip,
+            "front",
+            "x",
+        )
+        assert msg == (
+            "overall height dimension dropped "
+            "(front-view right strip full; occupied by: ldr_big, dim_small)"
+        )
+
+    def test_unknown_occupancy_leaves_message_untouched(self):
+        strip = Strip(anchor=90.0, outer_limit=140.0, direction=1.0)
+        base = "overall height dimension dropped (front-view right strip full)"
+        assert full_strip_message(base, _Dwg({}), strip, "front", "x") == base
+        assert full_strip_message(base, _Dwg({}), None, "front", "x") == base
+
+    def test_limit_caps_the_name_list(self):
+        strip = Strip(anchor=90.0, outer_limit=140.0, direction=1.0)
+        annos = {f"a{i}": _Anno(100 + i, 0, 139, 5) for i in range(5)}
+        assert len(strip_occupants(_Dwg(annos), strip, "front", "x")) == 3

--- a/tests/test_solve_trace.py
+++ b/tests/test_solve_trace.py
@@ -7,9 +7,11 @@ never change a placement decision (zero output risk; the golden corpus pins that
 """
 
 import json
+import logging
 from types import SimpleNamespace
 
-from build123d import Box
+import pytest
+from build123d import Box, Cylinder, Pos
 
 from draftwright import build_drawing
 from draftwright._core import Strip
@@ -20,16 +22,26 @@ def _build_box(tmp_path, **kw):
     return build_drawing(Box(60, 40, 20), out=str(tmp_path / "t"), **kw)
 
 
+def _load(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 class TestTraceRecording:
     def test_trace_kwarg_writes_one_json_per_build(self, tmp_path):
         dwg = _build_box(tmp_path, trace=True)
         path = tmp_path / "t.trace.json"
         assert path.exists()
-        data = json.loads(path.read_text(encoding="utf-8"))
-        assert data["version"] == 1
+        data = _load(path)
+        assert data["version"] == 2
         assert data["solves"], "at least one strip solve must be recorded"
-        # seq is the drain's batch order — the per-strip solve sequence.
-        assert [s["seq"] for s in data["solves"]] == list(range(len(data["solves"])))
+        # Two distinct record types (schema honesty): corridor solves carry candidates/
+        # outcomes; everything else is a pass_event with per-item outcomes.
+        assert isinstance(data["pass_events"], list)
+        assert all(s["corridor"] for s in data["solves"])
+        assert all("items" in e and "label" in e for e in data["pass_events"])
+        # seq is ONE global event counter across solves + pass_events (decision order).
+        seqs = sorted([s["seq"] for s in data["solves"]] + [e["seq"] for e in data["pass_events"]])
+        assert seqs == list(range(len(seqs)))
         by_corridor = {tuple(s["corridor"]): s for s in data["solves"] if s["corridor"]}
         # A plain box registers its height ladder in the shared (front, right) corridor.
         s = by_corridor[("front", "right")]
@@ -52,14 +64,106 @@ class TestTraceRecording:
     def test_env_var_directory_activates(self, tmp_path, monkeypatch):
         monkeypatch.setenv("DRAFTWRIGHT_TRACE", str(tmp_path))
         _build_box(tmp_path)
-        data = json.loads((tmp_path / "t.trace.json").read_text(encoding="utf-8"))
-        assert data["version"] == 1 and data["solves"]
+        data = _load(tmp_path / "t.trace.json")
+        assert data["version"] == 2 and data["solves"]
 
     def test_off_by_default_no_file_no_recorder(self, tmp_path, monkeypatch):
         monkeypatch.delenv("DRAFTWRIGHT_TRACE", raising=False)
         dwg = _build_box(tmp_path)
         assert dwg.solve_trace is None, "tracing must be off by default (nil cost)"
         assert not list(tmp_path.glob("**/*.trace.json"))
+
+    def test_trace_is_byte_for_byte_deterministic(self, tmp_path):
+        # Strict serialisation (no default=str): same part → byte-identical trace.
+        for stem in ("a", "b"):
+            build_drawing(Box(60, 40, 20), out=str(tmp_path / stem), trace=True)
+        assert (tmp_path / "a.trace.json").read_bytes() == (tmp_path / "b.trace.json").read_bytes()
+
+    def test_unwritable_trace_path_never_aborts_the_build(self, tmp_path, caplog):
+        # Recording-only: an unwritable path degrades to a warning — the build (and
+        # any export after it) must complete untouched.
+        target = tmp_path / "no_such_dir" / "t.trace.json"
+        with caplog.at_level(logging.WARNING, logger="draftwright.annotations._common"):
+            dwg = _build_box(tmp_path, trace=str(target))
+        assert dwg is not None and dwg.solve_trace is not None
+        assert not target.exists()
+        assert any("trace: could not write" in r.getMessage() for r in caplog.records)
+
+
+class TestPassEvents:
+    """Finding-#733 coverage: the immediate placers — post-drain machined-feature leader
+    callouts and the turned diameter/step-length set-solves — must be trace-visible too
+    (pre-#734 the callouts WERE the drain-time occupants; their own story may not vanish)."""
+
+    def test_machined_feature_callout_pass_is_traced(self, tmp_path):
+        from build123d import Axis, chamfer
+
+        plate = Box(90, 60, 20)
+        e = plate.edges().filter_by(Axis.Z).sort_by(lambda e: e.center().X + e.center().Y)[-1]
+        build_drawing(chamfer(e, 12), out=str(tmp_path / "c"), trace=True)
+        data = _load(tmp_path / "c.trace.json")
+        ev = next(e for e in data["pass_events"] if e["label"] == "chamfer_callouts")
+        item = next(i for i in ev["items"] if i["name"].startswith("m_chamfer"))
+        # The callout's own story: where it leads from/to, what it dodged, how hard it tried.
+        assert item["outcome"] == "placed"
+        assert item["view"] == "plan" and item["label"] == "C12"
+        assert item["candidates_tried"] >= 1 and item["obstacles"] >= 0
+        assert len(item["tip"]) == 2 and len(item["elbow"]) == 2
+
+    def test_turned_immediate_placers_are_traced(self, tmp_path):
+        shaft = Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(10, 30)
+        build_drawing(shaft, out=str(tmp_path / "s"), trace=True)
+        data = _load(tmp_path / "s.trace.json")
+        labels = {e["label"] for e in data["pass_events"]}
+        assert "diameter_column_left" in labels and "step_length_chain" in labels
+        col = next(e for e in data["pass_events"] if e["label"] == "diameter_column_left")
+        assert any(
+            i["outcome"] == "placed" and i["name"].startswith("m_dia_z") and len(i["pos"]) == 2
+            for i in col["items"]
+        )
+        chain = next(e for e in data["pass_events"] if e["label"] == "step_length_chain")
+        assert chain["items"] and all(
+            i["outcome"] in ("placed", "dropped") for i in chain["items"]
+        )
+
+
+class TestFinalizeTransaction:
+    """Finding-2 coverage: the recorder appends during the finalize drain, and finalize is
+    transactional (#647) — a rolled-back drain must leave the trace state AND the on-disk
+    file exactly as they were before finalize()."""
+
+    def test_failed_finalize_leaves_trace_state_and_file_unchanged(self, tmp_path, monkeypatch):
+        from draftwright.annotations import _common
+
+        part = Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15)  # step only (cf. #647 tests)
+        dwg = build_drawing(part, out=str(tmp_path / "t"), trace=True, auto_dims=False)
+        path = tmp_path / "t.trace.json"
+        tr = dwg.solve_trace
+        before_state = tr.snapshot()
+        before_bytes = path.read_bytes()
+        step = next(f for f in dwg.model().features if f.kind == "step_level")
+        dwg._defer_intents = True
+        dwg.dimension(step, "length", role="step_position")
+
+        real = _common.drain_corridors
+        calls = {"n": 0}
+
+        def _boom(ctx, d):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("injected drain failure")
+            return real(ctx, d)
+
+        monkeypatch.setattr(_common, "drain_corridors", _boom)
+        with pytest.raises(RuntimeError):
+            dwg.finalize()
+        # Rolled back: no trace records for placements that no longer exist, file untouched.
+        assert tr.snapshot() == before_state
+        assert path.read_bytes() == before_bytes
+
+        dwg.finalize()  # the clean retry records its solves and rewrites the file once
+        assert len(tr.solves) > before_state[0]
+        assert path.read_bytes() != before_bytes
 
 
 class _Anno:


### PR DESCRIPTION
Child 1 of umbrella #735 (the #733 post-mortem improvements). Closes #736.

## What

- **Opt-in trace**: `build_drawing(trace=…)` or `DRAFTWRIGHT_TRACE=<path-or-dir>` writes one JSON per build recording, per strip solve: the corridor key, strip geometry, full candidate set (priority/size/force/anchored/dedup), the carved segments with **named** in-band obstacles, per-candidate outcomes (placed/dropped-with-reason/promoted/deferred), and escalations. `jq '.solves[].outcomes[] | select(.name=="dim_height")'` answers "why did X drop" in one query — the #733 diagnosis that took a custom script and two 7-minute CTC builds becomes a glance.
- **Recorder seam**: `SolveTrace` rides `BuildState` (sanctioned fill via `attach_solve_trace` in `builder._assemble`; the encapsulation guard's writer inventory extended with rationale) and reaches the solves as `ctx.trace` — no module globals, so `finalize()` traces identically (`auto:N`/`finalize:N` phases). Off = a `None` check per hook; **zero output change verified** (traced-vs-untraced SVG line-set identical; goldens zero-shift).
- **Enriched lint**: height-ladder `placement_unsatisfiable` drops now name the top strip occupants — "front-view right strip full; **occupied by: m_pocket_xz3, …**". No existing test pinned the old strings (verified); sibling warning codes left for a one-liner later.

## Verification

- New `tests/test_solve_trace.py` (6 tests: both activations with schema assertions, off-by-default no-file, occupant-message pins)
- Guards (incl. the extended BuildState writer pin): green; goldens 14 passed zero-shift; targeted 119 passed
- Full fast tier: **1447 passed, 0 failed**; lint ×4 clean; rebased onto post-#747 main and re-verified (85 + targeted green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)