### PR TITLE
fix(#426): reconstruct side-drilled hole locations in the generated script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@
 
 ### Fixed
 
+- **Generated imperative script reconstructs side-drilled hole locations**
+  (#426/#133): an X/Y-axis (side-drilled) bore gets `dim_loc_*` position dims in
+  the direct build, but the `--script` emitter emitted a gap comment instead of a
+  `locate()` for non-Z holes (because `locate()`/`render_locations` are Z-plan
+  only, #133). The emitter now emits `dwg.locate(f)` for holes on any axis;
+  `finalize()` routes by the feature's axis — Z-plan holes drain through
+  `render_locations` as before, side-drilled bores through the whole-model
+  `_locate_off_axis_holes` pass (registered at the auto-pass's own
+  `off_axis_across`/`off_axis_along` stages, placed at the shared drain). The
+  Z-only `locate()` live contract is untouched (side-drilled locates never reach
+  it — they route to the off-axis stages). Closes the last direct-vs-generated
+  script parity gap tracked by #426.
 - **Generated imperative script reconstructs rotational furniture** (#426/#424):
   a turned/cylindrical part's `dwg.model()` carries a `RotationalFeature`, but the
   `--script` emitter parked it in the gap-comment list, so an executed

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -851,15 +851,11 @@ def _feature_listing(a: Analysis) -> str:
             continue
         if kind in ("hole", "pattern"):
             body.append("dwg.callout(f)")
-            if feat.frame.axis == "z":
-                body.append("dwg.locate(f)")
-            else:
-                # locate() is Z-axis only (it rejects side-drilled bores by contract, #133);
-                # an off-axis bore's position is auto-pass-only. Flag it like a gap kind (#424).
-                body.append(
-                    f"#     locate() is Z-axis only — this {feat.frame.axis}-drilled bore's "
-                    "position is auto-pass-only (#133). auto_dims=True to keep it."
-                )
+            # locate() records the position intent for a hole on ANY axis (#426/#133): a
+            # Z-plan hole drains through render_locations, a side-drilled (X/Y) bore through
+            # the whole-model _locate_off_axis_holes pass — finalize routes by the feature's
+            # axis, so the same verb line reconstructs both.
+            body.append("dwg.locate(f)")
             body.append("dwg.furniture(f)")
         elif kind in ("step", "boss"):
             if feat.frame.axis in ("x", "z"):

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -827,8 +827,11 @@ def _feature_listing(a: Analysis) -> str:
     concentric-bore leaders, #424/#426). A section A–A is recorded when a
     counterbored/spotfaced/blind Z-hole warrants one (finalize renders it last). Feature
     kinds with no verb yet (pmi) are emitted as flagged comments naming the gap (#424) —
-    never silently dropped. Commenting any line drops exactly that intent (nothing is
-    auto-drawn, so there is no double-dimension risk). Pure function of *a*.
+    never silently dropped. Commenting a per-feature verb line drops exactly that intent
+    (nothing is auto-drawn, so there is no double-dimension risk); the WHOLE-MODEL passes —
+    ``rotational``, the ``dwg.locate(f)`` of side-drilled bores, and the ``role="step_height"``
+    height ladder — reconstruct as a set, so commenting *some* of their lines still redraws
+    the whole group and only commenting them *all* drops it. Pure function of *a*.
     """
     model = cast(PartModel, a.model) if a.model is not None else build_model(a)
     feats = getattr(model, "features", [])

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1190,12 +1190,14 @@ class Drawing:
         # (_locate_off_axis_holes), placed at the shared drain like the Z-plan corridor —
         # not render_locations (Z-only, #133) and never live-replayed (add_feature_location
         # raises on non-Z; the intent is routed here before it can reach that verb).
+        # NB: no ``axes is None`` guard, unlike corridor_ids — the off-axis pass ignores the
+        # axes selector, so EVERY side-drilled locate (incl. a hand-written axes=… one) must
+        # route here, else it would live-replay into add_feature_location's ValueError.
         off_axis_loc_ids = {
             id(it)
             for it in self._intents
             if routable
             and it.kind == "locate"
-            and it.kwargs.get("axes") is None
             and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "y")
         }
         callout_ids = {

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -179,6 +179,7 @@ class _IntentRouting:
     explicit_envelope_height: bool
     user_dim_ids: set
     rotational_ids: set
+    off_axis_loc_ids: set
     only_loc: set
     pinned_loc: set
     only_callout: set
@@ -1178,7 +1179,24 @@ class Drawing:
         corridor_ids = {
             id(it)
             for it in self._intents
-            if routable and it.kind == "locate" and it.kwargs.get("axes") is None
+            if routable
+            and it.kind == "locate"
+            and it.kwargs.get("axes") is None
+            # Z-plan holes only — render_locations places X/Y position dims. A side-drilled
+            # (X/Y-axis) bore's location is a different pass (off_axis_loc_ids below).
+            and getattr(getattr(it.feature, "frame", None), "axis", None) == "z"
+        }
+        # Side-drilled (X/Y-axis) hole locations (#133/#426): a separate whole-model pass
+        # (_locate_off_axis_holes), placed at the shared drain like the Z-plan corridor —
+        # not render_locations (Z-only, #133) and never live-replayed (add_feature_location
+        # raises on non-Z; the intent is routed here before it can reach that verb).
+        off_axis_loc_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and it.kind == "locate"
+            and it.kwargs.get("axes") is None
+            and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "y")
         }
         callout_ids = {
             id(it)
@@ -1301,6 +1319,7 @@ class Drawing:
             explicit_envelope_height=explicit_envelope_height,
             user_dim_ids=user_dim_ids,
             rotational_ids=rotational_ids,
+            off_axis_loc_ids=off_axis_loc_ids,
             only_loc=only_loc,
             pinned_loc=pinned_loc,
             only_callout=only_callout,
@@ -1487,7 +1506,11 @@ class Drawing:
             render_step_lengths,
             render_step_positions,
         )
-        from draftwright.annotations.holes import _annotate_holes, build_view_of_axis
+        from draftwright.annotations.holes import (
+            _annotate_holes,
+            _locate_off_axis_holes,
+            build_view_of_axis,
+        )
         from draftwright.annotations.orchestrator import (
             _maybe_tabulate_holes,
             drain_and_reconcile,
@@ -1538,6 +1561,7 @@ class Drawing:
                 | r.step_position_ids
                 | r.user_dim_ids
                 | r.rotational_ids  # drained by _s_rotational; no _replay_intent branch
+                | r.off_axis_loc_ids  # drained by the off-axis stages; locate() raises on non-Z
             )
             i = 0
             while i < len(self._intents):
@@ -1576,6 +1600,22 @@ class Drawing:
             if r.only_loc:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
                 render_locations(self, model, a, ctx=ctx, only=r.only_loc, pinned=r.pinned_loc)
+
+        def _s_off_axis_across():
+            # Side-drilled holes' in-plane (side-below) locations — REGISTER-only, whole-model
+            # (_locate_off_axis_holes reads the IR's X/Y holes, no only= subset); they place at
+            # the shared drain. Whole-model like the auto pass: commenting SOME dwg.locate lines
+            # still redraws every side-drilled location; commenting them ALL empties the bucket.
+            if r.off_axis_loc_ids:
+                assert a is not None
+                _locate_off_axis_holes(self, ctx, a, which="across")
+
+        def _s_off_axis_along():
+            # Side-drilled (X/Y-axis) hole HEIGHT locations — register-only, placed at the drain
+            # (mirrors the auto pass's off_axis_along stage; after the envelope candidates).
+            if r.off_axis_loc_ids:
+                assert a is not None
+                _locate_off_axis_holes(self, ctx, a, which="along")
 
         def _s_height_ladder():
             # Prismatic step-height ladder through the auto-pass renderer. (#636) This
@@ -1648,6 +1688,7 @@ class Drawing:
             # shared verbatim with the auto-pass (drain_and_reconcile).
             if (
                 r.only_loc
+                or r.off_axis_loc_ids
                 or r.slot_feats
                 or r.user_dim_ids
                 or r.step_position_ids
@@ -1661,6 +1702,7 @@ class Drawing:
                 if id(it)
                 not in (
                     r.corridor_ids
+                    | r.off_axis_loc_ids
                     | r.slot_ids
                     | queued_dim_ids
                     | r.step_position_ids
@@ -1720,6 +1762,8 @@ class Drawing:
         run_stages(
             {
                 "rotational": _s_rotational,
+                "off_axis_across": _s_off_axis_across,
+                "off_axis_along": _s_off_axis_along,
                 "reserve_section": _s_reserve_section,
                 "live_replay": _s_live_replay,
                 "hole_callouts": _s_hole_callouts,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6439,9 +6439,13 @@ class TestFeatureEdits:
         self._reconstruct(dwg)  # many callout(step) calls — none may raise "no room"
         dwg.repair()  # the script must reach repair(), not abort before it
 
-    def test_generated_script_flags_side_drilled_locate_as_a_comment(self):
-        # #427 review F1: the emitted --script must gate dwg.locate(f) on a Z-axis hole —
-        # a side-drilled bore gets a flagged comment, not a bare locate() that would crash.
+    def test_generated_script_emits_locate_for_side_drilled_holes(self):
+        # #426/#133 (supersedes the #427 F1 gap comment): the emitter now records
+        # dwg.locate(f) for a side-drilled bore too. Safe because locate()'s deferred
+        # branch records the intent WITHOUT the Z-axis check, and finalize routes the
+        # off-axis location to the whole-model _locate_off_axis_holes pass — never the
+        # Z-only live verb (which still raises). End-to-end execution + the dim_loc_*
+        # parity is covered by test_generated_script_matches_direct_side_drilled_locations.
         import tempfile
         from pathlib import Path
 
@@ -6454,7 +6458,8 @@ class TestFeatureEdits:
             step = Path(d) / "sd.step"
             export_step(part, str(step))
             content = Path(generate_script(str(step), out=str(Path(d) / "sd"))).read_text()
-        assert "locate() is Z-axis only" in content  # the gate fired, no bare locate() crash
+        assert "locate() is Z-axis only" not in content  # the old gap comment is gone
+        assert "dwg.locate(f)" in content  # the side-drilled location is now reconstructed
 
     def test_intent_reconstruction_comment_drops_exactly_that(self):
         # #400 Ph2 soft acceptance: commenting one verb line drops exactly that annotation.

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -142,10 +142,6 @@ def test_generated_script_matches_direct_turned_head_detail(tmp_path):
 
 
 @pytest.mark.timeout(240)
-@pytest.mark.xfail(
-    strict=True,
-    reason="non-Z hole location dimensions are still auto-pass-only in generated scripts",
-)
 def test_generated_script_matches_direct_side_drilled_locations(tmp_path):
     """Compare actual location annotations, not only the emitter's gap comment."""
     part = (


### PR DESCRIPTION
## What

The **last** direct-vs-generated-script parity gap of #426. A side-drilled (X/Y-axis) bore gets `dim_loc_*` position dims in the direct build, but the imperative `--script` emitter emitted a gap comment instead of `dwg.locate(f)` for non-Z holes — because `locate()`/`render_locations` are Z-plan only (#133). Strict xfail `test_generated_script_matches_direct_side_drilled_locations`.

## How

Same shape as the rotational fix (#762): the machinery already existed. `_locate_off_axis_holes` (`annotations/holes.py`) is a **whole-model** pass that already draws the X/Y/Z side-drilled witness/datum geometry, and `_PASS_SEQUENCE` already lists the `off_axis_across`/`off_axis_along` slots. Wired into finalize:

- emitter emits **`dwg.locate(f)` for holes on any axis** (drop the gap comment).
- `_classify_intents` restricts `corridor_ids` to **Z-axis** locates, adds **`off_axis_loc_ids`** for X/Y; two **`_s_off_axis_{across,along}`** drain stages call `_locate_off_axis_holes` (register-only → placed at the shared drain); **routed out of `_s_live_replay`** so `add_feature_location`'s Z-only `ValueError` is never hit (`locate()`'s *deferred* branch records without the axis check); gated + dropped in `_s_drain` with the #639 retry-safety pattern.

The Z-only `locate()` **live** contract (#133) is untouched — side-drilled locates route to the off-axis stages before they can reach the live verb.

## Verification

- Strict xfail now **passes**; the parity suite is **0 xfailed** (both #426 gaps closed).
- 145-test regression sweep green; the one #427-F1 gap-comment test updated to assert the new `locate()` emission.
- lint ×4 clean; import-boundary / encapsulation / private-import guards pass; auto-pass path untouched.

With #762, this **closes #426** (the two remaining reconstruction gaps). Refs #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)