### PR TITLE
feat(#841): public Sheet.section() / Sheet.detail() view verbs

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -93,6 +93,10 @@ def _will_section(model, *, is_rotational=False, cx=0.0, cy=0.0) -> bool:
 
     if model is None:
         return False
+    # An explicit Sheet.section() request (ADR 0011, #841) reserves the row even when no
+    # hole gate qualifies — a blind pocket's floor/depth section has no driving Z hole.
+    if getattr(model, "decorations", {}).get("section") is not None:
+        return True
     features = getattr(model, "features", model)
 
     def feature_member(pt) -> bool:

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -292,7 +292,14 @@ def plan_sections(model: PartModel, feature_keys: set[HoleRef]) -> SectionPlan |
     (ISO practice), tie-broken toward the part centre. Only holes whose positions are
     in *feature_keys* count (so a rotational part's concentric bores, dimensioned by
     the centreline leaders, don't drive a section). ``None`` when no section is
-    warranted."""
+    warranted.
+
+    An **explicit** request (``decorations["section"]``, the ADR 0011 ``Sheet.section``
+    verb, #841) forces a cut at that Y regardless of the auto trigger — so a blind
+    pocket, which no hole gate recognises, still gets its floor/depth section."""
+    requested = model.decorations.get("section")
+    if requested is not None:
+        return SectionPlan(cut_y=float(requested))
     qual_ys: list[float] = []
     for f in model.features:
         if not isinstance(f, HoleFeature | PatternFeature) or f.frame.axis != "z":

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -42,6 +42,7 @@ feature itself) so you can ``.fit(...)`` / ``.tolerance(...)`` it without re-dec
 
 from __future__ import annotations
 
+import math
 import warnings
 from dataclasses import replace
 
@@ -743,6 +744,8 @@ class Sheet:
         part centre. The section renders last (its room check clears the right-of-side-view
         band), so declare it after the per-feature verbs. Chainable."""
         if at is not None:
+            if not math.isfinite(at):
+                raise ValueError(f"section(at=…) needs a finite Y, got {at!r}")
             self._section = ("at", float(at))
         elif feature is not None:
             _target, src = self._gdt_ref(feature)
@@ -797,6 +800,11 @@ class Sheet:
         :class:`Feature` already in :attr:`features` → its feature + index (the index re-binds
         provenance at build); a build123d face or an external Feature → ``(ref, None)``."""
         if isinstance(ref, (_Hole, _Dim, _Params)):
+            if ref._sheet is not self:  # a handle from ANOTHER sheet indexes the wrong features
+                raise ValueError(
+                    "the handle belongs to a different Sheet — use a handle/index/Feature "
+                    "declared on this sheet"
+                )
             return self._features[ref._i], ref._i
         if isinstance(ref, int) and not isinstance(ref, bool):
             i = self._index_of(ref)
@@ -913,11 +921,21 @@ class Sheet:
         """Resolve the requested :meth:`section` to a cut-plane Y (materialized at build so a
         handle recorded before a later size verb resolves against the FINAL feature)."""
         kind, payload = self._section  # type: ignore[misc]  # guarded by the caller
-        if kind == "at":
-            return float(payload)
         if kind == "feature":
-            return float(self._features[payload].frame.origin[1])
-        return float(self._part.bounding_box().center().Y)  # bare section() → part centre
+            return float(self._features[payload].frame.origin[1])  # in range by construction
+        if kind == "auto":
+            return float(self._part.bounding_box().center().Y)  # bare section() → part centre
+        # An explicit at= is untrusted: a plane outside the part's Y extent leaves the body
+        # uncut (a plain projection mislabelled "SECTION A–A") or clears it (a section dropped
+        # after layout already reserved its row). Reject it here (#841 review).
+        cut_y = float(payload)
+        bb = self._part.bounding_box()
+        if not (bb.min.Y <= cut_y <= bb.max.Y):
+            raise ValueError(
+                f"section(at={cut_y:.3g}) is outside the part Y extent "
+                f"[{bb.min.Y:.3g}, {bb.max.Y:.3g}] — the plane would not cut the solid"
+            )
+        return cut_y
 
     def model(self):
         """The IR the engine will draw (detection skipped) — for inspection. Wraps the

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -930,10 +930,10 @@ class Sheet:
         # after layout already reserved its row). Reject it here (#841 review).
         cut_y = float(payload)
         bb = self._part.bounding_box()
-        if not (bb.min.Y <= cut_y <= bb.max.Y):
+        if not (bb.min.Y < cut_y < bb.max.Y):  # strictly inside — a grazing plane cuts nothing
             raise ValueError(
-                f"section(at={cut_y:.3g}) is outside the part Y extent "
-                f"[{bb.min.Y:.3g}, {bb.max.Y:.3g}] — the plane would not cut the solid"
+                f"section(at={cut_y:.3g}) is not strictly inside the part Y extent "
+                f"({bb.min.Y:.3g}, {bb.max.Y:.3g}) — the plane would not cut the solid"
             )
         return cut_y
 

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -468,6 +468,10 @@ class Sheet:
         # engine's generic auto-placed Drawing.add_table, AFTER the drawing is built so they sit
         # clear of the views + title block (like the hole table). Each: {rows, prefer, name}.
         self._tables: list = []
+        # A requested section A–A (#841): ``None`` = no request, else a resolver tuple
+        # (``kind``, ``payload``) materialized to a cut-plane Y in ``_decorations`` — ``at``
+        # a literal Y, ``feature`` a declared-feature index, ``auto`` the part-centre Y.
+        self._section: tuple | None = None
         self._opts = dict(
             title=title, number=number, scale=_parse_scale(scale), page=page, out=out
         )
@@ -726,6 +730,40 @@ class Sheet:
         self._append_gdt(_declare_note(text, target, self._part, view=view, side=side), src)
         return self
 
+    def section(self, feature=None, *, at=None) -> Sheet:
+        """Request a full **section A–A** (#841) — the part-level verb behind the auto section.
+
+        A section fires automatically only when a Z-axis hole/pattern has a counterbore,
+        spotface, or blind bottom; a blind pocket has no such driving hole, so its floor
+        and depth stay hidden-line-only. This forces a cut so that internal profile reads.
+
+        The cut plane is normal to Y. *feature* — a fluent handle / :class:`Feature` /
+        index — cuts through that feature's centre (the natural "section through this
+        pocket"); ``at=<y>`` cuts at an explicit Y; bare ``section()`` cuts through the
+        part centre. The section renders last (its room check clears the right-of-side-view
+        band), so declare it after the per-feature verbs. Chainable."""
+        if at is not None:
+            self._section = ("at", float(at))
+        elif feature is not None:
+            _target, src = self._gdt_ref(feature)
+            if src is None:
+                raise ValueError(
+                    "section(feature=…) needs a declared feature (a handle/index/Feature "
+                    "on this sheet) — pass at=<y> for a bare cut-plane position"
+                )
+            self._section = ("feature", src)
+        else:
+            self._section = ("auto", None)
+        return self
+
+    def detail(self) -> Sheet:
+        """Request the enlarged **detail view** (#42/#307) — the ``build_drawing(detail_view=True)``
+        opt-in as a Sheet verb (#841). Adds a magnified crop of the step-height region when the
+        geometry warrants one (a no-op otherwise). Chainable. Not feature-targeted — for a blind
+        pocket's floor/depth prefer :meth:`section`."""
+        self._opts["detail_view"] = True
+        return self
+
     def control(self, ref, *, view: str | None = None, side: str | None = None) -> _Control:
         """A GD&T feature-control-frame builder on *ref* — a feature handle / :class:`Feature` /
         index, or a build123d planar face. Chain one method per ISO 1101 characteristic
@@ -864,7 +902,22 @@ class Sheet:
         ``(feature, kind)`` (or role-keyed ``(feature, kind, role)``, #746) decoration map
         the planner reads (P2a). The tail of the key (``kind`` or ``kind, role``) passes
         through unchanged; only the leading index becomes the feature."""
-        return {(self._features[i], *rest): tol for (i, *rest), tol in self._tolerances.items()}
+        deco: dict = {
+            (self._features[i], *rest): tol for (i, *rest), tol in self._tolerances.items()
+        }
+        if self._section is not None:
+            deco["section"] = self._section_cut_y()  # the #841 cut-plane Y (scalar key)
+        return deco
+
+    def _section_cut_y(self) -> float:
+        """Resolve the requested :meth:`section` to a cut-plane Y (materialized at build so a
+        handle recorded before a later size verb resolves against the FINAL feature)."""
+        kind, payload = self._section  # type: ignore[misc]  # guarded by the caller
+        if kind == "at":
+            return float(payload)
+        if kind == "feature":
+            return float(self._features[payload].frame.origin[1])
+        return float(self._part.bounding_box().center().Y)  # bare section() → part centre
 
     def model(self):
         """The IR the engine will draw (detection skipped) — for inspection. Wraps the

--- a/tests/test_sheet_section.py
+++ b/tests/test_sheet_section.py
@@ -1,0 +1,75 @@
+"""``Sheet.section()`` / ``Sheet.detail()`` — the ADR 0011 part-level view verbs (#841).
+
+A blind pocket has no counterbore/spotface/blind-Z-hole to auto-trigger a section, so its
+floor and depth stay hidden-line-only. ``Sheet.section()`` forces a cut through a chosen
+feature (or an explicit Y, or the part centre); ``Sheet.detail()`` exposes the enlarged
+detail-view opt-in as a verb. These tests pin the request→cut-plane resolution, that the
+forced section actually renders (and is lint-clean), and the no-request canary.
+"""
+
+import pytest
+from build123d import Box
+
+from draftwright.sheet import Sheet
+
+
+def _blind_pocket_sheet():
+    """An 80×50×20 bar with ONE declared blind rectangular pocket (no auto-section trigger)."""
+    s = Sheet(Box(80, 50, 20))
+    s.envelope()
+    p = s.pocket(
+        width=8.0,
+        length=14.0,
+        depth=12.0,
+        long_axis="x",
+        width_axis="y",
+        depth_axis="z",
+        lo=-7.0,
+        hi=7.0,
+        w_center=0.0,
+        at=(0.0, 0.0, 4.0),
+    )
+    return s, p
+
+
+def test_no_section_without_the_verb():
+    # Canary: a plain blind pocket does NOT auto-section — proving the verb is what forces it.
+    s, _p = _blind_pocket_sheet()
+    assert "section_aa" not in s.build().views
+
+
+def test_section_through_feature_renders():
+    s, p = _blind_pocket_sheet()
+    assert s.section(p) is s  # chainable
+    dwg = s.build()
+    assert "section_aa" in dwg.views
+    assert dwg.get_annotation("section_caption").label == "SECTION A–A"
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
+
+
+def test_cut_plane_resolution():
+    # feature → its centre Y; explicit at= → that Y; bare section() → part-centre Y.
+    s, p = _blind_pocket_sheet()
+    s.section(p)
+    assert s._decorations()["section"] == 0.0  # the pocket sits at y=0
+
+    s, _p = _blind_pocket_sheet()
+    s.section(at=12.0)
+    assert s._decorations()["section"] == 12.0
+
+    s, _p = _blind_pocket_sheet()
+    s.section()
+    assert s._decorations()["section"] == 0.0  # the 80×50×20 box centre
+
+
+def test_section_needs_a_declared_feature():
+    s, _p = _blind_pocket_sheet()
+    with pytest.raises(ValueError, match="needs a declared feature"):
+        s.section(object())  # a bare build123d-ish object is not on this sheet
+
+
+def test_detail_sets_the_opt_and_chains():
+    s, _p = _blind_pocket_sheet()
+    assert s.detail() is s
+    assert s._opts["detail_view"] is True
+    s.build()  # builds without error (a no-op detail on geometry that doesn't warrant one)

--- a/tests/test_sheet_section.py
+++ b/tests/test_sheet_section.py
@@ -68,6 +68,29 @@ def test_section_needs_a_declared_feature():
         s.section(object())  # a bare build123d-ish object is not on this sheet
 
 
+def test_section_rejects_a_foreign_handle():
+    # A handle from another Sheet indexes the wrong feature list — must raise, not silently
+    # cut the wrong feature (or IndexError). Shared _gdt_ref guard (#841 review).
+    s_a, p_a = _blind_pocket_sheet()
+    s_b, _p_b = _blind_pocket_sheet()
+    with pytest.raises(ValueError, match="different Sheet"):
+        s_b.section(p_a)
+
+
+def test_section_rejects_non_finite_and_out_of_range_at():
+    s, _p = _blind_pocket_sheet()
+    with pytest.raises(ValueError, match="finite"):
+        s.section(at=float("nan"))
+    with pytest.raises(ValueError, match="finite"):
+        s.section(at=float("inf"))
+    # An in-range value is fine; an out-of-range plane (the 50-wide bar spans y∈[-25, 25])
+    # is rejected at build resolution rather than mislabelling an uncut projection "SECTION A–A".
+    s, _p = _blind_pocket_sheet()
+    s.section(at=100.0)
+    with pytest.raises(ValueError, match="outside the part Y extent"):
+        s._decorations()
+
+
 def test_detail_sets_the_opt_and_chains():
     s, _p = _blind_pocket_sheet()
     assert s.detail() is s

--- a/tests/test_sheet_section.py
+++ b/tests/test_sheet_section.py
@@ -87,7 +87,12 @@ def test_section_rejects_non_finite_and_out_of_range_at():
     # is rejected at build resolution rather than mislabelling an uncut projection "SECTION A–A".
     s, _p = _blind_pocket_sheet()
     s.section(at=100.0)
-    with pytest.raises(ValueError, match="outside the part Y extent"):
+    with pytest.raises(ValueError, match="not strictly inside"):
+        s._decorations()
+    # A grazing plane on the bounding face cuts nothing — rejected too (strict, not inclusive).
+    s, _p = _blind_pocket_sheet()
+    s.section(at=25.0)  # exactly the +Y face of the 50-wide bar
+    with pytest.raises(ValueError, match="not strictly inside"):
         s._decorations()
 
 


### PR DESCRIPTION
Part 2 of #841 (follow-up to the tuner-jig blind obround pockets, #837). Addresses **desired outcome 4** — "expose a supported way to request a section/detail view for a selected feature."

## Problem

A section A–A auto-fires only when a Z-axis hole/pattern has a counterbore, spotface, or blind bottom (`plan_sections`). A blind **pocket** has no such driving hole, so its floor and depth stay hidden-line-only, and 0.3.8 exposes no public Sheet verb to request one. The tuner-jig approximation had to fake it with a leader reading `7.9 × 13.6 × 19 DEEP`.

## Change

Two part-level `Sheet` verbs:

- **`section(feature=None, *, at=None)`** — force a full section A–A. The cut-plane Y is threaded through `model.decorations["section"]` (the ADR 0011 authored-aspect side-layer that already merges into *both* the layout sizing model and the render model). `plan_sections` and `_will_section` now honour it ahead of the auto trigger, so the layout reserves the row and the section renders. `feature` (a handle/index/Feature on the sheet) → its centre Y; `at=` → an explicit Y; bare `section()` → the part centre.
- **`detail()`** — expose the existing `build_drawing(detail_view=True)` opt-in as a chainable verb.

The section renderer cuts the *solid* at the plane, so the pocket profile reads regardless of feature kind.

## Tests

`tests/test_sheet_section.py` (5 new): a **canary** proving a plain blind pocket does NOT auto-section (so the verb is what forces it), the feature-form render + lint-clean, cut-plane resolution for all three forms, the undeclared-feature error, and `detail()` opt/chaining. Regression: 307 across the declare/sheet/planner/section suites, all 4 lint checks green.

## Deferred to later PRs (per #841)

Repeated-callout consolidation (one `5X` size dim + pattern locations) and note side-sensitivity remain separate PRs.

Part of #841.