### PR TITLE
feat(#767): opt-in drawn sheet frame/border (Option B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **Opt-in drawn sheet frame / border** (#767): `build_drawing(frame=True)` /
+  `Sheet(frame=True)` / `--frame` draws a border rectangle at the page margin. It's
+  the *content boundary* (Option B), not a rectangle over the drawing: turning it on
+  raises the effective content margin, and because `compose._layout_geometry` is the
+  single authority shared by scale/page selection **and** placement, the reservation
+  flows through `choose_scale` — so a framed drawing may pick a smaller scale / larger
+  page (ADR 0004), with content clearing the border. Default `frame=False` is
+  byte-identical (guarded by the golden + layout-cleanliness suites). The page-spanning
+  border carries an `is_sheet_frame` rider so lint skips it.
+
 ## v0.3.4 — 2026-07-20
 
 ### Changed

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -50,6 +50,18 @@ _log = logging.getLogger(__name__)
 
 _MARGIN = 10.0
 
+# When a sheet frame is drawn (#767), content reserves this extra band inside the border so
+# it clears the drawn line rather than sitting on it. The frame draws AT _MARGIN (the old
+# drawable boundary); content insets to _content_margin(frame).
+_FRAME_BAND = 6.0
+
+
+def _content_margin(frame: bool) -> float:
+    """The effective content margin: ``_MARGIN``, plus the frame clearance band when a sheet
+    frame is drawn (#767). Threaded into the layout authority so the reservation flows through
+    scale/page selection (ADR 0004), not just the render."""
+    return _MARGIN + (_FRAME_BAND if frame else 0.0)
+
 
 _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for clearance
 
@@ -711,6 +723,9 @@ class Analysis:
     date: str = ""
     revision: str = "A"
     company: str = ""
+    # Draw a sheet border/frame (#767). When True, `margin` is already the reserved content
+    # margin (`_content_margin(True)`), so content clears the frame drawn at `_MARGIN`.
+    frame: bool = False
     # The PartModel built by _analyse's pre-scale sizing pass (#584 WP1 A) — stored so
     # the render path reuses it instead of re-running the detectors (ADR 0008 Amdt 5:
     # one inventory, detected once; #602). Typed `object` to keep _core free of a
@@ -797,6 +812,31 @@ def _add_title_block(dwg, a: Analysis):
         _TB_CLEAR + cell["max_y"],
     )
     dwg.add(tb, "title_block")
+
+
+def _make_sheet_frame(a: Analysis) -> Compound:
+    """The sheet border rectangle (#767) — a closed outline at the ``_MARGIN`` inset (the old
+    drawable boundary). Content clears it because ``a.margin`` is the reserved content margin.
+    Carries an ``is_sheet_frame`` rider (like ``is_centerline``) so lint skips its page-spanning
+    box, and so ``get_annotation`` / a removed frame drop it cleanly."""
+    x0, y0 = _MARGIN, _MARGIN
+    x1, y1 = a.PAGE_W - _MARGIN, a.PAGE_H - _MARGIN
+    frame = Compound(
+        children=[
+            Edge.make_line(Vector(x0, y0, 0), Vector(x1, y0, 0)),
+            Edge.make_line(Vector(x1, y0, 0), Vector(x1, y1, 0)),
+            Edge.make_line(Vector(x1, y1, 0), Vector(x0, y1, 0)),
+            Edge.make_line(Vector(x0, y1, 0), Vector(x0, y0, 0)),
+        ]
+    )
+    frame.is_sheet_frame = True  # furniture, not a dimension/view — exempt from overlap lint
+    return frame
+
+
+def _add_sheet_frame(dwg, a: Analysis):
+    """Add the sheet border (#767), drawn last like the title block. No-op is the caller's
+    (gated on ``a.frame``)."""
+    dwg.add(_make_sheet_frame(a), "sheet_frame")
 
 
 def _iso_bbox(dwg):

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -29,6 +29,7 @@ from draftwright._core import (
     _MIN_RENDER_MM,
     _MIN_VIEW_MM,
     Analysis,
+    _content_margin,
     _legible_steps,
     _Projector,
 )
@@ -409,6 +410,7 @@ def _validate_explicit_scale(
     strips_i,
     layout_section,
     layout_table_sizes,
+    margin=_MARGIN,
 ) -> None:
     """Enforce the two scale floors when the caller pinned an explicit *scale* (#489, #590 split
     of :func:`_analyse`). An explicit scale is the user's call — honour it, subject to:
@@ -441,6 +443,7 @@ def _validate_explicit_scale(
         strips=strips_i,
         section=layout_section,
         table_sizes=layout_table_sizes,
+        margin=margin,
     )
     # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
     # legible) but the requested scale is below the floor. A part illegible at every
@@ -474,11 +477,16 @@ def _analyse(
     date="",
     revision="A",
     company="",
+    frame: bool = False,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
     Returns an :class:`Analysis`.
     """
+    # The content margin — raised by the sheet-frame band (#767) so scale/page selection and
+    # placement both reserve room for the border. Computed up front so the choose_scale inside
+    # step-count convergence sees it too.
+    margin = _content_margin(frame)
     if isinstance(step_file, Shape):
         part = step_file
         src = "build123d object"
@@ -609,6 +617,7 @@ def _analyse(
             strips=strips_i,
             section=layout_section,
             table_sizes=layout_table_sizes,
+            margin=margin,
         )
 
     (SCALE, PAGE_W, PAGE_H, TB_W), strips_i, n_for_sizing = _converge_step_sizing(
@@ -628,9 +637,10 @@ def _analyse(
         strips_i,
         layout_section,
         layout_table_sizes,
+        margin=margin,
     )
     DIM_PAD = _DIM_PAD
-    margin = _MARGIN
+    # margin was computed up front (_content_margin(frame)) so scale selection already saw it.
     # Refine: apply the same legibility gate _auto_annotate uses for dim_step.
     n_steps = len(_legible_steps(step_zs, bb.min.Z, SCALE)[0])
     strips = _measure_strips(
@@ -656,6 +666,7 @@ def _analyse(
         n_steps,
         section=layout_section,
         table_sizes=layout_table_sizes,
+        margin=margin,
     )
     fv_hw = _g.fv_hw
     fv_hh = _g.fv_hh
@@ -778,6 +789,7 @@ def _analyse(
         date=date,
         revision=revision,
         company=company,
+        frame=frame,
         out=out,
         pmi=pmi_records,
         pmi_mode=pmi,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -21,6 +21,7 @@ from draftwright._core import (
     _TABULATE_MIN_HOLES,
     Analysis,
     HoleRef,
+    _add_sheet_frame,
     _add_title_block,
     _concentric_with_axis,
     _fmt,
@@ -125,6 +126,7 @@ _PASS_SEQUENCE: tuple[str, ...] = (
     "details",
     "title_block",
     "tabulate",
+    "sheet_frame",
 )
 
 
@@ -508,6 +510,12 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_title_block():
         _add_title_block(dwg, a)
 
+    def _s_sheet_frame():
+        # The sheet border, drawn LAST (#767) — gated on the frame opt-in; content already
+        # reserved room via the raised a.margin, so this only draws.
+        if a.frame:
+            _add_sheet_frame(dwg, a)
+
     def _s_tabulate():
         # Escalate to a hole table when the plan view is too dense to dimension
         # every hole — runs last so the table avoids every placed annotation
@@ -545,6 +553,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "details": _s_details,
             "title_block": _s_title_block,
             "tabulate": _s_tabulate,
+            "sheet_frame": _s_sheet_frame,
         }
     )
     if ctx.trace is not None:  # snapshot the run's escalations into the trace (#736)

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -29,6 +29,7 @@ from draftwright._core import (
     _PAGE_SIZES,
     _SCALES,
     Analysis,
+    _add_sheet_frame,
     _add_title_block,
     _iso_bbox,
     _log,
@@ -336,6 +337,8 @@ def _assemble(
     else:
         _fit_iso_view(dwg, a, annotate=False)
         _add_title_block(dwg, a)
+        if a.frame:  # sheet border, drawn last (#767) — auto path adds it via the orchestrator
+            _add_sheet_frame(dwg, a)
     return dwg
 
 
@@ -409,6 +412,7 @@ def _repack(
             section=a.layout_section,
             table_sizes=a.layout_table_sizes,
             warn_no_iso=False,
+            margin=a.margin,
         )
 
     candidates = _repack_candidates(a, scale, page)
@@ -603,6 +607,7 @@ def build_drawing(
     date: str = "",
     revision: str = "A",
     company: str = "",
+    frame: bool = False,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -690,6 +695,7 @@ def build_drawing(
         date=date,
         revision=revision,
         company=company,
+        frame=frame,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real
@@ -754,6 +760,7 @@ def make_drawing(
     date: str = "",
     revision: str = "A",
     company: str = "",
+    frame: bool = False,
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -799,6 +806,7 @@ def make_drawing(
         date=date,
         revision=revision,
         company=company,
+        frame=frame,
     ).export()
     assert svg_path is not None and dxf_path is not None  # export() writes both by default
     return svg_path, dxf_path

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -106,6 +106,9 @@ def main(
     date: str = typer.Option("", help="Date for the title block"),
     revision: str = typer.Option("A", help="Revision for the title block"),
     company: str = typer.Option("", help="Company / legal owner for the title block"),
+    frame: bool = typer.Option(
+        False, "--frame", help="Draw a sheet border; content reserves clearance inside it"
+    ),
     scale: float | None = typer.Option(
         None, help="Drawing-scale override, e.g. 5 for 5:1 or 0.5 for 1:2 (default: auto)"
     ),
@@ -242,6 +245,7 @@ def main(
         date=date,
         revision=revision,
         company=company,
+        frame=frame,
     )
     for path in _emit(dwg, formats):
         print(path)

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -278,7 +278,9 @@ def lint_drawing(
 
     boxes: list = []
     for item in items:
-        if getattr(item, "is_centerline", False):
+        # The sheet frame (#767) spans the page by design; a None box excludes it from every
+        # pairwise overlap (like a centerline), so it doesn't "overlap" every annotation.
+        if getattr(item, "is_centerline", False) or getattr(item, "is_sheet_frame", False):
             boxes.append(None)
             continue
         boxes.append(_label_box(item))
@@ -333,6 +335,8 @@ def lint_drawing(
     # (#701: unguarded — _ann_box absorbs the fragile measure; the rest is arithmetic.)
     if page_bbox is not None:
         for item in items:
+            if getattr(item, "is_sheet_frame", False):
+                continue  # the frame sits ON the page-bounds boundary by design (#767)
             bb = _ann_box(item, box_cache)
             if bb is None:
                 continue
@@ -498,6 +502,8 @@ def _lint_view_shapes(
                 continue  # a datum target sits on the part face by definition
             if getattr(ann, "is_section_hatch", False):
                 continue  # hatching is intentionally inside the section view
+            if getattr(ann, "is_sheet_frame", False):
+                continue  # the sheet border spans the page, enclosing every view (#767)
             # #701: unguarded — _label_bbox/_ann_box/_view_edge_entries absorb the
             # fragile reads; a bug in the check itself must fail loudly.
             label_box = _label_bbox(ann, warned)

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -374,6 +374,7 @@ class Sheet:
         date=None,
         revision=None,
         company=None,
+        frame=None,
     ):
         self._part = part
         self._features: list = []
@@ -404,6 +405,7 @@ class Sheet:
             ("date", date),
             ("revision", revision),
             ("company", company),
+            ("frame", frame),
         ):
             if _v is not None:
                 self._opts[_k] = _v

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -14,7 +14,7 @@ from build123d import Box, Compound, Cylinder, Edge, Pos, Rotation, export_step
 from build123d_drafting import HoleCallout, Leader, ViewCoordinates, view_axes
 
 from draftwright import Drawing, build_drawing, make_drawing
-from draftwright._core import _MIN_VIEW_MM, _fmt
+from draftwright._core import _MARGIN, _MIN_VIEW_MM, _fmt
 from draftwright.analysis import (
     _converge_step_sizing,
     _is_rotational,
@@ -9260,6 +9260,56 @@ def dense_plate_dwg():
     just to read a different property). Tests that mutate the drawing (append an
     escalation, record an issue, run the resolver) must build their own."""
     return build_drawing(_dense_plate())
+
+
+class TestSheetFrame:
+    """#767: an opt-in drawn sheet border (Option B) — the border is the content boundary,
+    so turning it on RESERVES clearance that flows through scale/page selection (ADR 0004),
+    not a rectangle drawn over content. Default off ⇒ byte-identical (guarded elsewhere)."""
+
+    def test_frame_off_by_default(self):
+        dwg = build_drawing(Box(80, 60, 20))
+        assert "sheet_frame" not in dwg.annotations()
+        assert dwg._analysis.margin == _MARGIN  # no reservation
+
+    def test_frame_drawn_at_the_margin_and_content_clears_it(self):
+        dwg = build_drawing(Box(80, 60, 20), frame=True)
+        a = dwg._analysis
+        fr = dwg.get_annotation("sheet_frame")
+        assert fr is not None and getattr(fr, "is_sheet_frame", False)
+        # the border is at the _MARGIN inset, strictly within the page
+        b = fr.bounding_box()
+        assert abs(b.min.X - _MARGIN) < 0.5 and abs(b.min.Y - _MARGIN) < 0.5
+        assert (
+            abs(b.max.X - (a.PAGE_W - _MARGIN)) < 0.5 and abs(b.max.Y - (a.PAGE_H - _MARGIN)) < 0.5
+        )
+        # content reserved a band inside the border: a.margin is raised, and every view +
+        # annotation clears the inner rectangle (not merely the page).
+        assert a.margin > _MARGIN
+        inner = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
+        for n, o in dwg.iter_annotations():
+            if n in ("sheet_frame", "title_block"):
+                continue
+            bb = o.bounding_box()
+            assert bb.min.X >= inner[0] - 0.5 and bb.min.Y >= inner[1] - 0.5
+            assert bb.max.X <= inner[2] + 0.5 and bb.max.Y <= inner[3] + 0.5
+
+    def test_reservation_flows_through_scale_selection(self):
+        # The border consumes layout budget BEFORE choose_scale, so the framed scale is never
+        # larger than the unframed one (monotone reservation), and the margin proves it is active.
+        part = Box(180, 130, 40)
+        a0 = build_drawing(part)._analysis
+        a1 = build_drawing(part, frame=True)._analysis
+        assert a1.margin == _MARGIN + 6.0  # _FRAME_BAND reserved
+        assert a1.SCALE <= a0.SCALE + 1e-9
+
+    def test_frame_build_is_lint_clean(self):
+        dwg = build_drawing(Box(80, 60, 20), frame=True)
+        by_code = dwg.lint_summary()["by_code"]
+        # the page-spanning border must not trip overlap / bounds lint
+        assert by_code.get("annotation_overlap", 0) == 0
+        assert by_code.get("annotation_out_of_bounds", 0) == 0
+        assert by_code.get("view_annotation_overlap", 0) == 0
 
 
 class TestEscalation:


### PR DESCRIPTION
**PR-2 of 2** — the frame feature (builds on the byte-identical margin-param refactor in #780).

## What
`build_drawing(frame=True)` / `Sheet(frame=True)` / `--frame` draws a sheet border. **Option B** (the proper drafting standard): the border is the *content boundary*, so turning it on **reserves** clearance that flows through scale/page selection — not a rectangle drawn over content.

## How
- `_content_margin(frame) = _MARGIN + _FRAME_BAND`, computed up front in `_analyse` and threaded (via #780's `margin` param) into **both** `choose_scale` and placement. Because `_layout_geometry` is the single authority, scale/page selection sees the smaller content area → a framed drawing may pick a smaller scale / larger page (**ADR 0004**), content clearing the border.
- `_make_sheet_frame`/`_add_sheet_frame`: a border rectangle at `_MARGIN`, drawn **last** (a `sheet_frame` orchestrator stage for the auto path; inline after the title block otherwise). `view=None` ⇒ auto-excluded from repack.
- `is_sheet_frame` rider ⇒ the page-spanning border is skipped in the 3 `structural.py` lint loops (else it 'overlaps' everything).
- Knobs: `build_drawing`/`make_drawing`/`Sheet(frame=)`/CLI `--frame`.

## Verification
- **Default `frame=False` byte-identical** — golden + layout-cleanliness green.
- New `TestSheetFrame` (4): off by default; border at `_MARGIN` + content clears it; reservation monotone through scale selection; **lint clean**.
- 281-test layout/lint/sheet/title-block regression green; lint ×4 + import/encapsulation guards clean.

Closes #767. (Follow-ups: #768 zone grid depends on this; #769 projection glyph waits on helpers#179.) Refs #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)