### PR TITLE
refactor(#840): transactional detail view — remove the place-then-rollback (Path B)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -604,13 +604,14 @@ class DetailRequest:
         axis:         part axis the band spans / is cropped along ("x"/"y"/"z").
         lo, hi:       band bounds along ``axis`` (world mm).
         scale_needed: detail world→page scale that makes the region legible.
-        redraw:       ``redraw(dwg, view_name, detail_scale) -> int`` — draws the
-                      detail's dimensions in the placed detail view's coordinate system
-                      and returns the count placed (0 → the detailer rolls the view
-                      back rather than leave an empty box). Called once the detail is
-                      placed; the main view always carries the located head/block
-                      inline regardless, so a placement failure loses no coverage (lint
-                      reports the un-located interior instead).
+        redraw:       ``redraw(dwg, view_name, coords, detail_scale) -> int`` — draws the
+                      detail's dimensions against *coords* (the detail's
+                      :class:`ViewCoordinates`, mapped via ``coords.pp``) and returns the count
+                      placed (0 → the detailer drops the detail without committing a view, #840).
+                      Called on the SCRATCH-projected coords before the view is committed, so a
+                      zero result needs no rollback; the main view always carries the located
+                      head/block inline regardless, so a placement failure loses no coverage
+                      (lint reports the un-located interior instead).
         pad_top:      page-mm band reserved above the detail view (a horizontal
                       chain); reserved in the fit + placement.
         pads:         optional ``pads(detail_scale) -> (pad_right, pad_top)`` for a

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2298,9 +2298,15 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
                     (dwg.at("front", hlo, 0, 0), dwg.at("front", hhi, 0, 0), hhi - hlo, None)
                 )
 
-                def _redraw(dwg, view, detail_scale, _hw=ra):
+                def _redraw(dwg, view, coords, detail_scale, _hw=ra):
                     # View-scoped name prefix so two detail views never collide (#307 review).
-                    hsegs = [(dwg.at(view, *a), dwg.at(view, *b), v, t) for a, b, v, t in _hw]
+                    # Map world→page against the detail coords (not a live dwg.at) so the view can be
+                    # committed only after these dims land — no place-then-roll-back (#840).
+                    def _at(x, y, z):
+                        px, py = coords.pp(x, y, z)
+                        return (px, py, 0.0)
+
+                    hsegs = [(_at(*a), _at(*b), v, t) for a, b, v, t in _hw]
                     return _draw_step_chain(
                         dwg, view, hsegs, f"dim_{view}_steplen", detail_scale, ctx=ctx
                     )

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -23,9 +23,7 @@ from build123d import (
 from build123d_drafting.helpers import (
     Centerline,
     Note,
-    ViewCoordinates,
     format_drawing_scale,
-    view_axes,
 )
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut
 from OCP.TopTools import TopTools_ListOfShape
@@ -48,6 +46,7 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import strip_obstacles
 from draftwright.model import plan_sections
+from draftwright.projection import project_view_geometry
 
 _DETAIL_LETTERS = "ABCDEFGH"
 
@@ -492,35 +491,41 @@ def _render_detail(
     DX = (rx0 + rx1) / 2 - pad_right / 2
     DY = (ry0 + ry1) / 2 - (pad_top - cap_h) / 2
 
-    # Project the cropped band front-on (look from −Y, up +Z) at detail_scale around
-    # its own centroid; rebuild ViewCoordinates so dwg.at(view_name, ...) maps
-    # world→page at the detail scale.
+    # Look from −Y, up +Z at detail_scale around the band's own centroid — the camera + coordinates
+    # for the scratch projection below.
     dcx = (cb.min.X + cb.max.X) / 2
     dcy = (cb.min.Y + cb.max.Y) / 2
     dcz = (cb.min.Z + cb.max.Z) / 2
     la = (dcx * detail_scale, dcy * detail_scale, dcz * detail_scale)
     dist_d = a.bbox_max * detail_scale + 100
     camera = (la[0], la[1] - dist_d, la[2])
+    # Project the cropped band front-on into a SCRATCH (no Drawing mutation) at the detail scale —
+    # project_view_geometry takes the scale directly, so its coordinates ARE the detail's (the old
+    # _add_view + override existed only because _add_view hard-codes the sheet scale). Trying the
+    # dims against these coords before committing the view is what lets us drop the place-then-roll-
+    # back (#840).
     try:
         band_s = cropped.scale(detail_scale)
-        dwg._add_view(view_name, band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True)
+        placed, placed_hid, coords = project_view_geometry(
+            detail_scale, view_name, band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True
+        )
     except Exception as exc:  # noqa: BLE001 — projection raises broadly on cast geometry
         _log.warning("Detail %s skipped (projection failed: %s)", letter, exc)
         return False
-    dwg._set_view_coordinates(
-        view_name,
-        ViewCoordinates(view_axes(camera, (0, 0, 1), la), DX, DY, dcx, dcy, dcz, detail_scale),
-    )
 
-    # The feature draws its own dims inside the detail. If nothing legible lands even
-    # at the detail scale, roll the view back rather than committing an empty DETAIL
-    # box — the request is then simply dropped (the main view already locates the
-    # head/block inline, so lint reports any un-located interior) (#307 review).
-    if not req.redraw(dwg, view_name, detail_scale):
+    # Commit the view GEOMETRY (public `views` dict) so the feature's dim pass can read its
+    # view_bounds, but keep the COORDINATES in `coords` (passed to redraw) — they reach the drawing
+    # through the layout seam only if the dims land. If nothing legible lands even at the detail
+    # scale, pop the geometry (a public dict removal) and drop the detail: no coordinate rollback is
+    # needed because the coords were never committed (#840, replacing the #307 _drop_view_coordinates
+    # place-then-drop). The main view always locates the head/block inline, so lint reports any
+    # un-located interior.
+    dwg.views[view_name] = (placed, placed_hid)
+    if not req.redraw(dwg, view_name, coords, detail_scale):
         dwg.views.pop(view_name, None)
-        dwg._drop_view_coordinates(view_name)
         _log.info("Detail %s skipped (no legible dims at the detail scale)", letter)
         return False
+    dwg._set_view_coordinates(view_name, coords)
 
     # Marker on the front view around the band (axis-aware) + letter.
     FX, FZ = a.proj.front_x, a.proj.front_z
@@ -711,15 +716,21 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
             0.0,
         )
 
-    def redraw(dwg, view, detail_scale):  # returns the count placed (for rollback, #307)
+    def redraw(
+        dwg, view, coords, detail_scale
+    ):  # returns the count placed (#840: 0 → not committed)
+        def _at(x, y, z):  # map world→page at the detail scale, matching dwg.at's (px, py, 0.0)
+            px, py = coords.pp(x, y, z)
+            return (px, py, 0.0)
+
         det_kept, _ = _legible_steps(a.step_zs, a.bb.min.Z, detail_scale)
-        ladder = dwg.at(view, a.bb.max.X, a.cy, a.bb.min.Z)[0] + 2
+        ladder = _at(a.bb.max.X, a.cy, a.bb.min.Z)[0] + 2
         placed = 0
         for i, z in enumerate([*det_kept, a.bb.max.Z]):
             label = _fmt(a.z_size) if z == a.bb.max.Z else _fmt(z - a.bb.min.Z)
             try:
-                p_lo = dwg.at(view, a.bb.max.X, a.cy, a.bb.min.Z)
-                p_hi = dwg.at(view, a.bb.max.X, a.cy, z)
+                p_lo = _at(a.bb.max.X, a.cy, a.bb.min.Z)
+                p_hi = _at(a.bb.max.X, a.cy, z)
                 det_dim = _dim(
                     (ladder, p_lo[1], 0),
                     (ladder, p_hi[1], 0),

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -29,16 +29,10 @@ else:
 
 from build123d import (
     Color,
-    Compound,
     ExportDXF,
     ExportSVG,
     LineType,
     Location,
-    Vector,
-)
-from build123d_drafting.helpers import (
-    ViewCoordinates,
-    view_axes,
 )
 
 from draftwright._core import (
@@ -82,8 +76,7 @@ from draftwright.linting import (
     lint_location_coverage,
 )
 from draftwright.projection import (
-    _exactify_silhouettes,
-    _raw_view_projector,
+    project_view_geometry,
 )
 from draftwright.recognition import analyse_cylinders
 from draftwright.registry import AnnotationRegistry
@@ -454,34 +447,11 @@ class Drawing:
             for mapping world points to page coordinates.
         """
         la = self.look_at if look_at is None else look_at
-        shape_s = shape if scaled else shape.scale(self.scale)
-        vis, hid = shape_s.project_to_viewport(camera, up, la)
-        vl, hl = list(vis), list(hid)
-        if not vl and not hl:
-            raise ValueError(
-                f"project_to_viewport returned empty geometry for view {name!r} "
-                f"(camera {camera}) — check the camera position and look_at."
-            )
-        axes = view_axes(camera, up, la)
-        # Recover exact circles for revolution silhouettes that HLR projected as
-        # approximating splines (#67) — a no-op when no revolution axis is
-        # parallel to the view direction (e.g. iso/section views).
-        if vl:
-            vd = Vector(la[0] - camera[0], la[1] - camera[1], la[2] - camera[2])
-            vd = vd.normalized()
-            proj = _raw_view_projector(axes, la)
-            vl, n_circ = _exactify_silhouettes(vl, shape_s.faces(), (vd.X, vd.Y, vd.Z), proj)
-            if n_circ:
-                _log.info("  %s: %d silhouette spline(s) refit to circles", name, n_circ)
-        loc = Location((position[0], position[1], 0))
-        placed = Compound(children=vl).locate(loc)
-        placed_hid = Compound(children=hl).locate(loc) if hl else None
-        self.views[name] = (placed, placed_hid)
-        cx, cy, cz = la[0] / self.scale, la[1] / self.scale, la[2] / self.scale
-        self._coords[name] = ViewCoordinates(
-            axes, position[0], position[1], cx, cy, cz, self.scale
+        placed, placed_hid, coords = project_view_geometry(
+            self.scale, name, shape, camera, up, position, look_at=la, scaled=scaled
         )
-        _log.info("  %s: %d visible / %d hidden", name, len(vl), len(hl))
+        self.views[name] = (placed, placed_hid)
+        self._coords[name] = coords
         return self._coords[name]
 
     def coords(self, view):

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -14,8 +14,8 @@ import logging
 import math
 
 import numpy as np
-from build123d import Compound, Edge, GeomType, Plane, ThreePointArc
-from build123d_drafting.helpers import Note, ViewCoordinates
+from build123d import Compound, Edge, GeomType, Location, Plane, ThreePointArc, Vector
+from build123d_drafting.helpers import Note, ViewCoordinates, view_axes
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.GeomAbs import (
     GeomAbs_Cone,
@@ -181,6 +181,43 @@ def _exactify_silhouettes(edges, faces, view_dir, proj_fn, tol=_SILHOUETTE_TOL):
 # scale so it still fills modest zones without dominating.  Shrinking to fit a
 # small zone is never capped.
 _ISO_MAX_GROW = 1.3
+
+
+def project_view_geometry(scale, name, shape, camera, up, position, *, look_at, scaled):
+    """Project *shape* into a view's placed geometry + coordinates — the pure core of
+    :meth:`Drawing._add_view`, returning ``(placed, placed_hid, ViewCoordinates)`` WITHOUT mutating
+    a Drawing (#830). ``Drawing._add_view`` wraps it (stores the result under ``name``); the detail
+    renderer projects a band into a scratch with it and commits the view only if the feature draws
+    legible dims — so no view is ever placed-then-rolled-back.
+
+    *scale* is the world→page scale the coordinates encode; *shape* is in world (unscaled) space
+    unless *scaled* is True. *camera*/*up*/*look_at* are in scaled space (the standard-view
+    convention). Raises ``ValueError`` when the projection is empty (bad camera/look_at)."""
+    shape_s = shape if scaled else shape.scale(scale)
+    vis, hid = shape_s.project_to_viewport(camera, up, look_at)
+    vl, hl = list(vis), list(hid)
+    if not vl and not hl:
+        raise ValueError(
+            f"project_to_viewport returned empty geometry for view {name!r} "
+            f"(camera {camera}) — check the camera position and look_at."
+        )
+    axes = view_axes(camera, up, look_at)
+    # Recover exact circles for revolution silhouettes that HLR projected as approximating splines
+    # (#67) — a no-op when no revolution axis is parallel to the view direction (iso/section views).
+    if vl:
+        vd = Vector(look_at[0] - camera[0], look_at[1] - camera[1], look_at[2] - camera[2])
+        vd = vd.normalized()
+        proj = _raw_view_projector(axes, look_at)
+        vl, n_circ = _exactify_silhouettes(vl, shape_s.faces(), (vd.X, vd.Y, vd.Z), proj)
+        if n_circ:
+            _log.info("  %s: %d silhouette spline(s) refit to circles", name, n_circ)
+    loc = Location((position[0], position[1], 0))
+    placed = Compound(children=vl).locate(loc)
+    placed_hid = Compound(children=hl).locate(loc) if hl else None
+    cx, cy, cz = look_at[0] / scale, look_at[1] / scale, look_at[2] / scale
+    coords = ViewCoordinates(axes, position[0], position[1], cx, cy, cz, scale)
+    _log.info("  %s: %d visible / %d hidden", name, len(vl), len(hl))
+    return placed, placed_hid, coords
 
 
 def _bbox_within(bb, region, tol: float = 0.5) -> bool:

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -114,16 +114,15 @@ def _dwg_getattr_probes(tree: ast.Module) -> list[str]:
 
 # The sanctioned in-build LAYOUT SEAM: the ONLY Drawing privates an engine module may invoke as
 # methods on the duck-typed drawing. The section/detail layout is inherently interactive — it reads
-# its own live output (placed views + occupancy), provisionally places a view, and can roll it back
-# — so these three cannot become "return data for the builder to assemble" without a parallel
-# canvas. #830 Path A accepts them as the PERMANENT seam, and in doing so narrows decision D's
-# method-call exemption (#817 PR4) from a blanket pass to this NAMED allowlist: every OTHER private
-# method call from an engine module is now flagged as a state-bus poke, so the engine cannot
-# re-grow a private-method back-channel beyond the seam. May only SHRINK (e.g. #830 Path B removing
-# the detail rollback would drop _drop_view_coordinates).
-_LAYOUT_SEAM: frozenset[str] = frozenset(
-    {"_add_view", "_set_view_coordinates", "_drop_view_coordinates"}
-)
+# its own live output (placed views + occupancy) to decide where a view goes — so committing a view
+# is a genuine mutation, not "return data for the builder to assemble". #830 Path A accepts these as
+# the PERMANENT seam, and in doing so narrows decision D's method-call exemption (#817 PR4) from a
+# blanket pass to this NAMED allowlist: every OTHER private method call from an engine module is
+# flagged as a state-bus poke, so the engine cannot re-grow a private-method back-channel beyond the
+# seam. May only SHRINK — #840 (Path B) already dropped _drop_view_coordinates by making the detail
+# view transactional (project into a scratch, commit only if the dims land, so no place-then-roll-
+# back). The two survivors are the view-commit primitives.
+_LAYOUT_SEAM: frozenset[str] = frozenset({"_add_view", "_set_view_coordinates"})
 
 
 def _method_call_attrs(tree: ast.Module) -> set[int]:
@@ -198,13 +197,17 @@ def test_write_guard_catches_every_mutation_form():
         assert writes, f"guard missed a mutation form: {snippet!r}"
     # A pure read must NOT register as a write (else every read is a false positive).
     assert not _dwg_private_writes(ast.parse("use(dwg._named)"))
-    # #830 Path A: a call to one of the sanctioned LAYOUT-SEAM methods is exempt from the read
-    # scan (the engine's only legitimate private-method calls) — and ONLY those three.
+    # #830 Path A: a call to one of the sanctioned LAYOUT-SEAM methods is exempt from the read scan
+    # (the engine's only legitimate private-method calls) — and ONLY those two (#840 dropped
+    # _drop_view_coordinates by making the detail view transactional).
     assert _dwg_private_reads(ast.parse("dwg._add_view(...)")) == set()
     assert _dwg_private_reads(ast.parse("dwg._set_view_coordinates(v)")) == set()
-    assert _dwg_private_reads(ast.parse("dwg._drop_view_coordinates(v)")) == set()
     # A call to any OTHER private method is NOT exempt — flagged like a data read, so decision D's
-    # exemption (#817 PR4) is a named seam, not a blanket pass (#830 Path A).
+    # exemption (#817 PR4) is a named seam, not a blanket pass (#830 Path A). _drop_view_coordinates
+    # left the seam (#840), so a call to it is now flagged too.
+    assert _dwg_private_reads(ast.parse("dwg._drop_view_coordinates(v)")) == {
+        "_drop_view_coordinates"
+    }
     assert _dwg_private_reads(ast.parse("dwg._add(x)")) == {"_add"}
     assert _dwg_private_reads(ast.parse("drawing._clear_annotations()")) == {"_clear_annotations"}
     # Every DATA read stays caught (the state-bus back-channel #722 targets).


### PR DESCRIPTION
Closes #840. The last piece of the #830 endgame: the detail view no longer places-then-rolls-back, so `_drop_view_coordinates` leaves the layout seam.

## Before

`_render_detail` placed the view (`_add_view` + `_set_view_coordinates`), called `req.redraw` to try dimensioning into it, and **rolled it back** (`views.pop` + `_drop_view_coordinates`) if nothing legible landed.

## After (try-in-scratch-then-commit)

1. **Pure projector** — extracts the projection out of `Drawing._add_view` into a module-level `project_view_geometry(scale, …)` in `projection.py`, returning `(placed, placed_hid, ViewCoordinates)` with **no Drawing mutation**. Taking `scale` explicitly means projecting at `detail_scale` yields the detail's own coords directly (the old `_add_view` + override existed only because `_add_view` hard-codes the sheet scale). `_add_view` is now a thin wrapper — behaviour-preserving for every view.
2. **`redraw` maps via the passed `coords`** (`coords.pp`) instead of a live `dwg.at(view)`, so it doesn't need the coordinates committed.
3. **Commit geometry (public `views` dict) before redraw** so the feature's dim pass can read `view_bounds`, but commit the **coordinates through the seam only if the dims land**. On failure, pop the geometry — the coords were never committed, so there's no coordinate rollback.

`_drop_view_coordinates` now has zero engine callers; **`_LAYOUT_SEAM` shrinks to `{_add_view, _set_view_coordinates}`** — the two view-commit primitives. The pin test + whole-engine guard track it.

## Note

A subtlety caught in testing: the turned-head redraw calls `_draw_step_chain`, which reads `view_bounds` — so the geometry must be committed before redraw (hence geometry-before / coords-after, with a public-dict rollback of geometry on failure). The prismatic redraw needs neither.

## Verification

- Detail canaries (`test_dense_sheet_canary`), `test_script_detail_parity`, turned-head + prismatic detail tests, section tests, and the smoke tier all pass; the pure-refactor step alone kept 116 view/iso/section tests green. 4-check lint clean.

This ends the #830 view-seam work: attach methods removed (#836/#838), exemption narrowed to a named seam (#839), and the seam now minimal (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)