### PR TITLE
feat(#874/#876): a build must say where its dimensions come from

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ dwg = build_drawing("part.step")            # or build_drawing(a_build123d_solid
 dwg.export("out", formats=("pdf", "png"))
 
 # 2. Declared — the Sheet façade (ADR 0011). Statement-style: declare features + aspects on `s`.
-s = Sheet(solid)                            # declare against the build123d part
+s = Sheet(solid).auto_dimensions()          # declare against the part; state the dim source
 h = s.hole(hole_solid)                      # returns a handle you can keep
 h.fit("H7")                                 # aspects: .fit/.tolerance/.note/.thread/.finish/…
 s.slot(slot_solid)
@@ -75,7 +75,7 @@ Use the declared surface — there is deliberately **no** public "add a raw fram
 the controlled **feature first**, then target it (a handle, `Feature`, index, or a face):
 
 ```python
-s = Sheet(solid)
+s = Sheet(solid).auto_dimensions()
 hole = s.hole(hole_solid)                   # the feature the tolerance controls
 s.datum("A", top_face)
 s.control(hole).position(0.1, to="A").perpendicularity(0.05, to="A")  # chain characteristics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
   exactly one place. It changes *selection*, not derivation — a request can never
   introduce a number the part does not have. Requesting something the planner already
   emits is a deliberate no-op, so a script can ask without first knowing the rule set's
-  mind. `sheet.auto_dimensions()` states the source explicitly (optional in this
-  release; #874 makes it mandatory).
+  mind. It augments the planner's set, so it requires `sheet.auto_dimensions()` — see
+  the mandatory dimension source below.
 - **A build must say where its dimensions come from — BREAKING** (ADR 0016 /
   #874/#876). The dimension set has exactly two sources and the script always says
   which: `sheet.auto_dimensions()` for the planner's selected set (optionally augmented
@@ -25,7 +25,15 @@
   planned suppressed with a reason and keeps its value — marked, not filtered — so the
   group retains its engineering data and a compound callout still refuses to orphan half
   a term. This is what makes the mandatory source worth having: omission only means
-  something inside a set declared complete.
+  something inside a set declared complete. The overall height, the prismatic step
+  rungs and the step-position shoulders honour it too: those passes rebuilt their marks
+  from the feature and the bounding box, so the plan said "omitted" while the page still
+  carried the dimension. Correlated sets are kept or dropped **whole** — one
+  `dimension(step, "step_height")` line addresses the whole ladder, never a rung.
+  A model that declares no envelope has no parameter naming its overall height, so an
+  authored build no longer draws the bounding-box fallback: declare `.envelope()` to
+  make it nameable. Location dimensions stay outside the authored set until they have
+  addressable identity (#883).
 - **Suppressing a dimension marks it; it no longer leaks into the callout** (ADR 0016 /
   #875). `PlannedDimension.suppressed` was honoured at thirteen render sites but not by
   the compound hole-callout path, so a suppressed counterbore still printed. The group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@
   emits is a deliberate no-op, so a script can ask without first knowing the rule set's
   mind. `sheet.auto_dimensions()` states the source explicitly (optional in this
   release; #874 makes it mandatory).
+- **A build must say where its dimensions come from — BREAKING** (ADR 0016 /
+  #874/#876). The dimension set has exactly two sources and the script always says
+  which: `sheet.auto_dimensions()` for the planner's selected set (optionally augmented
+  by `add_dimension`), or `sheet.dimension(feature, role)` declarations for the
+  **complete authored set**. Mixing the two raises, and so does building with neither —
+  `Sheet(part).build()` no longer auto-dimensions by default. `Sheet.from_part()` states
+  the automatic source itself, since asking for detection is asking for the engine's
+  reading of the part. **Migration:** add `.auto_dimensions()` to any `Sheet(...)` you
+  build; generated scripts already emit it.
+- **Suppression by omission** (#876): a measurement left out of an authored set is
+  planned suppressed with a reason and keeps its value — marked, not filtered — so the
+  group retains its engineering data and a compound callout still refuses to orphan half
+  a term. This is what makes the mandatory source worth having: omission only means
+  something inside a set declared complete.
 - **Suppressing a dimension marks it; it no longer leaks into the callout** (ADR 0016 /
   #875). `PlannedDimension.suppressed` was honoured at thirteen render sites but not by
   the compound hole-callout path, so a suppressed counterbore still printed. The group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@
   exactly these" back into "draw everything" on re-run; emitting those declarations needs
   nameable feature identity in the generated script (#922). The `--script` path is
   unaffected — it emits from a detected model.
+- **`Sheet.from_part(...)` can be taken over by an authored set**: detect the features,
+  then declare exactly which of their measurements to draw. `from_part` chooses the
+  automatic source on the caller's behalf, so adding `dimension(...)` lines overrides it
+  rather than conflicting; an explicit `auto_dimensions()` still conflicts, because there
+  the script has said both things. A `callout()` naming a feature the authored set omitted
+  is refused in both the live and deferred paths rather than silently drawing nothing.
 - **Suppressing a dimension marks it; it no longer leaks into the callout** (ADR 0016 /
   #875). `PlannedDimension.suppressed` was honoured at thirteen render sites but not by
   the compound hole-callout path, so a suppressed counterbore still printed. The group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,11 @@
   A model that declares no envelope has no parameter naming its overall height, so an
   authored build no longer draws the bounding-box fallback: declare `.envelope()` to
   make it nameable. Location dimensions stay outside the authored set until they have
-  addressable identity (#883).
+  addressable identity (#883). `emit_sheet_script()` refuses a model carrying an authored
+  set rather than emitting `auto_dimensions()` for it, which would have turned "draw
+  exactly these" back into "draw everything" on re-run; emitting those declarations needs
+  nameable feature identity in the generated script (#922). The `--script` path is
+  unaffected — it emits from a detected model.
 - **Suppressing a dimension marks it; it no longer leaks into the callout** (ADR 0016 /
   #875). `PlannedDimension.suppressed` was honoured at thirteen render sites but not by
   the compound hole-callout path, so a suppressed counterbore still printed. The group

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ from draftwright import Sheet
 plate = Box(120, 80, 20)
 bore = Pos(0, 0, 0) * Cylinder(4, 20)
 
-sheet = Sheet(plate - bore, title="Plate", number="DWG-002")
+sheet = Sheet(plate - bore, title="Plate", number="DWG-002").auto_dimensions()
 sheet.envelope()
 sheet.datum("A", plate.faces().sort_by()[-1])             # datum A on the top face
 hole = sheet.hole(bore).finish("1.6").note("M3x0.5 TAP")  # ⌀8 bore, Ra 1.6, tapped

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -41,6 +41,31 @@ planner's set (#872); dimension identity is `DimensionId(feature, parameter)`
 (#869/#870/#871). Location dimensions remain unaddressable (#883), and per-annotation
 provenance for compound callouts remains #886.
 
+### What the authored set governs
+
+An authored set replaces the planner's rule set for every dimension that has
+**addressable identity** — a parameter on an IR feature. Marking is not enough on its
+own: a renderer that rebuilds its marks from the feature or the bounding box never sees
+the mark, so the plan can say "omitted" while the page still carries the dimension.
+Three auto passes did exactly that until #921; they now read the plan
+(`env_dim_placed` / `set_dim_placed`), and the correlated sets — a `step_height` ladder,
+a `step_position` chain — are kept or dropped **whole**, matching the tier-3 identity
+rule that a single `role=` line addresses the set rather than a member.
+
+Two categories sit outside the set, both deliberately and both visible rather than
+silent:
+
+- **Location dimensions** have no addressable identity yet (`plan_locations` returns a
+  flat, cross-feature, ref-deduped list that never enters a `DimensionGroup`), so an
+  authored set neither names nor suppresses them. Giving them identity is a design
+  question — is a patterned hole's location one unit or one per member? — tracked as
+  **#883**, which also blocks the `"location"` role in the selector.
+- **A bounding-box fallback with no feature behind it.** A model that declares no
+  `EnvelopeFeature` still gets an overall height off the bbox, and no parameter anywhere
+  names it. Rather than let an authored drawing carry a dimension its author had no way
+  to ask for, the fallback is refused under an authored set: declaring `.envelope()` is
+  how the overall height becomes nameable. Automatic builds are unaffected.
+
 ## Context
 
 A user reading a generated `Sheet` script today sees the part's **features** — one

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -21,6 +21,26 @@
 > therefore be substantially less blocked than this ADR assumed. The constraint below is
 > flagged in step.
 
+## Implementation status (2026-07-29)
+
+**Phases 1 and 2 have landed.** The scheduling note below said phases 2–4 sat behind
+"the global recompose (#426/#707), the longest-open item on the roadmap". That premise
+was already stale when written, and the remaining question is now settled *by
+construction* rather than by waiting: suppression by omission in a `Sheet` script happens
+**before** `build()`, when the set is known at plan time, so it needed no recompose at
+all. The planner simply marks every measurement outside the authored set as suppressed
+(#875's marking + #874's mandatory source + #876's omission semantics).
+
+What genuinely still needs the recompose is the narrower case this ADR conflated with it:
+`Drawing.finalize()` dropping an *automatic* dimension **after** the solve has run. That
+is a different problem and does not gate the authoring surface.
+
+Also landed: the referential verb took the plain name (`Sheet.dimension`), and the
+materialized one became `Sheet.measured_dimension` (#873); `add_dimension` augments the
+planner's set (#872); dimension identity is `DimensionId(feature, parameter)`
+(#869/#870/#871). Location dimensions remain unaddressable (#883), and per-annotation
+provenance for compound callouts remains #886.
+
 ## Context
 
 A user reading a generated `Sheet` script today sees the part's **features** — one

--- a/docs/multi-feature-object-reference-workflow.md
+++ b/docs/multi-feature-object-reference-workflow.md
@@ -83,7 +83,7 @@ instead of the parametrised function itself.
 from draftwright import Sheet
 
 features = build_thumbwheel_features()
-sheet = Sheet(features.body, title="THUMBWHEEL", number="DWG-001")
+sheet = Sheet(features.body, title="THUMBWHEEL", number="DWG-001").auto_dimensions()
 
 sheet.step(features.journal)
 sheet.step(features.boss)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1097,7 +1097,7 @@ def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> in
         if only is not None and g.feature not in only:  # #426 finalize: recorded subset
             continue
         dpd = next((pd for pd in g.dims if pd.param.kind == "diameter"), None)
-        if dpd is None:
+        if dpd is None or dpd.suppressed:
             continue
         dia = dpd.param.value
         # An EXTERNAL thread (#859) makes a distinct callout: a threaded ⌀6 ("ø6 M6x1") and a
@@ -1954,7 +1954,7 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
     ):
         b = g.feature
         dpd = next((pd for pd in g.dims if pd.param.kind == "diameter"), None)
-        if dpd is None:
+        if dpd is None or dpd.suppressed:
             continue
         dia = dpd.param.value
         dtol = dpd.param.tolerance
@@ -2488,7 +2488,11 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
         if only is not None and g.feature not in only:  # #426 finalize: recorded subset
             continue
         length = next(
-            (pd.param for pd in g.dims if pd.param.kind == "length" and pd.param.span is not None),
+            (
+                pd.param
+                for pd in g.dims
+                if pd.param.kind == "length" and pd.param.span is not None and not pd.suppressed
+            ),
             None,
         )
         if length is None or length.span is None:
@@ -2865,9 +2869,9 @@ def render_height_ladder(
     this pass reads the plan rather than deciding again: the rungs are the `step_level`
     feature's `step_height` set, and the overall height is the `envelope` feature's
     `height` parameter — drawn here rather than in `render_envelope` only because it
-    stacks in the front-view right strip. What stays local is the render-layer part:
-    legibility, the leapfrog chain, and `include_overall`, which is drawing state
-    rather than model state. Returns the count REGISTERED."""
+    stacks in the front-view right strip. What stays local is legibility, the leapfrog
+    chain, `include_overall` (drawing state, not model state), and the structural rules
+    for a model that has no envelope feature to consult. Returns the count REGISTERED."""
     draft = dwg.draft
     FX, FZ = a.proj.front_x, a.proj.front_z
     edge2 = FX(a.bb.max.X) + 2
@@ -3222,23 +3226,29 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
         return f"ø{_fmt(pd.param.value)}{_tol_suffix(pd.param.tolerance, draft)}"
 
     od_label = _dia_label(od_pd)
+    # The OD and each bore are planned dimensions like any other, so a set that omits
+    # one must not draw it (#876). The CENTRELINES below are furniture, not dimensions:
+    # they show where the turning axis is and stay whichever way the plan falls, or a
+    # sheet that authors no diameter would lose the axis it is turned about.
+    od_planned = not od_pd.suppressed
 
     if axis == "z":
         # Vertical turning axis (the common case): OD across the top of the front
         # (profile) view; axis centrelines vertical on front + side.
-        ctx.place(
-            _dim(
-                (FX(a.cx - od / 2), FZ(a.bb.max.Z) + 2, 0),
-                (FX(a.cx + od / 2), FZ(a.bb.max.Z) + 2, 0),
-                "above",
-                8,
-                draft,
-                label=od_label,
-            ),
-            "dim_od",
-            view="front",
-        )
-        n += 1
+        if od_planned:
+            ctx.place(
+                _dim(
+                    (FX(a.cx - od / 2), FZ(a.bb.max.Z) + 2, 0),
+                    (FX(a.cx + od / 2), FZ(a.bb.max.Z) + 2, 0),
+                    "above",
+                    8,
+                    draft,
+                    label=od_label,
+                ),
+                "dim_od",
+                view="front",
+            )
+            n += 1
         ctx.place(
             Centerline((FX(a.cx), FZ(a.bb.min.Z) - 5, 0), (FX(a.cx), FZ(a.bb.max.Z) + 5, 0)),
             "centerline_front",
@@ -3262,19 +3272,25 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
                 # leader keeps that same symmetric natural, so plan_strip reproduces the old
                 # positions exactly when there is room (zero displacement) and only compresses /
                 # drops (larger bore outranks smaller, priority=d) when the band is over capacity.
-                nb = len(rot.bores)
+                # A bore omitted from an authored set never becomes a candidate, so it
+                # neither competes for the band nor gets reported as a capacity drop —
+                # it was not wanted, which is a different thing from not fitting (#876).
+                # With nothing suppressed this is every bore in order, so the automatic
+                # stack and its positions are unchanged.
+                live = [(i, d) for i, d in enumerate(rot.bores) if not bore_pds[i].suppressed]
+                nb = len(live)
                 z_lo, z_hi = a.FV_Y - a.fv_hh, a.FV_Y + a.fv_hh
                 cands = [
                     StripCandidate(
                         key=f"{i:03d}",
-                        anchor=(elbow_x, FZ(a.cz) + (i - (nb - 1) / 2) * pitch),
+                        anchor=(elbow_x, FZ(a.cz) + (k - (nb - 1) / 2) * pitch),
                         size=(draft.font_size * 3, pitch),
                         priority=d,
                     )
-                    for i, d in enumerate(rot.bores)
+                    for k, (i, d) in enumerate(live)
                 ]
                 placed = plan_strip(cands, z_lo, z_hi, pitch, axis="y").placed
-                for i, d in enumerate(rot.bores):
+                for i, d in live:
                     tip_z = placed.get(f"{i:03d}")
                     if tip_z is None:
                         continue  # over the front-view capacity — dropped (ranked), logged below
@@ -3289,7 +3305,7 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
                         view="front",
                     )
                     n += 1
-                dropped = [d for i, d in enumerate(rot.bores) if placed.get(f"{i:03d}") is None]
+                dropped = [d for i, d in live if placed.get(f"{i:03d}") is None]
                 for d in dropped:
                     ctx.coverage.drop_diam(
                         d
@@ -3310,19 +3326,20 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
         # Horizontal turning axis along X (#222): the OD is the Z extent — a vertical
         # ø dim left of the front (profile) view; axis centrelines run horizontally
         # through z=cz on front and y=cy on plan.
-        ctx.place(
-            _dim(
-                (FX(a.bb.min.X) - 2, FZ(a.cz - od / 2), 0),
-                (FX(a.bb.min.X) - 2, FZ(a.cz + od / 2), 0),
-                "left",
-                8,
-                draft,
-                label=od_label,
-            ),
-            "dim_od",
-            view="front",
-        )
-        n += 1
+        if od_planned:
+            ctx.place(
+                _dim(
+                    (FX(a.bb.min.X) - 2, FZ(a.cz - od / 2), 0),
+                    (FX(a.bb.min.X) - 2, FZ(a.cz + od / 2), 0),
+                    "left",
+                    8,
+                    draft,
+                    label=od_label,
+                ),
+                "dim_od",
+                view="front",
+            )
+            n += 1
         ctx.place(
             Centerline((FX(a.bb.min.X) - 5, FZ(a.cz), 0), (FX(a.bb.max.X) + 5, FZ(a.cz), 0)),
             "centerline_front",
@@ -3337,19 +3354,20 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
         # Horizontal turning axis along Y (#222): the OD is the Z extent — a vertical
         # ø dim left of the side (profile) view; axis centrelines run horizontally
         # through z=cz on side and vertically through x=cx on plan.
-        ctx.place(
-            _dim(
-                (SX(a.bb.min.Y) - 2, SZ(a.cz - od / 2), 0),
-                (SX(a.bb.min.Y) - 2, SZ(a.cz + od / 2), 0),
-                "left",
-                8,
-                draft,
-                label=od_label,
-            ),
-            "dim_od",
-            view="side",
-        )
-        n += 1
+        if od_planned:
+            ctx.place(
+                _dim(
+                    (SX(a.bb.min.Y) - 2, SZ(a.cz - od / 2), 0),
+                    (SX(a.bb.min.Y) - 2, SZ(a.cz + od / 2), 0),
+                    "left",
+                    8,
+                    draft,
+                    label=od_label,
+                ),
+                "dim_od",
+                view="side",
+            )
+            n += 1
         ctx.place(
             Centerline((SX(a.bb.min.Y) - 5, SZ(a.cz), 0), (SX(a.bb.max.Y) + 5, SZ(a.cz), 0)),
             "centerline_side",

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2876,7 +2876,7 @@ def render_height_ladder(
     step = next((f for f in model.features if f.kind == "step_level"), None)
     # The rungs are one addressable set: the planner keeps or drops them together.
     rungs_planned = step is not None and set_dim_placed(groups, "step_level", "step_height")
-    levels = list(step.levels) if rungs_planned else []
+    levels = list(step.levels) if step is not None and rungs_planned else []
     step_shoulders = tuple(step.shoulders) if step is not None else ()
     short_levels: list[float] = []
     rep = _detect_step_repeat(levels, a.bb.min.Z, a.bb.max.Z) if levels else None

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1350,12 +1350,31 @@ def envelope_group(groups):
 
 
 def env_dim_placed(pd) -> bool:
-    """Whether :func:`render_envelope` will actually place an envelope dim for the
-    PlannedDimension *pd* — present, not suppressed by the planner (square footprint /
-    X-turned, #250), and carrying a span. The single source of truth for that
-    decision, shared with the orchestrator's side-below tier reservation so the two
-    can never drift (#316 review)."""
+    """Whether an envelope dim will actually be placed for the PlannedDimension *pd* —
+    present, not suppressed by the planner (square footprint / X-turned, #250; an
+    authored set's omission, #876), and carrying a span. The single source of truth
+    for that decision, shared by :func:`render_envelope` (width/depth) and
+    :func:`render_height_ladder` (the overall height, which stacks in the front-view
+    right strip rather than below a view) so the two can never drift."""
     return pd is not None and not pd.suppressed and pd.param.span is not None
+
+
+def set_dim_placed(groups, feature_kind: str, role: str) -> bool:
+    """Whether the planner left a **correlated set** to be drawn (ADR 0016 identity
+    tier 3 — a `step_height` ladder, a `step_position` shoulder chain).
+
+    Those sets are routed whole through their auto-pass renderer, which rebuilds every
+    member from the feature rather than from the plan. So the renderer asks about the
+    *set*, not a member: naming the role keeps the whole ladder, omitting it from an
+    authored set suppresses the whole ladder, exactly as ADR 0016 says a single `role=`
+    intent addresses it. Un-suppressed members are the ones that count, so a partially
+    suppressed set still draws — no auto rule suppresses a member of these sets today,
+    and if one ever does it must say what a half-ladder means rather than have this
+    silently drop it."""
+    group = next((g for g in groups if g.feature_kind == feature_kind), None)
+    if group is None:
+        return False
+    return any(pd.param.role == role and not pd.suppressed for pd in group.dims)
 
 
 def _chamfer_label(leg, ch) -> str:
@@ -2827,7 +2846,7 @@ def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):
 
 
 def render_height_ladder(
-    dwg, model, a, *, ctx, include_overall: bool = True, detail_view: bool = False
+    dwg, model, groups, a, *, ctx, include_overall: bool = True, detail_view: bool = False
 ) -> int:
     """Front-view right ladder: prismatic step heights (from `StepLevelFeature`)
     stacked inner→outer, then the overall height outermost — registered as
@@ -2840,14 +2859,24 @@ def render_height_ladder(
     footprint with the witness modelled from the view edge (a conservative
     over-cover along the stack axis; the accept-time real-box validation trims any
     drift). A turned part has no `StepLevelFeature`; a Z-turned part suppresses the
-    overall height (the chain tiles it, ISO 129). Returns the count REGISTERED."""
+    overall height (the chain tiles it, ISO 129).
+
+    Both ladders it draws belong to features the **planner** has already ruled on, so
+    this pass reads the plan rather than deciding again: the rungs are the `step_level`
+    feature's `step_height` set, and the overall height is the `envelope` feature's
+    `height` parameter — drawn here rather than in `render_envelope` only because it
+    stacks in the front-view right strip. What stays local is the render-layer part:
+    legibility, the leapfrog chain, and `include_overall`, which is drawing state
+    rather than model state. Returns the count REGISTERED."""
     draft = dwg.draft
     FX, FZ = a.proj.front_x, a.proj.front_z
     edge2 = FX(a.bb.max.X) + 2
     zmin = FZ(a.bb.min.Z)
     tier = draft.font_size + 2 * draft.pad_around_text
     step = next((f for f in model.features if f.kind == "step_level"), None)
-    levels = list(step.levels) if step is not None else []
+    # The rungs are one addressable set: the planner keeps or drops them together.
+    rungs_planned = step is not None and set_dim_placed(groups, "step_level", "step_height")
+    levels = list(step.levels) if rungs_planned else []
     step_shoulders = tuple(step.shoulders) if step is not None else ()
     short_levels: list[float] = []
     rep = _detect_step_repeat(levels, a.bb.min.Z, a.bb.max.Z) if levels else None
@@ -2906,7 +2935,21 @@ def render_height_ladder(
 
     rot = next((f for f in model.features if f.kind == "rotational"), None)
     od_is_height = rot is not None and rot.frame.axis in ("x", "y")
-    suppress_height = (not include_overall) or model.orientation == "z" or od_is_height
+    # The overall height IS the envelope's `height` parameter, so the planner owns
+    # whether it is drawn (square footprint, X/Z-turned, an authored set's omission —
+    # #876). Some models carry no `EnvelopeFeature` at all — a round body, or a Sheet
+    # that never called `.envelope()` — and then the height falls back to the bbox with
+    # no parameter anywhere to address it by. An AUTHORED build must not draw a
+    # dimension its author had no way to ask for, so the fallback is refused there:
+    # declaring `.envelope()` is how you make the overall height nameable.
+    env = envelope_group(groups)
+    if env is not None:
+        height_planned = env_dim_placed(_env_pd(env, "height"))
+    else:
+        height_planned = model.authored_dimensions is None
+    suppress_height = (
+        (not include_overall) or model.orientation == "z" or od_is_height or not height_planned
+    )
     if not suppress_height:
         chain.append(
             (
@@ -3040,7 +3083,7 @@ def render_height_ladder(
     return len(chain) + len(short_levels)
 
 
-def render_step_positions(dwg, model, a, *, ctx) -> int:
+def render_step_positions(dwg, model, groups, a, *, ctx) -> int:
     """Prismatic step POSITIONS (#555): where each shoulder sits along its axis,
     dimensioned from the part datum so a stepped block is fully constrained (the step
     heights alone leave the shoulder location implicit — two geometries draw the same
@@ -3048,10 +3091,16 @@ def render_step_positions(dwg, model, a, *, ctx) -> int:
     horizontally, where the step profile reads); an X shoulder is above the plan view —
     the same axis→view mapping the hole-location ladder uses. Mixed-axis transitions use
     the side-below strip so they do not collide with the isometric furniture above.
-    A shoulder whose strip is full drops with a lint code, not silently. Returns the
-    count placed."""
+    A shoulder whose strip is full drops with a lint code, not silently.
+
+    The shoulders are the `step_level` feature's `step_position` set — one addressable
+    dimension with N members — so, like the height ladder, this pass asks the plan
+    whether the set is drawn at all rather than deciding for itself. Returns the count
+    placed."""
     step = next((f for f in model.features if f.kind == "step_level"), None)
     if step is None or not step.shoulders:
+        return 0
+    if not set_dim_placed(groups, "step_level", "step_position"):
         return 0
     draft = dwg.draft
     axes = {axis for axis, _ in step.shoulders}

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -63,6 +63,7 @@ from draftwright.annotations.from_model import (
 )
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.model import plan_dimensions
+from draftwright.model.callout import omitted_by_the_authored_set
 from draftwright.model.ir import HoleFeature, PatternFeature
 from draftwright.model.planner import plan_locations
 
@@ -99,6 +100,13 @@ def add_feature_callout(
     group = next((g for g in plan_dimensions(model) if g.feature is feature), None)
     spec = hole_callout_spec(group) if group is not None else None
     if spec is None:
+        if omitted_by_the_authored_set(group):
+            raise ValueError(
+                f"callout(): this {type(feature).__name__} was omitted from the authored "
+                "dimension set, so the drawing has no callout to add to. Declare it with a "
+                "dimension(feature, role) line on the Sheet instead of adding it after the "
+                "build — the authored set is the drawing's complete dimensioning."
+            )
         raise ValueError(
             f"callout() draws a hole/pattern ø-depth leader callout; "
             f"{type(feature).__name__} exposes none — use dimension() for a linear param"

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -381,7 +381,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # through fv_zones.right preserving the leapfrog cursor (#237). Replaces the inline
         # dim_step_* + dim_height; the turned step-length chain (render_step_lengths) handles
         # turned parts, and a Z-turned overall height is suppressed there (ISO 129).
-        render_height_ladder(dwg, _model, a, ctx=ctx, detail_view=detail_view)
+        render_height_ladder(dwg, _model, _groups, a, ctx=ctx, detail_view=detail_view)
 
     def _s_plates():
         # Plate/wall thicknesses on a multi-plate prismatic (#559): the thin extent of each
@@ -393,7 +393,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_step_positions():
         # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a
         # stepped block is fully constrained (the heights alone leave the shoulder implicit).
-        render_step_positions(dwg, _model, a, ctx=ctx)
+        render_step_positions(dwg, _model, _groups, a, ctx=ctx)
 
     def _s_chamfers():
         # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -212,6 +212,16 @@ def _coerce_model(model, part, decorations=None, requested=None, authored=None) 
     given (a bare ``PartModel`` keeps its own decorations otherwise). A verbatim
     ``PartModel`` is never mutated — decorations merge into a copy so the caller's
     reusable public input (ADR 0011) stays clean across builds."""
+    if requested and authored is not None:
+        # The mutual exclusion is a property of the MODEL, not of the façade that usually
+        # builds it — `build_drawing(part, model=…, requested=…, authored=…)` is a public
+        # entry point (ADR 0011) and could otherwise construct the state `Sheet` refuses
+        # (#921 review). An augment only means something against a set the planner chose.
+        raise ValueError(
+            "requested= augments the planner's automatic set and authored= replaces it — a "
+            "model cannot have both. Drop the requested= entries into the authored set, or "
+            "drop authored= to keep the automatic one."
+        )
     if isinstance(model, PartModel):
         if decorations or requested or authored is not None:
             return replace(
@@ -305,7 +315,7 @@ def _assemble(
             "model builds its own feature objects that no request can target"
         )
     pm = (
-        _coerce_model(model, a.part, decorations, requested)
+        _coerce_model(model, a.part, decorations, requested, authored)
         if model is not None
         else (a.model if a.model is not None else build_model(a))
     )

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -196,7 +196,7 @@ def _measure_blocks(dwg, a) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _coerce_model(model, part, decorations=None, requested=None) -> PartModel:
+def _coerce_model(model, part, decorations=None, requested=None, authored=None) -> PartModel:
     """Wrap a caller-supplied ``model=`` (ADR 0011) into a :class:`PartModel`. A
     ``PartModel`` is used verbatim; a sequence of features is wrapped with the part's
     bbox, a default corner location datum (matching ``detect.py``, so hole location
@@ -213,13 +213,19 @@ def _coerce_model(model, part, decorations=None, requested=None) -> PartModel:
     ``PartModel`` is never mutated — decorations merge into a copy so the caller's
     reusable public input (ADR 0011) stays clean across builds."""
     if isinstance(model, PartModel):
-        if decorations or requested:
+        if decorations or requested or authored is not None:
             return replace(
                 model,
                 decorations={**model.decorations, **decorations}
                 if decorations
                 else model.decorations,
                 requested_dimensions=tuple(requested) if requested else model.requested_dimensions,
+                # `authored is not None` rather than truthiness: an authored set is never
+                # empty (the façade refuses that), but None means "the planner chooses" and
+                # must not be confused with "the author chose nothing" (#874).
+                authored_dimensions=tuple(authored)
+                if authored is not None
+                else model.authored_dimensions,
             )
         return model
     features = list(model)
@@ -233,6 +239,7 @@ def _coerce_model(model, part, decorations=None, requested=None) -> PartModel:
         datums=[datum],
         decorations=decorations or {},
         requested_dimensions=tuple(requested or ()),
+        authored_dimensions=None if authored is None else tuple(authored),
     )
 
 
@@ -257,6 +264,7 @@ def _assemble(
     model=None,
     decorations=None,
     requested=None,
+    authored=None,
     trace=None,
 ) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
@@ -444,6 +452,7 @@ def _repack(
     model=None,
     decorations=None,
     requested=None,
+    authored=None,
     trace=None,
 ):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
@@ -583,6 +592,7 @@ def _repack(
         model=model,
         decorations=decorations,
         requested=requested,
+        authored=authored,
         trace=trace,
     )
     return a2, dwg2
@@ -599,6 +609,7 @@ def _repack_to_fixed_point(
     model=None,
     decorations=None,
     requested=None,
+    authored=None,
     trace=None,
 ):
     """Iterate measure→repack→assemble until stable or bounded (#302)."""
@@ -615,6 +626,7 @@ def _repack_to_fixed_point(
             model=model,
             decorations=decorations,
             requested=requested,
+            authored=authored,
             trace=trace,
         )
         if repacked is None:
@@ -672,6 +684,7 @@ def build_drawing(
     model: Sequence[Feature] | PartModel | None = None,
     decorations: dict | None = None,
     requested: tuple | None = None,
+    authored: tuple | None = None,
     trace: str | Path | bool | None = None,
     material: str = "",
     date: str = "",
@@ -786,6 +799,7 @@ def build_drawing(
         model=model,
         decorations=decorations,
         requested=requested,
+        authored=authored,
         trace=tracer,
     )
     if auto_dims:
@@ -800,6 +814,7 @@ def build_drawing(
             model=model,
             decorations=decorations,
             requested=requested,
+            authored=authored,
             trace=tracer,
         )
         if repacked is not None:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -212,19 +212,9 @@ def _coerce_model(model, part, decorations=None, requested=None, authored=None) 
     given (a bare ``PartModel`` keeps its own decorations otherwise). A verbatim
     ``PartModel`` is never mutated — decorations merge into a copy so the caller's
     reusable public input (ADR 0011) stays clean across builds."""
-    if requested and authored is not None:
-        # The mutual exclusion is a property of the MODEL, not of the façade that usually
-        # builds it — `build_drawing(part, model=…, requested=…, authored=…)` is a public
-        # entry point (ADR 0011) and could otherwise construct the state `Sheet` refuses
-        # (#921 review). An augment only means something against a set the planner chose.
-        raise ValueError(
-            "requested= augments the planner's automatic set and authored= replaces it — a "
-            "model cannot have both. Drop the requested= entries into the authored set, or "
-            "drop authored= to keep the automatic one."
-        )
     if isinstance(model, PartModel):
         if decorations or requested or authored is not None:
-            return replace(
+            out = replace(
                 model,
                 decorations={**model.decorations, **decorations}
                 if decorations
@@ -237,20 +227,43 @@ def _coerce_model(model, part, decorations=None, requested=None, authored=None) 
                 if authored is not None
                 else model.authored_dimensions,
             )
-        return model
-    features = list(model)
-    bbox = part.bounding_box()
-    orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
-    datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
-    return PartModel(
-        bbox=bbox,
-        orientation=orientation,
-        features=features,
-        datums=[datum],
-        decorations=decorations or {},
-        requested_dimensions=tuple(requested or ()),
-        authored_dimensions=None if authored is None else tuple(authored),
-    )
+        else:
+            out = model
+    else:
+        features = list(model)
+        bbox = part.bounding_box()
+        orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
+        datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
+        out = PartModel(
+            bbox=bbox,
+            orientation=orientation,
+            features=features,
+            datums=[datum],
+            decorations=decorations or {},
+            requested_dimensions=tuple(requested or ()),
+            authored_dimensions=None if authored is None else tuple(authored),
+        )
+    check_dimension_sources(out)
+    return out
+
+
+def check_dimension_sources(model: PartModel) -> None:
+    """Refuse a model that names **both** dimension sources (ADR 0016 / #874).
+
+    The mutual exclusion is a property of the MODEL, not of the façade that usually
+    builds it: `build_drawing(part, model=…, requested=…, authored=…)` is a public
+    entry point (ADR 0011) and could otherwise construct the state `Sheet` refuses.
+
+    Checked against the **effective** model rather than the arguments of any one call,
+    because either source can arrive two ways — as a keyword, or already carried by a
+    supplied `PartModel` — and an argument-level guard sees only half of each
+    combination (#921 review). Validating the merged result covers all four."""
+    if model.requested_dimensions and model.authored_dimensions is not None:
+        raise ValueError(
+            "requested= augments the planner's automatic set and authored= replaces it — a "
+            "model cannot have both. Drop the requested= entries into the authored set, or "
+            "drop authored= to keep the automatic one."
+        )
 
 
 def detect_part_model(part, *, pmi="off") -> PartModel:
@@ -305,13 +318,16 @@ def _assemble(
     # Detected path: reuse the model _analyse already built for sizing (#584 WP1 A) —
     # detectors run once per build (ADR 0008 Amdt 5, #602). build_model(a) remains the
     # fallback for a manually-constructed Analysis with no stored model.
-    if model is None and requested:
-        # A request names a DECLARED feature object (ADR 0016 / #872), and detection
-        # builds its own. Silently dropping them would leave a caller's add_dimension()
-        # with no effect and no diagnostic — the failure mode this project treats as
-        # worse than a visible error (#630/#631/#632).
+    if model is None and (requested or authored is not None):
+        # Both verbs name a DECLARED feature object (ADR 0016 / #872, #874), and detection
+        # builds its own. Silently dropping them would leave a caller's add_dimension() /
+        # dimension() with no effect and no diagnostic — the failure mode this project
+        # treats as worse than a visible error (#630/#631/#632). An authored set is the
+        # worse of the two to drop: the build would quietly revert to the automatic
+        # dimensions the author was replacing (#921 review).
+        verb = "requested=" if requested else "authored="
         raise ValueError(
-            "requested= names declared features, so it needs model= too; a detected "
+            f"{verb} names declared features, so it needs model= too; a detected "
             "model builds its own feature objects that no request can target"
         )
     pm = (

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -243,11 +243,11 @@ def _coerce_model(model, part, decorations=None, requested=None, authored=None) 
             requested_dimensions=tuple(requested or ()),
             authored_dimensions=None if authored is None else tuple(authored),
         )
-    check_dimension_sources(out)
+    _check_dimension_sources(out)
     return out
 
 
-def check_dimension_sources(model: PartModel) -> None:
+def _check_dimension_sources(model: PartModel) -> None:
     """Refuse a model that names **both** dimension sources (ADR 0016 / #874).
 
     The mutual exclusion is a property of the MODEL, not of the façade that usually

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1095,6 +1095,28 @@ class Drawing:
                 "view=/name= are unsupported for machined-feature callouts"
             )
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
+            # Validate what the drain cannot report. The drain re-plans against the SAME
+            # authored set, so a callout for an omitted measurement draws nothing — and the
+            # intent is dropped there unconditionally, so the edit vanished with no
+            # annotation, no pending intent and no warning (#921 review round 6). The live
+            # path already refuses this; the deferred path must refuse it at the same point
+            # the caller can still act on it, rather than reporting success.
+            from draftwright.model import plan_dimensions
+            from draftwright.model.callout import omitted_by_the_authored_set
+
+            model = self._part_model
+            if model is not None and model.authored_dimensions is not None:
+                group = next(
+                    (g for g in plan_dimensions(model) if g.feature is feature),
+                    None,
+                )
+                if omitted_by_the_authored_set(group):
+                    raise ValueError(
+                        f"callout(): this {type(feature).__name__} was omitted from the "
+                        "authored dimension set, so there is nothing to add to. Declare it "
+                        "with a dimension(feature, role) line on the Sheet — the authored "
+                        "set is the drawing's complete dimensioning."
+                    )
             self._intents.append(Intent("callout", feature, {"view": view, "name": name}))
             return ""
         from draftwright.annotations._common import PlacementContext

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1066,6 +1066,29 @@ class Drawing:
             self.pin(name)
         return name
 
+    def _refuse_authored_omission(self, feature) -> None:
+        """Refuse a post-build callout for a measurement the authored set left out (#876).
+
+        An authored set is the drawing's COMPLETE dimensioning, so adding a callout back
+        afterwards contradicts the script rather than extending it. Refusing beats the two
+        things it replaced: the live path's "exposes none" (untrue — the feature exposes
+        one and was told not to draw it) and the deferred path's silent success, where the
+        intent was recorded, drew nothing at the drain, and was dropped with no warning."""
+        model = self._part_model
+        if model is None or model.authored_dimensions is None:
+            return
+        from draftwright.model import plan_dimensions
+        from draftwright.model.callout import omitted_by_the_authored_set
+
+        group = next((g for g in plan_dimensions(model) if g.feature is feature), None)
+        if omitted_by_the_authored_set(group):
+            raise ValueError(
+                f"callout(): this {type(feature).__name__} was omitted from the authored "
+                "dimension set, so there is nothing to add to. Declare it with a "
+                "dimension(feature, role) line on the Sheet — the authored set is the "
+                "drawing's complete dimensioning."
+            )
+
     def callout(self, feature, *, view=None, name=None) -> str:
         """Add a **ø leader callout** for *feature* (#414/#419) — the callout half of the
         feature-referenced **add** surface, symmetric with :meth:`drop`.
@@ -1094,29 +1117,14 @@ class Drawing:
                 f"callout(): a {kind} is auto-named and placed in its characteristic view; "
                 "view=/name= are unsupported for machined-feature callouts"
             )
+        # BEFORE the deferred/live split, so the two cannot disagree. Placing it in the
+        # deferred branch alone left the live step/boss path drawing an explicitly omitted
+        # ø while the identical deferred call refused it — the answer depended on whether
+        # you were inside `deferred()` (#921 review round 7). The drain re-plans against the
+        # same authored set and then drops the intent unconditionally, so a refusal here is
+        # also the last point at which the caller can still act on it.
+        self._refuse_authored_omission(feature)
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
-            # Validate what the drain cannot report. The drain re-plans against the SAME
-            # authored set, so a callout for an omitted measurement draws nothing — and the
-            # intent is dropped there unconditionally, so the edit vanished with no
-            # annotation, no pending intent and no warning (#921 review round 6). The live
-            # path already refuses this; the deferred path must refuse it at the same point
-            # the caller can still act on it, rather than reporting success.
-            from draftwright.model import plan_dimensions
-            from draftwright.model.callout import omitted_by_the_authored_set
-
-            model = self._part_model
-            if model is not None and model.authored_dimensions is not None:
-                group = next(
-                    (g for g in plan_dimensions(model) if g.feature is feature),
-                    None,
-                )
-                if omitted_by_the_authored_set(group):
-                    raise ValueError(
-                        f"callout(): this {type(feature).__name__} was omitted from the "
-                        "authored dimension set, so there is nothing to add to. Declare it "
-                        "with a dimension(feature, role) line on the Sheet — the authored "
-                        "set is the drawing's complete dimensioning."
-                    )
             self._intents.append(Intent("callout", feature, {"view": view, "name": name}))
             return ""
         from draftwright.annotations._common import PlacementContext

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1833,6 +1833,7 @@ class Drawing:
                 render_height_ladder(
                     self,
                     model,
+                    plan_dimensions(model),
                     a,
                     ctx=ctx,
                     include_overall=not r.explicit_envelope_height,
@@ -1844,7 +1845,7 @@ class Drawing:
             # ladder above; placed and dropped at the drain (#639).
             if r.step_position_ids:
                 assert a is not None and isinstance(model, PartModel)
-                render_step_positions(self, model, a, ctx=ctx)
+                render_step_positions(self, model, plan_dimensions(model), a, ctx=ctx)
 
         def _s_detail_request():
             # Prismatic step-height detail (#661): queue it exactly as the auto pass

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -214,6 +214,22 @@ def _recess(group: DimensionGroup) -> tuple[float | None, float | None]:
     return None, None
 
 
+_AUTHORED_OMISSION = "not in the authored dimension set"
+
+
+def omitted_by_the_authored_set(group: DimensionGroup | None) -> bool:
+    """Whether this group draws nothing *because the author left it out* (ADR 0016 / #876).
+
+    Distinguishes the two ways a feature can yield no callout, which otherwise report the
+    same misleading "exposes none": a `FilletFeature` genuinely has no ø-depth callout,
+    while an omitted hole has one and was told not to draw it. The second is recoverable —
+    add a `dimension(...)` line — so the message must say which happened (#921 round 6)."""
+    if group is None:
+        return False
+    dims = group.dims
+    return bool(dims) and all(d.suppressed and d.reason == _AUTHORED_OMISSION for d in dims)
+
+
 def hole_callout_spec(group: DimensionGroup) -> dict | None:
     """A hole/pattern group's plan → `HoleCallout` kwargs, mirroring the engine's
     convention. ``None`` if not a hole-bearing callout.

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -216,18 +216,42 @@ def _recess(group: DimensionGroup) -> tuple[float | None, float | None]:
 
 _AUTHORED_OMISSION = "not in the authored dimension set"
 
+# What a `callout()` PRINTS, by feature kind — the parameter kinds whose values make up
+# the callout text. A dimension outside this set belongs to some other mark: a pattern's
+# `pitch` is a linear dim drawn between members, not a term in the callout, so a pattern
+# whose pocket size is omitted has an undrawable callout even though its pitch survives
+# (#921 review round 7). Kinds absent here fall back to "any un-suppressed dim will do".
+_CALLOUT_PARAM_KINDS: dict[str, frozenset[str]] = {
+    "hole": frozenset({"diameter", "depth", "angle"}),
+    "pattern": frozenset({"diameter", "depth", "angle"}),
+    "step": frozenset({"diameter"}),
+    "boss": frozenset({"diameter"}),
+    "pocket": frozenset({"length", "depth"}),
+    "slot": frozenset({"length", "width", "depth"}),
+    "pocket_pattern": frozenset({"length", "depth"}),
+    "slot_pattern": frozenset({"length", "width", "depth"}),
+}
+
 
 def omitted_by_the_authored_set(group: DimensionGroup | None) -> bool:
-    """Whether this group draws nothing *because the author left it out* (ADR 0016 / #876).
+    """Whether `callout()` would draw nothing *because the author left it out* (#876).
 
     Distinguishes the two ways a feature can yield no callout, which otherwise report the
     same misleading "exposes none": a `FilletFeature` genuinely has no ø-depth callout,
     while an omitted hole has one and was told not to draw it. The second is recoverable —
-    add a `dimension(...)` line — so the message must say which happened (#921 round 6)."""
+    add a `dimension(...)` line — so the message must say which happened.
+
+    Asks about the parameters the CALLOUT prints, not the whole group. A group-wide
+    ``all(...)`` answers the wrong question: one surviving dimension of an unrelated kind —
+    a pattern's pitch — made it report "not omitted" for a callout that still could not
+    render, and the edit went on vanishing silently (#921 review round 7)."""
     if group is None:
         return False
-    dims = group.dims
-    return bool(dims) and all(d.suppressed and d.reason == _AUTHORED_OMISSION for d in dims)
+    kinds = _CALLOUT_PARAM_KINDS.get(group.feature_kind)
+    dims = [d for d in group.dims if kinds is None or d.param.kind in kinds]
+    if not dims:
+        return False
+    return all(d.suppressed for d in dims) and any(d.reason == _AUTHORED_OMISSION for d in dims)
 
 
 def hole_callout_spec(group: DimensionGroup) -> dict | None:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -855,3 +855,12 @@ class PartModel:
     # a dimension the planner already chose, a request changes WHICH dimensions it
     # chooses. Empty on a detected model.
     requested_dimensions: tuple[RequestedDimension, ...] = ()
+    # The COMPLETE authored dimension set (ADR 0016 / #874/#876), or ``None`` for the
+    # planner's automatic set. The two are the model's only dimension sources and are
+    # mutually exclusive — omission is only meaningful inside a set declared complete,
+    # which is exactly why the source has to be stated rather than inferred.
+    #
+    # Suppression by omission MARKS rather than filters (#875): a parameter outside the
+    # authored set is planned with ``suppressed=True`` and keeps its value, so the group
+    # retains its engineering data and a later pass can still see what was left out.
+    authored_dimensions: tuple[RequestedDimension, ...] | None = None

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -438,10 +438,50 @@ def _authored_for(model, feature, param):
     return None
 
 
+def _check_authored_targets(model: PartModel) -> None:
+    """Every authored entry must address a measurement this model actually has.
+
+    An authored entry that hits nothing is not a no-op the way a stray `add_dimension`
+    is: `dimension(...)` DECLARES the set, so an entry matching no parameter leaves that
+    feature — potentially the whole drawing — silently blank, and the caller sees a clean
+    build with no dimensions rather than an error (#921 review round 4). This is the
+    failure mode #630/#631/#632 rank as worse than a visible raise.
+
+    The `Sheet` façade cannot reach this: it resolves the role when the verb is called
+    and materialises entries against the FINAL features at build. It is reachable through
+    the ADR 0011 public input — `build_drawing(part, model=…, authored=…)` with a
+    hand-built `PartModel` — where a feature object may be an equal-but-distinct CLONE of
+    the one in `model.features`. Matching stays identity-based on purpose (see
+    `_request_for`: two equal-valued features are two distinct targets, so structural
+    equality would make an authored dimension on one of a pair of identical holes
+    ambiguous). What changes is that a miss now says so."""
+    for authored in model.authored_dimensions or ():
+        if not any(
+            _authored_for(model, feature, p)
+            for feature in model.features
+            if authored.feature is feature
+            for p in feature.parameters()
+        ):
+            in_model = any(f is authored.feature for f in model.features)
+            why = (
+                f"no {authored.role!r} measurement on that {authored.feature.kind}"
+                if in_model
+                else "that feature object is not in model.features (an equal-valued COPY "
+                "is a different target — pass the instance the model holds)"
+            )
+            raise ValueError(
+                f"authored dimension {authored.role!r} matches nothing: {why}. An authored "
+                "set declares the complete dimensioning, so an entry that addresses nothing "
+                "would silently leave the drawing blank."
+            )
+
+
 def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
     view + planned dims, each carrying its render intent — convention, model-level
     suppression, datum). No cross- or within-feature value de-duplication."""
+    if model.authored_dimensions is not None:
+        _check_authored_targets(model)
     groups: list[DimensionGroup] = []
     for feature in model.features:
         dims = []

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -417,6 +417,27 @@ def _request_for(model, feature, param):
     return None
 
 
+def _authored_for(model, feature, param):
+    """The caller's `dimension(...)` naming this parameter, or ``None`` if it is omitted.
+
+    Same matching as :func:`_request_for` — the two verbs address a measurement identically;
+    what differs is what the answer means. `add_dimension` ADDS to the planner's set, so a
+    miss leaves the rule set's own decision standing. `dimension` DECLARES the set, so a miss
+    is an omission and the measurement is suppressed."""
+    for authored in model.authored_dimensions or ():
+        if authored.feature is not feature:
+            continue
+        if "." in authored.role:
+            if authored.role != param.parameter_id:
+                continue
+        elif authored.role != param.role:
+            continue
+        if authored.discriminator is not None and authored.discriminator != param.discriminator:
+            continue
+        return authored
+    return None
+
+
 def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
     view + planned dims, each carrying its render intent — convention, model-level
@@ -450,6 +471,16 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
             request = _request_for(model, feature, p)
             if request is not None:
                 suppressed, reason = False, None
+            if model.authored_dimensions is not None:
+                # An authored set REPLACES the rule set rather than adding to it: what the
+                # script lists is what the drawing carries, and everything else is omitted.
+                # Marked, not filtered (#875) — the value survives on the group so the
+                # omission stays inspectable, and the compound-callout dependency rules
+                # still refuse to orphan half a term.
+                if _authored_for(model, feature, p) is None:
+                    suppressed, reason = True, "not in the authored dimension set"
+                else:
+                    suppressed, reason = False, None
             dims.append(
                 PlannedDimension(
                     param=p,

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -653,10 +653,15 @@ class Sheet:
         # dimension sources, mutually exclusive with `_auto_dimensions`. Token-keyed like
         # every other feature reference on this class.
         self._authored: list[dict] = []
-        # Did the script explicitly ask for the planner's set? MANDATORY unless the sheet
-        # authors its own set instead (#874) — `_check_dimension_source` refuses a build
-        # that names neither, so the drawing never falls back to a source nobody chose.
+        # Did the script ask for the planner's set? MANDATORY unless the sheet authors its
+        # own set instead (#874) — `_check_dimension_source` refuses a build that names
+        # neither, so the drawing never falls back to a source nobody chose.
         self._auto_dimensions = False
+        # ...and did a SCRIPT LINE ask, or did `from_part` supply it? Only an explicit
+        # `auto_dimensions()` call conflicts with an authored set. `from_part` chooses the
+        # automatic source on the caller's behalf, so a later `dimension(...)` is the
+        # script changing its mind, not contradicting itself (#921 review round 6).
+        self._auto_dimensions_explicit = False
         # A requested section A–A (#841): ``None`` = no request, else a resolver tuple
         # (``kind``, ``payload``) materialized to a cut-plane Y in ``_decorations`` — ``at``
         # a literal Y, ``feature`` a declared-feature index, ``auto`` the part-centre Y.
@@ -693,8 +698,14 @@ class Sheet:
         This states the **automatic** dimension source (#874), because that is what asking for
         detection means: you have asked for the engine's reading of the part, features and
         dimensions alike. It is not the implicit default the breaking change removed — a
-        `Sheet(part)` still has to say — it is `from_part`'s own meaning. Declaring
-        `dimension(...)` lines on such a sheet raises, as mixing the two sources always does.
+        `Sheet(part)` still has to say — it is `from_part`'s own meaning.
+
+        Because the choice is `from_part`'s rather than a script line's, adding
+        `dimension(...)` declarations **overrides** it rather than conflicting: detect the
+        features, then declare exactly which of their measurements to draw. That is the
+        natural way to take over a detected drawing, and requiring the caller to redeclare
+        every feature by hand to reach it would be a poor trade (#921 review round 6). An
+        explicit `auto_dimensions()` still conflicts — there the script has said both things.
         """
         sheet = cls(part, **opts)
         sheet._features.extend(detect_part_model(part).features)  # detect only, no render (#453)
@@ -1231,6 +1242,7 @@ class Sheet:
         something against a set the planner chose.
         """
         self._auto_dimensions = True
+        self._auto_dimensions_explicit = True
         return self
 
     def add_dimension(self, feature, role: str, *, axis: str | None = None):
@@ -1279,13 +1291,18 @@ class Sheet:
         Rejected: implicit-by-usage — "any `dimension` line turns the automatic set off". A
         hand-author adding one pitch dimension would silently lose every ⌀ callout.
         """
-        if self._authored and self._auto_dimensions:
+        if self._authored and self._auto_dimensions_explicit:
             raise ValueError(
                 "a sheet has ONE dimension source: auto_dimensions() for the planner's set, or "
                 "dimension(...) declarations for the complete authored set. This sheet asks for "
                 "both, which cannot be honoured — omission is only meaningful inside a set "
                 "declared complete, and the automatic set has no omissions to read."
             )
+        if self._authored:
+            # `from_part` chose the automatic source on the caller's behalf; declaring an
+            # authored set is the script overriding that choice, not contradicting itself.
+            # (An explicit `auto_dimensions()` line already raised above.)
+            self._auto_dimensions = False
         if self._added_dimensions and not self._auto_dimensions:
             raise ValueError(
                 "add_dimension() augments the planner's automatic dimension set, so the sheet "

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1442,8 +1442,14 @@ class Sheet:
         inferred orientation + the P2a decorations), so inspection pays no projection/anno
         cost and can't hit a layout/render failure. Wraps the *solids body* (as :func:`_analyse`
         does), so the bbox/datum match what ``build()`` draws even when the part carries
-        bbox-extending non-solid geometry."""
+        bbox-extending non-solid geometry.
+
+        Gated on the dimension source like :meth:`build` (#874): this is the model the engine
+        WOULD draw, so a sheet that cannot be built must not hand one out — otherwise
+        ``build_drawing(part, model=sheet.model())`` is a way around the check, and the two
+        public surfaces disagree about the same sheet (the #707 class of divergence)."""
         self._prepare()
+        self._check_dimension_source()
         return _coerce_model(
             self._features,
             _solids_body(self._part),

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -653,15 +653,17 @@ class Sheet:
         # dimension sources, mutually exclusive with `_auto_dimensions`. Token-keyed like
         # every other feature reference on this class.
         self._authored: list[dict] = []
-        # Did the script ask for the planner's set? MANDATORY unless the sheet authors its
-        # own set instead (#874) — `_check_dimension_source` refuses a build that names
-        # neither, so the drawing never falls back to a source nobody chose.
-        self._auto_dimensions = False
-        # ...and did a SCRIPT LINE ask, or did `from_part` supply it? Only an explicit
-        # `auto_dimensions()` call conflicts with an authored set. `from_part` chooses the
-        # automatic source on the caller's behalf, so a later `dimension(...)` is the
-        # script changing its mind, not contradicting itself (#921 review round 6).
-        self._auto_dimensions_explicit = False
+        # Where the dimensions come from, and WHO said so — `None` (nobody has yet),
+        # ``"explicit"`` (an `auto_dimensions()` line) or ``"implicit"`` (`from_part`, which
+        # chooses on the caller's behalf). MANDATORY unless the sheet authors its own set
+        # instead (#874): `_check_dimension_source` refuses a build that names neither, so
+        # the drawing never falls back to a source nobody chose.
+        #
+        # One tri-state rather than a flag plus an "was it explicit" flag: the pair could
+        # be set to a combination that means nothing, and clearing the source then took two
+        # assignments — which is how the first cut of this broke the identity suite (#921
+        # review round 7). Only ``"explicit"`` conflicts with an authored set.
+        self._auto_dimensions: str | None = None
         # A requested section A–A (#841): ``None`` = no request, else a resolver tuple
         # (``kind``, ``payload``) materialized to a cut-plane Y in ``_decorations`` — ``at``
         # a literal Y, ``feature`` a declared-feature index, ``auto`` the part-centre Y.
@@ -709,7 +711,7 @@ class Sheet:
         """
         sheet = cls(part, **opts)
         sheet._features.extend(detect_part_model(part).features)  # detect only, no render (#453)
-        sheet._auto_dimensions = True
+        sheet._auto_dimensions = "implicit"
         return sheet
 
     # -- feature declaration --------------------------------------------------
@@ -1241,8 +1243,7 @@ class Sheet:
         This is also what :meth:`add_dimension` augments — an augment only means
         something against a set the planner chose.
         """
-        self._auto_dimensions = True
-        self._auto_dimensions_explicit = True
+        self._auto_dimensions = "explicit"
         return self
 
     def add_dimension(self, feature, role: str, *, axis: str | None = None):
@@ -1291,7 +1292,7 @@ class Sheet:
         Rejected: implicit-by-usage — "any `dimension` line turns the automatic set off". A
         hand-author adding one pitch dimension would silently lose every ⌀ callout.
         """
-        if self._authored and self._auto_dimensions_explicit:
+        if self._authored and self._auto_dimensions == "explicit":
             raise ValueError(
                 "a sheet has ONE dimension source: auto_dimensions() for the planner's set, or "
                 "dimension(...) declarations for the complete authored set. This sheet asks for "
@@ -1302,7 +1303,7 @@ class Sheet:
             # `from_part` chose the automatic source on the caller's behalf; declaring an
             # authored set is the script overriding that choice, not contradicting itself.
             # (An explicit `auto_dimensions()` line already raised above.)
-            self._auto_dimensions = False
+            self._auto_dimensions = None
         if self._added_dimensions and not self._auto_dimensions:
             raise ValueError(
                 "add_dimension() augments the planner's automatic dimension set, so the sheet "

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -643,19 +643,19 @@ class Sheet:
         # engine's generic auto-placed Drawing.add_table, AFTER the drawing is built so they sit
         # clear of the views + title block (like the hole table). Each: {rows, prefer, name}.
         self._tables: list = []
-        # ADR 0016 augmenting dimension intents (#872), keyed by feature INDEX for the
-        # same reason as `_tolerances`: a handle may be recorded before a later size verb
-        # replaces the feature. Materialized to `RequestedDimension` against the FINAL
-        # features at build. Each entry: {"index", "role", "discriminator", "pin", "priority"}.
+        # ADR 0016 augmenting dimension intents (#872), token-keyed for the same reason as
+        # `_tolerances`: a handle may be recorded before a later size verb replaces the
+        # feature, and a position would then name whatever moved into the slot.
+        # Materialized to `RequestedDimension` against the FINAL features at build.
+        # Each entry: {"token", "role", "discriminator"}.
         self._added_dimensions: list[dict] = []
         # The COMPLETE authored dimension set (#874/#876) — the other of the model's two
         # dimension sources, mutually exclusive with `_auto_dimensions`. Token-keyed like
         # every other feature reference on this class.
         self._authored: list[dict] = []
-        # Did the script explicitly ask for the planner's set? Optional here (#872) — a
-        # build without it still auto-dimensions, as it always has. Making it MANDATORY
-        # is the #874 breaking change; shipping that early would change this verb's
-        # meaning between phases, which the epic's own rule forbids.
+        # Did the script explicitly ask for the planner's set? MANDATORY unless the sheet
+        # authors its own set instead (#874) — `_check_dimension_source` refuses a build
+        # that names neither, so the drawing never falls back to a source nobody chose.
         self._auto_dimensions = False
         # A requested section A–A (#841): ``None`` = no request, else a resolver tuple
         # (``kind``, ``payload``) materialized to a cut-plane Y in ``_decorations`` — ``at``
@@ -1220,13 +1220,15 @@ class Sheet:
         return self._features
 
     def auto_dimensions(self) -> Sheet:
-        """Ask for the planner's automatic dimension set explicitly (ADR 0016).
+        """Ask for the planner's automatic dimension set (ADR 0016).
 
-        Today this is **optional** — a build without it still auto-dimensions, exactly as
-        before — and it exists so a script can *say* which dimension source it uses, and
-        so :meth:`add_dimension` has something to augment. Making it mandatory is the
-        #874 breaking change; landing that here would change this verb's meaning between
-        releases, which ADR 0016's phasing rule forbids.
+        **Required**, unless the sheet authors its own set with :meth:`dimension` (#874):
+        a build must say where its dimensions come from rather than defaulting to one
+        silently, so a script that means "dimension this for me" reads that way, and one
+        that means "draw exactly what I name" cannot be mistaken for it.
+
+        This is also what :meth:`add_dimension` augments — an augment only means
+        something against a set the planner chose.
         """
         self._auto_dimensions = True
         return self

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -648,6 +648,10 @@ class Sheet:
         # replaces the feature. Materialized to `RequestedDimension` against the FINAL
         # features at build. Each entry: {"index", "role", "discriminator", "pin", "priority"}.
         self._added_dimensions: list[dict] = []
+        # The COMPLETE authored dimension set (#874/#876) — the other of the model's two
+        # dimension sources, mutually exclusive with `_auto_dimensions`. Token-keyed like
+        # every other feature reference on this class.
+        self._authored: list[dict] = []
         # Did the script explicitly ask for the planner's set? Optional here (#872) — a
         # build without it still auto-dimensions, as it always has. Making it MANDATORY
         # is the #874 breaking change; shipping that early would change this verb's
@@ -684,9 +688,17 @@ class Sheet:
     def from_part(cls, part, **opts) -> Sheet:
         """Seed the declared set from *detection* (the hybrid mode, ADR 0011 §3): start
         from the model the detector recovers, then override specific features (edit the
-        list via :attr:`features`, or re-declare) before :meth:`build`."""
+        list via :attr:`features`, or re-declare) before :meth:`build`.
+
+        This states the **automatic** dimension source (#874), because that is what asking for
+        detection means: you have asked for the engine's reading of the part, features and
+        dimensions alike. It is not the implicit default the breaking change removed — a
+        `Sheet(part)` still has to say — it is `from_part`'s own meaning. Declaring
+        `dimension(...)` lines on such a sheet raises, as mixing the two sources always does.
+        """
         sheet = cls(part, **opts)
         sheet._features.extend(detect_part_model(part).features)  # detect only, no render (#453)
+        sheet._auto_dimensions = True
         return sheet
 
     # -- feature declaration --------------------------------------------------
@@ -724,11 +736,25 @@ class Sheet:
                 stacklevel=2,
             )
             return self.measured_dimension(*args, **kw)
-        raise TypeError(
-            "Sheet.dimension(): the referential form — dimension(feature, role), which declares "
-            "the complete authored dimension set — is #874. For a dimension carrying an explicit "
-            "measured value, call measured_dimension(kind=…, value=…, …)."
-        )
+        return self._authored_dimension(*args, **kw)
+
+    def _authored_dimension(self, feature, role: str, *, axis: str | None = None):
+        """`dimension(feature, role)` — declare one member of the COMPLETE authored set.
+
+        Referential, like every ADR 0016 intent: it names a feature and a role and carries no
+        number, so the value still comes from the geometry. What distinguishes it from
+        :meth:`add_dimension` is not how it addresses a measurement but what naming one MEANS —
+        `add_dimension` augments the planner's set, so a measurement you don't name keeps
+        whatever the rule set decided; `dimension` declares the set, so a measurement you don't
+        name is omitted.
+
+        That is why the source has to be stated (#874): omission is only meaningful inside a set
+        declared complete. A script that mixed the two would be saying "everything the planner
+        chooses, plus these" and "only these" at once.
+        """
+        token, target, discriminator = self._resolve_measurement(feature, role, axis, "dimension")
+        self._authored.append({"token": token, "role": role, "discriminator": discriminator})
+        return DimensionIntent(self, self._authored[-1])
 
     def measured_dimension(
         self,
@@ -1223,31 +1249,85 @@ class Sheet:
         a silent coin toss between the row and column pitch is the kind of wrong a reader
         cannot see.
         """
+        token, _target, discriminator = self._resolve_measurement(
+            feature, role, axis, "add_dimension"
+        )
+        entry = {"token": token, "role": role, "discriminator": discriminator}
+        self._added_dimensions.append(entry)
+        return DimensionIntent(self, entry)
+
+    def _check_dimension_source(self) -> None:
+        """A build must say where its dimensions come from (ADR 0016 / #874).
+
+        The set has exactly two sources and they are mutually exclusive:
+
+        - :meth:`auto_dimensions` — the planner's selected set, optionally augmented by
+          :meth:`add_dimension`;
+        - :meth:`dimension` declarations — the complete authored set.
+
+        Three errors follow, and all three are checked HERE rather than in the verbs, so intent
+        stays order-independent: declaring an augment before its source must read the same as
+        declaring it after.
+
+        Requiring a source at all is the breaking change. It is the project's standing
+        preference for a loud failure over a plausible-looking wrong drawing (#630/#631, the
+        #632 completeness lint): a sheet that asked for neither would otherwise build silently,
+        and *which* set it got would depend on a default the script never mentions.
+
+        Rejected: implicit-by-usage — "any `dimension` line turns the automatic set off". A
+        hand-author adding one pitch dimension would silently lose every ⌀ callout.
+        """
+        if self._authored and self._auto_dimensions:
+            raise ValueError(
+                "a sheet has ONE dimension source: auto_dimensions() for the planner's set, or "
+                "dimension(...) declarations for the complete authored set. This sheet asks for "
+                "both, which cannot be honoured — omission is only meaningful inside a set "
+                "declared complete, and the automatic set has no omissions to read."
+            )
+        if self._added_dimensions and not self._auto_dimensions:
+            raise ValueError(
+                "add_dimension() augments the planner's automatic dimension set, so the sheet "
+                "must request one — call auto_dimensions(). To declare the complete set "
+                "instead, use dimension(...) lines and drop the add_dimension() calls."
+            )
+        if not self._auto_dimensions and not self._authored:
+            raise ValueError(
+                "this sheet does not say where its dimensions come from. Call "
+                "auto_dimensions() for the planner's set, or declare the complete set with "
+                "dimension(feature, role) lines. (Building without either used to mean the "
+                "automatic set; ADR 0016 makes the source explicit so that omitting a "
+                "dimension can mean something.)"
+            )
+
+    def _resolve_measurement(self, feature, role: str, axis: str | None, verb: str):
+        """Resolve ``(feature, role, axis)`` to ``(token, feature, discriminator)``, or raise.
+
+        Shared by :meth:`add_dimension` and :meth:`dimension` — the two verbs ADDRESS a
+        measurement identically and differ only in what naming one means, so the addressing
+        lives in one place. A second copy is how the callout reading drifted in #875."""
         token = self._feature_token(feature)
         target = self._features[self._index_of_token(token)]
         params = target.parameters()
         roles = {p.role for p in params} | {p.parameter_id for p in params}
         if role not in roles:
             raise ValueError(
-                f"add_dimension: {type(target).__name__} has no {role!r} measurement "
+                f"{verb}: {type(target).__name__} has no {role!r} measurement "
                 f"(it carries {sorted(roles)})"
             )
         matching = [p for p in params if role in (p.role, p.parameter_id)]
         discs = {p.discriminator for p in matching}
         if len(discs) > 1 and axis is None:
             raise ValueError(
-                f"add_dimension({role!r}) is ambiguous on this feature — it carries "
+                f"{verb}({role!r}) is ambiguous on this feature — it carries "
                 f"{len(discs)} of them ({sorted(d for d in discs if d)}). Name one with "
                 f"axis=."
             )
         if axis is not None and axis not in discs:
             raise ValueError(
-                f"add_dimension({role!r}, axis={axis!r}): this feature has no such "
+                f"{verb}({role!r}, axis={axis!r}): this feature has no such "
                 f"variant ({sorted(d for d in discs if d)})"
             )
-        entry = {"token": token, "role": role, "discriminator": axis}
-        self._added_dimensions.append(entry)
-        return DimensionIntent(self, entry)
+        return token, target, axis
 
     def _replace_feature(self, index: int, feature) -> None:
         """Swap the frozen feature at *index* for an updated copy.
@@ -1304,6 +1384,23 @@ class Sheet:
             for e in self._added_dimensions
         )
 
+    def _authored_set(self) -> tuple | None:
+        """The complete authored set, or ``None`` when the planner's automatic set is in use.
+
+        ``None`` and ``()`` mean different things here and the distinction is load-bearing:
+        ``None`` is "the planner chooses", an empty tuple would be "the author chose nothing",
+        which :meth:`_check_dimension_source` rejects before we get here."""
+        if not self._authored:
+            return None
+        return tuple(
+            RequestedDimension(
+                feature=self._features[self._index_of_token(e["token"])],
+                role=e["role"],
+                discriminator=e["discriminator"],
+            )
+            for e in self._authored
+        )
+
     def _decorations(self) -> dict:
         """Materialize the token-keyed ± tolerances against the FINAL features (a handle may
         have been recorded before a later .depth()/… replaced the feature) → the
@@ -1352,6 +1449,7 @@ class Sheet:
             _solids_body(self._part),
             self._decorations(),
             self._requested_dimensions(),
+            self._authored_set(),
         )
 
     def build(self):
@@ -1363,17 +1461,13 @@ class Sheet:
         # one (ADR 0016 / #872). Checked HERE rather than in the verb so intent stays
         # order-independent: declaring the augment before the source must read the same
         # as declaring it after.
-        if self._added_dimensions and not self._auto_dimensions:
-            raise ValueError(
-                "add_dimension() augments the planner's automatic dimension set, so the "
-                "sheet must request one — call auto_dimensions(). (Declaring the complete "
-                "authored set with dimension(...) instead is #874.)"
-            )
+        self._check_dimension_source()
         dwg = build_drawing(
             self._part,
             model=self._features,
             decorations=self._decorations(),
             requested=self._requested_dimensions(),
+            authored=self._authored_set(),
             **self._opts,
         )
         # Add each declared table, uniquifying its name against everything already on the sheet

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -568,6 +568,15 @@ def emit_sheet_script(
         "",
         f"sheet = Sheet(part, {', '.join(ctor)})",
         "",
+        # The script must SAY where its dimensions come from (ADR 0016 / #874). A generated
+        # script uses the planner's set, so it emits that source explicitly rather than relying
+        # on a default — which is the whole point of making the source mandatory: an omitted
+        # dimension only means something inside a set that says it is complete. Edit these
+        # lines to `sheet.dimension(...)` declarations to take the set over by hand.
+        "# The planner selects the dimensions. Replace with dimension(feature, role) lines",
+        "# to declare the complete set by hand (ADR 0016).",
+        "sheet.auto_dimensions()",
+        "",
         # For a live-source part (#771), the values below were read off YOUR objects — point
         # each line back at the object to keep it a single source of truth (a STEP-sourced
         # script has no such objects, so this note is emitted only for object inputs).

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -522,7 +522,35 @@ def emit_sheet_script(
 
     AP242 PMI cannot be re-extracted from the ``import_step`` seam, so detected dimensional PMI is
     emitted as declared Sheet dimensions; unsupported raw PMI records are kept as explicit
-    ``sheet.add(PmiFeature(...))`` fallbacks (#503 / #422)."""
+    ``sheet.add(PmiFeature(...))`` fallbacks (#503 / #422).
+
+    A model carrying an **authored** dimension set is refused (see below): the emitter has no
+    way to write those declarations without addressing features by position, which this
+    generated script is the worst possible place for."""
+    if getattr(model, "authored_dimensions", None) is not None:
+        # Emitting `sheet.auto_dimensions()` here would silently turn "draw exactly these"
+        # back into "draw everything" — a script that produces a different drawing from the
+        # model it was generated from, which is the #707 class of divergence (#921 review
+        # round 5).
+        #
+        # Writing the declarations instead is NOT the cheap fix it looks like. The only way
+        # to name a feature in this script is its position (`sheet.dimension(3, "width")`) —
+        # the feature verbs bind no variables — and the documented workflow for these scripts
+        # is to comment a feature line out and re-run. That shifts every later index and
+        # silently retargets the dimensions onto their neighbours: exactly the position-
+        # addressing defect ADR 0016's identity work exists to remove, rebuilt inside the
+        # artefact we hand the user. Refusing beats emitting a booby trap.
+        #
+        # Giving emitted features nameable identity is the real fix, and it is the deferred
+        # emitter dimension-mirror the epic scopes out — tracked separately. Nothing in the
+        # product reaches this: `--script` emits from `detect_part_model`, which never carries
+        # an authored set.
+        raise ValueError(
+            "emit_sheet_script() cannot yet emit a model with an authored dimension set: "
+            "naming a feature in the generated script would have to address it by position, "
+            "which breaks as soon as a feature line is commented out. Emit from a detected "
+            "model (the --script path), or write the dimension(...) declarations by hand."
+        )
     model_imports = set()
     if any(f.kind in ("hole", "pattern") for f in model.features):
         model_imports.add("hole")

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -124,7 +124,7 @@ class TestSheetSurface:
 
     def test_add_dimension_requires_a_dimension_source(self):
         """`add_dimension` augments the planner's set, so there must be one."""
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N")  # deliberately no source
         bore = sheet.hole(diameter=10, at=(0, 0, 14), axis="z").depth(12)
         sheet.add_dimension(bore, "bore")
         with pytest.raises(ValueError, match="call auto_dimensions"):
@@ -133,7 +133,7 @@ class TestSheetSurface:
     def test_the_source_may_be_declared_after_the_augment(self):
         """Order independence (ADR 0016). The gate is at build, not in the verb, so
         these two scripts must not disagree."""
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N")  # the source arrives below
         bore = sheet.hole(diameter=10, at=(0, 0, 14), axis="z").depth(12)
         sheet.add_dimension(bore, "bore")
         sheet.auto_dimensions()
@@ -142,7 +142,7 @@ class TestSheetSurface:
     def test_a_sheet_without_augments_still_builds_without_the_source_verb(self):
         """`auto_dimensions()` is optional in this phase — making it mandatory is the
         #874 breaking change. A plain declarative script must keep working."""
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
         sheet.hole(diameter=10, at=(0, 0, 14), axis="z").depth(12)
         assert sheet.build() is not None
 
@@ -379,7 +379,7 @@ class TestInvalidCombinations:
         """The bug that motivated #908, and it predates add_dimension entirely:
         `_tolerances` was index-keyed since P2a, so a reorder moved a tolerance onto a
         neighbouring feature."""
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
         big = sheet.hole(diameter=10, at=(-20, 0, 14), axis="z").depth(12)
         sheet.hole(diameter=4, at=(20, 0, 14), axis="z").depth(7)
         big.tolerance(0.05)
@@ -419,7 +419,7 @@ class TestFeatureViewIdentity:
 
     @staticmethod
     def _two_holes():
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
         big = sheet.hole(diameter=10, at=(-20, 0, 14), axis="z").depth(12)
         sheet.hole(diameter=4, at=(20, 0, 14), axis="z").depth(7)
         big.tolerance(0.05)
@@ -467,7 +467,7 @@ class TestFeatureViewIdentity:
         frame later, and an index would name whatever occupied the slot by then (PR #910
         review). Everything else — `datum`/`finish`/`note` — resolves and appends in a single
         expression, so only this seam can span a mutation."""
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
         big = sheet.hole(diameter=10, at=(-20, 0, 14), axis="z").depth(12)
         sheet.hole(diameter=4, at=(20, 0, 14), axis="z").depth(7)
 
@@ -482,7 +482,7 @@ class TestFeatureViewIdentity:
     def test_a_control_builder_spans_a_mint_too(self):
         """The same seam against an *appending* mutation, which shifts no slot the builder
         already holds but does grow the view — a token stays correct either way."""
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
         big = sheet.hole(diameter=10, at=(-20, 0, 14), axis="z").depth(12)
 
         control = sheet.control(big)
@@ -509,7 +509,7 @@ class TestFeatureViewContract:
 
     @staticmethod
     def _sheet_with(n=3):
-        sheet = Sheet(_part(), title="T", number="N")
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
         for i in range(n):
             sheet.hole(diameter=4 + i, at=(-20 + 20 * i, 0, 14), axis="z").depth(5 + i)
         return sheet

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -139,11 +139,40 @@ class TestSheetSurface:
         sheet.auto_dimensions()
         assert sheet.build() is not None
 
-    def test_a_sheet_without_augments_still_builds_without_the_source_verb(self):
-        """`auto_dimensions()` is optional in this phase — making it mandatory is the
-        #874 breaking change. A plain declarative script must keep working."""
-        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
+    def test_a_sheet_with_no_source_at_all_raises(self):
+        """#874's third error, and the breaking one. This test previously asserted the
+        OPPOSITE — that `auto_dimensions()` was optional — and the mechanical migration
+        rewrote its setup to call the verb while leaving its name and docstring intact, so it
+        went on passing while proving nothing (#921 review). A gate with no test is worse
+        than no gate, because the suite claims otherwise."""
+        sheet = Sheet(_part(), title="T", number="N")
         sheet.hole(diameter=10, at=(0, 0, 14), axis="z").depth(12)
+        with pytest.raises(ValueError, match="does not say where its dimensions come from"):
+            sheet.build()
+
+    def test_the_model_surface_is_gated_too(self):
+        """`Sheet.model()` is the model the engine WOULD draw, so a sheet that cannot be built
+        must not hand one out — otherwise `build_drawing(part, model=sheet.model())` walks
+        straight around the check and the two public surfaces disagree about one sheet."""
+        sheet = Sheet(_part(), title="T", number="N")
+        sheet.hole(diameter=10, at=(0, 0, 14), axis="z").depth(12)
+        with pytest.raises(ValueError, match="does not say where its dimensions come from"):
+            sheet.model()
+
+    def test_declaring_both_sources_raises(self):
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
+        bore = sheet.hole(diameter=10, at=(0, 0, 14), axis="z").depth(12)
+        sheet.dimension(bore, "bore")
+        with pytest.raises(ValueError, match="ONE dimension source"):
+            sheet.build()
+
+    def test_from_part_states_the_automatic_source(self):
+        """Detection IS a request for the engine's reading of the part, so `from_part` says so
+        rather than leaving the caller to. Not the implicit default returning by the back
+        door — a plain `Sheet(part)` still has to say."""
+        from build123d import Box, Cylinder, Pos
+
+        sheet = Sheet.from_part(Box(90, 60, 20) - Pos(0, 0, 12) * Cylinder(6, 20))
         assert sheet.build() is not None
 
     def test_the_model_surface_reflects_requests(self):
@@ -598,3 +627,55 @@ class TestFeatureViewContract:
         sheet.features.reverse()
         toleranced = [f for f, *_ in sheet._decorations() if getattr(f, "kind", None) == "hole"]
         assert len(toleranced) == 1
+
+
+class TestOmissionReachesTheDrawing:
+    """#876 end to end, through the façade a caller actually uses.
+
+    Every unit test of the authored set passed while `build()` silently dropped it — one
+    `_coerce_model` call forwarded `requested` and not `authored`, so the planner never took
+    the authored branch (#921 review). Nothing asserted that omission changed a DRAWING, only
+    that the model carried the intent, and the gap between those two is exactly where the bug
+    lived. These assert the observable consequence.
+    """
+
+    @staticmethod
+    def _sheet():
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(90, 60, 20) - Pos(0, 0, 12) * Cylinder(6, 20)
+        sheet = Sheet(part, title="T", number="N")
+        return sheet, sheet.envelope()
+
+    def test_an_authored_set_survives_the_build(self):
+        sheet, env = self._sheet()
+        sheet.dimension(env, "width")
+        assert [d.role for d in sheet.build().model().authored_dimensions] == ["width"]
+
+    def test_an_omitted_measurement_is_marked_suppressed(self):
+        sheet, env = self._sheet()
+        sheet.dimension(env, "width")
+        groups = plan_dimensions(sheet.model())
+        marked = {pd.param.role: pd.suppressed for g in groups for pd in g.dims}
+        assert marked["width"] is False, "the named measurement prints"
+        assert marked["height"] is True and marked["depth"] is True, "the rest are omitted"
+
+    def test_an_omitted_measurement_keeps_its_value(self):
+        """Marked, NOT filtered (#875): the group retains its engineering data, so a later
+        pass can still see what was left out and why."""
+        sheet, env = self._sheet()
+        sheet.dimension(env, "width")
+        groups = plan_dimensions(sheet.model())
+        omitted = [pd for g in groups for pd in g.dims if pd.suppressed]
+        assert omitted and all(pd.param.value is not None for pd in omitted)
+        assert all(pd.reason == "not in the authored dimension set" for pd in omitted)
+
+    def test_the_automatic_set_is_unaffected(self):
+        """The contrast: with no authored set nothing is suppressed by omission, so the
+        assertions above cannot be passing for some unrelated reason."""
+        sheet, _env = self._sheet()
+        sheet.auto_dimensions()
+        groups = plan_dimensions(sheet.model())
+        assert not [
+            pd for g in groups for pd in g.dims if pd.reason == "not in the authored dimension set"
+        ]

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -166,6 +166,68 @@ class TestSheetSurface:
         with pytest.raises(ValueError, match="ONE dimension source"):
             sheet.build()
 
+    def test_a_detected_build_refuses_an_authored_set(self):
+        """`authored=` names DECLARED feature objects; detection builds its own, which no
+        authored entry can match. Dropping it silently would revert the build to exactly
+        the automatic dimensions the author was replacing (#921 review) — the `requested=`
+        guard beside it has always said so, and this is the worse of the two to lose."""
+        from draftwright import build_drawing
+        from draftwright.model import declare
+        from draftwright.model.ir import RequestedDimension
+
+        part = _part()
+        request = RequestedDimension(
+            feature=declare.envelope(part), role="width", discriminator=None
+        )
+        with pytest.raises(ValueError, match="authored= names declared features"):
+            build_drawing(part, authored=(request,))
+
+    @pytest.mark.parametrize(
+        "on_model,as_kwarg",
+        [("requested_dimensions", "authored"), ("authored_dimensions", "requested")],
+    )
+    def test_both_sources_are_refused_however_they_arrive(self, on_model, as_kwarg):
+        """The exclusion is a property of the EFFECTIVE model, not of one call's arguments.
+        Either source can arrive two ways — as a keyword, or already carried by a supplied
+        `PartModel` — so an argument-level guard sees only half of each combination and
+        both of these mixed forms slipped through it (#921 review)."""
+        from draftwright.builder import _coerce_model
+        from draftwright.model import declare
+        from draftwright.model.ir import PartModel, RequestedDimension
+
+        part = _part()
+        env = declare.envelope(part)
+        request = RequestedDimension(feature=env, role="width", discriminator=None)
+        model = PartModel(
+            bbox=part.bounding_box(),
+            orientation=None,
+            features=[env],
+            datums=[],
+            **{on_model: (request,)},
+        )
+        with pytest.raises(ValueError, match="cannot have both"):
+            _coerce_model(model, part, None, **{as_kwarg: (request,)})
+
+    def test_a_partmodel_already_naming_both_sources_is_refused(self):
+        """The public boundary rejects an invalid model even when no keyword adds to it."""
+        from draftwright.builder import _coerce_model
+        from draftwright.model import declare
+        from draftwright.model.ir import PartModel, RequestedDimension
+
+        part = _part()
+        env = declare.envelope(part)
+        request = RequestedDimension(feature=env, role="width", discriminator=None)
+        model = PartModel(
+            bbox=part.bounding_box(),
+            orientation=None,
+            features=[env],
+            datums=[],
+            requested_dimensions=(request,),
+            authored_dimensions=(request,),
+        )
+        with pytest.raises(ValueError, match="cannot have both"):
+            _coerce_model(model, part)
+
     def test_from_part_states_the_automatic_source(self):
         """Detection IS a request for the engine's reading of the part, so `from_part` says so
         rather than leaving the caller to. Not the implicit default returning by the back
@@ -708,8 +770,10 @@ class TestOmittedDimensionsDoNotRender:
         "the whole set is addressed" from "one member happened to survive"."""
         from build123d import Box, Pos
 
-        return Box(120, 60, 15) + Pos(-20, 0, 15) * Box(80, 60, 15) + Pos(-40, 0, 30) * Box(
-            40, 60, 15
+        return (
+            Box(120, 60, 15)
+            + Pos(-20, 0, 15) * Box(80, 60, 15)
+            + Pos(-40, 0, 30) * Box(40, 60, 15)
         )
 
     @staticmethod
@@ -794,3 +858,44 @@ class TestOmittedDimensionsDoNotRender:
         hole = sheet.hole(Pos(0, 0, 12) * Cylinder(6, 20))
         sheet.dimension(hole, "bore.diameter")
         assert "dim_height" not in _names(sheet.build())
+
+    def test_one_authored_line_leaves_only_that_dimension_on_the_page(self):
+        """The whole contract in one assertion, against a part with several competing
+        feature kinds. Each earlier test names a pass that leaked; this one would catch
+        the NEXT such pass without knowing its name, which is the property that matters
+        — the P0 was a class of defect (a renderer rebuilding its marks from geometry
+        instead of the plan), not a single site.
+
+        What legitimately remains is furniture, not dimensioning: centre marks, the
+        NTS note, the title block, and the location ladder, which stays outside the
+        authored set until it has addressable identity (#883).
+        """
+        from build123d import Box, Cylinder, Pos
+
+        part = (
+            Box(120, 80, 25)
+            - Pos(-30, 0, 17) * Cylinder(5, 20)
+            - Pos(30, 20, 17) * Cylinder(4, 20)
+        )
+        sheet = Sheet(part, title="T", number="N")
+        env = sheet.envelope()
+        sheet.hole(Pos(-30, 0, 17) * Cylinder(5, 20))
+        sheet.hole(Pos(30, 20, 17) * Cylinder(4, 20))
+        sheet.dimension(env, "width")
+
+        drawn = _names(sheet.build())
+        assert "m_env_width" in drawn, "the one authored measurement"
+        furniture = ("m_cm", "m_locx", "m_locy", "note_", "title_block")
+        assert not [n for n in drawn if n != "m_env_width" and not n.startswith(furniture)], (
+            f"an unauthored dimension reached the page: {sorted(drawn)}"
+        )
+
+        auto = Sheet(part, title="T", number="N")
+        auto.envelope()
+        auto.hole(Pos(-30, 0, 17) * Cylinder(5, 20))
+        auto.hole(Pos(30, 20, 17) * Cylinder(4, 20))
+        auto.auto_dimensions()
+        assert len(_names(auto.build())) > len(drawn), (
+            "the automatic build must carry MORE — otherwise the assertion above holds "
+            "for a part that was never richly dimensioned in the first place"
+        )

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -337,6 +337,87 @@ class TestSheetSurface:
         with pytest.raises(ValueError, match="omitted from the authored dimension set"):
             dwg.callout(hole)
 
+    def test_a_step_callout_is_refused_identically_live_and_deferred(self):
+        """The check sat in the deferred branch only, so the live step/boss path drew an
+        explicitly omitted ø while the identical deferred call refused it — the answer
+        depended on whether you were inside `deferred()` (#921 review round 7). It now
+        runs before the split, which is the only way the two cannot drift."""
+        from build123d import Cylinder, Pos, Rot
+
+        part = Rot(0, 90, 0) * Cylinder(4, 20) + Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)
+        sheet = Sheet(part, title="T", number="N")
+        sheet.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        sheet.dimension(sheet.envelope(), "width")
+        dwg = sheet.build()
+        step = next(f for f in dwg.model().features if f.kind == "step")
+
+        with pytest.raises(ValueError, match="omitted from the authored dimension set"):
+            dwg.callout(step)
+        with pytest.raises(ValueError, match="omitted from the authored dimension set"):
+            with dwg.deferred():
+                dwg.callout(step)
+
+    @pytest.mark.parametrize("authored", ["bore.diameter", None], ids=["authored", "automatic"])
+    def test_a_drawable_callout_is_never_refused(self, authored):
+        """The false-positive guard. A refusal that fires on a legitimate edit is as much a
+        defect as one that misses an illegitimate one, and this check runs on every
+        `callout()` call now that it sits above the split."""
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(100, 60, 20) - Pos(0, 0, 10) * Cylinder(5, 20)
+        sheet = Sheet.from_part(part)
+        if authored:
+            sheet.dimension(next(f for f in sheet.features if f.kind == "hole"), authored)
+        dwg = sheet.build()
+        hole = next(f for f in dwg.model().features if f.kind == "hole")
+        with dwg.deferred():
+            dwg.callout(hole)  # must not raise
+
+    def test_a_surviving_pitch_does_not_mask_an_undrawable_callout(self):
+        """`omitted_by_the_authored_set` asked whether the whole GROUP was omitted. One
+        surviving dimension of an unrelated kind — a pattern's pitch, which is a linear dim
+        between members rather than a term in the callout — made it answer "not omitted"
+        for a callout that still could not render, and the edit went on vanishing silently
+        (#921 review round 7). It now asks about the parameters the callout PRINTS."""
+        from draftwright.model.callout import _CALLOUT_PARAM_KINDS, omitted_by_the_authored_set
+
+        class _Param:
+            def __init__(self, kind):
+                self.kind = kind
+
+        class _Dim:
+            def __init__(self, kind, suppressed, reason):
+                self.param, self.suppressed, self.reason = _Param(kind), suppressed, reason
+
+        class _Group:
+            feature_kind = "pocket_pattern"
+
+            def __init__(self, dims):
+                self.dims = dims
+
+        omission = "not in the authored dimension set"
+        assert "pitch" not in _CALLOUT_PARAM_KINDS["pocket_pattern"], "pitch is not a callout term"
+        # Every PRINTED param omitted; only the pitch survives.
+        assert omitted_by_the_authored_set(
+            _Group(
+                [
+                    _Dim("length", True, omission),
+                    _Dim("depth", True, omission),
+                    _Dim("pitch", False, None),
+                ]
+            )
+        )
+        # A printable param survives → the callout draws, so nothing to refuse.
+        assert not omitted_by_the_authored_set(
+            _Group([_Dim("length", False, None), _Dim("depth", True, omission)])
+        )
+        # Wholly suppressed, but for a PLANNER reason rather than the author's omission.
+        assert not omitted_by_the_authored_set(
+            _Group(
+                [_Dim("length", True, "square footprint"), _Dim("depth", True, "square footprint")]
+            )
+        )
+
     def test_from_part_states_the_automatic_source(self):
         """Detection IS a request for the engine's reading of the part, so `from_part` says so
         rather than leaving the caller to. Not the implicit default returning by the back

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -679,3 +679,118 @@ class TestOmissionReachesTheDrawing:
         assert not [
             pd for g in groups for pd in g.dims if pd.reason == "not in the authored dimension set"
         ]
+
+
+def _names(dwg) -> set:
+    return {name for name, _obj in dwg.iter_annotations()}
+
+
+class TestOmittedDimensionsDoNotRender:
+    """The class above marks the plan; this one reads the PAGE (#921 review round 2).
+
+    Marking a `PlannedDimension` suppressed only matters if some renderer consults it,
+    and three auto passes did not: `render_height_ladder` rebuilt the overall height
+    and the step rungs from the bbox and the feature, and `render_step_positions` did
+    the same for the shoulders. The plan said "omitted" and the drawing drew it anyway,
+    which is why asserting on `plan_dimensions` could not catch this. Every assertion
+    here inspects annotations that actually reached the drawing.
+    """
+
+    @staticmethod
+    def _plate():
+        from build123d import Box, Cylinder, Pos
+
+        return Box(90, 60, 20) - Pos(0, 0, 12) * Cylinder(6, 20)
+
+    @staticmethod
+    def _staircase():
+        """Three tiers, so the rung set has TWO members. A one-rung part cannot tell
+        "the whole set is addressed" from "one member happened to survive"."""
+        from build123d import Box, Pos
+
+        return Box(120, 60, 15) + Pos(-20, 0, 15) * Box(80, 60, 15) + Pos(-40, 0, 30) * Box(
+            40, 60, 15
+        )
+
+    @staticmethod
+    def _shouldered():
+        """One rebate — a `step_position` shoulder to omit."""
+        from build123d import Box, Pos
+
+        return Box(120, 60, 20) + Pos(-30, 0, 20) * Box(60, 60, 25)
+
+    def test_an_omitted_overall_height_is_not_drawn(self):
+        sheet = Sheet(self._plate(), title="T", number="N")
+        sheet.dimension(sheet.envelope(), "width")
+        assert "dim_height" not in _names(sheet.build())
+
+    def test_the_authored_overall_height_is_drawn(self):
+        """The control for the test above: the same sheet, naming height as well, still
+        gets it. Without this, deleting the height ladder outright would pass."""
+        sheet = Sheet(self._plate(), title="T", number="N")
+        env = sheet.envelope()
+        sheet.dimension(env, "width")
+        sheet.dimension(env, "height")
+        assert "dim_height" in _names(sheet.build())
+
+    def test_the_automatic_set_still_draws_the_overall_height(self):
+        sheet = Sheet(self._plate(), title="T", number="N").auto_dimensions()
+        assert "dim_height" in _names(sheet.build())
+
+    @staticmethod
+    def _rungs(dwg):
+        return sorted(n for n in _names(dwg) if n.startswith("dim_step_"))
+
+    @staticmethod
+    def _shoulders(dwg):
+        return sorted(n for n in _names(dwg) if n.startswith("dim_shoulder_"))
+
+    def test_omitted_step_rungs_are_not_drawn(self):
+        part = self._staircase()
+        sheet = Sheet(part, title="T", number="N")
+        sheet.step_level(part)
+        sheet.dimension(sheet.envelope(), "width")
+        assert self._rungs(sheet.build()) == []
+
+    def test_a_correlated_set_is_addressed_whole(self):
+        """ADR 0016 identity tier 3: one `role=` line keeps the WHOLE ladder. With two
+        rungs in play this distinguishes "the set was addressed" from "one member
+        happened to survive" — a per-member reading of the plan would draw neither, and
+        a half-honoured one would draw a partial staircase."""
+        part = self._staircase()
+        authored = Sheet(part, title="T", number="N")
+        authored.step_level(part)
+        authored.dimension(authored.features[-1], "step_height")
+        auto = Sheet(part, title="T", number="N")
+        auto.step_level(part)
+        auto.auto_dimensions()
+        drawn = self._rungs(authored.build())
+        assert len(drawn) > 1, "the fixture must exercise a MULTI-member set"
+        assert drawn == self._rungs(auto.build())
+
+    def test_omitted_step_positions_are_not_drawn(self):
+        part = self._shouldered()
+        sheet = Sheet(part, title="T", number="N")
+        sheet.step_level(part)
+        sheet.dimension(sheet.features[-1], "step_height")
+        assert self._shoulders(sheet.build()) == [], "step_position was not authored"
+        assert self._rungs(sheet.build()), "but its sibling set on the same feature was"
+
+    def test_authored_step_positions_are_drawn(self):
+        part = self._shouldered()
+        sheet = Sheet(part, title="T", number="N")
+        sheet.step_level(part)
+        sheet.dimension(sheet.features[-1], "step_position")
+        assert self._shoulders(sheet.build())
+
+    def test_an_unaddressable_overall_height_is_refused_not_drawn(self):
+        """A sheet that never declared an envelope has no parameter naming the overall
+        height, so an authored set cannot ask for it — and must not silently get it.
+        The bbox fallback belongs to automatic builds only."""
+        from build123d import Cylinder, Pos
+
+        part = self._plate()
+        sheet = Sheet(part, title="T", number="N")
+        hole = sheet.hole(Pos(0, 0, 12) * Cylinder(6, 20))
+        sheet.dimension(hole, "bore.diameter")
+        assert "dim_height" not in _names(sheet.build())

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -284,6 +284,59 @@ class TestSheetSurface:
         marked = {pd.param.parameter_id: pd.suppressed for pd in plan_dimensions(model)[0].dims}
         assert marked == {"bore.diameter": False, "bore.depth": True}
 
+    def test_from_part_can_be_taken_over_by_an_authored_set(self):
+        """Detect the features, then declare exactly which of their measurements to draw.
+        `from_part` chooses the automatic source on the caller's behalf, so this is the
+        script changing its mind, not contradicting itself — and it is the natural way to
+        take over a detected drawing. Requiring every feature to be redeclared by hand to
+        reach suppression by omission would be a poor trade (#921 review round 6)."""
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(100, 60, 20) - Pos(0, 0, 10) * Cylinder(5, 20)
+        sheet = Sheet.from_part(part)
+        hole = next(f for f in sheet.features if f.kind == "hole")
+        sheet.dimension(hole, "bore.diameter")
+
+        drawn = {n for n, _ in sheet.build().iter_annotations()}
+        assert "hc_plan0" in drawn, "the authored callout"
+        assert not [n for n in drawn if n.startswith(("dim_height", "m_env"))], (
+            f"the automatic envelope survived the takeover: {sorted(drawn)}"
+        )
+        assert "m_env_width" in {n for n, _ in Sheet.from_part(part).build().iter_annotations()}, (
+            "the control: from_part alone still auto-dimensions"
+        )
+
+    def test_an_explicit_auto_dimensions_still_conflicts(self):
+        """The distinction that makes the override safe: a SCRIPT LINE asking for the
+        automatic set and then declaring an authored one has said both things, and one of
+        them must be wrong. Only `from_part`'s implicit choice is overridable."""
+        sheet = Sheet(_part(), title="T", number="N").auto_dimensions()
+        bore = sheet.hole(diameter=10, at=(0, 0, 14), axis="z").depth(12)
+        sheet.dimension(bore, "bore.diameter")
+        with pytest.raises(ValueError, match="ONE dimension source"):
+            sheet.build()
+
+    def test_a_callout_for_an_omitted_feature_is_refused_in_both_paths(self):
+        """A post-build edit naming something the authored set left out draws nothing. The
+        deferred path used to record the intent, draw nothing at the drain, drop the intent
+        unconditionally, and report success — the edit vanished with no annotation, no
+        pending intent and no warning (#921 review round 6). Both paths now refuse, with
+        the same message, at the point the caller can still act on it."""
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(100, 60, 20) - Pos(0, 0, 10) * Cylinder(5, 20)
+        sheet = Sheet.from_part(part)
+        env = next(f for f in sheet.features if f.kind == "envelope")
+        hole = next(f for f in sheet.features if f.kind == "hole")
+        sheet.dimension(env, "width")
+        dwg = sheet.build()
+
+        with pytest.raises(ValueError, match="omitted from the authored dimension set"):
+            with dwg.deferred():
+                dwg.callout(hole)
+        with pytest.raises(ValueError, match="omitted from the authored dimension set"):
+            dwg.callout(hole)
+
     def test_from_part_states_the_automatic_source(self):
         """Detection IS a request for the engine's reading of the part, so `from_part` says so
         rather than leaving the caller to. Not the implicit default returning by the back

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -228,6 +228,62 @@ class TestSheetSurface:
         with pytest.raises(ValueError, match="cannot have both"):
             _coerce_model(model, part)
 
+    def test_an_authored_entry_naming_a_feature_copy_raises(self):
+        """Matching is by object identity on purpose — two equal-valued features are two
+        distinct targets, so a part with two identical holes can dimension one of them
+        (see `_request_for`). The cost is that an equal-but-distinct COPY matches nothing,
+        and for an authored set a miss is not a no-op: it declares the complete set, so
+        every measurement on that feature goes silently blank (#921 review round 4).
+
+        Unreachable through `Sheet`, which materialises entries against the final
+        features; reachable through the ADR 0011 public input, which is exactly where a
+        caller assembles a `PartModel` by hand. So the miss says so."""
+        from dataclasses import replace
+
+        from draftwright.model import Frame, HoleFeature, PartModel, plan_dimensions
+        from draftwright.model.ir import RequestedDimension
+
+        hole = HoleFeature(Frame((0, 0, 10), "z"), 12.0, depth=8.0, through=False)
+        clone = replace(hole)
+        assert clone == hole and clone is not hole, "the fixture must be an equal COPY"
+        model = PartModel(
+            bbox=_part().bounding_box(),
+            orientation="prismatic",
+            features=[hole],
+            authored_dimensions=(RequestedDimension(clone, "bore.diameter"),),
+        )
+        with pytest.raises(ValueError, match="not in model.features"):
+            plan_dimensions(model)
+
+    def test_an_authored_entry_naming_a_measurement_that_does_not_exist_raises(self):
+        from draftwright.model import Frame, HoleFeature, PartModel, plan_dimensions
+        from draftwright.model.ir import RequestedDimension
+
+        hole = HoleFeature(Frame((0, 0, 10), "z"), 12.0, depth=8.0, through=False)
+        model = PartModel(
+            bbox=_part().bounding_box(),
+            orientation="prismatic",
+            features=[hole],
+            authored_dimensions=(RequestedDimension(hole, "nonesuch"),),
+        )
+        with pytest.raises(ValueError, match="no 'nonesuch' measurement"):
+            plan_dimensions(model)
+
+    def test_a_valid_authored_entry_still_plans(self):
+        """The control: the guard above must not reject the ordinary case."""
+        from draftwright.model import Frame, HoleFeature, PartModel, plan_dimensions
+        from draftwright.model.ir import RequestedDimension
+
+        hole = HoleFeature(Frame((0, 0, 10), "z"), 12.0, depth=8.0, through=False)
+        model = PartModel(
+            bbox=_part().bounding_box(),
+            orientation="prismatic",
+            features=[hole],
+            authored_dimensions=(RequestedDimension(hole, "bore.diameter"),),
+        )
+        marked = {pd.param.parameter_id: pd.suppressed for pd in plan_dimensions(model)[0].dims}
+        assert marked == {"bore.diameter": False, "bore.depth": True}
+
     def test_from_part_states_the_automatic_source(self):
         """Detection IS a request for the engine's reading of the part, so `from_part` says so
         rather than leaving the caller to. Not the implicit default returning by the back

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -899,3 +899,50 @@ class TestOmittedDimensionsDoNotRender:
             "the automatic build must carry MORE — otherwise the assertion above holds "
             "for a part that was never richly dimensioned in the first place"
         )
+
+    def test_a_turned_part_authors_one_dimension_too(self):
+        """The prismatic case above passed while the whole TURNED family ignored
+        suppression — `render_diameters`, `render_step_lengths`, `render_rotational` and
+        `render_boss_diameters` all selected parameters with no suppression check, so
+        authoring one step length still drew every diameter on the part (#921 review
+        round 3). One fixture per renderer family, because a fixture only guards the
+        family it exercises.
+
+        Centrelines survive by design: they show where the turning axis is and print no
+        value, so a sheet that authors one length still reads as a turned part."""
+        from build123d import Cylinder, Pos, Rot
+
+        part = Rot(0, 90, 0) * Cylinder(4, 20) + Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)
+        sheet = Sheet(part, title="T", number="N")
+        first = sheet.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
+        sheet.step(diameter=12, length=10, at=(15, 0, 0), axis="x")  # same-kind neighbour
+        sheet.dimension(first, "step.length")
+
+        drawn = _names(sheet.build())
+        assert "m_steplen0" in drawn, "the one authored measurement"
+        assert not [n for n in drawn if n.startswith(("m_dia", "dim_od", "ldr_"))], (
+            f"an unauthored turned dimension reached the page: {sorted(drawn)}"
+        )
+        assert "m_steplen1" not in drawn, "the neighbouring step's length was not authored"
+        assert {"centerline_front", "centerline_plan"} <= drawn, "furniture is not a dimension"
+
+    def test_an_omitted_rotational_od_and_bore_are_not_drawn(self):
+        """`render_rotational` places the OD and each concentric bore leader directly.
+        A bore omitted from the set must not even become a strip candidate — it was not
+        wanted, which is different from not fitting."""
+        from build123d import Cylinder
+
+        from draftwright.model.ir import Frame, RotationalFeature
+
+        part = Cylinder(radius=20, height=40) - Cylinder(radius=6, height=40)
+
+        def _built(role):
+            sheet = Sheet(part, title="T", number="N")
+            sheet.add(RotationalFeature(frame=Frame((0, 0, 0), "z"), od=40.0, bores=(12.0,)))
+            sheet.dimension(sheet.features[-1], role)
+            return _names(sheet.build())
+
+        od_only = _built("od")
+        assert "dim_od" in od_only and "ldr_z0" not in od_only
+        bore_only = _built("bore")
+        assert "ldr_z0" in bore_only and "dim_od" not in bore_only

--- a/tests/test_agents_guide.py
+++ b/tests/test_agents_guide.py
@@ -21,7 +21,7 @@ def test_declared_sheet_gdt_targets_the_declared_feature():
     """Front door 2 + GD&T: control(handle) must target the HOLE, not the datum/face. An
     off-centre hole makes the frame site distinguishable from the centred top face (Codex #819)."""
     part, hole_solid, top_face = _holed_block(hole_x=18.0)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     h = s.hole(hole_solid)
     h.fit("H7")
     s.datum("A", top_face)
@@ -107,7 +107,7 @@ def test_sheet_slot_declaration_builds():
     """The guide's `s.slot(...)` declaration: a slotted part declares + builds without error."""
     slot_solid = Pos(0, 0, 0) * Box(24, 8, 12)
     part = Box(80, 40, 12) - slot_solid
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.slot(slot_solid)
     dwg = s.build()
     assert dwg.model().features  # the slot is in the declared model

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -831,13 +831,13 @@ class TestCountersink:
         from build123d import Cone
 
         part = Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(3, 12)
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.hole(diameter=6, at=(0, 0, 6), axis="z").countersink(Cone(3, 7, 4))
         assert s._features[0].csink is not None
         assert abs(s._features[0].csink[0] - 14) < 0.1 and abs(s._features[0].csink[1] - 90) < 0.5
 
     def test_needs_cone_or_explicit(self):
-        s = Sheet(Box(10, 10, 10))
+        s = Sheet(Box(10, 10, 10)).auto_dimensions()
         with pytest.raises(ValueError):
             s.hole(diameter=6, at=(0, 0, 0), axis="z").countersink()
 
@@ -864,12 +864,12 @@ class TestThread:
     def test_declare_and_fluent_carry_the_thread(self):
         h = hole(diameter=2.5, at=(0, 0, 6), axis="z", through=True, thread="M3x0.5")
         assert h.thread == "M3x0.5"
-        s = Sheet(Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(1.25, 12))
+        s = Sheet(Box(90, 60, 12) - Pos(0, 0, 0) * Cylinder(1.25, 12)).auto_dimensions()
         s.hole(diameter=2.5, at=(0, 0, 6), axis="z").thread("M3x0.5")
         assert s._features[0].thread == "M3x0.5"
 
     def test_empty_spec_rejected(self):
-        s = Sheet(Box(30, 30, 12))
+        s = Sheet(Box(30, 30, 12)).auto_dimensions()
         with pytest.raises(ValueError):
             s.hole(diameter=2.5, at=(0, 0, 6), axis="z").thread("  ")
 
@@ -933,17 +933,17 @@ class TestExternalThread:
             == "M3x0.5"
         )
         assert boss(diameter=6, at=(0, 0, 0), axis="x", thread="M6x1").thread == "M6x1"
-        s = Sheet(self._shaft())
+        s = Sheet(self._shaft()).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").thread("M8x1.25")
         assert s._features[0].thread == "M8x1.25"
 
     def test_empty_spec_rejected(self):
-        s = Sheet(Rot(0, 90, 0) * Cylinder(radius=4, height=20))
+        s = Sheet(Rot(0, 90, 0) * Cylinder(radius=4, height=20)).auto_dimensions()
         with pytest.raises(ValueError):
             s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").thread("  ")
 
     def test_thread_appends_to_the_od_callout(self):
-        s = Sheet(self._shaft())
+        s = Sheet(self._shaft()).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
         s.step(diameter=3, length=10, at=(15, 0, 0), axis="x").thread("M3x0.5")
         dwg = s.build()
@@ -953,7 +953,7 @@ class TestExternalThread:
         assert not [x for x in dwg.lint() if x.code == "annotation_out_of_bounds"]
 
     def test_thread_and_finish_coexist_on_one_step(self):
-        s = Sheet(self._shaft())
+        s = Sheet(self._shaft()).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
         s.step(diameter=3, length=10, at=(15, 0, 0), axis="x").thread("M3x0.5").finish("1.6")
         dwg = s.build()
@@ -970,7 +970,7 @@ class TestExternalThread:
             + Pos(-11, 0, 0) * Rot(0, 90, 0) * Cylinder(radius=4, height=12)  # ø8 left shoulder
             + Pos(11, 0, 0) * Rot(0, 90, 0) * Cylinder(radius=4, height=12)  # ø8 right shoulder
         )
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.step(diameter=12, length=10, at=(0, 0, 0), axis="x")
         s.step(diameter=8, length=12, at=(-11, 0, 0), axis="x")
         s.step(diameter=8, length=12, at=(11, 0, 0), axis="x").thread("M8x1.25")
@@ -985,7 +985,7 @@ class TestExternalThread:
         # unthreaded ⌀ (#859, Codex #862 r2).
         part = Box(90, 50, 8) - Pos(-25, 0, 0) * Cylinder(4, 20)
         part = part + Pos(25, 0, 4) * Cylinder(4, 8)  # an ø8 threaded boss beside an ø8 bore
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.hole(diameter=8, at=(-25, 0, 0), axis="z")
         s.boss(diameter=8, at=(25, 0, 8), axis="z").thread("M8x1.25")
         dwg = s.build()
@@ -999,7 +999,7 @@ class TestExternalThread:
         # completed label (not a per-char estimate), so a wide spec drops cleanly rather than
         # crossing the sheet margin (annotation_out_of_bounds) — #859, Codex #862 r3.
         part = Cylinder(radius=4, height=20) + Pos(0, 0, 15) * Cylinder(radius=1.5, height=10)
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="z")
         s.step(diameter=3, length=10, at=(0, 0, 15), axis="z").thread("M" + "12" * 8)  # very wide
         dwg = s.build()
@@ -1468,7 +1468,7 @@ class TestSheet:
         h1 = Pos(20, 10, 4) * Cylinder(3, 8)
         h2 = Pos(-20, 10, 4) * Cylinder(3, 8)
         part = plate - h1 - h2
-        sheet = Sheet(part, title="PLATE", number="DWG-777", scale="2:1")
+        sheet = Sheet(part, title="PLATE", number="DWG-777", scale="2:1").auto_dimensions()
         sheet.envelope()
         sheet.hole(h1)
         sheet.hole(h2)
@@ -1480,14 +1480,14 @@ class TestSheet:
     def test_sheet_export_defaults_to_pdf_dict(self, tmp_path):
         # #702: the facade speaks the modern export API — PDF by default (matching
         # the CLI), {format: path} return — not the deprecated (svg, dxf) tuple.
-        sheet = Sheet(Box(40, 40, 10), title="EXPORT", number="DWG-702")
+        sheet = Sheet(Box(40, 40, 10), title="EXPORT", number="DWG-702").auto_dimensions()
         sheet.envelope()
         paths = sheet.export(str(tmp_path / "dwg702"))
         assert set(paths) == {"pdf"}
         assert paths["pdf"].endswith(".pdf") and (tmp_path / "dwg702.pdf").exists()
 
     def test_sheet_export_formats_passthrough(self, tmp_path):
-        sheet = Sheet(Box(40, 40, 10), title="EXPORT", number="DWG-702B")
+        sheet = Sheet(Box(40, 40, 10), title="EXPORT", number="DWG-702B").auto_dimensions()
         sheet.envelope()
         paths = sheet.export(str(tmp_path / "dwg702b"), formats=("svg", "dxf"))
         assert set(paths) == {"svg", "dxf"}
@@ -1495,13 +1495,13 @@ class TestSheet:
 
     def test_hole_depth_makes_it_blind(self):
         part = Box(40, 40, 10) - Pos(0, 0, 5) * Cylinder(3, 10)
-        sheet = Sheet(part)
+        sheet = Sheet(part).auto_dimensions()
         sheet.hole(Pos(0, 0, 5) * Cylinder(3, 10)).depth(6)
         f = sheet.features[0]
         assert f.through is False and f.depth == 6
 
     def test_hole_through_is_default(self):
-        sheet = Sheet(Box(10, 10, 10))
+        sheet = Sheet(Box(10, 10, 10)).auto_dimensions()
         h = sheet.hole(diameter=3, at=(0, 0, 0), axis="z")
         assert sheet.features[0].through is True
         # the handle is chainable and idempotent
@@ -1527,7 +1527,7 @@ class TestSheet:
 
     def test_envelope_defaults_to_the_part(self):
         part = Box(30, 20, 5)
-        sheet = Sheet(part)
+        sheet = Sheet(part).auto_dimensions()
         sheet.envelope()
         f = sheet.features[0]
         assert f.width == pytest.approx(30) and f.depth == pytest.approx(20)
@@ -1540,7 +1540,7 @@ class TestSheet:
 
         monkeypatch.setattr(sd, "build_drawing", _boom)
         part = Box(40, 40, 8) - Pos(10, 10, 4) * Cylinder(3, 8)
-        sheet = Sheet(part)
+        sheet = Sheet(part).auto_dimensions()
         sheet.envelope()
         sheet.hole(Pos(10, 10, 4) * Cylinder(3, 8))
         m = sheet.model()  # must not call build_drawing
@@ -1550,7 +1550,7 @@ class TestSheet:
         # The cheap model() returns the same IR build() hands the engine — features AND the
         # bbox/datum (the wrapping the engine draws), not just the feature list.
         part = Box(80, 50, 8) - Pos(20, 10, 4) * Cylinder(3, 8)
-        sheet = Sheet(part)
+        sheet = Sheet(part).auto_dimensions()
         sheet.envelope()
         sheet.hole(Pos(20, 10, 4) * Cylinder(3, 8))
         m, built = sheet.model(), sheet.build().model()
@@ -1568,7 +1568,7 @@ class TestSheet:
         box = Box(40, 40, 8)
         stray = Edge.make_line((-80, 0, 0), (0, 0, 0))  # extends the min-X corner past the solid
         part = Compound(children=[*box.solids(), stray])
-        sheet = Sheet(part)
+        sheet = Sheet(part).auto_dimensions()
         sheet.envelope()
         m, built = sheet.model(), sheet.build().model()
         assert m.bbox.min.X == pytest.approx(built.bbox.min.X)  # both drop the stray edge
@@ -1635,7 +1635,7 @@ class TestAuthoredDimension:
         from draftwright.model import measured_dimension
         from draftwright.sheet import Sheet
 
-        sheet = Sheet(Box(40, 20, 10), title="P")
+        sheet = Sheet(Box(40, 20, 10), title="P").auto_dimensions()
         sheet.measured_dimension(**self._KW)
         via_facade = next(f for f in sheet.features if f.kind == "authored_dimension")
         assert measured_dimension(**self._KW) == via_facade
@@ -1647,22 +1647,22 @@ class TestAuthoredDimension:
         from draftwright.model import measured_dimension
         from draftwright.sheet import Sheet
 
-        sheet = Sheet(Box(40, 20, 10), title="P")
+        sheet = Sheet(Box(40, 20, 10), title="P").auto_dimensions()
         with pytest.warns(DeprecationWarning, match="measured_dimension"):
             sheet.dimension(**self._KW)
         assert next(f for f in sheet.features if f.kind == "authored_dimension") == (
             measured_dimension(**self._KW)
         )
 
-    def test_the_overload_refuses_a_call_it_cannot_interpret(self):
-        """The referential form is #874. Until then `dimension(feature, role)` must say so
-        rather than raise a `TypeError` about missing keywords, which is what a plain rename
-        would have produced and what the transitional overload exists to avoid."""
+    def test_the_overload_dispatches_the_referential_form(self):
+        """#874 filled in the other half of the overload: a call carrying none of the measured
+        keywords is the ADR 0016 referential verb, and declares a member of the authored set."""
         from draftwright.sheet import Sheet
 
         sheet = Sheet(Box(40, 20, 10), title="P")
-        with pytest.raises(TypeError, match="referential form"):
-            sheet.dimension(0, "length")
+        sheet.envelope()
+        sheet.dimension(0, "width")
+        assert sheet._authored == [{"token": 0, "role": "width", "discriminator": None}]
 
     def test_validates_without_the_facade(self):
         from draftwright.model import measured_dimension

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -204,14 +204,14 @@ class TestSheetFit:
         return {n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia")}
 
     def test_boss_fit_class_renders_on_leader(self):
-        s = Sheet(self._stepped_shaft())
+        s = Sheet(self._stepped_shaft()).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
         s.diameter(diameter=12, at=(15, 0, 0), axis="x").fit("g6")
         dwg = s.build()
         assert any(lbl == "ø12 g6" for lbl in self._dias(dwg).values()), self._dias(dwg)
 
     def test_boss_fit_deviation_renders_on_leader(self):
-        s = Sheet(self._stepped_shaft())
+        s = Sheet(self._stepped_shaft()).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
         # h6 @ ⌀12 (10–18 band, IT6=11) = (-0.011, 0) → "0/-0.011"
         s.diameter(diameter=12, at=(15, 0, 0), axis="x").fit("h6", show="deviation")
@@ -219,7 +219,7 @@ class TestSheetFit:
         assert any(lbl == "ø12 0/-0.011" for lbl in self._dias(dwg).values()), self._dias(dwg)
 
     def test_fit_bad_class_raises_at_declaration(self):
-        s = Sheet(self._stepped_shaft())
+        s = Sheet(self._stepped_shaft()).auto_dimensions()
         d = s.diameter(diameter=12, at=(15, 0, 0), axis="x")
         with pytest.raises(ValueError):
             d.fit("Z9")  # unknown class

--- a/tests/test_lint_reconciliation.py
+++ b/tests/test_lint_reconciliation.py
@@ -105,7 +105,7 @@ class TestMatcherUnit:
 class TestEndToEnd:
     def test_phantom_hole_warns(self):
         # part is a solid box; the script still declares a hole (its Cylinder is only read for ⌀).
-        s = Sheet(Box(120, 80, 20))
+        s = Sheet(Box(120, 80, 20)).auto_dimensions()
         s.envelope()
         s.hole(Pos(0, 0, 0) * Cylinder(4, 20))
         codes = [i.code for i in s.build().lint()]
@@ -113,7 +113,7 @@ class TestEndToEnd:
 
     def test_real_hole_clean(self):
         part = Box(120, 80, 20) - Pos(0, 0, 0) * Cylinder(4, 20)
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.envelope()
         s.hole(Pos(0, 0, 0) * Cylinder(4, 20))
         codes = [i.code for i in s.build().lint()]
@@ -124,7 +124,7 @@ class TestEndToEnd:
         # still warn — there is no bore, the callout renders over solid material. Exercises the real
         # analyse_cylinders external flag end-to-end.
         part = Cylinder(10, 40)  # solid shaft, OD ⌀20, no bore
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.envelope()
         s.hole(Cylinder(10, 40))  # declares a phantom ⌀20 bore
         assert "declared_feature_absent" in [i.code for i in s.build().lint()]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1397,12 +1397,12 @@ class TestScaleMinimum:
         assert not [w for w in caught if "legibility floor" in str(w.message)]
 
     def test_sheet_explicit_scale_below_floor_is_honoured(self, tmp_path):
-        # #489 public surface: Sheet(scale="1:10") on a thin part is below the legibility floor
+        # #489 public surface: Sheet(scale="1:10").auto_dimensions() on a thin part is below the legibility floor
         # (80 mm × 0.1 = 8 mm) but is the user's intentional choice — warn, render, don't raise.
         from draftwright import Sheet
 
         with pytest.warns(UserWarning, match="legibility floor"):
-            sheet = Sheet(Box(680, 860, 80), scale="1:10")
+            sheet = Sheet(Box(680, 860, 80), scale="1:10").auto_dimensions()
             sheet.export(str(tmp_path / "s"))
         assert (tmp_path / "s.pdf").exists()  # #702: Sheet.export defaults to PDF
 
@@ -8753,7 +8753,7 @@ class TestPrismaticBossDiameter:
         bore = Pos(0, 0, 15) * Cylinder(6, 40)
         cover = Box(length, width, height) - pocket + boss - bore
 
-        sheet = Sheet(cover, title="C")
+        sheet = Sheet(cover, title="C").auto_dimensions()
         sheet.envelope()
         sheet.boss(boss)
         sheet.hole(bore).through()
@@ -8778,7 +8778,7 @@ class TestPrismaticBossDiameter:
         boss = Pos(0, 0, 24) * Cylinder(14, 10)
         part = Box(90, 64, 38) + boss
         for extra_boss in (False, True):
-            sheet = Sheet(part, title="C")
+            sheet = Sheet(part, title="C").auto_dimensions()
             sheet.envelope()
             if extra_boss:
                 sheet.boss(boss)
@@ -8796,7 +8796,7 @@ class TestPrismaticBossDiameter:
         lower = Pos(0, 0, 25) * Cylinder(35, 10)
         upper = Pos(0, 0, 35) * Cylinder(25, 10)
         part = Box(100, 100, 20) + lower + upper
-        sheet = Sheet(part, title="C")
+        sheet = Sheet(part, title="C").auto_dimensions()
         sheet.envelope()
         sheet.step(lower)
         sheet.step(upper)
@@ -9004,7 +9004,7 @@ class TestTurnedDiameters:
         from draftwright import Sheet
 
         part = self._issue_892_y_chain(axis_z=9.0)
-        sheet = Sheet(part, scale=1.0, page="A2")
+        sheet = Sheet(part, scale=1.0, page="A2").auto_dimensions()
         sheet.step(diameter=45, length=3, at=(0, -1.5, 9), axis="y").tolerance(0.2)
         sheet.step(diameter=34, length=5.5, at=(0, -5.75, 9), axis="y").tolerance(0.0, 0.3)
         sheet.step(diameter=28, length=3.5, at=(0, -10.25, 9), axis="y")

--- a/tests/test_object_aspects.py
+++ b/tests/test_object_aspects.py
@@ -50,7 +50,7 @@ class TestCboreVerb:
 
     def test_number_free_counterbore_renders_lint_clean(self):
         part, bore, cbore = self._plate()
-        s = Sheet(part, title="MP")
+        s = Sheet(part, title="MP").auto_dimensions()
         s.envelope()
         s.hole(bore).cbore(cbore)  # ⌀ + depth read off the objects — no numbers
         dwg = s.build()
@@ -59,23 +59,23 @@ class TestCboreVerb:
 
     def test_explicit_kwargs_override_the_object_read(self):
         part, bore, cbore = self._plate()
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.hole(bore).cbore(cbore, depth=6)  # keep the read ⌀, override the depth
         assert s.features[0].cbore == pytest.approx((30.0, 6.0))
 
     def test_explicit_values_without_an_object(self):
-        s = Sheet(Box(40, 40, 10))
+        s = Sheet(Box(40, 40, 10)).auto_dimensions()
         s.hole(diameter=6, at=(0, 0, 0), axis="z").cbore(diameter=12, depth=4)
         assert s.features[0].cbore == (12, 4)
 
     def test_needs_object_or_explicit_values(self):
-        s = Sheet(Box(40, 40, 10))
+        s = Sheet(Box(40, 40, 10)).auto_dimensions()
         with pytest.raises(ValueError):
             s.hole(diameter=6, at=(0, 0, 0), axis="z").cbore()
 
     def test_rejects_nonpositive_cbore(self):
         # #462 review: match declare.hole()'s positivity guard — a bad explicit value fails loud
-        s = Sheet(Box(40, 40, 10))
+        s = Sheet(Box(40, 40, 10)).auto_dimensions()
         with pytest.raises(ValueError):
             s.hole(diameter=6, at=(0, 0, 0), axis="z").cbore(diameter=-5, depth=6)
         with pytest.raises(ValueError):
@@ -84,6 +84,6 @@ class TestCboreVerb:
     def test_spotface_reads_off_the_tool(self):
         part = Box(60, 60, 20)
         sf = Pos(0, 0, 8) * Cylinder(12, 6)  # ⌀24, opens at +z(10), floor at 5 → depth 5
-        s = Sheet(part - Pos(0, 0, 0) * Cylinder(4, 40) - sf)
+        s = Sheet(part - Pos(0, 0, 0) * Cylinder(4, 40) - sf).auto_dimensions()
         s.hole(Pos(0, 0, 0) * Cylinder(4, 40)).spotface(sf)
         assert s.features[0].spotface == pytest.approx((24.0, 5.0))

--- a/tests/test_plan_consuming_renderers.py
+++ b/tests/test_plan_consuming_renderers.py
@@ -1,22 +1,31 @@
-"""Fail-closed ratchet: a renderer fed the plan must honour the plan's suppression.
+"""A renderer fed the plan must honour the plan's suppression.
 
 `PlannedDimension.suppressed` is the planner's decision that a measurement is not
 drawn — a square footprint's redundant depth, a turned part's doubled extent, or a
 measurement omitted from an authored set (ADR 0016 / #876). Marking is only half the
 mechanism: it means nothing unless the renderer *reads* it.
 
-Three review rounds on #921 each found renderers that did not. The first round found
-the authored set never reaching the planner at all; the second found
-`render_height_ladder` and `render_step_positions` rebuilding their marks from the
-feature and the bounding box; the third found the whole turned family —
-`render_diameters`, `render_boss_diameters`, `render_step_lengths`, `render_rotational`
-— selecting parameters with no suppression check, so authoring one step length still
-drew every diameter on the part.
+Three review rounds on #921 each found renderers that did not. The first found the
+authored set never reaching the planner at all; the second found `render_height_ladder`
+and `render_step_positions` rebuilding their marks from the feature and the bounding
+box; the third found the whole turned family — `render_diameters`,
+`render_boss_diameters`, `render_step_lengths`, `render_rotational` — selecting
+parameters with no suppression check, so authoring one step length still drew every
+diameter on the part.
 
-Each was found by a fixture that happened to cover it, which is exactly the wrong way
-to find the fourth. This guard is structural instead: every renderer handed the planned
-groups must consult suppression somewhere, and a new one that forgets fails here rather
-than in whichever drawing a user notices first.
+Each was caught by a fixture that happened to cover it, which is the wrong way to find
+the fourth: round two's fixtures were prismatic, so they were structurally incapable of
+seeing round three. Hence two guards, in order of strength:
+
+1. **Behavioural** (`TestNothingSurvivesATotallySuppressedPlan`) — suppress *everything*
+   the planner produces and assert no dimension reaches the page. This tests the
+   property itself, across whatever renderers the part exercises, and cannot be
+   satisfied by a renderer that merely mentions `suppressed`.
+2. **Structural** (`TestEveryPlanFedRendererReadsTheFlag`) — a cheap AST check that each
+   plan-consuming renderer at least references suppression. This is a smoke alarm, not
+   a proof: it cannot tell a live read from a dead one (a round-4 reviewer demonstrated
+   both `if False: ... pd.suppressed` and an ignored helper call satisfying it). Its
+   value is catching a NEW renderer whose feature kind no fixture above covers.
 """
 
 from __future__ import annotations
@@ -24,16 +33,137 @@ from __future__ import annotations
 import ast
 import pathlib
 
+import pytest
+from build123d import Box, Cylinder, Pos, Rot
+
+from draftwright import Sheet
+
 _SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "draftwright"
 _FROM_MODEL = _SRC / "annotations" / "from_model.py"
 
-# Helpers that encapsulate a suppression reading. A renderer delegating to one of these
-# has consulted the plan just as surely as one testing `pd.suppressed` itself.
+
+def _stepped_block():
+    return Box(120, 60, 15) + Pos(-20, 0, 15) * Box(80, 60, 15) + Pos(-40, 0, 30) * Box(40, 60, 15)
+
+
+def _turned_shaft():
+    return Rot(0, 90, 0) * Cylinder(4, 20) + Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)
+
+
+def _drilled_plate():
+    return Box(120, 80, 25) - Pos(-30, 0, 17) * Cylinder(5, 20) - Pos(30, 20, 17) * Cylinder(4, 20)
+
+
+# Annotations that are furniture rather than dimensioning, and so legitimately survive a
+# plan in which every measurement is suppressed. Each needs a reason it prints no value —
+# "it kept failing otherwise" is how the defects above got in.
+_FURNITURE = (
+    "centerline",  # shows where an axis is; carries no number
+    "m_cm",  # centre marks, sized off the hole they mark (#875)
+    "m_locx",  # location ladders have no addressable identity yet (#883), so an
+    "m_locy",  # authored set neither names nor suppresses them
+    "note_",  # the ISO NTS note
+    "title_block",
+    "section_",  # section arrows/labels — furniture for a view, not a measurement
+    "hatch",
+)
+
+
+class TestNothingSurvivesATotallySuppressedPlan:
+    """The property itself: if the planner suppresses everything, the page carries no
+    dimension. Patching the plan rather than authoring a set reaches renderers no
+    authored fixture would — it does not care which feature kinds the part has, so a
+    renderer family added later is covered by whichever part exercises it.
+
+    `Sheet.from_part` on purpose, not a bare `Sheet(part).auto_dimensions()`: the bare
+    form declares no features, so the plan is empty and nothing drawn can be traced to
+    it. Only a DETECTED model puts every measurement on the page under the planner's
+    authority, which is what makes "suppress it all" a meaningful instruction."""
+
+    @pytest.fixture
+    def suppress_everything(self, monkeypatch):
+        from dataclasses import replace
+
+        from draftwright.model import planner
+
+        real = planner.plan_dimensions
+
+        def _all_suppressed(model):
+            return [
+                replace(
+                    g,
+                    units=tuple(
+                        replace(
+                            u,
+                            members=tuple(
+                                replace(m, suppressed=True, reason="test: total suppression")
+                                for m in u.members
+                            ),
+                        )
+                        for u in g.units
+                    ),
+                )
+                for g in real(model)
+            ]
+
+        # Patch at every import site: the renderers take `groups` from the orchestrator,
+        # which resolves `plan_dimensions` through its own module reference.
+        for mod in ("draftwright.model.planner", "draftwright.model", "draftwright.drawing"):
+            monkeypatch.setattr(f"{mod}.plan_dimensions", _all_suppressed, raising=False)
+        monkeypatch.setattr(
+            "draftwright.annotations.orchestrator.plan_dimensions", _all_suppressed, raising=False
+        )
+        return _all_suppressed
+
+    @pytest.mark.parametrize(
+        "make_part",
+        [_stepped_block, _turned_shaft, _drilled_plate],
+        ids=["stepped", "turned", "drilled"],
+    )
+    def test_no_dimension_reaches_the_page(self, make_part, suppress_everything):
+        part = make_part()
+        dwg = Sheet.from_part(part).build()
+        drawn = {n for n, _ in dwg.iter_annotations()}
+        leaked = sorted(n for n in drawn if not n.startswith(_FURNITURE))
+
+        # The ONE documented exception, pinned rather than waved through: a model with no
+        # `EnvelopeFeature` (a round body, an all-`step` turned shaft) still gets an
+        # overall height off the bounding box, and no parameter anywhere names it — so no
+        # amount of planner suppression can reach it. An AUTHORED build refuses that
+        # fallback outright (`render_height_ladder`); an automatic one keeps it, because
+        # dropping it would leave those parts with no overall height at all. Narrowing
+        # this to `dim_height` on an envelope-less model means the exception cannot grow
+        # into cover for the next renderer that ignores the plan.
+        has_envelope = any(f.kind == "envelope" for f in dwg.model().features)
+        allowed = [] if has_envelope else ["dim_height"]
+        assert leaked == [n for n in allowed if n in drawn], (
+            f"{leaked} reached the page from a plan in which every measurement is marked "
+            "suppressed. Some renderer is rebuilding its marks from the feature or the "
+            "bounding box instead of reading the plan — the #921 defect, three times over."
+        )
+
+    @pytest.mark.parametrize(
+        "make_part",
+        [_stepped_block, _turned_shaft, _drilled_plate],
+        ids=["stepped", "turned", "drilled"],
+    )
+    def test_the_same_part_is_richly_dimensioned_without_the_patch(self, make_part):
+        """The anchor. Without it the test above passes for a part that draws nothing
+        anyway, which is how a guard quietly stops guarding."""
+        part = make_part()
+        drawn = {n for n, _ in Sheet.from_part(part).build().iter_annotations()}
+        assert [n for n in drawn if not n.startswith(_FURNITURE)], (
+            "this fixture must produce dimensions to be worth suppressing"
+        )
+
+
+# --- the cheap structural smoke alarm ------------------------------------------------
+
+# Helpers that encapsulate a suppression reading.
 _SANCTIONED = {"env_dim_placed", "set_dim_placed"}
 
 # Renderers that legitimately read the FEATURE rather than the planned dimension, with
-# the reason each is not a dimension. Anything added here needs the same kind of reason:
-# "it was easier" is how the defect above got in.
+# the reason each is not a dimension.
 _NOT_DIMENSIONS = {
     # Centre marks are furniture sizing themselves off the hole they mark. #875 made
     # them read `hole.diameter` on purpose: sized from the suppressible parameter, a
@@ -67,30 +197,29 @@ def _consults_suppression(fn: ast.FunctionDef) -> bool:
     return False
 
 
-def test_the_guard_is_looking_at_something():
-    """A ratchet that matches nothing passes forever. Pin the population so a rename or
-    a moved module fails loudly instead of quietly guarding an empty set."""
-    found = _plan_consuming_renderers()
-    assert len(found) >= 12, f"expected the renderer family, found {sorted(found)}"
-    assert "render_diameters" in found and "render_rotational" in found
+class TestEveryPlanFedRendererReadsTheFlag:
+    def test_the_guard_is_looking_at_something(self):
+        """A ratchet that matches nothing passes forever. Pin the population so a rename
+        or a moved module fails loudly instead of quietly guarding an empty set."""
+        found = _plan_consuming_renderers()
+        assert len(found) >= 12, f"expected the renderer family, found {sorted(found)}"
+        assert "render_diameters" in found and "render_rotational" in found
 
+    def test_every_plan_fed_renderer_mentions_suppression(self):
+        offenders = sorted(
+            name
+            for name, fn in _plan_consuming_renderers().items()
+            if name not in _NOT_DIMENSIONS and not _consults_suppression(fn)
+        )
+        assert not offenders, (
+            f"{offenders} take the planned groups but never consult `suppressed`. A "
+            "planner decision the renderer ignores is not a decision: the plan will say a "
+            "dimension is omitted while the drawing carries it. Read `pd.suppressed` (or "
+            f"a sanctioned helper: {sorted(_SANCTIONED)}), or add the renderer to "
+            "_NOT_DIMENSIONS with a reason it prints no value."
+        )
 
-def test_every_plan_fed_renderer_honours_suppression():
-    offenders = sorted(
-        name
-        for name, fn in _plan_consuming_renderers().items()
-        if name not in _NOT_DIMENSIONS and not _consults_suppression(fn)
-    )
-    assert not offenders, (
-        f"{offenders} take the planned groups but never consult `suppressed`. A planner "
-        "decision the renderer ignores is not a decision: the plan will say a dimension "
-        "is omitted while the drawing carries it. Read `pd.suppressed` (or a sanctioned "
-        f"helper: {sorted(_SANCTIONED)}), or add the renderer to _NOT_DIMENSIONS with a "
-        "reason it prints no value."
-    )
-
-
-def test_the_exemptions_still_exist():
-    """An exemption for a deleted function silently widens the guard."""
-    found = _plan_consuming_renderers()
-    assert not (_NOT_DIMENSIONS - set(found)), "stale exemption in _NOT_DIMENSIONS"
+    def test_the_exemptions_still_exist(self):
+        """An exemption for a deleted function silently widens the guard."""
+        found = _plan_consuming_renderers()
+        assert not (_NOT_DIMENSIONS - set(found)), "stale exemption in _NOT_DIMENSIONS"

--- a/tests/test_plan_consuming_renderers.py
+++ b/tests/test_plan_consuming_renderers.py
@@ -1,0 +1,96 @@
+"""Fail-closed ratchet: a renderer fed the plan must honour the plan's suppression.
+
+`PlannedDimension.suppressed` is the planner's decision that a measurement is not
+drawn — a square footprint's redundant depth, a turned part's doubled extent, or a
+measurement omitted from an authored set (ADR 0016 / #876). Marking is only half the
+mechanism: it means nothing unless the renderer *reads* it.
+
+Three review rounds on #921 each found renderers that did not. The first round found
+the authored set never reaching the planner at all; the second found
+`render_height_ladder` and `render_step_positions` rebuilding their marks from the
+feature and the bounding box; the third found the whole turned family —
+`render_diameters`, `render_boss_diameters`, `render_step_lengths`, `render_rotational`
+— selecting parameters with no suppression check, so authoring one step length still
+drew every diameter on the part.
+
+Each was found by a fixture that happened to cover it, which is exactly the wrong way
+to find the fourth. This guard is structural instead: every renderer handed the planned
+groups must consult suppression somewhere, and a new one that forgets fails here rather
+than in whichever drawing a user notices first.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "draftwright"
+_FROM_MODEL = _SRC / "annotations" / "from_model.py"
+
+# Helpers that encapsulate a suppression reading. A renderer delegating to one of these
+# has consulted the plan just as surely as one testing `pd.suppressed` itself.
+_SANCTIONED = {"env_dim_placed", "set_dim_placed"}
+
+# Renderers that legitimately read the FEATURE rather than the planned dimension, with
+# the reason each is not a dimension. Anything added here needs the same kind of reason:
+# "it was easier" is how the defect above got in.
+_NOT_DIMENSIONS = {
+    # Centre marks are furniture sizing themselves off the hole they mark. #875 made
+    # them read `hole.diameter` on purpose: sized from the suppressible parameter, a
+    # suppressed ⌀20 collapsed its mark from 42 mm to the 2.5 mm floor. A centre mark
+    # shows where an axis is; it prints no value, so there is nothing to suppress.
+    "render_centermarks",
+}
+
+
+def _plan_consuming_renderers() -> dict[str, ast.FunctionDef]:
+    """Every `render_*` in `from_model.py` that is handed the planned groups."""
+    tree = ast.parse(_FROM_MODEL.read_text(encoding="utf-8"))
+    out = {}
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("render_"):
+            continue
+        args = [a.arg for a in node.args.args] + [a.arg for a in node.args.kwonlyargs]
+        if "groups" in args:
+            out[node.name] = node
+    return out
+
+
+def _consults_suppression(fn: ast.FunctionDef) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Attribute) and node.attr == "suppressed":
+            return True
+        if isinstance(node, ast.Call):
+            name = node.func.id if isinstance(node.func, ast.Name) else None
+            if name in _SANCTIONED:
+                return True
+    return False
+
+
+def test_the_guard_is_looking_at_something():
+    """A ratchet that matches nothing passes forever. Pin the population so a rename or
+    a moved module fails loudly instead of quietly guarding an empty set."""
+    found = _plan_consuming_renderers()
+    assert len(found) >= 12, f"expected the renderer family, found {sorted(found)}"
+    assert "render_diameters" in found and "render_rotational" in found
+
+
+def test_every_plan_fed_renderer_honours_suppression():
+    offenders = sorted(
+        name
+        for name, fn in _plan_consuming_renderers().items()
+        if name not in _NOT_DIMENSIONS and not _consults_suppression(fn)
+    )
+    assert not offenders, (
+        f"{offenders} take the planned groups but never consult `suppressed`. A planner "
+        "decision the renderer ignores is not a decision: the plan will say a dimension "
+        "is omitted while the drawing carries it. Read `pd.suppressed` (or a sanctioned "
+        f"helper: {sorted(_SANCTIONED)}), or add the renderer to _NOT_DIMENSIONS with a "
+        "reason it prints no value."
+    )
+
+
+def test_the_exemptions_still_exist():
+    """An exemption for a deleted function silently widens the guard."""
+    found = _plan_consuming_renderers()
+    assert not (_NOT_DIMENSIONS - set(found)), "stale exemption in _NOT_DIMENSIONS"

--- a/tests/test_pocket_pattern.py
+++ b/tests/test_pocket_pattern.py
@@ -49,7 +49,7 @@ def test_declare_composes_member_and_layout():
 
 def test_linear_pattern_renders_one_grouped_callout_plus_pitch():
     part = Box(26, 161, 21)  # the tuner-jig bar
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.pocket_pattern(_member(), kind="linear", count=5, pitch=27.2, direction=(0, 1, 0))
     dwg = s.build()
@@ -79,7 +79,7 @@ def test_grid_pattern_renders_both_pitch_dims():
         w_center=0.0,
         at=(0.0, 0.0, 4.0),
     )
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.pocket_pattern(member, kind="grid", count=6, grid=(30.0, 40.0), rows=2, cols=3)
     dwg = s.build()
@@ -181,7 +181,7 @@ def test_pitch_dim_names_do_not_collide_with_hole_pattern():
     # `dim_pitch_plan0` — the second silently overwrote the first. Distinct prefixes now let
     # both pitch dims survive on one sheet (Codex #848 r2).
     part = Box(140, 120, 14)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.pattern(  # hole pattern, +Y half, plan view (z holes)
         hole(diameter=6.0, at=(0.0, 35.0, 0.0), axis="z"),
@@ -222,7 +222,7 @@ def test_manual_callout_verb_places_grouped_callout_and_pitch():
     # size/depth callout AND its pitch dim (render_pocket_patterns bundles both), returning the
     # grouped-callout name. It replaces the old deferred-stub that raised.
     part = Box(26, 161, 21)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.pocket_pattern(_member(), kind="linear", count=5, pitch=27.2, direction=(0, 1, 0))
     dwg = build_drawing(part, model=s.model(), auto_dims=False)  # nothing auto-drawn
@@ -238,7 +238,7 @@ def test_deferred_callout_reconstructs_the_pattern():
     # recorded inside `with dwg.deferred()` drains through finalize's pre-drain "pocket_patterns"
     # stage, drawing the same grouped callout + pitch (#841 outcome 3).
     part = Box(26, 161, 21)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.pocket_pattern(_member(), kind="linear", count=5, pitch=27.2, direction=(0, 1, 0))
     dwg = build_drawing(part, model=s.model(), auto_dims=False)
@@ -252,7 +252,7 @@ def test_deferred_callout_reconstructs_the_pattern():
 
 def test_model_inspection_sees_the_pattern():
     # the cheap no-render model() path exposes the declared pattern feature
-    s = Sheet(Box(26, 161, 21))
+    s = Sheet(Box(26, 161, 21)).auto_dimensions()
     s.pocket_pattern(_member(), kind="linear", count=5, pitch=27.2, direction=(0, 1, 0))
     model = s.model()
     pats = [f for f in model.features if f.kind == "pocket_pattern"]

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -90,6 +90,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_place_dim",
         "_queue_dimension_intent",
         "_record_build_issue",
+        "_refuse_authored_omission",
         "_replay_intent",
         "_resolve_dimension_span",
         "_set_view_coordinates",

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -63,6 +63,25 @@ class TestEmit:
         directly: a part with no features must still emit it."""
         assert "sheet.auto_dimensions()" in _script_for(part)
 
+    def test_a_model_with_an_authored_set_is_refused_not_silently_converted(self):
+        """The emitter used to write `sheet.auto_dimensions()` for ANY model, so running a
+        script generated from an authored model restored every dimension that model had
+        omitted — "width only" became the full automatic set (#921 review round 5). A
+        generated script that draws something other than its source model is the #707
+        class of divergence.
+
+        It refuses rather than emitting the declarations, because the only way to name a
+        feature in the generated script is by position, and the documented workflow for
+        these scripts is to comment a feature line out and re-run — which would shift the
+        indices and retarget the dimensions onto their neighbours."""
+        from draftwright import Sheet
+        from draftwright.sheet_emit import emit_sheet_script
+
+        sheet = Sheet(Box(90, 60, 20), title="T", number="N")
+        sheet.dimension(sheet.envelope(), "width")
+        with pytest.raises(ValueError, match="authored dimension set"):
+            emit_sheet_script(sheet.model(), "part = Box(90, 60, 20)", "s", title="T", number="N")
+
     def test_emits_one_declarative_line_per_feature(self):
         src = _script_for(_plate())
         assert "sheet = Sheet(part, title='T', number='N')" in src

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -104,7 +104,7 @@ class TestEmit:
     def test_measured_dimension_declares_renderable_authored_dimension(self, tmp_path):
         from draftwright import Sheet
 
-        sheet = Sheet(Box(40, 20, 10), title="P", out=str(tmp_path / "dim"))
+        sheet = Sheet(Box(40, 20, 10), title="P", out=str(tmp_path / "dim")).auto_dimensions()
         sheet.measured_dimension(
             kind="linear",
             value=40,
@@ -125,7 +125,7 @@ class TestEmit:
     def test_measured_dimension_rejects_unrenderable_kind(self):
         from draftwright import Sheet
 
-        sheet = Sheet(Box(40, 20, 10), title="P")
+        sheet = Sheet(Box(40, 20, 10), title="P").auto_dimensions()
         with pytest.raises(ValueError, match="kind must be one of"):
             sheet.measured_dimension(
                 kind="liner",
@@ -139,7 +139,7 @@ class TestEmit:
     def test_measured_dimension_rejects_unrenderable_axis(self):
         from draftwright import Sheet
 
-        sheet = Sheet(Box(40, 20, 10), title="P")
+        sheet = Sheet(Box(40, 20, 10), title="P").auto_dimensions()
         with pytest.raises(ValueError, match="dominant_axis must be X, Y, or Z"):
             sheet.measured_dimension(
                 kind="linear",
@@ -162,7 +162,7 @@ class TestEmit:
             "Z": [(-38, -30, 5), (-38, -30, 15)],
         }
         for axis, ref_pts in cases.items():
-            sheet = Sheet(Box(80, 60, 40), title="P")
+            sheet = Sheet(Box(80, 60, 40), title="P").auto_dimensions()
             sheet.measured_dimension(
                 kind="linear",
                 value=10,
@@ -182,7 +182,7 @@ class TestEmit:
         # for a real candidate that reached the corridor solver and could not fit.
         from draftwright import Sheet
 
-        sheet = Sheet(Box(80, 60, 40), title="P")
+        sheet = Sheet(Box(80, 60, 40), title="P").auto_dimensions()
         sheet.measured_dimension(
             kind="linear",
             value=10,
@@ -505,7 +505,7 @@ class TestEmit:
         model = detect_part_model(part)
         src = _script_for(part)
         line = next(ln for ln in src.splitlines() if "sheet.step_level(" in ln).split("#")[0]
-        sheet = Sheet(part, title="T", number="N")
+        sheet = Sheet(part, title="T", number="N").auto_dimensions()
         exec(compile(line, "<emit>", "exec"), {"sheet": sheet})
         got = sheet._features[-1]
         det = next(f for f in model.features if f.kind == "step_level")
@@ -545,7 +545,7 @@ class TestEmit:
 
         part = Box(60, 30, 12) - Pos(0, 0, 0) * Box(20.33, 8, 20)  # off-round → stresses rounding
         line = next(ln for ln in _script_for(part).splitlines() if ln.startswith("sheet.slot("))
-        eval(line, {"sheet": Sheet(part)})  # declare.slot() must not raise
+        eval(line, {"sheet": Sheet(part).auto_dimensions()})  # declare.slot() must not raise
 
     def test_pocket_line_re_runs_without_the_length_invariant_error(self):
         # #148a: declare.pocket() checks hi - lo == length to 1e-6; the emitter must derive
@@ -554,7 +554,7 @@ class TestEmit:
 
         part = Box(80, 60, 20) - Pos(0, 0, 6) * Box(30.33, 20, 8)  # off-round → stresses rounding
         line = next(ln for ln in _script_for(part).splitlines() if ln.startswith("sheet.pocket("))
-        eval(line, {"sheet": Sheet(part)})  # declare.pocket() must not raise
+        eval(line, {"sheet": Sheet(part).auto_dimensions()})  # declare.pocket() must not raise
 
     def test_linear_pattern_spells_out_members(self):
         # #461 review: the arrangement can't be recomputed faithfully (no reliable direction/angle),

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -53,6 +53,16 @@ def _script_for(part, part_expr="part = PART", stem="drawing", **kw):
 
 
 class TestEmit:
+    @pytest.mark.parametrize(
+        "part", [Box(40, 20, 10), _plate(), Box(80, 60, 40)], ids=["bare", "plate", "block"]
+    )
+    def test_every_emitted_script_states_its_dimension_source(self, part):
+        """#874's emitter gate. A generated script must SAY where its dimensions come
+        from, not rely on a default — that is what makes omission mean something. Round
+        trips cover this only implicitly (the build would raise), so assert the line
+        directly: a part with no features must still emit it."""
+        assert "sheet.auto_dimensions()" in _script_for(part)
+
     def test_emits_one_declarative_line_per_feature(self):
         src = _script_for(_plate())
         assert "sheet = Sheet(part, title='T', number='N')" in src

--- a/tests/test_sheet_gdt.py
+++ b/tests/test_sheet_gdt.py
@@ -23,7 +23,7 @@ def _top_face(part):
 
 def test_finish_on_feature_derives_face_on_view():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).finish("1.6")
     fin = next(f for f in s.features if f.kind == "finish")
     assert fin.ra == "1.6"
@@ -35,7 +35,7 @@ def test_finish_on_feature_derives_face_on_view():
 
 def test_datum_on_planar_face_derives_edge_on_view():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.datum("A", _top_face(part))
     d = next(f for f in s.features if f.kind == "datum_ref")
     assert d.letter == "A"
@@ -47,7 +47,7 @@ def test_datum_on_planar_face_derives_edge_on_view():
 
 def test_dim_handle_finish():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.diameter(Pos(30, 0, 0) * Cylinder(8, 20)).finish("3.2")
     fin = next(f for f in s.features if f.kind == "finish")
     assert fin.ra == "3.2" and fin.view == "plan"
@@ -68,7 +68,7 @@ def test_non_axis_aligned_face_raises():
 
 def test_bad_inputs_raise():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     with pytest.raises(ValueError, match="letter"):
         s.datum("", _top_face(part))
     with pytest.raises(ValueError, match="roughness"):
@@ -77,7 +77,7 @@ def test_bad_inputs_raise():
 
 def test_face_datum_places_lint_clean():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     s.datum("A", _top_face(part))
@@ -91,7 +91,7 @@ def test_finish_before_depth_keeps_provenance():
     # the SAME handle replaces the source feature; the finish's origin must re-bind to the FINAL
     # feature at build (index-sourced), else annotations_of() misses it and drop() orphans it.
     part = Box(80, 50, 20) - Pos(0, 0, 0) * Cylinder(6, 20)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     h = s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     h.finish("1.6", view="front", side="above")  # declared BEFORE the size verb
@@ -110,7 +110,7 @@ def test_feature_default_side_is_view_aware_and_places():
     # A z-feature defaults to plan/ABOVE (the plan's below strip always carries the width
     # envelope). A bare finish on the default side places, no override needed.
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).finish("1.6")
     dwg = s.build()
@@ -131,7 +131,7 @@ def test_parse_datums():
 
 def test_control_frame_chain_builds_stacked_frames():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     s.control(0).position(0.1, to="A B").perpendicularity(0.05, to="A")
     cfs = [f for f in s.features if f.kind == "control_frame"]
@@ -145,7 +145,7 @@ def test_control_frame_chain_builds_stacked_frames():
 
 def test_form_tolerance_has_no_datums():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.diameter(Pos(30, 0, 0) * Cylinder(8, 20))
     s.control(0).cylindricity(0.02)
     cf = next(f for f in s.features if f.kind == "control_frame")
@@ -154,7 +154,7 @@ def test_form_tolerance_has_no_datums():
 
 def test_control_frames_place_lint_clean():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     s.control(0).position(0.1, to="A").perpendicularity(0.05, to="A")  # default plan/above
@@ -166,7 +166,7 @@ def test_control_frames_place_lint_clean():
 
 def test_undeclared_datum_warns():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     s.control(0).position(0.1, to="Z")  # no sheet.datum("Z", …) declared
@@ -176,7 +176,7 @@ def test_undeclared_datum_warns():
 
 def test_declared_datum_does_not_warn():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.datum("A", _top_face(part))
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20))

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -64,7 +64,7 @@ def _part():
 
 
 def _sheet():
-    return Sheet(_part(), title="T", number="N")
+    return Sheet(_part(), title="T", number="N").auto_dimensions()
 
 
 def _canonical(model) -> tuple:
@@ -149,6 +149,14 @@ def _scn_note(s):
     return a, lambda a: s.note("M10x1.5 TAP", a)
 
 
+def _scn_dimension(s):
+    """The #874 authored set. Like `section`/`datum`/`note` it returns `Sheet`, so only the
+    state-field ratchet makes it mandatory here."""
+    a = s.hole(diameter=10, at=(-25, 0, 20), axis="z").depth(12)
+    s.hole(diameter=6, at=(25, 0, 20), axis="z").depth(8)
+    return a, lambda a: s.dimension(a, "bore")
+
+
 def _scn_add_dimension(s):
     """The verb runs in the DRIVER, not in setup — so the matrix exercises the resolver on an
     already-reordered sheet, which is a different claim from "a recorded intent survives a
@@ -178,6 +186,7 @@ _SCENARIOS = {
     "section": _scn_section,
     "datum": _scn_datum,
     "note": _scn_note,
+    "dimension": _scn_dimension,
 }
 
 #: Verbs that hand back a `_Params` by exactly the same route `envelope` does — declare the
@@ -567,7 +576,7 @@ def _handle_returning_verbs() -> set[str]:
 #: `Sheet` state that stores a reference to a declared feature. Each must be reached by at least
 #: one scenario, proven at runtime below rather than asserted by eye.
 _STATE_CARRYING_FEATURE_REFS = frozenset(
-    {"_tolerances", "_gdt_src", "_section", "_added_dimensions"}
+    {"_tolerances", "_gdt_src", "_section", "_added_dimensions", "_authored"}
 )
 
 #: `Sheet` state that stores no feature reference, so a reorder cannot affect it.

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -152,6 +152,10 @@ def _scn_note(s):
 def _scn_dimension(s):
     """The #874 authored set. Like `section`/`datum`/`note` it returns `Sheet`, so only the
     state-field ratchet makes it mandatory here."""
+    # `_sheet()` states the automatic source; the two are mutually exclusive (#874), so this
+    # scenario switches to the authored one. Reaching for the private flag rather than adding
+    # a public "unset the source" verb: nothing outside a test wants to change its mind.
+    s._auto_dimensions = False
     a = s.hole(diameter=10, at=(-25, 0, 20), axis="z").depth(12)
     s.hole(diameter=6, at=(25, 0, 20), axis="z").depth(8)
     return a, lambda a: s.dimension(a, "bore")

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -155,7 +155,7 @@ def _scn_dimension(s):
     # `_sheet()` states the automatic source; the two are mutually exclusive (#874), so this
     # scenario switches to the authored one. Reaching for the private flag rather than adding
     # a public "unset the source" verb: nothing outside a test wants to change its mind.
-    s._auto_dimensions = False
+    s._auto_dimensions = None
     a = s.hole(diameter=10, at=(-25, 0, 20), axis="z").depth(12)
     s.hole(diameter=6, at=(25, 0, 20), axis="z").depth(8)
     return a, lambda a: s.dimension(a, "bore")

--- a/tests/test_sheet_notes.py
+++ b/tests/test_sheet_notes.py
@@ -24,7 +24,7 @@ def _top_face(part):
 
 def test_note_on_feature_derives_face_on_view():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).note("M3x0.5 TAP")
     nt = next(f for f in s.features if f.kind == "note")
     assert nt.text == "M3x0.5 TAP"
@@ -36,7 +36,7 @@ def test_note_on_feature_derives_face_on_view():
 
 def test_note_on_planar_face_derives_edge_on_view():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.note("DEBURR", _top_face(part))
     nt = next(f for f in s.features if f.kind == "note")
     assert nt.text == "DEBURR"
@@ -48,7 +48,7 @@ def test_note_on_planar_face_derives_edge_on_view():
 
 def test_dim_handle_note():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.diameter(Pos(30, 0, 0) * Cylinder(8, 20)).note("KNURL 0.8 STRAIGHT")
     nt = next(f for f in s.features if f.kind == "note")
     assert nt.text == "KNURL 0.8 STRAIGHT" and nt.view == "plan"
@@ -61,7 +61,7 @@ def test_slot_and_pocket_handle_note():
     from build123d import Box, Plane, SlotOverall, extrude
 
     part = Box(60, 30, 12) - extrude(Plane.XY * SlotOverall(20, 8), 12, both=True)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     h = s.slot(width=8, length=20, long_axis="x", width_axis="y", lo=-10, hi=10, w_center=0)
     assert h.note("5X OBROUND SLOT") is h  # explicit method, chainable — no TypeError
     nt = next(f for f in s.features if f.kind == "note")
@@ -74,7 +74,7 @@ def test_slot_and_pocket_handle_note():
     assert any(f.kind == "note" and f.text == "DEBURR" and f.origin is None for f in s.features)
 
     p = Box(60, 30, 20) - Pos(0, 0, 4) * extrude(Plane.XY * SlotOverall(20, 8), 12)
-    s2 = Sheet(p)
+    s2 = Sheet(p).auto_dimensions()
     s2.pocket(
         width=8,
         length=20,
@@ -92,12 +92,12 @@ def test_slot_and_pocket_handle_note():
 def test_dim_handle_knurl():
     # #765: knurl() is sugar over note() with canonical KNURL formatting.
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.diameter(Pos(30, 0, 0) * Cylinder(8, 20)).knurl("0.8")
     nt = next(f for f in s.features if f.kind == "note")
     assert nt.text == "KNURL 0.8 STRAIGHT" and nt.view == "plan"
 
-    s2 = Sheet(part)
+    s2 = Sheet(part).auto_dimensions()
     s2.diameter(Pos(30, 0, 0) * Cylinder(8, 20)).knurl("0.5", "DIAMOND")
     nt2 = next(f for f in s2.features if f.kind == "note")
     assert nt2.text == "KNURL 0.5 DIAMOND"
@@ -105,7 +105,7 @@ def test_dim_handle_knurl():
 
 def test_view_side_overrides_win():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).note("TAP", view="front", side="left")
     nt = next(f for f in s.features if f.kind == "note")
     assert nt.view == "front" and nt.side == "left"
@@ -113,7 +113,7 @@ def test_view_side_overrides_win():
 
 def test_bad_inputs_raise():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     with pytest.raises(ValueError, match="note needs text"):
         s.note("   ", _top_face(part))
     with pytest.raises(ValueError, match="note needs text"):
@@ -122,7 +122,7 @@ def test_bad_inputs_raise():
 
 def test_note_places_lint_clean():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).note("M3x0.5 TAP")
     dwg = s.build()
@@ -133,7 +133,7 @@ def test_note_places_lint_clean():
 
 def test_face_note_places_lint_clean():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     s.note("BREAK ALL EDGES 0.3", _top_face(part))
@@ -147,7 +147,7 @@ def test_note_before_depth_keeps_provenance():
     # handle replaces the source feature; the note's origin must re-bind to the FINAL feature at
     # build (index-sourced), else annotations_of() misses it and drop() orphans it.
     part = Box(80, 50, 20) - Pos(0, 0, 0) * Cylinder(6, 20)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     h = s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     h.note("M3x0.5 TAP", view="front", side="above")  # declared BEFORE the size verb
@@ -166,7 +166,7 @@ def test_note_ignored_by_model_inspection_paths():
     # model() is the cheap no-render inspection path; a note is a render-time GD&T-kind aspect,
     # not a dimension-bearing feature — it must not add DimParameters.
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.hole(Pos(0, 0, 0) * Cylinder(6, 20)).note("TAP")
     nt = next(f for f in s.features if f.kind == "note")
     assert nt.parameters() == [] and nt.references() == []
@@ -174,7 +174,7 @@ def test_note_ignored_by_model_inspection_paths():
 
 def test_chaining_returns_the_handle_and_sheet():
     part = _part()
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     h = s.hole(Pos(0, 0, 0) * Cylinder(6, 20))
     assert h.note("TAP") is h  # handle chains
     assert s.note("DEBURR", _top_face(part)) is s  # sheet chains

--- a/tests/test_sheet_of.py
+++ b/tests/test_sheet_of.py
@@ -51,21 +51,21 @@ class TestOf:
     def test_of_matches_on_axis_not_just_in_plane(self):
         # #463 review: a same-⌀ feature on a DIFFERENT axis (a cross-hole) sharing the in-plane
         # coords must not match — the axis is part of the identity.
-        s = Sheet(Box(40, 40, 40))
+        s = Sheet(Box(40, 40, 40)).auto_dimensions()
         s.hole(diameter=8, at=(0, 0, 0), axis="z")  # the intended target
         s.diameter(diameter=8, at=(0, 0, 0), axis="x")  # same ⌀ + in-plane, different axis
         h = s.of(Pos(0, 0, 0) * Cylinder(4, 20))  # a z-axis tool → only the z hole
         assert s.features[h._i].frame.axis == "z"
 
     def test_of_ambiguous_object_raises(self):
-        s = Sheet(Box(40, 40, 30))
+        s = Sheet(Box(40, 40, 30)).auto_dimensions()
         s.hole(diameter=8, at=(0, 0, 5), axis="z")
         s.hole(diameter=8, at=(0, 0, 20), axis="z")  # same ⌀ + in-plane (0,0)
         with pytest.raises(ValueError):
             s.of(Pos(0, 0, 10) * Cylinder(4, 10))  # matches both → ambiguous
 
     def test_of_non_diameter_feature_raises(self):
-        s = Sheet(Box(30, 20, 5))
+        s = Sheet(Box(30, 20, 5)).auto_dimensions()
         s.envelope()
         with pytest.raises(ValueError):
             s.of(0)  # an envelope has no ⌀ aspect handle

--- a/tests/test_sheet_section.py
+++ b/tests/test_sheet_section.py
@@ -15,7 +15,7 @@ from draftwright.sheet import Sheet
 
 def _blind_pocket_sheet():
     """An 80×50×20 bar with ONE declared blind rectangular pocket (no auto-section trigger)."""
-    s = Sheet(Box(80, 50, 20))
+    s = Sheet(Box(80, 50, 20)).auto_dimensions()
     s.envelope()
     p = s.pocket(
         width=8.0,

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -12,7 +12,9 @@ from draftwright import Sheet
 
 
 def _sheet():
-    s = Sheet(Box(120, 80, 20) - Pos(0, 0, 0) * Cylinder(4, 20), title="Plate", number="DWG-T")
+    s = Sheet(
+        Box(120, 80, 20) - Pos(0, 0, 0) * Cylinder(4, 20), title="Plate", number="DWG-T"
+    ).auto_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(4, 20))
     return s

--- a/tests/test_slot_pattern.py
+++ b/tests/test_slot_pattern.py
@@ -45,7 +45,7 @@ def test_declare_composes_member_and_layout():
 
 
 def test_linear_pattern_renders_one_grouped_callout_plus_pitch():
-    s = Sheet(Box(60, 161, 21))
+    s = Sheet(Box(60, 161, 21)).auto_dimensions()
     s.envelope()
     s.slot_pattern(_member(), kind="linear", count=4, pitch=30.0, direction=(0, 1, 0))
     dwg = s.build()
@@ -73,7 +73,7 @@ def test_grid_pattern_renders_both_pitch_dims():
         w_center=0.0,
         at=(0.0, 0.0, 0.0),
     )
-    s = Sheet(Box(160, 120, 14))
+    s = Sheet(Box(160, 120, 14)).auto_dimensions()
     s.envelope()
     s.slot_pattern(member, kind="grid", count=6, grid=(30.0, 40.0), rows=2, cols=3)
     dwg = s.build()
@@ -111,7 +111,7 @@ def test_direction_through_plane_rejected():
 
 
 def test_model_inspection_sees_the_pattern():
-    s = Sheet(Box(60, 161, 21))
+    s = Sheet(Box(60, 161, 21)).auto_dimensions()
     s.slot_pattern(_member(), kind="linear", count=4, pitch=30.0, direction=(0, 1, 0))
     model = s.model()
     pats = [f for f in model.features if f.kind == "slot_pattern"]
@@ -123,7 +123,7 @@ def test_manual_callout_verb_places_grouped_callout_and_pitch():
     # grouped size callout AND its pitch dim (render_slot_patterns bundles both), returning the
     # grouped-callout name — mirroring the pocket-pattern editable surface.
     part = Box(60, 161, 21)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.slot_pattern(_member(), kind="linear", count=4, pitch=30.0, direction=(0, 1, 0))
     dwg = build_drawing(part, model=s.model(), auto_dims=False)  # nothing auto-drawn
@@ -139,7 +139,7 @@ def test_deferred_callout_reconstructs_the_pattern():
     # recorded inside `with dwg.deferred()` drains through finalize's pre-drain "slot_patterns"
     # stage, drawing the same grouped callout + pitch (#841 editable surface).
     part = Box(60, 161, 21)
-    s = Sheet(part)
+    s = Sheet(part).auto_dimensions()
     s.envelope()
     s.slot_pattern(_member(), kind="linear", count=4, pitch=30.0, direction=(0, 1, 0))
     dwg = build_drawing(part, model=s.model(), auto_dims=False)

--- a/tests/test_suppression_marks.py
+++ b/tests/test_suppression_marks.py
@@ -527,16 +527,14 @@ class TestTheHeadIsADependency:
         assert hole_callout_spec(group) is None
 
 
-def test_suppression_is_still_unreachable_from_a_user_path():
-    """Pins the honest scope of #875 (PR #920 review).
+def test_suppression_is_now_reachable_from_a_user_path():
+    """The #875 guard, discharged.
 
-    Nothing a user can write suppresses a hole parameter today — the planner suppresses only
-    envelope spans, and `add_dimension()` only clears suppression. So the raising above is a
-    mechanism waiting for #876, not a live authoring error, and this file's hand-built groups
-    are the right level to test it at.
-
-    This fails when that stops being true, which is exactly when end-to-end cases become
-    possible and should be written.
+    It was written to FAIL the moment a real authoring path could suppress a hole
+    parameter — "which is exactly when end-to-end cases become possible and should be
+    written". #876 landed that path (a measurement outside an authored set is marked
+    suppressed), so the guard fired as designed and is replaced by its own success
+    condition. The end-to-end cases live in `test_add_dimension.py::TestOmissionReachesTheDrawing`.
     """
     from build123d import Box, Cylinder, Pos
 
@@ -544,11 +542,12 @@ def test_suppression_is_still_unreachable_from_a_user_path():
 
     part = Box(90, 60, 20) - Pos(0, 0, 12) * Cylinder(6, 20)
     sheet = Sheet(part, title="T", number="N")
-    sheet.hole(diameter=12, at=(0, 0, 20), axis="z").depth(8)
+    hole = sheet.hole(diameter=12, at=(0, 0, 20), axis="z").depth(8)
+    # `bore.diameter`, not the bare role: naming the ROLE would match the depth too and omit
+    # nothing, which is a real distinction in the selector and an easy way to write a test
+    # that proves nothing.
+    sheet.dimension(hole, "bore.diameter")
     groups = plan_dimensions(sheet.model())
-    assert not [
-        pd for g in groups for pd in g.dims if pd.suppressed and g.feature.kind == "hole"
-    ], (
-        "a hole parameter is now suppressible from a declared Sheet — #876 has landed, so this "
-        "file should grow end-to-end suppression cases and this guard should go"
+    assert [pd for g in groups for pd in g.dims if pd.suppressed], (
+        "an authored set must suppress by omission — if this stops holding, #876 regressed"
     )

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -323,7 +323,7 @@ class TestSheetTolerance:
 
     def test_boss_diameter_tolerance_renders_on_leader(self):
         shaft = self._stepped_shaft()
-        s = Sheet(shaft)
+        s = Sheet(shaft).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
         s.diameter(diameter=12, at=(15, 0, 0), axis="x").tolerance(0.1)
         dwg = s.build()
@@ -331,7 +331,7 @@ class TestSheetTolerance:
 
     def test_boss_limit_pair_renders(self):
         shaft = self._stepped_shaft()
-        s = Sheet(shaft)
+        s = Sheet(shaft).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
         s.diameter(diameter=12, at=(15, 0, 0), axis="x").tolerance(0.0, 0.2)
         dwg = s.build()
@@ -339,7 +339,7 @@ class TestSheetTolerance:
 
     def test_step_length_tolerance_reaches_dimension(self):
         shaft = self._stepped_shaft()
-        s = Sheet(shaft)
+        s = Sheet(shaft).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").tolerance(0.0, 0.2)
         s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
         dwg = s.build()
@@ -363,41 +363,41 @@ class TestSheetTolerance:
     def test_pocket_role_keyed_depth_tolerance_via_sheet(self):
         # #746 Sheet surface: pocket() returns a role-aware handle; .tolerance(on="depth")
         # tolerances ONLY the depth (5), leaving width×length (18×30) plain.
-        s = Sheet(self._pocket_part(), title="P")
+        s = Sheet(self._pocket_part(), title="P").auto_dimensions()
         self._pocket_handle(s).tolerance(0.2, on="depth")
         assert self._deep_label(s.build()) == "18 × 30 × 5 ±0.2 DEEP"
 
     def test_pocket_whole_feature_tolerance_folds_onto_all(self):
         # A bare .tolerance() (no on=) on the handle folds onto every parameter — the
         # kind-keyed back-compat form.
-        s = Sheet(self._pocket_part(), title="P")
+        s = Sheet(self._pocket_part(), title="P").auto_dimensions()
         self._pocket_handle(s).tolerance(0.2)
         assert self._deep_label(s.build()) == "18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP"
 
     def test_pocket_role_selector_rejects_unknown_name(self):
         # on= must name exactly one parameter role of the feature.
-        s = Sheet(self._pocket_part(), title="P")
+        s = Sheet(self._pocket_part(), title="P").auto_dimensions()
         with pytest.raises(ValueError):
             self._pocket_handle(s).tolerance(0.2, on="nope")
 
     def test_params_handle_still_chains_to_further_declarations(self):
         # #807 review: the _Params handle forwards unknown attributes to the sheet, so a
         # verb returning it stays chainable (the declare-then-chain contract holds).
-        s = Sheet(self._pocket_part(), title="P")
+        s = Sheet(self._pocket_part(), title="P").auto_dimensions()
         dwg = self._pocket_handle(s).envelope().build()  # .envelope()/.build() forward
         assert "front" in dwg.views
 
     def test_bare_tolerance_supersedes_an_earlier_role_tolerance(self):
         # #807 review: a whole-feature .tolerance() means "all alike" and overrides an
         # earlier per-role one regardless of call order (drops the role-keyed entry).
-        s = Sheet(self._pocket_part(), title="P")
+        s = Sheet(self._pocket_part(), title="P").auto_dimensions()
         self._pocket_handle(s).tolerance(0.1, on="depth").tolerance(0.2)
         assert self._deep_label(s.build()) == "18 ±0.2 × 30 ±0.2 × 5 ±0.2 DEEP"
 
     def test_params_handle_is_a_valid_gdt_target(self):
         # #807 re-review: a _Params handle names a real feature, so it must be accepted
         # everywhere a feature handle is — datum/finish/control targets, like _Hole/_Dim.
-        s = Sheet(self._pocket_part(), title="P")
+        s = Sheet(self._pocket_part(), title="P").auto_dimensions()
         h = self._pocket_handle(s)
         s.datum("A", h)
         s.finish("1.6", h)
@@ -406,7 +406,7 @@ class TestSheetTolerance:
 
     def test_step_tolerance_defaults_to_length_not_diameter(self):
         shaft = self._stepped_shaft()
-        s = Sheet(shaft)
+        s = Sheet(shaft).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").tolerance(0.1)
         s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
         dwg = s.build()
@@ -418,7 +418,7 @@ class TestSheetTolerance:
 
     def test_step_on_diameter_tolerances_the_od(self):
         shaft = self._stepped_shaft()
-        s = Sheet(shaft)
+        s = Sheet(shaft).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").tolerance(0.1, on="diameter")
         s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
         dwg = s.build()
@@ -428,7 +428,7 @@ class TestSheetTolerance:
         # The same declared model without any .tolerance() carries no ± anywhere and leaves
         # every step dim untoleranced — the tolerance path is a no-op without decorations.
         shaft = self._stepped_shaft()
-        s = Sheet(shaft)
+        s = Sheet(shaft).auto_dimensions()
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
         s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
         dwg = s.build()
@@ -447,7 +447,7 @@ class TestSheetTolerance:
         plate = Box(120, 90, 8)
         part = plate - (Pos(0, 0, 4) * Cylinder(4, 8))
 
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.envelope(plate)
         s.hole(diameter=8, at=(0, 0, 4), axis="z").tolerance(0.1)
         dwg = s.build()
@@ -968,7 +968,7 @@ class TestToleranceHandle:
         plate = Box(60, 40, 8)
         h = Pos(0, 0, 4) * Cylinder(4, 6)
         part = plate - h
-        s = Sheet(part)
+        s = Sheet(part).auto_dimensions()
         s.hole(diameter=8, at=(0, 0, 4), axis="z").depth(6).tolerance(0.1)
         model = s.build().model()
         hf = next(f for f in model.features if f.kind == "hole")


### PR DESCRIPTION
## The decision

ADR 0016's phase 2. The dimension set gets **exactly two sources**, and the script always says which:

| source | meaning |
|---|---|
| `sheet.auto_dimensions()` | the planner's selected set, optionally augmented by `add_dimension(...)` |
| `sheet.dimension(feature, role)` | the **complete authored set** |

Three errors, all checked at `build()` rather than in the verbs so intent stays order-independent:

1. mixing the two raises
2. `add_dimension` without a source raises (as before)
3. **a build that requested neither raises**

## The breaking change

`Sheet(part).build()` no longer auto-dimensions by default.

This is the project's standing preference for a loud failure over a plausible-looking wrong drawing (#630/#631, the #632 completeness lint) — and it is what makes omission mean anything at all, which is the whole of #876. A sheet that asked for neither would otherwise build silently, with *which* set it got depending on a default the script never mentions.

**Rejected:** implicit-by-usage ("any `dimension` line turns the automatic set off"). A hand-author adding one pitch dimension would silently lose every ⌀ callout.

`Sheet.from_part()` states the automatic source itself. That is not the implicit default returning by the back door: asking for detection **is** asking for the engine's reading of the part, features and dimensions alike. A plain `Sheet(part)` still has to say.

## Suppression by omission (#876) falls out

With #875's marking in place, a parameter outside the authored set is planned `suppressed=True` with a reason and **keeps its value** — marked, not filtered — so the group retains its engineering data and the compound callout's dependency rules still refuse to orphan half a term.

**This settles the epic's open question the cheap way.** ADR 0016 said phases 2–4 sat behind the global recompose. They do not: a `Sheet` script's set is known *before* the solve, so the planner just marks. What genuinely still needs the recompose is the narrower case the ADR conflated with it — `Drawing.finalize()` dropping an *automatic* dimension **after** the solve has run. The ADR now says so.

## Shared addressing

`_resolve_measurement` is shared by both verbs. They address a measurement identically and differ only in what naming one **means** — `add_dimension` leaves the rule set's decision standing for anything unnamed, `dimension` omits it. A second copy of the addressing is exactly how the callout reading drifted in #875.

## Migration

128 test `Sheet` constructions across 18 files, plus `AGENTS.md`, `README.md` and the workflow doc. The emitter writes `sheet.auto_dimensions()` with a comment pointing at the authored alternative, so generated scripts state their source like any other.

The identity guard's state-field ratchet **fired on the new `_authored` field** — which is exactly what #912 built it for, one PR earlier.

## Verification

Full fast tier green (the 9 stragglers were in files my `-k` selection never matched — found by the full run, migrated, verified). Lint 4/4.

Closes #874. Closes #876.