### PR TITLE
feat(#798): route a nested ⌀ leader into a detail view instead of crossing the body

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -935,6 +935,80 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None) -> int:
     return placed
 
 
+def _escalate_crossing_diameters(dwg, ctx) -> int:
+    """Route a turned ⌀ leader that cuts THROUGH the part body — a nested feature
+    with no clear route in the row/column (#798) — into an enlarged DETAIL view,
+    rather than leaving a shaft crossing the silhouette.
+
+    The crossing is detected against the front silhouette with the shared lint
+    discriminator (``_leader_shaft_hits_edges``); the crossing leader is removed
+    and a :class:`DetailRequest` queued, resolved in the ``details`` stage with a
+    ⌀ callout redrawn at the enlarged scale. The main-view outline still carries
+    the feature, and if the detail cannot be placed the drop falls to honest
+    ``feature_not_dimensioned`` lint. Returns the number escalated."""
+    from draftwright.linting.structural import _leader_shaft_hits_edges, _shape_box2d
+
+    vs = dwg.views.get("front")
+    if not vs or vs[0] is None:
+        return 0
+    try:
+        edges = [(e, _shape_box2d(e)) for e in vs[0].edges()]
+    except Exception:  # noqa: BLE001 — an unanalysable projected shape just skips escalation
+        return 0
+    draft = dwg.draft
+    names = [n for n in dwg.annotations() if n.startswith(("m_dia_x", "m_dia_z"))]
+    escalated = 0
+    for name in names:
+        ldr = dwg.get_annotation(name)
+        if ldr is None or getattr(ldr, "elbow", None) is None:
+            continue
+        if not _leader_shaft_hits_edges(ldr.tip, ldr.elbow, edges):
+            continue
+        feat = dwg.registry.feature_of(name)
+        dia = getattr(feat, "diameter", None)
+        span = getattr(feat, "span", None)
+        if feat is None or not dia or not span:
+            continue
+        axis = feat.frame.axis
+        idx = {"x": 0, "y": 1, "z": 2}[axis]
+        ends = sorted(p[idx] for p in span)
+        lo, hi = ends[0], ends[1]
+        pad = 0.3 * (hi - lo) + 1.0
+        dwg.remove(name)  # the detail carries the ø now
+        escalated += 1
+
+        def _redraw(dwg, view, detail_scale, _feat=feat, _dia=dia, _axis=axis, _mid=(lo + hi) / 2):
+            o = list(_feat.frame.origin)
+            o[{"x": 0, "y": 1, "z": 2}[_axis]] = _mid
+            gap = draft.font_size + 4 * draft.pad_around_text
+            vb = dwg.view_bounds(view)  # the placed detail's page bounds — route the label clear
+            if _axis in ("x", "y"):
+                t = dwg.at(view, o[0], o[1], o[2] - _dia / 2)  # bottom silhouette
+                elbow = (t[0], (vb[1] - gap) if vb else (t[1] - gap), 0)
+            else:
+                t = dwg.at(view, o[0] - _dia / 2, o[1], o[2])  # left silhouette
+                elbow = ((vb[0] - gap) if vb else (t[0] - gap), t[1], 0)
+            dwg.add(
+                Leader(tip=(t[0], t[1], 0), elbow=elbow, label=f"ø{_fmt(_dia)}", draft=draft),
+                f"dim_{view}_dia",
+                view=view,
+            )
+            return 1
+
+        ctx.detail_requests.append(
+            DetailRequest(
+                axis=axis,
+                lo=lo - pad,
+                hi=hi + pad,
+                scale_needed=12.0 / dia,  # absolute world→page scale that reads the ⌀ legibly
+                redraw=_redraw,
+                pad_top=2 * (draft.font_size + 2 * draft.pad_around_text) + draft.arrow_length,
+                kind="turned-diameter",
+            )
+        )
+    return escalated
+
+
 def _diameter_step_anchor(anchor, features):
     """Anchor point for a turned ⌀ leader tip.
 
@@ -1038,9 +1112,15 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
     start_x = _next_start("m_dia_x") if only is not None else 0
     start_z = _next_start("m_dia_z") if only is not None else 0
     trace = getattr(ctx, "trace", None)  # the immediate placers report to the trace too (#736)
-    return _diameter_row_below(
+    placed = _diameter_row_below(
         dwg, _items(row_buckets), start=start_x, trace=trace
     ) + _diameter_column_left(dwg, _items(col_buckets), start=start_z, trace=trace)
+    # #798: a ⌀ leader that cuts through the body (a nested feature) has no clear
+    # route in the row/column — re-route it into an enlarged detail view. Auto-pass
+    # only; the finalize (only=) path replays recorded verbs verbatim.
+    if only is None:
+        _escalate_crossing_diameters(dwg, ctx)
+    return placed
 
 
 def _env_pd(group, role):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8701,9 +8701,16 @@ class TestTurnedDiameters:
 
         part = Rotation(0, 90, 0) * (cyl(3, 0.5, 0.0) + cyl(15, 20, 0.5) + cyl(10, 15, 20.5))
         dwg = build_drawing(part)
-        labels = {o.label for n, o in dwg.iter_annotations() if n.startswith("m_dia")}
-        assert {"ø6", "ø30", "ø20"} <= labels  # the nested ø6 is now called out
+        # ø30/ø20 are the clean main-view step callouts; the nested ø6 boss can't be
+        # leadered without crossing the flange body, so it is routed into a detail view
+        # (#798) — its ø6 still appears (as the detail callout), so coverage holds.
+        labels = {str(o.label) for _, o in dwg.iter_annotations()}
+        assert {"ø6", "ø30", "ø20"} <= labels
+        assert {"ø30", "ø20"} <= {
+            o.label for n, o in dwg.iter_annotations() if n.startswith("m_dia")
+        }
         assert dwg.lint_summary()["by_code"].get("feature_not_dimensioned", 0) == 0
+        assert dwg.lint_summary()["by_code"].get("leader_crosses_silhouette", 0) == 0
 
     def test_diameter_row_places_what_fits_not_all_or_nothing(self):
         # #298 hardening: on a part too small to fit every ø callout in the row, the
@@ -8756,24 +8763,21 @@ class TestTurnedDiameters:
         # Only STEP diameters are centred on their span. A boss is re-synthesised
         # WITHOUT a declared span in the emitted-Sheet path, so — unlike a step —
         # its ø leader must anchor at the frame origin (which round-trips) rather
-        # than a span mid, or the direct and scripted builds diverge (#707).
-        # (nested ø6 boss under the ø30 silhouette.)
-        from build123d import Align
-
-        def cyl(r, h, z):
-            return Pos(0, 0, z) * Cylinder(r, h, align=(Align.CENTER, Align.CENTER, Align.MIN))
-
-        dwg = build_drawing(
-            Rotation(0, 90, 0) * (cyl(3, 0.5, 0.0) + cyl(15, 20, 0.5) + cyl(10, 15, 20.5))
-        )
+        # than a span mid, or the direct and scripted builds diverge (#707). GRM-03's
+        # ø6 boss leads cleanly in the front row (it does not cross, so #798 leaves it
+        # in the main view — unlike the enclosed nested boss).
+        fixture = Path(__file__).parent / "fixtures" / "grm03_thumbwheel_drive_screw.step"
+        dwg = build_drawing(step_file=str(fixture))
         boss = next(
             f
             for f in dwg.model().features
-            if getattr(f, "diameter", None) == 6.0 and f.frame.axis == "x"
+            if getattr(f, "diameter", None) == 6.0 and getattr(f, "kind", None) == "boss"
         )
-        origin_x = dwg.at("front", boss.frame.origin[0], 0, 0)[0]
+        origin_x = dwg.at("front", *boss.frame.origin)[0]
         tip_x = next(
-            o.tip[0] for n, o in dwg.iter_annotations() if str(getattr(o, "label", "")) == "ø6"
+            o.tip[0]
+            for n, o in dwg.iter_annotations()
+            if n.startswith("m_dia") and str(getattr(o, "label", "")) == "ø6"
         )
         assert abs(tip_x - origin_x) < 1e-6, "ø6 boss leader should anchor at its frame origin"
 
@@ -8866,17 +8870,31 @@ class TestLeaderCrossesSilhouette:
 
         return Pos(0, 0, z) * Cylinder(r, h, align=(Align.CENTER, Align.CENTER, Align.MIN))
 
-    def test_nested_boss_leader_is_flagged(self):
-        # A ø6 boss stub protruding from a ø30 flange: its leader must cross the
-        # flange body to reach the row below — an unavoidable cut, reported as an
-        # info notice (a candidate for a detail view).
+    def test_crossing_leader_is_flagged(self):
+        # A thin-neck groove leader must cross a flange body to reach its label — an
+        # unavoidable cut. Grooves aren't ⌀-detail-routed (#798 handles step/boss
+        # diameters), so it surfaces as an info notice.
+        part = Rotation(0, 90, 0) * (
+            self._cyl(15, 10, 0.0) + self._cyl(3, 2, 10) + self._cyl(15, 10, 12)
+        )
+        dwg = build_drawing(part, number="X")
+        issues = [i for i in dwg.lint() if i.code == "leader_crosses_silhouette"]
+        assert issues, "expected a leader_crosses_silhouette notice"
+        assert all(i.severity == "info" for i in issues)
+
+    def test_nested_boss_diameter_routes_to_a_detail_not_a_crossing(self):
+        # #798: the ø6 boss stub whose leader would cross the ø30 flange is re-routed
+        # into an enlarged detail view instead — so no crossing survives, the ø6 is
+        # still called out (in the detail), and coverage holds.
         part = Rotation(0, 90, 0) * (
             self._cyl(3, 0.5, 0.0) + self._cyl(15, 20, 0.5) + self._cyl(10, 15, 20.5)
         )
         dwg = build_drawing(part)
-        issues = [i for i in dwg.lint() if i.code == "leader_crosses_silhouette"]
-        assert issues, "expected a leader_crosses_silhouette notice on the nested boss"
-        assert all(i.severity == "info" for i in issues)
+        assert any(v.startswith("detail_") for v in dwg.views), "expected a detail view"
+        assert "ø6" in {str(o.label) for _, o in dwg.iter_annotations()}
+        by_code = dwg.lint_summary()["by_code"]
+        assert by_code.get("leader_crosses_silhouette", 0) == 0
+        assert by_code.get("feature_not_dimensioned", 0) == 0
 
     def test_plain_stepped_shaft_is_not_flagged(self):
         # A clean turned shaft: every ⌀ leader runs outward to the row, none cut


### PR DESCRIPTION
Phase 2 of #796 / #798 — the real fix behind the Phase-1 `leader_crosses_silhouette` notice (#799).

## What

When a turned ⌀ step/boss leader's shaft would cut **through** the part body — a *nested* feature (e.g. a ⌀6 boss stub protruding from a ⌀30 flange) with no clear route in the row/column — it is re-routed into an enlarged **detail view** instead of leaving a shaft crossing the silhouette.

## How

At the end of the `diameters` stage, `_escalate_crossing_diameters`:
1. detects each crossing `m_dia` leader with the shared Phase-1 discriminator (`linting.structural._leader_shaft_hits_edges` — a legal L4→L2 downward import, as `_common.py` already does),
2. removes the crossing leader, and
3. queues a `DetailRequest` — reusing the axis-generic crop→project→place→redraw detail machinery that `render_step_lengths` (turned head) and `_request_prismatic_detail` already use. The `redraw` draws the ⌀ callout in the detail view, routed clear of the detail's own bounds.

The main-view outline still carries the feature; if the detail can't be placed, the drop falls to honest `feature_not_dimensioned` lint (no silent loss).

## Result (nested-boss fixture)

- **DETAIL A — SCALE 2:1** carries the ⌀6; the crossing leader is gone from the main views.
- `leader_crosses_silhouette` → **0**; `feature_not_dimensioned` → **0** (coverage preserved); **lint-clean** (0 non-info).

## Blast radius — contained

Only the nested-boss fixture tests shifted (no layout/parity ripple):
- `test_nested_band…` now checks ⌀6-in-detail + no crossing;
- the boss-origin parity test moved to **GRM-03's non-crossing ⌀6 boss** (untouched by escalation);
- the Phase-1 lint test moved to the **thin-neck groove** (still crosses; grooves aren't ⌀-routed);
- added `test_nested_boss_diameter_routes_to_a_detail_not_a_crossing`.

**Full fast tier: 1538 passed, 3 skipped.** ruff / format / mypy / codespell / import-boundaries clean.

## Scope

Turned ⌀ **step/boss** leaders only. Groove/non-turned crossing leaders remain surfaced by the Phase-1 notice (a natural follow-up). A fully general filled-region crossing test also remains #798's later scope.

Closes the core of #798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
