### PR TITLE
feat(#816): recognise obround through-slots from their end caps

### DIFF
--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -421,16 +421,17 @@ _OBROUND_RATIO_TOL = 0.1  # a half-cylinder's in-plane extents are 2r (across) /
 # by RATIO to the radius (2.0 / 1.0), so the discriminator holds at every scale, not just large r.
 
 
-def _obround_end(cap: tuple, part_ext: dict):
+def _obround_end(cap: tuple):
     """Classify a concave cylinder *cap* (from :func:`_cylinder_faces`) as a half-cylinder obround
-    THROUGH end, or None. A half-cylinder end's in-plane bounding box is ≈ 2r across (its width
-    axis) by ≈ r along the bulge (its long axis) — a full cylinder (round hole) is 2r × 2r and is
-    rejected. The 2r/r test is by RATIO to the radius so it holds at any scale (a sub-mm obround is
-    not a false negative, review). Returns ``(width_axis, long_axis, depth_axis, radius, w_center,
-    flat, direction, d_lo, d_hi)`` — ``flat`` is the cylinder-axis position on the long axis (the
-    straight-wall junction), ``direction`` (±1) the side the cap bulges toward. Requires the cap to
-    span the full thickness along its axis (a cheap through pre-filter; the authoritative through/
-    blind split is the caller's :func:`_has_floor`)."""
+    end, or None. A half-cylinder end's in-plane bounding box is ≈ 2r across (its width axis) by
+    ≈ r along the bulge (its long axis) — a full cylinder (round hole) is 2r × 2r and is rejected.
+    The 2r/r test is by RATIO to the radius so the classifier holds at any scale (fixing the
+    absolute-tolerance collapse for small r, review). Returns ``(width_axis, long_axis, depth_axis,
+    radius, w_center, flat, direction, d_lo, d_hi)`` — ``flat`` is the cylinder-axis position on the
+    long axis (the straight-wall junction), ``direction`` (±1) the side the cap bulges toward. The
+    through/blind split is left to the caller's :func:`_has_floor` (authoritative and local, so a
+    through-slot in a thin step of stepped stock is not rejected by a global-thickness assumption,
+    review)."""
     rad, ax, loc, bb, concave = cap
     if not concave or rad <= 0:
         return None
@@ -443,8 +444,6 @@ def _obround_end(cap: tuple, part_ext: dict):
     width_axis, long_axis = across[0], bulge[0]
     dc = "XYZ"[_AXES[ax]]
     d_lo, d_hi = getattr(bb.min, dc), getattr(bb.max, dc)
-    if (d_hi - d_lo) < _SLOT_MAX_SPAN_FRAC * part_ext[ax]:
-        return None  # not through — a through-slot spans the full thickness
     lc = "XYZ"[_AXES[long_axis]]
     flat = loc[_AXES[long_axis]]
     direction = -1 if (flat - getattr(bb.min, lc)) > (getattr(bb.max, lc) - flat) else 1
@@ -452,13 +451,15 @@ def _obround_end(cap: tuple, part_ext: dict):
 
 
 def _has_side_walls(faces, s: Slot) -> bool:
-    """True when the two flat side walls of obround slot *s* are present: anti-parallel wall faces
-    on the width axis at ``w_center ± width/2``, each overlapping the straight run ``[s.lo, s.hi]``.
+    """True when the two flat side walls of obround slot *s* are present: **inward-facing** wall
+    faces on the width axis at ``w_center - width/2`` (material-outward normal toward +width) and
+    ``w_center + width/2`` (normal toward -width), each overlapping the straight run ``[s.lo, s.hi]``.
     Confirms a genuine channel connects the two end caps — rejects two independent D-cutouts whose
-    caps merely alternate ``-1, +1`` across solid stock with no wall between them (#816 review)."""
+    caps merely alternate ``-1, +1`` across solid. The normal-direction test is essential: the
+    stock's own OUTWARD-facing side faces sit at the same ``w_center ± width/2`` when the stock is
+    exactly as wide as the slot, and would otherwise be mistaken for the channel walls (#816 review)."""
     wk, lk = _AXES[s.width_axis], _AXES[s.long_axis]
-    targets = (s.w_center - s.width / 2, s.w_center + s.width / 2)
-    hit = [False, False]
+    lo_wall, hi_wall = False, False
     for f in faces:
         if not f.wall or f.axis != s.width_axis:
             continue
@@ -466,13 +467,16 @@ def _has_side_walls(faces, s: Slot) -> bool:
         if min(hi, s.hi) - max(lo, s.lo) <= 0:  # wall does not span the straight run
             continue
         c = _center(f.bb, wk)
-        for idx, t in enumerate(targets):
-            if abs(c - t) <= _MERGE_TOL:
-                hit[idx] = True
-    return all(hit)
+        # inward-facing: the low-side wall's outward normal points toward the centreline (+width),
+        # the high-side wall's toward -width. The stock's exterior faces point the other way.
+        if abs(c - (s.w_center - s.width / 2)) <= _MERGE_TOL and f.normal[wk] > 0:
+            lo_wall = True
+        if abs(c - (s.w_center + s.width / 2)) <= _MERGE_TOL and f.normal[wk] < 0:
+            hi_wall = True
+    return lo_wall and hi_wall
 
 
-def _recognise_obround_from_ends(part, faces, part_ext: dict) -> list[Slot]:
+def _recognise_obround_from_ends(part, faces) -> list[Slot]:
     """Recognise obround through-slots from their semicircular end caps (#816) — the path for slots
     whose flat walls are too short for :func:`_candidate` to pair. Half-cylinder ends are grouped by
     centreline/radius/depth extent, then within a group (all slots on one centreline share it)
@@ -482,8 +486,12 @@ def _recognise_obround_from_ends(part, faces, part_ext: dict) -> list[Slot]:
     (a real channel connects the ends — not two D-cutouts across solid) and :func:`_has_floor` (it is
     through, not a blind pocket). ``lo``/``hi`` are emitted at the straight-wall junctions so
     :func:`_extend_obround_ends` adds the two radii (uniform with the flat-wall path, and `_merge`
-    folds any duplicate an elongated obround's flat walls also produced)."""
-    ends = [e for cap in _cylinder_faces(part) if (e := _obround_end(cap, part_ext)) is not None]
+    folds any duplicate an elongated obround's flat walls also produced).
+
+    The two flats must be more than ``_MERGE_TOL`` apart to count as distinct ends — so a genuinely
+    sub-millimetre obround (straight run < 0.5 mm) is not recovered; supporting that would need the
+    module-wide absolute ``_MERGE_TOL`` to go relative, out of scope here."""
+    ends = [e for cap in _cylinder_faces(part) if (e := _obround_end(cap)) is not None]
     groups: dict[tuple, list[tuple]] = {}
     for e in ends:
         wa, la, da, rad, wc, flat, direction, dlo, dhi = e
@@ -552,7 +560,7 @@ def recognise_slots(part) -> list[Slot]:
     # Stubby obround through-slots (straight section < width) have no pairable flat walls, so
     # recover them from their end caps (#816). Emitted at the straight-wall junctions like the
     # flat-wall path, so `_merge` folds any duplicate an elongated obround also produced.
-    candidates.extend(_recognise_obround_from_ends(part, faces, part_ext))
+    candidates.extend(_recognise_obround_from_ends(part, faces))
     # Recombine arms of a crossing channel split by the intersection (#604), then extend any
     # radiused-end (obround) slot to its overall length (#613).
     return _extend_obround_ends(_collapse_collinear(_merge(candidates), part), part)

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -410,13 +410,95 @@ def _extend_obround_ends(records: list[_R], part) -> list[_R]:
     return out
 
 
+# An obround through-slot whose straight section is shorter than its width (#816) has flat side
+# walls too short to pair as an elongated slot: `_candidate` either rejects it (width > the short
+# straight length) or mistakes the full through-thickness for the length (a full-span cut). Its
+# length lives in the two semicircular ends, so recognise it directly from the end caps — a pair of
+# concave HALF-cylinders (in-plane bbox ≈ 2r × r) of equal radius, coaxial about a through depth
+# axis, on a shared centreline, bulging apart along the long axis. A round hole is a FULL cylinder
+# (bbox 2r × 2r) so it is never read as an end; a lone unpaired end is a fillet/round.
+_OBROUND_EXT_TOL = 0.2  # mm — matching a cap's in-plane bbox extent to 2r (across) / r (bulge)
+
+
+def _obround_end(cap: tuple, part_ext: dict):
+    """Classify a concave cylinder *cap* (from :func:`_cylinder_faces`) as a half-cylinder obround
+    THROUGH end, or None. A half-cylinder end's in-plane bounding box is ≈ 2r across (its width
+    axis) by ≈ r along the bulge (its long axis) — a full cylinder (round hole) is 2r × 2r and is
+    rejected. Returns ``(width_axis, long_axis, depth_axis, radius, w_center, flat, direction,
+    d_lo, d_hi)`` — ``flat`` is the cylinder-axis position on the long axis (the straight-wall
+    junction), ``direction`` (±1) the side the cap bulges toward. Requires the cap to span the full
+    thickness along its axis (through, not a blind pocket end)."""
+    rad, ax, loc, bb, concave = cap
+    if not concave:
+        return None
+    others = [a for a in "xyz" if a != ax]
+    ext = {a: getattr(bb.max, "XYZ"[_AXES[a]]) - getattr(bb.min, "XYZ"[_AXES[a]]) for a in others}
+    across = [a for a in others if abs(ext[a] - 2 * rad) <= _OBROUND_EXT_TOL]
+    bulge = [a for a in others if abs(ext[a] - rad) <= _OBROUND_EXT_TOL]
+    if len(across) != 1 or len(bulge) != 1 or across[0] == bulge[0]:
+        return None
+    width_axis, long_axis = across[0], bulge[0]
+    dc = "XYZ"[_AXES[ax]]
+    d_lo, d_hi = getattr(bb.min, dc), getattr(bb.max, dc)
+    if (d_hi - d_lo) < _SLOT_MAX_SPAN_FRAC * part_ext[ax]:
+        return None  # blind — a through-slot spans the full thickness (recognise_pockets' job)
+    lc = "XYZ"[_AXES[long_axis]]
+    flat = loc[_AXES[long_axis]]
+    direction = -1 if (flat - getattr(bb.min, lc)) > (getattr(bb.max, lc) - flat) else 1
+    return (width_axis, long_axis, ax, rad, loc[_AXES[width_axis]], flat, direction, d_lo, d_hi)
+
+
+def _recognise_obround_from_ends(part, part_ext: dict) -> list[Slot]:
+    """Recognise obround through-slots from their semicircular end caps (#816) — the path for slots
+    whose flat walls are too short for :func:`_candidate` to pair. Half-cylinder ends are grouped by
+    centreline/radius/depth extent, then within a group (all slots on one centreline share it)
+    sorted along the run and paired: a cap bulging toward -long immediately followed by one bulging
+    toward +long is one slot's two ends (the void lies between their flats); the reverse adjacency
+    is the solid gap between two slots and is skipped. ``lo``/``hi`` are emitted at the straight-wall
+    junctions so :func:`_extend_obround_ends` adds the two radii (uniform with the flat-wall path,
+    and `_merge` folds any duplicate an elongated obround's flat walls also produced)."""
+    ends = [e for cap in _cylinder_faces(part) if (e := _obround_end(cap, part_ext)) is not None]
+    groups: dict[tuple, list[tuple]] = {}
+    for e in ends:
+        wa, la, da, rad, wc, flat, direction, dlo, dhi = e
+        key = (wa, la, da, round(rad, 2), round(wc, 2), round(dlo, 2), round(dhi, 2))
+        groups.setdefault(key, []).append(e)
+    slots: list[Slot] = []
+    for (wa, la, _da, rad, wc, dlo, dhi), grp in groups.items():
+        run = sorted(grp, key=lambda e: e[5])  # by flat along the long axis
+        i = 0
+        while i < len(run) - 1:
+            lo_end, hi_end = run[i], run[i + 1]
+            # A slot's two ends bulge APART (low end toward -long, high end toward +long), so the
+            # void is between their flats. The reverse pair is solid stock between slots — skip it.
+            if lo_end[6] == -1 and hi_end[6] == 1 and hi_end[5] - lo_end[5] > _MERGE_TOL:
+                slots.append(
+                    Slot(
+                        width_axis=wa,
+                        long_axis=la,
+                        width=round(2 * rad, 2),
+                        length=round(hi_end[5] - lo_end[5], 2),
+                        w_center=round(wc, 2),
+                        lo=round(lo_end[5], 2),
+                        hi=round(hi_end[5], 2),
+                        d_lo=round(dlo, 2),
+                        d_hi=round(dhi, 2),
+                    )
+                )
+                i += 2
+            else:
+                i += 1
+    return slots
+
+
 def recognise_slots(part) -> list[Slot]:
     """Recognise enclosed through-slots with rectangular walls in *part*.
 
     Returns a list of :class:`Slot`, one per physical feature, in a
     deterministic order (co-located candidate pairs are merged, keeping the
     narrower width).  See the module docstring for the recognition predicate and
-    its (deliberately narrow) scope.
+    its (deliberately narrow) scope. Obround slots too stubby for their flat walls
+    to pair are recovered from their end caps (#816).
     """
     faces = _planar_faces(part)
     pbb = part.bounding_box()
@@ -436,6 +518,10 @@ def recognise_slots(part) -> list[Slot]:
                 # between bosses) is capped by a floor and is out of scope (#148).
                 if s is not None and not _has_floor(faces, s):
                     candidates.append(s)
+    # Stubby obround through-slots (straight section < width) have no pairable flat walls, so
+    # recover them from their end caps (#816). Emitted at the straight-wall junctions like the
+    # flat-wall path, so `_merge` folds any duplicate an elongated obround also produced.
+    candidates.extend(_recognise_obround_from_ends(part, part_ext))
     # Recombine arms of a crossing channel split by the intersection (#604), then extend any
     # radiused-end (obround) slot to its overall length (#613).
     return _extend_obround_ends(_collapse_collinear(_merge(candidates), part), part)

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -417,46 +417,72 @@ def _extend_obround_ends(records: list[_R], part) -> list[_R]:
 # concave HALF-cylinders (in-plane bbox ≈ 2r × r) of equal radius, coaxial about a through depth
 # axis, on a shared centreline, bulging apart along the long axis. A round hole is a FULL cylinder
 # (bbox 2r × 2r) so it is never read as an end; a lone unpaired end is a fillet/round.
-_OBROUND_EXT_TOL = 0.2  # mm — matching a cap's in-plane bbox extent to 2r (across) / r (bulge)
+_OBROUND_RATIO_TOL = 0.1  # a half-cylinder's in-plane extents are 2r (across) / r (bulge) — match
+# by RATIO to the radius (2.0 / 1.0), so the discriminator holds at every scale, not just large r.
 
 
 def _obround_end(cap: tuple, part_ext: dict):
     """Classify a concave cylinder *cap* (from :func:`_cylinder_faces`) as a half-cylinder obround
     THROUGH end, or None. A half-cylinder end's in-plane bounding box is ≈ 2r across (its width
     axis) by ≈ r along the bulge (its long axis) — a full cylinder (round hole) is 2r × 2r and is
-    rejected. Returns ``(width_axis, long_axis, depth_axis, radius, w_center, flat, direction,
-    d_lo, d_hi)`` — ``flat`` is the cylinder-axis position on the long axis (the straight-wall
-    junction), ``direction`` (±1) the side the cap bulges toward. Requires the cap to span the full
-    thickness along its axis (through, not a blind pocket end)."""
+    rejected. The 2r/r test is by RATIO to the radius so it holds at any scale (a sub-mm obround is
+    not a false negative, review). Returns ``(width_axis, long_axis, depth_axis, radius, w_center,
+    flat, direction, d_lo, d_hi)`` — ``flat`` is the cylinder-axis position on the long axis (the
+    straight-wall junction), ``direction`` (±1) the side the cap bulges toward. Requires the cap to
+    span the full thickness along its axis (a cheap through pre-filter; the authoritative through/
+    blind split is the caller's :func:`_has_floor`)."""
     rad, ax, loc, bb, concave = cap
-    if not concave:
+    if not concave or rad <= 0:
         return None
     others = [a for a in "xyz" if a != ax]
     ext = {a: getattr(bb.max, "XYZ"[_AXES[a]]) - getattr(bb.min, "XYZ"[_AXES[a]]) for a in others}
-    across = [a for a in others if abs(ext[a] - 2 * rad) <= _OBROUND_EXT_TOL]
-    bulge = [a for a in others if abs(ext[a] - rad) <= _OBROUND_EXT_TOL]
+    across = [a for a in others if abs(ext[a] / rad - 2.0) <= _OBROUND_RATIO_TOL]
+    bulge = [a for a in others if abs(ext[a] / rad - 1.0) <= _OBROUND_RATIO_TOL]
     if len(across) != 1 or len(bulge) != 1 or across[0] == bulge[0]:
         return None
     width_axis, long_axis = across[0], bulge[0]
     dc = "XYZ"[_AXES[ax]]
     d_lo, d_hi = getattr(bb.min, dc), getattr(bb.max, dc)
     if (d_hi - d_lo) < _SLOT_MAX_SPAN_FRAC * part_ext[ax]:
-        return None  # blind — a through-slot spans the full thickness (recognise_pockets' job)
+        return None  # not through — a through-slot spans the full thickness
     lc = "XYZ"[_AXES[long_axis]]
     flat = loc[_AXES[long_axis]]
     direction = -1 if (flat - getattr(bb.min, lc)) > (getattr(bb.max, lc) - flat) else 1
     return (width_axis, long_axis, ax, rad, loc[_AXES[width_axis]], flat, direction, d_lo, d_hi)
 
 
-def _recognise_obround_from_ends(part, part_ext: dict) -> list[Slot]:
+def _has_side_walls(faces, s: Slot) -> bool:
+    """True when the two flat side walls of obround slot *s* are present: anti-parallel wall faces
+    on the width axis at ``w_center ± width/2``, each overlapping the straight run ``[s.lo, s.hi]``.
+    Confirms a genuine channel connects the two end caps — rejects two independent D-cutouts whose
+    caps merely alternate ``-1, +1`` across solid stock with no wall between them (#816 review)."""
+    wk, lk = _AXES[s.width_axis], _AXES[s.long_axis]
+    targets = (s.w_center - s.width / 2, s.w_center + s.width / 2)
+    hit = [False, False]
+    for f in faces:
+        if not f.wall or f.axis != s.width_axis:
+            continue
+        lo, hi = getattr(f.bb.min, "XYZ"[lk]), getattr(f.bb.max, "XYZ"[lk])
+        if min(hi, s.hi) - max(lo, s.lo) <= 0:  # wall does not span the straight run
+            continue
+        c = _center(f.bb, wk)
+        for idx, t in enumerate(targets):
+            if abs(c - t) <= _MERGE_TOL:
+                hit[idx] = True
+    return all(hit)
+
+
+def _recognise_obround_from_ends(part, faces, part_ext: dict) -> list[Slot]:
     """Recognise obround through-slots from their semicircular end caps (#816) — the path for slots
     whose flat walls are too short for :func:`_candidate` to pair. Half-cylinder ends are grouped by
     centreline/radius/depth extent, then within a group (all slots on one centreline share it)
     sorted along the run and paired: a cap bulging toward -long immediately followed by one bulging
     toward +long is one slot's two ends (the void lies between their flats); the reverse adjacency
-    is the solid gap between two slots and is skipped. ``lo``/``hi`` are emitted at the straight-wall
-    junctions so :func:`_extend_obround_ends` adds the two radii (uniform with the flat-wall path,
-    and `_merge` folds any duplicate an elongated obround's flat walls also produced)."""
+    is the solid gap between two slots and is skipped. Each pair is confirmed by :func:`_has_side_walls`
+    (a real channel connects the ends — not two D-cutouts across solid) and :func:`_has_floor` (it is
+    through, not a blind pocket). ``lo``/``hi`` are emitted at the straight-wall junctions so
+    :func:`_extend_obround_ends` adds the two radii (uniform with the flat-wall path, and `_merge`
+    folds any duplicate an elongated obround's flat walls also produced)."""
     ends = [e for cap in _cylinder_faces(part) if (e := _obround_end(cap, part_ext)) is not None]
     groups: dict[tuple, list[tuple]] = {}
     for e in ends:
@@ -471,20 +497,25 @@ def _recognise_obround_from_ends(part, part_ext: dict) -> list[Slot]:
             lo_end, hi_end = run[i], run[i + 1]
             # A slot's two ends bulge APART (low end toward -long, high end toward +long), so the
             # void is between their flats. The reverse pair is solid stock between slots — skip it.
-            if lo_end[6] == -1 and hi_end[6] == 1 and hi_end[5] - lo_end[5] > _MERGE_TOL:
-                slots.append(
-                    Slot(
-                        width_axis=wa,
-                        long_axis=la,
-                        width=round(2 * rad, 2),
-                        length=round(hi_end[5] - lo_end[5], 2),
-                        w_center=round(wc, 2),
-                        lo=round(lo_end[5], 2),
-                        hi=round(hi_end[5], 2),
-                        d_lo=round(dlo, 2),
-                        d_hi=round(dhi, 2),
-                    )
-                )
+            if not (lo_end[6] == -1 and hi_end[6] == 1 and hi_end[5] - lo_end[5] > _MERGE_TOL):
+                i += 1
+                continue
+            s = Slot(
+                width_axis=wa,
+                long_axis=la,
+                width=round(2 * rad, 2),
+                length=round(hi_end[5] - lo_end[5], 2),
+                w_center=round(wc, 2),
+                lo=round(lo_end[5], 2),
+                hi=round(hi_end[5], 2),
+                d_lo=round(dlo, 2),
+                d_hi=round(dhi, 2),
+            )
+            # Confirm a real channel (side walls) joins the ends and it is through, not a blind
+            # obround pocket or two D-cutouts bridging solid (#816 review). On failure the caps may
+            # belong to a later valid pair, so advance by one, not two.
+            if _has_side_walls(faces, s) and not _has_floor(faces, s):
+                slots.append(s)
                 i += 2
             else:
                 i += 1
@@ -521,7 +552,7 @@ def recognise_slots(part) -> list[Slot]:
     # Stubby obround through-slots (straight section < width) have no pairable flat walls, so
     # recover them from their end caps (#816). Emitted at the straight-wall junctions like the
     # flat-wall path, so `_merge` folds any duplicate an elongated obround also produced.
-    candidates.extend(_recognise_obround_from_ends(part, part_ext))
+    candidates.extend(_recognise_obround_from_ends(part, faces, part_ext))
     # Recombine arms of a crossing channel split by the intersection (#604), then extend any
     # radiused-end (obround) slot to its overall length (#613).
     return _extend_obround_ends(_collapse_collinear(_merge(candidates), part), part)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7747,9 +7747,11 @@ class TestFindSlots:
         # #816 review: two independent D-shaped (half-cylinder) through-cutouts bulging APART with
         # solid stock between their flats have end caps in the same -1,+1 order a real obround does,
         # but no side walls join them — they must not be paired into a phantom slot across solid.
+        # The stock is exactly as wide as the caps (8 = 2r), so its OUTWARD-facing exterior side
+        # faces sit at w_center ± width/2; only the inward-normal test in _has_side_walls rejects them.
         d1 = Pos(0, -10, 0) * Cylinder(4, 30) & Pos(0, -12, 0) * Box(20, 4, 40)
         d2 = Pos(0, 10, 0) * Cylinder(4, 30) & Pos(0, 12, 0) * Box(20, 4, 40)
-        assert recognise_slots(Box(26, 40, 21) - d1 - d2) == []
+        assert recognise_slots(Box(8, 40, 21) - d1 - d2) == []
 
     def test_pivot_boss_at_slot_end_does_not_extend_length(self):
         # A slotted lever with a cylindrical pivot boss (radius = width/2) protruding at one

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7734,6 +7734,23 @@ class TestFindSlots:
         part = Box(26, 40, 21) - Pos(0, -8, 0) * Cylinder(4, 30) - Pos(0, 8, 0) * Cylinder(4, 30)
         assert recognise_slots(part) == []
 
+    def test_deep_blind_obround_pocket_is_not_a_through_slot(self):
+        # #816 review: a blind obround pocket cut 9.5 mm into 10 mm stock has end caps spanning
+        # ≥90% of the thickness, so it passes the cheap through pre-filter — only the floor test
+        # (a through-slot has no floor) may reject it. It must not be read as a through-slot.
+        from build123d import Plane, SlotOverall, extrude
+
+        part = Box(60, 30, 10) - Pos(0, 0, -4.5) * extrude(Plane.XY * SlotOverall(13.5, 8), 9.5)
+        assert recognise_slots(part) == []
+
+    def test_two_d_cutouts_across_solid_are_not_a_slot(self):
+        # #816 review: two independent D-shaped (half-cylinder) through-cutouts bulging APART with
+        # solid stock between their flats have end caps in the same -1,+1 order a real obround does,
+        # but no side walls join them — they must not be paired into a phantom slot across solid.
+        d1 = Pos(0, -10, 0) * Cylinder(4, 30) & Pos(0, -12, 0) * Box(20, 4, 40)
+        d2 = Pos(0, 10, 0) * Cylinder(4, 30) & Pos(0, 12, 0) * Box(20, 4, 40)
+        assert recognise_slots(Box(26, 40, 21) - d1 - d2) == []
+
     def test_pivot_boss_at_slot_end_does_not_extend_length(self):
         # A slotted lever with a cylindrical pivot boss (radius = width/2) protruding at one
         # end must NOT be read as a radiused end: the boss sits at a different depth than the

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7688,6 +7688,52 @@ class TestFindSlots:
         declared = declare_slot(cutter, depth_axis="z")
         assert s.length == declared.length == 30.0
 
+    def test_obround_through_slot_shorter_than_wide_is_recognised(self):
+        # #816: a stubby obround (overall length < ... no, straight section < width) has flat side
+        # walls too short to pair — 8 wide, 13.5 overall → the 5.5 straight walls are narrower than
+        # the width, so _candidate rejects them (and the through-thickness is mistaken for length).
+        # The end-cap path recovers it. This is the reported failure: recognise_slots returned [].
+        from build123d import Plane, SlotOverall, extrude
+
+        part = Box(26, 40, 21) - extrude(Plane.XY * SlotOverall(13.5, 8), 21, both=True)
+        (s,) = recognise_slots(part)
+        assert s.width == 8.0
+        assert s.length == 13.5
+
+    def test_stubby_obround_recognise_matches_declare_length(self):
+        # The end-cap path must agree with declare.slot(obj) on the overall length (#816), as the
+        # flat-wall obround path does (test_recognise_matches_declare_on_obround_length).
+        from build123d import Plane, SlotOverall, extrude
+
+        from draftwright.model import slot as declare_slot
+
+        cutter = extrude(Plane.XY * SlotOverall(13.5, 8), 10)
+        part = Box(26, 40, 21) - extrude(Plane.XY * SlotOverall(13.5, 8), 21, both=True)
+        (s,) = recognise_slots(part)
+        assert s.length == declare_slot(cutter, depth_axis="z").length == 13.5
+
+    def test_row_of_stubby_obround_slots_on_one_centreline_stays_separate(self):
+        # #816 "tuner jig": five stubby obround through-slots down one centreline (spaced along the
+        # long axis) share a radius/centreline/depth, so all ten end caps land in one group. Pairing
+        # by bulge direction (a low end followed by a high end is one slot; the reverse is the solid
+        # gap between slots) must keep them five, not merge into one giant slot.
+        from build123d import Plane, SlotOverall, extrude
+
+        part = Box(26, 161, 21)
+        for cy in (-54, -27, 0, 27, 54):
+            part = part - Pos(0, cy, 0) * extrude(
+                Plane.XY * SlotOverall(13.5, 8, rotation=90), 21, both=True
+            )
+        slots = recognise_slots(part)
+        assert len(slots) == 5
+        assert all(s.width == 8.0 and s.length == 13.5 for s in slots)
+
+    def test_two_through_holes_are_not_an_obround_slot(self):
+        # #816 guard: a round through-hole is a FULL cylinder (bbox 2r × 2r), never a half-cylinder
+        # obround end — two coaxial holes must not be paired into a slot.
+        part = Box(26, 40, 21) - Pos(0, -8, 0) * Cylinder(4, 30) - Pos(0, 8, 0) * Cylinder(4, 30)
+        assert recognise_slots(part) == []
+
     def test_pivot_boss_at_slot_end_does_not_extend_length(self):
         # A slotted lever with a cylindrical pivot boss (radius = width/2) protruding at one
         # end must NOT be read as a radiused end: the boss sits at a different depth than the
@@ -7874,6 +7920,21 @@ class TestSlotDimensioning:
         part = Box(60, 30, 12) - Pos(0, 0, 0) * Box(20, 8, 20)
         dwg = build_drawing(part)
         assert [i for i in dwg.lint() if i.severity != "info"] == []
+
+    @pytest.mark.timeout(60)
+    def test_stubby_obround_through_slot_is_dimensioned_end_to_end(self):
+        # #816: a recognised stubby obround slot flows through IR → planner → render_slots and
+        # carries width + length dims (the reported failure drew it with no slot callouts at all).
+        from build123d import Plane, SlotOverall, extrude
+
+        part = Box(60, 30, 12) - extrude(Plane.XY * SlotOverall(13.5, 8), 12, both=True)
+        dwg = build_drawing(part)
+        assert any(f.kind == "slot" for f in dwg.model().features)
+        labels = {
+            n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_slot")
+        }
+        assert labels.get("m_slot0_width") == "8"
+        assert labels.get("m_slot0_length") == "13.5"
 
     @pytest.mark.timeout(60)
     def test_non_round_width_label_matches_geometry(self):


### PR DESCRIPTION
Fixes #816. A part whose only functional features are obround (racetrack) through-slots was drawn with **no slot callouts** — `recognise_slots` returned 0, and (compounding it) lint reported clean, a *false* completeness signal.

## Root cause

A **stubby** obround (straight section shorter than its width) has flat side walls too short to pair. `_candidate` either rejects them (`width > length` — the short straight span) or, because the flat walls span the full through-thickness, **mistakes that thickness for the length** and rejects it as a full-span cut (`_SLOT_MAX_SPAN_FRAC`). The slot's length lives in its two **semicircular ends**, not its flat walls — so the existing `_extend_obround_ends` (which only *extends* an already-found flat-wall slot) never runs.

## Fix — recognition only

The downstream surfaces (IR `SlotFeature`, planner, `render_slots`, `declare.slot`, `sheet_emit`) **already handle `Slot`** — so this recovers the missing record and nothing else.

`_recognise_obround_from_ends` finds pairs of **concave half-cylinders** (in-plane bbox ≈ `2r × r`) of equal radius, coaxial about a through depth axis, on a shared centreline, bulging apart along the long axis:
- A round hole is a **full** cylinder (`2r × 2r`) → never read as an end. A lone unpaired end is a fillet/round.
- Ends are emitted at the straight-wall junctions, so the existing `_extend_obround_ends` adds the two radii and `_merge` **folds any duplicate** an elongated obround's flat walls also produce (no double-count).
- Slots on one centreline (a row down a bar) share a cap group, so ends are paired by **bulge direction** — a low-bulging end followed by a high-bulging one is one slot; the reverse adjacency is the solid gap between slots.

## Effect

The tuner-jig repro now recognises **5 slots** (was 0), dimensions them, and where a dense sheet can't fit every dim, lint reports `slot_dim_dropped` (info) — an **honest** signal instead of a false clean (#632 intent).

## Tests

- `test_obround_through_slot_shorter_than_wide_is_recognised` (the reported failure)
- `test_stubby_obround_recognise_matches_declare_length` (recognise/declare parity)
- `test_row_of_stubby_obround_slots_on_one_centreline_stays_separate` (the tuner jig — 5, not merged)
- `test_two_through_holes_are_not_an_obround_slot` (the hole guard)
- `test_stubby_obround_through_slot_is_dimensioned_end_to_end` (recognition → render)

Full recognition/slot/declare/emit/contract/registry suites green; 4-check lint clean.

## Scope note

GD&T targeting of these slots (issue concern 2) now works automatically — a recognised slot is a referenceable feature. Blind stubby obround *pockets* remain out of scope (this fixes through-slots per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)