### PR TITLE
feat(#817): privatize view-coord/attach plumbing (PR4 — guard decision D)

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -290,7 +290,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # (dwg.model()) and feature edits work even in manual mode (#398); fall back to
     # building it here for any direct caller that skipped _assemble.
     _model = dwg.model() if dwg.model() is not None else build_model(a)
-    dwg.attach_part_model(_model)
+    dwg._attach_part_model(_model)
     # Thread the ensured model + declared flag onto the run's ctx so every pass reads them from
     # ctx, not the drawing's privates (#639). Set AFTER attach so ctx sees the ensured model.
     ctx.part_model = _model

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -262,7 +262,7 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
         _clear_section_reservation(dwg)
         return
     camera = (dwg.look_at[0], dwg.look_at[1] - dwg.dist, dwg.look_at[2])
-    dwg.add_view("section_aa", keep_behind, camera, (0, 0, 1), (pos_x, a.FV_Y))
+    dwg._add_view("section_aa", keep_behind, camera, (0, 0, 1), (pos_x, a.FV_Y))
     ctx.place(
         Note("SECTION A–A", (pos_x, a.FV_Y - half_h - 7), dwg.draft),
         "section_caption",
@@ -503,11 +503,11 @@ def _render_detail(
     camera = (la[0], la[1] - dist_d, la[2])
     try:
         band_s = cropped.scale(detail_scale)
-        dwg.add_view(view_name, band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True)
+        dwg._add_view(view_name, band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True)
     except Exception as exc:  # noqa: BLE001 — projection raises broadly on cast geometry
         _log.warning("Detail %s skipped (projection failed: %s)", letter, exc)
         return False
-    dwg.set_view_coordinates(
+    dwg._set_view_coordinates(
         view_name,
         ViewCoordinates(view_axes(camera, (0, 0, 1), la), DX, DY, dcx, dcy, dcz, detail_scale),
     )
@@ -518,7 +518,7 @@ def _render_detail(
     # head/block inline, so lint reports any un-located interior) (#307 review).
     if not req.redraw(dwg, view_name, detail_scale):
         dwg.views.pop(view_name, None)
-        dwg.drop_view_coordinates(view_name)
+        dwg._drop_view_coordinates(view_name)
         _log.info("Detail %s skipped (no legible dims at the detail scale)", letter)
         return False
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -335,12 +335,14 @@ def _assemble(
     dwg._build.detail_view = detail_view
     dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
     if trace is not None:  # opt-in solve trace (#736), threaded via a named method
-        dwg.attach_solve_trace(trace)
+        dwg._attach_solve_trace(trace)
 
     part_s = a.part.scale(a.SCALE)
-    dwg.add_view("front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True)
-    dwg.add_view("plan", part_s, (cxs, cys, czs + dist), (0, 1, 0), (a.PV_X, a.PV_Y), scaled=True)
-    dwg.add_view("side", part_s, (cxs + dist, cys, czs), (0, 0, 1), (a.SV_X, a.SV_Y), scaled=True)
+    dwg._add_view(
+        "front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True
+    )
+    dwg._add_view("plan", part_s, (cxs, cys, czs + dist), (0, 1, 0), (a.PV_X, a.PV_Y), scaled=True)
+    dwg._add_view("side", part_s, (cxs + dist, cys, czs), (0, 0, 1), (a.SV_X, a.SV_Y), scaled=True)
     _project_iso(dwg, a, a.SCALE, shape_s=part_s)
 
     if auto_dims:
@@ -1127,7 +1129,7 @@ def _write_script(
         "# dwg.pin(name) / dwg.unpin(name)  → fix a placement so repair never moves it\n"
         "# dwg.lint_summary()       → {passed, score, by_code, issues:[…suggestion]}\n"
         "# dwg.repair()             → auto-fix mechanically-fixable lint (never worsens)\n"
-        "# dwg.add_view(name, shape, camera, up, position)  → section / auxiliary view\n"
+        "# dwg.section()            → add the section A–A view (add_view is now engine-internal)\n"
         "# dwg.items / dwg.views / dwg.at(view,x,y,z) / dwg.view_bounds(view)  → low-level escape\n"
         "# dwg.place_dim(...)       → deprecated raw page-coordinate dimension escape hatch\n"
         "# Example — add a pinned feature-backed linear dimension:\n"

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -426,7 +426,16 @@ class Drawing:
         return self._coverage.is_scattered_hole_doc(name)
 
     # -- views ----------------------------------------------------------------
+    @deprecated(
+        "Drawing.add_view() is deprecated (#817): view projection is engine plumbing. Custom "
+        "section/auxiliary views come from the section verb; the raw projector is now private "
+        "(_add_view)."
+    )
     def add_view(self, name, shape, camera, up, position, *, look_at=None, scaled=False):
+        """DEPRECATED (#817): the raw view projector is now private (:meth:`_add_view`)."""
+        return self._add_view(name, shape, camera, up, position, look_at=look_at, scaled=scaled)
+
+    def _add_view(self, name, shape, camera, up, position, *, look_at=None, scaled=False):
         """Project ``shape`` from ``camera`` and place it at ``position``.
 
         Args:
@@ -479,11 +488,27 @@ class Drawing:
         """Return the :class:`ViewCoordinates` for a named view."""
         return self._coords[view]
 
+    @deprecated(
+        "Drawing.set_view_coordinates() is deprecated (#817): view-coordinate plumbing is "
+        "engine-internal; the mutator is now private (_set_view_coordinates)."
+    )
     def set_view_coordinates(self, view, coords) -> None:
+        """DEPRECATED (#817): now private (:meth:`_set_view_coordinates`)."""
+        self._set_view_coordinates(view, coords)
+
+    def _set_view_coordinates(self, view, coords) -> None:
         """Override a view's projected coordinates (a repositioned detail/section band, #307)."""
         self._coords[view] = coords
 
+    @deprecated(
+        "Drawing.drop_view_coordinates() is deprecated (#817): view-coordinate plumbing is "
+        "engine-internal; the mutator is now private (_drop_view_coordinates)."
+    )
     def drop_view_coordinates(self, view) -> None:
+        """DEPRECATED (#817): now private (:meth:`_drop_view_coordinates`)."""
+        self._drop_view_coordinates(view)
+
+    def _drop_view_coordinates(self, view) -> None:
         """Remove a view's projected coordinates (a bailed detail/section, #307)."""
         self._coords.pop(view, None)
 
@@ -613,7 +638,15 @@ class Drawing:
     def _ann_box_cache(self) -> dict:
         return self._build.ann_box_cache
 
+    @deprecated(
+        "Drawing.attach_part_model() is deprecated (#817): build-state attach is engine "
+        "plumbing; the mutator is now private (_attach_part_model)."
+    )
     def attach_part_model(self, model) -> None:
+        """DEPRECATED (#817): now private (:meth:`_attach_part_model`)."""
+        self._attach_part_model(model)
+
+    def _attach_part_model(self, model) -> None:
         """Attach the built PartModel so ``model()`` and feature edits see it. Lets the
         orchestrator hand the model back without an ``annotations/`` attribute write (#639)."""
         self._build.part_model = model
@@ -624,7 +657,15 @@ class Drawing:
         ``None`` (the default — tracing off). See ``build_drawing(trace=...)``."""
         return self._build.trace
 
+    @deprecated(
+        "Drawing.attach_solve_trace() is deprecated (#817): build-state attach is engine "
+        "plumbing; the mutator is now private (_attach_solve_trace)."
+    )
     def attach_solve_trace(self, trace) -> None:
+        """DEPRECATED (#817): now private (:meth:`_attach_solve_trace`)."""
+        self._attach_solve_trace(trace)
+
+    def _attach_solve_trace(self, trace) -> None:
         """Attach the #736 :class:`~draftwright.annotations._common.SolveTrace` recorder
         so the annotate and finalize paths thread it onto their per-run
         ``PlacementContext`` (build state flows through a named method, #639)."""
@@ -2151,11 +2192,20 @@ class Drawing:
         self._registry.unpin(name)
         return self
 
+    @deprecated(
+        "Drawing.clear_annotations() is deprecated (#817): wholesale annotation removal is a "
+        "footgun for user scripts — use the feature-scoped verbs (drop/remove). The primitive "
+        "is now private (_clear_annotations)."
+    )
     def clear_annotations(self, keep=("title_block",)):
+        """DEPRECATED (#817): now private (:meth:`_clear_annotations`)."""
+        return self._clear_annotations(keep)
+
+    def _clear_annotations(self, keep=("title_block",)):
         """Remove all annotations except those named in *keep* (#74).
 
         Wholesale removal that does not depend on the automatic naming
-        scheme — ``dwg.clear_annotations()`` strips every automatic dimension,
+        scheme — ``_clear_annotations()`` strips every automatic dimension,
         leader, and centreline but keeps the title block.
 
         Returns:

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -204,7 +204,7 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     # front (-Y), plan (+Z), right (+X). A +Y camera would show the *rear* Y face against a
     # front view, mirroring asymmetric features (#620).
     camera = (la[0] + off, la[1] - off, la[2] + off)
-    dwg.add_view(
+    dwg._add_view(
         "iso",
         shape_s if shape_s is not None else a.part.scale(scale),
         camera,
@@ -219,7 +219,7 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     # maps world points correctly — also covers an iso re-projected at a
     # different scale than the sheet. Through the public override verb, not a
     # direct _coords poke (#699 slice d).
-    dwg.set_view_coordinates(
+    dwg._set_view_coordinates(
         "iso",
         ViewCoordinates.from_viewport(
             camera, (0, 0, 1), la, a.ISO_X, a.ISO_Y, a.cx, a.cy, a.cz, scale

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -112,10 +112,26 @@ def _dwg_getattr_probes(tree: ast.Module) -> list[str]:
     return out
 
 
+def _method_call_attrs(tree: ast.Module) -> set[int]:
+    """``id()``s of Attribute nodes that are the DIRECT callee of a Call — i.e. the
+    ``dwg._m`` in a ``dwg._m(...)`` METHOD INVOCATION. #722 targets state-bus *data*
+    back-channels; calling a (now-private) engine-API method is explicit API, not a poke at
+    a shared field, so it is exempt (#817 PR4 / decision D). Data reads stay caught: in
+    ``dwg._registry.add(…)`` the private ``_registry`` is the call func's *value* (not the
+    func itself), and ``dwg._coords[k]`` is a subscript — neither is a callee here."""
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            out.add(id(node.func))
+    return out
+
+
 def _dwg_private_reads(tree: ast.Module) -> set[str]:
     """Distinct ``dwg._<name>`` private READS: attribute accesses in ``Load`` context (so a
     write/delete target — ``Store``/``Del`` — is never miscounted as a read), plus
-    ``getattr(dwg, "_name", …)`` probes."""
+    ``getattr(dwg, "_name", …)`` probes. A private that is the direct callee of a Call
+    (``dwg._m(...)``) is a method invocation, not a data read, so it is exempt (#817 PR4)."""
+    call_funcs = _method_call_attrs(tree)
     reads: set[str] = set()
     for node in ast.walk(tree):
         if (
@@ -123,6 +139,7 @@ def _dwg_private_reads(tree: ast.Module) -> set[str]:
             and _is_dwg(node.value)
             and node.attr.startswith("_")
             and isinstance(node.ctx, ast.Load)
+            and id(node) not in call_funcs
         ):
             reads.add(node.attr)
     reads |= set(_dwg_getattr_probes(tree))
@@ -166,6 +183,14 @@ def test_write_guard_catches_every_mutation_form():
         assert writes, f"guard missed a mutation form: {snippet!r}"
     # A pure read must NOT register as a write (else every read is a false positive).
     assert not _dwg_private_writes(ast.parse("use(dwg._named)"))
+    # #817 PR4 (decision D): a private METHOD CALL is explicit API, exempt from the read
+    # scan; every DATA read stays caught (the state-bus back-channel #722 targets).
+    assert _dwg_private_reads(ast.parse("dwg._set_view_coordinates(v)")) == set()
+    assert _dwg_private_reads(ast.parse("drawing._clear_annotations()")) == set()
+    assert _dwg_private_reads(ast.parse("use(dwg._coords)")) == {"_coords"}
+    assert _dwg_private_reads(ast.parse("dwg._registry.add(x)")) == {"_registry"}  # func.value
+    assert _dwg_private_reads(ast.parse("dwg._coords[k]")) == {"_coords"}  # subscript
+    assert _dwg_private_reads(ast.parse('getattr(dwg, "_analysis")')) == {"_analysis"}
     # The aliasing evasion is caught as the alias itself (#699 slice d, Codex review):
     assert _drawing_aliases(ast.parse("d = dwg"))
     assert _drawing_aliases(ast.parse("if (d := drawing): pass"))

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2739,7 +2739,7 @@ class TestComposeThenPackRepack:
         assert dwg.view_of("tag2") is None
 
         dwg._add(_leader("D"), "tag3", view="side")
-        dwg.clear_annotations()  # keeps title_block only
+        dwg._clear_annotations()  # keeps title_block only
         assert dwg.view_of("tag3") is None
 
 
@@ -3459,7 +3459,7 @@ def test_clear_annotations_keeps_title_block():
     # #74 — wholesale removal without knowing the auto-name scheme.
     dwg = build_drawing(Cylinder(15, 40))  # cylinder → od dim, centerlines, …
     assert len(dwg.items) > 1
-    removed = dwg.clear_annotations()
+    removed = dwg._clear_annotations()
     assert removed
     assert all(a not in dwg.items for a in removed)
     assert len(dwg.items) == 1
@@ -3473,10 +3473,28 @@ def test_clear_annotations_keep_custom_and_unnamed_removed():
         Leader(tip=dwg.at("front", 0, 0, 0), elbow=(5, 5, 0), label="K", draft=dwg.draft), "ldr_k"
     )
     dwg._add(Leader(tip=dwg.at("front", 0, 0, 0), elbow=(6, 6, 0), label="U", draft=dwg.draft))
-    dwg.clear_annotations(keep=("title_block", "ldr_k"))
+    dwg._clear_annotations(keep=("title_block", "ldr_k"))
     assert set(dwg.annotations()) == {"title_block", "ldr_k"}
     assert keep_me in dwg.items
     assert len(dwg.items) == 2  # unnamed leader removed too
+
+
+def test_plumbing_shims_are_deprecated():
+    # #817 PR4: the 6 view/annotation plumbing methods are now engine-internal; the public
+    # shims warn (and route to the private impl) for one release. Engine calls use the private
+    # names directly (no warning) — covered by the ordinary build path.
+    dwg = build_drawing(Box(60, 40, 20))
+    coords = dwg.coords("front")
+    for call in (
+        lambda: dwg.clear_annotations(),
+        lambda: dwg.drop_view_coordinates("nope"),
+        lambda: dwg.attach_part_model(dwg.model()),
+        lambda: dwg.attach_solve_trace(None),
+        lambda: dwg.set_view_coordinates("front", coords),
+        lambda: dwg.add_view("bottom", Box(10, 10, 10), (0, 0, -80), (0, 1, 0), (250.0, 60.0)),
+    ):
+        with pytest.warns(DeprecationWarning):
+            call()
 
 
 @pytest.fixture(scope="module")
@@ -3647,7 +3665,7 @@ def test_drawing_add_view(tmp_path):
     dwg = build_drawing(Box(30, 20, 10))
     look = dwg.look_at
     bottom_cam = (look[0], look[1], look[2] - dwg.dist)
-    vc = dwg.add_view("bottom", Box(30, 20, 10), bottom_cam, (0, 1, 0), (260.0, 60.0))
+    vc = dwg._add_view("bottom", Box(30, 20, 10), bottom_cam, (0, 1, 0), (260.0, 60.0))
     assert "bottom" in dwg.views
     assert isinstance(vc, ViewCoordinates)
     # The custom view exports alongside the standard ones.

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -66,13 +66,18 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_add",
         "_add_balloon",
         "_add_shapes",
+        "_add_view",
         "_analysis",
         "_ann_box_cache",
         "_anno_view",
+        "_attach_part_model",
+        "_attach_solve_trace",
         "_build_issues",
         "_classify_intents",
+        "_clear_annotations",
         "_derive_span",
         "_drain_intents",
+        "_drop_view_coordinates",
         "_dropped_callout_diams",
         "_hole_spec_groups",
         "_is_scattered_hole_doc",
@@ -87,6 +92,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_record_build_issue",
         "_replay_intent",
         "_resolve_dimension_span",
+        "_set_view_coordinates",
         "_user_dim_uses_corridor",
         "_view_edge_cache",
         "_write_dxf",
@@ -148,6 +154,14 @@ _ALLOW: dict[str, int] = {
     # DEPRECATED (#817); the deprecated shim's warning is asserted separately via the public name, so
     # this one read is genuinely internal.
     "_place_dim": 1,
+    # View/annotation plumbing privatized in #817 PR4 (public forms deprecated). The functional
+    # behaviour tests drive the primitives directly (wholesale clear keeps the title block;
+    # add_view projects + refits silhouettes); the deprecated shims' warnings are asserted
+    # separately via the public names. The other four plumbing privates
+    # (_set_view_coordinates/_drop_view_coordinates/_attach_part_model/_attach_solve_trace) have no
+    # direct test read — the engine build path exercises them.
+    "_clear_annotations": 3,
+    "_add_view": 1,
 }
 
 


### PR DESCRIPTION
Final step of #817 (privatize the low-level Drawing placement API). Privatizes the 6 view-coordinate / attach **plumbing** methods.

## The wrinkle

Unlike `add`/`place_dim` (never called by the engine on `dwg`), **5 of these 6 are called by engine modules** (projection/sections/orchestrator/builder). A naive `_name` rename makes those calls `dwg._name(...)` — which the **#722 whole-engine guard** flags, since a method call is an attribute Load. Worse, that guard's own docstring names these methods as the *sanctioned* encapsulation boundary (#639 made annotations/ call `dwg.set_view_coordinates(...)` instead of poking `dwg._coords`).

## Decision D — refine the guard (the principled fix)

#722 exists to stop **state-bus data back-channels**, not method calls. So the guard now exempts a private that is the **direct callee of a Call** (`dwg._m(...)`) while still catching every data read/write:
- `dwg._coords` / `getattr(dwg, "_analysis")` — data read, caught.
- `dwg._registry.add(...)` — `_registry` is the call func's *value*, not the func — caught.
- `dwg._coords[k]` — subscript — caught.
- `dwg._x = ...` — write — caught (unchanged).

No `_ENGINE_DWG_PRIVATE_ALLOW` growth. A pin test (`test_write_guard_catches_every_mutation_form`) locks both directions.

## Changes

- `add_view`, `set_view_coordinates`, `drop_view_coordinates`, `attach_part_model`, `attach_solve_trace`, `clear_annotations` → `_name`, each with a PEP 702 `@deprecated` public shim (one release, removal ~0.5.0).
- Engine callers use the private names directly (no self-warning).
- `#741` ratchet: 6 privates added to `_DRAWING_PRIVATES`; the two white-box functional tests allowlisted (`_clear_annotations`×3, `_add_view`×1); a new test asserts all 6 shims warn.
- Builder's emitted script tip now points users at `dwg.section()` (add_view is engine-internal).

## Follow-on (decision E — separate epic)

The real "Drawing is not the state bus" endgame: projection/sections **return** view-coordinate data that `builder` assembles at construction, instead of mutating a half-built Drawing. Too large for this PR; will be filed as its own issue.

## Verification

- #722 guard (+ new pins) and #741 ratchet green.
- Functional + deprecation tests green; section/iso/trace/detail slice (61) and script-emit (12) green.
- 4-check lint clean (ruff check, ruff format, mypy 52 files, codespell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)