### PR TITLE
chore: bump version to 0.3.9.dev0 after v0.3.8 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.3.8.dev0"
+version = "0.3.9.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.3.8.dev0"
+version = "0.3.9.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
Post-release housekeeping for **v0.3.8** (published to PyPI ✅).

The `publish.yml` `bump-version` job tried to push the `0.3.9.dev0` bump directly to `main` and was **rejected by branch protection** (`GH006: protected branch hook declined` — required status checks can't be satisfied by a direct bot push). So the dev bump goes through a PR, matching the previous cycle (#803).

- `pyproject.toml` + `uv.lock`: `0.3.8.dev0` → `0.3.9.dev0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)