### PR TITLE
fix(#797): include every step end face in TurnedProfile.shoulders

### DIFF
--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -414,7 +414,13 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
             if isinstance(ann, Dimension)
         ]
         for i, step in enumerate(prof.steps):
-            clo, chi = shoulder_c[step.lo], shoulder_c[step.hi]
+            clo, chi = shoulder_c.get(step.lo), shoulder_c.get(step.hi)
+            if clo is None or chi is None:
+                # Defence-in-depth (#797): `TurnedProfile.shoulders` now includes every
+                # step endpoint (so a non-contiguous profile's interior end face is a
+                # shoulder), and this branch should be unreachable — but a lint pass must
+                # never crash on an unguarded lookup, so skip rather than KeyError.
+                continue
             for name, label, cs in dims:
                 if not cs:
                     continue

--- a/src/draftwright/recognition/turned.py
+++ b/src/draftwright/recognition/turned.py
@@ -102,10 +102,16 @@ class TurnedProfile(Record):
 
     @property
     def shoulders(self) -> tuple[float, ...]:
-        """Sorted axial positions of the shoulders and the two end faces."""
+        """Sorted axial positions of every step's faces (shoulders + the two ends).
+
+        The union of every step's ``lo`` AND ``hi`` — identical to ``lo``s + the
+        last ``hi`` for a contiguous chain (each ``hi`` is the next ``lo``), but
+        also correct for a NON-contiguous profile (e.g. two coaxial discs with an
+        axial gap), where an interior ``hi`` is a real end face, not a shared
+        shoulder — so it is not silently dropped (#797)."""
         if not self.steps:
             return ()
-        return (*(s.lo for s in self.steps), self.steps[-1].hi)
+        return tuple(sorted({p for s in self.steps for p in (s.lo, s.hi)}))
 
 
 def recognise_turned_steps(part, *, cyls=None) -> list[TurnedStep]:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9213,6 +9213,30 @@ class TestTurnedLengths:
         assert not any("×" in v for v in main)  # no false uniform-staircase collapse
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
 
+    def test_non_contiguous_turned_profile_lints_without_crashing(self):
+        # #797: a non-contiguous turned profile — two coaxial discs (ø30, then ø20)
+        # with an axial GAP between them — carries a step whose interior end face
+        # (10) `TurnedProfile.shoulders` used to drop, so the axial-coverage lookup
+        # KeyError'd and crashed the whole lint pass. shoulders now includes every
+        # endpoint, so both discs are locatable: no crash AND — since both lengths
+        # are dimensioned — no false `axial_length_missing` from a dropped face.
+        from build123d import Align
+
+        b = Align.MIN
+        part = Rotation(0, 90, 0) * (
+            Cylinder(15, 10, align=(Align.CENTER, Align.CENTER, b))
+            + Pos(0, 0, 20) * Cylinder(10, 10, align=(Align.CENTER, Align.CENTER, b))
+        )
+        dwg = build_drawing(part, number="X")
+        codes = dwg.lint_summary()["by_code"]  # must not raise KeyError
+        assert sorted(
+            str(o.label) for n, o in dwg.iter_annotations() if n.startswith("m_steplen")
+        ) == [
+            "10",
+            "10",
+        ]
+        assert codes.get("axial_length_missing", 0) == 0
+
 
 class TestStepLadderRecognition:
     """ADR 0008 step 1: the Z step-height ladder draws its step levels from the


### PR DESCRIPTION
## Bug

`lint_axial_coverage` crashed with `KeyError` on a **non-contiguous** turned profile — two coaxial discs (⌀30, an axial gap, ⌀20). The whole lint pass died.

## Root cause

`TurnedProfile.shoulders` returned every step's `lo` plus only the **last** step's `hi`:

```python
return (*(s.lo for s in self.steps), self.steps[-1].hi)
```

That's fine for a contiguous chain (each `hi` is the next `lo`), but on a gapped profile the first disc's interior end face (`10`) is dropped from the shoulder set — so the axial-coverage lookup `shoulder_c[step.hi]` `KeyError`'d.

## Fix (at the source)

`shoulders` is now the **union of every step's `lo` and `hi`** — identical to before for a contiguous chain, and correct for a gapped one:

```python
return tuple(sorted({p for s in self.steps for p in (s.lo, s.hi)}))
```

Both discs become locatable, so: **no crash**, and **no false `axial_length_missing`** (both disc lengths *are* dimensioned). A `.get()` guard in `coverage.py` stays as defence-in-depth so a lint pass can never crash on this lookup again.

## Codex review

The first attempt guarded only the lookup (`.get()` + skip). Codex caught that this stopped the crash but **introduced a false positive** — skipping the located step mis-flagged `axial_length_missing`. Moved the fix to `shoulders`.

## Verification

- Regression test `test_non_contiguous_turned_profile_lints_without_crashing` reproduces ⌀30+gap+⌀20 and pins the contract (both lengths dimensioned, zero coverage issues). Canary-verified: **KeyErrors on `origin/main`**, and **fails with `axial_length_missing: 1` on the `.get()`-only version** (so it pins the root fix, not just the crash).
- **Full fast tier: 1543 passed, 3 skipped.** ruff / format / mypy / codespell clean.

Pre-existing bug, surfaced by the #794 review. Closes #797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
