### PR TITLE
chore: bump version to 0.3.5.dev0 after v0.3.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.3.4.dev0"
+version = "0.3.5.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.3.4.dev0"
+version = "0.3.5.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
Post-release version bump (`0.3.4.dev0` → `0.3.5.dev0`). The publish workflow's `bump-version` job failed to push directly to **protected main** (GH006); the **v0.3.4 PyPI publish itself succeeded** (`latest: 0.3.4`). Doing the bump by hand.

Follow-up filed separately: `bump-version` should open a PR (or use a bypass token) rather than push to main, so it doesn't fail on every release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)