### PR TITLE
fix(#709): forward --format into generated scripts; modern export in the imperative template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Changed
 
+- **Imperative `--script` output defaults to PDF and the modern export form**
+  (#709). **Breaking** for regenerated imperative scripts: without `-f`, a
+  regenerated script now writes `<stem>.pdf` (was SVG+DXF via the deprecated
+  legacy tuple), and the script-visible variables changed from
+  `svg_path, dxf_path` to a `paths` dict printed in the requested-format order.
+  This aligns the imperative flavour with the Sheet flavour and the direct CLI,
+  which have defaulted to PDF since #702/#288. Migration: regenerate with
+  `--format svg,dxf` to keep the old outputs. Previously-generated scripts are
+  unaffected (they carry their own export lines).
 - **`finalize()` drains in the auto-pass's order** (#699 slice b): both build
   paths now execute the orchestrator's one canonical `_PASS_SEQUENCE` (via the
   shared `run_stages`), removing the hand-mirrored second orchestration in
@@ -49,19 +58,16 @@
 
 ### Fixed
 
-- **`--format` now reaches `--script` output; the imperative script exports the
-  modern way** (#709, from the #702 adversarial review): `--script -f svg` used
-  to silently emit a PDF-producing script — the CLI parsed the flag but never
-  forwarded it. Both emitters now thread it through: the Sheet script emits
-  `sheet.export(stem, formats=(…,))` when non-default (bare call for the PDF
-  default), and the imperative template swaps the deprecated legacy tuple
-  (`svg_path, dxf_path = dwg.export(_stem)` — which made imperative scripts
-  produce SVG+DXF while sheet scripts produced PDF) for the modern dict form
-  `paths = dwg.export(_stem, formats=…)` with a matching print loop, so both
-  flavours default to PDF and honour `--format`. `generate_script` /
-  `generate_sheet_script` grow a `formats=` parameter. The dormant
-  script-parity characterisation module (`test_script_detail_parity.py`) is
-  also un-skipped so its strict xfails give the remaining gaps CI signal.
+- **`--format` now reaches `--script` output** (#709, from the #702 adversarial
+  review): `--script -f svg` used to silently emit a PDF-producing script — the
+  CLI parsed the flag but never forwarded it. Both emitters now thread it
+  through: the Sheet script emits `sheet.export(stem, formats=(…,))` when
+  non-default (bare call for the PDF default), the imperative template embeds
+  the requested tuple and prints in the **requested** order, and
+  `generate_script` / `generate_sheet_script` grow a `formats=` parameter. The
+  dormant script-parity characterisation module
+  (`test_script_detail_parity.py`) is also un-skipped so its strict xfails give
+  the remaining gaps CI signal.
 
 - **Authored fillet, flat, groove, pocket, plate and slot tolerances now render**
   (#725/#726/#727/#728/#729/#730 / #698): the four leader-callout kinds join

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@
 
 ### Fixed
 
+- **`--format` now reaches `--script` output; the imperative script exports the
+  modern way** (#709, from the #702 adversarial review): `--script -f svg` used
+  to silently emit a PDF-producing script — the CLI parsed the flag but never
+  forwarded it. Both emitters now thread it through: the Sheet script emits
+  `sheet.export(stem, formats=(…,))` when non-default (bare call for the PDF
+  default), and the imperative template swaps the deprecated legacy tuple
+  (`svg_path, dxf_path = dwg.export(_stem)` — which made imperative scripts
+  produce SVG+DXF while sheet scripts produced PDF) for the modern dict form
+  `paths = dwg.export(_stem, formats=…)` with a matching print loop, so both
+  flavours default to PDF and honour `--format`. `generate_script` /
+  `generate_sheet_script` grow a `formats=` parameter. The dormant
+  script-parity characterisation module (`test_script_detail_parity.py`) is
+  also un-skipped so its strict xfails give the remaining gaps CI signal.
+
 - **Authored fillet, flat, groove, pocket, plate and slot tolerances now render**
   (#725/#726/#727/#728/#729/#730 / #698): the four leader-callout kinds join
   `_CONVENTION` and their renderers (`render_fillets`/`render_flats`/

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1029,11 +1029,16 @@ def _write_script(
         "# ── Export ────────────────────────────────────────────────────────────────────\n"
         # The modern dict form, honouring the CLI's --format (#709); the legacy
         # `svg_path, dxf_path = dwg.export(_stem)` tuple path is deprecated.
-        f"paths = dwg.export(_stem, formats={tuple(formats)!r})\n"
-        "for _fmt, _path in paths.items():\n"
+        f"_formats = {tuple(formats)!r}\n"
+        "paths = dwg.export(_stem, formats=_formats)\n"
+        # Print in the REQUESTED order (#755 review): Drawing.export returns its
+        # dict in dependency order (svg before the png derived from it), so
+        # iterating paths.items() would reorder `-f png,svg` output vs the
+        # direct CLI's _emit, which prints as requested.
+        "for _fmt in _formats:\n"
         # ASCII arrow: a Unicode → crashes the print on a Windows cp1252 console
         # (UnicodeEncodeError) — the generated script must run everywhere.
-        '    print(f"{_fmt.upper()} -> {_path}")\n'
+        '    print(f"{_fmt.upper()} -> {paths[_fmt]}")\n'
     )
 
     content = header + cog_block + run_section

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -905,13 +905,19 @@ def _feature_listing(a: Analysis) -> str:
     return "\n".join(header + ["with dwg.deferred():"] + indented) + "\n"
 
 
-def _write_script(a: Analysis, scale: float | None = None, page: str | None = None) -> str:
+def _write_script(
+    a: Analysis,
+    scale: float | None = None,
+    page: str | None = None,
+    formats: Sequence[str] = ("pdf",),
+) -> str:
     """Write an editable script at ``a.out + '.py'`` that calls make_drawing().
 
     ``scale``/``page`` are the caller's *overrides* (``None`` = auto); ``pmi`` is
     carried from the analysis (``a.pmi_mode``). All three are preserved as config
     fields and threaded into the emitted ``build_drawing(...)`` call so the script
-    reproduces the CLI's intent (#388).
+    reproduces the CLI's intent (#388). ``formats`` (the CLI's ``--format``, #709)
+    is baked into the emitted ``dwg.export(...)`` call for the same reason.
     """
     py_path = a.out + ".py"
     py_name = Path(py_path).name
@@ -1021,11 +1027,13 @@ def _write_script(a: Analysis, scale: float | None = None, page: str | None = No
         "dwg.repair()\n"
         "\n"
         "# ── Export ────────────────────────────────────────────────────────────────────\n"
-        "svg_path, dxf_path = dwg.export(_stem)\n"
+        # The modern dict form, honouring the CLI's --format (#709); the legacy
+        # `svg_path, dxf_path = dwg.export(_stem)` tuple path is deprecated.
+        f"paths = dwg.export(_stem, formats={tuple(formats)!r})\n"
+        "for _fmt, _path in paths.items():\n"
         # ASCII arrow: a Unicode → crashes the print on a Windows cp1252 console
         # (UnicodeEncodeError) — the generated script must run everywhere.
-        'print(f"SVG -> {svg_path}")\n'
-        'print(f"DXF -> {dxf_path}")\n'
+        '    print(f"{_fmt.upper()} -> {_path}")\n'
     )
 
     content = header + cog_block + run_section
@@ -1044,8 +1052,12 @@ def generate_script(
     pmi: Literal["off", "report", "annotate"] = "off",
     scale: float | None = None,
     page: str | None = None,
+    formats: Sequence[str] = ("pdf",),
 ) -> str:
     """Generate an editable Cog-enabled drawing script from a STEP file.
+
+    ``formats`` (the CLI's ``--format``, #709) is baked into the script's
+    ``dwg.export(...)`` call so a re-run writes the requested outputs.
 
     Returns:
         Path to the generated ``.py`` file.
@@ -1069,7 +1081,7 @@ def generate_script(
     # 0.001 / --page A9) instead of writing the script and deferring — inconsistent with
     # a large unfittable scale, which already defers (review #401).
     a = _analyse(step_file, title, number, tolerance, drawn_by, out, pmi=pmi)
-    return _write_script(a, scale=scale, page=page)
+    return _write_script(a, scale=scale, page=page, formats=formats)
 
 
 # ---------------------------------------------------------------------------

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -179,6 +179,7 @@ def main(
                     scale=scale,
                     page=page,
                     part_expr=seam,
+                    formats=tuple(formats),
                 )
             else:
                 py_path = generate_sheet_script(
@@ -191,6 +192,7 @@ def main(
                     scale=scale,
                     page=page,
                     pmi=pmi.value,
+                    formats=tuple(formats),
                 )
         else:
             if _looks_like_object_spec(step_file):
@@ -209,6 +211,7 @@ def main(
                 pmi=pmi.value,
                 scale=scale,
                 page=page,
+                formats=tuple(formats),
             )
         print(py_path)
         return

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -22,6 +22,7 @@ fixtures (#472).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 from build123d import Shape
@@ -253,6 +254,7 @@ def emit_sheet_script(
     tolerance: str = "ISO 2768-m",
     scale=None,
     page=None,
+    formats: Sequence[str] = ("pdf",),
 ) -> str:
     """The generated declarative ``Sheet`` script text for a detected *model*.
 
@@ -260,6 +262,9 @@ def emit_sheet_script(
     seam); *stem* is the output basename the script exports to. The title-block / layout aspects
     (``drawn_by``/``tolerance``/``scale``/``page``, #474) are emitted into the ``Sheet(...)``
     constructor only when non-default, so a plain drawing keeps a clean one-line constructor.
+    *formats* (the CLI's ``--format``, #709) is emitted into the ``sheet.export(...)`` call when
+    it differs from ``Sheet.export``'s own default (PDF), so a re-run reproduces the requested
+    outputs.
 
     AP242 PMI cannot be re-extracted from the ``import_step`` seam, so detected dimensional PMI is
     emitted as declared Sheet dimensions; unsupported raw PMI records are kept as explicit
@@ -303,7 +308,15 @@ def emit_sheet_script(
     ]
     if _needs_section(model):
         lines.append("# Section A–A auto-triggers from the counterbore/blind bore above.")
-    lines += ["", f"sheet.export({stem!r})"]
+    # Only spell out formats when they differ from Sheet.export's own default (PDF),
+    # mirroring the constructor's non-default-aspects-only rule above (#709).
+    fmts = tuple(formats)
+    export_call = (
+        f"sheet.export({stem!r})"
+        if fmts == ("pdf",)
+        else f"sheet.export({stem!r}, formats={fmts!r})"
+    )
+    lines += ["", export_call]
     return "\n".join(lines) + "\n"
 
 
@@ -420,6 +433,7 @@ def generate_sheet_script(
     page=None,
     pmi: str = "off",
     part_expr: str | None = None,
+    formats: Sequence[str] = ("pdf",),
 ) -> str:
     """Write a declarative ``Sheet``-DSL script for *step_file* (a STEP path or a build123d
     object). Returns the path to the generated ``.py``. The mode-3 declarative counterpart of
@@ -427,7 +441,9 @@ def generate_sheet_script(
 
     ``tolerance``/``drawn_by``/``scale``/``page`` are the title-block / layout aspects (#474):
     when non-default they are emitted into the generated ``Sheet(...)`` so a re-run reproduces
-    them. ``pmi`` is threaded to detection so AP242 PMI features surface (flagged inline).
+    them. ``formats`` (the CLI's ``--format``, #709) is likewise emitted into the
+    ``sheet.export(...)`` call when non-default (PDF). ``pmi`` is threaded to detection so
+    AP242 PMI features surface (flagged inline).
     *part_expr*, when given, overrides the ``part = …`` seam — e.g. the import seam from
     :func:`resolve_object_spec` so the script references a live module (#469)."""
     is_shape = isinstance(step_file, Shape)
@@ -458,6 +474,7 @@ def generate_sheet_script(
         tolerance=tolerance,
         scale=scale,
         page=page,
+        formats=formats,
     )
     py_path = f"{stem}.py"
     Path(py_path).write_text(script, encoding="utf-8")  # the script has box-drawing / × / ← glyphs

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3671,6 +3671,26 @@ def test_generate_script_preserves_pmi_scale_page(tmp_path):
     assert "pmi=PMI," in content and "scale=SCALE," in content and "page=PAGE," in content
 
 
+def test_generate_script_uses_modern_dict_export(tmp_path):
+    # #709: the emitted export is the modern {format: path} dict form (default pdf,
+    # matching the CLI / sheet flavour) — never the deprecated legacy tuple path.
+    step = tmp_path / "p.step"
+    export_step(Box(30, 20, 10), str(step))
+    content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text()
+    assert "paths = dwg.export(_stem, formats=('pdf',))" in content
+    assert "svg_path, dxf_path = dwg.export" not in content  # the legacy tuple is gone
+
+
+def test_generate_script_forwards_formats(tmp_path):
+    # #709: --format reaches the emitted export call.
+    step = tmp_path / "p.step"
+    export_step(Box(30, 20, 10), str(step))
+    content = Path(
+        generate_script(str(step), out=str(tmp_path / "p"), formats=("svg", "png"))
+    ).read_text()
+    assert "paths = dwg.export(_stem, formats=('svg', 'png'))" in content
+
+
 def test_generate_script_defaults_are_auto(tmp_path):
     # Defaults: no overrides → PMI off, SCALE/PAGE None (auto) — still emitted so the
     # fields exist for the user to set.
@@ -3776,7 +3796,8 @@ def test_generated_script_runs_and_preserves_pmi(tmp_path):
         env=env,
     )
     assert r.returncode == 0, f"generated script failed:\n{r.stderr[-1500:]}"
-    assert (tmp_path / "p.svg").exists(), "generated script did not write the SVG"
+    # #709: the emitted export defaults to PDF (the CLI / sheet-flavour default).
+    assert (tmp_path / "p.pdf").exists(), "generated script did not write the PDF"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3677,7 +3677,8 @@ def test_generate_script_uses_modern_dict_export(tmp_path):
     step = tmp_path / "p.step"
     export_step(Box(30, 20, 10), str(step))
     content = Path(generate_script(str(step), out=str(tmp_path / "p"))).read_text()
-    assert "paths = dwg.export(_stem, formats=('pdf',))" in content
+    assert "_formats = ('pdf',)" in content
+    assert "paths = dwg.export(_stem, formats=_formats)" in content
     assert "svg_path, dxf_path = dwg.export" not in content  # the legacy tuple is gone
 
 
@@ -3688,7 +3689,28 @@ def test_generate_script_forwards_formats(tmp_path):
     content = Path(
         generate_script(str(step), out=str(tmp_path / "p"), formats=("svg", "png"))
     ).read_text()
-    assert "paths = dwg.export(_stem, formats=('svg', 'png'))" in content
+    assert "_formats = ('svg', 'png')" in content
+
+
+def test_generated_script_prints_in_requested_order(tmp_path):
+    # #755 review: Drawing.export returns its dict in DEPENDENCY order (svg before
+    # the png derived from it), so printing paths.items() would reorder a
+    # `-f png,svg` request vs the direct CLI's _emit. The template must iterate
+    # the requested tuple. Execute a non-canonical-order script and assert the
+    # printed order matches the request.
+    import subprocess
+    import sys
+
+    step = tmp_path / "p.step"
+    export_step(Box(30, 20, 10), str(step))
+    py = generate_script(str(step), out=str(tmp_path / "p"), formats=("png", "svg"))
+    r = subprocess.run(
+        [sys.executable, py], capture_output=True, text=True, cwd=str(tmp_path), timeout=150
+    )
+    assert r.returncode == 0, f"generated script failed:\n{r.stderr[-1500:]}"
+    assert (tmp_path / "p.png").exists() and (tmp_path / "p.svg").exists()
+    png_at, svg_at = r.stdout.find("PNG ->"), r.stdout.find("SVG ->")
+    assert 0 <= png_at < svg_at, f"requested png,svg order not preserved:\n{r.stdout}"
 
 
 def test_generate_script_defaults_are_auto(tmp_path):

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -13,13 +13,10 @@ from build123d import Align, Box, Cylinder, Pos, Rot, Rotation, export_step
 
 from draftwright import build_drawing, generate_script
 
-# Characterisation is checked in now so the known direct/script gaps have executable
-# acceptance criteria, but the group is intentionally dormant until the equality work is
-# scheduled. Keep the strict xfails below: removing this module skip should immediately show
-# which individual gaps remain (#707 umbrella; #661 details; #426 reconstruction convergence).
-pytestmark = pytest.mark.skip(
-    reason="temporarily disabled pending generated-script equality work (#707, #661, #426)"
-)
+# Characterisation with executable acceptance criteria for the known direct/script gaps
+# (#707 umbrella; #661 details; #426 reconstruction convergence). The strict xfails below
+# ARE the acceptance criteria: a fix that closes a gap surfaces as an XPASS failure and
+# the xfail is then removed deliberately, in that fix's PR (#709 un-skipped the module).
 
 
 def _crowded_shoulders():

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -60,6 +60,13 @@ class TestEmit:
         assert "sheet.add(EnvelopeFeature(" in src
         assert src.rstrip().endswith("sheet.export('drawing')")
 
+    def test_non_default_formats_are_emitted_into_the_export_call(self):
+        # #709: --format must survive into the generated script; the default (pdf)
+        # keeps the bare call so a plain script matches Sheet.export's own default.
+        src = _script_for(_plate(), formats=("svg", "dxf"))
+        assert src.rstrip().endswith("sheet.export('drawing', formats=('svg', 'dxf'))")
+        assert _script_for(_plate(), formats=("pdf",)).rstrip().endswith("sheet.export('drawing')")
+
     def test_step_seam_preserves_detected_ctc01_envelope(self, tmp_path):
         # #536: build123d.import_step reports CTC01's raw bbox as 1170 × 650, but the
         # detector's solid-body envelope is 800 × 450. The generated STEP-seam script
@@ -863,6 +870,60 @@ class TestCli:
         assert "number='DWG-001'" in ctor
         for kw in ("drawn_by=", "tolerance=", "scale=", "page="):
             assert kw not in ctor
+
+    def test_format_is_forwarded_into_the_sheet_script(self, tmp_path):
+        # #709: `--script -f svg` used to silently emit a PDF-producing script.
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        step = tmp_path / "plate.step"
+        export_step(_plate(), str(step))
+        r = CliRunner().invoke(
+            app, [str(step), "--script", "-f", "svg", "--out", str(tmp_path / "g")]
+        )
+        assert r.exit_code == 0, r.output
+        src = (tmp_path / "g.py").read_text(encoding="utf-8")
+        assert f"sheet.export({str(tmp_path / 'g')!r}, formats=('svg',))" in src
+
+    def test_default_format_keeps_the_bare_sheet_export_call(self, tmp_path):
+        # No --format → the emitted call stays bare (Sheet.export defaults to PDF).
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        step = tmp_path / "plate.step"
+        export_step(_plate(), str(step))
+        r = CliRunner().invoke(app, [str(step), "--script", "--out", str(tmp_path / "g")])
+        assert r.exit_code == 0, r.output
+        src = (tmp_path / "g.py").read_text(encoding="utf-8")
+        assert f"sheet.export({str(tmp_path / 'g')!r})" in src
+        assert "formats=" not in src
+
+    def test_format_is_forwarded_into_the_imperative_script(self, tmp_path):
+        # #709: the imperative flavour honours --format too, via the modern dict export.
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        step = tmp_path / "plate.step"
+        export_step(_plate(), str(step))
+        r = CliRunner().invoke(
+            app,
+            [
+                str(step),
+                "--script",
+                "--style",
+                "imperative",
+                "-f",
+                "svg,dxf",
+                "--out",
+                str(tmp_path / "g"),
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        src = (tmp_path / "g.py").read_text(encoding="utf-8")
+        assert "paths = dwg.export(_stem, formats=('svg', 'dxf'))" in src
 
     def test_bad_style_is_rejected(self, tmp_path):
         from typer.testing import CliRunner

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -923,7 +923,8 @@ class TestCli:
         )
         assert r.exit_code == 0, r.output
         src = (tmp_path / "g.py").read_text(encoding="utf-8")
-        assert "paths = dwg.export(_stem, formats=('svg', 'dxf'))" in src
+        assert "_formats = ('svg', 'dxf')" in src
+        assert "paths = dwg.export(_stem, formats=_formats)" in src
 
     def test_bad_style_is_rejected(self, tmp_path):
         from typer.testing import CliRunner


### PR DESCRIPTION
Loop item 1 of the script/CLI-parity cluster (per the cluster review on #707/#709/#661). Closes #709.

## What

- **`--format` now reaches generated scripts**: `cli.py` threads `formats` into all three script-branch call sites; both emitters grew `formats: Sequence[str] = ("pdf",)`. A default run still emits the bare `sheet.export('<stem>')`; `-f svg,dxf` emits `sheet.export('<stem>', formats=('svg', 'dxf'))`. Previously `-f svg --script` silently produced a PDF-writing script.
- **The imperative template stops using the deprecated legacy tuple**: `svg_path, dxf_path = dwg.export(_stem)` → the modern dict form `paths = dwg.export(_stem, formats=('pdf',))` with a format-agnostic print loop — defaulting to PDF, aligning the two script flavours and the direct CLI on one default.
- **The #743 parity characterization module gets CI signal**: the module-level skip on `tests/test_script_detail_parity.py` is removed; its 6 strict xfails (the acceptance criteria for the upcoming #661/#707 loop items) now run in the fast tier (~45 s) — a quiet fix or regression surfaces as XPASS/failure instead of silence. Verified on this branch: 1 passed, 6 xfailed, 0 xpassed.

## Notes

- One existing test updated as a direct consequence of the deliberate default change: the imperative round-trip test now asserts `p.pdf` (was `p.svg`).
- `README.md`'s direct-API legacy-tuple example is out of scope (documents the still-supported `Drawing.export` legacy path) — flagged for the docs follow-up.

## Verification

- 6 new tests across emitter/CLI/generator levels (incl. legacy-pattern-absent assertions)
- Guards 81 · targeted script/emit/export/cli selection 136 passed · goldens 14 · full fast tier **1471 passed** (only the known #710 hypothesis replay)
- lint ×4 clean; CHANGELOG Fixed entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)