### PR TITLE
refactor(#752): typed record→Feature converter registry in detect (ADR 0013 Phase 1c)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,13 +307,14 @@ Current ADRs:
   deferred intents through `_PASS_SEQUENCE`; it does not reconstruct auto candidates or
   perform a global auto-plus-user recompose. `place_dim()` remains the deprecated raw-
   coordinate escape hatch. Full recomposition/parity remains #426/#661/#707.
-- **0013** — **Accepted** (#568; Phase 1 in progress): the **uniform recogniser
+- **0013** — **Accepted** (#568; **Phase 1 complete**): the **uniform recogniser
   contract** — `recognise_<feature>(part, *, <injected deps>) -> list[<frozen
   record>]` (plus the part-less *derived* shape, e.g.
   `recognise_hole_patterns(holes)`), mechanically enforced by
-  `tests/test_recogniser_contract.py`. The shared `b123d-recognisers` package is
-  the deferred Phase-2 deployment (gated on a second committed consumer).
-  Remaining Phase 1: the typed `detect.py` adapter registry (roadmap item 1c).
+  `tests/test_recogniser_contract.py`; and the typed record→`Feature` converter
+  registry in `model/detect.py` (roadmap 1c / #752), whose completeness+uniqueness
+  is fail-closed by `tests/test_detect_registry.py`. The shared `b123d-recognisers`
+  package is the deferred Phase-2 deployment (gated on a second committed consumer).
   Roadmap: `docs/plans/0013-shared-recognisers-roadmap.md`.
 - **0014** — **Accepted** (supersedes 0009, #697): **collect-then-solve
   annotation placement as built** — collect every strip occupant as a

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -31,8 +31,11 @@ an ad-hoc inline branch; the record→IR-`Feature` mapping is one typed registry
 the *assembly* it always owned (pattern/hole grouping, groove/plate suppression, the
 classification-fed rotational/envelope/step-ladder furniture). Completeness and
 uniqueness are machine-enforced by `tests/test_detect_registry.py`: every recognition
-record type has **exactly one** home across three tiers, so a new recogniser cannot
-silently emit features with no converter. The **explicitly accepted residual scope**:
+record type has **exactly one** home across three tiers. The authoritative record-type
+universe is derived **mechanically** from the public `recognise_*` return annotations
+(not a hand-maintained list), so a new recogniser genuinely cannot silently emit
+features with no converter — its record type enters the universe automatically and the
+partition test fails until it is homed. The **explicitly accepted residual scope**:
 two tiers are not uniform `(record, ctx)` converters, by design — (a) *derived*
 converters (`HoleRecord`→`_member_hole`, the three pattern kinds→`_pattern_feature`)
 take per-group members/count the grouping computes; (b) *orchestrated* records

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -1,6 +1,7 @@
 # ADR 0013 — A uniform recogniser/feature contract (with `b123d-recognisers` as its deferred shared deployment)
 
-- **Status:** Accepted; Phase 1 is in progress (the core contract is enforced, typed adapter registry pending), and Phase 2 package extraction is deferred.
+- **Status:** Accepted; **Phase 1 complete** (the core contract is enforced and the
+  typed record→Feature converter registry landed, #752), Phase 2 package extraction deferred.
 - **Date:** 2026-07-12
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -22,6 +23,24 @@ solid, so `part` would be a dead argument. The sanctioned derived shape is
 `recognise_hole_patterns(holes)` — the inventory positional, no `part` — exactly as
 `recognition/__init__.py` documents and `tests/test_recogniser_contract.py` enforces.
 The base-feature shape (`part` first, keyword-only tuning/deps) is unchanged.
+
+**Amendment 3 (2026-07-22, #752) — Phase 1c landed: the typed converter registry.**
+Roadmap item 1c is done. `model/detect.py` no longer hand-translates each record with
+an ad-hoc inline branch; the record→IR-`Feature` mapping is one typed registry seam
+(`_CONVERTERS`, dispatched by `convert(record, ctx)`), and `build_part_model` keeps only
+the *assembly* it always owned (pattern/hole grouping, groove/plate suppression, the
+classification-fed rotational/envelope/step-ladder furniture). Completeness and
+uniqueness are machine-enforced by `tests/test_detect_registry.py`: every recognition
+record type has **exactly one** home across three tiers, so a new recogniser cannot
+silently emit features with no converter. The **explicitly accepted residual scope**:
+two tiers are not uniform `(record, ctx)` converters, by design — (a) *derived*
+converters (`HoleRecord`→`_member_hole`, the three pattern kinds→`_pattern_feature`)
+take per-group members/count the grouping computes; (b) *orchestrated* records
+(`CounterSink` nested in a hole callout; `FaceLevel`/`StepShoulder` aggregated into one
+`StepLevelFeature`) have no per-record feature at all. Both tiers are named and reason-
+carried in the registry, so "supported record type has a home" stays fail-closed
+without forcing a 1:1 shape onto genuinely N:1 assembly. 1d (the `callout()` crack)
+remains open.
 
 ## Context
 

--- a/docs/plans/0013-shared-recognisers-roadmap.md
+++ b/docs/plans/0013-shared-recognisers-roadmap.md
@@ -21,11 +21,14 @@ Delivers #568's value standalone. No new repo, no external dependency, no mcp co
 - **1b — geometry-only records + `.to_dict()`.** Give each recogniser a plain-geometry
   record (points/axes/radii/angles, no build123d types in the output) carrying
   `.to_dict()`. These sit *below* the IR — they are the future shared-package surface.
-- **1c — a uniform `detect.py` adapter protocol.** Replace the ad-hoc per-feature
-  translators with a typed registry of per-record converters (geometry-record →
-  IR `Feature`) dispatched one way — the per-type mapping stays (hole→`HoleFeature`
-  ≠ chamfer→`ChamferFeature`), its inconsistency goes. Remove the recognition-dataclass
-  ↔ IR mirroring duplication (the `equal_leg`-on-both class).
+- **1c — a uniform `detect.py` adapter protocol. ✅ DONE (#752).** The ad-hoc
+  per-feature translators are replaced by a typed registry of per-record converters
+  (geometry-record → IR `Feature`) dispatched one way through `convert(record, ctx)`;
+  the per-type mapping stays (hole→`HoleFeature` ≠ chamfer→`ChamferFeature`), its
+  inconsistency is gone. Completeness/uniqueness is fail-closed
+  (`tests/test_detect_registry.py`): every record type has exactly one home across the
+  uniform / derived / orchestrated tiers. (The `equal_leg`-on-both mirroring was already
+  removed during #560 review.)
 - **1d — the `callout()` crack.** Move callout formatting off `ChamferFeature` into the
   dimensioning layer (planner/IR) uniformly; geometric records carry no callout.
 - **Keep `recognition/` dependency-self-contained** — build123d/OCP only, no upward

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -246,7 +246,7 @@ class ConvContext:
 Converter = Callable[[Any, "ConvContext"], Feature]
 
 
-def _convert_slot(sl, ctx: ConvContext) -> SlotFeature:
+def _convert_slot(sl: Slot, ctx: ConvContext) -> SlotFeature:
     idx = "xyz".index(sl.long_axis)
     c = ctx.bbox.center()
     origin = [c.X, c.Y, c.Z]
@@ -263,7 +263,7 @@ def _convert_slot(sl, ctx: ConvContext) -> SlotFeature:
     )
 
 
-def _convert_pocket(pk, ctx: ConvContext) -> PocketFeature:
+def _convert_pocket(pk: Pocket, ctx: ConvContext) -> PocketFeature:
     # Frame at the recess centroid — in-plane centre + mid-depth. The render leader
     # projects into the view normal to the depth axis, so the depth coord is inert,
     # but a true centroid keeps the frame honest.
@@ -285,7 +285,7 @@ def _convert_pocket(pk, ctx: ConvContext) -> PocketFeature:
     )
 
 
-def _convert_step(s, ctx: ConvContext) -> StepFeature:
+def _convert_step(s: TurnedStep, ctx: ConvContext) -> StepFeature:
     assert ctx.orientation is not None  # only reached on the turned branch
     idx = "xyz".index(ctx.orientation)
     c = ctx.bbox.center()
@@ -305,7 +305,7 @@ def _convert_step(s, ctx: ConvContext) -> StepFeature:
     )
 
 
-def _convert_boss(b, ctx: ConvContext) -> BossFeature:
+def _convert_boss(b: BossRecord, ctx: ConvContext) -> BossFeature:
     return BossFeature(
         frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
         diameter=b.diameter,
@@ -321,7 +321,7 @@ def _convert_boss(b, ctx: ConvContext) -> BossFeature:
     )
 
 
-def _convert_plate(pl, ctx: ConvContext) -> PlateFeature:
+def _convert_plate(pl: Plate, ctx: ConvContext) -> PlateFeature:
     c = ctx.bbox.center()
     return PlateFeature(
         frame=Frame((c.X, c.Y, c.Z), pl.axis),
@@ -333,7 +333,7 @@ def _convert_plate(pl, ctx: ConvContext) -> PlateFeature:
     )
 
 
-def _convert_chamfer(ch, ctx: ConvContext) -> ChamferFeature:
+def _convert_chamfer(ch: Chamfer, ctx: ConvContext) -> ChamferFeature:
     at = ch.at
     return ChamferFeature(
         frame=Frame((at[0], at[1], at[2]), ch.axis),
@@ -344,21 +344,21 @@ def _convert_chamfer(ch, ctx: ConvContext) -> ChamferFeature:
     )
 
 
-def _convert_fillet(fl, ctx: ConvContext) -> FilletFeature:
+def _convert_fillet(fl: Fillet, ctx: ConvContext) -> FilletFeature:
     at = fl.at
     return FilletFeature(
         frame=Frame((at[0], at[1], at[2]), fl.axis), axis=fl.axis, radius=fl.radius
     )
 
 
-def _convert_flat(flat, ctx: ConvContext) -> FlatFeature:
+def _convert_flat(flat: Flat, ctx: ConvContext) -> FlatFeature:
     at = flat.at
     return FlatFeature(
         frame=Frame((at[0], at[1], at[2]), flat.axis), axis=flat.axis, across=flat.across
     )
 
 
-def _convert_groove(groove, ctx: ConvContext) -> GrooveFeature:
+def _convert_groove(groove: Groove, ctx: ConvContext) -> GrooveFeature:
     at = groove.at
     return GrooveFeature(
         frame=Frame((at[0], at[1], at[2]), groove.axis),

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -14,6 +14,10 @@ for any part.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
 from draftwright._geometry import _axis_letter, _xyz
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
@@ -40,10 +44,23 @@ from draftwright.model.ir import (
 )
 from draftwright.recognition import (
     BoltCircle,
+    BossRecord,
+    Chamfer,
+    CounterSink,
+    FaceLevel,
+    Fillet,
+    Flat,
+    Groove,
+    HoleRecord,
     HoleSpec,
     LinearArray,
+    Plate,
+    Pocket,
     RectGrid,
+    Slot,
+    StepShoulder,
     TurnedProfile,
+    TurnedStep,
     recognise_bosses,
     recognise_chamfers,
     recognise_countersinks,
@@ -198,6 +215,209 @@ def build_pmi_features(pmi, bbox) -> list[AuthoredDimension | PmiFeature]:
     return out
 
 
+# ---------------------------------------------------------------------------
+# ADR 0013 Phase 1c — the typed record→Feature converter registry (#752).
+#
+# `build_part_model` below owns the *assembly* — which records become features
+# (pattern/hole grouping, groove/plate suppression, the classification-fed
+# rotational/envelope/step-ladder furniture). *How* a single recognition record
+# becomes an IR `Feature` lives here, one typed converter per record type,
+# dispatched through the registry. The completeness/uniqueness of this table is
+# machine-enforced by tests/test_detect_registry.py: every recognition record
+# type has exactly one home across the three tiers below, so a new recogniser
+# cannot silently produce features with no converter.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConvContext:
+    """Shared build context threaded to every uniform record→Feature converter.
+
+    A converter is a pure function of ``(record, ctx)``; ``bbox`` supplies the
+    part's centre/extents for the off-axis frame coords and ``orientation`` the
+    turning axis a :class:`StepFeature` span is laid along (``None`` off the
+    turned branch, where no converter reads it)."""
+
+    bbox: Any  # build123d BoundBox (kept untyped so detect stays build123d-import-light)
+    orientation: str | None
+
+
+# A uniform converter: a pure function of one recognition record + the shared context.
+Converter = Callable[[Any, "ConvContext"], Feature]
+
+
+def _convert_slot(sl, ctx: ConvContext) -> SlotFeature:
+    idx = "xyz".index(sl.long_axis)
+    c = ctx.bbox.center()
+    origin = [c.X, c.Y, c.Z]
+    origin[idx] = (sl.lo + sl.hi) / 2
+    return SlotFeature(
+        frame=Frame(origin=(origin[0], origin[1], origin[2]), axis=sl.long_axis),
+        width_axis=sl.width_axis,
+        long_axis=sl.long_axis,
+        width=sl.width,
+        length=sl.length,
+        w_center=sl.w_center,
+        lo=sl.lo,
+        hi=sl.hi,
+    )
+
+
+def _convert_pocket(pk, ctx: ConvContext) -> PocketFeature:
+    # Frame at the recess centroid — in-plane centre + mid-depth. The render leader
+    # projects into the view normal to the depth axis, so the depth coord is inert,
+    # but a true centroid keeps the frame honest.
+    c = {
+        pk.long_axis: (pk.lo + pk.hi) / 2,
+        pk.width_axis: pk.w_center,
+        pk.depth_axis: (pk.d_lo + pk.d_hi) / 2,
+    }
+    return PocketFeature(
+        frame=Frame(origin=(c["x"], c["y"], c["z"]), axis=pk.long_axis),
+        width_axis=pk.width_axis,
+        long_axis=pk.long_axis,
+        width=pk.width,
+        length=pk.length,
+        depth=pk.depth,
+        w_center=pk.w_center,
+        lo=pk.lo,
+        hi=pk.hi,
+    )
+
+
+def _convert_step(s, ctx: ConvContext) -> StepFeature:
+    assert ctx.orientation is not None  # only reached on the turned branch
+    idx = "xyz".index(ctx.orientation)
+    c = ctx.bbox.center()
+    base = [c.X, c.Y, c.Z]
+    s_mid = (s.lo + s.hi) / 2
+    lo = list(base)
+    hi = list(base)
+    lo[idx] = s.lo
+    hi[idx] = s.hi
+    mid = list(base)
+    mid[idx] = s_mid
+    return StepFeature(
+        frame=Frame(origin=(mid[0], mid[1], mid[2]), axis=ctx.orientation),
+        length=s.length,
+        diameter=s.diameter,
+        span=((lo[0], lo[1], lo[2]), (hi[0], hi[1], hi[2])),
+    )
+
+
+def _convert_boss(b, ctx: ConvContext) -> BossFeature:
+    return BossFeature(
+        frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
+        diameter=b.diameter,
+        height=b.height,
+        span=(
+            (
+                float(b.location[0] - b.axis[0] * b.height),
+                float(b.location[1] - b.axis[1] * b.height),
+                float(b.location[2] - b.axis[2] * b.height),
+            ),
+            _xyz(b.location),
+        ),
+    )
+
+
+def _convert_plate(pl, ctx: ConvContext) -> PlateFeature:
+    c = ctx.bbox.center()
+    return PlateFeature(
+        frame=Frame((c.X, c.Y, c.Z), pl.axis),
+        axis=pl.axis,
+        lo=pl.lo,
+        hi=pl.hi,
+        u=pl.u,
+        v=pl.v,
+    )
+
+
+def _convert_chamfer(ch, ctx: ConvContext) -> ChamferFeature:
+    at = ch.at
+    return ChamferFeature(
+        frame=Frame((at[0], at[1], at[2]), ch.axis),
+        axis=ch.axis,
+        leg1=ch.leg1,
+        leg2=ch.leg2,
+        angle=ch.angle,
+    )
+
+
+def _convert_fillet(fl, ctx: ConvContext) -> FilletFeature:
+    at = fl.at
+    return FilletFeature(
+        frame=Frame((at[0], at[1], at[2]), fl.axis), axis=fl.axis, radius=fl.radius
+    )
+
+
+def _convert_flat(flat, ctx: ConvContext) -> FlatFeature:
+    at = flat.at
+    return FlatFeature(
+        frame=Frame((at[0], at[1], at[2]), flat.axis), axis=flat.axis, across=flat.across
+    )
+
+
+def _convert_groove(groove, ctx: ConvContext) -> GrooveFeature:
+    at = groove.at
+    return GrooveFeature(
+        frame=Frame((at[0], at[1], at[2]), groove.axis),
+        axis=groove.axis,
+        width=groove.width,
+        diameter=groove.diameter,
+    )
+
+
+# Tier 1 — uniform converters: a pure (record, ctx) -> Feature mapping.
+_CONVERTERS: dict[type, Converter] = {
+    Slot: _convert_slot,
+    Pocket: _convert_pocket,
+    TurnedStep: _convert_step,
+    BossRecord: _convert_boss,
+    Plate: _convert_plate,
+    Chamfer: _convert_chamfer,
+    Fillet: _convert_fillet,
+    Flat: _convert_flat,
+    Groove: _convert_groove,
+}
+
+# Tier 2 — derived converters: not a 1:1 record map. A hole callout groups identical
+# holes (members + count) and a pattern composes a representative member hole, so their
+# converters take per-group extras the orchestration computes — they cannot go through
+# the uniform `convert()` dispatcher, but they are still the record type's one converter.
+_DERIVED_CONVERTERS: dict[type, Callable[..., Feature]] = {
+    HoleRecord: _member_hole,
+    BoltCircle: _pattern_feature,
+    LinearArray: _pattern_feature,
+    RectGrid: _pattern_feature,
+}
+
+# Tier 3 — orchestrated records: no per-record converter, by design. Each is either a
+# nested sub-record or aggregated into a single furniture feature; the reason is the
+# residual scope ADR 0013 Phase 1 explicitly accepts.
+_ORCHESTRATED_RECORDS: dict[type, str] = {
+    CounterSink: "a nested sub-record of HoleRecord — rides on the hole callout, never a top-level feature",
+    FaceLevel: "aggregated into a single StepLevelFeature step ladder (one feature per part, not per level)",
+    StepShoulder: "aggregated into StepLevelFeature.shoulders (in-plane step positions, not a standalone feature)",
+}
+
+
+def convert(record, ctx: ConvContext) -> Feature:
+    """Dispatch a recognition record to its IR :class:`Feature` via the typed registry.
+
+    Fail-closed: a record type with no uniform converter raises, so a new
+    recogniser cannot silently emit features the registry never learned to
+    convert (the derived/orchestrated tiers are handled inline by
+    :func:`build_part_model`, not here)."""
+    try:
+        conv = _CONVERTERS[type(record)]
+    except KeyError:
+        raise TypeError(
+            f"no IR converter registered for recognition record {type(record).__name__} (#752)"
+        ) from None
+    return conv(record, ctx)
+
+
 def build_part_model(
     part,
     *,
@@ -232,6 +452,14 @@ def build_part_model(
     bbox = part.bounding_box()
     features: list[Feature] = []
 
+    # Turned-profile classification up front so the shared convert-context carries the
+    # part's turning axis (the StepFeature span axis). Pure detection — no feature is
+    # emitted here; the turned/boss branch below reads the same `prof`.
+    if prof is _UNSET:
+        prof = TurnedProfile.from_steps(recognise_turned_steps(part, cyls=cyls))
+    orientation = prof.axis if prof is not None else None
+    ctx = ConvContext(bbox=bbox, orientation=orientation)
+
     # Holes and hole patterns. A recognised pattern becomes one PatternFeature
     # (count× member-diameter + pattern dims); its member holes are NOT also
     # emitted individually — the grouped-callout rule the engine uses.
@@ -263,47 +491,13 @@ def build_part_model(
     if slots is None:
         slots = recognise_slots(part)
     for sl in slots:
-        idx = "xyz".index(sl.long_axis)
-        origin = [bbox.center().X, bbox.center().Y, bbox.center().Z]
-        origin[idx] = (sl.lo + sl.hi) / 2
-        features.append(
-            SlotFeature(
-                frame=Frame(origin=(origin[0], origin[1], origin[2]), axis=sl.long_axis),
-                width_axis=sl.width_axis,
-                long_axis=sl.long_axis,
-                width=sl.width,
-                length=sl.length,
-                w_center=sl.w_center,
-                lo=sl.lo,
-                hi=sl.hi,
-            )
-        )
+        features.append(convert(sl, ctx))
 
     # Blind rectangular recesses — floored slots/pockets (#148a).
     if pockets is None:
         pockets = recognise_pockets(part)
     for pk in pockets:
-        # Frame at the recess centroid — in-plane centre + mid-depth. The render
-        # leader projects into the view normal to the depth axis, so the depth coord
-        # is inert, but a true centroid keeps the frame honest.
-        c = {
-            pk.long_axis: (pk.lo + pk.hi) / 2,
-            pk.width_axis: pk.w_center,
-            pk.depth_axis: (pk.d_lo + pk.d_hi) / 2,
-        }
-        features.append(
-            PocketFeature(
-                frame=Frame(origin=(c["x"], c["y"], c["z"]), axis=pk.long_axis),
-                width_axis=pk.width_axis,
-                long_axis=pk.long_axis,
-                width=pk.width,
-                length=pk.length,
-                depth=pk.depth,
-                w_center=pk.w_center,
-                lo=pk.lo,
-                hi=pk.hi,
-            )
-        )
+        features.append(convert(pk, ctx))
 
     # Turned / circlip grooves (#148c) — recognised up front so the turned-step chain can
     # exclude any band a groove already dimensions: a groove floor is an annular band, and
@@ -312,17 +506,12 @@ def build_part_model(
     # double-dimension the floor ø (ISO 129) and break ADR 0008's one-band-one-owner waist.
     grooves = recognise_grooves(part, cyls=cyls)
 
-    # Turned profile → step segments; else external bosses → diameters.
-    if prof is _UNSET:
-        prof = TurnedProfile.from_steps(recognise_turned_steps(part, cyls=cyls))
-    orientation = prof.axis if prof is not None else None
+    # Turned profile → step segments; else external bosses → diameters. (`prof` and the
+    # convert-context were classified up front.)
     if prof is not None:
         idx = "xyz".index(prof.axis)
-        c = bbox.center()
-        base = [c.X, c.Y, c.Z]
         groove_bands = [(g.at[idx], g.width) for g in grooves if g.axis == prof.axis]
         for s in prof.steps:
-            s_mid = (s.lo + s.hi) / 2
             # Skip the band a groove owns (its callout dimensions width + floor ø). Match on
             # axial POSITION, not diameter: a narrow groove's step is reported at the WALL OD
             # (local_od's pad engulfs both walls when the groove is < ~1.4 mm), so a floor-ø
@@ -334,20 +523,7 @@ def build_part_model(
                 for gc, gw in groove_bands
             ):
                 continue
-            lo = list(base)
-            hi = list(base)
-            lo[idx] = s.lo
-            hi[idx] = s.hi
-            mid = list(base)
-            mid[idx] = s_mid
-            features.append(
-                StepFeature(
-                    frame=Frame(origin=(mid[0], mid[1], mid[2]), axis=prof.axis),
-                    length=s.length,
-                    diameter=s.diameter,
-                    span=((lo[0], lo[1], lo[2]), (hi[0], hi[1], hi[2])),
-                )
-            )
+            features.append(convert(s, ctx))
         # A narrow external band nested under / beside a larger OD reads as that OD in
         # local_od's max(), so it never becomes a step diameter and goes silently
         # undimensioned (#298). Emit each band the silhouette steps miss as a boss, so
@@ -361,21 +537,7 @@ def build_part_model(
             if all(
                 abs(b.diameter - d) > _DIA_TOL for d in step_dias
             ) and not _boss_is_groove_floor(b, grooves):
-                features.append(
-                    BossFeature(
-                        frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
-                        diameter=b.diameter,
-                        height=b.height,
-                        span=(
-                            (
-                                float(b.location[0] - b.axis[0] * b.height),
-                                float(b.location[1] - b.axis[1] * b.height),
-                                float(b.location[2] - b.axis[2] * b.height),
-                            ),
-                            _xyz(b.location),
-                        ),
-                    )
-                )
+                features.append(convert(b, ctx))
     else:
         raw_bosses = recognise_bosses(part, cyls=cyls) if bosses is None else bosses
         bosses_d = _distinct_by_diameter(raw_bosses)
@@ -386,21 +548,7 @@ def build_part_model(
             # (#148c 3rd-pass review).
             if _boss_is_groove_floor(b, grooves):
                 continue
-            features.append(
-                BossFeature(
-                    frame=Frame(origin=_xyz(b.location), axis=_axis_letter(b)),
-                    diameter=b.diameter,
-                    height=b.height,
-                    span=(
-                        (
-                            float(b.location[0] - b.axis[0] * b.height),
-                            float(b.location[1] - b.axis[1] * b.height),
-                            float(b.location[2] - b.axis[2] * b.height),
-                        ),
-                        _xyz(b.location),
-                    ),
-                )
-            )
+            features.append(convert(b, ctx))
         # Overall envelope dims for a *prismatic* part — not a round single-OD body
         # (a boss whose diameter fills the footprint is the body, dimensioned by its
         # OD, not a box).
@@ -431,18 +579,8 @@ def build_part_model(
     if prof is None and rotational is None:
         plates = recognise_plates(part)
         if len({pl.axis for pl in plates}) >= 2:
-            c = bbox.center()
             for pl in plates:
-                features.append(
-                    PlateFeature(
-                        frame=Frame((c.X, c.Y, c.Z), pl.axis),
-                        axis=pl.axis,
-                        lo=pl.lo,
-                        hi=pl.hi,
-                        u=pl.u,
-                        v=pl.v,
-                    )
-                )
+                features.append(convert(pl, ctx))
                 # A Z base plate (bottom == part base) IS the first step level; suppress
                 # it from the step ladder so the two don't both dimension base→hi.
                 if pl.axis == "z" and abs(pl.lo - bbox.min.Z) < 0.5:
@@ -481,28 +619,12 @@ def build_part_model(
     # {leg}×{angle}°. A turned part's chamfers are conical (recognise_chamfers finds none).
     if rotational is None:
         for ch in recognise_chamfers(part):
-            at = ch.at
-            features.append(
-                ChamferFeature(
-                    frame=Frame((at[0], at[1], at[2]), ch.axis),
-                    axis=ch.axis,
-                    leg1=ch.leg1,
-                    leg2=ch.leg2,
-                    angle=ch.angle,
-                )
-            )
+            features.append(convert(ch, ctx))
 
         # Fillets (#561) — external edge rounds on a non-turned part, called out R{radius}
         # (grouped n× at render). Same non-rotational guard as chamfers.
         for fl in recognise_fillets(part):
-            at = fl.at
-            features.append(
-                FilletFeature(
-                    frame=Frame((at[0], at[1], at[2]), fl.axis),
-                    axis=fl.axis,
-                    radius=fl.radius,
-                )
-            )
+            features.append(convert(fl, ctx))
 
     # Machined flats on round stock (#148b) — a planar face truncating a cylinder,
     # called out by its across-flats size. Detected UNCONDITIONALLY (not gated by the
@@ -510,14 +632,7 @@ def build_part_model(
     # yet its flat still needs a callout. The recogniser self-gates on OD adjacency, so a
     # part with no round stock yields none.
     for flat in recognise_flats(part, cyls=cyls):
-        at = flat.at
-        features.append(
-            FlatFeature(
-                frame=Frame((at[0], at[1], at[2]), flat.axis),
-                axis=flat.axis,
-                across=flat.across,
-            )
-        )
+        features.append(convert(flat, ctx))
 
     # Turned / circlip grooves on round stock (#148c) — an annular channel (a strict
     # local-minimum OD band) dimensioned by width + floor diameter, recognised above so the
@@ -525,15 +640,7 @@ def build_part_model(
     # is round stock and classifies rotational, yet the groove still needs its own callout.
     # The recogniser self-gates on external OD bands, so a prismatic part yields none.
     for groove in grooves:
-        at = groove.at
-        features.append(
-            GrooveFeature(
-                frame=Frame((at[0], at[1], at[2]), groove.axis),
-                axis=groove.axis,
-                width=groove.width,
-                diameter=groove.diameter,
-            )
-        )
+        features.append(convert(groove, ctx))
 
     # Rotational furniture — OD + centrelines + concentric bore leaders (#237). Its
     # presence marks the part rotational; emitted from the classification (od, bores).

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -14,15 +14,12 @@ typed registry seam. These tests are the fail-closed guard on that seam:
 
 from __future__ import annotations
 
+import typing
+
 import pytest
 from build123d import Box, Cylinder, Pos
 
-# The authoritative universe of recogniser record types is maintained by the
-# recogniser-contract suite; reusing it ties the two guards together — a new
-# recogniser must be added there (which forces it to be exercised) *and* placed in
-# exactly one registry tier here, or one of the two suites fails.
-from test_recogniser_contract import _EXPECTED_RECORD_TYPES
-
+import draftwright.recognition as recognition
 from draftwright.model.detect import (
     _CONVERTERS,
     _DERIVED_CONVERTERS,
@@ -35,17 +32,51 @@ from draftwright.model.ir import Feature
 from draftwright.recognition._record import Record
 
 
+def _record_types_in(annot) -> set[type]:
+    """Every `Record` subclass reachable in a return annotation — unwrapping
+    ``list[...]``, unions/``| None`` and nesting."""
+    if isinstance(annot, type):
+        return {annot} if issubclass(annot, Record) else set()
+    out: set[type] = set()
+    for arg in typing.get_args(annot):
+        out |= _record_types_in(arg)
+    return out
+
+
+def _recogniser_record_universe() -> set[type]:
+    """The authoritative set of record types, derived MECHANICALLY from the public
+    ``recognise_*`` return annotations (not a hand-maintained list). This is what makes
+    the completeness guard genuinely fail-closed: add ``recognise_threads() ->
+    list[ThreadRecord]`` and ``ThreadRecord`` enters this universe automatically, so the
+    partition test below fails until it is given a home — matching the ADR 0013 claim
+    that a new recogniser cannot silently emit features with no converter."""
+    universe: set[type] = set()
+    for name in dir(recognition):
+        if not name.startswith("recognise_"):
+            continue
+        fn = getattr(recognition, name)
+        try:
+            hints = typing.get_type_hints(fn)
+        except Exception:  # pragma: no cover — a recogniser with unresolved hints
+            continue
+        universe |= _record_types_in(hints.get("return"))
+    return universe
+
+
 def test_registry_tiers_partition_every_record_type():
     """Every recognition record type has exactly one home (completeness + uniqueness)."""
+    expected = _recogniser_record_universe()
+    assert expected, "mechanical record-type derivation found nothing — check recognition surface"
+
     tiers = [set(_CONVERTERS), set(_DERIVED_CONVERTERS), set(_ORCHESTRATED_RECORDS)]
     homed = tiers[0] | tiers[1] | tiers[2]
 
-    missing = _EXPECTED_RECORD_TYPES - homed
+    missing = expected - homed
     assert not missing, (
         f"record types with no converter/home: {sorted(t.__name__ for t in missing)}"
     )
 
-    extra = homed - _EXPECTED_RECORD_TYPES
+    extra = homed - expected
     assert not extra, f"registry names non-recogniser types: {sorted(t.__name__ for t in extra)}"
 
     # Pairwise disjoint — no record type lives in two tiers.

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -65,7 +65,17 @@ def _recogniser_record_universe() -> set[type]:
             raise AssertionError(
                 f"could not resolve return hints for recognition.{name}: {exc!r}"
             ) from exc
-        universe |= _record_types_in(hints.get("return"))
+        # Every recogniser must *declare* a Record-typed return (all 14 today do:
+        # `list[<Record...>]`). A missing annotation (`get_type_hints` → no "return")
+        # or a non-Record return contributes nothing to the universe — which would let a
+        # new recogniser's record type escape the completeness guard. Reject it here so
+        # the fail-closed property survives a recogniser added with a bad/absent annotation.
+        found = _record_types_in(hints.get("return"))
+        assert found, (
+            f"recognition.{name} has no Record-typed return annotation "
+            f"(got {hints.get('return')!r}) — the record→Feature completeness guard needs one"
+        )
+        universe |= found
     return universe
 
 

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -14,6 +14,7 @@ typed registry seam. These tests are the fail-closed guard on that seam:
 
 from __future__ import annotations
 
+import inspect
 import typing
 
 import pytest
@@ -55,10 +56,15 @@ def _recogniser_record_universe() -> set[type]:
         if not name.startswith("recognise_"):
             continue
         fn = getattr(recognition, name)
+        # Fail loud, not open: an unresolvable return annotation must surface as a test
+        # failure naming the recogniser, never be silently skipped (which would let a new
+        # record type escape the universe and defeat the completeness guard below).
         try:
             hints = typing.get_type_hints(fn)
-        except Exception:  # pragma: no cover — a recogniser with unresolved hints
-            continue
+        except Exception as exc:
+            raise AssertionError(
+                f"could not resolve return hints for recognition.{name}: {exc!r}"
+            ) from exc
         universe |= _record_types_in(hints.get("return"))
     return universe
 
@@ -95,6 +101,19 @@ def test_orchestrated_records_document_their_residual_reason():
 def test_uniform_converters_are_callable():
     assert all(callable(c) for c in _CONVERTERS.values())
     assert all(callable(c) for c in _DERIVED_CONVERTERS.values())
+
+
+def test_uniform_converter_is_registered_under_the_type_it_consumes():
+    """Each uniform converter is keyed under the record type its first parameter is
+    annotated for — a mechanical guard against a mis-registration (e.g. ``Slot ->
+    _convert_pocket``) that the ``Any``-typed registry value cannot catch statically."""
+    for key, conv in _CONVERTERS.items():
+        first = next(iter(inspect.signature(conv).parameters))
+        consumed = typing.get_type_hints(conv).get(first)
+        assert consumed is key, (
+            f"{conv.__name__} is registered under {key.__name__} but consumes "
+            f"{getattr(consumed, '__name__', consumed)}"
+        )
 
 
 def test_convert_fails_closed_on_unregistered_record():

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -35,13 +35,21 @@ from draftwright.recognition._record import Record
 
 def _record_types_in(annot) -> set[type]:
     """Every `Record` subclass reachable in a return annotation — unwrapping
-    ``list[...]``, unions/``| None`` and nesting."""
+    ``list[...]``, unions/``| None`` and nesting.
+
+    Decompose parameterised generics (``get_args``) BEFORE the bare-class check: on
+    Python 3.10 ``isinstance(list[X], type)`` is ``True`` (a GenericAlias quirk fixed in
+    3.11), so an ``isinstance``-first order would treat ``list[BossRecord]`` as a plain
+    class and never reach its args — silently dropping the record type on 3.10."""
+    args = typing.get_args(annot)
+    if args:
+        out: set[type] = set()
+        for arg in args:
+            out |= _record_types_in(arg)
+        return out
     if isinstance(annot, type):
         return {annot} if issubclass(annot, Record) else set()
-    out: set[type] = set()
-    for arg in typing.get_args(annot):
-        out |= _record_types_in(arg)
-    return out
+    return set()
 
 
 def _recogniser_record_universe() -> set[type]:

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -1,0 +1,98 @@
+"""ADR 0013 Phase 1c — the typed record→Feature converter registry (#752).
+
+`model/detect.py` translates recognition records into IR `Feature`s through one
+typed registry seam. These tests are the fail-closed guard on that seam:
+
+- **completeness + uniqueness** — every recognition record type has *exactly one*
+  home across the three tiers (uniform converter / derived converter / documented
+  orchestrated), so a new recogniser cannot silently produce a record no converter
+  handles, nor be double-registered.
+- **fail-closed dispatch** — `convert()` raises on an unregistered record type.
+- **no leak** — nothing produced by `build_part_model` is a recognition-layer
+  record; the seam always lowers to the IR.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+# The authoritative universe of recogniser record types is maintained by the
+# recogniser-contract suite; reusing it ties the two guards together — a new
+# recogniser must be added there (which forces it to be exercised) *and* placed in
+# exactly one registry tier here, or one of the two suites fails.
+from test_recogniser_contract import _EXPECTED_RECORD_TYPES
+
+from draftwright.model.detect import (
+    _CONVERTERS,
+    _DERIVED_CONVERTERS,
+    _ORCHESTRATED_RECORDS,
+    ConvContext,
+    build_part_model,
+    convert,
+)
+from draftwright.model.ir import Feature
+from draftwright.recognition._record import Record
+
+
+def test_registry_tiers_partition_every_record_type():
+    """Every recognition record type has exactly one home (completeness + uniqueness)."""
+    tiers = [set(_CONVERTERS), set(_DERIVED_CONVERTERS), set(_ORCHESTRATED_RECORDS)]
+    homed = tiers[0] | tiers[1] | tiers[2]
+
+    missing = _EXPECTED_RECORD_TYPES - homed
+    assert not missing, (
+        f"record types with no converter/home: {sorted(t.__name__ for t in missing)}"
+    )
+
+    extra = homed - _EXPECTED_RECORD_TYPES
+    assert not extra, f"registry names non-recogniser types: {sorted(t.__name__ for t in extra)}"
+
+    # Pairwise disjoint — no record type lives in two tiers.
+    for i, a in enumerate(tiers):
+        for b in tiers[i + 1 :]:
+            dup = a & b
+            assert not dup, f"record type in two tiers: {sorted(t.__name__ for t in dup)}"
+
+
+def test_orchestrated_records_document_their_residual_reason():
+    """Tier 3 is the ADR 0013 Phase 1 accepted residual — each entry states why."""
+    for rec_type, reason in _ORCHESTRATED_RECORDS.items():
+        assert isinstance(reason, str) and reason.strip(), f"{rec_type.__name__} needs a reason"
+
+
+def test_uniform_converters_are_callable():
+    assert all(callable(c) for c in _CONVERTERS.values())
+    assert all(callable(c) for c in _DERIVED_CONVERTERS.values())
+
+
+def test_convert_fails_closed_on_unregistered_record():
+    class _NotARecord:
+        pass
+
+    ctx = ConvContext(bbox=None, orientation=None)
+    with pytest.raises(TypeError, match="no IR converter registered"):
+        convert(_NotARecord(), ctx)
+
+
+def _rich_parts():
+    """Parts spanning the feature families detect.py emits — holes, prismatic
+    envelope, a turned profile (steps/boss), and a chamfer."""
+    plate = Box(60, 40, 20) - Pos(0, 0, 10) * Cylinder(4, 20)
+    shaft = Cylinder(8, 40) + Pos(0, 0, 25) * Cylinder(12, 10)
+    return [plate, shaft]
+
+
+def test_build_part_model_never_leaks_a_recognition_record():
+    """The seam always lowers to the IR: no `build_part_model` output is a
+    recognition-layer `Record`; every feature satisfies the IR `Feature` shape."""
+    for part in _rich_parts():
+        model = build_part_model(part)
+        assert model.features, "expected the drive part to yield features"
+        for f in model.features:
+            assert not isinstance(f, Record), (
+                f"recognition record leaked into IR: {type(f).__name__}"
+            )
+            # IR Feature shape (kind + frame + parameters), incl. the PMI/authored features.
+            assert hasattr(f, "kind") and hasattr(f, "frame") and hasattr(f, "parameters")
+            assert isinstance(f, Feature)


### PR DESCRIPTION
Closes #752. Completes **ADR 0013 Phase 1c** (roadmap item 1c).

## What

`model/detect.py::build_part_model` was a large hand-written seam that inlined the construction of every IR `Feature` behind a per-feature branch. This extracts the *construction* into a typed converter registry keyed by recognition record type, dispatched one way through `convert(record, ctx)`.

`build_part_model` keeps only the **assembly** it always owned — *which* records become features (pattern/hole grouping, groove/plate suppression, the classification-fed rotational/envelope/step-ladder furniture). *How* a record becomes a `Feature` is now one registered converter per type. The turned-profile classification is lifted to the top so a single `ConvContext` (bbox + turning axis) threads to every converter.

## The three tiers (machine-enforced partition)

`tests/test_detect_registry.py` asserts every recognition record type has **exactly one** home:

1. **Uniform converters** `(record, ctx) -> Feature` — `Slot`, `Pocket`, `TurnedStep`, `BossRecord`, `Plate`, `Chamfer`, `Fillet`, `Flat`, `Groove`.
2. **Derived converters** (per-group extras the grouping computes) — `HoleRecord`→`_member_hole`, the 3 pattern kinds→`_pattern_feature`.
3. **Documented-orchestrated** (no per-record feature, by design) — `CounterSink` (nested in a hole callout); `FaceLevel`/`StepShoulder` (aggregated into one `StepLevelFeature`).

`convert()` is **fail-closed**: an unregistered record type raises, so a new recogniser can't silently emit features with no converter. The partition reuses `_EXPECTED_RECORD_TYPES` from the recogniser-contract suite, so adding a recogniser forces both a contract-exercise entry and a registry home.

## Accepted residual scope

Tiers 2 and 3 are deliberately **not** uniform `(record, ctx)` converters — hole/pattern conversion is genuinely N:1 (needs members/count), and CounterSink/FaceLevel/StepShoulder have no standalone feature. Both tiers are named and reason-carried in the registry, so the completeness guarantee holds without forcing a 1:1 shape onto assembly logic. Recorded as ADR 0013 Amendment 3. (Roadmap 1d — the `callout()` crack — remains open.)

## Verification

- Output **unchanged** — construction moved verbatim; full fast tier **1559 passed, 3 skipped**.
- New `tests/test_detect_registry.py` (5) green; recogniser-contract + declare suites green.
- ruff / ruff-format / mypy / codespell clean.
- ADR 0013 marked Phase 1 complete (Amendment 3); roadmap + CLAUDE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)