### PR TITLE
feat(#766): standing ISO 7200 title-block fields (material/date/revision/company)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@
 
 ### Added
 
+- **Standing ISO 7200 title-block fields** (#766): `material`, `date`, `revision`,
+  and `company` (legal owner) are now first-class — settable on `build_drawing` /
+  `make_drawing`, the `Sheet(...)` constructor, and the CLI (`--material` /
+  `--date` / `--revision` / `--company`), and emitted into the generated `Sheet`
+  script when non-default so a re-run reproduces them. Defaults preserve the prior
+  output (revision `A`, the rest blank). The `revision`/`legal_owner` cells the
+  renderer previously hardcoded now flow from these. (The imperative `--script`
+  flavour's title-block round-trip of these fields is a follow-up.)
 - **First-class thread/tap callout on a hole** (#764): ``sheet.hole(...).thread("M3x0.5")``
   (and ``declare.hole(..., thread=)``) folds a tap/thread spec onto the hole's existing
   compound leader (e.g. ``ø2.5 THRU M3x0.5``) — a structured aspect that round-trips, so

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -704,6 +704,13 @@ class Analysis:
     out: str
     pmi: list
     pmi_mode: str
+    # Standing ISO 7200 title-block fields (#766) — defaulted, so they sit after the
+    # non-default fields above. Defaults preserve the prior output: revision "A", the rest
+    # blank (the TitleBlock helper's own defaults).
+    material: str = ""
+    date: str = ""
+    revision: str = "A"
+    company: str = ""
     # The PartModel built by _analyse's pre-scale sizing pass (#584 WP1 A) — stored so
     # the render path reuses it instead of re-running the detectors (ADR 0008 Amdt 5:
     # one inventory, detected once; #602). Typed `object` to keep _core free of a
@@ -741,8 +748,10 @@ def _make_title_block(dwg, a: Analysis):
         scale=format_drawing_scale(a.SCALE),
         general_tolerance=a.tolerance,
         designed_by=_attribution_author(a.drawn_by),
-        revision="A",
-        legal_owner="",
+        material=a.material,
+        date=a.date,
+        revision=a.revision,
+        legal_owner=a.company,
         width=a.TB_W,
         # Title block renders in condensed sans (the tight ISO 7200 cells), a
         # different face from the monospace dimensions — so it carries its own

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -470,6 +470,10 @@ def _analyse(
     pmi="off",
     model=None,
     decorations=None,
+    material="",
+    date="",
+    revision="A",
+    company="",
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -770,6 +774,10 @@ def _analyse(
         number=number,
         tolerance=tolerance,
         drawn_by=drawn_by,
+        material=material,
+        date=date,
+        revision=revision,
+        company=company,
         out=out,
         pmi=pmi_records,
         pmi_mode=pmi,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -599,6 +599,10 @@ def build_drawing(
     model: Sequence[Feature] | PartModel | None = None,
     decorations: dict | None = None,
     trace: str | Path | bool | None = None,
+    material: str = "",
+    date: str = "",
+    revision: str = "A",
+    company: str = "",
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -682,6 +686,10 @@ def build_drawing(
         pmi=pmi,
         model=model,
         decorations=decorations,
+        material=material,
+        date=date,
+        revision=revision,
+        company=company,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real
@@ -742,6 +750,10 @@ def make_drawing(
     detail_view: bool = False,
     pmi: Literal["off", "report", "annotate"] = "off",
     assembly: bool | None = None,
+    material: str = "",
+    date: str = "",
+    revision: str = "A",
+    company: str = "",
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -783,6 +795,10 @@ def make_drawing(
         detail_view=detail_view,
         pmi=pmi,
         assembly=assembly,
+        material=material,
+        date=date,
+        revision=revision,
+        company=company,
     ).export()
     assert svg_path is not None and dxf_path is not None  # export() writes both by default
     return svg_path, dxf_path

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -102,6 +102,10 @@ def main(
     number: str = typer.Option("DWG-001", help="Drawing number"),
     tolerance: str = typer.Option("ISO 2768-m", help="General tolerance"),
     drawn_by: str = typer.Option("", "--drawn-by", help="Designer name"),
+    material: str = typer.Option("", help="Material for the title block"),
+    date: str = typer.Option("", help="Date for the title block"),
+    revision: str = typer.Option("A", help="Revision for the title block"),
+    company: str = typer.Option("", help="Company / legal owner for the title block"),
     scale: float | None = typer.Option(
         None, help="Drawing-scale override, e.g. 5 for 5:1 or 0.5 for 1:2 (default: auto)"
     ),
@@ -178,6 +182,10 @@ def main(
                     drawn_by=drawn_by,
                     scale=scale,
                     page=page,
+                    material=material,
+                    date=date,
+                    revision=revision,
+                    company=company,
                     part_expr=seam,
                     formats=tuple(formats),
                 )
@@ -191,6 +199,10 @@ def main(
                     drawn_by=drawn_by,
                     scale=scale,
                     page=page,
+                    material=material,
+                    date=date,
+                    revision=revision,
+                    company=company,
                     pmi=pmi.value,
                     formats=tuple(formats),
                 )
@@ -226,6 +238,10 @@ def main(
         scale=scale,
         page=page,
         pmi=pmi.value,
+        material=material,
+        date=date,
+        revision=revision,
+        company=company,
     )
     for path in _emit(dwg, formats):
         print(path)

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -358,6 +358,10 @@ class Sheet:
         scale=None,
         page=None,
         out=None,
+        material=None,
+        date=None,
+        revision=None,
+        company=None,
     ):
         self._part = part
         self._features: list = []
@@ -381,6 +385,16 @@ class Sheet:
             self._opts["drawn_by"] = drawn_by
         if tolerance is not None:
             self._opts["tolerance"] = tolerance
+        # Standing ISO 7200 title-block fields (#766) — forward only when set, so an unset
+        # value keeps build_drawing's defaults ("" / revision "A").
+        for _k, _v in (
+            ("material", material),
+            ("date", date),
+            ("revision", revision),
+            ("company", company),
+        ):
+            if _v is not None:
+                self._opts[_k] = _v
 
     @classmethod
     def from_part(cls, part, **opts) -> Sheet:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -254,6 +254,10 @@ def emit_sheet_script(
     tolerance: str = "ISO 2768-m",
     scale=None,
     page=None,
+    material: str = "",
+    date: str = "",
+    revision: str = "A",
+    company: str = "",
     formats: Sequence[str] = ("pdf",),
 ) -> str:
     """The generated declarative ``Sheet`` script text for a detected *model*.
@@ -287,6 +291,14 @@ def emit_sheet_script(
         ctor.append(f"scale={scale!r}")
     if page is not None:
         ctor.append(f"page={page!r}")
+    if material:
+        ctor.append(f"material={material!r}")
+    if date:
+        ctor.append(f"date={date!r}")
+    if revision != "A":  # "A" is build_drawing's own default
+        ctor.append(f"revision={revision!r}")
+    if company:
+        ctor.append(f"company={company!r}")
     lines = [
         _HEADER,
         "from draftwright import Sheet",
@@ -431,6 +443,10 @@ def generate_sheet_script(
     drawn_by: str = "",
     scale=None,
     page=None,
+    material: str = "",
+    date: str = "",
+    revision: str = "A",
+    company: str = "",
     pmi: str = "off",
     part_expr: str | None = None,
     formats: Sequence[str] = ("pdf",),
@@ -474,6 +490,10 @@ def generate_sheet_script(
         tolerance=tolerance,
         scale=scale,
         page=page,
+        material=material,
+        date=date,
+        revision=revision,
+        company=company,
         formats=formats,
     )
     py_path = f"{stem}.py"

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1089,6 +1089,46 @@ class TestRoundTripParity:
 
         assert aspects(scripted) == aspects(direct)
 
+    def test_standing_title_block_fields_round_trip(self, tmp_path, monkeypatch):
+        # #766: material/date/revision/company thread through build_drawing and the emitted
+        # Sheet script reproduces them (like #474's drawn_by/tolerance). Defaults preserve
+        # the prior output: revision "A", the rest blank.
+        from draftwright import Sheet
+
+        flags = dict(material="STEEL", date="2026-07-20", revision="B", company="ACME")
+        step = tmp_path / "part.step"
+        export_step(_plate(), str(step))
+        direct = build_drawing(step_file=str(step), title="PART", **flags)
+        assert (direct._analysis.material, direct._analysis.revision) == ("STEEL", "B")
+        # defaults unchanged on a plain build (revision "A", the rest blank)
+        plain = build_drawing(step_file=str(step), title="PART")
+        assert (plain._analysis.material, plain._analysis.revision, plain._analysis.company) == (
+            "",
+            "A",
+            "",
+        )
+
+        captured = {}
+        monkeypatch.setattr(
+            Sheet, "export", lambda self, stem=None: captured.setdefault("dwg", self.build())
+        )
+        py = generate_sheet_script(str(step), out=str(tmp_path / "gen"), title="PART", **flags)
+        # the emitted ctor carries the non-default fields
+        ctor = next(
+            line
+            for line in open(py, encoding="utf-8").read().splitlines()
+            if line.startswith("sheet = Sheet(")
+        )
+        assert "material='STEEL'" in ctor and "revision='B'" in ctor and "company='ACME'" in ctor
+        exec(compile(open(py, encoding="utf-8").read(), py, "exec"), {})
+        scripted = captured["dwg"]
+
+        def fields(dwg):
+            a = dwg._analysis
+            return (a.material, a.date, a.revision, a.company)
+
+        assert fields(scripted) == fields(direct) == ("STEEL", "2026-07-20", "B", "ACME")
+
     def test_grm03_vendored_fixture_full_parity(self, tmp_path, monkeypatch):
         # #707: GRM-03 (the Maquetto thumbwheel drive screw) is the real STEP that
         # surfaced "emitted Sheet != direct CLI drawing" against 0.3.3. #709 (format


### PR DESCRIPTION
## What

Closes #766. `material` / `date` / `revision` / `company` (legal owner) are now first-class title-block fields. The `TitleBlock` helper already accepts them, but draftwright wired only a subset and **hardcoded** `revision='A'` / `legal_owner=''`. These are the fields most needed to reproduce a real company drawing.

## How (extends the #474 threading pattern across the stack)
- **`_core.py`**: 4 defaulted `Analysis` fields (placed after the non-default fields — a dataclass-ordering fix); `_make_title_block` passes them, replacing the hardcoded `revision`/`legal_owner`.
- **`analysis._analyse` / `build_drawing` / `make_drawing`**: new params (defaults preserve prior output — `revision='A'`, rest blank).
- **CLI**: `--material` / `--date` / `--revision` / `--company`.
- **`Sheet(...)`**: kwargs, forwarded only when set (like #474's `drawn_by`).
- **`sheet_emit`**: emits them into the generated `Sheet(...)` ctor when non-default, so a re-run reproduces them.

## Verification
- New `test_standing_title_block_fields_round_trip`: thread-through + defaults-unchanged + the emitted ctor carries the fields + the executed script reproduces the Analysis.
- 100-test title-block/emit regression green — **default output unchanged** (`revision='A'`). lint ×4 clean.

## Scope note
This closes #766 for the **API + CLI + Sheet-script** surfaces. The **imperative** `--script` flavour bakes config fields into a template block differently — its title-block round-trip of these four fields is a small follow-up (I'll file it). #769 (projection symbol) is **not** here: drafting-helpers has no projection glyph, so it's net-new rendering that batches with #767 (frame), not this field-threading PR.

Refs #474, #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)