### PR TITLE
feat(#746): role-keyed decorations — tolerance one param of a multi-param kind

### DIFF
--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -291,3 +291,28 @@ The earlier phrase “only P2d remains” referred only to the aspect-renderer
 sequence and did not account for the still-open authoring-completeness work.
 This amendment is authoritative for delivery status; the original phases above
 remain the historical execution record.
+
+## Amendment 3 — role-keyed decorations (2026-07-22, #746)
+
+The P2a tolerance/fit decoration side-layer (Decision item 4) originally keyed on
+`(feature, kind)`. That could not target one parameter of a **multi-parameter
+kind**: a pocket's width/length/depth are all `kind="length"`, and a rotational's
+OD + bores are all `kind="diameter"`, so a single decoration folded onto every one
+of them.
+
+The key is now **`(feature, kind, role)`** with kind-only **back-compat**: the
+planner (`plan_dimensions`) tries the role-specific key first and falls back to
+`(feature, kind)`, which still folds onto *every* parameter of that kind. `kind`
+stays in the key — a step's length and diameter share `role="step"`, so role alone
+cannot disambiguate them.
+
+On the `Sheet` façade, the *authored* multi-parameter verbs (`pocket`/`slot`/
+`envelope`) now return a `_Params` handle whose `.tolerance(..., on=<role>)` writes the
+role-keyed decoration (a bare `.tolerance()` keeps the kind-only fold), closing the
+authoring-surface gap noted for pockets (#728). The rotational OD/bore case surfaced
+by #754 is served at the **engine** level only: the planner fold now honours a
+role-keyed `(rot, "diameter", "od")` vs `(rot, "diameter", "bore")` decoration, but
+`RotationalFeature` is detection-only (no `sheet.rotational()` verb), so a caller
+authors it against the detected feature via the raw `decorations=` map, not a fluent
+handle. (All bores share `role="bore"`, so a bore decoration folds onto every bore —
+distinguishing individual bores is out of scope.)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -244,10 +244,16 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
             if p.kind == "location":
                 continue
             # An authored ± tolerance (ADR 0011 §4 / P2a) rides on the decorations side-
-            # layer keyed by (feature, kind); fold it onto the param so every renderer
-            # sees one carrier. `kind` (not `role`) is the key — a step's length and
-            # diameter share role="step", so role alone can't tell them apart.
-            tol = model.decorations.get((feature, p.kind))
+            # layer; fold it onto the param so every renderer sees one carrier. A
+            # ROLE-keyed (feature, kind, role) decoration wins — it tolerances ONE param
+            # of a multi-param kind (#746, e.g. a pocket's depth, or a rotational OD vs
+            # its bores). A KIND-keyed (feature, kind) decoration is the back-compat
+            # fallback that folds onto EVERY param of that kind. `kind` stays in the key —
+            # a step's length and diameter share role="step", so role alone can't tell
+            # them apart.
+            tol = model.decorations.get((feature, p.kind, p.role))
+            if tol is None:
+                tol = model.decorations.get((feature, p.kind))
             if tol is not None:
                 p = replace(p, tolerance=tol)
             suppressed, reason = _suppression(model, feature, p)

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -267,6 +267,67 @@ class _Dim:
         return self
 
 
+class _Params:
+    """A fluent handle for a declared MULTI-parameter feature — a pocket
+    (width/length/depth), slot (width/length) or envelope (width/height/depth) — whose
+    parameters share a KIND but have distinct ROLES. ``.tolerance(..., on=role)``
+    tolerances ONE parameter by role (#746: e.g. a pocket's depth without touching its
+    width/length); a bare ``.tolerance(...)`` (no ``on``) folds onto every parameter of
+    the feature (the back-compat kind-keyed form). ``on`` accepts the full role
+    (``"pocket_depth"``) or its short tail (``"depth"``).
+
+    Every other attribute forwards to the owning :class:`Sheet`, so these verbs stay
+    chainable (``sheet.pocket(...).hole(...).build()``) despite returning a handle —
+    the module's declare-then-chain contract holds (#807 review)."""
+
+    def __init__(self, sheet: Sheet, index: int) -> None:
+        self._sheet = sheet
+        self._i = index
+
+    def __getattr__(self, name: str):
+        # Only reached for attributes _Params doesn't define (every Sheet verb): forward
+        # to the owning sheet so the fluent chain is unbroken. Guard the two real fields:
+        # if they aren't set yet (an instance built WITHOUT __init__ — copy/pickle), raise
+        # rather than recurse forever resolving self._sheet (#807 review).
+        if name in ("_sheet", "_i"):
+            raise AttributeError(name)
+        return getattr(self._sheet, name)
+
+    def _roles(self) -> dict:
+        # {role: kind} for the feature's dimensioned params (skip the locations).
+        return {
+            p.role: p.kind
+            for p in self._sheet._features[self._i].parameters()
+            if p.kind != "location"
+        }
+
+    def tolerance(self, lo: float, hi: float | None = None, *, on: str | None = None) -> _Params:
+        """A ± tolerance: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a limit pair
+        ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` targets ONE parameter by role
+        (``on="depth"`` on a pocket → a role-keyed decoration); omit ``on`` to tolerance
+        every parameter of the feature alike (the kind-keyed form)."""
+        val = _tol_value(lo, hi)
+        roles = self._roles()
+        if on is None:
+            # A whole-feature tolerance supersedes any earlier per-role override on this
+            # feature — bare means "all alike", so it is order-independent (#807 review):
+            # drop this feature's role-keyed (3-tuple) entries, then set the kind keys.
+            for key in [k for k in self._sheet._tolerances if len(k) == 3 and k[0] == self._i]:
+                del self._sheet._tolerances[key]
+            for kind in set(roles.values()):
+                self._sheet._tolerances[(self._i, kind)] = val
+            return self
+        cands = [r for r in roles if r == on or r.rsplit("_", 1)[-1] == on]
+        if len(cands) != 1:
+            raise ValueError(
+                f"on={on!r} must name one parameter role of this feature; "
+                f"choose from {sorted(roles)}"
+            )
+        role = cands[0]
+        self._sheet._tolerances[(self._i, roles[role], role)] = val
+        return self
+
+
 class _Control:
     """A fluent GD&T feature-control-frame builder (ADR 0011 P2c.2). One method per ISO 1101
     characteristic — each appends a control frame on the same target, so chained calls stack::
@@ -354,9 +415,12 @@ class Sheet:
 
     Each declaration method mirrors a :mod:`draftwright.model` constructor: pass the
     build123d object to read its geometry, or explicit values. :meth:`hole` returns a
-    chainable :class:`_Hole` (``.through()`` / ``.depth()``); the others return the
-    ``Sheet`` so declarations can chain. :meth:`build` / :meth:`export` hand the declared
-    features to the engine with detection skipped.
+    chainable :class:`_Hole` (``.through()`` / ``.depth()``), :meth:`diameter` / :meth:`step`
+    a :class:`_Dim`, for their own aspects; :meth:`pocket` / :meth:`slot` / :meth:`envelope`
+    a :class:`_Params` (``.tolerance(on=…)``) which forwards unknown attributes to the
+    ``Sheet`` so those verbs still chain to any further declaration (preserving their prior
+    return-``Sheet`` behaviour); the remaining verbs return the ``Sheet``. :meth:`build` /
+    :meth:`export` hand the declared features to the engine with detection skipped.
     """
 
     def __init__(
@@ -548,17 +612,17 @@ class Sheet:
         self._features.append(_step(obj, **kw))
         return _Dim(self, len(self._features) - 1, "length")
 
-    def slot(self, obj=None, **kw) -> Sheet:
+    def slot(self, obj=None, **kw) -> _Params:
         """Declare a milled slot / reduced across-flats section (width + length)."""
         self._features.append(_slot(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def pocket(self, obj=None, **kw) -> Sheet:
+    def pocket(self, obj=None, **kw) -> _Params:
         """Declare a blind rectangular recess — a floored slot/pocket (width × length ×
         depth). From an object the depth axis defaults to the shortest bbox span; pass
         ``depth_axis=`` for a recess deeper than it is wide."""
         self._features.append(_pocket(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
     def chamfer(self, obj=None, **kw) -> Sheet:
         """Declare a chamfer (bevelled edge) — ``sheet.chamfer(bevel_face)`` reads axis, legs
@@ -616,10 +680,10 @@ class Sheet:
         self._features.append(_pattern(member, **kw))
         return self
 
-    def envelope(self, obj=None) -> Sheet:
+    def envelope(self, obj=None) -> _Params:
         """Declare the overall bounding dimensions. Defaults to the whole part."""
         self._features.append(_envelope(obj if obj is not None else self._part))
-        return self
+        return _Params(self, len(self._features) - 1)
 
     # -- GD&T / finish aspects (ADR 0011 P2c, #479) ---------------------------
 
@@ -681,7 +745,7 @@ class Sheet:
         """Resolve a GD&T target to ``(target, source_index)``: a fluent handle / index / a
         :class:`Feature` already in :attr:`features` → its feature + index (the index re-binds
         provenance at build); a build123d face or an external Feature → ``(ref, None)``."""
-        if isinstance(ref, (_Hole, _Dim)):
+        if isinstance(ref, (_Hole, _Dim, _Params)):
             return self._features[ref._i], ref._i
         if isinstance(ref, int) and not isinstance(ref, bool):
             i = self._index_of(ref)
@@ -784,8 +848,10 @@ class Sheet:
     def _decorations(self) -> dict:
         """Materialize the index-keyed ± tolerances against the FINAL features (a handle may
         have been recorded before a later .depth()/… replaced the feature) → the
-        ``(feature, kind)`` decoration map the planner reads (P2a)."""
-        return {(self._features[i], kind): tol for (i, kind), tol in self._tolerances.items()}
+        ``(feature, kind)`` (or role-keyed ``(feature, kind, role)``, #746) decoration map
+        the planner reads (P2a). The tail of the key (``kind`` or ``kind, role``) passes
+        through unchanged; only the leading index becomes the feature."""
+        return {(self._features[i], *rest): tol for (i, *rest), tol in self._tolerances.items()}
 
     def model(self):
         """The IR the engine will draw (detection skipped) — for inspection. Wraps the

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -9,6 +9,7 @@ into the label string, matching what ``Dimension(tolerance=…)`` formats (helpe
 precision (1 dp today), so tests use tolerances that survive 1 dp.
 """
 
+import pytest
 from build123d import Axis, Box, Cylinder, Pos, Rot
 from build123d import chamfer as b3d_chamfer
 from build123d import fillet as b3d_fillet
@@ -186,6 +187,58 @@ class TestPlannerDecorations:
             assert pd.param.tolerance == 0.2
             assert not pd.suppressed
 
+    def test_pocket_role_keyed_tolerance_targets_one_param(self):
+        # #746: a ROLE-keyed (feature, kind, role) decoration tolerances ONE param of a
+        # multi-param kind — here only the pocket's depth — leaving width/length
+        # untoleranced. (The kind-only form still folds onto all three; see the test
+        # above.) This is the seam that unlocks per-param tolerancing.
+        pk = pocket(width=18, length=30, depth=5, long_axis="x", width_axis="y", lo=-15, hi=15)
+        model = PartModel(
+            bbox=Box(90, 60, 20).bounding_box(),
+            orientation=None,
+            features=[pk],
+            decorations={(pk, "length", "pocket_depth"): 0.2},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "pocket")
+        tol = {pd.param.role: pd.param.tolerance for pd in g.dims}
+        assert tol == {"pocket_width": None, "pocket_length": None, "pocket_depth": 0.2}
+
+    def test_role_keyed_decoration_wins_over_kind_keyed(self):
+        # #746: when both are present, the role-specific decoration wins for its param
+        # and the kind-only one folds onto the rest.
+        pk = pocket(width=18, length=30, depth=5, long_axis="x", width_axis="y", lo=-15, hi=15)
+        model = PartModel(
+            bbox=Box(90, 60, 20).bounding_box(),
+            orientation=None,
+            features=[pk],
+            decorations={(pk, "length"): 0.2, (pk, "length", "pocket_depth"): 0.05},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "pocket")
+        tol = {pd.param.role: pd.param.tolerance for pd in g.dims}
+        assert tol == {"pocket_width": 0.2, "pocket_length": 0.2, "pocket_depth": 0.05}
+
+    def test_rotational_role_keyed_od_vs_bore_tolerance(self):
+        # #746/#754: a rotational's OD and bores all share kind "diameter"; a role-keyed
+        # decoration tolerances the OD (role "od") independently of the bores (role
+        # "bore"). RotationalFeature is detection-only, so this is authored via the raw
+        # decorations map (no Sheet handle) — the engine-level unlock behind #754.
+        from draftwright.model.ir import Frame, RotationalFeature
+
+        rot = RotationalFeature(frame=Frame((0.0, 0.0, 0.0), "z"), od=30.0, bores=(8.0, 5.0))
+        model = PartModel(
+            bbox=Box(60, 60, 20).bounding_box(),
+            orientation=None,
+            features=[rot],
+            decorations={(rot, "diameter", "od"): 0.1, (rot, "diameter", "bore"): 0.05},
+        )
+        g = next(g for g in plan_dimensions(model) if g.feature_kind == "rotational")
+        # OD gets 0.1; both bores share role "bore" so each gets 0.05.
+        assert [(pd.param.role, pd.param.tolerance) for pd in g.dims] == [
+            ("od", 0.1),
+            ("bore", 0.05),
+            ("bore", 0.05),
+        ]
+
     def test_plate_dim_is_linear_with_folded_tolerance(self):
         # #729: the plate thickness routes through the planner — convention "linear"
         # (the _CONVENTION default; the first non-leader kind migration, so no table
@@ -292,6 +345,64 @@ class TestSheetTolerance:
         dwg = s.build()
         tols = {self._steplen_tol(dwg, n) for n in dwg.annotations() if n.startswith("m_steplen")}
         assert (0.0, 0.2) in tols
+
+    @staticmethod
+    def _pocket_part():
+        return Box(90, 60, 20) - Pos(0, 0, 6) * Box(30, 18, 8)
+
+    def _pocket_handle(self, s):
+        return s.pocket(width=18, length=30, depth=5, long_axis="x", width_axis="y", lo=-15, hi=15)
+
+    def _deep_label(self, dwg):
+        return next(
+            str(dwg.get_annotation(n).label)
+            for n in dwg.annotations()
+            if "DEEP" in str(dwg.get_annotation(n).label)
+        )
+
+    def test_pocket_role_keyed_depth_tolerance_via_sheet(self):
+        # #746 Sheet surface: pocket() returns a role-aware handle; .tolerance(on="depth")
+        # tolerances ONLY the depth (5), leaving width×length (18×30) plain.
+        s = Sheet(self._pocket_part(), title="P")
+        self._pocket_handle(s).tolerance(0.2, on="depth")
+        assert self._deep_label(s.build()) == "18 × 30 × 5 ±0.2 DEEP"
+
+    def test_pocket_whole_feature_tolerance_folds_onto_all(self):
+        # A bare .tolerance() (no on=) on the handle folds onto every parameter — the
+        # kind-keyed back-compat form.
+        s = Sheet(self._pocket_part(), title="P")
+        self._pocket_handle(s).tolerance(0.2)
+        assert self._deep_label(s.build()) == "18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP"
+
+    def test_pocket_role_selector_rejects_unknown_name(self):
+        # on= must name exactly one parameter role of the feature.
+        s = Sheet(self._pocket_part(), title="P")
+        with pytest.raises(ValueError):
+            self._pocket_handle(s).tolerance(0.2, on="nope")
+
+    def test_params_handle_still_chains_to_further_declarations(self):
+        # #807 review: the _Params handle forwards unknown attributes to the sheet, so a
+        # verb returning it stays chainable (the declare-then-chain contract holds).
+        s = Sheet(self._pocket_part(), title="P")
+        dwg = self._pocket_handle(s).envelope().build()  # .envelope()/.build() forward
+        assert "front" in dwg.views
+
+    def test_bare_tolerance_supersedes_an_earlier_role_tolerance(self):
+        # #807 review: a whole-feature .tolerance() means "all alike" and overrides an
+        # earlier per-role one regardless of call order (drops the role-keyed entry).
+        s = Sheet(self._pocket_part(), title="P")
+        self._pocket_handle(s).tolerance(0.1, on="depth").tolerance(0.2)
+        assert self._deep_label(s.build()) == "18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP"
+
+    def test_params_handle_is_a_valid_gdt_target(self):
+        # #807 re-review: a _Params handle names a real feature, so it must be accepted
+        # everywhere a feature handle is — datum/finish/control targets, like _Hole/_Dim.
+        s = Sheet(self._pocket_part(), title="P")
+        h = self._pocket_handle(s)
+        s.datum("A", h)
+        s.finish("1.6", h)
+        s.control(h).position(0.1)
+        s.build()  # must not raise "GD&T target must be an IR feature..."
 
     def test_step_tolerance_defaults_to_length_not_diameter(self):
         shaft = self._stepped_shaft()


### PR DESCRIPTION
Milestone 2. Closes #746. The direct follow-on to #754's single-decoration-key limitation.

## Problem

The P2a tolerance/fit decoration side-layer keyed on `(feature, kind)`. But several features have multiple dimensions sharing a **kind**:
- a **pocket**'s width/length/depth are all `kind="length"`
- a **rotational** part's OD + bores are all `kind="diameter"` (the #754 limitation)

So one authored tolerance folded onto **every** param of that kind — tolerancing just the depth, or just the OD, was impossible.

## Engine

`plan_dimensions` now tries a **role-specific** `(feature, kind, role)` decoration first, falling back to the **kind-only** `(feature, kind)`:
- role-specific wins for its param;
- kind-only still folds onto every param of that kind (**back-compat** — the #728 pocket pinning test is unchanged).
- `kind` stays in the key (a step's length and diameter share `role="step"`, so role alone can't disambiguate).

## Sheet surface

The multi-param verbs `pocket()`/`slot()`/`envelope()` now return a `_Params` handle:
- `.tolerance(0.2, on="depth")` → **only the depth** (`18 × 30 × 5 ±0.2 DEEP`);
- bare `.tolerance(0.2)` → folds onto all (`18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP`);
- `on=` accepts the short tail (`"depth"`) or full role (`"pocket_depth"`), and raises on an unknown/ambiguous name.

**API note:** the return type changes `Sheet` → `_Params`, consistent with how `hole()`/`diameter()`/`step()` already return handles. No code/test chained off these verbs, so nothing broke — but it's a real (alpha-stage) surface change, called out for review.

## Verification

- Model-level: role-keyed targets only depth; role wins over kind-only. Sheet-level: depth-only / whole-feature / bad-role.
- The existing all-three back-compat pinning test still passes; tolerance + sheet suites green.
- **Full fast tier: 1550 passed, 3 skipped.** ruff / format / mypy / codespell clean.
- **ADR 0011 Amendment 3** records the role-keyed `(feature, kind, role)` key with kind-only back-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)