### PR TITLE
feat(#841): slot-pattern editable surface — callout/finalize + re-emit (PR C)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -975,6 +975,12 @@ def _feature_listing(a: Analysis) -> str:
             # has no location dims and render_pocket_patterns emits the pitch itself.
             body.append("dwg.callout(f)")
             continue
+        elif kind == "slot_pattern":
+            # A slot pattern reconstructs through callout(f), exactly like a pocket pattern:
+            # finalize drains it at the pre-drain "slot_patterns" stage, drawing the grouped
+            # SLOT W × L callout + its pitch dim(s). No locate()/furniture() (#841).
+            body.append("dwg.callout(f)")
+            continue
         for p in feat.parameters():
             if p.span is not None or kind == "slot":  # a linear dim dimension() accepts
                 body.append(f'dwg.dimension(f, "{p.kind}", role="{p.role}")   # {display(p)}')

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -201,6 +201,7 @@ class _IntentRouting:
     slot_feats: set
     machined_ids_by_kind: dict
     pocket_pattern_ids: set
+    slot_pattern_ids: set
 
 
 @dataclass
@@ -1080,7 +1081,7 @@ class Drawing:
         like the auto-pass), rather than raising, so a reconstruction script never aborts.
         """
         kind = getattr(feature, "kind", None)
-        if (kind in _MACHINED_CALLOUT_KINDS or kind == "pocket_pattern") and (
+        if (kind in _MACHINED_CALLOUT_KINDS or kind in ("pocket_pattern", "slot_pattern")) and (
             view is not None or name is not None
         ):
             raise ValueError(
@@ -1153,6 +1154,25 @@ class Drawing:
             )
             placed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
             return next((n for n in placed if n.startswith("m_pocketpat")), "")
+        if kind == "slot_pattern":
+            # A slot pattern renders through its own auto-pass renderer (grouped SLOT W × L
+            # callout + pitch dim(s)), restricted to THIS feature (#841). Like the pocket pattern
+            # it places furniture too, so several names change — return the grouped-callout name
+            # (m_slotpat*), the handle pin()/drop() address.
+            if self._part_model is None or self._analysis is None:
+                raise ValueError(
+                    "callout(): a slot-pattern callout needs the part model and analysis; "
+                    "add it to a drawing built by build_drawing(), not a bare Drawing"
+                )
+            from draftwright.annotations.holes import render_slot_patterns
+            from draftwright.model import plan_dimensions
+
+            before = {n: id(o) for n, o in self.iter_annotations()}
+            render_slot_patterns(
+                self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
+            )
+            placed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
+            return next((n for n in placed if n.startswith("m_slotpat")), "")
         return add_feature_callout(
             self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
         )
@@ -1453,6 +1473,15 @@ class Drawing:
             and it.kind == "callout"
             and getattr(it.feature, "kind", None) == "pocket_pattern"
         }
+        # Slot-pattern callout()s (#841): same as pocket patterns — one grouped callout + pitch
+        # furniture, drained at the pre-drain "slot_patterns" _PASS_SEQUENCE slot, only=-restricted.
+        slot_pattern_ids = {
+            id(it)
+            for it in self._intents
+            if routable
+            and it.kind == "callout"
+            and getattr(it.feature, "kind", None) == "slot_pattern"
+        }
         only_loc = {it.feature for it in self._intents if id(it) in corridor_ids}
         pinned_loc = {
             it.feature for it in self._intents if id(it) in corridor_ids and it.kwargs.get("pin")
@@ -1482,6 +1511,7 @@ class Drawing:
             slot_feats=slot_feats,
             machined_ids_by_kind=machined_ids_by_kind,
             pocket_pattern_ids=pocket_pattern_ids,
+            slot_pattern_ids=slot_pattern_ids,
         )
 
     def _user_dim_uses_corridor(self, it, routable, already_routed) -> bool:
@@ -1673,6 +1703,7 @@ class Drawing:
             _locate_off_axis_holes,
             build_view_of_axis,
             render_pocket_patterns,
+            render_slot_patterns,
         )
         from draftwright.annotations.orchestrator import (
             _maybe_tabulate_holes,
@@ -1727,6 +1758,7 @@ class Drawing:
                 | r.off_axis_loc_ids  # drained by the off-axis stages; locate() raises on non-Z
                 | {i for ids in r.machined_ids_by_kind.values() for i in ids}  # _s_<machined kind>
                 | r.pocket_pattern_ids  # _s_pocket_patterns (pre-drain)
+                | r.slot_pattern_ids  # _s_slot_patterns (pre-drain)
             )
             i = 0
             while i < len(self._intents):
@@ -1877,6 +1909,16 @@ class Drawing:
                 render_pocket_patterns(self, plan_dimensions(model), a, ctx=ctx, only=feats)
             self._intents = [it for it in self._intents if id(it) not in r.pocket_pattern_ids]
 
+        def _s_slot_patterns():
+            # Slot-pattern callouts + their pitch furniture (#841), restricted to the recorded
+            # feature(s). Keyed "slot_patterns" so run_stages fires it at that PRE-drain
+            # _PASS_SEQUENCE slot (same reason as pocket patterns).
+            feats = {it.feature for it in self._intents if id(it) in r.slot_pattern_ids}
+            if feats:
+                assert a is not None and isinstance(model, PartModel)  # ⟹ routable
+                render_slot_patterns(self, plan_dimensions(model), a, ctx=ctx, only=feats)
+            self._intents = [it for it in self._intents if id(it) not in r.slot_pattern_ids]
+
         def _s_user_dims():
             # User-authored pin/priority dimensions queue into the shared corridor as
             # first-class candidates (ADR 0012).
@@ -1980,6 +2022,7 @@ class Drawing:
                 "step_lengths": _s_step_lengths,
                 "slots": _s_slots,
                 "pocket_patterns": _s_pocket_patterns,
+                "slot_patterns": _s_slot_patterns,
                 "user_dims": _s_user_dims,
                 "drain": _s_drain,
                 "chamfers": _s_chamfers,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6483,8 +6483,8 @@ class TestFeatureEdits:
             elif f.kind in ("step", "boss"):
                 if f.frame.axis in ("x", "z"):  # callout() places X/Z-turned diameters only
                     dwg.callout(f)
-            elif f.kind == "pocket_pattern":
-                dwg.callout(f)  # grouped callout + pitch (no locate/furniture); #841 outcome 3
+            elif f.kind in ("pocket_pattern", "slot_pattern"):
+                dwg.callout(f)  # grouped callout + pitch (no locate/furniture); #841
                 continue
             elif f.kind == "step_level":
                 dwg.dimension(f, "length", role="step_height")

--- a/tests/test_slot_pattern.py
+++ b/tests/test_slot_pattern.py
@@ -10,6 +10,7 @@ composition, the grouped render (linear + grid), and the input guards.
 import pytest
 from build123d import Box
 
+from draftwright.make_drawing import build_drawing
 from draftwright.model import slot, slot_pattern
 from draftwright.sheet import Sheet
 
@@ -115,3 +116,36 @@ def test_model_inspection_sees_the_pattern():
     model = s.model()
     pats = [f for f in model.features if f.kind == "slot_pattern"]
     assert len(pats) == 1 and pats[0].count == 4
+
+
+def test_manual_callout_verb_places_grouped_callout_and_pitch():
+    # the manual dwg.callout() edit verb for a slot pattern (#841 editable surface) draws the
+    # grouped size callout AND its pitch dim (render_slot_patterns bundles both), returning the
+    # grouped-callout name — mirroring the pocket-pattern editable surface.
+    part = Box(60, 161, 21)
+    s = Sheet(part)
+    s.envelope()
+    s.slot_pattern(_member(), kind="linear", count=4, pitch=30.0, direction=(0, 1, 0))
+    dwg = build_drawing(part, model=s.model(), auto_dims=False)  # nothing auto-drawn
+    feat = next(f for f in dwg.model().features if f.kind == "slot_pattern")
+    name = dwg.callout(feat)
+    assert name.startswith("m_slotpat")
+    assert dwg.get_annotation(name).label == "4× SLOT 8 × 20"
+    assert [n for n in dwg.annotations() if n.startswith("dim_slotpat_pitch_")]
+
+
+def test_deferred_callout_reconstructs_the_pattern():
+    # the reconstruction path (builder._feature_listing emits `dwg.callout(f)`): a callout intent
+    # recorded inside `with dwg.deferred()` drains through finalize's pre-drain "slot_patterns"
+    # stage, drawing the same grouped callout + pitch (#841 editable surface).
+    part = Box(60, 161, 21)
+    s = Sheet(part)
+    s.envelope()
+    s.slot_pattern(_member(), kind="linear", count=4, pitch=30.0, direction=(0, 1, 0))
+    dwg = build_drawing(part, model=s.model(), auto_dims=False)
+    with dwg.deferred():
+        dwg.callout(next(f for f in dwg.model().features if f.kind == "slot_pattern"))
+    names = dwg.annotations()
+    assert [n for n in names if n.startswith("m_slotpat")]
+    assert [n for n in names if n.startswith("dim_slotpat_pitch_")]
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]


### PR DESCRIPTION
Completes the through-slot pattern sibling (declared #851, recognition+emit #852): the manual `dwg.callout()` edit verb and reconstruction re-emit for slot patterns are now wired, **mirroring the pocket-pattern editable surface (#850) exactly**.

- **`drawing.py` `callout()`** — a `slot_pattern` live branch renders the grouped `SLOT W × L` callout + pitch via `render_slot_patterns(only={feature})`, returning the `m_slotpat*` name; `view=`/`name=` rejected (auto-placed).
- **`drawing.py` finalize** — `_classify_intents` buckets slot-pattern callout intents (`slot_pattern_ids` on `_IntentRouting`); a new `_s_slot_patterns` stage drains them, keyed `"slot_patterns"` so `run_stages` fires it at its pre-drain slot; the ids join `_s_live_replay`'s `routed` set.
- **`builder._feature_listing`** — a `slot_pattern` branch emits `dwg.callout(f)` (no `locate`/`furniture` — a slot pattern has neither).

## Tests
- `test_manual_callout_verb_places_grouped_callout_and_pitch` + `test_deferred_callout_reconstructs_the_pattern` (live + deferred/finalize).
- The `_reconstruct` helper (mirrors `_feature_listing`) gains a `slot_pattern` branch.

This closes the #841 `SlotPatternFeature` sibling epic (declared → recognise+emit → editable, matching the pocket epic #848/#849/#850).

## Verification
18 slot-pattern + 16 reconstruction + 4 lint checks green locally; full fast tier running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)