### PR TITLE
Fix Y-axis stepped flange dimensioning

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1000,17 +1000,19 @@ def _diameter_step_anchor(anchor, features):
     return tuple(centred)
 
 
-def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
+def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> int:
     """ø leaders for a turned part's external step/boss diameters, from the IR —
     one distinct callout per diameter, in a tidy row below the front view
-    (X-turning) or a column to its left (Z-turning). Orientation is the feature
-    frame's axis, not two passes. Replaces the engine's ``_annotate_turned_diameters``
-    (ADR 0008 convergence). Diameters another annotation already covers are skipped.
+    (X-turning), a column to its left (Z-turning), or as radial leaders in the
+    end-on front view (Y-turning). Orientation is the feature frame's axis, not
+    separate detection paths. Replaces the engine's
+    ``_annotate_turned_diameters`` (ADR 0008 convergence). Diameters another
+    annotation already covers are skipped.
 
     *only*, when given, restricts placement to step/boss features in the set — the #426
-    finalize() path passes the recorded step/boss ``callout`` intents' features. ``None``
-    (the auto-pass) places every diameter with the historical 0-based ``m_dia_{x,z}``
-    naming, byte-identically."""
+    finalize() path passes the recorded step/boss ``callout`` intents' features.
+    ``None`` (the auto-pass) places every diameter with the historical 0-based
+    ``m_dia_{x,z}`` naming; Y-axis leaders use ``m_dia_y``."""
     mentioned = _mentioned_diameters(dwg)
     # One distinct callout per (axis, diameter). Accumulate EVERY feature that shares a
     # diameter (insertion-ordered), so provenance (#412) can tag the callout with its
@@ -1018,6 +1020,7 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
     # (the #398c/#406 shared-value rule, so drop can't over-strip a sibling).
     row_buckets: dict = {}  # round(dia,2) -> [anchor, dia, {features}, tolerance]  (X-turned)
     col_buckets: dict = {}  # Z-turned
+    end_buckets: dict = {}  # Y-turned: radial leaders in the end-on front view
     for g in groups:
         if g.feature_kind not in ("step", "boss"):
             continue
@@ -1037,7 +1040,7 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
         # a threaded ⌀ is a distinct callout, so a bare ⌀8 mention must not suppress ø8 M8x1.25.
         if thr is None and any(abs(dia - m) <= tol for m in mentioned):
             continue
-        bucket = {"x": row_buckets, "z": col_buckets}.get(g.feature.frame.axis)
+        bucket = {"x": row_buckets, "y": end_buckets, "z": col_buckets}.get(g.feature.frame.axis)
         if bucket is None:
             continue
         dtol = dpd.param.tolerance
@@ -1068,11 +1071,60 @@ def render_diameters(dwg, groups, tol: float = 0.15, *, ctx, only=None) -> int:
         return max(idxs) + 1 if idxs else 0
 
     start_x = _next_start("m_dia_x") if only is not None else 0
+    start_y = _next_start("m_dia_y") if only is not None else 0
     start_z = _next_start("m_dia_z") if only is not None else 0
     trace = getattr(ctx, "trace", None)  # the immediate placers report to the trace too (#736)
     placed = _diameter_row_below(
         dwg, _items(row_buckets), start=start_x, trace=trace, ctx=ctx
     ) + _diameter_column_left(dwg, _items(col_buckets), start=start_z, trace=trace, ctx=ctx)
+
+    # A Y-axis step is end-on in the front view, so the X/Z profile-strip
+    # leaders are geometrically inapplicable. Place one radial leader per
+    # distinct diameter around the concentric circles instead. Keep shared-value
+    # provenance honest: a diameter owned by several steps has no single feature.
+    if end_buckets:
+        vb = dwg.view_bounds("front")
+        if vb is not None:
+            reach = dwg.draft.font_size + 6 * dwg.draft.pad_around_text
+            jobs = []
+            covered_by_name = {}
+            for i, (_anchor, dia, features, dtol, thr) in enumerate(end_buckets.values()):
+                representative = next(iter(features))
+                owner = representative if len(features) == 1 else None
+                candidates = (
+                    (tip, elbow, owner)
+                    for tip, elbow, _feature in _radial_candidates(
+                        dwg,
+                        "front",
+                        vb,
+                        representative,
+                        reach,
+                        rim=dia / 2 * a.SCALE,
+                    )
+                )
+                label = f"ø{_fmt(dia)}{_tol_suffix(dtol, dwg.draft)}"
+                if thr:
+                    label += f" {thr}"
+                name = f"m_dia_y{start_y + i}"
+                jobs.append((name, "front", vb, label, candidates))
+                covered_by_name[name] = dia
+            placed += _leader_callout_pass(
+                dwg,
+                a,
+                jobs,
+                noun="Y-axis step diameter",
+                drop_code="diameter_dropped",
+                ctx=ctx,
+                geom_clear=True,
+            )
+            # These leaders intentionally start on an internal concentric circle
+            # and exit the outer silhouette, just like a bore callout. Structured
+            # diameter coverage both credits completeness lint and exempts that
+            # legitimate shaft crossing from leader_crosses_silhouette.
+            for name, dia in covered_by_name.items():
+                ann = ctx.registry.named(name)
+                if ann is not None:
+                    ann.covers_diameters = (dia,)
     # #798: a ⌀ leader the row/column solve sent DIAGONALLY into the body — cutting
     # the silhouette, or an end feature whose diagonal merely grazes it — is re-routed
     # to the clear side (the margin the feature sits at). Auto-pass only: the finalize
@@ -2265,30 +2317,22 @@ def _next_steplen_start(ctx, prefix: str = "m_steplen") -> int:
 
 def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     """Unified turned step-length chain (ADR 0008 #223): each `StepFeature`'s length
-    span projects into the front view and joins the chain that tiles the turning axis
-    so every shoulder is located. X-turned → horizontal chain above the view;
-    Z-turned → vertical chain to the right.
+    span projects into the profile view and joins the chain that tiles the turning
+    axis so every shoulder is located. X-turned → horizontal chain above the front
+    view; Z-turned → vertical chain to its right; Y-turned → horizontal chain above
+    the side view.
 
     A crowded **X-turned head** — a contiguous run of steps too short to dimension
     legibly even staggered (shoulders below the page arrowhead floor) — is not crammed
     in line: the main view locates that run as one *block* dim and an enlarged
     `DetailRequest` (#304/#307) is queued to break it down. If the detail later can't
     place, the block still locates the head extent and lint reports the un-located
-    interior shoulders — never worse than the prior skip. Returns the count placed on
-    the front view."""
-    rows = []  # (a_world, b_world, value) in axis order
+    interior shoulders — never worse than the prior skip. Returns the count placed."""
+    rows = []  # (axis, a_world, b_world, value, tolerance) in axis order
     for g in groups:
         if g.feature_kind != "step":
             continue
-        if g.feature.frame.axis not in ("x", "z"):
-            # A Y-turned step's length span is end-on in the front view — it projects
-            # to a point, and a degenerate segment raises inside _dim ("start and end
-            # points must be different", #661). No step render pipeline consumes Y
-            # today (#731, mirroring render_diameters' x/z bucketing), so skip it
-            # rather than crash the build.
-            _log.info(
-                "step-length chain skipped: %s-turned steps are unsupported", g.feature.frame.axis
-            )
+        if g.feature.frame.axis not in ("x", "y", "z"):
             continue
         if only is not None and g.feature not in only:  # #426 finalize: recorded subset
             continue
@@ -2298,14 +2342,31 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
         )
         if length is None or length.span is None:
             continue
-        rows.append((length.span[0], length.span[1], length.value, length.tolerance))
+        rows.append(
+            (
+                g.feature.frame.axis,
+                length.span[0],
+                length.span[1],
+                length.value,
+                length.tolerance,
+            )
+        )
     if not rows:
         return 0
     draft = dwg.draft
     # only=None (auto-pass) → start=0, historical m_steplen naming, byte-identical. The
     # finalize path (only set) starts past existing m_steplen names (#426 naming seam).
     start = _next_steplen_start(ctx) if only is not None else 0
-    fsegs = [(dwg.at("front", *a), dwg.at("front", *b), v, t) for a, b, v, t in rows]
+    axes = {axis for axis, *_ in rows}
+    if len(axes) != 1:
+        _log.warning(
+            "step-length chain has mixed axes; rendering each axis requires separate groups"
+        )
+        return 0
+    turn_axis = next(iter(axes))
+    view = "side" if turn_axis == "y" else "front"
+    bare_rows = [(a, b, v, t) for _axis, a, b, v, t in rows]
+    fsegs = [(dwg.at(view, *a), dwg.at(view, *b), v, t) for a, b, v, t in bare_rows]
     horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
 
     # X-turned crowded-head detour (#307): split off each contiguous *run of ≥2*
@@ -2313,7 +2374,7 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     # a block, and queue an enlarged detail. A single isolated thin step is left in the
     # main chain — a one-step block would just be that step at its sub-floor width
     # (#307 review). The legible steps + blocks stay as the main chain.
-    if horizontal:
+    if horizontal and turn_axis == "x":
         floor_pg = 2 * draft.arrow_length
         sub = [i for i, (pa, pb, *_) in enumerate(fsegs) if abs(pb[0] - pa[0]) < floor_pg]
         runs: list[list[int]] = []
@@ -2323,7 +2384,7 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
         if heads:
             blocks = []
             for run in heads:
-                ra = [rows[i] for i in run]
+                ra = [bare_rows[i] for i in run]
                 hlo = min(min(a[0], b[0]) for a, b, *_ in ra)
                 hhi = max(max(a[0], b[0]) for a, b, *_ in ra)
                 minlen = min(r[2] for r in ra)  # value is index 2 (rows are 4-tuples: a,b,v,tol)
@@ -2369,7 +2430,7 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
                 dwg, "front", main, "m_steplen", allow_collapse=False, ctx=ctx, start=start
             )
 
-    return _draw_step_chain(dwg, "front", fsegs, "m_steplen", ctx=ctx, start=start)
+    return _draw_step_chain(dwg, view, fsegs, "m_steplen", ctx=ctx, start=start)
 
 
 def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):
@@ -2788,6 +2849,58 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
             view="plan",
         )
     return n
+
+
+def render_local_turned_centerlines(dwg, a, *, ctx) -> int:
+    """Show the axis of a local turned stack on a non-rotational part.
+
+    Mounting lugs can prevent the complete part from classifying as rotational
+    while ``a.prof`` still identifies a coaxial stepped stack. Its centered bore
+    may be located by that axis only when the axis is actually present on the
+    drawing. Mirror the two centerlines from :func:`render_rotational` without
+    adding an overall-OD dimension for the non-rotational envelope (#881).
+    """
+    prof = a.prof
+    if a.is_rotational or prof is None:
+        return 0
+    axis = prof.axis
+    FX, FZ = a.proj.front_x, a.proj.front_z
+    SX, SZ = a.proj.side_x, a.proj.side_z
+    PX, PY = a.proj.plan_x, a.proj.plan_y
+    placed = 0
+
+    def _place(item, name, view):
+        nonlocal placed
+        if ctx.registry.named(name) is not None:
+            return
+        ctx.place(item, name, view=view)
+        placed += 1
+
+    if axis == "x":
+        _place(
+            Centerline((FX(a.bb.min.X) - 5, FZ(a.cz), 0), (FX(a.bb.max.X) + 5, FZ(a.cz), 0)),
+            "centerline_front",
+            "front",
+        )
+        _place(
+            Centerline((PX(a.bb.min.X) - 5, PY(a.cy), 0), (PX(a.bb.max.X) + 5, PY(a.cy), 0)),
+            "centerline_plan",
+            "plan",
+        )
+    elif axis == "y":
+        _place(
+            Centerline((SX(a.bb.min.Y) - 5, SZ(a.cz), 0), (SX(a.bb.max.Y) + 5, SZ(a.cz), 0)),
+            "centerline_side",
+            "side",
+        )
+        _place(
+            Centerline((PX(a.cx), PY(a.bb.min.Y) - 5, 0), (PX(a.cx), PY(a.bb.max.Y) + 5, 0)),
+            "centerline_plan",
+            "plan",
+        )
+    else:
+        return 0
+    return placed
 
 
 def _record_pmi_drop(ctx, dwg, ax, label, rec):

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -825,13 +825,21 @@ def _locate_off_axis_holes(dwg, ctx, a: Analysis, *, which):
         # dims; coverage already credits the bore via its centre mark, so lint stays
         # clean. Non-rotational parts and genuine off-centre side-drilled holes keep
         # their dims (the a.od_axis + perpendicular-centre gates).
-        if not a.is_rotational or h.axis != a.od_axis:
+        # A globally non-rotational flange can still carry a detected coaxial
+        # turned stack (for example a round stepped centre with mounting lugs).
+        # In that case ``a.prof`` is the stronger local relationship: the bore
+        # lies on the profile axis even though the outer silhouette correctly
+        # prevents ``a.is_rotational``. Treat either classification as a valid
+        # turning axis so the centreline, not redundant half-envelope offsets,
+        # locates the bore (#881).
+        turning_axis = a.od_axis if a.is_rotational else getattr(a.prof, "axis", None)
+        if turning_axis is None or h.axis != turning_axis:
             return False
         centre = (a.cx, a.cy, a.cz)
         return all(
             abs(h.location[i] - centre[i]) <= _CONCENTRIC_TOL_MM
             for i, ax in enumerate("xyz")
-            if ax != a.od_axis
+            if ax != turning_axis
         )
 
     # Off-axis holes sourced from the IR (ADR 0008 Am6; #584 WP1 B3) — the turning-axis

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -47,6 +47,7 @@ from draftwright.annotations.from_model import (
     render_gdt,
     render_grooves,
     render_height_ladder,
+    render_local_turned_centerlines,
     render_locations,
     render_plates,
     render_pmi,
@@ -339,6 +340,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Rotational furniture — OD dim + axis centrelines + concentric bore leaders — IR
         # renderer (#237), placed early like the engine's inline block it replaces.
         render_rotational(dwg, _groups, a, ctx=ctx)
+        # A stepped round stack on an otherwise non-rotational flange still needs
+        # its local axis shown before centered-bore offsets can be suppressed (#881).
+        render_local_turned_centerlines(dwg, a, ctx=ctx)
 
     def _s_centermarks():
         # Centre marks for every hole (all part classes) — IR renderer.
@@ -458,12 +462,13 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_diameters():
         # Turned-part dimensions via the IR (ADR 0008 convergence). The model is built
         # once and fed to both renderers (#229 — no per-pass rebuild): ø leaders, row
-        # below (X) / column left (Z), one path by frame axis. Replaces
+        # below (X) / end-on radial leaders (Y) / column left (Z), one path by
+        # frame axis. Replaces
         # _annotate_turned_diameters.
-        render_diameters(dwg, _groups, ctx=ctx)
+        render_diameters(dwg, _groups, a, ctx=ctx)
 
     def _s_step_lengths():
-        # The chain that locates every shoulder, X and Z from one path (#223). A crowded
+        # The chain that locates every shoulder, X/Y/Z from one path (#223). A crowded
         # X-turned head queues an enlarged detail request (#304/#307) instead of
         # cramming; the envelope dim along the turning axis was suppressed so the chain
         # does not double-dimension the length.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -935,18 +935,10 @@ def _feature_listing(a: Analysis) -> str:
             body.append("dwg.locate(f)")
             body.append("dwg.furniture(f)")
         elif kind in ("step", "boss"):
-            if feat.frame.axis in ("x", "z"):
-                body.append("dwg.callout(f)")
-            else:
-                # No step render pipeline consumes a Y-turned step/boss (#731): the
-                # auto-pass skips its ø AND its length (the span is end-on in the front
-                # view), so emit neither verb — a dimension() here could not replay
-                # (#661). Flagged like the other gap kinds (#424), never silently dropped.
-                body.append(
-                    f"#     the {feat.frame.axis}-turned step/boss ø and length are not "
-                    "drawn (no Y-turned step pipeline, #731) — the auto-pass skips them too."
-                )
-                continue
+            # X/Z steps route to the profile row/column; a Y step routes to radial
+            # leaders in the end-on front view. All three axes replay through the
+            # same deferred callout intent (#881).
+            body.append("dwg.callout(f)")
         elif kind == "step_level":
             body.append(
                 'dwg.dimension(f, "length", role="step_height")   # prismatic height ladder'

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1363,9 +1363,7 @@ class Drawing:
             if routable
             and it.kind == "callout"
             and getattr(it.feature, "kind", None) in ("step", "boss")
-            # X/Z-turned only — render_diameters can't place a Y-turned diameter, so leave
-            # it on live replay where callout() raises the same clear error (#432 review).
-            and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "z")
+            and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "y", "z")
         }
         # step LENGTH dimension intents (role="step") → render_step_lengths' chain (Phase 4b),
         # but only on a TURNED part (a.prof is not None, mirroring the auto-pass guard) — else
@@ -1378,10 +1376,7 @@ class Drawing:
             and a.prof is not None
             and it.kind == "dimension"
             and getattr(it.feature, "kind", None) == "step"
-            # X/Z-turned only, like dia_ids above — render_step_lengths skips Y-turned
-            # steps (#661/#731), so routing one would silently drop the user's explicit
-            # verb; live replay surfaces dimension()'s own behaviour instead.
-            and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "z")
+            and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "y", "z")
             and it.kwargs.get("param") == "length"
             and it.kwargs.get("role") == "step"
         }
@@ -1691,6 +1686,7 @@ class Drawing:
             render_flats,
             render_grooves,
             render_height_ladder,
+            render_local_turned_centerlines,
             render_locations,
             render_pockets,
             render_rotational,
@@ -1732,6 +1728,12 @@ class Drawing:
             if r.rotational_ids:
                 assert a is not None and isinstance(model, PartModel)
                 render_rotational(self, plan_dimensions(model), a, ctx=ctx)
+            # Generated/deferred reconstruction starts with auto_dims=False, so
+            # add a non-rotational stepped stack's local axis here before the
+            # location stages suppress a centered bore as axis-located (#881).
+            if routable and (r.dia_ids or r.len_ids or r.off_axis_loc_ids):
+                assert a is not None
+                render_local_turned_centerlines(self, a, ctx=ctx)
             self._intents = [it for it in self._intents if id(it) not in r.rotational_ids]
 
         def _s_reserve_section():
@@ -1849,7 +1851,7 @@ class Drawing:
             # deferred path different obstacle visibility).
             if r.only_dia:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render_diameters(self, plan_dimensions(model), ctx=ctx, only=r.only_dia)
+                render_diameters(self, plan_dimensions(model), a, ctx=ctx, only=r.only_dia)
             self._intents = [it for it in self._intents if id(it) not in r.dia_ids]
 
         def _s_step_lengths():

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -377,19 +377,18 @@ def lint_location_coverage(
 
 def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
     """How many of a turned part's step lengths are dimensioned **in the drawing**
-    — a step counts as covered when some front-view ``Dimension`` has witnesses at
-    both of its shoulders' page positions. Drawing-derived, so it judges any
+    — a step counts as covered when some profile-view ``Dimension`` has witnesses
+    at both of its shoulders' page positions. Drawing-derived, so it judges any
     producer (not the engine's :class:`CoverageState` side channel).
 
-    Works for both turning axes (orientation is data): an X-turned shaft's chain is
-    horizontal, so shoulders separate along page-x; a Z-turned shaft's chain is
-    vertical, so they separate along page-y. We match along whichever the chain
-    runs (page-x for X, page-y for Z)."""
+    Works for every turning axis (orientation is data): X- and Y-turned chains
+    are horizontal in their respective front/side profile views, while a
+    Z-turned chain is vertical in the front view."""
     bb = part.bounding_box()
     c = bb.center()
     idx = "xyz".index(prof.axis)
     base = [c.X, c.Y, c.Z]
-    use_x = prof.axis == "x"  # horizontal chain → match page-x; else vertical → page-y
+    use_x = prof.axis in ("x", "y")
 
     def shoulder_coord(view: str, s: float) -> float:
         pt = list(base)
@@ -399,8 +398,10 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
 
     # A crowded X-turned head is dimensioned in an enlarged detail view (#304/#307),
     # not the front chain — so a shoulder counts as located when matched in EITHER the
-    # front view or any detail view.
-    views = ["front"] + sorted(v for v in dwg.views if v.startswith("detail_"))
+    # front view or any detail view. Y chains use the side profile view.
+    views = ["side"] if prof.axis == "y" else ["front"]
+    if prof.axis == "x":
+        views += sorted(v for v in dwg.views if v.startswith("detail_"))
     covered_steps: set[int] = set()
     for view in views:
         shoulder_c = {s: shoulder_coord(view, s) for s in prof.shoulders}
@@ -456,10 +457,9 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
 
     *dwg* is the drawing, duck-typed (needs ``at``/``annotations``/``view_of``).
 
-    Covers **X- and Z-axis** turning: both are now located by the unified IR
-    step-length chain (ADR 0008 #223), so a missing chain on either is a real gap
-    (e.g. the chain skipped for want of page room). Only **Y-axis** turning is
-    excluded — it is drawn end-on, so no view shows its length. Severity mirrors
+    Covers **X-, Y-, and Z-axis** turning through the unified IR step-length
+    chain (ADR 0008 #223), so a missing chain on any axis is a real gap
+    (e.g. the chain skipped for want of page room). Severity mirrors
     :func:`lint_feature_coverage`: ``info`` for an assembly, else ``warning``.
     *prof* may be supplied (the single inventory, #244) to skip re-detection;
     omitted, it is detected here. A sentinel distinguishes "not supplied" from a
@@ -467,7 +467,7 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     """
     if prof is _UNSET:
         prof = TurnedProfile.from_steps(recognise_turned_steps(part))
-    if prof is None or prof.axis == "y":
+    if prof is None:
         return []
     if assembly is None:
         assembly = len(part.solids()) > 1

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import os
+import runpy
 import subprocess
 import sys
 import warnings
@@ -10,7 +11,7 @@ from pathlib import Path
 
 import pytest
 from _kernel import B123D_GE_011, SKIP_011
-from build123d import Box, Compound, Cylinder, Edge, Pos, Rotation, export_step
+from build123d import Align, Axis, Box, Compound, Cylinder, Edge, Pos, Rotation, export_step
 from build123d_drafting import HoleCallout, Leader, ViewCoordinates, view_axes
 
 from draftwright import Drawing, build_drawing, make_drawing
@@ -8843,9 +8844,101 @@ class TestPrismaticBossDiameter:
 
 
 class TestTurnedDiameters:
-    """#77/#131: external turned diameters get ø leader callouts. Migrated onto the
-    IR renderer (from_model.render_diameters, names ``m_dia_*``) — one path, row
-    below (X) / column left (Z) by frame axis (ADR 0008 convergence)."""
+    """External turned diameters get ø leader callouts through the IR renderer."""
+
+    @staticmethod
+    def _issue_881_y_step_flange():
+        """A non-rotational four-lug flange with a coaxial Y-axis stepped stack."""
+        part = Cylinder(21, 4)
+        for x in (-18, 18):
+            for y in (-18, 18):
+                part = part + Pos(x, y, 2) * Box(
+                    10,
+                    10,
+                    4,
+                    align=(Align.CENTER, Align.CENTER, Align.CENTER),
+                )
+        # Deliberate overlap keeps this one solid while leaving distinct axial bands.
+        part = part + Pos(0, 0, 2) * Cylinder(15.5, 12)
+        part = part + Pos(0, 0, 10) * Cylinder(12.5, 12)
+        part = part - Cylinder(8, 30)
+        for x in (-18, 18):
+            for y in (-18, 18):
+                part = part - Pos(x, y, 0) * Cylinder(2, 10)
+        return part.rotate(Axis.X, 90)
+
+    def test_issue_881_y_axis_steps_render_without_half_envelope_locations(self):
+        dwg = build_drawing(self._issue_881_y_step_flange())
+
+        steps = [f for f in dwg.model().features if f.kind == "step"]
+        assert steps and {f.frame.axis for f in steps} == {"y"}
+
+        y_diameters = {
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia_y")
+        }
+        assert y_diameters == {"ø25", "ø31", "ø42"}
+        assert {
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_steplen")
+        } >= {"8", "4", "2"}
+        assert {dwg.view_of(n) for n in dwg.annotations() if n.startswith("m_steplen")} == {"side"}
+
+        # The central Y-axis bore shares the detected turned-profile axis. Its
+        # centreline locates it; generic minimum-edge offsets would redundantly
+        # show half the 46 mm envelope in both X and Z (#881).
+        assert dwg.view_of("centerline_side") == "side"
+        assert dwg.view_of("centerline_plan") == "plan"
+        assert not any(n.startswith("dim_loc_front_") for n in dwg.annotations())
+        assert not any(n.startswith("dim_loc_side_") for n in dwg.annotations())
+
+        codes = {issue.code for issue in dwg.lint()}
+        assert "feature_not_dimensioned" not in codes
+        assert "leader_crosses_silhouette" not in codes
+        assert "axial_length_missing" not in codes
+
+        for name in tuple(dwg.annotations()):
+            if name.startswith("m_steplen"):
+                dwg.remove(name)
+        assert "axial_length_missing" in {issue.code for issue in dwg.lint()}
+
+    def test_issue_881_y_axis_steps_replay_through_deferred_intents(self):
+        dwg = build_drawing(self._issue_881_y_step_flange(), auto_dims=False)
+        steps = [f for f in dwg.model().features if f.kind == "step"]
+
+        with dwg.deferred():
+            for feature in steps:
+                dwg.callout(feature)
+                dwg.dimension(feature, "length", role="step")
+
+        assert {dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia_y")}
+        assert {
+            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_steplen")
+        }
+        assert dwg.view_of("centerline_side") == "side"
+        assert dwg.view_of("centerline_plan") == "plan"
+
+    def test_issue_881_generated_script_emits_y_step_intents(self, tmp_path):
+        step_path = tmp_path / "y-step.step"
+        export_step(self._issue_881_y_step_flange(), str(step_path))
+
+        script_path = Path(generate_script(str(step_path), out=str(tmp_path / "y-step-drawing")))
+        script = script_path.read_text()
+
+        assert "no Y-turned step pipeline" not in script
+        assert "the auto-pass skips them too" not in script
+        assert "dwg.callout(f)" in script
+        assert 'dwg.dimension(f, "length", role="step")' in script
+
+        # Execute the auto_dims=False reconstruction. Source-text checks cannot
+        # prove the deferred drain reproduced the automatic furniture.
+        rebuilt = runpy.run_path(str(script_path))["dwg"]
+        assert rebuilt.view_of("centerline_side") == "side"
+        assert rebuilt.view_of("centerline_plan") == "plan"
+        assert not any(n.startswith("dim_loc_front_") for n in rebuilt.annotations())
+        assert not any(n.startswith("dim_loc_side_") for n in rebuilt.annotations())
+        assert {
+            rebuilt.view_of(n) for n in rebuilt.annotations() if n.startswith("m_steplen")
+        } == {"side"}
+        assert not rebuilt.lint()
 
     def test_each_external_diameter_gets_a_callout(self):
         dwg = build_drawing(_x_stepped_shaft())

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -389,12 +389,20 @@ def test_live_machined_callout_returns_name_on_replacement(tmp_path):
 
 @pytest.mark.timeout(240)
 def test_generated_script_matches_direct_y_axis_turned_diameter_policy(tmp_path):
-    """Y-axis turned output runs and follows the direct no-diameter policy."""
+    """Y-axis turned diameters reconstruct as the same end-on radial leaders."""
     part = Rotation(90, 0, 0) * _turned_shaft([(20, 20), (14, 15)])
     step, scripted = _scripted_drawing(part, tmp_path, "y_turned")
     direct = build_drawing(str(step))
 
     def diameter_callouts(dwg):
-        return tuple(sorted(n for n in dwg.annotations() if n.startswith("m_dia")))
+        return tuple(
+            sorted(
+                (n, dwg.view_of(n), dwg.get_annotation(n).label)
+                for n in dwg.annotations()
+                if n.startswith("m_dia_y")
+            )
+        )
 
-    assert diameter_callouts(scripted) == diameter_callouts(direct) == ()
+    expected = diameter_callouts(direct)
+    assert {label for _name, view, label in expected if view == "front"} == {"ø14", "ø20"}
+    assert diameter_callouts(scripted) == expected


### PR DESCRIPTION
Closes #881.

## What changed

- Render Y-axis turned-step diameters as radial leaders in the end-on front view.
- Render Y-axis step-length chains in the side profile view.
- Add local turned-axis centerlines for non-rotational flanges with coaxial stepped stacks.
- Suppress redundant half-envelope bore locations only when that local axis furniture is present.
- Route the same behavior through deferred intents and generated `auto_dims=False` reconstruction scripts.
- Extend axial-coverage lint to validate Y-axis step chains.

## Why

Y-axis stepped stacks on non-rotational flanges were detected but their diameters and axial lengths were silently skipped. Centered bores were also shown with redundant half- and full-envelope dimensions. The rendering and coverage pipelines previously assumed only X/Z turned profiles were dimensionable.

## Impact

The supplied P10 STEP now produces Ø45, Ø34, and Ø28 callouts plus 3, 5.5, and 3.5 step lengths, without duplicate 24.4 half-envelope dimensions. Automatic and generated/deferred drawings now agree and lint cleanly.

## Validation

- Issue-specific tests, including execution of the generated reconstruction script
- 82 lint/layout/strip tests
- Ruff and formatting checks
- Mypy across 52 source files
- Supplied STEP case study retested with clean lint