### PR TITLE
test(#741): ratchet test-side Drawing private-attribute reads + migrate _registry (PR 1)

### DIFF
--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6059,7 +6059,7 @@ def _assert_drop_is_complete(dwg):
     (2) CONSISTENCY: for every feature, drop() removes exactly annotations_of() and leaves
     nothing behind. Distinct features never share an owned annotation, so dropping each in
     turn is independent."""
-    reg = dwg._registry
+    reg = dwg.registry
     for name in dwg.annotations():
         if name.startswith(_ALWAYS_OWNED):
             assert reg.feature_of(name) is not None, f"{name}: feature annotation left unowned"
@@ -7308,8 +7308,8 @@ class TestFeatureEdits:
         mdia = [n for n in dwg.annotations() if n.startswith("m_dia")]
         assert mdia, "expected turned-diameter callouts"
         for n in mdia:
-            assert dwg._registry.feature_of(n) is not None, f"{n} unowned (#412 regression)"
-        owner = dwg._registry.feature_of(mdia[0])
+            assert dwg.registry.feature_of(n) is not None, f"{n} unowned (#412 regression)"
+        owner = dwg.registry.feature_of(mdia[0])
         assert mdia[0] in dwg.drop(owner)
 
     def test_drop_step_clears_its_diameter_callout_x_turned(self):
@@ -7322,7 +7322,7 @@ class TestFeatureEdits:
         mdia_x = [n for n in dwg.annotations() if n.startswith("m_dia_x")]
         assert mdia_x, "expected X-turned diameter callouts (row path)"
         for n in mdia_x:
-            assert dwg._registry.feature_of(n) is not None, f"{n} unowned (#412 row path)"
+            assert dwg.registry.feature_of(n) is not None, f"{n} unowned (#412 row path)"
 
     def test_drop_is_complete_for_side_drilled_holes(self):
         # #410 review F1: a side-drilled (X/Y-axis) hole's location dims (dim_loc_side/
@@ -7341,7 +7341,7 @@ class TestFeatureEdits:
         # Directly: each (distinct-offset) side-drilled dim is owned by its hole — the F1
         # fix. Without it these were feature=None and drop(hole) left them behind.
         for n in side_loc:
-            assert dwg._registry.feature_of(n) is not None, f"{n} unowned (F1 regression)"
+            assert dwg.registry.feature_of(n) is not None, f"{n} unowned (F1 regression)"
         _assert_drop_is_complete(dwg)
 
     def test_dimension_rejects_non_orthographic_view(self):

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -1,0 +1,172 @@
+"""Ratchet: tests may read only a DOCUMENTED, shrinking set of ``Drawing`` private attributes.
+
+The #720/#721 family closed test reach-through into the *aliased* privates (the seven with a
+public read equivalent, 361 sites) and #722 froze the **src**-side ``dwg._*`` reads to zero. The
+last unpoliced quadrant (#741) is test-side **attribute reads** of ``Drawing`` internals that have
+no public read yet — ``_analysis``/``_intents``/… They coupled the tests to build-state internals
+with no ratchet, so they could silently multiply.
+
+This pins today's read-sites as a per-name ceiling that may only **SHRINK**: thread a read through
+a new/existing public surface, lower its count; when it reaches zero, delete the entry. A NEW
+private name, or a GROWN count on an existing one, fails here — nudging the author onto the public
+seam (as ``_registry`` → :pyattr:`Drawing.registry`, ``_part_model`` → :pymeth:`Drawing.model`).
+
+Scope is **reads** (attribute access in ``Load`` context + ``getattr(_, "_name")`` probes), the
+#741 title; private *writes* (chiefly ``dwg._defer_intents = …``, which should become
+``with dwg.deferred():``) are the separate follow-on and are eliminated, not allowlisted.
+
+Keyed on the attribute *name* (∈ :data:`_DRAWING_PRIVATES`), not the receiver — test receivers
+vary (``dwg``/``d``/``direct``/``scripted``/…), unlike the src guard's ``dwg``/``drawing``. A stray
+same-named private on a non-Drawing object would be pinned too (harmless, fail-closed). Mirrors
+``test_private_test_imports`` / ``test_drawing_encapsulation``; stdlib ``ast`` + ``pathlib`` only
+(:func:`test_drawing_privates_set_is_current` alone imports ``Drawing``, to keep the name-set honest).
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+_TESTS = Path(__file__).resolve().parent
+_SELF = Path(__file__).name
+
+# ``Drawing``'s private attributes — ``__init__`` instance attrs ∪ class-level privates
+# (properties/methods). Hardcoded so the scanner stays import-light;
+# :func:`test_drawing_privates_set_is_current` imports ``Drawing`` and fails if this drifts, so a
+# newly added private cannot escape the guard by being absent from the name-set.
+_DRAWING_PRIVATES: frozenset[str] = frozenset(
+    {
+        # instance attributes (set in Drawing.__init__)
+        "_build",
+        "_coords",
+        "_coverage",
+        "_cyl_cache",
+        "_defer_intents",
+        "_intents",
+        "_model_declared",
+        "_registry",
+        # class-level privates (properties / methods)
+        "_add_balloon",
+        "_add_shapes",
+        "_analysis",
+        "_ann_box_cache",
+        "_anno_view",
+        "_build_issues",
+        "_classify_intents",
+        "_derive_span",
+        "_drain_intents",
+        "_dropped_callout_diams",
+        "_hole_spec_groups",
+        "_is_scattered_hole_doc",
+        "_lint_and_log",
+        "_named",
+        "_part_model",
+        "_pattern_callouts",
+        "_patterned_holes",
+        "_pinned",
+        "_queue_dimension_intent",
+        "_record_build_issue",
+        "_replay_intent",
+        "_resolve_dimension_span",
+        "_user_dim_uses_corridor",
+        "_view_edge_cache",
+        "_write_dxf",
+        "_write_svg",
+    }
+)
+
+# Per-name READ-site ceiling — shrink-only (#741). Migrate a read onto the public surface, lower
+# the number; delete the entry at zero. A new/grown read fails :func:`test_no_new_or_grown_...`.
+_ALLOW: dict[str, int] = {
+    "_analysis": 82,
+    "_intents": 25,
+    "_coords": 5,
+    "_record_build_issue": 5,
+    "_coverage": 4,
+    "_ann_box_cache": 3,
+    "_defer_intents": 3,
+    "_write_dxf": 2,
+    "_model_declared": 1,
+    "_add_balloon": 1,
+    "_is_scattered_hole_doc": 1,
+}
+
+
+def _read_counts(tree: ast.Module) -> Counter[str]:
+    """Count ``<recv>._<name>`` reads (``Load`` context) + ``getattr(<recv>, "_name", …)`` probes
+    for every ``_name`` in :data:`_DRAWING_PRIVATES`. Store/Del targets (writes) are excluded."""
+    counts: Counter[str] = Counter()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr in _DRAWING_PRIVATES
+            and isinstance(node.ctx, ast.Load)
+        ):
+            counts[node.attr] += 1
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value in _DRAWING_PRIVATES
+        ):
+            counts[node.args[1].value] += 1
+    return counts
+
+
+def _scan_all() -> Counter[str]:
+    total: Counter[str] = Counter()
+    for path in sorted(_TESTS.rglob("*.py")):
+        if "__pycache__" in path.parts or path.name == _SELF:
+            continue
+        total.update(_read_counts(ast.parse(path.read_text(encoding="utf-8"))))
+    return total
+
+
+def test_no_new_or_grown_drawing_private_reads() -> None:
+    """No test may read a Drawing private the allowlist does not already sanction (a new name),
+    nor add reads beyond a name's pinned ceiling (a grown count)."""
+    actual = _scan_all()
+    over = {n: (c, _ALLOW.get(n, 0)) for n, c in actual.items() if c > _ALLOW.get(n, 0)}
+    assert not over, (
+        "new or grown test-side reads of Drawing privates (#741) — thread them through the public "
+        f"read surface, do not add reach-through:\n{over}\n(name: (found, allowed))"
+    )
+
+
+def test_allowlist_is_tight_no_stale_or_slack_entries() -> None:
+    """The ratchet only ratchets if it stays exact: an entry whose real count dropped (a migrated
+    read) must be lowered here, and a fully-migrated name deleted — so the ceiling tracks reality."""
+    actual = _scan_all()
+    slack = {
+        n: (actual.get(n, 0), allowed)
+        for n, allowed in _ALLOW.items()
+        if actual.get(n, 0) < allowed
+    }
+    assert not slack, (
+        "reads were migrated but the allowlist was not lowered (#741) — set each entry to the real "
+        f"count, delete it at zero:\n{slack}\n(name: (found, allowed))"
+    )
+
+
+def test_drawing_privates_set_is_current() -> None:
+    """Guard the name-set: every real ``Drawing`` private must be in :data:`_DRAWING_PRIVATES`, so a
+    newly added private is covered by the scanner rather than silently escaping it."""
+    import inspect
+    import re
+
+    from draftwright.drawing import Drawing
+
+    init_attrs = set(
+        re.findall(r"self\.(_[a-z][a-z_]*)\s*[:=]", inspect.getsource(Drawing.__init__))
+    )
+    class_privates = {n for n in vars(Drawing) if n.startswith("_") and not n.startswith("__")}
+    actual = {
+        n for n in (init_attrs | class_privates) if not n.isupper()
+    }  # drop constants (_EXPORT_FORMATS)
+    missing = actual - _DRAWING_PRIVATES
+    assert not missing, (
+        f"Drawing gained private(s) not in _DRAWING_PRIVATES — add them so reads are policed: {missing}"
+    )

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -20,6 +20,17 @@ vary (``dwg``/``d``/``direct``/``scripted``/…), unlike the src guard's ``dwg``
 same-named private on a non-Drawing object would be pinned too (harmless, fail-closed). Mirrors
 ``test_private_test_imports`` / ``test_drawing_encapsulation``; stdlib ``ast`` + ``pathlib`` only
 (:func:`test_drawing_privates_set_is_current` alone imports ``Drawing``, to keep the name-set honest).
+
+**A ratchet, not a sandbox** (the sibling guards' stance). Two limits are accepted by design:
+
+- *Static reflection is unresolvable.* ``getattr(dwg, name)`` with a non-literal ``name``,
+  ``dwg.__dict__["_analysis"]``, ``vars(dwg)[…]``, ``object.__getattribute__`` — the scanner sees
+  only the *common, honest* forms (attribute access, ``getattr`` with a constant, ``+=`` targets).
+  Reflective escapes can't be caught statically; they are rare and would surface in review.
+- *This is a CARDINALITY ratchet.* The guarantee is that the **net per-name read count never
+  grows** — you cannot add reach-through without the total rising. It does not pin individual
+  sites, so migrating one read while adding another of the same name (net zero) is permitted; that
+  is deliberate (net non-increasing coupling), and it keeps the allowlist line-number-churn-free.
 """
 
 from __future__ import annotations
@@ -29,7 +40,6 @@ from collections import Counter
 from pathlib import Path
 
 _TESTS = Path(__file__).resolve().parent
-_SELF = Path(__file__).name
 
 # ``Drawing``'s private attributes — ``__init__`` instance attrs ∪ class-level privates
 # (properties/methods). Hardcoded so the scanner stays import-light;
@@ -95,7 +105,9 @@ _ALLOW: dict[str, int] = {
 
 def _read_counts(tree: ast.Module) -> Counter[str]:
     """Count ``<recv>._<name>`` reads (``Load`` context) + ``getattr(<recv>, "_name", …)`` probes
-    for every ``_name`` in :data:`_DRAWING_PRIVATES`. Store/Del targets (writes) are excluded."""
+    for every ``_name`` in :data:`_DRAWING_PRIVATES`. A plain assignment/``del`` target (``Store``/
+    ``Del``) is excluded, but an ``AugAssign`` target (``dwg._intents += …``) IS counted — ``+=``
+    reads the old value before writing, so it couples like a read (Codex #814)."""
     counts: Counter[str] = Counter()
     for node in ast.walk(tree):
         if (
@@ -104,6 +116,14 @@ def _read_counts(tree: ast.Module) -> Counter[str]:
             and isinstance(node.ctx, ast.Load)
         ):
             counts[node.attr] += 1
+        elif (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Attribute)
+            and node.target.attr in _DRAWING_PRIVATES
+        ):
+            # The target carries Store context (missed by the Load branch), but ``x._p += y``
+            # reads ``x._p`` first — a read-modify-write reach-through.
+            counts[node.target.attr] += 1
         elif (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
@@ -118,8 +138,11 @@ def _read_counts(tree: ast.Module) -> Counter[str]:
 
 def _scan_all() -> Counter[str]:
     total: Counter[str] = Counter()
+    # This guard file is NOT exempted (Codex #814 L5): it only references the private names as
+    # string constants (in _DRAWING_PRIVATES / _ALLOW), which are not attribute reads, so it scans
+    # to zero — and a future real reach-through added here is then policed like anywhere else.
     for path in sorted(_TESTS.rglob("*.py")):
-        if "__pycache__" in path.parts or path.name == _SELF:
+        if "__pycache__" in path.parts:
             continue
         total.update(_read_counts(ast.parse(path.read_text(encoding="utf-8"))))
     return total
@@ -153,18 +176,34 @@ def test_allowlist_is_tight_no_stale_or_slack_entries() -> None:
 
 def test_drawing_privates_set_is_current() -> None:
     """Guard the name-set: every real ``Drawing`` private must be in :data:`_DRAWING_PRIVATES`, so a
-    newly added private is covered by the scanner rather than silently escaping it."""
+    newly added private is covered by the scanner rather than silently escaping it.
+
+    Discovers ``self._x = …`` Store attributes across the WHOLE class body — not only ``__init__``
+    (Codex #814 H1: ``Drawing`` sets ``_build_issues`` in ``finalize``, ``_coords``/``_intents``
+    there too) — plus every class-level private in ``vars(Drawing)``. Names reachable only through
+    ``setattr``/``__dict__``/inheritance still can't be discovered statically (documented limit)."""
     import inspect
-    import re
 
     from draftwright.drawing import Drawing
 
-    init_attrs = set(
-        re.findall(r"self\.(_[a-z][a-z_]*)\s*[:=]", inspect.getsource(Drawing.__init__))
+    cls = next(
+        n
+        for n in ast.walk(ast.parse(inspect.getsource(Drawing)))
+        if isinstance(n, ast.ClassDef) and n.name == "Drawing"
     )
+    self_attrs = {
+        node.attr
+        for node in ast.walk(cls)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+        and node.attr.startswith("_")
+        and not node.attr.startswith("__")
+        and isinstance(node.ctx, (ast.Store, ast.Del))
+    }
     class_privates = {n for n in vars(Drawing) if n.startswith("_") and not n.startswith("__")}
     actual = {
-        n for n in (init_attrs | class_privates) if not n.isupper()
+        n for n in (self_attrs | class_privates) if not n.isupper()
     }  # drop constants (_EXPORT_FORMATS)
     missing = actual - _DRAWING_PRIVATES
     assert not missing, (

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -174,14 +174,42 @@ def test_allowlist_is_tight_no_stale_or_slack_entries() -> None:
     )
 
 
+class _ReceiverStores(ast.NodeVisitor):
+    """Collect ``<recv>._x = …`` / ``del`` private-attribute stores in a method body, where
+    *recv* is that method's first parameter (its ``self``). SCOPE-AWARE (Codex #814 r2): does
+    NOT descend into a nested ``class`` — a helper class defined inside a method has its own
+    ``self``, and its stores are not ``Drawing`` privates. Nested *functions* (closures) still
+    close over the method's ``self``, so their stores are kept."""
+
+    def __init__(self, recv: str) -> None:
+        self.recv = recv
+        self.names: set[str] = set()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        pass  # a nested class rebinds `self`; its stores aren't Drawing's — don't recurse
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if (
+            isinstance(node.value, ast.Name)
+            and node.value.id == self.recv
+            and node.attr.startswith("_")
+            and not node.attr.startswith("__")
+            and isinstance(node.ctx, (ast.Store, ast.Del))
+        ):
+            self.names.add(node.attr)
+        self.generic_visit(node)
+
+
 def test_drawing_privates_set_is_current() -> None:
     """Guard the name-set: every real ``Drawing`` private must be in :data:`_DRAWING_PRIVATES`, so a
     newly added private is covered by the scanner rather than silently escaping it.
 
-    Discovers ``self._x = …`` Store attributes across the WHOLE class body — not only ``__init__``
-    (Codex #814 H1: ``Drawing`` sets ``_build_issues`` in ``finalize``, ``_coords``/``_intents``
-    there too) — plus every class-level private in ``vars(Drawing)``. Names reachable only through
-    ``setattr``/``__dict__``/inheritance still can't be discovered statically (documented limit)."""
+    Discovers ``self._x = …`` Store attributes across ``Drawing``'s own methods — the WHOLE class,
+    not only ``__init__`` (Codex #814 H1: ``Drawing`` sets ``_build_issues`` in ``finalize`` etc.),
+    but scope-aware so a nested helper class's ``self`` is not miscredited (r2) — plus every
+    class-level private in ``vars(Drawing)``. Still a best-effort SYNTACTIC scan: a private reached
+    only via a ``self`` alias (``d = self; d._x = …``), ``setattr``/``__dict__``, or inheritance
+    can't be discovered statically — the same accepted static-analysis limit as the read scanner."""
     import inspect
 
     from draftwright.drawing import Drawing
@@ -191,16 +219,13 @@ def test_drawing_privates_set_is_current() -> None:
         for n in ast.walk(ast.parse(inspect.getsource(Drawing)))
         if isinstance(n, ast.ClassDef) and n.name == "Drawing"
     )
-    self_attrs = {
-        node.attr
-        for node in ast.walk(cls)
-        if isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "self"
-        and node.attr.startswith("_")
-        and not node.attr.startswith("__")
-        and isinstance(node.ctx, (ast.Store, ast.Del))
-    }
+    self_attrs: set[str] = set()
+    for fn in cls.body:
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and fn.args.args:
+            visitor = _ReceiverStores(fn.args.args[0].arg)  # the method's receiver (its `self`)
+            for stmt in fn.body:
+                visitor.visit(stmt)
+            self_attrs |= visitor.names
     class_privates = {n for n in vars(Drawing) if n.startswith("_") and not n.startswith("__")}
     actual = {
         n for n in (self_attrs | class_privates) if not n.isupper()


### PR DESCRIPTION
Part of #741 — **PR 1 of the epic** (the ratchet foundation + trivial migration).

## Context

The #720/#721 family closed test reach-through into the *aliased* privates (361 sites) and #722 froze **src**-side `dwg._*` reads to zero. The remaining unpoliced quadrant is test-side **attribute reads** of `Drawing` internals with no public read equivalent (`_analysis`/`_intents`/…) — no ratchet, so they could silently multiply. This PR adds that ratchet and clears the one trivial group.

## What

- **`tests/test_private_test_attr_reads.py`** — an AST scanner (stdlib `ast`+`pathlib` only, mirroring `test_private_test_imports` / `test_drawing_encapsulation`) that counts `Load`-context reads + `getattr(_, "_name")` probes of `Drawing`'s private names across the suite, pinned to a **shrink-only per-name ceiling** (`_ALLOW`). Fail-closed, verified in all three directions:
  - a **new** private name with reads → fails,
  - a **grown** count on an existing name → fails,
  - an **un-lowered** ceiling after a migration (slack) → fails.
  Keyed on the attribute *name* (not the receiver), since test receivers vary (`dwg`/`d`/`direct`/`scripted`/…). A `test_drawing_privates_set_is_current` check imports `Drawing` so a newly added private can't escape the name-set.
- **Migrate the 5 `dwg._registry` reads → `dwg.registry`** (public property); dropped from the allowlist.

## Scope / roadmap

Reads today: **132 sites**, dominated by `_analysis` (82) and `_intents` (25) — each needs *new* public surface, so they're pinned now and migrated in later phases (PR 2 `_defer_intents` writes→`deferred()`, PR 3 `_intents`, PR 4 `_analysis` projection). Private **writes** (chiefly `dwg._defer_intents = …`) are the separate follow-on — eliminated, not allowlisted.

## Verification

- New guard (3 tests) + `test_drawing_encapsulation` + `test_private_test_imports` green (10 passed); migrated `test_make_drawing` cases green.
- ruff / ruff-format / mypy / codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)