### PR TITLE
feat(#817): privatize place_dim → _place_dim (PR3)

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -638,7 +638,6 @@ class Drawing:
         name=None,
         slot=8.0,
         feature=None,
-        _warn_deprecated=True,
         **kwargs,
     ):
         """Deprecated low-level page-coordinate dimension escape hatch.
@@ -673,15 +672,39 @@ class Drawing:
         layout analysis is available (e.g. when ``auto_dims=False`` was not used
         with :func:`build_drawing`).
         """
-        if _warn_deprecated:
-            warnings.warn(
-                "Drawing.place_dim() is deprecated for normal editable scripts; use "
-                "Drawing.dimension(feature, param, ..., pin=True) or "
-                "Drawing.locate(feature, ..., pin=True) for feature-backed edits. "
-                "place_dim() remains only as a raw page-coordinate escape hatch.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        warnings.warn(
+            "Drawing.place_dim() is deprecated for normal editable scripts; use "
+            "Drawing.dimension(feature, param, ..., pin=True) or "
+            "Drawing.locate(feature, ..., pin=True) for feature-backed edits. "
+            "place_dim() remains only as a raw page-coordinate escape hatch.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._place_dim(
+            p1, p2, side, view, draft, name=name, slot=slot, feature=feature, **kwargs
+        )
+
+    def _place_dim(
+        self,
+        p1,
+        p2,
+        side,
+        view,
+        draft,
+        *,
+        name=None,
+        slot=8.0,
+        feature=None,
+        **kwargs,
+    ):
+        """Raw page-coordinate dimension placement **primitive** (#817).
+
+        Private: the public door for dimensions is :meth:`dimension`/:meth:`locate`
+        (feature-backed, solve-aware). This single-position strip carve is the escape
+        hatch behind the deprecated public :meth:`place_dim` shim and the internal
+        :meth:`dimension` raw-span fallback. See :meth:`place_dim` for the argument and
+        behaviour notes.
+        """
         a = self._analysis
         _view_zones = {"front": "fv_zones", "plan": "pv_zones", "side": "sv_zones"}
         strip = None
@@ -999,7 +1022,7 @@ class Drawing:
             i = 0
             while (name := f"dim_{param}{i}") in self._named:
                 i += 1
-        self.place_dim(
+        self._place_dim(
             p1,
             p2,
             side,
@@ -1007,7 +1030,6 @@ class Drawing:
             self.draft,
             name=name,
             feature=feature,
-            _warn_deprecated=False,
             **kwargs,
         )
         if pin:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7893,19 +7893,21 @@ class TestSlotDimensioning:
             assert not any(overlaps(full, e) for e in external), f"{n} overprints a callout"
 
 
-def _deprecated_place_dim(dwg, *args, **kwargs):
-    with pytest.warns(DeprecationWarning, match="Drawing.place_dim"):
-        return dwg.place_dim(*args, **kwargs)
+def _place_dim(dwg, *args, **kwargs):
+    # White-box: these exercise the private placement primitive directly (#817).
+    # The deprecated public shim's warning is covered by
+    # test_dimension_does_not_warn_when_using_place_dim_internally.
+    return dwg._place_dim(*args, **kwargs)
 
 
 class TestPlaceDim:
-    """#25: dwg.place_dim() stacks with the auto-dimension strip."""
+    """#25: the raw page-coordinate dim primitive stacks with the auto-dimension strip."""
 
     def test_place_dim_adds_named_annotation(self):
         dwg = build_drawing(Box(80, 60, 20))
         p1 = dwg.at("plan", -40, 0, 0)
         p2 = dwg.at("plan", 40, 0, 0)
-        _deprecated_place_dim(dwg, p1, p2, "below", "plan", dwg.draft, name="my_dim", label="80")
+        _place_dim(dwg, p1, p2, "below", "plan", dwg.draft, name="my_dim", label="80")
         assert "my_dim" in dwg.annotations()
         assert dwg.get_annotation("my_dim").label == "80"
 
@@ -7915,7 +7917,7 @@ class TestPlaceDim:
         dwg = build_drawing(Box(60, 40, 20))
         p1 = dwg.at("front", -30, 0, -10)
         p2 = dwg.at("front", 30, 0, -10)
-        result = _deprecated_place_dim(dwg, p1, p2, "below", "front", dwg.draft)
+        result = _place_dim(dwg, p1, p2, "below", "front", dwg.draft)
         assert isinstance(result, Dimension)
 
     def test_two_place_dim_calls_stack_without_overlap(self):
@@ -7925,8 +7927,8 @@ class TestPlaceDim:
         dwg = build_drawing(Box(80, 60, 20), auto_dims=False)
         p1 = dwg.at("plan", -40, 0, 0)
         p2 = dwg.at("plan", 40, 0, 0)
-        d1 = _deprecated_place_dim(dwg, p1, p2, "above", "plan", dwg.draft, name="d1")
-        d2 = _deprecated_place_dim(dwg, p1, p2, "above", "plan", dwg.draft, name="d2")
+        d1 = _place_dim(dwg, p1, p2, "above", "plan", dwg.draft, name="d1")
+        d2 = _place_dim(dwg, p1, p2, "above", "plan", dwg.draft, name="d2")
         # dim_level_y is the y-coordinate of the dim line on the page;
         # two stacked dims must land at different y values.
         assert d1.dim_level_y != d2.dim_level_y
@@ -7949,7 +7951,7 @@ class TestPlaceDim:
             centroid=(0, 0, 0),
             out="",
         )
-        result = _deprecated_place_dim(dwg, (0, 0, 0), (80, 0, 0), "below", "plan", d, slot=8.0)
+        result = _place_dim(dwg, (0, 0, 0), (80, 0, 0), "below", "plan", d, slot=8.0)
         assert isinstance(result, Dimension)
 
     def test_place_dim_labels_real_world_length_at_non_unity_scale(self):
@@ -7962,7 +7964,7 @@ class TestPlaceDim:
         assert dwg.scale == 2.0
         p1 = dwg.at("plan", -40, 0, 0)
         p2 = dwg.at("plan", 40, 0, 0)
-        d = _deprecated_place_dim(dwg, p1, p2, "below", "plan", dwg.draft, name="w")
+        d = _place_dim(dwg, p1, p2, "below", "plan", dwg.draft, name="w")
         assert d.label == "80"
         assert [
             i for i in lint_drawing([d], drawing_scale=dwg.scale) if i.code == "label_vs_measured"
@@ -7972,7 +7974,7 @@ class TestPlaceDim:
         dwg = build_drawing(Box(80, 60, 20), scale=2.0)
         p1 = dwg.at("plan", -40, 0, 0)
         p2 = dwg.at("plan", 40, 0, 0)
-        d = _deprecated_place_dim(dwg, p1, p2, "below", "plan", dwg.draft, label="CUSTOM")
+        d = _place_dim(dwg, p1, p2, "below", "plan", dwg.draft, label="CUSTOM")
         assert d.label == "CUSTOM"
 
     def test_dimension_does_not_warn_when_using_place_dim_internally(self):

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -82,6 +82,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_pattern_callouts",
         "_patterned_holes",
         "_pinned",
+        "_place_dim",
         "_queue_dimension_intent",
         "_record_build_issue",
         "_replay_intent",
@@ -141,6 +142,12 @@ _ALLOW: dict[str, int] = {
     # annotation object by name (`dimension`/`callout`/`note` compute their own), so these unit tests
     # legitimately hold the primitive. A count, not a TODO — like the `_analysis` white-box entry.
     "_add": 26,
+    # The raw page-coordinate dimension primitive (#817): a single white-box helper wraps
+    # `dwg._place_dim(*args)` so the TestPlaceDim behaviour tests (strip stacking, slot fallback,
+    # real-world autolabel) drive the primitive directly. Its public form (`Drawing.place_dim`) is
+    # DEPRECATED (#817); the deprecated shim's warning is asserted separately via the public name, so
+    # this one read is genuinely internal.
+    "_place_dim": 1,
 }
 
 


### PR DESCRIPTION
Part of #817 (privatize the low-level Drawing placement API). PR3 of 4.

## What

Completes the privatization of the raw page-coordinate dimension escape hatch, following the PR2 `add`→`_add` pattern:

- The primitive body moves to a private **`_place_dim`**; public **`place_dim`** becomes a pure deprecated shim (warn → delegate).
- The internal `dimension()` raw-span fallback retargets to `_place_dim`, **removing the `_warn_deprecated` flag hack** that previously threaded through the deprecated public method to suppress its own warning.

## Encapsulation bookkeeping

- `_place_dim` added to `_DRAWING_PRIVATES` (#741 ratchet); the single white-box helper read allowlisted (`_ALLOW["_place_dim"] = 1`). The `TestPlaceDim` behaviour tests (strip stacking, slot fallback, real-world autolabel) now drive the primitive directly; the deprecated shim's warning stays asserted via the public name (`test_dimension_does_not_warn_when_using_place_dim_internally`, `test_place_dim_feature_kwarg_tags_provenance`).
- No engine module reads `dwg._place_dim` (only `self._place_dim` in `drawing.py`), so the #722 whole-engine guard stays at zero.

## Verification

- `TestPlaceDim` + ratchet + encapsulation guard + dimension/finalize/deferred paths: all green locally.
- 4-check lint clean (ruff check, ruff format, mypy, codespell).

Next: PR4 privatizes the view-coordinate/attach plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)