### PR TITLE
fix(#894): front-view dims must join the corridor solve, not commit to the strip

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -759,6 +759,36 @@ def box_within_page_and_clear(bb, page_box, obstacles) -> bool:
     )
 
 
+# ── The corridor priority ladder (#894) ───────────────────────────────────────
+# `CorridorCandidate.priority` is an over-capacity survival rank, and a rank only
+# means anything RELATIVE to the other rungs. Defining the whole ladder here — beside
+# the field it ranks, at the bottom of the annotations DAG every pass imports from —
+# is what makes it reviewable: a bare `priority=0.5` at a call site cannot be judged
+# without knowing what else sits at 0.5.
+#
+# This is not hypothetical tidiness. #894 happened one rung down: the principal
+# front-view chain took the implicit default and silently TIED with pocket location
+# dims, so an over-capacity strip dropped a step height on an arbitrary generated key.
+# Nobody could see the collision because nothing showed what else lived at 0.
+#
+# Rungs are ordered, and the gaps are deliberate — insert between rather than
+# renumbering, so existing relative order is never disturbed.
+class PRIORITY:
+    """Corridor survival ranks, lowest to highest."""
+
+    #: Ordinary auto dims — feature sizes, feature locations. The engine's own choices.
+    AUTO = 0.0
+    #: Principal part dims — step heights, the overall height. What a print is least
+    #: usable without, so they outrank ordinary auto dims when a strip is full.
+    PRINCIPAL = 0.5
+    #: Authored intent — GD&T frames, imported PMI. The user asked for these by name,
+    #: so they outrank anything the engine chose for itself (#357).
+    AUTHORED = 1.0
+    #: Never-drop: the mandatory envelope dims, and a user-pinned intent (ADR 0012).
+    #: Two distinct meanings that deliberately share a rung — both are non-negotiable.
+    MANDATORY = 100.0
+
+
 @dataclass
 class CorridorCandidate:
     """One datum-referenced linear dim collected for a shared corridor's single solve
@@ -780,9 +810,9 @@ class CorridorCandidate:
             escalation) outranks a coincident slot *position* line.
         priority:   over-capacity survival rank (#357). When a strip cannot hold every
             candidate, :func:`plan_strip` drops the lowest ``(priority, key)`` — so a higher
-            ``priority`` is kept. An authored GD&T frame sets this above the auto dims so it
-            is not dropped in favour of a lower-value auto dim purely by stacking-key order.
-            Default 0 (every auto dim) → key order, unchanged.
+            ``priority`` is kept. Pick a rung from :data:`PRIORITY` below rather than a bare
+            number: the value only means anything *relative to the others*, so a literal at
+            a call site cannot be reviewed on its own.
         anchored/natural: when ``anchored`` is true, the strip solve keeps this candidate
             near its own natural stacking-axis page coordinate instead of the segment edge.
             This is how user-authored pinned dimension intents join the shared solve
@@ -958,14 +988,27 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             if trace is not None:
                 trace.record_outcome(c.name, "placed")
         else:
-            n_deferred = len(ctx.post_drain) if trace is not None else 0
+            pending = ctx.post_drain if ctx is not None else None
+            n_deferred = len(pending) if pending is not None else 0
             c.on_drop(c.name)  # dropped / not force-kept — the pass's drop handler runs
+            deferred = pending is not None and len(pending) > n_deferred
             if trace is not None:  # did on_drop queue a post-drain fallthrough?
-                trace.record_outcome(
-                    c.name, "dropped", deferred_post_drain=len(ctx.post_drain) > n_deferred
-                )
+                trace.record_outcome(c.name, "dropped", deferred_post_drain=deferred)
             if c.dedup is not None:  # a deduped winner failed → promote its top loser
-                _promote_losers(c)
+                if deferred and pending is not None:
+                    # …but not yet. `on_drop` queued an opposite-strip retry, so this
+                    # measurement may still land. Promoting now double-dimensions the
+                    # span whenever that retry succeeds (#894 review: observed on CTC-03,
+                    # where m_pocket0_pos_long fell through cleanly and the solver
+                    # promoted its coincident twin anyway). Queue the decision BEHIND the
+                    # retry — appended after it, and post_drain runs in order — so a
+                    # successful fallthrough keeps the loser suppressed and only a
+                    # genuine miss promotes.
+                    pending.append(
+                        lambda _c=c: None if _c.name in dwg.annotations() else _promote_losers(_c)
+                    )
+                else:
+                    _promote_losers(c)
     if trace is not None:
         trace.end_solve()
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -994,20 +994,24 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             deferred = pending is not None and len(pending) > n_deferred
             if trace is not None:  # did on_drop queue a post-drain fallthrough?
                 trace.record_outcome(c.name, "dropped", deferred_post_drain=deferred)
-            if c.dedup is not None:  # a deduped winner failed → promote its top loser
+            if c.dedup is not None:
+                # A deduped winner that did not place hands its measurement to the best
+                # surviving loser — but ONLY if the measurement is genuinely absent.
+                # `on_drop` may have rescued it onto the opposite strip, and promoting
+                # then draws the same span twice (#894 review: observed on CTC-03, where
+                # m_pocket0_pos_long fell through cleanly and its coincident twin was
+                # promoted anyway).
+                #
+                # The predicate is "winner still absent", not "did on_drop defer" — a
+                # SYNCHRONOUS retry has resolved by now, and if it succeeded the loser
+                # must stay suppressed just the same. Only the *moment* of the check
+                # differs: immediately when the retry already ran, or queued behind it
+                # when it was deferred (appended after, and post_drain runs in order).
                 if deferred and pending is not None:
-                    # …but not yet. `on_drop` queued an opposite-strip retry, so this
-                    # measurement may still land. Promoting now double-dimensions the
-                    # span whenever that retry succeeds (#894 review: observed on CTC-03,
-                    # where m_pocket0_pos_long fell through cleanly and the solver
-                    # promoted its coincident twin anyway). Queue the decision BEHIND the
-                    # retry — appended after it, and post_drain runs in order — so a
-                    # successful fallthrough keeps the loser suppressed and only a
-                    # genuine miss promotes.
                     pending.append(
                         lambda _c=c: None if _c.name in dwg.annotations() else _promote_losers(_c)
                     )
-                else:
+                elif c.name not in dwg.annotations():
                     _promote_losers(c)
     if trace is not None:
         trace.end_solve()

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -906,6 +906,12 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             for loser in group:
                 trace.record_outcome(loser.name, "deduped", winner=winners[dk].name)
 
+    def _winner_placed(c) -> bool:
+        """Did this candidate's measurement reach the sheet after all? `on_drop` may
+        have rescued it onto the opposite strip, in which case a coincident loser must
+        stay suppressed rather than draw the same span twice (#894)."""
+        return c.name in dwg.annotations()
+
     def _promote_losers(dropped_winner):
         # The winner did not place → hand its measurement to the best surviving loser
         # (e.g. the slot position's below-strip fallthrough), then stop.
@@ -920,7 +926,10 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             c.on_drop(c.name)
             if trace is not None:
                 trace.record_outcome(c.name, "dropped", reason="no_strip")
-            if c.dedup is not None:
+            # Same rule as the solved path below: `on_drop` may have rescued this
+            # measurement onto the OPPOSITE strip, which can exist even when this one
+            # does not. Promoting a coincident loser then draws the span twice (#894).
+            if c.dedup is not None and not _winner_placed(c):
                 _promote_losers(c)
         if trace is not None:
             trace.end_solve()
@@ -1009,9 +1018,9 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
                 # when it was deferred (appended after, and post_drain runs in order).
                 if deferred and pending is not None:
                     pending.append(
-                        lambda _c=c: None if _c.name in dwg.annotations() else _promote_losers(_c)
+                        lambda _c=c: None if _winner_placed(_c) else _promote_losers(_c)
                     )
-                elif c.name not in dwg.annotations():
+                elif not _winner_placed(c):
                     _promote_losers(c)
     if trace is not None:
         trace.end_solve()

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -60,6 +60,7 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import (
     CROSSABLE_TYPES,
+    PRIORITY,
     CorridorCandidate,
     Escalation,
     _anno_box,
@@ -326,85 +327,136 @@ def render_slots(dwg, groups, a, *, ctx, only=None) -> int:
                     ),
                 )
 
-            # Unified above corridor (ADR 0009 end state, #345/#346): a plan/side slot dim
-            # measured along the horizontal axis shares the SAME strip as the hole-location
-            # ladder, so it registers into the corridor batch instead of committing here.
-            # One solve then dedups a slot POSITION line coincident with a hole location
-            # (#345) and orders size + location as segregated, monotonic runs (#346). The
-            # on_drop falls through to the below strip (place-what-fits) before recording a
-            # genuine drop; a *deduped* position fires no drop (it was never starved).
-            if meas_axis == ha and vw[0] in ("plan", "side"):
-                is_pos = kind.startswith("pos")
-                drop_word = "position" if is_pos else kind
-                _, below_strip, below_hi = sides[1]
-
-                def _below_or_drop(nm, _bs=below_strip, _bh=below_hi, _feat=s, _dw=drop_word):
-                    if _bs is not None and not place_strip_candidates(
+            # Register into the corridor batch (ADR 0014 collect-then-solve). One solve
+            # per strip dedups a POSITION line coincident with a hole location (#345),
+            # orders size + location as segregated monotonic runs (#346), and — the part
+            # that matters here — arbitrates against every other occupant by `priority`
+            # when the strip is over capacity.
+            #
+            # #894: the FRONT view used to *commit* instead, via a direct
+            # `place_strip_candidates` loop — a local solve that spaces only its own
+            # call's candidates and then takes the space. Whichever pass ran first won,
+            # so #888's pocket location dims filled the front-right strip and the height
+            # ladder, registered later, found it gone: both `dim_step_0` and `dim_height`
+            # dropped on CTC-03/04. Registering is most of the fix; the ladder also needed
+            # a priority, since once co-solved it merely TIED with the pocket dims and lost
+            # on the generated key. (`_MANDATORY_OVERALL_PRIORITY` is the envelope dims'
+            # rank, not this ladder's — the base trace records both height candidates at 0.)
+            #
+            # SCOPED TO THE FRONT VIEW deliberately. The plan/side right-left case keeps
+            # the immediate path, because the corridor carve is strictly more conservative:
+            # it marks a region obstructed from FULL annotation geometry, where a label can
+            # legitimately sit between two extension lines. Routing those dims through it
+            # cost #885's part two pad size dims that place cleanly today — verified by
+            # label-box measurement, not inferred. Closing that gap needs the carve to
+            # reason about label boxes, which is its own change; tracked on #894.
+            # The plan/side horizontal case has been corridor-routed since #345/#346 and
+            # stays that way; the front view joins it here. Only plan/side right-left
+            # keeps the immediate path.
+            use_corridor = vw[0] == "front" or (meas_axis == ha and vw[0] in ("plan", "side"))
+            if not use_corridor:
+                for side, strip, hi in sides:
+                    if strip is None:
+                        continue
+                    axis = "y" if side in ("above", "below") else "x"
+                    if not place_strip_candidates(
                         dwg,
-                        _bs,
+                        strip,
                         vw[0],
-                        "y",
-                        [_cand_for("below", _bh)],
+                        axis,
+                        [_cand_for(side, hi)],
+                        tier,
+                        ctx=ctx,
+                        features={cname: s},
+                        trace=ctx.trace,
+                        trace_label=f"slot_{side}",
+                    ):
+                        return True
+                return False
+
+            is_pos = kind.startswith("pos")
+            drop_word = "position" if is_pos else kind
+            near_side, near_strip, near_hi = sides[0]
+            far_side, far_strip, far_hi = sides[1]
+            corridor_axis = "y" if near_side in ("above", "below") else "x"
+
+            def _far_or_drop(
+                nm,
+                _fs=far_strip,
+                _fsd=far_side,
+                _fh=far_hi,
+                _ax=corridor_axis,
+                _feat=s,
+                _dw=drop_word,
+            ):
+                # Opposite-strip fallthrough. On the FRONT view — the path this change
+                # adds — it is DEFERRED to ctx.post_drain so it runs after every corridor
+                # has drained (the #684 rule, and the shape `render_plates` / `render_gdt`
+                # use): placing mid-drain could occupy space a later sibling's force
+                # candidate needs, since that sibling has not solved yet.
+                #
+                # The plan/side path keeps placing synchronously, as it has since
+                # #345/#346. Deferring it too is the architecturally consistent end state
+                # and was tried — it costs #885's part a pad length dim, because by the
+                # time a post-drain retry runs the opposite strip has filled. Changing
+                # behaviour that was not broken, at a measured cost, is not this PR's job;
+                # the migration is tracked on #894.
+                def _retry(_fs=_fs, _fsd=_fsd, _fh=_fh, _ax=_ax, _feat=_feat, _dw=_dw) -> None:
+                    if _fs is not None and not place_strip_candidates(
+                        dwg,
+                        _fs,
+                        vw[0],
+                        _ax,
+                        [_cand_for(_fsd, _fh)],
                         tier,
                         ctx=ctx,
                         features={cname: _feat},
                         trace=ctx.trace,
-                        trace_label="slot_below_fallthrough",
+                        trace_label=f"slot_{_fsd}_fallthrough",
                     ):
-                        return  # placed on the below strip
+                        return  # placed on the opposite strip
                     _record_slot_drop(ctx, dwg, _dw, idx, vw[0], _feat)
 
-                register_corridor(
-                    ctx,
-                    (vw[0], "above"),
-                    zn.above,
-                    vw[0],
-                    "y",
-                    tier,
-                    CorridorCandidate(
-                        name=cname,
-                        build=_cand_for("above", sides[0][2])[1],
-                        # A position nests in the datum-distance location ladder; a size dim
-                        # forms the inner run, ordered left-to-right by its span midpoint.
-                        order=(
-                            (_LOC_SUBCHAIN, disp, cname)
-                            if is_pos
-                            else (_SIZE_SUBCHAIN, (p_lo + p_hi) / 2, cname)
-                        ),
-                        on_place=lambda nm: None,
-                        on_drop=_below_or_drop,
-                        dedup=(
-                            (vw[0], round(meas_proj(raw_lo), 1), round(meas_proj(raw_hi), 1))
-                            if is_pos
-                            else None
-                        ),
-                        precedence=1 if is_pos else 0,
-                        force=False,
-                        feature=s,  # provenance (ADR 0010): this dim belongs to the slot
-                    ),
-                )
-                return True  # deferred — the callback owns the drop; caller's else must not fire
+                if vw[0] == "front":
+                    ctx.post_drain.append(_retry)
+                else:
+                    _retry()
 
-            # Immediate path: right/left dims, and any front-view above/below. Try each side
-            # through the shared carve; the first that takes the dim wins, else the caller drops.
-            for side, strip, hi in sides:
-                if strip is None:
-                    continue
-                axis = "y" if side in ("above", "below") else "x"
-                if not place_strip_candidates(
-                    dwg,
-                    strip,
-                    vw[0],
-                    axis,
-                    [_cand_for(side, hi)],
-                    tier,
-                    ctx=ctx,
-                    features={cname: s},
-                    trace=ctx.trace,
-                    trace_label=f"slot_{side}",
-                ):
-                    return True
-            return False
+            if near_strip is None:
+                # Nothing to register against; the opposite side is the only chance.
+                _far_or_drop(cname)
+                return True
+
+            register_corridor(
+                ctx,
+                (vw[0], near_side),
+                near_strip,
+                vw[0],
+                corridor_axis,
+                tier,
+                CorridorCandidate(
+                    name=cname,
+                    build=_cand_for(near_side, near_hi)[1],
+                    # A position nests in the datum-distance location ladder; a size dim
+                    # forms the inner run, ordered left-to-right by its span midpoint.
+                    order=(
+                        (_LOC_SUBCHAIN, disp, cname)
+                        if is_pos
+                        else (_SIZE_SUBCHAIN, (p_lo + p_hi) / 2, cname)
+                    ),
+                    on_place=lambda nm: None,
+                    on_drop=_far_or_drop,
+                    dedup=(
+                        (vw[0], round(meas_proj(raw_lo), 1), round(meas_proj(raw_hi), 1))
+                        if is_pos
+                        else None
+                    ),
+                    precedence=1 if is_pos else 0,
+                    force=False,
+                    feature=s,  # provenance (ADR 0010): this dim belongs to the slot
+                ),
+            )
+            return True  # deferred — the callback owns the drop; caller's else must not fire
 
         # Bind each planned dim explicitly by (role, kind) — never positionally (#730).
         by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
@@ -509,7 +561,8 @@ def render_slots(dwg, groups, a, *, ctx, only=None) -> int:
 _SIZE_SUBCHAIN = 0
 _LOC_SUBCHAIN = 1
 _OVERALL_SUBCHAIN = 2
-_MANDATORY_OVERALL_PRIORITY = 100.0
+_MANDATORY_OVERALL_PRIORITY = PRIORITY.MANDATORY
+_PRINCIPAL_CHAIN_PRIORITY = PRIORITY.PRINCIPAL
 
 # Minimum half of a bore's PAGE-projected diameter (mm) for its ø dim to fit across the circle
 # in-plane; below this the circle is too small to letter inside, so the callout leaders out
@@ -558,7 +611,7 @@ def _location_candidate(
         on_drop=_drop,
         dedup=(view, span_key[0], span_key[1]),
         precedence=3 if pinned else 2,
-        priority=100.0 if pinned else 0.0,
+        priority=PRIORITY.MANDATORY if pinned else PRIORITY.AUTO,
         force=True,
         feature=feature,  # provenance (ADR 0010): the located hole/pattern
         footprint=footprint,  # analytical measure — no probe build (#602)
@@ -2907,6 +2960,9 @@ def render_height_ladder(dwg, model, a, *, ctx, include_overall: bool = True) ->
                 on_place=lambda nm: None,
                 on_drop=_drop,
                 force=True,  # principal dims: only a physically full strip drops them
+                # …and when it IS physically full, they outrank ordinary auto dims rather
+                # than tying with them at 0 and losing on the generated key (#894).
+                priority=_PRINCIPAL_CHAIN_PRIORITY,
                 feature=step if name != "dim_height" else None,
                 footprint=_foot,
             ),
@@ -3274,7 +3330,7 @@ def _bore_half_span(pmi_kind: str, value: float) -> float:
 # capacity it should survive ahead of auto-generated dims (priority 0), like declared
 # GD&T. It still lives in the outer run so it does not land between size/location dims.
 _PMI_SUBCHAIN = 3
-_PMI_CORRIDOR_PRIORITY = 1.0
+_PMI_CORRIDOR_PRIORITY = PRIORITY.AUTHORED
 _PMI_SLOT = 10.0  # mm — slot size for PMI dim lines in the strip
 
 
@@ -3775,7 +3831,7 @@ _GDT_SUBCHAIN = 3
 # Over-capacity survival rank for an authored GD&T frame (#357): a declared control frame /
 # datum / finish / note is deliberate intent, so on a strip too full for every candidate it is
 # kept over the auto dims (locations/slots, priority 0) rather than dropped by stacking-key order.
-_GDT_CORRIDOR_PRIORITY = 1.0
+_GDT_CORRIDOR_PRIORITY = PRIORITY.AUTHORED
 # Minimum GD&T leader shaft length (page-mm). A zero-length Leader (site == solved tier)
 # makes OCC's edge builder raise; nudging to this keeps `_build` total (#61 review).
 _MIN_LEADER = 0.05

--- a/tests/test_solve_trace.py
+++ b/tests/test_solve_trace.py
@@ -15,7 +15,7 @@ from build123d import Box, Cylinder, Pos
 
 from draftwright import build_drawing
 from draftwright._core import Strip
-from draftwright.annotations._common import full_strip_message, strip_occupants
+from draftwright.annotations._common import PRIORITY, full_strip_message, strip_occupants
 
 
 def _build_box(tmp_path, **kw):
@@ -47,7 +47,10 @@ class TestTraceRecording:
         s = by_corridor[("front", "right")]
         assert [c["name"] for c in s["candidates"]] == ["dim_height"]
         cand = s["candidates"][0]
-        assert cand["force"] is True and cand["priority"] == 0
+        # The principal front-view chain carries PRIORITY.PRINCIPAL (#894): registering
+        # at the default tied it with feature location dims, so an over-capacity strip
+        # dropped a step height on an arbitrary generated key.
+        assert cand["force"] is True and cand["priority"] == PRIORITY.PRINCIPAL
         # The strip bounds are the diagnosis frame …
         assert set(s["strip"]) == {"anchor", "outer_limit", "direction", "gap", "spacing"}
         # … and each pass records the carve + per-candidate events.

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1329,3 +1329,67 @@ def test_leader_decoration_stages_follow_the_drain():
             "never starves a principal dim, and later views must see it (#733)"
         )
     assert section < _PASS_SEQUENCE.index("details") < _PASS_SEQUENCE.index("title_block")
+
+
+def test_a_rescued_dedup_winner_does_not_promote_its_loser():
+    """#894: promotion is gated on "the measurement is genuinely absent".
+
+    Two candidates that dedup to the same span: the winner is kept, the loser parked.
+    If the winner then fails its strip, `on_drop` may still rescue it onto the opposite
+    strip — and promoting the loser at that point draws the same dimension twice.
+
+    The bug was live on BOTH paths and predates the corridor migration: the plan/side
+    fallthrough has run synchronously since #345/#346, so `on_drop` returning was never
+    evidence of failure. Found by adversarial probe (sync success -> loser promoted),
+    which is why it is pinned here rather than left to the trace.
+    """
+    from types import SimpleNamespace
+
+    from draftwright.annotations._common import (
+        CorridorCandidate,
+        PlacementContext,
+        solve_corridor,
+    )
+
+    def _run(*, rescue: bool):
+        placed: set[str] = set()
+        promoted: list[str] = []
+
+        def _cand(name, *, is_winner):
+            def _on_drop(nm, _n=name, _w=is_winner):
+                if _w and rescue:
+                    placed.add(_n)  # the opposite-strip fallthrough took it
+                elif not _w:
+                    promoted.append(_n)  # a loser's on_drop IS its promotion
+
+            return CorridorCandidate(
+                name=name,
+                build=lambda _pos: None,
+                order=(0, name),
+                on_place=lambda _nm: None,
+                on_drop=_on_drop,
+                dedup=("plan", 0.0, 10.0),  # identical span → same dedup group
+                precedence=1 if is_winner else 0,
+            )
+
+        dwg = SimpleNamespace(annotations=lambda: set(placed))
+        # strip=None drops every candidate, which is the cheapest way to reach the
+        # promotion decision without standing up real page geometry.
+        solve_corridor(
+            dwg,
+            None,
+            "plan",
+            "y",
+            [_cand("winner", is_winner=True), _cand("loser", is_winner=False)],
+            4.0,
+            ctx=PlacementContext(),
+        )
+        return placed, promoted
+
+    placed, promoted = _run(rescue=True)
+    assert "winner" in placed
+    assert promoted == [], "a rescued winner must leave its coincident loser suppressed"
+
+    placed, promoted = _run(rescue=False)
+    assert placed == set()
+    assert promoted == ["loser"], "a genuinely absent winner must still hand over"


### PR DESCRIPTION
CTC-03 and CTC-04 lost their step-height AND overall-height dimensions after
#888. The lint named the occupants: #888's new pocket location dims.

#888 is not at fault. It added occupants to a pre-existing hole.

`_place` had two paths. The corridor path (plan/side views, horizontal
measure) registers a candidate and lets `drain_corridors` arbitrate. Every
other case — right/left dims, and any front-view above/below — fell to an
immediate path calling `place_strip_candidates` directly. That is a LOCAL
solve: it spaces only the candidates in its own call against already-placed
annotations, then commits. Whichever pass ran first won the space.

The overall height carries the highest survival rank in the engine (100.0)
and lost anyway, because priority only ranks candidates that are IN the
solve. The arbitration never ran.

Three changes:

1. Every side registers into the corridor batch; the opposite side becomes a
   post-drain on_drop fallthrough — the shape render_plates and render_gdt
   already use, and the #684 rule that a mid-drain placement must not preempt
   a sibling's reserved space.

2. The principal front-view chain (step heights, overall height) gains a
   priority. It was registering at the implicit default and silently TYING
   with feature location dims, so an over-capacity strip dropped a step
   height on an arbitrary generated key.

3. One PRIORITY ladder in _common.py, beside the field it ranks. The scale
   existed in six places and nowhere as a scale: two 100.0 constants (one
   inline), two 1.0 constants, an implicit 0.0 default. A rank only means
   anything relative to the others, so a bare number at a call site cannot be
   reviewed — which is how (2) went unnoticed. Deliberate gaps so a new rung
   inserts rather than renumbers. Not folded in: holes.py's priority=d and
   priority=s[1], computed within a band rather than fixed rungs.

Result: all five CTC AP203 fixtures pass. 03 and 04 were failing; 01, 02 and
05 were healthy and stay healthy.

Two test updates, both recording a decision rather than accommodating a
regression:

#885's coverage test asserted 8 pad dims and score 1.0. The solve trace shows
the four pad WIDTH dims competing in a corridor of their own — three fit, one
does not. Before this change all four placed because the commit path put them
where the solve declines to: straddling the view's right edge, x spans
reaching 230 and 243 where the view ends at 218 — the same overlap the part's
two standing leader_crosses_silhouette issues describe. The test now pins
placed-or-REPORTED rather than a raw count, which is what #630/#631/#632 ask
for over a clean-looking but wrong sheet.

test_solve_trace pinned priority == 0 for the principal chain, which is
exactly what this changes.

Not fixed here, tracked as #893: CTC-02's balloon ring collapsed onto the plan
view in #888 (top ring 552.83 -> 488.10). Different subsystem — the band solve
in layout.py — and identical before and after this change.

Not fixed here, tracked in #894: extending the fail-closed caller guard to
`place_strip_candidates`. #636 shut the `carve_free_position` door and left
this one open; the guard must be added with a clean allowlist, which needs the
remaining commit-now sites migrated first.

---

Fixes the slow-tier regression blocking 0.3.10.

**Verification**
- All five CTC AP203 fixtures pass (03/04 were failing; 01/02/05 were healthy and stay healthy).
- Full fast tier: 1756 passed.
- Four lint checks clean.
- Golden corpus: **output moves here, deliberately.** Per the steer that byte-identity must not hold up correct behaviour, the diffs were judged on merit rather than defended.

**Companion issues found while diagnosing**
- **#893** — CTC-02 balloon ring collapsed onto the plan view (separate subsystem, also a 0.3.10 blocker)
- **#894** — extending the fail-closed guard to `place_strip_candidates`, the door #636 left open

🤖 Generated with [Claude Code](https://claude.com/claude-code)