### PR TITLE
Fix ambiguous Y-axis step-length chains

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -618,6 +618,11 @@ class DetailRequest:
                       footprint that depends on the chosen scale (the prismatic
                       ladder reserves one rung per *legible-at-that-scale* step, so it
                       shrinks with the scale during the fit). Overrides ``pad_top``.
+        source_view:  orthographic direction to preserve in the detail (``"front"``
+                      or ``"side"``). The latter is used for Y-turned axial profiles.
+        cross_axis/cross_lo/cross_hi: optional second crop band, used to isolate a
+                      narrow profile strip when enlarging the full radial extent
+                      would not fit on the sheet.
         kind:         short label for logging.
     """
 
@@ -628,6 +633,10 @@ class DetailRequest:
     redraw: Callable[..., int]
     pad_top: float = 0.0
     pads: Callable[[float], tuple[float, float]] | None = None
+    source_view: str = "front"
+    cross_axis: str | None = None
+    cross_lo: float | None = None
+    cross_hi: float | None = None
     kind: str = "detail"
 
 

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from draftwright.compose import StripDepths
@@ -633,8 +633,8 @@ class DetailRequest:
     redraw: Callable[..., int]
     pad_top: float = 0.0
     pads: Callable[[float], tuple[float, float]] | None = None
-    source_view: str = "front"
-    cross_axis: str | None = None
+    source_view: Literal["front", "side"] = "front"
+    cross_axis: Literal["x", "y", "z"] | None = None
     cross_lo: float | None = None
     cross_hi: float | None = None
     kind: str = "detail"

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2519,7 +2519,12 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
             c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
             for (c1, w1), (c2, w2) in zip(cw, cw[1:])
         )
-        if not labels_clear:
+        inside_arrows_fit = all(
+            abs(pb[0] - pa[0])
+            >= label_widths[i] + 2 * draft.arrow_length + 2 * draft.pad_around_text
+            for i, (pa, pb, *_rest) in enumerate(fsegs)
+        )
+        if not (labels_clear and inside_arrows_fit):
             alo = min(min(a[1], b[1]) for a, b, *_ in bare_rows)
             ahi = max(max(a[1], b[1]) for a, b, *_ in bare_rows)
             page_xs = [p[0] for pa, pb, *_ in fsegs for p in (pa, pb)]
@@ -2541,8 +2546,9 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
             # Use the detected turning axis, not the sheet/bounding-box centroid:
             # an eccentric shaft's profile may be nowhere near the latter. A single
             # side-profile detail is valid only for a coaxial chain.
+            axis_xs = [origin[0] for origin in step_origins]
             axis_zs = [origin[2] for origin in step_origins]
-            coaxial = max(axis_zs) - min(axis_zs) <= 0.5
+            coaxial = max(axis_xs) - min(axis_xs) <= 0.5 and max(axis_zs) - min(axis_zs) <= 0.5
             if not coaxial:
                 return _draw_step_chain(dwg, view, fsegs, "m_steplen", ctx=ctx, start=start)
             axis_z = sum(axis_zs) / len(axis_zs)
@@ -2581,9 +2587,11 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
                         prev, _prev_width = run[-1]
                         cur, _cur_width = dpairs[k]
                         contiguous = (
-                            abs(max(prev[0][0], prev[1][0]) - min(cur[0][0], cur[1][0])) <= 0.6
+                            abs(max(prev[0][0], prev[1][0]) - min(cur[0][0], cur[1][0])) <= 1e-4
                         )
-                        equal = abs(cur[2] - seg0[2]) <= 0.1 * seg0[2]
+                        # A repeated-pitch claim must be true at the drawing's
+                        # displayed precision, not merely "within 10%".
+                        equal = _fmt(cur[2]) == _fmt(seg0[2])
                         untoleranced = prev[3] is None and cur[3] is None
                         if not (contiguous and equal and untoleranced):
                             break

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2525,15 +2525,15 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
             for i, (pa, pb, *_rest) in enumerate(fsegs)
         )
         if not (labels_clear and inside_arrows_fit):
-            alo = min(min(a[1], b[1]) for a, b, *_ in bare_rows)
-            ahi = max(max(a[1], b[1]) for a, b, *_ in bare_rows)
+            axis_lo = min(min(a[1], b[1]) for a, b, *_ in bare_rows)
+            axis_hi = max(max(a[1], b[1]) for a, b, *_ in bare_rows)
             page_xs = [p[0] for pa, pb, *_ in fsegs for p in (pa, pb)]
             page_y = fsegs[0][0][1]
             block = [
                 (
                     (min(page_xs), page_y, 0.0),
                     (max(page_xs), page_y, 0.0),
-                    ahi - alo,
+                    axis_hi - axis_lo,
                     None,
                 )
             ]
@@ -2663,8 +2663,8 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
             ctx.detail_requests.append(
                 DetailRequest(
                     axis="y",
-                    lo=alo,
-                    hi=ahi,
+                    lo=axis_lo,
+                    hi=axis_hi,
                     scale_needed=scale_needed,
                     redraw=_redraw_y,
                     pad_top=draft.font_size + 2 * draft.pad_around_text + draft.arrow_length,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2318,8 +2318,14 @@ def _draw_step_chain(
     gap = draft.font_size + 4 * draft.pad_around_text
     horizontal = abs(segs[0][1][0] - segs[0][0][0]) >= abs(segs[0][1][1] - segs[0][0][1])
     vals = [s[2] for s in segs]  # value is index 2 (segs are 4-tuples: pa, pb, value, tol)
+    labels = [s[4] if len(s) > 4 and s[4] is not None else _fmt(s[2]) for s in segs]
     mean_v = sum(vals) / len(vals)
-    if allow_collapse and len(segs) >= 3 and (max(vals) - min(vals)) <= 0.10 * mean_v:
+    if (
+        allow_collapse
+        and all(len(s) < 5 or s[4] is None for s in segs)
+        and len(segs) >= 3
+        and (max(vals) - min(vals)) <= 0.10 * mean_v
+    ):
         # A uniform run collapses to one "N× v" dim; a per-step ± would be a false claim on
         # N equal steps, so the collapse carries NO tolerance (#28 / P2a).
         label = f"{len(segs)}× {_fmt(mean_v)}"
@@ -2336,20 +2342,20 @@ def _draw_step_chain(
         tiers = [0] * len(segs)
         if horizontal:
             cw = [
-                ((pa[0] + pb[0]) / 2, len(_fmt(v)) * draft.font_size * _EST_CHAR_WIDTH_EM)
-                for pa, pb, v, *_ in segs
+                ((s[0][0] + s[1][0]) / 2, len(labels[i]) * draft.font_size * _EST_CHAR_WIDTH_EM)
+                for i, s in enumerate(segs)
             ]
 
-            def _clear(items):  # (center, width) pairs in x order — labels don't overlap
+            def _clear(items):
                 return all(
                     c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
                     for (c1, w1), (c2, w2) in zip(items, items[1:])
                 )
 
             if _clear(cw):
-                pass  # one tier suffices — no needless zig-zag for a roomy chain
+                pass
             elif _clear(cw[0::2]) and _clear(cw[1::2]):
-                tiers = [i % 2 for i in range(len(segs))]  # alternate to make room
+                tiers = [i % 2 for i in range(len(segs))]
             else:
                 _log.info("step-length chain skipped: too dense even when staggered")
                 _record_step_chain_drop(
@@ -2378,7 +2384,8 @@ def _draw_step_chain(
                 return 0
 
         candidates = []
-        for i, (pa, pb, value, seg_tol) in enumerate(segs):
+        for i, seg in enumerate(segs):
+            pa, pb, value, seg_tol, *_rest = seg
             if horizontal:
                 p1, p2, side = (pa[0], y1, 0), (pb[0], y1, 0), "above"
                 dist = gap + tiers[i] * tier_step
@@ -2388,7 +2395,7 @@ def _draw_step_chain(
             candidates.append(
                 (
                     f"{name_prefix}{start + i}",
-                    _dim(p1, p2, side, dist, draft, label=_fmt(value), tolerance=seg_tol),
+                    _dim(p1, p2, side, dist, draft, label=labels[i], tolerance=seg_tol),
                 )
             )
 
@@ -2448,6 +2455,8 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     place, the block still locates the head extent and lint reports the un-located
     interior shoulders — never worse than the prior skip. Returns the count placed."""
     rows = []  # (axis, a_world, b_world, value, tolerance) in axis order
+    step_origins = []
+    step_radii = []
     for g in groups:
         if g.feature_kind != "step":
             continue
@@ -2470,6 +2479,8 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
                 length.tolerance,
             )
         )
+        step_origins.append(g.feature.frame.origin)
+        step_radii.append(g.feature.diameter / 2)
     if not rows:
         return 0
     draft = dwg.draft
@@ -2487,6 +2498,184 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     bare_rows = [(a, b, v, t) for _axis, a, b, v, t in rows]
     fsegs = [(dwg.at(view, *a), dwg.at(view, *b), v, t) for a, b, v, t in bare_rows]
     horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
+
+    # A Y-turned chain that would need near/far staggering is ambiguous in the
+    # narrow side view: an interior far-tier segment reads like an overall
+    # dimension (#892). Keep one overall block on the side view and redraw the
+    # complete shoulder chain in a true enlarged side-profile detail instead.
+    if horizontal and turn_axis == "y" and len(fsegs) >= 2:
+        label_widths = [
+            _text_size(
+                _fmt(v) + _tol_suffix(t, draft),
+                draft.font_size,
+                font=getattr(draft, "font", "Arial"),
+            )[0]
+            for *_span, v, t in bare_rows
+        ]
+        cw = sorted(
+            ((pa[0] + pb[0]) / 2, label_widths[i]) for i, (pa, pb, *_rest) in enumerate(fsegs)
+        )
+        labels_clear = all(
+            c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
+            for (c1, w1), (c2, w2) in zip(cw, cw[1:])
+        )
+        if not labels_clear:
+            alo = min(min(a[1], b[1]) for a, b, *_ in bare_rows)
+            ahi = max(max(a[1], b[1]) for a, b, *_ in bare_rows)
+            page_xs = [p[0] for pa, pb, *_ in fsegs for p in (pa, pb)]
+            page_y = fsegs[0][0][1]
+            block = [
+                (
+                    (min(page_xs), page_y, 0.0),
+                    (max(page_xs), page_y, 0.0),
+                    ahi - alo,
+                    None,
+                )
+            ]
+            scale_needed = max(
+                (w + 2 * draft.arrow_length + 2 * draft.pad_around_text) / row[2]
+                for w, row in zip(label_widths, bare_rows)
+                if row[2] > 0
+            )
+
+            # Use the detected turning axis, not the sheet/bounding-box centroid:
+            # an eccentric shaft's profile may be nowhere near the latter. A single
+            # side-profile detail is valid only for a coaxial chain.
+            axis_zs = [origin[2] for origin in step_origins]
+            coaxial = max(axis_zs) - min(axis_zs) <= 0.5
+            if not coaxial:
+                return _draw_step_chain(dwg, view, fsegs, "m_steplen", ctx=ctx, start=start)
+            axis_z = sum(axis_zs) / len(axis_zs)
+
+            # Choose the same standard scale family as the detail renderer, then
+            # crop a geometry-relative strip: at most half the smallest radius and
+            # at most 12 page-mm tall. This stays useful from tiny pins to large
+            # flanges without a magic world-space ±2 mm band.
+            detail_target = dwg.scale * 10
+            for factor in (2, 5, 10):
+                candidate = dwg.scale * factor
+                if candidate >= scale_needed:
+                    detail_target = candidate
+                    break
+            min_radius = min(step_radii)
+            cross_half = max(0.1, min(min_radius / 2, 6.0 / detail_target))
+
+            def _redraw_y(dwg, detail_view, coords, detail_scale, _rows=bare_rows):
+                def _at(x, y, z):
+                    px, py = coords.pp(x, y, z)
+                    return (px, py, 0.0)
+
+                dpairs = [
+                    ((_at(*a), _at(*b), v, t), label_widths[i])
+                    for i, (a, b, v, t) in enumerate(_rows)
+                ]
+                dpairs.sort(key=lambda item: (item[0][0][0] + item[0][1][0]) / 2)
+                dsegs = []
+                detail_widths = []
+                j = 0
+                while j < len(dpairs):
+                    seg0, _width0 = dpairs[j]
+                    run = [dpairs[j]]
+                    k = j + 1
+                    while k < len(dpairs):
+                        prev, _prev_width = run[-1]
+                        cur, _cur_width = dpairs[k]
+                        contiguous = (
+                            abs(max(prev[0][0], prev[1][0]) - min(cur[0][0], cur[1][0])) <= 0.6
+                        )
+                        equal = abs(cur[2] - seg0[2]) <= 0.1 * seg0[2]
+                        untoleranced = prev[3] is None and cur[3] is None
+                        if not (contiguous and equal and untoleranced):
+                            break
+                        run.append(dpairs[k])
+                        k += 1
+                    if len(run) >= 3:
+                        run_segs = [seg for seg, _width in run]
+                        xs = [p[0] for seg in run_segs for p in seg[:2]]
+                        y = run_segs[0][0][1]
+                        pitch = sum(seg[2] for seg in run_segs) / len(run_segs)
+                        label = f"{len(run_segs)}× {_fmt(pitch)}"
+                        dsegs.append(
+                            (
+                                (min(xs), y, 0.0),
+                                (max(xs), y, 0.0),
+                                sum(seg[2] for seg in run_segs),
+                                None,
+                                label,
+                            )
+                        )
+                        detail_widths.append(
+                            _text_size(
+                                label,
+                                draft.font_size,
+                                font=getattr(draft, "font", "Arial"),
+                            )[0]
+                        )
+                    else:
+                        for seg, width in run:
+                            dsegs.append(seg)
+                            detail_widths.append(width)
+                    j = k
+                # Never recreate the ambiguous stagger inside a detail. Validate
+                # both text clearance and full inside-arrow capacity at the actual
+                # fitted scale; returning zero transactionally drops the detail.
+                dcw = sorted(
+                    ((pa[0] + pb[0]) / 2, detail_widths[i])
+                    for i, (pa, pb, *_rest) in enumerate(dsegs)
+                )
+                if not all(
+                    c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
+                    for (c1, w1), (c2, w2) in zip(dcw, dcw[1:])
+                ):
+                    _log.info(
+                        "Y-chain detail rejected at scale %.3g: labels still collide",
+                        detail_scale,
+                    )
+                    return 0
+                if any(
+                    abs(pb[0] - pa[0])
+                    < detail_widths[i] + 2 * draft.arrow_length + 2 * draft.pad_around_text
+                    for i, (pa, pb, *_rest) in enumerate(dsegs)
+                ):
+                    _log.info(
+                        "Y-chain detail rejected at scale %.3g: label + inside arrows "
+                        "do not fit a segment",
+                        detail_scale,
+                    )
+                    return 0
+                return _draw_step_chain(
+                    dwg,
+                    detail_view,
+                    dsegs,
+                    f"dim_{detail_view}_steplen",
+                    detail_scale,
+                    ctx=ctx,
+                )
+
+            ctx.detail_requests.append(
+                DetailRequest(
+                    axis="y",
+                    lo=alo,
+                    hi=ahi,
+                    scale_needed=scale_needed,
+                    redraw=_redraw_y,
+                    pad_top=draft.font_size + 2 * draft.pad_around_text + draft.arrow_length,
+                    source_view="side",
+                    cross_axis="z",
+                    cross_lo=axis_z - cross_half,
+                    cross_hi=axis_z + cross_half,
+                    kind="y-turned-chain",
+                )
+            )
+            return _draw_step_chain(
+                dwg,
+                "side",
+                block,
+                "m_steplen",
+                allow_collapse=False,
+                ctx=ctx,
+                start=start,
+            )
 
     # X-turned crowded-head detour (#307): split off each contiguous *run of ≥2*
     # sub-floor steps (segment narrower than two arrowheads on the page), locate it as

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2576,8 +2576,8 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
                     for i, (a, b, v, t) in enumerate(_rows)
                 ]
                 dpairs.sort(key=lambda item: (item[0][0][0] + item[0][1][0]) / 2)
-                dsegs = []
-                detail_widths = []
+                dsegs: list[tuple] = []
+                detail_widths: list[float] = []
                 j = 0
                 while j < len(dpairs):
                     seg0, _width0 = dpairs[j]

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -428,17 +428,25 @@ def _render_detail(
         return False
     body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
     big = 4 * a.bbox_max
-    idx = "xyz".index(req.axis)
 
-    def _cut(edge):
+    def _cut(axis, edge):
         c = [a.cx, a.cy, a.cz]
-        c[idx] = edge
+        c["xyz".index(axis)] = edge
         return Pos(*c) * Box(big, big, big)
 
     try:
-        cropped = _fuzzy_cut(body, _cut(req.lo - big / 2))
+        cropped = _fuzzy_cut(body, _cut(req.axis, req.lo - big / 2))
         if cropped is not None:
-            cropped = _fuzzy_cut(cropped, _cut(req.hi + big / 2))
+            cropped = _fuzzy_cut(cropped, _cut(req.axis, req.hi + big / 2))
+        if (
+            cropped is not None
+            and req.cross_axis is not None
+            and req.cross_lo is not None
+            and req.cross_hi is not None
+        ):
+            cropped = _fuzzy_cut(cropped, _cut(req.cross_axis, req.cross_lo - big / 2))
+            if cropped is not None:
+                cropped = _fuzzy_cut(cropped, _cut(req.cross_axis, req.cross_hi + big / 2))
     except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
         _log.warning("Detail %s skipped (crop failed: %s)", letter, exc)
         return False
@@ -469,7 +477,8 @@ def _render_detail(
     # Footprint = the projected cropped band + the request's annotation pads (the
     # dim ladder/chain) + the caption row. Shrink the scale to fit if necessary.
     cb = cropped.bounding_box()
-    view_w, view_h = (cb.max.X - cb.min.X), (cb.max.Z - cb.min.Z)
+    view_w = cb.max.Y - cb.min.Y if req.source_view == "side" else cb.max.X - cb.min.X
+    view_h = cb.max.Z - cb.min.Z
     cap_h = 8.0
 
     def _pads(s):  # annotation bands may depend on the scale (the prismatic ladder)
@@ -491,14 +500,18 @@ def _render_detail(
     DX = (rx0 + rx1) / 2 - pad_right / 2
     DY = (ry0 + ry1) / 2 - (pad_top - cap_h) / 2
 
-    # Look from −Y, up +Z at detail_scale around the band's own centroid — the camera + coordinates
-    # for the scratch projection below.
+    # Preserve the request's orthographic direction at detail scale around the
+    # band's own centroid: front looks from −Y; side looks from +X.
     dcx = (cb.min.X + cb.max.X) / 2
     dcy = (cb.min.Y + cb.max.Y) / 2
     dcz = (cb.min.Z + cb.max.Z) / 2
     la = (dcx * detail_scale, dcy * detail_scale, dcz * detail_scale)
     dist_d = a.bbox_max * detail_scale + 100
-    camera = (la[0], la[1] - dist_d, la[2])
+    camera = (
+        (la[0] + dist_d, la[1], la[2])
+        if req.source_view == "side"
+        else (la[0], la[1] - dist_d, la[2])
+    )
     # Project the cropped band front-on into a SCRATCH (no Drawing mutation) at the detail scale —
     # project_view_geometry takes the scale directly, so its coordinates ARE the detail's (the old
     # _add_view + override existed only because _add_view hard-codes the sheet scale). Trying the
@@ -527,12 +540,19 @@ def _render_detail(
         return False
     dwg._set_view_coordinates(view_name, coords)
 
-    # Marker on the front view around the band (axis-aware) + letter.
-    FX, FZ = a.proj.front_x, a.proj.front_z
-    if req.axis == "z":  # band runs along page-y
-        mx0, mx1, my0, my1 = FX(a.bb.min.X), FX(a.bb.max.X), FZ(req.lo), FZ(req.hi)
-    else:  # x band runs along page-x
-        mx0, mx1, my0, my1 = FX(req.lo), FX(req.hi), FZ(a.bb.min.Z), FZ(a.bb.max.Z)
+    # Marker on the source orthographic view around the band + letter.
+    if req.source_view == "side":
+        zlo = req.cross_lo if req.cross_lo is not None else a.bb.min.Z
+        zhi = req.cross_hi if req.cross_hi is not None else a.bb.max.Z
+        corners = [dwg.at("side", a.bb.max.X, y, z) for y in (req.lo, req.hi) for z in (zlo, zhi)]
+        mx0, mx1 = min(p[0] for p in corners), max(p[0] for p in corners)
+        my0, my1 = min(p[1] for p in corners), max(p[1] for p in corners)
+    else:
+        FX, FZ = a.proj.front_x, a.proj.front_z
+        if req.axis == "z":  # band runs along page-y
+            mx0, mx1, my0, my1 = FX(a.bb.min.X), FX(a.bb.max.X), FZ(req.lo), FZ(req.hi)
+        else:  # x band runs along page-x
+            mx0, mx1, my0, my1 = FX(req.lo), FX(req.hi), FZ(a.bb.min.Z), FZ(a.bb.max.Z)
     marker = Compound(
         children=[
             Edge.make_line(Vector(mx0, my0, 0), Vector(mx1, my0, 0)),

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -576,11 +576,11 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
         px, py, *_ = dwg.at(view, *pt)
         return float(px if use_x else py)
 
-    # A crowded X-turned head is dimensioned in an enlarged detail view (#304/#307),
-    # not the front chain — so a shoulder counts as located when matched in EITHER the
-    # front view or any detail view. Y chains use the side profile view.
+    # A crowded X-turned head or Y-turned side chain can be dimensioned in an
+    # enlarged detail view (#304/#307/#892), not the principal profile — so a
+    # shoulder counts as located when matched in EITHER source or detail view.
     views = ["side"] if prof.axis == "y" else ["front"]
-    if prof.axis == "x":
+    if prof.axis in ("x", "y"):
         views += sorted(v for v in dwg.views if v.startswith("detail_"))
     covered_steps: set[int] = set()
     for view in views:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9015,6 +9015,22 @@ class TestTurnedDiameters:
             for left, right in zip(labels, labels[1:])
         )
 
+    def test_issue_892_clear_labels_but_tight_arrows_still_request_detail(self):
+        # Single-digit labels clear one another at 1:1, but the 3/5/4 mm spans
+        # cannot contain text plus two inside arrowheads. Outside-arrow tails on
+        # the principal chain would intrude into neighbouring links.
+        b = Align.MIN
+        part = Cylinder(12, 3, align=(Align.CENTER, Align.CENTER, b))
+        part += Pos(0, 0, 3) * Cylinder(10, 5, align=(Align.CENTER, Align.CENTER, b))
+        part += Pos(0, 0, 8) * Cylinder(8, 4, align=(Align.CENTER, Align.CENTER, b))
+        dwg = build_drawing(part.rotate(Axis.X, 90), scale=1.0)
+
+        assert "detail_a" in dwg.views
+        detail = {
+            o.label for n, o in dwg.iter_annotations() if n.startswith("dim_detail_a_steplen")
+        }
+        assert detail == {"3", "5", "4"}
+
     def test_issue_892_no_detail_room_keeps_block_and_reports_uncovered_shoulders(self):
         # Transactional failure: a deliberately undersized sheet has no rectangle
         # for the enlarged profile. Do not leave half a detail or reinstate the

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8887,6 +8887,14 @@ class TestTurnedDiameters:
         return part.rotate(Axis.X, 90)
 
     @staticmethod
+    def _issue_892_y_chain(*, axis_z=0.0, rotation=90):
+        b = Align.MIN
+        part = Cylinder(22.5, 3, align=(Align.CENTER, Align.CENTER, b))
+        part += Pos(0, 0, 3) * Cylinder(17, 5.5, align=(Align.CENTER, Align.CENTER, b))
+        part += Pos(0, 0, 8.5) * Cylinder(14, 3.5, align=(Align.CENTER, Align.CENTER, b))
+        return Pos(0, 0, axis_z) * part.rotate(Axis.X, rotation)
+
+    @staticmethod
     def _assert_y_diameter_leaders_clear_holes(dwg):
         circles = []
         for feature in dwg.model().features:
@@ -8938,9 +8946,9 @@ class TestTurnedDiameters:
             assert owner is (matches[0] if len(matches) == 1 else None)
 
         self._assert_y_diameter_leaders_clear_holes(dwg)
-        assert {
-            dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_steplen")
-        } >= {"8", "4", "2"}
+        step_labels = {dwg.get_annotation(n).label for n in dwg.annotations() if "steplen" in n}
+        assert step_labels >= {"8", "4"}
+        assert "2" in step_labels or "4× 2" in step_labels
         assert {dwg.view_of(n) for n in dwg.annotations() if n.startswith("m_steplen")} == {"side"}
 
         # The central Y-axis bore shares the detected turned-profile axis. Its
@@ -8957,9 +8965,66 @@ class TestTurnedDiameters:
         assert "axial_length_missing" not in codes
 
         for name in tuple(dwg.annotations()):
-            if name.startswith("m_steplen"):
+            if "steplen" in name:
                 dwg.remove(name)
         assert "axial_length_missing" in {issue.code for issue in dwg.lint()}
+
+    @pytest.mark.parametrize(("axis_z", "rotation"), [(0.0, 90), (17.0, 90), (-11.0, -90)])
+    def test_issue_892_short_y_step_chain_moves_to_enlarged_side_detail(self, axis_z, rotation):
+        # P10-base axial profile: 3 | 5.5 | 3.5 mm along Y.  Centred labels crowd at
+        # 1:1, but lifting the middle 5.5 onto a far tier makes it read like an
+        # overall dimension. Keep only the 12 mm block on the side view and redraw
+        # the three shoulder-to-shoulder links in a genuine enlarged side detail.
+        dwg = build_drawing(self._issue_892_y_chain(axis_z=axis_z, rotation=rotation), scale=1.0)
+
+        main = {n: o for n, o in dwg.iter_annotations() if n.startswith("m_steplen")}
+        assert {o.label for o in main.values()} == {"12"}
+        assert {dwg.view_of(n) for n in main} == {"side"}
+        assert "detail_a" in dwg.views
+
+        detail = {n: o for n, o in dwg.iter_annotations() if n.startswith("dim_detail_a_steplen")}
+        assert {o.label for o in detail.values()} == {"3", "5.5", "3.5"}
+        assert {dwg.view_of(n) for n in detail} == {"detail_a"}
+        assert len({round(o._dw_spec.distance, 6) for o in detail.values()}) == 1
+
+        labels = sorted((o.label_bbox for o in detail.values()), key=lambda bb: bb[0])
+        assert all(
+            left[2] + dwg.draft.pad_around_text <= right[0] + 1e-6
+            for left, right in zip(labels, labels[1:])
+        )
+        marker = dwg.get_annotation("detail_marker_A").bounding_box()
+        axis_page_y = dwg.at("side", 0, 0, axis_z)[1]
+        assert marker.min.Y <= axis_page_y <= marker.max.Y
+
+    def test_issue_892_toleranced_labels_drive_detail_scale_from_rendered_text(self):
+        from draftwright import Sheet
+
+        part = self._issue_892_y_chain(axis_z=9.0)
+        sheet = Sheet(part, scale=1.0, page="A2")
+        sheet.step(diameter=45, length=3, at=(0, -1.5, 9), axis="y").tolerance(0.2)
+        sheet.step(diameter=34, length=5.5, at=(0, -5.75, 9), axis="y").tolerance(0.0, 0.3)
+        sheet.step(diameter=28, length=3.5, at=(0, -10.25, 9), axis="y")
+        dwg = sheet.build()
+
+        detail = [o for n, o in dwg.iter_annotations() if n.startswith("dim_detail_a_steplen")]
+        assert len(detail) == 3
+        assert {o._dw_scale for o in detail} == {10.0}
+        labels = sorted((o.label_bbox for o in detail), key=lambda bb: bb[0])
+        assert all(
+            left[2] + dwg.draft.pad_around_text <= right[0] + 1e-6
+            for left, right in zip(labels, labels[1:])
+        )
+
+    def test_issue_892_no_detail_room_keeps_block_and_reports_uncovered_shoulders(self):
+        # Transactional failure: a deliberately undersized sheet has no rectangle
+        # for the enlarged profile. Do not leave half a detail or reinstate the
+        # ambiguous stagger; retain the overall block and let coverage lint expose
+        # that the interior shoulders are not located.
+        dwg = build_drawing(self._issue_892_y_chain(), scale=1.0, page="140x100")
+        assert "detail_a" not in dwg.views
+        main = [o for n, o in dwg.iter_annotations() if n.startswith("m_steplen")]
+        assert [o.label for o in main] == ["12"]
+        assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 1
 
     def test_issue_890_rotated_bolt_pattern_selects_clear_diameter_rays(self):
         self._assert_y_diameter_leaders_clear_holes(
@@ -9496,8 +9561,6 @@ class TestTurnedLengths:
         # scale (#293). Scale pinned so the crowding regime is deterministic.
         from build123d import Align, Cylinder, Pos, Rotation
 
-        from draftwright.annotations._common import _anno_box
-
         b = Align.MIN
         specs = [(8, 3.1), (12, 2.9), (8, 3.2), (12, 2.8), (6, 3.0)]  # ~3 mm, > floor
         shaft = None
@@ -9512,11 +9575,12 @@ class TestTurnedLengths:
         assert len(steps) == 5  # every segment dimensioned, none dropped
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
         # Two tiers: the dims sit at (at least) two distinct offset rows.
-        boxes = [_anno_box(o) for o in steps.values()]
-        rows = {round((bb[1] + bb[3]) / 2, 1) for bb in boxes if bb}
+        rows = {round(o._dw_spec.distance, 6) for o in steps.values()}
         assert len(rows) >= 2, "chain did not stagger into multiple tiers"
 
         # Labels don't overprint each other.
+        boxes = [o.label_bbox for o in steps.values()]
+
         def overlap(a, c):
             return a and c and not (a[2] <= c[0] or a[0] >= c[2] or a[3] <= c[1] or a[1] >= c[3])
 


### PR DESCRIPTION
Closes #892.

## What changed

- Replace ambiguous near/far staggering for crowded Y-axis step chains with an overall block dimension in the principal side view and an enlarged side-profile detail containing the individual chain.
- Generalize detail requests with a source orthographic view and an optional transverse crop band.
- Derive the crop from the detected turning-axis frame and smallest step radius rather than the sheet centroid or a fixed world-space width.
- Measure rendered label text, including tolerance suffixes, when selecting the detail scale.
- Compact contiguous untoleranced equal-pitch runs to `N× pitch` when individual links cannot fit cleanly.
- Credit Y-axis detail dimensions in axial-coverage linting.

## Root cause

The horizontal step-chain placer avoided label collisions by alternating adjacent dimensions between near and far tiers. In a short three-link chain such as `3 | 5.5 | 3.5`, this made the middle `5.5` segment look like an overall dimension. The Y-axis path also lacked the enlarged-detail fallback already available to crowded X-axis heads.

## Impact

Crowded Y-turned profiles now preserve clear dimension-chain semantics. The principal side view retains the overall axial extent, while a standards-readable detail locates every interior shoulder. If no detail fits, placement remains transactional: the block is kept and coverage lint reports the missing shoulder locations.

## Validation

- Off-centre and reversed-Y profile variants.
- Tolerance-driven 10:1 detail scaling using rendered text metrics.
- Mixed chains with repeated fine-pitch runs.
- Deliberately constrained sheets where no detail can fit.
- Existing Y-axis deferred/script parity and X-axis detail/stagger regressions.
- Focused pytest suite, Ruff, and `git diff --check` pass.
- Regenerated and visually inspected the GrabCAD P10 base drawing.