### PR TITLE
chore(release): finalize CHANGELOG for v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.5 — 2026-07-20
+
 ### Fixed
 
 - **Generated `Sheet` script round-trips `--frame` / `--zones` / `--projection`**:


### PR DESCRIPTION
Release prep for **0.3.5** — the title-block / sheet-furniture line (drawn frame #767, projection symbol #769, zone grid #768, + the #784 Sheet-script round-trip). Renames Unreleased to `v0.3.5 — 2026-07-20`. No version bump (pyproject `0.3.5.dev0`; the workflow strips `.dev` on release). After merge I create the GitHub Release `v0.3.5` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)