### PR TITLE
feat(#875): suppression marks a dimension, it does not filter the group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
   emits is a deliberate no-op, so a script can ask without first knowing the rule set's
   mind. `sheet.auto_dimensions()` states the source explicitly (optional in this
   release; #874 makes it mandatory).
+- **Suppressing a dimension marks it; it no longer leaks into the callout** (ADR 0016 /
+  #875). `PlannedDimension.suppressed` was honoured at thirteen render sites but not by
+  the compound hole-callout path, so a suppressed counterbore still printed. The group
+  keeps its engineering data either way — what changes is whether a value reaches the
+  page. Suppressing the bore ⌀ while a counterbore, spotface or countersink segment
+  remains now **raises** and names the orphan: `⌀20 THRU ⌴ ⌀32 ↓ 1.5` has no reading with
+  its leading term removed, and silently dropping the segments would discard authored
+  intent while silently restoring the head would make the drawing say something the
+  script does not.
 - **Addressable dimension identity** (#869/#870/#871): every planned measurement now has
   a stable `DimensionId(feature, parameter)`, and correlated measurements that must be
   named as one — a grid pattern's row and column pitch, a step ladder — group into an

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -76,118 +76,18 @@ from draftwright.annotations._common import (
     strip_obstacles,
 )
 from draftwright.layout import StripCandidate, plan_strip
+
+# Re-exported: `annotations/holes.py` and the tests import the spec from here, and the
+# renderer is its natural home from a caller's point of view even though the reading
+# itself now lives in the IR waist so the page estimator can share it (#875 review).
+# `hole_callout_spec` is re-exported: `annotations/holes.py` and the tests reach it here, and
+# the renderer is its natural home from a caller's point of view — the READING moved down to the
+# IR waist only so the page/scale estimator can share it instead of keeping a second copy that
+# drifts (#875 review). `as` form so the re-export is deliberate, not an unused import.
+from draftwright.model.callout import _first as _first
+from draftwright.model.callout import hole_callout_spec as hole_callout_spec
 from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, HoleFeature, PatternFeature
-from draftwright.model.planner import DimensionGroup, plan_locations
-
-
-def _planned(group: DimensionGroup, kind: str, *roles: str):
-    """First PLANNED dimension matching *kind* and any of *roles*, in role order — suppressed
-    or not. The lookup suppression is decided against; :func:`_first` is what honours it."""
-    for role in roles:
-        for pd in group.dims:
-            if pd.param.kind == kind and pd.param.role == role:
-                return pd
-    return None
-
-
-def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
-    """First **unsuppressed** parameter value matching *kind* and any of *roles*, in role order.
-
-    Honouring ``suppressed`` here is ADR 0016 / #875. Thirteen render sites already skipped
-    suppressed dimensions; the compound-callout path did not, so a suppressed segment still
-    printed. Suppression MARKS a dimension rather than removing it (the group keeps its
-    engineering data either way) — what changes is whether it reaches the page."""
-    pd = _planned(group, kind, *roles)
-    return None if pd is None or pd.suppressed else pd.param.value
-
-
-#: Segments of a compound hole callout that cannot be printed without the bore ⌀ that heads it:
-#: `⌀20 THRU ⌴ ⌀32 ↓ 1.5` has no reading with the leading term removed.
-_CALLOUT_HEAD_DEPENDENTS = (
-    ("diameter", "counterbore"),
-    ("depth", "counterbore"),
-    ("diameter", "spotface"),
-    ("depth", "spotface"),
-    ("diameter", "countersink"),
-    ("angle", "countersink"),
-)
-
-
-def _refuse_headless_callout(group: DimensionGroup, bore_pd) -> None:
-    """Raise if the bore ⌀ is suppressed while a segment that depends on it is not (ADR 0016).
-
-    The head of a compound callout is a **declared dependency**. Suppressing it while a
-    counterbore or countersink intent remains is an authoring error, and the alternatives are
-    both worse: lint-and-drop silently discards authored intent, and implicitly restoring the
-    head makes the drawing say something the script does not. So it raises and names the
-    dependency, which is the only option that leaves the author in control."""
-    orphans = [
-        f"{role}.{kind}"
-        for kind, role in _CALLOUT_HEAD_DEPENDENTS
-        if (pd := _planned(group, kind, role)) is not None and not pd.suppressed
-    ]
-    if not orphans:
-        return  # the whole callout is suppressed — coherent, and nothing to print
-    raise ValueError(
-        f"suppressing the bore diameter would leave {', '.join(orphans)} with no callout to "
-        f"head ({bore_pd.reason or 'suppressed'}). A compound callout reads as one string, so "
-        "its leading ⌀ is a dependency: suppress those segments too, or keep the bore ⌀."
-    )
-
-
-def hole_callout_spec(group: DimensionGroup) -> dict | None:
-    """A hole/pattern group's plan → `HoleCallout` kwargs, mirroring the engine's
-    convention. ``None`` if not a hole-bearing callout.
-
-    From the plan: bore from `DimParameter` roles; the cbore/spotface *step* with
-    counterbore precedence (``step = cbore or spotface``, as the engine does);
-    ``count`` and the pattern *suffix* (``EQ SP ON ø50 BC`` / ``(3×3)``) from the
-    source feature.
-
-    ``through`` is read off the FEATURE, never inferred from a missing bore-depth
-    param (#868). `HoleFeature.parameters()` only emits the depth for a blind hole,
-    so absence-as-signal would make any consumer that filters the parameter list —
-    ADR 0016 suppression above all — silently render a blind hole as ``THRU``. The
-    rule that follows (ADR 0016): a renderer may not infer an engineering *fact*
-    from the presence or absence of a dimension parameter — parameters carry values
-    for display, facts live on the feature."""
-    feat = group.feature
-    if not isinstance(feat, HoleFeature | PatternFeature):
-        return None
-    bore_pd = _planned(group, "diameter", "bore")
-    if bore_pd is not None and bore_pd.suppressed:
-        _refuse_headless_callout(group, bore_pd)
-    bore = _first(group, "diameter", "bore")
-    if bore is None:
-        return None
-    bore_tol = bore_pd.param.tolerance if bore_pd is not None else None
-    depth = _first(group, "depth", "bore")
-    count = feat.count
-    suffix = None
-    if isinstance(feat, PatternFeature):
-        if feat.pattern == "bolt_circle" and feat.bcd is not None:
-            suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
-        elif feat.pattern == "grid" and feat.rows and feat.cols:
-            suffix = f"({feat.rows}×{feat.cols})"
-    # A thread spec (#764) folds onto the compound callout — it lives on the bore hole
-    # (the pattern's member for a threaded array). Lead with it (the tap/thread is the
-    # defining call), then any pattern suffix: e.g. "M3x0.5" or "M3x0.5 EQ SP ON ø50 BC".
-    hole = feat.member if isinstance(feat, PatternFeature) else feat
-    thread = getattr(hole, "thread", None)
-    suffix = " ".join(p for p in (thread, suffix) if p) or None
-    return {
-        "diameter": bore,
-        "count": count if count and count > 1 else None,
-        "through": hole.through,  # the feature's fact, not the param list's shape (#868)
-        "depth": depth,
-        # counterbore precedence, spotface fallback — the engine's mapping
-        "cbore_dia": _first(group, "diameter", "counterbore", "spotface"),
-        "cbore_depth": _first(group, "depth", "counterbore", "spotface"),
-        "csink_dia": _first(group, "diameter", "countersink"),
-        "csink_angle": _first(group, "angle", "countersink"),
-        "suffix": suffix,
-        "tolerance": bore_tol,  # P2a: ± on the bore ⌀, baked into the callout string below
-    }
+from draftwright.model.planner import plan_locations
 
 
 def callout_from_spec(spec, draft, count) -> HoleCallout | None:

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -80,13 +80,59 @@ from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, HoleFeature, PatternF
 from draftwright.model.planner import DimensionGroup, plan_locations
 
 
-def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
-    """First parameter value matching *kind* and any of *roles*, in role order."""
+def _planned(group: DimensionGroup, kind: str, *roles: str):
+    """First PLANNED dimension matching *kind* and any of *roles*, in role order — suppressed
+    or not. The lookup suppression is decided against; :func:`_first` is what honours it."""
     for role in roles:
         for pd in group.dims:
             if pd.param.kind == kind and pd.param.role == role:
-                return pd.param.value
+                return pd
     return None
+
+
+def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
+    """First **unsuppressed** parameter value matching *kind* and any of *roles*, in role order.
+
+    Honouring ``suppressed`` here is ADR 0016 / #875. Thirteen render sites already skipped
+    suppressed dimensions; the compound-callout path did not, so a suppressed segment still
+    printed. Suppression MARKS a dimension rather than removing it (the group keeps its
+    engineering data either way) — what changes is whether it reaches the page."""
+    pd = _planned(group, kind, *roles)
+    return None if pd is None or pd.suppressed else pd.param.value
+
+
+#: Segments of a compound hole callout that cannot be printed without the bore ⌀ that heads it:
+#: `⌀20 THRU ⌴ ⌀32 ↓ 1.5` has no reading with the leading term removed.
+_CALLOUT_HEAD_DEPENDENTS = (
+    ("diameter", "counterbore"),
+    ("depth", "counterbore"),
+    ("diameter", "spotface"),
+    ("depth", "spotface"),
+    ("diameter", "countersink"),
+    ("angle", "countersink"),
+)
+
+
+def _refuse_headless_callout(group: DimensionGroup, bore_pd) -> None:
+    """Raise if the bore ⌀ is suppressed while a segment that depends on it is not (ADR 0016).
+
+    The head of a compound callout is a **declared dependency**. Suppressing it while a
+    counterbore or countersink intent remains is an authoring error, and the alternatives are
+    both worse: lint-and-drop silently discards authored intent, and implicitly restoring the
+    head makes the drawing say something the script does not. So it raises and names the
+    dependency, which is the only option that leaves the author in control."""
+    orphans = [
+        f"{role}.{kind}"
+        for kind, role in _CALLOUT_HEAD_DEPENDENTS
+        if (pd := _planned(group, kind, role)) is not None and not pd.suppressed
+    ]
+    if not orphans:
+        return  # the whole callout is suppressed — coherent, and nothing to print
+    raise ValueError(
+        f"suppressing the bore diameter would leave {', '.join(orphans)} with no callout to "
+        f"head ({bore_pd.reason or 'suppressed'}). A compound callout reads as one string, so "
+        "its leading ⌀ is a dependency: suppress those segments too, or keep the bore ⌀."
+    )
 
 
 def hole_callout_spec(group: DimensionGroup) -> dict | None:
@@ -108,17 +154,13 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     feat = group.feature
     if not isinstance(feat, HoleFeature | PatternFeature):
         return None
+    bore_pd = _planned(group, "diameter", "bore")
+    if bore_pd is not None and bore_pd.suppressed:
+        _refuse_headless_callout(group, bore_pd)
     bore = _first(group, "diameter", "bore")
     if bore is None:
         return None
-    bore_tol = next(
-        (
-            pd.param.tolerance
-            for pd in group.dims
-            if pd.param.kind == "diameter" and pd.param.role == "bore"
-        ),
-        None,
-    )
+    bore_tol = bore_pd.param.tolerance if bore_pd is not None else None
     depth = _first(group, "depth", "bore")
     count = feat.count
     suffix = None

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -768,13 +768,21 @@ def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
 def render_centermarks(dwg, groups, *, ctx) -> int:
     """A centre mark on every hole (plain holes + each pattern member), in the view
     normal to the hole's axis (`_END_ON`), sized by its diameter — the IR migration
-    of the engine's inline centre-mark loop. Returns the count placed."""
+    of the engine's inline centre-mark loop. Returns the count placed.
+
+    The size comes off the FEATURE, not the planned bore parameter (ADR 0016 / #875 review).
+    A centre mark is furniture derived from the hole's physical size; it is not a displayed
+    value, so suppressing the bore dimension must not shrink it. Reading the parameter here
+    made a suppressed ⌀20 collapse from a 42 mm mark to the 2.5 mm floor — the governing rule
+    (facts live on the feature, parameters carry display values) applied to geometry rather
+    than to text."""
     n = 0
     for g in groups:
         feat = g.feature
         if not isinstance(feat, HoleFeature | PatternFeature):
             continue
-        dia = _first(g, "diameter", "bore") or 0.0
+        hole = feat.member if isinstance(feat, PatternFeature) else feat
+        dia = hole.diameter or 0.0
         size = max(2.5, dia * dwg.scale + 2.0)
         view = _END_ON.get(feat.frame.axis, "plan")
         members = feat.members or (g.anchor,)

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -53,6 +53,7 @@ from draftwright._core import (
     _wrap_rows,
 )
 from draftwright.layout import fit_box
+from draftwright.model.callout import hole_callout_spec
 
 _log = logging.getLogger(__name__)
 
@@ -217,58 +218,32 @@ def _est_planned_bore_callout_width(
     estimator layer so page/scale selection does not import renderers to size text (#450).
     """
 
-    def _first(group, kind: str, *roles: str) -> float | None:
-        for role in roles:
-            for pd in group.dims:
-                if pd.param.kind == kind and pd.param.role == role:
-                    return float(pd.param.value)
-        return None
-
-    def _tol(group):
-        return next(
-            (
-                pd.param.tolerance
-                for pd in group.dims
-                if pd.param.kind == "diameter" and pd.param.role == "bore"
-            ),
-            None,
-        )
-
     gap = 0.45 * font_size
     sym_w = font_size
     max_w = 0.0
     for group in groups:
-        feat = group.feature
-        if getattr(feat, "kind", None) not in ("hole", "pattern"):
+        # ONE reading of the plan, shared with the renderer (#875 review). This function used to
+        # re-derive bore/depth/cbore/suffix itself, and the two drifted: the copy here inferred
+        # THRU from a missing depth (the inference #868 removed from the renderer) and ignored
+        # `suppressed` entirely, so a callout could be reserved 33 mm and rendered at 14 mm.
+        spec = hole_callout_spec(group)
+        if spec is None:
             continue
-        bore = _first(group, "diameter", "bore")
-        if bore is None:
-            continue
-        depth = _first(group, "depth", "bore")
-        cbore_dia = _first(group, "diameter", "counterbore", "spotface")
-        cbore_depth = _first(group, "depth", "counterbore", "spotface")
-        suffix = None
-        if getattr(feat, "kind", None) == "pattern":
-            if getattr(feat, "pattern", None) == "bolt_circle" and feat.bcd is not None:
-                suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
-            elif getattr(feat, "pattern", None) == "grid" and feat.rows and feat.cols:
-                suffix = f"({feat.rows}×{feat.cols})"
-        # The thread spec (#764) widens the callout — mirror hole_callout_spec so the strip
-        # reservation matches the rendered width (the #261 estimator/render agreement), else a
-        # threaded callout is reserved too narrow and dropped for "no room beside the view".
-        hole = getattr(feat, "member", feat)
-        thread = getattr(hole, "thread", None)
-        suffix = " ".join(p for p in (thread, suffix) if p) or None
+        bore = spec["diameter"]
+        depth = spec["depth"]
+        cbore_dia, cbore_depth = spec["cbore_dia"], spec["cbore_depth"]
+        suffix = spec["suffix"]
 
         token_w: list[float] = []
-        count = getattr(feat, "count", None)
-        if count and count > 1:
-            token_w.append(_text_width(f"{count}×", font_size))
+        if spec["count"]:
+            token_w.append(_text_width(f"{spec['count']}×", font_size))
         token_w.append(sym_w)  # ⌀ symbol
-        token_w.append(_text_width(f"{_fmt(bore)}{_tol_suffix(_tol(group), draft)}", font_size))
-        if depth is None:
+        token_w.append(
+            _text_width(f"{_fmt(bore)}{_tol_suffix(spec['tolerance'], draft)}", font_size)
+        )
+        if spec["through"]:
             token_w.append(_text_width("THRU", font_size))
-        else:
+        elif depth is not None:
             token_w.append(sym_w)  # depth symbol
             token_w.append(_text_width(_fmt(depth), font_size))
         if cbore_dia is not None:
@@ -278,12 +253,12 @@ def _est_planned_bore_callout_width(
             if cbore_depth is not None:
                 token_w.append(sym_w)  # depth symbol
                 token_w.append(_text_width(_fmt(cbore_depth), font_size))
-        csink_dia = _first(group, "diameter", "countersink")
+        csink_dia = spec["csink_dia"]
         if csink_dia is not None:
             token_w.append(sym_w)  # countersink symbol
             token_w.append(sym_w)  # ⌀
             token_w.append(_text_width(_fmt(csink_dia), font_size))
-            csink_angle = _first(group, "angle", "countersink")
+            csink_angle = spec["csink_angle"]
             if csink_angle is not None:
                 token_w.append(_text_width(f"× {_fmt(csink_angle)}°", font_size))
         if suffix is not None:

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -45,68 +45,78 @@ def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
     return None if pd is None or pd.suppressed else pd.param.value
 
 
-#: The compound callout's segments, each as the (kind, role) parameters that make it readable.
-#: A segment is ATOMIC: `⌴ ⌀32 ↓ 1.5` needs both terms, and half of it is not a shorter callout,
-#: it is a different and wrong one. The bore is listed first because it also heads the string.
-_CALLOUT_SEGMENTS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
-    ("bore", (("diameter", "bore"),)),
-    ("counterbore", (("diameter", "counterbore"), ("depth", "counterbore"))),
-    ("spotface", (("diameter", "spotface"), ("depth", "spotface"))),
-    ("countersink", (("diameter", "countersink"), ("angle", "countersink"))),
+#: The compound callout's segments: ``(name, head, dependents)``.
+#:
+#: Each segment has a HEAD term — always its ⌀ — and terms that only mean something beside it.
+#: The relation is ASYMMETRIC, which two review rounds were needed to pin down:
+#:
+#: - ``⌴ ⌀32`` is a readable counterbore; its depth is optional detail. Suppressing the depth
+#:   while the ⌀ survives is a legitimate authoring choice, not an error.
+#: - ``⌴ ↓ 1.5`` is not a counterbore at all. Suppressing the ⌀ while the depth survives leaves
+#:   a number with nothing to be the depth OF, and the renderer would silently drop both.
+#:
+#: The bore behaves identically — ``⌀12`` is fine, ``↓ 8`` alone is not — so its depth is a
+#: dependent rather than, as the first version had it, no part of the segment.
+_CALLOUT_SEGMENTS: tuple[tuple[str, tuple[str, str], tuple[tuple[str, str], ...]], ...] = (
+    ("bore", ("diameter", "bore"), (("depth", "bore"),)),
+    ("counterbore", ("diameter", "counterbore"), (("depth", "counterbore"),)),
+    ("spotface", ("diameter", "spotface"), (("depth", "spotface"),)),
+    ("countersink", ("diameter", "countersink"), (("angle", "countersink"),)),
 )
 
 
-def _segment_state(group: DimensionGroup, params) -> tuple[list[str], list[str]]:
-    """(present-and-printing, present-but-suppressed) for one segment's parameters."""
-    printing: list[str] = []
-    suppressed: list[str] = []
+def _printing(group: DimensionGroup, *params) -> list[str]:
+    """Labels for the given (kind, role) parameters that are present and not suppressed."""
+    out = []
     for kind, role in params:
         pd = _planned(group, kind, role)
-        if pd is None:
-            continue
-        (suppressed if pd.suppressed else printing).append(f"{role}.{kind}")
-    return printing, suppressed
+        if pd is not None and not pd.suppressed:
+            out.append(f"{role}.{kind}")
+    return out
 
 
-def _refuse_headless_callout(group: DimensionGroup, bore_pd=None) -> None:
+def _is_suppressed(group: DimensionGroup, kind: str, role: str) -> bool:
+    pd = _planned(group, kind, role)
+    return pd is not None and pd.suppressed
+
+
+def _refuse_headless_callout(group: DimensionGroup) -> None:
     """Raise if suppression would leave part of a compound callout orphaned (ADR 0016 / #875).
 
-    Two ways that happens, and they are the same rule at two scales:
+    Two scales of the same rule:
 
-    - **Within a segment.** Suppressing `counterbore.diameter` while its depth survives leaves
-      a depth with nothing to be the depth OF, and the renderer would quietly drop both.
-    - **Across segments.** The bore ⌀ heads the string, so suppressing it while a counterbore or
-      countersink segment prints leaves those with no callout to attach to.
+    - **Within a segment.** Suppressing a segment's ⌀ while its depth or angle survives leaves
+      a number with nothing to qualify.
+    - **Across segments.** The bore ⌀ heads the whole string, so suppressing it while a
+      counterbore or countersink segment prints leaves those with nothing to attach to.
 
     Raising is the only option that keeps the author in control. Lint-and-drop silently discards
     intent they expressed; implicitly restoring the missing term makes the drawing say something
     the script does not. Suppressing a whole segment — or the whole callout — is coherent and
     stays silent, because nothing is orphaned.
-
-    The first version of this check only guarded the bore head, which left the within-segment
-    case doing exactly the silent discard the rule exists to forbid (PR #920 review).
     """
-    for name, params in _CALLOUT_SEGMENTS:
-        printing, suppressed = _segment_state(group, params)
-        if suppressed and printing:
+    for name, head, dependents in _CALLOUT_SEGMENTS:
+        if not _is_suppressed(group, *head):
+            continue
+        orphans = _printing(group, *dependents)
+        if orphans:
             raise ValueError(
-                f"suppressing {', '.join(suppressed)} would leave {', '.join(printing)} with "
-                f"nothing to attach to — a {name} reads as one term. Suppress the whole segment, "
-                "or keep it whole."
+                f"suppressing {head[1]}.{head[0]} would leave {', '.join(orphans)} with nothing "
+                f"to attach to — a {name} reads as one term, led by its ⌀. Suppress the whole "
+                "segment, or keep its diameter."
             )
 
-    bore_printing, bore_suppressed = _segment_state(group, (("diameter", "bore"),))
-    if not bore_suppressed or bore_printing:
+    if not _is_suppressed(group, "diameter", "bore"):
         return
-    orphans = [
+    across = [
         label
-        for _name, params in _CALLOUT_SEGMENTS[1:]
-        for label in _segment_state(group, params)[0]
+        for _name, head, dependents in _CALLOUT_SEGMENTS[1:]
+        for label in _printing(group, head, *dependents)
     ]
-    if not orphans:
+    if not across:
         return  # the whole callout is suppressed — coherent, and nothing to print
     raise ValueError(
-        f"suppressing the bore diameter would leave {', '.join(orphans)} with no callout to "
+        f"suppressing the bore diameter would leave {', '.join(across)} with no callout to "
         "head. A compound callout reads as one string, so its leading ⌀ is a dependency: "
         "suppress those segments too, or keep the bore ⌀."
     )

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -90,6 +90,30 @@ def _is_suppressed(group: DimensionGroup, kind: str, role: str) -> bool:
     return pd is not None and pd.suppressed
 
 
+def _pattern_suffix(group: DimensionGroup) -> str | None:
+    """The pattern's trailing term — ``EQ SP ON ø50 BC`` or ``(3×3)`` — or ``None``.
+
+    Shared by the spec and the dependency rule, because the rule has to know exactly what WOULD
+    print. Listing the multiplier and thread as head-dependents but not this was invisible while
+    every fixture used ``count > 1``: with ``count=1`` the multiplier check does not fire, and a
+    one-member bolt circle lost its ``EQ SP ON ø50 BC`` in silence (#920 review).
+
+    The BCD is a planned, addressable dimension (``bolt_circle.diameter``), so suppressing it
+    stops the suffix printing — the value is a fact off the feature, but WHETHER it prints is
+    the parameter's business. The grid's ``(3×3)`` is a count, not a dimension, and has no
+    parameter to suppress.
+    """
+    feat = group.feature
+    if not isinstance(feat, PatternFeature):
+        return None
+    if feat.pattern == "bolt_circle":
+        bcd = _first(group, "diameter", "bolt_circle")
+        return None if bcd is None else f"EQ SP ON ø{_fmt(bcd)} BC"
+    if feat.pattern == "grid" and feat.rows and feat.cols:
+        return f"({feat.rows}×{feat.cols})"
+    return None
+
+
 def _shadowed(group: DimensionGroup, name: str) -> bool:
     """Is this segment invisible because another one takes precedence over it?
 
@@ -155,6 +179,9 @@ def _refuse_headless_callout(group: DimensionGroup) -> None:
     multiplier = getattr(feat, "count", 0) or 0
     if multiplier > 1:
         across.append(f"the {multiplier}× multiplier")
+    pattern_suffix = _pattern_suffix(group)
+    if pattern_suffix:
+        across.append(f"the pattern suffix {pattern_suffix!r}")
     if not across:
         return  # the whole callout is suppressed — coherent, and nothing to print
     raise ValueError(
@@ -215,18 +242,7 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     bore_tol = bore_pd.param.tolerance if bore_pd is not None else None
     depth = _first(group, "depth", "bore")
     count = feat.count
-    suffix = None
-    if isinstance(feat, PatternFeature):
-        # The BCD is a planned, addressable dimension (`bolt_circle.diameter`), so suppressing
-        # it must stop `EQ SP ON ø50 BC` printing. Reading `feat.bcd` unconditionally bypassed
-        # the mark entirely (#920 review) — the value is a fact off the feature, but WHETHER it
-        # prints is the parameter's business. The `(3×3)` grid suffix is a count, not a
-        # dimension, and has no parameter to suppress.
-        bcd = _first(group, "diameter", "bolt_circle")
-        if feat.pattern == "bolt_circle" and bcd is not None:
-            suffix = f"EQ SP ON ø{_fmt(bcd)} BC"
-        elif feat.pattern == "grid" and feat.rows and feat.cols:
-            suffix = f"({feat.rows}×{feat.cols})"
+    suffix = _pattern_suffix(group)
     # A thread spec (#764) folds onto the compound callout — it lives on the bore hole
     # (the pattern's member for a threaded array). Lead with it (the tap/thread is the
     # defining call), then any pattern suffix: e.g. "M3x0.5" or "M3x0.5 EQ SP ON ø50 BC".

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -143,6 +143,29 @@ def _refuse_headless_callout(group: DimensionGroup) -> None:
     )
 
 
+def _recess(group: DimensionGroup) -> tuple[float | None, float | None]:
+    """The counterbore-or-spotface recess as ONE segment: ``(diameter, depth)``.
+
+    ``counterbore`` takes precedence and ``spotface`` is the fallback — but the choice is made
+    once, for the segment, and both terms then come from the role that won. Resolving the two
+    terms through independent fallbacks (as the first version did) let a suppressed
+    ``counterbore.depth`` pair the counterbore's ⌀32 with the spotface's 0.5 depth: a recess
+    present on neither feature, and a wrong drawing rather than a missing one.
+
+    A role wins on its HEAD being unsuppressed, matching the asymmetric segment rule — its
+    depth may legitimately be suppressed, which yields a ⌀ with no stated depth.
+    """
+    for role in ("counterbore", "spotface"):
+        dia = _planned(group, "diameter", role)
+        if dia is not None and not dia.suppressed:
+            depth = _planned(group, "depth", role)
+            return (
+                float(dia.param.value),
+                None if depth is None or depth.suppressed else float(depth.param.value),
+            )
+    return None, None
+
+
 def hole_callout_spec(group: DimensionGroup) -> dict | None:
     """A hole/pattern group's plan → `HoleCallout` kwargs, mirroring the engine's
     convention. ``None`` if not a hole-bearing callout.
@@ -163,6 +186,7 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     if not isinstance(feat, HoleFeature | PatternFeature):
         return None
     _refuse_headless_callout(group)  # every segment, not just the head — see the docstring
+    cbore_dia, cbore_depth = _recess(group)
     bore_pd = _planned(group, "diameter", "bore")
     bore = _first(group, "diameter", "bore")
     if bore is None:
@@ -188,8 +212,11 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
         "through": hole.through,  # the feature's fact, not the param list's shape (#868)
         "depth": depth,
         # counterbore precedence, spotface fallback — the engine's mapping
-        "cbore_dia": _first(group, "diameter", "counterbore", "spotface"),
-        "cbore_depth": _first(group, "depth", "counterbore", "spotface"),
+        # ONE role, both terms. Reading ⌀ and depth through independent fallbacks let a
+        # drawing pair the counterbore's ⌀32 with the spotface's 0.5 depth — a recess that
+        # exists on neither feature (#920 review). The chain picks a segment, not a value.
+        "cbore_dia": cbore_dia,
+        "cbore_depth": cbore_depth,
         "csink_dia": _first(group, "diameter", "countersink"),
         "csink_angle": _first(group, "angle", "countersink"),
         "suffix": suffix,

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -132,8 +132,11 @@ def _refuse_headless_callout(group: DimensionGroup) -> None:
     thread = getattr(hole, "thread", None)
     if thread:
         across.append(f"the thread spec {thread}")
-    if isinstance(feat, PatternFeature) and (feat.count or 0) > 1:
-        across.append(f"the {feat.count}× pattern")
+    # A plain `HoleFeature` may also carry a count — `4× ⌀6 THRU` — so the multiplier is a
+    # dependent of the head for both feature kinds, not just for patterns (#920 review).
+    multiplier = getattr(feat, "count", 0) or 0
+    if multiplier > 1:
+        across.append(f"the {multiplier}× multiplier")
     if not across:
         return  # the whole callout is suppressed — coherent, and nothing to print
     raise ValueError(
@@ -196,8 +199,14 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     count = feat.count
     suffix = None
     if isinstance(feat, PatternFeature):
-        if feat.pattern == "bolt_circle" and feat.bcd is not None:
-            suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
+        # The BCD is a planned, addressable dimension (`bolt_circle.diameter`), so suppressing
+        # it must stop `EQ SP ON ø50 BC` printing. Reading `feat.bcd` unconditionally bypassed
+        # the mark entirely (#920 review) — the value is a fact off the feature, but WHETHER it
+        # prints is the parameter's business. The `(3×3)` grid suffix is a count, not a
+        # dimension, and has no parameter to suppress.
+        bcd = _first(group, "diameter", "bolt_circle")
+        if feat.pattern == "bolt_circle" and bcd is not None:
+            suffix = f"EQ SP ON ø{_fmt(bcd)} BC"
         elif feat.pattern == "grid" and feat.rows and feat.cols:
             suffix = f"({feat.rows}×{feat.cols})"
     # A thread spec (#764) folds onto the compound callout — it lives on the bore hole

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -90,6 +90,21 @@ def _is_suppressed(group: DimensionGroup, kind: str, role: str) -> bool:
     return pd is not None and pd.suppressed
 
 
+def _shadowed(group: DimensionGroup, name: str) -> bool:
+    """Is this segment invisible because another one takes precedence over it?
+
+    Only the spotface can be, and only while the counterbore's ⌀ prints — the two share the one
+    recess slot in the callout string. A shadowed segment is not rendered before OR after a
+    suppression, so suppressing part of it orphans nothing and must not raise: the first version
+    validated every role and refused `spotface.diameter` on a hole whose counterbore was intact,
+    which is a spurious error about a term the drawing never carried (#920 review).
+    """
+    if name != "spotface":
+        return False
+    cbore = _planned(group, "diameter", "counterbore")
+    return cbore is not None and not cbore.suppressed
+
+
 def _refuse_headless_callout(group: DimensionGroup) -> None:
     """Raise if suppression would leave part of a compound callout orphaned (ADR 0016 / #875).
 
@@ -106,6 +121,8 @@ def _refuse_headless_callout(group: DimensionGroup) -> None:
     stays silent, because nothing is orphaned.
     """
     for name, head, dependents in _CALLOUT_SEGMENTS:
+        if _shadowed(group, name):
+            continue
         if not _is_suppressed(group, *head):
             continue
         orphans = _printing(group, *dependents)
@@ -120,7 +137,8 @@ def _refuse_headless_callout(group: DimensionGroup) -> None:
         return
     across = [
         label
-        for _name, head, dependents in _CALLOUT_SEGMENTS[1:]
+        for name, head, dependents in _CALLOUT_SEGMENTS[1:]
+        if not _shadowed(group, name)
         for label in _printing(group, head, *dependents)
     ]
     # Not every dependent is a dimension. The thread spec and a pattern's count/suffix ride the

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -25,8 +25,9 @@ from draftwright.model.planner import DimensionGroup
 
 
 def _planned(group: DimensionGroup, kind: str, *roles: str):
-    """First PLANNED dimension matching *kind* and any of *roles*, in role order — suppressed
-    or not. The lookup suppression is decided against; :func:`_first` is what honours it."""
+    """First PLANNED dimension matching *kind* and any of *roles*, in role order — **suppressed
+    or not**. This is the lookup suppression is decided *against*; :func:`_first` is what
+    honours it. Keeping the two separate is what makes each call site's intent legible."""
     for role in roles:
         for pd in group.dims:
             if pd.param.kind == kind and pd.param.role == role:
@@ -40,9 +41,18 @@ def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
     Honouring ``suppressed`` here is ADR 0016 / #875. Thirteen render sites already skipped
     suppressed dimensions; the compound-callout path did not, so a suppressed segment still
     printed. Suppression MARKS a dimension rather than removing it (the group keeps its
-    engineering data either way) — what changes is whether it reaches the page."""
-    pd = _planned(group, kind, *roles)
-    return None if pd is None or pd.suppressed else pd.param.value
+    engineering data either way) — what changes is whether it reaches the page.
+
+    Suppression is applied per role, BEFORE the precedence between them. The roles are ordered
+    as a fallback chain (counterbore, then spotface), so a suppressed counterbore must fall
+    through to an unsuppressed spotface rather than swallowing it — the first draft resolved
+    precedence first and then nulled the winner, which silently dropped the spotface (#920
+    review)."""
+    for role in roles:
+        pd = _planned(group, kind, role)
+        if pd is not None and not pd.suppressed:
+            return None if pd.param.value is None else float(pd.param.value)
+    return None
 
 
 #: The compound callout's segments: ``(name, head, dependents)``.
@@ -113,6 +123,17 @@ def _refuse_headless_callout(group: DimensionGroup) -> None:
         for _name, head, dependents in _CALLOUT_SEGMENTS[1:]
         for label in _printing(group, head, *dependents)
     ]
+    # Not every dependent is a dimension. The thread spec and a pattern's count/suffix ride the
+    # same string and live on the FEATURE, so they survive any amount of parameter suppression
+    # and would be discarded in silence — the very outcome the head rule exists to prevent
+    # (#920 review). They are dependents of the head exactly as a counterbore is.
+    feat = group.feature
+    hole = feat.member if isinstance(feat, PatternFeature) else feat
+    thread = getattr(hole, "thread", None)
+    if thread:
+        across.append(f"the thread spec {thread}")
+    if isinstance(feat, PatternFeature) and (feat.count or 0) > 1:
+        across.append(f"the {feat.count}× pattern")
     if not across:
         return  # the whole callout is suppressed — coherent, and nothing to print
     raise ValueError(

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -1,0 +1,166 @@
+"""The compound hole-callout specification — one reading of a plan, two consumers.
+
+`⌀20 THRU ⌴ ⌀32 ↓ 1.5` is assembled twice in this engine: once by the renderer that draws it,
+and once by the page/scale estimator that must reserve the right width for it before any
+geometry exists (#261's estimator/render agreement). Those were separate implementations, and
+they drifted — the estimator still inferred `THRU` from a missing depth parameter after #868
+fixed that inference in the renderer, and it ignored `suppressed` entirely after #875 taught
+the renderer to honour it. A callout could therefore be reserved 33 mm of strip and rendered
+at 14 mm.
+
+So the reading lives here, in the IR waist, below both consumers (`compose` ranks 2,
+`annotations` ranks 4, `model` ranks 0). The renderer turns the spec into a `HoleCallout`; the
+estimator turns the same spec into token widths. Neither re-derives it.
+
+The governing rule (ADR 0016): **no renderer may infer an engineering fact from the presence or
+absence of a dimension parameter.** Parameters carry values for display; facts live on the
+feature. `through` is read off the feature for exactly this reason.
+"""
+
+from __future__ import annotations
+
+from draftwright._geometry import _fmt
+from draftwright.model.ir import HoleFeature, PatternFeature
+from draftwright.model.planner import DimensionGroup
+
+
+def _planned(group: DimensionGroup, kind: str, *roles: str):
+    """First PLANNED dimension matching *kind* and any of *roles*, in role order — suppressed
+    or not. The lookup suppression is decided against; :func:`_first` is what honours it."""
+    for role in roles:
+        for pd in group.dims:
+            if pd.param.kind == kind and pd.param.role == role:
+                return pd
+    return None
+
+
+def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
+    """First **unsuppressed** parameter value matching *kind* and any of *roles*, in role order.
+
+    Honouring ``suppressed`` here is ADR 0016 / #875. Thirteen render sites already skipped
+    suppressed dimensions; the compound-callout path did not, so a suppressed segment still
+    printed. Suppression MARKS a dimension rather than removing it (the group keeps its
+    engineering data either way) — what changes is whether it reaches the page."""
+    pd = _planned(group, kind, *roles)
+    return None if pd is None or pd.suppressed else pd.param.value
+
+
+#: The compound callout's segments, each as the (kind, role) parameters that make it readable.
+#: A segment is ATOMIC: `⌴ ⌀32 ↓ 1.5` needs both terms, and half of it is not a shorter callout,
+#: it is a different and wrong one. The bore is listed first because it also heads the string.
+_CALLOUT_SEGMENTS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
+    ("bore", (("diameter", "bore"),)),
+    ("counterbore", (("diameter", "counterbore"), ("depth", "counterbore"))),
+    ("spotface", (("diameter", "spotface"), ("depth", "spotface"))),
+    ("countersink", (("diameter", "countersink"), ("angle", "countersink"))),
+)
+
+
+def _segment_state(group: DimensionGroup, params) -> tuple[list[str], list[str]]:
+    """(present-and-printing, present-but-suppressed) for one segment's parameters."""
+    printing: list[str] = []
+    suppressed: list[str] = []
+    for kind, role in params:
+        pd = _planned(group, kind, role)
+        if pd is None:
+            continue
+        (suppressed if pd.suppressed else printing).append(f"{role}.{kind}")
+    return printing, suppressed
+
+
+def _refuse_headless_callout(group: DimensionGroup, bore_pd=None) -> None:
+    """Raise if suppression would leave part of a compound callout orphaned (ADR 0016 / #875).
+
+    Two ways that happens, and they are the same rule at two scales:
+
+    - **Within a segment.** Suppressing `counterbore.diameter` while its depth survives leaves
+      a depth with nothing to be the depth OF, and the renderer would quietly drop both.
+    - **Across segments.** The bore ⌀ heads the string, so suppressing it while a counterbore or
+      countersink segment prints leaves those with no callout to attach to.
+
+    Raising is the only option that keeps the author in control. Lint-and-drop silently discards
+    intent they expressed; implicitly restoring the missing term makes the drawing say something
+    the script does not. Suppressing a whole segment — or the whole callout — is coherent and
+    stays silent, because nothing is orphaned.
+
+    The first version of this check only guarded the bore head, which left the within-segment
+    case doing exactly the silent discard the rule exists to forbid (PR #920 review).
+    """
+    for name, params in _CALLOUT_SEGMENTS:
+        printing, suppressed = _segment_state(group, params)
+        if suppressed and printing:
+            raise ValueError(
+                f"suppressing {', '.join(suppressed)} would leave {', '.join(printing)} with "
+                f"nothing to attach to — a {name} reads as one term. Suppress the whole segment, "
+                "or keep it whole."
+            )
+
+    bore_printing, bore_suppressed = _segment_state(group, (("diameter", "bore"),))
+    if not bore_suppressed or bore_printing:
+        return
+    orphans = [
+        label
+        for _name, params in _CALLOUT_SEGMENTS[1:]
+        for label in _segment_state(group, params)[0]
+    ]
+    if not orphans:
+        return  # the whole callout is suppressed — coherent, and nothing to print
+    raise ValueError(
+        f"suppressing the bore diameter would leave {', '.join(orphans)} with no callout to "
+        "head. A compound callout reads as one string, so its leading ⌀ is a dependency: "
+        "suppress those segments too, or keep the bore ⌀."
+    )
+
+
+def hole_callout_spec(group: DimensionGroup) -> dict | None:
+    """A hole/pattern group's plan → `HoleCallout` kwargs, mirroring the engine's
+    convention. ``None`` if not a hole-bearing callout.
+
+    From the plan: bore from `DimParameter` roles; the cbore/spotface *step* with
+    counterbore precedence (``step = cbore or spotface``, as the engine does);
+    ``count`` and the pattern *suffix* (``EQ SP ON ø50 BC`` / ``(3×3)``) from the
+    source feature.
+
+    ``through`` is read off the FEATURE, never inferred from a missing bore-depth
+    param (#868). `HoleFeature.parameters()` only emits the depth for a blind hole,
+    so absence-as-signal would make any consumer that filters the parameter list —
+    ADR 0016 suppression above all — silently render a blind hole as ``THRU``. The
+    rule that follows (ADR 0016): a renderer may not infer an engineering *fact*
+    from the presence or absence of a dimension parameter — parameters carry values
+    for display, facts live on the feature."""
+    feat = group.feature
+    if not isinstance(feat, HoleFeature | PatternFeature):
+        return None
+    _refuse_headless_callout(group)  # every segment, not just the head — see the docstring
+    bore_pd = _planned(group, "diameter", "bore")
+    bore = _first(group, "diameter", "bore")
+    if bore is None:
+        return None
+    bore_tol = bore_pd.param.tolerance if bore_pd is not None else None
+    depth = _first(group, "depth", "bore")
+    count = feat.count
+    suffix = None
+    if isinstance(feat, PatternFeature):
+        if feat.pattern == "bolt_circle" and feat.bcd is not None:
+            suffix = f"EQ SP ON ø{_fmt(feat.bcd)} BC"
+        elif feat.pattern == "grid" and feat.rows and feat.cols:
+            suffix = f"({feat.rows}×{feat.cols})"
+    # A thread spec (#764) folds onto the compound callout — it lives on the bore hole
+    # (the pattern's member for a threaded array). Lead with it (the tap/thread is the
+    # defining call), then any pattern suffix: e.g. "M3x0.5" or "M3x0.5 EQ SP ON ø50 BC".
+    hole = feat.member if isinstance(feat, PatternFeature) else feat
+    thread = getattr(hole, "thread", None)
+    suffix = " ".join(p for p in (thread, suffix) if p) or None
+    return {
+        "diameter": bore,
+        "count": count if count and count > 1 else None,
+        "through": hole.through,  # the feature's fact, not the param list's shape (#868)
+        "depth": depth,
+        # counterbore precedence, spotface fallback — the engine's mapping
+        "cbore_dia": _first(group, "diameter", "counterbore", "spotface"),
+        "cbore_depth": _first(group, "depth", "counterbore", "spotface"),
+        "csink_dia": _first(group, "diameter", "countersink"),
+        "csink_angle": _first(group, "angle", "countersink"),
+        "suffix": suffix,
+        "tolerance": bore_tol,  # P2a: ± on the bore ⌀, baked into the callout string below
+    }

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -1,0 +1,162 @@
+"""Suppression MARKS a dimension; it does not filter the group (ADR 0016 / #875).
+
+The rule the whole ADR rests on:
+
+> **No renderer may infer an engineering fact from the presence or absence of a dimension
+> parameter.** Parameters carry values *for display*; facts live on the feature.
+
+Two mechanics follow, and this file pins both.
+
+**Suppression is honoured everywhere.** `PlannedDimension` has carried `suppressed`/`reason`
+for some time and thirteen render sites already skipped them. The compound-callout path
+(`_first` → `hole_callout_spec`) was the one reader that did not, so a suppressed counterbore
+still printed. The group keeps its engineering data either way — what suppression changes is
+whether a value reaches the page, which is why "marks, not filters" is the accurate verb.
+
+**The head of a compound callout is a declared dependency.** `⌀20 THRU ⌴ ⌀32 ↓ 1.5` has no
+reading with its leading term removed, so suppressing the bore ⌀ while a counterbore or
+countersink intent remains raises. The two alternatives were rejected on the same ground:
+lint-and-drop silently discards authored intent, and implicitly restoring the head makes the
+drawing say something the script does not.
+
+The gate, from #875: **a blind hole never prints `THRU` under any suppression combination.**
+That is the #868 rule under adversarial pressure — `through` is read off the feature, so no
+amount of removing parameters can turn a blind hole into a through one.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import replace
+
+import pytest
+
+from draftwright.annotations.from_model import hole_callout_spec
+from draftwright.model import Frame, HoleFeature, PartModel
+from draftwright.model.planner import plan_dimensions
+
+_BBOX = (-45.0, -30.0, -10.0, 45.0, 30.0, 10.0)
+
+
+def _group(feature):
+    (group,) = plan_dimensions(PartModel(bbox=_BBOX, orientation="prismatic", features=[feature]))
+    return group
+
+
+def _suppress(group, *targets):
+    """Mark the named (kind, role) dimensions suppressed, as the planner would.
+
+    Rebuilds each unit from ITS OWN members. The first draft assigned the flattened `group.dims`
+    to every unit, which duplicated each dimension across the units — a two-unit group came back
+    with four dims. The tests passed anyway, because `_first` returns the first match either way;
+    that is the shape of a harness bug that hides the very thing it exists to measure.
+    """
+    wanted = set(targets)
+    units = tuple(
+        replace(
+            unit,
+            members=tuple(
+                replace(pd, suppressed=True, reason="authored omission")
+                if (pd.param.kind, pd.param.role) in wanted
+                else pd
+                for pd in unit.members
+            ),
+        )
+        for unit in group.units
+    )
+    marked = replace(group, units=units)
+    assert sum(pd.suppressed for pd in marked.dims) == len(wanted), (
+        f"expected to suppress {sorted(wanted)}, but the group carries "
+        f"{sorted({(pd.param.kind, pd.param.role) for pd in group.dims})} — a suppression that "
+        "marks nothing would make every assertion below vacuous"
+    )
+    assert len(marked.dims) == len(group.dims), "suppressing must not add or drop dimensions"
+    return marked
+
+
+def _blind():
+    return HoleFeature(Frame((0, 0, 10), "z"), 12.0, depth=8.0, through=False)
+
+
+def _through_with_cbore():
+    return HoleFeature(Frame((0, 0, 10), "z"), 20.0, depth=None, through=True, cbore=(32.0, 1.5))
+
+
+class TestTheBlindHoleGate:
+    """#875's acceptance criterion, run over the whole power set rather than a chosen case."""
+
+    def test_a_blind_hole_never_prints_through_under_any_suppression(self):
+        group = _group(_blind())
+        suppressible = sorted({(pd.param.kind, pd.param.role) for pd in group.dims})
+        assert suppressible, "the fixture must carry parameters, or this proves nothing"
+
+        checked = 0
+        for r in range(len(suppressible) + 1):
+            for combo in itertools.combinations(suppressible, r):
+                marked = _suppress(group, *combo) if combo else group
+                spec = hole_callout_spec(marked)
+                if spec is None:
+                    continue  # the bore ⌀ itself is suppressed — nothing is printed at all
+                checked += 1
+                assert spec["through"] is False, (
+                    f"suppressing {list(combo)} made a blind hole read as THRU — a renderer "
+                    "inferred an engineering fact from a missing parameter"
+                )
+        assert checked, "every combination suppressed the callout; the gate tested nothing"
+
+    def test_suppressing_the_depth_does_not_change_the_fact(self):
+        """The specific inversion #868 fixed, now under deliberate suppression rather than the
+        planner's own choice: `through` comes off the feature, and the depth is display only."""
+        group = _suppress(_group(_blind()), ("depth", "bore"))
+        spec = hole_callout_spec(group)
+        assert spec["through"] is False
+        assert spec["depth"] is None
+
+
+class TestSuppressionIsHonoured:
+    def test_a_suppressed_counterbore_does_not_print(self):
+        group = _suppress(
+            _group(_through_with_cbore()), ("diameter", "counterbore"), ("depth", "counterbore")
+        )
+        spec = hole_callout_spec(group)
+        assert spec["cbore_dia"] is None and spec["cbore_depth"] is None
+        assert spec["diameter"] == 20.0, "the head is unaffected by suppressing a segment"
+
+    def test_the_group_keeps_its_data(self):
+        """ "Marks, not filters": the engineering data survives, so a later pass — the emitter,
+        a lint, `Drawing.drop` — can still see what was suppressed and why."""
+        group = _suppress(
+            _group(_through_with_cbore()), ("diameter", "counterbore"), ("depth", "counterbore")
+        )
+        marked = [pd for pd in group.dims if pd.suppressed]
+        assert {pd.param.role for pd in marked} == {"counterbore"}
+        assert all(pd.reason for pd in marked), "a mark without a reason cannot be explained"
+        assert all(pd.param.value is not None for pd in marked), "the value is retained"
+
+
+class TestTheHeadIsADependency:
+    def test_suppressing_the_head_alone_raises_and_names_the_orphan(self):
+        group = _suppress(_group(_through_with_cbore()), ("diameter", "bore"))
+        with pytest.raises(ValueError, match="counterbore"):
+            hole_callout_spec(group)
+
+    def test_the_message_says_what_to_do(self):
+        group = _suppress(_group(_through_with_cbore()), ("diameter", "bore"))
+        with pytest.raises(ValueError, match="suppress those segments too, or keep the bore"):
+            hole_callout_spec(group)
+
+    def test_suppressing_head_and_dependents_together_is_coherent(self):
+        """Not an error — the author asked for no callout at all, which is a thing to want."""
+        group = _suppress(
+            _group(_through_with_cbore()),
+            ("diameter", "bore"),
+            ("diameter", "counterbore"),
+            ("depth", "counterbore"),
+        )
+        assert hole_callout_spec(group) is None
+
+    def test_a_plain_hole_may_suppress_its_head(self):
+        """With no dependent segment there is no dependency to violate, so the callout simply
+        does not print. The rule is about orphaning, not about the head being sacred."""
+        group = _suppress(_group(_blind()), ("diameter", "bore"))
+        assert hole_callout_spec(group) is None

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -227,6 +227,55 @@ class TestTheEstimatorAgreesWithTheRenderer:
         assert compose.hole_callout_spec is canonical
 
 
+class TestFurnitureIsSizedByTheFeature:
+    """Geometry derived from a hole's physical size must not shrink when its dimension is
+    suppressed — the governing rule applied to geometry rather than to text.
+
+    This was introduced BY the #875 fix and caught in review: making `_first` suppression-aware
+    silently changed `render_centermarks`, which used it to read the bore ⌀. A suppressed ⌀20
+    collapsed from a 42 mm centre mark to the 2.5 mm floor. Suppression expresses "do not print
+    this value", never "this hole is smaller".
+    """
+
+    class _Dwg:
+        scale = 2.0
+        draft = None
+
+        def at(self, view, *loc):
+            return (0.0, 0.0, 0.0)
+
+    @staticmethod
+    def _mark_widths(group):
+        from draftwright.annotations.from_model import render_centermarks
+
+        widths = []
+
+        class _Ctx:
+            def place(self, obj, name, **kw):
+                bbox = obj.bounding_box()
+                widths.append(round(bbox.max.X - bbox.min.X, 2))
+
+        render_centermarks(TestFurnitureIsSizedByTheFeature._Dwg(), [group], ctx=_Ctx())
+        return widths
+
+    def test_a_centre_mark_keeps_its_size_when_the_bore_is_suppressed(self):
+        feature = HoleFeature(Frame((0, 0, 10), "z"), 20.0, depth=None, through=True)
+        plain = _group(feature)
+        marked = _suppress(plain, ("diameter", "bore"))
+        assert self._mark_widths(plain) == self._mark_widths(marked)
+
+    def test_and_the_size_actually_tracks_the_diameter(self):
+        """Otherwise the test above would pass on any constant, including the 2.5 mm floor that
+        was the bug."""
+        small = self._mark_widths(
+            _group(HoleFeature(Frame((0, 0, 10), "z"), 4.0, depth=None, through=True))
+        )
+        large = self._mark_widths(
+            _group(HoleFeature(Frame((0, 0, 10), "z"), 20.0, depth=None, through=True))
+        )
+        assert small < large
+
+
 class TestTheHeadIsADependency:
     def test_suppressing_the_head_alone_raises_and_names_the_orphan(self):
         group = _suppress(_group(_through_with_cbore()), ("diameter", "bore"))

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -364,6 +364,29 @@ class TestDependentsThatAreNotDimensions:
         marked = _suppress(plain, ("diameter", "bolt_circle"))
         assert "BC" not in (hole_callout_spec(marked)["suffix"] or "")
 
+    @pytest.mark.parametrize(
+        ("kind", "kwargs", "expected"),
+        [
+            ("bolt_circle", {"pattern": "bolt_circle", "bcd": 50.0}, "EQ SP ON"),
+            ("grid", {"pattern": "grid", "rows": 1, "cols": 1}, r"\(1×1\)"),
+        ],
+    )
+    def test_a_one_member_pattern_suffix_is_a_dependent_too(self, kind, kwargs, expected):
+        """`count=1` is a legal declaration, and with it the multiplier check never fires — so
+        a one-member bolt circle silently lost its `EQ SP ON ø50 BC` when the head went. Every
+        earlier fixture used `count > 1`, where the multiplier masked the missing dependency
+        (#920 review). The SUFFIX is a dependent in its own right."""
+        from draftwright.model import PatternFeature
+
+        member = HoleFeature(Frame((0, 0, 10), "z"), 6.0, depth=None, through=True)
+        pattern = PatternFeature(Frame((0, 0, 10), "z"), member=member, count=1, **kwargs)
+        plain = _group(pattern)
+        assert hole_callout_spec(plain)["suffix"], "the fixture must carry a suffix to lose"
+
+        group = _suppress(plain, ("diameter", "bore"))
+        with pytest.raises(ValueError, match=expected):
+            hole_callout_spec(group)
+
     def test_a_plain_unthreaded_hole_still_suppresses_silently(self):
         """The contrast, so the rule is not read as "the head may never be suppressed"."""
         plain = HoleFeature(Frame((0, 0, 10), "z"), 12.0, depth=None, through=True)

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -262,6 +262,28 @@ class TestTheRecessIsOneSegment:
         assert spec["cbore_dia"] == 32.0, "the counterbore still wins — its head is unsuppressed"
         assert spec["cbore_depth"] is None, "and it has no depth, rather than the spotface's"
 
+    def test_suppressing_a_shadowed_spotface_is_a_no_op(self):
+        """The counterbore wins, so the spotface is never rendered — suppressing part of it
+        orphans nothing and must not raise. Validating every role regardless produced a
+        spurious error about a term the drawing never carried (#920 review)."""
+        group = _group(self._both())
+        before = hole_callout_spec(group)
+        marked = _suppress(group, ("diameter", "spotface"))
+        assert hole_callout_spec(marked) == before
+
+    def test_but_a_shadowed_spotface_still_matters_once_it_is_uncovered(self):
+        """The contrast that keeps the exemption honest: shadowing is conditional on the
+        counterbore printing, so once its head goes the spotface is live again and its own
+        half-suppression raises."""
+        group = _suppress(
+            _group(self._both()),
+            ("diameter", "counterbore"),
+            ("depth", "counterbore"),
+            ("diameter", "spotface"),
+        )
+        with pytest.raises(ValueError, match="spotface.depth"):
+            hole_callout_spec(group)
+
     def test_terms_always_come_from_one_role(self):
         """The general property, over the whole suppression power set of both roles: whatever
         the callout prints must exist together on ONE of the two features."""

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -235,6 +235,64 @@ class TestPrecedenceRespectsSuppression:
         assert spec["cbore_dia"] is None and spec["cbore_depth"] is None
 
 
+class TestTheRecessIsOneSegment:
+    """`counterbore` takes precedence and `spotface` is the fallback — but the choice is made
+    once, for the SEGMENT, not independently for the ⌀ and the depth.
+
+    Reading the two terms through separate fallbacks let a suppressed `counterbore.depth` pair
+    the counterbore's ⌀32 with the spotface's 0.5 depth: a recess present on neither feature.
+    That is a *wrong* drawing rather than a missing one, which is the worse failure — found by
+    a 10,500-outcome review sweep, and 168 accepted combinations produced it.
+    """
+
+    @staticmethod
+    def _both():
+        return HoleFeature(
+            Frame((0, 0, 10), "z"),
+            20.0,
+            depth=None,
+            through=True,
+            cbore=(32.0, 1.5),
+            spotface=(35.0, 0.5),
+        )
+
+    def test_suppressing_the_winners_depth_does_not_borrow_the_fallbacks(self):
+        group = _suppress(_group(self._both()), ("depth", "counterbore"))
+        spec = hole_callout_spec(group)
+        assert spec["cbore_dia"] == 32.0, "the counterbore still wins — its head is unsuppressed"
+        assert spec["cbore_depth"] is None, "and it has no depth, rather than the spotface's"
+
+    def test_terms_always_come_from_one_role(self):
+        """The general property, over the whole suppression power set of both roles: whatever
+        the callout prints must exist together on ONE of the two features."""
+        feature = self._both()
+        group = _group(feature)
+        roles = [
+            ("diameter", "counterbore"),
+            ("depth", "counterbore"),
+            ("diameter", "spotface"),
+            ("depth", "spotface"),
+        ]
+        legitimate = {(32.0, 1.5), (32.0, None), (35.0, 0.5), (35.0, None), (None, None)}
+        seen = set()
+        for r in range(len(roles) + 1):
+            for combo in itertools.combinations(roles, r):
+                marked = _suppress(group, *combo) if combo else group
+                try:
+                    spec = hole_callout_spec(marked)
+                except ValueError:
+                    continue
+                if spec is None:
+                    continue
+                pair = (spec["cbore_dia"], spec["cbore_depth"])
+                assert pair in legitimate, (
+                    f"suppressing {list(combo)} produced recess {pair}, which exists on neither "
+                    "the counterbore (32.0, 1.5) nor the spotface (35.0, 0.5)"
+                )
+                seen.add(pair)
+        assert {(32.0, 1.5), (35.0, 0.5)} <= seen, "the sweep never exercised either role intact"
+
+
 class TestDependentsThatAreNotDimensions:
     """Not everything riding the callout string is a dimension parameter. A thread spec and a
     pattern's `4× … EQ SP ON ⌀50 BC` live on the FEATURE, so they survive any amount of

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -98,19 +98,26 @@ class TestTheBlindHoleGate:
         suppressible = sorted({(pd.param.kind, pd.param.role) for pd in group.dims})
         assert suppressible, "the fixture must carry parameters, or this proves nothing"
 
-        checked = 0
+        printed = refused = silent = 0
         for r in range(len(suppressible) + 1):
             for combo in itertools.combinations(suppressible, r):
                 marked = _suppress(group, *combo) if combo else group
-                spec = hole_callout_spec(marked)
+                try:
+                    spec = hole_callout_spec(marked)
+                except ValueError:
+                    refused += 1  # an orphaned term — an authoring error, and not a THRU
+                    continue
                 if spec is None:
-                    continue  # the bore ⌀ itself is suppressed — nothing is printed at all
-                checked += 1
+                    silent += 1  # the whole callout is suppressed — nothing is printed
+                    continue
+                printed += 1
                 assert spec["through"] is False, (
                     f"suppressing {list(combo)} made a blind hole read as THRU — a renderer "
                     "inferred an engineering fact from a missing parameter"
                 )
-        assert checked, "every combination suppressed the callout; the gate tested nothing"
+        assert printed, "every combination refused or fell silent; the gate tested nothing"
+        assert refused, "no combination orphaned a term — the segment rule is not being exercised"
+        assert silent, "no combination suppressed the callout entirely"
 
     def test_suppressing_the_depth_does_not_change_the_fact(self):
         """The specific inversion #868 fixed, now under deliberate suppression rather than the
@@ -152,19 +159,21 @@ class TestSegmentsAreAtomic:
     dropped the whole counterbore — authored intent gone, no error, no mark on the drawing.
     """
 
-    @pytest.mark.parametrize(
-        ("suppress", "survivor"),
-        [
-            (("diameter", "counterbore"), "counterbore.depth"),
-            (("depth", "counterbore"), "counterbore.diameter"),
-        ],
-    )
-    def test_suppressing_half_a_segment_raises(self, suppress, survivor):
-        group = _suppress(_group(_through_with_cbore()), suppress)
+    def test_suppressing_a_segments_head_orphans_its_dependents(self):
+        group = _suppress(_group(_through_with_cbore()), ("diameter", "counterbore"))
         with pytest.raises(ValueError, match="nothing to attach to"):
             hole_callout_spec(group)
 
-    def test_the_message_names_both_sides(self):
+    def test_suppressing_a_dependent_is_legitimate(self):
+        """The asymmetry, and the correction to an earlier draft of this file that demanded a
+        raise here too: `⌴ ⌀32` is a readable counterbore with unstated depth, whereas
+        `⌴ ↓ 1.5` is not a counterbore at all. The dependency runs one way."""
+        group = _suppress(_group(_through_with_cbore()), ("depth", "counterbore"))
+        spec = hole_callout_spec(group)
+        assert spec["cbore_dia"] == 32.0
+        assert spec["cbore_depth"] is None
+
+    def test_the_message_names_the_orphan(self):
         group = _suppress(_group(_through_with_cbore()), ("diameter", "counterbore"))
         with pytest.raises(ValueError, match="counterbore.depth"):
             hole_callout_spec(group)
@@ -297,10 +306,27 @@ class TestTheHeadIsADependency:
         )
         assert hole_callout_spec(group) is None
 
-    def test_a_plain_hole_may_suppress_its_head(self):
+    def test_a_plain_through_hole_may_suppress_its_head(self):
         """With no dependent segment there is no dependency to violate, so the callout simply
-        does not print. The rule is about orphaning, not about the head being sacred."""
+        does not print. The rule is about orphaning, not about the head being sacred.
+
+        A THROUGH hole, deliberately: the first version of this test used a blind one and so
+        enshrined a bug — a blind hole carries a `bore.depth`, which suppressing the ⌀ alone
+        left orphaned and silently discarded (PR #920 review). The case below covers that."""
+        plain = HoleFeature(Frame((0, 0, 10), "z"), 12.0, depth=None, through=True)
+        group = _suppress(_group(plain), ("diameter", "bore"))
+        assert hole_callout_spec(group) is None
+
+    def test_suppressing_a_blind_bore_diameter_orphans_its_depth(self):
+        """`⌀12 ↓ 8` is one term. Suppressing the ⌀ while the depth survives is the same
+        half-segment error the counterbore case raises on — the bore is not exempt from its
+        own rule just because it also heads the string."""
         group = _suppress(_group(_blind()), ("diameter", "bore"))
+        with pytest.raises(ValueError, match="nothing to attach to"):
+            hole_callout_spec(group)
+
+    def test_a_blind_hole_may_suppress_its_whole_bore_segment(self):
+        group = _suppress(_group(_blind()), ("diameter", "bore"), ("depth", "bore"))
         assert hole_callout_spec(group) is None
 
 

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -315,8 +315,32 @@ class TestDependentsThatAreNotDimensions:
             Frame((0, 0, 10), "z"), member=member, count=4, pattern="bolt_circle", bcd=50.0
         )
         group = _suppress(_group(pattern), ("diameter", "bore"))
-        with pytest.raises(ValueError, match="pattern"):
+        with pytest.raises(ValueError, match="4× multiplier"):
             hole_callout_spec(group)
+
+    def test_a_grouped_plain_hole_counts_too(self):
+        """`4× ⌀6 THRU` is a plain `HoleFeature` with a count, not a `PatternFeature` — the
+        multiplier is a dependent of the head for both kinds. Guarding only patterns silently
+        discarded the `4×` (#920 review)."""
+        grouped = HoleFeature(Frame((0, 0, 10), "z"), 6.0, depth=None, through=True, count=4)
+        group = _suppress(_group(grouped), ("diameter", "bore"))
+        with pytest.raises(ValueError, match="4× multiplier"):
+            hole_callout_spec(group)
+
+    def test_a_suppressed_bolt_circle_diameter_does_not_print(self):
+        """The BCD is an addressable dimension (`bolt_circle.diameter`). Reading `feat.bcd`
+        unconditionally bypassed its mark, so `EQ SP ON ø50 BC` printed on a callout that had
+        asked not to carry it — a 38.4 mm callout where 16.3 mm was intended."""
+        from draftwright.model import PatternFeature
+
+        member = HoleFeature(Frame((0, 0, 10), "z"), 6.0, depth=None, through=True)
+        pattern = PatternFeature(
+            Frame((0, 0, 10), "z"), member=member, count=4, pattern="bolt_circle", bcd=50.0
+        )
+        plain = _group(pattern)
+        assert "BC" in (hole_callout_spec(plain)["suffix"] or "")
+        marked = _suppress(plain, ("diameter", "bolt_circle"))
+        assert "BC" not in (hole_callout_spec(marked)["suffix"] or "")
 
     def test_a_plain_unthreaded_hole_still_suppresses_silently(self):
         """The contrast, so the rule is not read as "the head may never be suppressed"."""

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -22,6 +22,14 @@ drawing say something the script does not.
 The gate, from #875: **a blind hole never prints `THRU` under any suppression combination.**
 That is the #868 rule under adversarial pressure — `through` is read off the feature, so no
 amount of removing parameters can turn a blind hole into a through one.
+
+**Why these tests construct suppression by hand.** No user-facing path can suppress a hole
+parameter yet: the planner suppresses only envelope spans, and `add_dimension()` can merely
+CLEAR a suppression. Authored suppression-by-omission is #876. So #875 lands the mechanism
+that makes suppression safe *before* anything can reach it, and these tests exercise it at the
+level where it lives — hand-built planner output. When #876 arrives, this file is where the
+end-to-end cases belong, and `test_suppression_is_still_unreachable_from_a_user_path` below is
+the reminder: it fails the moment a real path can produce one.
 """
 
 from __future__ import annotations
@@ -134,6 +142,91 @@ class TestSuppressionIsHonoured:
         assert all(pd.param.value is not None for pd in marked), "the value is retained"
 
 
+class TestSegmentsAreAtomic:
+    """A segment is one term: `⌴ ⌀32 ↓ 1.5` needs both halves, and half of it is not a shorter
+    callout but a different and wrong one.
+
+    The first version of the dependency rule guarded only the bore head, which left this case
+    doing exactly the silent discard the rule exists to forbid: suppressing `counterbore.diameter`
+    while its depth survived produced `cbore_dia=None, cbore_depth=1.5`, and the renderer quietly
+    dropped the whole counterbore — authored intent gone, no error, no mark on the drawing.
+    """
+
+    @pytest.mark.parametrize(
+        ("suppress", "survivor"),
+        [
+            (("diameter", "counterbore"), "counterbore.depth"),
+            (("depth", "counterbore"), "counterbore.diameter"),
+        ],
+    )
+    def test_suppressing_half_a_segment_raises(self, suppress, survivor):
+        group = _suppress(_group(_through_with_cbore()), suppress)
+        with pytest.raises(ValueError, match="nothing to attach to"):
+            hole_callout_spec(group)
+
+    def test_the_message_names_both_sides(self):
+        group = _suppress(_group(_through_with_cbore()), ("diameter", "counterbore"))
+        with pytest.raises(ValueError, match="counterbore.depth"):
+            hole_callout_spec(group)
+
+    def test_a_countersink_is_atomic_too(self):
+        feature = HoleFeature(
+            Frame((0, 0, 10), "z"), 20.0, depth=None, through=True, csink=(30.0, 90.0)
+        )
+        group = _suppress(_group(feature), ("diameter", "countersink"))
+        with pytest.raises(ValueError, match="nothing to attach to"):
+            hole_callout_spec(group)
+
+    def test_a_whole_segment_may_be_suppressed(self):
+        """The contrast: nothing is orphaned, so nothing raises and the callout simply loses
+        that term. This is what suppression is FOR."""
+        group = _suppress(
+            _group(_through_with_cbore()), ("diameter", "counterbore"), ("depth", "counterbore")
+        )
+        spec = hole_callout_spec(group)
+        assert spec["cbore_dia"] is None and spec["cbore_depth"] is None
+        assert spec["diameter"] == 20.0
+
+
+class TestTheEstimatorAgreesWithTheRenderer:
+    """The page/scale estimator reserves strip width for a callout before any geometry exists
+    (#261's estimator/render agreement). It used to re-derive the callout itself, and the two
+    drifted: the estimator inferred `THRU` from a missing depth — the inference #868 removed
+    from the renderer — and ignored `suppressed` entirely. A blind hole with its depth
+    suppressed was reserved 12.8 mm and rendered at 6.1 mm.
+
+    Both now read one spec, so the classes of drift are structurally gone rather than fixed
+    twice. These tests pin the two that were observed.
+    """
+
+    @staticmethod
+    def _estimate(group):
+        from draftwright.compose import _est_planned_bore_callout_width
+
+        return _est_planned_bore_callout_width(
+            [group], font_size=2.5, pad_around_text=0.5, draft=None
+        )
+
+    def test_a_blind_hole_is_not_reserved_room_for_THRU(self):
+        plain = _group(_blind())
+        marked = _suppress(plain, ("depth", "bore"))
+        assert hole_callout_spec(marked)["through"] is False
+        # THRU is four glyphs; reserving them for a hole that prints none is the drift.
+        assert self._estimate(marked) < self._estimate(plain)
+
+    def test_a_suppressed_counterbore_is_not_reserved(self):
+        plain = _group(_through_with_cbore())
+        marked = _suppress(plain, ("diameter", "counterbore"), ("depth", "counterbore"))
+        assert self._estimate(marked) < self._estimate(plain)
+
+    def test_the_estimator_sees_the_same_spec_the_renderer_does(self):
+        """The structural claim, not just its two symptoms: one reading, two consumers."""
+        import draftwright.compose as compose
+        from draftwright.model.callout import hole_callout_spec as canonical
+
+        assert compose.hole_callout_spec is canonical
+
+
 class TestTheHeadIsADependency:
     def test_suppressing_the_head_alone_raises_and_names_the_orphan(self):
         group = _suppress(_group(_through_with_cbore()), ("diameter", "bore"))
@@ -160,3 +253,30 @@ class TestTheHeadIsADependency:
         does not print. The rule is about orphaning, not about the head being sacred."""
         group = _suppress(_group(_blind()), ("diameter", "bore"))
         assert hole_callout_spec(group) is None
+
+
+def test_suppression_is_still_unreachable_from_a_user_path():
+    """Pins the honest scope of #875 (PR #920 review).
+
+    Nothing a user can write suppresses a hole parameter today — the planner suppresses only
+    envelope spans, and `add_dimension()` only clears suppression. So the raising above is a
+    mechanism waiting for #876, not a live authoring error, and this file's hand-built groups
+    are the right level to test it at.
+
+    This fails when that stops being true, which is exactly when end-to-end cases become
+    possible and should be written.
+    """
+    from build123d import Box, Cylinder, Pos
+
+    from draftwright import Sheet
+
+    part = Box(90, 60, 20) - Pos(0, 0, 12) * Cylinder(6, 20)
+    sheet = Sheet(part, title="T", number="N")
+    sheet.hole(diameter=12, at=(0, 0, 20), axis="z").depth(8)
+    groups = plan_dimensions(sheet.model())
+    assert not [
+        pd for g in groups for pd in g.dims if pd.suppressed and g.feature.kind == "hole"
+    ], (
+        "a hole parameter is now suppressible from a declared Sheet — #876 has landed, so this "
+        "file should grow end-to-end suppression cases and this guard should go"
+    )

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -197,6 +197,76 @@ class TestSegmentsAreAtomic:
         assert spec["diameter"] == 20.0
 
 
+class TestPrecedenceRespectsSuppression:
+    """The counterbore/spotface roles are a FALLBACK CHAIN, so suppression has to be applied
+    per role before the precedence between them — otherwise a suppressed counterbore swallows
+    the spotface that should have taken its place (#920 review). The first draft resolved
+    precedence first and nulled the winner, which dropped an unsuppressed spotface in silence.
+    """
+
+    @staticmethod
+    def _both():
+        return HoleFeature(
+            Frame((0, 0, 10), "z"),
+            20.0,
+            depth=None,
+            through=True,
+            cbore=(32.0, 1.5),
+            spotface=(35.0, 0.5),
+        )
+
+    def test_a_suppressed_counterbore_falls_through_to_the_spotface(self):
+        group = _group(self._both())
+        assert hole_callout_spec(group)["cbore_dia"] == 32.0, "counterbore wins when both print"
+        marked = _suppress(group, ("diameter", "counterbore"), ("depth", "counterbore"))
+        spec = hole_callout_spec(marked)
+        assert spec["cbore_dia"] == 35.0, "the spotface is the documented fallback"
+        assert spec["cbore_depth"] == 0.5
+
+    def test_suppressing_both_leaves_neither(self):
+        group = _suppress(
+            _group(self._both()),
+            ("diameter", "counterbore"),
+            ("depth", "counterbore"),
+            ("diameter", "spotface"),
+            ("depth", "spotface"),
+        )
+        spec = hole_callout_spec(group)
+        assert spec["cbore_dia"] is None and spec["cbore_depth"] is None
+
+
+class TestDependentsThatAreNotDimensions:
+    """Not everything riding the callout string is a dimension parameter. A thread spec and a
+    pattern's `4× … EQ SP ON ⌀50 BC` live on the FEATURE, so they survive any amount of
+    parameter suppression — and would then be discarded in silence when the head goes, which is
+    the exact outcome the head rule exists to prevent (#920 review)."""
+
+    def test_suppressing_the_head_of_a_threaded_hole_raises(self):
+        threaded = HoleFeature(
+            Frame((0, 0, 10), "z"), 10.0, depth=None, through=True, thread="M10x1.5"
+        )
+        group = _suppress(_group(threaded), ("diameter", "bore"))
+        with pytest.raises(ValueError, match="M10x1.5"):
+            hole_callout_spec(group)
+
+    def test_suppressing_the_head_of_a_pattern_raises(self):
+        from draftwright.model import PatternFeature
+
+        member = HoleFeature(Frame((0, 0, 10), "z"), 6.0, depth=None, through=True)
+        pattern = PatternFeature(
+            Frame((0, 0, 10), "z"), member=member, count=4, pattern="bolt_circle", bcd=50.0
+        )
+        group = _suppress(_group(pattern), ("diameter", "bore"))
+        with pytest.raises(ValueError, match="pattern"):
+            hole_callout_spec(group)
+
+    def test_a_plain_unthreaded_hole_still_suppresses_silently(self):
+        """The contrast, so the rule is not read as "the head may never be suppressed"."""
+        plain = HoleFeature(Frame((0, 0, 10), "z"), 12.0, depth=None, through=True)
+        group = _suppress(_group(plain), ("diameter", "bore"))
+        assert hole_callout_spec(group) is None
+
+
 class TestTheEstimatorAgreesWithTheRenderer:
     """The page/scale estimator reserves strip width for a callout before any geometry exists
     (#261's estimator/render agreement). It used to re-derive the callout itself, and the two


### PR DESCRIPTION
## The rule

ADR 0016 rests on one:

> **No renderer may infer an engineering fact from the presence or absence of a dimension parameter.** Parameters carry values *for display*; facts live on the feature.

Two mechanics follow.

## 1. Suppression is honoured everywhere

Thirteen render sites already skipped suppressed dimensions. The compound-callout path did not — `_first` walked `group.dims` and returned the first match regardless — so a suppressed counterbore still printed.

It now consults the flag, with `_planned` kept beside it as the deliberate **raw** lookup. Suppression has to be *decided against* somewhere; separating the two makes which is which explicit rather than leaving a caller to wonder whether a given lookup was filtered.

## 2. The head of a compound callout is a declared dependency

`⌀20 THRU ⌴ ⌀32 ↓ 1.5` has no reading with its leading term removed. So suppressing the bore ⌀ while a counterbore, spotface or countersink segment remains **raises**, naming the orphan and saying what to do about it.

Both alternatives lose information the author supplied:

- **lint-and-drop** silently discards authored intent
- **implicit restore** makes the drawing say something the script does not

Suppressing the head *and* its dependents together is coherent and stays silent — the rule is about orphaning, not about the head being sacred.

## The gate

> a blind hole never prints `THRU` under any suppression combination

Tested over the **whole power set** of the hole's parameters rather than a chosen case, with a guard that fails if every combination happened to suppress the callout entirely (otherwise the gate could pass by testing nothing).

## Verification

Mutation-verified both mechanics: `_first` ignoring the flag fails 4 tests; dropping the head-dependency check fails 2.

One harness bug found and fixed **before** review: `_suppress` assigned the flattened `group.dims` to every unit, so a two-unit group came back with four dims. The tests passed anyway — `_first` returns the first match either way — which is exactly the shape of a harness bug that hides what it exists to measure. It now rebuilds each unit from its own members and asserts the dimension count is unchanged.

538 targeted tests pass; lint 4/4.

Closes #875.