### PR TITLE
fix(#632): model and reconcile boss heights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@
 
 ### Fixed
 
+- **Boss heights are modeled, rendered, and coverage-checked** (#632): detected
+  and object-declared cylindrical bosses now carry their axial extent through
+  `BossFeature` and the dimension planner. Prismatic bosses receive a linear
+  height dimension in a profile view in addition to their end-on diameter
+  leader. `Drawing.lint()` reconciles that modeled height against the live
+  feature-owned `Dimension`, reporting `boss_height_missing` if it is removed
+  or otherwise absent (demoted to `info` on assembly drawings). This closes the
+  declarative false-negative where a boss's diameter and the overall envelope
+  were documented but its own independent height was not.
+
 - **`--format` now reaches `--script` output** (#709, from the #702 adversarial
   review): `--script -f svg` used to silently emit a PDF-producing script — the
   CLI parsed the flag but never forwarded it. Both emitters now thread it

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1564,6 +1564,67 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
     )
 
 
+def render_boss_heights(dwg, groups, a, *, ctx) -> int:
+    """Queue the axial height of each prismatic boss in a profile-view corridor (#632)."""
+    if a.is_rotational or a.prof is not None:
+        return 0
+    tier = dwg.draft.font_size + 2 * dwg.draft.pad_around_text
+    specs = {
+        "z": ("front", "right", a.fv_zones.right, "x"),
+        "x": ("front", "above", a.fv_zones.above, "y"),
+        "y": ("side", "above", a.sv_zones.above, "y"),
+    }
+    n = 0
+    for bi, g in enumerate(
+        sorted(
+            (g for g in groups if g.feature_kind == "boss"),
+            key=lambda g: (g.feature.frame.axis, g.feature.frame.origin),
+        )
+    ):
+        b = g.feature
+        pd = next(
+            (d for d in g.dims if (d.param.role, d.param.kind) == ("boss_height", "length")),
+            None,
+        )
+        if pd is None or pd.suppressed or pd.param.span is None:
+            continue
+        view, side, strip, stack = specs[b.frame.axis]
+        p1 = dwg.at(view, *pd.param.span[0])
+        p2 = dwg.at(view, *pd.param.span[1])
+        edge = max(p1[0], p2[0]) if side == "right" else max(p1[1], p2[1])
+        label = _fmt(pd.param.value) + _tol_suffix(pd.param.tolerance, dwg.draft)
+        name = f"m_bossheight_{b.frame.axis}{bi}"
+
+        def build(pos, p1=p1, p2=p2, side=side, edge=edge, label=label):
+            return _dim(p1, p2, side, abs(pos - edge), dwg.draft, label=label)
+
+        def footprint(pos, p1=p1, p2=p2, side=side, edge=edge, label=label):
+            return dim_footprint(p1, p2, side, abs(pos - edge), dwg.draft, label)
+
+        register_corridor(
+            ctx,
+            (view, side),
+            strip,
+            view,
+            stack,
+            tier,
+            CorridorCandidate(
+                name=name,
+                build=build,
+                order=(_SIZE_SUBCHAIN, bi, name),
+                on_place=lambda _nm: None,
+                on_drop=lambda _nm, value=pd.param.value: ctx.record_issue(
+                    "warning", "boss_height_dropped", f"boss height {_fmt(value)} not dimensioned"
+                ),
+                force=True,
+                feature=b,
+                footprint=footprint,
+            ),
+        )
+        n += 1
+    return n
+
+
 def render_plates(dwg, groups, a, *, ctx) -> int:
     """Plate/wall thicknesses (#559): the thin extent of each recognised slab
     (`PlateFeature`), placed in the view where its thin axis is characteristic — a Z

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1613,9 +1613,10 @@ def render_boss_heights(dwg, groups, a, *, ctx) -> int:
                 build=build,
                 order=(_SIZE_SUBCHAIN, bi, name),
                 on_place=lambda _nm: None,
-                on_drop=lambda _nm, value=pd.param.value: ctx.record_issue(
-                    "warning", "boss_height_dropped", f"boss height {_fmt(value)} not dimensioned"
-                ),
+                # Live feature reconciliation below Drawing.lint() is authoritative:
+                # an absent height becomes one boss_height_missing issue. Recording a
+                # second build-time drop here would double-count the same omission.
+                on_drop=lambda _nm: None,
                 force=True,
                 feature=b,
                 footprint=footprint,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -34,6 +34,7 @@ from draftwright.annotations._common import PlacementContext
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.from_model import (
     render_boss_diameters,
+    render_boss_heights,
     render_centermarks,
     render_chamfers,
     render_diameters,
@@ -100,6 +101,7 @@ _PASS_SEQUENCE: tuple[str, ...] = (
     "envelope",
     "detail_request",
     "boss_diameters",  # documented invariant: before "diameters" (ø then 'mentioned')
+    "boss_heights",
     "diameters",
     "step_lengths",
     "off_axis_along",
@@ -424,6 +426,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # (they keep the OD stack).
         render_boss_diameters(dwg, _groups, a, ctx=ctx)
 
+    def _s_boss_heights():
+        render_boss_heights(dwg, _groups, a, ctx=ctx)
+
     def _s_diameters():
         # Turned-part dimensions via the IR (ADR 0008 convergence). The model is built
         # once and fed to both renderers (#229 — no per-pass rebuild): ø leaders, row
@@ -527,6 +532,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "envelope": _s_envelope,
             "detail_request": _s_detail_request,
             "boss_diameters": _s_boss_diameters,
+            "boss_heights": _s_boss_heights,
             "diameters": _s_diameters,
             "step_lengths": _s_step_lengths,
             "off_axis_along": _s_off_axis_along,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -66,6 +66,7 @@ from draftwright.linting import (
     LintIssue,
     _suggest_fix,
     lint_axial_coverage,
+    lint_boss_height_coverage,
     lint_declaration_reconciliation,
     lint_drawing,
     lint_feature_coverage,
@@ -1951,6 +1952,16 @@ class Drawing:
                 assembly=self.assembly,
                 **prof_kw,
             )
+            model = self._part_model
+            # Turned bosses/bands remain in the OD + axial-step policy; this check is
+            # specifically for a prismatic boss's independent projection height.
+            if model is not None and (a is None or (not a.is_rotational and a.prof is None)):
+                issues += lint_boss_height_coverage(
+                    self.part,
+                    self,
+                    getattr(model, "features", ()),
+                    assembly=self.assembly,
+                )
             issues += lint_location_coverage(
                 self.part,
                 self,

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from draftwright.linting.coverage import (
     CoverageState,
     lint_axial_coverage,
+    lint_boss_height_coverage,
     lint_declaration_reconciliation,
     lint_feature_coverage,
     lint_location_coverage,
@@ -32,6 +33,7 @@ __all__ = [
     "LintIssue",
     "_suggest_fix",
     "lint_axial_coverage",
+    "lint_boss_height_coverage",
     "lint_declaration_reconciliation",
     "lint_drawing",
     "lint_feature_coverage",

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -487,6 +487,39 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     ]
 
 
+def lint_boss_height_coverage(part, dwg, features, assembly=None) -> list:
+    """Report modeled boss heights that have no rendered linear dimension (#632).
+
+    Coverage is reconciled from the drawing registry's feature provenance, not a
+    renderer side channel: a boss is covered only when one of its live annotations
+    is a ``Dimension``. Boss diameter annotations are leaders, so they cannot mask a
+    missing axial height. Bosses without a modeled height retain the historical
+    diameter-only contract and are outside this check.
+    """
+    bosses = [
+        feature
+        for feature in features
+        if getattr(feature, "kind", None) == "boss"
+        and getattr(feature, "height", None) is not None
+    ]
+    missing = sum(
+        1
+        for boss in bosses
+        if not any(isinstance(ann, Dimension) for ann in dwg.annotations_of(boss).values())
+    )
+    if not missing:
+        return []
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    return [
+        LintIssue(
+            severity="info" if assembly else "warning",
+            code="boss_height_missing",
+            message=f"{missing} boss height(s) are not dimensioned",
+        )
+    ]
+
+
 def lint_declaration_reconciliation(features, cyls) -> list:
     """Flag a *declared* cylindrical feature with no matching geometry in the part (#487).
 

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -280,7 +280,7 @@ def read_countersink(cone) -> tuple[float, float]:
     return round(2 * major_e.radius, 4), included
 
 
-def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:
+def boss(obj=None, *, diameter=None, height=None, at=None, axis=None, span=None) -> BossFeature:
     """An external cylindrical boss / OD. Either ``boss(cylinder)`` or
     ``boss(diameter=6, at=(0, 0, 0), axis="x")`` (parametric). An object supplies
     *defaults*; any explicit keyword overrides that field (#451)."""
@@ -289,12 +289,21 @@ def boss(obj=None, *, diameter=None, at=None, axis=None) -> BossFeature:
         axis = r_axis if axis is None else axis
         diameter = r_diameter if diameter is None else diameter
         at = r_at if at is None else at
+        if height is None:
+            bb = obj.bounding_box()
+            height = [bb.size.X, bb.size.Y, bb.size.Z]["xyz".index(_norm_axis(axis))]
     if diameter is None or at is None or axis is None:
         raise ValueError("boss() needs an object, or explicit diameter=, at= and axis=")
     axis = _norm_axis(axis)
     _require_positive(diameter=diameter)
+    if height is not None:
+        _require_positive(height=height)
     _require_point("at", at)
-    return BossFeature(frame=Frame(origin=at, axis=axis), diameter=diameter)
+    if height is not None and span is None:
+        span = _span(at, axis, height)
+    return BossFeature(
+        frame=Frame(origin=at, axis=axis), diameter=diameter, height=height, span=span
+    )
 
 
 def step(obj=None, *, diameter=None, length=None, at=None, axis=None, span=None) -> StepFeature:

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -365,6 +365,11 @@ def build_part_model(
                     BossFeature(
                         frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
                         diameter=b.diameter,
+                        height=b.height,
+                        span=(
+                            tuple(float(b.location[i] - b.axis[i] * b.height) for i in range(3)),
+                            _xyz(b.location),
+                        ),
                     )
                 )
     else:
@@ -381,6 +386,11 @@ def build_part_model(
                 BossFeature(
                     frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
                     diameter=b.diameter,
+                    height=b.height,
+                    span=(
+                        tuple(float(b.location[i] - b.axis[i] * b.height) for i in range(3)),
+                        _xyz(b.location),
+                    ),
                 )
             )
         # Overall envelope dims for a *prismatic* part — not a round single-OD body

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -367,7 +367,11 @@ def build_part_model(
                         diameter=b.diameter,
                         height=b.height,
                         span=(
-                            tuple(float(b.location[i] - b.axis[i] * b.height) for i in range(3)),
+                            (
+                                float(b.location[0] - b.axis[0] * b.height),
+                                float(b.location[1] - b.axis[1] * b.height),
+                                float(b.location[2] - b.axis[2] * b.height),
+                            ),
                             _xyz(b.location),
                         ),
                     )
@@ -388,7 +392,11 @@ def build_part_model(
                     diameter=b.diameter,
                     height=b.height,
                     span=(
-                        tuple(float(b.location[i] - b.axis[i] * b.height) for i in range(3)),
+                        (
+                            float(b.location[0] - b.axis[0] * b.height),
+                            float(b.location[1] - b.axis[1] * b.height),
+                            float(b.location[2] - b.axis[2] * b.height),
+                        ),
                         _xyz(b.location),
                     ),
                 )

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -306,14 +306,19 @@ class PocketFeature:
 
 @dataclass(frozen=True)
 class BossFeature:
-    """An external cylindrical boss/OD on a non-turned part — its diameter."""
+    """An external cylindrical boss/OD — its diameter and optional axial height."""
 
     frame: Frame
     diameter: float
+    height: float | None = None
+    span: tuple[Point, Point] | None = None
     kind: ClassVar[str] = "boss"
 
     def parameters(self) -> list[DimParameter]:
-        return [DimParameter("diameter", "boss", self.diameter)]
+        params = [DimParameter("diameter", "boss", self.diameter)]
+        if self.height is not None:
+            params.append(DimParameter("length", "boss_height", self.height, span=self.span))
+        return params
 
     def references(self) -> list[Datum]:
         return []

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -44,6 +44,7 @@ _CONVENTION = {
     ("spotface", "diameter"): "leader",
     ("spotface", "depth"): "leader",
     ("boss", "diameter"): "leader",
+    ("boss_height", "length"): "linear",
     ("bolt_circle", "diameter"): "leader",  # BCD (a pitch-circle diameter)
     ("pitch", "length"): "pitch",  # linear-array pitch — distinct from a plain linear dim
     ("grid_pitch", "length"): "pitch",

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8230,6 +8230,37 @@ class TestPrismaticBossDiameter:
             o.label == "ø28" for n, o in dwg.iter_annotations() if n.startswith("m_dia_z")
         )
 
+    def test_prismatic_boss_height_is_dimensioned_in_profile(self):
+        # #632: the boss's own 10 mm axial extent is independent of the 48 mm
+        # overall envelope and must be modeled and rendered explicitly.
+        dwg = build_drawing(self._box_boss())
+        heights = [(n, o) for n, o in dwg.iter_annotations() if n.startswith("m_bossheight_")]
+        assert len(heights) == 1
+        name, dim = heights[0]
+        assert dim.label == "10"
+        assert dwg.view_of(name) == "front"
+        assert not any(i.code == "boss_height_missing" for i in dwg.lint())
+
+    def test_removed_boss_height_is_linted_from_live_drawing(self):
+        # Coverage is drawing-derived: deleting the rendered height must expose the
+        # gap even though the overall envelope and boss diameter remain present.
+        dwg = build_drawing(self._box_boss())
+        height_name = next(n for n in dwg.annotations() if n.startswith("m_bossheight_"))
+        dwg.remove(height_name)
+        issues = [i for i in dwg.lint() if i.code == "boss_height_missing"]
+        assert len(issues) == 1
+        assert issues[0].severity == "warning"
+
+    def test_declared_boss_object_carries_height_into_the_model(self):
+        from draftwright import Sheet
+
+        boss_obj = Pos(0, 0, 24) * Cylinder(14, 10)
+        sheet = Sheet.from_part(Box(90, 64, 38) + boss_obj)
+        sheet.boss(boss_obj)
+        feature = next(f for f in sheet.build().model().features if f.kind == "boss")
+        assert feature.height == pytest.approx(10)
+        assert feature.span is not None
+
     def test_shelled_cover_boss_diameter_not_dropped(self):
         # The regression: even forced onto A4 (scale 0.5, front view against the left
         # margin) the boss ø28 places into the clear sheet, so it never lints uncovered.
@@ -8257,6 +8288,7 @@ class TestPrismaticBossDiameter:
         dwg = build_drawing(Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(10, 30))
         assert not any(n.startswith("m_bossdia_") for n in dwg.annotations())
         assert any(n.startswith("m_dia_z") for n in dwg.annotations())
+        assert not any(i.code == "boss_height_missing" for i in dwg.lint())
 
 
 class TestTurnedDiameters:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8251,6 +8251,31 @@ class TestPrismaticBossDiameter:
         assert len(issues) == 1
         assert issues[0].severity == "warning"
 
+    def test_unplaceable_boss_height_reports_one_authoritative_issue(self):
+        # Adversarial review of #632: a physically absent corridor forces the
+        # candidate's drop path. Reconciliation must report the omission once,
+        # rather than adding boss_height_dropped + boss_height_missing for one gap.
+        from types import SimpleNamespace
+
+        from draftwright.annotations._common import PlacementContext, drain_corridors
+        from draftwright.annotations.from_model import render_boss_heights
+        from draftwright.model import plan_dimensions
+
+        dwg = build_drawing(self._box_boss(), auto_dims=False)
+        analysis = dwg._analysis
+        constrained = SimpleNamespace(
+            **{
+                **vars(analysis),
+                "fv_zones": SimpleNamespace(**{**vars(analysis.fv_zones), "right": None}),
+            }
+        )
+        ctx = PlacementContext(registry=dwg.registry, coverage=dwg._coverage)
+        render_boss_heights(dwg, plan_dimensions(dwg.model()), constrained, ctx=ctx)
+        drain_corridors(ctx, dwg)
+
+        boss_issues = [i for i in dwg.lint() if i.code.startswith("boss_height_")]
+        assert [i.code for i in boss_issues] == ["boss_height_missing"]
+
     def test_declared_boss_object_carries_height_into_the_model(self):
         from draftwright import Sheet
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8261,6 +8261,31 @@ class TestPrismaticBossDiameter:
         assert feature.height == pytest.approx(10)
         assert feature.span is not None
 
+    def test_issue_632_declarative_cover_reconciles_rendered_boss_height(self):
+        """The original #632 repro stays covered end-to-end: declaration → IR →
+        planner → renderer → lint, including its shell, bore, and pocket declarations."""
+        from draftwright import Sheet
+
+        wall, length, width, height = 3.0, 90, 64, 38
+        pocket = Pos(0, 0, -wall) * Box(length - 2 * wall, width - 2 * wall, height)
+        boss = Pos(0, 0, height / 2 + 5) * Cylinder(14, 10)
+        bore = Pos(0, 0, 15) * Cylinder(6, 40)
+        cover = Box(length, width, height) - pocket + boss - bore
+
+        sheet = Sheet(cover, title="C")
+        sheet.envelope()
+        sheet.boss(boss)
+        sheet.hole(bore).through()
+        sheet.pocket(pocket)
+        dwg = sheet.build()
+
+        height_name = next(n for n in dwg.annotations() if n.startswith("m_bossheight_"))
+        assert dwg.get_annotation(height_name).label == "10"
+        assert dwg.lint_summary()["by_code"].get("boss_height_missing", 0) == 0
+
+        dwg.remove(height_name)
+        assert dwg.lint_summary()["by_code"]["boss_height_missing"] == 1
+
     def test_shelled_cover_boss_diameter_not_dropped(self):
         # The regression: even forced onto A4 (scale 0.5, front view against the left
         # margin) the boss ø28 places into the clear sheet, so it never lints uncovered.


### PR DESCRIPTION
## Summary

- carry detected and object-declared boss axial height/span through `BossFeature` and the dimension planner
- render a prismatic boss-height linear dimension in a profile-view corridor alongside the existing end-on diameter leader
- reconcile each modeled prismatic boss height against live feature-owned dimensions and report `boss_height_missing` when absent
- preserve the existing turned OD/step policy and legacy explicit diameter-only boss declarations

## Root cause

The existing completeness checks reconciled boss diameters, turned axial lengths, and hole locations, but `BossFeature` did not contain the boss axial extent. As a result, the reported boss could receive `ø28` and the part could receive an overall `48` envelope dimension while the boss-specific `10` height was neither rendered nor checkable.

## User impact

Declarative and detected prismatic bosses now document their independent height. Removing or dropping that height no longer leaves a falsely perfect lint score; assembly drawings receive the same informational severity policy as the other coverage checks.

Closes #632.

## Validation

- exact issue repro: `m_bossdia_z0 ø28` plus `m_bossheight_z0 10`; lint clean
- focused boss/model suite: 27 passed
- script-detail/model suite: 21 passed, 6 expected xfails
- Ruff format/check and `git diff --check`: clean
- full fast suite reached 58% with no failures before the local run was interrupted; GitHub CI will run the complete matrix