### PR TITLE
feat(#817): @deprecated (PEP 702) on the add/place_dim shims — static enforcement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "reportlab>=4.0",
     "svglib>=1.5",
     "typer>=0.12",
+    # PEP 702 @deprecated: stdlib `warnings.deprecated` lands in 3.13; backport for 3.10–3.12.
+    "typing_extensions>=4.5 ; python_full_version < '3.13'",
 ]
 keywords = ["build123d", "cad", "drafting", "engineering-drawing", "technical-drawing", "automation"]
 classifiers = [

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -12,11 +12,20 @@ from __future__ import annotations
 import contextlib
 import math
 import os
+import sys
 import tempfile
 import warnings
 from dataclasses import dataclass
 from dataclasses import field as dataclasses_field
 from typing import Any, NamedTuple
+
+# PEP 702 @deprecated. A `sys.version_info` guard (not try/except) so the type checker,
+# which targets the 3.10 floor, resolves the backport branch instead of `warnings.deprecated`
+# (only in 3.13+ typeshed).
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 from build123d import (
     Color,
@@ -627,6 +636,12 @@ class Drawing:
         detected — the public read the annotation pass threads onto its PlacementContext (#639)."""
         return self._model_declared
 
+    @deprecated(
+        "Drawing.place_dim() is deprecated for normal editable scripts; use "
+        "Drawing.dimension(feature, param, ..., pin=True) or "
+        "Drawing.locate(feature, ..., pin=True) for feature-backed edits. "
+        "place_dim() remains only as a raw page-coordinate escape hatch."
+    )
     def place_dim(
         self,
         p1,
@@ -671,15 +686,10 @@ class Drawing:
         Falls back to a fixed ``slot`` offset when the strip is full or when no
         layout analysis is available (e.g. when ``auto_dims=False`` was not used
         with :func:`build_drawing`).
+
+        The ``@deprecated`` (PEP 702) decorator both emits the runtime
+        ``DeprecationWarning`` and lets type checkers/IDEs flag call sites statically (#817).
         """
-        warnings.warn(
-            "Drawing.place_dim() is deprecated for normal editable scripts; use "
-            "Drawing.dimension(feature, param, ..., pin=True) or "
-            "Drawing.locate(feature, ..., pin=True) for feature-backed edits. "
-            "place_dim() remains only as a raw page-coordinate escape hatch.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self._place_dim(
             p1, p2, side, view, draft, name=name, slot=slot, feature=feature, **kwargs
         )
@@ -754,17 +764,18 @@ class Drawing:
         """
         return place_annotation(self._registry, self.items, obj, name, view, feature)
 
+    @deprecated(
+        "Drawing.add() is deprecated (#817): use the placement verbs (callout/dimension/note/"
+        "add_table/…); free text is note(). The raw add primitive is now private (_add)."
+    )
     def add(self, obj, name=None, view=None, feature=None):
         """DEPRECATED (#817): the raw placement primitive is now private (:meth:`_add`). Use the
         placement **verbs** — :meth:`callout`/:meth:`dimension`/:meth:`note`/:meth:`add_table`/
         :meth:`add_balloons` — which route through the solve; :meth:`note` is the door for free
-        text. The public wrapper remains one release for compatibility."""
-        warnings.warn(
-            "Drawing.add() is deprecated (#817): use the placement verbs (callout/dimension/note/"
-            "add_table/…); free text is note(). The raw add primitive is now private (_add).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        text. The public wrapper remains one release for compatibility.
+
+        The ``@deprecated`` (PEP 702) decorator both emits the runtime ``DeprecationWarning`` and
+        lets type checkers/IDEs flag call sites statically (#817)."""
         return self._add(obj, name, view, feature)
 
     def remove(self, name):

--- a/uv.lock
+++ b/uv.lock
@@ -688,6 +688,7 @@ dependencies = [
     { name = "reportlab" },
     { name = "svglib" },
     { name = "typer" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 
 [package.dev-dependencies]
@@ -713,6 +714,7 @@ requires-dist = [
     { name = "reportlab", specifier = ">=4.0" },
     { name = "svglib", specifier = ">=1.5" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.5" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Follow-up to the #817 privatization (after #820/#821/#822). Makes the deprecated public placement surface enforceable **statically**, not just at runtime.

## What

Decorate the two deprecated public shims — `Drawing.add` and `Drawing.place_dim` — with PEP 702 `@deprecated`. Type checkers (mypy) and IDEs (Pylance/PyCharm) now flag call sites at edit/check time, closing the #817 footgun one step earlier than the runtime `DeprecationWarning`.

- The decorator **also** emits the runtime `DeprecationWarning`, so the manual `warnings.warn(...)` blocks are removed. The messages move into the decorator verbatim — keeping the `Drawing.add` / `Drawing.place_dim` substrings the existing `pytest.warns(match=...)` tests assert.
- Imported via a **`sys.version_info` guard** (not `try/except ImportError`): mypy targets the 3.10 floor, where `warnings.deprecated` isn't in typeshed, so it must resolve the `typing_extensions` backport branch. The version guard is version-aware to mypy; the `try/except` idiom is not.
- `typing_extensions>=4.5` added as a **conditional dependency** for Python <3.13 (stdlib `warnings.deprecated` lands in 3.13).

## Scope

Only the two #817 placement shims. `export_pdf` (a separate export-API deprecation) is left on its manual `warnings.warn` — out of #817's scope.

## Verification

- `add()`/`place_dim()` still emit the runtime `Drawing.add`/`Drawing.place_dim` warning; both now carry `__deprecated__`.
- No internal call site uses the deprecated names (`dimension()` + render passes route through `_add`/`_place_dim`), so **mypy stays clean** (full `src/draftwright`, 52 files).
- Deprecation + ratchet + note-verb tests green; 4-check lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)