### PR TITLE
fix: centre turned ø leaders on the feature's length, not a step corner

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -776,8 +776,8 @@ def _diameter_row_below(dwg, items, start: int = 0, trace=None) -> int:
                 for _, d, _, _ in items
             )
         return 0
-    specs = []  # (tip_page, dia, label, feature), tip on the step's bottom silhouette
-    for anchor, dia, feat, dtol in items:
+    specs = []  # (tip_page, dia, label, feature), tip on the step's bottom silhouette,
+    for anchor, dia, feat, dtol in items:  # centred along the feature's length (not a corner)
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
         specs.append((tip, dia, f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}", feat))
@@ -890,8 +890,8 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None) -> int:
                 for _, d, _, _ in items
             )
         return 0
-    specs = []  # (tip_page, dia, label, feature), tip on the step's left silhouette
-    for anchor, dia, feat, dtol in items:
+    specs = []  # (tip_page, dia, label, feature), tip on the step's left silhouette,
+    for anchor, dia, feat, dtol in items:  # centred along the feature's length (not a corner)
         ax, ay, az = anchor
         tip = dwg.at("front", ax - dia / 2, ay, az)
         specs.append((tip, dia, f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}", feat))
@@ -933,6 +933,45 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None) -> int:
         occupied.append(_anno_box(ldr))
         placed += 1
     return placed
+
+
+def _diameter_step_anchor(anchor, features):
+    """Anchor point for a turned ⌀ leader tip.
+
+    Centre the leader at the MID-LENGTH of the STEP carrying this diameter, rather
+    than the frame origin passed in (which for a boss or a shared ⌀'s first-bucketed
+    step can be an end corner). Only STEP spans are used: a step round-trips its
+    length + centre through the emitted Sheet script (declared ``length=``/``at=``),
+    so direct and scripted builds agree (#707 parity); a boss is re-synthesised
+    without a declared span and keeps its frame origin in both paths (``anchor``).
+
+    When a ⌀ is shared by several steps, select ONE — the longest run, leftmost on
+    ties — and use THAT step's OWN origin (radial + axial). Never the convex-hull
+    midpoint (which for disjoint ⌀A–⌀B–⌀A steps falls in the ⌀B gap, off any
+    silhouette) and never the bucket ``anchor``'s radial (which for non-coaxial
+    same-⌀ steps belongs to a different feature). The selection quantises both the
+    length and the lower end to the emitter's 3-dp values, so direct and scripted
+    pick the same run. In the #426 finalize/``only=`` path this centres over the
+    recorded subset, as the pre-#794 first-recorded-origin anchor also did.
+    """
+    steps = [
+        f for f in features if getattr(f, "kind", None) == "step" and getattr(f, "span", None)
+    ]
+    if not steps:
+        return anchor
+    idx = {"x": 0, "y": 1, "z": 2}[steps[0].frame.axis]
+
+    def _key(f):
+        ends = sorted(end[idx] for end in f.span)
+        length = round(ends[1] - ends[0], 3)  # emitter rounds step length and centre (`at`) to
+        at = round((ends[0] + ends[1]) / 2, 3)  # 3dp — quantise both so the selection round-trips
+        return (length, -(at - length / 2))
+
+    step = max(steps, key=_key)
+    ends = sorted(end[idx] for end in step.span)
+    centred = list(step.frame.origin)  # the SELECTED step's own origin (radial + axial)
+    centred[idx] = (ends[0] + ends[1]) / 2
+    return tuple(centred)
 
 
 def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
@@ -978,7 +1017,8 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
 
     def _items(buckets):
         return [
-            (a, d, next(iter(fs)) if len(fs) == 1 else None, t) for a, d, fs, t in buckets.values()
+            (_diameter_step_anchor(a, fs), d, next(iter(fs)) if len(fs) == 1 else None, t)
+            for a, d, fs, t in buckets.values()
         ]
 
     # The placers name leaders m_dia_{x,z}{start+i} CONTIGUOUSLY from one start. The auto-pass

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8723,6 +8723,137 @@ class TestTurnedDiameters:
         undim = {i.message.split()[2] for i in dwg.lint() if i.code == "feature_not_dimensioned"}
         assert "ø6" in undim  # only the finest band falls to honest lint
 
+    def test_leader_tip_on_the_edge_centred_on_the_feature_length(self):
+        # The ø leader lands on the step's silhouette EDGE — a full radius off the
+        # turning axis, not on it (an arrow floating on the centre line reads
+        # wrong) — and is CENTRED along the feature's length, not at a step
+        # corner (a boss/free-end anchor would otherwise put it on an end face).
+        dwg = build_drawing(_x_stepped_shaft())
+        fb = dwg.view_bounds("front")
+        axis_y = (fb[1] + fb[3]) / 2
+        by_dia = {
+            f.diameter: f
+            for f in dwg.model().features
+            if getattr(f, "diameter", None) and getattr(f, "frame", None) and f.frame.axis == "x"
+        }
+        tips = [
+            (o, float(str(o.label)[1:]))
+            for n, o in dwg.iter_annotations()
+            if n.startswith("m_dia")
+        ]
+        assert len(tips) >= 2
+        for ldr, dia in tips:
+            # radial: on the bottom edge (one radius below the axis), NOT on it
+            assert abs((axis_y - ldr.tip[1]) - dwg.scale * dia / 2) < 1e-6, (
+                f"{ldr.label} off the edge"
+            )
+            # axial: at the mid-length of the feature(s) sharing this diameter
+            ends = [e[0] for e in by_dia[dia].span]
+            exp_x = dwg.at("front", (min(ends) + max(ends)) / 2, 0, 0)[0]
+            assert abs(ldr.tip[0] - exp_x) < 1e-6, f"{ldr.label} not centred on its length"
+
+    def test_boss_leader_keeps_its_frame_origin_for_script_parity(self):
+        # Only STEP diameters are centred on their span. A boss is re-synthesised
+        # WITHOUT a declared span in the emitted-Sheet path, so — unlike a step —
+        # its ø leader must anchor at the frame origin (which round-trips) rather
+        # than a span mid, or the direct and scripted builds diverge (#707).
+        # (nested ø6 boss under the ø30 silhouette.)
+        from build123d import Align
+
+        def cyl(r, h, z):
+            return Pos(0, 0, z) * Cylinder(r, h, align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+        dwg = build_drawing(
+            Rotation(0, 90, 0) * (cyl(3, 0.5, 0.0) + cyl(15, 20, 0.5) + cyl(10, 15, 20.5))
+        )
+        boss = next(
+            f
+            for f in dwg.model().features
+            if getattr(f, "diameter", None) == 6.0 and f.frame.axis == "x"
+        )
+        origin_x = dwg.at("front", boss.frame.origin[0], 0, 0)[0]
+        tip_x = next(
+            o.tip[0] for n, o in dwg.iter_annotations() if str(getattr(o, "label", "")) == "ø6"
+        )
+        assert abs(tip_x - origin_x) < 1e-6, "ø6 boss leader should anchor at its frame origin"
+
+    def test_shared_diameter_leader_centres_on_the_longest_disjoint_run(self):
+        # A ⌀ shared by DISJOINT, UNEQUAL steps (⌀20 len-5 · ⌀30 · ⌀20 len-20):
+        # the callout must centre on the LONGEST ⌀20 run (the prominent feature),
+        # not the first step in feature order — the short left run the pre-#794
+        # frame-origin anchor picked — nor the convex-hull midpoint, which falls
+        # in the ⌀30 gap, off any silhouette. This is the ONE case #794 changes:
+        # a single detected step's origin is already its own midpoint, so only a
+        # shared, unequal, disjoint ⌀ exercises the fix (fails on origin/main).
+        part = (
+            Cylinder(10, 5)
+            + Pos(0, 0, 7.5) * Cylinder(15, 10)
+            + Pos(0, 0, 22.5) * Cylinder(10, 20)
+        )
+        dwg = build_drawing(part, number="X")
+        o = next(o for n, o in dwg.iter_annotations() if str(getattr(o, "label", "")) == "ø20")
+        on_long = dwg.at("front", 0, 0, 22.5)[1]  # longest ⌀20 run (z 12.5..32.5) midpoint
+        on_short = dwg.at("front", 0, 0, 0)[1]  # short ⌀20 run (z -2.5..2.5) midpoint
+        in_gap = dwg.at("front", 0, 0, 7.5)[1]  # ⌀30 gap midpoint
+        assert abs(o.tip[1] - on_long) < 1e-6, "ø20 not centred on the longest run"
+        assert abs(o.tip[1] - on_short) > 1e-6 and abs(o.tip[1] - in_gap) > 1e-6
+
+    def test_z_column_leader_lands_on_the_left_edge(self):
+        # Cover the Z-turned column placer too (mirror of the X row): its tips sit
+        # a radius to the LEFT of the axis, on the silhouette, not on the axis.
+        dwg = build_drawing(Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(10, 30))
+        fb = dwg.view_bounds("front")
+        axis_x = (fb[0] + fb[2]) / 2
+        tips = [
+            (o, float(str(o.label)[1:]))
+            for n, o in dwg.iter_annotations()
+            if n.startswith("m_dia")
+        ]
+        assert tips, "expected a Z-column ø callout"
+        for ldr, dia in tips:
+            assert abs((axis_x - ldr.tip[0]) - dwg.scale * dia / 2) < 1e-6, (
+                f"{ldr.label} off the left edge"
+            )
+
+
+class TestDiameterStepAnchor:
+    """Unit tests for the shared-diameter leader anchor (#794 review)."""
+
+    @staticmethod
+    def _step(axis, origin, lo, hi):
+        from draftwright.model.ir import Frame, StepFeature
+
+        idx = {"x": 0, "y": 1, "z": 2}[axis]
+        p_lo, p_hi = [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]
+        p_lo[idx], p_hi[idx] = lo, hi
+        return StepFeature(
+            frame=Frame(tuple(origin), axis),
+            length=hi - lo,
+            diameter=10.0,
+            span=(tuple(p_lo), tuple(p_hi)),
+        )
+
+    def test_uses_the_longest_runs_own_origin_for_non_coaxial_steps(self):
+        # Two X-axis ø10 steps on DIFFERENT axes: a short run centred at y=0 and a
+        # longer run centred at y=20. The anchor must be the LONG step's own point
+        # (axial mid 30, radial y=20), not a hybrid that takes the axial from the
+        # long step and the radial from the bucket's first (short) step — which
+        # would land the arrow off the selected step's silhouette.
+        from draftwright.annotations.from_model import _diameter_step_anchor
+
+        short = self._step("x", (0.0, 0.0, 0.0), -2.5, 2.5)  # len 5, centre x=0
+        long = self._step("x", (30.0, 20.0, 0.0), 20.0, 40.0)  # len 20, centre x=30, y=20
+        # `anchor` is the FIRST-bucketed feature's origin (the short step, y=0).
+        got = _diameter_step_anchor(short.frame.origin, {short, long})
+        assert got == (30.0, 20.0, 0.0), f"hybrid/wrong anchor: {got}"
+
+    def test_no_step_in_the_group_falls_back_to_the_given_anchor(self):
+        # A boss-only ⌀ (no step span to centre on) keeps the frame origin, which
+        # round-trips through the emitted script (#707).
+        from draftwright.annotations.from_model import _diameter_step_anchor
+
+        assert _diameter_step_anchor((1.0, 2.0, 3.0), set()) == (1.0, 2.0, 3.0)
+
 
 class TestTurnedLengths:
     """Axial step-length chain for X-axis turned parts (the drive-screw gap:

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -50,6 +50,10 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         # Pure geometry/selection helpers with unit-level coverage.
         ("from_model", "_bore_half_span"),
         ("from_model", "_diameter_column_left"),
+        # _diameter_step_anchor: the shared-⌀ leader anchor (#794). The non-coaxial
+        # same-⌀ case can't be reached through the public build seam, so its unit
+        # test reads the pure helper directly (like _bore_half_span above).
+        ("from_model", "_diameter_step_anchor"),
         ("from_model", "_renderable_pmi_records"),
         ("holes", "_legible_locations"),
         # Pass-level helpers exercised directly (candidates to retarget onto the ctx seam later).


### PR DESCRIPTION
## Problem

On a turned/stepped part, the auto-placed ⌀ leaders point their arrowheads at a **corner** of a step rather than the middle of the feature. Reported on GRM-03: ⌀10 landed on the disc's left corner instead of its centre.

## Root cause

The X-row (`_diameter_row_below`) and Z-column (`_diameter_column_left`) placers anchor the tip at the feature's `frame.origin`. For a step whose ⌀ is shared with another step, that origin is the *first* step's origin, so the arrow lands on that step's corner rather than the feature's middle.

## Fix

`render_diameters` now anchors the tip at the **mid-length of the step** carrying the diameter (new `_axis_centre`). The tip stays on the **silhouette edge** — only its position *along* the step moves to the centre. Details:

- **Only step spans are used.** A step round-trips its length through the emitted Sheet script (declared `length=`), so direct and scripted builds agree (#707 parity). A **boss** is re-synthesised without a declared span, so it keeps its frame origin in both paths — otherwise the two paths diverge (this is what CI's `test_grm03_vendored_fixture_full_parity` caught on an earlier revision).
- **Disjoint shared ⌀ (⌀A–⌀B–⌀A):** centre on one *real* span (the longest; leftmost on ties), never the convex-hull midpoint — which falls in the ⌀B gap and would put the ⌀A arrow inside the ⌀B body.

## Verification

- GRM-03 re-rendered: ⌀10 → disc centre; ⌀5/⌀3 unchanged; ⌀6 boss stays at its free end; **lint clean**; direct/scripted **parity holds**.
- Regression tests (`TestTurnedDiameters`): edge-not-axis + centred-on-length, disjoint shared-diameter canary, boss-keeps-origin, Z-column placer.
- **Full fast tier: 1525 passed, 3 skipped.** ruff / format / mypy / codespell clean.

## History

Two earlier revisions were wrong and reverted: (1) moving the tip to the turning axis (arrow floats on the centre line, crossing the body); (2) span-centring the boss (broke #707 parity). Current form centres only step spans, on the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
