### PR TITLE
refactor(#830): fill the solve-trace into BuildState at construction

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -333,9 +333,11 @@ def _assemble(
     # reaches no pass here, but the finalize drain gates the prismatic detail
     # request on it exactly as the auto pass does (#661).
     dwg._build.detail_view = detail_view
+    # The opt-in #736 solve-trace recorder rides BuildState like the rest of the build context
+    # (or None when tracing is off) — filled here at the single construction site, not poked onto
+    # a live Drawing through a named method (#830: the engine constructs, never mutates).
+    dwg._build.trace = trace
     dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
-    if trace is not None:  # opt-in solve trace (#736), threaded via a named method
-        dwg._attach_solve_trace(trace)
 
     part_s = a.part.scale(a.SCALE)
     dwg._add_view(

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -383,13 +383,20 @@ def test_build_state_has_a_single_construction_and_fill_site():
         # _build.detail_view: the caller's build_drawing(detail_view=…) opt-in,
         # persisted at the one fill site so the finalize drain gates the
         # prismatic detail request exactly as the auto pass does (#661).
-        "builder.py": ["_build.analysis", "_build.part_model", "_build.detail_view"],
-        # _build.trace: attach_solve_trace — the #736 solve-trace recorder rides
-        # BuildState like the rest of the build context (filled via the named
-        # method by builder._assemble — its ONLY caller; read by the annotate/
-        # finalize ctx threading). The recorder also participates in finalize()'s
-        # #647 transaction: finalize snapshots it beside the registry/coverage
-        # snapshots and restores it on rollback, so a failed drain leaves no
-        # trace records for placements that no longer exist.
+        # _build.trace: the #736 solve-trace recorder now rides BuildState filled
+        # directly at the one construction site (#830 — the engine constructs the
+        # build state, it does not mutate a live Drawing through attach_solve_trace).
+        "builder.py": [
+            "_build.analysis",
+            "_build.part_model",
+            "_build.detail_view",
+            "_build.trace",
+        ],
+        # drawing.py still writes _build.trace via the deprecated attach_solve_trace
+        # shim/primitive (kept until 0.5.0) — no engine caller reaches it now. The
+        # recorder also participates in finalize()'s #647 transaction: finalize
+        # snapshots it beside the registry/coverage snapshots and restores it on
+        # rollback, so a failed drain leaves no trace records for placements that no
+        # longer exist.
         "drawing.py": ["_build", "_build.analysis", "_build.part_model", "_build.trace"],
     }, writers


### PR DESCRIPTION
First step of the #817 decision-E endgame (#830) — the engine should **construct** the drawing's build state, not mutate a live `Drawing` through named plumbing methods.

## Change

`builder._assemble` already fills `_build.analysis` / `_build.part_model` / `_build.detail_view` at the one sanctioned construction site. The opt-in #736 solve-trace recorder now rides there too:

```python
dwg._build.trace = trace   # was: dwg._attach_solve_trace(trace) after the fill
```

`_attach_solve_trace` now has **zero engine callers** (only the deprecated public shim + its private primitive remain in `drawing.py`, until 0.5.0).

## Guard

`test_build_state_has_a_single_construction_and_fill_site` updated — `builder.py`'s writer inventory gains `_build.trace` (drawing.py keeps it via the shim). Encapsulation guard + all 13 solve-trace tests green; 4-check lint clean.

Part of the incremental #830 series (attach → standard views → the interleaved section/detail flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)