### PR TITLE
chore: bump version to 0.3.7.dev0 after v0.3.6 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.3.6.dev0"
+version = "0.3.7.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Post-release dev-version bump. The publish workflow's `bump-version` job cannot push to protected `main` (#779), so this is done manually.

- v0.3.6 released and published to PyPI: https://pypi.org/project/draftwright/0.3.6/
- Bumps `pyproject.toml` `0.3.6.dev0` → `0.3.7.dev0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)