### PR TITLE
fix: reconstruct machined-feature callouts in the emitted script (#148 parity)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1311,7 +1311,7 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
     return n
 
 
-def render_chamfers(dwg, groups, a, *, ctx) -> int:
+def render_chamfers(dwg, groups, a, *, ctx, only=None) -> int:
     """Chamfer callouts (#560): a leader from each recognised chamfer face to its
     ``C{leg}`` / ``{leg}×{angle}°`` label, in the view normal to the chamfered edge (a Z
     edge reads in the plan, an X edge in the side, a Y edge in the front). The leader runs
@@ -1334,6 +1334,8 @@ def render_chamfers(dwg, groups, a, *, ctx) -> int:
         sorted(chamfer_groups, key=lambda g: (g.feature.axis, g.feature.frame.origin))
     ):
         ch = g.feature
+        if only is not None and ch not in only:
+            continue  # #426 Ph2b subset (finalize): skip in place — i stays the model index
         # Bind the intended planned dim EXPLICITLY by (role, kind), never dims[0]
         # (#724 review): the pattern the remaining #698 migrations copy must not
         # silently grab the wrong dimension on a multi-parameter kind.
@@ -1366,7 +1368,7 @@ def _fillet_label(radius, count) -> str:
     return f"{count}× {r}" if count > 1 else r
 
 
-def render_fillets(dwg, groups, a, *, ctx) -> int:
+def render_fillets(dwg, groups, a, *, ctx, only=None) -> int:
     """Fillet radius callouts (#561): a leader from an external edge fillet to its
     ``R{radius}`` label — the arc analog of :func:`render_chamfers`. Equal-radius fillets on
     the same edge axis share ONE ``n× R`` callout (#561 acceptance), placed in the view
@@ -1388,6 +1390,8 @@ def render_fillets(dwg, groups, a, *, ctx) -> int:
     reach = _leader_callout_reach(draft)
     collapse: dict = {}
     for g in (g for g in groups if g.feature_kind == "fillet"):
+        if only is not None and g.feature not in only:
+            continue  # #426 Ph2b subset (finalize): drop filtered members before the n× collapse
         pd = next(
             (d for d in g.dims if (d.param.role, d.param.kind) == ("fillet", "radius")),
             None,
@@ -1432,7 +1436,7 @@ def _flat_label(across, sfx="") -> str:
     return f"{_fmt(across)}{sfx} A/F"
 
 
-def render_flats(dwg, groups, a, *, ctx) -> int:
+def render_flats(dwg, groups, a, *, ctx, only=None) -> int:
     """Machined-flat callouts (#148b): a leader from a flat truncating round stock to its
     ``{across} A/F`` label, in the view down the stock axis (a Z-axis bar reads in the plan).
     Flats sharing an axis and across-flats size — the faces of a double-D or hex — share ONE
@@ -1451,6 +1455,8 @@ def render_flats(dwg, groups, a, *, ctx) -> int:
     reach = _leader_callout_reach(draft)
     collapse: dict = {}
     for g in (g for g in groups if g.feature_kind == "flat"):
+        if only is not None and g.feature not in only:
+            continue  # #426 Ph2b subset (finalize): drop filtered members before the shared collapse
         pd = next(
             (d for d in g.dims if (d.param.role, d.param.kind) == ("flat", "length")),
             None,
@@ -1555,7 +1561,7 @@ def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0):
         yield (tip, elbow, feature)
 
 
-def render_pockets(dwg, groups, a, *, ctx) -> int:
+def render_pockets(dwg, groups, a, *, ctx, only=None) -> int:
     """Blind-recess callouts (#148a): a leader from each floored slot/pocket to its
     ``W × L × D DEEP`` label, in the view normal to the recess opening (a Z-depth pocket
     reads in the plan, an X-depth in the side, a Y-depth in the front). A pocket sits
@@ -1579,6 +1585,8 @@ def render_pockets(dwg, groups, a, *, ctx) -> int:
         sorted(pocket_groups, key=lambda g: (g.feature.width_axis, g.feature.frame.origin))
     ):
         pk = g.feature
+        if only is not None and pk not in only:
+            continue  # #426 Ph2b subset (finalize): skip in place — i stays the model index
         by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
         wpd = by_key.get(("pocket_width", "length"))
         lpd = by_key.get(("pocket_length", "length"))
@@ -1612,7 +1620,7 @@ def render_pockets(dwg, groups, a, *, ctx) -> int:
     return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped", ctx=ctx)
 
 
-def render_grooves(dwg, groups, a, *, ctx) -> int:
+def render_grooves(dwg, groups, a, *, ctx, only=None) -> int:
     """Turned/circlip-groove callouts (#148c): a leader from each annular groove in round
     stock to its ``{width} WIDE × ø{diameter}`` label. The groove's width is *axial*, so the
     callout lands in the **profile** view (the one showing the stock axis in-plane, where the
@@ -1639,6 +1647,8 @@ def render_grooves(dwg, groups, a, *, ctx) -> int:
         sorted(groove_groups, key=lambda g: (g.feature.axis, g.feature.frame.origin))
     ):
         gr = g.feature
+        if only is not None and gr not in only:
+            continue  # #426 Ph2b subset (finalize): skip in place — gi stays the model index
         wpd = next(
             (d for d in g.dims if (d.param.role, d.param.kind) == ("groove", "length")), None
         )
@@ -1792,7 +1802,7 @@ def render_boss_heights(dwg, groups, a, *, ctx) -> int:
     return n
 
 
-def render_plates(dwg, groups, a, *, ctx) -> int:
+def render_plates(dwg, groups, a, *, ctx, only=None) -> int:
     """Plate/wall thicknesses (#559): the thin extent of each recognised slab
     (`PlateFeature`), placed in the view where its thin axis is characteristic — a Z
     plate (horizontal slab) as a vertical dim left of the front elevation, a Y plate
@@ -1827,6 +1837,8 @@ def render_plates(dwg, groups, a, *, ctx) -> int:
         lbl = _fmt(val) + _tol_suffix(pd.param.tolerance, draft)
         i = counts[pl.axis]
         counts[pl.axis] += 1
+        if only is not None and pl not in only:
+            continue  # #426 Ph2b subset (finalize): skip AFTER consuming i so names stay stable
         if pl.axis == "z":
             # Horizontal slab (base plate): vertical dim on the front-elevation left strip.
             # For a Z plate the in-plane centroids are (u=X, v=Y); the front view discards

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1390,8 +1390,6 @@ def render_fillets(dwg, groups, a, *, ctx, only=None) -> int:
     reach = _leader_callout_reach(draft)
     collapse: dict = {}
     for g in (g for g in groups if g.feature_kind == "fillet"):
-        if only is not None and g.feature not in only:
-            continue  # #426 Ph2b subset (finalize): drop filtered members before the n× collapse
         pd = next(
             (d for d in g.dims if (d.param.role, d.param.kind) == ("fillet", "radius")),
             None,
@@ -1401,6 +1399,13 @@ def render_fillets(dwg, groups, a, *, ctx, only=None) -> int:
         collapse.setdefault((g.feature.axis, round(pd.param.value, 3)), []).append((g, pd))
     jobs = []
     for gi, ((axis, _radius), members) in enumerate(sorted(collapse.items())):
+        if only is not None:
+            # #426 Ph2b subset (finalize): filter members AFTER the collapse is enumerated so
+            # gi stays the full-drawing group index — a survivor keeps its m_fillet name even
+            # when a sibling group is dropped (Codex #811). The n× count reflects survivors.
+            members = [gp for gp in members if gp[0].feature in only]
+            if not members:
+                continue
         # One grouped ``n× R`` callout, but its leader may anchor at ANY of the equal fillets
         # — _corner_candidates tries each corner (nearest-clear first) so the group is not
         # dropped just because its first corner leads into an occupied region.
@@ -1455,8 +1460,6 @@ def render_flats(dwg, groups, a, *, ctx, only=None) -> int:
     reach = _leader_callout_reach(draft)
     collapse: dict = {}
     for g in (g for g in groups if g.feature_kind == "flat"):
-        if only is not None and g.feature not in only:
-            continue  # #426 Ph2b subset (finalize): drop filtered members before the shared collapse
         pd = next(
             (d for d in g.dims if (d.param.role, d.param.kind) == ("flat", "length")),
             None,
@@ -1466,6 +1469,12 @@ def render_flats(dwg, groups, a, *, ctx, only=None) -> int:
         collapse.setdefault((g.feature.axis, round(pd.param.value, 3)), []).append((g, pd))
     jobs = []
     for gi, ((axis, _across), members) in enumerate(sorted(collapse.items())):
+        if only is not None:
+            # #426 Ph2b subset (finalize): filter members AFTER enumerating the collapse so gi
+            # stays the full-drawing group index (Codex #811) — see render_fillets.
+            members = [gp for gp in members if gp[0].feature in only]
+            if not members:
+                continue
         ordered = sorted(members, key=lambda gp: gp[0].feature.frame.origin)
         view = ordered[0][0].view
         vb = dwg.view_bounds(view)
@@ -1802,7 +1811,7 @@ def render_boss_heights(dwg, groups, a, *, ctx) -> int:
     return n
 
 
-def render_plates(dwg, groups, a, *, ctx, only=None) -> int:
+def render_plates(dwg, groups, a, *, ctx) -> int:
     """Plate/wall thicknesses (#559): the thin extent of each recognised slab
     (`PlateFeature`), placed in the view where its thin axis is characteristic — a Z
     plate (horizontal slab) as a vertical dim left of the front elevation, a Y plate
@@ -1837,8 +1846,6 @@ def render_plates(dwg, groups, a, *, ctx, only=None) -> int:
         lbl = _fmt(val) + _tol_suffix(pd.param.tolerance, draft)
         i = counts[pl.axis]
         counts[pl.axis] += 1
-        if only is not None and pl not in only:
-            continue  # #426 Ph2b subset (finalize): skip AFTER consuming i so names stay stable
         if pl.axis == "z":
             # Horizontal slab (base plate): vertical dim on the front-elevation left strip.
             # For a Z plate the in-plane centroids are (u=X, v=Y); the front view discards

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -956,11 +956,12 @@ def _feature_listing(a: Analysis) -> str:
                 )
             continue
         elif kind in _MACHINED_CALLOUT_KINDS:
-            # Machined-feature leader callouts (#148): a chamfer/fillet/flat/pocket/groove/plate
+            # Machined-feature leader callouts (#148): a chamfer/fillet/flat/pocket/groove
             # carries no linear-dim param (span=None — it is a Leader callout, not a Dimension),
             # so dimension() can't reconstruct it. callout(f) records a per-feature intent that
             # finalize renders through the kind's auto-pass renderer restricted to this feature
-            # (only={f}, #811) — commenting one line drops exactly that one callout.
+            # (only={f}, #811) — commenting one line drops exactly that one callout. (A plate is
+            # a spanned dimension, so it falls through to the dimension() emit below, not here.)
             body.append("dwg.callout(f)")
             continue
         for p in feat.parameters():

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -54,7 +54,7 @@ from draftwright.compose import (
     _layout_geometry,
     _view_geom,
 )
-from draftwright.drawing import Drawing
+from draftwright.drawing import _MACHINED_CALLOUT_KINDS, Drawing
 from draftwright.fonts import PLEX_MONO
 from draftwright.model import (
     Datum,
@@ -954,6 +954,13 @@ def _feature_listing(a: Analysis) -> str:
                 body.append(
                     'dwg.dimension(f, "length", role="step_position")   # shoulder position(s)'
                 )
+            continue
+        elif kind in _MACHINED_CALLOUT_KINDS:
+            # Machined-feature leader callouts (#148): a chamfer/fillet/flat/pocket/groove/plate
+            # carries no linear-dim param (span=None — it is a Leader callout, not a Dimension),
+            # so dimension() can't reconstruct it. callout(f) rebuilds the feature's whole-kind
+            # callout set on finalize (whole-set, like rotational — see Drawing._s_machined).
+            body.append("dwg.callout(f)")
             continue
         for p in feat.parameters():
             if p.span is not None or kind == "slot":  # a linear dim dimension() accepts

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -958,8 +958,9 @@ def _feature_listing(a: Analysis) -> str:
         elif kind in _MACHINED_CALLOUT_KINDS:
             # Machined-feature leader callouts (#148): a chamfer/fillet/flat/pocket/groove/plate
             # carries no linear-dim param (span=None — it is a Leader callout, not a Dimension),
-            # so dimension() can't reconstruct it. callout(f) rebuilds the feature's whole-kind
-            # callout set on finalize (whole-set, like rotational — see Drawing._s_machined).
+            # so dimension() can't reconstruct it. callout(f) records a per-feature intent that
+            # finalize renders through the kind's auto-pass renderer restricted to this feature
+            # (only={f}, #811) — commenting one line drops exactly that one callout.
             body.append("dwg.callout(f)")
             continue
         for p in feat.parameters():

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -158,13 +158,15 @@ def _ir_hole_groups(model, target_axis: str) -> list[tuple]:
     return groups
 
 
-# Machined-feature leader callouts (#148) whose auto-pass renderers are whole-kind
-# batches (like render_rotational): a chamfer/fillet/flat/pocket/groove/plate exposes no
+# Machined-feature LEADER callouts (#148): a chamfer/fillet/flat/pocket/groove exposes no
 # linear-dim param (its params carry no span — it is a Leader callout, not a Dimension), so
-# the reconstruction can't route it through dimension(). callout(f) records it and the
-# per-kind finalize stage rebuilds that kind's whole callout set through its renderer at the
-# canonical _PASS_SEQUENCE slot. Each name is BOTH the feature.kind and the stage/sequence key.
-_MACHINED_CALLOUT_KINDS = ("chamfer", "fillet", "flat", "pocket", "groove", "plate")
+# the reconstruction can't route it through dimension(). callout(f) records a per-feature
+# intent that the matching per-kind finalize stage renders through the kind's auto-pass
+# renderer, restricted to that feature (only=), at the canonical _PASS_SEQUENCE slot. Each
+# name is BOTH the feature.kind and the stage/sequence key. Plate is deliberately EXCLUDED —
+# it IS a spanned dimension (corridor-registered + drained, not a direct leader), so it
+# reconstructs through dimension(f, "length", role="thickness"), not callout() (#811 review).
+_MACHINED_CALLOUT_KINDS = ("chamfer", "fillet", "flat", "pocket", "groove")
 
 
 @dataclass(frozen=True)
@@ -1021,8 +1023,8 @@ class Drawing:
         so :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
 
         Raises ``ValueError`` if *feature* exposes no callout (use :meth:`dimension` for a
-        linear param). A machined-feature callout (pocket/fillet/flat/chamfer/groove/plate)
-        is auto-named and placed in its characteristic view by the whole-kind renderer, so
+        linear param). A machined-feature callout (pocket/fillet/flat/chamfer/groove) is
+        auto-named and placed in its characteristic view by the kind's renderer, so
         ``view=``/``name=`` are unsupported for those kinds and raise ``ValueError`` rather
         than being silently ignored (Codex #811). Placed reasonably, not via the auto-pass's
         whole-set solve (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the
@@ -1045,10 +1047,10 @@ class Drawing:
         if kind in ("step", "boss"):
             return add_feature_diameter(self, feature, self._part_model, ctx=ctx)
         if kind in _MACHINED_CALLOUT_KINDS:
-            # Machined callouts render through their auto-pass whole-kind renderer, restricted
-            # to THIS feature (only={feature}) so a live call draws exactly one callout — the
-            # per-feature `only=` subset the finalize stages also use. The deferred path above
-            # routes the recorded intent to the matching per-kind finalize stage instead.
+            # Machined callouts render through their auto-pass renderer, restricted to THIS
+            # feature (only={feature}) so a live call draws exactly one callout — the per-feature
+            # `only=` subset the finalize stages also use. The deferred path above routes the
+            # recorded intent to the matching per-kind finalize stage instead.
             if self._part_model is None or self._analysis is None:
                 raise ValueError(
                     f"callout(): a {kind} callout needs the part model and analysis; "
@@ -1059,7 +1061,6 @@ class Drawing:
                 render_fillets,
                 render_flats,
                 render_grooves,
-                render_plates,
                 render_pockets,
             )
             from draftwright.model import plan_dimensions
@@ -1070,12 +1071,17 @@ class Drawing:
                 "flat": render_flats,
                 "pocket": render_pockets,
                 "groove": render_grooves,
-                "plate": render_plates,
             }
+            # Return the placed annotation's name (Codex #811) so pin()/drop() can address it:
+            # only={feature} attempts exactly one callout, so at most one name is new. A drop
+            # (no clear room) adds none and returns "" — the same empty-string drop signal the
+            # step/boss diameter branch already gives.
+            before = set(self.annotations())
             renderers[kind](
                 self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
             )
-            return ""
+            new = set(self.annotations()) - before
+            return next(iter(new)) if len(new) == 1 else ""
         return add_feature_callout(
             self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
         )
@@ -1353,10 +1359,11 @@ class Drawing:
         # Rotational furniture intent (#424/#426): the whole-model render_rotational —
         # no per-feature subset, so just the id set; it drains at the "rotational" slot.
         rotational_ids = {id(it) for it in self._intents if routable and it.kind == "rotational"}
-        # Machined-feature callout intents (#148): pocket/fillet/flat/chamfer/groove/plate
-        # callout()s. Bucketed per kind so each drains at its own _PASS_SEQUENCE stage,
-        # restricted to the recorded features via only= (per-feature, #811). The id union
-        # also joins `routed` so live_replay skips these (they route through finalize).
+        # Machined-feature leader callout intents (#148): pocket/fillet/flat/chamfer/groove
+        # callout()s (plate is a spanned dimension, routed via dimension(), not here). Bucketed
+        # per kind so each drains at its own _PASS_SEQUENCE stage, restricted to the recorded
+        # features via only= (per-feature, #811). The id union also joins `routed` so
+        # live_replay skips these (they route through finalize).
         machined_ids_by_kind: dict = {}
         for it in self._intents:
             if routable and it.kind == "callout":
@@ -1570,7 +1577,6 @@ class Drawing:
             render_grooves,
             render_height_ladder,
             render_locations,
-            render_plates,
             render_pockets,
             render_rotational,
             render_slots,
@@ -1748,8 +1754,8 @@ class Drawing:
         # its own feature — the renderer is restricted to the surviving intents' features via
         # only= (the render_slots #426 Ph2b subset idiom), so commenting one dwg.callout line
         # drops that one feature (Codex #811) while the full script reproduces the auto pass.
-        # Each kind places at its own _PASS_SEQUENCE slot (chamfers/fillets/flats/pockets after
-        # the drain; plates earlier, before step_positions), matching the auto pass's order.
+        # Each kind places directly at its own _PASS_SEQUENCE slot (after the drain). Plate is
+        # NOT here — it is a spanned corridor dimension, not a direct leader (#811 review).
         def _s_machined(kind, render):
             ids = r.machined_ids_by_kind.get(kind, set())
             feats = {it.feature for it in self._intents if id(it) in ids}
@@ -1772,9 +1778,6 @@ class Drawing:
 
         def _s_grooves():
             _s_machined("groove", render_grooves)
-
-        def _s_plates():
-            _s_machined("plate", render_plates)
 
         def _s_user_dims():
             # User-authored pin/priority dimensions queue into the shared corridor as
@@ -1878,7 +1881,6 @@ class Drawing:
                 "diameters": _s_diameters,
                 "step_lengths": _s_step_lengths,
                 "slots": _s_slots,
-                "plates": _s_plates,
                 "user_dims": _s_user_dims,
                 "drain": _s_drain,
                 "chamfers": _s_chamfers,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1072,16 +1072,18 @@ class Drawing:
                 "pocket": render_pockets,
                 "groove": render_grooves,
             }
-            # Return the placed annotation's name (Codex #811) so pin()/drop() can address it:
-            # only={feature} attempts exactly one callout, so at most one name is new. A drop
-            # (no clear room) adds none and returns "" — the same empty-string drop signal the
-            # step/boss diameter branch already gives.
-            before = set(self.annotations())
+            # Return the placed annotation's name (Codex #811) so pin()/drop() can address it.
+            # only={feature} places exactly one callout, so at most one name changes. Diff by
+            # object IDENTITY, not just the name set, so re-placing over an existing canonical
+            # name (or a grouped callout collapsing to an already-present name) is still detected
+            # as the placed name (Codex #811 r3). A drop (no clear room) changes nothing and
+            # returns "" — the same empty-string drop signal the step/boss diameter branch gives.
+            before = {n: id(o) for n, o in self.iter_annotations()}
             renderers[kind](
                 self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
             )
-            new = set(self.annotations()) - before
-            return next(iter(new)) if len(new) == 1 else ""
+            changed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
+            return changed[0] if len(changed) == 1 else ""
         return add_feature_callout(
             self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
         )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1021,11 +1021,20 @@ class Drawing:
         so :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
 
         Raises ``ValueError`` if *feature* exposes no callout (use :meth:`dimension` for a
-        linear param). Placed reasonably, not via the auto-pass's whole-set solve
-        (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the rest. A
-        step/boss diameter that finds no room returns ``""`` (a warning-level drop, like
-        the auto-pass), rather than raising, so a reconstruction script never aborts.
+        linear param). A machined-feature callout (pocket/fillet/flat/chamfer/groove/plate)
+        is auto-named and placed in its characteristic view by the whole-kind renderer, so
+        ``view=``/``name=`` are unsupported for those kinds and raise ``ValueError`` rather
+        than being silently ignored (Codex #811). Placed reasonably, not via the auto-pass's
+        whole-set solve (byte-identity is not a goal, #400 Ph2) — :meth:`repair` tidies the
+        rest. A step/boss diameter that finds no room returns ``""`` (a warning-level drop,
+        like the auto-pass), rather than raising, so a reconstruction script never aborts.
         """
+        kind = getattr(feature, "kind", None)
+        if kind in _MACHINED_CALLOUT_KINDS and (view is not None or name is not None):
+            raise ValueError(
+                f"callout(): a {kind} is auto-named and placed in its characteristic view; "
+                "view=/name= are unsupported for machined-feature callouts"
+            )
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
             self._intents.append(Intent("callout", feature, {"view": view, "name": name}))
             return ""
@@ -1033,13 +1042,18 @@ class Drawing:
         from draftwright.annotations.holes import add_feature_callout, add_feature_diameter
 
         ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
-        kind = getattr(feature, "kind", None)
         if kind in ("step", "boss"):
             return add_feature_diameter(self, feature, self._part_model, ctx=ctx)
         if kind in _MACHINED_CALLOUT_KINDS:
-            # Machined callouts render whole-kind (like rotational); a live call rebuilds the
-            # feature's whole kind set through its auto-pass renderer. The deferred path above
+            # Machined callouts render through their auto-pass whole-kind renderer, restricted
+            # to THIS feature (only={feature}) so a live call draws exactly one callout — the
+            # per-feature `only=` subset the finalize stages also use. The deferred path above
             # routes the recorded intent to the matching per-kind finalize stage instead.
+            if self._part_model is None or self._analysis is None:
+                raise ValueError(
+                    f"callout(): a {kind} callout needs the part model and analysis; "
+                    "add it to a drawing built by build_drawing(), not a bare Drawing"
+                )
             from draftwright.annotations.from_model import (
                 render_chamfers,
                 render_fillets,
@@ -1058,7 +1072,9 @@ class Drawing:
                 "groove": render_grooves,
                 "plate": render_plates,
             }
-            renderers[kind](self, plan_dimensions(self._part_model), self._analysis, ctx=ctx)
+            renderers[kind](
+                self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
+            )
             return ""
         return add_feature_callout(
             self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
@@ -1338,10 +1354,9 @@ class Drawing:
         # no per-feature subset, so just the id set; it drains at the "rotational" slot.
         rotational_ids = {id(it) for it in self._intents if routable and it.kind == "rotational"}
         # Machined-feature callout intents (#148): pocket/fillet/flat/chamfer/groove/plate
-        # callout()s. Their renderers are whole-kind batches (no only= subset), so — like
-        # rotational — one recorded intent of a kind means "rebuild that kind's whole callout
-        # set". Bucketed per kind so each drains at its own _PASS_SEQUENCE stage; the union
-        # also joins `routed` so live_replay skips them (callout() raises on these live).
+        # callout()s. Bucketed per kind so each drains at its own _PASS_SEQUENCE stage,
+        # restricted to the recorded features via only= (per-feature, #811). The id union
+        # also joins `routed` so live_replay skips these (they route through finalize).
         machined_ids_by_kind: dict = {}
         for it in self._intents:
             if routable and it.kind == "callout":
@@ -1729,19 +1744,19 @@ class Drawing:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
                 render_slots(self, plan_dimensions(model), a, ctx=ctx, only=r.slot_feats)
 
-        # Machined-feature leader callouts (#148): whole-kind renderers like _s_rotational —
-        # one recorded callout intent of a kind rebuilds that kind's WHOLE callout set (so
-        # commenting some dwg.callout lines still redraws the kind; commenting all drops it,
-        # matching the rotational/locate/height-ladder whole-set precedent). Each places at
-        # its own _PASS_SEQUENCE slot (chamfers/fillets/flats/pockets after the drain; plates
-        # earlier, before step_positions), so the reconstruction matches the auto pass's order.
+        # Machined-feature leader callouts (#148): each recorded callout intent draws exactly
+        # its own feature — the renderer is restricted to the surviving intents' features via
+        # only= (the render_slots #426 Ph2b subset idiom), so commenting one dwg.callout line
+        # drops that one feature (Codex #811) while the full script reproduces the auto pass.
+        # Each kind places at its own _PASS_SEQUENCE slot (chamfers/fillets/flats/pockets after
+        # the drain; plates earlier, before step_positions), matching the auto pass's order.
         def _s_machined(kind, render):
-            if kind in r.machined_ids_by_kind:
+            ids = r.machined_ids_by_kind.get(kind, set())
+            feats = {it.feature for it in self._intents if id(it) in ids}
+            if feats:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render(self, plan_dimensions(model), a, ctx=ctx)
-            self._intents = [
-                it for it in self._intents if id(it) not in r.machined_ids_by_kind.get(kind, set())
-            ]
+                render(self, plan_dimensions(model), a, ctx=ctx, only=feats)
+            self._intents = [it for it in self._intents if id(it) not in ids]
 
         def _s_chamfers():
             _s_machined("chamfer", render_chamfers)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -158,6 +158,15 @@ def _ir_hole_groups(model, target_axis: str) -> list[tuple]:
     return groups
 
 
+# Machined-feature leader callouts (#148) whose auto-pass renderers are whole-kind
+# batches (like render_rotational): a chamfer/fillet/flat/pocket/groove/plate exposes no
+# linear-dim param (its params carry no span — it is a Leader callout, not a Dimension), so
+# the reconstruction can't route it through dimension(). callout(f) records it and the
+# per-kind finalize stage rebuilds that kind's whole callout set through its renderer at the
+# canonical _PASS_SEQUENCE slot. Each name is BOTH the feature.kind and the stage/sequence key.
+_MACHINED_CALLOUT_KINDS = ("chamfer", "fillet", "flat", "pocket", "groove", "plate")
+
+
 @dataclass(frozen=True)
 class _IntentRouting:
     """How :meth:`Drawing.finalize` routes each recorded intent to an auto-pass solver (#426).
@@ -186,6 +195,7 @@ class _IntentRouting:
     only_dia: set
     only_len: set
     slot_feats: set
+    machined_ids_by_kind: dict
 
 
 @dataclass
@@ -1023,8 +1033,33 @@ class Drawing:
         from draftwright.annotations.holes import add_feature_callout, add_feature_diameter
 
         ctx = PlacementContext(registry=self._registry, coverage=self._coverage)
-        if getattr(feature, "kind", None) in ("step", "boss"):
+        kind = getattr(feature, "kind", None)
+        if kind in ("step", "boss"):
             return add_feature_diameter(self, feature, self._part_model, ctx=ctx)
+        if kind in _MACHINED_CALLOUT_KINDS:
+            # Machined callouts render whole-kind (like rotational); a live call rebuilds the
+            # feature's whole kind set through its auto-pass renderer. The deferred path above
+            # routes the recorded intent to the matching per-kind finalize stage instead.
+            from draftwright.annotations.from_model import (
+                render_chamfers,
+                render_fillets,
+                render_flats,
+                render_grooves,
+                render_plates,
+                render_pockets,
+            )
+            from draftwright.model import plan_dimensions
+
+            renderers = {
+                "chamfer": render_chamfers,
+                "fillet": render_fillets,
+                "flat": render_flats,
+                "pocket": render_pockets,
+                "groove": render_grooves,
+                "plate": render_plates,
+            }
+            renderers[kind](self, plan_dimensions(self._part_model), self._analysis, ctx=ctx)
+            return ""
         return add_feature_callout(
             self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
         )
@@ -1302,6 +1337,17 @@ class Drawing:
         # Rotational furniture intent (#424/#426): the whole-model render_rotational —
         # no per-feature subset, so just the id set; it drains at the "rotational" slot.
         rotational_ids = {id(it) for it in self._intents if routable and it.kind == "rotational"}
+        # Machined-feature callout intents (#148): pocket/fillet/flat/chamfer/groove/plate
+        # callout()s. Their renderers are whole-kind batches (no only= subset), so — like
+        # rotational — one recorded intent of a kind means "rebuild that kind's whole callout
+        # set". Bucketed per kind so each drains at its own _PASS_SEQUENCE stage; the union
+        # also joins `routed` so live_replay skips them (callout() raises on these live).
+        machined_ids_by_kind: dict = {}
+        for it in self._intents:
+            if routable and it.kind == "callout":
+                k = getattr(it.feature, "kind", None)
+                if k in _MACHINED_CALLOUT_KINDS:
+                    machined_ids_by_kind.setdefault(k, set()).add(id(it))
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         pinned_loc = {
             it.feature for it in self._intents if id(it) in corridor_ids and it.kwargs.get("pin")
@@ -1329,6 +1375,7 @@ class Drawing:
             only_dia=only_dia,
             only_len=only_len,
             slot_feats=slot_feats,
+            machined_ids_by_kind=machined_ids_by_kind,
         )
 
     def _user_dim_uses_corridor(self, it, routable, already_routed) -> bool:
@@ -1501,9 +1548,15 @@ class Drawing:
         :meth:`_classify_intents`; finalize wraps this call in the snapshot/rollback/finally,
         so a raise here still rolls the drawing back as before."""
         from draftwright.annotations.from_model import (
+            render_chamfers,
             render_diameters,
+            render_fillets,
+            render_flats,
+            render_grooves,
             render_height_ladder,
             render_locations,
+            render_plates,
+            render_pockets,
             render_rotational,
             render_slots,
             render_step_lengths,
@@ -1565,6 +1618,7 @@ class Drawing:
                 | r.user_dim_ids
                 | r.rotational_ids  # drained by _s_rotational; no _replay_intent branch
                 | r.off_axis_loc_ids  # drained by the off-axis stages; locate() raises on non-Z
+                | {i for ids in r.machined_ids_by_kind.values() for i in ids}  # _s_<machined kind>
             )
             i = 0
             while i < len(self._intents):
@@ -1675,6 +1729,38 @@ class Drawing:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
                 render_slots(self, plan_dimensions(model), a, ctx=ctx, only=r.slot_feats)
 
+        # Machined-feature leader callouts (#148): whole-kind renderers like _s_rotational —
+        # one recorded callout intent of a kind rebuilds that kind's WHOLE callout set (so
+        # commenting some dwg.callout lines still redraws the kind; commenting all drops it,
+        # matching the rotational/locate/height-ladder whole-set precedent). Each places at
+        # its own _PASS_SEQUENCE slot (chamfers/fillets/flats/pockets after the drain; plates
+        # earlier, before step_positions), so the reconstruction matches the auto pass's order.
+        def _s_machined(kind, render):
+            if kind in r.machined_ids_by_kind:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render(self, plan_dimensions(model), a, ctx=ctx)
+            self._intents = [
+                it for it in self._intents if id(it) not in r.machined_ids_by_kind.get(kind, set())
+            ]
+
+        def _s_chamfers():
+            _s_machined("chamfer", render_chamfers)
+
+        def _s_fillets():
+            _s_machined("fillet", render_fillets)
+
+        def _s_flats():
+            _s_machined("flat", render_flats)
+
+        def _s_pockets():
+            _s_machined("pocket", render_pockets)
+
+        def _s_grooves():
+            _s_machined("groove", render_grooves)
+
+        def _s_plates():
+            _s_machined("plate", render_plates)
+
         def _s_user_dims():
             # User-authored pin/priority dimensions queue into the shared corridor as
             # first-class candidates (ADR 0012).
@@ -1777,8 +1863,14 @@ class Drawing:
                 "diameters": _s_diameters,
                 "step_lengths": _s_step_lengths,
                 "slots": _s_slots,
+                "plates": _s_plates,
                 "user_dims": _s_user_dims,
                 "drain": _s_drain,
+                "chamfers": _s_chamfers,
+                "fillets": _s_fillets,
+                "flats": _s_flats,
+                "pockets": _s_pockets,
+                "grooves": _s_grooves,
                 "section": _s_section,
                 "details": _s_details,
                 "tabulate": _s_tabulate,

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -10,7 +10,7 @@ import runpy
 from pathlib import Path
 
 import pytest
-from build123d import Align, Axis, Box, Cylinder, Pos, Rot, Rotation, chamfer, export_step
+from build123d import Align, Axis, Box, Cylinder, Pos, Rot, Rotation, chamfer, export_step, fillet
 
 from draftwright import build_drawing, generate_script
 
@@ -239,6 +239,39 @@ def test_generated_script_reproduces_machined_callouts(tmp_path):
 
 
 @pytest.mark.timeout(240)
+def test_generated_script_reproduces_grouped_fillet_callout(tmp_path):
+    """Grouped-fillet parity (Codex #811, P3): two equal-radius fillets collapse to ONE ``n× R``
+    callout. The emitted script must reproduce the same grouped count — exercising the collapse +
+    ``only=`` member-filter path (F2) that the single-callout pocket/chamfer fixtures do not.
+    """
+    box = Box(120, 80, 30)
+    box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[0], 5)
+    box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[-1], 5)
+    step, scripted = _scripted_drawing(box, tmp_path, "grpfillet")
+    direct = build_drawing(str(step))
+
+    assert _machined_callouts(direct) == [("fillet", "2× R5")]  # guard: one grouped 2× callout
+    assert _machined_callouts(scripted) == _machined_callouts(direct)
+
+
+@pytest.mark.timeout(240)
+def test_generated_script_reproduces_groove_callout(tmp_path):
+    """Groove leader parity (Codex #811, P3): an annular groove on round stock reconstructs
+    through the ``_s_grooves`` finalize stage — a leader kind beyond pocket/chamfer.
+    """
+    shaft = Cylinder(12, 60, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    shaft -= Pos(0, 0, 30) * (
+        Cylinder(12, 4, align=(Align.CENTER, Align.CENTER, Align.MIN))
+        - Cylinder(9, 4, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    )
+    step, scripted = _scripted_drawing(shaft, tmp_path, "groove")
+    direct = build_drawing(str(step))
+
+    assert [k for k, _ in _machined_callouts(direct)] == ["groove"]  # guard: the groove is drawn
+    assert _machined_callouts(scripted) == _machined_callouts(direct)
+
+
+@pytest.mark.timeout(240)
 def test_generated_script_machined_callout_is_per_feature(tmp_path):
     """Editable-script contract (Codex #811): commenting ONE machined callout line drops
     exactly that feature, not the whole kind. Two separated pockets on a roomy block emit two
@@ -281,8 +314,6 @@ def test_finalize_fillet_keeps_stable_index_when_sibling_dropped(tmp_path):
     the R8 callout must keep ``m_fillet_z1`` — a pre-#811-style filter-before-collapse would
     renumber it to ``m_fillet_z0`` and break name-based drop()/pin().
     """
-    from build123d import fillet
-
     box = Box(120, 80, 30)
     box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[0], 4)
     box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[-1], 8)
@@ -332,6 +363,28 @@ def test_live_machined_callout_returns_placed_name(tmp_path):
     name = dwg.callout(pocket)
     assert name.startswith("m_pocket")
     assert dwg.get_annotation(name) is not None
+
+
+@pytest.mark.timeout(240)
+def test_live_machined_callout_returns_name_on_replacement(tmp_path):
+    """A live callout that REPLACES an existing annotation (same collapsed name) still returns
+    that name, not "" (Codex #811, P3/P2): two equal-radius fillets each render a 1× callout at
+    the same ``m_fillet_z0`` name, so the second call overwrites the first. A name-set diff would
+    see no new name and wrongly return ""; the object-identity diff returns the placed name.
+    """
+    box = Box(120, 80, 30)
+    box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[0], 5)
+    box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[-1], 5)
+    step = tmp_path / "two_equal_fillets.step"
+    export_step(box, str(step))
+    dwg = build_drawing(str(step), auto_dims=False)
+    fillets = [f for f in dwg.model().features if f.kind == "fillet"]
+    assert len(fillets) == 2
+
+    first = dwg.callout(fillets[0])
+    second = dwg.callout(fillets[1])  # same collapsed name → a replacement, not a new name
+    assert first.startswith("m_fillet")
+    assert second.startswith("m_fillet")  # NOT "" despite the name already existing
 
 
 @pytest.mark.timeout(240)

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -204,6 +204,35 @@ def test_generated_script_reproduces_nts_iso_note(tmp_path):
     assert note(scripted) == note(direct)
 
 
+def _machined_callouts(dwg):
+    """(kind, label) of every machined-feature leader callout on the drawing."""
+    prefixes = ("m_pocket", "m_fillet", "m_flat", "m_chamfer", "m_groove", "m_plate")
+    return sorted(
+        (name.split("_")[1], getattr(dwg.get_annotation(name), "label", None))
+        for name in dwg.annotations()
+        if name.startswith(prefixes)
+    )
+
+
+@pytest.mark.timeout(240)
+def test_generated_script_reproduces_machined_callouts(tmp_path):
+    """Machined-feature callout parity (#148): a pocket/fillet/flat/chamfer/groove/plate is a
+    Leader callout, not a linear Dimension (its IR params carry no span), so the emitted script
+    could not route it through ``dimension()``. The reconstruction had NO callout verb for these
+    kinds, so ``_feature_listing`` emitted nothing and every machined callout was silently
+    dropped from the script's drawing — contradicting its own "never silently dropped" contract.
+
+    A single floored pocket on a roomy block places identically on both paths (no crowding, so
+    no layout-driven drop divergence), giving an exact-parity check.
+    """
+    part = Box(120, 80, 30) - Pos(0, 0, 12) * Box(40, 25, 8)
+    step, scripted = _scripted_drawing(part, tmp_path, "machined")
+    direct = build_drawing(str(step))
+
+    assert _machined_callouts(direct)  # guard the fixture: the direct build draws the pocket
+    assert _machined_callouts(scripted) == _machined_callouts(direct)
+
+
 @pytest.mark.timeout(240)
 def test_generated_script_matches_direct_y_axis_turned_diameter_policy(tmp_path):
     """Y-axis turned output runs and follows the direct no-diameter policy."""

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -234,6 +234,57 @@ def test_generated_script_reproduces_machined_callouts(tmp_path):
 
 
 @pytest.mark.timeout(240)
+def test_generated_script_machined_callout_is_per_feature(tmp_path):
+    """Editable-script contract (Codex #811): commenting ONE machined callout line drops
+    exactly that feature, not the whole kind. Two separated pockets on a roomy block emit two
+    ``dwg.callout(f)`` lines; removing the first must leave exactly the second pocket's callout.
+    The pre-#811 whole-kind renderer redrew BOTH pockets from the single surviving intent, so
+    this fails on that approach — the ``only=`` per-feature subset is what makes it pass.
+    """
+    part = Box(160, 90, 30) - Pos(-40, 0, 12) * Box(24, 20, 8) - Pos(40, 0, 12) * Box(24, 20, 8)
+    step = tmp_path / "two_pockets.step"
+    export_step(part, str(step))
+
+    direct = build_drawing(str(step))
+    assert len(_machined_callouts(direct)) == 2  # guard: both pockets drawn on the direct path
+
+    script = Path(generate_script(str(step), out=str(tmp_path / "two_pockets")))
+    baseline = runpy.run_path(str(script))["dwg"]
+    assert len(_machined_callouts(baseline)) == 2  # the unedited script reproduces both
+
+    # Comment out the FIRST pocket callout line only, then re-run the edited script.
+    lines = script.read_text(encoding="utf-8").splitlines()
+    for idx, ln in enumerate(lines):
+        if ln.strip() == "dwg.callout(f)":
+            indent = ln[: len(ln) - len(ln.lstrip())]
+            lines[idx] = f"{indent}# {ln.strip()}"
+            break
+    else:
+        raise AssertionError("generated script has no dwg.callout(f) line to comment out")
+    script.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    edited = runpy.run_path(str(script))["dwg"]
+
+    # Exactly one pocket survives — per-feature only=, not a whole-kind redraw.
+    assert len(_machined_callouts(edited)) == 1
+
+
+@pytest.mark.timeout(240)
+def test_callout_rejects_name_view_for_machined_feature(tmp_path):
+    """A machined callout is auto-named/placed by its whole-kind renderer, so ``name=``/``view=``
+    are unsupported and raise rather than being silently discarded (Codex #811, F2)."""
+    part = Box(120, 80, 30) - Pos(0, 0, 12) * Box(40, 25, 8)
+    step = tmp_path / "pocket.step"
+    export_step(part, str(step))
+    dwg = build_drawing(str(step))
+    pocket = next(f for f in dwg.model().features if f.kind == "pocket")
+
+    with pytest.raises(ValueError, match="machined"):
+        dwg.callout(pocket, name="critical_depth")
+    with pytest.raises(ValueError, match="machined"):
+        dwg.callout(pocket, view="plan")
+
+
+@pytest.mark.timeout(240)
 def test_generated_script_matches_direct_y_axis_turned_diameter_policy(tmp_path):
     """Y-axis turned output runs and follows the direct no-diameter policy."""
     part = Rotation(90, 0, 0) * _turned_shaft([(20, 20), (14, 15)])

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -10,7 +10,7 @@ import runpy
 from pathlib import Path
 
 import pytest
-from build123d import Align, Box, Cylinder, Pos, Rot, Rotation, export_step
+from build123d import Align, Axis, Box, Cylinder, Pos, Rot, Rotation, chamfer, export_step
 
 from draftwright import build_drawing, generate_script
 
@@ -205,8 +205,10 @@ def test_generated_script_reproduces_nts_iso_note(tmp_path):
 
 
 def _machined_callouts(dwg):
-    """(kind, label) of every machined-feature leader callout on the drawing."""
-    prefixes = ("m_pocket", "m_fillet", "m_flat", "m_chamfer", "m_groove", "m_plate")
+    """(kind, label) of every machined-feature LEADER callout on the drawing. Plate is a
+    spanned dimension (``dim_plate_*``), reconstructed via ``dimension()`` not ``callout()``,
+    so it is deliberately not a machined-callout prefix here (#811 review)."""
+    prefixes = ("m_pocket", "m_fillet", "m_flat", "m_chamfer", "m_groove")
     return sorted(
         (name.split("_")[1], getattr(dwg.get_annotation(name), "label", None))
         for name in dwg.annotations()
@@ -216,21 +218,24 @@ def _machined_callouts(dwg):
 
 @pytest.mark.timeout(240)
 def test_generated_script_reproduces_machined_callouts(tmp_path):
-    """Machined-feature callout parity (#148): a pocket/fillet/flat/chamfer/groove/plate is a
-    Leader callout, not a linear Dimension (its IR params carry no span), so the emitted script
-    could not route it through ``dimension()``. The reconstruction had NO callout verb for these
+    """Machined-feature callout parity (#148): a pocket/fillet/flat/chamfer/groove is a Leader
+    callout, not a linear Dimension (its IR params carry no span), so the emitted script could
+    not route it through ``dimension()``. The reconstruction had NO callout verb for these
     kinds, so ``_feature_listing`` emitted nothing and every machined callout was silently
     dropped from the script's drawing — contradicting its own "never silently dropped" contract.
 
-    A single floored pocket on a roomy block places identically on both paths (no crowding, so
-    no layout-driven drop divergence), giving an exact-parity check.
+    A chamfered block with a floored pocket exercises TWO kinds (four ``C6`` chamfer leaders +
+    one pocket) that place identically on both paths (roomy, so no layout-driven drop
+    divergence), giving an exact-parity check across more than one machined kind.
     """
-    part = Box(120, 80, 30) - Pos(0, 0, 12) * Box(40, 25, 8)
+    box = chamfer(Box(120, 80, 30).edges().filter_by(Axis.Z), 6)
+    part = box - Pos(0, 0, 12) * Box(40, 25, 8)
     step, scripted = _scripted_drawing(part, tmp_path, "machined")
     direct = build_drawing(str(step))
 
-    assert _machined_callouts(direct)  # guard the fixture: the direct build draws the pocket
-    assert _machined_callouts(scripted) == _machined_callouts(direct)
+    got = _machined_callouts(direct)
+    assert {kind for kind, _ in got} == {"chamfer", "pocket"}  # guard: both kinds drawn direct
+    assert _machined_callouts(scripted) == got
 
 
 @pytest.mark.timeout(240)
@@ -269,6 +274,34 @@ def test_generated_script_machined_callout_is_per_feature(tmp_path):
 
 
 @pytest.mark.timeout(240)
+def test_finalize_fillet_keeps_stable_index_when_sibling_dropped(tmp_path):
+    """Index stability under filtering (Codex #811, F2): fillets/flats collapse by (axis, value)
+    and name by the collapse-key index, so dropping one group must NOT renumber a survivor.
+    Two vertical edges filleted R4 (``m_fillet_z0``) and R8 (``m_fillet_z1``); recording only
+    the R8 callout must keep ``m_fillet_z1`` — a pre-#811-style filter-before-collapse would
+    renumber it to ``m_fillet_z0`` and break name-based drop()/pin().
+    """
+    from build123d import fillet
+
+    box = Box(120, 80, 30)
+    box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[0], 4)
+    box = fillet(box.edges().filter_by(Axis.Z).sort_by(Axis.X)[-1], 8)
+    step = tmp_path / "two_fillets.step"
+    export_step(box, str(step))
+
+    direct = build_drawing(str(step))
+    names = sorted(n for n in direct.annotations() if n.startswith("m_fillet"))
+    assert names == ["m_fillet_z0", "m_fillet_z1"]  # guard: R4→z0, R8→z1
+
+    dwg = build_drawing(str(step), auto_dims=False)
+    r8 = next(f for f in dwg.model().features if f.kind == "fillet" and f.radius == 8)
+    with dwg.deferred():
+        dwg.callout(r8)
+    survivors = sorted(n for n in dwg.annotations() if n.startswith("m_fillet"))
+    assert survivors == ["m_fillet_z1"]  # survivor keeps its full-drawing index, not renamed
+
+
+@pytest.mark.timeout(240)
 def test_callout_rejects_name_view_for_machined_feature(tmp_path):
     """A machined callout is auto-named/placed by its whole-kind renderer, so ``name=``/``view=``
     are unsupported and raise rather than being silently discarded (Codex #811, F2)."""
@@ -282,6 +315,23 @@ def test_callout_rejects_name_view_for_machined_feature(tmp_path):
         dwg.callout(pocket, name="critical_depth")
     with pytest.raises(ValueError, match="machined"):
         dwg.callout(pocket, view="plan")
+
+
+@pytest.mark.timeout(240)
+def test_live_machined_callout_returns_placed_name(tmp_path):
+    """A live (non-deferred) machined callout returns the placed annotation's name so pin()/drop()
+    can address it, honouring callout()'s "Returns the annotation name" contract (Codex #811, F3)
+    — the pre-fix branch unconditionally returned "" even on a successful placement.
+    """
+    part = Box(120, 80, 30) - Pos(0, 0, 12) * Box(40, 25, 8)
+    step = tmp_path / "pocket.step"
+    export_step(part, str(step))
+    dwg = build_drawing(str(step), auto_dims=False)
+    pocket = next(f for f in dwg.model().features if f.kind == "pocket")
+
+    name = dwg.callout(pocket)
+    assert name.startswith("m_pocket")
+    assert dwg.get_annotation(name) is not None
 
 
 @pytest.mark.timeout(240)


### PR DESCRIPTION
## What

The imperative editable script (`--script`) builds with `auto_dims=False` and reconstructs annotations through per-feature intent verbs. It had a callout verb only for hole/pattern/step/boss — so **pocket / fillet / flat / chamfer / groove / plate** callouts were **silently dropped** from the script's drawing on the entire NIST CTC-01..05 corpus.

These are Leader callouts (`38.1 × 60.3 × 8.9 DEEP`, `4× R203.2`, `A/F`), not linear `Dimension`s: their IR parameters carry **no span**, so they fall through `_feature_listing`'s `dimension()` loop and emit nothing — contradicting that function's own *"never silently dropped"* contract (only `pmi` is a declared gap kind). This is exactly the recognition-only debt ADR 0011/0015 warns against: recognise + emit must round-trip.

## How

Their auto-pass renderers (`render_chamfers`/`render_fillets`/`render_flats`/`render_pockets`/`render_grooves`/`render_plates`) are **whole-kind batches — structurally identical to `render_rotational`**. So they're routed the same way, following the established rotational / locate / height-ladder whole-set reconstruction precedent:

- `Drawing.callout(f)` records a callout intent for these kinds (deferred) and, live, rebuilds the feature's whole kind-set through its renderer (symmetric with live `rotational()`).
- `_classify_intents` buckets machined callout intents per kind (`machined_ids_by_kind`); the union joins `routed` so `live_replay` skips them (live `callout()` raises on them).
- New per-kind finalize stages render each present kind once at its **canonical `_PASS_SEQUENCE` slot** (chamfers..pockets/grooves after the drain, plates before step_positions), so the reconstruction matches the auto pass's placement order.
- `_feature_listing` emits `dwg.callout(f)` for these kinds.

**Whole-set semantics**, like rotational: commenting some callout lines still redraws the kind; commenting all drops it.

## Parity scope (honest)

On a roomy part the reconstruction is **exact**. On a crowded sheet the placed/dropped set can differ by a callout or two — the same layout-approximation the other reconstruction passes carry (byte-identity is explicitly not a goal, ADR 0004). What this PR fixes is the **silent total loss** of every machined callout.

## Test

- Canary `test_generated_script_reproduces_machined_callouts`: a single floored pocket on a roomy block places identically on both paths; asserts the script's machined-callout `(kind, label)` set equals the direct build's. **Fails on pre-fix `main`** (script draws zero) — verified in an isolated worktree.
- Full `test_script_detail_parity` (9), `test_e2e_standards` (4), `test_make_drawing` (681), `test_drawing_encapsulation`/`test_render_seam`/`test_sheet_emit`/`test_refactor_golden`/`test_detect_once`/`test_solve_trace`/`test_tolerances` (191) all green.
- Four lint checks clean.

Second of the script↔CLI parity series (after #810, the NTS note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)