### PR TITLE
Keep absolute step-height datums inside detail views

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -620,6 +620,10 @@ class DetailRequest:
                       shrinks with the scale during the fit). Overrides ``pad_top``.
         source_view:  orthographic direction to preserve in the detail (``"front"``
                       or ``"side"``). The latter is used for Y-turned axial profiles.
+        crop_lo/crop_hi: optional crop bounds along ``axis`` when the projected
+                      detail must include context outside the marked feature band.
+                      Prismatic absolute-height details use this to retain their
+                      base datum without enlarging the source-view marker.
         cross_axis/cross_lo/cross_hi: optional second crop band, used to isolate a
                       narrow profile strip when enlarging the full radial extent
                       would not fit on the sheet.
@@ -634,6 +638,8 @@ class DetailRequest:
     pad_top: float = 0.0
     pads: Callable[[float], tuple[float, float]] | None = None
     source_view: Literal["front", "side"] = "front"
+    crop_lo: float | None = None
+    crop_hi: float | None = None
     cross_axis: Literal["x", "y", "z"] | None = None
     cross_lo: float | None = None
     cross_hi: float | None = None

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -434,10 +434,12 @@ def _render_detail(
         c["xyz".index(axis)] = edge
         return Pos(*c) * Box(big, big, big)
 
+    crop_lo = req.lo if req.crop_lo is None else req.crop_lo
+    crop_hi = req.hi if req.crop_hi is None else req.crop_hi
     try:
-        cropped = _fuzzy_cut(body, _cut(req.axis, req.lo - big / 2))
+        cropped = _fuzzy_cut(body, _cut(req.axis, crop_lo - big / 2))
         if cropped is not None:
-            cropped = _fuzzy_cut(cropped, _cut(req.axis, req.hi + big / 2))
+            cropped = _fuzzy_cut(cropped, _cut(req.axis, crop_hi + big / 2))
         if (
             cropped is not None
             and req.cross_axis is not None
@@ -836,6 +838,11 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
             scale_needed=scale_needed,
             redraw=redraw,
             pads=pads,
+            # These are absolute heights from the part's base datum, not local
+            # rise dimensions. Keep that datum in the projected crop so every
+            # witness point belongs to visible detail geometry, while ``lo``
+            # remains the crowded band marked on the source view.
+            crop_lo=a.bb.min.Z,
             cross_axis="x" if len(x_stations) >= 2 else None,
             cross_lo=max(a.bb.min.X, x_stations[0] - xpad) if len(x_stations) >= 2 else None,
             cross_hi=min(a.bb.max.X, x_stations[-1] + xpad) if len(x_stations) >= 2 else None,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5695,6 +5695,23 @@ class TestDetailView:
         assert any(n.startswith("dim_detail_a_step") for n in dwg.annotations())
         # Drawn at a larger scale than the sheet.
         assert dwg.coords("detail_a")._scale > a.SCALE
+        # Absolute step heights use the part base as their datum. The detail
+        # must include that datum so neither witness endpoint floats outside
+        # the visible crop.
+        _, detail_y0, _, detail_y1 = dwg.view_bounds("detail_a")
+        detail_dims = (
+            dwg.get_annotation(n) for n in dwg.annotations() if n.startswith("dim_detail_a_step")
+        )
+        assert all(
+            detail_y0 - 1e-6 <= point[1] <= detail_y1 + 1e-6
+            for dim in detail_dims
+            for point in (dim._dw_spec.p1, dim._dw_spec.p2)
+        )
+        # Crop context and source marker are separate: including the base datum
+        # must not make the marker claim the whole part as the crowded region.
+        marker = dwg.get_annotation("detail_marker_A").bounding_box()
+        source_base_y = dwg.at("front", a.cx, a.cy, a.bb.min.Z)[1]
+        assert not marker.min.Y <= source_base_y <= marker.max.Y
         # No error-severity lint introduced.
         assert [i for i in dwg.lint() if i.severity == "error"] == []
 


### PR DESCRIPTION
## What changed

- Added optional detail crop bounds separate from the feature band used by the source-view marker.
- Kept the part base datum inside prismatic step-height detail crops.
- Added regressions proving detail dimension witness endpoints stay inside visible detail geometry and the source marker remains limited to the crowded feature band.

## Root cause

Prismatic detail dimensions report absolute heights from the part base, but the enlarged detail cropped that base away. The coordinate projector correctly mapped the missing datum, leaving both dimension lines detached below Detail A. Reusing the feature-band lower bound to include the base would also have enlarged the source marker, so crop bounds and marker bounds now remain distinct.

## User impact

Absolute step heights such as 18.6 and 24.8 now attach to a visible base datum inside Detail A instead of pointing into blank page space.

## Validation

- 95 focused detail/layout/case-study tests pass.
- Ruff lint and format checks pass.
- Mypy passes.
- Codespell passes.
- The uploaded slanted/blind STEP exports with both witness endpoints inside Detail A and no warning/error lint.