### PR TITLE
feat(#765): knurl callout verb on the diameter handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@
 
 ### Added
 
+- **Knurl callout verb** (#765): `sheet.diameter(shaft).knurl("0.8")` →
+  `KNURL 0.8 STRAIGHT` (or `.knurl("0.8", "DIAMOND")`). Named sugar over
+  `.note()` with canonical formatting — a knurl is a text callout on a leader,
+  not modelled geometry, so it flows through the existing note path (no new
+  IR/render).
 - **Standing ISO 7200 title-block fields** (#766): `material`, `date`, `revision`,
   and `company` (legal owner) are now first-class — settable on `build_drawing` /
   `make_drawing`, the `Sheet(...)` constructor, and the CLI (`--material` /

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -254,6 +254,18 @@ class _Dim:
         self._sheet._gdt_note(text, self._i, view=view, side=side)
         return self
 
+    def knurl(
+        self, pitch, pattern: str = "STRAIGHT", *, view: str | None = None, side: str | None = None
+    ) -> _Dim:
+        """A knurl callout on this diameter (#765) — ``diameter(shaft).knurl("0.8")`` →
+        ``KNURL 0.8 STRAIGHT``, or ``.knurl("0.8", "DIAMOND")``. Named sugar over :meth:`note`
+        (canonical formatting + discoverability): knurl is a text callout on a leader, not
+        modelled geometry, so no IR/render — it flows through the same note path. ``view``/
+        ``side`` override the derived strip."""
+        text = f"KNURL {pitch} {pattern}".strip()
+        self._sheet._gdt_note(text, self._i, view=view, side=side)
+        return self
+
 
 class _Control:
     """A fluent GD&T feature-control-frame builder (ADR 0011 P2c.2). One method per ISO 1101

--- a/tests/test_sheet_notes.py
+++ b/tests/test_sheet_notes.py
@@ -54,6 +54,20 @@ def test_dim_handle_note():
     assert nt.text == "KNURL 0.8 STRAIGHT" and nt.view == "plan"
 
 
+def test_dim_handle_knurl():
+    # #765: knurl() is sugar over note() with canonical KNURL formatting.
+    part = _part()
+    s = Sheet(part)
+    s.diameter(Pos(30, 0, 0) * Cylinder(8, 20)).knurl("0.8")
+    nt = next(f for f in s.features if f.kind == "note")
+    assert nt.text == "KNURL 0.8 STRAIGHT" and nt.view == "plan"
+
+    s2 = Sheet(part)
+    s2.diameter(Pos(30, 0, 0) * Cylinder(8, 20)).knurl("0.5", "DIAMOND")
+    nt2 = next(f for f in s2.features if f.kind == "note")
+    assert nt2.text == "KNURL 0.5 DIAMOND"
+
+
 def test_view_side_overrides_win():
     part = _part()
     s = Sheet(part)


### PR DESCRIPTION
Closes #765. `sheet.diameter(shaft).knurl("0.8")` → `KNURL 0.8 STRAIGHT` (or `.knurl("0.8", "DIAMOND")`). Named **sugar over `.note()`** with canonical formatting — a knurl is a text callout on a leader, not modelled geometry, so it flows through the existing `_gdt_note` path (no new IR/render, no new placement). Test mirrors the existing `test_dim_handle_note`.

Refs #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)