### PR TITLE
fix: emit the NTS iso note on the auto_dims=False path (script↔CLI parity)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -659,8 +659,9 @@ def build_drawing(
         auto_dims: pass ``False`` to skip the automatic dimensions,
             centrelines, and leaders (#74) — the automatic set assumes a
             turned part and is wrong for prismatic geometry. Views, scale,
-            page, and title block are still produced; add your own
-            annotations before export. (Annotations added by the default can
+            page, and sheet furniture (title block, and the "ISO VIEW (NTS)"
+            note when the iso is rescaled off sheet scale) are still produced;
+            add your own annotations before export. (Annotations added by the default can
             also be removed wholesale with :meth:`Drawing.clear_annotations`.)
         repair: run the bounded lint→repair loop (:meth:`Drawing.repair`) after
             placement to fix mechanically-clear violations (a dim on the wrong

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -364,7 +364,11 @@ def _assemble(
         else:
             a.sv_zones.right.outer_limit = _sv_ol
     else:
-        _fit_iso_view(dwg, a, annotate=False)
+        # Fit + label the iso as the auto path does (annotate defaults True): the NTS
+        # note is sheet furniture — like the title block below — that states the iso is
+        # not to scale. Suppressing it here silently diverged the emitted-script drawing
+        # (auto_dims=False) from the direct CLI, which always labels it (script↔CLI parity).
+        _fit_iso_view(dwg, a)
         _add_title_block(dwg, a)
         if a.frame:  # sheet border, drawn last (#767) — auto path adds it via the orchestrator
             _add_sheet_frame(dwg, a)

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -230,7 +230,9 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
 def _fit_iso_view(dwg, a: Analysis, annotate: bool = True):
     """Scale the iso view to fill its page zone, captioning it NTS when the
     scale differs from sheet scale.  Pass ``annotate=False`` to suppress the
-    NTS note (used when ``auto_dims=False``).
+    NTS note — used on the finalize detail-refit, which re-fits an iso whose
+    note the build already placed (both the auto and ``auto_dims=False`` build
+    paths label it, so a second add would be redundant).
 
     The iso is always centred at (ISO_X, ISO_Y) which sits at the centre of
     the available zone.  The projection is linear, so the factor needed to

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3438,10 +3438,14 @@ def test_build_drawing_scale_and_page_override(tmp_path):
 
 @pytest.mark.timeout(60)
 def test_build_drawing_auto_dims_false():
-    # #74 — views, scale, page, and title block only; no turned-part dims.
+    # #74 — views, scale, page, and sheet furniture only; no turned-part dims.
     dwg = build_drawing(Cylinder(15, 40), auto_dims=False)
     assert set(dwg.views) == {"front", "plan", "side", "iso"}
-    assert [a for a in dwg.items] == [dwg.get_annotation("title_block")]
+    # Furniture the manual path shares with the auto path: the title block and — since the
+    # cylinder's iso is rescaled off sheet scale — the truthful "ISO VIEW (NTS)" note. The
+    # note is furniture, not a dimension, so it belongs here (script↔CLI parity); auto_dims
+    # still suppresses every *dimension*.
+    assert set(dwg.annotations()) == {"title_block", "note_iso_nts"}
 
 
 @pytest.mark.timeout(60)

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -186,8 +186,22 @@ def test_generated_script_reproduces_nts_iso_note(tmp_path):
     step, scripted = _scripted_drawing(part, tmp_path, "nts_note")
     direct = build_drawing(str(step))
 
-    assert "note_iso_nts" in direct.annotations()  # guard the fixture: iso is rescaled
-    assert "note_iso_nts" in scripted.annotations()
+    def note(dwg):
+        """(label, rounded bbox centre) of the NTS note, or None if absent."""
+        obj = dwg.get_annotation("note_iso_nts")
+        if obj is None:
+            return None
+        bb = obj.bounding_box()
+        return obj.label, (
+            round((bb.min.X + bb.max.X) / 2, 1),
+            round((bb.min.Y + bb.max.Y) / 2, 1),
+        )
+
+    assert note(direct) is not None  # guard the fixture: the iso is rescaled off sheet scale
+    # Genuine parity, not mere presence (Codex #810): a stale/mislabelled/misplaced scripted
+    # note must fail. This part has no machined-callout features, so the two layouts do not
+    # diverge — the note's label AND page position match exactly between the paths.
+    assert note(scripted) == note(direct)
 
 
 @pytest.mark.timeout(240)

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -173,6 +173,24 @@ def test_generated_script_matches_direct_rotational_furniture(tmp_path):
 
 
 @pytest.mark.timeout(240)
+def test_generated_script_reproduces_nts_iso_note(tmp_path):
+    """Furniture parity: the "ISO VIEW (NTS)" note the direct CLI adds whenever it
+    rescales the iso view off sheet scale must also appear on the emitted-script drawing.
+
+    The script builds with ``auto_dims=False``, which used to fit the iso with
+    ``annotate=False`` and silently drop the note — so the editable script's drawing
+    disagreed with the direct CLI on every part whose iso is not to scale. The note is
+    sheet furniture (like the title block, always added on both paths), not a dimension.
+    """
+    part = Box(60, 40, 20) - Pos(0, 0, 10) * Cylinder(4, 20)
+    step, scripted = _scripted_drawing(part, tmp_path, "nts_note")
+    direct = build_drawing(str(step))
+
+    assert "note_iso_nts" in direct.annotations()  # guard the fixture: iso is rescaled
+    assert "note_iso_nts" in scripted.annotations()
+
+
+@pytest.mark.timeout(240)
 def test_generated_script_matches_direct_y_axis_turned_diameter_policy(tmp_path):
     """Y-axis turned output runs and follows the direct no-diameter policy."""
     part = Rotation(90, 0, 0) * _turned_shaft([(20, 20), (14, 15)])


### PR DESCRIPTION
## What

The generated editable script (`--script`) builds with `build_drawing(auto_dims=False)` and reconstructs dimensions through intent verbs. That path fitted the iso view with `annotate=False`, **silently dropping the "ISO VIEW (NTS)" note** — so every emitted script whose iso is rescaled off sheet scale disagreed with the direct CLI output, which always labels it.

## Why it's the right fix

The NTS note is **sheet furniture, not a dimension**. Like the title block — which *is* added on both the auto and `auto_dims=False` paths — it states a fact about the drawing: the iso view is not to scale. `auto_dims` is meant to suppress *dimensions*, not furniture. Suppressing the note made the manual-path drawing quietly untruthful and broke script↔CLI parity.

The default of `_fit_iso_view(..., annotate=True)` is unchanged; this PR just stops the one manual-path call from opting out.

## How it was found

An emit→execute→diff parity sweep over the real example corpus (NIST CTC-01..05 in AP203/AP242 + GRM-03 thumbwheel): `note_iso_nts` was missing from the generated-script build on **all 11** fixtures.

## Changes

- `builder._assemble`: drop `annotate=False` on the manual-path iso fit.
- `tests/test_script_detail_parity.py`: canary asserting the script reproduces the note. **Fails on pre-fix `main`** (verified in an isolated worktree), passes here.
- `tests/test_make_drawing.py::test_build_drawing_auto_dims_false`: the manual-path furniture set is now `{title_block, note_iso_nts}`; #74's "no dimensions" intent still holds.

## Test

- New canary + full `test_script_detail_parity` (8 passed).
- Affected modules green: `test_make_drawing` (681), `test_detect_once`/`test_solve_trace`/`test_tolerances` (73), `test_e2e_standards` (4).
- Four lint checks clean (ruff check, ruff format, mypy, codespell).

First of a small series closing script↔CLI divergences found by the sweep (next: machined-feature callout emit for pocket/fillet/chamfer/flat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)