### PR TITLE
fix(#841): add _Params.note() so slot/pocket handles can anchor notes

### DIFF
--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -327,6 +327,14 @@ class _Params:
         self._sheet._tolerances[(self._i, roles[role], role)] = val
         return self
 
+    def note(self, text, *, view: str | None = None, side: str | None = None) -> _Params:
+        """A free-text manufacturing note on a leader to this feature (#841) —
+        ``sheet.slot(...).note("5X OBROUND SLOT")``. Mirrors :meth:`_Hole.note` /
+        :meth:`_Dim.note`: the handle supplies itself as the target, so (unlike the forwarded
+        ``Sheet.note``) no explicit ``ref`` is needed. ``view``/``side`` override the derived strip."""
+        self._sheet._gdt_note(text, self._i, view=view, side=side)
+        return self
+
 
 class _Control:
     """A fluent GD&T feature-control-frame builder (ADR 0011 P2c.2). One method per ISO 1101

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -327,12 +327,17 @@ class _Params:
         self._sheet._tolerances[(self._i, roles[role], role)] = val
         return self
 
-    def note(self, text, *, view: str | None = None, side: str | None = None) -> _Params:
-        """A free-text manufacturing note on a leader to this feature (#841) —
-        ``sheet.slot(...).note("5X OBROUND SLOT")``. Mirrors :meth:`_Hole.note` /
-        :meth:`_Dim.note`: the handle supplies itself as the target, so (unlike the forwarded
-        ``Sheet.note``) no explicit ``ref`` is needed. ``view``/``side`` override the derived strip."""
-        self._sheet._gdt_note(text, self._i, view=view, side=side)
+    def note(self, text, ref=None, *, view: str | None = None, side: str | None = None) -> _Params:
+        """A free-text manufacturing note (#841). With no *ref* the note anchors to THIS feature —
+        ``sheet.slot(...).note("5X OBROUND SLOT")`` — mirroring :meth:`_Hole.note` / :meth:`_Dim.note`
+        (previously this raised, because the forwarded ``Sheet.note`` needs a target). An explicit
+        *ref* (a face or feature) still forwards to :meth:`Sheet.note`, preserving the handle's
+        forwarding contract for ``sheet.slot(...).note("DEBURR", face)``. Returns the handle
+        (chainable); ``view``/``side`` override the derived strip."""
+        if ref is None:
+            self._sheet._gdt_note(text, self._i, view=view, side=side)
+        else:
+            self._sheet.note(text, ref, view=view, side=side)
         return self
 
 

--- a/tests/test_sheet_notes.py
+++ b/tests/test_sheet_notes.py
@@ -66,6 +66,12 @@ def test_slot_and_pocket_handle_note():
     assert h.note("5X OBROUND SLOT") is h  # explicit method, chainable — no TypeError
     nt = next(f for f in s.features if f.kind == "note")
     assert nt.text == "5X OBROUND SLOT"
+    assert nt.origin is s.features[0]  # anchored to THIS slot feature
+
+    # The explicit-ref form still forwards to Sheet.note (the __getattr__ contract is preserved):
+    top = part.faces().sort_by()[-1]
+    h.note("DEBURR", top)
+    assert any(f.kind == "note" and f.text == "DEBURR" and f.origin is None for f in s.features)
 
     p = Box(60, 30, 20) - Pos(0, 0, 4) * extrude(Plane.XY * SlotOverall(20, 8), 12)
     s2 = Sheet(p)

--- a/tests/test_sheet_notes.py
+++ b/tests/test_sheet_notes.py
@@ -54,6 +54,35 @@ def test_dim_handle_note():
     assert nt.text == "KNURL 0.8 STRAIGHT" and nt.view == "plan"
 
 
+def test_slot_and_pocket_handle_note():
+    # #841: the multi-param handle (slot/pocket/envelope) grew an explicit .note(), so
+    # `sheet.slot(...).note("...")` works like a hole/dim handle instead of forwarding to the
+    # bare Sheet.note and raising "missing 'ref'".
+    from build123d import Box, Plane, SlotOverall, extrude
+
+    part = Box(60, 30, 12) - extrude(Plane.XY * SlotOverall(20, 8), 12, both=True)
+    s = Sheet(part)
+    h = s.slot(width=8, length=20, long_axis="x", width_axis="y", lo=-10, hi=10, w_center=0)
+    assert h.note("5X OBROUND SLOT") is h  # explicit method, chainable — no TypeError
+    nt = next(f for f in s.features if f.kind == "note")
+    assert nt.text == "5X OBROUND SLOT"
+
+    p = Box(60, 30, 20) - Pos(0, 0, 4) * extrude(Plane.XY * SlotOverall(20, 8), 12)
+    s2 = Sheet(p)
+    s2.pocket(
+        width=8,
+        length=20,
+        depth=12,
+        long_axis="x",
+        width_axis="y",
+        depth_axis="z",
+        w_center=0,
+        lo=-10,
+        hi=10,
+    ).note("POCKET NOTE")
+    assert any(f.kind == "note" and f.text == "POCKET NOTE" for f in s2.features)
+
+
 def test_dim_handle_knurl():
     # #765: knurl() is sugar over note() with canonical KNURL formatting.
     part = _part()


### PR DESCRIPTION
First of the #841 items — the small, self-contained API-consistency fix.

## Problem

`sheet.slot(...)` / `sheet.pocket(...)` return a `_Params` handle whose `__getattr__` forwards unknown attributes to the owning `Sheet`. So `slot.note("...")` resolved to the bare `Sheet.note(text, ref, *, view, side)` and raised:
```
TypeError: Sheet.note() missing 1 required positional argument: 'ref'
```
— unlike `_Hole.note()` / `_Dim.note()`, which have explicit `.note()` methods that supply the target implicitly. Easy for an AI author to trip on.

## Fix

Add an explicit `_Params.note(text, *, view=None, side=None)` mirroring the hole/dim handles — it calls `self._sheet._gdt_note(text, self._i, ...)`, supplying the handle's own feature as the target, and returns `self` (chainable). No `ref` needed.

Test covers both slot and pocket handles (chainable, and the note lands as a `note` feature).

## The rest of #841 (separate PRs)

- `Sheet.section()` / `Sheet.detail()` public verbs (needs wiring to the section/detail machinery).
- Repeated slot/pocket callout consolidation (one representative + `NX`/pitch location dims) and note side-sensitivity — the substantive rendering/layout piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)