### PR TITLE
feat(#841): recognised pocket-pattern kind — recognition + emit (PR 2/2)

### DIFF
--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -37,6 +37,7 @@ from draftwright.model.ir import (
     PlateFeature,
     PmiFeature,
     PocketFeature,
+    PocketPatternFeature,
     RotationalFeature,
     SlotFeature,
     StepFeature,
@@ -56,6 +57,8 @@ from draftwright.recognition import (
     LinearArray,
     Plate,
     Pocket,
+    PocketArray,
+    PocketGrid,
     RectGrid,
     Slot,
     StepShoulder,
@@ -70,6 +73,7 @@ from draftwright.recognition import (
     recognise_hole_patterns,
     recognise_holes,
     recognise_plates,
+    recognise_pocket_patterns,
     recognise_pockets,
     recognise_slots,
     recognise_step_shoulders,
@@ -263,7 +267,10 @@ def _convert_slot(sl: Slot, ctx: ConvContext) -> SlotFeature:
     )
 
 
-def _convert_pocket(pk: Pocket, ctx: ConvContext) -> PocketFeature:
+def _member_pocket(pk: Pocket) -> PocketFeature:
+    """A recogniser `Pocket` → an IR `PocketFeature`. The representative member of a
+    `PocketPatternFeature` too (its size/axes drive the grouped callout), so it is factored
+    out of :func:`_convert_pocket` and reused by :func:`_pocket_pattern_feature` (#841)."""
     # Frame at the recess centroid — in-plane centre + mid-depth. The render leader
     # projects into the view normal to the depth axis, so the depth coord is inert,
     # but a true centroid keeps the frame honest.
@@ -282,6 +289,49 @@ def _convert_pocket(pk: Pocket, ctx: ConvContext) -> PocketFeature:
         w_center=pk.w_center,
         lo=pk.lo,
         hi=pk.hi,
+    )
+
+
+def _convert_pocket(pk: Pocket, ctx: ConvContext) -> PocketFeature:
+    return _member_pocket(pk)
+
+
+def _pocket_pattern_feature(pat, members) -> PocketPatternFeature:
+    """Map a recognised pocket array + its member pockets to a `PocketPatternFeature` (#841) —
+    the recess analog of :func:`_pattern_feature`. Composes a representative member pocket (its
+    width/length/depth drive the grouped ``count× W×L×D DEEP`` callout) and keeps the member
+    centres as the raw arrangement the pitch furniture indexes. The frame axis is the members'
+    shared DEPTH axis (the opening normal), matching the declared `pocket_pattern`."""
+    n = len(members)
+    axis = members[0].depth_axis  # the opening normal — the plane the array lies in
+    locs = tuple(_xyz(m.location) for m in members)  # raw arrangement — never discarded
+    if isinstance(pat, PocketGrid):
+        frame = Frame(_xyz(pat.center), axis)
+        return PocketPatternFeature(
+            frame=frame,
+            pattern="grid",
+            count=n,
+            member=_member_pocket(members[0]),
+            members=locs,
+            grid=(pat.row_pitch, pat.col_pitch),
+            rows=pat.rows,
+            cols=pat.cols,
+            angle=pat.angle,
+        )
+    # PocketArray (linear) — the frame sits at the array centroid (no separate centre field).
+    c = (
+        sum(m.location[0] for m in members) / n,
+        sum(m.location[1] for m in members) / n,
+        sum(m.location[2] for m in members) / n,
+    )
+    return PocketPatternFeature(
+        frame=Frame(c, axis),
+        pattern="linear",
+        count=n,
+        member=_member_pocket(members[0]),
+        members=locs,
+        pitch=pat.pitch,
+        direction=tuple(pat.direction),
     )
 
 
@@ -390,6 +440,8 @@ _DERIVED_CONVERTERS: dict[type, Callable[..., Feature]] = {
     BoltCircle: _pattern_feature,
     LinearArray: _pattern_feature,
     RectGrid: _pattern_feature,
+    PocketArray: _pocket_pattern_feature,
+    PocketGrid: _pocket_pattern_feature,
 }
 
 # Tier 3 — orchestrated records: no per-record converter, by design. Each is either a
@@ -426,6 +478,7 @@ def build_part_model(
     bosses=None,
     slots=None,
     pockets=None,
+    pocket_patterns=None,
     prof=_UNSET,
     step_zs=None,
     rotational=None,
@@ -493,10 +546,21 @@ def build_part_model(
     for sl in slots:
         features.append(convert(sl, ctx))
 
-    # Blind rectangular recesses — floored slots/pockets (#148a).
+    # Blind rectangular recesses — floored slots/pockets (#148a). A recognised array of
+    # identical pockets becomes ONE PocketPatternFeature (count× W×L×D + pitch, #841); its
+    # member pockets are NOT also emitted individually — the same grouped-callout rule as
+    # hole patterns above (member exclusion by id()).
     if pockets is None:
         pockets = recognise_pockets(part)
+    if pocket_patterns is None:
+        pocket_patterns = recognise_pocket_patterns(pockets)
+    patterned_pk: set[int] = set()
+    for pat in pocket_patterns:
+        patterned_pk.update(id(pk) for pk in pat.pockets)
+        features.append(_pocket_pattern_feature(pat, list(pat.pockets)))
     for pk in pockets:
+        if id(pk) in patterned_pk:
+            continue
         features.append(convert(pk, ctx))
 
     # Turned / circlip grooves (#148c) — recognised up front so the turned-step chain can

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -554,12 +554,17 @@ def build_part_model(
         pockets = recognise_pockets(part)
     if pocket_patterns is None:
         pocket_patterns = recognise_pocket_patterns(pockets)
-    patterned_pk: set[int] = set()
+    # Exclude members by VALUE, not id(): `Pocket` is a frozen (hashable) value record and two
+    # distinct pockets can never be value-equal (their positions differ), so a value-set
+    # excludes members even when `pocket_patterns=` is INJECTED from value-equal copies whose
+    # ids differ from `pockets` (Codex #849) — where an id-set would emit both the pattern and
+    # the individual pockets, restoring the competing dims this grouping removes.
+    patterned_pk: set = set()
     for pat in pocket_patterns:
-        patterned_pk.update(id(pk) for pk in pat.pockets)
+        patterned_pk.update(pat.pockets)
         features.append(_pocket_pattern_feature(pat, list(pat.pockets)))
     for pk in pockets:
-        if id(pk) in patterned_pk:
+        if pk in patterned_pk:
             continue
         features.append(convert(pk, ctx))
 

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -90,7 +90,15 @@ from draftwright.recognition.levels import (
     step_level_zs,
 )
 from draftwright.recognition.plates import Plate, recognise_plates
-from draftwright.recognition.slots import Pocket, Slot, recognise_pockets, recognise_slots
+from draftwright.recognition.slots import (
+    Pocket,
+    PocketArray,
+    PocketGrid,
+    Slot,
+    recognise_pocket_patterns,
+    recognise_pockets,
+    recognise_slots,
+)
 from draftwright.recognition.turned import TurnedProfile, TurnedStep, recognise_turned_steps
 
 __all__ = [
@@ -108,6 +116,8 @@ __all__ = [
     "LinearArray",
     "Plate",
     "Pocket",
+    "PocketArray",
+    "PocketGrid",
     "RectGrid",
     "Slot",
     "StepShoulder",
@@ -132,6 +142,7 @@ __all__ = [
     "recognise_hole_patterns",
     "recognise_holes",
     "recognise_plates",
+    "recognise_pocket_patterns",
     "recognise_pockets",
     "recognise_slots",
     "recognise_turned_steps",

--- a/src/draftwright/recognition/_features.py
+++ b/src/draftwright/recognition/_features.py
@@ -838,8 +838,12 @@ def _as_bolt_circle(holes, pts):
     return BoltCircle(holes=tuple(holes), center=center, diameter=round(2 * r, 2))
 
 
-def _as_linear_array(holes, pts):
-    """LinearArray when *pts* (2D) are collinear at constant pitch."""
+def _as_linear_array(members, pts, make):
+    """A linear-array record when *pts* (2D) are collinear at constant pitch.
+
+    Record-generic (#635): *make* ``(ordered_members, pitch, direction) -> Record`` builds the
+    concrete record (a :class:`LinearArray` for holes, a ``PocketArray`` for pockets) so the
+    collinearity/pitch geometry is shared. *members* need a ``.location`` (world centre)."""
     n = len(pts)
     # endpoints are the farthest-apart pair: robust for any orientation. A
     # lexicographic (x, y) sort would pick the wrong ends for a near-axis row
@@ -871,15 +875,15 @@ def _as_linear_array(holes, pts):
     if max(abs(p - pitch) for p in pitches) > _pattern_tol(pitch):
         return None
     # order members along the array, in world coordinates
-    ordered = sorted(zip(proj, holes, strict=True), key=lambda t: t[0])
+    ordered = sorted(zip(proj, members, strict=True), key=lambda t: t[0])
     w0 = ordered[0][1].location
     w1 = ordered[-1][1].location
     d = tuple(b - a for a, b in zip(w0, w1, strict=True))
     norm = math.hypot(d[0], d[1], d[2])
-    return LinearArray(
-        holes=tuple(h for _, h in ordered),
-        pitch=round(pitch, 2),
-        direction=_unit(tuple(c / norm for c in d)),
+    return make(
+        tuple(h for _, h in ordered),
+        round(pitch, 2),
+        _unit(tuple(c / norm for c in d)),
     )
 
 
@@ -933,11 +937,11 @@ def _bolt_circle_candidates(members, pts):
     return out
 
 
-def _linear_array_candidates(members, pts):
+def _linear_array_candidates(members, pts, make):
     """All linear arrays within a spec group: every pair seeds a line, the
     group's collinear points are gathered and sorted, and each maximal
     constant-pitch run of ≥3 becomes a candidate. Returns
-    ``(LinearArray, frozenset(member indices))`` candidates."""
+    ``(record, frozenset(member indices))`` candidates; *make* builds the record (#635)."""
     n = len(pts)
     out, seen = [], set()
     for i in range(n):
@@ -971,19 +975,20 @@ def _linear_array_candidates(members, pts):
                 run_key = frozenset(run)
                 if len(run) >= 3 and run_key not in seen:
                     seen.add(run_key)
-                    pat = _as_linear_array([members[m] for m in run], [pts[m] for m in run])
+                    pat = _as_linear_array([members[m] for m in run], [pts[m] for m in run], make)
                     if pat is not None:
                         out.append((pat, run_key))
                 a = b  # a broken pitch starts the next run at the break point
     return out
 
 
-def _rect_grid(members, pts):
-    """A :class:`RectGrid` when the whole spec group fills a regular N×M
-    rectangular lattice, else ``None``. The two shortest near-orthogonal
-    pairwise vectors define the lattice basis; every point must land on an
-    integer cell and every cell must be occupied (no holes, no extras). 2×2 is
-    excluded — four lattice corners are a rectangle, not a grid."""
+def _rect_grid(members, pts, make):
+    """A rectangular-grid record when the whole spec group fills a regular N×M
+    lattice, else ``None``. The two shortest near-orthogonal pairwise vectors
+    define the lattice basis; every point must land on an integer cell and every
+    cell must be occupied (no holes, no extras). 2×2 is excluded — four lattice
+    corners are a rectangle, not a grid. *make* ``(members, rows, cols, row_pitch,
+    col_pitch, angle, center) -> Record`` builds the concrete record (#635)."""
     n = len(pts)
     if n < 6:
         return None
@@ -1030,13 +1035,29 @@ def _rect_grid(members, pts):
     if rows < 2 or cols < 2 or max(rows, cols) < 3 or rows * cols != n:
         return None
     center = tuple(sum(c) / n for c in zip(*(h.location for h in members), strict=True))
+    return make(
+        tuple(members),
+        rows,
+        cols,
+        round(l1, 2),
+        round(l2, 2),
+        round(math.degrees(math.atan2(u1[1], u1[0])) % 90.0, 2),
+        center,
+    )
+
+
+def _mk_hole_linear(members, pitch, direction):
+    return LinearArray(holes=tuple(members), pitch=pitch, direction=direction)
+
+
+def _mk_hole_grid(members, rows, cols, row_pitch, col_pitch, angle, center):
     return RectGrid(
         holes=tuple(members),
         rows=rows,
         cols=cols,
-        row_pitch=round(l1, 2),
-        col_pitch=round(l2, 2),
-        angle=round(math.degrees(math.atan2(u1[1], u1[0])) % 90.0, 2),
+        row_pitch=row_pitch,
+        col_pitch=col_pitch,
+        angle=angle,
         center=center,
     )
 
@@ -1075,11 +1096,11 @@ def recognise_hole_patterns(holes) -> list[BoltCircle | LinearArray | RectGrid]:
             for h in members
         ]
         candidates: list = []
-        grid = _rect_grid(members, pts)
+        grid = _rect_grid(members, pts, _mk_hole_grid)
         if grid is not None:
             candidates.append((grid, frozenset(range(len(members)))))
         candidates += _bolt_circle_candidates(members, pts)
-        candidates += _linear_array_candidates(members, pts)
+        candidates += _linear_array_candidates(members, pts, _mk_hole_linear)
         # allocate largest-first; a hole used by one pattern is off the table
         # for the rest (stable sort keeps grids ahead of circles ahead of rows
         # at equal size)

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -133,6 +133,46 @@ class Pocket(Record):
     def depth_axis(self) -> str:
         return next(a for a in "xyz" if a not in (self.width_axis, self.long_axis))
 
+    @property
+    def location(self) -> tuple[float, float, float]:
+        """The recess centroid in world XYZ — mid-span along ``long_axis``, the centreline on
+        ``width_axis``, mid-depth on ``depth_axis`` (matches ``detect._convert_pocket``). The
+        `.location` the shared pattern geometry (#635) clusters on, as holes carry."""
+        coord = {
+            self.long_axis: (self.lo + self.hi) / 2,
+            self.width_axis: self.w_center,
+            self.depth_axis: (self.d_lo + self.d_hi) / 2,
+        }
+        return (coord["x"], coord["y"], coord["z"])
+
+
+@dataclass(frozen=True)
+class PocketArray(Record):
+    """N identical blind pockets in a straight, constant-pitch line (#841) — the recess analog
+    of :class:`~draftwright.recognition._features.LinearArray`. ``pockets`` are the member
+    :class:`Pocket` records (ordered along the array); ``pitch`` is the centre-to-centre spacing
+    and ``direction`` the (unit) array axis, both read by ``detect._pocket_pattern_feature``."""
+
+    pockets: tuple
+    pitch: float
+    direction: tuple
+
+
+@dataclass(frozen=True)
+class PocketGrid(Record):
+    """N×M identical blind pockets on a rectangular lattice (#841) — the recess analog of
+    :class:`~draftwright.recognition._features.RectGrid`. ``pockets`` are the member
+    :class:`Pocket` records; the lattice is ``rows``×``cols`` at ``row_pitch``/``col_pitch``,
+    rotated ``angle`` degrees about ``center``."""
+
+    pockets: tuple
+    rows: int
+    cols: int
+    row_pitch: float
+    col_pitch: float
+    angle: float
+    center: tuple
+
 
 # When the two non-width slot extents are within this fraction of each other the
 # slot is near-square in that plane and "which is the length" is ambiguous; the
@@ -900,3 +940,83 @@ def recognise_pockets(part) -> list[Pocket]:
     # recover them from their end caps (#837) — the blind counterpart of the through-slot path.
     candidates.extend(_recognise_obround_from_ends(part, faces, blind=True))
     return _extend_obround_ends(_merge(candidates), part)
+
+
+def _pocket_spec_key(pk: Pocket) -> tuple:
+    """The grouping key shared by pockets of the *same milled recess* — same orientation and
+    size. Only identical, same-orientation pockets can form one array (a 90°-rotated pocket
+    swaps width_axis/long_axis and reads as a different feature). Sizes snap to 3 dp so
+    boolean-op float noise does not split an array (mirrors ``HoleSpec``'s axis snap)."""
+    return (
+        pk.width_axis,
+        pk.long_axis,
+        round(pk.width, 3),
+        round(pk.length, 3),
+        round(pk.depth, 3),
+    )
+
+
+def _mk_pocket_linear(members, pitch, direction) -> PocketArray:
+    return PocketArray(pockets=tuple(members), pitch=pitch, direction=direction)
+
+
+def _mk_pocket_grid(members, rows, cols, row_pitch, col_pitch, angle, center) -> PocketGrid:
+    return PocketGrid(
+        pockets=tuple(members),
+        rows=rows,
+        cols=cols,
+        row_pitch=row_pitch,
+        col_pitch=col_pitch,
+        angle=angle,
+        center=center,
+    )
+
+
+def recognise_pocket_patterns(pockets) -> list[PocketArray | PocketGrid]:
+    """Recognise :class:`PocketArray` (linear) and :class:`PocketGrid` (rectangular) arrays
+    among *pockets* (``Pocket`` records, e.g. from :func:`recognise_pockets`) — the recess
+    analog of :func:`~draftwright.recognition._features.recognise_hole_patterns`.
+
+    A DERIVED recogniser (single positional inventory, ADR 0013): pockets are grouped by
+    orientation + size (:func:`_pocket_spec_key`), each group's centres are projected into the
+    opening plane (perpendicular to the shared depth axis), and the same collinear / lattice
+    geometry the hole patterns use (shared via *make* factories, #635) is enumerated and
+    allocated greedily largest-first so each pocket belongs to at most one array. Pockets have
+    no bolt-circle form, so only grid + linear candidates are considered. Un-arrayed pockets
+    are simply absent from the result."""
+    from draftwright.recognition._features import (
+        _linear_array_candidates,
+        _plane_uv,
+        _rect_grid,
+    )
+
+    axis_unit = {"x": (1.0, 0.0, 0.0), "y": (0.0, 1.0, 0.0), "z": (0.0, 0.0, 1.0)}
+    groups: dict = {}
+    for pk in pockets:
+        groups.setdefault(_pocket_spec_key(pk), []).append(pk)
+
+    patterns: list[PocketArray | PocketGrid] = []
+    for members in groups.values():
+        if len(members) < 3:
+            continue
+        u, v = _plane_uv(axis_unit[members[0].depth_axis])
+        pts = [
+            (
+                sum(a * b for a, b in zip(pk.location, u, strict=True)),
+                sum(a * b for a, b in zip(pk.location, v, strict=True)),
+            )
+            for pk in members
+        ]
+        candidates: list = []
+        grid = _rect_grid(members, pts, _mk_pocket_grid)
+        if grid is not None:
+            candidates.append((grid, frozenset(range(len(members)))))
+        candidates += _linear_array_candidates(members, pts, _mk_pocket_linear)
+        candidates.sort(key=lambda c: -len(c[1]))
+        used: set = set()
+        for pattern, idx in candidates:
+            if idx & used:
+                continue
+            patterns.append(pattern)
+            used |= idx
+    return patterns

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -943,16 +943,22 @@ def recognise_pockets(part) -> list[Pocket]:
 
 
 def _pocket_spec_key(pk: Pocket) -> tuple:
-    """The grouping key shared by pockets of the *same milled recess* — same orientation and
-    size. Only identical, same-orientation pockets can form one array (a 90°-rotated pocket
-    swaps width_axis/long_axis and reads as a different feature). Sizes snap to 3 dp so
-    boolean-op float noise does not split an array (mirrors ``HoleSpec``'s axis snap)."""
+    """The grouping key shared by pockets of the *same milled recess* — same orientation, size,
+    AND opening plane. Only identical, same-orientation, COPLANAR pockets can form one array (a
+    90°-rotated pocket swaps width_axis/long_axis and reads as a different feature). The
+    depth-axis extent (d_lo, d_hi) is part of the key: pattern detection projects the depth
+    coordinate away, so without it pockets on different-height stepped faces — or opening
+    opposite directions — whose in-plane centres happen to line up would merge into one planar
+    array that does not exist (Codex #849). Coordinates snap to 3 dp so boolean-op float noise
+    does not split an array (mirrors ``HoleSpec``'s axis snap)."""
     return (
         pk.width_axis,
         pk.long_axis,
         round(pk.width, 3),
         round(pk.length, 3),
         round(pk.depth, 3),
+        round(pk.d_lo, 3),
+        round(pk.d_hi, 3),
     )
 
 

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -128,6 +128,11 @@ class Pocket(Record):
     hi: float
     d_lo: float
     d_hi: float
+    # Which depth end is the OPENING: +1 opens toward +depth (floor at d_lo), -1 toward -depth
+    # (floor at d_hi). d_lo/d_hi alone are the unordered extent, so without this two pockets on
+    # opposite faces sharing an absolute depth range are indistinguishable — and would merge into
+    # one impossible array (Codex #849). Defaults to +1 for hand-built records.
+    open_sign: int = 1
 
     @property
     def depth_axis(self) -> str:
@@ -368,6 +373,18 @@ def _floor_ends(faces, s: Slot) -> int:
     return int(_end_capped(faces, foot, foot_area, s.depth_axis, s.d_lo, 1.0)) + int(
         _end_capped(faces, foot, foot_area, s.depth_axis, s.d_hi, -1.0)
     )
+
+
+def _open_sign(faces, s) -> int:
+    """Which depth end *s* opens toward: ``+1`` (floor at ``d_lo``, opens +depth) or ``-1``
+    (floor at ``d_hi``, opens -depth). The capped end is the floor; the pocket opens the other
+    way. Assumes *s* is a blind recess (exactly one floor); the caller has already checked."""
+    foot = {
+        s.width_axis: (s.w_center - s.width / 2, s.w_center + s.width / 2),
+        s.long_axis: (s.lo, s.hi),
+    }
+    foot_area = math.prod(hi - lo for lo, hi in foot.values())
+    return 1 if _end_capped(faces, foot, foot_area, s.depth_axis, s.d_lo, 1.0) else -1
 
 
 def _has_floor(faces, s: Slot) -> bool:
@@ -658,6 +675,7 @@ def _recognise_obround_from_ends(part, faces, *, blind: bool = False):
                         hi=hi_f,
                         d_lo=round(dlo, 2),
                         d_hi=round(dhi, 2),
+                        open_sign=_open_sign(faces, s),  # which face this obround pocket opens
                     )
                 )
                 i += 2
@@ -888,10 +906,9 @@ def _pocket_candidate(fa, fb, faces, part_ext) -> Pocket | None:
         l_lo, l_hi = ranges[long_axis]
         foot = {axis: w_range, long_axis: (l_lo, l_hi)}
         foot_area = width * (l_hi - l_lo)
-        capped = _end_capped(faces, foot, foot_area, depth_axis, d_lo, 1.0) + _end_capped(
-            faces, foot, foot_area, depth_axis, d_hi, -1.0
-        )
-        if capped != 1:
+        cap_lo = _end_capped(faces, foot, foot_area, depth_axis, d_lo, 1.0)
+        cap_hi = _end_capped(faces, foot, foot_area, depth_axis, d_hi, -1.0)
+        if int(cap_lo) + int(cap_hi) != 1:
             continue  # 0 = through on this axis; 2 = an enclosed end-cap pair, not a floor
         length = l_hi - l_lo
         if width > length:
@@ -909,6 +926,7 @@ def _pocket_candidate(fa, fb, faces, part_ext) -> Pocket | None:
             hi=round(l_hi, 2),
             d_lo=round(d_lo, 2),
             d_hi=round(d_hi, 2),
+            open_sign=1 if cap_lo else -1,  # floor is the capped end; open the other way
         )
     return None
 
@@ -959,6 +977,7 @@ def _pocket_spec_key(pk: Pocket) -> tuple:
         round(pk.depth, 3),
         round(pk.d_lo, 3),
         round(pk.d_hi, 3),
+        pk.open_sign,  # opposite-facing pockets sharing a depth range are on different faces
     )
 
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -94,6 +94,20 @@ def _member_hole_str(m) -> str:
     return f"hole({', '.join(kw)})"
 
 
+def _member_pocket_str(m) -> str:
+    """The ``pocket(...)`` template for a pocket-pattern member — carries its width × length ×
+    depth and orientation. Its own position is irrelevant (the pattern's ``at=`` fixes the
+    array centre), so only the size/axes need round-trip. Length is derived from the emitted
+    lo/hi so ``hi - lo == length`` exactly (declare.pocket rejects a 1e-6 mismatch)."""
+    lo, hi = _n(m.lo), _n(m.hi)
+    length = _n(round(float(hi) - float(lo), 3))
+    return (
+        f"pocket(width={_n(m.width)}, length={length}, depth={_n(m.depth)}, "
+        f'long_axis="{m.long_axis}", width_axis="{m.width_axis}", '
+        f"lo={lo}, hi={hi}, w_center={_n(m.w_center)})"
+    )
+
+
 def _authored_dimension_line(f) -> str:
     kw = [
         f"kind={f.dimension_kind!r}",
@@ -195,6 +209,21 @@ def _feature_line(f) -> str:
         if f.members:
             parts.append("members=[" + ", ".join(_pt(p) for p in f.members) + "]")
         return f"sheet.pattern({_member_hole_str(f.member)}, " + ", ".join(parts) + ")"
+    if k == "pocket_pattern":
+        # declare.pocket_pattern() REJECTS members= (it recomputes the layout from
+        # count + pitch/grid), so emit the array CENTRE as at= and the arrangement params —
+        # the computed layout then lands where detected. direction= is required for a linear
+        # array (else declare defaults to the first in-plane axis, mis-orienting the row).
+        parts = [f'kind="{f.pattern}"', f"count={f.count}", f"at={_pt(f.frame.origin)}"]
+        if f.pattern == "linear":
+            parts.append(f"pitch={_n(f.pitch)}")
+            if f.direction:
+                parts.append(f"direction={_pt(f.direction)}")
+        elif f.pattern == "grid" and f.grid:
+            parts.append(f"grid=({_n(f.grid[0])}, {_n(f.grid[1])}), rows={f.rows}, cols={f.cols}")
+            if f.angle:
+                parts.append(f"angle={_n(f.angle)}")
+        return f"sheet.pocket_pattern({_member_pocket_str(f.member)}, " + ", ".join(parts) + ")"
     if k == "chamfer":
         return (
             f'sheet.chamfer(axis="{f.axis}", leg1={_n(f.leg1)}, leg2={_n(f.leg2)}, '

--- a/tests/test_pocket_pattern_recognition.py
+++ b/tests/test_pocket_pattern_recognition.py
@@ -1,0 +1,119 @@
+"""Recognition + emit for the pocket-pattern kind (#841 outcome 1, PR 2/2).
+
+PR 1 landed the declared path (`pocket_pattern`/`Sheet.pocket_pattern`/`render_pocket_patterns`).
+This pins the RECOGNITION half: `recognise_pocket_patterns` groups identical pockets into one
+`PocketArray`/`PocketGrid`, `build_part_model` emits ONE `PocketPatternFeature` and excludes the
+member pockets, and `sheet_emit` round-trips it. The #837 tuner-jig STEP (five blind obround
+pockets on one centreline) is the end-to-end regression: it must render ONE grouped
+``5× W×L×D DEEP`` callout, not five competing per-pocket size dims.
+"""
+
+from pathlib import Path
+
+from build123d import Box, Pos, import_step
+
+from draftwright.make_drawing import build_drawing
+from draftwright.model import pocket, pocket_pattern  # noqa: F401  (declared-path symmetry)
+from draftwright.model.detect import build_part_model
+from draftwright.recognition import (
+    PocketArray,
+    PocketGrid,
+    recognise_pocket_patterns,
+    recognise_pockets,
+)
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "tuner_jig_blind_obround_pockets.step"
+
+
+def _pocket_row(n=4, pitch=30.0):
+    part = Box(30, pitch * (n + 1), 20)
+    for i in range(n):  # n identical blind pockets on one Y centreline
+        part -= Pos(0, (i - (n - 1) / 2) * pitch, 7) * Box(10, 12, 6)
+    return part
+
+
+def _pocket_grid(nx=2, ny=3, px=40.0, py=30.0):
+    part = Box(px * (nx + 2), py * (ny + 1), 20)
+    for i in range(nx):
+        for j in range(ny):
+            part -= Pos((i - (nx - 1) / 2) * px, (j - (ny - 1) / 2) * py, 7) * Box(8, 10, 6)
+    return part
+
+
+def test_recognise_linear_pocket_array():
+    pockets = recognise_pockets(_pocket_row(n=4, pitch=30.0))
+    assert len(pockets) == 4
+    pats = recognise_pocket_patterns(pockets)
+    assert len(pats) == 1
+    pa = pats[0]
+    assert isinstance(pa, PocketArray)
+    assert len(pa.pockets) == 4
+    assert pa.pitch == 30.0
+    assert abs(pa.direction[1]) == 1.0  # runs along Y
+
+
+def test_recognise_pocket_grid():
+    pats = recognise_pocket_patterns(recognise_pockets(_pocket_grid(2, 3)))
+    assert len(pats) == 1
+    pg = pats[0]
+    assert isinstance(pg, PocketGrid)
+    assert len(pg.pockets) == 6
+    assert {pg.rows, pg.cols} == {2, 3}
+
+
+def test_two_pockets_are_not_a_pattern():
+    # an array needs >=3 members (a pair is just two pockets)
+    assert recognise_pocket_patterns(recognise_pockets(_pocket_row(n=2, pitch=30.0))) == []
+
+
+def test_different_size_pockets_do_not_group():
+    # three collinear pockets of DIFFERENT sizes share no spec key, so none form an array
+    part = Box(30, 150, 20)
+    part -= Pos(0, -45, 7) * Box(10, 12, 6)
+    part -= Pos(0, 0, 7) * Box(14, 12, 6)  # wider
+    part -= Pos(0, 45, 7) * Box(10, 18, 6)  # longer
+    assert recognise_pocket_patterns(recognise_pockets(part)) == []
+
+
+def test_build_part_model_groups_and_excludes_members():
+    pm = build_part_model(_pocket_row(n=4, pitch=30.0))
+    kinds = [f.kind for f in pm.features]
+    assert kinds.count("pocket_pattern") == 1
+    assert kinds.count("pocket") == 0  # members folded into the pattern, not emitted individually
+    pat = next(f for f in pm.features if f.kind == "pocket_pattern")
+    assert pat.count == 4
+    assert pat.member.width == 10.0 and pat.member.length == 12.0 and pat.member.depth == 6.0
+
+
+def test_sheet_emit_round_trips_the_pattern():
+    from draftwright.sheet_emit import generate_sheet_script
+
+    py = generate_sheet_script(_pocket_row(n=4, pitch=30.0), out="/tmp/pp_emit_rt")
+    src = Path(py).read_text()
+    line = next(ln for ln in src.splitlines() if "sheet.pocket_pattern(" in ln)
+    # declare rejects members= — the emit must use at=/pitch=/direction= instead
+    assert "members=" not in line
+    assert 'kind="linear"' in line and "count=4" in line
+    assert "at=" in line and "pitch=" in line and "direction=" in line
+
+
+def test_tuner_jig_fixture_recognised_as_one_pattern():
+    # #837/#841: five blind obround pockets on one centreline collapse to ONE PocketArray.
+    part = import_step(str(_FIXTURE))
+    pats = recognise_pocket_patterns(recognise_pockets(part))
+    assert len(pats) == 1 and isinstance(pats[0], PocketArray)
+    assert len(pats[0].pockets) == 5
+
+
+def test_tuner_jig_renders_one_grouped_callout_not_five():
+    # the payoff: the imported STEP renders ONE `5× 7.9 × 13.6 × 19 DEEP` callout + a pitch dim,
+    # not five competing per-pocket size dims (#841 outcome 1).
+    part = import_step(str(_FIXTURE))
+    dwg = build_drawing(part)
+    names = dwg.annotations()
+    callouts = [n for n in names if n.startswith("m_pocketpat")]
+    assert len(callouts) == 1
+    assert dwg.get_annotation(callouts[0]).label == "5× 7.9 × 13.6 × 19 DEEP"
+    # the individual member pockets are NOT separately called out
+    assert not [n for n in names if n.startswith("m_pocket_")]
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]

--- a/tests/test_pocket_pattern_recognition.py
+++ b/tests/test_pocket_pattern_recognition.py
@@ -75,6 +75,52 @@ def test_different_size_pockets_do_not_group():
     assert recognise_pocket_patterns(recognise_pockets(part)) == []
 
 
+def test_non_coplanar_aligned_pockets_do_not_merge():
+    # three identical pockets whose in-plane (XY) centres form a constant-pitch row but which
+    # sit on DIFFERENT depth planes (staggered d_lo/d_hi) must NOT merge into one planar array
+    # that does not exist — pattern detection projects the depth coord away (Codex #849).
+    from draftwright.recognition.slots import Pocket
+
+    def pk(cy, d_lo):
+        return Pocket(
+            width_axis="x",
+            long_axis="y",
+            width=10.0,
+            length=12.0,
+            depth=6.0,
+            w_center=0.0,
+            lo=cy - 6,
+            hi=cy + 6,
+            d_lo=d_lo,
+            d_hi=d_lo + 6,
+        )
+
+    staggered = [pk(-30, 0.0), pk(0, 5.0), pk(30, 10.0)]  # aligned in XY, different depth planes
+    assert recognise_pocket_patterns(staggered) == []
+    coplanar = [pk(-30, 0.0), pk(0, 0.0), pk(30, 0.0)]  # same depth plane → one array
+    assert len(recognise_pocket_patterns(coplanar)) == 1
+
+
+def test_injected_value_equal_pattern_still_excludes_members():
+    # member exclusion is by VALUE, so an INJECTED pattern inventory built from value-equal
+    # (deserialized/copied) pockets whose ids differ still suppresses the individual pockets —
+    # an id()-based set would emit both the pattern and the members (Codex #849).
+    import dataclasses
+
+    part = _pocket_row(n=4, pitch=30.0)
+    pockets = recognise_pockets(part)
+    pats = recognise_pocket_patterns(pockets)
+    copied_pockets = [dataclasses.replace(pk) for pk in pockets]  # value-equal, new ids
+    copied_pats = [
+        dataclasses.replace(p, pockets=tuple(dataclasses.replace(m) for m in p.pockets))
+        for p in pats
+    ]
+    pm = build_part_model(part, pockets=copied_pockets, pocket_patterns=copied_pats)
+    kinds = [f.kind for f in pm.features]
+    assert kinds.count("pocket_pattern") == 1
+    assert kinds.count("pocket") == 0  # value-equal copies still excluded
+
+
 def test_build_part_model_groups_and_excludes_members():
     pm = build_part_model(_pocket_row(n=4, pitch=30.0))
     kinds = [f.kind for f in pm.features]
@@ -85,10 +131,10 @@ def test_build_part_model_groups_and_excludes_members():
     assert pat.member.width == 10.0 and pat.member.length == 12.0 and pat.member.depth == 6.0
 
 
-def test_sheet_emit_round_trips_the_pattern():
+def test_sheet_emit_round_trips_the_pattern(tmp_path):
     from draftwright.sheet_emit import generate_sheet_script
 
-    py = generate_sheet_script(_pocket_row(n=4, pitch=30.0), out="/tmp/pp_emit_rt")
+    py = generate_sheet_script(_pocket_row(n=4, pitch=30.0), out=str(tmp_path / "pp_emit_rt"))
     src = Path(py).read_text()
     line = next(ln for ln in src.splitlines() if "sheet.pocket_pattern(" in ln)
     # declare rejects members= — the emit must use at=/pitch=/direction= instead

--- a/tests/test_pocket_pattern_recognition.py
+++ b/tests/test_pocket_pattern_recognition.py
@@ -101,6 +101,32 @@ def test_non_coplanar_aligned_pockets_do_not_merge():
     assert len(recognise_pocket_patterns(coplanar)) == 1
 
 
+def test_opposite_facing_pockets_do_not_merge():
+    # identical pockets sharing the SAME absolute depth range but opening OPPOSITE faces sit on
+    # different faces — d_lo/d_hi alone can't tell them apart, so open_sign keys them (Codex #849).
+    from draftwright.recognition.slots import Pocket
+
+    def pk(cy, sign):
+        return Pocket(
+            width_axis="x",
+            long_axis="y",
+            width=10.0,
+            length=12.0,
+            depth=6.0,
+            w_center=0.0,
+            lo=cy - 6,
+            hi=cy + 6,
+            d_lo=5.0,
+            d_hi=11.0,
+            open_sign=sign,
+        )
+
+    mixed = [pk(-30, 1), pk(0, -1), pk(30, 1)]  # same depth range, alternating opening face
+    assert recognise_pocket_patterns(mixed) == []
+    same = [pk(-30, 1), pk(0, 1), pk(30, 1)]  # all open the same face → one array
+    assert len(recognise_pocket_patterns(same)) == 1
+
+
 def test_injected_value_equal_pattern_still_excludes_members():
     # member exclusion is by VALUE, so an INJECTED pattern inventory built from value-equal
     # (deserialized/copied) pockets whose ids differ still suppresses the individual pockets —
@@ -135,7 +161,7 @@ def test_sheet_emit_round_trips_the_pattern(tmp_path):
     from draftwright.sheet_emit import generate_sheet_script
 
     py = generate_sheet_script(_pocket_row(n=4, pitch=30.0), out=str(tmp_path / "pp_emit_rt"))
-    src = Path(py).read_text()
+    src = Path(py).read_text(encoding="utf-8")  # the script carries non-ASCII (ø/×); Windows
     line = next(ln for ln in src.splitlines() if "sheet.pocket_pattern(" in ln)
     # declare rejects members= — the emit must use at=/pitch=/direction= instead
     assert "members=" not in line

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -33,6 +33,8 @@ from draftwright.recognition import (
     LinearArray,
     Plate,
     Pocket,
+    PocketArray,
+    PocketGrid,
     RectGrid,
     Slot,
     StepShoulder,
@@ -48,6 +50,7 @@ from draftwright.recognition import (
     recognise_hole_patterns,
     recognise_holes,
     recognise_plates,
+    recognise_pocket_patterns,
     recognise_pockets,
     recognise_slots,
     recognise_step_shoulders,
@@ -73,6 +76,8 @@ _EXPECTED_RECORD_TYPES = {
     Groove,
     Slot,
     Pocket,
+    PocketArray,
+    PocketGrid,
     Plate,
     FaceLevel,
     StepShoulder,
@@ -110,6 +115,21 @@ def _grid_plate(nx=3, ny=3, px=25, py=25):
     for i in range(nx):
         for j in range(ny):
             part -= Pos((i - (nx - 1) / 2) * px, (j - (ny - 1) / 2) * py, 0) * Cylinder(3, 10)
+    return part
+
+
+def _pocket_array_plate():
+    part = Box(30, 150, 20)
+    for cy in (-45, -15, 15, 45):  # four identical blind pockets on one Y centreline, pitch 30
+        part -= Pos(0, cy, 7) * Box(10, 12, 6)  # floored (opening +Z) → a Pocket, not a Slot
+    return part
+
+
+def _pocket_grid_plate():
+    part = Box(140, 110, 20)
+    for i in range(2):  # 2×3 lattice of identical blind pockets (rect_grid needs n>=6)
+        for j in range(3):
+            part -= Pos((i - 0.5) * 40, (j - 1) * 30, 7) * Box(8, 10, 6)
     return part
 
 
@@ -162,6 +182,14 @@ def _records_from_recognisers():
         ("recognise_fillets", recognise_fillets(_filleted_box())),
         ("recognise_slots", recognise_slots(slotted)),
         ("recognise_pockets", recognise_pockets(pocketed)),
+        (
+            "pocket_patterns:linear",
+            recognise_pocket_patterns(recognise_pockets(_pocket_array_plate())),
+        ),
+        (
+            "pocket_patterns:grid",
+            recognise_pocket_patterns(recognise_pockets(_pocket_grid_plate())),
+        ),
         ("recognise_flats", recognise_flats(dshaft)),
         ("recognise_grooves", recognise_grooves(grooved)),
         ("recognise_plates", recognise_plates(_l_bracket())),


### PR DESCRIPTION
Completes **#841 outcome 1** (PR 2/2). PR 1 (#848) landed the declared `PocketPatternFeature` path; this adds the **recognition** and **emit** surfaces so identical blind pockets detected from geometry render as ONE grouped `count× W×L×D DEEP` callout + pitch dim(s), not N competing per-pocket size dims.

## What's here
- **`recognition/slots.py`** — `recognise_pocket_patterns(pockets)`, a derived recogniser (single positional inventory, ADR 0013) producing `PocketArray` (linear) / `PocketGrid` (grid) records; `Pocket.location` for the shared clustering.
- **`recognition/_features.py`** — the hole-pattern geometry (`_as_linear_array` / `_linear_array_candidates` / `_rect_grid`) is now **record-generic via a `make` factory** (consolidation epic #635), so holes and pockets *share* the collinear/lattice clustering instead of duplicating ~120 lines. Hole patterns are unchanged (they pass `_mk_hole_*` factories) — verified regression-free.
- **`model/detect.py`** — `_pocket_pattern_feature` converter (mirrors `_pattern_feature`) + `_member_pocket`; registered in `_DERIVED_CONVERTERS`; `build_part_model` groups identical pockets into one `PocketPatternFeature` and **excludes the member pockets** (id-set, exactly like hole patterns). New `pocket_patterns=` injection param.
- **`sheet_emit.py`** — a `pocket_pattern` branch emitting `sheet.pocket_pattern(pocket(...), at=<centre>, pitch=/grid=…, direction=)` — deliberately **without** `members=` (declare rejects it), so `at=`/`direction=` carry the placement. Round-trips exactly.

## Tests
- `tests/test_pocket_pattern_recognition.py` — recogniser (linear/grid + non-pattern guards), `build_part_model` grouping + member exclusion, sheet_emit round-trip, and the **#837 tuner-jig STEP fixture e2e**: five blind obround pockets → ONE `5× 7.9 × 13.6 × 19 DEEP` callout, not five competing dims.
- `tests/test_recogniser_contract.py` — drive-parts + expected-types extended so the new records get mechanical contract coverage; `test_detect_registry.py` auto-picks them up (homed in `_DERIVED_CONVERTERS`).

## Verification
Full fast tier green (**1630 passed**, 3 skipped); all 4 lint checks green.

Follows #848 (declared path). The imperative `_feature_listing` re-emit verb for pocket patterns stays the honest deferred comment (the #841 outcome-3 editable-surface follow-up); the sheet-style emit round-trips fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)