### PR TITLE
refactor(#523): break the builder→cli→sheet_emit import cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ entry. Keep `_LAYERS` and this section in step.
     measure-and-repack → `Drawing`), `make_drawing` (+ export), and the
     editable-script generator (`generate_script`). Imports `drawing`/`analysis`/
     the annotation orchestrator/the stage modules — never `make_drawing` (a DAG).
-    *(The CLI moved out to `cli.py`; `_cli` is now a thin shim.)*
+    *(The CLI moved out to `cli.py`; the `_cli` compat shim lives there too (#523),
+    so `builder` no longer imports `cli`.)*
   - **`cli.py`** — the Typer command-line interface (#289): argument parsing,
     `--version`, shell completion, `--format`, rich help. The engine (build123d)
     is imported **lazily inside the command body** so completion/`--help`/
@@ -154,10 +155,11 @@ entry. Keep `_LAYERS` and this section in step.
   `sheet_dsl` alias shim remains until 0.4.0).
 - **`sheet_emit.py`** — the Sheet-script emitter behind `--script --style sheet`:
   generates an editable `Sheet` script from a detected model. Facade tier;
-  imports `builder` downward at module level, but `builder`'s lazy `_cli` shim
-  still closes a builder→cli→sheet_emit lazy-import cycle (the `builder→cli`
-  edge is the one `_LAZY_UPWARD_EXEMPT` entry) — breaking it is tracked by
-  #523 (open).
+  imports `builder` downward at module level. The old builder→cli→sheet_emit
+  lazy cycle is **gone** (#523): the `_cli` compat shim moved from `builder` to
+  `cli.py` (beside the Typer `app`), so `builder` no longer imports `cli` and
+  `_LAZY_UPWARD_EXEMPT` is now empty. The graph is a plain DAG —
+  `cli → {builder, sheet_emit}`, `sheet_emit → builder`, `builder → ∅`.
 - **`score.py`** — `feature_census` (#148f/#608): a standalone
   recognition-completeness measurement tool; depends only on `recognition/` +
   build123d, and nothing in the engine imports it. Ranked 0 in `_LAYERS` (#704),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,11 @@ This DAG is **machine-enforced** by `tests/test_import_boundaries.py` (#640): th
 import that points up a layer fails CI, as does an import cycle. The precise
 placement refines the coarse grouping above (e.g. `linting`/`pmi`/`export`/`repair`/
 `projection`/`compose` sit *above* `_core` since they depend on it; `model/` is the
-IR-waist leaf it is guarded as). Lazy in-function imports are the sanctioned
-cycle-breakers (`builder`↔`cli`); the one type-only upward reference
+IR-waist leaf it is guarded as). The `_LAZY_UPWARD_EXEMPT` sanctioned-cycle-breaker
+mechanism is now empty (#523 removed its last occupant, the `builder→cli` edge — see
+below); a new upward lazy import must earn an entry with a rationale. The remaining
+lazy in-function imports (`cli`→`builder`/`sheet_emit`, for the #313 build123d
+lazy-load) are *downward*, not cycle-breakers. The one type-only upward reference
 (`_core`→`compose.StripDepths`, under `TYPE_CHECKING`) is an explicit allowlist
 entry. Keep `_LAYERS` and this section in step.
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1209,23 +1209,6 @@ def generate_script(
     return _write_script(a, scale=scale, page=page, formats=formats)
 
 
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-
-
-def _cli():
-    """Compat shim: the CLI moved to the Typer app in ``draftwright.cli`` (#289).
-
-    Kept so ``python -m draftwright.make_drawing`` and existing
-    ``from draftwright... import _cli`` imports keep working; the engine entry
-    point (``[project.scripts]``) points straight at ``draftwright.cli:app``.
-    Imported lazily so a bare ``import draftwright.builder`` does not pull Typer.
-    """
-    from draftwright.cli import app
-
-    app()
-
-
-if __name__ == "__main__":
-    _cli()
+# The CLI moved out to draftwright.cli (#289); the `_cli` compat shim now lives there
+# too (#523), so `builder` no longer imports `cli` — the builder→cli→sheet_emit cycle
+# is gone. `from draftwright.make_drawing import _cli` still works (re-exported from cli).

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -270,3 +270,12 @@ def main(
     )
     for path in _emit(dwg, formats):
         print(path)
+
+
+def _cli() -> None:
+    """Compat shim (#289 / #523): the CLI is the Typer ``app`` defined in this module.
+    ``_cli`` keeps ``from draftwright.make_drawing import _cli`` (and running the
+    facade as ``__main__``) working; the console-script entry point
+    (``[project.scripts]``) points straight at ``draftwright.cli:app``. Living beside
+    ``app`` (not in ``builder``) is what removes the builder→cli import edge (#523)."""
+    app()

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -1,9 +1,10 @@
 """Compat facade: the engine split into stage modules (#138 / ADR 0005).
 
 The `Drawing` result object now lives in `drawing.py`; build orchestration
-(`build_drawing`/`make_drawing`/`generate_script`/`_cli`) in `builder.py`. This
-module re-exports the public surface so `from draftwright.make_drawing import ...`
-and the `draftwright` CLI entry point keep working.
+(`build_drawing`/`make_drawing`/`generate_script`) in `builder.py`; the `_cli`
+compat shim beside the Typer app in `cli.py` (#523). This module re-exports the
+public surface so `from draftwright.make_drawing import ...` and the `draftwright`
+CLI entry point keep working.
 """
 
 from draftwright.builder import (  # noqa: F401

--- a/src/draftwright/make_drawing.py
+++ b/src/draftwright/make_drawing.py
@@ -7,11 +7,11 @@ and the `draftwright` CLI entry point keep working.
 """
 
 from draftwright.builder import (  # noqa: F401
-    _cli,
     build_drawing,
     generate_script,
     make_drawing,
 )
+from draftwright.cli import _cli  # noqa: F401 — #523: the shim lives beside the Typer app now
 from draftwright.drawing import Drawing, FeatureInfo  # noqa: F401
 from draftwright.export import fix_svg_page_size  # noqa: F401
 from draftwright.linting import lint_feature_coverage  # noqa: F401

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -105,11 +105,10 @@ _TC_UPWARD_ALLOW: dict[tuple[str, str], str] = {
 # Lazy (in-function) imports that point UP the DAG — the sanctioned cycle-breakers. Recorded so
 # a NEW upward lazy import (a would-be hidden cycle) forces a documented decision, not silence.
 _LAZY_UPWARD_EXEMPT: dict[tuple[str, str], str] = {
-    ("builder", "cli"): (
-        "builder._cli (a compat shim) launches the Typer app lazily so a bare "
-        "`import draftwright.builder` doesn't pull Typer; cli imports builder lazily too, so "
-        "there is no module-level cycle (#313/#523)."
-    ),
+    # Empty (#523): the last exempt edge, builder→cli, is gone — the `_cli` compat shim
+    # moved to `cli.py` (beside the Typer `app`), so `builder` no longer imports `cli`
+    # and the builder→cli→sheet_emit cycle is broken. Keep this closed; a new upward
+    # lazy import must earn its entry with a rationale, not inherit one.
 }
 
 _RUN, _TC, _LAZY = 0, 1, 2


### PR DESCRIPTION
Closes #523.

## What

`builder._cli` was a compat shim whose body lazily ran `from draftwright.cli import app`. That single upward edge was the only thing holding the `builder`/`cli`/`sheet_emit` **strongly-connected component** together — the other three edges (`cli→builder`, `cli→sheet_emit`, `sheet_emit→builder`) are all downward.

This moves the `_cli` shim from `builder.py` to `cli.py`, right beside the Typer `app` it launches, so it needs no import at all. `make_drawing` re-exports `_cli` from `cli` instead of `builder`. `builder` no longer references `cli`.

The graph is now a plain DAG:

```
cli → {builder, sheet_emit}
sheet_emit → builder
builder → ∅
```

The last `_LAZY_UPWARD_EXEMPT` entry (`("builder","cli")`) is removed — the dict is now empty, kept closed as a ratchet.

## Acceptance (from the issue)

- ✅ No SCC involving `builder`/`cli`/`sheet_emit` (verified by AST scan + `test_import_boundaries`).
- ✅ `import draftwright.builder` / `.cli` / `.sheet_emit` all still work.
- ✅ CLI behaviour + script emission unchanged — the console-script entry point was always `draftwright.cli:app`, and `from draftwright.make_drawing import _cli` still resolves.
- ✅ Ruff, ruff-format, mypy, codespell clean; `test_import_boundaries` (11) + CLI/script-emitter suite (126) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)