### PR TITLE
feat(#841): slot-pattern recognition + emit (SlotPatternFeature PR B)

### DIFF
--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -40,6 +40,7 @@ from draftwright.model.ir import (
     PocketPatternFeature,
     RotationalFeature,
     SlotFeature,
+    SlotPatternFeature,
     StepFeature,
     StepLevelFeature,
 )
@@ -61,6 +62,8 @@ from draftwright.recognition import (
     PocketGrid,
     RectGrid,
     Slot,
+    SlotArray,
+    SlotGrid,
     StepShoulder,
     TurnedProfile,
     TurnedStep,
@@ -75,6 +78,7 @@ from draftwright.recognition import (
     recognise_plates,
     recognise_pocket_patterns,
     recognise_pockets,
+    recognise_slot_patterns,
     recognise_slots,
     recognise_step_shoulders,
     recognise_turned_steps,
@@ -267,6 +271,68 @@ def _convert_slot(sl: Slot, ctx: ConvContext) -> SlotFeature:
     )
 
 
+def _member_slot(sl: Slot) -> SlotFeature:
+    """The representative member of a `SlotPatternFeature` — its width/length/axes drive the
+    grouped callout. Built at the slot's own centroid (not `_convert_slot`'s bbox-centred frame,
+    which is a lone-slot dim-placement convention): `render_slot_patterns` anchors the leader at
+    the PATTERN centre and reads only the member's size/axes, so the member frame origin is
+    inert (#841)."""
+    c = {
+        sl.long_axis: (sl.lo + sl.hi) / 2,
+        sl.width_axis: sl.w_center,
+        sl.depth_axis: (sl.d_lo + sl.d_hi) / 2,
+    }
+    return SlotFeature(
+        frame=Frame(origin=(c["x"], c["y"], c["z"]), axis=sl.long_axis),
+        width_axis=sl.width_axis,
+        long_axis=sl.long_axis,
+        width=sl.width,
+        length=sl.length,
+        w_center=sl.w_center,
+        lo=sl.lo,
+        hi=sl.hi,
+    )
+
+
+def _slot_pattern_feature(pat, members) -> SlotPatternFeature:
+    """Map a recognised slot array + its member slots to a `SlotPatternFeature` (#841) — the
+    through-slot analog of :func:`_pocket_pattern_feature`. Composes a representative member slot
+    (its width/length drive the grouped ``count× SLOT W × L`` callout) and keeps the member
+    centres as the raw arrangement the pitch furniture indexes. The frame axis is the members'
+    shared THROUGH axis, matching the declared `slot_pattern`."""
+    n = len(members)
+    axis = members[0].depth_axis  # the through axis — the face plane the array lies in
+    locs = tuple(_xyz(m.location) for m in members)  # raw arrangement — never discarded
+    if isinstance(pat, SlotGrid):
+        frame = Frame(_xyz(pat.center), axis)
+        return SlotPatternFeature(
+            frame=frame,
+            pattern="grid",
+            count=n,
+            member=_member_slot(members[0]),
+            members=locs,
+            grid=(pat.row_pitch, pat.col_pitch),
+            rows=pat.rows,
+            cols=pat.cols,
+            angle=pat.angle,
+        )
+    # SlotArray (linear) — the frame sits at the array centroid (no separate centre field).
+    c = (
+        sum(m.location[0] for m in members) / n,
+        sum(m.location[1] for m in members) / n,
+        sum(m.location[2] for m in members) / n,
+    )
+    return SlotPatternFeature(
+        frame=Frame(c, axis),
+        pattern="linear",
+        count=n,
+        member=_member_slot(members[0]),
+        members=locs,
+        pitch=pat.pitch,
+        direction=tuple(pat.direction),
+    )
+
+
 def _member_pocket(pk: Pocket) -> PocketFeature:
     """A recogniser `Pocket` → an IR `PocketFeature`. The representative member of a
     `PocketPatternFeature` too (its size/axes drive the grouped callout), so it is factored
@@ -442,6 +508,8 @@ _DERIVED_CONVERTERS: dict[type, Callable[..., Feature]] = {
     RectGrid: _pattern_feature,
     PocketArray: _pocket_pattern_feature,
     PocketGrid: _pocket_pattern_feature,
+    SlotArray: _slot_pattern_feature,
+    SlotGrid: _slot_pattern_feature,
 }
 
 # Tier 3 — orchestrated records: no per-record converter, by design. Each is either a
@@ -477,6 +545,7 @@ def build_part_model(
     patterns=None,
     bosses=None,
     slots=None,
+    slot_patterns=None,
     pockets=None,
     pocket_patterns=None,
     prof=_UNSET,
@@ -540,10 +609,21 @@ def build_part_model(
         mem_locs = tuple(_xyz(h.location) for h in grp)
         features.append(_member_hole(rep, frame, members=mem_locs, count=len(grp)))
 
-    # Milled slots / reduced across-flats sections (detected for any part).
+    # Milled slots / reduced across-flats sections (detected for any part). A recognised array
+    # of identical slots becomes ONE SlotPatternFeature (count× SLOT W×L + pitch, #841); its
+    # member slots are NOT also emitted individually — the same grouped-callout rule as pockets
+    # below (member exclusion by VALUE-set, robust to injected value-copy inventories).
     if slots is None:
         slots = recognise_slots(part)
+    if slot_patterns is None:
+        slot_patterns = recognise_slot_patterns(slots)
+    patterned_sl: set = set()
+    for pat in slot_patterns:
+        patterned_sl.update(pat.slots)
+        features.append(_slot_pattern_feature(pat, list(pat.slots)))
     for sl in slots:
+        if sl in patterned_sl:
+            continue
         features.append(convert(sl, ctx))
 
     # Blind rectangular recesses — floored slots/pockets (#148a). A recognised array of

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -95,8 +95,11 @@ from draftwright.recognition.slots import (
     PocketArray,
     PocketGrid,
     Slot,
+    SlotArray,
+    SlotGrid,
     recognise_pocket_patterns,
     recognise_pockets,
+    recognise_slot_patterns,
     recognise_slots,
 )
 from draftwright.recognition.turned import TurnedProfile, TurnedStep, recognise_turned_steps
@@ -120,6 +123,8 @@ __all__ = [
     "PocketGrid",
     "RectGrid",
     "Slot",
+    "SlotArray",
+    "SlotGrid",
     "StepShoulder",
     "TurnedProfile",
     "TurnedStep",
@@ -144,6 +149,7 @@ __all__ = [
     "recognise_plates",
     "recognise_pocket_patterns",
     "recognise_pockets",
+    "recognise_slot_patterns",
     "recognise_slots",
     "recognise_turned_steps",
     "full_cylinders",

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -96,6 +96,46 @@ class Slot(Record):
     def depth_axis(self) -> str:
         return next(a for a in "xyz" if a not in (self.width_axis, self.long_axis))
 
+    @property
+    def location(self) -> tuple[float, float, float]:
+        """The slot centroid in world XYZ — mid-span along ``long_axis``, the centreline on
+        ``width_axis``, mid-through on ``depth_axis``. The `.location` the shared pattern geometry
+        (#635) clusters on, as pockets/holes carry."""
+        coord = {
+            self.long_axis: (self.lo + self.hi) / 2,
+            self.width_axis: self.w_center,
+            self.depth_axis: (self.d_lo + self.d_hi) / 2,
+        }
+        return (coord["x"], coord["y"], coord["z"])
+
+
+@dataclass(frozen=True)
+class SlotArray(Record):
+    """N identical milled slots in a straight, constant-pitch line (#841) — the through-slot
+    analog of :class:`PocketArray`. ``slots`` are the member :class:`Slot` records (ordered along
+    the array); ``pitch`` is the centre-to-centre spacing and ``direction`` the (unit) array
+    axis, both read by ``detect._slot_pattern_feature``."""
+
+    slots: tuple
+    pitch: float
+    direction: tuple
+
+
+@dataclass(frozen=True)
+class SlotGrid(Record):
+    """N×M identical milled slots on a rectangular lattice (#841) — the through-slot analog of
+    :class:`PocketGrid`. ``slots`` are the member :class:`Slot` records; the lattice is
+    ``rows``×``cols`` at ``row_pitch``/``col_pitch``, rotated ``angle`` degrees about
+    ``center``."""
+
+    slots: tuple
+    rows: int
+    cols: int
+    row_pitch: float
+    col_pitch: float
+    angle: float
+    center: tuple
+
 
 @dataclass(frozen=True)
 class Pocket(Record):
@@ -1037,6 +1077,89 @@ def recognise_pocket_patterns(pockets) -> list[PocketArray | PocketGrid]:
         if grid is not None:
             candidates.append((grid, frozenset(range(len(members)))))
         candidates += _linear_array_candidates(members, pts, _mk_pocket_linear)
+        candidates.sort(key=lambda c: -len(c[1]))
+        used: set = set()
+        for pattern, idx in candidates:
+            if idx & used:
+                continue
+            patterns.append(pattern)
+            used |= idx
+    return patterns
+
+
+def _slot_spec_key(sl: Slot) -> tuple:
+    """The grouping key shared by slots of the *same milled feature* — same orientation, size,
+    AND through plane. Only identical, same-orientation, coplanar slots form one array. The
+    through-axis extent (d_lo, d_hi) is part of the key so slots on different-height stepped
+    faces whose in-plane centres line up don't merge into a planar array that does not exist
+    (mirrors ``_pocket_spec_key``). A slot is THROUGH — no floor, no opening direction — so
+    unlike the pocket key there is no ``depth`` and no ``open_sign``. Coordinates snap to 3 dp so
+    boolean-op float noise does not split an array."""
+    return (
+        sl.width_axis,
+        sl.long_axis,
+        round(sl.width, 3),
+        round(sl.length, 3),
+        round(sl.d_lo, 3),
+        round(sl.d_hi, 3),
+    )
+
+
+def _mk_slot_linear(members, pitch, direction) -> SlotArray:
+    return SlotArray(slots=tuple(members), pitch=pitch, direction=direction)
+
+
+def _mk_slot_grid(members, rows, cols, row_pitch, col_pitch, angle, center) -> SlotGrid:
+    return SlotGrid(
+        slots=tuple(members),
+        rows=rows,
+        cols=cols,
+        row_pitch=row_pitch,
+        col_pitch=col_pitch,
+        angle=angle,
+        center=center,
+    )
+
+
+def recognise_slot_patterns(slots) -> list[SlotArray | SlotGrid]:
+    """Recognise :class:`SlotArray` (linear) and :class:`SlotGrid` (rectangular) arrays among
+    *slots* (``Slot`` records, e.g. from :func:`recognise_slots`) — the through-slot analog of
+    :func:`recognise_pocket_patterns`.
+
+    A DERIVED recogniser (single positional inventory, ADR 0013): slots are grouped by
+    orientation + size + through plane (:func:`_slot_spec_key`), each group's centres are
+    projected into the face plane (perpendicular to the shared through axis), and the same
+    collinear / lattice geometry the hole/pocket patterns use (shared via *make* factories,
+    #635) is enumerated and allocated greedily largest-first. Slots have no bolt-circle form, so
+    only grid + linear candidates are considered. Un-arrayed slots are absent from the result."""
+    from draftwright.recognition._features import (
+        _linear_array_candidates,
+        _plane_uv,
+        _rect_grid,
+    )
+
+    axis_unit = {"x": (1.0, 0.0, 0.0), "y": (0.0, 1.0, 0.0), "z": (0.0, 0.0, 1.0)}
+    groups: dict = {}
+    for sl in slots:
+        groups.setdefault(_slot_spec_key(sl), []).append(sl)
+
+    patterns: list[SlotArray | SlotGrid] = []
+    for members in groups.values():
+        if len(members) < 3:
+            continue
+        u, v = _plane_uv(axis_unit[members[0].depth_axis])
+        pts = [
+            (
+                sum(a * b for a, b in zip(sl.location, u, strict=True)),
+                sum(a * b for a, b in zip(sl.location, v, strict=True)),
+            )
+            for sl in members
+        ]
+        candidates: list = []
+        grid = _rect_grid(members, pts, _mk_slot_grid)
+        if grid is not None:
+            candidates.append((grid, frozenset(range(len(members)))))
+        candidates += _linear_array_candidates(members, pts, _mk_slot_linear)
         candidates.sort(key=lambda c: -len(c[1]))
         used: set = set()
         for pattern, idx in candidates:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -108,6 +108,20 @@ def _member_pocket_str(m) -> str:
     )
 
 
+def _member_slot_str(m) -> str:
+    """The ``slot(...)`` template for a slot-pattern member — carries its width × length and
+    orientation (a slot has no depth). Its own position is irrelevant (the pattern's ``at=``
+    fixes the array centre); length is derived from the emitted lo/hi so ``hi - lo == length``
+    exactly (declare.slot rejects a 1e-6 mismatch)."""
+    lo, hi = _n(m.lo), _n(m.hi)
+    length = _n(round(float(hi) - float(lo), 3))
+    return (
+        f"slot(width={_n(m.width)}, length={length}, "
+        f'long_axis="{m.long_axis}", width_axis="{m.width_axis}", '
+        f"lo={lo}, hi={hi}, w_center={_n(m.w_center)})"
+    )
+
+
 def _authored_dimension_line(f) -> str:
     kw = [
         f"kind={f.dimension_kind!r}",
@@ -224,6 +238,19 @@ def _feature_line(f) -> str:
             if f.angle:
                 parts.append(f"angle={_n(f.angle)}")
         return f"sheet.pocket_pattern({_member_pocket_str(f.member)}, " + ", ".join(parts) + ")"
+    if k == "slot_pattern":
+        # Like pocket_pattern: declare rejects members=, so emit the array centre + arrangement
+        # params and let the computed layout land where detected. direction= carries orientation.
+        parts = [f'kind="{f.pattern}"', f"count={f.count}", f"at={_pt(f.frame.origin)}"]
+        if f.pattern == "linear":
+            parts.append(f"pitch={_n(f.pitch)}")
+            if f.direction:
+                parts.append(f"direction={_pt(f.direction)}")
+        elif f.pattern == "grid" and f.grid:
+            parts.append(f"grid=({_n(f.grid[0])}, {_n(f.grid[1])}), rows={f.rows}, cols={f.cols}")
+            if f.angle:
+                parts.append(f"angle={_n(f.angle)}")
+        return f"sheet.slot_pattern({_member_slot_str(f.member)}, " + ", ".join(parts) + ")"
     if k == "chamfer":
         return (
             f'sheet.chamfer(axis="{f.axis}", leg1={_n(f.leg1)}, leg2={_n(f.leg2)}, '

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -37,6 +37,8 @@ from draftwright.recognition import (
     PocketGrid,
     RectGrid,
     Slot,
+    SlotArray,
+    SlotGrid,
     StepShoulder,
     TurnedStep,
     analyse_cylinders,
@@ -52,6 +54,7 @@ from draftwright.recognition import (
     recognise_plates,
     recognise_pocket_patterns,
     recognise_pockets,
+    recognise_slot_patterns,
     recognise_slots,
     recognise_step_shoulders,
     recognise_turned_steps,
@@ -75,6 +78,8 @@ _EXPECTED_RECORD_TYPES = {
     Flat,
     Groove,
     Slot,
+    SlotArray,
+    SlotGrid,
     Pocket,
     PocketArray,
     PocketGrid,
@@ -130,6 +135,21 @@ def _pocket_grid_plate():
     for i in range(2):  # 2×3 lattice of identical blind pockets (rect_grid needs n>=6)
         for j in range(3):
             part -= Pos((i - 0.5) * 40, (j - 1) * 30, 7) * Box(8, 10, 6)
+    return part
+
+
+def _slot_array_plate():
+    part = Box(60, 200, 20)
+    for cy in (-45, -15, 15, 45):  # four identical THROUGH slots on one Y centreline, pitch 30
+        part -= Pos(0, cy, 0) * Box(30, 8, 20)  # cutter spans the full Z → a Slot, not a Pocket
+    return part
+
+
+def _slot_grid_plate():
+    part = Box(180, 130, 20)
+    for i in range(2):  # 2×3 lattice of identical through slots (rect_grid needs n>=6)
+        for j in range(3):
+            part -= Pos((i - 0.5) * 44, (j - 1) * 34, 0) * Box(24, 8, 20)
     return part
 
 
@@ -189,6 +209,14 @@ def _records_from_recognisers():
         (
             "pocket_patterns:grid",
             recognise_pocket_patterns(recognise_pockets(_pocket_grid_plate())),
+        ),
+        (
+            "slot_patterns:linear",
+            recognise_slot_patterns(recognise_slots(_slot_array_plate())),
+        ),
+        (
+            "slot_patterns:grid",
+            recognise_slot_patterns(recognise_slots(_slot_grid_plate())),
         ),
         ("recognise_flats", recognise_flats(dshaft)),
         ("recognise_grooves", recognise_grooves(grooved)),

--- a/tests/test_slot_pattern_recognition.py
+++ b/tests/test_slot_pattern_recognition.py
@@ -131,6 +131,42 @@ def test_sheet_emit_round_trips_the_pattern(tmp_path):
     assert "depth=" not in line  # a slot has no depth
 
 
+def test_rectangular_grid_emit_round_trips_faithfully():
+    # a RECTANGULAR (rows≠cols, row_pitch≠col_pitch) grid must reconstruct its exact member
+    # lattice through the emitted at=/grid=/rows=/cols=/angle= (guards the recognition angle/
+    # basis convention against declare._pattern_members' — Codex #852 flagged a possible
+    # rows↔cols transpose; this pins that it does NOT transpose).
+    from draftwright.model import slot, slot_pattern
+
+    pm = build_part_model(_slot_grid(2, 3))  # 44 mm × 34 mm rectangular lattice
+    feat = next(f for f in pm.features if f.kind == "slot_pattern")
+    assert feat.rows != feat.cols and feat.grid[0] != feat.grid[1]  # genuinely rectangular
+    m = feat.member
+    rebuilt = slot_pattern(
+        slot(
+            width=m.width,
+            length=m.length,
+            long_axis=m.long_axis,
+            width_axis=m.width_axis,
+            depth_axis="z",
+            lo=m.lo,
+            hi=m.hi,
+            w_center=m.w_center,
+            at=m.frame.origin,
+        ),
+        kind="grid",
+        count=feat.count,
+        grid=feat.grid,
+        rows=feat.rows,
+        cols=feat.cols,
+        angle=feat.angle,
+        at=feat.frame.origin,
+    )
+    detected = sorted((round(p[0], 2), round(p[1], 2)) for p in feat.members)
+    reconstructed = sorted((round(p[0], 2), round(p[1], 2)) for p in rebuilt.members)
+    assert detected == reconstructed
+
+
 def test_slot_row_renders_one_grouped_callout_not_four():
     # the payoff: a row of four identical slots renders ONE `4× SLOT 8 × 30` (width × length)
     # callout + a pitch dim, not four competing per-slot size dims (#841 confirmed-behaviour #1).

--- a/tests/test_slot_pattern_recognition.py
+++ b/tests/test_slot_pattern_recognition.py
@@ -1,0 +1,145 @@
+"""Recognition + emit for the slot-pattern kind (#841 confirmed-behaviour #1, recognise side).
+
+The through-slot analog of `test_pocket_pattern_recognition`: `recognise_slot_patterns` groups
+identical milled slots into one `SlotArray`/`SlotGrid`, `build_part_model` emits ONE
+`SlotPatternFeature` and excludes the member slots, and `sheet_emit` round-trips it. The payoff
+is that a row of identical slots renders ONE grouped ``count× SLOT W × L`` callout, not N
+competing per-slot size dims (some of which drop for lack of room — #841 confirmed-behaviour #1).
+"""
+
+import dataclasses
+from pathlib import Path
+
+from build123d import Box, Pos
+
+from draftwright.make_drawing import build_drawing
+from draftwright.model.detect import build_part_model
+from draftwright.recognition import (
+    SlotArray,
+    SlotGrid,
+    recognise_slot_patterns,
+    recognise_slots,
+)
+
+
+def _slot_row(n=4, pitch=30.0):
+    part = Box(60, pitch * (n + 2), 20)
+    for i in range(n):  # n identical THROUGH slots on one Y centreline (cutter spans full Z)
+        part -= Pos(0, (i - (n - 1) / 2) * pitch, 0) * Box(30, 8, 20)
+    return part
+
+
+def _slot_grid(nx=2, ny=3, px=44.0, py=34.0):
+    part = Box(px * (nx + 2), py * (ny + 1), 20)
+    for i in range(nx):
+        for j in range(ny):
+            part -= Pos((i - (nx - 1) / 2) * px, (j - (ny - 1) / 2) * py, 0) * Box(24, 8, 20)
+    return part
+
+
+def test_recognise_linear_slot_array():
+    slots = recognise_slots(_slot_row(n=4, pitch=30.0))
+    assert len(slots) == 4
+    pats = recognise_slot_patterns(slots)
+    assert len(pats) == 1
+    sa = pats[0]
+    assert isinstance(sa, SlotArray)
+    assert len(sa.slots) == 4
+    assert sa.pitch == 30.0
+    assert abs(sa.direction[1]) == 1.0  # runs along Y
+
+
+def test_recognise_slot_grid():
+    pats = recognise_slot_patterns(recognise_slots(_slot_grid(2, 3)))
+    assert len(pats) == 1
+    sg = pats[0]
+    assert isinstance(sg, SlotGrid)
+    assert len(sg.slots) == 6
+    assert {sg.rows, sg.cols} == {2, 3}
+
+
+def test_two_slots_are_not_a_pattern():
+    assert recognise_slot_patterns(recognise_slots(_slot_row(n=2, pitch=30.0))) == []
+
+
+def test_different_size_slots_do_not_group():
+    part = Box(60, 200, 20)
+    part -= Pos(0, -45, 0) * Box(30, 8, 20)
+    part -= Pos(0, 0, 0) * Box(30, 12, 20)  # wider
+    part -= Pos(0, 45, 0) * Box(40, 8, 20)  # longer
+    assert recognise_slot_patterns(recognise_slots(part)) == []
+
+
+def test_non_coplanar_slots_do_not_merge():
+    # identical slots whose in-plane centres line up but which lie on DIFFERENT through planes
+    # (staggered d_lo/d_hi) must NOT merge into one array — the spec key includes the through
+    # extent (mirrors _pocket_spec_key).
+    from draftwright.recognition.slots import Slot
+
+    def sl(cy, d_lo):
+        return Slot(
+            width_axis="y",
+            long_axis="x",
+            width=8.0,
+            length=30.0,
+            w_center=cy,
+            lo=-15.0,
+            hi=15.0,
+            d_lo=d_lo,
+            d_hi=d_lo + 20,
+        )
+
+    staggered = [sl(-30, 0.0), sl(0, 5.0), sl(30, 10.0)]
+    assert recognise_slot_patterns(staggered) == []
+    coplanar = [sl(-30, 0.0), sl(0, 0.0), sl(30, 0.0)]
+    assert len(recognise_slot_patterns(coplanar)) == 1
+
+
+def test_build_part_model_groups_and_excludes_members():
+    pm = build_part_model(_slot_row(n=4, pitch=30.0))
+    kinds = [f.kind for f in pm.features]
+    assert kinds.count("slot_pattern") == 1
+    assert kinds.count("slot") == 0  # members folded into the pattern, not emitted individually
+    pat = next(f for f in pm.features if f.kind == "slot_pattern")
+    assert pat.count == 4
+    assert pat.member.width == 8.0 and pat.member.length == 30.0
+
+
+def test_injected_value_equal_pattern_still_excludes_members():
+    part = _slot_row(n=4, pitch=30.0)
+    slots = recognise_slots(part)
+    pats = recognise_slot_patterns(slots)
+    copied_slots = [dataclasses.replace(sl) for sl in slots]  # value-equal, new ids
+    copied_pats = [
+        dataclasses.replace(p, slots=tuple(dataclasses.replace(m) for m in p.slots)) for p in pats
+    ]
+    pm = build_part_model(part, slots=copied_slots, slot_patterns=copied_pats)
+    kinds = [f.kind for f in pm.features]
+    assert kinds.count("slot_pattern") == 1
+    assert kinds.count("slot") == 0  # value-equal copies still excluded
+
+
+def test_sheet_emit_round_trips_the_pattern(tmp_path):
+    from draftwright.sheet_emit import generate_sheet_script
+
+    py = generate_sheet_script(_slot_row(n=4, pitch=30.0), out=str(tmp_path / "sp_emit_rt"))
+    src = Path(py).read_text(encoding="utf-8")  # the script carries non-ASCII (×); Windows
+    line = next(ln for ln in src.splitlines() if "sheet.slot_pattern(" in ln)
+    assert "members=" not in line  # declare rejects members= — uses at=/pitch=/direction=
+    assert 'kind="linear"' in line and "count=4" in line
+    assert "at=" in line and "pitch=" in line and "direction=" in line
+    assert "depth=" not in line  # a slot has no depth
+
+
+def test_slot_row_renders_one_grouped_callout_not_four():
+    # the payoff: a row of four identical slots renders ONE `4× SLOT 8 × 30` (width × length)
+    # callout + a pitch dim, not four competing per-slot size dims (#841 confirmed-behaviour #1).
+    dwg = build_drawing(_slot_row(n=4, pitch=30.0))
+    names = dwg.annotations()
+    callouts = [n for n in names if n.startswith("m_slotpat")]
+    assert len(callouts) == 1
+    assert dwg.get_annotation(callouts[0]).label == "4× SLOT 8 × 30"
+    assert not [
+        n for n in names if n.startswith("m_slot0")
+    ]  # members not individually dimensioned
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]


### PR DESCRIPTION
The **recognition + emit** half of the through-slot pattern sibling (declared path landed in #851). Identical milled slots are now RECOGNISED as one grouped `count× SLOT W × L` callout — closing **#841 confirmed-behaviour #1** (five `sheet.slot()` render only 3 of 5 length dims) end-to-end. Mirrors the pocket recognition (#849).

## What's here
- **`recognition/slots.py`** — `recognise_slot_patterns(slots)` (derived recogniser → `SlotArray`/`SlotGrid`) + `Slot.location`. `_slot_spec_key` is **simpler** than the pocket key: a slot is through, so no `depth` and no `open_sign` (just axes + size + the through extent `d_lo`/`d_hi`, which still separates slots on different through-planes). Reuses the record-generic `_linear_array_candidates`/`_rect_grid` factory (#635) — no `_features` change.
- **`model/detect.py`** — `_slot_pattern_feature` + a standalone `_member_slot` (slot-centroid, **not** `_convert_slot`'s bbox-centred frame, so lone-slot dim placement is untouched); registered in `_DERIVED_CONVERTERS`; `build_part_model` groups identical slots into one `SlotPatternFeature` and excludes members by VALUE-set. New `slot_patterns=` injection param.
- **`sheet_emit.py`** — `k=="slot_pattern"` branch + `_member_slot_str`, emitting `sheet.slot_pattern(slot(...), at=<centre>, pitch=/grid=, direction=)` — **without** `members=` (declare rejects it) and without `depth=`.

## Tests
- `tests/test_slot_pattern_recognition.py` — recogniser (linear/grid + non-pattern/non-coplanar guards), `build_part_model` grouping + value-exclusion, sheet_emit round-trip, and a `build_drawing` e2e (four identical slots → ONE `4× SLOT 8 × 30` callout).
- `tests/test_recogniser_contract.py` — through-slot drive parts + `SlotArray`/`SlotGrid` in `_EXPECTED_RECORD_TYPES`; `test_detect_registry` auto-picks them up.

## Follow-up
The editable surface (`dwg.callout(slot_pattern)` + finalize + re-emit) is the final sibling PR, mirroring pocket #850.

## Verification
15 slot-pattern + 208 recognition/detect/emit regression + 4 lint checks green locally; full fast tier running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)