### PR TITLE
chore(release): finalize CHANGELOG for v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.4 — 2026-07-20
+
 ### Changed
 
 - **Imperative `--script` output defaults to PDF and the modern export form**


### PR DESCRIPTION
Release prep for **0.3.4** — renames the Unreleased CHANGELOG section to `v0.3.4 — 2026-07-20` and opens a fresh Unreleased. No version bump (pyproject is `0.3.4.dev0`; the publish workflow strips `.dev` on the GitHub Release event).

After this merges I'll create the GitHub Release `v0.3.4`, which triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)