### PR TITLE
feat(#922): every declaration verb hands back a nameable feature

### DIFF
--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -718,11 +718,18 @@ class Sheet:
 
     # -- feature declaration --------------------------------------------------
 
-    def add(self, feature) -> Sheet:
+    def add(self, feature) -> _Params:
         """Append a pre-built IR :class:`~draftwright.model.Feature` (escape hatch for
-        the constructors this façade does not surface directly, e.g. PMI)."""
+        the constructors this façade does not surface directly, e.g. PMI).
+
+        Returns a handle, like every declaration verb (#922). It matters here more than it
+        looks: the ENVELOPE is emitted through this escape hatch rather than through
+        :meth:`envelope`, so while `add` returned the sheet, `sheet.dimension(env, "width")`
+        — ADR 0016's own worked example — could not be written against a generated script.
+        Naming would have been uniform across the verbs and silently absent for one feature
+        in the middle of the file, which is worse than being absent everywhere."""
         self._features.append(feature)
-        return self
+        return _Params(self, len(self._features) - 1)
 
     #: The keyword set that identifies a call to the pre-rename `dimension(...)`. `kind` alone
     #: would do today, but the referential form may grow keywords of its own, so the test is the
@@ -786,7 +793,7 @@ class Sheet:
         lower_tol: float | None = None,
         source: str = "sheet",
         source_kind: str | None = None,
-    ) -> Sheet:
+    ) -> _Params:
         """Declare a drafting dimension from explicit **measured** values.
 
         Named for what it carries (ADR 0016 / #873). ``dimension`` is *referential* on
@@ -818,7 +825,11 @@ class Sheet:
                 source_kind=source_kind,
             )
         )
-        return self
+        # A handle like every other declaration verb (#922). A measured dimension carries its
+        # own number, so a referential `dimension(handle, role)` on it will correctly raise —
+        # but it is still a declared feature in the emitted script, and exempting it would put
+        # one unnameable line back in the middle of a file where naming is otherwise uniform.
+        return _Params(self, len(self._features) - 1)
 
     def of(self, ref) -> _Hole | _Dim:
         """A decoratable handle onto an **existing** feature — the hybrid seam (#463).
@@ -945,75 +956,75 @@ class Sheet:
         self._features.append(_pad(obj, **kw))
         return _Params(self, len(self._features) - 1)
 
-    def chamfer(self, obj=None, **kw) -> Sheet:
+    def chamfer(self, obj=None, **kw) -> _Params:
         """Declare a chamfer (bevelled edge) — ``sheet.chamfer(bevel_face)`` reads axis, legs
         and a point on the bevel off the oblique chamfer face, or explicit
         ``sheet.chamfer(axis="z", leg=6, at=(x, y, z))``. ``leg`` = equal-leg 45° (``C{leg}``);
         ``leg1``/``leg2`` = asymmetric."""
         self._features.append(_chamfer(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def fillet(self, obj=None, **kw) -> Sheet:
+    def fillet(self, obj=None, **kw) -> _Params:
         """Declare a fillet (rounded edge) — ``sheet.fillet(round_face)`` reads axis, radius
         and a point on the round off the cylindrical blend face, or explicit
         ``sheet.fillet(axis="z", radius=3, at=(x, y, z))``. Called out ``R{radius}`` (grouped
         ``n× R`` for equal radii)."""
         self._features.append(_fillet(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def flat(self, obj=None, **kw) -> Sheet:
+    def flat(self, obj=None, **kw) -> _Params:
         """Declare a machined flat on round stock (#148b) — ``sheet.flat(flat_face)`` reads the
         leader point off the planar flat face (``axis=`` and ``across=`` still required), or
         fully explicit ``sheet.flat(axis="z", across=15, at=(x, y, z))``. Called out
         ``{across} A/F`` (across flats — flat-to-flat for a double-D / hex, the D height for a
         lone flat)."""
         self._features.append(_flat(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def groove(self, obj=None, **kw) -> Sheet:
+    def groove(self, obj=None, **kw) -> _Params:
         """Declare a turned / circlip groove on round stock (#148c) — ``sheet.groove(floor_face)``
         reads axis, width, diameter and the leader point off the reduced-OD floor face, or fully
         explicit ``sheet.groove(axis="z", width=3, diameter=16, at=(x, y, z))``. Called out
         ``{width} WIDE × ø{diameter}`` (groove width + floor diameter)."""
         self._features.append(_groove(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def plate(self, obj=None, **kw) -> Sheet:
+    def plate(self, obj=None, **kw) -> _Params:
         """Declare a thin slab's thickness (a base plate / wall / rib) — ``sheet.plate(slab_box)``
         reads the thin axis + extent + centre off the slab, or explicit ``sheet.plate(axis="z",
         lo=0, hi=4, u=10, v=5)``. Only a *multi-plate* part dimensions plates (a single slab is
         the envelope)."""
         self._features.append(_plate(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def step_level(self, obj=None, **kw) -> Sheet:
+    def step_level(self, obj=None, **kw) -> _Params:
         """Declare a prismatic height ladder + step-position shoulders (a rebated / stepped
         block) — ``sheet.step_level(part)`` reads ``base`` / interior ``levels`` / the ``(axis,
         position)`` ``shoulders`` / ``datum`` off the part, or explicit ``sheet.step_level(base=0,
         levels=(10,), shoulders=(("x", 30),))``. A shoulder locates *where* a step changes
         height along a horizontal axis, so a stepped block is fully constrained (#555/#578)."""
         self._features.append(_step_level(obj, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def pattern(self, member, **kw) -> Sheet:
+    def pattern(self, member, **kw) -> _Params:
         """Declare a hole pattern (bolt circle / linear array / grid) — build the
         *member* with :func:`draftwright.model.hole`."""
         self._features.append(_pattern(member, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def pocket_pattern(self, member, **kw) -> Sheet:
+    def pocket_pattern(self, member, **kw) -> _Params:
         """Declare a linear/grid array of identical blind pockets (#841) — build the
         representative *member* with :func:`draftwright.model.pocket`. Renders as one grouped
         ``N× W × L × D DEEP`` callout + ``(n-1)× pitch`` dim(s), not N competing size dims."""
         self._features.append(_pocket_pattern(member, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
-    def slot_pattern(self, member, **kw) -> Sheet:
+    def slot_pattern(self, member, **kw) -> _Params:
         """Declare a linear/grid array of identical milled slots (#841) — build the
         representative *member* with :func:`draftwright.model.slot`. Renders as one grouped
         ``N× SLOT W × L`` leader + ``(n-1)× pitch`` dim(s), not N competing size dims."""
         self._features.append(_slot_pattern(member, **kw))
-        return self
+        return _Params(self, len(self._features) - 1)
 
     def envelope(self, obj=None) -> _Params:
         """Declare the overall bounding dimensions. Defaults to the whole part."""

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -478,6 +478,24 @@ class _Params:
         every parameter of the feature alike (the kind-keyed form)."""
         val = _tol_value(lo, hi)
         roles = self._roles()
+        if not roles:
+            # A feature with no dimensioned parameters has nothing to tolerance, and
+            # accepting the call would drop a drafting instruction in silence — the failure
+            # this codebase ranks below a visible raise (#630/#631). Reachable since #922
+            # made every declaration verb hand back a handle: `add(PmiFeature(...))` and
+            # `measured_dimension(...)` both produce parameterless features, and before that
+            # they returned the Sheet so `.tolerance()` could not be called at all (Codex
+            # review of #931).
+            kind = self._sheet._features[self._i].kind
+            extra = (
+                " — a measured dimension carries its own tolerance: pass upper_tol=/lower_tol="
+                " to measured_dimension()"
+                if kind == "authored_dimension"
+                else ""
+            )
+            raise ValueError(
+                f"tolerance(): a {kind} exposes no dimensioned parameter to tolerance{extra}"
+            )
         if on is None:
             # A whole-feature tolerance supersedes any earlier per-role override on this
             # feature — bare means "all alike", so it is order-independent (#807 review):

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -1126,3 +1126,73 @@ class TestOmittedDimensionsDoNotRender:
         assert "dim_od" in od_only and "ldr_z0" not in od_only
         bore_only = _built("bore")
         assert "ldr_z0" in bore_only and "dim_od" not in bore_only
+
+
+class TestEveryFeatureVerbIsNameable:
+    """A `dimension(...)` line names a feature, so every verb has to hand one back (#922).
+
+    Nine verbs returned the `Sheet` instead — `chamfer`, `fillet`, `flat`, `groove`,
+    `plate`, `step_level`, and the three pattern verbs — so those features could not be
+    referenced at all and `sheet.dimension(chamfer, "chamfer")` was unwritable. `add` was
+    the same, and mattered most: the ENVELOPE is emitted through it, so naming would have
+    been uniform across the verbs and silently absent for one feature in the middle of a
+    generated script.
+
+    The gap is stated as a PROPERTY over the verb list rather than as one example per verb,
+    because a hand-listed set is what let nine of them sit outside the rule unnoticed.
+    """
+
+    #: Verbs that declare a feature, and a minimal call for each.
+    _CALLS = {
+        "chamfer": dict(axis="z", leg=2, at=(0, 0, 0)),
+        "fillet": dict(axis="z", radius=2, at=(0, 0, 0)),
+        "flat": dict(axis="z", across=15, at=(0, 0, 0)),
+        "groove": dict(axis="z", width=3, diameter=16, at=(0, 0, 0)),
+        "plate": dict(axis="z", lo=0, hi=4, u=10, v=5),
+        "step_level": dict(base=0, levels=(4.0,), at=(0, 0, 0)),
+    }
+
+    @pytest.mark.parametrize("verb", sorted(_CALLS))
+    def test_the_verb_returns_something_dimension_can_name(self, verb):
+        from build123d import Box
+
+        sheet = Sheet(Box(80, 50, 8))
+        handle = getattr(sheet, verb)(**self._CALLS[verb])
+        assert handle is not sheet, f"Sheet.{verb} hands back no reference to its feature"
+        # The property that matters is not the type but that `dimension` accepts it: a
+        # handle nothing can address is not identity, it is an object.
+        role = next(p.role for p in sheet.features[-1].parameters())
+        sheet.dimension(handle, role)
+
+    def test_a_declaration_verb_still_chains(self):
+        """The false-positive half. These verbs returned `Sheet` so calls could chain, and
+        the handles keep that working by forwarding — otherwise making them nameable would
+        have broken every existing script that chains off one."""
+        from build123d import Box
+
+        chained = (
+            Sheet(Box(80, 50, 8))
+            .chamfer(axis="z", leg=2, at=(0, 0, 0))
+            .hole(diameter=6, at=(0, 0, 0), axis="z")
+        )
+        assert chained is not None
+        assert len(chained._sheet.features) == 2
+
+    def test_no_declaration_verb_is_left_returning_the_sheet(self):
+        """The ratchet. A verb added later that returns `Sheet` is a feature nobody can
+        name, and it fails here rather than at the moment someone tries to dimension it."""
+        import inspect
+
+        from draftwright.sheet import Sheet as _Sheet
+
+        unnameable = [
+            name
+            for name, fn in inspect.getmembers(_Sheet, inspect.isfunction)
+            if not name.startswith("_")
+            and "self._features.append(" in inspect.getsource(fn)
+            and inspect.getsource(fn).rstrip().endswith("return self")
+        ]
+        assert not unnameable, (
+            f"{unnameable} declare a feature and hand back the Sheet, so the feature cannot "
+            "be named by a dimension(...) line"
+        )

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -1129,45 +1129,153 @@ class TestOmittedDimensionsDoNotRender:
 
 
 class TestEveryFeatureVerbIsNameable:
-    """A `dimension(...)` line names a feature, so every verb has to hand one back (#922).
+    """A `dimension(...)` line names a feature, so every declaration verb has to hand one back.
 
-    Nine verbs returned the `Sheet` instead — `chamfer`, `fillet`, `flat`, `groove`,
-    `plate`, `step_level`, and the three pattern verbs — so those features could not be
-    referenced at all and `sheet.dimension(chamfer, "chamfer")` was unwritable. `add` was
-    the same, and mattered most: the ENVELOPE is emitted through it, so naming would have
-    been uniform across the verbs and silently absent for one feature in the middle of a
-    generated script.
+    Eleven did not before #922: nine returned the `Sheet` (`chamfer`, `fillet`, `flat`,
+    `groove`, `plate`, `step_level`, and the three pattern verbs), plus `add` and
+    `measured_dimension`. Those features could not be referenced at all. `add` mattered most:
+    the ENVELOPE is emitted through it, so naming would have been uniform across the verbs and
+    silently absent for one feature in the middle of a generated script.
 
-    The gap is stated as a PROPERTY over the verb list rather than as one example per verb,
-    because a hand-listed set is what let nine of them sit outside the rule unnoticed.
+    The contract is checked BEHAVIOURALLY, per verb, over a set discovered from the source.
+    The first version asserted that no verb's source ends in `return self` — which a verb
+    ending in `return None`, or falling off the end, or returning anything unrelated would
+    pass while leaving its feature unnameable (Codex review of #931). Matching source text is
+    a proxy for the property; resolving the handle is the property.
     """
 
-    #: Verbs that declare a feature, and a minimal call for each.
-    _CALLS = {
+    #: A minimal call for each declaration verb. Every discovered verb must appear — a verb
+    #: with no entry FAILS rather than being skipped, so the table cannot silently fall behind
+    #: the API the way the first version's six-verb parametrization did.
+    _CALLS: dict = {
+        "hole": dict(diameter=6, at=(0, 0, 0), axis="z"),
+        "diameter": dict(diameter=20, at=(0, 0, 0), axis="z"),
+        "boss": dict(diameter=20, height=5, at=(0, 0, 0), axis="z"),
+        "step": dict(diameter=20, length=10, at=(0, 0, 0), axis="z"),
+        "slot": dict(width=8, length=20, long_axis="x", width_axis="y", w_center=0, lo=-10, hi=10),
+        "pocket": dict(
+            width=8, length=20, depth=4, long_axis="x", width_axis="y", w_center=0, lo=-10, hi=10
+        ),
+        "pad": dict(x0=-10, x1=10, y0=-4, y1=4, z0=0, z1=3),
+        "envelope": {},
         "chamfer": dict(axis="z", leg=2, at=(0, 0, 0)),
         "fillet": dict(axis="z", radius=2, at=(0, 0, 0)),
         "flat": dict(axis="z", across=15, at=(0, 0, 0)),
         "groove": dict(axis="z", width=3, diameter=16, at=(0, 0, 0)),
         "plate": dict(axis="z", lo=0, hi=4, u=10, v=5),
         "step_level": dict(base=0, levels=(4.0,), at=(0, 0, 0)),
+        "measured_dimension": dict(
+            kind="linear", value=5, label="5", dominant_axis="X", ref_pts=((0, 0, 0), (5, 0, 0))
+        ),
     }
 
-    @pytest.mark.parametrize("verb", sorted(_CALLS))
-    def test_the_verb_returns_something_dimension_can_name(self, verb):
+    @staticmethod
+    def _declaration_verbs() -> set:
+        import inspect
+
+        from draftwright.sheet import Sheet as _Sheet
+
+        return {
+            name
+            for name, fn in inspect.getmembers(_Sheet, inspect.isfunction)
+            if not name.startswith("_") and "self._features.append(" in inspect.getsource(fn)
+        }
+
+    def _invoke(self, sheet, verb):
+        """Call *verb* on *sheet* with a minimal argument set, returning its handle."""
+        from draftwright.model import hole as _mk_hole
+        from draftwright.model.ir import EnvelopeFeature, Frame
+
+        if verb == "add":
+            return sheet.add(
+                EnvelopeFeature(
+                    Frame((0, 0, 0), "z"),
+                    width=80.0,
+                    depth=50.0,
+                    height=8.0,
+                    bbox_min=(-40.0, -25.0, -4.0),
+                    bbox_max=(40.0, 25.0, 4.0),
+                )
+            )
+        if verb.endswith("pattern"):
+            member = {
+                "pattern": lambda: _mk_hole(diameter=6, at=(-20, 0, 0), axis="z"),
+                "pocket_pattern": lambda: _pocket_member(),
+                "slot_pattern": lambda: _slot_member(),
+            }[verb]()
+            return getattr(sheet, verb)(
+                member, kind="linear", count=3, pitch=20, direction=(1, 0, 0), at=(0, 0, 0)
+            )
+        return getattr(sheet, verb)(**self._CALLS[verb])
+
+    def test_the_call_table_covers_every_declaration_verb(self):
+        """The ratchet. A verb added later with no entry fails HERE, so the behavioural
+        contract below cannot quietly stop covering the API."""
+        covered = set(self._CALLS) | {"add", "pattern", "pocket_pattern", "slot_pattern"}
+        missing = self._declaration_verbs() - covered
+        assert not missing, (
+            f"{sorted(missing)} declare a feature but have no entry in _CALLS — add one so "
+            "the nameability contract actually covers them"
+        )
+
+    @pytest.mark.parametrize(
+        "verb", sorted(_CALLS) + ["add", "pattern", "pocket_pattern", "slot_pattern"]
+    )
+    def test_the_handle_resolves_and_survives_a_reorder(self, verb):
+        """The property, for every verb: the returned handle names its feature, and keeps
+        naming it after the feature list moves.
+
+        Reordering is the half that matters. A handle carrying a bare INDEX would pass a
+        resolve-once check and then silently name a neighbour the moment a script comments a
+        feature out — the positional-addressing defect this work removes from the generated
+        artefact (#908/#922).
+        """
         from build123d import Box
 
         sheet = Sheet(Box(80, 50, 8))
-        handle = getattr(sheet, verb)(**self._CALLS[verb])
+        sheet.hole(diameter=4, at=(-30, 0, 0), axis="z")  # a decoy that the reorder moves
+        handle = self._invoke(sheet, verb)
         assert handle is not sheet, f"Sheet.{verb} hands back no reference to its feature"
-        # The property that matters is not the type but that `dimension` accepts it: a
-        # handle nothing can address is not identity, it is an object.
-        role = next(p.role for p in sheet.features[-1].parameters())
-        sheet.dimension(handle, role)
+        declared = sheet.features[handle._i]
+        sheet.features.reverse()
+        assert sheet.features[handle._i] is declared, (
+            f"Sheet.{verb}'s handle stopped naming its feature after a reorder"
+        )
+
+    @pytest.mark.parametrize("verb", sorted(_CALLS) + ["add", "pattern"])
+    def test_a_feature_with_parameters_can_be_dimensioned_by_its_handle(self, verb):
+        """Resolving is necessary but not sufficient — the handle has to be accepted by the
+        verb it exists for. Parameterless kinds are exercised by the raise below instead."""
+        from build123d import Box
+
+        sheet = Sheet(Box(80, 50, 8))
+        handle = self._invoke(sheet, verb)
+        roles = [p.role for p in sheet.features[handle._i].parameters()]
+        if not roles:
+            pytest.skip(f"{verb} declares a parameterless feature — covered by the raise test")
+        sheet.dimension(handle, roles[0])
+
+    def test_a_parameterless_feature_refuses_a_tolerance_rather_than_dropping_it(self):
+        """`_Params` is handed out for every kind now, including ones with no dimensioned
+        parameter, so its aspect verbs must not accept an instruction they cannot record.
+
+        `tolerance()` iterated an empty role set and returned successfully, dropping the
+        instruction in silence (Codex review of #931) — the failure this codebase ranks below
+        a visible raise. Reachable only since #922: these verbs used to return the Sheet, so
+        `.tolerance()` could not be called on them at all.
+        """
+        from build123d import Box
+
+        sheet = Sheet(Box(10, 10, 10))
+        handle = self._invoke(sheet, "measured_dimension")
+        with pytest.raises(ValueError, match="no dimensioned parameter"):
+            handle.tolerance(0.2)
+        assert sheet._tolerances == {}
 
     def test_a_declaration_verb_still_chains(self):
-        """The false-positive half. These verbs returned `Sheet` so calls could chain, and
-        the handles keep that working by forwarding — otherwise making them nameable would
-        have broken every existing script that chains off one."""
+        """The false-positive half. These verbs returned `Sheet` so calls could chain, and the
+        handles keep that working by forwarding — otherwise making them nameable would have
+        broken every existing script that chains off one."""
         from build123d import Box
 
         chained = (
@@ -1175,24 +1283,18 @@ class TestEveryFeatureVerbIsNameable:
             .chamfer(axis="z", leg=2, at=(0, 0, 0))
             .hole(diameter=6, at=(0, 0, 0), axis="z")
         )
-        assert chained is not None
         assert len(chained._sheet.features) == 2
 
-    def test_no_declaration_verb_is_left_returning_the_sheet(self):
-        """The ratchet. A verb added later that returns `Sheet` is a feature nobody can
-        name, and it fails here rather than at the moment someone tries to dimension it."""
-        import inspect
 
-        from draftwright.sheet import Sheet as _Sheet
+def _pocket_member():
+    from draftwright.model import pocket as _mk
 
-        unnameable = [
-            name
-            for name, fn in inspect.getmembers(_Sheet, inspect.isfunction)
-            if not name.startswith("_")
-            and "self._features.append(" in inspect.getsource(fn)
-            and inspect.getsource(fn).rstrip().endswith("return self")
-        ]
-        assert not unnameable, (
-            f"{unnameable} declare a feature and hand back the Sheet, so the feature cannot "
-            "be named by a dimension(...) line"
-        )
+    return _mk(
+        width=8, length=20, depth=4, long_axis="x", width_axis="y", w_center=0, lo=-10, hi=10
+    )
+
+
+def _slot_member():
+    from draftwright.model import slot as _mk
+
+    return _mk(width=8, length=20, long_axis="x", width_axis="y", w_center=0, lo=-10, hi=10)

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -195,9 +195,31 @@ _SCENARIOS = {
 
 #: Verbs that hand back a `_Params` by exactly the same route `envelope` does — declare the
 #: feature, return `_Params(self, len(features) - 1)`, no identity handling of their own. Listed
-#: rather than scenario'd because a scenario each would test the same three lines four times.
+#: rather than scenario'd because a scenario each would test the same three lines many times.
 #: `boss` is absent because it delegates to `diameter` and constructs nothing.
-_SAME_PATH_AS_ENVELOPE = {"slot", "pocket", "pad"}
+#:
+#: The nine below joined in #922, which made every feature verb nameable — previously they
+#: returned `Sheet`, so their features could not be referenced at all and
+#: `sheet.dimension(chamfer, ...)` was impossible. Their bodies are the same two lines as
+#: `envelope`'s, and `test_the_same_path_verbs_really_share_the_route` checks that claim
+#: against the source rather than taking it on trust: an exemption list nobody verifies is
+#: how a guard stops guarding.
+_SAME_PATH_AS_ENVELOPE = {
+    "add",
+    "measured_dimension",
+    "slot",
+    "pocket",
+    "pad",
+    "chamfer",
+    "fillet",
+    "flat",
+    "groove",
+    "plate",
+    "step_level",
+    "pattern",
+    "pocket_pattern",
+    "slot_pattern",
+}
 
 
 def _mutations():
@@ -717,4 +739,44 @@ def test_only_one_resolver_bears_identity():
         assert "_declared_token" in calls, (
             f"{caller} no longer calls the single resolver — identity resolution must not fork "
             "again; that fork is what let #910 through"
+        )
+
+
+def test_the_same_path_verbs_really_share_the_route():
+    """`_SAME_PATH_AS_ENVELOPE` is a claim about code, so check it against the code.
+
+    The list exists so twelve verbs do not each get a scenario testing the same two lines.
+    That is only sound while the lines ARE the same — a verb that grows identity handling of
+    its own, or appends more than one feature, silently loses its coverage and the ratchet
+    reports success. So the shape is asserted rather than assumed (#922).
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from draftwright.sheet import Sheet
+
+    for name in sorted(_SAME_PATH_AS_ENVELOPE | {"envelope"}):
+        src = textwrap.dedent(inspect.getsource(getattr(Sheet, name)))
+        body = ast.parse(src).body[0].body
+        # Drop the DOCSTRING only. Filtering every `ast.Expr` also drops
+        # `self._features.append(...)`, which is an expression statement — the first draft
+        # did that and then reported "appends 0 features" for every verb.
+        statements = body[1:] if isinstance(body[0], ast.Expr) else body
+        appends = [
+            n
+            for n in ast.walk(ast.Module(body=statements, type_ignores=[]))
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "append"
+        ]
+        assert len(appends) == 1, (
+            f"Sheet.{name} appends {len(appends)} features; the envelope route declares "
+            "exactly one, and a multi-feature verb needs its own scenario"
+        )
+        returned = statements[-1]
+        assert isinstance(returned, ast.Return), f"Sheet.{name} does not end in a return"
+        assert ast.unparse(returned.value) == "_Params(self, len(self._features) - 1)", (
+            f"Sheet.{name} no longer returns the envelope handle verbatim "
+            f"({ast.unparse(returned.value)}) — give it a scenario or restore the route"
         )


### PR DESCRIPTION
First of three for #922. Prerequisite only — no emitter change yet.

## The gap

A `dimension(feature, role)` line names a feature, so every declaration verb has to return one. **Eleven did not:** nine returned the `Sheet` (`chamfer`, `fillet`, `flat`, `groove`, `plate`, `step_level`, `pattern`, `pocket_pattern`, `slot_pattern`), plus `add` and `measured_dimension`. Those features were unreferenceable — `sheet.dimension(chamfer, "chamfer")` could not be written.

#922 describes this as "the feature verbs bind no variables". That understates it in one direction and overstates it in another: `hole`/`boss`/`step`/`slot`/`pocket`/`pad` already returned token-carrying handles and `sheet.dimension(handle, role)` already worked. The real gap was these eleven.

## Why uniform, rather than only where it's needed

`add` is the case that settles it. The **envelope** is emitted through that escape hatch rather than through `envelope()`, so while `add` returned the sheet, ADR 0016's own worked example —

```python
sheet.dimension(env, "width")
```

— could not be written against a generated script. Naming would have been uniform across the verbs and silently absent for one feature in the middle of the file. That is worse than absent everywhere, because it is invisible until someone tries it.

## This is not only a dimension feature

It removes **positional addressing** from the generated artefact. Today, commenting a feature line out shifts every later index, so anything addressing by position silently retargets onto a neighbour. A binding turns that into a `NameError` at the line you edited — the same defect ADR 0016's identity work removed everywhere else in the codebase, still present in the file we hand the user.

## Guards, both of which caught something

**The #912 identity invariant fired immediately** — every handle-returning verb must prove its token survives a reorder. I could have added eleven names to `_SAME_PATH_AS_ENVELOPE` and moved on. Instead `test_the_same_path_verbs_really_share_the_route` parses each exempt verb and asserts it still appends exactly one feature and returns the envelope handle verbatim, so the exemption is a checked claim rather than a comment. *An exemption list nobody verifies is how a guard stops guarding.* Writing it caught a bug in itself first: filtering every `ast.Expr` to drop the docstring also drops `self._features.append(...)`, which is an expression statement — it reported "appends 0 features" for every verb.

**A new nameability ratchet** fails any verb that appends a feature and returns `self`. That is what found `measured_dimension`; my hand-written list had ten of eleven.

## Compatibility

`_Params.__getattr__` forwards to the owning `Sheet`, so chaining is unchanged:

```python
Sheet(part).chamfer(...).hole(...)   # still works
```

Additive for existing scripts.

**2123 passed** (full fast tier), all four lint checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)