### PR TITLE
feat(#768): ISO 5457 zone-grid border ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- **ISO 5457 zone-grid border ruler** (#768): `build_drawing(zones=True)` /
+  `Sheet(zones=True)` / `--zones` draws the grid reference system — numbers 1..
+  along the top/bottom edges, letters A.. (skipping I/O) down the sides — in the
+  band between the frame and the page edge, with the standard division count per
+  A-series page (~50 mm zones). Implies a frame (the ticks sit on it). Off by
+  default → byte-identical. The border ticks are lint-exempt like the frame; the
+  labels are exempt only from the page-bounds check (they legitimately sit outside
+  the drawable), still covered by overlap lint.
 - **Projection-method symbol** (#769): `build_drawing(projection="third"|"first")` /
   `Sheet(projection=…)` / `--projection` draws the ISO 5456-2 third-/first-angle
   glyph in the reserved title-block band (above the title block). Uses the new

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -67,17 +67,26 @@ def _content_margin(frame: bool) -> float:
 _ZONE_LETTERS = "ABCDEFGHJKLMNPQRSTUVWXYZ"
 
 # ISO 5457 reference-grid division counts (columns=numbers × rows=letters) per A-series page,
-# keyed by page width (draftwright pages are landscape). ~50 mm zones.
-_ZONE_DIVISIONS = {297: (6, 4), 420: (8, 6), 594: (12, 8), 841: (16, 12), 1189: (24, 16)}
+# keyed by the full (width, height) so a same-width custom page doesn't borrow the count.
+_ZONE_DIVISIONS = {
+    (297, 210): (6, 4),
+    (420, 297): (8, 6),
+    (594, 420): (12, 8),
+    (841, 594): (16, 12),
+    (1189, 841): (24, 16),
+}
 
 
 def _zone_divisions(page_w: float, page_h: float) -> tuple[int, int]:
     """``(columns, rows)`` for the ISO 5457 zone grid (#768) — the standard count for an
-    A-series page, else ~50 mm zones for a custom page (min 2 each)."""
-    std = _ZONE_DIVISIONS.get(int(round(page_w)))
+    A-series page (matched on BOTH dimensions), else ~50 mm zones for a custom page. Rows are
+    clamped to the available letters (I/O skipped) so a very tall custom page can't over-index."""
+    std = _ZONE_DIVISIONS.get((int(round(page_w)), int(round(page_h))))
     if std is not None:
         return std
-    return (max(2, round(page_w / 49.5)), max(2, round(page_h / 49.5)))
+    cols = max(2, round(page_w / 49.5))
+    rows = min(len(_ZONE_LETTERS), max(2, round(page_h / 49.5)))
+    return (cols, rows)
 
 
 _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for clearance

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -63,6 +63,23 @@ def _content_margin(frame: bool) -> float:
     return _MARGIN + (_FRAME_BAND if frame else 0.0)
 
 
+# ISO 5457 zone-grid letters (vertical edges): A.. skipping I and O (confusable with 1 / 0).
+_ZONE_LETTERS = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+
+# ISO 5457 reference-grid division counts (columns=numbers × rows=letters) per A-series page,
+# keyed by page width (draftwright pages are landscape). ~50 mm zones.
+_ZONE_DIVISIONS = {297: (6, 4), 420: (8, 6), 594: (12, 8), 841: (16, 12), 1189: (24, 16)}
+
+
+def _zone_divisions(page_w: float, page_h: float) -> tuple[int, int]:
+    """``(columns, rows)`` for the ISO 5457 zone grid (#768) — the standard count for an
+    A-series page, else ~50 mm zones for a custom page (min 2 each)."""
+    std = _ZONE_DIVISIONS.get(int(round(page_w)))
+    if std is not None:
+        return std
+    return (max(2, round(page_w / 49.5)), max(2, round(page_h / 49.5)))
+
+
 _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for clearance
 
 _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built with this
@@ -728,6 +745,8 @@ class Analysis:
     frame: bool = False
     # Projection-method symbol (#769): "third" / "first" (ISO 5456-2) or None (omit).
     projection: str | None = None
+    # Draw the ISO 5457 zone-grid border ruler (#768). Implies a frame (the ticks sit on it).
+    zones: bool = False
     # The PartModel built by _analyse's pre-scale sizing pass (#584 WP1 A) — stored so
     # the render path reuses it instead of re-running the detectors (ADR 0008 Amdt 5:
     # one inventory, detected once; #602). Typed `object` to keep _core free of a
@@ -866,6 +885,53 @@ def _add_projection_symbol(dwg, a: Analysis):
     sym = sym.locate(Location((cx - bx, cy - by, 0)))
     sym.is_projection_symbol = True
     dwg.add(sym, "projection_symbol")
+
+
+def _add_zone_grid(dwg, a: Analysis):
+    """Draw the ISO 5457 zone-grid border ruler (#768) — numbers 1.. along the top/bottom
+    edges, letters A.. (skipping I/O) down the left/right — in the band between the frame
+    (at ``_MARGIN``) and the page edge. Requires ``a.frame`` (the ticks sit on the border);
+    the caller gates on ``a.zones`` and ensures the frame. Tick lines register as ``zone_grid``
+    (``is_zone_grid``); each label carries an ``is_zone_label`` rider so it is exempt from the
+    page-bounds lint (it legitimately sits outside the drawable) — but NOT from overlap lint."""
+    from build123d_drafting import Note
+
+    cols, rows = _zone_divisions(a.PAGE_W, a.PAGE_H)
+    x0, y0, x1, y1 = _MARGIN, _MARGIN, a.PAGE_W - _MARGIN, a.PAGE_H - _MARGIN
+    cw, rh = (x1 - x0) / cols, (y1 - y0) / rows
+    band = _MARGIN
+    tick = min(3.0, band * 0.6)
+    draft = draft_preset(
+        font_size=dwg.draft.font_size * 0.8,
+        decimal_precision=dwg.draft.decimal_precision,
+        font_path=PLEX_SANS_CONDENSED,
+    )
+    ticks = []
+    for i in range(1, cols):  # interior column boundaries → ticks on top + bottom edges
+        xb = x0 + i * cw
+        ticks.append(Edge.make_line(Vector(xb, y0, 0), Vector(xb, y0 - tick, 0)))
+        ticks.append(Edge.make_line(Vector(xb, y1, 0), Vector(xb, y1 + tick, 0)))
+    for j in range(1, rows):  # interior row boundaries → ticks on left + right edges
+        yb = y0 + j * rh
+        ticks.append(Edge.make_line(Vector(x0, yb, 0), Vector(x0 - tick, yb, 0)))
+        ticks.append(Edge.make_line(Vector(x1, yb, 0), Vector(x1 + tick, yb, 0)))
+    grid = Compound(children=ticks)
+    grid.is_zone_grid = True
+    dwg.add(grid, "zone_grid")
+
+    def _label(text, cx, cy, name):
+        note = Note(text, (cx, cy), draft, align=(Align.CENTER, Align.CENTER))
+        note.is_zone_label = True
+        dwg.add(note, name)
+
+    for i in range(cols):  # numbers 1.. left→right, in the bottom + top bands
+        cx = x0 + (i + 0.5) * cw
+        _label(str(i + 1), cx, y0 - band / 2, f"zone_num_b_{i}")
+        _label(str(i + 1), cx, y1 + band / 2, f"zone_num_t_{i}")
+    for j in range(rows):  # letters A.. top→bottom, in the left + right bands
+        cy = y1 - (j + 0.5) * rh
+        _label(_ZONE_LETTERS[j], x0 - band / 2, cy, f"zone_ltr_l_{j}")
+        _label(_ZONE_LETTERS[j], x1 + band / 2, cy, f"zone_ltr_r_{j}")
 
 
 def _iso_bbox(dwg):

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -479,11 +479,14 @@ def _analyse(
     company="",
     frame: bool = False,
     projection: str | None = None,
+    zones: bool = False,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
     Returns an :class:`Analysis`.
     """
+    # The zone-grid ruler (#768) draws its ticks on the frame, so it implies one.
+    frame = frame or zones
     # The content margin — raised by the sheet-frame band (#767) so scale/page selection and
     # placement both reserve room for the border. Computed up front so the choose_scale inside
     # step-count convergence sees it too.
@@ -792,6 +795,7 @@ def _analyse(
         company=company,
         frame=frame,
         projection=projection,
+        zones=zones,
         out=out,
         pmi=pmi_records,
         pmi_mode=pmi,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -24,6 +24,7 @@ from draftwright._core import (
     _add_projection_symbol,
     _add_sheet_frame,
     _add_title_block,
+    _add_zone_grid,
     _concentric_with_axis,
     _fmt,
     _iso_bbox,
@@ -128,6 +129,7 @@ _PASS_SEQUENCE: tuple[str, ...] = (
     "title_block",
     "tabulate",
     "sheet_frame",
+    "zone_grid",
     "projection_symbol",
 )
 
@@ -518,6 +520,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         if a.frame:
             _add_sheet_frame(dwg, a)
 
+    def _s_zone_grid():
+        # ISO 5457 zone-grid border ruler (#768), on the frame (a.zones implies a.frame).
+        if a.zones:
+            _add_zone_grid(dwg, a)
+
     def _s_projection_symbol():
         # ISO 5456-2 projection-method glyph (#769) in the reserved title-block band.
         if a.projection:
@@ -561,6 +568,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "title_block": _s_title_block,
             "tabulate": _s_tabulate,
             "sheet_frame": _s_sheet_frame,
+            "zone_grid": _s_zone_grid,
             "projection_symbol": _s_projection_symbol,
         }
     )

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -32,6 +32,7 @@ from draftwright._core import (
     _add_projection_symbol,
     _add_sheet_frame,
     _add_title_block,
+    _add_zone_grid,
     _iso_bbox,
     _log,
     _parse_page,
@@ -340,6 +341,8 @@ def _assemble(
         _add_title_block(dwg, a)
         if a.frame:  # sheet border, drawn last (#767) — auto path adds it via the orchestrator
             _add_sheet_frame(dwg, a)
+        if a.zones:  # zone-grid ruler (#768), on the frame
+            _add_zone_grid(dwg, a)
         if a.projection:  # projection-method glyph (#769) — auto path adds it via the orchestrator
             _add_projection_symbol(dwg, a)
     return dwg
@@ -612,6 +615,7 @@ def build_drawing(
     company: str = "",
     frame: bool = False,
     projection: str | None = None,
+    zones: bool = False,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -701,6 +705,7 @@ def build_drawing(
         company=company,
         frame=frame,
         projection=projection,
+        zones=zones,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real
@@ -767,6 +772,7 @@ def make_drawing(
     company: str = "",
     frame: bool = False,
     projection: str | None = None,
+    zones: bool = False,
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -814,6 +820,7 @@ def make_drawing(
         company=company,
         frame=frame,
         projection=projection,
+        zones=zones,
     ).export()
     assert svg_path is not None and dxf_path is not None  # export() writes both by default
     return svg_path, dxf_path

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -112,6 +112,9 @@ def main(
     projection: str = typer.Option(
         "", "--projection", help="Projection-method symbol: 'third' or 'first' (default: none)"
     ),
+    zones: bool = typer.Option(
+        False, "--zones", help="Draw the ISO 5457 zone-grid border ruler (implies --frame)"
+    ),
     scale: float | None = typer.Option(
         None, help="Drawing-scale override, e.g. 5 for 5:1 or 0.5 for 1:2 (default: auto)"
     ),
@@ -250,6 +253,7 @@ def main(
         company=company,
         frame=frame,
         projection=projection or None,
+        zones=zones,
     )
     for path in _emit(dwg, formats):
         print(path)

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -280,7 +280,11 @@ def lint_drawing(
     for item in items:
         # The sheet frame (#767) spans the page by design; a None box excludes it from every
         # pairwise overlap (like a centerline), so it doesn't "overlap" every annotation.
-        if getattr(item, "is_centerline", False) or getattr(item, "is_sheet_frame", False):
+        if (
+            getattr(item, "is_centerline", False)
+            or getattr(item, "is_sheet_frame", False)
+            or getattr(item, "is_zone_grid", False)  # border ticks span the frame, like the frame
+        ):
             boxes.append(None)
             continue
         boxes.append(_label_box(item))
@@ -335,8 +339,13 @@ def lint_drawing(
     # (#701: unguarded — _ann_box absorbs the fragile measure; the rest is arithmetic.)
     if page_bbox is not None:
         for item in items:
-            if getattr(item, "is_sheet_frame", False):
-                continue  # the frame sits ON the page-bounds boundary by design (#767)
+            if (
+                getattr(item, "is_sheet_frame", False)
+                or getattr(item, "is_zone_grid", False)
+                or getattr(item, "is_zone_label", False)
+            ):
+                # Frame + zone ruler sit ON / outside the drawable boundary by design (#767/#768).
+                continue
             bb = _ann_box(item, box_cache)
             if bb is None:
                 continue
@@ -502,8 +511,8 @@ def _lint_view_shapes(
                 continue  # a datum target sits on the part face by definition
             if getattr(ann, "is_section_hatch", False):
                 continue  # hatching is intentionally inside the section view
-            if getattr(ann, "is_sheet_frame", False):
-                continue  # the sheet border spans the page, enclosing every view (#767)
+            if getattr(ann, "is_sheet_frame", False) or getattr(ann, "is_zone_grid", False):
+                continue  # sheet border / zone ticks span the page, enclosing every view (#767/#768)
             # #701: unguarded — _label_bbox/_ann_box/_view_edge_entries absorb the
             # fragile reads; a bug in the check itself must fail loudly.
             label_box = _label_bbox(ann, warned)

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -376,6 +376,7 @@ class Sheet:
         company=None,
         frame=None,
         projection=None,
+        zones=None,
     ):
         self._part = part
         self._features: list = []
@@ -408,6 +409,7 @@ class Sheet:
             ("company", company),
             ("frame", frame),
             ("projection", projection),
+            ("zones", zones),
         ):
             if _v is not None:
                 self._opts[_k] = _v

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9343,6 +9343,55 @@ class TestProjectionSymbol:
         assert by_code.get("view_annotation_overlap", 0) == 0
 
 
+class TestZoneGrid:
+    """#768: the ISO 5457 zone-grid border ruler — numbers along top/bottom, letters (skip
+    I/O) down the sides, in the band between the frame and the page edge. Implies a frame."""
+
+    def test_off_by_default(self):
+        dwg = build_drawing(Box(80, 60, 20))
+        assert "zone_grid" not in dwg.annotations()
+        assert not any(n.startswith("zone_") for n in dwg.annotations())
+        assert dwg._analysis.zones is False
+
+    def test_zones_imply_frame_and_have_iso_counts(self):
+        from draftwright._core import _zone_divisions
+
+        dwg = build_drawing(Box(80, 60, 20), zones=True)
+        a = dwg._analysis
+        assert a.zones and a.frame  # zones imply the frame the ticks sit on
+        assert "zone_grid" in dwg.annotations()
+        cols, rows = _zone_divisions(a.PAGE_W, a.PAGE_H)
+        nums = [n for n in dwg.annotations() if n.startswith("zone_num_")]
+        ltrs = [n for n in dwg.annotations() if n.startswith("zone_ltr_")]
+        assert len(nums) == cols * 2 and len(ltrs) == rows * 2  # both edges
+
+    def test_labels_sit_in_the_border_band(self):
+        dwg = build_drawing(Box(80, 60, 20), zones=True)
+        a = dwg._analysis
+        # a bottom number is below the frame (in the [0, _MARGIN] band); a right letter is
+        # right of the frame (in the [PAGE_W - _MARGIN, PAGE_W] band).
+        nb = dwg.get_annotation("zone_num_b_0").bounding_box()
+        assert 0 <= (nb.min.Y + nb.max.Y) / 2 <= _MARGIN
+        lr = dwg.get_annotation("zone_ltr_r_0").bounding_box()
+        assert a.PAGE_W - _MARGIN <= (lr.min.X + lr.max.X) / 2 <= a.PAGE_W
+
+    def test_letters_skip_i_and_o(self):
+        # A1 has 12 rows → A..H then J,K,L,M (I skipped). Force the page so the count is stable.
+        dwg = build_drawing(Box(700, 500, 40), page="A1", zones=True)
+        letters = {
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("zone_ltr_l_")
+        }
+        assert "I" not in letters and "O" not in letters
+        assert {"H", "J"} <= letters  # J follows H (I skipped)
+
+    def test_zone_build_is_lint_clean(self):
+        dwg = build_drawing(Box(80, 60, 20), zones=True)
+        by_code = dwg.lint_summary()["by_code"]
+        assert by_code.get("annotation_overlap", 0) == 0
+        assert by_code.get("annotation_out_of_bounds", 0) == 0
+        assert by_code.get("view_annotation_overlap", 0) == 0
+
+
 class TestEscalation:
     """#93: a too-dense plan view auto-escalates to a hole chart + balloons."""
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9391,6 +9391,17 @@ class TestZoneGrid:
         assert by_code.get("annotation_out_of_bounds", 0) == 0
         assert by_code.get("view_annotation_overlap", 0) == 0
 
+    def test_custom_page_divisions_are_safe(self):
+        # Codex review: match a standard on BOTH dims (a same-width custom page must not borrow
+        # the A-series count), and clamp rows to the available letters so a tall page can't
+        # index past _ZONE_LETTERS.
+        from draftwright._core import _ZONE_DIVISIONS, _ZONE_LETTERS, _zone_divisions
+
+        assert _zone_divisions(420, 297) == _ZONE_DIVISIONS[(420, 297)]  # A3 unchanged
+        assert _zone_divisions(297, 100) != _ZONE_DIVISIONS[(297, 210)]  # not the A4 count
+        _cols, rows = _zone_divisions(500, 3000)  # absurdly tall
+        assert rows <= len(_ZONE_LETTERS)
+
 
 class TestEscalation:
     """#93: a too-dense plan view auto-escalates to a hole chart + balloons."""


### PR DESCRIPTION
Closes #768 — the last #488 child, for completeness. Builds on the frame (#767).

## What
`build_drawing(zones=True)` / `Sheet(zones=True)` / `--zones` draws the ISO 5457 grid reference system: **numbers 1.. along the top/bottom, letters A.. (skipping I/O) down the sides**, in the band between the frame and the page edge — the standard division count per A-series page (~50 mm zones).

## How (mirrors the frame/projection wiring)
- `_zone_divisions` — ISO count per A-series page + compute fallback; `_ZONE_LETTERS` skips I/O.
- `_add_zone_grid` — tick lines (a `zone_grid` Compound) + centered `Note` labels; drawn last (orchestrator `zone_grid` stage + inline for `auto_dims=False`).
- **Zones imply the frame** (the ticks sit on it): `_analyse` sets `frame = frame or zones`, so the content reservation still flows through scale selection.
- **Lint:** the border ticks (`is_zone_grid`) are exempt like the frame; the labels (`is_zone_label`) are exempt **only** from the page-bounds check (they legitimately sit outside the drawable) — still covered by overlap lint (the #769-review lesson: don't over-suppress small well-placed annotations).

## Verification
- Off by default ⇒ **byte-identical** (golden + layout-cleanliness green).
- `TestZoneGrid` (5): off by default; zones imply frame + ISO counts; labels in the border band; letters skip I/O (A1); **lint clean**.
- 121-test regression green; lint ×4 clean.

Refs #767, #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)