### PR TITLE
feat(#796): lint notice when a leader shaft crosses the part silhouette

### DIFF
--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -454,6 +454,89 @@ def _edges_intersect_rect(edge_entries, rect) -> bool:
     return False
 
 
+def _seg_seg_point(a, b, c, d):
+    """Intersection point of segments *a*-*b* and *c*-*d*, or ``None`` (parallel,
+    collinear, or no overlap). Collinear returns ``None`` on purpose — a shaft
+    running ALONG an edge does not cut across it."""
+    rx, ry = b[0] - a[0], b[1] - a[1]
+    sx, sy = d[0] - c[0], d[1] - c[1]
+    denom = rx * sy - ry * sx
+    if abs(denom) < 1e-12:
+        return None
+    qpx, qpy = c[0] - a[0], c[1] - a[1]
+    t = (qpx * sy - qpy * sx) / denom
+    u = (qpx * ry - qpy * rx) / denom
+    if 0.0 <= t <= 1.0 and 0.0 <= u <= 1.0:
+        return (a[0] + t * rx, a[1] + t * ry)
+    return None
+
+
+def _leader_shaft_hits_edges(tip, elbow, edge_entries, skip_mm=0.5) -> bool:
+    """True if the leader shaft *tip*→*elbow* cuts THROUGH the projected view
+    silhouette *edge_entries* (``(edge, bbox2d)`` pairs, #796).
+
+    The discriminator is the count of DISTINCT crossing points, past a *skip_mm*
+    step off the tip:
+
+    * A leader that legitimately EXITS the outline — a hole/feature callout whose
+      tip is at an internal point, or a ⌀ callout whose tip is on the surface and
+      whose shaft runs outward — crosses the outline **once** (or not at all).
+    * A shaft that cuts THROUGH a body — a ⌀ leader clipping a neighbouring step,
+      a groove leader crossing a flange — **enters and exits**, crossing **twice**.
+
+    Genuine crossing POINTS are computed (not edge-bbox hits) and deduped within
+    0.5 mm, so a shaft merely grazing a shared vertex, or a doubled/coincident
+    projected edge, counts once — not two (review of #799). Straight edges use an
+    exact segment intersection; a curved edge is sampled ~1 mm; an edge whose
+    geometry THROWS during analysis counts as one crossing (conservative). A cut
+    is **two or more** distinct crossings beyond the tip's on-outline touch, which
+    the skip removes (the tip's own edge crosses at t<0 of the skipped shaft).
+
+    The 0.5 mm dedup radius is a page-space resolution floor: a shaft cutting a
+    feature narrower than ~0.5 mm ON THE PAGE merges to one crossing and is not
+    flagged — acceptable for a Phase-1 observability notice (#798 owns the robust
+    filled-region test)."""
+    tx, ty = tip[0], tip[1]
+    ex, ey = elbow[0], elbow[1]
+    length = ((ex - tx) ** 2 + (ey - ty) ** 2) ** 0.5
+    if length < 1e-9:
+        return False
+    t = min(0.5, skip_mm / length)  # step off the tip; never past the shaft midpoint
+    a = (tx + t * (ex - tx), ty + t * (ey - ty))
+    b = (ex, ey)
+    points: list[tuple[float, float]] = []
+    opaque = 0
+    for e, eb in edge_entries:
+        if eb is None:
+            continue
+        if not _segment_clips_box(a, b, eb):  # cheap bbox prefilter
+            continue
+        try:
+            if e.geom_type == GeomType.LINE:
+                s, d = e.start_point(), e.end_point()
+                p = _seg_seg_point(a, b, (s.X, s.Y), (d.X, d.Y))
+                if p is not None:
+                    points.append(p)
+            else:
+                n = min(200, max(8, int(e.length) + 1))
+                prev = e.position_at(0)
+                for i in range(1, n + 1):
+                    cur = e.position_at(i / n)
+                    p = _seg_seg_point(a, b, (prev.X, prev.Y), (cur.X, cur.Y))
+                    if p is not None:
+                        points.append(p)
+                    prev = cur
+        except Exception:
+            opaque += 1
+    distinct = 0
+    seen: list[tuple[float, float]] = []
+    for p in points:
+        if not any(abs(p[0] - q[0]) < 0.5 and abs(p[1] - q[1]) < 0.5 for q in seen):
+            seen.append(p)
+            distinct += 1
+    return (distinct + opaque) >= 2
+
+
 def _view_edge_entries(vs, cache):
     """Per-edge ``(edge, bbox2d)`` list for view shape *vs*, memoised in *cache*.
 
@@ -545,6 +628,51 @@ def _lint_view_shapes(
                             f"blank region — legitimate for callouts on large faces"
                         ),
                         code="view_annotation_inside_extents",
+                    )
+                )
+
+    # #796 — leader shaft crosses the view silhouette. A leader that routes its
+    # shaft THROUGH the part body to reach its label reads as clipping the
+    # outline; the tip-on-silhouette touch is excluded (see _leader_shaft_hits_edges).
+    # Only tested where the shaft's own bbox overlaps the view (a leader far from a
+    # view can't cross it), reusing the shared edge cache.
+    for vname, vbb, vs in named_views:
+        for ann in ann_items:
+            if id(ann) in view_shape_ids:
+                continue
+            if getattr(ann, "elbow", None) is None:
+                continue
+            if getattr(ann, "is_centerline", False) or getattr(ann, "is_section_hatch", False):
+                continue
+            if getattr(ann, "covers_diameters", None):
+                continue  # a hole/bore callout legitimately exits the part from an internal hole
+            try:
+                tip, elbow = ann.tip, ann.elbow
+                shaft_bb = (
+                    min(tip[0], elbow[0]),
+                    min(tip[1], elbow[1]),
+                    max(tip[0], elbow[0]),
+                    max(tip[1], elbow[1]),
+                )
+            except Exception:
+                continue
+            if not _boxes_overlap(vbb, shaft_bb):
+                continue
+            edges = _view_edge_entries(vs, cache)
+            if edges is None:
+                continue
+            if _leader_shaft_hits_edges(tip, elbow, edges):
+                albl = getattr(ann, "label", None) or getattr(ann, "name", None) or "leader"
+                issues.append(
+                    LintIssue(
+                        severity="info",
+                        message=(
+                            f"leader '{albl}' shaft crosses view '{vname}' silhouette "
+                            f"— route it clear of the outline, or dimension the feature "
+                            f"in a detail view"
+                        ),
+                        location=(elbow[0], elbow[1]),
+                        code="leader_crosses_silhouette",
                     )
                 )
 

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -481,3 +481,82 @@ class TestLintSelfSilencing:
         b = SimpleNamespace(label_bbox=(0.0, 0.0, 4.0, 4.0), label="B")
         with pytest.raises(IndexError):
             lint_drawing([a, b])
+
+
+class TestLeaderCrossesSilhouette:
+    """#796: leader_crosses_silhouette — a leader shaft that cuts THROUGH the part
+    body. Discriminator unit-tested here on controlled real edges (no projection);
+    the real projected-view behaviour is integration-tested in test_make_drawing."""
+
+    @staticmethod
+    def _edges(*segs):
+        from build123d import Edge
+
+        from draftwright.linting.structural import _shape_box2d
+
+        out = []
+        for (x0, y0), (x1, y1) in segs:
+            e = Edge.make_line((x0, y0, 0), (x1, y1, 0))
+            out.append((e, _shape_box2d(e)))
+        return out
+
+    def test_two_crossings_is_a_cut(self):
+        from draftwright.linting.structural import _leader_shaft_hits_edges
+
+        # shaft x=5, y 0→20; two horizontal edges at y=8 and y=12 → enters+exits.
+        edges = self._edges(((0, 8), (10, 8)), ((0, 12), (10, 12)))
+        assert _leader_shaft_hits_edges((5.0, 0.0), (5.0, 20.0), edges)
+
+    def test_single_crossing_is_a_legitimate_exit(self):
+        from draftwright.linting.structural import _leader_shaft_hits_edges
+
+        # only one edge on the way out (a hole callout exiting the outline once).
+        edges = self._edges(((0, 12), (10, 12)))
+        assert not _leader_shaft_hits_edges((5.0, 0.0), (5.0, 20.0), edges)
+
+    def test_tip_edge_is_skipped(self):
+        from draftwright.linting.structural import _leader_shaft_hits_edges
+
+        # the tip sits ON an edge (y=0) and the shaft runs away: the tip's own edge
+        # crosses at t<0 of the skipped shaft, so a lone outward ⌀ leader is not a cut.
+        edges = self._edges(((0, 0), (10, 0)))
+        assert not _leader_shaft_hits_edges((5.0, 0.0), (5.0, 20.0), edges)
+
+    def test_shared_vertex_counts_once(self):
+        from draftwright.linting.structural import _leader_shaft_hits_edges
+
+        # Two edges meet at (5, 5) forming a V; a shaft grazing that vertex crosses
+        # BOTH edges at the same point — deduped to one, so it is not a cut (the
+        # bbox-count version over-counted this to two — #799 review).
+        edges = self._edges(((0, 0), (5, 5)), ((5, 5), (10, 0)))
+        assert not _leader_shaft_hits_edges((5.0, -5.0), (5.0, 10.0), edges)
+
+    def test_doubled_edge_counts_once(self):
+        from draftwright.linting.structural import _leader_shaft_hits_edges
+
+        # A coincident/doubled projected edge (front+back face project alike) is one
+        # crossing, not two.
+        edges = self._edges(((0, 10), (10, 10)), ((0, 10), (10, 10)))
+        assert not _leader_shaft_hits_edges((5.0, 0.0), (5.0, 20.0), edges)
+
+    def test_tip_skip_prevents_near_edge_false_positive(self):
+        from draftwright.linting.structural import _leader_shaft_hits_edges
+
+        # Tip ON a near edge (y=0), with a far edge (y=12); the shaft exits through
+        # the far edge only. The tip's own edge must be stepped over — WITHOUT the
+        # skip this counts 2 (near tip-touch + far exit) and false-fires. This is the
+        # case that actually pins the load-bearing tip-skip (#799 review).
+        edges = self._edges(((0, 0), (10, 0)), ((0, 12), (10, 12)))
+        assert not _leader_shaft_hits_edges((5.0, 0.0), (5.0, 20.0), edges)
+
+    def test_shaft_through_a_curved_edge_twice_is_a_cut(self):
+        from build123d import Edge
+
+        from draftwright.linting.structural import _leader_shaft_hits_edges, _shape_box2d
+
+        # A single CURVED edge crossed twice (enter+exit) is a cut — exercises the
+        # curve-sampling + cross-subsegment dedup path. Circle r5 at origin; the
+        # shaft along y=0 passes through it at x=-5 and x=+5.
+        arc = Edge.make_circle(5)
+        edges = [(arc, _shape_box2d(arc))]
+        assert _leader_shaft_hits_edges((-10.0, 0.0), (10.0, 0.0), edges)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8855,6 +8855,45 @@ class TestDiameterStepAnchor:
         assert _diameter_step_anchor((1.0, 2.0, 3.0), set()) == (1.0, 2.0, 3.0)
 
 
+class TestLeaderCrossesSilhouette:
+    """#796 Phase 1: an info-level lint notice when a ⌀ leader shaft cuts through
+    the part body. Integration-level (real projected views); the discriminator
+    itself is unit-tested in test_lint_structural."""
+
+    @staticmethod
+    def _cyl(r, h, z):
+        from build123d import Align
+
+        return Pos(0, 0, z) * Cylinder(r, h, align=(Align.CENTER, Align.CENTER, Align.MIN))
+
+    def test_nested_boss_leader_is_flagged(self):
+        # A ø6 boss stub protruding from a ø30 flange: its leader must cross the
+        # flange body to reach the row below — an unavoidable cut, reported as an
+        # info notice (a candidate for a detail view).
+        part = Rotation(0, 90, 0) * (
+            self._cyl(3, 0.5, 0.0) + self._cyl(15, 20, 0.5) + self._cyl(10, 15, 20.5)
+        )
+        dwg = build_drawing(part)
+        issues = [i for i in dwg.lint() if i.code == "leader_crosses_silhouette"]
+        assert issues, "expected a leader_crosses_silhouette notice on the nested boss"
+        assert all(i.severity == "info" for i in issues)
+
+    def test_plain_stepped_shaft_is_not_flagged(self):
+        # A clean turned shaft: every ⌀ leader runs outward to the row, none cut
+        # through the body.
+        dwg = build_drawing(
+            Rotation(0, 90, 0) * (Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(8, 30))
+        )
+        assert not any(i.code == "leader_crosses_silhouette" for i in dwg.lint())
+
+    def test_hole_callout_exiting_the_part_is_not_flagged(self):
+        # GRM-03: the side-view hole callout legitimately exits the disc from an
+        # internal hole (covers_diameters), and the ⌀ leaders don't cut the body.
+        fixture = Path(__file__).parent / "fixtures" / "grm03_thumbwheel_drive_screw.step"
+        dwg = build_drawing(step_file=str(fixture))
+        assert not any(i.code == "leader_crosses_silhouette" for i in dwg.lint())
+
+
 class TestTurnedLengths:
     """Axial step-length chain for X-axis turned parts (the drive-screw gap:
     every diameter dimensioned, no shoulder locatable)."""


### PR DESCRIPTION
Phase 1 of #796 — an observability net; the routing fix is the #798 design follow-up.

## What

An **info-level** `leader_crosses_silhouette` structural-lint notice fires when a leader's shaft passes **through** the projected view body — a ⌀ step/boss leader clipping a neighbouring step, or a nested feature whose leader has no clear route (a detail-view candidate). This makes the gap the two #794 reviews flagged (leaders can cross the part and lint stays clean) observable.

## Discriminator

`_leader_shaft_hits_edges`: step 0.5 mm off the tip (a ⌀ tip sits on the outline by design), then **count edge crossings** —
- a leader that legitimately **exits** (hole callout from an internal hole; a ⌀ leader running outward) crosses the outline **once** (or zero);
- a shaft that cuts **through** a body **enters and exits** → **≥2** crossings.

Hole callouts (which exit an internal hole once) are additionally excluded via `covers_diameters`. Reuses the shared per-view edge cache; **info** severity so it's a notice, not a gate.

## Scope (why Phase 2 is separate — #798)

The crossings aren't a free elbow choice: the ⌀ diagonals come from label **row-packing** (GRM-03's ⌀6 is a near-miss forced by a full row), and a genuinely **nested** feature can't be routed clear at all (needs detail-view escalation or a new leader-to-part-end mode). A fully general crossing test also wants filled point-in-polygon over curved end-view silhouettes. All of that is the #798 design work.

## Verification

- Integration (real projected views): nested boss + thin-neck groove flagged (info); plain stepped shaft + GRM-03 clean.
- Unit tests pin the ≥2-crossing discriminator and the tip-skip.
- **Full fast tier: 1533 passed, 3 skipped** — no existing fixture regressed by the new code.
- ruff / format / mypy / codespell clean.

Closes part of #796; Phase 2 tracked in #798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
