### PR TITLE
feat(#770/#771): object-reference script workflow — docs + inline tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@
 
 ### Added
 
+- **Object-reference script workflow: docs + an inline tip** (#770/#771): a
+  generated `Sheet` script from a **live-source** input (a `module:attr` /
+  `file.py:attr` object spec, or a build123d object) now carries an inline tip
+  showing how to swap each detected-numbers line for a reference to your object
+  (ADR 0011 declare — the size is read off the object). A STEP-sourced script is
+  unchanged (byte-stable — no object to reference). The README documents the full
+  from-a-part-to-an-object-referenced-script workflow.
 - **Knurl callout verb** (#765): `sheet.diameter(shaft).knurl("0.8")` →
   `KNURL 0.8 STRAIGHT` (or `.knurl("0.8", "DIAMOND")`). Named sugar over
   `.note()` with canonical formatting — a knurl is a text callout on a leader,

--- a/README.md
+++ b/README.md
@@ -100,11 +100,40 @@ sheet.export("plate")                                     # writes plate.pdf
 Every aspect the geometry can't carry is a declared verb: `.tolerance(±)` / `.fit("H7")`
 (ISO 286), `.finish("Ra")` (ISO 1302), `sheet.datum(letter, ref)` (ISO 5459), and
 `sheet.control(ref)` with all 14 ISO 1101 characteristics
-(`.position`/`.flatness`/`.perpendicularity`/`.circular_runout`/…), plus `sheet.note(text, ref)`
-/ `.note(text)` for free-text shop callouts (thread specs, `DEBURR`, knurl). A feature verb returns
+(`.position`/`.flatness`/`.perpendicularity`/`.circular_runout`/…), plus `.thread("M3x0.5")`
+(a tap/thread spec folded onto the hole callout), `.knurl("0.8")`, and `sheet.note(text, ref)`
+/ `.note(text)` for any other free-text shop callout (`DEBURR`, chip-relief). A feature verb returns
 a chainable handle (`sheet.hole(bore)`) that the aspect and `control(...)` verbs decorate;
 targets are placed automatically — the view and strip are derived from the referenced
 feature or face, with `view=`/`side=` overrides.
+
+### From a part to an object-referenced script
+
+`draftwright part.step --script` writes an editable `Sheet` script. When you built the part
+yourself (rather than importing a STEP), pass your **live source** as a `module:attr` (or
+`file.py:attr`) object spec, and the script binds `part` back to your real object:
+
+```bash
+draftwright mymodule:thumbwheel --script
+```
+
+The emitted values are *detected* off the geometry — honest, and a good starting point. Since
+you have the objects, swap each numbered line for a reference so the object stays the single
+source of truth (ADR 0011 — the size is read off the object, no numbers restated):
+
+```python
+# generated (detected):
+sheet.step(diameter=8, length=25, at=(0, 0, 12), axis="z")
+
+# edited to reference your objects:
+features = mymodule.thumbwheel_features()
+part = features.part
+sheet.step(features.journal)
+sheet.hole(features.m3_bore).thread("M3x0.5").finish("1.6")   # tapped + Ra on the same hole
+```
+
+An object-sourced script carries an inline tip pointing at exactly this edit; a STEP-sourced
+script keeps the detected numbers (there's no object to reference).
 
 ## What it produces
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -258,6 +258,7 @@ def emit_sheet_script(
     date: str = "",
     revision: str = "A",
     company: str = "",
+    object_ref: bool = False,
     formats: Sequence[str] = ("pdf",),
 ) -> str:
     """The generated declarative ``Sheet`` script text for a detected *model*.
@@ -313,6 +314,18 @@ def emit_sheet_script(
         f"sheet = Sheet(part, {', '.join(ctor)})",
         "",
         "# ── Features (each line is one declared feature) ──────────────────────────────",
+        # For a live-source part (#771), the values below were read off YOUR objects — point
+        # each line back at the object to keep it a single source of truth (a STEP-sourced
+        # script has no such objects, so this note is emitted only for object inputs).
+        *(
+            [
+                "# Object-reference tip: you built these objects, so swap a numbered arg for the",
+                "# object itself to read the size off it — e.g.  sheet.step(journal)  /",
+                "#  sheet.hole(m3_bore).thread('M3x0.5')  — no numbers restated (ADR 0011 declare).",
+            ]
+            if object_ref
+            else []
+        ),
         *(_feature_line(f) for f in model.features),
         "",
         "# ── Views ─────────────────────────────────────────────────────────────────────",
@@ -494,6 +507,7 @@ def generate_sheet_script(
         date=date,
         revision=revision,
         company=company,
+        object_ref=is_shape,  # a live Shape / resolved object-spec has objects to reference (#771)
         formats=formats,
     )
     py_path = f"{stem}.py"

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -593,11 +593,11 @@ class TestObjectSpec:
         # object-reference idiom; a STEP-sourced script does NOT — the numbers ARE the honest
         # source and there are no objects to reference (keeps STEP scripts byte-stable).
         py = generate_sheet_script(Box(60, 40, 12), out=str(tmp_path / "shape"))
-        assert "Object-reference tip" in Path(py).read_text()
+        assert "Object-reference tip" in Path(py).read_text(encoding="utf-8")
         step = tmp_path / "p.step"
         export_step(Box(60, 40, 12), str(step))
         py2 = generate_sheet_script(str(step), out=str(tmp_path / "step"))
-        assert "Object-reference tip" not in Path(py2).read_text()
+        assert "Object-reference tip" not in Path(py2).read_text(encoding="utf-8")
 
     def test_zero_arg_factory_is_called(self, tmp_path):
         p = self._mod(tmp_path)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -588,6 +588,17 @@ class TestObjectSpec:
         assert "spec_from_file_location(" in seam and repr(str(p.resolve())) in seam
         assert "part = _mod.bracket" in seam
 
+    def test_object_input_emits_object_reference_tip(self, tmp_path):
+        # #771: a live-source (Shape) input gets a discoverability tip pointing at the
+        # object-reference idiom; a STEP-sourced script does NOT — the numbers ARE the honest
+        # source and there are no objects to reference (keeps STEP scripts byte-stable).
+        py = generate_sheet_script(Box(60, 40, 12), out=str(tmp_path / "shape"))
+        assert "Object-reference tip" in Path(py).read_text()
+        step = tmp_path / "p.step"
+        export_step(Box(60, 40, 12), str(step))
+        py2 = generate_sheet_script(str(step), out=str(tmp_path / "step"))
+        assert "Object-reference tip" not in Path(py2).read_text()
+
     def test_zero_arg_factory_is_called(self, tmp_path):
         p = self._mod(tmp_path)
         obj, seam = resolve_object_spec(f"{p}:make_bracket")


### PR DESCRIPTION
Closes #770 and #771 (the residual #488 object-reference item — which turned out ~90% discoverability, not missing engine capability).

## What
- **#771 (inline tip):** `emit_sheet_script` gains `object_ref` (= `isinstance(step_file, Shape)`, so it also covers a resolved `module:attr`/`file.py:attr` object spec). When set, the features section carries an inline tip showing how to swap a detected-numbers line for an object reference. A **STEP-sourced script is byte-stable** (no tip — the numbers are the honest source).
- **#770 (docs):** README documents the from-a-part-to-an-object-referenced-script workflow (detected → referenced before/after); refreshes the aspect-verb list for `.thread()`/`.knurl()`.

## Explicitly declined (recorded on #488)
A bundle-consuming emitter that auto-emits `sheet.step(features.journal)` by matching detected geometry to caller objects — the `Feature` IR carries no feature→object back-reference and ADR 0010/0011 argue against reverse-matching. The declared front door (author in your own code) is the intended path; this PR closes the discoverability gap.

## Verification
85-test `test_sheet_emit` suite green — incl. a new test asserting the tip appears for a Shape input and is **absent** for a STEP path (GRM-03 fixture parity byte-stable). lint ×4 clean.

Refs #488, #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)