### PR TITLE
feat(#841): auto-relax anchored-note side instead of silently dropping (behaviour C)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3448,28 +3448,50 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                 _zones=_zones,
                 _px=_px,
                 _py=_py,
-                _hz=_hz,
                 _sz=_sz,
                 _bld=_bld,
                 _feat=_feat,
                 _tb=_tb,
             ):
-                alt = {"above": "below", "below": "above", "left": "right", "right": "left"}[_s]
-                alt_strip = getattr(_zones, alt, None)
-                if alt_strip is not None:
-                    axis2 = "y" if alt in ("above", "below") else "x"
+                # Auto-relax the requested side (#841 outcome C): the requested strip is full, so
+                # try the OPPOSITE side, then the two PERPENDICULAR sides, placing on the first
+                # with room. A note the caller asked to see should appear somewhere legible
+                # rather than vanish; when the requested strip has no room, an explicit `side=`
+                # is a preference, not a hard constraint. A perpendicular side flips the leader
+                # orientation (`_bld(pos, _hz=hz)`). If the placement lands on a side other than
+                # requested, record an INFO issue so the relaxation is visible, not silent — the
+                # #841 goal is that a requested annotation is never *silently* lost.
+                relax_order = {
+                    "above": ("below", "right", "left"),
+                    "below": ("above", "right", "left"),
+                    "left": ("right", "above", "below"),
+                    "right": ("left", "above", "below"),
+                }[_s]
+                for alt in relax_order:
+                    alt_strip = getattr(_zones, alt, None)
+                    if alt_strip is None:
+                        continue
+                    hz = alt in ("above", "below")  # perpendicular sides flip the leader axis
+                    axis2 = "y" if hz else "x"
                     extent = _sz[1] if axis2 == "y" else _sz[0]  # the glyph's stacking-axis size
-                    perp = (_px, _px + _sz[0]) if _hz else (_py - _sz[1] / 2, _py + _sz[1] / 2)
+                    perp = (_px, _px + _sz[0]) if hz else (_py - _sz[1] / 2, _py + _sz[1] / 2)
                     pos = carve_free_position(dwg, alt_strip, _v, axis2, max(tier, extent), perp)
-                    if pos is not None:
-                        dim = _bld(pos)
-                        if not _box_hits(_anno_box(dim), (_tb,)):  # clear of the title block
-                            ctx.place(dim, nm, view=_v, feature=_feat)  # alternate side
-                            return
+                    if pos is None:
+                        continue
+                    dim = _bld(pos, _hz=hz)
+                    if _box_hits(_anno_box(dim), (_tb,)):  # would overlap the title block — skip
+                        continue
+                    ctx.place(dim, nm, view=_v, feature=_feat)  # relaxed side
+                    ctx.record_issue(
+                        "info",
+                        "gdt_side_relaxed",
+                        f"{nm}: the {_v} {_s} strip was full — placed on {alt} instead",
+                    )
+                    return
                 ctx.record_issue(
                     "warning",
                     "gdt_dropped",
-                    f"{nm} not placed (no room in the {_v} {_s} strip or its opposite)",
+                    f"{nm} not placed (no room in any {_v} strip)",
                 )
 
             ctx.post_drain.append(_retry)

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -13,7 +13,7 @@ from build123d import Box, Cylinder, Draft, Pos
 from build123d_drafting import FeatureControlFrame
 
 from draftwright.builder import build_drawing, detect_part_model
-from draftwright.model.ir import ControlFrame, DatumRef, Finish, Frame
+from draftwright.model.ir import ControlFrame, DatumRef, Finish, Frame, Note
 
 
 def _part():
@@ -160,12 +160,13 @@ def test_invalid_glyph_spec_drops_not_crashes():
     assert "m_gdt0" not in dwg.annotations()
 
 
-def test_wide_frame_in_narrow_strip_drops_not_overshoots():
-    # Adversarial-review finding (CONFIRMED): a wide GD&T glyph (multi-datum FCF ~33 mm) on
-    # a left/right strip narrower than the glyph must DROP with a gdt_dropped warning — not
-    # render off the drawable area. Pre-fix it placed at min.X=-7.17 (17 mm past outer_limit,
-    # annotation_out_of_bounds error). The boundary reservation now uses the glyph's real
-    # outward extent, so a too-narrow strip has no feasible tier and the frame drops.
+def test_wide_frame_in_narrow_strip_relaxes_not_overshoots():
+    # Adversarial-review finding (CONFIRMED): a wide GD&T glyph (multi-datum FCF ~33 mm) on a
+    # left/right strip narrower than the glyph must never render off the drawable area
+    # (annotation_out_of_bounds — pre-fix it placed at min.X=-7.17, 17 mm past outer_limit).
+    # The requested left/right strips are too narrow, so under the #841 side auto-relax the
+    # frame moves to a wider above/below strip where it fits IN BOUNDS — placed (with a
+    # gdt_side_relaxed info notice), not overshooting and not vanishing.
     frame = ControlFrame(
         frame=Frame((0.0, 0.0, 0.0), "z"),
         characteristic="position",
@@ -175,9 +176,37 @@ def test_wide_frame_in_narrow_strip_drops_not_overshoots():
         datums=("A", "B"),
     )
     dwg = _build(frame)
-    assert [i for i in dwg.registry.issues if i.code == "gdt_dropped"]
-    assert "m_gdt0" not in dwg.annotations()
+    assert "m_gdt0" in dwg.annotations()  # placed on a relaxed side, not dropped
+    assert [i for i in dwg.registry.issues if i.code == "gdt_side_relaxed"]
+    assert not [i for i in dwg.registry.issues if i.code == "gdt_dropped"]
+    assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]  # never overshoots
+
+
+def test_note_relaxes_side_when_requested_strip_full():
+    # #841 confirmed-behaviour #2 / outcome C: an anchored note whose requested view/side strip
+    # has no room must NOT silently drop — it auto-relaxes to a strip that fits (with a
+    # gdt_side_relaxed info notice), so a requested annotation always appears somewhere legible.
+    # A wide note text on the narrow left strip forces the relaxation to above/below.
+    note = Note(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        text="5X OBROUND SLOT 13.60 X 7.88",
+        view="plan",
+        side="left",
+    )
+    dwg = _build(note)
+    assert "m_gdt0" in dwg.annotations()  # placed, not dropped
+    assert [i for i in dwg.registry.issues if i.code == "gdt_side_relaxed"]
+    assert not [i for i in dwg.registry.issues if i.code == "gdt_dropped"]
     assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
+
+
+def test_note_honors_requested_side_when_it_fits():
+    # The relax fires ONLY when the requested strip is full: a note that fits its requested side
+    # is placed there with NO gdt_side_relaxed notice (no spurious relaxation).
+    note = Note(frame=Frame((0.0, 0.0, 0.0), "z"), text="DEBURR", view="plan", side="above")
+    dwg = _build(note)
+    assert "m_gdt0" in dwg.annotations()
+    assert not [i for i in dwg.registry.issues if i.code == "gdt_side_relaxed"]
 
 
 def test_degenerate_leader_site_does_not_crash():


### PR DESCRIPTION
Closes the last substantive **#841** item (confirmed-behaviour #2/#3): an anchored note (or GD&T frame / surface finish) declared with an explicit `view=`/`side=` **silently dropped** when that strip had no room (`gdt_dropped`, warning) even while the export "succeeded" — a requested annotation vanishing without recourse.

Per the chosen design (option **C — auto-relax side, keep the note**):

## Change
Generalise the #481 opposite-side fallthrough in `render_gdt`'s on-drop `_retry`: when the requested strip is full, try the **opposite** side, then the two **perpendicular** sides (flipping the leader orientation), placing on the first strip with room — via the same `carve_free_position` / title-block-clear checks, so it **never overshoots** the drawable area. Only when **no** strip fits does it drop.

A relaxed placement records an **INFO `gdt_side_relaxed`** issue naming requested-vs-actual side, so the override is visible, not silent — the #841 goal is that a requested annotation is never *silently* lost. An explicit `side=` is now a **preference honoured when the strip has room**, not a hard constraint that forfeits the annotation.

## Tests
- `test_note_relaxes_side_when_requested_strip_full` — a wide note on the narrow left strip relaxes to above/below, places in-bounds, records `gdt_side_relaxed`, no `gdt_dropped`.
- `test_note_honors_requested_side_when_it_fits` — a fitting note keeps its requested side with **no** spurious relax notice.
- `test_wide_frame_in_narrow_strip_relaxes_not_overshoots` (was `..._drops_not_overshoots`) — the wide multi-datum FCF now relaxes + places **in bounds** rather than dropping; the real no-overshoot invariant (`annotation_out_of_bounds`) is preserved.

## Verification
14 GD&T-placement + 4 lint checks green locally; full fast tier running.

Note: the pocket + slot pattern epics (#848–#854) already closed confirmed-behaviour #1 and outcomes 2–4; this closes the remaining note-side-sensitivity item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)