### PR TITLE
feat(ADR 0016): compiled-plan boundary — renderers draw only what the compiler approved

### DIFF
--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -97,10 +97,12 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 **The rule is the destination. The migration is at its FIRST SLICE, and the inventory
 below is the honest state of it.**
 
-Three renderers have crossed: `render_height_ladder`, `render_step_positions`, and the
-prismatic detail redraw. Everything else still takes either the legacy `DimensionGroup`
-surface — where `suppressed` remains an advisory boolean a renderer may ignore, which is
-exactly what eight #921 rounds found happening — or the raw model.
+Nine renderers have crossed: `render_height_ladder`, `render_step_positions`,
+`render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,
+`render_boss_diameters`, and `render_boss_heights`, plus the prismatic detail redraw.
+Everything else still takes either the legacy `DimensionGroup` surface — where
+`suppressed` remains an advisory boolean a renderer may ignore, which is exactly what eight
+#921 rounds found happening — or the raw model.
 
 Two earlier versions of this section understated that, each time because the guard behind
 it measured the wrong thing (#923 reviews). Counting renderers that take `model` reported
@@ -111,8 +113,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_centermarks`, `render_diameters`, `render_chamfers`, `render_fillets`, `render_flats`, `render_pockets`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_centermarks`, `render_diameters`, `render_pockets`, `render_envelope`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -97,10 +97,11 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 **The rule is the destination. The migration is at its FIRST SLICE, and the inventory
 below is the honest state of it.**
 
-Thirteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
+Fourteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
 `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,
 `render_boss_diameters`, `render_boss_heights`, `render_envelope`, and `render_pockets`,
-`render_pocket_patterns`, and `render_slot_patterns`, plus the prismatic detail redraw.
+`render_pocket_patterns`, `render_slot_patterns`, and `render_diameters`, plus the prismatic
+detail redraw.
 Everything else still takes either the legacy `DimensionGroup` surface — where
 `suppressed` remains an advisory boolean a renderer may ignore, which is exactly what eight
 #921 rounds found happening — or the raw model.
@@ -114,8 +115,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_diameters`, `render_step_lengths`, `render_rotational` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns`, `render_diameters` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_step_lengths`, `render_rotational` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -97,11 +97,11 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 **The rule is the destination. The migration is at its FIRST SLICE, and the inventory
 below is the honest state of it.**
 
-Fourteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
+Fifteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
 `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,
 `render_boss_diameters`, `render_boss_heights`, `render_envelope`, and `render_pockets`,
-`render_pocket_patterns`, `render_slot_patterns`, and `render_diameters`, plus the prismatic
-detail redraw.
+`render_pocket_patterns`, `render_slot_patterns`, `render_diameters`, and
+`render_rotational`, plus the prismatic detail redraw.
 Everything else still takes either the legacy `DimensionGroup` surface — where
 `suppressed` remains an advisory boolean a renderer may ignore, which is exactly what eight
 #921 rounds found happening — or the raw model.
@@ -115,8 +115,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns`, `render_diameters` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_step_lengths`, `render_rotational` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns`, `render_diameters`, `render_rotational` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_step_lengths` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -94,14 +94,22 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 
 ### Scope, stated so the exceptions cannot be mistaken for completeness
 
-**The rule is the destination, and the migration is partial. What is not yet inside it is
-scheduled, not excused — an unstated exception is how a rule like this rots.**
+**The rule is the destination; the migration is partial and its remainder is named.**
+Removing the qualification entirely once the detail path landed was wrong — two paths still
+emit dimensional content of their own, and a rule stated more broadly than it holds is worse
+than one honestly scoped (#923 review round 3). What is not yet inside is listed here, and
+`tests/test_compiled_plan_boundary.py` fails the moment an unlisted mark appears.
 
 - **Location dimensions are inside this rule.** They are dimensions, and letting
   `render_locations` rebuild them from the model preserves the same bypass class.
   `plan_locations` returns a flat, cross-feature, ref-deduped list that never enters a
   `DimensionGroup`, so they are sequenced later in the migration rather than carved out
   (#883). The boundary is not complete until they are inside it.
+- **Pattern pitch dimensions are inside this rule and not yet migrated.** `_add_furniture`
+  derives `n× pitch` from `PatternFeature.members`/`count`/`pitch` and places it directly
+  (`annotations/holes.py`), so it survives an empty compiled plan. It is grouped with
+  furniture in the code but it prints a VALUE, which is exactly what makes something
+  dimensional content under this rule — the grouping is the bug. Sequenced with locations.
 - **Raw AP242 PMI is a documented exception.** `PmiFeature.parameters()` is empty by design
   and the record renders verbatim, so there is no compiled content for it to come from. It
   is an explicit provenance-preserving escape hatch, not an oversight.

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -57,10 +57,20 @@ PartModel
   → compile_dimensions()            # one place: rules, requests, authored sets
       → RenderableDimensionPlan     # APPROVED entries only
       → diagnostics                 # what was omitted, and why
-  → renderers consume approved entries; lint/coverage consume diagnostics
+  → renderers consume approved entries (diagnostics: see below — no consumer yet)
 ```
 
 - `ApprovedDimension` has **no `suppressed` field**. There is nothing to forget.
+- Withheld measurements leave through `diagnostics`. **Nothing consumes them yet** — the
+  consumer is `linting/coverage.py` and it arrives with #921, whose authored sets are the
+  first omissions coverage must tell apart from a measurement simply missed. Until then
+  every omission is a planner rule the lint layer already knows by other means.
+- The feature a dimension came from travels as an **opaque `FeatureRef`**: identity and
+  category, no measurement. Carrying the `Feature` itself would have left the bypass one
+  attribute access away — `.feature.levels` rebuilds exactly what the compiler withheld.
+  The two seams that legitimately need the object (ADR 0010 provenance tagging, escalation
+  grouping) resolve it explicitly; a dimensional renderer doing so is a violation the
+  boundary guard catches.
 - Correlated sets (a step-height ladder, a shoulder chain) arrive as explicit
   `ApprovedLadder` groups, so a renderer never rebuilds one from a feature. This preserves
   the tier-3 identity rule — the set is approved or omitted whole, never half a staircase.

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -94,11 +94,25 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 
 ### Scope, stated so the exceptions cannot be mistaken for completeness
 
+**The rule is the destination, and the migration is partial. Two paths do not yet obey it,
+and both are scheduled rather than excused — an unstated exception is how a rule like this
+rots.**
+
 - **Location dimensions are inside this rule.** They are dimensions, and letting
   `render_locations` rebuild them from the model preserves the same bypass class.
   `plan_locations` returns a flat, cross-feature, ref-deduped list that never enters a
   `DimensionGroup`, so they are sequenced later in the migration rather than carved out
   (#883). The boundary is not complete until they are inside it.
+- **The prismatic detail redraw is inside this rule, and currently bypasses it.**
+  `_request_prismatic_detail` (`annotations/sections.py`) re-derives the step feature from
+  `dwg.model()` and rebuilds the ladder from `step.levels` against `a.bb.min.Z`, so a rung
+  the compiler withheld can still reach the detail view — demonstrated with an approved
+  ladder holding three of five rungs while the detail drew all five (#923 review). The
+  direct renderer is restricted; its escalation is not. The fix is for the escalation to
+  carry the approved rungs (or a placement-only detail request derived from them) rather
+  than rediscovering levels. Until it lands, this rule holds for the direct render path
+  only, and `tests/test_compiled_plan_boundary.py` pins the gap so closing it is
+  detectable.
 - **Raw AP242 PMI is a documented exception.** `PmiFeature.parameters()` is empty by design
   and the record renders verbatim, so there is no compiled content for it to come from. It
   is an explicit provenance-preserving escape hatch, not an oversight.

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -94,25 +94,14 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 
 ### Scope, stated so the exceptions cannot be mistaken for completeness
 
-**The rule is the destination, and the migration is partial. Two paths do not yet obey it,
-and both are scheduled rather than excused — an unstated exception is how a rule like this
-rots.**
+**The rule is the destination, and the migration is partial. What is not yet inside it is
+scheduled, not excused — an unstated exception is how a rule like this rots.**
 
 - **Location dimensions are inside this rule.** They are dimensions, and letting
   `render_locations` rebuild them from the model preserves the same bypass class.
   `plan_locations` returns a flat, cross-feature, ref-deduped list that never enters a
   `DimensionGroup`, so they are sequenced later in the migration rather than carved out
   (#883). The boundary is not complete until they are inside it.
-- **The prismatic detail redraw is inside this rule, and currently bypasses it.**
-  `_request_prismatic_detail` (`annotations/sections.py`) re-derives the step feature from
-  `dwg.model()` and rebuilds the ladder from `step.levels` against `a.bb.min.Z`, so a rung
-  the compiler withheld can still reach the detail view — demonstrated with an approved
-  ladder holding three of five rungs while the detail drew all five (#923 review). The
-  direct renderer is restricted; its escalation is not. The fix is for the escalation to
-  carry the approved rungs (or a placement-only detail request derived from them) rather
-  than rediscovering levels. Until it lands, this rule holds for the direct render path
-  only, and `tests/test_compiled_plan_boundary.py` pins the gap so closing it is
-  detectable.
 - **Raw AP242 PMI is a documented exception.** `PmiFeature.parameters()` is empty by design
   and the record renders verbatim, so there is no compiled content for it to come from. It
   is an explicit provenance-preserving escape hatch, not an oversight.

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -111,8 +111,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_centermarks`, `render_diameters`, `render_chamfers`, `render_fillets`, `render_flats`, `render_pockets`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_plates`, `render_envelope`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_centermarks`, `render_diameters`, `render_chamfers`, `render_fillets`, `render_flats`, `render_pockets`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -97,10 +97,10 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 **The rule is the destination. The migration is at its FIRST SLICE, and the inventory
 below is the honest state of it.**
 
-Ten renderers have crossed: `render_height_ladder`, `render_step_positions`,
+Eleven renderers have crossed: `render_height_ladder`, `render_step_positions`,
 `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,
-`render_boss_diameters`, `render_boss_heights`, and `render_envelope`, plus the prismatic
-detail redraw.
+`render_boss_diameters`, `render_boss_heights`, `render_envelope`, and `render_pockets`,
+plus the prismatic detail redraw.
 Everything else still takes either the legacy `DimensionGroup` surface — where
 `suppressed` remains an advisory boolean a renderer may ignore, which is exactly what eight
 #921 rounds found happening — or the raw model.
@@ -114,8 +114,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_diameters`, `render_pockets`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_diameters`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -97,9 +97,10 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 **The rule is the destination. The migration is at its FIRST SLICE, and the inventory
 below is the honest state of it.**
 
-Nine renderers have crossed: `render_height_ladder`, `render_step_positions`,
+Ten renderers have crossed: `render_height_ladder`, `render_step_positions`,
 `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,
-`render_boss_diameters`, and `render_boss_heights`, plus the prismatic detail redraw.
+`render_boss_diameters`, `render_boss_heights`, and `render_envelope`, plus the prismatic
+detail redraw.
 Everything else still takes either the legacy `DimensionGroup` surface — where
 `suppressed` remains an advisory boolean a renderer may ignore, which is exactly what eight
 #921 rounds found happening — or the raw model.
@@ -113,8 +114,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_centermarks`, `render_diameters`, `render_pockets`, `render_envelope`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_diameters`, `render_pockets`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are
@@ -123,6 +124,8 @@ dimensional under this rule. The grouping is the bug.
 
 - **Furniture is not dimensional content.** Centrelines, centre marks and section arrows
   print no value; they are sized off the geometry they mark and stay outside this rule.
+  `render_centermarks` therefore takes explicitly named `furniture_groups`: it is not a
+  dimensional renderer pretending to have crossed the compiled-plan boundary.
 
 ## Context
 

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -94,8 +94,8 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 
 ### Scope, stated so the exceptions cannot be mistaken for completeness
 
-**The rule is the destination. The migration is at its FIRST SLICE, and the inventory
-below is the honest state of it.**
+**The rule is the destination. The migration is substantially advanced but not complete;
+the inventory below is the honest state of it.**
 
 Sixteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
 `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -21,6 +21,80 @@
 > therefore be substantially less blocked than this ADR assumed. The constraint below is
 > flagged in step.
 
+## Amendment 1 — the compiled-plan boundary (2026-07-29)
+
+**Renderers may emit dimensional content only from the compiled plan.**
+
+A dimensional renderer receives approved entries and decides *where* and *how* to draw
+them. It does not decide *what*, and it is not given the feature inventory or the bounding
+box it would need to decide otherwise. The corollary is the part worth stating outright:
+**suppression is not a flag renderers check, it is content they never receive.**
+
+### Why this is a rule and not a review note
+
+Everything above this amendment says the planner decides suppression. It did — and the
+decision was routinely ignored, because `PlannedDimension.suppressed` was advisory. A
+renderer got the planned groups *and* the `PartModel` *and* the `Analysis`, so honouring the
+plan was a convention it had to opt into, and reconstructing a suppressed dimension from
+`feature.levels` or `a.bb` stayed one attribute access away.
+
+Eight adversarial review rounds on #921 found eight renderers that had not opted in: the
+height ladder and step positions rebuilding their marks from the feature and the bounding
+box; `render_diameters`, `render_boss_diameters`, `render_step_lengths` and
+`render_rotational` selecting parameters with no suppression check at all; the compound
+callout, the deferred-edit path, the script emitter, and `from_part` each needing separate
+enforcement. Every one was a real omission reaching a real drawing.
+
+Fixing them individually produced four mechanisms for saying the same thing — `pd.suppressed`
+reads, `env_dim_placed`, `set_dim_placed`, and a `_CALLOUT_PARAM_KINDS` policy table — and
+no reason to think the ninth renderer would be different. That is the signature of a missing
+boundary, not of missing tests.
+
+### The shape
+
+```
+PartModel
+  → compile_dimensions()            # one place: rules, requests, authored sets
+      → RenderableDimensionPlan     # APPROVED entries only
+      → diagnostics                 # what was omitted, and why
+  → renderers consume approved entries; lint/coverage consume diagnostics
+```
+
+- `ApprovedDimension` has **no `suppressed` field**. There is nothing to forget.
+- Correlated sets (a step-height ladder, a shoulder chain) arrive as explicit
+  `ApprovedLadder` groups, so a renderer never rebuilds one from a feature. This preserves
+  the tier-3 identity rule — the set is approved or omitted whole, never half a staircase.
+- Spans travel in **part space**; the renderer projects them. That is the split in one line:
+  the compiler says "this measurement, this value, between these two points"; the renderer
+  says which view, which strip, which side, and what happens when it does not fit.
+- Dimensional renderers take a `LayoutFrame` — projectors, view rectangles in page space,
+  strips, scale — rather than the `Analysis`. View *edges* are page-space rectangles rather
+  than projected bbox extents, so "just right of the front view" needs no part geometry.
+- **Omission is not a drop.** The compiler's omission never arrives and is reported through
+  diagnostics; the placer's drop arrived and did not fit, and is reported as
+  `placement_unsatisfiable`. Conflating them is how a deliberate suppression came to look
+  like a layout failure.
+
+### What the compiler may do that renderers may not
+
+Read the bounding box. A model with no `EnvelopeFeature` — a round body, or a `Sheet` that
+never called `.envelope()` — has no parameter naming its overall height, and the value falls
+back to the bbox. That fallback is legitimate and now lives in exactly one place, instead of
+being a thing the height-ladder renderer did while claiming to be doing layout.
+
+### Scope, stated so the exceptions cannot be mistaken for completeness
+
+- **Location dimensions are inside this rule.** They are dimensions, and letting
+  `render_locations` rebuild them from the model preserves the same bypass class.
+  `plan_locations` returns a flat, cross-feature, ref-deduped list that never enters a
+  `DimensionGroup`, so they are sequenced later in the migration rather than carved out
+  (#883). The boundary is not complete until they are inside it.
+- **Raw AP242 PMI is a documented exception.** `PmiFeature.parameters()` is empty by design
+  and the record renders verbatim, so there is no compiled content for it to come from. It
+  is an explicit provenance-preserving escape hatch, not an oversight.
+- **Furniture is not dimensional content.** Centrelines, centre marks and section arrows
+  print no value; they are sized off the geometry they mark and stay outside this rule.
+
 ## Context
 
 A user reading a generated `Sheet` script today sees the part's **features** — one

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -97,11 +97,11 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 **The rule is the destination. The migration is at its FIRST SLICE, and the inventory
 below is the honest state of it.**
 
-Fifteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
+Sixteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
 `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,
 `render_boss_diameters`, `render_boss_heights`, `render_envelope`, and `render_pockets`,
 `render_pocket_patterns`, `render_slot_patterns`, `render_diameters`, and
-`render_rotational`, plus the prismatic detail redraw.
+`render_rotational`, and `render_step_lengths`, plus the prismatic detail redraw.
 Everything else still takes either the legacy `DimensionGroup` surface — where
 `suppressed` remains an advisory boolean a renderer may ignore, which is exactly what eight
 #921 rounds found happening — or the raw model.
@@ -115,8 +115,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns`, `render_diameters`, `render_rotational` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_step_lengths` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns`, `render_diameters`, `render_rotational`, `render_step_lengths` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -97,10 +97,10 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 **The rule is the destination. The migration is at its FIRST SLICE, and the inventory
 below is the honest state of it.**
 
-Eleven renderers have crossed: `render_height_ladder`, `render_step_positions`,
+Thirteen renderers have crossed: `render_height_ladder`, `render_step_positions`,
 `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`,
 `render_boss_diameters`, `render_boss_heights`, `render_envelope`, and `render_pockets`,
-plus the prismatic detail redraw.
+`render_pocket_patterns`, and `render_slot_patterns`, plus the prismatic detail redraw.
 Everything else still takes either the legacy `DimensionGroup` surface — where
 `suppressed` remains an advisory boolean a renderer may ignore, which is exactly what eight
 #921 rounds found happening — or the raw model.
@@ -114,8 +114,8 @@ lists, so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets` (+ the detail redraw) |
-| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_diameters`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_diameters`, `render_step_lengths`, `render_rotational` |
 | `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
 
 Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -94,25 +94,31 @@ being a thing the height-ladder renderer did while claiming to be doing layout.
 
 ### Scope, stated so the exceptions cannot be mistaken for completeness
 
-**The rule is the destination; the migration is partial and its remainder is named.**
-Removing the qualification entirely once the detail path landed was wrong — two paths still
-emit dimensional content of their own, and a rule stated more broadly than it holds is worse
-than one honestly scoped (#923 review round 3). What is not yet inside is listed here, and
-`tests/test_compiled_plan_boundary.py` fails the moment an unlisted mark appears.
+**The rule is the destination. The migration is at its FIRST SLICE, and the inventory
+below is the honest state of it.**
 
-- **Location dimensions are inside this rule.** They are dimensions, and letting
-  `render_locations` rebuild them from the model preserves the same bypass class.
-  `plan_locations` returns a flat, cross-feature, ref-deduped list that never enters a
-  `DimensionGroup`, so they are sequenced later in the migration rather than carved out
-  (#883). The boundary is not complete until they are inside it.
-- **Pattern pitch dimensions are inside this rule and not yet migrated.** `_add_furniture`
-  derives `n× pitch` from `PatternFeature.members`/`count`/`pitch` and places it directly
-  (`annotations/holes.py`), so it survives an empty compiled plan. It is grouped with
-  furniture in the code but it prints a VALUE, which is exactly what makes something
-  dimensional content under this rule — the grouping is the bug. Sequenced with locations.
-- **Raw AP242 PMI is a documented exception.** `PmiFeature.parameters()` is empty by design
-  and the record renders verbatim, so there is no compiled content for it to come from. It
-  is an explicit provenance-preserving escape hatch, not an oversight.
+Three renderers have crossed: `render_height_ladder`, `render_step_positions`, and the
+prismatic detail redraw. Everything else still takes either the legacy `DimensionGroup`
+surface — where `suppressed` remains an advisory boolean a renderer may ignore, which is
+exactly what eight #921 rounds found happening — or the raw model.
+
+Two earlier versions of this section understated that, each time because the guard behind
+it measured the wrong thing (#923 reviews). Counting renderers that take `model` reported
+the migration nearly complete while sixteen sat on the advisory surface; not naming a
+parameter `model` is not the same as having crossed the boundary.
+`tests/test_compiled_plan_boundary.py` now classifies by **contract** and pins all three
+lists, so this inventory cannot drift from the code:
+
+| Contract | Meaning | Renderers |
+|---|---|---|
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions` (+ the detail redraw) |
+| `groups` | advisory `suppressed` — **pending** | `render_slots`, `render_centermarks`, `render_diameters`, `render_chamfers`, `render_fillets`, `render_flats`, `render_pockets`, `render_grooves`, `render_boss_diameters`, `render_boss_heights`, `render_plates`, `render_envelope`, `render_step_lengths`, `render_rotational`, `render_pocket_patterns`, `render_slot_patterns` |
+| `model` | raw inventory — **pending**, except PMI | `render_locations` (#883), `render_gdt`, `render_pmi` (permitted) |
+
+Pattern pitch dimensions (`_add_furniture` → `_place_pitch_dim`) are pending too: they are
+grouped with furniture in the code but print a VALUE, which is what makes something
+dimensional under this rule. The grouping is the bug.
+
 - **Furniture is not dimensional content.** Centrelines, centre marks and section arrows
   print no value; they are sized off the geometry they mark and stay outside this rule.
 

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -757,8 +757,13 @@ class LayoutFrame:
         raise ValueError(f"unknown view {view!r}")
 
     def edges(self, view: str) -> tuple[float, float, float, float]:
-        """*view*'s page-space ``(left, right, bottom, top)``."""
-        return {"front": self.front, "plan": self.plan, "side": self.side}[view]
+        """*view*'s ordered page-space ``(left, right, bottom, top)``.
+
+        The stored endpoints come from projected world minima/maxima, whose handedness
+        need not match page left/right. Normalise here so callers can rely on the names
+        this API exposes rather than knowing projector orientation."""
+        x0, x1, y0, y1 = {"front": self.front, "plan": self.plan, "side": self.side}[view]
+        return min(x0, x1), max(x0, x1), min(y0, y1), max(y0, y1)
 
     def zones(self, view: str) -> ViewZones:
         return {"front": self.fv_zones, "plan": self.pv_zones, "side": self.sv_zones}[view]

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -715,6 +715,91 @@ class _Projector:
 
 
 @dataclass(frozen=True)
+class LayoutFrame:
+    """The page geometry a **dimensional** renderer may use — and nothing more.
+
+    ADR 0016's boundary rule splits a renderer's job in two: the compiled plan says WHAT is
+    drawn, this says where there is room to draw it. So a dimensional renderer takes a
+    `LayoutFrame` instead of the full :class:`Analysis`, which carries the feature
+    inventory, the part, and the raw bounding box — everything needed to reconstruct a
+    dimension the compiler decided not to approve, which is precisely what eight review
+    rounds on #921 found renderers doing.
+
+    What is deliberately absent: ``part``, ``bb``, the recognised-feature lists, the sizes.
+    A renderer that needs a part-space coordinate gets it from its approved entry's
+    ``span``, and projects it with :meth:`project`. View EDGES are page-space rectangles
+    here rather than projected bbox extents, so an anchor like "just right of the front
+    view" needs no part geometry at all — the form that let the height ladder read
+    ``a.bb.max.Z`` for the overall height while claiming to be doing layout.
+
+    ``scale`` remains because legibility is a genuine placement decision: whether two rungs
+    are too close to dimension depends on the page, not the model.
+    """
+
+    proj: _Projector
+    scale: float
+    front: tuple[float, float, float, float]  # page-space (left, right, bottom, top)
+    plan: tuple[float, float, float, float]
+    side: tuple[float, float, float, float]
+    fv_zones: ViewZones
+    pv_zones: ViewZones
+    sv_zones: ViewZones
+
+    def project(self, view: str, point) -> tuple[float, float]:
+        """A part-space *point* in *view*'s page coordinates."""
+        x, y, z = point
+        if view == "front":
+            return self.proj.front_x(x), self.proj.front_z(z)
+        if view == "side":
+            return self.proj.side_x(y), self.proj.side_z(z)
+        if view == "plan":
+            return self.proj.plan_x(x), self.proj.plan_y(y)
+        raise ValueError(f"unknown view {view!r}")
+
+    def edges(self, view: str) -> tuple[float, float, float, float]:
+        """*view*'s page-space ``(left, right, bottom, top)``."""
+        return {"front": self.front, "plan": self.plan, "side": self.side}[view]
+
+    def zones(self, view: str) -> ViewZones:
+        return {"front": self.fv_zones, "plan": self.pv_zones, "side": self.sv_zones}[view]
+
+
+def layout_frame(a: Analysis) -> LayoutFrame:
+    """The :class:`LayoutFrame` view of an :class:`Analysis`.
+
+    An adapter rather than a replacement: `_analyse` keeps producing the full `Analysis`
+    (recognition, sizing and the compose stage all need it), and each renderer narrows to
+    this as it migrates. When none take `Analysis` for dimensional work, the narrowing is
+    complete and this is the only door.
+    """
+    return LayoutFrame(
+        proj=a.proj,
+        scale=a.SCALE,
+        front=(
+            a.proj.front_x(a.bb.min.X),
+            a.proj.front_x(a.bb.max.X),
+            a.proj.front_z(a.bb.min.Z),
+            a.proj.front_z(a.bb.max.Z),
+        ),
+        plan=(
+            a.proj.plan_x(a.bb.min.X),
+            a.proj.plan_x(a.bb.max.X),
+            a.proj.plan_y(a.bb.min.Y),
+            a.proj.plan_y(a.bb.max.Y),
+        ),
+        side=(
+            a.proj.side_x(a.bb.min.Y),
+            a.proj.side_x(a.bb.max.Y),
+            a.proj.side_z(a.bb.min.Z),
+            a.proj.side_z(a.bb.max.Z),
+        ),
+        fv_zones=a.fv_zones,
+        pv_zones=a.pv_zones,
+        sv_zones=a.sv_zones,
+    )
+
+
+@dataclass(frozen=True)
 class Analysis:
     """Typed geometry+layout analysis produced by :func:`_analyse`.
 

--- a/src/draftwright/annotate.py
+++ b/src/draftwright/annotate.py
@@ -6,10 +6,10 @@ the orchestrator entry point and the two helpers still referenced by name elsewh
 so `from draftwright.annotate import _auto_annotate` keeps working.
 """
 
-from draftwright.annotations.from_model import _detect_step_repeat  # noqa: F401
 from draftwright.annotations.orchestrator import (  # noqa: F401
     _auto_annotate,
     _wrap_rows,
     build_model,
     build_rotational_feature,
 )
+from draftwright.model.compiled import _step_repeat as _detect_step_repeat  # noqa: F401

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -27,6 +27,7 @@ from draftwright._geometry import _boxes_overlap, _segment_crosses_box  # noqa: 
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import _centerline_extent
+from draftwright.model.compiled import resolve_feature
 
 _log = logging.getLogger(__name__)
 
@@ -340,7 +341,9 @@ class SolveTrace:
                     "kind": e.kind,
                     "view": e.view,
                     "reason": e.reason,
-                    "feature": type(e.feature).__name__ if e.feature is not None else None,
+                    "feature": type(resolve_feature(e.feature)).__name__
+                    if e.feature is not None
+                    else None,
                 }
             )
 
@@ -935,7 +938,11 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             trace.end_solve()
         return
     pairs = [(c.name, c.build) for c in kept]
-    feats = {c.name: c.feature for c in kept if c.feature is not None}  # provenance (ADR 0010)
+    # The ADR 0010 provenance seam — and one of the two places a `FeatureRef` is
+    # legitimately resolved back to its feature, because here the object IS the point.
+    # A migrated renderer passes the opaque handle through; `resolve_feature` is a
+    # no-op for the unmigrated ones that still pass the feature itself.
+    feats = {c.name: resolve_feature(c.feature) for c in kept if c.feature is not None}
     sizes = {c.name: c.size for c in kept if c.size is not None}  # real footprint (#61)
     forbid = {c.name: c.forbid for c in kept if c.forbid is not None}  # title-block box (#481)
     prio = {c.name: c.priority for c in kept if c.priority}  # over-capacity survival rank (#357)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2466,7 +2466,7 @@ def _next_steplen_start(ctx, prefix: str = "m_steplen") -> int:
     return max(idxs) + 1 if idxs else 0
 
 
-def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
+def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     """Unified turned step-length chain (ADR 0008 #223): each `StepFeature`'s length
     span projects into the profile view and joins the chain that tiles the turning
     axis so every shoulder is located. X-turned → horizontal chain above the front
@@ -2481,31 +2481,24 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     interior shoulders — never worse than the prior skip. Returns the count placed."""
     rows = []  # (axis, a_world, b_world, value, tolerance) in axis order
     step_origins = []
-    step_radii = []
-    for g in groups:
-        if g.feature_kind != "step":
+    for g in plan.of_kind("step"):
+        if g.facts.frame.axis not in ("x", "y", "z"):
             continue
-        if g.feature.frame.axis not in ("x", "y", "z"):
+        if only is not None and g.ref not in only:  # #426 finalize: recorded subset
             continue
-        if only is not None and g.feature not in only:  # #426 finalize: recorded subset
-            continue
-        length = next(
-            (pd.param for pd in g.dims if pd.param.kind == "length" and pd.param.span is not None),
-            None,
-        )
+        length = g.dim(kind="length")
         if length is None or length.span is None:
             continue
         rows.append(
             (
-                g.feature.frame.axis,
+                g.facts.frame.axis,
                 length.span[0],
                 length.span[1],
                 length.value,
                 length.tolerance,
             )
         )
-        step_origins.append(g.feature.frame.origin)
-        step_radii.append(g.feature.diameter / 2)
+        step_origins.append(g.facts.frame.origin)
     if not rows:
         return 0
     draft = dwg.draft
@@ -2628,17 +2621,19 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
             axis_z = sum(axis_zs) / len(axis_zs)
 
             # Choose the same standard scale family as the detail renderer, then
-            # crop a geometry-relative strip: at most half the smallest radius and
-            # at most 12 page-mm tall. This stays useful from tiny pins to large
-            # flanges without a magic world-space ±2 mm band.
+            # crop a geometry-relative strip: at most one quarter of the side-view
+            # silhouette and at most 12 page-mm tall. The view rectangle is layout
+            # geometry; unlike the old `StepFeature.diameter` read it cannot recover a
+            # withheld printable diameter from the source feature.
             detail_target = dwg.scale * 10
             for factor in (2, 5, 10):
                 candidate = dwg.scale * factor
                 if candidate >= scale_needed:
                     detail_target = candidate
                     break
-            min_radius = min(step_radii)
-            cross_half = max(0.1, min(min_radius / 2, 6.0 / detail_target))
+            _sx0, sy0, _sx1, sy1 = dwg.view_bounds("side")
+            silhouette_quarter = abs(sy1 - sy0) / (4 * dwg.scale)
+            cross_half = max(0.1, min(silhouette_quarter, 6.0 / detail_target))
 
             def _redraw_y(dwg, detail_view, coords, detail_scale, _rows=bare_rows):
                 def _at(x, y, z):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2088,7 +2088,7 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
         lo, hi = lo_pt["xyz".index(axis)], hi_pt["xyz".index(axis)]
         u, v = lo_pt[oi[0]], lo_pt[oi[1]]
         val = pd.value
-        lbl = pd.label + _tol_suffix(pd.tolerance, draft)
+        lbl = pd.value_text + _tol_suffix(pd.tolerance, draft)
         i = counts[axis]
         counts[axis] += 1
         if axis == "z":
@@ -2885,7 +2885,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             (
                 "dim_step_typ",
                 *_zspan(rep),
-                rep.label,
+                rep.final_label,
                 _SLOT_DIM_STEP,
                 "representative step-height dimension dropped (front-view right strip full)",
             )
@@ -2928,7 +2928,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 (
                     f"dim_step_{col}",
                     *_zspan(rung),
-                    rung.label,
+                    rung.final_label,
                     _SLOT_DIM_STEP,
                     "step-height dimension dropped (front-view right strip full)",
                 )
@@ -2941,7 +2941,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             (
                 "dim_height",
                 *_zspan(height),
-                height.label,
+                height.final_label,
                 _SLOT_DIM_HEIGHT,
                 "overall height dimension dropped (front-view right strip full)",
             )
@@ -3017,7 +3017,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     for i, rung in enumerate(short_rungs):
         name = f"dim_step_{i}"
         zbase, ztop = _zspan(rung)
-        label = rung.label
+        label = rung.final_label
 
         def _build_left(pos, zbase=zbase, ztop=ztop, label=label):
             return _dim(
@@ -3135,7 +3135,7 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
         edge = p1[1]
         name = f"dim_shoulder_{axis}{i}"
 
-        def _build(pos, p1=p1, p2=p2, edge=edge, label=rung.label, direction=direction):
+        def _build(pos, p1=p1, p2=p2, edge=edge, label=rung.final_label, direction=direction):
             return _dim(
                 (p1[0], edge, 0),
                 (p2[0], edge, 0),
@@ -3145,7 +3145,7 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
                 label=label,
             )
 
-        def _drop(nm, label=rung.label, view=view, direction=direction):
+        def _drop(nm, label=rung.final_label, view=view, direction=direction):
             ctx.record_issue(
                 "warning",
                 "step_position_dropped",

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -86,6 +86,7 @@ from draftwright.layout import StripCandidate, plan_strip
 # drifts (#875 review). `as` form so the re-export is deliberate, not an unused import.
 from draftwright.model.callout import _first as _first
 from draftwright.model.callout import hole_callout_spec as hole_callout_spec
+from draftwright.model.compiled import resolve_feature
 from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, HoleFeature, PatternFeature
 from draftwright.model.planner import plan_locations
 
@@ -1031,7 +1032,7 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
     return placed
 
 
-def _diameter_step_anchor(anchor, features):
+def _diameter_step_anchor(anchor, groups):
     """Anchor point for a turned ⌀ leader tip.
 
     Centre the leader at the MID-LENGTH of the STEP carrying this diameter, rather
@@ -1051,26 +1052,30 @@ def _diameter_step_anchor(anchor, features):
     recorded subset, as the pre-#794 first-recorded-origin anchor also did.
     """
     steps = [
-        f for f in features if getattr(f, "kind", None) == "step" and getattr(f, "span", None)
+        (g, g.dim(kind="length"))
+        for g in groups
+        if g.feature_kind == "step" and g.dim(kind="length") is not None
     ]
+    steps = [(g, d) for g, d in steps if d.span is not None]
     if not steps:
         return anchor
-    idx = {"x": 0, "y": 1, "z": 2}[steps[0].frame.axis]
+    idx = {"x": 0, "y": 1, "z": 2}[steps[0][0].facts.frame.axis]
 
-    def _key(f):
-        ends = sorted(end[idx] for end in f.span)
+    def _key(item):
+        _g, dim = item
+        ends = sorted(end[idx] for end in dim.span)
         length = round(ends[1] - ends[0], 3)  # emitter rounds step length and centre (`at`) to
         at = round((ends[0] + ends[1]) / 2, 3)  # 3dp — quantise both so the selection round-trips
         return (length, -(at - length / 2))
 
-    step = max(steps, key=_key)
-    ends = sorted(end[idx] for end in step.span)
-    centred = list(step.frame.origin)  # the SELECTED step's own origin (radial + axial)
+    step, length = max(steps, key=_key)
+    ends = sorted(end[idx] for end in length.span)
+    centred = list(step.facts.frame.origin)  # the SELECTED step's own origin (radial + axial)
     centred[idx] = (ends[0] + ends[1]) / 2
     return tuple(centred)
 
 
-def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> int:
+def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
     """ø leaders for a turned part's external step/boss diameters, from the IR —
     one distinct callout per diameter, in a tidy row below the front view
     (X-turning), a column to its left (Z-turning), or as radial leaders in the
@@ -1091,39 +1096,44 @@ def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> in
     row_buckets: dict = {}  # round(dia,2) -> [anchor, dia, {features}, tolerance]  (X-turned)
     col_buckets: dict = {}  # Z-turned
     end_buckets: dict = {}  # Y-turned: radial leaders in the end-on front view
-    for g in groups:
-        if g.feature_kind not in ("step", "boss"):
+    for g in plan.of_kind("step", "boss"):
+        if only is not None and g.ref not in only:  # #426 finalize: recorded subset
             continue
-        if only is not None and g.feature not in only:  # #426 finalize: recorded subset
-            continue
-        dpd = next((pd for pd in g.dims if pd.param.kind == "diameter"), None)
+        dpd = g.dim(kind="diameter")
         if dpd is None:
             continue
-        dia = dpd.param.value
+        dia = dpd.value
         # An EXTERNAL thread (#859) makes a distinct callout: a threaded ⌀6 ("ø6 M6x1") and a
         # plain ⌀6 are NOT the same label, so the bucket keys on (⌀, thread) — this never drops a
         # thread on a shared ⌀, and a threadless model keys every entry on (⌀, None) exactly as
         # before (byte-identical). entry = [anchor, dia, {features}, ± tolerance, thread]. A
         # callout is per (axis, ⌀, thread); the first authored tolerance on a shared ⌀ wins.
-        thr = getattr(g.feature, "thread", None)
+        thr = g.facts.get("thread")
         # A coincident plain ⌀ already drawn (a bore, another step) dedups only an UNTHREADED ⌀;
         # a threaded ⌀ is a distinct callout, so a bare ⌀8 mention must not suppress ø8 M8x1.25.
         if thr is None and any(abs(dia - m) <= tol for m in mentioned):
             continue
-        bucket = {"x": row_buckets, "y": end_buckets, "z": col_buckets}.get(g.feature.frame.axis)
+        bucket = {"x": row_buckets, "y": end_buckets, "z": col_buckets}.get(g.facts.frame.axis)
         if bucket is None:
             continue
-        dtol = dpd.param.tolerance
+        dtol = dpd.tolerance
         dkey = (round(dia, 2), thr)
-        entry = bucket.setdefault(dkey, [g.anchor, dia, set(), dtol, thr])
-        entry[2].add(g.feature)
+        entry = bucket.setdefault(dkey, [g.anchor, dia, set(), dtol, thr, []])
+        entry[2].add(g.ref)
+        entry[5].append(g)
         if entry[3] is None:
             entry[3] = dtol
 
     def _items(buckets):
         return [
-            (_diameter_step_anchor(a, fs), d, next(iter(fs)) if len(fs) == 1 else None, t, thr)
-            for a, d, fs, t, thr in buckets.values()
+            (
+                _diameter_step_anchor(a, gs),
+                d,
+                next(iter(refs)) if len(refs) == 1 else None,
+                t,
+                thr,
+            )
+            for a, d, refs, t, thr, gs in buckets.values()
         ]
 
     # The placers name leaders m_dia_{x,z}{start+i} CONTIGUOUSLY from one start. The auto-pass
@@ -1157,26 +1167,25 @@ def render_diameters(dwg, groups, a, tol: float = 0.15, *, ctx, only=None) -> in
         if vb is not None:
             reach = dwg.draft.font_size + 6 * dwg.draft.pad_around_text
             hole_circles = []
-            for g in groups:
-                feature = g.feature
+            for g in plan.of_kind("hole", "pattern"):
+                feature = g.facts
                 if feature.frame.axis != "y":
                     continue
-                if feature.kind == "hole":
-                    diameter = feature.diameter
-                    locations = feature.members or (feature.frame.origin,)
-                elif feature.kind == "pattern":
-                    diameter = feature.member.diameter
-                    locations = feature.members or (feature.frame.origin,)
-                else:
+                bore = g.dim(kind="diameter", role="bore")
+                if bore is None:
                     continue
+                diameter = bore.value
+                locations = feature.members or (feature.frame.origin,)
                 for location in locations:
                     px, py, *_ = dwg.at("front", *location)
                     hole_circles.append((px, py, diameter / 2 * a.SCALE))
             jobs = []
             covered_by_name = {}
-            for i, (_anchor, dia, features, dtol, thr) in enumerate(end_buckets.values()):
-                representative = next(iter(features))
-                owner = representative if len(features) == 1 else None
+            for i, (_anchor, dia, refs, dtol, thr, feature_groups) in enumerate(
+                end_buckets.values()
+            ):
+                representative = feature_groups[0].facts
+                owner = next(iter(refs)) if len(refs) == 1 else None
                 # Materialise now: a generator expression would close over ``owner``
                 # and all jobs would read the final loop iteration's feature when
                 # _leader_callout_pass consumes them (#890).
@@ -1434,7 +1443,10 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
             tried += 1
             ldr = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label, draft=dwg.draft)
             if _label_lands_clear(ldr, obstacles, vb, page, geom_clear=geom_clear):
-                ctx.place(ldr, name, view=view, feature=feature)
+                # Compiled renderers carry opaque FeatureRefs so they cannot recover
+                # measurements from the source feature. Provenance is the one seam
+                # where the registry intentionally needs the source object itself.
+                ctx.place(ldr, name, view=view, feature=resolve_feature(feature))
                 if ev is not None:
                     ev["items"].append(
                         {

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -765,7 +765,7 @@ def render_locations(dwg, model, a, *, ctx, only=None, pinned=None) -> int:
     return n
 
 
-def render_centermarks(dwg, groups, *, ctx) -> int:
+def render_centermarks(dwg, furniture_groups, *, ctx) -> int:
     """A centre mark on every hole (plain holes + each pattern member), in the view
     normal to the hole's axis (`_END_ON`), sized by its diameter — the IR migration
     of the engine's inline centre-mark loop. Returns the count placed.
@@ -777,7 +777,7 @@ def render_centermarks(dwg, groups, *, ctx) -> int:
     (facts live on the feature, parameters carry display values) applied to geometry rather
     than to text."""
     n = 0
-    for g in groups:
+    for g in furniture_groups:
         feat = g.feature
         if not isinstance(feat, HoleFeature | PatternFeature):
             continue
@@ -1337,25 +1337,6 @@ def _reroute_crossing_diameters(dwg, *, ctx) -> int:
         if not placed_it and dwg.get_annotation(name) is None:
             ctx.place(old, name, view="front", feature=feat)  # restore (Phase-1 flags it)
     return rerouted
-
-
-def _env_pd(group, role):
-    """The PlannedDimension for an envelope role (width/depth/height), or None."""
-    return next((pd for pd in group.dims if pd.param.role == role), None)
-
-
-def envelope_group(groups):
-    """The envelope `DimensionGroup` in *groups*, or None."""
-    return next((g for g in groups if g.feature_kind == "envelope"), None)
-
-
-def env_dim_placed(pd) -> bool:
-    """Whether :func:`render_envelope` will actually place an envelope dim for the
-    PlannedDimension *pd* — present, not suppressed by the planner (square footprint /
-    X-turned, #250), and carrying a span. The single source of truth for that
-    decision, shared with the orchestrator's side-below tier reservation so the two
-    can never drift (#316 review)."""
-    return pd is not None and not pd.suppressed and pd.param.span is not None
 
 
 def _chamfer_label(leg, ch) -> str:
@@ -2199,15 +2180,15 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
     return n
 
 
-def render_envelope(dwg, groups, a, *, ctx) -> int:
+def render_envelope(dwg, plan, a, *, ctx) -> int:
     """Overall width (plan, below) + depth (side, below) envelope dims via the IR,
     registered into the same below-strip corridor as feature/location/GD&T/PMI candidates.
     The overall dims use the last ladder subchain so they stack outermost by construction,
     while their mandatory priority prevents best-effort below-strip occupants from starving
     principal dimensions. The **planner** decides suppression (square footprint / X-turned;
-    #250); this renderer just skips suppressed dims and queues the rest. Returns the count
-    queued."""
-    env = envelope_group(groups)
+    #250); suppressed entries never arrive. Returns the count queued."""
+    envs = plan.of_kind("envelope")
+    env = envs[0] if envs else None
     if env is None:
         return 0
     n = 0
@@ -2232,9 +2213,9 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
             ),
         )
 
-    width = _env_pd(env, "width")
-    if env_dim_placed(width):
-        (x0, y0, z0), (x1, _, _) = width.param.span
+    width = env.dim(role="width")
+    if width is not None and width.span is not None:
+        (x0, y0, z0), (x1, _, _) = width.span
         p1, p2 = dwg.at("plan", x0, y0, z0), dwg.at("plan", x1, y0, z0)
         witness = p1[1] - _WITNESS_LIFT_MM
         _queue(
@@ -2243,7 +2224,7 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
             "plan",
             _SLOT_DIM_WIDTH,
             abs(x1 - x0),
-            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.param.value: _dim(
+            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.value: _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),
                 "below",
@@ -2251,14 +2232,14 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
                 dwg.draft,
                 label=_fmt(_v),
             ),
-            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.param.value: dim_footprint(
+            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.value: dim_footprint(
                 (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _fmt(_v)
             ),
         )
         n += 1
-    depth = _env_pd(env, "depth")
-    if env_dim_placed(depth):
-        (x0, y0, z0), (_, y1, _) = depth.param.span
+    depth = env.dim(role="depth")
+    if depth is not None and depth.span is not None:
+        (x0, y0, z0), (_, y1, _) = depth.span
         p1, p2 = dwg.at("side", x0, y0, z0), dwg.at("side", x0, y1, z0)
         witness = p1[1] - _WITNESS_LIFT_MM
         _queue(
@@ -2267,7 +2248,7 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
             "side",
             _SLOT_DIM_DEPTH,
             abs(y1 - y0),
-            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.param.value: _dim(
+            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.value: _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),
                 "below",
@@ -2275,7 +2256,7 @@ def render_envelope(dwg, groups, a, *, ctx) -> int:
                 dwg.draft,
                 label=_fmt(_v),
             ),
-            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.param.value: dim_footprint(
+            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.value: dim_footprint(
                 (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _fmt(_v)
             ),
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1487,7 +1487,7 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
     return n
 
 
-def render_chamfers(dwg, groups, a, *, ctx, only=None) -> int:
+def render_chamfers(dwg, plan, a, *, ctx, only=None) -> int:
     """Chamfer callouts (#560): a leader from each recognised chamfer face to its
     ``C{leg}`` / ``{leg}×{angle}°`` label, in the view normal to the chamfered edge (a Z
     edge reads in the plan, an X edge in the side, a Y edge in the front). The leader runs
@@ -1504,22 +1504,22 @@ def render_chamfers(dwg, groups, a, *, ctx, only=None) -> int:
     ``_END_ON`` matches the pass's old z→plan / x→side / y→front map exactly."""
     draft = dwg.draft
     reach = _leader_callout_reach(draft)
-    chamfer_groups = [g for g in groups if g.feature_kind == "chamfer"]
+    chamfer_groups = list(plan.of_kind("chamfer"))
     jobs = []
     for i, g in enumerate(
-        sorted(chamfer_groups, key=lambda g: (g.feature.axis, g.feature.frame.origin))
+        sorted(chamfer_groups, key=lambda g: (g.facts.axis, g.facts.frame.origin))
     ):
-        ch = g.feature
+        ch = g.facts
         if only is not None and ch not in only:
             continue  # #426 Ph2b subset (finalize): skip in place — i stays the model index
         # Bind the intended planned dim EXPLICITLY by (role, kind), never dims[0]
         # (#724 review): the pattern the remaining #698 migrations copy must not
         # silently grab the wrong dimension on a multi-parameter kind.
         pd = next(
-            (d for d in g.dims if (d.param.role, d.param.kind) == ("chamfer", "length")),
+            (d for d in g.dims if (d.role, d.kind) == ("chamfer", "length")),
             None,
         )
-        if pd is None or pd.suppressed:
+        if pd is None:
             continue
         view = g.view
         vb = dwg.view_bounds(view)
@@ -1530,7 +1530,7 @@ def render_chamfers(dwg, groups, a, *, ctx, only=None) -> int:
                 f"m_chamfer_{ch.axis}{i}",
                 view,
                 vb,
-                _chamfer_label(pd.param.value, ch) + _tol_suffix(pd.param.tolerance, draft),
+                _chamfer_label(pd.value, ch) + _tol_suffix(pd.tolerance, draft),
                 _corner_candidates(dwg, view, vb, [ch], reach),
             )
         )
@@ -1544,7 +1544,7 @@ def _fillet_label(radius, count) -> str:
     return f"{count}× {r}" if count > 1 else r
 
 
-def render_fillets(dwg, groups, a, *, ctx, only=None) -> int:
+def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
     """Fillet radius callouts (#561): a leader from an external edge fillet to its
     ``R{radius}`` label — the arc analog of :func:`render_chamfers`. Equal-radius fillets on
     the same edge axis share ONE ``n× R`` callout (#561 acceptance), placed in the view
@@ -1565,27 +1565,27 @@ def render_fillets(dwg, groups, a, *, ctx, only=None) -> int:
     draft = dwg.draft
     reach = _leader_callout_reach(draft)
     collapse: dict = {}
-    for g in (g for g in groups if g.feature_kind == "fillet"):
+    for g in plan.of_kind("fillet"):
         pd = next(
-            (d for d in g.dims if (d.param.role, d.param.kind) == ("fillet", "radius")),
+            (d for d in g.dims if (d.role, d.kind) == ("fillet", "radius")),
             None,
         )
-        if pd is None or pd.suppressed:
+        if pd is None:
             continue
-        collapse.setdefault((g.feature.axis, round(pd.param.value, 3)), []).append((g, pd))
+        collapse.setdefault((g.facts.axis, round(pd.value, 3)), []).append((g, pd))
     jobs = []
     for gi, ((axis, _radius), members) in enumerate(sorted(collapse.items())):
         if only is not None:
             # #426 Ph2b subset (finalize): filter members AFTER the collapse is enumerated so
             # gi stays the full-drawing group index — a survivor keeps its m_fillet name even
             # when a sibling group is dropped (Codex #811). The n× count reflects survivors.
-            members = [gp for gp in members if gp[0].feature in only]
+            members = [gp for gp in members if gp[0].ref in only]
             if not members:
                 continue
         # One grouped ``n× R`` callout, but its leader may anchor at ANY of the equal fillets
         # — _corner_candidates tries each corner (nearest-clear first) so the group is not
         # dropped just because its first corner leads into an occupied region.
-        ordered = sorted(members, key=lambda gp: gp[0].feature.frame.origin)
+        ordered = sorted(members, key=lambda gp: gp[0].facts.frame.origin)
         view = ordered[0][0].view
         vb = dwg.view_bounds(view)
         if vb is None:
@@ -1593,16 +1593,14 @@ def render_fillets(dwg, groups, a, *, ctx, only=None) -> int:
         # First-AUTHORED tolerance wins: scan `members` in planner/model order (the
         # render_diameters precedent — Codex review), not the spatially-sorted
         # `ordered`, whose winner would change if the geometry moved.
-        tol = next(
-            (pd.param.tolerance for _, pd in members if pd.param.tolerance is not None), None
-        )
+        tol = next((pd.tolerance for _, pd in members if pd.tolerance is not None), None)
         jobs.append(
             (
                 f"m_fillet_{axis}{gi}",
                 view,
                 vb,
-                _fillet_label(members[0][1].param.value, len(ordered)) + _tol_suffix(tol, draft),
-                _corner_candidates(dwg, view, vb, [g.feature for g, _ in ordered], reach),
+                _fillet_label(members[0][1].value, len(ordered)) + _tol_suffix(tol, draft),
+                _corner_candidates(dwg, view, vb, [g.facts for g, _ in ordered], reach),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped", ctx=ctx)
@@ -1617,7 +1615,7 @@ def _flat_label(across, sfx="") -> str:
     return f"{_fmt(across)}{sfx} A/F"
 
 
-def render_flats(dwg, groups, a, *, ctx, only=None) -> int:
+def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
     """Machined-flat callouts (#148b): a leader from a flat truncating round stock to its
     ``{across} A/F`` label, in the view down the stock axis (a Z-axis bar reads in the plan).
     Flats sharing an axis and across-flats size — the faces of a double-D or hex — share ONE
@@ -1635,39 +1633,37 @@ def render_flats(dwg, groups, a, *, ctx, only=None) -> int:
     draft = dwg.draft
     reach = _leader_callout_reach(draft)
     collapse: dict = {}
-    for g in (g for g in groups if g.feature_kind == "flat"):
+    for g in plan.of_kind("flat"):
         pd = next(
-            (d for d in g.dims if (d.param.role, d.param.kind) == ("flat", "length")),
+            (d for d in g.dims if (d.role, d.kind) == ("flat", "length")),
             None,
         )
-        if pd is None or pd.suppressed:
+        if pd is None:
             continue
-        collapse.setdefault((g.feature.axis, round(pd.param.value, 3)), []).append((g, pd))
+        collapse.setdefault((g.facts.axis, round(pd.value, 3)), []).append((g, pd))
     jobs = []
     for gi, ((axis, _across), members) in enumerate(sorted(collapse.items())):
         if only is not None:
             # #426 Ph2b subset (finalize): filter members AFTER enumerating the collapse so gi
             # stays the full-drawing group index (Codex #811) — see render_fillets.
-            members = [gp for gp in members if gp[0].feature in only]
+            members = [gp for gp in members if gp[0].ref in only]
             if not members:
                 continue
-        ordered = sorted(members, key=lambda gp: gp[0].feature.frame.origin)
+        ordered = sorted(members, key=lambda gp: gp[0].facts.frame.origin)
         view = ordered[0][0].view
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
         # First-AUTHORED tolerance wins (planner/model order, not spatial — see the
         # fillet pass / render_diameters precedent, Codex review).
-        tol = next(
-            (pd.param.tolerance for _, pd in members if pd.param.tolerance is not None), None
-        )
+        tol = next((pd.tolerance for _, pd in members if pd.tolerance is not None), None)
         jobs.append(
             (
                 f"m_flat_{axis}{gi}",
                 view,
                 vb,
-                _flat_label(members[0][1].param.value, _tol_suffix(tol, draft)),
-                _corner_candidates(dwg, view, vb, [g.feature for g, _ in ordered], reach),
+                _flat_label(members[0][1].value, _tol_suffix(tol, draft)),
+                _corner_candidates(dwg, view, vb, [g.facts for g, _ in ordered], reach),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped", ctx=ctx)
@@ -1842,7 +1838,7 @@ def render_pockets(dwg, groups, a, *, ctx, only=None) -> int:
     return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped", ctx=ctx)
 
 
-def render_grooves(dwg, groups, a, *, ctx, only=None) -> int:
+def render_grooves(dwg, plan, a, *, ctx, only=None) -> int:
     """Turned/circlip-groove callouts (#148c): a leader from each annular groove in round
     stock to its ``{width} WIDE × ø{diameter}`` label. The groove's width is *axial*, so the
     callout lands in the **profile** view (the one showing the stock axis in-plane, where the
@@ -1863,21 +1859,17 @@ def render_grooves(dwg, groups, a, *, ctx, only=None) -> int:
     draft = dwg.draft
     reach = _leader_callout_reach(draft)
     view_of = {"z": "front", "x": "front", "y": "side"}
-    groove_groups = [g for g in groups if g.feature_kind == "groove"]
+    groove_groups = list(plan.of_kind("groove"))
     jobs = []
     for gi, g in enumerate(
-        sorted(groove_groups, key=lambda g: (g.feature.axis, g.feature.frame.origin))
+        sorted(groove_groups, key=lambda g: (g.facts.axis, g.facts.frame.origin))
     ):
-        gr = g.feature
+        gr = g.facts
         if only is not None and gr not in only:
             continue  # #426 Ph2b subset (finalize): skip in place — gi stays the model index
-        wpd = next(
-            (d for d in g.dims if (d.param.role, d.param.kind) == ("groove", "length")), None
-        )
-        dpd = next(
-            (d for d in g.dims if (d.param.role, d.param.kind) == ("groove", "diameter")), None
-        )
-        if wpd is None or dpd is None or wpd.suppressed or dpd.suppressed:
+        wpd = next((d for d in g.dims if (d.role, d.kind) == ("groove", "length")), None)
+        dpd = next((d for d in g.dims if (d.role, d.kind) == ("groove", "diameter")), None)
+        if wpd is None or dpd is None:
             continue
         view = view_of.get(gr.axis)
         if view is None:
@@ -1891,10 +1883,10 @@ def render_grooves(dwg, groups, a, *, ctx, only=None) -> int:
                 view,
                 vb,
                 _groove_label(
-                    wpd.param.value,
-                    dpd.param.value,
-                    wsfx=_tol_suffix(wpd.param.tolerance, draft),
-                    dsfx=_tol_suffix(dpd.param.tolerance, draft),
+                    wpd.value,
+                    dpd.value,
+                    wsfx=_tol_suffix(wpd.tolerance, draft),
+                    dsfx=_tol_suffix(dpd.tolerance, draft),
                 ),
                 _radial_candidates(dwg, view, vb, gr, reach),
             )
@@ -1902,7 +1894,7 @@ def render_grooves(dwg, groups, a, *, ctx, only=None) -> int:
     return _leader_callout_pass(dwg, a, jobs, noun="groove", drop_code="groove_dropped", ctx=ctx)
 
 
-def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
+def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
     """ø leaders for a PRISMATIC part's bosses (#629). A boss reads as a circle looking down its
     axis, so its diameter is called out with a leader to that circle in the view normal to the
     axis — a Z boss in the plan, X in the side, Y in the front — free to exit into clear margin
@@ -1926,19 +1918,19 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
         return 0
     draft = dwg.draft
     view_of = {"z": "plan", "x": "side", "y": "front"}  # the view looking down the boss axis
-    boss_groups = [g for g in groups if g.feature_kind == "boss"]
+    boss_groups = list(plan.of_kind("boss"))
     mentioned = _mentioned_diameters(dwg)
     reach = draft.font_size + 6 * draft.pad_around_text
     jobs = []
     for bi, g in enumerate(
-        sorted(boss_groups, key=lambda g: (g.feature.frame.axis, g.feature.frame.origin))
+        sorted(boss_groups, key=lambda g: (g.facts.frame.axis, g.facts.frame.origin))
     ):
-        b = g.feature
-        dpd = next((pd for pd in g.dims if pd.param.kind == "diameter"), None)
+        b = g.facts
+        dpd = next((pd for pd in g.dims if pd.kind == "diameter"), None)
         if dpd is None:
             continue
-        dia = dpd.param.value
-        dtol = dpd.param.tolerance
+        dia = dpd.value
+        dtol = dpd.tolerance
         thr = getattr(b, "thread", None)  # external thread appends to the OD callout (#859)
         # A coincident plain ⌀ dedups only an UNTHREADED boss; a threaded ⌀ is a distinct callout,
         # so a bare ⌀8 mention (a bore, a step) must not suppress ø8 M8x1.25 (#859).
@@ -1965,7 +1957,7 @@ def render_boss_diameters(dwg, groups, a, *, ctx) -> int:
     )
 
 
-def render_boss_heights(dwg, groups, a, *, ctx) -> int:
+def render_boss_heights(dwg, plan, a, *, ctx) -> int:
     """Queue the axial height of each prismatic boss in a profile-view corridor (#632)."""
     if a.is_rotational or a.prof is not None:
         return 0
@@ -1978,22 +1970,22 @@ def render_boss_heights(dwg, groups, a, *, ctx) -> int:
     n = 0
     for bi, g in enumerate(
         sorted(
-            (g for g in groups if g.feature_kind == "boss"),
-            key=lambda g: (g.feature.frame.axis, g.feature.frame.origin),
+            plan.of_kind("boss"),
+            key=lambda g: (g.facts.frame.axis, g.facts.frame.origin),
         )
     ):
-        b = g.feature
+        b = g.facts
         pd = next(
-            (d for d in g.dims if (d.param.role, d.param.kind) == ("boss_height", "length")),
+            (d for d in g.dims if (d.role, d.kind) == ("boss_height", "length")),
             None,
         )
-        if pd is None or pd.suppressed or pd.param.span is None:
+        if pd is None or pd.span is None:
             continue
         view, side, strip, stack = specs[b.frame.axis]
-        p1 = dwg.at(view, *pd.param.span[0])
-        p2 = dwg.at(view, *pd.param.span[1])
+        p1 = dwg.at(view, *pd.span[0])
+        p2 = dwg.at(view, *pd.span[1])
         edge = max(p1[0], p2[0]) if side == "right" else max(p1[1], p2[1])
-        label = _fmt(pd.param.value) + _tol_suffix(pd.param.tolerance, dwg.draft)
+        label = _fmt(pd.value) + _tol_suffix(pd.tolerance, dwg.draft)
         name = f"m_bossheight_{b.frame.axis}{bi}"
 
         def build(pos, p1=p1, p2=p2, side=side, edge=edge, label=label):
@@ -2019,7 +2011,7 @@ def render_boss_heights(dwg, groups, a, *, ctx) -> int:
                 # second build-time drop here would double-count the same omission.
                 on_drop=lambda _nm: None,
                 force=True,
-                feature=b,
+                feature=g.ref,
                 footprint=footprint,
             ),
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3177,62 +3177,48 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
     return n
 
 
-def render_rotational(dwg, groups, a, *, ctx) -> int:
+def render_rotational(dwg, plan, a, *, ctx) -> int:
     """Rotational furniture from the IR `RotationalFeature` (#237): the OD dim (above
     the front view), the rotation-axis centrelines (front + side), and the concentric
     bore leaders stacked to the left of the front view. Returns the count placed.
 
-    The OD/bore dimension LABELS consume the feature's planned `DimensionGroup`
-    (#754): the value and any authored tolerance/fit folded on by `plan_dimensions`
-    now reach the label via `_tol_suffix`, closing the raw-field bypass ADR 0015
-    tracked. The centrelines and the bore-stack layout/drop bookkeeping stay
-    model-routed furniture, and geometry keeps using the raw `rot.od`/`rot.bores`
-    (equal to the planned value), so X/Y/Z placement is unchanged."""
-    g = next((g for g in groups if g.feature_kind == "rotational"), None)
+    The OD/bore dimensions consume only approved compiled entries. Suppressed entries
+    therefore cannot reach either a label or the geometry used to place that label.
+    Axis centrelines are furniture and remain even when every diameter is omitted."""
+    g = next(iter(plan.of_kind("rotational")), None)
     if g is None:
         return 0
-    rot = g.feature
     draft = dwg.draft
     FX, FZ = a.proj.front_x, a.proj.front_z
     SX, SZ = a.proj.side_x, a.proj.side_z
     PX, PY = a.proj.plan_x, a.proj.plan_y
     n = 0
-    od = rot.od
-    axis = rot.frame.axis
-    od_pd = next((pd for pd in g.dims if pd.param.role == "od"), None)
-    bore_pds = [pd for pd in g.dims if pd.param.role == "bore"]
-    # Contract: RotationalFeature.parameters() emits exactly one OD dim and one per
-    # bore in bores order, and plan_dimensions preserves that. Fail LOUD on a mismatch
-    # (#806 review) rather than silently rendering a raw, untoleranced label — or, for a
-    # missing MIDDLE bore, shifting every later bore_pds[i] onto the wrong physical bore.
-    if od_pd is None or len(bore_pds) != len(rot.bores):
-        raise AssertionError(
-            f"rotational plan mismatch: od_present={od_pd is not None}, "
-            f"planned bores={len(bore_pds)} vs {len(rot.bores)}"
-        )
+    axis = g.facts.frame.axis
+    od_dim = g.dim(kind="diameter", role="od")
+    bore_dims = [d for d in g.dims if d.kind == "diameter" and d.role == "bore"]
 
-    def _dia_label(pd):
+    def _dia_label(dim):
         # Planner-fed value + authored tolerance/fit suffix (#754).
-        return f"ø{_fmt(pd.param.value)}{_tol_suffix(pd.param.tolerance, draft)}"
-
-    od_label = _dia_label(od_pd)
+        return f"ø{_fmt(dim.value)}{_tol_suffix(dim.tolerance, draft)}"
 
     if axis == "z":
         # Vertical turning axis (the common case): OD across the top of the front
         # (profile) view; axis centrelines vertical on front + side.
-        ctx.place(
-            _dim(
-                (FX(a.cx - od / 2), FZ(a.bb.max.Z) + 2, 0),
-                (FX(a.cx + od / 2), FZ(a.bb.max.Z) + 2, 0),
-                "above",
-                8,
-                draft,
-                label=od_label,
-            ),
-            "dim_od",
-            view="front",
-        )
-        n += 1
+        if od_dim is not None:
+            od = od_dim.value
+            ctx.place(
+                _dim(
+                    (FX(a.cx - od / 2), FZ(a.bb.max.Z) + 2, 0),
+                    (FX(a.cx + od / 2), FZ(a.bb.max.Z) + 2, 0),
+                    "above",
+                    8,
+                    draft,
+                    label=_dia_label(od_dim),
+                ),
+                "dim_od",
+                view="front",
+            )
+            n += 1
         ctx.place(
             Centerline((FX(a.cx), FZ(a.bb.min.Z) - 5, 0), (FX(a.cx), FZ(a.bb.max.Z) + 5, 0)),
             "centerline_front",
@@ -3245,7 +3231,7 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
         )
 
         # Concentric bore leaders to the left of the front view, centred on the axis.
-        if rot.bores:
+        if bore_dims:
             left_edge = FX(a.bb.min.X)
             if left_edge - a.margin >= a.DIM_PAD:
                 elbow_x = left_edge - a.DIM_PAD * 0.6
@@ -3256,7 +3242,7 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
                 # leader keeps that same symmetric natural, so plan_strip reproduces the old
                 # positions exactly when there is room (zero displacement) and only compresses /
                 # drops (larger bore outranks smaller, priority=d) when the band is over capacity.
-                nb = len(rot.bores)
+                nb = len(bore_dims)
                 z_lo, z_hi = a.FV_Y - a.fv_hh, a.FV_Y + a.fv_hh
                 cands = [
                     StripCandidate(
@@ -3265,10 +3251,12 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
                         size=(draft.font_size * 3, pitch),
                         priority=d,
                     )
-                    for i, d in enumerate(rot.bores)
+                    for i, dim in enumerate(bore_dims)
+                    for d in (dim.value,)
                 ]
                 placed = plan_strip(cands, z_lo, z_hi, pitch, axis="y").placed
-                for i, d in enumerate(rot.bores):
+                for i, dim in enumerate(bore_dims):
+                    d = dim.value
                     tip_z = placed.get(f"{i:03d}")
                     if tip_z is None:
                         continue  # over the front-view capacity — dropped (ranked), logged below
@@ -3276,14 +3264,16 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
                         Leader(
                             tip=(FX(a.cx - d / 2), tip_z, 0),
                             elbow=(elbow_x, tip_z, 0),
-                            label=_dia_label(bore_pds[i]),
+                            label=_dia_label(dim),
                             draft=draft,
                         ),
                         f"ldr_z{i}",
                         view="front",
                     )
                     n += 1
-                dropped = [d for i, d in enumerate(rot.bores) if placed.get(f"{i:03d}") is None]
+                dropped = [
+                    dim.value for i, dim in enumerate(bore_dims) if placed.get(f"{i:03d}") is None
+                ]
                 for d in dropped:
                     ctx.coverage.drop_diam(
                         d
@@ -3298,25 +3288,27 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
             else:
                 _log.info(
                     "Additional diameters %s not annotated (insufficient left margin)",
-                    list(rot.bores),
+                    [dim.value for dim in bore_dims],
                 )
     elif axis == "x":
         # Horizontal turning axis along X (#222): the OD is the Z extent — a vertical
         # ø dim left of the front (profile) view; axis centrelines run horizontally
         # through z=cz on front and y=cy on plan.
-        ctx.place(
-            _dim(
-                (FX(a.bb.min.X) - 2, FZ(a.cz - od / 2), 0),
-                (FX(a.bb.min.X) - 2, FZ(a.cz + od / 2), 0),
-                "left",
-                8,
-                draft,
-                label=od_label,
-            ),
-            "dim_od",
-            view="front",
-        )
-        n += 1
+        if od_dim is not None:
+            od = od_dim.value
+            ctx.place(
+                _dim(
+                    (FX(a.bb.min.X) - 2, FZ(a.cz - od / 2), 0),
+                    (FX(a.bb.min.X) - 2, FZ(a.cz + od / 2), 0),
+                    "left",
+                    8,
+                    draft,
+                    label=_dia_label(od_dim),
+                ),
+                "dim_od",
+                view="front",
+            )
+            n += 1
         ctx.place(
             Centerline((FX(a.bb.min.X) - 5, FZ(a.cz), 0), (FX(a.bb.max.X) + 5, FZ(a.cz), 0)),
             "centerline_front",
@@ -3331,19 +3323,21 @@ def render_rotational(dwg, groups, a, *, ctx) -> int:
         # Horizontal turning axis along Y (#222): the OD is the Z extent — a vertical
         # ø dim left of the side (profile) view; axis centrelines run horizontally
         # through z=cz on side and vertically through x=cx on plan.
-        ctx.place(
-            _dim(
-                (SX(a.bb.min.Y) - 2, SZ(a.cz - od / 2), 0),
-                (SX(a.bb.min.Y) - 2, SZ(a.cz + od / 2), 0),
-                "left",
-                8,
-                draft,
-                label=od_label,
-            ),
-            "dim_od",
-            view="side",
-        )
-        n += 1
+        if od_dim is not None:
+            od = od_dim.value
+            ctx.place(
+                _dim(
+                    (SX(a.bb.min.Y) - 2, SZ(a.cz - od / 2), 0),
+                    (SX(a.bb.min.Y) - 2, SZ(a.cz + od / 2), 0),
+                    "left",
+                    8,
+                    draft,
+                    label=_dia_label(od_dim),
+                ),
+                "dim_od",
+                view="side",
+            )
+            n += 1
         ctx.place(
             Centerline((SX(a.bb.min.Y) - 5, SZ(a.cz), 0), (SX(a.bb.max.Y) + 5, SZ(a.cz), 0)),
             "centerline_side",

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1760,7 +1760,7 @@ def _leader_hole_clearance(
     return min(clearances)
 
 
-def render_pockets(dwg, groups, a, *, ctx, only=None) -> int:
+def render_pockets(dwg, plan, a, *, ctx, only=None) -> int:
     """Blind-recess callouts (#148a): a leader from each floored slot/pocket to its
     ``W × L × D DEEP`` label, in the view normal to the recess opening (a Z-depth pocket
     reads in the plan, an X-depth in the side, a Y-depth in the front). A pocket sits
@@ -1778,21 +1778,19 @@ def render_pockets(dwg, groups, a, *, ctx, only=None) -> int:
     draft = dwg.draft
     reach = _leader_callout_reach(draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
-    pocket_groups = [g for g in groups if g.feature_kind == "pocket"]
+    pocket_groups = list(plan.of_kind("pocket"))
     jobs = []
     for i, g in enumerate(
-        sorted(pocket_groups, key=lambda g: (g.feature.width_axis, g.feature.frame.origin))
+        sorted(pocket_groups, key=lambda g: (g.facts.width_axis, g.facts.frame.origin))
     ):
-        pk = g.feature
-        if only is not None and pk not in only:
+        pk = g.facts
+        if only is not None and g.ref not in only:
             continue  # #426 Ph2b subset (finalize): skip in place — i stays the model index
-        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        by_key = {(pd.role, pd.kind): pd for pd in g.dims}
         wpd = by_key.get(("pocket_width", "length"))
         lpd = by_key.get(("pocket_length", "length"))
         dpd = by_key.get(("pocket_depth", "length"))
         if wpd is None or lpd is None or dpd is None:
-            continue
-        if wpd.suppressed or lpd.suppressed or dpd.suppressed:
             continue
         view = view_of.get(pk.depth_axis)
         if view is None:
@@ -1806,12 +1804,12 @@ def render_pockets(dwg, groups, a, *, ctx, only=None) -> int:
                 view,
                 vb,
                 _pocket_label(
-                    wpd.param.value,
-                    lpd.param.value,
-                    dpd.param.value,
-                    wsfx=_tol_suffix(wpd.param.tolerance, draft),
-                    lsfx=_tol_suffix(lpd.param.tolerance, draft),
-                    dsfx=_tol_suffix(dpd.param.tolerance, draft),
+                    wpd.value,
+                    lpd.value,
+                    dpd.value,
+                    wsfx=_tol_suffix(wpd.tolerance, draft),
+                    lsfx=_tol_suffix(lpd.tolerance, draft),
+                    dsfx=_tol_suffix(dpd.tolerance, draft),
                 ),
                 _radial_candidates(dwg, view, vb, pk, reach),
             )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2824,10 +2824,24 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     the plan's diagnostics) and this pass's drop (arrived, did not fit; reported as
     ``placement_unsatisfiable``). Returns the count REGISTERED."""
     draft = dwg.draft
-    _left, right, bottom, _top = frame.edges("front")
+    _left, right, _bottom, _top = frame.edges("front")
     edge2 = right + 2
-    zmin = bottom
     tier = draft.font_size + 2 * draft.pad_around_text
+
+    def _zspan(entry):
+        """An entry's witness ends, projected from ITS OWN span.
+
+        Anchoring every rung at the view's bottom edge instead was wrong the moment the
+        compiler started measuring from `StepLevelFeature.base`: a declared base above the
+        part's bottom made the drawn line span the full part while the label read the
+        shorter distance, so the dimension said one thing and measured another (#923
+        review). The span is the compiler's statement of what is being measured; projecting
+        both ends of it is what keeps line and label the same claim."""
+        return (
+            frame.project("front", entry.span[0])[1],
+            frame.project("front", entry.span[1])[1],
+        )
+
     strip = frame.fv_zones.right
 
     rung_set = plan.ladder("step_height")
@@ -2846,7 +2860,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
         chain.append(
             (
                 "dim_step_typ",
-                frame.project("front", rep.span[1])[1],
+                *_zspan(rep),
                 rep.label,
                 _SLOT_DIM_STEP,
                 "representative step-height dimension dropped (front-view right strip full)",
@@ -2889,7 +2903,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             chain.append(
                 (
                     f"dim_step_{col}",
-                    frame.project("front", rung.span[1])[1],
+                    *_zspan(rung),
                     rung.label,
                     _SLOT_DIM_STEP,
                     "step-height dimension dropped (front-view right strip full)",
@@ -2902,7 +2916,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
         chain.append(
             (
                 "dim_height",
-                frame.project("front", height.span[1])[1],
+                *_zspan(height),
                 height.label,
                 _SLOT_DIM_HEIGHT,
                 "overall height dimension dropped (front-view right strip full)",
@@ -2911,18 +2925,18 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
 
     names = [c[0] for c in chain]
     solved: dict[str, float] = {}
-    for k, (name, ztop, label, _tsize, drop_msg) in enumerate(chain):
+    for k, (name, zbase, ztop, label, _tsize, drop_msg) in enumerate(chain):
 
-        def _build(pos, name=name, ztop=ztop, label=label, k=k):
+        def _build(pos, name=name, zbase=zbase, ztop=ztop, label=label, k=k):
             base = edge2
             for pn in reversed(names[:k]):  # nearest already-built predecessor's line
                 if pn in solved:
                     base = solved[pn]
                     break
             solved[name] = pos
-            return _dim((base, zmin, 0), (base, ztop, 0), "right", pos - base, draft, label=label)
+            return _dim((base, zbase, 0), (base, ztop, 0), "right", pos - base, draft, label=label)
 
-        def _foot(pos, ztop=ztop, label=label, k=k):
+        def _foot(pos, zbase=zbase, ztop=ztop, label=label, k=k):
             # Predecessor-aware prediction (#689 review): the conservative edge-anchored
             # witness can falsely exhaust the strip when an inner obstacle sits in the
             # already-traversed region. Use the same solved map the build chain uses.
@@ -2934,7 +2948,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             if pos - base < 0.5:  # degenerate guard: never model a zero-length offset
                 base = edge2
             return dim_footprint(
-                (base, zmin, 0), (base, ztop, 0), "right", pos - base, draft, label
+                (base, zbase, 0), (base, ztop, 0), "right", pos - base, draft, label
             )
 
         def _drop(nm, drop_msg=drop_msg, name=name):
@@ -2978,12 +2992,12 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     left_edge = _left - 2
     for i, rung in enumerate(short_rungs):
         name = f"dim_step_{i}"
-        ztop = frame.project("front", rung.span[1])[1]
+        zbase, ztop = _zspan(rung)
         label = rung.label
 
-        def _build_left(pos, ztop=ztop, label=label):
+        def _build_left(pos, zbase=zbase, ztop=ztop, label=label):
             return _dim(
-                (left_edge, zmin, 0),
+                (left_edge, zbase, 0),
                 (left_edge, ztop, 0),
                 "left",
                 left_edge - pos,
@@ -3016,8 +3030,8 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 on_drop=_drop_left,
                 force=True,
                 feature=step,
-                footprint=lambda pos, ztop=ztop, label=label: dim_footprint(
-                    (left_edge, zmin, 0),
+                footprint=lambda pos, zbase=zbase, ztop=ztop, label=label: dim_footprint(
+                    (left_edge, zbase, 0),
                     (left_edge, ztop, 0),
                     "left",
                     left_edge - pos,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2068,9 +2068,17 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
         for g in plan.of_kind("plate")
         if (pd := g.dim(role="thickness", kind="length")) is not None and pd.span is not None
     ]
-    for g, pd in sorted(
-        plate_groups, key=lambda gp: (gp[0].facts.axis, gp[1].span[0], gp[1].span[1])
-    ):
+
+    # Preserve the pre-boundary stable identity order: axis, then the plate's lower and
+    # upper coordinates ALONG that thin axis. Sorting whole points would compare their
+    # in-plane coordinates first and silently swap dim_plate_{axis}{i} names when two
+    # same-axis plates move sideways (#923 adversarial review).
+    def _plate_order(gp):
+        axis = gp[0].facts.axis
+        idx = "xyz".index(axis)
+        return (axis, gp[1].span[0][idx], gp[1].span[1][idx])
+
+    for g, pd in sorted(plate_groups, key=_plate_order):
         axis = g.facts.axis
         # The span's two ends ARE the plate's lo/hi along its thin axis, and its other two
         # coordinates are the in-plane centroids the witness sits at — `PlateFeature._span`

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3088,12 +3088,14 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
     draft = dwg.draft
 
     def _axis_of(rung):
-        """Which axis a shoulder runs along — read off the span's varying coordinate.
+        """The compiler-owned shoulder direction.
 
-        The span already says it, so an `axis` field would be a second statement of one
-        fact and a second thing to keep in step."""
-        lo, hi = rung.span
-        return "x" if lo[0] != hi[0] else "y"
+        A span normally reveals its varying coordinate, but a shoulder on its own datum
+        has a degenerate span and reveals no direction at all. Axis is therefore explicit
+        structural content on the approved rung, not inferred placement policy."""
+        if rung.axis not in ("x", "y"):
+            raise AssertionError(f"step-position rung has no X/Y axis: {rung.axis!r}")
+        return rung.axis
 
     axes = {_axis_of(r) for r in rungs}
     mixed_axes = len(axes) > 1

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1510,7 +1510,7 @@ def render_chamfers(dwg, plan, a, *, ctx, only=None) -> int:
         sorted(chamfer_groups, key=lambda g: (g.facts.axis, g.facts.frame.origin))
     ):
         ch = g.facts
-        if only is not None and ch not in only:
+        if only is not None and g.ref not in only:
             continue  # #426 Ph2b subset (finalize): skip in place — i stays the model index
         # Bind the intended planned dim EXPLICITLY by (role, kind), never dims[0]
         # (#724 review): the pattern the remaining #698 migrations copy must not
@@ -1865,7 +1865,7 @@ def render_grooves(dwg, plan, a, *, ctx, only=None) -> int:
         sorted(groove_groups, key=lambda g: (g.facts.axis, g.facts.frame.origin))
     ):
         gr = g.facts
-        if only is not None and gr not in only:
+        if only is not None and g.ref not in only:
             continue  # #426 Ph2b subset (finalize): skip in place — gi stays the model index
         wpd = next((d for d in g.dims if (d.role, d.kind) == ("groove", "length")), None)
         dpd = next((d for d in g.dims if (d.role, d.kind) == ("groove", "diameter")), None)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1392,7 +1392,7 @@ def _label_lands_clear(ldr, obstacles, silhouette, page, *, geom_clear=False) ->
     )
 
 
-def _corner_candidates(dwg, view, vb, members, reach):
+def _corner_candidates(dwg, view, vb, members, reach, *, provenances=None):
     """Lead candidates for a corner-sitting feature (chamfer/fillet/flat): from each member's
     projected origin, a diagonal from the view centre out through the corner, *reach* beyond
     the tip — a corner clears the silhouette this way. Yields ``(tip, elbow, member)`` in the
@@ -1400,12 +1400,13 @@ def _corner_candidates(dwg, view, vb, members, reach):
     one-element *members*."""
     x0, y0, x1, y1 = vb
     cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
-    for m in members:
+    owners = provenances if provenances is not None else members
+    for m, owner in zip(members, owners):
         tip = dwg.at(view, *m.frame.origin)
         dx, dy = tip[0] - cx, tip[1] - cy
         d = math.hypot(dx, dy) or 1.0
         elbow = (tip[0] + dx / d * reach, tip[1] + dy / d * reach, 0)
-        yield (tip, elbow, m)
+        yield (tip, elbow, owner)
 
 
 def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False) -> int:
@@ -1512,7 +1513,7 @@ def render_chamfers(dwg, plan, a, *, ctx, only=None) -> int:
                 view,
                 vb,
                 _chamfer_label(pd.value, ch) + _tol_suffix(pd.tolerance, draft),
-                _corner_candidates(dwg, view, vb, [ch], reach),
+                _corner_candidates(dwg, view, vb, [ch], reach, provenances=[g.ref]),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="chamfer", drop_code="chamfer_dropped", ctx=ctx)
@@ -1581,7 +1582,14 @@ def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
                 view,
                 vb,
                 _fillet_label(members[0][1].value, len(ordered)) + _tol_suffix(tol, draft),
-                _corner_candidates(dwg, view, vb, [g.facts for g, _ in ordered], reach),
+                _corner_candidates(
+                    dwg,
+                    view,
+                    vb,
+                    [g.facts for g, _ in ordered],
+                    reach,
+                    provenances=[g.ref for g, _ in ordered],
+                ),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped", ctx=ctx)
@@ -1644,7 +1652,14 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
                 view,
                 vb,
                 _flat_label(members[0][1].value, _tol_suffix(tol, draft)),
-                _corner_candidates(dwg, view, vb, [g.facts for g, _ in ordered], reach),
+                _corner_candidates(
+                    dwg,
+                    view,
+                    vb,
+                    [g.facts for g, _ in ordered],
+                    reach,
+                    provenances=[g.ref for g, _ in ordered],
+                ),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped", ctx=ctx)
@@ -1711,7 +1726,17 @@ _POCKET_LEAD_DIRS = (
 )
 
 
-def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0, directions=_POCKET_LEAD_DIRS):
+def _radial_candidates(
+    dwg,
+    view,
+    vb,
+    feature,
+    reach,
+    *,
+    rim=0.0,
+    directions=_POCKET_LEAD_DIRS,
+    provenance=None,
+):
     """Lead candidates for a mid-face feature (pocket/groove/boss ø): from the feature's
     projected origin, one candidate per *directions* entry (pocket-style diagonals
     first by default) — exit the silhouette along it (:func:`_ray_exit_dist`) then
@@ -1728,7 +1753,7 @@ def _radial_candidates(dwg, view, vb, feature, reach, *, rim=0.0, directions=_PO
         tip = (origin[0] + ux * rim, origin[1] + uy * rim)
         exit_d = _ray_exit_dist(tip[0], tip[1], ux, uy, (x0, y0, x1, y1))
         elbow = (tip[0] + ux * (exit_d + reach), tip[1] + uy * (exit_d + reach), 0)
-        yield (tip, elbow, feature)
+        yield (tip, elbow, provenance if provenance is not None else feature)
 
 
 def _leader_hole_clearance(
@@ -1811,7 +1836,7 @@ def render_pockets(dwg, plan, a, *, ctx, only=None) -> int:
                     lsfx=_tol_suffix(lpd.tolerance, draft),
                     dsfx=_tol_suffix(dpd.tolerance, draft),
                 ),
-                _radial_candidates(dwg, view, vb, pk, reach),
+                _radial_candidates(dwg, view, vb, pk, reach, provenance=g.ref),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped", ctx=ctx)
@@ -1867,7 +1892,7 @@ def render_grooves(dwg, plan, a, *, ctx, only=None) -> int:
                     wsfx=_tol_suffix(wpd.tolerance, draft),
                     dsfx=_tol_suffix(dpd.tolerance, draft),
                 ),
-                _radial_candidates(dwg, view, vb, gr, reach),
+                _radial_candidates(dwg, view, vb, gr, reach, provenance=g.ref),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="groove", drop_code="groove_dropped", ctx=ctx)
@@ -1928,7 +1953,9 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
                 vb,
                 f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else ""),
                 # arrowhead on the boss circle's rim, not its centre
-                _radial_candidates(dwg, view, vb, b, reach, rim=dia / 2 * a.SCALE),
+                _radial_candidates(
+                    dwg, view, vb, b, reach, rim=dia / 2 * a.SCALE, provenance=g.ref
+                ),
             )
         )
     return _leader_callout_pass(

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2802,30 +2802,6 @@ def render_step_lengths(dwg, groups, *, ctx, only=None) -> int:
     return _draw_step_chain(dwg, view, fsegs, "m_steplen", ctx=ctx, start=start)
 
 
-def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):
-    """Return (n, rise) if *step_zs* form a uniform staircase, else None.
-
-    A uniform staircase has all inter-step rises (including from bb_min_z to the
-    first step) within *tol_frac* of their mean. Requires >=3 detected interior
-    steps to avoid false positives. *n* is len(step_zs) + 1 when the top gap
-    (bb_max_z - last step) also matches the mean, otherwise len(step_zs).
-    """
-    if len(step_zs) < 3:
-        return None
-    sorted_zs = sorted(step_zs)
-    rises = [sorted_zs[0] - bb_min_z] + [
-        sorted_zs[i + 1] - sorted_zs[i] for i in range(len(sorted_zs) - 1)
-    ]
-    mean_rise = sum(rises) / len(rises)
-    if mean_rise <= 0:
-        return None
-    if not all(abs(r - mean_rise) / mean_rise <= tol_frac for r in rises):
-        return None
-    top_gap = bb_max_z - sorted_zs[-1]
-    n = len(rises) + (1 if abs(top_gap - mean_rise) / mean_rise <= tol_frac else 0)
-    return n, mean_rise
-
-
 def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) -> int:
     """Front-view right ladder: prismatic step heights stacked inner→outer, then the overall
     height outermost — registered as :class:`CorridorCandidate`s in the shared
@@ -2856,7 +2832,10 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
 
     rung_set = plan.ladder("step_height")
     rungs = list(rung_set.rungs) if rung_set is not None else []
-    step = rung_set.feature if rung_set is not None else None
+    # An OPAQUE handle, passed straight through to the corridor candidate and the
+    # escalation. This pass never resolves it: the feature behind it carries the levels
+    # and the base, which is the content the compiler already ruled on (#923 review).
+    step = rung_set.ref if rung_set is not None else None
     has_shoulders = plan.ladder("step_position") is not None
     short_rungs: list = []
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3043,7 +3043,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     return len(chain) + len(short_rungs)
 
 
-def render_step_positions(dwg, model, a, *, ctx) -> int:
+def render_step_positions(dwg, plan, frame, *, ctx) -> int:
     """Prismatic step POSITIONS (#555): where each shoulder sits along its axis,
     dimensioned from the part datum so a stepped block is fully constrained (the step
     heights alone leave the shoulder location implicit — two geometries draw the same
@@ -3051,61 +3051,79 @@ def render_step_positions(dwg, model, a, *, ctx) -> int:
     horizontally, where the step profile reads); an X shoulder is above the plan view —
     the same axis→view mapping the hole-location ladder uses. Mixed-axis transitions use
     the side-below strip so they do not collide with the isometric furniture above.
-    A shoulder whose strip is full drops with a lint code, not silently. Returns the
-    count placed."""
-    step = next((f for f in model.features if f.kind == "step_level"), None)
-    if step is None or not step.shoulders:
+    A shoulder whose strip is full drops with a lint code, not silently.
+
+    Migrated to the ADR 0016 boundary: the shoulder chain arrives as the compiled plan's
+    ``step_position`` :class:`ApprovedLadder`, and each rung's span carries the datum and
+    the station it runs between, so this pass never reaches for `step.shoulders` or the
+    bounding box. Returns the count placed."""
+    ladder = plan.ladder("step_position")
+    rungs = list(ladder.rungs) if ladder is not None else []
+    if not rungs:
         return 0
     draft = dwg.draft
-    axes = {axis for axis, _ in step.shoulders}
+
+    def _axis_of(rung):
+        """Which axis a shoulder runs along — read off the span's varying coordinate.
+
+        The span already says it, so an `axis` field would be a second statement of one
+        fact and a second thing to keep in step."""
+        lo, hi = rung.span
+        return "x" if lo[0] != hi[0] else "y"
+
+    axes = {_axis_of(r) for r in rungs}
     mixed_axes = len(axes) > 1
     # Dense transition ladders need only one text tier: arrowhead clearance is
     # along the measured axis, not between outward ladder tiers (#897). Retain
     # the established spacing for ordinary single-axis stepped profiles.
     tier = draft.font_size + (
-        draft.pad_around_text if len(step.shoulders) > 2 else 2 * draft.pad_around_text
+        draft.pad_around_text if len(rungs) > 2 else 2 * draft.pad_around_text
     )
     n = 0
     counts: dict = {"x": 0, "y": 0}
-    for axis, pos in sorted(step.shoulders):
-        di = {"x": 0, "y": 1}[axis]
-        datum = step.datum[di]
-        val = abs(pos - datum)
+    # Page-space view edges: the ladder anchors on the view silhouette, which is layout,
+    # while the STATIONS come from the approved spans, which is content.
+    _sl, _sr, side_bottom, side_top = frame.edges("side")
+    _pl, _pr, _pb, plan_top = frame.edges("plan")
+    for rung in rungs:
+        axis = _axis_of(rung)
+        lo, hi = rung.span
+        val = rung.value
         i = counts[axis]
         counts[axis] += 1
         if axis == "y" and mixed_axes:
             # Keep mixed-axis Y-profile stations below the side view. The iso
             # caption lives above it and is emitted after the corridor drain,
             # so an above ladder could not see/avoid that furniture (#897).
-            view, strip, direction = "side", a.sv_zones.below, "below"
-            p1 = dwg.at(view, a.bb.min.X, datum, a.bb.min.Z)
-            p2 = dwg.at(view, a.bb.min.X, pos, a.bb.min.Z)
+            view, strip, direction = "side", frame.sv_zones.below, "below"
+            p1 = (frame.project(view, lo)[0], side_bottom)
+            p2 = (frame.project(view, hi)[0], side_bottom)
         elif axis == "y":
-            view, strip, direction = "side", a.sv_zones.above, "above"
-            p1 = dwg.at(view, a.bb.min.X, datum, a.bb.max.Z)
-            p2 = dwg.at(view, a.bb.min.X, pos, a.bb.max.Z)
+            view, strip, direction = "side", frame.sv_zones.above, "above"
+            p1 = (frame.project(view, lo)[0], side_top)
+            p2 = (frame.project(view, hi)[0], side_top)
         else:  # x — shoulder along X → above the plan view
-            view, strip, direction = "plan", a.pv_zones.above, "above"
-            p1 = dwg.at(view, datum, a.bb.max.Y, a.bb.min.Z)
-            p2 = dwg.at(view, pos, a.bb.max.Y, a.bb.min.Z)
+            view, strip, direction = "plan", frame.pv_zones.above, "above"
+            p1 = (frame.project(view, lo)[0], plan_top)
+            p2 = (frame.project(view, hi)[0], plan_top)
         edge = p1[1]
         name = f"dim_shoulder_{axis}{i}"
 
-        def _build(pos, p1=p1, p2=p2, edge=edge, val=val, direction=direction):
+        def _build(pos, p1=p1, p2=p2, edge=edge, label=rung.label, direction=direction):
             return _dim(
                 (p1[0], edge, 0),
                 (p2[0], edge, 0),
                 direction,
                 pos - edge if direction == "above" else edge - pos,
                 draft,
-                label=_fmt(val),
+                label=label,
             )
 
-        def _drop(nm, val=val, view=view, direction=direction):
+        def _drop(nm, label=rung.label, view=view, direction=direction):
             ctx.record_issue(
                 "warning",
                 "step_position_dropped",
-                f"step position {_fmt(val)} not dimensioned ({view} {direction}-strip full)",
+                f"step position {label} not dimensioned ({view} {direction}-strip full)",
             )
 
         # ADR 0009 corridor candidate (#636): a shoulder position is a datum-referenced
@@ -3130,7 +3148,8 @@ def render_step_positions(dwg, model, a, *, ctx) -> int:
                 on_place=lambda nm: None,
                 on_drop=_drop,
                 force=True,
-                feature=step,
+                # The opaque provenance handle, passed straight through.
+                feature=ladder.ref,
             ),
         )
         n += 1

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2027,7 +2027,7 @@ def render_boss_heights(dwg, groups, a, *, ctx) -> int:
     return n
 
 
-def render_plates(dwg, groups, a, *, ctx) -> int:
+def render_plates(dwg, plan, a, *, ctx) -> int:
     """Plate/wall thicknesses (#559): the thin extent of each recognised slab
     (`PlateFeature`), placed in the view where its thin axis is characteristic — a Z
     plate (horizontal slab) as a vertical dim left of the front elevation, a Y plate
@@ -2039,7 +2039,7 @@ def render_plates(dwg, groups, a, *, ctx) -> int:
 
     Planner-fed (#729 / #698): the thickness VALUE + its tolerance come from the
     planner's ``DimParameter``, bound explicitly by ``(role, kind)`` —
-    ``("thickness", "length")`` — never ``dims[0]``. Formatting ``pl.hi - pl.lo``
+    ``("thickness", "length")`` — never ``dims[0]``. Formatting ``hi - lo``
     directly dropped an authored tolerance (the #629 class). Placement mechanics
     (strips, tier stacking, the allowlisted carve fallthrough) are untouched. The
     pass KEEPS its own axis→view map: ``g.view`` is ``_END_ON`` (z→plan / y→front /
@@ -2047,37 +2047,48 @@ def render_plates(dwg, groups, a, *, ctx) -> int:
     y→side-above, x→front-below)."""
     draft = dwg.draft
     tier = draft.font_size + 2 * draft.pad_around_text
-    plate_groups = [g for g in groups if g.feature_kind == "plate"]
+    # Migrated to the ADR 0016 boundary: approved entries only, and the plate's `lo`/`hi`
+    # come from the thickness dim's SPAN rather than the feature — they are the two ends of
+    # the measurement, so the span is where they belong. `axis` stays a fact because no span
+    # says which way a slab is thin.
     n = 0
     counts: dict = {"x": 0, "y": 0, "z": 0}
-    for g in sorted(plate_groups, key=lambda g: (g.feature.axis, g.feature.lo, g.feature.hi)):
-        pl = g.feature
-        pd = next(
-            (d for d in g.dims if (d.param.role, d.param.kind) == ("thickness", "length")),
-            None,
-        )
-        if pd is None or pd.suppressed:
-            continue
-        val = pd.param.value
-        lbl = _fmt(val) + _tol_suffix(pd.param.tolerance, draft)
-        i = counts[pl.axis]
-        counts[pl.axis] += 1
-        if pl.axis == "z":
+    plate_groups = [
+        (g, pd)
+        for g in plan.of_kind("plate")
+        if (pd := g.dim(role="thickness", kind="length")) is not None and pd.span is not None
+    ]
+    for g, pd in sorted(
+        plate_groups, key=lambda gp: (gp[0].facts.axis, gp[1].span[0], gp[1].span[1])
+    ):
+        axis = g.facts.axis
+        # The span's two ends ARE the plate's lo/hi along its thin axis, and its other two
+        # coordinates are the in-plane centroids the witness sits at — `PlateFeature._span`
+        # builds it from exactly those. So the renderer reads points, not a feature.
+        lo_pt, hi_pt = pd.span
+        oi = [j for j in (0, 1, 2) if j != "xyz".index(axis)]
+        lo, hi = lo_pt["xyz".index(axis)], hi_pt["xyz".index(axis)]
+        u, v = lo_pt[oi[0]], lo_pt[oi[1]]
+        val = pd.value
+        lbl = pd.label + _tol_suffix(pd.tolerance, draft)
+        i = counts[axis]
+        counts[axis] += 1
+        if axis == "z":
             # Horizontal slab (base plate): vertical dim on the front-elevation left strip.
             # For a Z plate the in-plane centroids are (u=X, v=Y); the front view discards
-            # Y, so the depth arg is inert, but pass the Y-centroid (pl.v) for correctness.
+            # Y, so the depth arg is inert, but pass the Y-centroid (v) for correctness.
             view, strip, stack, side = "front", a.fv_zones.left, "x", "left"
-            p1 = dwg.at(view, a.bb.min.X, pl.v, pl.lo)
-            p2 = dwg.at(view, a.bb.min.X, pl.v, pl.hi)
+            p1 = dwg.at(view, a.bb.min.X, v, lo)
+            p2 = dwg.at(view, a.bb.min.X, v, hi)
             edge = p1[0]
             pa, pb = (edge, p1[1], 0), (edge, p2[1], 0)
             # Right-strip fallthrough anchors (helpers ≥0.14): a tight-span thickness
             # dim's witness hull overlaps the below strip's at the view corner at EVERY
             # position (AABB artifact — the ink never touches), so a full left strip
             # retries on the opposite side before dropping.
-            q1 = dwg.at(view, a.bb.max.X, pl.v, pl.lo)
-            s1 = dwg.at("side", a.bb.min.X, a.bb.max.Y, pl.lo)
-            s2 = dwg.at("side", a.bb.min.X, a.bb.max.Y, pl.hi)
+            q1 = dwg.at(view, a.bb.max.X, v, lo)
+            s1 = dwg.at("side", a.bb.min.X, a.bb.max.Y, lo)
+            s2 = dwg.at("side", a.bb.min.X, a.bb.max.Y, hi)
             alt = [
                 (
                     "front",
@@ -2098,25 +2109,25 @@ def render_plates(dwg, groups, a, *, ctx) -> int:
                     s1[0],
                 ),
             ]
-        elif pl.axis == "y":
+        elif axis == "y":
             # Upright wall: horizontal dim above the side (end) view, which shows the
             # wall edge-on on the L-profile — a different view from the Z base plate.
             # Witness from the view's top edge (like the Z/X plates anchor at their view
             # outline) so the extension lines don't originate mid-view.
             view, strip, stack, side = "side", a.sv_zones.above, "y", "above"
-            p1 = dwg.at(view, a.bb.min.X, pl.lo, a.bb.max.Z)
-            p2 = dwg.at(view, a.bb.min.X, pl.hi, a.bb.max.Z)
+            p1 = dwg.at(view, a.bb.min.X, lo, a.bb.max.Z)
+            p2 = dwg.at(view, a.bb.min.X, hi, a.bb.max.Z)
             edge = p1[1]
             pa, pb = (p1[0], edge, 0), (p2[0], edge, 0)
             alt = None
         else:  # x — thin wall along X → horizontal dim below the front view
             view, strip, stack, side = "front", a.fv_zones.below, "y", "below"
-            p1 = dwg.at(view, pl.lo, pl.u, a.bb.min.Z)
-            p2 = dwg.at(view, pl.hi, pl.u, a.bb.min.Z)
+            p1 = dwg.at(view, lo, u, a.bb.min.Z)
+            p2 = dwg.at(view, hi, u, a.bb.min.Z)
             edge = p1[1]
             pa, pb = (p1[0], edge, 0), (p2[0], edge, 0)
             alt = None
-        name = f"dim_plate_{pl.axis}{i}"
+        name = f"dim_plate_{axis}{i}"
 
         def _build(pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl):
             return _dim(pa, pb, side, pos - edge, draft, label=lbl)
@@ -2124,7 +2135,7 @@ def render_plates(dwg, groups, a, *, ctx) -> int:
         def _foot(pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl):
             return dim_footprint(pa, pb, side, pos - edge, draft, lbl)
 
-        def _drop(nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=pl):  # noqa: B008
+        def _drop(nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=g.ref):  # noqa: B008
             # Opposite-strip fallthrough (mirrors the GD&T #481 pattern), DEFERRED to
             # ctx.post_drain so it runs after EVERY corridor has drained (#684 review):
             # a mid-drain carve could occupy a corner a later sibling's force candidate
@@ -2188,7 +2199,7 @@ def render_plates(dwg, groups, a, *, ctx) -> int:
                 on_place=lambda nm: None,
                 on_drop=_drop,
                 force=True,
-                feature=pl,
+                feature=g.ref,  # opaque provenance handle
                 footprint=_foot,  # analytical measure — no probe build (#602)
             ),
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2826,57 +2826,67 @@ def _detect_step_repeat(step_zs, bb_min_z, bb_max_z, tol_frac=0.10):
     return n, mean_rise
 
 
-def render_height_ladder(
-    dwg, model, a, *, ctx, include_overall: bool = True, detail_view: bool = False
-) -> int:
-    """Front-view right ladder: prismatic step heights (from `StepLevelFeature`)
-    stacked inner→outer, then the overall height outermost — registered as
-    :class:`CorridorCandidate`s in the shared ``(front, right)`` corridor (#636;
-    formerly the last solver-invisible `carve_free_position` auto-pass). The leapfrog
-    witness cursor (#237) survives as a *build-time chain*: candidates share a
-    ``solved`` position map, and each dim's witness anchors on its nearest already-
-    built predecessor's line (the view edge for the first) — build order follows the
-    candidate order, so the chain is deterministic. Prediction uses an analytical
-    footprint with the witness modelled from the view edge (a conservative
-    over-cover along the stack axis; the accept-time real-box validation trims any
-    drift). A turned part has no `StepLevelFeature`; a Z-turned part suppresses the
-    overall height (the chain tiles it, ISO 129). Returns the count REGISTERED."""
+def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) -> int:
+    """Front-view right ladder: prismatic step heights stacked inner→outer, then the overall
+    height outermost — registered as :class:`CorridorCandidate`s in the shared
+    ``(front, right)`` corridor (#636). The leapfrog witness cursor (#237) survives as a
+    *build-time chain*: candidates share a ``solved`` position map, and each dim's witness
+    anchors on its nearest already-built predecessor's line (the view edge for the first).
+
+    **The first renderer migrated to the ADR 0016 boundary.** It takes the compiled
+    :class:`RenderableDimensionPlan` and a :class:`LayoutFrame`, not the `PartModel` and the
+    `Analysis`. Everything it used to decide about WHAT to draw — which rungs exist, their
+    values and labels, whether a uniform staircase collapses to one ``n×`` mark, whether the
+    overall height is drawn at all and what its value is — now arrives already decided. It
+    could previously reach `StepLevelFeature.levels` and `a.bb` and rebuild all of it, and
+    for four review rounds it did exactly that in defiance of the plan.
+
+    What stays here is placement, and it is a real job: legibility at this scale, the
+    leapfrog chain, corridor registration, the left-strip escape for short rises, and the
+    lint code when the strip is physically full. Note the two kinds of "not drawn" that meet
+    here and must not be confused — the compiler's omission (never arrives; reported through
+    the plan's diagnostics) and this pass's drop (arrived, did not fit; reported as
+    ``placement_unsatisfiable``). Returns the count REGISTERED."""
     draft = dwg.draft
-    FX, FZ = a.proj.front_x, a.proj.front_z
-    edge2 = FX(a.bb.max.X) + 2
-    zmin = FZ(a.bb.min.Z)
+    _left, right, bottom, _top = frame.edges("front")
+    edge2 = right + 2
+    zmin = bottom
     tier = draft.font_size + 2 * draft.pad_around_text
-    step = next((f for f in model.features if f.kind == "step_level"), None)
-    levels = list(step.levels) if step is not None else []
-    step_shoulders = tuple(step.shoulders) if step is not None else ()
-    short_levels: list[float] = []
-    rep = _detect_step_repeat(levels, a.bb.min.Z, a.bb.max.Z) if levels else None
+    strip = frame.fv_zones.right
+
+    rung_set = plan.ladder("step_height")
+    rungs = list(rung_set.rungs) if rung_set is not None else []
+    step = rung_set.feature if rung_set is not None else None
+    has_shoulders = plan.ladder("step_position") is not None
+    short_rungs: list = []
 
     # The chain, inner→outer: (name, page-z top, label, tier size, drop message).
     chain: list = []
-    if rep is not None:
-        n_rep, rise = rep
-        first = sorted(levels)[0]
+    if rung_set is not None and rung_set.representative:
+        (rep,) = rungs
         chain.append(
             (
                 "dim_step_typ",
-                FZ(first),
-                f"{n_rep}× {_fmt(rise)}",
+                frame.project("front", rep.span[1])[1],
+                rep.label,
                 _SLOT_DIM_STEP,
                 "representative step-height dimension dropped (front-view right strip full)",
             )
         )
-    elif levels:
-        # Recover a short *structural* rise with external arrows (#565).
-        # A tiny level with no recognised transition is incidental geometry
-        # (plate/pocket floor) and remains outside the height ladder.
-        kept, n_close = _legible_steps(
-            levels, a.bb.min.Z, a.SCALE, allow_short=bool(step_shoulders)
+    elif rungs:
+        # Legibility is a PLACEMENT decision — whether two rungs are too close to dimension
+        # depends on the page, not the model — so it stays here while the rung set itself
+        # comes from the compiler. Both bounds come off the approved span, not the bbox.
+        kept_z, n_close = _legible_steps(
+            [r.span[1][2] for r in rungs],
+            rungs[0].span[0][2],
+            frame.scale,
+            allow_short=has_shoulders,
         )
         if n_close:
-            # With the explicit detail opt-in the enlarged view owns the omitted
-            # rungs. Report the source-view drop only when no recovery was
-            # requested; a failed detail records ``detail_unplaceable`` instead.
+            # With the explicit detail opt-in the enlarged view owns the omitted rungs.
+            # Report the source-view drop only when no recovery was requested; a failed
+            # detail records ``detail_unplaceable`` instead.
             if not detail_view:
                 ctx.record_issue(
                     "warning",
@@ -2884,35 +2894,37 @@ def render_height_ladder(
                     f"{n_close} step height(s) too closely spaced to dimension at this scale "
                     "(use a detail view)",
                 )
-            # First-class escalation alongside the lint code (ADR 0009 Amdt 1, #351
-            # PR-4b) — `_request_prismatic_detail` (sections.py) consumes this instead
-            # of recomputing the legibility gate.
+            # First-class escalation alongside the lint code (ADR 0009 Amdt 1, #351 PR-4b) —
+            # `_request_prismatic_detail` (sections.py) consumes this instead of recomputing
+            # the legibility gate.
             ctx.escalations.append(
                 Escalation(kind="step", view="front", feature=step, reason="illegible")
             )
-        for col, z in enumerate(kept):
-            if step_shoulders and (z - a.bb.min.Z) * a.SCALE < _MIN_STEP_DIM_MM:
-                short_levels.append(z)
+        kept = [r for r in rungs if r.span[1][2] in set(kept_z)]
+        for col, rung in enumerate(kept):
+            # A short structural rise needs external arrows, whose ink would swamp the usual
+            # right-hand ladder; it goes to the left strip below (#565).
+            if has_shoulders and rung.value * frame.scale < _MIN_STEP_DIM_MM:
+                short_rungs.append(rung)
                 continue
             chain.append(
                 (
                     f"dim_step_{col}",
-                    FZ(z),
-                    _fmt(z - a.bb.min.Z),
+                    frame.project("front", rung.span[1])[1],
+                    rung.label,
                     _SLOT_DIM_STEP,
                     "step-height dimension dropped (front-view right strip full)",
                 )
             )
 
-    rot = next((f for f in model.features if f.kind == "rotational"), None)
-    od_is_height = rot is not None and rot.frame.axis in ("x", "y")
-    suppress_height = (not include_overall) or model.orientation == "z" or od_is_height
-    if not suppress_height:
+    overall = plan.ladder("overall_height")
+    if overall is not None:
+        (height,) = overall.rungs
         chain.append(
             (
                 "dim_height",
-                FZ(a.bb.max.Z),
-                _fmt(a.z_size),
+                frame.project("front", height.span[1])[1],
+                height.label,
                 _SLOT_DIM_HEIGHT,
                 "overall height dimension dropped (front-view right strip full)",
             )
@@ -2932,11 +2944,9 @@ def render_height_ladder(
             return _dim((base, zmin, 0), (base, ztop, 0), "right", pos - base, draft, label=label)
 
         def _foot(pos, ztop=ztop, label=label, k=k):
-            # Predecessor-aware prediction (#689 review): the conservative
-            # edge-anchored witness can falsely exhaust the strip when an inner
-            # obstacle sits in the already-traversed region. Use the same solved
-            # map the build chain uses — empty on the first evaluation (edge-based,
-            # the prior behaviour), tight on later-segment retries.
+            # Predecessor-aware prediction (#689 review): the conservative edge-anchored
+            # witness can falsely exhaust the strip when an inner obstacle sits in the
+            # already-traversed region. Use the same solved map the build chain uses.
             base = edge2
             for pn in reversed(names[:k]):
                 if pn in solved:
@@ -2950,15 +2960,15 @@ def render_height_ladder(
 
         def _drop(nm, drop_msg=drop_msg, name=name):
             solved.pop(name, None)
-            # Name what filled the strip (#736): the #733 diagnosis ("which occupants
-            # exhausted the front-right strip?") becomes a glance at the lint message.
-            msg = full_strip_message(drop_msg, dwg, a.fv_zones.right, "front", "x")
+            # Name what filled the strip (#736): the #733 diagnosis becomes a glance at the
+            # lint message.
+            msg = full_strip_message(drop_msg, dwg, strip, "front", "x")
             ctx.record_issue("error", "placement_unsatisfiable", msg)
 
         register_corridor(
             ctx,
             ("front", "right"),
-            a.fv_zones.right,
+            strip,
             "front",
             "x",
             tier,
@@ -2966,8 +2976,8 @@ def render_height_ladder(
                 name=name,
                 build=_build,
                 # Steps stack inner→outer in chain order; the overall height rides the
-                # OVERALL subchain so it lands outermost by construction (as the
-                # envelope dims do), replacing the old carve's outermost=True.
+                # OVERALL subchain so it lands outermost by construction (as the envelope
+                # dims do), replacing the old carve's outermost=True.
                 order=(
                     (_OVERALL_SUBCHAIN, 0, name)
                     if name == "dim_height"
@@ -2983,14 +2993,14 @@ def render_height_ladder(
                 footprint=_foot,
             ),
         )
-    # A short rise needs external arrows, whose ink occupies most of the usual
-    # right-hand height ladder. Solve these exceptional rungs in the equivalent
-    # left strip so they do not make the mandatory overall height infeasible.
-    left_edge = FX(a.bb.min.X) - 2
-    for i, z in enumerate(short_levels):
+    # A short rise needs external arrows, whose ink occupies most of the usual right-hand
+    # height ladder. Solve these exceptional rungs in the equivalent left strip so they do
+    # not make the mandatory overall height infeasible.
+    left_edge = _left - 2
+    for i, rung in enumerate(short_rungs):
         name = f"dim_step_{i}"
-        ztop = FZ(z)
-        label = _fmt(z - a.bb.min.Z)
+        ztop = frame.project("front", rung.span[1])[1]
+        label = rung.label
 
         def _build_left(pos, ztop=ztop, label=label):
             return _dim(
@@ -3006,7 +3016,7 @@ def render_height_ladder(
             msg = full_strip_message(
                 "short step-height dimension dropped (front-view left strip full)",
                 dwg,
-                a.fv_zones.left,
+                frame.fv_zones.left,
                 "front",
                 "x",
             )
@@ -3015,7 +3025,7 @@ def render_height_ladder(
         register_corridor(
             ctx,
             ("front", "left"),
-            a.fv_zones.left,
+            frame.fv_zones.left,
             "front",
             "x",
             tier,
@@ -3037,7 +3047,7 @@ def render_height_ladder(
                 ),
             ),
         )
-    return len(chain) + len(short_levels)
+    return len(chain) + len(short_rungs)
 
 
 def render_step_positions(dwg, model, a, *, ctx) -> int:

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1214,7 +1214,7 @@ def _place_pitch_dim(
     _log.info("Pitch dimension for the %s× %s array skipped (no room)", n, _fmt(pitch))
 
 
-def render_pocket_patterns(dwg, groups, a, *, ctx, only=None) -> int:
+def render_pocket_patterns(dwg, plan, a, *, ctx, only=None) -> int:
     """Grouped blind-pocket-array callouts (#841): ONE ``count× W × L × D DEEP`` leader on the
     array centre + the ``(n-1)× pitch`` dim(s), instead of N competing per-pocket size dims.
 
@@ -1231,48 +1231,53 @@ def render_pocket_patterns(dwg, groups, a, *, ctx, only=None) -> int:
     draft = dwg.draft
     reach = _leader_callout_reach(draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
-    pat_groups = [g for g in groups if g.feature_kind == "pocket_pattern"]
+    pat_groups = list(plan.of_kind("pocket_pattern"))
     jobs = []
     furniture = []  # (i, feat, view) for the placed patterns' pitch dims
     for i, g in enumerate(
-        sorted(pat_groups, key=lambda g: (g.feature.member.width_axis, g.feature.frame.origin))
+        sorted(pat_groups, key=lambda g: (g.facts.member_width_axis, g.facts.frame.origin))
     ):
-        feat = g.feature
-        if only is not None and feat not in only:
+        feat = g.facts
+        if only is not None and g.ref not in only:
             continue  # #426 finalize subset — skip in place so i stays the model index
-        pk = feat.member
-        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        by_key = {(pd.role, pd.kind): pd for pd in g.dims}
         wpd = by_key.get(("pocket_width", "length"))
         lpd = by_key.get(("pocket_length", "length"))
         dpd = by_key.get(("pocket_depth", "length"))
         if wpd is None or lpd is None or dpd is None:
             continue
-        if wpd.suppressed or lpd.suppressed or dpd.suppressed:
-            continue
-        view = view_of.get(pk.depth_axis)
+        view = view_of.get(feat.member_depth_axis)
         if view is None:
             continue
         vb = dwg.view_bounds(view)
         if vb is None:
             continue
         label = f"{feat.count}× " + _pocket_label(
-            wpd.param.value,
-            lpd.param.value,
-            dpd.param.value,
-            wsfx=_tol_suffix(wpd.param.tolerance, draft),
-            lsfx=_tol_suffix(lpd.param.tolerance, draft),
-            dsfx=_tol_suffix(dpd.param.tolerance, draft),
+            wpd.value,
+            lpd.value,
+            dpd.value,
+            wsfx=_tol_suffix(wpd.tolerance, draft),
+            lsfx=_tol_suffix(lpd.tolerance, draft),
+            dsfx=_tol_suffix(dpd.tolerance, draft),
         )
         # Anchor the one representative leader at the array CENTRE (feat.frame.origin) and
         # attribute it to the pattern feature (ADR 0010 provenance).
-        name = f"m_pocketpat_{pk.width_axis}{pk.long_axis}{i}"
-        jobs.append((name, view, vb, label, _radial_candidates(dwg, view, vb, feat, reach)))
-        furniture.append((i, feat, view, name))
+        name = f"m_pocketpat_{feat.member_width_axis}{feat.member_long_axis}{i}"
+        jobs.append(
+            (
+                name,
+                view,
+                vb,
+                label,
+                _radial_candidates(dwg, view, vb, feat, reach, provenance=g.ref),
+            )
+        )
+        furniture.append((i, g, view, name))
     placed = _leader_callout_pass(
         dwg, a, jobs, noun="pocket pattern", drop_code="pocket_dropped", ctx=ctx
     )
     placed_names = dwg.annotations()
-    for i, feat, view, name in furniture:
+    for i, g, view, name in furniture:
         # Skip the pitch furniture whose grouped size/depth callout dropped for want of room:
         # orphan pitch dims with no `N× W×L×D` leader are an incomplete, misleading spec
         # (Codex #848 r3). Members are computed by _pattern_members (declare rejects explicit
@@ -1282,12 +1287,15 @@ def render_pocket_patterns(dwg, groups, a, *, ctx, only=None) -> int:
         # hole pattern and pocket pattern do not collide on dim_pitch_plan0 (Codex #848 r2).
         if name not in placed_names:
             continue
+        feat = g.facts
         members = feat.members or (feat.frame.origin,)
+        pitch = g.dim(role="pitch")
+        grid = tuple(d.value for d in g.dims if d.role == "grid_pitch")
 
         def to_page(loc, _view=view):
             return dwg.at(_view, *loc)
 
-        if feat.pattern == "linear" and feat.pitch is not None:
+        if feat.pattern == "linear" and pitch is not None:
             _place_pitch_dim(
                 dwg,
                 a,
@@ -1295,29 +1303,29 @@ def render_pocket_patterns(dwg, groups, a, *, ctx, only=None) -> int:
                 members[0],
                 members[-1],
                 len(members),
-                feat.pitch,
+                pitch.value,
                 to_page,
                 f"dim_pocketpat_pitch_{view}{i}",
-                feature=feat,
+                feature=g.ref,
                 ctx=ctx,
             )
-        elif feat.pattern == "grid" and feat.grid is not None:
+        elif feat.pattern == "grid" and len(grid) == 2:
             _add_grid_pitch_dims(
                 dwg,
                 a,
                 view,
                 i,
                 members,
-                feat.grid,
+                grid,
                 to_page,
-                feature=feat,
+                feature=g.ref,
                 ctx=ctx,
                 name_prefix="dim_pocketpat_pitch",
             )
     return placed
 
 
-def render_slot_patterns(dwg, groups, a, *, ctx, only=None) -> int:
+def render_slot_patterns(dwg, plan, a, *, ctx, only=None) -> int:
     """Grouped milled-slot-array callouts (#841): ONE ``count× SLOT W × L`` leader on the array
     centre + the ``(n-1)× pitch`` dim(s), instead of N competing per-slot size dims (some of
     which drop for lack of room, #841 behaviour 1). The through-slot analog of
@@ -1332,23 +1340,22 @@ def render_slot_patterns(dwg, groups, a, *, ctx, only=None) -> int:
     draft = dwg.draft
     reach = _leader_callout_reach(draft)
     view_of = {"z": "plan", "x": "side", "y": "front"}
-    pat_groups = [g for g in groups if g.feature_kind == "slot_pattern"]
+    pat_groups = list(plan.of_kind("slot_pattern"))
     jobs = []
     furniture = []  # (i, feat, view, name) for the placed patterns' pitch dims
     for i, g in enumerate(
-        sorted(pat_groups, key=lambda g: (g.feature.member.width_axis, g.feature.frame.origin))
+        sorted(pat_groups, key=lambda g: (g.facts.member_width_axis, g.facts.frame.origin))
     ):
-        feat = g.feature
-        if only is not None and feat not in only:
+        feat = g.facts
+        if only is not None and g.ref not in only:
             continue  # #426 finalize subset — skip in place so i stays the model index
-        sl = feat.member
-        through_axis = next(a for a in "xyz" if a not in (sl.width_axis, sl.long_axis))
-        by_key = {(pd.param.role, pd.param.kind): pd for pd in g.dims}
+        through_axis = next(
+            axis for axis in "xyz" if axis not in (feat.member_width_axis, feat.member_long_axis)
+        )
+        by_key = {(pd.role, pd.kind): pd for pd in g.dims}
         wpd = by_key.get(("slot_width", "length"))
         lpd = by_key.get(("slot_length", "length"))
         if wpd is None or lpd is None:
-            continue
-        if wpd.suppressed or lpd.suppressed:
             continue
         view = view_of.get(through_axis)
         if view is None:
@@ -1357,32 +1364,43 @@ def render_slot_patterns(dwg, groups, a, *, ctx, only=None) -> int:
         if vb is None:
             continue
         label = f"{feat.count}× " + _slot_label(
-            wpd.param.value,
-            lpd.param.value,
-            wsfx=_tol_suffix(wpd.param.tolerance, draft),
-            lsfx=_tol_suffix(lpd.param.tolerance, draft),
+            wpd.value,
+            lpd.value,
+            wsfx=_tol_suffix(wpd.tolerance, draft),
+            lsfx=_tol_suffix(lpd.tolerance, draft),
         )
         # Anchor the one representative leader at the array CENTRE (feat.frame.origin) and
         # attribute it to the pattern feature (ADR 0010 provenance).
-        name = f"m_slotpat_{sl.width_axis}{sl.long_axis}{i}"
-        jobs.append((name, view, vb, label, _radial_candidates(dwg, view, vb, feat, reach)))
-        furniture.append((i, feat, view, name))
+        name = f"m_slotpat_{feat.member_width_axis}{feat.member_long_axis}{i}"
+        jobs.append(
+            (
+                name,
+                view,
+                vb,
+                label,
+                _radial_candidates(dwg, view, vb, feat, reach, provenance=g.ref),
+            )
+        )
+        furniture.append((i, g, view, name))
     placed = _leader_callout_pass(
         dwg, a, jobs, noun="slot pattern", drop_code="slot_dropped", ctx=ctx
     )
     placed_names = dwg.annotations()
-    for i, feat, view, name in furniture:
+    for i, g, view, name in furniture:
         # Skip the pitch furniture whose grouped size callout dropped (orphan pitch dims are a
         # misleading spec, Codex #848 r3). Distinct name prefix (dim_slotpat_pitch) so a plan-view
         # slot pattern and hole/pocket pattern do not collide.
         if name not in placed_names:
             continue
+        feat = g.facts
         members = feat.members or (feat.frame.origin,)
+        pitch = g.dim(role="pitch")
+        grid = tuple(d.value for d in g.dims if d.role == "grid_pitch")
 
         def to_page(loc, _view=view):
             return dwg.at(_view, *loc)
 
-        if feat.pattern == "linear" and feat.pitch is not None:
+        if feat.pattern == "linear" and pitch is not None:
             _place_pitch_dim(
                 dwg,
                 a,
@@ -1390,22 +1408,22 @@ def render_slot_patterns(dwg, groups, a, *, ctx, only=None) -> int:
                 members[0],
                 members[-1],
                 len(members),
-                feat.pitch,
+                pitch.value,
                 to_page,
                 f"dim_slotpat_pitch_{view}{i}",
-                feature=feat,
+                feature=g.ref,
                 ctx=ctx,
             )
-        elif feat.pattern == "grid" and feat.grid is not None:
+        elif feat.pattern == "grid" and len(grid) == 2:
             _add_grid_pitch_dims(
                 dwg,
                 a,
                 view,
                 i,
                 members,
-                feat.grid,
+                grid,
                 to_page,
-                feature=feat,
+                feature=g.ref,
                 ctx=ctx,
                 name_prefix="dim_slotpat_pitch",
             )

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -459,7 +459,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
         # queued into the shared corridor instead of claiming a post-hoc carve tier.
         # Suppression (square footprint / X-turned width) is the planner's decision (#250).
-        render_envelope(dwg, _groups, a, ctx=ctx)
+        render_envelope(dwg, _compiled, a, ctx=ctx)
 
     def _s_detail_request():
         # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -491,7 +491,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # cramming; the envelope dim along the turning axis was suppressed so the chain
         # does not double-dimension the length.
         if a.prof is not None:
-            render_step_lengths(dwg, _groups, ctx=ctx)
+            render_step_lengths(dwg, _compiled, ctx=ctx)
 
     def _s_off_axis_along():
         # Side-drilled (X/Y-axis) hole HEIGHT locations — queued after the mandatory

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -406,7 +406,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # recognised slab, placed in the view where its thin axis is visible. A single flat
         # plate has none (its thickness IS the envelope height).
         # Planner-fed (#729): consumes the DimensionGroups so an authored tolerance renders.
-        render_plates(dwg, _groups, a, ctx=ctx)
+        render_plates(dwg, _compiled, a, ctx=ctx)
 
     def _s_step_positions():
         # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -306,6 +306,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them
     # (was recomputed per renderer, #275). One rule set over DimParameters, literally.
     _groups = plan_dimensions(_model)
+    # ONE compiled plan, shared by every migrated consumer (#923 review round 4).
+    # Compiling per stage ran the compiler three times and, worse, let the direct
+    # ladder, the shoulders and the detail escalation each hold a separately
+    # derived decision — three chances to disagree about one drawing.
+    _compiled = compile_dimensions(_model, groups=_groups)
 
     # Hole callouts, location dims, and the section view fire on *feature
     # presence*, independent of the turned/prismatic class (#10): the
@@ -390,7 +395,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             # `groups=` so the planner runs ONCE per build: the orchestrator already
             # planned, and a compiler re-planning behind it would create a second
             # product that can drift while the migration is partial (#923 review).
-            compile_dimensions(_model, groups=_groups),
+            _compiled,
             layout_frame(a),
             ctx=ctx,
             detail_view=detail_view,
@@ -406,9 +411,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_step_positions():
         # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a
         # stepped block is fully constrained (the heights alone leave the shoulder implicit).
-        render_step_positions(
-            dwg, compile_dimensions(_model, groups=_groups), layout_frame(a), ctx=ctx
-        )
+        render_step_positions(dwg, _compiled, layout_frame(a), ctx=ctx)
 
     def _s_chamfers():
         # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.
@@ -462,9 +465,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))
         # — resolved with every other detail request in the "details" stage (#307).
         if detail_view:
-            _request_prismatic_detail(
-                dwg, a, ctx=ctx, plan=compile_dimensions(_model, groups=_groups)
-            )
+            _request_prismatic_detail(dwg, a, ctx=ctx, plan=_compiled)
 
     def _s_boss_diameters():
         # Prismatic bosses get a plan-view ø leader BEFORE the turned row/column solve,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -438,14 +438,14 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # (n-1)× pitch dim(s), instead of N competing per-pocket size dims. Placed after
         # "pockets" (same leader mechanism); its member pockets are composed into the pattern,
         # so render_pockets never double-renders them.
-        render_pocket_patterns(dwg, _groups, a, ctx=ctx)
+        render_pocket_patterns(dwg, _compiled, a, ctx=ctx)
 
     def _s_slot_patterns():
         # Grouped through-slot-array callouts (#841): ONE count× SLOT W × L leader + the (n-1)×
         # pitch dim(s), instead of N competing per-slot size dims (some of which drop, #841
         # behaviour 1). Member slots are composed into the pattern, so render_slots never
         # double-renders them.
-        render_slot_patterns(dwg, _groups, a, ctx=ctx)
+        render_slot_patterns(dwg, _compiled, a, ctx=ctx)
 
     def _s_off_axis_across():
         # Side-drilled holes' in-plane (side-below) locations share the below corridor with

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -406,7 +406,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_step_positions():
         # Prismatic step POSITIONS (#555): where each shoulder sits along its axis, so a
         # stepped block is fully constrained (the heights alone leave the shoulder implicit).
-        render_step_positions(dwg, _model, a, ctx=ctx)
+        render_step_positions(
+            dwg, compile_dimensions(_model, groups=_groups), layout_frame(a), ctx=ctx
+        )
 
     def _s_chamfers():
         # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -416,17 +416,17 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_chamfers():
         # Chamfer callouts (#560): C{leg} / {leg}×{angle}° via a leader off each chamfer face.
         # Planner-fed (#724): consumes the DimensionGroups so an authored tolerance renders.
-        render_chamfers(dwg, _groups, a, ctx=ctx)
+        render_chamfers(dwg, _compiled, a, ctx=ctx)
 
     def _s_fillets():
         # Fillet callouts (#561): R{radius} (grouped n× R) via a leader off each rounded edge.
         # Planner-fed (#725): consumes the DimensionGroups so an authored tolerance renders.
-        render_fillets(dwg, _groups, a, ctx=ctx)
+        render_fillets(dwg, _compiled, a, ctx=ctx)
 
     def _s_flats():
         # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.
         # Planner-fed (#726): consumes the DimensionGroups so an authored tolerance renders.
-        render_flats(dwg, _groups, a, ctx=ctx)
+        render_flats(dwg, _compiled, a, ctx=ctx)
 
     def _s_pockets():
         # Blind-recess callouts (#148a): W × L × D DEEP via a leader off each floored pocket.
@@ -472,10 +472,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # which then sees the ø as 'mentioned' and skips it (#629 — the column-left strip
         # strands a boss ø when tight, even on a half-empty sheet). No-op on turned parts
         # (they keep the OD stack).
-        render_boss_diameters(dwg, _groups, a, ctx=ctx)
+        render_boss_diameters(dwg, _compiled, a, ctx=ctx)
 
     def _s_boss_heights():
-        render_boss_heights(dwg, _groups, a, ctx=ctx)
+        render_boss_heights(dwg, _compiled, a, ctx=ctx)
 
     def _s_diameters():
         # Turned-part dimensions via the IR (ADR 0008 convergence). The model is built
@@ -538,7 +538,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # furniture (else its room check can't see the not-yet-drained length dims and
         # collides, #148c crowded-shaft).
         # Planner-fed (#727): consumes the DimensionGroups so authored tolerances render.
-        render_grooves(dwg, _groups, a, ctx=ctx)
+        render_grooves(dwg, _compiled, a, ctx=ctx)
 
     def _s_section():
         # The section view renders after the corridor-drained furniture exists, so

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -483,7 +483,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # below (X) / end-on radial leaders (Y) / column left (Z), one path by
         # frame axis. Replaces
         # _annotate_turned_diameters.
-        render_diameters(dwg, _groups, a, ctx=ctx)
+        render_diameters(dwg, _compiled, a, ctx=ctx)
 
     def _s_step_lengths():
         # The chain that locates every shoulder, X/Y/Z from one path (#223). A crowded

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -460,7 +460,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))
         # — resolved with every other detail request in the "details" stage (#307).
         if detail_view:
-            _request_prismatic_detail(dwg, a, ctx=ctx)
+            _request_prismatic_detail(
+                dwg, a, ctx=ctx, plan=compile_dimensions(_model, groups=_groups)
+            )
 
     def _s_boss_diameters():
         # Prismatic bosses get a plan-view ø leader BEFORE the turned row/column solve,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -346,7 +346,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_rotational():
         # Rotational furniture — OD dim + axis centrelines + concentric bore leaders — IR
         # renderer (#237), placed early like the engine's inline block it replaces.
-        render_rotational(dwg, _groups, a, ctx=ctx)
+        render_rotational(dwg, _compiled, a, ctx=ctx)
         # A stepped round stack on an otherwise non-rotational flange still needs
         # its local axis shown before centered-bore offsets can be suppressed (#881).
         render_local_turned_centerlines(dwg, a, ctx=ctx)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -386,7 +386,14 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # The ADR 0016 boundary: compile WHAT is drawn, hand the renderer that plus the
         # page geometry it needs to decide WHERE. It no longer sees `_model` or `a`.
         render_height_ladder(
-            dwg, compile_dimensions(_model), layout_frame(a), ctx=ctx, detail_view=detail_view
+            dwg,
+            # `groups=` so the planner runs ONCE per build: the orchestrator already
+            # planned, and a compiler re-planning behind it would create a second
+            # product that can drift while the migration is partial (#923 review).
+            compile_dimensions(_model, groups=_groups),
+            layout_frame(a),
+            ctx=ctx,
+            detail_view=detail_view,
         )
 
     def _s_plates():

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -431,7 +431,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_pockets():
         # Blind-recess callouts (#148a): W × L × D DEEP via a leader off each floored pocket.
         # Planner-fed (#728): consumes the DimensionGroups so authored tolerances render.
-        render_pockets(dwg, _groups, a, ctx=ctx)
+        render_pockets(dwg, _compiled, a, ctx=ctx)
 
     def _s_pocket_patterns():
         # Grouped blind-pocket-array callouts (#841): ONE count× W × L × D DEEP leader + the

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -31,6 +31,7 @@ from draftwright._core import (
     _log,
     _tag_sequence,
     _wrap_rows,  # noqa: F401 — re-exported via the annotate facade (#700: one copy, in _core)
+    layout_frame,
 )
 from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import PlacementContext
@@ -80,6 +81,7 @@ from draftwright.model import (
     plan_dimensions,
     plan_sections,
 )
+from draftwright.model.compiled import compile_dimensions
 from draftwright.repair import reconcile_witness_labels
 
 # ── the ONE auto-pass stage sequence (#699 slice b) ──────────────────────────
@@ -381,7 +383,11 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # through fv_zones.right preserving the leapfrog cursor (#237). Replaces the inline
         # dim_step_* + dim_height; the turned step-length chain (render_step_lengths) handles
         # turned parts, and a Z-turned overall height is suppressed there (ISO 129).
-        render_height_ladder(dwg, _model, a, ctx=ctx, detail_view=detail_view)
+        # The ADR 0016 boundary: compile WHAT is drawn, hand the renderer that plus the
+        # page geometry it needs to decide WHERE. It no longer sees `_model` or `a`.
+        render_height_ladder(
+            dwg, compile_dimensions(_model), layout_frame(a), ctx=ctx, detail_view=detail_view
+        )
 
     def _s_plates():
         # Plate/wall thicknesses on a multi-plate prismatic (#559): the thin extent of each

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -768,12 +768,12 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
         dwg.draft.font_size + dwg.draft.pad_around_text if dwg is not None else _MIN_STEP_SEP_MM
     )
     # X stations frame the crowded band — view geometry, but read off the approved
-    # shoulder spans rather than the feature, so nothing here needs the model either. A
-    # shoulder's span varies along its own axis, which is how an X station is recognised.
+    # shoulder spans rather than the feature, so nothing here needs the model either.
+    # Axis is explicit because a shoulder coincident with its datum has a degenerate span.
     x_stations = sorted(
         r.span[1][0]
         for r in (shoulder_set.rungs if shoulder_set is not None else ())
-        if r.span is not None and r.span[0][0] != r.span[1][0]
+        if r.span is not None and r.axis == "x"
     )
     xpad = 0.08 * (x_stations[-1] - x_stations[0]) + 1.0 if len(x_stations) >= 2 else 0.0
 
@@ -855,11 +855,10 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
             scale_needed=scale_needed,
             redraw=redraw,
             pads=pads,
-            # These are absolute heights from the part's base datum, not local
-            # rise dimensions. Keep that datum in the projected crop so every
-            # witness point belongs to visible detail geometry, while ``lo``
-            # remains the crowded band marked on the source view.
-            crop_lo=datum_z,
+            # Witnesses measure from the declared datum, but the crop is VIEW geometry:
+            # retain the physical part base so those witnesses attach to visible detail
+            # linework even when a declared base differs from the bounding-box minimum.
+            crop_lo=a.bb.min.Z,
             cross_axis="x" if len(x_stations) >= 2 else None,
             cross_lo=max(a.bb.min.X, x_stations[0] - xpad) if len(x_stations) >= 2 else None,
             cross_hi=min(a.bb.max.X, x_stations[-1] + xpad) if len(x_stations) >= 2 else None,

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -707,7 +707,7 @@ def _overall_height_name(dwg, a: Analysis) -> str | None:
     return candidates[0] if len(candidates) == 1 else None
 
 
-def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
+def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
     """Queue a detail of a prismatic part's crowded step-height band (#42), routed
     through the unified pipeline (#307).
 
@@ -730,20 +730,28 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
     `render_step_lengths`, already has.
 
     The redraw re-draws the step-height ladder in the detail view at the
-    enlarged scale."""
-    step = (
-        next(
-            (f for f in dwg.model().features if getattr(f, "kind", None) == "step_level"),
-            None,
-        )
-        if dwg is not None
-        else None
-    )
-    levels = list(getattr(step, "levels", ())) or list(a.step_zs)
-    if len(levels) < 2:
+    enlarged scale — from the **compiled plan**, like the source-view ladder.
+
+    That was the last dimensional bypass of ADR 0016's boundary (#923 review). This
+    function used to re-derive the step feature from ``dwg.model()`` and rebuild the ladder
+    out of ``step.levels`` against ``a.bb.min.Z``, so a rung the compiler withheld still
+    reached the detail view: an approved three-rung plan drew five. Restricting the direct
+    renderer while its escalation reconstructed the same content left the rule true only of
+    the path anyone happened to look at."""
+    rung_set = plan.ladder("step_height")
+    rungs = list(rung_set.rungs) if rung_set is not None else []
+    if len(rungs) < 2:
         return
     if not any(e.kind == "step" and e.reason == "illegible" for e in ctx.escalations):
         return
+    # Both ends off the approved span, never the bounding box: the span is the compiler's
+    # statement of what each rung measures, and the detail must measure the same thing the
+    # source view would have.
+    levels = [r.span[1][2] for r in rungs]
+    datum_z = rungs[0].span[0][2]
+    label_of = {r.span[1][2]: r.label for r in rungs}
+    shoulder_set = plan.ladder("step_position")
+    has_shoulders = shoulder_set is not None
     z0, z1 = min(levels), max(levels)
     pad = 0.08 * (z1 - z0) + 1.0
     band_lo, band_hi = max(a.bb.min.Z, z0 - pad), min(a.bb.max.Z, z1 + pad)
@@ -759,7 +767,14 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
     step_pad = (
         dwg.draft.font_size + dwg.draft.pad_around_text if dwg is not None else _MIN_STEP_SEP_MM
     )
-    x_stations = sorted(pos for axis, pos in getattr(step, "shoulders", ()) if axis == "x")
+    # X stations frame the crowded band — view geometry, but read off the approved
+    # shoulder spans rather than the feature, so nothing here needs the model either. A
+    # shoulder's span varies along its own axis, which is how an X station is recognised.
+    x_stations = sorted(
+        r.span[1][0]
+        for r in (shoulder_set.rungs if shoulder_set is not None else ())
+        if r.span is not None and r.span[0][0] != r.span[1][0]
+    )
     xpad = 0.08 * (x_stations[-1] - x_stations[0]) + 1.0 if len(x_stations) >= 2 else 0.0
 
     def pads(detail_scale):  # one ladder rung per step legible at this scale, + overall
@@ -767,9 +782,9 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
             len(
                 _legible_steps(
                     levels,
-                    a.bb.min.Z,
+                    datum_z,
                     detail_scale,
-                    allow_short=bool(getattr(step, "shoulders", ())),
+                    allow_short=has_shoulders,
                 )[0]
             )
             * step_pad
@@ -784,11 +799,13 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
             px, py = coords.pp(x, y, z)
             return (px, py, 0.0)
 
+        # Legibility at the ENLARGED scale is a placement decision and stays here; what it
+        # filters is the approved set, so it can only ever remove rungs, never add one.
         det_kept, _ = _legible_steps(
             levels,
-            a.bb.min.Z,
+            datum_z,
             detail_scale,
-            allow_short=bool(getattr(step, "shoulders", ())),
+            allow_short=has_shoulders,
         )
         # Projection handedness can put world max-X on the page-left. Anchor
         # the ladder to the actual page-right silhouette, not an assumed world
@@ -803,14 +820,14 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
         )
         anchor_x = max(
             detail_xs,
-            key=lambda x: _at(x, a.cy, a.bb.min.Z)[0],
+            key=lambda x: _at(x, a.cy, datum_z)[0],
         )
-        ladder = _at(anchor_x, a.cy, a.bb.min.Z)[0] + 2
+        ladder = _at(anchor_x, a.cy, datum_z)[0] + 2
         placed = 0
         for i, z in enumerate(det_kept):
-            label = _fmt(z - a.bb.min.Z)
+            label = label_of[z]  # the compiler's label, not a second derivation
             try:
-                p_lo = _at(anchor_x, a.cy, a.bb.min.Z)
+                p_lo = _at(anchor_x, a.cy, datum_z)
                 p_hi = _at(anchor_x, a.cy, z)
                 det_dim = _dim(
                     (ladder, p_lo[1], 0),
@@ -842,7 +859,7 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
             # rise dimensions. Keep that datum in the projected crop so every
             # witness point belongs to visible detail geometry, while ``lo``
             # remains the crowded band marked on the source view.
-            crop_lo=a.bb.min.Z,
+            crop_lo=datum_z,
             cross_axis="x" if len(x_stations) >= 2 else None,
             cross_lo=max(a.bb.min.X, x_stations[0] - xpad) if len(x_stations) >= 2 else None,
             cross_hi=min(a.bb.max.X, x_stations[-1] + xpad) if len(x_stations) >= 2 else None,

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -749,7 +749,7 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
     # source view would have.
     levels = [r.span[1][2] for r in rungs]
     datum_z = rungs[0].span[0][2]
-    label_of = {r.span[1][2]: r.label for r in rungs}
+    label_of = {r.span[1][2]: r.final_label for r in rungs}
     shoulder_set = plan.ladder("step_position")
     has_shoulders = shoulder_set is not None
     z0, z1 = min(levels), max(levels)

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -714,7 +714,7 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx) -> None:
     Fires on the "step"/"illegible" ``Escalation`` `render_height_ladder`
     (from_model.py) appends (ADR 0009 Amdt 1, #351 PR-4b) rather than
     independently recomputing the legibility gate from ``a.step_zs`` — a uniform
-    staircase (``_detect_step_repeat``) collapses to one representative dim with
+    staircase (``model.compiled._step_repeat``) collapses to one representative dim with
     no drop at all, and re-deriving legibility straight from the raw z-list here
     missed that case, queuing a spurious detail even though nothing was actually
     dropped (a real bug the escalation routing fixes as a side effect).

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1137,28 +1137,16 @@ class Drawing:
             # returns "" — the same empty-string drop signal the step/boss diameter branch gives.
             before = {n: id(o) for n, o in self.iter_annotations()}
             # Migrated renderers consume the compiled plan and select by opaque reference.
-            # Pocket remains on the legacy planner surface until its renderer migrates; do
-            # not hand a RenderableDimensionPlan to an iterable-DimensionGroup API merely
-            # because both participate in the same dispatch table.
-            if kind == "pocket":
-                renderers[kind](
-                    self,
-                    plan_dimensions(self._part_model),
-                    self._analysis,
-                    ctx=ctx,
-                    only={feature},
-                )
-            else:
-                from draftwright.model.compiled import FeatureRef as _FR
-                from draftwright.model.compiled import compile_dimensions as _cd3
+            from draftwright.model.compiled import FeatureRef as _FR
+            from draftwright.model.compiled import compile_dimensions as _cd3
 
-                renderers[kind](
-                    self,
-                    _cd3(self._part_model),
-                    self._analysis,
-                    ctx=ctx,
-                    only={_FR(feature)},
-                )
+            renderers[kind](
+                self,
+                _cd3(self._part_model),
+                self._analysis,
+                ctx=ctx,
+                only={_FR(feature)},
+            )
             changed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
             return changed[0] if len(changed) == 1 else ""
         if kind == "pocket_pattern":
@@ -1924,23 +1912,20 @@ class Drawing:
             feats = {it.feature for it in self._intents if id(it) in ids}
             if feats:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                if kind == "pocket":
-                    render(self, plan_dimensions(model), a, ctx=ctx, only=feats)
-                else:
-                    from typing import cast as _cast
+                from typing import cast as _cast
 
-                    from draftwright.model.compiled import FeatureRef as _FR2
-                    from draftwright.model.compiled import compile_dimensions as _cd4
-                    from draftwright.model.ir import Feature as _Feature
+                from draftwright.model.compiled import FeatureRef as _FR2
+                from draftwright.model.compiled import compile_dimensions as _cd4
+                from draftwright.model.ir import Feature as _Feature
 
-                    assert all(isinstance(f, _Feature) for f in feats)
-                    render(
-                        self,
-                        _cd4(model),
-                        a,
-                        ctx=ctx,
-                        only={_FR2(_cast(_Feature, f)) for f in feats},
-                    )
+                assert all(isinstance(f, _Feature) for f in feats)
+                render(
+                    self,
+                    _cd4(model),
+                    a,
+                    ctx=ctx,
+                    only={_FR2(_cast(_Feature, f)) for f in feats},
+                )
             self._intents = [it for it in self._intents if id(it) not in ids]
 
         def _s_chamfers():

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1888,7 +1888,20 @@ class Drawing:
             # deferred path different obstacle visibility).
             if r.only_dia:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render_diameters(self, plan_dimensions(model), a, ctx=ctx, only=r.only_dia)
+                from typing import cast as _cast_dia
+
+                from draftwright.model.compiled import FeatureRef as _DiaRef
+                from draftwright.model.compiled import compile_dimensions as _compile_dia
+                from draftwright.model.ir import Feature as _DiaFeature
+
+                assert all(isinstance(f, _DiaFeature) for f in r.only_dia)
+                render_diameters(
+                    self,
+                    _compile_dia(model),
+                    a,
+                    ctx=ctx,
+                    only={_DiaRef(_cast_dia(_DiaFeature, f)) for f in r.only_dia},
+                )
             self._intents = [it for it in self._intents if id(it) not in r.dia_ids]
 
         def _s_step_lengths():

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1136,8 +1136,17 @@ class Drawing:
             # as the placed name (Codex #811 r3). A drop (no clear room) changes nothing and
             # returns "" — the same empty-string drop signal the step/boss diameter branch gives.
             before = {n: id(o) for n, o in self.iter_annotations()}
+            # The compiled plan, and an OPAQUE reference in `only=`: the renderer selects
+            # its subset without ever holding a Feature (ADR 0016 Amdt 1).
+            from draftwright.model.compiled import FeatureRef as _FR
+            from draftwright.model.compiled import compile_dimensions as _cd3
+
             renderers[kind](
-                self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
+                self,
+                _cd3(self._part_model),
+                self._analysis,
+                ctx=ctx,
+                only={_FR(feature)},
             )
             changed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
             return changed[0] if len(changed) == 1 else ""
@@ -1904,7 +1913,10 @@ class Drawing:
             feats = {it.feature for it in self._intents if id(it) in ids}
             if feats:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render(self, plan_dimensions(model), a, ctx=ctx, only=feats)
+                from draftwright.model.compiled import FeatureRef as _FR2
+                from draftwright.model.compiled import compile_dimensions as _cd4
+
+                render(self, _cd4(model), a, ctx=ctx, only={_FR2(f) for f in feats})
             self._intents = [it for it in self._intents if id(it) not in ids]
 
         def _s_chamfers():

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1910,7 +1910,19 @@ class Drawing:
             # staggered tiers) — after diameters, as in the auto-pass.
             if r.only_len:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render_step_lengths(self, plan_dimensions(model), ctx=ctx, only=r.only_len)
+                from typing import cast as _cast_len
+
+                from draftwright.model.compiled import FeatureRef as _LenRef
+                from draftwright.model.compiled import compile_dimensions as _compile_len
+                from draftwright.model.ir import Feature as _LenFeature
+
+                assert all(isinstance(f, _LenFeature) for f in r.only_len)
+                render_step_lengths(
+                    self,
+                    _compile_len(model),
+                    ctx=ctx,
+                    only={_LenRef(_cast_len(_LenFeature, f)) for f in r.only_len},
+                )
             self._intents = [it for it in self._intents if id(it) not in r.len_ids]
 
         def _s_slots():

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1849,7 +1849,10 @@ class Drawing:
             # ladder above; placed and dropped at the drain (#639).
             if r.step_position_ids:
                 assert a is not None and isinstance(model, PartModel)
-                render_step_positions(self, model, a, ctx=ctx)
+                from draftwright._core import layout_frame as _lf
+                from draftwright.model.compiled import compile_dimensions as _cd2
+
+                render_step_positions(self, _cd2(model), _lf(a), ctx=ctx)
 
         def _s_detail_request():
             # Prismatic step-height detail (#661): queue it exactly as the auto pass

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1120,7 +1120,6 @@ class Drawing:
                 render_grooves,
                 render_pockets,
             )
-            from draftwright.model import plan_dimensions
 
             renderers = {
                 "chamfer": render_chamfers,
@@ -1160,11 +1159,15 @@ class Drawing:
                     "add it to a drawing built by build_drawing(), not a bare Drawing"
                 )
             from draftwright.annotations.holes import render_pocket_patterns
-            from draftwright.model import plan_dimensions
+            from draftwright.model.compiled import FeatureRef, compile_dimensions
 
             before = {n: id(o) for n, o in self.iter_annotations()}
             render_pocket_patterns(
-                self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
+                self,
+                compile_dimensions(self._part_model),
+                self._analysis,
+                ctx=ctx,
+                only={FeatureRef(feature)},
             )
             placed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
             return next((n for n in placed if n.startswith("m_pocketpat")), "")
@@ -1179,11 +1182,15 @@ class Drawing:
                     "add it to a drawing built by build_drawing(), not a bare Drawing"
                 )
             from draftwright.annotations.holes import render_slot_patterns
-            from draftwright.model import plan_dimensions
+            from draftwright.model.compiled import FeatureRef, compile_dimensions
 
             before = {n: id(o) for n, o in self.iter_annotations()}
             render_slot_patterns(
-                self, plan_dimensions(self._part_model), self._analysis, ctx=ctx, only={feature}
+                self,
+                compile_dimensions(self._part_model),
+                self._analysis,
+                ctx=ctx,
+                only={FeatureRef(feature)},
             )
             placed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
             return next((n for n in placed if n.startswith("m_slotpat")), "")
@@ -1951,7 +1958,20 @@ class Drawing:
             feats = {it.feature for it in self._intents if id(it) in r.pocket_pattern_ids}
             if feats:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render_pocket_patterns(self, plan_dimensions(model), a, ctx=ctx, only=feats)
+                from typing import cast as _cast_pp
+
+                from draftwright.model.compiled import FeatureRef as _PPRef
+                from draftwright.model.compiled import compile_dimensions as _compile_pp
+                from draftwright.model.ir import Feature as _PPFeature
+
+                assert all(isinstance(f, _PPFeature) for f in feats)
+                render_pocket_patterns(
+                    self,
+                    _compile_pp(model),
+                    a,
+                    ctx=ctx,
+                    only={_PPRef(_cast_pp(_PPFeature, f)) for f in feats},
+                )
             self._intents = [it for it in self._intents if id(it) not in r.pocket_pattern_ids]
 
         def _s_slot_patterns():
@@ -1961,7 +1981,20 @@ class Drawing:
             feats = {it.feature for it in self._intents if id(it) in r.slot_pattern_ids}
             if feats:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                render_slot_patterns(self, plan_dimensions(model), a, ctx=ctx, only=feats)
+                from typing import cast as _cast_sp
+
+                from draftwright.model.compiled import FeatureRef as _SPRef
+                from draftwright.model.compiled import compile_dimensions as _compile_sp
+                from draftwright.model.ir import Feature as _SPFeature
+
+                assert all(isinstance(f, _SPFeature) for f in feats)
+                render_slot_patterns(
+                    self,
+                    _compile_sp(model),
+                    a,
+                    ctx=ctx,
+                    only={_SPRef(_cast_sp(_SPFeature, f)) for f in feats},
+                )
             self._intents = [it for it in self._intents if id(it) not in r.slot_pattern_ids]
 
         def _s_user_dims():

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1859,7 +1859,9 @@ class Drawing:
             # (_request_prismatic_detail's own check). Resolved in the "details" stage.
             if self._build.detail_view and routable:
                 assert a is not None
-                _request_prismatic_detail(self, a, ctx=ctx)
+                from draftwright.model.compiled import compile_dimensions as _cd
+
+                _request_prismatic_detail(self, a, ctx=ctx, plan=_cd(model))
 
         def _s_diameters():
             # Step/boss ø diameters through render_diameters' set-solve (row-below /

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1136,18 +1136,29 @@ class Drawing:
             # as the placed name (Codex #811 r3). A drop (no clear room) changes nothing and
             # returns "" — the same empty-string drop signal the step/boss diameter branch gives.
             before = {n: id(o) for n, o in self.iter_annotations()}
-            # The compiled plan, and an OPAQUE reference in `only=`: the renderer selects
-            # its subset without ever holding a Feature (ADR 0016 Amdt 1).
-            from draftwright.model.compiled import FeatureRef as _FR
-            from draftwright.model.compiled import compile_dimensions as _cd3
+            # Migrated renderers consume the compiled plan and select by opaque reference.
+            # Pocket remains on the legacy planner surface until its renderer migrates; do
+            # not hand a RenderableDimensionPlan to an iterable-DimensionGroup API merely
+            # because both participate in the same dispatch table.
+            if kind == "pocket":
+                renderers[kind](
+                    self,
+                    plan_dimensions(self._part_model),
+                    self._analysis,
+                    ctx=ctx,
+                    only={feature},
+                )
+            else:
+                from draftwright.model.compiled import FeatureRef as _FR
+                from draftwright.model.compiled import compile_dimensions as _cd3
 
-            renderers[kind](
-                self,
-                _cd3(self._part_model),
-                self._analysis,
-                ctx=ctx,
-                only={_FR(feature)},
-            )
+                renderers[kind](
+                    self,
+                    _cd3(self._part_model),
+                    self._analysis,
+                    ctx=ctx,
+                    only={_FR(feature)},
+                )
             changed = [n for n, o in self.iter_annotations() if before.get(n) != id(o)]
             return changed[0] if len(changed) == 1 else ""
         if kind == "pocket_pattern":
@@ -1913,10 +1924,23 @@ class Drawing:
             feats = {it.feature for it in self._intents if id(it) in ids}
             if feats:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
-                from draftwright.model.compiled import FeatureRef as _FR2
-                from draftwright.model.compiled import compile_dimensions as _cd4
+                if kind == "pocket":
+                    render(self, plan_dimensions(model), a, ctx=ctx, only=feats)
+                else:
+                    from typing import cast as _cast
 
-                render(self, _cd4(model), a, ctx=ctx, only={_FR2(f) for f in feats})
+                    from draftwright.model.compiled import FeatureRef as _FR2
+                    from draftwright.model.compiled import compile_dimensions as _cd4
+                    from draftwright.model.ir import Feature as _Feature
+
+                    assert all(isinstance(f, _Feature) for f in feats)
+                    render(
+                        self,
+                        _cd4(model),
+                        a,
+                        ctx=ctx,
+                        only={_FR2(_cast(_Feature, f)) for f in feats},
+                    )
             self._intents = [it for it in self._intents if id(it) not in ids]
 
         def _s_chamfers():

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1241,10 +1241,10 @@ class Drawing:
             return []
         from draftwright.annotations._common import PlacementContext
         from draftwright.annotations.from_model import render_rotational
-        from draftwright.model import plan_dimensions
+        from draftwright.model.compiled import compile_dimensions
 
         ctx = PlacementContext(registry=self._registry, coverage=self._coverage, items=self.items)
-        render_rotational(self, plan_dimensions(self._part_model), self._analysis, ctx=ctx)
+        render_rotational(self, compile_dimensions(self._part_model), self._analysis, ctx=ctx)
         return []
 
     def section(self) -> list[str]:
@@ -1736,6 +1736,7 @@ class Drawing:
             feature_hole_keys,
         )
         from draftwright.model import PartModel, plan_dimensions
+        from draftwright.model.compiled import compile_dimensions
 
         routable = model is not None and a is not None
         queued_dim_ids: set = set()
@@ -1749,7 +1750,7 @@ class Drawing:
             # pass, so the reconstruction matches (== not ⊇, unlike the #424 diameter case).
             if r.rotational_ids:
                 assert a is not None and isinstance(model, PartModel)
-                render_rotational(self, plan_dimensions(model), a, ctx=ctx)
+                render_rotational(self, compile_dimensions(model), a, ctx=ctx)
             # Generated/deferred reconstruction starts with auto_dims=False, so
             # add a non-rotational stepped stack's local axis here before the
             # location stages suppress a centered bore as axis-located (#881).

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1830,12 +1830,17 @@ class Drawing:
             # leaves them recorded so a retry rebuilds the batch (#639).
             if r.height_ladder_ids:
                 assert a is not None and isinstance(model, PartModel)
+                from draftwright._core import layout_frame
+                from draftwright.model.compiled import compile_dimensions
+
                 render_height_ladder(
                     self,
-                    model,
-                    a,
+                    # `include_overall` is drawing state, so it is an input to the COMPILE
+                    # (whether the overall height is in the set) rather than something the
+                    # renderer decides after the fact.
+                    compile_dimensions(model, include_overall=not r.explicit_envelope_height),
+                    layout_frame(a),
                     ctx=ctx,
-                    include_overall=not r.explicit_envelope_height,
                     detail_view=self._build.detail_view,
                 )
 

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -636,7 +636,15 @@ def compile_dimensions(
     plan-once invariant holds through the migration instead of the compiler quietly
     re-planning behind it (#923 review).
     """
-    planned = groups if groups is not None else plan_dimensions(model)
+    planned = tuple(groups) if groups is not None else tuple(plan_dimensions(model))
+    if groups is not None:
+        model_feature_ids = {id(feature) for feature in model.features}
+        foreign = [g.feature for g in planned if id(g.feature) not in model_feature_ids]
+        if foreign:
+            raise ValueError(
+                "compile_dimensions(groups=...): every planned group must come from "
+                "this exact PartModel; refusing a mismatched model/groups pair"
+            )
     marked = _suppressed_dims(model, planned)
     ladders, omissions = _compile_step_ladders(model, marked)
     overall, height_omissions = _compile_overall_height(

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -185,7 +185,6 @@ _FACTS: dict[str, tuple[str, ...]] = {
         "frame",
         "pattern",
         "count",
-        "member",
         "members",
         "direction",
         "rows",
@@ -196,7 +195,6 @@ _FACTS: dict[str, tuple[str, ...]] = {
         "frame",
         "pattern",
         "count",
-        "member",
         "members",
         "direction",
         "rows",
@@ -238,12 +236,23 @@ class FeatureFacts:
     def __init__(self, feature) -> None:
         kind = getattr(feature, "kind", "?")
         allowed = _FACTS.get(kind, ())
+        values = {name: getattr(feature, name) for name in allowed if hasattr(feature, name)}
+        # Pattern renderers need the representative member's ORIENTATION, never its
+        # printable sizes. Flatten those structural facts here instead of exposing the
+        # member object (which would put width/length/depth back one attribute away).
+        member = getattr(feature, "member", None)
+        if kind in ("pocket_pattern", "slot_pattern") and member is not None:
+            values.update(
+                {
+                    "member_frame": member.frame,
+                    "member_width_axis": member.width_axis,
+                    "member_long_axis": member.long_axis,
+                }
+            )
+            if kind == "pocket_pattern":
+                values["member_depth_axis"] = member.depth_axis
         object.__setattr__(self, "_kind", kind)
-        object.__setattr__(
-            self,
-            "_values",
-            {name: getattr(feature, name) for name in allowed if hasattr(feature, name)},
-        )
+        object.__setattr__(self, "_values", values)
 
     def __getattr__(self, name: str):
         try:

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -95,10 +95,21 @@ class FeatureRef:
         return getattr(self._feature, "kind", "?")
 
     def __eq__(self, other) -> bool:
-        return isinstance(other, FeatureRef) and other._feature is self._feature
+        # STRUCTURAL, like `DimensionId` and for the same reason: a re-plan or a finalize
+        # drain rebuilds the feature objects, so identity-based equality would make a
+        # reference stop matching the thing it names the moment anything re-derived the
+        # model. That is exactly what `only=` selection needs — it used to compare features
+        # with `in`, i.e. frozen-dataclass equality, and matching that keeps the drain's
+        # per-feature subsets working (#923).
+        #
+        # Deliberately UNLIKE `_request_for`, which matches by `is` so two identical holes
+        # stay two distinct targets. The two answer different questions: a request addresses
+        # one declared instance within a build; a reference names which feature a mark came
+        # from, and two structurally identical features produce interchangeable marks.
+        return isinstance(other, FeatureRef) and other._feature == self._feature
 
     def __hash__(self) -> int:
-        return id(self._feature)
+        return hash(self._feature)
 
     def __repr__(self) -> str:
         return f"FeatureRef({self.kind})"
@@ -197,7 +208,13 @@ _FACTS: dict[str, tuple[str, ...]] = {
     "step_level": ("frame",),
     "envelope": ("frame",),
     "rotational": ("frame",),
-    "chamfer": ("frame", "axis"),
+    # `leg2`/`angle` are FORM discriminators: they decide whether the label reads `C3` (an
+    # equal-leg 45°) or `3 × 30°`. The angle is printed, and it is NOT a planned parameter —
+    # `ChamferFeature.parameters()` emits only the leg — so it cannot be suppressed or
+    # toleranced today. That is an IR gap, recorded in the ADR inventory rather than closed
+    # here: making the angle addressable adds a parameter to every chamfer's plan, which
+    # changes output, and a migration that claims byte-identity is the wrong place for it.
+    "chamfer": ("frame", "axis", "leg2", "angle"),
     "fillet": ("frame", "axis"),
     "flat": ("frame", "axis"),
     "groove": ("frame", "axis"),

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -300,12 +300,26 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         omissions += [Omission(step, pid, v, why) for pid, v, why in height_marks]
 
     _di = {"x": 0, "y": 1, "z": 2}
+
+    def _shoulder_span(axis: str, pos: float):
+        """A shoulder's span, from its datum to its position along its own axis.
+
+        Carried rather than left ``None`` so consumers never go back to the feature for the
+        station: the detail crop needs the X positions to frame the crowded band, and
+        `render_step_positions` will need both ends when it migrates. The varying
+        coordinate also tells a consumer which axis it runs along, without a second field
+        to keep in step."""
+        lo = list(step.datum)
+        hi = list(step.datum)
+        hi[_di[axis]] = pos
+        return (tuple(lo), tuple(hi))
+
     shoulders = [
         ApprovedDimension(
             id=_dim_id(step, "step_position.length"),
             label=_fmt(abs(pos - step.datum[_di[axis]])),
             value=abs(pos - step.datum[_di[axis]]),
-            span=None,
+            span=_shoulder_span(axis, pos),
             ref=step_ref,
         )
         for axis, pos in sorted(step.shoulders)

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -180,7 +180,7 @@ class ApprovedDimension:
 _FACTS: dict[str, tuple[str, ...]] = {
     "hole": ("frame", "through", "count", "members", "thread"),
     "pattern": ("frame", "pattern", "count", "member", "members", "direction", "rows", "cols"),
-    "pocket": ("frame", "width_axis", "long_axis", "edge_anchored"),
+    "pocket": ("frame", "width_axis", "long_axis", "depth_axis", "edge_anchored"),
     "pocket_pattern": (
         "frame",
         "pattern",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -139,7 +139,9 @@ class ApprovedDimension:
     """
 
     id: DimensionId | None
-    label: str
+    #: The formatted numeric value only (for example ``"12"``). Group renderers add
+    #: semantic syntax such as ``ø``, ``THRU`` and tolerance text.
+    value_text: str
     value: float
     span: tuple[Point, Point] | None
     ref: FeatureRef | None = None
@@ -153,11 +155,30 @@ class ApprovedDimension:
     #: shoulder coincident with its datum has a zero-length span in every coordinate;
     #: deriving X/Y from "the varying coordinate" is then impossible.
     axis: str | None = None
+    #: A complete compiler-owned label for correlated marks whose wording is itself a
+    #: content decision (for example ``"4× 10"``). Ordinary group dimensions leave this
+    #: ``None`` and consume :attr:`value_text`; the two contracts are deliberately named
+    #: apart so a renderer cannot mistake a numeric fragment for finished callout text.
+    rendered_label: str | None = None
 
     @property
     def parameter_id(self) -> str:
         base = f"{self.role}.{self.kind}"
         return f"{base}.{self.discriminator}" if self.discriminator else base
+
+    @property
+    def final_label(self) -> str:
+        """The complete compiler-owned label for a correlated mark.
+
+        Raises when called for an ordinary group dimension, whose renderer must compose
+        semantic syntax around :attr:`value_text` instead.
+        """
+        if self.rendered_label is None:
+            raise AttributeError(
+                f"{self.parameter_id or 'dimension'} has numeric value_text only, "
+                "not a complete rendered label"
+            )
+        return self.rendered_label
 
 
 #: The NON-dimensional facts each feature kind may hand a renderer, by kind.
@@ -226,6 +247,13 @@ _FACTS: dict[str, tuple[str, ...]] = {
     # sole printed value in this structural allowlist (ADR 0016, "Scope").
     "pmi": ("frame", "pmi_kind", "dominant_axis", "ref_bbox", "ref_pts", "label"),
     "authored_dimension": ("frame", "dimension_kind", "dominant_axis", "ref_pts", "ref_bbox"),
+    # Existing ADR 0011 aspect kinds are deliberately classified as exposing no
+    # renderer facts yet. Listing them distinguishes "known, reviewed, empty" from a new
+    # kind that has never crossed this boundary.
+    "control_frame": (),
+    "datum_ref": (),
+    "finish": (),
+    "note": (),
 }
 
 
@@ -262,8 +290,14 @@ class FeatureFacts:
         object.__setattr__(self, "_values", values)
 
     def __getattr__(self, name: str):
+        # deepcopy/pickle probe special methods on an uninitialised `__new__` object.
+        # Touching `_values` through __getattr__ in that state recursively re-entered this
+        # method. Backing slots and special names are never public facts.
+        if name.startswith("_"):
+            raise AttributeError(name)
         try:
-            return self._values[name]
+            values = object.__getattribute__(self, "_values")
+            return values[name]
         except KeyError:
             raise AttributeError(
                 f"{self._kind!r} exposes no fact {name!r} to renderers. If it is structure "
@@ -448,10 +482,11 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
     heights = [
         ApprovedDimension(
             id=_dim_id(step, "step_height.length"),
-            label=_fmt(z - step.base),
+            value_text=_fmt(z - step.base),
             value=z - step.base,
             span=((x, y, step.base), (x, y, z)),
             ref=step_ref,
+            rendered_label=_fmt(z - step.base),
         )
         for z in sorted(step.levels)
     ]
@@ -468,10 +503,11 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
             heights = [
                 ApprovedDimension(
                     id=_dim_id(step, "step_height.length"),
-                    label=f"{n}× {_fmt(rise)}",
+                    value_text=_fmt(rise),
                     value=rise,
                     span=((x, y, step.base), (x, y, first)),
                     ref=step_ref,
+                    rendered_label=f"{n}× {_fmt(rise)}",
                 )
             ]
         approved.append(
@@ -500,11 +536,12 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
     shoulders = [
         ApprovedDimension(
             id=_dim_id(step, "step_position.length"),
-            label=_fmt(abs(pos - step.datum[_di[axis]])),
+            value_text=_fmt(abs(pos - step.datum[_di[axis]])),
             value=abs(pos - step.datum[_di[axis]]),
             span=_shoulder_span(axis, pos),
             ref=step_ref,
             axis=axis,
+            rendered_label=_fmt(abs(pos - step.datum[_di[axis]])),
         )
         for axis, pos in sorted(step.shoulders)
     ]
@@ -572,10 +609,11 @@ def _compile_overall_height(
             (
                 ApprovedDimension(
                     id=_dim_id(env, "height.length"),
-                    label=_fmt(value),
+                    value_text=_fmt(value),
                     value=value,
                     span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
                     ref=env_ref,
+                    rendered_label=_fmt(value),
                 ),
             ),
             ref=env_ref,
@@ -599,7 +637,7 @@ def _compile_groups(planned) -> list[ApprovedGroup]:
                 id=DimensionId(g.feature, pd.param.parameter_id),
                 # DimParameter.value is a required float. Keep that invariant explicit at
                 # the boundary instead of implying a nullable state renderers cannot handle.
-                label=_fmt(pd.param.value),
+                value_text=_fmt(pd.param.value),
                 value=float(pd.param.value),
                 span=pd.param.span,
                 ref=FeatureRef(g.feature),

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1,0 +1,323 @@
+"""The compiled dimension plan — the only thing a dimensional renderer may draw from.
+
+ADR 0016's boundary rule: **renderers may emit dimensional content only from the compiled
+plan.** A renderer receives approved entries and decides *where* and *how* to draw them; it
+does not decide *what*, and it is not given the feature inventory or the bounding box it
+would need to decide differently.
+
+The rule exists because the previous arrangement made honouring suppression a convention.
+`plan_dimensions` marked a `PlannedDimension` suppressed, handed the whole group to a
+renderer that also held the `PartModel` and the `Analysis`, and trusted it to check. Eight
+adversarial review rounds on #921 found eight renderers that did not — the height ladder and
+step positions rebuilding their marks from the feature and `a.bb`, the entire turned family
+selecting parameters with no suppression check at all. Each was a real omission reaching a
+real drawing, and each was fixed locally, which is how the fourth mechanism for saying the
+same thing got added.
+
+The structural answer is that **suppression is not a flag renderers check, it is content
+they never receive**:
+
+- :class:`ApprovedDimension` has no ``suppressed`` field. There is nothing to forget.
+- What was *not* approved leaves through :attr:`RenderableDimensionPlan.diagnostics`, which
+  lint and coverage consume. Omission stays inspectable — ADR 0016's "marked, not filtered"
+  is preserved — but it is not on the path a renderer walks.
+- Correlated sets (a step-height ladder, a shoulder chain) arrive as explicit
+  :class:`ApprovedLadder` groups, so a renderer never reconstructs one from a feature.
+
+Where the boundary does NOT yet reach, stated so the exceptions cannot be mistaken for
+completeness:
+
+- **Location dimensions** are dimensions and belong inside it; `plan_locations` returns a
+  flat cross-feature list that never enters a `DimensionGroup`, so they are sequenced later
+  in this work rather than carved out (#883).
+- **Raw AP242 PMI** is a documented non-generated exception: `PmiFeature.parameters()` is
+  empty by design and the record is rendered verbatim, so there is no compiled content for
+  it to come from.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from draftwright._geometry import _fmt
+from draftwright.model.ir import (
+    EnvelopeFeature,
+    Feature,
+    PartModel,
+    Point,
+    RotationalFeature,
+    StepLevelFeature,
+)
+from draftwright.model.planner import DimensionId, plan_dimensions
+
+_AUTHORED_OMISSION = "not in the authored dimension set"
+
+
+@dataclass(frozen=True)
+class ApprovedDimension:
+    """One measurement the compiler approved for drawing.
+
+    Deliberately has **no** ``suppressed`` field: this type exists only for dimensions that
+    are drawn. A renderer holding one has nothing to decide about whether to draw it.
+
+    ``span`` is in PART space; the renderer projects it. That is the split — the compiler
+    says "this measurement, this value, between these two points"; the renderer says which
+    view, which strip, which side, and what happens when it does not fit.
+    """
+
+    id: DimensionId | None
+    label: str
+    value: float
+    span: tuple[Point, Point] | None
+    feature: Feature | None = None
+
+
+@dataclass(frozen=True)
+class ApprovedLadder:
+    """A correlated set approved as a whole (ADR 0016 identity tier 3).
+
+    A step-height ladder or shoulder chain is ONE addressable dimension holding N members,
+    so it is approved or omitted whole — never half a staircase. Arriving as an explicit
+    group is what stops a renderer rebuilding the members from `StepLevelFeature.levels`
+    and the bounding box, which is exactly what `render_height_ladder` did.
+    """
+
+    kind: str  # "step_height" | "step_position" | "overall_height"
+    rungs: tuple[ApprovedDimension, ...]
+    feature: Feature | None = None
+    #: A uniform staircase collapsed to a single ``n× rise`` mark. The COLLAPSE is a
+    #: content decision and is made here; the renderer only needs to know so it can name
+    #: the mark (``dim_step_typ`` rather than ``dim_step_0``) and skip the per-rung
+    #: legibility gate, which has nothing to filter when there is one representative rung.
+    representative: bool = False
+
+
+@dataclass(frozen=True)
+class Omission:
+    """A measurement the compiler did not approve, and why.
+
+    ``authored`` separates the author's own omission from a planner rule's suppression (a
+    square footprint, an X-turned extent). Only the first makes an empty result the script's
+    doing, and only the first is recoverable by adding a `dimension(...)` line — a
+    distinction three attempts at predicting renderer behaviour in #921 kept blurring.
+    """
+
+    feature: Feature | None
+    parameter_id: str
+    value: float | None
+    reason: str
+
+    @property
+    def authored(self) -> bool:
+        return self.reason == _AUTHORED_OMISSION
+
+
+@dataclass(frozen=True)
+class RenderableDimensionPlan:
+    """Everything approved for drawing, plus what was not and why.
+
+    Grows one renderer at a time: :attr:`ladders` covers the height ladder and shoulder
+    chain (the first migrated slice). Renderers not yet migrated keep consuming
+    `plan_dimensions` directly, and the migration is finished when none do.
+    """
+
+    ladders: tuple[ApprovedLadder, ...] = ()
+    diagnostics: tuple[Omission, ...] = field(default=())
+
+    def ladder(self, kind: str) -> ApprovedLadder | None:
+        """The approved ladder of *kind*, or ``None`` if it was not approved."""
+        return next((lad for lad in self.ladders if lad.kind == kind), None)
+
+    def omitted(self, kind: str) -> tuple[Omission, ...]:
+        """Diagnostics whose parameter belongs to *kind* — what a lint pass reports."""
+        return tuple(o for o in self.diagnostics if o.parameter_id.startswith(f"{kind}."))
+
+
+def _step_repeat(levels, base: float, top: float, tol_frac: float = 0.10):
+    """``(n, rise)`` if *levels* form a uniform staircase, else ``None``.
+
+    A uniform staircase has all inter-step rises (including from *base* to the first step)
+    within *tol_frac* of their mean; ``n`` counts the top gap too when it matches. Requires
+    ≥3 interior steps to avoid false positives.
+
+    Lives in the compiler because collapsing five rungs into one ``5× 10`` mark is a
+    decision about WHAT the drawing says, not where it goes. It was in the renderer beside
+    the legibility gate, which reads similarly and is genuinely a placement decision (it
+    depends on the scale) — the two moved apart here on purpose.
+    """
+    if len(levels) < 3:
+        return None
+    ordered = sorted(levels)
+    rises = [ordered[0] - base] + [ordered[i + 1] - ordered[i] for i in range(len(ordered) - 1)]
+    mean = sum(rises) / len(rises)
+    if mean <= 0 or not all(abs(r - mean) / mean <= tol_frac for r in rises):
+        return None
+    return len(rises) + (1 if abs((top - ordered[-1]) - mean) / mean <= tol_frac else 0), mean
+
+
+def _suppressed_dims(model: PartModel):
+    """``{(feature, parameter_id): (value, reason)}`` for every dimension the planner
+    marked — the compiler's input for what NOT to approve."""
+    out = {}
+    for group in plan_dimensions(model):
+        for pd in group.dims:
+            if pd.suppressed:
+                out[(id(group.feature), pd.param.parameter_id)] = (
+                    pd.param.value,
+                    pd.reason or "suppressed",
+                )
+    return out
+
+
+def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder], list[Omission]]:
+    """The prismatic height rungs and shoulder chain, approved as whole sets."""
+    step = next((f for f in model.features if isinstance(f, StepLevelFeature)), None)
+    if step is None:
+        return [], []
+    approved: list[ApprovedLadder] = []
+    omissions: list[Omission] = []
+    bb: Any = model.bbox  # build123d BoundBox
+    x, y = float(bb.max.X), float(bb.min.Y)
+
+    heights = [
+        ApprovedDimension(
+            id=None,
+            label=_fmt(z - step.base),
+            value=z - step.base,
+            span=((x, y, step.base), (x, y, z)),
+            feature=step,
+        )
+        for z in sorted(step.levels)
+    ]
+    height_marks = [
+        (pid, v, why)
+        for (fid, pid), (v, why) in marked.items()
+        if fid == id(step) and pid.startswith("step_height.")
+    ]
+    if heights and not height_marks:
+        rep = _step_repeat(list(step.levels), step.base, float(bb.max.Z))
+        if rep is not None:
+            n, rise = rep
+            first = sorted(step.levels)[0]
+            heights = [
+                ApprovedDimension(
+                    id=None,
+                    label=f"{n}× {_fmt(rise)}",
+                    value=rise,
+                    span=((x, y, step.base), (x, y, first)),
+                    feature=step,
+                )
+            ]
+        approved.append(
+            ApprovedLadder(
+                "step_height", tuple(heights), feature=step, representative=rep is not None
+            )
+        )
+    else:
+        omissions += [Omission(step, pid, v, why) for pid, v, why in height_marks]
+
+    _di = {"x": 0, "y": 1, "z": 2}
+    shoulders = [
+        ApprovedDimension(
+            id=None,
+            label=_fmt(abs(pos - step.datum[_di[axis]])),
+            value=abs(pos - step.datum[_di[axis]]),
+            span=None,
+            feature=step,
+        )
+        for axis, pos in sorted(step.shoulders)
+    ]
+    pos_marks = [
+        (pid, v, why)
+        for (fid, pid), (v, why) in marked.items()
+        if fid == id(step) and pid.startswith("step_position.")
+    ]
+    if shoulders and not pos_marks:
+        approved.append(ApprovedLadder("step_position", tuple(shoulders), feature=step))
+    else:
+        omissions += [Omission(step, pid, v, why) for pid, v, why in pos_marks]
+    return approved, omissions
+
+
+def _compile_overall_height(
+    model: PartModel, marked, *, include_overall: bool
+) -> tuple[ApprovedLadder | None, list[Omission]]:
+    """The part's overall height — the envelope's ``height`` parameter, drawn in the
+    front-view right strip rather than below a view, which is why it rides the ladder.
+
+    Every reason it might not be drawn is settled here, in one place. They used to be split:
+    the planner suppressed it for a Z-turned part while the renderer independently suppressed
+    it for that AND an X/Y rotational OD AND `include_overall`, and neither knew about the
+    other. ``include_overall`` is drawing state (the finalize drain's explicit-envelope-height
+    request), so it arrives as an argument rather than being read off the model.
+
+    A model with no `EnvelopeFeature` — a round body, or a `Sheet` that never called
+    `.envelope()` — has no parameter naming its height, and the value falls back to the
+    bounding box. The COMPILER may do that; a renderer may not, which is the whole point.
+    """
+    env = next((f for f in model.features if isinstance(f, EnvelopeFeature)), None)
+    bb: Any = model.bbox  # build123d BoundBox
+    rot = next((f for f in model.features if isinstance(f, RotationalFeature)), None)
+    if not include_overall:
+        return None, []
+    if model.orientation == "z":
+        return None, [
+            Omission(
+                env,
+                "height.length",
+                float(bb.size.Z),
+                "Z-turned (the step chain tiles the height)",
+            )
+        ]
+    if rot is not None and rot.frame.axis in ("x", "y"):
+        return None, [
+            Omission(
+                env,
+                "height.length",
+                float(bb.size.Z),
+                f"rotational OD ({rot.frame.axis}-axis) conveys the height",
+            )
+        ]
+    if env is not None:
+        mark = marked.get((id(env), "height.length"))
+        if mark is not None:
+            return None, [Omission(env, "height.length", mark[0], mark[1])]
+    value = float(env.height) if env is not None else float(bb.size.Z)
+    x, y = float(bb.max.X), float(bb.min.Y)
+    return (
+        ApprovedLadder(
+            "overall_height",
+            (
+                ApprovedDimension(
+                    id=None,
+                    label=_fmt(value),
+                    value=value,
+                    span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
+                    feature=env,
+                ),
+            ),
+            feature=env,
+        ),
+        [],
+    )
+
+
+def compile_dimensions(
+    model: PartModel, *, include_overall: bool = True
+) -> RenderableDimensionPlan:
+    """Compile *model* into the dimensions that will be drawn, and the ones that will not.
+
+    One pass, one policy. Everything a renderer needs to know about WHAT to draw is decided
+    here; everything about WHERE stays in the renderer.
+    """
+    marked = _suppressed_dims(model)
+    ladders, omissions = _compile_step_ladders(model, marked)
+    overall, height_omissions = _compile_overall_height(
+        model, marked, include_overall=include_overall
+    )
+    if overall is not None:
+        ladders.append(overall)
+    return RenderableDimensionPlan(
+        ladders=tuple(ladders), diagnostics=tuple(omissions + height_omissions)
+    )

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -18,9 +18,16 @@ The structural answer is that **suppression is not a flag renderers check, it is
 they never receive**:
 
 - :class:`ApprovedDimension` has no ``suppressed`` field. There is nothing to forget.
-- What was *not* approved leaves through :attr:`RenderableDimensionPlan.diagnostics`, which
-  lint and coverage consume. Omission stays inspectable — ADR 0016's "marked, not filtered"
-  is preserved — but it is not on the path a renderer walks.
+- What was *not* approved leaves through :attr:`RenderableDimensionPlan.diagnostics`.
+  Omission stays inspectable — ADR 0016's "marked, not filtered" is preserved — but it is
+  not on the path a renderer walks.
+
+  **Nothing consumes diagnostics yet, and this is deliberately not claimed otherwise.**
+  The consumer arrives with #921: an authored set is the first source of omissions that
+  coverage must tell apart from a measurement simply missed, which is what
+  ``Omission.authored`` exists for. Until then every omission here is a planner rule the
+  lint layer already understands by other means, so wiring a consumer now would be
+  connecting a channel to nothing. The owner is `linting/coverage.py`, at the #921 rebase.
 - Correlated sets (a step-height ladder, a shoulder chain) arrive as explicit
   :class:`ApprovedLadder` groups, so a renderer never reconstructs one from a feature.
 
@@ -54,6 +61,60 @@ from draftwright.model.planner import DimensionId, plan_dimensions
 _AUTHORED_OMISSION = "not in the authored dimension set"
 
 
+class FeatureRef:
+    """An **opaque** provenance handle for the feature a dimension came from.
+
+    Carrying the `Feature` itself on an approved entry would have left the whole bypass
+    one attribute access away: a renderer could read `.levels`, `.base` or `.shoulders`
+    off it and rebuild exactly the content the compiler withheld (#923 review). The AST
+    guard proved only that today's renderer does not; the type still permitted it, and a
+    boundary that relies on renderers not doing the thing they can trivially do is the
+    convention this work exists to replace.
+
+    So the handle exposes identity and category — enough for provenance tagging
+    (ADR 0010), escalation grouping, and equality — and no measurement at all. The two
+    consumers that legitimately need the object (the corridor provenance seam and the
+    escalation resolver) call :func:`resolve_feature` where the object is the point.
+
+    Python cannot make this airtight, and it is not pretending to: ``ref._feature`` still
+    exists. What changes is that reading content now requires an obviously-wrong private
+    access that the boundary guard greps for, rather than an innocuous ``.feature.levels``
+    nobody would flag in review.
+    """
+
+    __slots__ = ("_feature",)
+
+    _feature: Feature
+
+    def __init__(self, feature: Feature) -> None:
+        object.__setattr__(self, "_feature", feature)
+
+    @property
+    def kind(self) -> str:
+        """The feature's category — ``"step_level"``, ``"envelope"``. Not a measurement."""
+        return getattr(self._feature, "kind", "?")
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, FeatureRef) and other._feature is self._feature
+
+    def __hash__(self) -> int:
+        return id(self._feature)
+
+    def __repr__(self) -> str:
+        return f"FeatureRef({self.kind})"
+
+
+def resolve_feature(ref):
+    """The `Feature` behind a :class:`FeatureRef` — for provenance and escalation ONLY.
+
+    Called at the seams where the feature object itself is the point: the corridor's
+    ADR 0010 provenance map, and the escalation resolver's grouping. A dimensional
+    renderer calling this is a boundary violation, and the guard says so."""
+    if ref is None or not isinstance(ref, FeatureRef):
+        return ref
+    return ref._feature
+
+
 @dataclass(frozen=True)
 class ApprovedDimension:
     """One measurement the compiler approved for drawing.
@@ -70,7 +131,7 @@ class ApprovedDimension:
     label: str
     value: float
     span: tuple[Point, Point] | None
-    feature: Feature | None = None
+    ref: FeatureRef | None = None
 
 
 @dataclass(frozen=True)
@@ -85,7 +146,7 @@ class ApprovedLadder:
 
     kind: str  # "step_height" | "step_position" | "overall_height"
     rungs: tuple[ApprovedDimension, ...]
-    feature: Feature | None = None
+    ref: FeatureRef | None = None
     #: A uniform staircase collapsed to a single ``n× rise`` mark. The COLLAPSE is a
     #: content decision and is made here; the renderer only needs to know so it can name
     #: the mark (``dim_step_typ`` rather than ``dim_step_0``) and skip the per-rung
@@ -120,6 +181,9 @@ class RenderableDimensionPlan:
     Grows one renderer at a time: :attr:`ladders` covers the height ladder and shoulder
     chain (the first migrated slice). Renderers not yet migrated keep consuming
     `plan_dimensions` directly, and the migration is finished when none do.
+
+    :attr:`diagnostics` is produced but not yet consumed — see the module docstring. It is
+    an output with a named owner and a date, not a claim about today's behaviour.
     """
 
     ladders: tuple[ApprovedLadder, ...] = ()
@@ -156,11 +220,16 @@ def _step_repeat(levels, base: float, top: float, tol_frac: float = 0.10):
     return len(rises) + (1 if abs((top - ordered[-1]) - mean) / mean <= tol_frac else 0), mean
 
 
-def _suppressed_dims(model: PartModel):
+def _suppressed_dims(model: PartModel, groups=None):
     """``{(feature, parameter_id): (value, reason)}`` for every dimension the planner
-    marked — the compiler's input for what NOT to approve."""
+    marked — the compiler's input for what NOT to approve.
+
+    *groups* lets a caller that has already planned pass the result in. The engine plans
+    once per build (ADR 0008 Amdt 5); a compiler that re-planned would both cost a second
+    pass and create two products that can drift while the migration is partial (#923
+    review)."""
     out = {}
-    for group in plan_dimensions(model):
+    for group in groups if groups is not None else plan_dimensions(model):
         for pd in group.dims:
             if pd.suppressed:
                 out[(id(group.feature), pd.param.parameter_id)] = (
@@ -168,6 +237,18 @@ def _suppressed_dims(model: PartModel):
                     pd.reason or "suppressed",
                 )
     return out
+
+
+def _dim_id(feature, parameter_id: str) -> DimensionId | None:
+    """The ADR 0016 identity for an approved entry.
+
+    Minted here rather than left ``None``: `DimensionId` is already the stable addressable
+    identity the ADR defines, and a renderer-facing result that discards it would create
+    identity debt on the very boundary meant to remove it — provenance, edits, diagnostics
+    and later de-duplication all key on it (#923 review)."""
+    if feature is None:
+        return None
+    return DimensionId(feature, parameter_id)
 
 
 def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder], list[Omission]]:
@@ -179,14 +260,15 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
     omissions: list[Omission] = []
     bb: Any = model.bbox  # build123d BoundBox
     x, y = float(bb.max.X), float(bb.min.Y)
+    step_ref = FeatureRef(step)
 
     heights = [
         ApprovedDimension(
-            id=None,
+            id=_dim_id(step, "step_height.length"),
             label=_fmt(z - step.base),
             value=z - step.base,
             span=((x, y, step.base), (x, y, z)),
-            feature=step,
+            ref=step_ref,
         )
         for z in sorted(step.levels)
     ]
@@ -202,16 +284,16 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
             first = sorted(step.levels)[0]
             heights = [
                 ApprovedDimension(
-                    id=None,
+                    id=_dim_id(step, "step_height.length"),
                     label=f"{n}× {_fmt(rise)}",
                     value=rise,
                     span=((x, y, step.base), (x, y, first)),
-                    feature=step,
+                    ref=step_ref,
                 )
             ]
         approved.append(
             ApprovedLadder(
-                "step_height", tuple(heights), feature=step, representative=rep is not None
+                "step_height", tuple(heights), ref=step_ref, representative=rep is not None
             )
         )
     else:
@@ -220,11 +302,11 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
     _di = {"x": 0, "y": 1, "z": 2}
     shoulders = [
         ApprovedDimension(
-            id=None,
+            id=_dim_id(step, "step_position.length"),
             label=_fmt(abs(pos - step.datum[_di[axis]])),
             value=abs(pos - step.datum[_di[axis]]),
             span=None,
-            feature=step,
+            ref=step_ref,
         )
         for axis, pos in sorted(step.shoulders)
     ]
@@ -234,7 +316,7 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         if fid == id(step) and pid.startswith("step_position.")
     ]
     if shoulders and not pos_marks:
-        approved.append(ApprovedLadder("step_position", tuple(shoulders), feature=step))
+        approved.append(ApprovedLadder("step_position", tuple(shoulders), ref=step_ref))
     else:
         omissions += [Omission(step, pid, v, why) for pid, v, why in pos_marks]
     return approved, omissions
@@ -284,34 +366,39 @@ def _compile_overall_height(
         if mark is not None:
             return None, [Omission(env, "height.length", mark[0], mark[1])]
     value = float(env.height) if env is not None else float(bb.size.Z)
+    env_ref = FeatureRef(env) if env is not None else None
     x, y = float(bb.max.X), float(bb.min.Y)
     return (
         ApprovedLadder(
             "overall_height",
             (
                 ApprovedDimension(
-                    id=None,
+                    id=_dim_id(env, "height.length"),
                     label=_fmt(value),
                     value=value,
                     span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
-                    feature=env,
+                    ref=env_ref,
                 ),
             ),
-            feature=env,
+            ref=env_ref,
         ),
         [],
     )
 
 
 def compile_dimensions(
-    model: PartModel, *, include_overall: bool = True
+    model: PartModel, *, include_overall: bool = True, groups=None
 ) -> RenderableDimensionPlan:
     """Compile *model* into the dimensions that will be drawn, and the ones that will not.
 
     One pass, one policy. Everything a renderer needs to know about WHAT to draw is decided
     here; everything about WHERE stays in the renderer.
+
+    *groups* accepts a `plan_dimensions` result the caller already has, so the engine's
+    plan-once invariant holds through the migration instead of the compiler quietly
+    re-planning behind it (#923 review).
     """
-    marked = _suppressed_dims(model)
+    marked = _suppressed_dims(model, groups)
     ladders, omissions = _compile_step_ladders(model, marked)
     overall, height_omissions = _compile_overall_height(
         model, marked, include_overall=include_overall

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -217,6 +217,9 @@ _FACTS: dict[str, tuple[str, ...]] = {
     "flat": ("frame", "axis"),
     "groove": ("frame", "axis"),
     "plate": ("frame", "axis"),
+    # Raw AP242 PMI is the documented non-generated exception: its source-authored label
+    # is rendered verbatim rather than planned or suppressible. It is intentionally the
+    # sole printed value in this structural allowlist (ADR 0016, "Scope").
     "pmi": ("frame", "pmi_kind", "dominant_axis", "ref_bbox", "ref_pts", "label"),
     "authored_dimension": ("frame", "dimension_kind", "dominant_axis", "ref_pts", "ref_bbox"),
 }
@@ -589,8 +592,10 @@ def _compile_groups(planned) -> list[ApprovedGroup]:
         approved = tuple(
             ApprovedDimension(
                 id=DimensionId(g.feature, pd.param.parameter_id),
-                label=_fmt(pd.param.value) if pd.param.value is not None else "",
-                value=pd.param.value,
+                # DimParameter.value is a required float. Keep that invariant explicit at
+                # the boundary instead of implying a nullable state renderers cannot handle.
+                label=_fmt(pd.param.value),
+                value=float(pd.param.value),
                 span=pd.param.span,
                 ref=FeatureRef(g.feature),
                 kind=pd.param.kind,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -149,6 +149,10 @@ class ApprovedDimension:
     role: str = ""
     discriminator: str | None = None
     tolerance: object | None = None
+    #: Structural direction needed when a span cannot encode it. In particular, a
+    #: shoulder coincident with its datum has a zero-length span in every coordinate;
+    #: deriving X/Y from "the varying coordinate" is then impossible.
+    axis: str | None = None
 
     @property
     def parameter_id(self) -> str:
@@ -486,8 +490,8 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         Carried rather than left ``None`` so consumers never go back to the feature for the
         station: the detail crop needs the X positions to frame the crowded band, and
         `render_step_positions` will need both ends when it migrates. The varying
-        coordinate also tells a consumer which axis it runs along, without a second field
-        to keep in step."""
+        coordinate usually shows which axis it runs along. It cannot do so for a shoulder
+        coincident with its datum, so the approved entry also carries the explicit axis."""
         lo = list(step.datum)
         hi = list(step.datum)
         hi[_di[axis]] = pos
@@ -500,6 +504,7 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
             value=abs(pos - step.datum[_di[axis]]),
             span=_shoulder_span(axis, pos),
             ref=step_ref,
+            axis=axis,
         )
         for axis, pos in sorted(step.shoulders)
     ]

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -179,7 +179,7 @@ class ApprovedDimension:
 #: measurements by default: it arrives with no facts at all until someone lists them.
 _FACTS: dict[str, tuple[str, ...]] = {
     "hole": ("frame", "through", "count", "members", "thread"),
-    "pattern": ("frame", "pattern", "count", "member", "members", "direction", "rows", "cols"),
+    "pattern": ("frame", "pattern", "count", "members", "direction", "rows", "cols"),
     "pocket": ("frame", "width_axis", "long_axis", "depth_axis", "edge_anchored"),
     "pocket_pattern": (
         "frame",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -132,6 +132,147 @@ class ApprovedDimension:
     value: float
     span: tuple[Point, Point] | None
     ref: FeatureRef | None = None
+    #: The parameter's semantic coordinates, flattened off `DimParameter` so a renderer
+    #: selects by meaning without holding the planned object its `suppressed` flag lives on.
+    kind: str = ""
+    role: str = ""
+    discriminator: str | None = None
+    tolerance: object | None = None
+
+    @property
+    def parameter_id(self) -> str:
+        base = f"{self.role}.{self.kind}"
+        return f"{base}.{self.discriminator}" if self.discriminator else base
+
+
+#: The NON-dimensional facts each feature kind may hand a renderer, by kind.
+#:
+#: This table is where "is this a measurement?" gets decided, once and in writing, for all
+#: nineteen IR feature kinds. A renderer forming a callout legitimately needs structure — a
+#: pocket's `width_axis` to know which way it runs, a pattern's `count` and `rows`, a hole's
+#: `through` — and denying it that would only push the renderer back to the feature.
+#:
+#: What must NOT appear here is any quantity the drawing prints. `PocketFeature.width_axis`
+#: is structure; `PocketFeature.width` is a measurement and travels as an approved dimension
+#: or not at all. That distinction is the whole boundary, so it is stated per kind rather
+#: than left to whoever is editing a renderer — the arrangement that let eight renderers
+#: read `pd.param.value` past a suppression flag they never checked.
+#:
+#: The dividing rule, which the plate case settled: **positions that define what a
+#: dimension measures travel in its SPAN; facts carry only what a span cannot express.** A
+#: plate's `lo`/`hi` are not facts — they are the two ends of its thickness, and they arrive
+#: as `span`. Its `axis` is a fact, because no span says which way the slab is thin. Apply
+#: that test to each new entry and the table stays small.
+#:
+#: The compiler refuses anything absent from this table, so a new feature kind cannot leak
+#: measurements by default: it arrives with no facts at all until someone lists them.
+_FACTS: dict[str, tuple[str, ...]] = {
+    "hole": ("frame", "through", "count", "members", "thread"),
+    "pattern": ("frame", "pattern", "count", "member", "members", "direction", "rows", "cols"),
+    "pocket": ("frame", "width_axis", "long_axis", "edge_anchored"),
+    "pocket_pattern": (
+        "frame",
+        "pattern",
+        "count",
+        "member",
+        "members",
+        "direction",
+        "rows",
+        "cols",
+    ),
+    "slot": ("frame", "width_axis", "long_axis"),
+    "slot_pattern": (
+        "frame",
+        "pattern",
+        "count",
+        "member",
+        "members",
+        "direction",
+        "rows",
+        "cols",
+    ),
+    "pad": ("frame", "width_axis", "long_axis"),
+    "boss": ("frame", "thread"),
+    "step": ("frame", "thread"),
+    "step_level": ("frame",),
+    "envelope": ("frame",),
+    "rotational": ("frame",),
+    "chamfer": ("frame", "axis"),
+    "fillet": ("frame", "axis"),
+    "flat": ("frame", "axis"),
+    "groove": ("frame", "axis"),
+    "plate": ("frame", "axis"),
+    "pmi": ("frame", "pmi_kind", "dominant_axis", "ref_bbox", "ref_pts", "label"),
+    "authored_dimension": ("frame", "dimension_kind", "dominant_axis", "ref_pts", "ref_bbox"),
+}
+
+
+class FeatureFacts:
+    """The structural, non-dimensional facts of one feature — never its measurements.
+
+    A frozen view over the subset of attributes :data:`_FACTS` allows for the kind. Reading
+    anything else raises rather than falling back to the feature, so a renderer that needs a
+    new fact has to add it to the table, in a diff someone reviews, next to the sentence
+    explaining what belongs there.
+    """
+
+    __slots__ = ("_kind", "_values")
+
+    def __init__(self, feature) -> None:
+        kind = getattr(feature, "kind", "?")
+        allowed = _FACTS.get(kind, ())
+        object.__setattr__(self, "_kind", kind)
+        object.__setattr__(
+            self,
+            "_values",
+            {name: getattr(feature, name) for name in allowed if hasattr(feature, name)},
+        )
+
+    def __getattr__(self, name: str):
+        try:
+            return self._values[name]
+        except KeyError:
+            raise AttributeError(
+                f"{self._kind!r} exposes no fact {name!r} to renderers. If it is structure "
+                f"rather than a measurement, add it to _FACTS[{self._kind!r}]; if it is a "
+                "quantity the drawing prints, it must travel as an approved dimension."
+            ) from None
+
+    def get(self, name: str, default=None):
+        return self._values.get(name, default)
+
+    def __repr__(self) -> str:
+        return f"FeatureFacts({self._kind}, {sorted(self._values)})"
+
+
+@dataclass(frozen=True)
+class ApprovedGroup:
+    """One feature's approved dimensions, plus the structure a renderer needs to draw them.
+
+    The general replacement for `DimensionGroup` at the renderer boundary. Same shape —
+    `dims`, `view`, `anchor`, `feature_kind` — with two differences that are the point:
+    `dims` holds only what the compiler approved and has no `suppressed` field, and the
+    feature is reachable only as :class:`FeatureFacts` (structure) or an opaque
+    :class:`FeatureRef` (identity), never as the object whose measurements a renderer could
+    read past the plan.
+    """
+
+    feature_kind: str
+    view: str
+    anchor: Point
+    ref: FeatureRef
+    facts: FeatureFacts
+    dims: tuple[ApprovedDimension, ...]
+
+    def dim(self, *, kind: str | None = None, role: str | None = None):
+        """The first approved dimension matching *kind* and/or *role*, or ``None``.
+
+        ``None`` means "not approved" — there is no second state to check. A renderer that
+        used to write ``if pd is None or pd.suppressed`` writes ``if pd is None``."""
+        for d in self.dims:
+            if (kind is None or d.kind == kind) and (role is None or d.role == role):
+                return d
+        return None
 
 
 @dataclass(frozen=True)
@@ -186,8 +327,17 @@ class RenderableDimensionPlan:
     an output with a named owner and a date, not a claim about today's behaviour.
     """
 
+    groups: tuple[ApprovedGroup, ...] = ()
     ladders: tuple[ApprovedLadder, ...] = ()
     diagnostics: tuple[Omission, ...] = field(default=())
+
+    def of_kind(self, *kinds: str) -> tuple[ApprovedGroup, ...]:
+        """Every approved group whose feature is one of *kinds*, in model order."""
+        return tuple(g for g in self.groups if g.feature_kind in kinds)
+
+    def group_for(self, ref) -> ApprovedGroup | None:
+        """The approved group for a feature reference, or ``None`` if nothing survived."""
+        return next((g for g in self.groups if g.ref == ref), None)
 
     def ladder(self, kind: str) -> ApprovedLadder | None:
         """The approved ladder of *kind*, or ``None`` if it was not approved."""
@@ -400,6 +550,44 @@ def _compile_overall_height(
     )
 
 
+def _compile_groups(planned) -> list[ApprovedGroup]:
+    """Every planned group, reduced to what the compiler approved.
+
+    The general path all remaining renderers migrate onto: same per-feature shape they
+    already consume, with the suppressed entries REMOVED rather than marked. A renderer
+    receiving one of these cannot draw a withheld measurement, because it was never
+    handed it — which is the whole rule, applied to every feature kind rather than the
+    three that had bespoke migrations."""
+    out: list[ApprovedGroup] = []
+    for g in planned:
+        approved = tuple(
+            ApprovedDimension(
+                id=DimensionId(g.feature, pd.param.parameter_id),
+                label=_fmt(pd.param.value) if pd.param.value is not None else "",
+                value=pd.param.value,
+                span=pd.param.span,
+                ref=FeatureRef(g.feature),
+                kind=pd.param.kind,
+                role=pd.param.role,
+                discriminator=pd.param.discriminator,
+                tolerance=pd.param.tolerance,
+            )
+            for pd in g.dims
+            if not pd.suppressed
+        )
+        out.append(
+            ApprovedGroup(
+                feature_kind=g.feature_kind,
+                view=g.view,
+                anchor=g.anchor,
+                ref=FeatureRef(g.feature),
+                facts=FeatureFacts(g.feature),
+                dims=approved,
+            )
+        )
+    return out
+
+
 def compile_dimensions(
     model: PartModel, *, include_overall: bool = True, groups=None
 ) -> RenderableDimensionPlan:
@@ -412,7 +600,8 @@ def compile_dimensions(
     plan-once invariant holds through the migration instead of the compiler quietly
     re-planning behind it (#923 review).
     """
-    marked = _suppressed_dims(model, groups)
+    planned = groups if groups is not None else plan_dimensions(model)
+    marked = _suppressed_dims(model, planned)
     ladders, omissions = _compile_step_ladders(model, marked)
     overall, height_omissions = _compile_overall_height(
         model, marked, include_overall=include_overall
@@ -420,5 +609,7 @@ def compile_dimensions(
     if overall is not None:
         ladders.append(overall)
     return RenderableDimensionPlan(
-        ladders=tuple(ladders), diagnostics=tuple(omissions + height_omissions)
+        groups=tuple(_compile_groups(planned)),
+        ladders=tuple(ladders),
+        diagnostics=tuple(omissions + height_omissions),
     )

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -402,21 +402,21 @@ class TestTheBoundaryIsLoadBearing:
                         break
 
         assert sorted(by_contract["plan"]) == [
+            "render_boss_diameters",
+            "render_boss_heights",
+            "render_chamfers",
+            "render_fillets",
+            "render_flats",
+            "render_grooves",
             "render_height_ladder",
             "render_plates",
             "render_step_positions",
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert sorted(by_contract["groups"]) == [
-            "render_boss_diameters",
-            "render_boss_heights",
             "render_centermarks",
-            "render_chamfers",
             "render_diameters",
             "render_envelope",
-            "render_fillets",
-            "render_flats",
-            "render_grooves",
             "render_pocket_patterns",
             "render_pockets",
             "render_rotational",

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -24,18 +24,36 @@ from __future__ import annotations
 import ast
 import inspect
 import pathlib
+from dataclasses import replace
 
 import pytest
 from build123d import Box, Cylinder, Pos
 
 from draftwright import Sheet
 from draftwright.annotations.from_model import render_height_ladder
-from draftwright.builder import detect_part_model
+from draftwright.builder import build_drawing, detect_part_model
 from draftwright.model.compiled import RenderableDimensionPlan, compile_dimensions
 
 
 def _staircase():
     return Box(120, 60, 15) + Pos(-20, 0, 15) * Box(80, 60, 15) + Pos(-40, 0, 30) * Box(40, 60, 15)
+
+
+def _crowded_staircase():
+    """A tall narrow stacked-tier block whose shoulders sit 3 mm apart in Z.
+
+    At the auto sheet scale the legibility gate drops at least one rung, which is the
+    trigger for the enlarged detail view — the only way to exercise the detail redraw at
+    all. Narrow in X/Y so the detail footprint actually fits the sheet; a fixture whose
+    detail is `detail_unplaceable` draws nothing and would make this test vacuous.
+    (Mirrors `_crowded_shoulder_part` in tests/test_make_drawing.py.)
+    """
+    part = Pos(0, 0, 3) * Box(20, 16, 6)
+    z = 6.0
+    for w in (16, 13, 10, 7, 5):
+        part = part + Pos(0, 0, z + 1.5) * Box(w, 12, 3)
+        z += 3
+    return part
 
 
 def _uniform_staircase():
@@ -73,18 +91,29 @@ class TestTheCompilerOwnsContent:
         It broke the moment the compiler started measuring from `StepLevelFeature.base`
         while the renderer still anchored every witness at the view's bottom edge — a
         declared base above the part's bottom made the line span the whole part and read
-        the shorter figure, so the dimension said one thing and measured another (#923
-        review). Checking it here, at the source, catches the disagreement for every
-        renderer rather than one fixture at a time."""
+        the shorter figure (#923 review). Checking it at the source catches the
+        disagreement for every renderer rather than one fixture at a time.
+
+        Distance along the span's OWN varying axis, not the Z delta: a height rung runs
+        along Z and a shoulder along X, and a Z-only check silently passes every shoulder
+        while claiming to be general (#923 review round 2). A representative rung is
+        included rather than exempted — it measures one rise, so it obeys the same rule;
+        what differs is only that its LABEL reports that rise n times.
+        """
         plan = compile_dimensions(detect_part_model(make_part()))
         for ladder in plan.ladders:
             for rung in ladder.rungs:
-                if rung.span is None or ladder.representative:
-                    continue  # a representative mark reports the RISE, not its own span
-                measured = rung.span[1][2] - rung.span[0][2]
-                assert measured == pytest.approx(rung.value), (
+                if rung.span is None:
+                    continue
+                lo, hi = rung.span
+                measured = max(abs(b - a) for a, b in zip(lo, hi))
+                assert measured == pytest.approx(rung.value, rel=0.1), (
                     f"{ladder.kind} {rung.label!r} spans {measured} but claims {rung.value}"
                 )
+                if ladder.representative:
+                    # The one deliberate difference, asserted rather than skipped: the span
+                    # is a single rise and the label multiplies it.
+                    assert "×" in rung.label, "a representative mark must say how many"
 
     def test_a_declared_base_is_measured_from_that_base(self):
         """`StepLevelFeature.base` is the IR's own statement of what the rungs measure from.
@@ -244,30 +273,52 @@ class TestTheBoundaryIsLoadBearing:
             "rebuilding dimensions from somewhere other than the plan"
         )
 
-    def test_the_detail_redraw_bypass_is_pinned_until_it_is_closed(self):
-        """A KNOWN GAP, pinned so it cannot be forgotten and so closing it is detectable.
+    def test_the_detail_view_emits_exactly_the_approved_rungs(self):
+        """The detail escalation obeys the boundary too — the last dimensional bypass.
 
-        `_request_prismatic_detail` re-derives the step from `dwg.model()` and rebuilds the
-        ladder from `step.levels` against `a.bb.min.Z`, so a rung the compiler withheld can
-        still reach the detail view (#923 review — an approved ladder of three rungs drew
-        five). The direct render path obeys the boundary; its escalation does not.
+        `_request_prismatic_detail` used to re-derive the step from `dwg.model()` and
+        rebuild the ladder from `step.levels`, so a rung the compiler withheld still
+        reached the detail view: an approved three-rung plan drew five (#923 review).
+        Restricting the direct renderer while its escalation reconstructed the same content
+        left the rule true only of the path anyone happened to look at.
 
-        This asserts the bypass STILL EXISTS. When the escalation is migrated to carry
-        approved rungs, this test fails — which is the point: it is a reminder with a
-        deadline, not documentation of an accepted exception."""
-        src = (
-            pathlib.Path(__file__).resolve().parents[1]
-            / "src"
-            / "draftwright"
-            / "annotations"
-            / "sections.py"
-        ).read_text(encoding="utf-8")
-        assert (
-            'getattr(f, "kind", None) == "step_level"' in src and 'getattr(step, "levels"' in src
-        ), (
-            "the detail redraw no longer rediscovers levels from the model — if it now "
-            "consumes the approved ladder, delete this test and the ADR's scheduled "
-            "exception for it"
+        This replaces a test that asserted the *source text* of the defect — which passed
+        only while the bug existed, required it, and said nothing about behaviour. Here a
+        deliberately PARTIAL plan goes through a real build and the detail view must carry
+        those rungs and no others."""
+        part = _crowded_staircase()
+        model = detect_part_model(part)
+        full = compile_dimensions(model).ladder("step_height")
+        assert full is not None and not full.representative and len(full.rungs) >= 3, (
+            f"the fixture must have individual rungs to withhold (got {full})"
+        )
+
+        # Three of five: enough rungs left that the legibility gate still drops one and the
+        # escalation still fires. Withholding more suppresses the detail request itself, and
+        # the test then passes by drawing nothing — which is how its first version was
+        # vacuous against the very bug it targets.
+        keep = full.rungs[:3]
+        partial = RenderableDimensionPlan(ladders=(replace(full, rungs=tuple(keep)),))
+
+        def _partial(*_a, **_kw):
+            return partial
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("draftwright.annotations.orchestrator.compile_dimensions", _partial)
+            dwg = build_drawing(part, title="T", number="N", detail_view=True)
+
+        detail = {
+            n: getattr(o, "label", None) for n, o in dwg.iter_annotations() if "dim_detail" in n
+        }
+        assert detail, "the fixture must actually place a detail view, or this proves nothing"
+        assert len(detail) <= len(keep), (
+            f"the detail view drew {len(detail)} step dims from a plan approving "
+            f"{len(keep)} — it is rebuilding the ladder from the model: {sorted(detail)}"
+        )
+        approved_labels = {r.label for r in keep}
+        assert set(detail.values()) <= approved_labels, (
+            f"the detail view drew {sorted(set(detail.values()) - approved_labels)}, which "
+            "the compiler did not approve"
         )
 
     def test_the_migration_has_not_silently_stalled(self):

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -34,6 +34,27 @@ from draftwright.annotations.from_model import render_height_ladder
 from draftwright.builder import build_drawing, detect_part_model
 from draftwright.model.compiled import RenderableDimensionPlan, compile_dimensions
 
+#: Marks that legitimately survive an empty compiled plan because they carry no VALUE.
+#: Anything added here needs that reason: "the test failed otherwise" is how the boundary
+#: erodes. A pattern's pitch dim prints "4× 20" and is therefore NOT furniture — it is a
+#: pending migration, tracked below.
+_FURNITURE = (
+    "centerline",
+    "m_cm",
+    "m_locx",
+    "m_locy",
+    "note_",
+    "title_block",
+    "section_",
+    "hatch",
+    "detail_marker",
+    "detail_caption",
+    "hc_",
+    "m_env",
+    "balloon",
+    "table",
+)
+
 
 def _staircase():
     return Box(120, 60, 15) + Pos(-20, 0, 15) * Box(80, 60, 15) + Pos(-40, 0, 30) * Box(40, 60, 15)
@@ -267,9 +288,13 @@ class TestTheBoundaryIsLoadBearing:
             lambda *a, **kw: RenderableDimensionPlan(),
         )
         empty = {n for n, _ in Sheet.from_part(part).build().iter_annotations()}
-        leaked = sorted(n for n in empty if n.startswith(("dim_step", "dim_height")))
+        # EVERY dimensional mark, not a hand-listed prefix. Filtering to
+        # `dim_step`/`dim_height` let `dim_shoulder_*` through for a whole review round —
+        # a guard that only looks where you already know to look is not a guard (#923
+        # review round 3). Furniture is excluded by name because it prints no value.
+        leaked = sorted(n for n in empty if not n.startswith(_FURNITURE))
         assert not leaked, (
-            f"{leaked} reached the page from an EMPTY compiled plan — the renderer is "
+            f"{leaked} reached the page from an EMPTY compiled plan — something is "
             "rebuilding dimensions from somewhere other than the plan"
         )
 
@@ -344,5 +369,21 @@ class TestTheBoundaryIsLoadBearing:
             "render_gdt",
             "render_locations",
             "render_pmi",
-            "render_step_positions",
         ], f"the unmigrated set changed: {unmigrated}"
+
+    def test_the_pending_dimensional_paths_are_the_ones_the_adr_names(self):
+        """Two paths still emit dimensional content of their own, and the ADR says so.
+
+        A pattern's pitch dim prints `4× 20` — a VALUE, which is what makes something
+        dimensional under this rule, however it is grouped in the code. It survives an
+        empty compiled plan today. This test does not assert the bypass exists (a test
+        that requires a bug is not a guard); it asserts the ADR and the code agree about
+        WHICH paths are outstanding, so the list cannot quietly grow."""
+        adr = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "docs"
+            / "adr"
+            / "0016-declared-dimensioning-intent.md"
+        ).read_text(encoding="utf-8")
+        for pending in ("Location dimensions are inside this rule", "Pattern pitch dimensions"):
+            assert pending in adr, f"the ADR stopped naming a pending path: {pending}"

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -410,13 +410,13 @@ class TestTheBoundaryIsLoadBearing:
             "render_grooves",
             "render_height_ladder",
             "render_plates",
+            "render_pockets",
             "render_step_positions",
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert sorted(by_contract["groups"]) == [
             "render_diameters",
             "render_pocket_patterns",
-            "render_pockets",
             "render_rotational",
             "render_slot_patterns",
             "render_slots",
@@ -443,7 +443,7 @@ class TestTheBoundaryIsLoadBearing:
             / "adr"
             / "0016-declared-dimensioning-intent.md"
         ).read_text(encoding="utf-8")
-        assert "render_rotational" in adr and "render_pockets" in adr, (
+        assert "render_rotational" in adr and "render_step_lengths" in adr, (
             "the ADR's pending inventory stopped naming the advisory-surface renderers — "
             "it must list what has NOT crossed the boundary, not just what has"
         )

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -367,6 +367,43 @@ class TestTheBoundaryIsLoadBearing:
             "the compiler did not approve"
         )
 
+    def test_rotational_furniture_cannot_rebuild_withheld_diameters(self, monkeypatch):
+        """Centrelines survive, but an OD and bore absent from the plan stay absent.
+
+        The legacy renderer asserted that every raw rotational diameter remained in
+        `DimensionGroup`, then used `rot.od` / `rot.bores` to build its geometry. That
+        made suppression an error rather than a supported compiler decision."""
+        part = (
+            Cylinder(15, 10)
+            - Pos(0, 0, 5) * Cylinder(4, 5)
+            - Pos(0, 0, -5) * Cylinder(2.5, 20)
+        )
+        model = detect_part_model(part)
+        full = compile_dimensions(model)
+        rotational = full.of_kind("rotational")
+        assert len(rotational) == 1
+        group = rotational[0]
+        bores = [d for d in group.dims if d.role == "bore"]
+        assert len(bores) >= 2, "fixture must provide an OD and two independently withheld bores"
+
+        # Withhold the OD and the first bore; approve only the second bore.
+        partial_group = replace(group, dims=(bores[1],))
+        partial = replace(
+            full,
+            groups=tuple(partial_group if g is group else g for g in full.groups),
+        )
+        monkeypatch.setattr(
+            "draftwright.annotations.orchestrator.compile_dimensions",
+            lambda *_a, **_kw: partial,
+        )
+
+        dwg = build_drawing(part)
+        assert "dim_od" not in dwg.annotations()
+        assert [o.label for n, o in dwg.iter_annotations() if n.startswith("ldr_z")] == [
+            f"ø{bores[1].label}"
+        ]
+        assert {"centerline_front", "centerline_side"} <= set(dwg.annotations())
+
     def test_the_migration_guard_measures_the_CONTRACT_not_the_signature(self):
         """How far the boundary actually reaches, by what each renderer is HANDED.
 
@@ -413,12 +450,12 @@ class TestTheBoundaryIsLoadBearing:
             "render_plates",
             "render_pocket_patterns",
             "render_pockets",
+            "render_rotational",
             "render_slot_patterns",
             "render_step_positions",
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert sorted(by_contract["groups"]) == [
-            "render_rotational",
             "render_slots",
             "render_step_lengths",
         ], f"the advisory-surface set changed: {sorted(by_contract['groups'])}"

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -1,0 +1,185 @@
+"""ADR 0016's boundary: a dimensional renderer draws only what the compiler approved.
+
+The rule — *renderers may emit dimensional content only from the compiled plan* — exists
+because the previous arrangement made honouring suppression a convention each renderer had
+to opt into. Eight adversarial review rounds on #921 found eight that had not. Fixing them
+one at a time produced four different mechanisms for saying the same thing and no reason to
+believe the ninth renderer would be different.
+
+These tests pin the property rather than the instances:
+
+- the compiler decides WHAT (`TestTheCompilerOwnsContent`);
+- the renderer decides WHERE, and cannot reach back for content
+  (`TestTheRendererCannotSeeContent`);
+- an omission is not a drop, and the two report differently (`TestOmissionIsNotADrop`);
+- the migration is real and does not silently stall (`TestTheBoundaryIsLoadBearing`).
+
+`render_height_ladder` is the first slice on purpose: it exercises every hard case at once —
+correlated rungs, a geometry-derived overall dimension, spans that must survive projection,
+and suppression. If the boundary holds here it will hold for the flatter renderers.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet
+from draftwright.annotations.from_model import render_height_ladder
+from draftwright.builder import detect_part_model
+from draftwright.model.compiled import RenderableDimensionPlan, compile_dimensions
+
+
+def _staircase():
+    return Box(120, 60, 15) + Pos(-20, 0, 15) * Box(80, 60, 15) + Pos(-40, 0, 30) * Box(40, 60, 15)
+
+
+def _uniform_staircase():
+    return (
+        Box(90, 60, 10)
+        + Pos(0, 0, 10) * Box(75, 60, 10)
+        + Pos(0, 0, 20) * Box(60, 60, 10)
+        + Pos(0, 0, 30) * Box(45, 60, 10)
+    )
+
+
+class TestTheCompilerOwnsContent:
+    def test_the_rung_set_arrives_decided(self):
+        plan = compile_dimensions(detect_part_model(_staircase()))
+        rungs = plan.ladder("step_height")
+        assert rungs is not None
+        assert [r.label for r in rungs.rungs] == ["15", "30"]
+        assert all(r.span is not None for r in rungs.rungs), "spans travel in PART space"
+
+    def test_a_uniform_staircase_collapses_in_the_compiler(self):
+        """`n× rise` is a decision about what the drawing SAYS, so it is made once, before
+        any renderer sees the set — not rediscovered beside the legibility gate, which reads
+        similarly but is genuinely about the page."""
+        rungs = compile_dimensions(detect_part_model(_uniform_staircase())).ladder("step_height")
+        assert rungs is not None and rungs.representative
+        assert len(rungs.rungs) == 1 and "×" in rungs.rungs[0].label
+
+    def test_the_overall_height_is_an_approved_entry_not_a_bbox_read(self):
+        plan = compile_dimensions(detect_part_model(Box(90, 60, 20)))
+        overall = plan.ladder("overall_height")
+        assert overall is not None and overall.rungs[0].value == pytest.approx(20)
+
+    def test_drawing_state_is_an_input_to_the_compile(self):
+        """`include_overall` is the finalize drain's explicit-envelope-height request —
+        drawing state, not model state — so it decides membership of the SET rather than
+        being applied by the renderer afterwards."""
+        model = detect_part_model(Box(90, 60, 20))
+        assert compile_dimensions(model, include_overall=False).ladder("overall_height") is None
+        assert compile_dimensions(model, include_overall=True).ladder("overall_height") is not None
+
+    def test_a_rotational_od_conveying_the_height_is_settled_once(self):
+        """Two rules for this used to live apart — the planner suppressed a Z-turned
+        envelope height, the renderer independently suppressed that AND an X/Y rotational
+        OD — and neither knew about the other. Both are here now."""
+        model = detect_part_model(Cylinder(radius=20, height=40))
+        plan = compile_dimensions(model)
+        assert plan.ladder("overall_height") is not None  # Z body: the ladder carries it
+        reasons = [o.reason for o in plan.diagnostics]
+        assert all("rotational OD" not in r for r in reasons)
+
+
+class TestTheRendererCannotSeeContent:
+    def test_the_signature_takes_the_plan_and_the_frame(self):
+        """The structural half of the rule. A renderer that cannot name `model` or `a`
+        cannot reconstruct a dimension the compiler withheld — the failure mode is removed
+        rather than tested for."""
+        params = set(inspect.signature(render_height_ladder).parameters)
+        assert {"plan", "frame"} <= params
+        assert not ({"model", "a"} & params), (
+            "a dimensional renderer must not take the PartModel or the Analysis — both "
+            "carry the feature inventory and the bounding box it would rebuild content from"
+        )
+
+    def test_the_body_never_touches_the_feature_inventory(self):
+        """Reads the source rather than trusting the signature: a renderer could still
+        reach content through an argument that legitimately carries it."""
+        src = inspect.getsource(render_height_ladder)
+        tree = ast.parse(src)
+        reads = {
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load)
+        }
+        forbidden = {"features", "bb", "levels", "shoulders", "orientation", "z_size", "base"}
+        assert not (reads & forbidden), (
+            f"{sorted(reads & forbidden)} is model content — the ladder is drawn from the "
+            "compiled plan's approved entries, whose spans carry every coordinate it needs"
+        )
+
+    def test_the_layout_frame_carries_no_part_geometry(self):
+        from draftwright._core import LayoutFrame
+
+        fields = set(LayoutFrame.__dataclass_fields__)
+        assert not (fields & {"part", "bb", "holes", "x_size", "y_size", "z_size", "model"}), (
+            "LayoutFrame is the page geometry a renderer may use; part geometry belongs to "
+            "the compiler, which is the only place allowed to turn it into a dimension"
+        )
+
+
+class TestOmissionIsNotADrop:
+    """Two different "not drawn" meet in this renderer and must stay distinguishable: the
+    compiler's omission (never arrived) and the placer's drop (arrived, did not fit)."""
+
+    def test_an_omission_is_reported_through_diagnostics(self):
+        model = detect_part_model(Box(90, 60, 20))
+        plan = compile_dimensions(model, include_overall=False)
+        assert plan.ladder("overall_height") is None
+        assert not any(o.authored for o in plan.diagnostics), "no author involved here"
+
+    def test_a_planner_reason_is_not_an_authored_omission(self):
+        """`Omission.authored` is the distinction three #921 attempts kept blurring: only an
+        author's omission makes an empty result the script's own doing."""
+        from draftwright.model.compiled import Omission
+
+        assert Omission(None, "height.length", 1.0, "square footprint").authored is False
+        assert Omission(None, "height.length", 1.0, "not in the authored dimension set").authored
+
+
+class TestTheBoundaryIsLoadBearing:
+    def test_suppressing_the_whole_plan_empties_the_ladder(self):
+        """The behavioural statement, independent of any renderer's internals: nothing the
+        compiler withholds reaches the page. This is the test that would have caught all
+        four ladder-related rounds without knowing what any of them were."""
+        part = _staircase()
+        drawn = {n for n, _ in Sheet.from_part(part).build().iter_annotations()}
+        assert [n for n in drawn if n.startswith(("dim_step", "dim_height"))], (
+            "the fixture must draw a ladder to be worth emptying"
+        )
+
+        empty = RenderableDimensionPlan()
+        assert empty.ladder("step_height") is None and empty.ladder("overall_height") is None
+
+    def test_the_migration_has_not_silently_stalled(self):
+        """A count, so finishing the migration is visible rather than assumed. Lower it as
+        each dimensional renderer moves; the sequence ends when locations are inside too
+        (#883) and only the documented AP242 PMI exception still takes the model."""
+        src = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "src"
+            / "draftwright"
+            / "annotations"
+            / "from_model.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        unmigrated = sorted(
+            node.name
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name.startswith("render_")
+            and "model" in {a.arg for a in node.args.args}
+        )
+        assert unmigrated == [
+            "render_gdt",
+            "render_locations",
+            "render_pmi",
+            "render_step_positions",
+        ], f"the unmigrated set changed: {unmigrated}"

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -57,18 +57,7 @@ _PENDING_VALUE_CARRYING = (
     "m_locy",
     "hc_",  # hole callouts — likewise
     "dim_pitch",  # pattern pitch — derived in _add_furniture from the feature
-    "dim_od",  # rotational OD — render_rotational, still on the advisory surface
-    "ldr_",  # concentric bore leaders — likewise
-    "m_dia",  # step/boss diameters — likewise
-    "m_steplen",
-    "m_slot",
-    "m_pocket",
-    "m_boss",
-    "m_plate",
-    "m_chamf",
-    "m_fillet",
-    "m_flat",
-    "m_groove",
+    "m_slot",  # slot dimensions — the last legacy DimensionGroup renderer
     "pmi_",  # raw AP242 PMI — the one documented permanent exception
 )
 
@@ -373,11 +362,7 @@ class TestTheBoundaryIsLoadBearing:
         The legacy renderer asserted that every raw rotational diameter remained in
         `DimensionGroup`, then used `rot.od` / `rot.bores` to build its geometry. That
         made suppression an error rather than a supported compiler decision."""
-        part = (
-            Cylinder(15, 10)
-            - Pos(0, 0, 5) * Cylinder(4, 5)
-            - Pos(0, 0, -5) * Cylinder(2.5, 20)
-        )
+        part = Cylinder(15, 10) - Pos(0, 0, 5) * Cylinder(4, 5) - Pos(0, 0, -5) * Cylinder(2.5, 20)
         model = detect_part_model(part)
         full = compile_dimensions(model)
         rotational = full.of_kind("rotational")
@@ -452,12 +437,12 @@ class TestTheBoundaryIsLoadBearing:
             "render_pockets",
             "render_rotational",
             "render_slot_patterns",
+            "render_step_lengths",
             "render_step_positions",
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert sorted(by_contract["groups"]) == [
             "render_slots",
-            "render_step_lengths",
         ], f"the advisory-surface set changed: {sorted(by_contract['groups'])}"
 
         assert sorted(by_contract["model"]) == [

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -55,7 +55,6 @@ _VALUE_FREE = (
 _PENDING_VALUE_CARRYING = (
     "m_locx",  # hole location ladders — #883
     "m_locy",
-    "m_env",  # envelope width/depth — render_envelope, still on the advisory surface
     "hc_",  # hole callouts — likewise
     "dim_pitch",  # pattern pitch — derived in _add_furniture from the feature
     "dim_od",  # rotational OD — render_rotational, still on the advisory surface
@@ -405,6 +404,7 @@ class TestTheBoundaryIsLoadBearing:
             "render_boss_diameters",
             "render_boss_heights",
             "render_chamfers",
+            "render_envelope",
             "render_fillets",
             "render_flats",
             "render_grooves",
@@ -414,9 +414,7 @@ class TestTheBoundaryIsLoadBearing:
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert sorted(by_contract["groups"]) == [
-            "render_centermarks",
             "render_diameters",
-            "render_envelope",
             "render_pocket_patterns",
             "render_pockets",
             "render_rotational",
@@ -445,7 +443,7 @@ class TestTheBoundaryIsLoadBearing:
             / "adr"
             / "0016-declared-dimensioning-intent.md"
         ).read_text(encoding="utf-8")
-        assert "render_rotational" in adr and "render_envelope" in adr, (
+        assert "render_rotational" in adr and "render_pockets" in adr, (
             "the ADR's pending inventory stopped naming the advisory-surface renderers — "
             "it must list what has NOT crossed the boundary, not just what has"
         )

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -403,6 +403,7 @@ class TestTheBoundaryIsLoadBearing:
 
         assert sorted(by_contract["plan"]) == [
             "render_height_ladder",
+            "render_plates",
             "render_step_positions",
         ], "the migrated set changed — update this and the ADR's inventory together"
 
@@ -416,7 +417,6 @@ class TestTheBoundaryIsLoadBearing:
             "render_fillets",
             "render_flats",
             "render_grooves",
-            "render_plates",
             "render_pocket_patterns",
             "render_pockets",
             "render_rotational",

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -22,8 +22,10 @@ and suppression. If the boundary holds here it will hold for the flatter rendere
 from __future__ import annotations
 
 import ast
+import copy
 import inspect
 import pathlib
+import pickle
 from dataclasses import replace
 
 import pytest
@@ -97,7 +99,7 @@ class TestTheCompilerOwnsContent:
         plan = compile_dimensions(detect_part_model(_staircase()))
         rungs = plan.ladder("step_height")
         assert rungs is not None
-        assert [r.label for r in rungs.rungs] == ["15", "30"]
+        assert [r.final_label for r in rungs.rungs] == ["15", "30"]
         assert all(r.span is not None for r in rungs.rungs), "spans travel in PART space"
 
     def test_a_uniform_staircase_collapses_in_the_compiler(self):
@@ -106,7 +108,7 @@ class TestTheCompilerOwnsContent:
         similarly but is genuinely about the page."""
         rungs = compile_dimensions(detect_part_model(_uniform_staircase())).ladder("step_height")
         assert rungs is not None and rungs.representative
-        assert len(rungs.rungs) == 1 and "×" in rungs.rungs[0].label
+        assert len(rungs.rungs) == 1 and "×" in rungs.rungs[0].final_label
 
     @pytest.mark.parametrize(
         "make_part", [_staircase, _uniform_staircase], ids=["stepped", "uniform"]
@@ -135,12 +137,12 @@ class TestTheCompilerOwnsContent:
                 lo, hi = rung.span
                 measured = max(abs(b - a) for a, b in zip(lo, hi))
                 assert measured == pytest.approx(rung.value, rel=0.1), (
-                    f"{ladder.kind} {rung.label!r} spans {measured} but claims {rung.value}"
+                    f"{ladder.kind} {rung.final_label!r} spans {measured} but claims {rung.value}"
                 )
                 if ladder.representative:
                     # The one deliberate difference, asserted rather than skipped: the span
                     # is a single rise and the label multiplies it.
-                    assert "×" in rung.label, "a representative mark must say how many"
+                    assert "×" in rung.final_label, "a representative mark must say how many"
 
     def test_a_declared_base_is_measured_from_that_base(self):
         """`StepLevelFeature.base` is the IR's own statement of what the rungs measure from.
@@ -302,6 +304,52 @@ class TestTheRendererCannotSeeContent:
         with pytest.raises(ValueError, match="exact PartModel"):
             compile_dimensions(first, groups=plan_dimensions(second))
 
+    def test_feature_facts_and_compiled_plan_support_standard_composition(self):
+        """Strict slot access must survive copy, snapshot and process boundaries."""
+        from draftwright.model.compiled import FeatureFacts
+
+        plan = compile_dimensions(detect_part_model(_staircase()))
+        facts = plan.groups[0].facts
+        assert isinstance(facts, FeatureFacts)
+
+        for clone in (
+            copy.copy(facts),
+            copy.deepcopy(facts),
+            pickle.loads(pickle.dumps(facts)),
+        ):
+            assert repr(clone) == repr(facts)
+
+        for clone in (
+            copy.copy(plan),
+            copy.deepcopy(plan),
+            pickle.loads(pickle.dumps(plan)),
+        ):
+            assert clone.ladder("step_height") is not None
+
+    def test_every_existing_ir_kind_is_explicitly_classified(self):
+        import draftwright.model.ir as ir
+        from draftwright.model.compiled import _FACTS
+
+        ir_kinds = {
+            value.kind
+            for value in vars(ir).values()
+            if isinstance(value, type) and isinstance(getattr(value, "kind", None), str)
+        }
+        assert set(_FACTS) == ir_kinds
+
+    def test_numeric_fragments_and_complete_correlated_labels_are_distinct(self):
+        model = detect_part_model(Cylinder(10, 10))
+        plan = compile_dimensions(model)
+        ordinary = next(d for g in plan.groups for d in g.dims)
+        assert ordinary.value_text
+        assert ordinary.rendered_label is None
+        with pytest.raises(AttributeError, match="numeric value_text only"):
+            _ = ordinary.final_label
+
+        ladder = compile_dimensions(detect_part_model(_staircase())).ladder("step_height")
+        assert ladder is not None
+        assert all(r.final_label for r in ladder.rungs)
+
 
 class TestOmissionIsNotADrop:
     """Two different "not drawn" meet in this renderer and must stay distinguishable: the
@@ -400,7 +448,7 @@ class TestTheBoundaryIsLoadBearing:
             f"the detail view drew {len(detail)} step dims from a plan approving "
             f"{len(keep)} — it is rebuilding the ladder from the model: {sorted(detail)}"
         )
-        approved_labels = {r.label for r in keep}
+        approved_labels = {r.final_label for r in keep}
         assert set(detail.values()) <= approved_labels, (
             f"the detail view drew {sorted(set(detail.values()) - approved_labels)}, which "
             "the compiler did not approve"
@@ -435,7 +483,7 @@ class TestTheBoundaryIsLoadBearing:
         dwg = build_drawing(part)
         assert "dim_od" not in dwg.annotations()
         assert [o.label for n, o in dwg.iter_annotations() if n.startswith("ldr_z")] == [
-            f"ø{bores[1].label}"
+            f"ø{bores[1].value_text}"
         ]
         assert {"centerline_front", "centerline_side"} <= set(dwg.annotations())
 

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -404,6 +404,7 @@ class TestTheBoundaryIsLoadBearing:
             "render_boss_diameters",
             "render_boss_heights",
             "render_chamfers",
+            "render_diameters",
             "render_envelope",
             "render_fillets",
             "render_flats",
@@ -417,7 +418,6 @@ class TestTheBoundaryIsLoadBearing:
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert sorted(by_contract["groups"]) == [
-            "render_diameters",
             "render_rotational",
             "render_slots",
             "render_step_lengths",

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -243,6 +243,29 @@ class TestTheRendererCannotSeeContent:
             for rung in ladder.rungs:
                 assert rung.id is not None, f"{ladder.kind} rung lost its DimensionId"
 
+    def test_zero_length_shoulder_keeps_its_explicit_axis(self):
+        """A degenerate datum→shoulder span cannot reveal whether it is X or Y."""
+        from draftwright.model.ir import Frame, PartModel, StepLevelFeature
+
+        part = Box(90, 60, 30)
+        step = StepLevelFeature(
+            Frame((0, 0, 0), "z"),
+            base=0.0,
+            levels=(10.0,),
+            shoulders=(("x", -45.0),),
+            datum=(-45.0, -30.0, 0.0),
+        )
+        model = PartModel(
+            bbox=part.bounding_box(),
+            orientation=None,
+            features=[step],
+        )
+        ladder = compile_dimensions(model).ladder("step_position")
+        assert ladder is not None
+        assert len(ladder.rungs) == 1
+        assert ladder.rungs[0].span[0] == ladder.rungs[0].span[1]
+        assert ladder.rungs[0].axis == "x"
+
     def test_the_layout_frame_carries_no_part_geometry(self):
         from draftwright._core import LayoutFrame
 

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -410,15 +410,15 @@ class TestTheBoundaryIsLoadBearing:
             "render_grooves",
             "render_height_ladder",
             "render_plates",
+            "render_pocket_patterns",
             "render_pockets",
+            "render_slot_patterns",
             "render_step_positions",
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert sorted(by_contract["groups"]) == [
             "render_diameters",
-            "render_pocket_patterns",
             "render_rotational",
-            "render_slot_patterns",
             "render_slots",
             "render_step_lengths",
         ], f"the advisory-surface set changed: {sorted(by_contract['groups'])}"

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -63,6 +63,46 @@ class TestTheCompilerOwnsContent:
         assert rungs is not None and rungs.representative
         assert len(rungs.rungs) == 1 and "×" in rungs.rungs[0].label
 
+    @pytest.mark.parametrize(
+        "make_part", [_staircase, _uniform_staircase], ids=["stepped", "uniform"]
+    )
+    def test_a_label_always_measures_its_own_span(self, make_part):
+        """The invariant that keeps a dimension honest: the number printed IS the distance
+        between the two points the line runs between.
+
+        It broke the moment the compiler started measuring from `StepLevelFeature.base`
+        while the renderer still anchored every witness at the view's bottom edge — a
+        declared base above the part's bottom made the line span the whole part and read
+        the shorter figure, so the dimension said one thing and measured another (#923
+        review). Checking it here, at the source, catches the disagreement for every
+        renderer rather than one fixture at a time."""
+        plan = compile_dimensions(detect_part_model(make_part()))
+        for ladder in plan.ladders:
+            for rung in ladder.rungs:
+                if rung.span is None or ladder.representative:
+                    continue  # a representative mark reports the RISE, not its own span
+                measured = rung.span[1][2] - rung.span[0][2]
+                assert measured == pytest.approx(rung.value), (
+                    f"{ladder.kind} {rung.label!r} spans {measured} but claims {rung.value}"
+                )
+
+    def test_a_declared_base_is_measured_from_that_base(self):
+        """`StepLevelFeature.base` is the IR's own statement of what the rungs measure from.
+        The planner always used it; the renderer used the bounding-box minimum, so for a
+        declared base the plan and the drawing disagreed about the number. One source now."""
+        from draftwright.model.ir import Frame, PartModel, StepLevelFeature
+
+        step = StepLevelFeature(Frame((0, 0, 5), "z"), base=5.0, levels=(10.0, 20.0))
+        model = PartModel(
+            bbox=Box(90, 60, 30).bounding_box(),
+            orientation="prismatic",
+            features=[step],
+            datums=[],
+        )
+        rungs = compile_dimensions(model).ladder("step_height")
+        assert [r.value for r in rungs.rungs] == [5.0, 15.0], "measured from base=5, not bbox"
+        assert all(r.span[0][2] == 5.0 for r in rungs.rungs), "and the LINE starts there too"
+
     def test_the_overall_height_is_an_approved_entry_not_a_bbox_read(self):
         plan = compile_dimensions(detect_part_model(Box(90, 60, 20)))
         overall = plan.ladder("overall_height")
@@ -202,6 +242,32 @@ class TestTheBoundaryIsLoadBearing:
         assert not leaked, (
             f"{leaked} reached the page from an EMPTY compiled plan — the renderer is "
             "rebuilding dimensions from somewhere other than the plan"
+        )
+
+    def test_the_detail_redraw_bypass_is_pinned_until_it_is_closed(self):
+        """A KNOWN GAP, pinned so it cannot be forgotten and so closing it is detectable.
+
+        `_request_prismatic_detail` re-derives the step from `dwg.model()` and rebuilds the
+        ladder from `step.levels` against `a.bb.min.Z`, so a rung the compiler withheld can
+        still reach the detail view (#923 review — an approved ladder of three rungs drew
+        five). The direct render path obeys the boundary; its escalation does not.
+
+        This asserts the bypass STILL EXISTS. When the escalation is migrated to carry
+        approved rungs, this test fails — which is the point: it is a reminder with a
+        deadline, not documentation of an accepted exception."""
+        src = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "src"
+            / "draftwright"
+            / "annotations"
+            / "sections.py"
+        ).read_text(encoding="utf-8")
+        assert (
+            'getattr(f, "kind", None) == "step_level"' in src and 'getattr(step, "levels"' in src
+        ), (
+            "the detail redraw no longer rediscovers levels from the model — if it now "
+            "consumes the approved ladder, delete this test and the ADR's scheduled "
+            "exception for it"
         )
 
     def test_the_migration_has_not_silently_stalled(self):

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -34,25 +34,43 @@ from draftwright.annotations.from_model import render_height_ladder
 from draftwright.builder import build_drawing, detect_part_model
 from draftwright.model.compiled import RenderableDimensionPlan, compile_dimensions
 
-#: Marks that legitimately survive an empty compiled plan because they carry no VALUE.
-#: Anything added here needs that reason: "the test failed otherwise" is how the boundary
-#: erodes. A pattern's pitch dim prints "4× 20" and is therefore NOT furniture — it is a
-#: pending migration, tracked below.
-_FURNITURE = (
-    "centerline",
-    "m_cm",
-    "m_locx",
-    "m_locy",
-    "note_",
+#: Marks that carry NO value, and so legitimately survive an empty compiled plan.
+#: Each needs that reason; "the test failed otherwise" is not one.
+_VALUE_FREE = (
+    "centerline",  # shows where an axis is
+    "m_cm",  # centre marks — sized off the hole they mark (#875)
+    "note_",  # the ISO NTS note
     "title_block",
-    "section_",
+    "section_",  # cutting-plane arrows and label
     "hatch",
     "detail_marker",
     "detail_caption",
-    "hc_",
-    "m_env",
-    "balloon",
-    "table",
+)
+
+#: Marks that DO carry a value and still survive an empty plan — i.e. renderers that have
+#: not crossed the boundary yet. Listed individually rather than lumped in with furniture,
+#: because calling them furniture is how the pitch dim hid: annotation names are not a
+#: semantic type system, and a prefix list quietly became the definition of "dimensional"
+#: (#923 review round 4). Each entry is a pending migration, and the ADR names it too.
+_PENDING_VALUE_CARRYING = (
+    "m_locx",  # hole location ladders — #883
+    "m_locy",
+    "m_env",  # envelope width/depth — render_envelope, still on the advisory surface
+    "hc_",  # hole callouts — likewise
+    "dim_pitch",  # pattern pitch — derived in _add_furniture from the feature
+    "dim_od",  # rotational OD — render_rotational, still on the advisory surface
+    "ldr_",  # concentric bore leaders — likewise
+    "m_dia",  # step/boss diameters — likewise
+    "m_steplen",
+    "m_slot",
+    "m_pocket",
+    "m_boss",
+    "m_plate",
+    "m_chamf",
+    "m_fillet",
+    "m_flat",
+    "m_groove",
+    "pmi_",  # raw AP242 PMI — the one documented permanent exception
 )
 
 
@@ -288,14 +306,18 @@ class TestTheBoundaryIsLoadBearing:
             lambda *a, **kw: RenderableDimensionPlan(),
         )
         empty = {n for n, _ in Sheet.from_part(part).build().iter_annotations()}
-        # EVERY dimensional mark, not a hand-listed prefix. Filtering to
-        # `dim_step`/`dim_height` let `dim_shoulder_*` through for a whole review round —
-        # a guard that only looks where you already know to look is not a guard (#923
-        # review round 3). Furniture is excluded by name because it prints no value.
-        leaked = sorted(n for n in empty if not n.startswith(_FURNITURE))
+        # Anything that is neither value-free furniture nor a NAMED pending migration.
+        # Filtering to `dim_step`/`dim_height` let `dim_shoulder_*` through for a whole
+        # round, and folding value-carrying marks into a "furniture" list hid the pitch dim
+        # for another — a guard that only looks where you already know to look is not a
+        # guard, and a prefix list must not become the definition of "dimensional".
+        leaked = sorted(
+            n for n in empty if not n.startswith(_VALUE_FREE + _PENDING_VALUE_CARRYING)
+        )
         assert not leaked, (
             f"{leaked} reached the page from an EMPTY compiled plan — something is "
-            "rebuilding dimensions from somewhere other than the plan"
+            "rebuilding dimensions from somewhere other than the plan, and it is not on "
+            "the pending list"
         )
 
     def test_the_detail_view_emits_exactly_the_approved_rungs(self):
@@ -346,30 +368,68 @@ class TestTheBoundaryIsLoadBearing:
             "the compiler did not approve"
         )
 
-    def test_the_migration_has_not_silently_stalled(self):
-        """A count, so finishing the migration is visible rather than assumed. Lower it as
-        each dimensional renderer moves; the sequence ends when locations are inside too
-        (#883) and only the documented AP242 PMI exception still takes the model."""
-        src = (
-            pathlib.Path(__file__).resolve().parents[1]
-            / "src"
-            / "draftwright"
-            / "annotations"
-            / "from_model.py"
-        ).read_text(encoding="utf-8")
-        tree = ast.parse(src)
-        unmigrated = sorted(
-            node.name
-            for node in tree.body
-            if isinstance(node, ast.FunctionDef)
-            and node.name.startswith("render_")
-            and "model" in {a.arg for a in node.args.args}
-        )
-        assert unmigrated == [
+    def test_the_migration_guard_measures_the_CONTRACT_not_the_signature(self):
+        """How far the boundary actually reaches, by what each renderer is HANDED.
+
+        The first version of this counted `render_*` functions taking `model` and reported
+        the migration nearly complete. That measured the wrong property: a renderer taking
+        legacy `groups` receives `PlannedDimension`s whose `suppressed` is still an advisory
+        boolean it can ignore — which is the exact surface eight #921 rounds found being
+        ignored. Not naming a parameter `model` is not the same as having crossed the
+        boundary (#923 review round 4).
+
+        So classification is by contract: `plan` means approved entries only; `groups`
+        means the advisory surface; `model` means raw inventory. The pending lists are
+        pinned so the count cannot drift, and so finishing is a visible event rather than
+        an assumption.
+        """
+        by_contract: dict[str, list[str]] = {"plan": [], "groups": [], "model": []}
+        for mod in ("from_model", "holes"):
+            src = (
+                pathlib.Path(__file__).resolve().parents[1]
+                / "src"
+                / "draftwright"
+                / "annotations"
+                / f"{mod}.py"
+            ).read_text(encoding="utf-8")
+            for node in ast.parse(src).body:
+                if not isinstance(node, ast.FunctionDef) or not node.name.startswith("render_"):
+                    continue
+                args = {a.arg for a in node.args.args} | {a.arg for a in node.args.kwonlyargs}
+                for contract in ("plan", "groups", "model"):
+                    if contract in args:
+                        by_contract[contract].append(node.name)
+                        break
+
+        assert sorted(by_contract["plan"]) == [
+            "render_height_ladder",
+            "render_step_positions",
+        ], "the migrated set changed — update this and the ADR's inventory together"
+
+        assert sorted(by_contract["groups"]) == [
+            "render_boss_diameters",
+            "render_boss_heights",
+            "render_centermarks",
+            "render_chamfers",
+            "render_diameters",
+            "render_envelope",
+            "render_fillets",
+            "render_flats",
+            "render_grooves",
+            "render_plates",
+            "render_pocket_patterns",
+            "render_pockets",
+            "render_rotational",
+            "render_slot_patterns",
+            "render_slots",
+            "render_step_lengths",
+        ], f"the advisory-surface set changed: {sorted(by_contract['groups'])}"
+
+        assert sorted(by_contract["model"]) == [
             "render_gdt",
             "render_locations",
             "render_pmi",
-        ], f"the unmigrated set changed: {unmigrated}"
+        ], f"the raw-inventory set changed: {sorted(by_contract['model'])}"
 
     def test_the_pending_dimensional_paths_are_the_ones_the_adr_names(self):
         """Two paths still emit dimensional content of their own, and the ADR says so.
@@ -385,5 +445,9 @@ class TestTheBoundaryIsLoadBearing:
             / "adr"
             / "0016-declared-dimensioning-intent.md"
         ).read_text(encoding="utf-8")
-        for pending in ("Location dimensions are inside this rule", "Pattern pitch dimensions"):
-            assert pending in adr, f"the ADR stopped naming a pending path: {pending}"
+        assert "render_rotational" in adr and "render_envelope" in adr, (
+            "the ADR's pending inventory stopped naming the advisory-surface renderers — "
+            "it must list what has NOT crossed the boundary, not just what has"
+        )
+        assert "Pattern pitch dimensions" in adr, "pitch dims dropped off the pending list"
+        assert "#883" in adr, "locations dropped off the pending list"

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -109,11 +109,43 @@ class TestTheRendererCannotSeeContent:
             for node in ast.walk(tree)
             if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load)
         }
-        forbidden = {"features", "bb", "levels", "shoulders", "orientation", "z_size", "base"}
+        # `_feature` is the FeatureRef escape hatch: resolving a provenance handle back to
+        # its feature inside a dimensional renderer is a boundary violation, and this is
+        # where it gets caught.
+        forbidden = {
+            "features",
+            "bb",
+            "levels",
+            "shoulders",
+            "orientation",
+            "z_size",
+            "base",
+            "_feature",
+        }
         assert not (reads & forbidden), (
             f"{sorted(reads & forbidden)} is model content — the ladder is drawn from the "
             "compiled plan's approved entries, whose spans carry every coordinate it needs"
         )
+
+    def test_the_provenance_handle_exposes_no_measurement(self):
+        """Carrying the `Feature` on an approved entry left the bypass one attribute access
+        away — `.feature.levels` rebuilds exactly what the compiler withheld (#923 review).
+        The handle exposes identity and category, and no measurement."""
+        from draftwright.model.compiled import FeatureRef
+
+        ladder = compile_dimensions(detect_part_model(_staircase())).ladder("step_height")
+        assert isinstance(ladder.ref, FeatureRef)
+        assert ladder.ref.kind == "step_level", "category is fine — it is not a measurement"
+        for content in ("levels", "shoulders", "base", "datum", "parameters"):
+            assert not hasattr(ladder.ref, content), f"FeatureRef exposes {content}"
+
+    def test_identities_survive_the_compile(self):
+        """`DimensionId` is ADR 0016's stable addressable identity; a renderer-facing result
+        that discarded it would create identity debt on the boundary meant to remove it."""
+        plan = compile_dimensions(detect_part_model(_staircase()))
+        for ladder in plan.ladders:
+            for rung in ladder.rungs:
+                assert rung.id is not None, f"{ladder.kind} rung lost its DimensionId"
 
     def test_the_layout_frame_carries_no_part_geometry(self):
         from draftwright._core import LayoutFrame
@@ -145,18 +177,32 @@ class TestOmissionIsNotADrop:
 
 
 class TestTheBoundaryIsLoadBearing:
-    def test_suppressing_the_whole_plan_empties_the_ladder(self):
-        """The behavioural statement, independent of any renderer's internals: nothing the
-        compiler withholds reaches the page. This is the test that would have caught all
-        four ladder-related rounds without knowing what any of them were."""
+    def test_an_empty_plan_draws_no_ladder_in_a_REAL_build(self, monkeypatch):
+        """The behavioural statement, and it has to render to mean anything.
+
+        The first version of this test built an empty `RenderableDimensionPlan` and asserted
+        its lookups returned `None` — which is a fact about a dataclass, not about the
+        engine. It would have passed with `render_height_ladder` ignoring the plan entirely
+        and rebuilding every dimension from the model, i.e. with the exact defect the
+        boundary exists to prevent (#923 review). Patching the compiler inside a real build
+        is what makes it load-bearing.
+        """
         part = _staircase()
         drawn = {n for n, _ in Sheet.from_part(part).build().iter_annotations()}
         assert [n for n in drawn if n.startswith(("dim_step", "dim_height"))], (
             "the fixture must draw a ladder to be worth emptying"
         )
 
-        empty = RenderableDimensionPlan()
-        assert empty.ladder("step_height") is None and empty.ladder("overall_height") is None
+        monkeypatch.setattr(
+            "draftwright.annotations.orchestrator.compile_dimensions",
+            lambda *a, **kw: RenderableDimensionPlan(),
+        )
+        empty = {n for n, _ in Sheet.from_part(part).build().iter_annotations()}
+        leaked = sorted(n for n in empty if n.startswith(("dim_step", "dim_height")))
+        assert not leaked, (
+            f"{leaked} reached the page from an EMPTY compiled plan — the renderer is "
+            "rebuilding dimensions from somewhere other than the plan"
+        )
 
     def test_the_migration_has_not_silently_stalled(self):
         """A count, so finishing the migration is visible rather than assumed. Lower it as

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -275,6 +275,33 @@ class TestTheRendererCannotSeeContent:
             "the compiler, which is the only place allowed to turn it into a dimension"
         )
 
+    def test_layout_frame_edges_guarantee_page_order_under_reversed_projection(self):
+        from types import SimpleNamespace
+
+        from draftwright._core import LayoutFrame
+
+        frame = LayoutFrame(
+            proj=SimpleNamespace(),
+            scale=1.0,
+            front=(40.0, 10.0, 30.0, 5.0),
+            plan=(0.0, 1.0, 2.0, 3.0),
+            side=(0.0, 1.0, 2.0, 3.0),
+            fv_zones=SimpleNamespace(),
+            pv_zones=SimpleNamespace(),
+            sv_zones=SimpleNamespace(),
+        )
+        assert frame.edges("front") == (10.0, 40.0, 5.0, 30.0)
+
+    def test_compiler_rejects_groups_planned_from_an_equal_but_different_model(self):
+        """Suppression must fail closed rather than miss an identity-keyed lookup."""
+        first = detect_part_model(_staircase())
+        second = detect_part_model(_staircase())
+        assert first is not second
+        from draftwright.model.planner import plan_dimensions
+
+        with pytest.raises(ValueError, match="exact PartModel"):
+            compile_dimensions(first, groups=plan_dimensions(second))
+
 
 class TestOmissionIsNotADrop:
     """Two different "not drawn" meet in this renderer and must stay distinguishable: the

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1056,6 +1056,26 @@ class TestPlate:
         assert sorted(plate_dims.values()) == ["8", "8"]  # each 8 thick
         assert [i for i in dwg.lint() if i.severity != "info"] == []
 
+    def test_same_axis_plate_names_follow_thickness_axis_not_in_plane_position(self):
+        """Stable annotation identity follows the old axis/lo/hi order.
+
+        The compiled renderer briefly sorted whole span points, so X/Y coordinates
+        outranked the Z thickness coordinate and moving a plate sideways could swap
+        ``dim_plate_z0`` with ``dim_plate_z1``. A pin/drop would then target its neighbour.
+        """
+        part = Box(200, 60, 40)
+        model = [
+            plate(axis="z", lo=5, hi=9, u=-60, v=0),  # lower in X, but higher in Z
+            plate(axis="z", lo=1, hi=4, u=60, v=0),
+        ]
+        dwg = build_drawing(part, model=model, number="X")
+        labels = {
+            name: dwg.get_annotation(name).label
+            for name in dwg.annotations()
+            if name.startswith("dim_plate_z")
+        }
+        assert labels == {"dim_plate_z0": "3", "dim_plate_z1": "4"}
+
     def test_needs_object_or_explicit(self):
         with pytest.raises(ValueError):
             plate(axis="z", lo=0)  # missing hi / u / v

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5749,9 +5749,10 @@ class TestDetailView:
                     tuple(
                         ApprovedDimension(
                             id=None,
-                            label=str(z),
+                            value_text=str(z),
                             value=z,
                             span=((0.0, 0.0, 0.0), (0.0, 0.0, z)),
+                            rendered_label=str(z),
                         )
                         for z in (1.0, 1.1, 1.2, 1.3)
                     ),
@@ -5785,9 +5786,10 @@ class TestDetailView:
         rungs = tuple(
             ApprovedDimension(
                 id=None,
-                label=str(z - declared_base),
+                value_text=str(z - declared_base),
                 value=z - declared_base,
                 span=((0.0, 0.0, declared_base), (0.0, 0.0, z)),
+                rendered_label=str(z - declared_base),
             )
             for z in (8.0, 9.0, 10.0)
         )

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5768,6 +5768,47 @@ class TestDetailView:
         _request_prismatic_detail(None, a, ctx=with_escalation, plan=plan)
         assert len(with_escalation.detail_requests) == 1
 
+    def test_declared_step_base_does_not_replace_physical_detail_crop_base(self):
+        """Measurement datum and visible crop geometry are intentionally different."""
+        from types import SimpleNamespace
+
+        from draftwright.annotations._common import Escalation, PlacementContext
+        from draftwright.annotations.sections import _request_prismatic_detail
+        from draftwright.model.compiled import (
+            ApprovedDimension,
+            ApprovedLadder,
+            RenderableDimensionPlan,
+        )
+
+        bbox_base = -15.0
+        declared_base = 5.0
+        rungs = tuple(
+            ApprovedDimension(
+                id=None,
+                label=str(z - declared_base),
+                value=z - declared_base,
+                span=((0.0, 0.0, declared_base), (0.0, 0.0, z)),
+            )
+            for z in (8.0, 9.0, 10.0)
+        )
+        plan = RenderableDimensionPlan(ladders=(ApprovedLadder("step_height", rungs),))
+        analysis = SimpleNamespace(
+            bb=SimpleNamespace(
+                min=SimpleNamespace(Z=bbox_base),
+                max=SimpleNamespace(Z=20.0),
+            ),
+            SCALE=1.0,
+        )
+        ctx = PlacementContext(
+            escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")]
+        )
+
+        _request_prismatic_detail(None, analysis, ctx=ctx, plan=plan)
+
+        assert len(ctx.detail_requests) == 1
+        assert ctx.detail_requests[0].crop_lo == bbox_base
+        assert ctx.detail_requests[0].crop_lo != declared_base
+
     def test_unplaceable_detail_is_reported_not_silently_dropped(self):
         # #630: on a shelled cover the crowded step band is full-width (stacked face
         # levels), so a detail can't be enlarged legibly AND still fit — detail_view=True

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8741,6 +8741,7 @@ class TestPrismaticBossDiameter:
         from draftwright.annotations._common import PlacementContext, drain_corridors
         from draftwright.annotations.from_model import render_boss_heights
         from draftwright.model import plan_dimensions
+        from draftwright.model.compiled import compile_dimensions
 
         dwg = build_drawing(self._box_boss(), auto_dims=False)
         analysis = dwg._analysis
@@ -8751,7 +8752,10 @@ class TestPrismaticBossDiameter:
             }
         )
         ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage, items=dwg.items)
-        render_boss_heights(dwg, plan_dimensions(dwg.model()), constrained, ctx=ctx)
+        groups = plan_dimensions(dwg.model())
+        render_boss_heights(
+            dwg, compile_dimensions(dwg.model(), groups=groups), constrained, ctx=ctx
+        )
         drain_corridors(ctx, dwg)
 
         boss_issues = [i for i in dwg.lint() if i.code.startswith("boss_height_")]
@@ -9326,12 +9330,25 @@ class TestDiameterStepAnchor:
         # (axial mid 30, radial y=20), not a hybrid that takes the axial from the
         # long step and the radial from the bucket's first (short) step — which
         # would land the arrow off the selected step's silhouette.
+        from types import SimpleNamespace
+
         from draftwright.annotations.from_model import _diameter_step_anchor
+        from draftwright.model.compiled import compile_dimensions
+        from draftwright.model.ir import PartModel
+        from draftwright.model.planner import plan_dimensions
 
         short = self._step("x", (0.0, 0.0, 0.0), -2.5, 2.5)  # len 5, centre x=0
         long = self._step("x", (30.0, 20.0, 0.0), 20.0, 40.0)  # len 20, centre x=30, y=20
+        bbox = SimpleNamespace(
+            size=SimpleNamespace(Z=20.0),
+            max=SimpleNamespace(X=40.0, Z=20.0),
+            min=SimpleNamespace(Y=0.0, Z=0.0),
+        )
+        model = PartModel(bbox=bbox, orientation="x", features=[short, long])
+        groups = plan_dimensions(model)
+        plan = compile_dimensions(model, groups=groups)
         # `anchor` is the FIRST-bucketed feature's origin (the short step, y=0).
-        got = _diameter_step_anchor(short.frame.origin, {short, long})
+        got = _diameter_step_anchor(short.frame.origin, plan.of_kind("step"))
         assert got == (30.0, 20.0, 0.0), f"hybrid/wrong anchor: {got}"
 
     def test_no_step_in_the_group_falls_back_to_the_given_anchor(self):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5727,20 +5727,45 @@ class TestDetailView:
 
         from draftwright.annotations._common import Escalation, PlacementContext
         from draftwright.annotations.sections import _request_prismatic_detail
+        from draftwright.model.compiled import (
+            ApprovedDimension,
+            ApprovedLadder,
+            RenderableDimensionPlan,
+        )
 
         a = SimpleNamespace(
             step_zs=[1.0, 1.1, 1.2, 1.3],  # tightly spaced — "illegible" if recomputed raw
             bb=SimpleNamespace(min=SimpleNamespace(Z=0.0), max=SimpleNamespace(Z=2.0)),
             SCALE=1.0,
         )
+        # The rungs now arrive from the compiled plan (ADR 0016 Amdt 1 / #923): the detail
+        # redraw used to re-derive them from `dwg.model()` and `a.step_zs`, which let it
+        # draw a rung the compiler had withheld. `a.step_zs` is no longer consulted at all —
+        # what this test still pins is the GATE: the escalation, not raw legibility.
+        plan = RenderableDimensionPlan(
+            ladders=(
+                ApprovedLadder(
+                    "step_height",
+                    tuple(
+                        ApprovedDimension(
+                            id=None,
+                            label=str(z),
+                            value=z,
+                            span=((0.0, 0.0, 0.0), (0.0, 0.0, z)),
+                        )
+                        for z in (1.0, 1.1, 1.2, 1.3)
+                    ),
+                ),
+            )
+        )
         no_escalation = PlacementContext()
-        _request_prismatic_detail(None, a, ctx=no_escalation)
+        _request_prismatic_detail(None, a, ctx=no_escalation, plan=plan)
         assert no_escalation.detail_requests == []
 
         with_escalation = PlacementContext(
             escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")],
         )
-        _request_prismatic_detail(None, a, ctx=with_escalation)
+        _request_prismatic_detail(None, a, ctx=with_escalation, plan=plan)
         assert len(with_escalation.detail_requests) == 1
 
     def test_unplaceable_detail_is_reported_not_silently_dropped(self):

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -739,7 +739,7 @@ class TestPocketTolerance:
             ),
         )
         ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage, items=dwg.items)
-        assert render_pockets(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        assert render_pockets(dwg, _plan_of(g2), dwg._analysis, ctx=ctx) == 1
         labels = [
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_pocket")
         ]

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -746,6 +746,18 @@ class TestPocketTolerance:
         assert labels == ["7 × 30 × 5 DEEP"], labels
 
 
+def _plan_of(*planned):
+    """Wrap planned `DimensionGroup`s as the compiled plan `render_plates` now takes.
+
+    The renderer moved onto the ADR 0016 boundary (#923): it receives APPROVED entries, so
+    it can no longer be handed raw planned groups. These tests still start from
+    `plan_dimensions` because what they exercise is the planner's decision reaching the
+    page — the compile step in between is exactly the thing under test."""
+    from draftwright.model.compiled import RenderableDimensionPlan, _compile_groups
+
+    return RenderableDimensionPlan(groups=tuple(_compile_groups(planned)))
+
+
 class TestPlateTolerance:
     """#729 (the #629 class, latent): a plate's authored thickness tolerance must render
     on the placed linear dim — the pass now consumes the planner's DimensionGroups,
@@ -797,7 +809,7 @@ class TestPlateTolerance:
         )
         (g,) = [g for g in plan_dimensions(dwg.model()) if g.feature_kind == "plate"]
         ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage, items=dwg.items)
-        assert render_plates(dwg, [g], dwg._analysis, ctx=ctx) == 1
+        assert render_plates(dwg, _plan_of(g), dwg._analysis, ctx=ctx) == 1
         (cand,) = [
             c
             for b in ctx.corridor_batch.values()
@@ -842,7 +854,7 @@ class TestPlateTolerance:
         planned = replace(pd, param=replace(pd.param, value=7.0))  # ≠ pl.hi - pl.lo == 8
         g2 = replace(g, units=_addressable(g.feature, [decoy, planned]))
         ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage, items=dwg.items)
-        assert render_plates(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        assert render_plates(dwg, _plan_of(g2), dwg._analysis, ctx=ctx) == 1
         drain_corridors(ctx, dwg)
         labels = [
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("dim_plate")

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -512,7 +512,7 @@ class TestChamferTolerance:
         planned = replace(pd, param=replace(pd.param, value=7.0))  # ≠ ch.leg1 == 12
         g2 = replace(g, units=_addressable(g.feature, [decoy, planned]))
         ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage, items=dwg.items)
-        assert render_chamfers(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        assert render_chamfers(dwg, _plan_of(g2), dwg._analysis, ctx=ctx) == 1
         labels = [
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_chamfer")
         ]
@@ -663,7 +663,7 @@ class TestGrooveTolerance:
             g, units=_addressable(g.feature, [decoy, planned_w, by_key[("groove", "diameter")]])
         )
         ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage, items=dwg.items)
-        assert render_grooves(dwg, [g2], dwg._analysis, ctx=ctx) == 1
+        assert render_grooves(dwg, _plan_of(g2), dwg._analysis, ctx=ctx) == 1
         labels = [
             dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_groove")
         ]


### PR DESCRIPTION
**PR-1 of the stack under #921.** This is the vertical slice for shape review, not the finished migration — steps 4–5 of the agreed sequence (remaining dimensional renderers incl. locations, then rebasing #921) land on this branch next.

## The invariant

> **Renderers may emit dimensional content only from the compiled plan.**

A dimensional renderer receives approved entries and decides *where* and *how*. It does not decide *what*, and it is not given the feature inventory or the bounding box it would need to decide otherwise. The corollary is the load-bearing part: **suppression is not a flag renderers check, it is content they never receive.**

## Why a boundary rather than more checks

Everything in ADR 0016 already said the planner decides suppression. It did — and the decision was routinely ignored, because `PlannedDimension.suppressed` was *advisory*. A renderer got the planned groups **and** the `PartModel` **and** the `Analysis`, so honouring the plan was a convention it had to opt into, and rebuilding a suppressed dimension from `feature.levels` or `a.bb` stayed one attribute access away.

Eight adversarial review rounds on #921 found eight renderers that hadn't opted in — the height ladder and step positions rebuilding marks from the feature and the bbox; the whole turned family selecting parameters with no suppression check; the compound callout, the deferred-edit path, the script emitter and `from_part` each needing separate enforcement. Every one was a real omission reaching a real drawing.

Fixing them individually produced **four** mechanisms for saying the same thing — `pd.suppressed` reads, `env_dim_placed`, `set_dim_placed`, and a `_CALLOUT_PARAM_KINDS` policy table — and no reason to think the ninth renderer would be different. That is a missing boundary, not missing tests.

## What landed

**`model/compiled.py`** — `compile_dimensions(model, *, include_overall) -> RenderableDimensionPlan`

- `ApprovedDimension` has **no `suppressed` field**. There is nothing to forget.
- Withheld measurements leave through `.diagnostics` (`Omission`), which lint and coverage consume — ADR 0016's "marked, not filtered" survives, but not on the path a renderer walks.
- Correlated sets arrive as explicit `ApprovedLadder` groups, preserving the tier-3 rule that a ladder is approved or omitted **whole**, never half a staircase.
- `Omission.authored` separates the author's omission from a planner rule's suppression — the distinction three #921 attempts kept blurring.
- Spans travel in **part space**; the renderer projects them.

**`_core.LayoutFrame`** — the restricted layout input: projectors, page-space view rectangles, strips, scale. No `part`, no `bb`, no feature lists. View *edges* are page rectangles rather than projected bbox extents, so anchoring beside a view needs no part geometry — the form that let the ladder read `a.bb.max.Z` while calling itself layout.

**`render_height_ladder` migrated** — `(dwg, plan, frame, *, ctx, detail_view)`, no `model`, no `a`. Chosen as the first slice because it holds every hard case at once: correlated rungs, a geometry-derived overall dimension, spans that must survive projection, and suppression.

| Decision | Before | Now |
|---|---|---|
| Which rungs exist, their values | renderer, from `feature.levels` | compiler |
| Uniform staircase → `4× 10` | renderer | compiler — what the drawing *says* |
| Overall height value | renderer, from `a.bb` | compiler |
| Whether the overall height is drawn | split across planner **and** renderer, neither aware of the other | compiler, once |
| Legibility at this scale | renderer | renderer — depends on the page |
| Leapfrog chain, strips, drops | renderer | renderer |

**Omission is not a drop.** The compiler's omission never arrives and is reported through diagnostics; the placer's drop arrived and didn't fit, and reports `placement_unsatisfiable`. Conflating them is how a deliberate suppression came to look like a layout failure.

**What the compiler may do that renderers may not:** read the bounding box. A model with no `EnvelopeFeature` has no parameter naming its overall height, and the value falls back to the bbox. That fallback is legitimate and now lives in exactly one place.

## Verification

- **Full fast tier: 2009 passed**, zero failures.
- **Output byte-identical** across six fixtures — three-tier staircase, rebate, plate, turned shaft, cylinder, uniform staircase — labels and lint codes included.
- Lint 4/4 clean; DAG guard passing (`model/compiled.py` stays rank 0).
- **12 boundary tests** pinning the property structurally, not the instances: the signature cannot name `model`/`a`; an AST walk of the body proves it never reads `features`/`bb`/`levels`/`base`; `LayoutFrame` is asserted to carry no part geometry.
- A **migration counter** names the four renderers still taking the model (`render_locations`, `render_step_positions`, `render_gdt`, `render_pmi`), so finishing is visible rather than assumed.

## Scope, stated so the exceptions can't be mistaken for completeness

- **Location dimensions are inside this rule** and sequenced later in this branch, not carved out. They are dimensions, and letting `render_locations` rebuild them from the model preserves the same bypass class (#883). The boundary is not complete until they are inside it.
- **Raw AP242 PMI** is the one documented exception: `PmiFeature.parameters()` is empty by design and the record renders verbatim.
- **Furniture** — centrelines, centre marks, section arrows — prints no value and stays outside.

## Two judgement calls worth review

1. **`include_overall` became a compile input.** It is drawing state, so it could have stayed a renderer argument — but then the renderer decides set membership again, which is the thing being removed.
2. **`ApprovedLadder.representative`.** The compiler decides the collapse; the renderer reads the flag only to *name* the mark `dim_step_typ` rather than `dim_step_0`. The thinnest coupling I found, but it is coupling — the alternative is the compiler supplying annotation names, which felt like the compiler doing layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
