### PR TITLE
fix(#426): reconstruct rotational furniture in the generated script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@
 
 ### Fixed
 
+- **Generated imperative script reconstructs rotational furniture** (#426/#424):
+  a turned/cylindrical part's `dwg.model()` carries a `RotationalFeature`, but the
+  `--script` emitter parked it in the gap-comment list, so an executed
+  reconstruction of e.g. a plain cylinder was missing `dim_od` and the
+  `centerline_front`/`centerline_side` marks the direct build draws. A new
+  `Drawing.rotational(feature)` add-verb records the intent, and `finalize()`
+  drains it through the shared whole-model `render_rotational` at the auto-pass's
+  own `"rotational"` stage — byte-identical to the direct build (no `only=` subset,
+  fixed literal names, so no naming-seam or `⊇`-vs-`==` gap). The emitter now emits
+  `dwg.rotational(f)` for rotational features. Closes the rotational half of the
+  direct-vs-generated-script convergence.
 - **Emitted `Sheet` script now faithfully reproduces the direct CLI drawing**
   (#707): the divergence reported against 0.3.3 on the Maquetto GRM-03 part was
   closed by #709 (script `--format` forwarding) + #661 (finalize detail drain).

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -805,8 +805,6 @@ def _fmt_pt(p) -> str:
 # Feature kinds with no intent verb yet — emitted as a flagged comment, never a broken
 # call. The build_drawing(auto_dims=True) pointer recovers the full auto drawing (#424).
 _GAP_KINDS = {
-    "rotational": "auto-pass draws the overall OD + centrelines + concentric bore leaders; "
-    "out of scope for the intent verbs (#419)",
     "pmi": "pre-authored PMI, rendered by --pmi annotate; an add verb is deferred to #422",
 }
 
@@ -825,11 +823,12 @@ def _feature_listing(a: Analysis) -> str:
     ADR-0008 IR): holes/patterns → ``callout`` + ``locate`` + ``furniture``; steps/bosses →
     ``callout`` (ø); steps/envelopes/slots → ``dimension(...)`` per linear param; prismatic
     step levels → one ``dimension(..., role="step_height")`` intent that regenerates the
-    correlated height ladder. A section A–A is recorded when a counterbored/spotfaced/blind
-    Z-hole warrants one (finalize renders it last). Feature kinds with no verb yet
-    (rotational, pmi) are emitted as flagged comments naming the gap (#424) — never silently
-    dropped. Commenting any line drops exactly that intent (nothing is auto-drawn, so there
-    is no double-dimension risk). Pure function of *a*.
+    correlated height ladder; a rotational body → ``rotational`` (OD + centrelines +
+    concentric-bore leaders, #424/#426). A section A–A is recorded when a
+    counterbored/spotfaced/blind Z-hole warrants one (finalize renders it last). Feature
+    kinds with no verb yet (pmi) are emitted as flagged comments naming the gap (#424) —
+    never silently dropped. Commenting any line drops exactly that intent (nothing is
+    auto-drawn, so there is no double-dimension risk). Pure function of *a*.
     """
     model = cast(PartModel, a.model) if a.model is not None else build_model(a)
     feats = getattr(model, "features", [])
@@ -847,6 +846,9 @@ def _feature_listing(a: Analysis) -> str:
             body.append(f"#     {kind} — {_GAP_KINDS[kind]}. auto_dims=True to keep it.")
             continue
         body.append(f"f = dwg.model().features[{i}]")
+        if kind == "rotational":
+            body.append("dwg.rotational(f)")  # OD + centrelines + bore leaders (#424/#426)
+            continue
         if kind in ("hole", "pattern"):
             body.append("dwg.callout(f)")
             if feat.frame.axis == "z":

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -178,6 +178,7 @@ class _IntentRouting:
     step_position_ids: set
     explicit_envelope_height: bool
     user_dim_ids: set
+    rotational_ids: set
     only_loc: set
     pinned_loc: set
     only_callout: set
@@ -1052,6 +1053,29 @@ class Drawing:
             self, feature, self._part_model, self._analysis, view=view, ctx=ctx
         )
 
+    def rotational(self, feature) -> list[str]:
+        """Add a rotational part's **turned furniture** (#424/#426) — the overall OD
+        dimension, the axis centrelines, and any concentric-bore leaders.
+
+        The editable handle for the whole-model rotational renderer: where the
+        per-feature verbs place callouts/locations, ``rotational`` draws the furniture
+        the auto-pass synthesises for a part's ``RotationalFeature`` (a turned /
+        cylindrical body). *feature* is the rotational feature from :meth:`model`.
+        Placed by the shared :func:`render_rotational` — the same whole-model renderer
+        the auto-pass runs, so a script-reconstructed drawing is byte-identical to the
+        direct build (no ``only=`` subset, no positional-naming seam: the renderer
+        names its own outputs ``dim_od`` / ``centerline_*`` / ``ldr_*``). Returns ``[]``.
+        """
+        if self._defer_intents:  # #426: record, don't place — finalize() drains it
+            self._intents.append(Intent("rotational", feature, {}))
+            return []
+        from draftwright.annotations._common import PlacementContext
+        from draftwright.annotations.from_model import render_rotational
+
+        ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
+        render_rotational(self, self._part_model, self._analysis, ctx=ctx)
+        return []
+
     def section(self) -> list[str]:
         """Add the automatic full **section A–A** (#420) — the section half of the
         editable surface.
@@ -1254,6 +1278,9 @@ class Drawing:
             for it in self._intents
             if self._user_dim_uses_corridor(it, routable, already_routed)
         }
+        # Rotational furniture intent (#424/#426): the whole-model render_rotational —
+        # no per-feature subset, so just the id set; it drains at the "rotational" slot.
+        rotational_ids = {id(it) for it in self._intents if routable and it.kind == "rotational"}
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         pinned_loc = {
             it.feature for it in self._intents if id(it) in corridor_ids and it.kwargs.get("pin")
@@ -1273,6 +1300,7 @@ class Drawing:
             step_position_ids=step_position_ids,
             explicit_envelope_height=explicit_envelope_height,
             user_dim_ids=user_dim_ids,
+            rotational_ids=rotational_ids,
             only_loc=only_loc,
             pinned_loc=pinned_loc,
             only_callout=only_callout,
@@ -1454,6 +1482,7 @@ class Drawing:
             render_diameters,
             render_height_ladder,
             render_locations,
+            render_rotational,
             render_slots,
             render_step_lengths,
             render_step_positions,
@@ -1476,6 +1505,18 @@ class Drawing:
         routable = model is not None and a is not None
         queued_dim_ids: set = set()
 
+        def _s_rotational():
+            # Rotational furniture — OD dim + axis centrelines + concentric-bore leaders —
+            # through the shared whole-model render_rotational (#424/#426). Runs FIRST (its
+            # "rotational" _PASS_SEQUENCE slot), so on a turned STEPPED part it places before
+            # the diameter/callout stages exactly as the auto-pass does. No only= subset and
+            # fixed literal output names (dim_od/centerline_*) ⇒ byte-identical to the auto
+            # pass, so the reconstruction matches (== not ⊇, unlike the #424 diameter case).
+            if r.rotational_ids:
+                assert a is not None and isinstance(model, PartModel)
+                render_rotational(self, model, a, ctx=ctx)
+            self._intents = [it for it in self._intents if id(it) not in r.rotational_ids]
+
         def _s_reserve_section():
             # Reserve the section's cutting-plane row BEFORE the callout carve so the
             # carve sees it as an obstacle (Coupling A, ADR 0009 P5 strand 3); rendered
@@ -1496,6 +1537,7 @@ class Drawing:
                 | r.height_ladder_ids
                 | r.step_position_ids
                 | r.user_dim_ids
+                | r.rotational_ids  # drained by _s_rotational; no _replay_intent branch
             )
             i = 0
             while i < len(self._intents):
@@ -1677,6 +1719,7 @@ class Drawing:
 
         run_stages(
             {
+                "rotational": _s_rotational,
                 "reserve_section": _s_reserve_section,
                 "live_replay": _s_live_replay,
                 "hole_callouts": _s_hole_callouts,

--- a/src/draftwright/intents.py
+++ b/src/draftwright/intents.py
@@ -1,7 +1,7 @@
 """Deferred placement intents — the low IR of the layout backend (#426).
 
-The add verbs (`callout`/`locate`/`furniture`/`dimension`/`section`) place *live* by
-default. When a :class:`~draftwright.drawing.Drawing` is in **deferred** mode
+The add verbs (`callout`/`locate`/`furniture`/`dimension`/`section`/`rotational`) place
+*live* by default. When a :class:`~draftwright.drawing.Drawing` is in **deferred** mode
 (``_defer_intents``), each verb records an :class:`Intent` instead of placing, and
 ``Drawing.finalize()`` drains the recorded list.
 
@@ -19,8 +19,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-# The five add verbs that record intents (`section` is part-level → feature is None).
-IntentKind = str  # "callout" | "locate" | "furniture" | "dimension" | "section"
+# The add verbs that record intents (`section`/`rotational` are part-/whole-model → the
+# feature arg is the part's rotational feature or None for a section).
+IntentKind = str  # "callout" | "locate" | "furniture" | "dimension" | "section" | "rotational"
 
 
 @dataclass

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -164,10 +164,6 @@ def test_generated_script_matches_direct_side_drilled_locations(tmp_path):
 
 
 @pytest.mark.timeout(240)
-@pytest.mark.xfail(
-    strict=True,
-    reason="rotational OD and centreline furniture are not represented by script intents",
-)
 def test_generated_script_matches_direct_rotational_furniture(tmp_path):
     """A plain cylinder characterises the smallest rotational reconstruction gap."""
     step, scripted = _scripted_drawing(Cylinder(15, 40), tmp_path, "rotational")


### PR DESCRIPTION
## What

Partial #426 (the rotational half of direct-vs-generated-script convergence). A turned/cylindrical part's `dwg.model()` carries a `RotationalFeature`, but the imperative `--script` emitter parked it in `_GAP_KINDS` (a flagged comment, no intent) — so an executed reconstruction of e.g. a plain `Cylinder(15, 40)` was missing `dim_od` and the `centerline_front`/`centerline_side` marks the direct auto-pass draws. This was the strict xfail `test_generated_script_matches_direct_rotational_furniture`.

## How

Everything needed already existed — the `RotationalFeature` IR, the `render_rotational` renderer, and the `"rotational"` slot at index 0 of `_PASS_SEQUENCE`; only the record verb and the finalize drain stage were missing:

- **`Drawing.rotational(feature)`** — records `Intent("rotational", …)` in deferred mode, else calls the shared `render_rotational` live (API symmetry).
- **classify** `rotational_ids` + a **`_s_rotational` drain stage** registered under the `"rotational"` key, so `run_stages` runs it **first** (matching the auto-pass — a turned stepped part places OD/centrelines before the diameter/callout stages); excluded from `_s_live_replay`.
- emit **`dwg.rotational(f)`** from `_feature_listing`; drop `"rotational"` from `_GAP_KINDS`.

`render_rotational` is a **whole-model** renderer with no `only=` subset and **fixed literal** output names, so the reconstruction is **byte-identical** to the direct build (`==` not `⊇`, unlike the #424 turned-diameter case) — no naming-seam risk, and the auto-pass path is untouched.

## Verification

- The strict xfail `test_generated_script_matches_direct_rotational_furniture` now **passes** (marker removed); the Y-turned diameter-policy test still holds.
- 113-test regression sweep (sheet round-trip, turned steps, prismatic classification, emitter shape, intents) green — prismatic parts still emit no `dim_od`.
- lint ×4 clean; import-boundary / encapsulation / private-import guards pass.

Refs #426, #424. Remaining #426 gap after this: side-drilled location dims (the other strict xfail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)