### PR TITLE
refactor(#873): the verb that carries a number is measured_dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`sheet.add_dimension(feature, role)` — ask the planner to carry one more
+  measurement** (ADR 0016 / #872). Referential: it names a feature and a role and
+  carries **no number**, so the value still comes from the geometry and a size lives in
+  exactly one place. It changes *selection*, not derivation — a request can never
+  introduce a number the part does not have. Requesting something the planner already
+  emits is a deliberate no-op, so a script can ask without first knowing the rule set's
+  mind. `sheet.auto_dimensions()` states the source explicitly (optional in this
+  release; #874 makes it mandatory).
+- **Addressable dimension identity** (#869/#870/#871): every planned measurement now has
+  a stable `DimensionId(feature, parameter)`, and correlated measurements that must be
+  named as one — a grid pattern's row and column pitch, a step ladder — group into an
+  `AddressableDimension`. This is what a `dimension(...)` line will name, and what
+  suppression and provenance key on.
+
+### Changed
+
+- **`Sheet.dimension(kind=…, value=…)` is now `Sheet.measured_dimension(...)`**
+  (ADR 0016 / #873), and `model.declare.authored_dimension` is
+  `model.declare.measured_dimension` to match. `dimension` becomes the *referential*
+  verb on both `Sheet` and `Drawing` — name a feature and a role, read the value off the
+  geometry — so the verb that carries an explicit number needed a name that says so.
+  The old spelling is a **transitional overload**, not a deprecation wrapper: because the
+  name is reused rather than retired, `Sheet.dimension` dispatches on how it was called
+  and warns, for one release. It expires at 0.4.0 with the #720 alias removals.
+  Generated AP242 scripts emit `measured_dimension` and so arrive un-deprecated.
+- **`Sheet` handles address features by identity, not position** (#908/#910/#912). A
+  handle, tolerance, GD&T origin, section request or dimension intent now follows *its*
+  feature through a `features` reorder instead of naming whatever took the slot.
+  Reordering with `reverse()`/`sort()` preserves every reference; deleting or replacing
+  a referenced feature raises rather than silently retargeting a neighbour. `of()` now
+  accepts a handle, and negative indices resolve uniformly across `of()`,
+  `add_dimension()` and the GD&T verbs.
+
+### Fixed
+
+- **Front-view dimensions join the placement solve instead of committing to the strip**
+  (#894): they previously took strip space before the global solve ran, so a
+  higher-ranked dimension could find its space already gone. Priority only ranks
+  candidates that are *in* the solve.
+- **A hole callout reads the feature's own `through` fact** (#868) rather than inferring
+  it from whether a depth parameter happens to be present — so a suppressed depth can no
+  longer make a blind hole print `THRU`.
+- **The balloon ring clears the view it annotates after a hole-table escalation**
+  (#901/#903).
+
 ## v0.3.9 — 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,14 @@
 
 - **`Sheet.dimension(kind=…, value=…)` is now `Sheet.measured_dimension(...)`**
   (ADR 0016 / #873), and `model.declare.authored_dimension` is
-  `model.declare.measured_dimension` to match. `dimension` becomes the *referential*
-  verb on both `Sheet` and `Drawing` — name a feature and a role, read the value off the
-  geometry — so the verb that carries an explicit number needed a name that says so.
-  The old spelling is a **transitional overload**, not a deprecation wrapper: because the
-  name is reused rather than retired, `Sheet.dimension` dispatches on how it was called
-  and warns, for one release. It expires at 0.4.0 with the #720 alias removals.
+  `model.declare.measured_dimension` to match. This **reserves** the name `dimension` for
+  the referential verb ADR 0016 defines — name a feature and a role, carry no number, let
+  the engine read the value off the geometry — which `Drawing.dimension` already is and
+  `Sheet.dimension` will become. The verb that carries an explicit number needed a name
+  saying so first. The old spelling is a **transitional overload**, not a deprecation
+  wrapper: because the name is reused rather than retired, `Sheet.dimension` dispatches on
+  how it was called and warns, for one release, expiring at 0.4.0 with the #720 alias
+  removals. Calling it referentially raises today, naming the issue that delivers it.
   Generated AP242 scripts emit `measured_dimension` and so arrive un-deprecated.
 - **`Sheet` handles address features by identity, not position** (#908/#910/#912). A
   handle, tolerance, GD&T origin, section request or dimension intent now follows *its*

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -61,7 +61,9 @@ dimensions. Today you cannot declare "dimension the pitch between these two boss
 this wall an overall-thickness dimension", or "do **not** auto-dimension this hole's
 location" as *intent* and let the engine place the result.
 
-The near-miss primitive is today's `sheet.dimension(...)` (`model.declare.authored_dimension`),
+The near-miss primitive is today's `sheet.measured_dimension(...)` (`model.declare.measured_dimension`
+— both renamed from `dimension`/`authored_dimension` by #873, so the referential verb could take
+the plain name),
 used for imported AP242 PMI. But it is *materialized* — it carries `ref_pts` / `ref_bbox` /
 `at` — so it leans toward the hardcoded-geometry form ADR 0001 rejected. It is the escape
 hatch for "a source already measured this", not the intent layer for "this measurement

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3523,7 +3523,7 @@ def _pmi_witness_from_bbox(rec, view: str, a):
     (e.g. two parallel faces of a slot or step).  Not suitable for bore
     diameters — use _bore_info instead.
 
-    When the record carries no ``ref_bbox`` (an authored ``Sheet.dimension()`` with
+    When the record carries no ``ref_bbox`` (an authored ``Sheet.measured_dimension()`` with
     only ``ref_pts``, #562), the span is derived from the ref points — so a ref_pts-only
     dimension renders instead of silently vanishing.
     """

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -380,7 +380,7 @@ def _compose_anno_boxes(
         bore_depth += pad_around_text + arrow_length
         boxes.append(AnnoBox("right", bore_depth))  # FV/PV right bore callouts
         boxes.append(AnnoBox("left", bore_depth))  # FV/PV left bore callouts
-    # Authored Z-axis linear dimensions (Sheet.dimension / AP242 PMI) render as height
+    # Authored Z-axis linear dimensions (Sheet.measured_dimension / AP242 PMI) render as height
     # dims to the front LEFT/RIGHT strips (#562). The right strip already holds the
     # envelope height + step ladder, but the left has only its _DIM_PAD floor, so an
     # authored Z dim was queued and then dropped as "no room". Reserve a slot per authored

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -23,7 +23,6 @@ reads recognised geometry, by design (ground truth, not the plan).
 from __future__ import annotations
 
 from draftwright.model.declare import (
-    authored_dimension,
     boss,
     chamfer,
     control_frame,
@@ -34,6 +33,7 @@ from draftwright.model.declare import (
     flat,
     groove,
     hole,
+    measured_dimension,
     note,
     pad,
     pattern,
@@ -116,7 +116,7 @@ __all__ = [
     "StepFeature",
     "PlateFeature",
     "StepLevelFeature",
-    "authored_dimension",
+    "measured_dimension",
     "build_part_model",
     "build_pmi_features",
     "boss",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1551,7 +1551,7 @@ def control_frame(
 def _point3(name: str, p) -> Point:
     vals = tuple(float(c) for c in p)
     if len(vals) != 3:
-        raise ValueError(f"dimension() {name} must be a 3-tuple")
+        raise ValueError(f"measured_dimension() {name} must be a 3-tuple")
     return (vals[0], vals[1], vals[2])
 
 
@@ -1579,17 +1579,17 @@ def measured_dimension(
     dim_kind = str(kind).lower()
     if dim_kind not in AUTHORED_DIMENSION_KINDS:
         allowed = ", ".join(sorted(AUTHORED_DIMENSION_KINDS))
-        raise ValueError(f"dimension() kind must be one of: {allowed}")
+        raise ValueError(f"measured_dimension() kind must be one of: {allowed}")
     pts = tuple(_point3("ref_pts item", p) for p in ref_pts)
     if len(pts) < 2:
-        raise ValueError("dimension() needs at least two ref_pts")
+        raise ValueError("measured_dimension() needs at least two ref_pts")
     bbox = None if ref_bbox is None else tuple(float(c) for c in ref_bbox)
     if bbox is not None and len(bbox) != 6:
-        raise ValueError("dimension() ref_bbox must be a 6-tuple")
+        raise ValueError("measured_dimension() ref_bbox must be a 6-tuple")
     dom = str(dominant_axis).upper()
     if dom not in ("X", "Y", "Z"):
         if not (dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None):
-            raise ValueError("dimension() dominant_axis must be X, Y, or Z")
+            raise ValueError("measured_dimension() dominant_axis must be X, Y, or Z")
     if at is None:
         if bbox is not None:
             x0, y0, z0, x1, y1, z1 = bbox

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1555,7 +1555,7 @@ def _point3(name: str, p) -> Point:
     return (vals[0], vals[1], vals[2])
 
 
-def authored_dimension(
+def measured_dimension(
     *,
     kind: str,
     value: float,
@@ -1571,8 +1571,8 @@ def authored_dimension(
     source_kind: str | None = None,
 ) -> AuthoredDimension:
     """A pre-authored drafting dimension from explicit measured values — the IR constructor
-    behind :meth:`Sheet.dimension` (#704: extracted so ``build_drawing(model=…)`` callers can
-    author one without the façade). Validates the kind against
+    behind :meth:`Sheet.measured_dimension` (#704: extracted so ``build_drawing(model=…)``
+    callers can author one without the façade). Validates the kind against
     :data:`~draftwright.model.ir.AUTHORED_DIMENSION_KINDS`, needs ≥2 ``ref_pts``, and derives
     ``at`` (the ``ref_bbox`` centre, else the ``ref_pts`` centroid) when not given."""
     _require_positive(value=value)

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -748,10 +748,11 @@ class Sheet:
     ) -> Sheet:
         """Declare a drafting dimension from explicit **measured** values.
 
-        Named for what it carries (ADR 0016 / #873). ``dimension`` now means *referential* on
-        both :class:`Sheet` and ``Drawing`` — it names a feature and a role and the engine reads
-        the value off the geometry — so the verb that carries a number of its own needed a name
-        that says so. A measured dimension is the one place a value does NOT come from the part.
+        Named for what it carries (ADR 0016 / #873). ``dimension`` is *referential* on
+        ``Drawing`` today and becomes so on :class:`Sheet` in #874 — it names a feature and a
+        role, and the engine reads the value off the geometry. The verb that carries a number of
+        its own needed a name saying so before that name could be reused. A measured dimension is
+        the one place a value does NOT come from the part.
 
         This is the concept-shaped Sheet API used by generated AP242 scripts: the source file
         may call the record PMI, but the editable script declares a dimension category, value,

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -51,7 +51,6 @@ from draftwright.analysis import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
 from draftwright.model import Feature
-from draftwright.model import authored_dimension as _authored_dimension
 from draftwright.model import boss as _boss
 from draftwright.model import chamfer as _chamfer
 from draftwright.model import control_frame as _declare_control
@@ -62,6 +61,7 @@ from draftwright.model import finish as _declare_finish
 from draftwright.model import flat as _flat
 from draftwright.model import groove as _groove
 from draftwright.model import hole as _hole
+from draftwright.model import measured_dimension as _measured_dimension
 from draftwright.model import note as _declare_note
 from draftwright.model import pad as _pad
 from draftwright.model import pattern as _pattern
@@ -697,7 +697,40 @@ class Sheet:
         self._features.append(feature)
         return self
 
-    def dimension(
+    #: The keyword set that identifies a call to the pre-rename `dimension(...)`. `kind` alone
+    #: would do today, but the referential form may grow keywords of its own, so the test is the
+    #: intersection of what only a measured call can supply.
+    _MEASURED_KEYWORDS = frozenset({"kind", "value", "label", "dominant_axis", "ref_pts"})
+
+    def dimension(self, *args, **kw):
+        """Transitional overload for the pre-#873 spelling of :meth:`measured_dimension`.
+
+        A **transitional overload, not a deprecation wrapper**, because the name is *reused*
+        rather than retired: ADR 0016 gives ``dimension`` the referential meaning — name a
+        feature and a role, carry no number — on both :class:`Sheet` and ``Drawing``. A plain
+        rename would leave old keyword calls raising ``TypeError`` from the new signature's
+        argument list rather than saying what happened, which is the worst of both.
+
+        So this dispatches on how it was called, for one release. It expires at 0.4.0 with the
+        ADR 0005 §4 alias removals (#720).
+        """
+        if self._MEASURED_KEYWORDS & set(kw):
+            warnings.warn(
+                "Sheet.dimension(kind=…, value=…) is now Sheet.measured_dimension(...) — "
+                "`dimension` is becoming the referential verb that names a feature and a role "
+                "and reads the value off the geometry (ADR 0016). This overload expires at "
+                "0.4.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.measured_dimension(*args, **kw)
+        raise TypeError(
+            "Sheet.dimension(): the referential form — dimension(feature, role), which declares "
+            "the complete authored dimension set — is #874. For a dimension carrying an explicit "
+            "measured value, call measured_dimension(kind=…, value=…, …)."
+        )
+
+    def measured_dimension(
         self,
         *,
         kind: str,
@@ -713,17 +746,22 @@ class Sheet:
         source: str = "sheet",
         source_kind: str | None = None,
     ) -> Sheet:
-        """Declare a pre-authored drafting dimension from explicit measured values.
+        """Declare a drafting dimension from explicit **measured** values.
+
+        Named for what it carries (ADR 0016 / #873). ``dimension`` now means *referential* on
+        both :class:`Sheet` and ``Drawing`` — it names a feature and a role and the engine reads
+        the value off the geometry — so the verb that carries a number of its own needed a name
+        that says so. A measured dimension is the one place a value does NOT come from the part.
 
         This is the concept-shaped Sheet API used by generated AP242 scripts: the source file
         may call the record PMI, but the editable script declares a dimension category, value,
         label, referenced model points, and optional structured tolerances. For ordinary
         geometry-backed edits prefer feature handles such as ``sheet.hole(...).tolerance(...)``.
-        Delegates to :func:`draftwright.model.declare.authored_dimension` (#704), so
+        Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
         self._features.append(
-            _authored_dimension(
+            _measured_dimension(
                 kind=kind,
                 value=value,
                 label=label,

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -14,7 +14,9 @@ authoritative. A caller who
 
 Kinds with no declarative verb yet (``rotational``) are flagged inline — never silently dropped —
 and left to the auto-pass that runs over the declared model on re-run. Imported authored
-dimensions, including AP242 dimensional PMI, emit as Sheet ``dimension(...)`` declarations.
+dimensions, including AP242 dimensional PMI, emit as Sheet ``measured_dimension(...)``
+declarations (#873 — never the transitional ``dimension`` overload, so a regenerated script is
+not born deprecated).
 Fidelity: the script reproduces a lint-clean drawing of the same features. The generated script is
 validated against the direct build for prismatic, slot/pattern, section, and turned/rotational
 fixtures (#472).

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -126,7 +126,7 @@ def _member_slot_str(m) -> str:
     )
 
 
-def _authored_dimension_line(f) -> str:
+def _measured_dimension_line(f) -> str:
     kw = [
         f"kind={f.dimension_kind!r}",
         f"value={_n(f.value)}",
@@ -145,7 +145,9 @@ def _authored_dimension_line(f) -> str:
         kw.append(f"source={f.source!r}")
     if f.source_kind is not None and f.source_kind != f.dimension_kind:
         kw.append(f"source_kind={f.source_kind!r}")
-    return "sheet.dimension(" + ", ".join(kw) + ")"
+    # `measured_dimension` since #873 — a generated script must not emit the transitional
+    # overload, or every regenerated AP242 script would arrive pre-deprecated.
+    return "sheet.measured_dimension(" + ", ".join(kw) + ")"
 
 
 def _raw_pmi_line(f) -> str:
@@ -162,7 +164,7 @@ def _raw_pmi_line(f) -> str:
 def _feature_line(f) -> str:
     k = f.kind
     if k == "authored_dimension":
-        return _authored_dimension_line(f)
+        return _measured_dimension_line(f)
     if k == "pmi":
         return _raw_pmi_line(f)
     if k == "envelope":
@@ -345,7 +347,7 @@ _NOUN = {
     "plate": "plate",
     "envelope": "envelope",
     "step_level": "step-ladder",
-    "authored_dimension": "dimension",
+    "authored_dimension": "measured dimension",
     "pmi": "PMI record",
 }
 # Kinds whose _feature_line carries NO inline comment of its own — the emit loop appends a

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1671,3 +1671,36 @@ class TestAuthoredDimension:
             measured_dimension(**{**self._KW, "kind": "liner"})
         with pytest.raises(ValueError, match="at least two ref_pts"):
             measured_dimension(**{**self._KW, "ref_pts": [(0, 0, 0)]})
+
+    def test_every_validation_branch_names_the_verb_that_was_called(self):
+        """#873 renamed these seven messages from `dimension()`. Left stale they get actively
+        misleading rather than merely dated: once `dimension` is the referential verb,
+        `dimension() kind must be one of…` implicates an API that has no `kind` at all.
+
+        Covering each branch is also what stops the rename being asserted only where a test
+        happened to exist — two of these were unexercised, which is how the stale text survived
+        the first pass."""
+        from draftwright.model import measured_dimension
+
+        cases = [
+            ({"ref_pts": [(0, 0), (1, 1)]}, "ref_pts item must be a 3-tuple"),
+            ({"ref_bbox": (0, 0, 0, 1, 1)}, "ref_bbox must be a 6-tuple"),
+            ({"dominant_axis": "W"}, "dominant_axis must be X, Y, or Z"),
+            ({"kind": "liner"}, "kind must be one of"),
+            ({"ref_pts": [(0, 0, 0)]}, "needs at least two ref_pts"),
+        ]
+        for override, message in cases:
+            with pytest.raises(ValueError, match=f"measured_dimension\\(\\) {message}"):
+                measured_dimension(**{**self._KW, **override})
+
+    def test_a_diameter_may_decline_a_dominant_axis(self):
+        """The one exemption from the axis check, so the branch above is not read as absolute:
+        a diameter or radius WITH a ref_bbox may pass '?' — the axis is derivable."""
+        from draftwright.model import measured_dimension
+
+        assert (
+            measured_dimension(
+                **{**self._KW, "kind": "diameter", "dominant_axis": "?"}
+            ).dominant_axis
+            == "?"
+        )

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1614,7 +1614,8 @@ class TestSheetDslShim:
 
 
 class TestAuthoredDimension:
-    """``model.authored_dimension`` — the IR constructor behind ``Sheet.dimension`` (#704),
+    """``model.measured_dimension`` — the IR constructor behind ``Sheet.measured_dimension``
+    (#704/#873),
     so ``build_drawing(model=…)`` callers can author one without the façade."""
 
     _KW = dict(
@@ -1631,18 +1632,42 @@ class TestAuthoredDimension:
     def test_matches_the_sheet_facade_feature(self):
         # The façade must append EXACTLY the feature the constructor builds — the
         # frozen-dataclass equality pins the delegation against re-inlining drift.
-        from draftwright.model import authored_dimension
+        from draftwright.model import measured_dimension
         from draftwright.sheet import Sheet
 
         sheet = Sheet(Box(40, 20, 10), title="P")
-        sheet.dimension(**self._KW)
+        sheet.measured_dimension(**self._KW)
         via_facade = next(f for f in sheet.features if f.kind == "authored_dimension")
-        assert authored_dimension(**self._KW) == via_facade
+        assert measured_dimension(**self._KW) == via_facade
+
+    def test_the_transitional_overload_still_reaches_the_same_feature(self):
+        """#873 REUSES the name `dimension` rather than retiring it, so an old keyword call
+        cannot be left to fail with a `TypeError` from the new signature's argument list. It
+        warns and delegates for one release, and must build the identical feature."""
+        from draftwright.model import measured_dimension
+        from draftwright.sheet import Sheet
+
+        sheet = Sheet(Box(40, 20, 10), title="P")
+        with pytest.warns(DeprecationWarning, match="measured_dimension"):
+            sheet.dimension(**self._KW)
+        assert next(f for f in sheet.features if f.kind == "authored_dimension") == (
+            measured_dimension(**self._KW)
+        )
+
+    def test_the_overload_refuses_a_call_it_cannot_interpret(self):
+        """The referential form is #874. Until then `dimension(feature, role)` must say so
+        rather than raise a `TypeError` about missing keywords, which is what a plain rename
+        would have produced and what the transitional overload exists to avoid."""
+        from draftwright.sheet import Sheet
+
+        sheet = Sheet(Box(40, 20, 10), title="P")
+        with pytest.raises(TypeError, match="referential form"):
+            sheet.dimension(0, "length")
 
     def test_validates_without_the_facade(self):
-        from draftwright.model import authored_dimension
+        from draftwright.model import measured_dimension
 
         with pytest.raises(ValueError, match="kind must be one of"):
-            authored_dimension(**{**self._KW, "kind": "liner"})
+            measured_dimension(**{**self._KW, "kind": "liner"})
         with pytest.raises(ValueError, match="at least two ref_pts"):
-            authored_dimension(**{**self._KW, "ref_pts": [(0, 0, 0)]})
+            measured_dimension(**{**self._KW, "ref_pts": [(0, 0, 0)]})

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -151,7 +151,7 @@ class TestEmit:
             )
 
     def test_refpts_only_linear_dim_renders_on_each_axis(self):
-        # #562: a linear Sheet.dimension() with two valid ref_pts and NO ref_bbox must
+        # #562: a linear Sheet.measured_dimension() with two valid ref_pts and NO ref_bbox must
         # render (the witness is derived from the ref points) — for X, Y, and Z. Z needs
         # the front left/right strip reserved for authored height dims (the sizing fix).
         from draftwright import Sheet

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -86,7 +86,10 @@ class TestEmit:
         py = generate_sheet_script(str(AP242_CTC01), out=str(tmp_path / "ctc01"), pmi="annotate")
         src = Path(py).read_text(encoding="utf-8")
         ast.parse(src)
-        assert "sheet.dimension(" in src
+        # `measured_dimension` since #873: a generated script must not emit the
+        # transitional overload, or every regenerated AP242 script arrives deprecated.
+        assert "sheet.measured_dimension(" in src
+        assert "sheet.dimension(" not in src
         assert "sheet.pmi(" not in src
         assert "# authored_dimension" not in src
         assert "source='ap242_pmi'" in src
@@ -98,11 +101,11 @@ class TestEmit:
         assert "Frame" in import_line and "PmiFeature" in import_line
         assert "StepLevelFeature" not in import_line
 
-    def test_sheet_dimension_declares_renderable_authored_dimension(self, tmp_path):
+    def test_measured_dimension_declares_renderable_authored_dimension(self, tmp_path):
         from draftwright import Sheet
 
         sheet = Sheet(Box(40, 20, 10), title="P", out=str(tmp_path / "dim"))
-        sheet.dimension(
+        sheet.measured_dimension(
             kind="linear",
             value=40,
             label="40",
@@ -119,12 +122,12 @@ class TestEmit:
         assert feat.source == "sheet"
         assert any(n.startswith("pmi_") for n in sheet.build().annotations())
 
-    def test_sheet_dimension_rejects_unrenderable_kind(self):
+    def test_measured_dimension_rejects_unrenderable_kind(self):
         from draftwright import Sheet
 
         sheet = Sheet(Box(40, 20, 10), title="P")
         with pytest.raises(ValueError, match="kind must be one of"):
-            sheet.dimension(
+            sheet.measured_dimension(
                 kind="liner",
                 value=40,
                 label="40",
@@ -133,12 +136,12 @@ class TestEmit:
                 ref_bbox=(-20, -10, -5, 20, 10, 5),
             )
 
-    def test_sheet_dimension_rejects_unrenderable_axis(self):
+    def test_measured_dimension_rejects_unrenderable_axis(self):
         from draftwright import Sheet
 
         sheet = Sheet(Box(40, 20, 10), title="P")
         with pytest.raises(ValueError, match="dominant_axis must be X, Y, or Z"):
-            sheet.dimension(
+            sheet.measured_dimension(
                 kind="linear",
                 value=40,
                 label="40",
@@ -160,7 +163,7 @@ class TestEmit:
         }
         for axis, ref_pts in cases.items():
             sheet = Sheet(Box(80, 60, 40), title="P")
-            sheet.dimension(
+            sheet.measured_dimension(
                 kind="linear",
                 value=10,
                 label="10",
@@ -180,7 +183,7 @@ class TestEmit:
         from draftwright import Sheet
 
         sheet = Sheet(Box(80, 60, 40), title="P")
-        sheet.dimension(
+        sheet.measured_dimension(
             kind="linear",
             value=10,
             label="10",


### PR DESCRIPTION
## Why

`dimension` means **referential** on both `Sheet` and `Drawing` (ADR 0016) — it names a feature and a role, and the engine reads the value off the geometry. The verb that carries an explicit number needed a name that says so:

| before | after |
|---|---|
| `Sheet.dimension(kind=…, value=…)` | `Sheet.measured_dimension(...)` |
| `model.declare.authored_dimension` | `model.declare.measured_dimension` |

One vocabulary across the façade and the model layer. A measured dimension is the one place a value does *not* come from the part — which is exactly what the name should carry.

## The shim is an overload, not a deprecation wrapper

Because the name is **reused** rather than retired, a plain rename would leave old keyword calls raising `TypeError` from the new signature's argument list rather than saying what happened. So `Sheet.dimension` dispatches on how it was called, warns, and delegates — for one release, expiring at 0.4.0 with the #720 alias removals.

A call it cannot interpret says the referential form is #874, rather than complaining about missing keywords.

The **model-layer** function is a plain rename with no alias: unlike the Sheet verb, nothing takes over the old name there, so an alias would be compat debt with no migration to smooth. Alpha project; the mandate is a clean surface.

## Gate

Generated AP242 scripts must regenerate clean — asserted **both ways**: the new spelling present *and* the old absent, so the emitter can't quietly keep writing a pre-deprecated script.

## Also

Adds the `Unreleased` changelog section this epic had been accruing debt against. #868, #869/#870/#871, #872, #894, #901/#903 and #908/#910/#912 have all merged since v0.3.9 with no entry.

637 targeted tests pass; lint 4/4.

Closes #873.