### PR TITLE
refactor(#754): route rotational OD/bore labels through planner output

### DIFF
--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -5,6 +5,10 @@
   epic #698 are complete. The remaining model-routed passes are classified
   honestly below, including rotational dimension debt now tracked by #754.
   The open/closed consequence is narrowed accordingly.
+- **Amendment 2** (2026-07-22): #754 closed — `render_rotational`'s OD and bore
+  dimension *labels* are now planner-fed (they read the folded value/tolerance off
+  the feature's `DimensionGroup`), moving out of the model-routed list. Only its
+  axis centrelines and bore-stack layout remain model-routed furniture.
 - **Date:** 2026-07-18
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -94,8 +98,8 @@ audit found that many dimension-bearing feature passes still bypassed it and
 opened **#698**. The migrations owned by that epic are now complete:
 `orchestrator._auto_annotate` calls `plan_dimensions` exactly once and threads
 its `DimensionGroup`s to the migrated renderers. The audit of this amendment
-found one residual dimension-bearing bypass, rotational OD/bores, now tracked
-separately by #754.
+found one residual dimension-bearing bypass, rotational OD/bores — since closed
+by #754 (Amendment 2): those labels are now planner-fed.
 
 **Planner-fed today** (the renderer consumes `DimensionGroup`s from
 `plan_dimensions`, or another planner entry point):
@@ -106,6 +110,7 @@ separately by #754.
 | hole / pattern locations | `from_model.render_locations` | `plan_locations` (refs + datum) |
 | turned diameters (ø leaders, row/column) | `from_model.render_diameters` | `plan_dimensions` |
 | boss diameters | `from_model.render_boss_diameters` | `plan_dimensions` |
+| rotational OD + concentric bore diameters (labels; #754) | `from_model.render_rotational` | `plan_dimensions` |
 | envelope (overall W/D/L, with model-level suppression) | `from_model.render_envelope` | `plan_dimensions` |
 | turned step lengths (the chain) | `from_model.render_step_lengths` | `plan_dimensions` |
 | chamfers (C{leg} / {leg}×{angle}° leader, #724) | `from_model.render_chamfers` | `plan_dimensions` |
@@ -120,10 +125,12 @@ separately by #754.
 **Model-routed today** (where a feature exposes parameters, `plan_dimensions`
 still computes a group that these passes do not consume):
 
-- `render_rotational` formats OD and bore parameters from raw
-  `RotationalFeature` fields, discarding their computed group and any authored
-  decoration folded into it. That is debt tracked by #754. Its axis centrelines
-  are furniture and remain model-routed.
+- `render_rotational`'s axis centrelines and the concentric-bore leader-stack
+  layout/drop bookkeeping are furniture and remain model-routed. Its OD and bore
+  dimension **labels** are now planner-fed (#754): they read the value and any
+  authored tolerance/fit off the feature's `DimensionGroup`, not the raw
+  `RotationalFeature` fields. (A single `(feature, "diameter")` decoration still
+  folds onto OD *and* every bore alike — per-role targeting is #746, not #754.)
 - `render_height_ladder` and `render_step_positions` are also model-routed,
   **by design**: `StepLevelFeature` carries correlated sets that must never be
   flattened into independent dims, so group-per-feature is the wrong shape for
@@ -142,7 +149,7 @@ belong. #698 migrated chamfer, fillet, flat, groove, pocket, plate, and slot
 dimensions (#724–#730), closing the latent authored-tolerance failure class for
 those features. Model-routing is legitimate where there is no independent
 `DimParameter` to plan or where flattening a correlated set would destroy its
-semantics; otherwise it remains explicit debt such as #754.
+semantics; otherwise it is explicit debt to be closed (as #754 since was).
 
 ## The lint/coverage carve-out
 
@@ -203,7 +210,7 @@ boundary decisions), not for current state. Step 1 of the original 0008
 - #698 — completed planner-bypass migration epic tracked by this ADR's coverage
   table and Amendment 1.
 - #754 — residual rotational OD/bore planner bypass found during Amendment 1's
-  accuracy review.
+  accuracy review; closed by Amendment 2 (labels now planner-fed).
 - #699 — the one canonical `_PASS_SEQUENCE` shared by the auto-pass and
   `finalize()` (orchestrator `run_stages`), which orders the passes named
   above.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2544,14 +2544,21 @@ def render_step_positions(dwg, model, a, *, ctx) -> int:
     return n
 
 
-def render_rotational(dwg, model, a, *, ctx) -> int:
+def render_rotational(dwg, groups, a, *, ctx) -> int:
     """Rotational furniture from the IR `RotationalFeature` (#237): the OD dim (above
     the front view), the rotation-axis centrelines (front + side), and the concentric
-    bore leaders stacked to the left of the front view. Replaces the engine's inline
-    OD / centreline / `ldr_z` blocks. Returns the count placed."""
-    rot = next((f for f in model.features if f.kind == "rotational"), None)
-    if rot is None:
+    bore leaders stacked to the left of the front view. Returns the count placed.
+
+    The OD/bore dimension LABELS consume the feature's planned `DimensionGroup`
+    (#754): the value and any authored tolerance/fit folded on by `plan_dimensions`
+    now reach the label via `_tol_suffix`, closing the raw-field bypass ADR 0015
+    tracked. The centrelines and the bore-stack layout/drop bookkeeping stay
+    model-routed furniture, and geometry keeps using the raw `rot.od`/`rot.bores`
+    (equal to the planned value), so X/Y/Z placement is unchanged."""
+    g = next((g for g in groups if g.feature_kind == "rotational"), None)
+    if g is None:
         return 0
+    rot = g.feature
     draft = dwg.draft
     FX, FZ = a.proj.front_x, a.proj.front_z
     SX, SZ = a.proj.side_x, a.proj.side_z
@@ -2559,6 +2566,23 @@ def render_rotational(dwg, model, a, *, ctx) -> int:
     n = 0
     od = rot.od
     axis = rot.frame.axis
+    od_pd = next((pd for pd in g.dims if pd.param.role == "od"), None)
+    bore_pds = [pd for pd in g.dims if pd.param.role == "bore"]
+    # Contract: RotationalFeature.parameters() emits exactly one OD dim and one per
+    # bore in bores order, and plan_dimensions preserves that. Fail LOUD on a mismatch
+    # (#806 review) rather than silently rendering a raw, untoleranced label — or, for a
+    # missing MIDDLE bore, shifting every later bore_pds[i] onto the wrong physical bore.
+    if od_pd is None or len(bore_pds) != len(rot.bores):
+        raise AssertionError(
+            f"rotational plan mismatch: od_present={od_pd is not None}, "
+            f"planned bores={len(bore_pds)} vs {len(rot.bores)}"
+        )
+
+    def _dia_label(pd):
+        # Planner-fed value + authored tolerance/fit suffix (#754).
+        return f"ø{_fmt(pd.param.value)}{_tol_suffix(pd.param.tolerance, draft)}"
+
+    od_label = _dia_label(od_pd)
 
     if axis == "z":
         # Vertical turning axis (the common case): OD across the top of the front
@@ -2570,7 +2594,7 @@ def render_rotational(dwg, model, a, *, ctx) -> int:
                 "above",
                 8,
                 draft,
-                label=f"ø{_fmt(od)}",
+                label=od_label,
             ),
             "dim_od",
             view="front",
@@ -2619,7 +2643,7 @@ def render_rotational(dwg, model, a, *, ctx) -> int:
                         Leader(
                             tip=(FX(a.cx - d / 2), tip_z, 0),
                             elbow=(elbow_x, tip_z, 0),
-                            label=f"ø{_fmt(d)}",
+                            label=_dia_label(bore_pds[i]),
                             draft=draft,
                         ),
                         f"ldr_z{i}",
@@ -2654,7 +2678,7 @@ def render_rotational(dwg, model, a, *, ctx) -> int:
                 "left",
                 8,
                 draft,
-                label=f"ø{_fmt(od)}",
+                label=od_label,
             ),
             "dim_od",
             view="front",
@@ -2681,7 +2705,7 @@ def render_rotational(dwg, model, a, *, ctx) -> int:
                 "left",
                 8,
                 draft,
-                label=f"ø{_fmt(od)}",
+                label=od_label,
             ),
             "dim_od",
             view="side",

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -332,7 +332,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_rotational():
         # Rotational furniture — OD dim + axis centrelines + concentric bore leaders — IR
         # renderer (#237), placed early like the engine's inline block it replaces.
-        render_rotational(dwg, _model, a, ctx=ctx)
+        render_rotational(dwg, _groups, a, ctx=ctx)
 
     def _s_centermarks():
         # Centre marks for every hole (all part classes) — IR renderer.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1072,9 +1072,10 @@ class Drawing:
             return []
         from draftwright.annotations._common import PlacementContext
         from draftwright.annotations.from_model import render_rotational
+        from draftwright.model import plan_dimensions
 
         ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
-        render_rotational(self, self._part_model, self._analysis, ctx=ctx)
+        render_rotational(self, plan_dimensions(self._part_model), self._analysis, ctx=ctx)
         return []
 
     def section(self) -> list[str]:
@@ -1539,7 +1540,7 @@ class Drawing:
             # pass, so the reconstruction matches (== not ⊇, unlike the #424 diameter case).
             if r.rotational_ids:
                 assert a is not None and isinstance(model, PartModel)
-                render_rotational(self, model, a, ctx=ctx)
+                render_rotational(self, plan_dimensions(model), a, ctx=ctx)
             self._intents = [it for it in self._intents if id(it) not in r.rotational_ids]
 
         def _s_reserve_section():

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4892,6 +4892,27 @@ class TestIsRotational:
         dwg = build_drawing(part)
         assert dwg.get_annotation("dim_od").label == "ø85"
 
+    def test_rotational_od_bore_labels_are_planner_fed(self):
+        # #754: render_rotational consumes the feature's planned DimensionGroup, so an
+        # authored tolerance folded by plan_dimensions reaches the OD AND bore labels.
+        # Pre-#754 it read the raw RotationalFeature fields and the decoration was lost.
+        from draftwright.model.ir import Frame, RotationalFeature
+
+        part = Cylinder(15, 10) - Cylinder(4, 20)  # ø30 OD, ø8 bore, Z axis
+        rot = RotationalFeature(frame=Frame((0.0, 0.0, 0.0), "z"), od=30.0, bores=(8.0,))
+        dwg = build_drawing(part, model=[rot], decorations={(rot, "diameter"): 0.2})
+        assert str(dwg.get_annotation("dim_od").label) == "ø30 ±0.2"
+        assert [str(o.label) for n, o in dwg.iter_annotations() if n.startswith("ldr_z")] == [
+            "ø8 ±0.2"
+        ]
+
+    def test_rotational_plain_labels_unchanged(self):
+        # No authored decoration → labels are the plain planned value, identical to the
+        # pre-#754 raw-field output (placement/centrelines are furniture, unchanged).
+        dwg = build_drawing(Cylinder(15, 10) - Cylinder(4, 20))
+        assert str(dwg.get_annotation("dim_od").label) == "ø30"
+        assert [str(o.label) for n, o in dwg.iter_annotations() if n.startswith("ldr_z")] == ["ø8"]
+
     @pytest.mark.timeout(60)
     def test_unrounded_od_does_not_duplicate_a_bore_leader(self, monkeypatch):
         # analyse_cylinders rounds diameters at source today, which masks the


### PR DESCRIPTION
First **Milestone 2** item. Closes #754.

## Problem

`render_rotational` formatted OD and bore dimension values from the **raw** `RotationalFeature` fields, discarding the `DimensionGroup` `plan_dimensions` computes for the feature — so an authored **tolerance/fit** folded onto those planned dims never reached the labels. This is the same latent authored-tolerance failure class #698 removed from the chamfer/fillet/groove/… renderers (#724–#730); ADR 0015 tracked it as the one residual dimension-bearing bypass.

## Fix

`render_rotational` now **consumes the feature's planned group**:
- signature `(dwg, model, a, *, ctx)` → `(dwg, groups, a, *, ctx)`;
- finds the `g.feature_kind == "rotational"` group, reads its `role="od"` / `role="bore"` planned dims, and formats each label as `ø{value}{_tol_suffix(tolerance)}` (mirroring `render_diameters`);
- all three call sites (orchestrator + the two `drawing.py` rotational paths) pass the planned groups.

**Furniture stays model-routed:** the axis centrelines and the concentric-bore leader-stack layout/drop bookkeeping are unchanged, and geometry still uses `rot.od`/`rot.bores` (== the planned value), so **X/Y/Z placement is byte-identical**.

## Acceptance (per #754)

- ✅ `render_rotational` no longer formats OD/bore values from raw fields.
- ✅ Authored tolerance/fit reaches the OD and bore labels — binding test: `ø30 ±0.2` / `ø8 ±0.2` (dropped pre-#754); plain parts unchanged (`ø30`/`ø8`).
- ✅ Axis-specific output + rotational coverage unchanged (full tier byte-stable).
- ✅ ADR 0015 records rotational labels as planner-fed (Amendment 2 + table row), distinguishing the still-model-routed centrelines/layout.

## Note

The `(feature, "diameter")` decoration key folds one authored tolerance onto OD **and every bore** alike — per-role targeting (OD vs a specific bore) is **#746**, out of scope here.

## Verification

- Binding + plain tests in `TestIsRotational`; **full fast tier: 1545 passed, 3 skipped**. ruff / format / mypy / codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)