### PR TITLE
chore(release): finalize CHANGELOG for v0.3.9 and reconcile the roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## v0.3.9 — 2026-07-26
+
+### Added
+
+- **Repeated recesses are dimensioned as one pattern, not N competing callouts**
+  (#841): identical blind pockets and identical through-slots now collapse to a single
+  grouped `5× 7.9 × 13.6 × 19 DEEP` / `4× SLOT 8 × 30` leader plus `(n-1)× pitch`
+  dim(s). Previously each member competed for its own size dims and some silently
+  dropped for want of strip room — five declared slots rendered only three length dims.
+  Both new kinds (`PocketPatternFeature`, `SlotPatternFeature`) round-trip every
+  surface: declare (`sheet.pocket_pattern(...)` / `sheet.slot_pattern(...)`),
+  recognition from a real solid (coplanar, same-facing members only), the emitted
+  Sheet script, and the editable surface (`dwg.callout(feature)` + `finalize()`).
+- **`Sheet.section()` and `Sheet.detail()` — ask for the view you need** (#841/#847):
+  a section A–A auto-fires only for a Z-axis hole with a counterbore, spotface, or
+  blind bottom, so a blind pocket's floor and depth stayed hidden-line-only with no
+  supported way to request a cut. `sheet.section(feature)` / `section(at=y)` /
+  bare `section()` force one (the cut plane is validated to lie strictly inside the
+  part), and `sheet.detail()` exposes the existing `detail_view=True` opt-in as a
+  chainable verb.
+- **External threads are a first-class declared aspect** (#859): the turned analog of
+  the #764 internal thread — `sheet.step(shaft).thread("M3x0.5")`,
+  `sheet.diameter(...).thread(...)`, and `sheet.boss(...).thread(...)` append the
+  spec to the ⌀ callout (`ø3 M3x0.5`) instead of needing a free-text `.note()`. It
+  composes with `.finish()` for Ra-on-thread, keys the callout bucket on `(⌀, thread)`
+  so a threaded and a plain ø6 stay distinct, and now round-trips through the Sheet
+  emitter — including pattern-member holes, closing the symmetric latent #764 gap.
+  Declaration-only: a plain cylinder is geometrically indistinguishable from a
+  threaded one, so there is no recogniser. *(Known limitation: the incremental
+  `callout`/`finalize(only=…)` paths still dedup thread-blind — #863.)*
+- **Blind obround pocket recognition, including imported STEP** (#837): the blind
+  counterpart of the #816 through-slot work. A stubby floored obround has side walls
+  too short to pair, so it is recovered from its semicircular end caps — clustering
+  faces by axis proximity so the quarter-cylinder split a STEP importer commonly
+  produces recognises as well as build123d's half-cylinder. A sealed internal void
+  (capped at both ends) is correctly *not* a pocket. A real tuner-jig STEP with five
+  blind pockets ships as a fixture.
+- **`sheet.slot(...).note(...)` / `sheet.pocket(...).note(...)`** (#841/#845): the
+  slot/pocket handle now anchors a note to its own feature, with no `ref=` needed
+  (an explicit `ref` still forwards, as before).
+
+### Changed
+
+- **An anchored note, GD&T frame, or finish relaxes its side instead of silently
+  vanishing** (#841/#855): an annotation declared with an explicit `view=`/`side=`
+  used to drop with only a warning when that strip was full, while the export still
+  reported success. The requested side is now a *preference* — when the strip has no
+  room the placer tries the opposite side, then the two perpendicular sides, taking
+  the first with room (via the same bounds and title-block checks, so it never
+  overshoots). A relaxed placement records an INFO `gdt_side_relaxed` issue naming
+  requested versus actual. Only when no strip fits does it drop.
+
+### Internal
+
+- **The state-bus endgame is closed to its permanent seam** (#830/#840): the
+  solve trace is filled into `BuildState` at the one construction site, the redundant
+  part-model re-attach is gone, and the detail view is now *transactional* — geometry
+  is projected at the detail scale and committed only if dimensions land, so
+  `_drop_view_coordinates` has zero engine callers. With those removed, the #817
+  decision-D method-call exemption narrows from a blanket pass to a named
+  `_LAYOUT_SEAM` allowlist (`_add_view`, `_set_view_coordinates`), accepted as the
+  permanent interactive-layout seam; every other private-method call on the drawing
+  is now flagged.
+- **A draftwright logo set** (#843) — drafting-idiom mark, all text outlined so the
+  SVGs render font-independently; the README now leads with the lockup.
+- **A worked multi-feature object-reference example** (#853) in
+  `docs/multi-feature-object-reference-workflow.md`.
+
 ## v0.3.8 — 2026-07-23
 
 ### Added

--- a/docs/plans/product-backlog-roadmap.md
+++ b/docs/plans/product-backlog-roadmap.md
@@ -1,7 +1,7 @@
 # Product backlog roadmap
 
 - **Status:** Active delivery plan
-- **Last reviewed:** 2026-07-21
+- **Last reviewed:** 2026-07-26
 - **Live tracker:** [#758 — trustworthy drawing pipeline and backlog
   burn-down](https://github.com/pzfreo/draftwright/issues/758)
 
@@ -37,10 +37,10 @@ decision that prevents progress.
 
 | Workstream | Objective | Now | Next |
 | --- | --- | --- | --- |
-| Trust and correctness | Never certify or silently emit an incomplete drawing | [#632](https://github.com/pzfreo/draftwright/issues/632) truthful dimensional coverage | [#707](https://github.com/pzfreo/draftwright/issues/707) direct/generated Sheet parity |
-| Reliability and diagnostics | Make failures fast, reproducible, and representative | [#692](https://github.com/pzfreo/draftwright/issues/692) deterministic Hypothesis generation | [#737](https://github.com/pzfreo/draftwright/issues/737) dense-sheet fast canaries |
-| Architecture | Remove boundaries that make correctness work risky | [#754](https://github.com/pzfreo/draftwright/issues/754) rotational dimensions through planner output | [#752](https://github.com/pzfreo/draftwright/issues/752) typed recognition adapter registry |
-| Manufacturing coverage | Expand independently verified feature coverage | No active implementation until a WIP slot clears | [#676](https://github.com/pzfreo/draftwright/issues/676) polygonal boss recognition |
+| Trust and correctness | Never certify or silently emit an incomplete drawing | [#863](https://github.com/pzfreo/draftwright/issues/863) thread-blind ⌀ dedup on the incremental paths | [#812](https://github.com/pzfreo/draftwright/issues/812)-class emit gaps as found |
+| Reliability and diagnostics | Make failures fast, reproducible, and representative | No active implementation | [#826](https://github.com/pzfreo/draftwright/issues/826) dependency/static-security/secret scanning |
+| Architecture | Remove boundaries that make correctness work risky | No active implementation — Milestone 2 exited | [#830](https://github.com/pzfreo/draftwright/issues/830) residual state-bus seam review |
+| Manufacturing coverage | Expand independently verified feature coverage | [#676](https://github.com/pzfreo/draftwright/issues/676) polygonal boss recognition | [#675](https://github.com/pzfreo/draftwright/issues/675) paired bilateral PMI tolerances |
 
 The table is intentionally small. The live roadmap issue records ownership,
 blockers, and session-to-session movement.
@@ -91,6 +91,18 @@ replay deterministically.
 - The fast CI tier has no known unreproducible or full-suite-only flake.
 
 ## Milestone 2 — Architectural closure
+
+**Status: EXITED (2026-07-23).** All five scope items delivered (#754, #746, #752,
+#523, #741), each through independent adversarial review, and all four exit criteria
+met. The follow-on state-bus endgame (#830) subsequently reached its designed end
+state: the engine no longer mutates build state onto a live `Drawing` outside a named
+two-method layout seam, which the guard now enforces as an allowlist. Focus moves to
+Milestone 3.
+
+Off-milestone work shipped alongside in **v0.3.8** (the #817 placement-API
+privatisation, obround through-slot recognition) and **v0.3.9** (pocket/slot pattern
+kinds, `Sheet.section()`/`.detail()`, external threads, blind obround pockets); none
+of it changed milestone scope or exit criteria.
 
 ### Outcome
 
@@ -146,15 +158,19 @@ drafting concepts, rendered, and checked by independent coverage lint.
 
 ## Parked product expansion
 
-These are valid product ideas, but they do not enter **Now** until Milestone 1's
-trust criteria are met or a named user/experiment changes the priority:
+These are valid product ideas, but they do not enter **Now** until a named
+user, milestone, or experiment changes the priority (Milestones 1 and 2 have
+both exited):
 
 - [#71](https://github.com/pzfreo/draftwright/issues/71) — shaded pictorial.
 - [#276](https://github.com/pzfreo/draftwright/issues/276) — rich CLI/event
   stream.
 - [#492](https://github.com/pzfreo/draftwright/issues/492) — assembly/GA mode.
 - [#486](https://github.com/pzfreo/draftwright/issues/486) — published API
-  reference.
+  reference (umbrella; its concrete deliverable
+  [#846](https://github.com/pzfreo/draftwright/issues/846), a mkdocs/mkdocstrings
+  site, is flagged by the maintainer as a priority and is a scheduling candidate,
+  not parked).
 - [#54](https://github.com/pzfreo/draftwright/issues/54) — advanced detail-view
   capabilities beyond the correctness work in Milestone 1.
 - [#488](https://github.com/pzfreo/draftwright/issues/488) — replica-oriented


### PR DESCRIPTION
## Why

Eighteen commits landed on `main` since v0.3.8 with **no `Unreleased` CHANGELOG section**. That work — two new IR feature kinds, three new public Sheet verbs, a recognition gap closed, and a behaviour change to annotation placement — was invisible to users, and would have had to be reconstructed from commit messages at release time. This writes it up while it is fresh and cuts v0.3.9.

## CHANGELOG — v0.3.9

**Added**
- **Repeated recesses dimension as one pattern** (#841): identical blind pockets and identical through-slots collapse to a single grouped `5× 7.9 × 13.6 × 19 DEEP` / `4× SLOT 8 × 30` leader + `(n-1)× pitch`, instead of N competing size dims (some of which silently dropped). Both kinds round-trip declare → recognition → emit → editable surface.
- **`Sheet.section()` / `Sheet.detail()`** (#847): force a section A–A at a feature or explicit Y (validated strictly inside the part); a blind pocket previously had no way to ask for the cut that shows its floor.
- **External threads as a declared aspect** (#859): `sheet.step(shaft).thread("M3x0.5")` → `ø3 M3x0.5`, composes with `.finish()`, round-trips the emitter incl. pattern-member holes. Known limitation #863 noted inline.
- **Blind obround pocket recognition incl. imported STEP** (#837).
- **`sheet.slot(...).note(...)` / `pocket(...).note(...)`** (#845).

**Changed**
- **Anchored notes / GD&T / finish relax their side instead of vanishing** (#855): an explicit `side=` is now a preference, with an INFO `gdt_side_relaxed` when overridden; it drops only when no strip fits.

**Internal**
- **State-bus endgame at its permanent seam** (#830/#840): transactional detail view, trace filled at construction, `_LAYOUT_SEAM` allowlist replacing the blanket #817 decision-D exemption.
- Logo set (#843), object-reference worked example (#853).

## Roadmap reconciliation

`docs/plans/product-backlog-roadmap.md` was stale in two ways: the WIP table still listed **Milestone 1** items as *Now*, and **Milestone 2** had no status line despite all five scope items (#754, #746, #752, #523, #741) being merged. This marks M2 exited, refreshes the four workstream slots against current `main`, and records that #486's concrete deliverable (#846, the mkdocs reference site) is a scheduling candidate rather than parked.

## Version

Stays `0.3.9.dev0` — the publish workflow strips the dev suffix on release, matching the v0.3.8 procedure (#834 → release → #835 bump).

## Verification

`ruff check` · `ruff format --check` · `codespell` all clean. No source changes — CHANGELOG and roadmap doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
