### PR TITLE
chore(release): finalize CHANGELOG for v0.3.6 + mark Milestone 1 exited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-## Unreleased
+## v0.3.6 — 2026-07-21
 
 ### Fixed
 
+- **`Sheet.step(boss)` on a prismatic part fails loudly instead of silently
+  dropping the height** (#631): declaring a turned `.step()` at a cylinder that is
+  really an external boss set `orientation="z"`, which made `render_height_ladder`
+  suppress the overall-height dim on the assumption the OD/step chain conveyed it —
+  but on a prismatic box that chain never renders, so the height vanished and
+  nothing replaced it (11 → 10 annotations). The build now detects a `StepFeature`
+  coincident with a `BossFeature` (same axis, origin, diameter) — a combination
+  that can never be legitimate — and raises a clear `ValueError` pointing to
+  `.boss()` (which renders its own ø and height per #632). Legitimate turned shafts
+  have steps but no coincident boss, so they are unaffected.
 - **`detail_view=True` no longer a silent no-op when the detail can't be placed**
   (#630): a part whose lint recommends a detail view (`step_dim_dropped`) but whose
   crowded band is full-width (e.g. a shelled cover's stacked face levels) can't be
@@ -19,6 +29,21 @@
   imperative script didn't match the direct CLI. They now ride the emitted script's
   cog config block and its `build_drawing(...)` call (the Sheet flavour already
   round-tripped them), and the CLI forwards them to `generate_script`.
+
+### Internal
+
+- **Fast-tier dense-sheet canary for the #733/#734 strip-pressure regression**
+  (#737): a synthetic contended-front-strip fixture that drops a step-height
+  principal dim on the pre-#734 commit and stays clean on `main` — closing the
+  fast-tier gap the #733 regression fell through (only the CI-only slow CTC
+  fixtures exercised real strip pressure before).
+- **Layout-hypothesis fuzz tier is now a reproducible PR gate** (#692):
+  `derandomize=True` makes every run generate the same fixed example set (with
+  `print_blob` for paste-able reproduction), so a failure recurs deterministically
+  instead of surfacing on a seed-dependent minority of runs; exploratory fuzzing
+  moves behind `DRAFTWRIGHT_FUZZ_EXPLORE=1`. The two `test_make_drawing.py` xdist
+  observations (#669) were investigated and found non-reproducible — both tests are
+  non-flaky by construction/measurement on current `main`.
 
 ## v0.3.5 — 2026-07-20
 

--- a/docs/plans/product-backlog-roadmap.md
+++ b/docs/plans/product-backlog-roadmap.md
@@ -47,6 +47,14 @@ blockers, and session-to-session movement.
 
 ## Milestone 1 — Trustworthy 0.3.x
 
+**Status: EXITED (2026-07-21, v0.3.6).** All initial scope delivered (#632, #707,
+#630, #661, #631, #692, #737) and all four exit criteria met. The last gate — the
+fast-tier flake — resolved on investigation: #669's two `test_make_drawing.py`
+observations are non-reproducible on current `main` (byte-identity is tautological
+since the strip-sizing routed through the annotation boxes; the pitch test clears
+its boundaries by millimetres, not ULPs; 15 stress runs clean), so it was closed as
+not-reproducible. Focus moves to Milestone 2.
+
 ### Outcome
 
 Direct and generated paths agree semantically, lint cannot pass the known


### PR DESCRIPTION
Release-prep for **v0.3.6** (patch). Docs only — no code changes.

## CHANGELOG
- Rename `## Unreleased` → `## v0.3.6 — 2026-07-21`.
- Add the missing **#631** entry under `Fixed` (`Sheet.step(boss)` now fails loudly instead of silently dropping the height).
- New `Internal` section: the **#737** dense-sheet canary and the **#692** hypothesis-tier derandomisation, noting **#669** was investigated and closed as not-reproducible.

Already present in the section from earlier merges: #630, #775.

## Roadmap
- Mark **Milestone 1 — Trustworthy 0.3.x** as **EXITED (2026-07-21, v0.3.6)**: all initial scope delivered and all four exit criteria met; the last flake gate resolved via the #669 investigation.

## Release mechanics
Version stays `0.3.6.dev0`; `publish.yml` strips `.dev0` → `0.3.6` when the GitHub Release is published, then auto-bumps `main` to `0.3.7.dev0`. So this PR touches no version fields.

Once merged, I'll cut the `v0.3.6` GitHub Release to trigger the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)