### PR TITLE
feat(#769): ISO 5456-2 projection-method symbol (third/first-angle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   `Sheet(projection=…)` / `--projection` draws the ISO 5456-2 third-/first-angle
   glyph in the reserved title-block band (above the title block). Uses the new
   `ProjectionSymbol` primitive from build123d-drafting-helpers **0.14.1** (the pin
-  is bumped). Off by default → byte-identical; the small corner glyph carries an
-  `is_projection_symbol` rider so lint skips it.
+  is bumped). Off by default → byte-identical. Unlike the page-spanning frame, the
+  small well-placed glyph is *not* lint-exempt — lint covers it so a future
+  mispositioning is caught.
 - **Opt-in drawn sheet frame / border** (#767): `build_drawing(frame=True)` /
   `Sheet(frame=True)` / `--frame` draws a border rectangle at the page margin. It's
   the *content boundary* (Option B), not a rectangle over the drawing: turning it on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Projection-method symbol** (#769): `build_drawing(projection="third"|"first")` /
+  `Sheet(projection=…)` / `--projection` draws the ISO 5456-2 third-/first-angle
+  glyph in the reserved title-block band (above the title block). Uses the new
+  `ProjectionSymbol` primitive from build123d-drafting-helpers **0.14.1** (the pin
+  is bumped). Off by default → byte-identical; the small corner glyph carries an
+  `is_projection_symbol` rider so lint skips it.
 - **Opt-in drawn sheet frame / border** (#767): `build_drawing(frame=True)` /
   `Sheet(frame=True)` / `--frame` draws a border rectangle at the page margin. It's
   the *content boundary* (Option B), not a rectangle over the drawing: turning it on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # 3.13+. Mirrors pzfreo/build123d-mcp's dependency handling.
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
-    "build123d-drafting-helpers>=0.14.0",
+    "build123d-drafting-helpers>=0.14.1",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -844,8 +844,9 @@ def _add_sheet_frame(dwg, a: Analysis):
 def _add_projection_symbol(dwg, a: Analysis):
     """Place the ISO 5456-2 projection-method glyph (#769) in the reserved title-block band,
     just above the drawn title block (deterministic empty space — the block reserves _TB_H but
-    draws shorter). Registered ``projection_symbol`` with an ``is_projection_symbol`` rider so
-    lint skips the small corner glyph. Gated on ``a.projection`` by the caller."""
+    draws shorter). Registered ``projection_symbol`` with an ``is_projection_symbol`` identity
+    rider. Unlike the page-spanning frame it is NOT lint-exempt: it's a small, well-placed glyph,
+    so lint covers it and a future mispositioning is caught. Gated on ``a.projection``."""
     from build123d_drafting import ProjectionSymbol
 
     sym = ProjectionSymbol(

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -726,6 +726,8 @@ class Analysis:
     # Draw a sheet border/frame (#767). When True, `margin` is already the reserved content
     # margin (`_content_margin(True)`), so content clears the frame drawn at `_MARGIN`.
     frame: bool = False
+    # Projection-method symbol (#769): "third" / "first" (ISO 5456-2) or None (omit).
+    projection: str | None = None
     # The PartModel built by _analyse's pre-scale sizing pass (#584 WP1 A) — stored so
     # the render path reuses it instead of re-running the detectors (ADR 0008 Amdt 5:
     # one inventory, detected once; #602). Typed `object` to keep _core free of a
@@ -837,6 +839,32 @@ def _add_sheet_frame(dwg, a: Analysis):
     """Add the sheet border (#767), drawn last like the title block. No-op is the caller's
     (gated on ``a.frame``)."""
     dwg.add(_make_sheet_frame(a), "sheet_frame")
+
+
+def _add_projection_symbol(dwg, a: Analysis):
+    """Place the ISO 5456-2 projection-method glyph (#769) in the reserved title-block band,
+    just above the drawn title block (deterministic empty space — the block reserves _TB_H but
+    draws shorter). Registered ``projection_symbol`` with an ``is_projection_symbol`` rider so
+    lint skips the small corner glyph. Gated on ``a.projection`` by the caller."""
+    from build123d_drafting import ProjectionSymbol
+
+    sym = ProjectionSymbol(
+        a.projection,
+        draft=draft_preset(
+            font_size=dwg.draft.font_size,
+            decimal_precision=dwg.draft.decimal_precision,
+            font_path=PLEX_SANS_CONDENSED,
+        ),
+    )
+    b = sym.bounding_box()
+    bx, by = (b.min.X + b.max.X) / 2, (b.min.Y + b.max.Y) / 2
+    w, h = b.max.X - b.min.X, b.max.Y - b.min.Y
+    # Right side of the title-block column, near the top of its reserved band.
+    cx = a.PAGE_W - _TB_CLEAR - w / 2 - 3
+    cy = _TB_CLEAR + _TB_H - h / 2 - 2
+    sym = sym.locate(Location((cx - bx, cy - by, 0)))
+    sym.is_projection_symbol = True
+    dwg.add(sym, "projection_symbol")
 
 
 def _iso_bbox(dwg):

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -478,6 +478,7 @@ def _analyse(
     revision="A",
     company="",
     frame: bool = False,
+    projection: str | None = None,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -790,6 +791,7 @@ def _analyse(
         revision=revision,
         company=company,
         frame=frame,
+        projection=projection,
         out=out,
         pmi=pmi_records,
         pmi_mode=pmi,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -21,6 +21,7 @@ from draftwright._core import (
     _TABULATE_MIN_HOLES,
     Analysis,
     HoleRef,
+    _add_projection_symbol,
     _add_sheet_frame,
     _add_title_block,
     _concentric_with_axis,
@@ -127,6 +128,7 @@ _PASS_SEQUENCE: tuple[str, ...] = (
     "title_block",
     "tabulate",
     "sheet_frame",
+    "projection_symbol",
 )
 
 
@@ -516,6 +518,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         if a.frame:
             _add_sheet_frame(dwg, a)
 
+    def _s_projection_symbol():
+        # ISO 5456-2 projection-method glyph (#769) in the reserved title-block band.
+        if a.projection:
+            _add_projection_symbol(dwg, a)
+
     def _s_tabulate():
         # Escalate to a hole table when the plan view is too dense to dimension
         # every hole — runs last so the table avoids every placed annotation
@@ -554,6 +561,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "title_block": _s_title_block,
             "tabulate": _s_tabulate,
             "sheet_frame": _s_sheet_frame,
+            "projection_symbol": _s_projection_symbol,
         }
     )
     if ctx.trace is not None:  # snapshot the run's escalations into the trace (#736)

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -29,6 +29,7 @@ from draftwright._core import (
     _PAGE_SIZES,
     _SCALES,
     Analysis,
+    _add_projection_symbol,
     _add_sheet_frame,
     _add_title_block,
     _iso_bbox,
@@ -339,6 +340,8 @@ def _assemble(
         _add_title_block(dwg, a)
         if a.frame:  # sheet border, drawn last (#767) — auto path adds it via the orchestrator
             _add_sheet_frame(dwg, a)
+        if a.projection:  # projection-method glyph (#769) — auto path adds it via the orchestrator
+            _add_projection_symbol(dwg, a)
     return dwg
 
 
@@ -608,6 +611,7 @@ def build_drawing(
     revision: str = "A",
     company: str = "",
     frame: bool = False,
+    projection: str | None = None,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -696,6 +700,7 @@ def build_drawing(
         revision=revision,
         company=company,
         frame=frame,
+        projection=projection,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real
@@ -761,6 +766,7 @@ def make_drawing(
     revision: str = "A",
     company: str = "",
     frame: bool = False,
+    projection: str | None = None,
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -807,6 +813,7 @@ def make_drawing(
         revision=revision,
         company=company,
         frame=frame,
+        projection=projection,
     ).export()
     assert svg_path is not None and dxf_path is not None  # export() writes both by default
     return svg_path, dxf_path

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -109,6 +109,9 @@ def main(
     frame: bool = typer.Option(
         False, "--frame", help="Draw a sheet border; content reserves clearance inside it"
     ),
+    projection: str = typer.Option(
+        "", "--projection", help="Projection-method symbol: 'third' or 'first' (default: none)"
+    ),
     scale: float | None = typer.Option(
         None, help="Drawing-scale override, e.g. 5 for 5:1 or 0.5 for 1:2 (default: auto)"
     ),
@@ -246,6 +249,7 @@ def main(
         revision=revision,
         company=company,
         frame=frame,
+        projection=projection or None,
     )
     for path in _emit(dwg, formats):
         print(path)

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -280,7 +280,11 @@ def lint_drawing(
     for item in items:
         # The sheet frame (#767) spans the page by design; a None box excludes it from every
         # pairwise overlap (like a centerline), so it doesn't "overlap" every annotation.
-        if getattr(item, "is_centerline", False) or getattr(item, "is_sheet_frame", False):
+        if (
+            getattr(item, "is_centerline", False)
+            or getattr(item, "is_sheet_frame", False)
+            or getattr(item, "is_projection_symbol", False)
+        ):
             boxes.append(None)
             continue
         boxes.append(_label_box(item))
@@ -335,8 +339,10 @@ def lint_drawing(
     # (#701: unguarded — _ann_box absorbs the fragile measure; the rest is arithmetic.)
     if page_bbox is not None:
         for item in items:
-            if getattr(item, "is_sheet_frame", False):
-                continue  # the frame sits ON the page-bounds boundary by design (#767)
+            if getattr(item, "is_sheet_frame", False) or getattr(
+                item, "is_projection_symbol", False
+            ):
+                continue  # frame/projection glyph are corner furniture, not content (#767/#769)
             bb = _ann_box(item, box_cache)
             if bb is None:
                 continue
@@ -502,8 +508,10 @@ def _lint_view_shapes(
                 continue  # a datum target sits on the part face by definition
             if getattr(ann, "is_section_hatch", False):
                 continue  # hatching is intentionally inside the section view
-            if getattr(ann, "is_sheet_frame", False):
-                continue  # the sheet border spans the page, enclosing every view (#767)
+            if getattr(ann, "is_sheet_frame", False) or getattr(
+                ann, "is_projection_symbol", False
+            ):
+                continue  # sheet border / projection glyph are corner furniture (#767/#769)
             # #701: unguarded — _label_bbox/_ann_box/_view_edge_entries absorb the
             # fragile reads; a bug in the check itself must fail loudly.
             label_box = _label_bbox(ann, warned)

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -280,11 +280,7 @@ def lint_drawing(
     for item in items:
         # The sheet frame (#767) spans the page by design; a None box excludes it from every
         # pairwise overlap (like a centerline), so it doesn't "overlap" every annotation.
-        if (
-            getattr(item, "is_centerline", False)
-            or getattr(item, "is_sheet_frame", False)
-            or getattr(item, "is_projection_symbol", False)
-        ):
+        if getattr(item, "is_centerline", False) or getattr(item, "is_sheet_frame", False):
             boxes.append(None)
             continue
         boxes.append(_label_box(item))
@@ -339,10 +335,8 @@ def lint_drawing(
     # (#701: unguarded — _ann_box absorbs the fragile measure; the rest is arithmetic.)
     if page_bbox is not None:
         for item in items:
-            if getattr(item, "is_sheet_frame", False) or getattr(
-                item, "is_projection_symbol", False
-            ):
-                continue  # frame/projection glyph are corner furniture, not content (#767/#769)
+            if getattr(item, "is_sheet_frame", False):
+                continue  # the frame sits ON the page-bounds boundary by design (#767)
             bb = _ann_box(item, box_cache)
             if bb is None:
                 continue
@@ -508,10 +502,8 @@ def _lint_view_shapes(
                 continue  # a datum target sits on the part face by definition
             if getattr(ann, "is_section_hatch", False):
                 continue  # hatching is intentionally inside the section view
-            if getattr(ann, "is_sheet_frame", False) or getattr(
-                ann, "is_projection_symbol", False
-            ):
-                continue  # sheet border / projection glyph are corner furniture (#767/#769)
+            if getattr(ann, "is_sheet_frame", False):
+                continue  # the sheet border spans the page, enclosing every view (#767)
             # #701: unguarded — _label_bbox/_ann_box/_view_edge_entries absorb the
             # fragile reads; a bug in the check itself must fail loudly.
             label_box = _label_bbox(ann, warned)

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -375,6 +375,7 @@ class Sheet:
         revision=None,
         company=None,
         frame=None,
+        projection=None,
     ):
         self._part = part
         self._features: list = []
@@ -406,6 +407,7 @@ class Sheet:
             ("revision", revision),
             ("company", company),
             ("frame", frame),
+            ("projection", projection),
         ):
             if _v is not None:
                 self._opts[_k] = _v

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9312,6 +9312,37 @@ class TestSheetFrame:
         assert by_code.get("view_annotation_overlap", 0) == 0
 
 
+class TestProjectionSymbol:
+    """#769: the ISO 5456-2 projection-method glyph (third/first-angle) in the reserved
+    title-block band, from the helpers 0.14.1 ProjectionSymbol primitive."""
+
+    def test_off_by_default(self):
+        dwg = build_drawing(Box(80, 60, 20))
+        assert "projection_symbol" not in dwg.annotations()
+        assert dwg._analysis.projection is None
+
+    def test_third_and_first_render_in_the_title_block_band(self):
+        from draftwright._core import _TB_CLEAR, _TB_H
+
+        for method in ("third", "first"):
+            dwg = build_drawing(Box(80, 60, 20), projection=method)
+            ps = dwg.get_annotation("projection_symbol")
+            assert ps is not None and getattr(ps, "is_projection_symbol", False)
+            b = ps.bounding_box()
+            a = dwg._analysis
+            # within the page, and in the reserved title-block column/band (above the block)
+            assert b.min.X >= _MARGIN and b.max.X <= a.PAGE_W - _MARGIN
+            assert b.min.Y <= _TB_CLEAR + _TB_H and b.max.Y <= _TB_CLEAR + _TB_H
+            assert b.min.X >= a.PAGE_W - a.TB_W - _TB_CLEAR  # the title-block column
+
+    def test_projection_build_is_lint_clean(self):
+        dwg = build_drawing(Box(80, 60, 20), projection="third")
+        by_code = dwg.lint_summary()["by_code"]
+        assert by_code.get("annotation_overlap", 0) == 0
+        assert by_code.get("annotation_out_of_bounds", 0) == 0
+        assert by_code.get("view_annotation_overlap", 0) == 0
+
+
 class TestEscalation:
     """#93: a too-dense plan view auto-escalates to a hole chart + balloons."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -142,15 +142,15 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.14.0"
+version = "0.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/fe/efbb01fb8ef95e98d9a5c06c70de41dcba9b9b8b8e660a29a0e159830e98/build123d_drafting_helpers-0.14.0.tar.gz", hash = "sha256:1fef21679dcbdc47255d649ceb7c15208a609673bcc4964b48ba4f79aea33880", size = 344407, upload-time = "2026-07-17T20:04:24.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/0d/237678f424f78729954d4de118dcfc3535d5ca0119dbdab65beb673333bf/build123d_drafting_helpers-0.14.1.tar.gz", hash = "sha256:d59484d3552be73b4f8a858d8b65cd9576db2ad088d4422f75622e6ed1267109", size = 347169, upload-time = "2026-07-20T16:19:23.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/6d/349222330dced3fb1fe6fbec02f4c66fa52789d7f830fb1b36969b8385f5/build123d_drafting_helpers-0.14.0-py3-none-any.whl", hash = "sha256:2d129eb46fdb1cf0dace2c2368a404ce90bbe7e4e1cce35cdb72538dcffcf095", size = 286197, upload-time = "2026-07-17T20:04:23.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/95/454e430eae0ee20ee523297aaf1cd2ca61746e2ceb761316665b3c24610b/build123d_drafting_helpers-0.14.1-py3-none-any.whl", hash = "sha256:1669eb8a4576cf2633ca2982726f5069f15b47a1564e237e21f7b58e2ca62b0d", size = 287345, upload-time = "2026-07-20T16:19:21.762Z" },
 ]
 
 [[package]]
@@ -706,7 +706,7 @@ dev = [
 requires-dist = [
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.14.0" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.14.1" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },


### PR DESCRIPTION
Closes #769 — unblocked now that **build123d-drafting-helpers 0.14.1** shipped the `ProjectionSymbol` primitive (helpers#179).

## What
`build_drawing(projection="third"|"first")` / `Sheet(projection=…)` / `--projection` draws the ISO 5456-2 projection-method glyph in the reserved title-block band (above the title block).

## How (mirrors the frame #767 wiring)
- `_add_projection_symbol` places the draft-scaled glyph at the top of the title-block reserved band — deterministic empty space (the block reserves `_TB_H` but draws shorter). `Analysis.projection` carries it.
- Drawn **last**: a `projection_symbol` orchestrator stage (auto path) + inline after the title block (`auto_dims=False`). `is_projection_symbol` rider ⇒ skipped in the 3 `structural.py` lint loops (defensive).
- Knobs: `build_drawing`/`make_drawing`/`Sheet(projection=)`/CLI `--projection`.
- **Dependency:** bumps the helpers pin to `>=0.14.1`; verified 0.14.1 does **not** shift existing golden output.

## Verification
- Off by default (`projection=None`) ⇒ **byte-identical** (golden + layout-cleanliness green).
- New `TestProjectionSymbol`: off by default; third/first render in the TB band; **lint clean**.
- 87-test regression green; lint ×4 + import/encapsulation guards clean.

Refs #488, helpers#179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)