### PR TITLE
fix: round-trip frame/zones/projection into the generated Sheet script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Generated `Sheet` script round-trips `--frame` / `--zones` / `--projection`**:
+  the sheet-furniture flags added in #767/#768/#769 were not emitted into the
+  generated `Sheet(...)` constructor (nor forwarded by the CLI's `--script` path),
+  so a regenerated script dropped the border / zone ruler / projection symbol —
+  the script no longer matched the direct CLI drawing. The emitter now emits
+  `frame=True` / `zones=True` / `projection=…` when set (a plain drawing keeps a
+  clean constructor), and the CLI forwards them to `generate_sheet_script`.
+
 ### Added
 
 - **ISO 5457 zone-grid border ruler** (#768): `build_drawing(zones=True)` /

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -195,6 +195,9 @@ def main(
                     date=date,
                     revision=revision,
                     company=company,
+                    frame=frame,
+                    zones=zones,
+                    projection=projection or None,
                     part_expr=seam,
                     formats=tuple(formats),
                 )
@@ -212,6 +215,9 @@ def main(
                     date=date,
                     revision=revision,
                     company=company,
+                    frame=frame,
+                    zones=zones,
+                    projection=projection or None,
                     pmi=pmi.value,
                     formats=tuple(formats),
                 )

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -258,6 +258,9 @@ def emit_sheet_script(
     date: str = "",
     revision: str = "A",
     company: str = "",
+    frame: bool = False,
+    zones: bool = False,
+    projection: str | None = None,
     object_ref: bool = False,
     formats: Sequence[str] = ("pdf",),
 ) -> str:
@@ -300,6 +303,12 @@ def emit_sheet_script(
         ctor.append(f"revision={revision!r}")
     if company:
         ctor.append(f"company={company!r}")
+    if frame:
+        ctor.append("frame=True")
+    if zones:
+        ctor.append("zones=True")
+    if projection:
+        ctor.append(f"projection={projection!r}")
     lines = [
         _HEADER,
         "from draftwright import Sheet",
@@ -460,6 +469,9 @@ def generate_sheet_script(
     date: str = "",
     revision: str = "A",
     company: str = "",
+    frame: bool = False,
+    zones: bool = False,
+    projection: str | None = None,
     pmi: str = "off",
     part_expr: str | None = None,
     formats: Sequence[str] = ("pdf",),
@@ -507,6 +519,9 @@ def generate_sheet_script(
         date=date,
         revision=revision,
         company=company,
+        frame=frame,
+        zones=zones,
+        projection=projection,
         object_ref=is_shape,  # a live Shape / resolved object-spec has objects to reference (#771)
         formats=formats,
     )

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1140,6 +1140,49 @@ class TestRoundTripParity:
 
         assert fields(scripted) == fields(direct) == ("STEEL", "2026-07-20", "B", "ACME")
 
+    def test_frame_zones_projection_round_trip(self, tmp_path, monkeypatch):
+        # Script parity: --frame/--zones/--projection on the CLI must round-trip into the
+        # emitted Sheet so the regenerated drawing matches the direct build (the furniture
+        # was added in #767/#768/#769 but not wired into the emitter until now).
+        from draftwright import Sheet
+
+        flags = dict(frame=True, zones=True, projection="third")
+        step = tmp_path / "part.step"
+        export_step(_plate(), str(step))
+        direct = build_drawing(step_file=str(step), title="PART", **flags)
+
+        captured = {}
+        monkeypatch.setattr(
+            Sheet, "export", lambda self, stem=None: captured.setdefault("dwg", self.build())
+        )
+        py = generate_sheet_script(str(step), out=str(tmp_path / "gen"), title="PART", **flags)
+        ctor = next(
+            line
+            for line in open(py, encoding="utf-8").read().splitlines()
+            if line.startswith("sheet = Sheet(")
+        )
+        assert "frame=True" in ctor and "zones=True" in ctor and "projection='third'" in ctor
+        exec(compile(open(py, encoding="utf-8").read(), py, "exec"), {})
+        scripted = captured["dwg"]
+
+        def furniture(dwg):
+            names = set(dwg.annotations())
+            return (
+                "sheet_frame" in names,
+                "zone_grid" in names,
+                "projection_symbol" in names,
+            )
+
+        assert furniture(scripted) == furniture(direct) == (True, True, True)
+        # a plain script carries none of them
+        plain_py = generate_sheet_script(str(step), out=str(tmp_path / "plain"), title="PART")
+        plain_ctor = next(
+            line
+            for line in open(plain_py, encoding="utf-8").read().splitlines()
+            if line.startswith("sheet = Sheet(")
+        )
+        assert "frame" not in plain_ctor and "zones" not in plain_ctor
+
     def test_grm03_vendored_fixture_full_parity(self, tmp_path, monkeypatch):
         # #707: GRM-03 (the Maquetto thumbwheel drive screw) is the real STEP that
         # surfaced "emitted Sheet != direct CLI drawing" against 0.3.3. #709 (format


### PR DESCRIPTION
## What

A **script-parity regression** the recent furniture PRs introduced: `--frame` (#767), `--zones` (#768), and `--projection` (#769) were wired into `build_drawing`/`Sheet`/CLI but **not** into the Sheet emitter — so `draftwright part.step --frame --zones --projection third --script` emitted a `Sheet` script *without* them, and the regenerated drawing no longer matched the direct CLI drawing.

## How
- `emit_sheet_script` / `generate_sheet_script` gain `frame`/`zones`/`projection` params, emitted into the `Sheet(...)` ctor **only when non-default** (a plain drawing keeps its clean one-line ctor).
- The CLI forwards them to **both** `generate_sheet_script` call sites (object-spec + STEP path).

## Verification
- New `test_frame_zones_projection_round_trip`: emit + execute a framed/zoned/projection Sheet script → the ctor carries `frame=True`/`zones=True`/`projection='third'` and the reconstructed drawing reproduces `sheet_frame`/`zone_grid`/`projection_symbol`; a plain script carries none.
- 86-test `test_sheet_emit` suite green; lint ×4 clean.

Refs #767, #768, #769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)