### PR TITLE
docs: reconcile current architecture guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,14 @@ entry. Keep `_LAYERS` and this section in step.
     (#699 slice b): `_auto_annotate` and `Drawing._drain_intents` (the finalize
     drain) both hand name→thunk dicts to the shared `run_stages`, so the two
     build paths cannot diverge in sequencing (the drain step itself is the
-    shared `drain_and_reconcile`). End state (ADR 0008) is
-    `build model → plan → render`; some inline engine code remains — chiefly
+    shared `drain_and_reconcile`). The current ADR 0015 shape is
+    `build model → plan/model-routed intents → render`; some inline engine code remains — chiefly
     `_maybe_tabulate_holes` (the hole-table/balloon escalation resolver) and the
     iso right-strip outer-limit tightening — pending the last convergence steps.
   - **`annotations/from_model.py`** — the **IR render layer** (largest annotations
     module): turns the planner's `DimensionGroup`/render-intents into placed
     dimensions/callouts/centre marks/section triggers. This is where the turned,
-    PMI/GD&T, envelope/OD, centre-mark and step-length passes converged (ADR 0008,
+    PMI/GD&T, envelope/OD, centre-mark and step-length passes converged (ADR 0015,
     #200/#208/#237) — the old per-feature `annotations/{turned,pmi}.py` modules
     were deleted as each migrated here.
   - **`annotations/holes.py`** — hole/pattern callouts, balloons, location dims
@@ -129,7 +129,7 @@ entry. Keep `_LAYERS` and this section in step.
   `suggest.py` (`_suggest_fix`, #29 snippets). Depends only on `_core`,
   `recognition/` (typed hole records in `coverage.py`) + build123d_drafting. `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
-- **`model/`** — the ADR 0008 IR waist: `ir.py` (the `Feature`/`DimParameter`/
+- **`model/`** — the ADR 0015 IR waist: `ir.py` (the `Feature`/`DimParameter`/
   `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
   `Feature` objects, adapting `recognition/`), `planner.py` (`plan_dimensions` —
   one rule set → a `DimensionGroup` per feature, + `plan_sections`), and
@@ -142,7 +142,7 @@ entry. Keep `_LAYERS` and this section in step.
   (#640) so the layout engine stops shadowing the user-facing `Sheet` facade
   (which now owns the `sheet.py` name).
 - **`analysis.py`** — the `_analyse` stage: solid classification, the one-shot
-  feature-inventory detection (ADR 0008 Am5), view sizing, and the strip/zone
+  feature-inventory detection (ADR 0015), view sizing, and the strip/zone
   model (`fv_zones`/`pv_zones`/`sv_zones`) that ADR 0014 placement reads.
 - **`projection.py`** — HLR projection and view-coordinate transforms
   (`_assemble`'s geometry half; #161).
@@ -214,7 +214,7 @@ incomplete until they weigh the change against the ADRs, not just its local
 correctness. Ask: does this feature round-trip **all** the surfaces its kind
 requires — recognise **+** emit **+** declare (ADR 0011 / epic #574; no
 recognition-only debt)? Does it fit the compiler pipeline and one-inventory waist
-(ADR 0008)? Does it conform to the recogniser contract (ADR 0013)? Does it sit
+(ADR 0015)? Does it conform to the recogniser contract (ADR 0013)? Does it sit
 where it belongs in the DAG, or re-introduce a coupling an ADR removed? Does it
 place geometry through the corridor solve rather than around it, and extend a
 shared pass rather than adding another copy (consolidation epic #635)? A change
@@ -320,9 +320,11 @@ Current ADRs:
 - **0015** — **Accepted** (supersedes 0008, #697): **the part-drawing compiler
   as built** — detectors + declared features → the one PartModel waist (two
   tiers, ADR 0013) → planner → render-intents → shared infra; with the
-  **honest planner-coverage split** (which kinds flow through `plan_dimensions`
-  vs bypass it — convergence tracked by #698) and the lint/coverage carve-out
-  stated properly. New feature kinds must take the planner path.
+  planner-coverage split (dimension-bearing kinds flow through
+  `plan_dimensions`; correlated furniture/aspects remain model-routed by design)
+  and the lint/coverage carve-out stated properly. Planner convergence #698 is
+  complete; new kinds must add every applicable IR, planning, rendering,
+  coverage, and test surface while keeping orientation data-driven.
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,10 +320,10 @@ Current ADRs:
 - **0015** — **Accepted** (supersedes 0008, #697): **the part-drawing compiler
   as built** — detectors + declared features → the one PartModel waist (two
   tiers, ADR 0013) → planner → render-intents → shared infra; with the
-  planner-coverage split (dimension-bearing kinds flow through
-  `plan_dimensions`; correlated furniture/aspects remain model-routed by design)
-  and the lint/coverage carve-out stated properly. Planner convergence #698 is
-  complete; new kinds must add every applicable IR, planning, rendering,
+  planner-coverage split (the #698 migrations are complete; correlated
+  furniture/aspects remain model-routed by design, while rotational OD/bore
+  groups are residual debt tracked by #754) and the lint/coverage carve-out
+  stated properly. New kinds must add every applicable IR, planning, rendering,
   coverage, and test surface while keeping orientation data-driven.
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -159,14 +159,16 @@ dwg.repair()                # auto-fix mechanically-fixable lint; never worsens
 
 Each `LintIssue` carries a domain-meaningful `code` and, when computable, a
 ready-to-apply `suggestion`. See `docs/adr/` for the design (deterministic
-generation, the lint→repair loop, and the constraint-based layout engine).
+generation, the lint→repair loop, and collect-then-solve placement).
 
 ## Architecture
 
-draftwright is structured as a **part-drawing compiler** (ADR 0008): feature
-detectors → a `PartModel` IR (`Feature`s exposing `DimParameter`s) → a dimensioning
-planner → renderers, feeding a shared layout/projection/export stack. It builds on
-two libraries:
+draftwright is structured as a **part-drawing compiler** (ADR 0015): recognised
+or declared features converge on a `PartModel` IR, then planner-fed and
+sanctioned model-routed render intents feed shared placement, projection, and
+export. Coverage lint independently compares recognised geometry with the
+placed drawing, so an upstream omission cannot hide from verification. It
+builds on two libraries:
 
 ```
 draftwright
@@ -179,8 +181,7 @@ primitives (`Dimension`, `Leader`, etc.) live in `build123d-drafting-helpers` an
 be used independently. The compiler is largely converged in production — turned
 dims/lengths, centre marks, envelope, slots, holes (callouts/locations/grouping),
 the section A–A trigger, the prismatic step-ladder + rotational furniture, and PMI/GD&T
-are all on the IR — the migration is complete (one path; the orchestrator is
-build → plan → render). See
+are all on the IR. See
 [`docs/target-architecture.md`](docs/target-architecture.md) and
 [`docs/layout-algorithm-primer.md`](docs/layout-algorithm-primer.md) for a short walkthrough, plus
 [`docs/adr/`](docs/adr/). The engine handles view layout (strip/zone model), scale

--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -37,9 +37,10 @@ that the edit surface is the model; #400 made the model a **read** surface
 The missing half is symmetric: let the caller **supply the IR as an input**, so
 detection becomes *a* producer of the model, not the *only* one.
 
-The `proto/declare-features` spike proved the seam is small: the orchestrator already
-honours a pre-set `dwg._part_model` (`orchestrator.py:170`) — `build_drawing` merely
-always overwrote it with detection.
+The historical `proto/declare-features` spike proved the seam was small by
+pre-setting drawing model state before orchestration. The production seam is now
+explicit: `builder._assemble` attaches the selected `PartModel` through
+`BuildState`, and the orchestrator consumes that attached model.
 
 ## Decision
 

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -1,6 +1,10 @@
 # ADR 0015 — The part-drawing compiler, as built
 
 - **Status:** Accepted. **Supersedes [ADR 0008](0008-unified-feature-model-and-dimensioning-planner.md).**
+- **Amendment 1** (2026-07-19): planner convergence #698 is complete. All
+  dimension-bearing feature passes suited to `DimensionGroup` planning now
+  consume planner output; correlated furniture and aspect passes remain
+  model-routed by design. The open/closed consequence is narrowed accordingly.
 - **Date:** 2026-07-18
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -85,13 +89,11 @@ The load-bearing properties, all live in the code today:
 
 ## The planner, honestly: what flows through it and what bypasses it
 
-0008 §3 claimed "one rule set over DimParameters … uniformly". As built, that
-centralisation covers a **core, not the whole surface** — the 2026-07-18 audit
-finding, tracked as **#698**. `orchestrator._auto_annotate` calls
-`plan_dimensions` exactly once and threads the `DimensionGroup`s to every
-renderer that reads them; but a majority of feature kinds are rendered by
-passes that take the `model` and format raw feature fields directly, ignoring
-the groups the orchestrator computed for them.
+0008 §3 claimed "one rule set over DimParameters … uniformly". The 2026-07-18
+audit found that many dimension-bearing feature passes still bypassed it and
+opened **#698**. That convergence is now complete: `orchestrator._auto_annotate`
+calls `plan_dimensions` exactly once and threads its `DimensionGroup`s to every
+dimension-bearing renderer suited to group-per-feature planning.
 
 **Planner-fed today** (the renderer consumes `DimensionGroup`s from
 `plan_dimensions`, or another planner entry point):
@@ -113,9 +115,9 @@ the groups the orchestrator computed for them.
 | slots (width/length linear dims, #730; the datum position dim stays model-derived — it is drawing state, not a feature parameter) | `from_model.render_slots` | `plan_dimensions` |
 | section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |
 
-**Planner-bypassing today** (the renderer takes `model`, re-filters
-`model.features` by kind, and formats raw fields — its computed
-`DimensionGroup`s are discarded):
+**Intentionally model-routed today** (these passes do not discard applicable
+`DimensionGroup`s; their inputs are furniture, correlated sets, or aspects that
+do not fit group-per-parameter planning):
 
 - `render_rotational`
   (OD/centreline/bore furniture), `render_pmi` — both in
@@ -129,25 +131,13 @@ the groups the orchestrator computed for them.
   `DimParameter`-bearing features — there is nothing for `plan_dimensions` to
   plan.
 
-**Why the bypass list matters** (from #698, adversarially verified): the
-planner is where authored decorations fold onto the parameter
-(`plan_dimensions` merges `model.decorations` into `DimParameter.tolerance`),
-so a bypassed kind silently drops an authored tolerance — the exact #629 bug
-class already fixed for bosses, latent in the bypassed passes. And ISO 129
-no-double-dimensioning/suppression rules currently have no single home
-(`detect.py` exclusions, `planner._suppression`, per-renderer collapses).
-`_CONVENTION` in `planner.py` has entries only for the planner-fed roles.
-
-**The convergence tracker is #698** — extend `_CONVENTION` +
-`plan_dimensions` kind-by-kind (chamfer landed first, #724; fillet/flat/
-groove/pocket followed, #725–#728; plate, #729 — the first *linear*-convention
-migration; slots, #730 — the mixed corridor/immediate pass) and convert each
-renderer to consume its
-group, pulling the
-scattered suppression rules into the planner as each kind migrates. This ADR
-deliberately does **not** claim that work done; it records the split so the
-ADR stays true while #698 proceeds. New feature kinds must take the planner
-path, not add to the bypass list.
+**Why the split matters:** the planner is where authored decorations fold onto
+dimension parameters and where dimension-level convention and suppression
+belong. #698 migrated chamfer, fillet, flat, groove, pocket, plate, and slot
+dimensions (#724–#730), closing the latent authored-tolerance failure class for
+those features. Model-routed passes remain legitimate only where there is no
+independent `DimParameter` to plan or where flattening a correlated set would
+destroy its semantics.
 
 ## The lint/coverage carve-out
 
@@ -184,10 +174,10 @@ records cross is the sanctioned `build_part_model` boundary itself.
 
 ## Consequences
 
-- New shapes remain **new `Feature` types + a detector and/or declare
-  constructor**, never new back-end branches — with the added, explicit rule
-  that their rendering goes through `plan_dimensions` (#698), so the planner's
-  coverage grows instead of shrinking.
+- New shapes require the applicable detector and/or declaration constructor,
+  IR adapter/declaration, planner convention for dimension parameters,
+  renderer/stage support, coverage, and tests. Orientation and view selection
+  must remain data-driven rather than growing producer- or axis-specific paths.
 - The duplicate-recogniser and orientation-gate bug classes stay designed out
   (one inventory, axis-as-data).
 - The ADR now matches the code: readers get the real planner coverage and the
@@ -205,8 +195,8 @@ boundary decisions), not for current state. Step 1 of the original 0008
 ## Related
 
 - #697 — the audit item mandating this supersession (and ADR 0014's).
-- #698 — the planner-bypass audit finding; the convergence epic this ADR's
-  coverage table tracks.
+- #698 — completed planner-bypass convergence epic tracked by this ADR's
+  coverage table and Amendment 1.
 - #699 — the one canonical `_PASS_SEQUENCE` shared by the auto-pass and
   `finalize()` (orchestrator `run_stages`), which orders the passes named
   above.

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -1,10 +1,10 @@
 # ADR 0015 — The part-drawing compiler, as built
 
 - **Status:** Accepted. **Supersedes [ADR 0008](0008-unified-feature-model-and-dimensioning-planner.md).**
-- **Amendment 1** (2026-07-19): planner convergence #698 is complete. All
-  dimension-bearing feature passes suited to `DimensionGroup` planning now
-  consume planner output; correlated furniture and aspect passes remain
-  model-routed by design. The open/closed consequence is narrowed accordingly.
+- **Amendment 1** (2026-07-19): the migrations tracked by planner-convergence
+  epic #698 are complete. The remaining model-routed passes are classified
+  honestly below, including rotational dimension debt now tracked by #754.
+  The open/closed consequence is narrowed accordingly.
 - **Date:** 2026-07-18
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -91,9 +91,11 @@ The load-bearing properties, all live in the code today:
 
 0008 §3 claimed "one rule set over DimParameters … uniformly". The 2026-07-18
 audit found that many dimension-bearing feature passes still bypassed it and
-opened **#698**. That convergence is now complete: `orchestrator._auto_annotate`
-calls `plan_dimensions` exactly once and threads its `DimensionGroup`s to every
-dimension-bearing renderer suited to group-per-feature planning.
+opened **#698**. The migrations owned by that epic are now complete:
+`orchestrator._auto_annotate` calls `plan_dimensions` exactly once and threads
+its `DimensionGroup`s to the migrated renderers. The audit of this amendment
+found one residual dimension-bearing bypass, rotational OD/bores, now tracked
+separately by #754.
 
 **Planner-fed today** (the renderer consumes `DimensionGroup`s from
 `plan_dimensions`, or another planner entry point):
@@ -115,17 +117,20 @@ dimension-bearing renderer suited to group-per-feature planning.
 | slots (width/length linear dims, #730; the datum position dim stays model-derived — it is drawing state, not a feature parameter) | `from_model.render_slots` | `plan_dimensions` |
 | section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |
 
-**Intentionally model-routed today** (these passes do not discard applicable
-`DimensionGroup`s; their inputs are furniture, correlated sets, or aspects that
-do not fit group-per-parameter planning):
+**Model-routed today** (where a feature exposes parameters, `plan_dimensions`
+still computes a group that these passes do not consume):
 
-- `render_rotational`
-  (OD/centreline/bore furniture), `render_pmi` — both in
-  `annotations/from_model.py`.
+- `render_rotational` formats OD and bore parameters from raw
+  `RotationalFeature` fields, discarding their computed group and any authored
+  decoration folded into it. That is debt tracked by #754. Its axis centrelines
+  are furniture and remain model-routed.
 - `render_height_ladder` and `render_step_positions` are also model-routed,
   **by design**: `StepLevelFeature` carries correlated sets that must never be
   flattened into independent dims, so group-per-feature is the wrong shape for
-  them. Their model-routing is sanctioned, not debt.
+  them. Their computed groups are discarded; the whole-set renderers are the
+  sanctioned owner of those correlated dimensions.
+- `render_pmi` is model-routed by design: authored PMI features expose no
+  parameters for `plan_dimensions`, so no group is computed or discarded.
 - `render_gdt` is model-routed and **out of the planner's scope by design**:
   `ControlFrame`/`DatumRef`/`Finish` (ADR 0011 P2b) are placement intents, not
   `DimParameter`-bearing features — there is nothing for `plan_dimensions` to
@@ -135,9 +140,9 @@ do not fit group-per-parameter planning):
 dimension parameters and where dimension-level convention and suppression
 belong. #698 migrated chamfer, fillet, flat, groove, pocket, plate, and slot
 dimensions (#724–#730), closing the latent authored-tolerance failure class for
-those features. Model-routed passes remain legitimate only where there is no
-independent `DimParameter` to plan or where flattening a correlated set would
-destroy its semantics.
+those features. Model-routing is legitimate where there is no independent
+`DimParameter` to plan or where flattening a correlated set would destroy its
+semantics; otherwise it remains explicit debt such as #754.
 
 ## The lint/coverage carve-out
 
@@ -195,8 +200,10 @@ boundary decisions), not for current state. Step 1 of the original 0008
 ## Related
 
 - #697 — the audit item mandating this supersession (and ADR 0014's).
-- #698 — completed planner-bypass convergence epic tracked by this ADR's
-  coverage table and Amendment 1.
+- #698 — completed planner-bypass migration epic tracked by this ADR's coverage
+  table and Amendment 1.
+- #754 — residual rotational OD/bore planner bypass found during Amendment 1's
+  accuracy review.
 - #699 — the one canonical `_PASS_SEQUENCE` shared by the auto-pass and
   `finalize()` (orchestrator `run_stages`), which orders the passes named
   above.

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -39,16 +39,19 @@ pending typed adapter-registry refinement.
 
 The planner maps a feature's typed `DimParameter`s to `DimensionGroup`s,
 choosing conventions and views from semantic roles and feature frames. Issue
-#698 completed the migration of every dimension-bearing feature pass that fits
-that abstraction. Holes/patterns, locations, turned and boss diameters,
+#698 completed its planned migrations of dimension-bearing feature passes.
+Holes/patterns, locations, turned and boss diameters,
 envelopes, step lengths, chamfers, fillets, flats, grooves, pockets, plates,
 slots, and section triggers consume planner output.
 
-Some rendering remains model-routed **by design**:
+Some rendering remains model-routed:
 
-- rotational OD/centreline/bore furniture and pre-authored PMI;
+- rotational centrelines are furniture, but rotational OD/bore dimensions still
+  discard computed planner groups; that residual debt is tracked by #754;
+- pre-authored PMI exposes no dimension parameters and is model-routed by design;
 - correlated step-height and step-position sets, which must not be flattened
-  into independent dimensions;
+  into independent dimensions, are model-routed by design even though their
+  computed groups are not consumed;
 - GD&T and finish placement intents, which are not `DimParameter`s.
 
 Adding a feature kind therefore means adding the applicable recognition and/or
@@ -86,8 +89,8 @@ feature inventory.
 - Detection and declaration converge on the same frozen `PartModel` IR.
 - Recognition records cross only at the sanctioned `model/detect.py` adapter
   boundary.
-- Dimension-bearing feature passes use the planner; explicitly correlated
-  furniture and aspect passes may remain model-routed.
+- Dimension-bearing feature passes use planner output unless an ADR records a
+  correlated-set exception; #754 tracks the remaining rotational exception.
 - Orientation and view choice are derived from feature data, not duplicated by
   producer or axis.
 - Render intents feed shared placement, projection, tables, sections, and export;

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -1,174 +1,103 @@
-# Target Architecture
+# Target architecture
 
-draftwright is a **part-drawing compiler**: it turns a build123d B-rep solid into a
-fully-annotated, standards-compliant multi-view technical drawing —
-**deterministically** (no model in the loop) and **verifiably**. The shape is a
-compiler hourglass: many feature front-ends → one narrow intermediate
-representation → many dimensioning back-ends, all judged by one correctness check.
-
-This is the *target* state defined by [ADR 0008](adr/0008-unified-feature-model-and-dimensioning-planner.md)
-(+ Amendments 1–5). For where the codebase is **today** vs this target, see
-[Current gaps](#current-gaps); for the migration plan, see
-[`plans/0008-convergence-roadmap.md`](plans/0008-convergence-roadmap.md).
+draftwright is a **part-drawing compiler**: it turns a build123d B-rep solid or
+caller-declared feature model into a deterministic, standards-aware technical
+drawing. [ADR 0015](adr/0015-part-drawing-compiler-as-built.md) is the current
+compiler contract; ADR 0008 is its frozen historical why-trail.
 
 ## The pipeline
 
-```
- Solid
-   │  geometry: faces · edges · cylinders · silhouettes (scanned once)
-   ▼
- Detectors ── recognise holes / steps / bosses / patterns / slots / envelope
-   │          → typed Feature objects
-   ▼
-┌──────────────────────────────────────────────┐
-│  IR · PartModel   ── THE ONE INVENTORY        │   ← detect once, consume thrice
-│  Features + DimParameters + datums + frame    │
-└──────────────────────────────────────────────┘
-   │            ╲ (same inventory)
-   ▼             ╲
- Planner          ╲──────────────► Verification (linting + scoring) ⟲ repair
-   │  one rule set → a DimensionGroup (view · datum · convention) per feature
-   ▼
- Renderers ── groups → placed callouts / dims / leaders / centre marks
-   │
-   ▼
- Shared infrastructure ── layout · projection · tables · sections · export
-   │
-   ▼
- Drawing  (SVG / DXF / PDF)
+```text
+ recognised geometry                 declared features
+ (ADR 0013 records)                  (ADR 0011 constructors)
+          │                              │
+          └──────────────┐    ┌──────────────┘
+                         ▼    ▼
+                   PartModel IR waist
+                 (one inventory per build)
+                         │
+          ┌───────────────┴───────────────┐
+          ▼                               ▼
+ dimension planners                 sanctioned model-routed
+ (groups and section plans)         furniture / aspect passes
+          └───────────────┐   ┌───────────────┘
+                          ▼   ▼
+                    render intents
+                          │
+          shared placement / projection / export
+                          │
+                          ▼
+                       Drawing
 ```
 
-The **same `PartModel` inventory** feeds the planner, the renderers, *and*
-verification — detection happens once, three consumers read it.
+Detection runs once for a build. `model/detect.py` adapts geometry-only
+recognition records into frozen IR features; declaration enters through the same
+waist. Recognition records do not cross that boundary. ADR 0013 still owns the
+pending typed adapter-registry refinement.
 
-## Label, annotation & dimension creation
+## Planning and rendering
 
-- **Detect → IR.** Each `Feature` exposes `DimParameter`s: a *kind*
-  (diameter / length / depth …) + a semantic *role* (bore, counterbore, step, od,
-  slot-width …), a model-space span, and datums. **No baked label** — GD&T symbols
-  (⌴ ⌵ ↧) are drawn as *geometry*, so the IR carries meaning, not glyphs.
-- **Plan.** One rule set maps `(role, kind)` → a convention (chain · ordinate ·
-  leader · pitch), with **view & datum chosen geometrically** from the feature
-  frame — so X- and Z-oriented parts flow through the *same* path. Output: one
-  `DimensionGroup` per feature (a compound callout stays together).
-- **Render.** Groups become placed `HoleCallout` / `Dimension` / `Leader` /
-  `CenterMark` via the helper primitives, allocating from the shared layout.
-- **Open/Closed.** A new shape = a new `Feature` type + a detector exposing
-  *existing* `DimParameter` kinds → **zero planner/layout change**.
+The planner maps a feature's typed `DimParameter`s to `DimensionGroup`s,
+choosing conventions and views from semantic roles and feature frames. Issue
+#698 completed the migration of every dimension-bearing feature pass that fits
+that abstraction. Holes/patterns, locations, turned and boss diameters,
+envelopes, step lengths, chamfers, fillets, flats, grooves, pockets, plates,
+slots, and section triggers consume planner output.
 
-## Layout
+Some rendering remains model-routed **by design**:
 
-- **Inner** (collect-then-solve, ADR 0014): a dependency-free weighted-median
-  PAVA solver places labels in deterministic 1-D corridors; `fit_box` handles
-  bounded free-rectangle furniture placement. ADR 0003 is retired history.
-- **Outer** (compose-then-pack, ADR 0004): each view is a *block* = projected
-  geometry + its annotation boxes; `(scale, page)` is chosen by a monotone search
-  that packs the blocks **disjoint** — so cross-view overlap cannot occur.
-- **Zone strips** (above/below/left/right of each view) coordinate placement;
-  renderers allocate from them, so a migrated renderer shares the strip and never
-  collides with an un-migrated one.
-- **Deterministic.** Layout depends on measured text width, so fonts are
-  **bundled & path-pinned** (IBM Plex, ADR 0006) for identical output on every
-  platform.
+- rotational OD/centreline/bore furniture and pre-authored PMI;
+- correlated step-height and step-position sets, which must not be flattened
+  into independent dimensions;
+- GD&T and finish placement intents, which are not `DimParameter`s.
 
-## Scoring
+Adding a feature kind therefore means adding the applicable recognition and/or
+declaration surface, IR conversion, planner convention when it has dimension
+parameters, renderer or stage support, coverage, and tests. Orientation and view
+selection remain data-driven; “new feature” does not mean “zero back-end work.”
 
-- One call (`lint_summary`) → `score ∈ [0, 1]` (clean = 1.0; −0.2 per error,
-  −0.05 per warning), `passed` (no errors), `by_code` counts, and a
-  `geometry_issues` tally (standards vs pure layout).
-- A **single non-interactive signal**: a script — or an LLM driving the API — can
-  gate and optimise *without* rendering the SVG.
-- The bar is **correctness, not byte-equivalence** to any prior output — the
-  drawing may legitimately improve.
+## Placement and page composition
 
-## Verification — linting is the single judge
+- **Inner placement** is ADR 0014's collect-then-solve corridor model. Measured
+  candidates sharing a strip are selected, ordered, and spaced together; its
+  small `carve_free_position` exemption set is guarded fail-closed.
+- **Outer layout** is ADR 0004's compose-then-pack model. Projected geometry and
+  annotation footprints form disjoint view blocks before page and scale are
+  chosen.
+- Text measurement uses bundled, path-pinned fonts (ADR 0006), so layout is
+  deterministic across platforms.
 
-(ADR 0002 / 0007.)
+## Verification
 
-- **Structural:** annotation overlap, out-of-bounds, label-vs-measured mismatch.
-- **Coverage** (read from the *drawing* against the one inventory): every detected
-  feature **dimensioned**, **located**, **centre-marked**; turned steps' lengths
-  present. Lint checks the pipeline's output against the pipeline's own input.
-- **Standards:** ISO/ASME conventions & legibility gates.
-- **lint → repair** loop: deterministic re-placement is a *safety net*, not the
-  primary placement mechanism.
+Lint is an independent judge, not another consumer of the dimensioning plan.
+Structural and standards checks inspect the placed drawing. Coverage lint
+deliberately runs recognition to establish geometry ground truth, then compares
+that truth with witnesses on the placed drawing. Reading the plan or `PartModel`
+would be circular: anything omitted upstream would also disappear from the
+judge's input.
 
-## Why this approach — vs the alternatives
+The boundary is machine-checked: `linting/` may not import `draftwright.model`.
+This is ADR 0015's intentional lint/coverage carve-out, not a second production
+feature inventory.
 
-| Approach | Pros | Cons |
-|---|---|---|
-| **Compiler IR + planner + lint** *(this)* | Open/Closed — Nth shape costs the same as the 3rd; orientation is data, not branches; one inventory feeds dims *and* verification; fully deterministic & machine-verifiable; output free to improve. | Recognition stays heuristic (B-rep); convention rules are hand-written; one-time migration cost off the accreted engine. |
-| **Accreted per-feature passes** *(the prior engine)* | Fast to add the first few features; nothing to design up front. | N×M coupling of recognisers × passes; orientation `if`-branches multiply; duplicate recognisers diverge → "ball of mud". |
-| **Reproduce-and-swap under a byte / golden gate** | Guarantees the new path matches the old exactly. | Freezes the old engine's quirks bug-for-bug; parity-first / value-last; *forbids* the improvement that motivates the rewrite. |
-| **ML / LLM end-to-end dimensioning** | Tolerates messy or ambiguous intent; little explicit rule-writing. | Non-deterministic; hard to guarantee standards; no audit trail; can't be unit-tested or repaired predictably. |
-| **Hand-authored template / DSL per part** | Total control over each drawing. | Manual per part — not automated generation; doesn't scale to arbitrary solids. |
+## Load-bearing rules
 
-## Load-bearing principles
+- One feature inventory per build; detect once.
+- Detection and declaration converge on the same frozen `PartModel` IR.
+- Recognition records cross only at the sanctioned `model/detect.py` adapter
+  boundary.
+- Dimension-bearing feature passes use the planner; explicitly correlated
+  furniture and aspect passes may remain model-routed.
+- Orientation and view choice are derived from feature data, not duplicated by
+  producer or axis.
+- Render intents feed shared placement, projection, tables, sections, and export;
+  the IR does not absorb that infrastructure.
+- Correctness is judged by lint and standards, not byte identity with an older
+  drawing.
+- Generation and repair are deterministic; repair is a safety net, not the
+  primary placement strategy.
 
-- **Orientation is data, not branches** — X/Y/Z/turned/prismatic are inputs
-  (`Feature.frame`), never code paths.
-- **Correctness, not equivalence** — judged by lint/standards, not byte-identity.
-- **The IR feeds shared infrastructure; it doesn't reabsorb it** (Amendment 4) —
-  layout, tables, sections, projection, export stay shared — **through an IR-typed
-  interface: no recognition objects cross the boundary** (Amendment 6). The IR is
-  the single representation downstream of detection.
-- **One feature inventory per build** (Amendment 5) — detect once.
-- **Deterministic generation — no model in the pipeline** (ADR 0001).
-- **Lint is the single correctness judge** (no standing golden gate).
-
-## Current gaps
-
-Where the codebase is **today** vs the target above (as of 2026-06-29). The
-architecture and pipeline exist and are load-bearing in production; convergence is
-partial. Tracked under epic [#195](https://github.com/pzfreo/draftwright/issues/195).
-
-**On the IR path in production (migrated + engine recognition/placement deleted):**
-turned step lengths, turned diameters, hole centre marks, envelope width/depth,
-slots, hole **location dims** (`_add_location_dims` deleted, #256), and the full
-hole **callout** pass — grouping by machining spec (#257), the callout spec
-(#259), the callout loop (#260), and the **IR-typed interface** (#263, ADR
-Amendment 6: cover/table, furniture, placement, and the section trigger all consume
-IR data — no recogniser `Hole`/`Pattern` object crosses into the renderers). The
-**section A–A trigger** is planner-decided too (`plan_sections`, #207); the cut /
-hatch / arrow rendering stays shared infrastructure it feeds. `annotations/turned.py`
-and the `render_into` test-only parallel are gone. The prismatic step-height ladder,
-overall height, and the rotational OD/centreline/bore furniture are on the IR too
-(`StepLevelFeature`/`RotationalFeature` + `render_height_ladder`/`render_rotational`,
-#237) — the orchestrator's inline `_right_ladder` block is deleted. Finally, **PMI/GD&T**
-is on the IR (`PmiFeature` + `render_pmi`, #208): `extract_pmi`'s AP242 records are
-re-homed as features and rendered directly (PMI is pre-authored, so it bypasses the
-planner — empty `parameters()`); `_annotate_pmi`/`annotations/pmi.py` are deleted.
-
-**Migration complete (2026-06-30).** Every feature pass is on the IR; no engine
-feature pass remains. The orchestrator is `build model → plan → render` + the shared
-section/table/PMI rendering it feeds. Remaining open items are *enhancements*, not
-migrations: #230 (turned `N×`-rise), #222 (OD on the profile view), #279 (phantom ø0).
-
-**Foundation track — ✅ complete** (umbrella
-[#241](https://github.com/pzfreo/draftwright/issues/241); ADR Amendment 5):
-
-- ✅ **One feature inventory** (keystone,
-  [#244](https://github.com/pzfreo/draftwright/issues/244), done via #246/#247;
-  bosses threaded too in #264). `_analyse` detects holes/patterns/bosses/turned-steps
-  **once**; `build_part_model` and `Drawing.lint()` consume its results — each
-  detector runs once per build, zero extra in lint.
-- ✅ **Docs/comment sweep** ([#248](https://github.com/pzfreo/draftwright/issues/248),
-  PR #253).
-- ✅ **Annotation-ownership accessor**
-  ([#249](https://github.com/pzfreo/draftwright/issues/249), PR #254) — production no
-  longer reads `dwg._named`/`_anno_view` directly; registry-backed accessors +
-  mutation API.
-- ✅ **Planner render-intents**
-  ([#250](https://github.com/pzfreo/draftwright/issues/250), PR #255) — model-level
-  suppression moved into the planner; `datum` slot added (consumed by #238).
-- ✅ **Delete `render_into`**
-  ([#251](https://github.com/pzfreo/draftwright/issues/251)) — the test-only parallel
-  (`render_into`/`render_callouts` + their leader helpers) is removed; the seam/e2e
-  tests are repointed at the production renderers.
-- ✅ **IR-typed interface** ([#263](https://github.com/pzfreo/draftwright/issues/263),
-  ADR Amendment 6) — the data crossing IR→shared-infra is IR-typed (a `HoleRef`
-  position key), not recogniser objects; enforced by typed signatures.
-
-**Inherent (not a migration gap):** recognition is heuristic — a chamfered bore in
-a tapered section will not recognise itself cleanly. The architecture *contains*
-that mess inside detectors behind the IR; it does not eliminate it.
+For rationale and precise boundaries, read the
+[ADR index](adr/README.md), especially ADRs 0011–0015. Historical migration
+roadmaps under `docs/plans/` explain how the architecture arrived here; they are
+not current implementation trackers.

--- a/tests/test_architecture_docs.py
+++ b/tests/test_architecture_docs.py
@@ -9,7 +9,7 @@ _ROOT = Path(__file__).resolve().parent.parent
 
 
 def _read(relative: str) -> str:
-    return (_ROOT / relative).read_text()
+    return (_ROOT / relative).read_text(encoding="utf-8")
 
 
 def test_live_architecture_docs_name_current_compiler_authority():

--- a/tests/test_architecture_docs.py
+++ b/tests/test_architecture_docs.py
@@ -12,26 +12,19 @@ def _read(relative: str) -> str:
     return (_ROOT / relative).read_text()
 
 
-def _prose(relative: str) -> str:
-    """Read prose with Markdown wrapping made irrelevant to phrase assertions."""
-    return " ".join(_read(relative).split())
-
-
 def test_live_architecture_docs_name_current_compiler_authority():
-    target = _prose("docs/target-architecture.md")
-    assert "current compiler contract; ADR 0008 is its frozen historical" in target
+    target = _read("docs/target-architecture.md")
+    readme = _read("README.md")
     assert "target state defined by [ADR 0008]" not in target
+    assert "part-drawing compiler** (ADR 0008)" not in readme
 
 
 def test_live_architecture_docs_record_planner_convergence_complete():
-    target = _prose("docs/target-architecture.md")
-    adr = _prose("docs/adr/0015-part-drawing-compiler-as-built.md")
-    claude = _prose("CLAUDE.md")
-    assert "#698 completed" in target
-    assert "Planner convergence #698 is complete" in claude
-    assert "convergence is now complete" in adr
+    adr = _read("docs/adr/0015-part-drawing-compiler-as-built.md")
+    claude = _read("CLAUDE.md")
     assert "while #698 proceeds" not in adr
     assert "convergence tracked by #698" not in claude
+    assert "deliberately does **not** claim that work done" not in adr
 
 
 def test_current_architecture_docs_have_no_source_line_anchors():
@@ -46,5 +39,5 @@ def test_current_architecture_docs_have_no_source_line_anchors():
 
 def test_carve_guard_points_to_current_placement_adr():
     guard = _read("tests/test_carve_free_position_callers.py")
-    assert "amending ADR 0014" in guard
-    assert "amendment in ADR 0009" not in guard.lower()
+    assert "ADR 0009's remaining-migration note" not in guard
+    assert "Pending migration (#636)" not in guard

--- a/tests/test_architecture_docs.py
+++ b/tests/test_architecture_docs.py
@@ -1,0 +1,50 @@
+"""Small drift guards for documents that present current architecture.
+
+Frozen ADRs and historical roadmaps are deliberately outside this scope.
+"""
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read(relative: str) -> str:
+    return (_ROOT / relative).read_text()
+
+
+def _prose(relative: str) -> str:
+    """Read prose with Markdown wrapping made irrelevant to phrase assertions."""
+    return " ".join(_read(relative).split())
+
+
+def test_live_architecture_docs_name_current_compiler_authority():
+    target = _prose("docs/target-architecture.md")
+    assert "current compiler contract; ADR 0008 is its frozen historical" in target
+    assert "target state defined by [ADR 0008]" not in target
+
+
+def test_live_architecture_docs_record_planner_convergence_complete():
+    target = _prose("docs/target-architecture.md")
+    adr = _prose("docs/adr/0015-part-drawing-compiler-as-built.md")
+    claude = _prose("CLAUDE.md")
+    assert "#698 completed" in target
+    assert "Planner convergence #698 is complete" in claude
+    assert "convergence is now complete" in adr
+    assert "while #698 proceeds" not in adr
+    assert "convergence tracked by #698" not in claude
+
+
+def test_current_architecture_docs_have_no_source_line_anchors():
+    for relative in (
+        "docs/target-architecture.md",
+        "docs/adr/0011-ir-as-public-input.md",
+        "docs/adr/0015-part-drawing-compiler-as-built.md",
+    ):
+        text = _read(relative)
+        assert "orchestrator.py:" not in text, relative
+
+
+def test_carve_guard_points_to_current_placement_adr():
+    guard = _read("tests/test_carve_free_position_callers.py")
+    assert "amending ADR 0014" in guard
+    assert "amendment in ADR 0009" not in guard.lower()

--- a/tests/test_carve_free_position_callers.py
+++ b/tests/test_carve_free_position_callers.py
@@ -4,9 +4,9 @@
 *without* joining the shared corridor solve — the "solver-invisible" placement
 the ADR 0014 collect-then-solve model exists to retire. Its guarantee (the
 invisible-occupant collision class removed **by construction**) only holds once
-every auto-pass strip occupant is a candidate in the solve. #636 migrates the
-remainder; this guard stops the legacy path from silently attracting **new**
-callers (two 0.3.0 features, plates #559 and step positions #555, already
+every non-exempt auto-pass strip occupant is a candidate in the solve. #636
+completed that migration; this guard stops the legacy path from silently
+attracting **new** callers (two 0.3.0 features, plates #559 and step positions #555, already
 regressed onto it before the migration — that is the failure mode this test
 prevents from recurring).
 
@@ -30,15 +30,15 @@ from pathlib import Path
 _ANNO_DIR = Path(__file__).resolve().parent.parent / "src" / "draftwright" / "annotations"
 
 # The only ``annotations/`` functions permitted to call ``carve_free_position``.
-# Each is either a permanent exemption or a site still tracked by #636 for
-# migration. Removing an entry as its site migrates is the intended direction;
-# the allowlist must never grow for un-migrated new work.
+# Each is a permanent exemption recorded by ADR 0014. Removing an entry when a
+# site no longer needs the carve is still the intended direction; the allowlist
+# must never grow without an ADR amendment.
 _ALLOWED_CALLERS = {
     # Permanent exemption (ADR 0014): the pitch-dim fallback searches an
     # arbitrary diagonal outward vector — a diagonal dim cannot occupy a 1-D
     # axis-aligned strip tier, so it cannot be a solve candidate at all.
     ("holes.py", "_place_pitch_dim"),
-    # Pending migration (#636), each with a genuine design fork:
+    # Post-drain fallbacks retained explicitly by ADR 0014:
     ("from_model.py", "render_gdt"),  # alt-strip fallback DEFERRED via ctx.post_drain (#636)
     # Beyond render_gdt's pattern (helpers ≥0.14): the primary placement IS the
     # corridor candidate; the carve runs in a ctx.post_drain-DEFERRED drop fallthrough,

--- a/tests/test_carve_free_position_callers.py
+++ b/tests/test_carve_free_position_callers.py
@@ -1,8 +1,8 @@
-"""Fail-closed guard on ``carve_free_position`` callers (ADR 0009; #636).
+"""Fail-closed guard on ``carve_free_position`` callers (ADR 0014; #636).
 
 ``carve_free_position`` (`annotations/_common.py`) returns a single free tier
 *without* joining the shared corridor solve — the "solver-invisible" placement
-the ADR 0009 collect-then-solve model exists to retire. Its guarantee (the
+the ADR 0014 collect-then-solve model exists to retire. Its guarantee (the
 invisible-occupant collision class removed **by construction**) only holds once
 every auto-pass strip occupant is a candidate in the solve. #636 migrates the
 remainder; this guard stops the legacy path from silently attracting **new**
@@ -14,9 +14,9 @@ The guard is a **fail-closed allowlist** of ``(file, function)`` pairs. Every
 ``carve_free_position`` call anywhere under ``annotations/`` is attributed to a caller
 — a top-level function, a class method, a nested closure's owning function, or
 ``"<module>"`` for a bare module-scope call — and any caller outside the allowlist
-trips the test. The fix is to make the site a corridor candidate (the Amendment 8
+trips the test. The fix is to make the site a corridor candidate (the ADR 0014
 pattern), not to widen the allowlist. The allowlist may only grow for a site recorded
-as an explicit exemption in ADR 0009's remaining-migration note. Import aliases
+as an explicit exemption in ADR 0014. Import aliases
 (``from ._common import carve_free_position as carve``) and module-qualified calls
 (``_common.carve_free_position(...)``) are both tracked; only a runtime rebinding
 (``carve = carve_free_position``) escapes, which is contrived rather than a foot-gun.
@@ -34,7 +34,7 @@ _ANNO_DIR = Path(__file__).resolve().parent.parent / "src" / "draftwright" / "an
 # migration. Removing an entry as its site migrates is the intended direction;
 # the allowlist must never grow for un-migrated new work.
 _ALLOWED_CALLERS = {
-    # Permanent exemption (ADR 0009 Amendment 8): the pitch-dim fallback searches an
+    # Permanent exemption (ADR 0014): the pitch-dim fallback searches an
     # arbitrary diagonal outward vector — a diagonal dim cannot occupy a 1-D
     # axis-aligned strip tier, so it cannot be a solve candidate at all.
     ("holes.py", "_place_pitch_dim"),
@@ -47,8 +47,8 @@ _ALLOWED_CALLERS = {
     ("from_model.py", "render_plates"),
     # Manual post-build verbs (the #426 half of the convergence): a single user-driven
     # annotation onto a FINISHED sheet, where every occupant is already placed — the
-    # carve is the correct tool and there is no shared drain to join. Recorded as an
-    # explicit exemption in ADR 0009's migration note (#636 close-out).
+    # carve is the correct tool and there is no shared drain to join. Retained as an
+    # explicit exemption by ADR 0014 (#636 close-out).
     ("holes.py", "add_feature_callout"),
     ("holes.py", "add_feature_location"),
 }
@@ -121,10 +121,9 @@ def test_carve_free_position_callers_are_allowlisted():
     new = found - _ALLOWED_CALLERS
     assert not new, (
         "New carve_free_position caller(s) in annotations/ — place geometry through the "
-        "shared corridor solve (register_corridor + CorridorCandidate, the ADR 0009 "
-        f"Amendment 8 pattern), not the solver-invisible carve. Offenders: {sorted(new)}. "
-        "A genuine exemption must first be recorded in ADR 0009's remaining-migration note "
-        "(#636)."
+        "shared corridor solve (register_corridor + CorridorCandidate, the ADR 0014 "
+        f"pattern), not the solver-invisible carve. Offenders: {sorted(new)}. "
+        "A genuine exemption must first be recorded by amending ADR 0014."
     )
     # The allowlist must not carry stale entries: a migrated site is removed, not left.
     gone = _ALLOWED_CALLERS - found


### PR DESCRIPTION
## Summary

- replace the stale ADR 0008 migration narrative in the target architecture guide and README with the current ADR 0015 compiler shape
- amend ADR 0015 to record the #698 migrations as complete while honestly distinguishing planner-fed dimensions, sanctioned correlated/model-routed passes, and residual rotational debt tracked by #754
- update ADR 0011, CLAUDE.md, and the carve-caller guard to use current symbols, completed-migration tense, and active ADR authority
- add narrow negative drift tests for stale architecture authority, stale #698 state, source-line anchors, and frozen-ADR contributor guidance

## Why

The ADR index had become the correct architecture front door, but the live target guide and contributor guidance still described pre-convergence state. That made the repository's current guidance conflict with ADR 0015 and the code, particularly around coverage lint independence and planner coverage.

The review also identified that rotational OD/bore `DimensionGroup`s are still computed and discarded. This PR records that accurately rather than silently sanctioning it; #754 owns the implementation follow-up.

## Impact

Documentation now describes the implemented architecture consistently. There is no runtime behavior change. The new tests ban the specific stale states and source-line anchors that caused this drift without pinning exact replacement sentences. Frozen ADRs and historical roadmaps remain untouched.

## Out of scope

Active source docstrings still contain historical ADR 0008/0009 references across 20 modules. This PR limits its authority sweep to live architecture/contributor documents and the active carve guard; a broader source-comment cleanup should be handled separately so historical references can be distinguished deliberately.

## Validation

- `uv run pytest -q` — 1469 passed, 10 skipped, 18 deselected
- `uv run pytest -q tests/test_architecture_docs.py tests/test_carve_free_position_callers.py tests/test_import_boundaries.py` — 19 passed
- `uv run ruff check tests/test_architecture_docs.py tests/test_carve_free_position_callers.py`
- `uv run mypy src/draftwright`
- `git diff --check`

Closes #751