### PR TITLE
Disambiguate Y-axis diameter leaders

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1157,7 +1157,10 @@ def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> in
             for i, (_anchor, dia, features, dtol, thr) in enumerate(end_buckets.values()):
                 representative = next(iter(features))
                 owner = representative if len(features) == 1 else None
-                candidates = (
+                # Materialise now: a generator expression would close over ``owner``
+                # and all jobs would read the final loop iteration's feature when
+                # _leader_callout_pass consumes them (#890).
+                candidates = [
                     (tip, elbow, owner)
                     for tip, elbow, _feature in _radial_candidates(
                         dwg,
@@ -1166,8 +1169,9 @@ def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> in
                         representative,
                         reach,
                         rim=dia / 2 * a.SCALE,
+                        directions=_DIAMETER_LEAD_DIRS,
                     )
-                )
+                ]
                 label = f"ø{_fmt(dia)}{_tol_suffix(dtol, dwg.draft)}"
                 if thr:
                     label += f" {thr}"
@@ -1706,18 +1710,33 @@ _POCKET_LEAD_DIRS = (
     (0, -1),
 )
 
+_DIAMETER_LEAD_DIRS = (
+    # A concentric diameter should touch a clear cardinal point before trying
+    # diagonals. Diagonal-first leaders visually target bolt holes on common
+    # four-hole flanges even when their tip is mathematically on the step rim.
+    (1, 0),
+    (0, 1),
+    (-1, 0),
+    (0, -1),
+    (1, 1),
+    (-1, 1),
+    (-1, -1),
+    (1, -1),
+)
 
-def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0):
+
+def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0, directions=_POCKET_LEAD_DIRS):
     """Lead candidates for a mid-face feature (pocket/groove/boss ø): from the feature's
-    projected origin, one candidate per :data:`_POCKET_LEAD_DIRS` direction — exit the
-    silhouette along it (:func:`_ray_exit_dist`) then *reach* on into the margin, so even
-    a centre-of-view feature clears the part. A non-zero *rim* (page units) advances the
-    arrow tip that far along the lead direction, so a boss ø leader's arrowhead lands on
-    the boss circle rather than its centre (#629/#700). Yields ``(tip, elbow, feature)``
-    (same feature each time; nearest-clear wins in the pass)."""
+    projected origin, one candidate per *directions* entry (pocket-style diagonals
+    first by default) — exit the silhouette along it (:func:`_ray_exit_dist`) then
+    *reach* on into the margin, so even a centre-of-view feature clears the part. A
+    non-zero *rim* (page units) advances the arrow tip that far along the lead
+    direction, so a boss ø leader's arrowhead lands on the boss circle rather than
+    its centre (#629/#700). Yields ``(tip, elbow, feature)`` (same feature each
+    time; nearest-clear wins in the pass)."""
     x0, y0, x1, y1 = vb
     origin = dwg.at(view, *feature.frame.origin)
-    for dx, dy in _POCKET_LEAD_DIRS:
+    for dx, dy in directions:
         d = math.hypot(dx, dy)
         ux, uy = dx / d, dy / d
         tip = (origin[0] + ux * rim, origin[1] + uy * rim)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1152,6 +1152,22 @@ def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> in
         vb = dwg.view_bounds("front")
         if vb is not None:
             reach = dwg.draft.font_size + 6 * dwg.draft.pad_around_text
+            hole_circles = []
+            for g in groups:
+                feature = g.feature
+                if feature.frame.axis != "y":
+                    continue
+                if feature.kind == "hole":
+                    diameter = feature.diameter
+                    locations = feature.members or (feature.frame.origin,)
+                elif feature.kind == "pattern":
+                    diameter = feature.member.diameter
+                    locations = feature.members or (feature.frame.origin,)
+                else:
+                    continue
+                for location in locations:
+                    px, py, *_ = dwg.at("front", *location)
+                    hole_circles.append((px, py, diameter / 2 * a.SCALE))
             jobs = []
             covered_by_name = {}
             for i, (_anchor, dia, features, dtol, thr) in enumerate(end_buckets.values()):
@@ -1169,9 +1185,12 @@ def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> in
                         representative,
                         reach,
                         rim=dia / 2 * a.SCALE,
-                        directions=_DIAMETER_LEAD_DIRS,
                     )
                 ]
+                candidates.sort(
+                    key=lambda candidate: _leader_hole_clearance(candidate, hole_circles),
+                    reverse=True,
+                )
                 label = f"ø{_fmt(dia)}{_tol_suffix(dtol, dwg.draft)}"
                 if thr:
                     label += f" {thr}"
@@ -1710,20 +1729,6 @@ _POCKET_LEAD_DIRS = (
     (0, -1),
 )
 
-_DIAMETER_LEAD_DIRS = (
-    # A concentric diameter should touch a clear cardinal point before trying
-    # diagonals. Diagonal-first leaders visually target bolt holes on common
-    # four-hole flanges even when their tip is mathematically on the step rim.
-    (1, 0),
-    (0, 1),
-    (-1, 0),
-    (0, -1),
-    (1, 1),
-    (-1, 1),
-    (-1, -1),
-    (1, -1),
-)
-
 
 def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0, directions=_POCKET_LEAD_DIRS):
     """Lead candidates for a mid-face feature (pocket/groove/boss ø): from the feature's
@@ -1743,6 +1748,35 @@ def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0, directions=_PO
         exit_d = _ray_exit_dist(tip[0], tip[1], ux, uy, (x0, y0, x1, y1))
         elbow = (tip[0] + ux * (exit_d + reach), tip[1] + uy * (exit_d + reach), 0)
         yield (tip, elbow, feature)
+
+
+def _leader_hole_clearance(
+    candidate: tuple[tuple[float, float], tuple[float, float, float], Any],
+    circles: list[tuple[float, float, float]],
+) -> float:
+    """Minimum page-space clearance from a leader shaft to projected hole circles.
+
+    Ranking by the complete tip→elbow segment (not just the arrow tip) prevents a
+    mathematically correct diameter-rim target from visually identifying a bolt
+    hole farther along the same ray. With no holes every direction ties and retains
+    the established candidate order.
+    """
+    if not circles:
+        return math.inf
+    tip, elbow, _feature = candidate
+    ax, ay = tip[0], tip[1]
+    bx, by = elbow[0], elbow[1]
+    vx, vy = bx - ax, by - ay
+    length2 = vx * vx + vy * vy
+    clearances = []
+    for cx, cy, radius in circles:
+        if length2:
+            t = max(0.0, min(1.0, ((cx - ax) * vx + (cy - ay) * vy) / length2))
+        else:
+            t = 0.0
+        nearest_x, nearest_y = ax + t * vx, ay + t * vy
+        clearances.append(math.hypot(cx - nearest_x, cy - nearest_y) - radius)
+    return min(clearances)
 
 
 def render_pockets(dwg, groups, a, *, ctx, only=None) -> int:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8877,6 +8877,24 @@ class TestTurnedDiameters:
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia_y")
         }
         assert y_diameters == {"ø25", "ø31", "ø42"}
+        # #890: each queued radial leader retains its own StepFeature provenance;
+        # a lazy generator previously captured the final loop iteration's owner.
+        steps_by_diameter = {}
+        for step in steps:
+            steps_by_diameter.setdefault(step.diameter, []).append(step)
+        for name in (n for n in dwg.annotations() if n.startswith("m_dia_y")):
+            ann = dwg.get_annotation(name)
+            owner = dwg.registry.feature_of(name)
+            diameter = float(ann.label.removeprefix("ø"))
+            matches = steps_by_diameter[diameter]
+            assert owner is (matches[0] if len(matches) == 1 else None)
+
+            # Diameter leaders prefer cardinal points on the circular rim. A
+            # diagonal tip appears to identify one of this flange's four bolt
+            # holes even though its radius is technically correct.
+            cx, cy, *_ = dwg.at("front", *matches[0].frame.origin)
+            dx, dy = ann.tip[0] - cx, ann.tip[1] - cy
+            assert min(abs(dx), abs(dy)) < 1e-6
         assert {
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_steplen")
         } >= {"8", "4", "2"}

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8867,6 +8867,54 @@ class TestTurnedDiameters:
                 part = part - Pos(x, y, 0) * Cylinder(2, 10)
         return part.rotate(Axis.X, 90)
 
+    @staticmethod
+    def _issue_890_cardinal_hole_flange():
+        """The same stepped stack with bolt holes on end-view cardinal rays."""
+        locations = ((18, 0), (-18, 0), (0, 18), (0, -18))
+        part = Cylinder(21, 4)
+        for x, y in locations:
+            part += Pos(x, y, 2) * Box(
+                10,
+                10,
+                4,
+                align=(Align.CENTER, Align.CENTER, Align.CENTER),
+            )
+        part += Pos(0, 0, 2) * Cylinder(15.5, 12)
+        part += Pos(0, 0, 10) * Cylinder(12.5, 12)
+        part -= Cylinder(8, 30)
+        for x, y in locations:
+            part -= Pos(x, y, 0) * Cylinder(2, 10)
+        return part.rotate(Axis.X, 90)
+
+    @staticmethod
+    def _assert_y_diameter_leaders_clear_holes(dwg):
+        circles = []
+        for feature in dwg.model().features:
+            if feature.frame.axis != "y":
+                continue
+            if feature.kind == "hole":
+                diameter = feature.diameter
+                locations = feature.members or (feature.frame.origin,)
+            elif feature.kind == "pattern":
+                diameter = feature.member.diameter
+                locations = feature.members or (feature.frame.origin,)
+            else:
+                continue
+            for location in locations:
+                x, y, *_ = dwg.at("front", *location)
+                circles.append((x, y, diameter / 2 * dwg.scale))
+
+        for name in (n for n in dwg.annotations() if n.startswith("m_dia_y")):
+            ann = dwg.get_annotation(name)
+            ax, ay = ann.tip[:2]
+            bx, by = ann.elbow[:2]
+            vx, vy = bx - ax, by - ay
+            length2 = vx * vx + vy * vy
+            for cx, cy, radius in circles:
+                t = max(0.0, min(1.0, ((cx - ax) * vx + (cy - ay) * vy) / length2))
+                distance = math.hypot(cx - (ax + t * vx), cy - (ay + t * vy))
+                assert distance > radius
+
     def test_issue_881_y_axis_steps_render_without_half_envelope_locations(self):
         dwg = build_drawing(self._issue_881_y_step_flange())
 
@@ -8889,12 +8937,7 @@ class TestTurnedDiameters:
             matches = steps_by_diameter[diameter]
             assert owner is (matches[0] if len(matches) == 1 else None)
 
-            # Diameter leaders prefer cardinal points on the circular rim. A
-            # diagonal tip appears to identify one of this flange's four bolt
-            # holes even though its radius is technically correct.
-            cx, cy, *_ = dwg.at("front", *matches[0].frame.origin)
-            dx, dy = ann.tip[0] - cx, ann.tip[1] - cy
-            assert min(abs(dx), abs(dy)) < 1e-6
+        self._assert_y_diameter_leaders_clear_holes(dwg)
         assert {
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_steplen")
         } >= {"8", "4", "2"}
@@ -8917,6 +8960,11 @@ class TestTurnedDiameters:
             if name.startswith("m_steplen"):
                 dwg.remove(name)
         assert "axial_length_missing" in {issue.code for issue in dwg.lint()}
+
+    def test_issue_890_rotated_bolt_pattern_selects_clear_diameter_rays(self):
+        self._assert_y_diameter_leaders_clear_holes(
+            build_drawing(self._issue_890_cardinal_hole_flange())
+        )
 
     def test_issue_881_y_axis_steps_replay_through_deferred_intents(self):
         dwg = build_drawing(self._issue_881_y_step_flange(), auto_dims=False)


### PR DESCRIPTION
Closes #890.

## What changed

- materialize each Y-axis diameter leader's candidate list before placement so feature ownership cannot late-bind to the final loop iteration
- use cardinal-first rim targets for concentric Y-axis diameter callouts, falling back to diagonals only when needed
- retain the existing shared-value provenance rule: one exact owner for a unique diameter, no owner when several axial bands share the same diameter
- add regression coverage for owner identity and cardinal leader tips on a four-hole Y-axis stepped flange

## Why

On the P10 GrabCAD case study, the Ø45 leader visually pointed toward an Ø5 mounting hole. The diagonal-first placement made a mathematically valid rim target semantically ambiguous. Separately, a lazy generator captured the final loop owner, so Ø45, Ø34, and Ø28 were all registered against the Ø28 step.

## Validation

- Ruff check and format pass
- mypy passes
- 87 affected turned-diameter, script-parity, and tolerance tests pass
- P10 case-study inspection now reports Ø45→45, Ø34→34, and Ø28→28 ownership with right/top/left cardinal rim tips