### PR TITLE
feat(#817): add public Drawing.note() free-text verb (PR 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,14 @@ dwg.pin("dim_width"); dwg.unpin("dim_width")   # freeze / unfreeze an already-pl
 
 `drop()` takes a **feature** (`dwg.model().features[i]`), not a name; `remove()` takes a name.
 
+Free-form text (a general note, "SEE NOTE 1") is user-positioned — it has no feature and no
+strip, so you give the page position (mm from the sheet origin, the space `view_bounds`/`at` use):
+
+```python
+x0, y0, x1, y1 = dwg.view_bounds("front")
+dwg.note("SEE NOTE 1", (x1 + 5, (y0 + y1) / 2), view="front")   # free text, positioned by you
+```
+
 ## GD&T — always declared, never raw
 
 GD&T frames / datums / surface finishes are placed as first-class candidates by the solve.
@@ -100,9 +108,9 @@ paths = dwg.export("out", formats=("svg", "dxf", "pdf", "png"))   # -> {format: 
 
 - ❌ Raw page coordinates for feature annotations; `Drawing.place_dim(...)` (deprecated raw
   hatch). To influence placement use `pin=`/`priority=`, not coordinates.
-- ❌ `dwg.add(Dimension/Leader/FeatureControlFrame(...))` to place a *feature* callout — `add`
-  is the engine's low-level primitive (fine for free `Note`s / tables that have no strip, not
-  for solve-able annotations).
+- ❌ `dwg.add(Dimension/Leader/FeatureControlFrame(...))` / raw `Note` objects — `add` is the
+  engine's low-level placement primitive (being made private, #817). Use the verbs: `note()` for
+  free text, `add_table()`/`add_hole_table()` for tables, the feature verbs for callouts/dims.
 - ❌ Bypassing recognition / assuming byte-identical output (it is not a goal — ADR 0004/0012).
 
 ## Source of truth

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1944,6 +1944,34 @@ class Drawing:
         """Return the named annotation object, or ``None`` if no such name (#27)."""
         return self._registry.named(name)
 
+    def note(self, text, at, *, view=None, rotation=0.0, name=None, align=None):
+        """Add a free-form text **note** at page position *at* — ``(x, y)`` in mm from the sheet
+        origin, the space :meth:`at` / :meth:`view_bounds` return (#817).
+
+        A note is user-positioned free text ("SEE NOTE 1", a general-tolerance line): it carries
+        no feature and is not part of the placement solve, so — unlike :meth:`callout` /
+        :meth:`dimension`, which the solve places — you give the position. Pass *view* to fold it
+        into that view's block for the cross-view repack; ``rotation`` (degrees) and ``align``
+        (a build123d ``Align`` pair, default centred on *at*) are forwarded to the note. Returns
+        the annotation name. This is the public door for free text — the raw ``Note`` object +
+        low-level placement primitive are internal."""
+        from build123d import Align
+        from build123d_drafting import Note
+
+        n = Note(
+            text,
+            at,
+            self.draft,
+            rotation=rotation,
+            align=align if align is not None else (Align.CENTER, Align.CENTER),
+        )
+        if name is None:
+            i = 0
+            while (name := f"note{i}") in self._named:
+                i += 1
+        self.add(n, name, view=view)
+        return name
+
     def add_table(self, rows, *, prefer="tr", name="table", block_cols=None):
         """Add a generic data table, placed in a free corner (#93).
 

--- a/tests/test_agents_guide.py
+++ b/tests/test_agents_guide.py
@@ -88,6 +88,10 @@ def test_editing_verbs_each_produce_their_annotation():
 
     assert dwg.features("plan") is not None  # dwg.features(view) — the per-view read cited
 
+    x0, y0, x1, y1 = dwg.view_bounds("front")  # note(): free text, positioned by the caller
+    note_name = dwg.note("SEE NOTE 1", (x1 + 5, (y0 + y1) / 2), view="front")
+    assert type(dwg.get_annotation(note_name)).__name__ == "Note"
+
 
 def test_section_verb_generates_section_aa():
     """The `dwg.section()` verb: on section-triggering geometry (a blind underside counterbore),

--- a/tests/test_note_verb.py
+++ b/tests/test_note_verb.py
@@ -1,0 +1,48 @@
+"""The public `Drawing.note()` free-text verb (#817).
+
+`note()` is the sanctioned door for free-form text — a note is user-positioned (it carries no
+feature and is not solve-placed), so it takes a page position. It replaces the raw
+`dwg.add(Note(...))` pattern as the low-level placement API is privatised.
+"""
+
+from build123d import Box, Cylinder, Pos
+
+from draftwright import build_drawing
+
+
+def _dwg():
+    return build_drawing(Box(60, 40, 20) - Pos(0, 0, 5) * Cylinder(4, 20))
+
+
+def test_note_places_text_at_the_page_position():
+    dwg = _dwg()
+    x0, y0, x1, y1 = dwg.view_bounds("front")
+    name = dwg.note("SEE NOTE 1", (x1 + 5, (y0 + y1) / 2))
+
+    obj = dwg.get_annotation(name)
+    assert obj is not None and type(obj).__name__ == "Note"
+    assert obj.label == "SEE NOTE 1"
+    # placed at the requested page position (centred on it by default).
+    bb = obj.bounding_box()
+    assert abs((bb.min.X + bb.max.X) / 2 - (x1 + 5)) < 2.0
+
+
+def test_note_autonames_and_can_be_named():
+    dwg = _dwg()
+    assert dwg.note("A", (10, 10)) == "note0"
+    assert dwg.note("B", (10, 20)) == "note1"
+    assert dwg.note("C", (10, 30), name="my_note") == "my_note"
+    assert {"note0", "note1", "my_note"} <= set(dwg.annotations())
+
+
+def test_note_tagged_to_a_view_is_owned_by_it():
+    dwg = _dwg()
+    name = dwg.note("PLAN NOTE", (10, 10), view="plan")
+    assert dwg.view_of(name) == "plan"
+
+
+def test_note_exports(tmp_path):
+    dwg = _dwg()
+    dwg.note("SEE NOTE 1", (150, 100))
+    out = dwg.export(str(tmp_path / "out"), formats=("svg",))
+    assert set(out) == {"svg"}


### PR DESCRIPTION
PR 1 of the **#817 epic** (privatize the low-level Drawing placement API; safe-by-default public surface).

## Why first

A free-form note ("SEE NOTE 1", a general-tolerance line) is *user-positioned* — no feature, not solve-placed — so today it can only be added via the raw `dwg.add(Note(...))` primitive. Before `add` can be made private (PR 2), free text needs a sanctioned public door. This adds it.

## What

- **`Drawing.note(text, at, *, view=None, rotation=0.0, name=None, align=None)`** — builds the `Note` with the drawing's `draft`, auto-names `note{i}` (or a caller name), tags an optional owning view for the cross-view repack, centres on `at` by default. Returns the name.
- **AGENTS.md**: documents `note()` in the editing section; the "don't raw-add" rule now points at `note()`/`add_table()` rather than `add`.
- **Tests**: `tests/test_note_verb.py` (position, auto-naming, view ownership, export) + a `note()` line in the guide validator.

No behaviour change to existing surfaces; `note()` is additive. The #741 encapsulation guard is unaffected (note() is public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)