### PR TITLE
feat(#764): first-class thread/tap callout on holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@
   `Sheet.dimension()`, extracted so `build_drawing(model=…)` callers can author
   a pre-measured drafting dimension without the `Sheet` façade.
 
+### Added
+
+- **First-class thread/tap callout on a hole** (#764): ``sheet.hole(...).thread("M3x0.5")``
+  (and ``declare.hole(..., thread=)``) folds a tap/thread spec onto the hole's existing
+  compound leader (e.g. ``ø2.5 THRU M3x0.5``) — a structured aspect that round-trips, so
+  ``.thread(...).finish(...)`` yields Ra-on-thread. A declaration-only aspect (ADR 0011
+  side-layer: threads are cosmetic, not modelled geometry — no recogniser). The layout
+  width estimator (``_est_planned_bore_callout_width``) now accounts for the thread text so
+  the wider callout is reserved room and not dropped (the #261 estimator/render agreement).
+
 ### Fixed
 
 - **Generated imperative script reconstructs side-drilled hole locations**

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -116,6 +116,12 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
             suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
         elif feat.pattern == "grid" and feat.rows and feat.cols:
             suffix = f"({feat.rows}×{feat.cols})"
+    # A thread spec (#764) folds onto the compound callout — it lives on the bore hole
+    # (the pattern's member for a threaded array). Lead with it (the tap/thread is the
+    # defining call), then any pattern suffix: e.g. "M3x0.5" or "M3x0.5 EQ SP ON ø50 BC".
+    hole = feat.member if isinstance(feat, PatternFeature) else feat
+    thread = getattr(hole, "thread", None)
+    suffix = " ".join(p for p in (thread, suffix) if p) or None
     return {
         "diameter": bore,
         "count": count if count and count > 1 else None,

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -252,6 +252,12 @@ def _est_planned_bore_callout_width(
                 suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
             elif getattr(feat, "pattern", None) == "grid" and feat.rows and feat.cols:
                 suffix = f"({feat.rows}×{feat.cols})"
+        # The thread spec (#764) widens the callout — mirror hole_callout_spec so the strip
+        # reservation matches the rendered width (the #261 estimator/render agreement), else a
+        # threaded callout is reserved too narrow and dropped for "no room beside the view".
+        hole = getattr(feat, "member", feat)
+        thread = getattr(hole, "thread", None)
+        suffix = " ".join(p for p in (thread, suffix) if p) or None
 
         token_w: list[float] = []
         count = getattr(feat, "count", None)

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -219,6 +219,7 @@ def hole(
     cbore=None,
     spotface=None,
     csink=None,
+    thread=None,
     count=1,
     members=(),
 ) -> HoleFeature:
@@ -227,7 +228,8 @@ def hole(
 
     ``cbore`` / ``spotface`` are ``(diameter, depth)`` pairs; ``csink`` is a
     ``(major_diameter, included_angle)`` pair (a flat-head seat, callout ``⌵ Ø.. × ..°``);
-    ``count`` + ``members`` describe a machining-spec group drawn as one ``count×`` callout.
+    ``thread`` is a tap/thread spec string (e.g. ``"M3x0.5"``) folded onto the callout
+    (#764); ``count`` + ``members`` describe a machining-spec group drawn as one ``count×``.
 
     An object supplies *defaults*; any explicit keyword overrides that field (#451)."""
     if obj is not None:
@@ -254,6 +256,7 @@ def hole(
         cbore=cbore,
         spotface=spotface,
         csink=csink,
+        thread=thread,
     )
 
 

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -130,6 +130,10 @@ class HoleFeature:
     # A countersink (flat-head screw seat): ``(major_diameter, included_angle°)`` or
     # ``None`` — plain tuple, the IR stays decoupled from the recogniser's type (#558).
     csink: tuple[float, float] | None = None
+    # A thread spec (tap/thread), e.g. ``"M3x0.5"`` — free text folded onto the hole's
+    # compound callout (#764). A declaration-only aspect (ADR 0011 side-layer): threads
+    # are cosmetic, rarely modelled as geometry, so there is no recogniser — declare + emit.
+    thread: str | None = None
     kind: ClassVar[str] = "hole"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -27,11 +27,11 @@ slots, patterns, the overall envelope, and the auto section — plus the P2a
 #479 — which derive their target view/strip from the referenced feature or planar face), and
 **``sheet.table()``** / **``sheet.notes()``** corner-block tables (notes / revision / BOM /
 schedule, over the engine's auto-placed ``Drawing.add_table``, #488), and **``sheet.note()``** /
-**``.note()``** anchored free-text manufacturing-note leaders (thread specs, ``DEBURR``,
-chip-relief, knurl — the shop callouts detection can't infer, placed via the GD&T corridor
-machinery, #488). The remaining #445 aspect verb that still needs wiring — a structured
-``.thread`` — is deliberately **not** stubbed here yet, so the surface only exposes what
-actually draws.
+**``.note()``** anchored free-text manufacturing-note leaders (``DEBURR``, chip-relief,
+knurl — the shop callouts detection can't infer, placed via the GD&T corridor machinery,
+#488), and the structured **``.thread``** aspect (#764/#445 — a tap/thread spec folded onto
+the hole's own compound callout, so it round-trips and ``.thread(...).finish(...)`` gives
+Ra-on-thread; a declaration-only aspect, no recogniser).
 
 **Hybrid.** :meth:`Sheet.from_part` seeds the declared set from *detection*, so you
 can start from the detected model and override specific features (declaration is for
@@ -188,6 +188,15 @@ class _Hole:
         # same positivity guard declare.hole() applies to cbore/spotface (#452/#462 review)
         _require_positive(**{f"{kind} diameter": diameter, f"{kind} depth": depth})
         return (diameter, depth)
+
+    def thread(self, spec: str) -> _Hole:
+        """A thread/tap spec folded onto this hole's callout (#764). ``.thread("M3x0.5")``
+        renders the tap/thread on the bore leader (e.g. ``ø2.5 THRU M3x0.5``) — a structured
+        aspect that round-trips, so ``.thread(...).finish(...)`` gives Ra-on-thread. A
+        declaration-only aspect (threads are cosmetic, not modelled geometry — no recogniser)."""
+        if not (isinstance(spec, str) and spec.strip()):
+            raise ValueError('thread() needs a non-empty spec string, e.g. "M3x0.5"')
+        return self._set(thread=spec.strip())
 
     def finish(self, ra, *, view: str | None = None, side: str | None = None) -> _Hole:
         """A surface-finish symbol (Ra) on this hole's bore (ADR 0011 P2c). ``.finish("1.6")``

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -854,6 +854,64 @@ class TestCountersink:
             hole(diameter=6, at=(0, 0, 0), axis="z", csink=(14, 200))
 
 
+class TestThread:
+    """#764: a first-class thread/tap callout on a hole — an ADR-0011 declaration-only
+    aspect (threads are cosmetic, not modelled geometry, so declare + emit, no recogniser).
+    It rides the EXISTING hole compound leader (like csink) rather than a new placement path."""
+
+    def test_declare_and_fluent_carry_the_thread(self):
+        h = hole(diameter=2.5, at=(0, 0, 6), axis="z", through=True, thread="M3x0.5")
+        assert h.thread == "M3x0.5"
+        s = Sheet(Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(1.25, 12))
+        s.hole(diameter=2.5, at=(0, 0, 6), axis="z").thread("M3x0.5")
+        assert s._features[0].thread == "M3x0.5"
+
+    def test_empty_spec_rejected(self):
+        s = Sheet(Box(30, 30, 12))
+        with pytest.raises(ValueError):
+            s.hole(diameter=2.5, at=(0, 0, 6), axis="z").thread("  ")
+
+    def test_thread_folds_into_the_callout_and_is_not_dropped(self):
+        # The thread widens the callout; if the strip estimator did not reserve for it the
+        # callout would drop for "no room beside the view" (the #261 estimator/render
+        # agreement). Assert it renders, lint is clean, and the spec carries the thread.
+        from draftwright.annotations.from_model import hole_callout_spec
+        from draftwright.model import plan_dimensions
+
+        part = Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(1.25, 12)
+        dwg = build_drawing(
+            part,
+            model=[hole(diameter=2.5, at=(0, 0, 6), axis="z", through=True, thread="M3x0.5")],
+            number="X",
+        )
+        assert [n for n in dwg.annotations() if n.startswith("hc_")]  # rendered, not dropped
+        assert dwg.lint_summary()["by_code"].get("callout_dropped", 0) == 0
+        g = next(
+            g for g in plan_dimensions(dwg.model()) if getattr(g.feature, "kind", None) == "hole"
+        )
+        assert "M3x0.5" in (hole_callout_spec(g)["suffix"] or "")
+
+    def test_estimator_matches_the_rendered_width(self):
+        # The #261 invariant made explicit: the layout-tier width estimate must be >= the
+        # rendered callout width, or placement drops. This is the guard that would have
+        # caught the estimator missing the thread suffix.
+        from draftwright.annotations.from_model import callout_from_spec, hole_callout_spec
+        from draftwright.compose import _est_planned_bore_callout_width
+        from draftwright.model import plan_dimensions
+
+        part = Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(1.25, 12)
+        dwg = build_drawing(
+            part,
+            model=[hole(diameter=2.5, at=(0, 0, 6), axis="z", through=True, thread="M3x0.5")],
+            number="X",
+        )
+        groups = list(plan_dimensions(dwg.model()))
+        g = next(gg for gg in groups if getattr(gg.feature, "kind", None) == "hole")
+        rendered = callout_from_spec(hole_callout_spec(g), dwg.draft, None).callout_width
+        estimated = _est_planned_bore_callout_width(groups, dwg.draft)
+        assert estimated >= rendered  # estimator reserves at least the rendered width
+
+
 class TestPlate:
     """#577: declare a thin slab's thickness — the third ADR-0011 surface for #559."""
 


### PR DESCRIPTION
## What

Closes #764 (first #488 manufacturing-concepts child). `sheet.hole(...).thread("M3x0.5")` (and `declare.hole(..., thread=)`) folds a tap/thread spec onto the hole's **existing** compound leader (e.g. `ø2.5 THRU M3x0.5`). Threads are the most common shop callout (M2 tap, M3 thread, Ra-on-thread) and were previously only free text via `note()`.

## Design (per the architecture-cleanliness discipline)
- **Tier:** a declaration-only **ADR 0011 aspect** — threads are cosmetic, not modelled geometry, so a `HoleFeature` **field** (like `csink`), **no recogniser**, **no new placement path**. Structured (not sugar-over-note) so it round-trips and `.thread(...).finish(...)` gives **Ra-on-thread** for free.
- **Rides existing machinery:** folded into the hole callout `suffix`; no new corridor candidate.
- **The #261 estimator/render agreement:** the thread widens the callout, so `compose._est_planned_bore_callout_width` folds in the **same** thread text — without it the wider callout is reserved too narrow and dropped for 'no room beside the view' (csink already did this; the single-hole suffix path did not). A test asserts `estimated >= rendered` as a standing guard.

## Changes
- `ir.HoleFeature.thread`; `declare.hole(thread=)`; `_Hole.thread()` verb (validates non-empty).
- `hole_callout_spec` folds thread (+ any pattern suffix) into the callout suffix.
- `_est_planned_bore_callout_width` mirrors it.

## Verification
- New `TestThread`: declare/fluent set + validation; renders and is **not dropped**; spec carries the thread; **estimator ≥ rendered width** guard.
- 90-test regression (holes/callouts/compose/scale/parity) green; prismatic/detected parts unaffected (`thread=None` ⇒ suffix unchanged). lint ×4 + import/encapsulation/recogniser guards clean.

Refs #488, #445, #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)