### PR TITLE
feat(#871): DimensionId — which feature, which measurement

### DIFF
--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -199,7 +199,9 @@ class DimensionGroup:                      # existing type, one field added
 
 @dataclass(frozen=True)
 class DimensionId:
-    feature: FeatureId
+    feature: Feature       # the IR feature, compared STRUCTURALLY (#871) — not a
+                           # minted FeatureId, and not `is`: a re-plan builds new
+                           # objects, so identity must survive reconstruction
     parameter: ParameterId                 # the AddressableDimension's id
 ```
 
@@ -306,11 +308,13 @@ This makes the "not every dimension is nameable" edge below a *bounded* gap rath
 open one: inter-feature spans are nameable, just not as `(feature, role)`.
 
 **Feature identity is a separate sub-problem this ADR does not solve.** There is no
-`FeatureId` in the IR today — the plan carries features by object (`DimensionGroup.feature`)
-— and within one script run that is sufficient: the script holds the variable, so
-`sheet.dimension(bore, "diameter")` resolves by object identity with no key at all. A
-*durable* `FeatureId` is only needed where an intent must survive re-detection, which is the
-`of(...)` question left open below. So `FeatureId` above reads as "whatever identifies a
+`FeatureId` in the IR today — the plan carries the feature itself (`DimensionGroup.feature`),
+and the **structural** equality every frozen-dataclass `Feature` already has is sufficient:
+`sheet.dimension(bore, "diameter")` resolves with no minted key at all, and — because it is
+structural rather than `is` — an id still resolves after a re-plan rebuilds the feature
+objects (#871). A *durable* `FeatureId` is only needed where an intent must survive
+re-**detection**, where the feature's own values may shift; that is the `of(...)` question
+left open below. So `FeatureId` elsewhere in this ADR reads as "whatever identifies a
 feature", not as a new type this decision mints.
 
 **The governing principle**, which is what keeps this stable as the planner evolves:

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -130,7 +130,10 @@ the design keys on:
 - it carries the `DimensionId` defined in the next section — the identity used for
   suppression, for the planner input, and for matching an emitted line back to its intent;
 - it is the ADR 0010 provenance anchor: intent → the annotation names the render seam
-  produced, so `drop` / `annotations_of` resolve through it;
+  produced, so `drop` / `annotations_of` resolve through it. **Not yet wired (#886):**
+  the seam records `name → one feature`, while a compound callout is one annotation
+  rendering N addressable dimensions — so the channel has to become
+  `name → tuple[DimensionId, ...]` before per-dimension resolution is possible at all;
 - it is *not* a placement handle. It exposes no coordinate, no strip, and no view
   assignment beyond the derived-with-override `view=` / `side=` arguments.
 
@@ -573,10 +576,11 @@ absence both mean something exact** — which is all suppression-by-omission nee
 ### Constraints this forces (the honest edges)
 
 - **Auto dimensions must be semantically nameable.** Suppression and override require a
-  stable identity for "the location dimension of hole H" that survives a re-solve at a
+  stable identity for "the bore diameter of hole H" that survives a re-solve at a
   different scale. That identity is the `DimensionId` above, not a page-keyed annotation
-  name — this leans on ADR 0010 provenance and on the ADR 0015 planner keeping parameter
-  roles stable. Both intents need the key — `add_dimension` for its handle and for
+  name — it leans on the ADR 0015 planner keeping parameter roles stable, and on ADR 0010
+  provenance growing an N-ids channel (#886) before an id can resolve to the annotations
+  it produced. (*Location* dims are not nameable at all yet — #883.) Both intents need the key — `add_dimension` for its handle and for
   idempotence against the plan — but **suppressive intent additionally needs that identity
   to be stable across re-detection and recomposition**, which is why identity lands *with*
   the augmenting verb while suppression waits for the set boundary.
@@ -823,9 +827,10 @@ second with the single-source-of-truth of the first — over the identified set,
 
 1. **Semantic identity, then augmenting intent — one phase.** Land the addressable-dimension
    model first: `AddressableDimension` / `DimensionId` / `ParameterId` (derived keys, the
-   `axis=` discriminator, correlated sets as one identity with N members), exposed as a
-   handle on planned dimensions (ADR 0010 provenance + ADR 0015 roles) so intent can
-   *reference* an auto dimension. Then `add_dimension(...)` on top of it: a
+   `axis=` discriminator, correlated sets as one identity with N members), derivable from
+   the plan (ADR 0015 roles) so intent can *reference* an auto dimension. Per-dimension
+   ADR 0010 provenance is **split out to #886** — it needs an N-ids channel, since one
+   compound callout renders several addressable dimensions. Then `add_dimension(...)` on top of it: a
    scale-independent augmenting measurement recorded on the model and entered as a
    `CorridorCandidate` alongside the planner's set; reachable on today's solve. Reuses /
    narrows `authored_dimension` so intent and materialized-PMI stay distinct.

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -78,6 +78,7 @@ from draftwright.model.ir import (
 from draftwright.model.planner import (
     AddressableDimension,
     DimensionGroup,
+    DimensionId,
     PlannedDimension,
     SectionPlan,
     plan_dimensions,
@@ -97,6 +98,7 @@ __all__ = [
     "EnvelopeFeature",
     "AddressableDimension",
     "DimensionGroup",
+    "DimensionId",
     "Feature",
     "Frame",
     "HoleFeature",

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -159,11 +159,17 @@ class DimensionId:
     it — `parameter` is an `AddressableDimension`'s `ParameterId`, which already carries
     the `kind` and any discriminator the role alone cannot supply.
 
-    `feature` is the IR feature **by object**, which is sufficient within one script run:
-    the script holds the variable, so `sheet.dimension(bore, "diameter")` resolves without
-    any key at all. A *durable* `FeatureId` is only needed where an intent must survive
-    re-detection, and ADR 0016 deliberately leaves that open — so this type reads
-    "whatever identifies a feature" rather than minting one."""
+    `feature` is the IR feature itself, compared **structurally** — the frozen-dataclass
+    equality every `Feature` already has. Not `is`: re-running a script builds new feature
+    objects, so an identity that resolved only against the original instance would break on
+    every re-plan, destroying the stability the whole identity model exists for. Structural
+    equality also keeps the law dedup depends on — *equal ids are interchangeable in
+    lookup* — which `is`-based lookup silently violated, since two structurally identical
+    features yield `==` (and hash-colliding) ids.
+
+    A *durable* `FeatureId` is only needed where an intent must survive re-**detection**
+    (where the feature values themselves may shift), and ADR 0016 deliberately leaves that
+    open — so this type reads "whatever identifies a feature" rather than minting one."""
 
     feature: Feature
     parameter: ParameterId
@@ -220,8 +226,11 @@ class DimensionGroup:
 
     def unit_for(self, dim_id: DimensionId) -> AddressableDimension | None:
         """The addressable dimension *dim_id* names, or `None` if it names another
-        feature or a measurement this group does not carry."""
-        if dim_id.feature is not self.feature:
+        feature or a measurement this group does not carry.
+
+        Structural comparison, deliberately — see `DimensionId`. Using `is` here made
+        equal ids non-interchangeable in lookup, and broke resolution across re-planning."""
+        if dim_id.feature != self.feature:
             return None
         return next((u for u in self.units if u.id == dim_id.parameter), None)
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -150,6 +150,25 @@ class AddressableDimension:
     members: tuple[PlannedDimension, ...]
 
 
+@dataclass(frozen=True)
+class DimensionId:
+    """The identity of one addressable dimension: **which feature**, and **which of its
+    measurements** (ADR 0016).
+
+    `(feature, role)` is how a caller *addresses* a dimension; this is the key underneath
+    it — `parameter` is an `AddressableDimension`'s `ParameterId`, which already carries
+    the `kind` and any discriminator the role alone cannot supply.
+
+    `feature` is the IR feature **by object**, which is sufficient within one script run:
+    the script holds the variable, so `sheet.dimension(bore, "diameter")` resolves without
+    any key at all. A *durable* `FeatureId` is only needed where an intent must survive
+    re-detection, and ADR 0016 deliberately leaves that open — so this type reads
+    "whatever identifies a feature" rather than minting one."""
+
+    feature: Feature
+    parameter: ParameterId
+
+
 def _addressable(feature: Feature, planned: list[PlannedDimension]):
     """Group planned dimensions into addressable units — by **declaration**
     (`CORRELATED_SETS`), never by two ids happening to collide."""
@@ -192,6 +211,19 @@ class DimensionGroup:
     def dims(self) -> tuple[PlannedDimension, ...]:
         """Every planned dimension in the group, ignoring identity grouping."""
         return tuple(m for u in self.units for m in u.members)
+
+    @property
+    def dimension_ids(self) -> tuple[DimensionId, ...]:
+        """This group's addressable dimensions, by identity — one per unit, so an
+        N-member correlated set yields **one** id (ADR 0016)."""
+        return tuple(DimensionId(self.feature, u.id) for u in self.units)
+
+    def unit_for(self, dim_id: DimensionId) -> AddressableDimension | None:
+        """The addressable dimension *dim_id* names, or `None` if it names another
+        feature or a measurement this group does not carry."""
+        if dim_id.feature is not self.feature:
+            return None
+        return next((u for u in self.units if u.id == dim_id.parameter), None)
 
     @property
     def feature_kind(self) -> str:

--- a/tests/test_parameter_id.py
+++ b/tests/test_parameter_id.py
@@ -28,7 +28,7 @@ import pytest
 from build123d import Box, Cylinder, Pos
 
 import draftwright.model.ir as ir
-from draftwright.model import DimParameter, PartModel, build_part_model
+from draftwright.model import DimensionId, DimParameter, PartModel, build_part_model
 from draftwright.model.planner import (
     CORRELATED_SETS,
     PlannedDimension,
@@ -328,6 +328,52 @@ class TestUniquenessAudit:
         heights = [p for p in ladder if p.role == "step_height"]
         assert len(heights) == 3
         assert len({p.parameter_id for p in heights}) == 1
+
+
+class TestDimensionId:
+    """`DimensionId(feature, parameter)` — the key suppression, dedup and the emitter
+    mirror address (#871). A `ParameterId` alone is not enough: two holes on one part
+    both carry `bore.diameter`, so identity is *which feature* plus *which measurement*."""
+
+    def test_one_id_per_addressable_unit(self):
+        (group,) = _plan(_SAMPLES["HoleFeature"])
+        assert [d.parameter for d in group.dimension_ids] == [u.id for u in group.units]
+
+    def test_a_correlated_set_yields_one_id_not_n(self):
+        """The ladder is one addressable dimension, so it has one identity — the whole
+        reason `units` exists rather than keying raw parameters."""
+        (group,) = _plan(_SAMPLES["StepLevelFeature"])
+        ladder = [d for d in group.dimension_ids if d.parameter == "step_height.length"]
+        assert len(ladder) == 1
+        assert len(group.unit_for(ladder[0]).members) == 3
+
+    def test_unit_for_round_trips_every_id(self):
+        for name in ("HoleFeature", "PatternFeature", "RotationalFeature"):
+            for group in _plan(_SAMPLES[name]):
+                for dim_id in group.dimension_ids:
+                    assert group.unit_for(dim_id).id == dim_id.parameter
+
+    def test_the_same_parameter_id_on_two_features_is_two_identities(self):
+        """Why the feature is in the key at all. Both holes measure `bore.diameter`;
+        an intent aimed at one must not resolve against the other."""
+        a = ir.HoleFeature(ir.Frame((-20.0, 0.0, 0.0), "z"), 5.0, depth=None, through=True)
+        b = ir.HoleFeature(ir.Frame((20.0, 0.0, 0.0), "z"), 9.0, depth=None, through=True)
+        ga, gb = plan_dimensions(PartModel(bbox=_BBOX, orientation="prismatic", features=[a, b]))
+        (ida,), (idb,) = ga.dimension_ids, gb.dimension_ids
+        assert ida.parameter == idb.parameter == "bore.diameter"
+        assert ida != idb
+        assert ga.unit_for(idb) is None and gb.unit_for(ida) is None
+
+    def test_an_unknown_measurement_resolves_to_none(self):
+        (group,) = _plan(_SAMPLES["HoleFeature"])
+        assert group.unit_for(DimensionId(group.feature, "nope.length")) is None
+
+    def test_ids_are_stable_across_replanning(self):
+        """An id written into a script must still name the same thing next run."""
+        feat = _SAMPLES["HoleFeature"]
+        first = [(d.feature, d.parameter) for g in _plan(feat) for d in g.dimension_ids]
+        second = [(d.feature, d.parameter) for g in _plan(feat) for d in g.dimension_ids]
+        assert first == second
 
 
 class TestStability:

--- a/tests/test_parameter_id.py
+++ b/tests/test_parameter_id.py
@@ -375,6 +375,35 @@ class TestDimensionId:
         second = [(d.feature, d.parameter) for g in _plan(feat) for d in g.dimension_ids]
         assert first == second
 
+    def test_equal_ids_are_interchangeable_in_lookup(self):
+        """The identity law dedup rests on. `DimensionId` is a frozen dataclass, so two
+        *structurally identical* features give `==`, hash-colliding ids — while an
+        `is`-based lookup rejected each other's id. Equal ids that do not resolve alike
+        are a broken key: a dict would treat them as one entry and the lookup as two.
+
+        The earlier two-hole test could not catch this — its holes differ in position
+        and diameter, so their ids were never equal in the first place.
+        """
+        a = ir.HoleFeature(_F, 8.0, depth=None, through=True)
+        b = ir.HoleFeature(_F, 8.0, depth=None, through=True)
+        assert a is not b and a == b
+
+        (ga,) = _plan(a)
+        id_a, id_b = DimensionId(a, "bore.diameter"), DimensionId(b, "bore.diameter")
+        assert id_a == id_b and len({id_a, id_b}) == 1
+        assert ga.unit_for(id_a) is not None
+        assert ga.unit_for(id_b) is not None  # the law: equal id, same result
+
+    def test_an_id_resolves_against_a_rebuilt_feature(self):
+        """Why lookup is structural rather than `is`: re-running a script constructs new
+        feature objects. An identity that only resolved against the original instance
+        would break on every re-plan — the opposite of the stability ids exist for."""
+        original = ir.HoleFeature(_F, 8.0, depth=None, through=True)
+        dim_id = DimensionId(original, "bore.diameter")
+        rebuilt = ir.HoleFeature(_F, 8.0, depth=None, through=True)  # a fresh run
+        (group,) = _plan(rebuilt)
+        assert group.unit_for(dim_id) is not None
+
 
 class TestStability:
     """What makes an id safe to write into a version-controlled script.


### PR DESCRIPTION
`DimensionId(feature, parameter)` is the key suppression, dedup and the emitter
mirror address. A ParameterId alone is not enough: two holes on one part both
carry `bore.diameter`, so identity is which feature plus which measurement.

Derived at the group level — `DimensionGroup.dimension_ids` yields one id per
addressable unit, so an N-member correlated set has ONE identity, and
`unit_for(dim_id)` resolves back. The feature is held by object, which suffices
within a script run (the script holds the variable); ADR 0016 deliberately
leaves durable FeatureId open, so this type reads "whatever identifies a
feature" rather than minting one.

Per-dimension ADR 0010 provenance is deliberately NOT wired here, and the
reason is a design finding rather than a shortcut. The seam records
`name -> one feature`: `_leader_callout_pass` places a single leader with a
single feature. But that one annotation renders FIVE addressable dimensions
for a fully-specified hole — bore diameter and depth, counterbore, spotface,
countersink. So provenance keyed to one DimensionId per annotation is wrong by
construction, not merely unimplemented; the channel has to become
`name -> tuple[DimensionId, ...]`. Threading that through the 11
CorridorCandidate sites is tractable, but it needs a decision about which
passes populate it and what an unpopulated one means — a lookup that silently
returns nothing for half the annotations cannot distinguish "not placed" from
"this pass does not record ids yet". Split to #886, which blocks the
suppression children.

ADR swept in one pass this time rather than a passage at a time: all three
provenance claims now say what is and is not wired, and the "location
dimension of hole H" example — which #883 invalidated — is now a bore
diameter.

Closes #871.

---

**Epic:** #867 (ADR 0016 implementation), PR 3 of 8.

**Verification**
- Full fast tier: 1738 passed.
- Golden corpus unchanged. *(Worth stating its limit, as on #882: the golden cannot see identity state at all — flattening `units` yields the same `dims`, and this PR adds only derived accessors. Correctness rests on `test_parameter_id.py`.)*
- All four lint checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)