### PR TITLE
sheet_emit: make the generated Sheet script self-describing

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -232,6 +232,170 @@ def _needs_section(model) -> bool:
     return False
 
 
+# The section a feature line is grouped under, and the singular noun the header manifest tallies
+# it by. Kinds sharing a section (hole+pattern, chamfer+fillet) are emitted under one header —
+# grouping is on CONSECUTIVE runs of the existing feature order (never a reorder: ADR 0014 makes
+# the corridor solve order-sensitive), so a kind that recurs in two runs earns two headers.
+_SECTION = {
+    "hole": "Holes",
+    "pattern": "Holes",
+    "boss": "Diameters",
+    "step": "Turned steps",
+    "groove": "Grooves",
+    "slot": "Slots",
+    "pocket": "Pockets",
+    "chamfer": "Edges",
+    "fillet": "Edges",
+    "flat": "Flats",
+    "plate": "Plates",
+    "envelope": "Envelope",
+    "step_level": "Prismatic steps",
+    "authored_dimension": "Dimensions",
+    "pmi": "Dimensions",
+}
+_NOUN = {
+    "hole": "hole",
+    "pattern": "pattern",
+    "boss": "diameter",
+    "step": "step",
+    "groove": "groove",
+    "slot": "slot",
+    "pocket": "pocket",
+    "chamfer": "chamfer",
+    "fillet": "fillet",
+    "flat": "flat",
+    "plate": "plate",
+    "envelope": "envelope",
+    "step_level": "step-ladder",
+    "authored_dimension": "dimension",
+    "pmi": "PMI record",
+}
+# Kinds whose _feature_line carries NO inline comment of its own — the emit loop appends a
+# describing comment for these. envelope/step_level/pmi and the no-verb fallback already end in a
+# `# …`, so they stay out (double-commenting, and _feature_line is called bare in a test).
+_DESCRIBED = frozenset(
+    (
+        "hole",
+        "boss",
+        "step",
+        "slot",
+        "pocket",
+        "pattern",
+        "chamfer",
+        "fillet",
+        "flat",
+        "plate",
+        "groove",
+    )
+)
+
+
+def _short_label(f) -> str:
+    """A compact human descriptor of *f* for the trailing per-line comment and the section-header
+    tally — ``⌀8 THRU ×4`` / ``slot 40 × 120`` / ``6× ⌀3 bolt circle`` / ``R50``. Empty for the
+    kinds that already describe themselves inline (envelope/step_level/pmi) or have no verb yet."""
+    k = f.kind
+    if k == "hole":
+        s = f"⌀{_n(f.diameter)}"
+        if f.cbore:
+            s += " c'bore"
+        if f.spotface:
+            s += " spotface"
+        if f.csink:
+            s += " csink"
+        s += (
+            " THRU"
+            if f.through
+            else (f" blind {_n(f.depth)}" if f.depth is not None else " blind")
+        )
+        if f.count and f.count > 1:
+            s += f" ×{f.count}"
+        return s
+    if k == "boss":
+        return f"⌀{_n(f.diameter)}"
+    if k == "step":
+        return f"⌀{_n(f.diameter)} × {_n(f.length)} step"
+    if k in ("slot", "pocket"):
+        s = f"{k} {_n(f.width)} × {_n(f.length)}"
+        return s + (f" × {_n(f.depth)} deep" if k == "pocket" else "")
+    if k == "pattern":
+        return f"{f.count}× ⌀{_n(f.member.diameter)} {f.pattern.replace('_', ' ')}"
+    if k == "chamfer":
+        equal = f.leg1 == f.leg2 and f.angle == 45
+        return f"C{_n(f.leg1)}" if equal else f"chamfer {_n(f.leg1)} × {_n(f.leg2)}"
+    if k == "fillet":
+        return f"R{_n(f.radius)}"
+    if k == "flat":
+        return f"{_n(f.across)} A/F flat"
+    if k == "groove":
+        return f"groove {_n(f.width)} × ⌀{_n(f.diameter)}"
+    if k == "plate":
+        return f"plate t{_n(round(float(f.hi) - float(f.lo), 3))}"
+    if k == "authored_dimension":
+        return str(f.label)
+    return ""
+
+
+def _run_summary(run) -> str:
+    """The header tally for a consecutive run of one section: ``8× R50`` when uniform, a short
+    ``3× ⌀14 linear, ⌀6 blind`` list otherwise, or just the count when it would run long. Empty
+    for a singleton (its own line already reads clearly)."""
+    if len(run) <= 1:
+        return ""
+    counts: dict[str, int] = {}
+    for f in run:
+        lbl = _short_label(f)
+        counts[lbl] = counts.get(lbl, 0) + 1
+    counts.pop("", None)
+    if not counts:
+        return f"{len(run)}×"
+    if len(counts) == 1:
+        ((lbl, n),) = counts.items()
+        return f"{n}× {lbl}"
+    if len(counts) > 3:
+        return f"{len(run)} total"
+    return ", ".join(f"{n}× {lbl}" if n > 1 else lbl for lbl, n in counts.items())
+
+
+def _manifest(features) -> str:
+    """A one-line feature census for the Features banner — ``3 holes · 2 slots · 1 envelope``,
+    kinds in first-appearance order, so the editor has a map before scrolling."""
+    tally: dict[str, int] = {}
+    for f in features:
+        tally[f.kind] = tally.get(f.kind, 0) + 1
+    parts = []
+    for kind, n in tally.items():
+        noun = _NOUN.get(kind, kind)
+        parts.append(f"{n} {noun}" + ("s" if n != 1 else ""))
+    return " · ".join(parts)
+
+
+def _feature_block(features) -> list[str]:
+    """The emitted feature lines, grouped under section sub-headers (with a repeat tally) and each
+    carrying a trailing describing comment. Runs are CONSECUTIVE in the given order — no reorder."""
+    if not features:
+        return ["# ── Features: none detected ──"]
+    out = [f"# ── Features ({len(features)}): {_manifest(features)} ──"]
+    i = 0
+    while i < len(features):
+        section = _SECTION.get(features[i].kind, "Other")
+        j = i
+        while j < len(features) and _SECTION.get(features[j].kind, "Other") == section:
+            j += 1
+        run = features[i:j]
+        summary = _run_summary(run)
+        out.append(f"#   {section}" + (f" · {summary}" if summary else "") + " ─────")
+        for f in run:
+            line = _feature_line(f)
+            if f.kind in _DESCRIBED:
+                lbl = _short_label(f)
+                if lbl:
+                    line += f"   # {lbl}"
+            out.append(line)
+        i = j
+    return out
+
+
 _HEADER = '''"""Editable drawing — generated by draftwright (declarative Sheet script).
 
 Each line below declares one feature. Comment a line out to drop that feature; edit a
@@ -322,7 +486,6 @@ def emit_sheet_script(
         "",
         f"sheet = Sheet(part, {', '.join(ctor)})",
         "",
-        "# ── Features (each line is one declared feature) ──────────────────────────────",
         # For a live-source part (#771), the values below were read off YOUR objects — point
         # each line back at the object to keep it a single source of truth (a STEP-sourced
         # script has no such objects, so this note is emitted only for object inputs).
@@ -331,11 +494,15 @@ def emit_sheet_script(
                 "# Object-reference tip: you built these objects, so swap a numbered arg for the",
                 "# object itself to read the size off it — e.g.  sheet.step(journal)  /",
                 "#  sheet.hole(m3_bore).thread('M3x0.5')  — no numbers restated (ADR 0011 declare).",
+                "",
             ]
             if object_ref
             else []
         ),
-        *(_feature_line(f) for f in model.features),
+        # One commentable line per feature, grouped under section sub-headers with a describing
+        # comment on each (ADR 0011 Amdt 1: still one declared feature per line — comment out, edit
+        # a value, re-run). Runs are consecutive in feature order; never reordered (ADR 0014).
+        *_feature_block(model.features),
         "",
         "# ── Views ─────────────────────────────────────────────────────────────────────",
         "# front / plan / side / iso are always produced.",

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -312,6 +312,51 @@ class TestEmit:
         assert redeclared.axis == det.axis and redeclared.radius == det.radius
         assert redeclared.frame.origin == pytest.approx(det.frame.origin)
 
+    def _four_fillets(self):
+        from build123d import Axis
+        from build123d import fillet as bd_fillet
+
+        return bd_fillet(Box(80, 50, 8).edges().filter_by(Axis.Z), 3)  # 4 equal R3 corners
+
+    def test_feature_lines_carry_a_describing_comment(self):
+        # Each verb line ends in a plain-language comment so the body is readable without
+        # decoding the coordinates — a hole reads "⌀8 THRU ×N", a fillet "R3".
+        src = _script_for(_plate())
+        hole = next(ln for ln in src.splitlines() if ln.startswith("sheet.hole("))
+        assert "   # ⌀8 THRU" in hole
+
+    def test_body_is_grouped_under_section_sub_headers(self):
+        # Consecutive same-section features sit under a "#   Edges …" sub-header, so a long
+        # script is navigable. (Holes/Edges are distinct sections.)
+        src = _script_for(self._four_fillets())
+        assert "#   Edges" in src
+        assert "#   Holes" not in src  # this part has no holes
+
+    def test_repeat_run_shows_a_tally_in_its_header(self):
+        # A run of near-identical features tallies in the header (4 equal R3 fillets → "4× R3"),
+        # signalling the repetition below is expected, not noise.
+        edges = next(
+            ln
+            for ln in _script_for(self._four_fillets()).splitlines()
+            if ln.startswith("#   Edges")
+        )
+        assert "4× R3" in edges
+
+    def test_header_lists_a_feature_manifest(self):
+        # The Features banner is a one-line census so the editor has a map before scrolling.
+        banner = next(
+            ln for ln in _script_for(_plate()).splitlines() if ln.startswith("# ── Features (")
+        )
+        assert "hole" in banner and "envelope" in banner
+
+    def test_section_headers_never_name_step_level_internally(self):
+        # The step_level section header is human-worded ("Prismatic steps"); the internal kind
+        # string must not leak (guards the same contract as the existing "# step_level" check).
+        part = Box(100, 70, 24) - Pos(0, 0, 0) * Cylinder(9, 40) - Pos(0, 0, 8) * Cylinder(15, 20)
+        src = _script_for(part)
+        assert "Prismatic steps" in src
+        assert "# step_level" not in src
+
     def test_flat_emits_the_flat_verb(self):
         # #148b: a detected machined flat emits `sheet.flat(...)` — the emit surface for the
         # across-flats callout.


### PR DESCRIPTION
## Summary

The declarative Sheet script emitted by `--script --style sheet` was a flat wall of coordinate-bearing lines, with comments on only the envelope and step-ladder. As an *editable artifact* it was hard to navigate and each line was opaque. This adds three readability improvements to the emitter.

Example (`nist_ctc_01`), before → after:

```python
# before
sheet.hole(diameter=25, at=(-160, 45, 0), axis="z", count=4, members=[...])
sheet.fillet(axis="z", radius=50, at=(-385.355, -210.355, -50))
```
```python
# after
# ── Features (17): 3 holes · 2 slots · 1 envelope · 1 step-ladder · 3 chamfers · 7 fillets ──
#   Holes · ⌀25 THRU ×4, ⌀35 THRU ×4, ⌀20 blind 45 ×2 ─────
sheet.hole(diameter=25, at=(-160, 45, 0), axis="z", count=4, members=[...])   # ⌀25 THRU ×4
#   Edges · 2× C5, C50, 7× R50 ─────
sheet.fillet(axis="z", radius=50, at=(-385.355, -210.355, -50))   # R50
```

## What changed

- **Per-line describing comments** — every verb line ends with a plain-language descriptor (`# ⌀8 THRU ×4`, `# slot 40 × 120`, `# 6× ⌀3 bolt circle`, `# R50`), appended in the emit loop so `_feature_line` (which one test calls bare) is unchanged.
- **Header manifest + section sub-headers** — a one-line feature census in the Features banner, plus `#   Holes …` / `#   Edges …` sub-headers inserted on consecutive runs of the existing feature order.
- **Repeat tally on each sub-header** (`8× R50`, `4× R3`) so a run of near-identical features reads as expected rather than as noise.

## Why it's safe

All three additions are **comment-only**, so re-run fidelity, `ast.parse`, and the `eval`/`exec` round-trips used in the tests are untouched. Section grouping runs over **consecutive runs of the existing feature order** — never a reorder, which the ADR 0014 corridor solve is sensitive to. The step-ladder section header is human-worded (`Prismatic steps`); the internal `step_level` kind string never leaks into the output.

## Architectural fit

Preserves the ADR 0011 Amendment 1 contract (one commentable declared feature per line — comment out, edit a value, re-run). Emitter-local change; no DAG, IR, or planner surface touched.

## Testing

- 5 new tests lock in the describing comments, section grouping, repeat tally, feature manifest, and the "no `step_level` leak" guard.
- Full `tests/test_sheet_emit.py` (91), `tests/test_script_detail_parity.py` + `tests/test_dense_sheet_canary.py` (17), and the smoke tier (42) all pass; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dxfx6MBFZReLkZc8hRxfzK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxfx6MBFZReLkZc8hRxfzK)_