### PR TITLE
ci: govern coverage reporting and add Codecov badge (#825)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         run: uv run codespell src/ tests/ docs/
 
   test:
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +68,33 @@ jobs:
         # export) can exceed 120 s on the slower macOS runners.
         # Coverage runs in CI; it is kept out of the default addopts so local
         # runs stay lean (see pyproject [tool.pytest.ini_options]).
-        run: uv run pytest tests/ -n auto --dist loadscope --cov=src/draftwright --cov-report=term-missing --cov-report=xml
+        run: >-
+          uv run pytest tests/ -n auto --dist loadscope
+          --cov=src/draftwright
+          --cov-report=term-missing
+          --cov-report=xml
+          --cov-report=html:htmlcov
+
+      - name: Upload canonical coverage to Codecov
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        uses: codecov/codecov-action@v6
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
+          use_oidc: true
+
+      - name: Upload coverage report
+        # Every matrix entry enforces the coverage floor; retain one canonical
+        # report rather than 15 near-identical artifacts (#825).
+        if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-linux-py3.12
+          path: |
+            coverage.xml
+            htmlcov/
+          if-no-files-found: warn
+          retention-days: 14
 
   test-slow:
     # Heavy end-to-end CTC fixture builds (minutes each); run once, not across

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
   test:
     permissions:
       contents: read
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -43,6 +42,11 @@ jobs:
         # 0.11 (cadquery-ocp-novtk — VTK dropped, and the only kernel with 3.13/3.14 wheels).
         # A few exact-position snapshots are skipped on 0.11 (see tests/_kernel.py).
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # Ubuntu/Python 3.12 is the canonical coverage job below. Excluding it
+        # here keeps the OS/Python matrix complete without running it twice.
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.12"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -72,21 +76,45 @@ jobs:
           uv run pytest tests/ -n auto --dist loadscope
           --cov=src/draftwright
           --cov-report=term-missing
+
+  coverage:
+    # The fifteenth OS/Python matrix entry, split out so only the one job that
+    # uploads to Codecov receives an OIDC token and renders retained reports.
+    name: test (ubuntu-latest, 3.12)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests with canonical coverage reports
+        run: >-
+          uv run pytest tests/ -n auto --dist loadscope
+          --cov=src/draftwright
+          --cov-report=term-missing
           --cov-report=xml
           --cov-report=html:htmlcov
 
-      - name: Upload canonical coverage to Codecov
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           files: coverage.xml
-          fail_ci_if_error: true
+          # The repository's fail_under gate is authoritative; a third-party
+          # service outage must not block an otherwise valid change.
+          fail_ci_if_error: false
           use_oidc: true
 
       - name: Upload coverage report
-        # Every matrix entry enforces the coverage floor; retain one canonical
-        # report rather than 15 near-identical artifacts (#825).
-        if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: coverage-linux-py3.12

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ build/
 .pytest_cache/
 testenv/
 .coverage
+.coverage.*
 coverage.xml
+coverage*.json
+htmlcov/
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,10 @@ before changing those areas.
 
 ### Coverage
 
-CI measures line and branch coverage on the full fast tier, enforces the
-`[tool.coverage.report] fail_under` floor in `pyproject.toml`, uploads the canonical
-Linux/Python 3.12 result to Codecov, and retains the XML plus browsable HTML reports
-for 14 days. To reproduce that run locally:
+CI measures line and branch coverage on the full fast tier and enforces the
+`[tool.coverage.report] fail_under` floor in `pyproject.toml` on every supported
+OS/Python combination. The canonical Linux/Python 3.12 job uploads to Codecov and
+retains the XML plus browsable HTML reports for 14 days. To reproduce that run locally:
 
 ```
 uv run pytest tests/ -n auto --dist loadscope \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,25 @@ tiers and the architecture overview, and `docs/adr/` for the design decisions
 behind layout, scaling, and annotation placement — please read the relevant ADRs
 before changing those areas.
 
+### Coverage
+
+CI measures line and branch coverage on the full fast tier, enforces the
+`[tool.coverage.report] fail_under` floor in `pyproject.toml`, uploads the canonical
+Linux/Python 3.12 result to Codecov, and retains the XML plus browsable HTML reports
+for 14 days. To reproduce that run locally:
+
+```
+uv run pytest tests/ -n auto --dist loadscope \
+  --cov=src/draftwright --cov-report=term-missing \
+  --cov-report=xml --cov-report=html:htmlcov
+```
+
+The baseline recorded for #825 on Linux/Python 3.13 was **92.05% combined
+line-and-branch coverage** (93.90% statements and 86.89% branches); the initial
+floor is 90%. Coverage thresholds are a ratchet: raise the floor after the lowest
+result across the supported CI matrix remains above the proposed value, and do not
+lower it to accommodate an untested change.
+
 ## Pull requests
 
 - Branch off `main` and open a PR with a clear description of **why**.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # draftwright
 
 [![CI](https://github.com/pzfreo/draftwright/actions/workflows/ci.yml/badge.svg)](https://github.com/pzfreo/draftwright/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/pzfreo/draftwright/branch/main/graph/badge.svg)](https://codecov.io/gh/pzfreo/draftwright)
 [![PyPI](https://img.shields.io/pypi/v/draftwright.svg)](https://pypi.org/project/draftwright/)
 [![Python](https://img.shields.io/pypi/pyversions/draftwright.svg)](https://pypi.org/project/draftwright/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,17 @@ addopts = "--tb=short -m 'not slow'"
 [tool.coverage.run]
 source = ["src/draftwright"]
 omit = ["src/draftwright/__init__.py"]
+# Branch coverage makes the regression gate sensitive to untested decision paths,
+# which matter more than raw statement execution in the recognition/layout code.
+branch = true
 
 [tool.coverage.report]
+# Baseline measured on the full fast tier on Linux/Python 3.13 (#825):
+# 92.05% combined line+branch coverage (93.90% statements, 86.89% branches).
+# Keep two points of cross-platform/kernel headroom; ratchet upward only after the
+# lowest CI matrix result has stayed above the proposed floor.
+fail_under = 90
+precision = 1
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",


### PR DESCRIPTION
Closes #825.

## What changed

- enables branch coverage and enforces a 90% combined line/branch regression floor
- generates XML and browsable HTML reports in the existing full fast-tier matrix
- retains one canonical Linux/Python 3.12 report for 14 days
- uploads that canonical report to Codecov using GitHub OIDC (no repository token)
- adds the Codecov badge to the README
- ignores generated coverage outputs and documents the baseline/reproduction/ratchet policy

## Why

CI already collected coverage, but no threshold prevented regressions and reports were not retained. The README also had no stable coverage signal.

The measured Linux/Python 3.13 fast-tier baseline is 92.05% combined coverage (93.90% statements, 86.89% branches), so the initial 90% floor leaves limited cross-platform/kernel headroom while catching meaningful regression.

## Validation

- full fast tier: 1,584 passed, 3 skipped
- combined coverage: 92.1%; configured 90% floor passes
- XML and HTML report generation succeeds
- Ruff lint and formatting pass
- codespell passes
- workflow YAML parses successfully
- git diff check passes