### PR TITLE
fix(#812): reconstruct plate thickness dimensions in the emitted --script

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1811,7 +1811,7 @@ def render_boss_heights(dwg, groups, a, *, ctx) -> int:
     return n
 
 
-def render_plates(dwg, groups, a, *, ctx) -> int:
+def render_plates(dwg, groups, a, *, ctx, only=None) -> int:
     """Plate/wall thicknesses (#559): the thin extent of each recognised slab
     (`PlateFeature`), placed in the view where its thin axis is characteristic — a Z
     plate (horizontal slab) as a vertical dim left of the front elevation, a Y plate
@@ -1846,6 +1846,8 @@ def render_plates(dwg, groups, a, *, ctx) -> int:
         lbl = _fmt(val) + _tol_suffix(pd.param.tolerance, draft)
         i = counts[pl.axis]
         counts[pl.axis] += 1
+        if only is not None and pl not in only:
+            continue  # #812 finalize subset: skip AFTER consuming i so dim_plate names stay stable
         if pl.axis == "z":
             # Horizontal slab (base plate): vertical dim on the front-elevation left strip.
             # For a Z plate the in-plane centroids are (u=X, v=Y); the front view discards

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -198,6 +198,8 @@ class _IntentRouting:
     only_len: set
     slot_feats: set
     machined_ids_by_kind: dict
+    plate_ids: set
+    plate_feats: set
 
 
 @dataclass
@@ -1313,6 +1315,22 @@ class Drawing:
             and it.kwargs.get("param") == "length"
             and it.kwargs.get("role") in ("slot_width", "slot_length")
         }
+        # PLATE thickness dimension intents (#812) → render_plates' corridor placement, like
+        # slots. A PlateFeature exposes ONE spanned ("length", "thickness") param, so the
+        # emitter emits dimension(f, "length", role="thickness"); route it to render_plates
+        # (which registers a corridor candidate drained by the shared solve) restricted to the
+        # recorded plates via only=. Match on param/role like slot_ids so a malformed plate dim
+        # falls through to live replay. (Before #812 this intent matched NO route and was
+        # silently dropped — dim_plate_* never reconstructed in the emitted script.)
+        plate_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and it.kind == "dimension"
+            and getattr(it.feature, "kind", None) == "plate"
+            and it.kwargs.get("param") == "length"
+            and it.kwargs.get("role") == "thickness"
+        }
         # Prismatic height-ladder intent. StepLevelFeature exposes one value per interior
         # level, but those rungs are a correlated chain whose witness bases leapfrog from
         # the previous placed tier. Treat one semantic dimension intent as "rebuild the
@@ -1380,6 +1398,7 @@ class Drawing:
         only_dia = {it.feature for it in self._intents if id(it) in dia_ids}
         only_len = {it.feature for it in self._intents if id(it) in len_ids}
         slot_feats = {it.feature for it in self._intents if id(it) in slot_ids}
+        plate_feats = {it.feature for it in self._intents if id(it) in plate_ids}
         return _IntentRouting(
             section=_section,
             corridor_ids=corridor_ids,
@@ -1400,6 +1419,8 @@ class Drawing:
             only_len=only_len,
             slot_feats=slot_feats,
             machined_ids_by_kind=machined_ids_by_kind,
+            plate_ids=plate_ids,
+            plate_feats=plate_feats,
         )
 
     def _user_dim_uses_corridor(self, it, routable, already_routed) -> bool:
@@ -1579,6 +1600,7 @@ class Drawing:
             render_grooves,
             render_height_ladder,
             render_locations,
+            render_plates,
             render_pockets,
             render_rotational,
             render_slots,
@@ -1636,6 +1658,7 @@ class Drawing:
                 | r.dia_ids
                 | r.len_ids
                 | r.slot_ids
+                | r.plate_ids  # drained by _s_plates + the shared drain (#812)
                 | r.height_ladder_ids
                 | r.step_position_ids
                 | r.user_dim_ids
@@ -1752,6 +1775,15 @@ class Drawing:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
                 render_slots(self, plan_dimensions(model), a, ctx=ctx, only=r.slot_feats)
 
+        def _s_plates():
+            # Plate thicknesses (#812) register corridor candidates (like slots), placed by the
+            # shared drain below — restricted to the recorded plates via only=. Runs at the
+            # "plates" _PASS_SEQUENCE slot (before the drain), matching the auto-pass order; the
+            # intents are dropped in _s_drain after the solve succeeds (clean-retry on a raise).
+            if r.plate_feats:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render_plates(self, plan_dimensions(model), a, ctx=ctx, only=r.plate_feats)
+
         # Machined-feature leader callouts (#148): each recorded callout intent draws exactly
         # its own feature — the renderer is restricted to the surviving intents' features via
         # only= (the render_slots #426 Ph2b subset idiom), so commenting one dwg.callout line
@@ -1799,6 +1831,7 @@ class Drawing:
                 r.only_loc
                 or r.off_axis_loc_ids
                 or r.slot_feats
+                or r.plate_feats
                 or r.user_dim_ids
                 or r.step_position_ids
                 or r.height_ladder_ids
@@ -1813,6 +1846,7 @@ class Drawing:
                     r.corridor_ids
                     | r.off_axis_loc_ids
                     | r.slot_ids
+                    | r.plate_ids
                     | queued_dim_ids
                     | r.step_position_ids
                     | r.height_ladder_ids
@@ -1883,6 +1917,7 @@ class Drawing:
                 "diameters": _s_diameters,
                 "step_lengths": _s_step_lengths,
                 "slots": _s_slots,
+                "plates": _s_plates,
                 "user_dims": _s_user_dims,
                 "drain": _s_drain,
                 "chamfers": _s_chamfers,

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -239,6 +239,25 @@ def test_generated_script_reproduces_machined_callouts(tmp_path):
 
 
 @pytest.mark.timeout(240)
+def test_generated_script_reproduces_plate_thickness_dims(tmp_path):
+    """Plate thickness parity (#812): a PlateFeature is a SPANNED dimension, so the emitter emits
+    ``dwg.dimension(f, "length", role="thickness")``. That intent matched no finalize route and
+    was silently dropped — the script's drawing had NO ``dim_plate_*`` even though the direct CLI
+    draws them. An L-bracket (base plate + upright wall) has two plate thicknesses on a roomy
+    sheet, giving an exact-parity check that the new plate route reconstructs both.
+    """
+    part = Box(80, 60, 8) + Pos(0, 26, 24) * Box(80, 8, 40)
+    step, scripted = _scripted_drawing(part, tmp_path, "lbracket")
+    direct = build_drawing(str(step))
+
+    def plate_dims(dwg):
+        return sorted(n for n in dwg.annotations() if n.startswith("dim_plate"))
+
+    assert plate_dims(direct) == ["dim_plate_y0", "dim_plate_z0"]  # guard: two plate thicknesses
+    assert plate_dims(scripted) == plate_dims(direct)
+
+
+@pytest.mark.timeout(240)
 def test_generated_script_reproduces_grouped_fillet_callout(tmp_path):
     """Grouped-fillet parity (Codex #811, P3): two equal-radius fillets collapse to ONE ``n× R``
     callout. The emitted script must reproduce the same grouped count — exercising the collapse +


### PR DESCRIPTION
## Summary

Closes #812. The imperative `--script` emitter did not reconstruct **plate thickness** dimensions: the executed script's drawing had no `dim_plate_*` annotations even though the direct `build_drawing` path draws them.

A `PlateFeature` is a **spanned dimension** — its `parameters()` returns a `("length", "thickness")` `DimParameter` with a span — so the emitter correctly emits `dwg.dimension(f, "length", role="thickness")`. But that intent matched **no route** in `_classify_intents` and was silently dropped in `finalize()`, so nothing was placed. (Distinct from the machined leader-callout kinds fixed in #811; this predates #811 — verified on `main`.)

## Fix

Route plate thickness like a slot — a corridor-registered dimension drained by the shared solve:
- **`_classify_intents`**: classify `role="thickness"` plate-dimension intents into `plate_ids`/`plate_feats`.
- **`_s_plates`**: registers `render_plates(..., only=plate_feats)` at the existing `plates` `_PASS_SEQUENCE` slot (before the drain); `_s_drain` now runs when plates are present and drops the intents only after a successful solve (clean retry on a raise, per the #647 transaction).
- **`render_plates`** regains its `only=` subset (skip-in-place *after* consuming the per-axis index, so `dim_plate_*` names stay stable); `only=None` is the unchanged auto-pass.
- **`plate_ids`** joins the live-replay routed set so a plate dim doesn't double-place.

## Testing

- New canary `test_generated_script_reproduces_plate_thickness_dims`: an L-bracket (base plate + upright wall) whose script reproduces `dim_plate_y0`/`dim_plate_z0` exactly — **verified to fail on `main`** (`[] != [...]`) via the worktree ritual.
- Full local suites green: parity module (17), make_drawing (767), e2e_standards + carve/declare/tolerances/encapsulation/fillets (241). All four lint checks clean.

## Context

This is the last discrete **emit gap** in the script↔CLI parity sweep. After #810 (NTS note), #811 (machined leader callouts), and this, the residual corpus divergences are the finalize-vs-auto **placement-quality** differences (crowded-sheet layout-driven drops) — explicitly out of byte-identity scope (ADR 0004/0012) and tracked by the #426/#661/#707 convergence work, not discrete emit bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)