### PR TITLE
chore: bump version to 0.3.10.dev0 after v0.3.9 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.3.9.dev0"
+version = "0.3.10.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.3.9.dev0"
+version = "0.3.10.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
v0.3.9 is published to PyPI (sdist + wheel, via OIDC trusted publishing). The publish workflow's `bump-version` job then failed as expected — it cannot push to protected `main` (GH006: required status checks + no direct push), the known #779 behaviour left as-is by decision.

So the post-release dev bump goes through a PR, as in #803 (0.3.8.dev0) and #835 (0.3.9.dev0).

`0.3.9.dev0` → `0.3.10.dev0` in `pyproject.toml` and `uv.lock`, via `uv version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)