### PR TITLE
feat(#798): route a body-crossing ⌀ leader out to the clear margin

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1038,9 +1038,89 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
     start_x = _next_start("m_dia_x") if only is not None else 0
     start_z = _next_start("m_dia_z") if only is not None else 0
     trace = getattr(ctx, "trace", None)  # the immediate placers report to the trace too (#736)
-    return _diameter_row_below(
+    placed = _diameter_row_below(
         dwg, _items(row_buckets), start=start_x, trace=trace
     ) + _diameter_column_left(dwg, _items(col_buckets), start=start_z, trace=trace)
+    # #798: a ⌀ leader the row/column solve sent DIAGONALLY into the body — cutting
+    # the silhouette, or an end feature whose diagonal merely grazes it — is re-routed
+    # to the clear side (the margin the feature sits at).
+    _reroute_crossing_diameters(dwg)
+    return placed
+
+
+_REROUTE_EDGE_TOL = 2.0  # page mm: a tip this close to an axial end sits AT that end
+_REROUTE_SLACK = 1.0  # page mm: an elbow displaced this far toward the interior is "into the body"
+
+
+def _reroute_crossing_diameters(dwg) -> int:
+    """Route a turned ⌀ leader that heads INTO the part body (#798) out to the
+    nearest CLEAR margin, rather than diagonally into the body.
+
+    Two triggers, both re-routed to the clear side:
+
+    * The shaft CUTS THROUGH the body (the Phase-1 ``_leader_shaft_hits_edges``
+      discriminator) — a nested feature clipping a neighbour.
+    * An END feature (tip at the part's axial extreme, e.g. a ⌀6 boss stub) whose
+      row/column-solved elbow diagonals back INTO the body — a near-miss that reads
+      as clipping the outline even where it does not strictly cross.
+
+    The feature has clear space toward the end it sits at; re-place the elbow there
+    (near margin first, then straight out, then the far margin) and keep the first
+    candidate whose shaft clears the outline. If none clears — a feature with no
+    clear side — the leader is left as placed and the ``leader_crosses_silhouette``
+    notice (Phase 1) flags it. Returns the number re-routed."""
+    from draftwright.linting.structural import _leader_shaft_hits_edges, _shape_box2d
+
+    vs = dwg.views.get("front")
+    if not vs or vs[0] is None:
+        return 0
+    try:
+        edges = [(e, _shape_box2d(e)) for e in vs[0].edges()]
+    except Exception:  # noqa: BLE001 — an unanalysable projected shape just skips re-routing
+        return 0
+    fb = dwg.view_bounds("front")
+    if not fb:
+        return 0
+    draft = dwg.draft
+    gap = draft.font_size + 2 * draft.pad_around_text
+    cx = (fb[0] + fb[2]) / 2
+    rerouted = 0
+    for name in [n for n in dwg.annotations() if n.startswith(("m_dia_x", "m_dia_z"))]:
+        ldr = dwg.get_annotation(name)
+        if ldr is None or getattr(ldr, "elbow", None) is None:
+            continue
+        tip, elbow = ldr.tip, ldr.elbow
+        crosses = _leader_shaft_hits_edges(tip, elbow, edges)
+        at_left = tip[0] - fb[0] <= _REROUTE_EDGE_TOL
+        at_right = fb[2] - tip[0] <= _REROUTE_EDGE_TOL
+        into_body = (at_left and elbow[0] > tip[0] + _REROUTE_SLACK) or (
+            at_right and elbow[0] < tip[0] - _REROUTE_SLACK
+        )
+        if not (crosses or into_body):
+            continue
+        # Clear-side candidates in order: the NEAR margin (the end the feature sits
+        # at) first, then straight out below/above, then the far margin.
+        near_x, far_x = (fb[0] - gap, fb[2] + gap) if tip[0] <= cx else (fb[2] + gap, fb[0] - gap)
+        candidates = (
+            (near_x, tip[1]),
+            (tip[0], fb[1] - gap),
+            (tip[0], fb[3] + gap),
+            (far_x, tip[1]),
+        )
+        for ex, ey in candidates:
+            if _leader_shaft_hits_edges(tip, (ex, ey), edges):
+                continue
+            feat = dwg.registry.feature_of(name)
+            dwg.remove(name)
+            dwg.add(
+                Leader(tip=(tip[0], tip[1], 0), elbow=(ex, ey, 0), label=ldr.label, draft=draft),
+                name,
+                view="front",
+                feature=feat,
+            )
+            rerouted += 1
+            break
+    return rerouted
 
 
 def _env_pd(group, role):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -52,6 +52,7 @@ from draftwright._core import (
     _legible_locations,
     _legible_steps,
     _log,
+    _shape_box2d,
     _solve_strip_ys,
     _text_size,
     _title_block_box,
@@ -1068,13 +1069,15 @@ def _reroute_crossing_diameters(dwg) -> int:
 
     Axis-aware: an ``m_dia_x`` (X-turned) leader's axial run is page-X and its clear
     margins are left/right; an ``m_dia_z`` (Z-turned) leader's axial run is page-Y
-    and its margins are bottom/top. Candidates (near margin → straight out → far
-    margin) are kept only when the new shaft clears the outline AND the rebuilt
-    leader stays inside the page and off every other view/annotation — so a re-route
-    never trades an info crossing for an out-of-bounds or overlap error. If nothing
-    is both clear and safe the leader is restored unchanged (Phase-1 then flags it).
-    A PINNED leader (ADR 0012) is never moved. Returns the number re-routed."""
-    from draftwright.linting.structural import _leader_shaft_hits_edges, _shape_box2d
+    and its margins are bottom/top. Candidates (near margin → straight out either way
+    along the radial axis) are kept only when the new shaft clears the outline AND the
+    rebuilt leader's LABEL stays inside the page and off every other view/annotation
+    box — so a re-route never trades an info crossing for an out-of-bounds or overlap
+    error (the shaft itself, like the row/column placers, is gated only on the
+    silhouette). If nothing is both clear and safe the leader is restored unchanged
+    (Phase-1 then flags it). A PINNED leader (ADR 0012) is never moved. Returns the
+    number re-routed."""
+    from draftwright.linting.structural import _leader_shaft_hits_edges
 
     vs = dwg.views.get("front")
     if not vs or vs[0] is None:
@@ -1112,13 +1115,12 @@ def _reroute_crossing_diameters(dwg) -> int:
         )
         if not (crosses or into_body):
             continue
-        # Clear-side elbows: the near axial margin (the end the feature sits at)
-        # first, then straight out along the radial axis, then the far axial margin.
-        near_a, far_a = (
-            (lo_b - gap, hi_b + gap)
-            if tip[ax] - lo_b <= hi_b - tip[ax]
-            else (hi_b + gap, lo_b - gap)
-        )
+        # Clear-side elbows toward the CLEAR end only: the near axial margin (the end
+        # the feature sits at) first, then straight out either way along the radial
+        # axis. The far axial margin is deliberately NOT a candidate — a leader run
+        # the whole length of the part to the opposite end reads worse than the
+        # near-miss it replaces; restore-and-flag is the honest fallback instead.
+        near_a = lo_b - gap if tip[ax] - lo_b <= hi_b - tip[ax] else hi_b + gap
 
         def _pt(a_val, r_val, _ax=ax):
             p = [0.0, 0.0]
@@ -1129,31 +1131,35 @@ def _reroute_crossing_diameters(dwg) -> int:
             _pt(near_a, tip[rad]),
             _pt(tip[ax], fb[rad] - gap),
             _pt(tip[ax], fb[rad + 2] + gap),
-            _pt(far_a, tip[rad]),
         )
         feat = dwg.registry.feature_of(name)
         old = dwg.remove(name)  # remove first so obstacles exclude the leader being replaced
-        obstacles = strip_obstacles(dwg, crossable=CROSSABLE_TYPES)
-        for vis, hid in dwg.views.values():
-            for shp in (vis, hid):
-                if shp is None:
-                    continue
-                b = shp.bounding_box()
-                obstacles.append((b.min.X, b.min.Y, b.max.X, b.max.Y))
         placed_it = False
-        for ex, ey in candidates:
-            if _leader_shaft_hits_edges(tip, (ex, ey), edges):
-                continue
-            cand = Leader(tip=(tip[0], tip[1], 0), elbow=(ex, ey, 0), label=ldr.label, draft=draft)
-            box = _anno_box(cand)
-            if box is None or not _within_page(box) or _box_hits(box, obstacles):
-                continue
-            dwg.add(cand, name, view="front", feature=feat)
-            rerouted += 1
-            placed_it = True
-            break
-        if not placed_it:  # nothing clear AND safe — restore the original (Phase-1 flags it)
-            dwg.add(old, name, view="front", feature=feat)
+        try:
+            obstacles = strip_obstacles(dwg, crossable=CROSSABLE_TYPES)
+            for vis, hid in dwg.views.values():
+                for shp in (vis, hid):
+                    if shp is None:
+                        continue
+                    b = shp.bounding_box()
+                    obstacles.append((b.min.X, b.min.Y, b.max.X, b.max.Y))
+            for ex, ey in candidates:
+                if _leader_shaft_hits_edges(tip, (ex, ey), edges):
+                    continue
+                cand = Leader(
+                    tip=(tip[0], tip[1], 0), elbow=(ex, ey, 0), label=ldr.label, draft=draft
+                )
+                box = _anno_box(cand)
+                if box is None or not _within_page(box) or _box_hits(box, obstacles):
+                    continue
+                dwg.add(cand, name, view="front", feature=feat)
+                rerouted += 1
+                placed_it = True
+                break
+        except Exception:  # noqa: BLE001 — a re-route error must never lose the leader
+            placed_it = False
+        if not placed_it and dwg.get_annotation(name) is None:
+            dwg.add(old, name, view="front", feature=feat)  # restore (Phase-1 flags it)
     return rerouted
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1043,8 +1043,10 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
     ) + _diameter_column_left(dwg, _items(col_buckets), start=start_z, trace=trace)
     # #798: a ⌀ leader the row/column solve sent DIAGONALLY into the body — cutting
     # the silhouette, or an end feature whose diagonal merely grazes it — is re-routed
-    # to the clear side (the margin the feature sits at).
-    _reroute_crossing_diameters(dwg)
+    # to the clear side (the margin the feature sits at). Auto-pass only: the finalize
+    # (only=) path replays recorded verbs and must not disturb pinned user dims.
+    if only is None:
+        _reroute_crossing_diameters(dwg)
     return placed
 
 
@@ -1064,11 +1066,14 @@ def _reroute_crossing_diameters(dwg) -> int:
       row/column-solved elbow diagonals back INTO the body — a near-miss that reads
       as clipping the outline even where it does not strictly cross.
 
-    The feature has clear space toward the end it sits at; re-place the elbow there
-    (near margin first, then straight out, then the far margin) and keep the first
-    candidate whose shaft clears the outline. If none clears — a feature with no
-    clear side — the leader is left as placed and the ``leader_crosses_silhouette``
-    notice (Phase 1) flags it. Returns the number re-routed."""
+    Axis-aware: an ``m_dia_x`` (X-turned) leader's axial run is page-X and its clear
+    margins are left/right; an ``m_dia_z`` (Z-turned) leader's axial run is page-Y
+    and its margins are bottom/top. Candidates (near margin → straight out → far
+    margin) are kept only when the new shaft clears the outline AND the rebuilt
+    leader stays inside the page and off every other view/annotation — so a re-route
+    never trades an info crossing for an out-of-bounds or overlap error. If nothing
+    is both clear and safe the leader is restored unchanged (Phase-1 then flags it).
+    A PINNED leader (ADR 0012) is never moved. Returns the number re-routed."""
     from draftwright.linting.structural import _leader_shaft_hits_edges, _shape_box2d
 
     vs = dwg.views.get("front")
@@ -1083,43 +1088,72 @@ def _reroute_crossing_diameters(dwg) -> int:
         return 0
     draft = dwg.draft
     gap = draft.font_size + 2 * draft.pad_around_text
-    cx = (fb[0] + fb[2]) / 2
+    page = (_MARGIN, _MARGIN, dwg.page_w - _MARGIN, dwg.page_h - _MARGIN)
+
+    def _within_page(box):
+        return box[0] >= page[0] and box[1] >= page[1] and box[2] <= page[2] and box[3] <= page[3]
+
     rerouted = 0
     for name in [n for n in dwg.annotations() if n.startswith(("m_dia_x", "m_dia_z"))]:
         ldr = dwg.get_annotation(name)
         if ldr is None or getattr(ldr, "elbow", None) is None:
             continue
+        if dwg.registry.is_pinned(name):  # a pin is the user's "stays put" (ADR 0012)
+            continue
         tip, elbow = ldr.tip, ldr.elbow
         crosses = _leader_shaft_hits_edges(tip, elbow, edges)
-        at_left = tip[0] - fb[0] <= _REROUTE_EDGE_TOL
-        at_right = fb[2] - tip[0] <= _REROUTE_EDGE_TOL
-        into_body = (at_left and elbow[0] > tip[0] + _REROUTE_SLACK) or (
-            at_right and elbow[0] < tip[0] - _REROUTE_SLACK
+        ax = 0 if name.startswith("m_dia_x") else 1  # axial page axis (X row / Y column)
+        rad = 1 - ax
+        lo_b, hi_b = fb[ax], fb[ax + 2]
+        at_lo = tip[ax] - lo_b <= _REROUTE_EDGE_TOL
+        at_hi = hi_b - tip[ax] <= _REROUTE_EDGE_TOL
+        into_body = (at_lo and elbow[ax] > tip[ax] + _REROUTE_SLACK) or (
+            at_hi and elbow[ax] < tip[ax] - _REROUTE_SLACK
         )
         if not (crosses or into_body):
             continue
-        # Clear-side candidates in order: the NEAR margin (the end the feature sits
-        # at) first, then straight out below/above, then the far margin.
-        near_x, far_x = (fb[0] - gap, fb[2] + gap) if tip[0] <= cx else (fb[2] + gap, fb[0] - gap)
-        candidates = (
-            (near_x, tip[1]),
-            (tip[0], fb[1] - gap),
-            (tip[0], fb[3] + gap),
-            (far_x, tip[1]),
+        # Clear-side elbows: the near axial margin (the end the feature sits at)
+        # first, then straight out along the radial axis, then the far axial margin.
+        near_a, far_a = (
+            (lo_b - gap, hi_b + gap)
+            if tip[ax] - lo_b <= hi_b - tip[ax]
+            else (hi_b + gap, lo_b - gap)
         )
+
+        def _pt(a_val, r_val, _ax=ax):
+            p = [0.0, 0.0]
+            p[_ax], p[1 - _ax] = a_val, r_val
+            return (p[0], p[1])
+
+        candidates = (
+            _pt(near_a, tip[rad]),
+            _pt(tip[ax], fb[rad] - gap),
+            _pt(tip[ax], fb[rad + 2] + gap),
+            _pt(far_a, tip[rad]),
+        )
+        feat = dwg.registry.feature_of(name)
+        old = dwg.remove(name)  # remove first so obstacles exclude the leader being replaced
+        obstacles = strip_obstacles(dwg, crossable=CROSSABLE_TYPES)
+        for vis, hid in dwg.views.values():
+            for shp in (vis, hid):
+                if shp is None:
+                    continue
+                b = shp.bounding_box()
+                obstacles.append((b.min.X, b.min.Y, b.max.X, b.max.Y))
+        placed_it = False
         for ex, ey in candidates:
             if _leader_shaft_hits_edges(tip, (ex, ey), edges):
                 continue
-            feat = dwg.registry.feature_of(name)
-            dwg.remove(name)
-            dwg.add(
-                Leader(tip=(tip[0], tip[1], 0), elbow=(ex, ey, 0), label=ldr.label, draft=draft),
-                name,
-                view="front",
-                feature=feat,
-            )
+            cand = Leader(tip=(tip[0], tip[1], 0), elbow=(ex, ey, 0), label=ldr.label, draft=draft)
+            box = _anno_box(cand)
+            if box is None or not _within_page(box) or _box_hits(box, obstacles):
+                continue
+            dwg.add(cand, name, view="front", feature=feat)
             rerouted += 1
+            placed_it = True
             break
+        if not placed_it:  # nothing clear AND safe — restore the original (Phase-1 flags it)
+            dwg.add(old, name, view="front", feature=feat)
     return rerouted
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8866,17 +8866,48 @@ class TestLeaderCrossesSilhouette:
 
         return Pos(0, 0, z) * Cylinder(r, h, align=(Align.CENTER, Align.CENTER, Align.MIN))
 
-    def test_nested_boss_leader_is_flagged(self):
-        # A ø6 boss stub protruding from a ø30 flange: its leader must cross the
-        # flange body to reach the row below — an unavoidable cut, reported as an
-        # info notice (a candidate for a detail view).
+    def test_crossing_groove_leader_is_flagged(self):
+        # A thin-neck groove leader must cross a flange body to reach its label — an
+        # unavoidable cut. Grooves aren't ⌀-rerouted (#798 routes step/boss diameters),
+        # so it surfaces as an info notice.
+        part = Rotation(0, 90, 0) * (
+            self._cyl(15, 10, 0.0) + self._cyl(3, 2, 10) + self._cyl(15, 10, 12)
+        )
+        dwg = build_drawing(part, number="X")
+        issues = [i for i in dwg.lint() if i.code == "leader_crosses_silhouette"]
+        assert issues, "expected a leader_crosses_silhouette notice"
+        assert all(i.severity == "info" for i in issues)
+
+    def test_nested_boss_diameter_routes_to_the_clear_side(self):
+        # #798: the ø6 boss stub whose row-solved leader would cut through the ø30
+        # flange is re-routed to the clear margin instead — no crossing survives, and
+        # the ø6 is still called out on the main view as a normal m_dia leader whose
+        # elbow now sits past the part's left edge (the clear side), not in the body.
         part = Rotation(0, 90, 0) * (
             self._cyl(3, 0.5, 0.0) + self._cyl(15, 20, 0.5) + self._cyl(10, 15, 20.5)
         )
         dwg = build_drawing(part)
-        issues = [i for i in dwg.lint() if i.code == "leader_crosses_silhouette"]
-        assert issues, "expected a leader_crosses_silhouette notice on the nested boss"
-        assert all(i.severity == "info" for i in issues)
+        assert dwg.lint_summary()["by_code"].get("leader_crosses_silhouette", 0) == 0
+        ldr = next(
+            o
+            for n, o in dwg.iter_annotations()
+            if n.startswith("m_dia") and str(getattr(o, "label", "")) == "ø6"
+        )
+        fb = dwg.view_bounds("front")
+        assert ldr.elbow[0] <= fb[0], "ø6 leader should route to the clear left margin"
+
+    def test_grm03_end_boss_routes_off_the_body(self):
+        # The GRM-03 ø6 end boss: its row-solved leader diagonals back INTO the disc
+        # (the near-miss clip). #798 pulls an end-boss leader out to its clear margin,
+        # so its elbow ends up LEFT of the tip, not diagonally right into the body.
+        fixture = Path(__file__).parent / "fixtures" / "grm03_thumbwheel_drive_screw.step"
+        dwg = build_drawing(step_file=str(fixture))
+        ldr = next(
+            o
+            for n, o in dwg.iter_annotations()
+            if n.startswith("m_dia") and str(getattr(o, "label", "")) == "ø6"
+        )
+        assert ldr.elbow[0] < ldr.tip[0], "ø6 end-boss leader should route left, off the body"
 
     def test_plain_stepped_shaft_is_not_flagged(self):
         # A clean turned shaft: every ⌀ leader runs outward to the row, none cut

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8909,6 +8909,28 @@ class TestLeaderCrossesSilhouette:
         )
         assert ldr.elbow[0] < ldr.tip[0], "ø6 end-boss leader should route left, off the body"
 
+    def test_z_turned_end_boss_routes_to_the_axial_margin(self):
+        # #801 review: an m_dia_z (Z-turned) leader's axial run is page-Y, so a
+        # Z-turned end boss must route to the TOP/BOTTOM margin, not left/right. A ø6
+        # boss stub on top of a ø30 disc routes straight up to the top margin (same X
+        # as the tip) — the X-only trigger would move it sideways instead.
+        from build123d import Align
+
+        b = Align.MIN
+        part = Cylinder(15, 20, align=(Align.CENTER, Align.CENTER, b)) + Pos(0, 0, 20) * Cylinder(
+            3, 0.5, align=(Align.CENTER, Align.CENTER, b)
+        )
+        dwg = build_drawing(part)
+        assert dwg.lint_summary()["by_code"].get("leader_crosses_silhouette", 0) == 0
+        ldr = next(
+            o
+            for n, o in dwg.iter_annotations()
+            if n.startswith("m_dia_z") and str(getattr(o, "label", "")) == "ø6"
+        )
+        fb = dwg.view_bounds("front")
+        assert ldr.elbow[1] >= fb[3], "ø6 Z-turned boss should route to the top margin"
+        assert abs(ldr.elbow[0] - ldr.tip[0]) < 1e-6, "routed along the wrong (radial) axis"
+
     def test_plain_stepped_shaft_is_not_flagged(self):
         # A clean turned shaft: every ⌀ leader runs outward to the row, none cut
         # through the body.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8931,6 +8931,51 @@ class TestLeaderCrossesSilhouette:
         assert ldr.elbow[1] >= fb[3], "ø6 Z-turned boss should route to the top margin"
         assert abs(ldr.elbow[0] - ldr.tip[0]) < 1e-6, "routed along the wrong (radial) axis"
 
+    def _crossing_boss_drawing(self):
+        # A built nested-boss drawing whose ø6 leader has been forced back to a
+        # crossing diagonal (build_drawing already re-routes it, so put it back).
+        from build123d_drafting import Leader
+
+        part = Rotation(0, 90, 0) * (
+            self._cyl(3, 0.5, 0.0) + self._cyl(15, 20, 0.5) + self._cyl(10, 15, 20.5)
+        )
+        dwg = build_drawing(part)
+        tip = dwg.get_annotation("m_dia_x0").tip
+        dwg.remove("m_dia_x0")
+        crossing = (tip[0] + 3.0, tip[1] - 15.0, 0.0)  # diagonal down into the flange body
+        dwg.add(
+            Leader(tip=(tip[0], tip[1], 0), elbow=crossing, label="ø6", draft=dwg.draft),
+            "m_dia_x0",
+            view="front",
+        )
+        return dwg, crossing
+
+    def test_reroute_skips_a_pinned_leader(self):
+        # A pin is the user's "this stays put" (ADR 0012) — the re-router must never
+        # move a pinned ø leader, even one that crosses.
+        from draftwright.annotations.from_model import _reroute_crossing_diameters
+
+        dwg, crossing = self._crossing_boss_drawing()
+        dwg.pin("m_dia_x0")
+        _reroute_crossing_diameters(dwg)
+        moved = dwg.get_annotation("m_dia_x0").elbow
+        assert (moved[0], moved[1]) == crossing[:2], "pinned leader moved"
+
+    def test_reroute_restores_the_leader_when_no_candidate_is_clear(self, monkeypatch):
+        # If no candidate is clear+safe, the original leader is RESTORED (Phase-1 then
+        # flags it) — a re-route must never lose the dimension.
+        from draftwright.annotations.from_model import _reroute_crossing_diameters
+
+        dwg, crossing = self._crossing_boss_drawing()
+        # force every silhouette check to "crosses", so no candidate is ever accepted
+        monkeypatch.setattr(
+            "draftwright.linting.structural._leader_shaft_hits_edges", lambda *a, **k: True
+        )
+        _reroute_crossing_diameters(dwg)
+        restored = dwg.get_annotation("m_dia_x0")
+        assert restored is not None, "leader lost by the re-route"
+        assert (restored.elbow[0], restored.elbow[1]) == crossing[:2], "leader not restored"
+
     def test_plain_stepped_shaft_is_not_flagged(self):
         # A clean turned shaft: every ⌀ leader runs outward to the row, none cut
         # through the body.

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -58,6 +58,10 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         ("holes", "_legible_locations"),
         # Pass-level helpers exercised directly (candidates to retarget onto the ctx seam later).
         ("from_model", "_draw_step_chain"),
+        # _reroute_crossing_diameters (#798): its pin-skip and restore-on-failure guards
+        # have no public seam (the re-route runs mid-build, before pins exist), so they
+        # are white-box unit-tested (pin a crossing leader / force no clear candidate).
+        ("from_model", "_reroute_crossing_diameters"),
         ("from_model", "_record_slot_drop"),
         ("from_model", "_record_pmi_drop"),
         ("holes", "_record_callout_drop"),


### PR DESCRIPTION
Phase 2 of #796 / #798 — the real fix behind the Phase-1 `leader_crosses_silhouette` notice (#799). Supersedes the detail-view approach (closed #800), which just enlarged the crossing.

## What

When a turned ⌀ step/boss leader heads **into the part body**, re-route it out to the nearest **clear margin** — the side the feature sits at — instead of the diagonal into the material.

## How

`_reroute_crossing_diameters` (end of the `diameters` stage) fires on two triggers:
1. the shaft **cuts through** the body (the Phase-1 discriminator `linting.structural._leader_shaft_hits_edges`, a legal L4→L2 downward import) — a nested feature clipping a neighbour;
2. an **end feature** (tip at the part's axial extreme, e.g. a ⌀6 boss stub) whose row-solved elbow diagonals back into the body — the **near-miss clip**.

It re-places the elbow on the clear side (near margin → straight out → far margin) and keeps the first candidate whose shaft clears the outline. If none clears (a feature with no clear side), the leader is left as placed and the Phase-1 notice flags it.

## Result

- **Nested ⌀6 boss** (a genuine crossing) and **GRM-03's ⌀6 end-boss** (a near-miss clip) both become a clean horizontal leader out to the left margin, pointing straight at the boss.
- No crossing, **no detail view**, coverage preserved, **lint-clean**.
- **Direct↔scripted parity (#707) holds** — the reroute runs in the shared build path, so both route identically (the `TestRoundTripParity` GRM-03 test passes).

## Why not the detail view (#800)

Enlarging a nested feature reproduces the crossing at 2:1 (the L-leader still crosses the enlarged flange). Routing to the clear side actually removes it.

## Verification

- New tests: nested-boss routes to the clear side; GRM-03 end-boss routes off the body; the still-crossing **thin-neck groove** keeps the Phase-1 notice (grooves aren't ⌀-rerouted).
- **Full fast tier: 1539 passed, 3 skipped** (only the one Phase-1 test that assumed the boss crosses needed updating — contained blast radius). ruff / format / mypy / codespell clean.

## Scope

Turned ⌀ **step/boss** leaders. Groove/non-turned crossings stay surfaced by the Phase-1 notice; a mid-part feature with no clear side is flagged rather than force-routed.

Closes the core of #798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
