### PR TITLE
Fix balloon perimeter assignment after hole-table escalation

### DIFF
--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -48,11 +48,13 @@ Per view, per strip: **collect → solve → emit.**
     band assignment — a deterministic max-cardinality flow solve
     (`_assign_balloon_bands`, `layout.py`, #516).  A dense scattered-hole
     table escalation requests perimeter coverage (#901): within the maximum
-    flow, the solver lexicographically maximises the number of requested usable
-    bands activated before minimising leader length.  The render pass supplies
-    only band names, capacities, and numeric costs, keeping the solver
-    geometry-only; ordinary and manually requested balloons retain pure
-    minimum-cost assignment.  The perimeter render pass measures candidate
+    flow, the first use of each preferred usable band receives a bounded
+    distance credit before leader length is minimised. This is deliberately a
+    preference rather than a lexicographic override—a remote band stays empty
+    instead of creating a cross-part leader. The render pass supplies only band
+    names, capacities, and numeric costs, keeping the solver geometry-only;
+    ordinary and manually requested balloons retain pure minimum-cost
+    assignment. The perimeter render pass measures candidate
     lanes at obstacle boundaries and carves each into free horizontal segments;
     a geometry-only dynamic-programming solve assigns ordered members across
     those segments at minimum L1 leader cost.  This keeps a local remote
@@ -60,7 +62,9 @@ Per view, per strip: **collect → solve → emit.**
     preserving crossing-free member order.  The selected lane must hold both
     its balanced share and any member-count deficit left by the other bands, so
     lane selection cannot weaken the downstream solver's maximum-cardinality
-    guarantee.
+    guarantee whenever such a lane exists. If no lane meets the target, the
+    nearest lane wins rather than recreating the remote beyond-all-obstacles
+    geometry; any resulting capacity loss is surfaced as `balloon_dropped`.
   - **Order** — label order along the strip = site/feature order (candidates
     sort by anchor coordinate), so leaders between **distinct** strip-axis
     coordinates are **crossing-free by construction**; coincident sites

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -57,7 +57,10 @@ Per view, per strip: **collect → solve → emit.**
     a geometry-only dynamic-programming solve assigns ordered members across
     those segments at minimum L1 leader cost.  This keeps a local remote
     obstacle from pushing the entire ring beyond its outer edge (#125), while
-    preserving crossing-free member order.
+    preserving crossing-free member order.  The selected lane must hold both
+    its balanced share and any member-count deficit left by the other bands, so
+    lane selection cannot weaken the downstream solver's maximum-cardinality
+    guarantee.
   - **Order** — label order along the strip = site/feature order (candidates
     sort by anchor coordinate), so leaders between **distinct** strip-axis
     coordinates are **crossing-free by construction**; coincident sites

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -45,8 +45,14 @@ Per view, per strip: **collect → solve → emit.**
     assignment is (a) segment assignment within a carved strip
     (`carve_free_segments` + innermost-first fill in
     `place_strip_candidates`), and (b) the balloon pass's genuinely global
-    band assignment — a deterministic min-cost max-flow solve
-    (`_assign_balloon_bands`, `layout.py`, #516).
+    band assignment — a deterministic max-cardinality flow solve
+    (`_assign_balloon_bands`, `layout.py`, #516).  A dense scattered-hole
+    table escalation requests perimeter coverage (#901): within the maximum
+    flow, the solver lexicographically maximises the number of requested usable
+    bands activated before minimising leader length.  The render pass supplies
+    only band names, capacities, and numeric costs, keeping the solver
+    geometry-only; ordinary and manually requested balloons retain pure
+    minimum-cost assignment.
   - **Order** — label order along the strip = site/feature order (candidates
     sort by anchor coordinate), so leaders between **distinct** strip-axis
     coordinates are **crossing-free by construction**; coincident sites

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -52,7 +52,12 @@ Per view, per strip: **collect → solve → emit.**
     bands activated before minimising leader length.  The render pass supplies
     only band names, capacities, and numeric costs, keeping the solver
     geometry-only; ordinary and manually requested balloons retain pure
-    minimum-cost assignment.
+    minimum-cost assignment.  The perimeter render pass measures candidate
+    lanes at obstacle boundaries and carves each into free horizontal segments;
+    a geometry-only dynamic-programming solve assigns ordered members across
+    those segments at minimum L1 leader cost.  This keeps a local remote
+    obstacle from pushing the entire ring beyond its outer edge (#125), while
+    preserving crossing-free member order.
   - **Order** — label order along the strip = site/feature order (candidates
     sort by anchor coordinate), so leaders between **distinct** strip-axis
     coordinates are **crossing-free by construction**; coincident sites

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -374,12 +374,19 @@ def _dim(p1, p2, side, distance, draft, **kwargs):
 # extension-line origins) and subsequent parallel lines stack tighter and uniform (#347).
 _STRIP_GAP = 10.0  # clearance between the view outline and the first dimension line
 _STRIP_SPACING = 2.5  # clear gap between successive parallel dimension lines (beyond the label)
+_BALLOON_RADIUS_FONT_FACTOR = 1.5
+
+
+def _balloon_radius(font_size: float = _FONT_SIZE) -> float:
+    """Balloon glyph radius in page-mm for the active annotation font."""
+
+    return _BALLOON_RADIUS_FONT_FACTOR * font_size
 
 
 def _balloon_halo(font_size: float = _FONT_SIZE) -> float:
     """Reserved/rendered plan-balloon extent from the view edge, in page-mm."""
 
-    return _STRIP_GAP + 3 * font_size + _STRIP_SPACING
+    return _STRIP_GAP + 2 * _balloon_radius(font_size) + _STRIP_SPACING
 
 
 # Small lift (page-mm) of an overall/envelope witness line off the projected silhouette edge,

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -374,6 +374,14 @@ def _dim(p1, p2, side, distance, draft, **kwargs):
 # extension-line origins) and subsequent parallel lines stack tighter and uniform (#347).
 _STRIP_GAP = 10.0  # clearance between the view outline and the first dimension line
 _STRIP_SPACING = 2.5  # clear gap between successive parallel dimension lines (beyond the label)
+
+
+def _balloon_halo(font_size: float = _FONT_SIZE) -> float:
+    """Reserved/rendered plan-balloon extent from the view edge, in page-mm."""
+
+    return _STRIP_GAP + 3 * font_size + _STRIP_SPACING
+
+
 # Small lift (page-mm) of an overall/envelope witness line off the projected silhouette edge,
 # so its extension line reads as distinct from the outline rather than sitting on top of it.
 _WITNESS_LIFT_MM = 2.0

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -33,6 +33,25 @@ from draftwright.layout import (
 _MIN_PERIMETER_EXTENT = 20.0 + _STRIP_SPACING
 
 
+def _top_lane_target(member_count, other_capacities, usable_band_count):
+    """Capacity the top lane needs for both balance and maximum cardinality."""
+
+    balanced_share = math.ceil(member_count / usable_band_count)
+    capacity_deficit = max(0, member_count - sum(other_capacities))
+    return max(balanced_share, capacity_deficit)
+
+
+def _select_top_lane(lane_options, target, fallback_line):
+    """Nearest sufficient lane, else nearest maximum-capacity best effort."""
+
+    fitting = [option for option in lane_options if option[2] >= target]
+    if fitting:
+        return fitting[0]
+    if lane_options:
+        return max(lane_options, key=lambda option: (option[2], -option[0]))
+    return fallback_line, [], 0
+
+
 def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
     """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
     fitted into the halo the layout reserved around the view (#111).
@@ -125,7 +144,12 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         # carry a balanced share of the ring.  This is measured render geometry;
         # ordered placement across the resulting segments remains in layout.py.
         top_lo, top_hi = band_defs["top"][2:]
-        top_target = math.ceil(len(specs) / (3 + int(has_bottom)))
+        other_capacities = [
+            _strip_capacity(*band_defs[name][2:], gap) for name in ("left", "right")
+        ]
+        if has_bottom:
+            other_capacities.append(_strip_capacity(*band_defs["bottom"][2:], gap))
+        top_target = _top_lane_target(len(specs), other_capacities, 3 + int(has_bottom))
         first_line = pt + centre_offset
         last_line = ph - margin - r
         candidates = {first_line}
@@ -144,17 +168,9 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
             capacity = sum(_strip_capacity(lo, hi, gap) for lo, hi in segments)
             lane_options.append((line, segments, capacity))
 
-        fitting = [option for option in lane_options if option[2] >= top_target]
-        if fitting:
-            top_line, top_segments, _ = fitting[0]
-        elif lane_options:
-            # Best effort on a genuinely constrained sheet: retain the nearest
-            # maximum-capacity lane and let the global assignment use the sides.
-            top_line, top_segments, _ = max(
-                lane_options, key=lambda option: (option[2], -option[0])
-            )
-        else:
-            top_line, top_segments = band_defs["top"][1], []
+        # Best effort on a genuinely constrained sheet retains the nearest
+        # maximum-capacity lane and lets the global assignment use the sides.
+        top_line, top_segments, _ = _select_top_lane(lane_options, top_target, band_defs["top"][1])
         axis, _line, lo, hi = band_defs["top"]
         band_defs["top"] = (axis, top_line, lo, hi)
 

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -16,19 +16,21 @@ from build123d import Align, Circle, Compound, Location, Mode, Text
 from build123d_drafting.helpers import Leader
 
 from draftwright._core import _STRIP_GAP, _STRIP_SPACING
-from draftwright.annotations._common import strip_obstacles
+from draftwright.annotations._common import carve_free_segments, strip_obstacles
 from draftwright.fonts import PLEX_MONO
 from draftwright.layout import (
     _assign_balloon_bands,
     _greedy_strip_1d,
+    _solve_segmented_strip_1d,
     _solve_strip_1d,
     _strip_capacity,
 )
 
-# Minimum view-edge-to-outer-glyph extent for an unobstructed balloon band.
-# Keeping this as render geometry (rather than an assignment cost) makes the
-# visual contract explicit and measurable while the solver stays unitless.
-_MIN_PERIMETER_EXTENT = 20.0
+# The acceptance floor is 20 mm; retain one ordinary strip-spacing unit of real
+# clearance rather than balancing a rendered bbox exactly on a floating-point
+# threshold. Keeping this as render geometry (rather than an assignment cost)
+# makes the visual contract explicit and measurable while the solver stays unitless.
+_MIN_PERIMETER_EXTENT = 20.0 + _STRIP_SPACING
 
 
 def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
@@ -74,7 +76,8 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
     # This intentionally shares the same full-footprint occupancy source as
     # corridor placement (#518), instead of re-growing a per-furniture allowlist.
     top_dim = bot_dim = left_dim = right_dim = 0.0
-    for x0, y0, x1, y1 in strip_obstacles(dwg, view=view):
+    obstacles = strip_obstacles(dwg, view=view)
+    for x0, y0, x1, y1 in obstacles:
         if x1 > pl and x0 < pr:  # spans the plan's width → top/bottom bands
             if y1 > pt:
                 top_dim = max(top_dim, y1 - pt)
@@ -114,6 +117,47 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         "bottom": ("x", bottom_line, pl - standoff, sv_left - r),
     }
 
+    top_segments = None
+    if perimeter:
+        # A single remote label must not push the whole top row beyond the
+        # deepest occupant (#125/#901).  Probe lanes at obstacle boundaries,
+        # carve their horizontal free spans, and take the nearest lane that can
+        # carry a balanced share of the ring.  This is measured render geometry;
+        # ordered placement across the resulting segments remains in layout.py.
+        top_lo, top_hi = band_defs["top"][2:]
+        top_target = math.ceil(len(specs) / (3 + int(has_bottom)))
+        first_line = pt + centre_offset
+        last_line = ph - margin - r
+        candidates = {first_line}
+        for x0, _y0, x1, y1 in obstacles:
+            if x1 > top_lo and x0 < top_hi and y1 >= pt:
+                candidates.add(y1 + _STRIP_SPACING + r)
+
+        lane_options = []
+        for line in sorted(y for y in candidates if first_line <= y <= last_line):
+            blocked = [
+                (x0, x1)
+                for x0, y0, x1, y1 in obstacles
+                if y0 - _STRIP_SPACING < line + r and y1 + _STRIP_SPACING > line - r
+            ]
+            segments = carve_free_segments(top_lo, top_hi, blocked, r + _STRIP_SPACING)
+            capacity = sum(_strip_capacity(lo, hi, gap) for lo, hi in segments)
+            lane_options.append((line, segments, capacity))
+
+        fitting = [option for option in lane_options if option[2] >= top_target]
+        if fitting:
+            top_line, top_segments, _ = fitting[0]
+        elif lane_options:
+            # Best effort on a genuinely constrained sheet: retain the nearest
+            # maximum-capacity lane and let the global assignment use the sides.
+            top_line, top_segments, _ = max(
+                lane_options, key=lambda option: (option[2], -option[0])
+            )
+        else:
+            top_line, top_segments = band_defs["top"][1], []
+        axis, _line, lo, hi = band_defs["top"]
+        band_defs["top"] = (axis, top_line, lo, hi)
+
     # Globally assign holes across the usable reserved bands.  Nearest-band
     # greedy could crowd one side and drop balloons while another side sat
     # empty; the assignment maximises placed balloons first, then minimises
@@ -133,7 +177,13 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         choices_by_member.append(choices)
 
     capacities = {
-        name: (_strip_capacity(lo, hi, gap) if name != "bottom" or has_bottom else 0)
+        name: (
+            sum(_strip_capacity(seg_lo, seg_hi, gap) for seg_lo, seg_hi in top_segments)
+            if name == "top" and top_segments is not None
+            else _strip_capacity(lo, hi, gap)
+            if name != "bottom" or has_bottom
+            else 0
+        )
         for name, (_axis, _line, lo, hi) in band_defs.items()
     }
     activate_bands = tuple(name for name, capacity in capacities.items() if capacity > 0)
@@ -163,7 +213,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         r,
         ctx,
     )
-    dropped += _place_band(
+    top_args = (
         dwg,
         view,
         bands["top"],
@@ -172,6 +222,11 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         fs,
         r,
         ctx,
+    )
+    dropped += (
+        _place_band(*top_args)
+        if top_segments is None
+        else _place_band(*top_args, segments=top_segments)
     )
     dropped += _place_band(
         dwg,
@@ -195,7 +250,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         )
 
 
-def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx) -> int:
+def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx, *, segments=None) -> int:
     """Spread *members* (``(tag, j, hole, cx, cy)``) along one reserved band
     with the strip solver, then render a leadered balloon for each (#111).
 
@@ -211,11 +266,14 @@ def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx) -> int:
     k = 4 if axis == "y" else 3  # index of cy / cx in the member tuple
     members.sort(key=lambda m: m[k])
     naturals = [m[k] for m in members]
-    coords = (
-        _solve_strip_1d(naturals, gap, lo, hi)
-        or _greedy_strip_1d(naturals, gap, lo, hi)
-        or _greedy_strip_1d(naturals, gap, lo, hi, prefix=True)
-    )
+    if segments is not None:
+        coords = _solve_segmented_strip_1d(naturals, gap, segments) or []
+    else:
+        coords = (
+            _solve_strip_1d(naturals, gap, lo, hi)
+            or _greedy_strip_1d(naturals, gap, lo, hi)
+            or _greedy_strip_1d(naturals, gap, lo, hi, prefix=True)
+        )
     for (tag, j, hole, cx, cy), c in zip(members, coords):
         bx, by = (line, c) if axis == "y" else (c, line)
         _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx)

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -15,7 +15,12 @@ import math
 from build123d import Align, Circle, Compound, Location, Mode, Text
 from build123d_drafting.helpers import Leader
 
-from draftwright._core import _STRIP_GAP, _STRIP_SPACING, _balloon_halo
+from draftwright._core import (
+    _STRIP_GAP,
+    _STRIP_SPACING,
+    _balloon_halo,
+    _balloon_radius,
+)
 from draftwright.annotations._common import carve_free_segments, strip_obstacles
 from draftwright.fonts import PLEX_MONO
 from draftwright.layout import (
@@ -26,6 +31,8 @@ from draftwright.layout import (
     _strip_capacity,
 )
 
+_BALLOON_RING_STROKE = 0.35
+
 
 def _top_lane_target(member_count, other_capacities, usable_band_count):
     """Capacity the top lane needs for both balance and maximum cardinality."""
@@ -33,6 +40,12 @@ def _top_lane_target(member_count, other_capacities, usable_band_count):
     balanced_share = math.ceil(member_count / usable_band_count)
     capacity_deficit = max(0, member_count - sum(other_capacities))
     return max(balanced_share, capacity_deficit)
+
+
+def _band_preference_limit(font_size):
+    """Maximum extra leader length justified by perimeter spreading."""
+
+    return _balloon_halo(font_size)
 
 
 def _select_top_lane(lane_options, target, fallback_line):
@@ -68,7 +81,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
     """
     pp = dwg.coords(view).pp
     fs = dwg.draft.font_size
-    r = fs * 1.5  # circle comfortably larger than the glyph
+    r = _balloon_radius(fs)
     standoff = _STRIP_GAP
     perimeter_extent = _balloon_halo(fs) if perimeter else standoff + 2 * r
     centre_offset = perimeter_extent - r
@@ -136,12 +149,14 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         # carry a balanced share of the ring.  This is measured render geometry;
         # ordered placement across the resulting segments remains in layout.py.
         top_lo, top_hi = band_defs["top"][2:]
-        other_capacities = [
-            _strip_capacity(*band_defs[name][2:], gap) for name in ("left", "right")
-        ]
+        other_band_names = ["left", "right"]
         if has_bottom:
-            other_capacities.append(_strip_capacity(*band_defs["bottom"][2:], gap))
-        top_target = _top_lane_target(len(specs), other_capacities, 3 + int(has_bottom))
+            other_band_names.append("bottom")
+        other_capacities = [
+            _strip_capacity(*band_defs[name][2:], gap) for name in other_band_names
+        ]
+        usable_band_count = len(other_band_names) + 1  # plus top
+        top_target = _top_lane_target(len(specs), other_capacities, usable_band_count)
         first_line = pt + centre_offset
         last_line = ph - margin - r
         candidates = {first_line}
@@ -200,7 +215,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         choices_by_member,
         capacities,
         prefer_bands=preferred_bands if perimeter else (),
-        preference_limit=perimeter_extent if perimeter else 0.0,
+        preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
     )
     dropped += _place_band(
         dwg,
@@ -295,7 +310,7 @@ def _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx):
     loc = Location((bx, by, 0))
     # The annotation layer fills closed paths, so a circle edge renders as a
     # disc. A thin annular FACE fills as a ring — i.e. a circle outline.
-    ring_faces = [f.moved(loc) for f in (Circle(r) - Circle(r - 0.35)).faces()]
+    ring_faces = [f.moved(loc) for f in (Circle(r) - Circle(r - _BALLOON_RING_STROKE)).faces()]
     text = Text(
         txt=tag,
         font_size=fs,

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -25,8 +25,13 @@ from draftwright.layout import (
     _strip_capacity,
 )
 
+# Minimum view-edge-to-outer-glyph extent for an unobstructed balloon band.
+# Keeping this as render geometry (rather than an assignment cost) makes the
+# visual contract explicit and measurable while the solver stays unitless.
+_MIN_PERIMETER_EXTENT = 20.0
 
-def render_balloons(dwg, a, view, specs, ctx):
+
+def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
     """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
     fitted into the halo the layout reserved around the view (#111).
 
@@ -38,7 +43,10 @@ def render_balloons(dwg, a, view, specs, ctx):
     :class:`Leader` then runs from the hole rim to the glyph.  Because the
     layout reserved this band before placing the views (:func:`_est_plan_halo`
     / :func:`_will_balloon`), the balloons sit in clear space off the part and
-    no leader crosses a neighbouring view.
+    no leader crosses a neighbouring view.  When *perimeter* is true, every
+    usable band receives a balloon when the member count permits; this is the
+    dense-hole table escalation's deliberate ring treatment (#901).  Ordinary
+    and manually requested balloons retain nearest-band assignment.
 
     The drawing is duck-typed as *dwg* and touched only through its public
     surface; build state rides *a* and *ctx* (ADR 0005 §2 / #639, #699).
@@ -47,6 +55,10 @@ def render_balloons(dwg, a, view, specs, ctx):
     fs = dwg.draft.font_size
     r = fs * 1.5  # circle comfortably larger than the glyph
     standoff = _STRIP_GAP
+    perimeter_extent = (
+        max(standoff + 2 * r, _MIN_PERIMETER_EXTENT) if perimeter else standoff + 2 * r
+    )
+    centre_offset = perimeter_extent - r
     gap = 2 * r + 2 * _STRIP_SPACING  # min centre-to-centre: balloon + padding both sides
 
     # Plan-view page edges; the reserved bands sit just outside them.
@@ -81,24 +93,24 @@ def render_balloons(dwg, a, view, specs, ctx):
     # ring then sits at the margin and overlaps the far witness lines instead,
     # which is only a tolerated warning (structural.py compares label_bbox, not
     # the full bbox, for overlap), never the out_of_bounds error.
-    left_dim = min(left_dim, max(0.0, pl - standoff - 2 * r - margin))
-    right_dim = min(right_dim, max(0.0, pw - margin - pr - standoff - 2 * r))
-    top_dim = min(top_dim, max(0.0, ph - margin - pt - standoff - 2 * r))
-    bot_dim = min(bot_dim, max(0.0, pb - standoff - 2 * r - margin))
+    left_dim = min(left_dim, max(0.0, pl - perimeter_extent - margin))
+    right_dim = min(right_dim, max(0.0, pw - margin - pr - perimeter_extent))
+    top_dim = min(top_dim, max(0.0, ph - margin - pt - perimeter_extent))
+    bot_dim = min(bot_dim, max(0.0, pb - perimeter_extent - margin))
 
     # A bottom band (below PV, beyond the overall-width dim) is usable only
     # when the FV↔PV gap has room for the width dim *and* a balloon row;
     # otherwise bottom-edge holes fall back to the nearest side/top band.
-    bottom_line = pb - bot_dim - standoff - r
-    has_bottom = pb - (a.FV_Y + a.fv_hh) > bot_dim + standoff + 2 * r
+    bottom_line = pb - bot_dim - centre_offset
+    has_bottom = pb - (a.FV_Y + a.fv_hh) > bot_dim + perimeter_extent
 
     # left/right balloons vary in Y at a fixed X just outside the part; top
     # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
     # offset by its side's dim depth so the ring sits clear of the dims.
     band_defs = {
-        "left": ("y", pl - left_dim - standoff - r, margin + r, ph - margin - r),
-        "right": ("y", pr + right_dim + standoff + r, margin + r, ph - margin - r),
-        "top": ("x", pt + top_dim + standoff + r, pl - standoff, sv_left - r),
+        "left": ("y", pl - left_dim - centre_offset, margin + r, ph - margin - r),
+        "right": ("y", pr + right_dim + centre_offset, margin + r, ph - margin - r),
+        "top": ("x", pt + top_dim + centre_offset, pl - standoff, sv_left - r),
         "bottom": ("x", bottom_line, pl - standoff, sv_left - r),
     }
 
@@ -124,7 +136,13 @@ def render_balloons(dwg, a, view, specs, ctx):
         name: (_strip_capacity(lo, hi, gap) if name != "bottom" or has_bottom else 0)
         for name, (_axis, _line, lo, hi) in band_defs.items()
     }
-    bands, dropped = _assign_balloon_bands(members, choices_by_member, capacities)
+    activate_bands = tuple(name for name, capacity in capacities.items() if capacity > 0)
+    bands, dropped = _assign_balloon_bands(
+        members,
+        choices_by_member,
+        capacities,
+        activate_bands=activate_bands if perimeter else (),
+    )
     dropped += _place_band(
         dwg,
         view,

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -15,7 +15,7 @@ import math
 from build123d import Align, Circle, Compound, Location, Mode, Text
 from build123d_drafting.helpers import Leader
 
-from draftwright._core import _STRIP_GAP, _STRIP_SPACING
+from draftwright._core import _STRIP_GAP, _STRIP_SPACING, _balloon_halo
 from draftwright.annotations._common import carve_free_segments, strip_obstacles
 from draftwright.fonts import PLEX_MONO
 from draftwright.layout import (
@@ -25,12 +25,6 @@ from draftwright.layout import (
     _solve_strip_1d,
     _strip_capacity,
 )
-
-# The acceptance floor is 20 mm; retain one ordinary strip-spacing unit of real
-# clearance rather than balancing a rendered bbox exactly on a floating-point
-# threshold. Keeping this as render geometry (rather than an assignment cost)
-# makes the visual contract explicit and measurable while the solver stays unitless.
-_MIN_PERIMETER_EXTENT = 20.0 + _STRIP_SPACING
 
 
 def _top_lane_target(member_count, other_capacities, usable_band_count):
@@ -42,13 +36,13 @@ def _top_lane_target(member_count, other_capacities, usable_band_count):
 
 
 def _select_top_lane(lane_options, target, fallback_line):
-    """Nearest sufficient lane, else nearest maximum-capacity best effort."""
+    """Nearest sufficient lane, else the nearest best-effort lane."""
 
     fitting = [option for option in lane_options if option[2] >= target]
     if fitting:
         return fitting[0]
     if lane_options:
-        return max(lane_options, key=lambda option: (option[2], -option[0]))
+        return lane_options[0]
     return fallback_line, [], 0
 
 
@@ -76,9 +70,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
     fs = dwg.draft.font_size
     r = fs * 1.5  # circle comfortably larger than the glyph
     standoff = _STRIP_GAP
-    perimeter_extent = (
-        max(standoff + 2 * r, _MIN_PERIMETER_EXTENT) if perimeter else standoff + 2 * r
-    )
+    perimeter_extent = _balloon_halo(fs) if perimeter else standoff + 2 * r
     centre_offset = perimeter_extent - r
     gap = 2 * r + 2 * _STRIP_SPACING  # min centre-to-centre: balloon + padding both sides
 
@@ -168,8 +160,8 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
             capacity = sum(_strip_capacity(lo, hi, gap) for lo, hi in segments)
             lane_options.append((line, segments, capacity))
 
-        # Best effort on a genuinely constrained sheet retains the nearest
-        # maximum-capacity lane and lets the global assignment use the sides.
+        # Best effort on a genuinely constrained sheet retains the nearest lane;
+        # it never recreates the remote "beyond the deepest occupant" geometry.
         top_line, top_segments, _ = _select_top_lane(lane_options, top_target, band_defs["top"][1])
         axis, _line, lo, hi = band_defs["top"]
         band_defs["top"] = (axis, top_line, lo, hi)
@@ -202,12 +194,13 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         )
         for name, (_axis, _line, lo, hi) in band_defs.items()
     }
-    activate_bands = tuple(name for name, capacity in capacities.items() if capacity > 0)
+    preferred_bands = tuple(name for name, capacity in capacities.items() if capacity > 0)
     bands, dropped = _assign_balloon_bands(
         members,
         choices_by_member,
         capacities,
-        activate_bands=activate_bands if perimeter else (),
+        prefer_bands=preferred_bands if perimeter else (),
+        preference_limit=perimeter_extent if perimeter else 0.0,
     )
     dropped += _place_band(
         dwg,
@@ -283,7 +276,7 @@ def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx, *, segm
     members.sort(key=lambda m: m[k])
     naturals = [m[k] for m in members]
     if segments is not None:
-        coords = _solve_segmented_strip_1d(naturals, gap, segments) or []
+        coords = _solve_segmented_strip_1d(naturals, gap, segments, prefix=True) or []
     else:
         coords = (
             _solve_strip_1d(naturals, gap, lo, hi)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -750,7 +750,11 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
         # independent render_balloons calls could stack a pattern balloon on a
         # per-hole one in the same band. Called sideways into the render layer
         # (#699) — no longer an upward duck-typed dwg.add_balloons call.
-        render_balloons(dwg, a, "plan", balloon_specs, ctx)
+        # A scattered-hole table is a visual escalation, not merely another
+        # balloon request: spread its tags around the usable perimeter so a
+        # deep occupied strip cannot collapse the ring onto two near sides
+        # (#901). Pattern-only and public-verb balloons keep nearest-band cost.
+        render_balloons(dwg, a, "plan", balloon_specs, ctx, perimeter=table_placed)
         placed_names = {n for n, _ in dwg.iter_annotations()}
 
     # Clear `callout_dropped` only when EVERY dropped plan-view callout is now

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -41,6 +41,7 @@ from draftwright._core import (
     Strip,
     ViewZones,
     _anno_box,
+    _balloon_halo,
     _fmt,
     _largest_empty_rect,
     _parse_page,
@@ -116,7 +117,7 @@ def _est_plan_halo(font_size: float = _FONT_SIZE) -> float:
     Scale-independent (font_size is fixed page-mm), like the strip depths: a
     leader standoff + one balloon diameter (``2·r = 3·font_size``) + clearance.
     """
-    return _STRIP_GAP + 3 * font_size + _STRIP_SPACING
+    return _balloon_halo(font_size)
 
 
 def _will_balloon(model) -> bool:

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -216,6 +216,46 @@ def _strip_capacity(lo: float, hi: float, gap: float) -> int:
     return int(math.floor((hi - lo) / gap + 1e-9)) + 1
 
 
+def _solve_segmented_strip_1d(
+    naturals: list[float], gap: float, segments: list[tuple[float, float]]
+) -> list[float] | None:
+    """Minimum-L1 ordered placement across disjoint free segments (#901).
+
+    Members retain their natural order, so leaders remain crossing-free.  Dynamic
+    programming chooses how many consecutive members each segment receives; the
+    existing continuous-strip solver supplies the optimal positions within each
+    segment.  Adjacent segments must be separated by at least *gap* (the balloon
+    carve guarantees this). ``None`` means the combined capacity is insufficient.
+    """
+
+    if not naturals:
+        return []
+    ordered = sorted(segments)
+    if any(b[0] - a[1] < gap - 1e-9 for a, b in zip(ordered, ordered[1:])):
+        raise ValueError("segmented strip intervals must be separated by gap")
+    # member-count -> (cost, coordinates); ties keep the first (leftmost) split.
+    states: dict[int, tuple[float, list[float]]] = {0: (0.0, [])}
+    for lo, hi in ordered:
+        capacity = _strip_capacity(lo, hi, gap)
+        next_states = dict(states)  # this segment may remain unused
+        for placed, (cost, coords) in states.items():
+            for count in range(1, min(capacity, len(naturals) - placed) + 1):
+                chunk = naturals[placed : placed + count]
+                solved = _solve_strip_1d(chunk, gap, lo, hi)
+                if solved is None:
+                    continue
+                candidate = (
+                    cost + sum(abs(x - n) for x, n in zip(solved, chunk)),
+                    coords + solved,
+                )
+                previous = next_states.get(placed + count)
+                if previous is None or candidate[0] < previous[0] - 1e-9:
+                    next_states[placed + count] = candidate
+        states = next_states
+    result = states.get(len(naturals))
+    return None if result is None else result[1]
+
+
 def _assign_balloon_bands(members, choices_by_member, capacities, *, activate_bands=()):
     """Globally assign balloons to side bands (#516/#901).
 

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -242,8 +242,7 @@ def _solve_segmented_strip_1d(
             for count in range(1, min(capacity, len(naturals) - placed) + 1):
                 chunk = naturals[placed : placed + count]
                 solved = _solve_strip_1d(chunk, gap, lo, hi)
-                if solved is None:
-                    continue
+                assert solved is not None  # count never exceeds _strip_capacity
                 candidate = (
                     cost + sum(abs(x - n) for x, n in zip(solved, chunk)),
                     coords + solved,

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -49,6 +49,8 @@ from dataclasses import dataclass
 from typing import Literal, NamedTuple
 
 Axis = Literal["x", "y"]
+_LAYOUT_EPSILON = 1e-9
+_FLOW_COST_SCALE = 1000
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +215,7 @@ def _strip_capacity(lo: float, hi: float, gap: float) -> int:
 
     if hi < lo:
         return 0
-    return int(math.floor((hi - lo) / gap + 1e-9)) + 1
+    return int(math.floor((hi - lo) / gap + _LAYOUT_EPSILON)) + 1
 
 
 def _solve_segmented_strip_1d(
@@ -236,7 +238,7 @@ def _solve_segmented_strip_1d(
     if not naturals:
         return []
     ordered = sorted(segments)
-    if any(b[0] - a[1] < gap - 1e-9 for a, b in zip(ordered, ordered[1:])):
+    if any(b[0] - a[1] < gap - _LAYOUT_EPSILON for a, b in zip(ordered, ordered[1:])):
         raise ValueError("segmented strip intervals must be separated by gap")
     # member-count -> (cost, coordinates); ties keep the first (leftmost) split.
     states: dict[int, tuple[float, list[float]]] = {0: (0.0, [])}
@@ -253,7 +255,7 @@ def _solve_segmented_strip_1d(
                     coords + solved,
                 )
                 previous = next_states.get(placed + count)
-                if previous is None or candidate[0] < previous[0] - 1e-9:
+                if previous is None or candidate[0] < previous[0] - _LAYOUT_EPSILON:
                     next_states[placed + count] = candidate
         states = next_states
     result = states.get(len(naturals))
@@ -307,14 +309,14 @@ def _assign_balloon_bands(
                 continue
             # Costs are integerised for deterministic shortest paths; the tiny band
             # ordinal keeps exact ties stable without changing real distance order.
-            cost = int(round(max(0.0, choices[band]) * 1000)) + band_order.index(band)
+            cost = int(round(max(0.0, choices[band]) * _FLOW_COST_SCALE)) + band_order.index(band)
             used_edges[(i, band)] = add_edge(member0 + i, band0 + j, 1, cost)
 
     # Give the first balloon in each preferred band a bounded distance credit.
     # Unlike the old lexicographically dominant activation bonus (#901 review),
     # this cannot justify a leader more than `preference_limit` longer merely to
     # occupy another side. SPFA supports the negative residual edges.
-    preference_bonus = int(round(max(0.0, preference_limit) * 1000))
+    preference_bonus = int(round(max(0.0, preference_limit) * _FLOW_COST_SCALE))
     preferred = set(prefer_bands)
     for j, band in enumerate(bands):
         capacity = capacities[band]

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -217,7 +217,11 @@ def _strip_capacity(lo: float, hi: float, gap: float) -> int:
 
 
 def _solve_segmented_strip_1d(
-    naturals: list[float], gap: float, segments: list[tuple[float, float]]
+    naturals: list[float],
+    gap: float,
+    segments: list[tuple[float, float]],
+    *,
+    prefix: bool = False,
 ) -> list[float] | None:
     """Minimum-L1 ordered placement across disjoint free segments (#901).
 
@@ -225,7 +229,8 @@ def _solve_segmented_strip_1d(
     programming chooses how many consecutive members each segment receives; the
     existing continuous-strip solver supplies the optimal positions within each
     segment.  Adjacent segments must be separated by at least *gap* (the balloon
-    carve guarantees this). ``None`` means the combined capacity is insufficient.
+    carve guarantees this). ``None`` means the combined capacity is insufficient;
+    with *prefix*, the largest placeable leading subset is returned instead.
     """
 
     if not naturals:
@@ -252,17 +257,27 @@ def _solve_segmented_strip_1d(
                     next_states[placed + count] = candidate
         states = next_states
     result = states.get(len(naturals))
-    return None if result is None else result[1]
+    if result is not None:
+        return result[1]
+    if prefix:
+        return states[max(states)][1]
+    return None
 
 
-def _assign_balloon_bands(members, choices_by_member, capacities, *, activate_bands=()):
+def _assign_balloon_bands(
+    members,
+    choices_by_member,
+    capacities,
+    *,
+    prefer_bands=(),
+    preference_limit=0.0,
+):
     """Globally assign balloons to side bands (#516/#901).
 
-    The primary objective is maximum cardinality.  Within that maximum flow,
-    as many reachable bands named by *activate_bands* as the member count permits
-    are used before leader length is minimised.  This lets a caller request a
-    perimeter treatment without encoding drawing semantics or page geometry in
-    this leaf solver.
+    The primary objective is maximum cardinality. Within that maximum flow, the
+    first member assigned to a band named by *prefer_bands* receives a bounded
+    *preference_limit* distance credit before leader length is minimised. This is
+    a preference, not a lexicographic override: a remote band stays unused.
     """
 
     band_order = ("left", "right", "top", "bottom")
@@ -285,31 +300,26 @@ def _assign_balloon_bands(members, choices_by_member, capacities, *, activate_ba
         return fwd
 
     used_edges: dict[tuple[int, str], _FlowEdge] = {}
-    integer_costs: list[dict[str, int]] = []
     for i, choices in enumerate(choices_by_member):
         add_edge(source, member0 + i, 1, 0)
-        member_costs = {}
         for j, band in enumerate(bands):
             if band not in choices:
                 continue
             # Costs are integerised for deterministic shortest paths; the tiny band
             # ordinal keeps exact ties stable without changing real distance order.
             cost = int(round(max(0.0, choices[band]) * 1000)) + band_order.index(band)
-            member_costs[band] = cost
             used_edges[(i, band)] = add_edge(member0 + i, band0 + j, 1, cost)
-        integer_costs.append(member_costs)
 
-    # One additional requested band must dominate every possible change in the
-    # real assignment cost.  A one-capacity negative edge therefore gives the
-    # first balloon in each requested band a lexicographic activation bonus;
-    # remaining capacity retains the ordinary zero cost.  SPFA already supports
-    # negative residual edges, and the graph remains deterministic.
-    activation_bonus = 1 + sum(max(costs.values(), default=0) for costs in integer_costs)
-    requested = set(activate_bands)
+    # Give the first balloon in each preferred band a bounded distance credit.
+    # Unlike the old lexicographically dominant activation bonus (#901 review),
+    # this cannot justify a leader more than `preference_limit` longer merely to
+    # occupy another side. SPFA supports the negative residual edges.
+    preference_bonus = int(round(max(0.0, preference_limit) * 1000))
+    preferred = set(prefer_bands)
     for j, band in enumerate(bands):
         capacity = capacities[band]
-        if band in requested:
-            add_edge(band0 + j, sink, 1, -activation_bonus)
+        if band in preferred and preference_bonus:
+            add_edge(band0 + j, sink, 1, -preference_bonus)
             capacity -= 1
         if capacity:
             add_edge(band0 + j, sink, capacity, 0)

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -216,8 +216,15 @@ def _strip_capacity(lo: float, hi: float, gap: float) -> int:
     return int(math.floor((hi - lo) / gap + 1e-9)) + 1
 
 
-def _assign_balloon_bands(members, choices_by_member, capacities):
-    """Global max-cardinality/min-cost assignment of balloons to side bands (#516)."""
+def _assign_balloon_bands(members, choices_by_member, capacities, *, activate_bands=()):
+    """Globally assign balloons to side bands (#516/#901).
+
+    The primary objective is maximum cardinality.  Within that maximum flow,
+    as many reachable bands named by *activate_bands* as the member count permits
+    are used before leader length is minimised.  This lets a caller request a
+    perimeter treatment without encoding drawing semantics or page geometry in
+    this leaf solver.
+    """
 
     band_order = ("left", "right", "top", "bottom")
     bands = [b for b in band_order if capacities.get(b, 0) > 0]
@@ -239,17 +246,34 @@ def _assign_balloon_bands(members, choices_by_member, capacities):
         return fwd
 
     used_edges: dict[tuple[int, str], _FlowEdge] = {}
+    integer_costs: list[dict[str, int]] = []
     for i, choices in enumerate(choices_by_member):
         add_edge(source, member0 + i, 1, 0)
+        member_costs = {}
         for j, band in enumerate(bands):
             if band not in choices:
                 continue
             # Costs are integerised for deterministic shortest paths; the tiny band
             # ordinal keeps exact ties stable without changing real distance order.
             cost = int(round(max(0.0, choices[band]) * 1000)) + band_order.index(band)
+            member_costs[band] = cost
             used_edges[(i, band)] = add_edge(member0 + i, band0 + j, 1, cost)
+        integer_costs.append(member_costs)
+
+    # One additional requested band must dominate every possible change in the
+    # real assignment cost.  A one-capacity negative edge therefore gives the
+    # first balloon in each requested band a lexicographic activation bonus;
+    # remaining capacity retains the ordinary zero cost.  SPFA already supports
+    # negative residual edges, and the graph remains deterministic.
+    activation_bonus = 1 + sum(max(costs.values(), default=0) for costs in integer_costs)
+    requested = set(activate_bands)
     for j, band in enumerate(bands):
-        add_edge(band0 + j, sink, capacities[band], 0)
+        capacity = capacities[band]
+        if band in requested:
+            add_edge(band0 + j, sink, 1, -activation_bonus)
+            capacity -= 1
+        if capacity:
+            add_edge(band0 + j, sink, capacity, 0)
 
     def shortest_path():
         dist = [math.inf] * len(graph)

--- a/tests/test_balloon_ring_standoff.py
+++ b/tests/test_balloon_ring_standoff.py
@@ -18,13 +18,12 @@ to come back and unmark it).
 
 from __future__ import annotations
 
-import pytest
 from build123d import Box, Cylinder, Pos
 
 from draftwright import build_drawing
 
-#: Minimum air between the plan view and the balloon ring that annotates it. Below
-#: this the glyphs crowd the geometry; the CTC-02 e2e check uses the same figure.
+#: Minimum extent from the plan edge to the balloon ring's outer edge. Below this
+#: the glyphs crowd the geometry; the CTC-02 e2e check uses the same figure.
 _MIN_STANDOFF_MM = 20.0
 
 
@@ -45,13 +44,6 @@ def _dense_plate(n: int = 18):
     return part
 
 
-@pytest.mark.xfail(
-    reason="#901: the ring's standoff is unbounded below after escalation — it lands "
-    "at 19.0 mm here, 6.5 mm on CTC-02. The top band is pushed beyond the deepest "
-    "occupant, so the min-cost band assignment (#516) prefers the near left/right "
-    "bands and no ring forms above the view.",
-    strict=True,
-)
 def test_balloon_ring_clears_the_plan_view_after_escalation():
     drawing = build_drawing(_dense_plate())
     plan_top = drawing.view_bounds("plan")[3]
@@ -63,7 +55,7 @@ def test_balloon_ring_clears_the_plan_view_after_escalation():
     assert tops, (
         "the dense plate must escalate to balloons — otherwise this is not the case under test"
     )
-    assert max(tops) > plan_top + _MIN_STANDOFF_MM
+    assert max(tops) >= plan_top + _MIN_STANDOFF_MM - 1e-6
 
 
 def test_the_dense_plate_actually_escalates():

--- a/tests/test_balloon_ring_standoff.py
+++ b/tests/test_balloon_ring_standoff.py
@@ -55,7 +55,7 @@ def test_balloon_ring_clears_the_plan_view_after_escalation():
     assert tops, (
         "the dense plate must escalate to balloons — otherwise this is not the case under test"
     )
-    assert max(tops) >= plan_top + _MIN_STANDOFF_MM - 1e-6
+    assert max(tops) > plan_top + _MIN_STANDOFF_MM
 
 
 def test_the_dense_plate_actually_escalates():

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -101,6 +101,8 @@ def test_e2e_from_step_meets_standards(tmp_path):
 FIXTURES = Path(__file__).parent / "fixtures"
 _CTC_AP203_OK = ["01", "02", "03", "04", "05"]
 _CTC_AP242_OK = ["01", "02", "03", "04", "05"]
+_MIN_BALLOON_RING_EXTENT_MM = 20.0
+_MAX_BALLOON_RING_EXTENT_MM = 60.0
 
 
 @pytest.mark.slow
@@ -169,7 +171,7 @@ def test_ctc02_top_balloon_ring_hugs_dimensions():
     assert balloon_tops, "expected balloons on CTC-02"
     assert max(balloon_tops) > pt + 20, "expected a balloon ring above the plan view"
     gap = max(balloon_tops) - dim_top
-    assert gap < 60, (
+    assert gap < _MAX_BALLOON_RING_EXTENT_MM, (
         f"a plan balloon floats {gap:.0f} mm above the dimension stack — the pre-#125 "
         f"stale-cursor phantom corridor was ~150 mm; expected a small standoff"
     )
@@ -188,8 +190,12 @@ def test_ctc04_top_balloon_ring_stays_near_plan():
         if name.startswith("balloon_plan")
     )
 
-    assert balloon_top > plan_top + 20, "expected a balloon ring above the plan view"
-    assert balloon_top - plan_top < 60, "top balloon ring is remote from the plan view"
+    assert balloon_top > plan_top + _MIN_BALLOON_RING_EXTENT_MM, (
+        "expected a balloon ring above the plan view"
+    )
+    assert balloon_top - plan_top < _MAX_BALLOON_RING_EXTENT_MM, (
+        "top balloon ring is remote from the plan view"
+    )
 
 
 def _dense_scattered_plate():

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -175,6 +175,23 @@ def test_ctc02_top_balloon_ring_hugs_dimensions():
     )
 
 
+@pytest.mark.slow
+@pytest.mark.timeout(600)
+def test_ctc04_top_balloon_ring_stays_near_plan():
+    """#901: the other real escalating fixture must use the nearby carved lane,
+    not regress to the old hundreds-of-millimetres top-band depth."""
+    dwg = build_drawing(str(FIXTURES / "nist_ctc_04_asme1_ap203.stp"))
+    plan_top = dwg.view_bounds("plan")[3]
+    balloon_top = max(
+        obj.bounding_box().max.Y
+        for name, obj in dwg.iter_annotations()
+        if name.startswith("balloon_plan")
+    )
+
+    assert balloon_top > plan_top + 20, "expected a balloon ring above the plan view"
+    assert balloon_top - plan_top < 60, "top balloon ring is remote from the plan view"
+
+
 def _dense_scattered_plate():
     """20 unpatterned Z-holes of distinct diameters — dense enough that even the
     auto-grown sheet (#121) can't fit their callouts, so the plan view escalates to a

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -69,6 +69,9 @@ class TestAssignBalloonBands:
 
 
 class TestSolveSegmentedStrip1d:
+    def test_empty_members_need_no_segments(self):
+        assert _solve_segmented_strip_1d([], 10.0, []) == []
+
     def test_uses_disjoint_segments_without_crossing_member_order(self):
         result = _solve_segmented_strip_1d([8.0, 12.0, 88.0], 10.0, [(0.0, 20.0), (80.0, 100.0)])
         assert result is not None

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -11,6 +11,7 @@ from draftwright.layout import (
     _ANCHOR_WEIGHT,
     _assign_balloon_bands,
     _greedy_strip_1d,
+    _solve_segmented_strip_1d,
     _solve_strip_1d,
     _solve_strip_1d_pava,
     fit_box,
@@ -65,6 +66,29 @@ class TestAssignBalloonBands:
         assert bands["right"] == ["b"]
         assert bands["top"] == []
         assert dropped == 0
+
+
+class TestSolveSegmentedStrip1d:
+    def test_uses_disjoint_segments_without_crossing_member_order(self):
+        result = _solve_segmented_strip_1d([8.0, 12.0, 88.0], 10.0, [(0.0, 20.0), (80.0, 100.0)])
+        assert result is not None
+        assert 0.0 <= result[0] < result[1] <= 20.0
+        assert result[1] - result[0] >= 10.0
+        assert result[2] == pytest.approx(88.0)
+
+    def test_chooses_the_minimum_leader_length_partition(self):
+        assert _solve_segmented_strip_1d(
+            [5.0, 45.0, 55.0], 10.0, [(0.0, 20.0), (40.0, 60.0)]
+        ) == pytest.approx([5.0, 45.0, 55.0])
+
+    def test_rejects_segments_too_close_to_preserve_the_global_gap(self):
+        with pytest.raises(ValueError, match="separated by gap"):
+            _solve_segmented_strip_1d([4.0, 6.0], 5.0, [(0.0, 5.0), (6.0, 15.0)])
+
+    def test_returns_none_when_combined_capacity_is_too_small(self):
+        assert (
+            _solve_segmented_strip_1d([0.0, 10.0, 20.0], 10.0, [(0.0, 5.0), (20.0, 25.0)]) is None
+        )
 
 
 class TestSolveStrip1d:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -9,6 +9,7 @@ import pytest
 import draftwright.layout as L
 from draftwright.layout import (
     _ANCHOR_WEIGHT,
+    _assign_balloon_bands,
     _greedy_strip_1d,
     _solve_strip_1d,
     _solve_strip_1d_pava,
@@ -18,6 +19,52 @@ from draftwright.layout import (
 # Pure solver unit tests — fast, no OCC builds — so the whole module is part of
 # the build-light `smoke` subset (#153).
 pytestmark = pytest.mark.smoke
+
+
+class TestAssignBalloonBands:
+    def test_nearest_band_remains_the_default(self):
+        members = ["a", "b", "c"]
+        choices = [{"left": 1.0, "top": 100.0} for _ in members]
+
+        bands, dropped = _assign_balloon_bands(members, choices, {"left": 3, "top": 3})
+
+        assert bands["left"] == members
+        assert bands["top"] == []
+        assert dropped == 0
+
+    def test_requested_band_is_activated_before_distance_is_minimised(self):
+        members = ["a", "b", "c"]
+        choices = [{"left": 1.0, "top": 100.0} for _ in members]
+
+        bands, dropped = _assign_balloon_bands(
+            members,
+            choices,
+            {"left": 3, "top": 3},
+            activate_bands=("left", "top"),
+        )
+
+        assert len(bands["left"]) == 2
+        assert len(bands["top"]) == 1
+        assert dropped == 0
+
+    def test_activation_is_best_effort_when_members_are_fewer_than_bands(self):
+        members = ["a", "b"]
+        choices = [
+            {"left": 1.0, "right": 20.0, "top": 40.0},
+            {"left": 2.0, "right": 10.0, "top": 30.0},
+        ]
+
+        bands, dropped = _assign_balloon_bands(
+            members,
+            choices,
+            {"left": 2, "right": 2, "top": 2},
+            activate_bands=("left", "right", "top"),
+        )
+
+        assert bands["left"] == ["a"]
+        assert bands["right"] == ["b"]
+        assert bands["top"] == []
+        assert dropped == 0
 
 
 class TestSolveStrip1d:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -33,7 +33,23 @@ class TestAssignBalloonBands:
         assert bands["top"] == []
         assert dropped == 0
 
-    def test_requested_band_is_activated_before_distance_is_minimised(self):
+    def test_near_band_preference_can_outweigh_small_distance_cost(self):
+        members = ["a", "b", "c"]
+        choices = [{"left": 1.0, "top": 20.0} for _ in members]
+
+        bands, dropped = _assign_balloon_bands(
+            members,
+            choices,
+            {"left": 3, "top": 3},
+            prefer_bands=("left", "top"),
+            preference_limit=25.0,
+        )
+
+        assert len(bands["left"]) == 2
+        assert len(bands["top"]) == 1
+        assert dropped == 0
+
+    def test_preference_does_not_force_a_remote_band(self):
         members = ["a", "b", "c"]
         choices = [{"left": 1.0, "top": 100.0} for _ in members]
 
@@ -41,29 +57,11 @@ class TestAssignBalloonBands:
             members,
             choices,
             {"left": 3, "top": 3},
-            activate_bands=("left", "top"),
+            prefer_bands=("left", "top"),
+            preference_limit=25.0,
         )
 
-        assert len(bands["left"]) == 2
-        assert len(bands["top"]) == 1
-        assert dropped == 0
-
-    def test_activation_is_best_effort_when_members_are_fewer_than_bands(self):
-        members = ["a", "b"]
-        choices = [
-            {"left": 1.0, "right": 20.0, "top": 40.0},
-            {"left": 2.0, "right": 10.0, "top": 30.0},
-        ]
-
-        bands, dropped = _assign_balloon_bands(
-            members,
-            choices,
-            {"left": 2, "right": 2, "top": 2},
-            activate_bands=("left", "right", "top"),
-        )
-
-        assert bands["left"] == ["a"]
-        assert bands["right"] == ["b"]
+        assert bands["left"] == members
         assert bands["top"] == []
         assert dropped == 0
 
@@ -92,6 +90,14 @@ class TestSolveSegmentedStrip1d:
         assert (
             _solve_segmented_strip_1d([0.0, 10.0, 20.0], 10.0, [(0.0, 5.0), (20.0, 25.0)]) is None
         )
+
+    def test_prefix_mode_places_the_largest_leading_subset(self):
+        assert _solve_segmented_strip_1d(
+            [0.0, 10.0, 20.0],
+            10.0,
+            [(0.0, 5.0), (20.0, 25.0)],
+            prefix=True,
+        ) == [0.0, 20.0]
 
 
 class TestSolveStrip1d:

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9859,6 +9859,12 @@ class TestHoleTable:
 
         assert _top_lane_target(18, [41, 41], 3) == 6
 
+    def test_balloon_render_extent_and_compose_reservation_share_geometry(self):
+        from draftwright._core import _balloon_halo
+        from draftwright.compose import _est_plan_halo
+
+        assert _est_plan_halo(3.0) == _balloon_halo(3.0) == 21.5
+
     def test_top_lane_target_covers_capacity_deficit_on_other_bands(self):
         from draftwright.annotations.balloons import _top_lane_target
 
@@ -9872,7 +9878,7 @@ class TestHoleTable:
         lanes = [(20.0, [(0.0, 10.0)], 2), (40.0, [(0.0, 30.0)], 4)]
         assert _select_top_lane(lanes, 2, 99.0) == lanes[0]
 
-    def test_top_lane_selection_falls_back_to_nearest_maximum_capacity(self):
+    def test_top_lane_selection_falls_back_to_nearest_lane(self):
         from draftwright.annotations.balloons import _select_top_lane
 
         lanes = [
@@ -9880,7 +9886,7 @@ class TestHoleTable:
             (40.0, [(0.0, 30.0)], 4),
             (60.0, [(0.0, 30.0)], 4),
         ]
-        assert _select_top_lane(lanes, 8, 99.0) == lanes[1]
+        assert _select_top_lane(lanes, 8, 99.0) == lanes[0]
 
     def test_top_lane_selection_handles_no_lane_on_a_constrained_page(self):
         from draftwright.annotations.balloons import _select_top_lane
@@ -9996,6 +10002,14 @@ class TestHoleTable:
         obstacle = self._Boxed((47.0, pt + 2.0, 53.0, pt + 80.0))
 
         import draftwright.annotations.balloons as balloons
+        from draftwright._core import _balloon_halo
+
+        real_assign = balloons._assign_balloon_bands
+        assignment_kwargs = []
+
+        def assign_bands(*args, **kwargs):
+            assignment_kwargs.append(kwargs)
+            return real_assign(*args, **kwargs)
 
         def place_band(
             dwg,
@@ -10016,7 +10030,11 @@ class TestHoleTable:
             return 0
 
         monkeypatch.setattr(balloons, "_place_band", place_band)
-        coords = {"plan": SimpleNamespace(pp=lambda x, y, _z: (50.0 + x, 50.0 + y))}
+        monkeypatch.setattr(balloons, "_assign_balloon_bands", assign_bands)
+        # Left is naturally ~14 mm cheaper than top for these sites. The bounded
+        # perimeter preference must still seed the nearby top band; disabling
+        # production preference wiring makes `top_members` below empty.
+        coords = {"plan": SimpleNamespace(pp=lambda x, y, _z: (30.0 + x, 50.0 + y))}
         stub = SimpleNamespace(
             coords=coords.__getitem__,
             draft=SimpleNamespace(font_size=3.0),
@@ -10039,8 +10057,39 @@ class TestHoleTable:
             call for call in calls if call[1] == "x" and call[2] > a.PV_Y
         )
         assert top_members
-        assert top_line == pytest.approx(pt + balloons._MIN_PERIMETER_EXTENT - 4.5)
+        assert top_line == pytest.approx(pt + _balloon_halo(3.0) - 4.5)
         assert segments and len(segments) == 2
+        assert assignment_kwargs == [
+            {
+                "prefer_bands": ("left", "right", "top", "bottom"),
+                "preference_limit": _balloon_halo(3.0),
+            }
+        ]
+
+    def test_segmented_band_overflow_uses_prefix_instead_of_dropping_all(self, monkeypatch):
+        import draftwright.annotations.balloons as balloons
+
+        rendered = []
+        monkeypatch.setattr(balloons, "_render_balloon", lambda *args: rendered.append(args))
+        members = [(str(i), 0, object(), float(i * 10), 0.0) for i in range(3)]
+
+        dropped = balloons._place_band(
+            None,
+            "plan",
+            members,
+            "x",
+            50.0,
+            0.0,
+            25.0,
+            10.0,
+            3.0,
+            4.5,
+            None,
+            segments=[(0.0, 5.0), (20.0, 25.0)],
+        )
+
+        assert dropped == 1
+        assert len(rendered) == 2
 
     def test_balloon_assignment_rebalances_across_bands_before_dropping(self, monkeypatch):
         from types import SimpleNamespace

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9940,6 +9940,75 @@ class TestHoleTable:
         assert line == pytest.approx(pt + 12.0 + _STRIP_GAP + r)
         assert fs == 3.0
 
+    def test_perimeter_top_lane_carves_around_deep_local_obstacle(self, monkeypatch):
+        """#901/#125: one tall, narrow occupant must carve the near lane, not
+        push the entire top ring beyond the occupant's remote outer edge."""
+        from types import SimpleNamespace
+
+        calls = []
+        a = SimpleNamespace(
+            PV_X=50.0,
+            PV_Y=50.0,
+            fv_hw=20.0,
+            pv_hh=10.0,
+            SV_X=95.0,
+            sv_hw=10.0,
+            margin=0.0,
+            PAGE_H=180.0,
+            PAGE_W=140.0,
+            FV_Y=20.0,
+            fv_hh=5.0,
+        )
+        pt = a.PV_Y + a.pv_hh
+        obstacle = self._Boxed((47.0, pt + 2.0, 53.0, pt + 80.0))
+
+        import draftwright.annotations.balloons as balloons
+
+        def place_band(
+            dwg,
+            view,
+            members,
+            axis,
+            line,
+            lo,
+            hi,
+            gap,
+            fs,
+            r,
+            ctx,
+            *,
+            segments=None,
+        ):
+            calls.append((list(members), axis, line, segments))
+            return 0
+
+        monkeypatch.setattr(balloons, "_place_band", place_band)
+        coords = {"plan": SimpleNamespace(pp=lambda x, y, _z: (50.0 + x, 50.0 + y))}
+        stub = SimpleNamespace(
+            coords=coords.__getitem__,
+            draft=SimpleNamespace(font_size=3.0),
+            iter_annotations=lambda: iter([("local_obstacle", obstacle)]),
+            view_of=lambda _name: "plan",
+        )
+        ctx = SimpleNamespace(record_issue=lambda *_args: None)
+        holes = [SimpleNamespace(location=(float(i), 0.0, 0.0), diameter=4.0) for i in range(6)]
+
+        balloons.render_balloons(
+            stub,
+            a,
+            "plan",
+            [(str(i), 0, hole) for i, hole in enumerate(holes)],
+            ctx,
+            perimeter=True,
+        )
+
+        top_members, _axis, top_line, segments = next(
+            call for call in calls if call[1] == "x" and call[2] > a.PV_Y
+        )
+        assert top_members
+        assert top_line == pytest.approx(pt + balloons._MIN_PERIMETER_EXTENT - 4.5)
+        assert segments and len(segments) == 2
+
     def test_balloon_assignment_rebalances_across_bands_before_dropping(self, monkeypatch):
         from types import SimpleNamespace
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9854,6 +9854,39 @@ class TestHoleTable:
         bb = obj.bounding_box()
         return (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y)
 
+    def test_top_lane_target_keeps_balanced_share_when_sides_have_room(self):
+        from draftwright.annotations.balloons import _top_lane_target
+
+        assert _top_lane_target(18, [41, 41], 3) == 6
+
+    def test_top_lane_target_covers_capacity_deficit_on_other_bands(self):
+        from draftwright.annotations.balloons import _top_lane_target
+
+        # Balanced share alone is 3, but only three members fit elsewhere: the
+        # top lane needs seven or the max-cardinality assignment would drop one.
+        assert _top_lane_target(10, [2, 1], 3) == 7
+
+    def test_top_lane_selection_prefers_nearest_sufficient_lane(self):
+        from draftwright.annotations.balloons import _select_top_lane
+
+        lanes = [(20.0, [(0.0, 10.0)], 2), (40.0, [(0.0, 30.0)], 4)]
+        assert _select_top_lane(lanes, 2, 99.0) == lanes[0]
+
+    def test_top_lane_selection_falls_back_to_nearest_maximum_capacity(self):
+        from draftwright.annotations.balloons import _select_top_lane
+
+        lanes = [
+            (20.0, [(0.0, 10.0)], 2),
+            (40.0, [(0.0, 30.0)], 4),
+            (60.0, [(0.0, 30.0)], 4),
+        ]
+        assert _select_top_lane(lanes, 8, 99.0) == lanes[1]
+
+    def test_top_lane_selection_handles_no_lane_on_a_constrained_page(self):
+        from draftwright.annotations.balloons import _select_top_lane
+
+        assert _select_top_lane([], 1, 99.0) == (99.0, [], 0)
+
     def test_table_has_a_row_per_spec_group(self):
         dwg = build_drawing(_multi_hole_plate())
         n_groups = len([f for f in dwg.features("plan") if f.type == "hole"])
@@ -9956,7 +9989,7 @@ class TestHoleTable:
             margin=0.0,
             PAGE_H=180.0,
             PAGE_W=140.0,
-            FV_Y=20.0,
+            FV_Y=0.0,
             fv_hh=5.0,
         )
         pt = a.PV_Y + a.pv_hh

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9860,10 +9860,13 @@ class TestHoleTable:
         assert _top_lane_target(18, [41, 41], 3) == 6
 
     def test_balloon_render_extent_and_compose_reservation_share_geometry(self):
-        from draftwright._core import _balloon_halo
+        from draftwright._core import _balloon_halo, _balloon_radius
+        from draftwright.annotations.balloons import _band_preference_limit
         from draftwright.compose import _est_plan_halo
 
         assert _est_plan_halo(3.0) == _balloon_halo(3.0) == 21.5
+        assert _band_preference_limit(3.0) == _balloon_halo(3.0)
+        assert _balloon_radius(3.0) == 4.5
 
     def test_top_lane_target_covers_capacity_deficit_on_other_bands(self):
         from draftwright.annotations.balloons import _top_lane_target
@@ -10002,7 +10005,7 @@ class TestHoleTable:
         obstacle = self._Boxed((47.0, pt + 2.0, 53.0, pt + 80.0))
 
         import draftwright.annotations.balloons as balloons
-        from draftwright._core import _balloon_halo
+        from draftwright._core import _balloon_halo, _balloon_radius
 
         real_assign = balloons._assign_balloon_bands
         assignment_kwargs = []
@@ -10057,7 +10060,7 @@ class TestHoleTable:
             call for call in calls if call[1] == "x" and call[2] > a.PV_Y
         )
         assert top_members
-        assert top_line == pytest.approx(pt + _balloon_halo(3.0) - 4.5)
+        assert top_line == pytest.approx(pt + _balloon_halo(3.0) - _balloon_radius(3.0))
         assert segments and len(segments) == 2
         assert assignment_kwargs == [
             {
@@ -10094,7 +10097,11 @@ class TestHoleTable:
     def test_balloon_assignment_rebalances_across_bands_before_dropping(self, monkeypatch):
         from types import SimpleNamespace
 
-        from draftwright._core import _STRIP_GAP, _STRIP_SPACING
+        from draftwright._core import (
+            _STRIP_GAP,
+            _STRIP_SPACING,
+            _balloon_radius,
+        )
         from draftwright.layout import _strip_capacity
 
         calls = []
@@ -10134,7 +10141,7 @@ class TestHoleTable:
         )
 
         fs = stub.draft.font_size
-        r = fs * 1.5
+        r = _balloon_radius(fs)
         gap = 2 * r + 2 * _STRIP_SPACING
         top_cap = _strip_capacity(a.PV_X - a.fv_hw - _STRIP_GAP, a.SV_X - a.sv_hw - r, gap)
         top_members = next(call[1] for call in calls if call[2] == "x" and call[3] > a.PV_Y)


### PR DESCRIPTION
Closes #901.

Stacked on #902, which contributes the synthetic dense-plate reproduction.

## Design
- expresses the scattered-hole-table remedy as a `perimeter` render intent
- extends the geometry-only band solver with a lexicographic activation objective: maximum cardinality, then maximum requested-band coverage, then minimum leader length
- gives perimeter rings a measured 20 mm minimum view-edge-to-outer-glyph extent
- preserves nearest-band placement and existing spacing for manual and pattern-only balloons
- records the updated solve contract in ADR 0014

## Verification
- `uv run ruff check ...`
- `uv run pytest -m smoke -q` (45 passed)
- focused balloon/solver regression selection (9 passed)

After #902 merges, this PR can be retargeted to `main` without changing its effective diff.