### PR TITLE
chore: re-lock uv.lock to 0.3.7.dev0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.3.6.dev0"
+version = "0.3.7.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
The manual post-release bump (#793) updated `pyproject.toml` to `0.3.7.dev0` but not `uv.lock`, which stayed pinned at `0.3.6.dev0`. This re-locks so the two agree.

Single-line change (the `draftwright` package version field in `uv.lock`); no dependency resolution changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)