### PR TITLE
fix(#878): a blind hole round-trips its blindness without a measured depth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,30 @@ Current ADRs:
   groups are residual debt tracked by #754) and the lint/coverage carve-out
   stated properly. New kinds must add every applicable IR, planning, rendering,
   coverage, and test surface while keeping orientation data-driven.
+- **0016** — **Accepted; epic #867 complete** (PR0–PR8, #868–#876): **declared
+  dimensioning intent**. `sheet.dimension(feature, role)` is *referential* — it names
+  a measurement and carries no number; the engine still derives the value from the
+  geometry and owns placement. Three parts landed:
+  - **A build must say where its dimensions come from** (#874, breaking): either
+    `auto_dimensions()` (the planner's set, optionally augmented by `add_dimension`)
+    or an authored set of `dimension(...)` declarations. Mutually exclusive, because
+    "everything the planner chooses, plus these" and "only these" cannot both hold.
+  - **Omission from an authored set means suppression** (#876) — on *every* generated
+    dimensional path, positions included. A dimension the author cannot address is a
+    dimension the author cannot omit, so `location` became addressable per feature
+    (`planner.location_datum` is the single eligibility answer; per-*member* identity
+    remains #883).
+  - **Amendment 1 — the compiled-plan boundary**: renderers may emit dimensional
+    content only from `model/compiled.py`'s `RenderableDimensionPlan`. *Suppression is
+    not a flag renderers check, it is content they never receive* — `ApprovedDimension`
+    has no `suppressed` field. Guarded on both the symptom
+    (`tests/test_compiled_plan_boundary.py`: an empty plan draws nothing) and the cause
+    (`tests/test_label_provenance.py`: a renderer that formats a number got it as a
+    number rather than as the compiler's `value_text`). Hole callouts (`hc_`) are the
+    one renderer still on the legacy surface (#926); the label budget drawdown is #927.
+  **Not** shipped: the emitter dimension-mirror (phase 4). `emit_sheet_script` refuses a
+  model with an authored set rather than silently writing `auto_dimensions()`, because
+  naming a feature in a generated script would have to address it by position — #922.
 
 ## Dependencies
 

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -4,22 +4,28 @@
 - **Date:** 2026-07-26 (accepted 2026-07-27; implementation epic **#867**)
 - **Deciders:** Paul Fremantle (pzfreo)
 
-> **Scheduling reality (corrected 2026-07-27).** Phase 1 (identity + `add_dimension`)
-> is reachable on today's machinery. Phases 2–4 were written as sitting behind "the
-> global recompose (#426/#707), the longest-open item on the roadmap" — **that premise
-> was stale when this ADR merged.** #426 and #661 closed 2026-07-19, #707 on 07-21, all
-> as completed; there is no open recompose issue.
+> **Scheduling reality — settled by implementation (2026-07-30).** Phases 1–3 have
+> shipped as epic **#867** (PR0–PR8, #868–#876). The question this header carried is
+> answered, and the answer was the cheap one it floated:
 >
-> Closed-as-umbrella is not the same as capability-landed, so the blocker is now an
-> open question rather than a stated fact (#867): #426's closing comment says the parity
-> work "remains observably incomplete", the #743 parity suite is skipped with strict
-> xfails underneath, and `drain_and_reconcile` solves registered corridors and reconciles
-> witness labels without reconstructing the automatic candidate population. There is also
-> a cheaper question inside it — **suppression by omission in a `Sheet` script happens
-> before `build()`**, when the set is known at plan time, so it may need no recompose at
-> all; only `Drawing.finalize()` dropping an *automatic* dimension does. Phase 2 may
-> therefore be substantially less blocked than this ADR assumed. The constraint below is
-> flagged in step.
+> **Suppression by omission needed no recompose at all.** In a `Sheet` script the authored
+> set is known *before* `build()`, so `plan_dimensions` marks the omissions and the
+> compiled plan withholds them — nothing has to be un-drawn afterwards. Only
+> `Drawing.finalize()` dropping an *automatic* dimension would need the global recompose,
+> and that is not what the authored set does. So phases 2–3 were never blocked on it, and
+> the "longest-open item on the roadmap" framing was doubly stale: the issues were closed
+> AND the dependency was not real.
+>
+> What the implementation did need was different and unanticipated: a **compiled-plan
+> boundary** (Amendment 1). Marking a dimension suppressed and trusting sixteen renderers
+> to check the flag failed sixteen times, so the mark became content renderers never
+> receive. That was #923's work, not scheduling.
+>
+> **Phase 4 (the emitter dimension-mirror) has not shipped and is not blocked on the
+> recompose either.** Its blocker is that emitted features have no names, so a
+> `dimension(...)` line in a generated script would address a feature by position and
+> break the moment a feature line is commented out — the documented editing workflow.
+> `emit_sheet_script` refuses an authored model rather than emit that. Tracked as **#922**.
 
 ## Amendment 1 — the compiled-plan boundary (2026-07-29)
 
@@ -790,8 +796,8 @@ absence both mean something exact** — which is all suppression-by-omission nee
   idempotence against the plan — but **suppressive intent additionally needs that identity
   to be stable across re-detection and recomposition**, which is why identity lands *with*
   the augmenting verb while suppression waits for the set boundary.
-- **Honest reconciliation needs the full recompose** *(status open — see the corrected
-  scheduling note above; #426/#707 are closed but the capability is unverified)*.
+- **Honest reconciliation needs the full recompose** *(the pre-build half is settled —
+  it needed no recompose; the post-build half is still open, see the scheduling note)*.
   Suppressing or re-emphasizing an *automatic* dimension means the finalize path must
   reconstruct the automatic candidate population and co-solve it with the declared
   intents — the global recompose ADR 0012 Amendment 1 records as still open. Note this
@@ -801,8 +807,9 @@ absence both mean something exact** — which is all suppression-by-omission nee
   reconcile against the auto-plan. So **augmenting intent (`add_dimension`) is reachable on
   today's machinery — it is simply a new candidate. Suppression splits into two paths that
   this ADR previously conflated:**
-  - **pre-build**, a `Sheet` script's authored set — known before the solve, so it plausibly
-    needs no reconstruction at all, and phase 2 can carry it;
+  - **pre-build**, a `Sheet` script's authored set — known before the solve, so it needs no
+    reconstruction at all. **Confirmed by #876**: the planner marks the omissions and the
+    compiled plan withholds them, so nothing is ever drawn to be un-drawn;
   - **post-build**, `Drawing.finalize()` dropping an *automatic* dimension — this is what
     needs the candidate-population reconstruction.
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -74,9 +74,17 @@ def _hole_line(f) -> str:
         kw.append(f"csink=({_n(f.csink[0])}, {_n(f.csink[1])})")
     if getattr(f, "thread", None):  # internal thread round-trips too (#859, symmetric with steps)
         kw.append(f"thread={f.thread!r}")
+    # Blindness is a FACT on the feature, so it round-trips whether or not a depth was
+    # measured. Guarding it on `depth is not None` emitted neither `through=False` nor a
+    # depth for a `HoleFeature(through=False, depth=None)`, and `declare.hole` defaults
+    # `through=True` — so the script rebuilt a THROUGH hole and the blindness vanished on
+    # the emit path (#878). Same rule as #868, which fixed the render side: a renderer (or
+    # an emitter) may not infer an engineering fact from a dimension's presence.
+    if not f.through and f.depth is None:
+        kw.append("through=False")
     line = f"sheet.hole({', '.join(kw)})"
     if not f.through and f.depth is not None:
-        line += f".depth({_n(f.depth)})"
+        line += f".depth({_n(f.depth)})"  # sets through=False too
     return line
 
 
@@ -94,8 +102,10 @@ def _member_hole_str(m) -> str:
         kw.append(f"csink=({_n(m.csink[0])}, {_n(m.csink[1])})")
     if getattr(m, "thread", None):  # a patterned threaded bore keeps its thread on re-run (#859)
         kw.append(f"thread={m.thread!r}")
-    if not m.through and m.depth is not None:
-        kw.append(f"depth={_n(m.depth)}")
+    # `through=False` independent of the depth — see `_hole_line` (#878).
+    if not m.through:
+        if m.depth is not None:
+            kw.append(f"depth={_n(m.depth)}")
         kw.append("through=False")
     return f"hole({', '.join(kw)})"
 

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -13,8 +13,11 @@ import pytest
 from build123d import Box, Cylinder, Pos, Shape, export_step
 
 from draftwright.builder import build_drawing, detect_part_model
+from draftwright.model.declare import hole as _declare_hole
 from draftwright.pmi import _PMI_AVAILABLE
 from draftwright.sheet_emit import (
+    _hole_line,
+    _member_hole_str,
     emit_sheet_script,
     generate_sheet_script,
     resolve_object_spec,
@@ -445,6 +448,43 @@ class TestEmit:
         part = Box(40, 40, 20) - Pos(0, 0, 6) * Cylinder(4, 16)  # blind ⌀8
         src = _script_for(part)
         assert ".depth(" in src
+
+    def test_a_blind_hole_with_no_measured_depth_stays_blind(self):
+        """Blindness is a FACT on the feature, so it must round-trip whether or not a depth
+        was measured.
+
+        Both emitters guarded `through=False` on `depth is not None`, so a
+        `HoleFeature(through=False, depth=None)` emitted neither — and `declare.hole`
+        defaults `through=True`, so the regenerated script declared a THROUGH hole and the
+        blindness vanished. This is #868's rule (a fact is not inferred from a dimension's
+        presence) applied to the emit side; after #868 fixed the render side, the two
+        disagreed about the same hole (#878).
+
+        The assertion is on the REBUILT feature, not on the emitted text: the point is that
+        the round trip preserves the fact, and an emitted-substring check would pass on any
+        spelling that happened to contain the token.
+        """
+        from draftwright import Sheet
+        from draftwright.model.ir import Frame, HoleFeature
+
+        blind = HoleFeature(Frame((0, 0, 0), "z"), 6.0, depth=None, through=False)
+        part = Box(40, 40, 20)
+        for line, prefix in (
+            (_hole_line(blind), "sheet.hole"),
+            # The pattern member goes through a second, independent emitter with the same
+            # bug — one fix per site, so one assertion per site.
+            (
+                f"sheet.pattern({_member_hole_str(blind)}, kind='linear', count=2, pitch=10)",
+                "sheet.pattern",
+            ),
+        ):
+            assert line.startswith(prefix)
+            sheet = Sheet(part, title="T", number="N").auto_dimensions()
+            exec(compile(line, "<emit>", "exec"), {"sheet": sheet, "hole": _declare_hole})  # noqa: S102
+            feature = sheet._features[-1]
+            rebuilt = getattr(feature, "member", feature)
+            assert rebuilt.through is False, f"{line} rebuilt a THROUGH hole"
+            assert rebuilt.depth is None
 
     def _bolt_circle(self, cbore=False):
         part = Cylinder(40, 8)


### PR DESCRIPTION
Closes #878. Also cleans up the ADR 0016 docs, which were wrong about the work that just merged in #925.

## The bug

Both hole emitters guarded `through=False` on the *depth* being present:

```python
if not f.through and f.depth is not None:   # _hole_line
if not m.through and m.depth is not None:   # _member_hole_str
```

So `HoleFeature(through=False, depth=None)` emitted **neither** `through=False` nor a depth, and `declare.hole` defaults `through=True`. The regenerated script declared a **through hole** — the blindness lost on the emit path, the #707 class of divergence.

This is **#868's rule at a different site**: a fact is not inferred from a dimension's presence. #868 fixed the render side (`hole_callout_spec` reads `feat.through`), which is what made this visible — the callout became correct for such a hole while the emitted script stayed wrong, so render and emit disagreed about the same feature.

## The fix

Option 1 from the issue: emit the fact independent of the depth, at both sites. Option 2 (make `declare.hole(through=False, depth=None)` raise) was not taken — on its own it leaves any detection-sourced case broken, and whether that state should exist at all is a separate judgement.

```
before:  sheet.hole(diameter=6, at=(0, 0, 0), axis="z")
after:   sheet.hole(diameter=6, at=(0, 0, 0), axis="z", through=False)
```

A measured blind hole is unchanged (`.depth(4)` already sets `through=False`).

## The canary

Asserts the **rebuilt feature**, not the emitted text: the property is that the round trip preserves the fact, and a substring check would pass on any spelling that happened to contain the token. Both emitters are exercised — they are independent sites with the same bug, and the pattern-member one is reached through a different call path.

Verified against `main`:

```
E   AssertionError: sheet.hole(diameter=6, at=(0, 0, 0), axis="z") rebuilt a THROUGH hole
```

## Docs, in the same PR because they were wrong about the same work

- **CLAUDE.md's ADR list stopped at 0015.** ADR 0016 was entirely absent despite its epic being complete — added, including what did *not* ship (the emitter dimension-mirror, #922) so the gap is visible from the index rather than only from deep in the ADR.
- **ADR 0016's scheduling header carried an open question that implementation settled.** It asked whether phase 2 was blocked on the global recompose and floated that it might not be. It was not: a `Sheet` script's authored set is known before `build()`, so the planner marks the omissions and the compiled plan withholds them — nothing is drawn that must be un-drawn. Recorded as answered, along with the note that what the work *did* need was unanticipated and structural (the compiled-plan boundary), not scheduling.
- The "honest reconciliation needs the full recompose" constraint now separates its **settled** pre-build half from its still-open post-build one, instead of marking the whole thing open.

**2114 passed** (full fast tier), all four lint checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)