### PR TITLE
refactor(#830): drop the redundant part-model re-attach; thread via ctx only

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -286,13 +286,13 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
     # The part model — the IR-migrated passes (centre marks, turned diameters/lengths)
     # render from it (ADR 0008 convergence / #229). Built once by the pipeline
-    # (:func:`build_model`, attached to the drawing before this pass) so the read surface
-    # (dwg.model()) and feature edits work even in manual mode (#398); fall back to
-    # building it here for any direct caller that skipped _assemble.
+    # (:func:`build_model`) and filled into BuildState at builder._assemble's single
+    # construction site, so the read surface (dwg.model()) works on every real path; the
+    # `build_model(a)` fallback covers a direct caller that reached _auto_annotate without a
+    # model. #830: this pass no longer RE-attaches the model onto the drawing (the redundant
+    # dwg._attach_part_model was the only engine caller) — it threads the ensured model onto
+    # the run's ctx so every pass reads it from ctx, not the drawing's privates (#639).
     _model = dwg.model() if dwg.model() is not None else build_model(a)
-    dwg._attach_part_model(_model)
-    # Thread the ensured model + declared flag onto the run's ctx so every pass reads them from
-    # ctx, not the drawing's privates (#639). Set AFTER attach so ctx sees the ensured model.
     ctx.part_model = _model
     ctx.model_declared = dwg.model_declared
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them


### PR DESCRIPTION
Second step of the #830 decision-E endgame.

## Change

The orchestrator re-attached the part model onto the drawing before threading it onto the run's `ctx`:
```python
_model = dwg.model() if dwg.model() is not None else build_model(a)
dwg._attach_part_model(_model)   # ← removed
ctx.part_model = _model
```
But `builder._assemble` already fills `dwg._build.part_model = pm` at the single construction site **before** `_auto_annotate` runs, so `dwg.model()` is already set on every real path — the re-attach was a no-op. It only did anything for a direct `_auto_annotate` caller with an unbuilt drawing, which doesn't exist (the one direct caller, `test_auto_annotate_clears_stale_build_issues`, passes a fully built drawing).

Removing it leaves `_attach_part_model` with **zero engine callers**: builder is now the sole writer of `_build.part_model`, matching the getter-only `_part_model` property. `_model` is still computed and threaded onto `ctx.part_model` (with the `build_model(a)` fallback), which every pass reads.

## Verification

- Encapsulation guard green; `test_auto_annotate_clears_stale_build_issues` + 43 section/detail/annotation tests pass; `dwg.model()` still resolves on the normal path. 4-check lint clean.

## Series status

`_attach_solve_trace` (#836) and now `_attach_part_model` have no engine callers — **2 of the 6 plumbing methods are fully freed**. The 3 view-coordinate methods (`_add_view`/`_set_view_coordinates`/`_drop_view_coordinates`) remain via the *interleaved* section/detail flow; whether to eliminate those needs the layout-builder restructure I'll bring a design for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)