### PR TITLE
feat(#841): pocket-pattern editable surface — callout/finalize + re-emit (outcome 3)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -969,14 +969,11 @@ def _feature_listing(a: Analysis) -> str:
             body.append("dwg.callout(f)")
             continue
         elif kind == "pocket_pattern":
-            # A declared pocket pattern is auto-drawn as one grouped callout + pitch dim(s)
-            # (its pre-drain "pocket_patterns" stage). The manual re-emit verb — which needs
-            # the same pre-drain furniture placement — is a #841 outcome-3 follow-up. Flag it
-            # like the Y-turned step gap (#731) so reconstruction never SILENTLY drops it.
-            body.append(
-                "#     pocket pattern — auto-drawn (grouped callout + pitch); the re-emit "
-                "verb is a #841 follow-up, so it is flagged here, not silently dropped."
-            )
+            # A pocket pattern reconstructs through callout(f) (#841 outcome 3): finalize drains
+            # the recorded intent at the pre-drain "pocket_patterns" stage, drawing the grouped
+            # size/depth callout + its pitch dim(s). No locate()/furniture() — a pocket pattern
+            # has no location dims and render_pocket_patterns emits the pitch itself.
+            body.append("dwg.callout(f)")
             continue
         for p in feat.parameters():
             if p.span is not None or kind == "slot":  # a linear dim dimension() accepts

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -200,6 +200,7 @@ class _IntentRouting:
     only_len: set
     slot_feats: set
     machined_ids_by_kind: dict
+    pocket_pattern_ids: set
 
 
 @dataclass
@@ -1079,18 +1080,9 @@ class Drawing:
         like the auto-pass), rather than raising, so a reconstruction script never aborts.
         """
         kind = getattr(feature, "kind", None)
-        if kind == "pocket_pattern":
-            # A pocket pattern is auto-drawn at build time as one grouped callout + pitch
-            # dim(s) (its "pocket_patterns" _PASS_SEQUENCE stage). The manual callout()/
-            # finalize() edit verb for it — which must place the pitch furniture PRE-drain,
-            # unlike the post-drain lone machined callouts — is a #841 outcome-3 follow-up.
-            # Raise clearly here rather than fall through to the hole-callout path (which has
-            # no pocket-pattern spec and would crash confusingly).
-            raise ValueError(
-                "callout(): a pocket pattern is placed automatically at build time; the "
-                "manual pocket-pattern callout edit verb is not yet supported (#841)"
-            )
-        if kind in _MACHINED_CALLOUT_KINDS and (view is not None or name is not None):
+        if (kind in _MACHINED_CALLOUT_KINDS or kind == "pocket_pattern") and (
+            view is not None or name is not None
+        ):
             raise ValueError(
                 f"callout(): a {kind} is auto-named and placed in its characteristic view; "
                 "view=/name= are unsupported for machined-feature callouts"
@@ -1142,6 +1134,25 @@ class Drawing:
             )
             changed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
             return changed[0] if len(changed) == 1 else ""
+        if kind == "pocket_pattern":
+            # A pocket pattern renders through its own auto-pass renderer (grouped size/depth
+            # callout + pitch dim(s)), restricted to THIS feature (#841 outcome 3). Unlike the
+            # lone machined callouts it places furniture too, so several names change — return
+            # the grouped-callout name (m_pocketpat*), the handle pin()/drop() address.
+            if self._part_model is None or self._analysis is None:
+                raise ValueError(
+                    "callout(): a pocket-pattern callout needs the part model and analysis; "
+                    "add it to a drawing built by build_drawing(), not a bare Drawing"
+                )
+            from draftwright.annotations.holes import render_pocket_patterns
+            from draftwright.model import plan_dimensions
+
+            before = {n: id(o) for n, o in self.iter_annotations()}
+            render_pocket_patterns(
+                self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
+            )
+            placed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
+            return next((n for n in placed if n.startswith("m_pocketpat")), "")
         return add_feature_callout(
             self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
         )
@@ -1431,6 +1442,17 @@ class Drawing:
                 k = getattr(it.feature, "kind", None)
                 if k in _MACHINED_CALLOUT_KINDS:
                     machined_ids_by_kind.setdefault(k, set()).add(id(it))
+        # Pocket-pattern callout()s (#841 outcome 3): one grouped callout + pitch furniture per
+        # pattern. Drained at the pre-drain "pocket_patterns" _PASS_SEQUENCE slot (render places
+        # the pitch dim directly and needs the strip room the post-drain machined callouts lack),
+        # restricted to the recorded feature(s) via only=.
+        pocket_pattern_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and it.kind == "callout"
+            and getattr(it.feature, "kind", None) == "pocket_pattern"
+        }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         pinned_loc = {
             it.feature for it in self._intents if id(it) in corridor_ids and it.kwargs.get("pin")
@@ -1459,6 +1481,7 @@ class Drawing:
             only_len=only_len,
             slot_feats=slot_feats,
             machined_ids_by_kind=machined_ids_by_kind,
+            pocket_pattern_ids=pocket_pattern_ids,
         )
 
     def _user_dim_uses_corridor(self, it, routable, already_routed) -> bool:
@@ -1649,6 +1672,7 @@ class Drawing:
             _annotate_holes,
             _locate_off_axis_holes,
             build_view_of_axis,
+            render_pocket_patterns,
         )
         from draftwright.annotations.orchestrator import (
             _maybe_tabulate_holes,
@@ -1702,6 +1726,7 @@ class Drawing:
                 | r.rotational_ids  # drained by _s_rotational; no _replay_intent branch
                 | r.off_axis_loc_ids  # drained by the off-axis stages; locate() raises on non-Z
                 | {i for ids in r.machined_ids_by_kind.values() for i in ids}  # _s_<machined kind>
+                | r.pocket_pattern_ids  # _s_pocket_patterns (pre-drain)
             )
             i = 0
             while i < len(self._intents):
@@ -1841,6 +1866,17 @@ class Drawing:
         def _s_grooves():
             _s_machined("groove", render_grooves)
 
+        def _s_pocket_patterns():
+            # Pocket-pattern callouts + their pitch furniture (#841 outcome 3), restricted to the
+            # recorded feature(s). Keyed "pocket_patterns" so run_stages fires it at that PRE-drain
+            # _PASS_SEQUENCE slot — render_pocket_patterns places the pitch dim directly and needs
+            # the strip room the post-drain machined callouts lack.
+            feats = {it.feature for it in self._intents if id(it) in r.pocket_pattern_ids}
+            if feats:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render_pocket_patterns(self, plan_dimensions(model), a, ctx=ctx, only=feats)
+            self._intents = [it for it in self._intents if id(it) not in r.pocket_pattern_ids]
+
         def _s_user_dims():
             # User-authored pin/priority dimensions queue into the shared corridor as
             # first-class candidates (ADR 0012).
@@ -1943,6 +1979,7 @@ class Drawing:
                 "diameters": _s_diameters,
                 "step_lengths": _s_step_lengths,
                 "slots": _s_slots,
+                "pocket_patterns": _s_pocket_patterns,
                 "user_dims": _s_user_dims,
                 "drain": _s_drain,
                 "chamfers": _s_chamfers,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6483,6 +6483,9 @@ class TestFeatureEdits:
             elif f.kind in ("step", "boss"):
                 if f.frame.axis in ("x", "z"):  # callout() places X/Z-turned diameters only
                     dwg.callout(f)
+            elif f.kind == "pocket_pattern":
+                dwg.callout(f)  # grouped callout + pitch (no locate/furniture); #841 outcome 3
+                continue
             elif f.kind == "step_level":
                 dwg.dimension(f, "length", role="step_height")
                 continue

--- a/tests/test_pocket_pattern.py
+++ b/tests/test_pocket_pattern.py
@@ -10,6 +10,7 @@ pockets are not double-rendered.
 import pytest
 from build123d import Box
 
+from draftwright.make_drawing import build_drawing
 from draftwright.model import hole, pocket, pocket_pattern
 from draftwright.sheet import Sheet
 
@@ -216,16 +217,37 @@ def test_pitch_dim_names_do_not_collide_with_hole_pattern():
     assert set(hole_pitch).isdisjoint(pocket_pitch)
 
 
-def test_manual_callout_verb_raises_clearly():
-    # the manual dwg.callout() edit verb for a pocket pattern is a deferred #841 follow-up;
-    # it must raise a clear error, NOT fall through to the hole-callout path and crash.
-    s = Sheet(Box(26, 161, 21))
+def test_manual_callout_verb_places_grouped_callout_and_pitch():
+    # the manual dwg.callout() edit verb for a pocket pattern (#841 outcome 3) draws the grouped
+    # size/depth callout AND its pitch dim (render_pocket_patterns bundles both), returning the
+    # grouped-callout name. It replaces the old deferred-stub that raised.
+    part = Box(26, 161, 21)
+    s = Sheet(part)
     s.envelope()
     s.pocket_pattern(_member(), kind="linear", count=5, pitch=27.2, direction=(0, 1, 0))
-    dwg = s.build()
+    dwg = build_drawing(part, model=s.model(), auto_dims=False)  # nothing auto-drawn
     feat = next(f for f in dwg.model().features if f.kind == "pocket_pattern")
-    with pytest.raises(ValueError, match="placed automatically at build time.*#841"):
-        dwg.callout(feat)
+    name = dwg.callout(feat)
+    assert name.startswith("m_pocketpat")
+    assert dwg.get_annotation(name).label == "5× 7.9 × 13.6 × 19 DEEP"
+    assert [n for n in dwg.annotations() if n.startswith("dim_pocketpat_pitch_")]
+
+
+def test_deferred_callout_reconstructs_the_pattern():
+    # the reconstruction path (builder._feature_listing emits `dwg.callout(f)`): a callout intent
+    # recorded inside `with dwg.deferred()` drains through finalize's pre-drain "pocket_patterns"
+    # stage, drawing the same grouped callout + pitch (#841 outcome 3).
+    part = Box(26, 161, 21)
+    s = Sheet(part)
+    s.envelope()
+    s.pocket_pattern(_member(), kind="linear", count=5, pitch=27.2, direction=(0, 1, 0))
+    dwg = build_drawing(part, model=s.model(), auto_dims=False)
+    with dwg.deferred():
+        dwg.callout(next(f for f in dwg.model().features if f.kind == "pocket_pattern"))
+    names = dwg.annotations()
+    assert [n for n in names if n.startswith("m_pocketpat")]
+    assert [n for n in names if n.startswith("dim_pocketpat_pitch_")]
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
 
 
 def test_model_inspection_sees_the_pattern():


### PR DESCRIPTION
Closes the **#841 outcome-3** deferral left by PR1 (#848) / PR2 (#849): the manual `dwg.callout()` edit verb and the reconstruction re-emit for pocket patterns are now wired, mirroring the hole `pattern` kind.

The wrinkle a pocket pattern has (and why it was deferred): its pitch furniture must place **pre-drain** — unlike the post-drain lone machined callouts — because `render_pocket_patterns` places the pitch dim directly and needs strip room. The existing `"pocket_patterns"` `_PASS_SEQUENCE` slot + the name-keyed finalize `run_stages` make this clean: adding a `"pocket_patterns"` stage key fires it at exactly the right pre-drain point.

## What's here
- **`drawing.py` `callout()`** — the deferred-stub `raise` is replaced by a live branch that renders the grouped size/depth callout **+ pitch** via `render_pocket_patterns(only={feature})`, returning the grouped-callout name (`m_pocketpat*`). `view=`/`name=` are rejected (auto-placed), like the machined callouts.
- **`drawing.py` finalize** — `_classify_intents` buckets pocket-pattern callout intents (`pocket_pattern_ids` on `_IntentRouting`); a new `_s_pocket_patterns` stage drains them, keyed `"pocket_patterns"` so `run_stages` fires it at its pre-drain slot; the ids join `_s_live_replay`'s `routed` set so they don't double-place.
- **`builder._feature_listing`** — the honest-comment branch becomes `dwg.callout(f)` (no `locate`/`furniture` — a pocket pattern has neither location dims nor separate furniture; `render_pocket_patterns` emits the pitch itself).

## Tests
- The PR1 `test_manual_callout_verb_raises_clearly` flips to `..._places_grouped_callout_and_pitch`.
- New `test_deferred_callout_reconstructs_the_pattern` (deferred → finalize pre-drain drain).
- The `_reconstruct` helper (mirrors `_feature_listing`) gets a `pocket_pattern` branch, keeping the `test_deferred_reconstruction_*` / `test_intent_reconstruction_*` suite green.

## Verification
26 pocket-pattern + 16 reconstruction + 111 emit/parity/e2e + 4 lint checks green locally; full fast tier running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)