### PR TITLE
chore: bump version to 0.3.8.dev0 after v0.3.7 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.3.7.dev0"
+version = "0.3.8.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.3.7.dev0"
+version = "0.3.8.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
Post-release dev-version bump + re-lock. The publish workflow's `bump-version` job cannot push to protected `main` (#779), so this is done manually.

- v0.3.7 released and published to PyPI: https://pypi.org/project/draftwright/0.3.7/
- `pyproject.toml` `0.3.7.dev0` → `0.3.8.dev0` and `uv.lock` re-locked to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)