### PR TITLE
fix(#889): give the overall height an intent, so a generated script can replay it

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2822,6 +2822,33 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     return _draw_step_chain(dwg, view, fsegs, "m_steplen", ctx=ctx, start=start)
 
 
+def ladder_plan_for(plan, *, step_height: bool, overall: bool):
+    """*plan* narrowed to the ladders a caller actually asked :func:`render_height_ladder` for.
+
+    The renderer draws TWO independent things — a `step_level` feature's correlated rungs and
+    the envelope/bbox overall height — and reads a third, `step_position`, only for its
+    PRESENCE (short-rung placement). Handing it a plan containing more than was asked for
+    draws more than was asked for: the #889 drain passed the whole compiled plan once either
+    intent was recorded, so `overall_height()` alone also rebuilt the step rungs — a
+    dimension nobody recorded, and live/deferred divergence in the one PR relying on their
+    equivalence (#934 review).
+
+    Exists so the live verb and the finalize drain project the plan the SAME way. Two
+    spellings of "which ladders did they ask for" is how they diverged in the first place.
+
+    `step_position` rides `step_height`: it is not content here, it is how those rungs are
+    placed, so it is meaningless without them.
+    """
+    from dataclasses import replace
+
+    kinds = []
+    if step_height:
+        kinds += ["step_height", "step_position"]
+    if overall:
+        kinds.append("overall_height")
+    return replace(plan, ladders=tuple(lad for lad in plan.ladders if lad.kind in kinds))
+
+
 def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) -> int:
     """Front-view right ladder: prismatic step heights stacked inner→outer, then the overall
     height outermost — registered as :class:`CorridorCandidate`s in the shared

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1054,6 +1054,21 @@ def _feature_listing(a: Analysis) -> str:
         for p in feat.parameters():
             if p.span is not None or kind in ("slot", "pad"):
                 body.append(f'dwg.dimension(f, "{p.kind}", role="{p.role}")   # {display(p)}')
+    # The overall height, when it comes from the compiler's BOUNDING-BOX fallback rather
+    # than from an `EnvelopeFeature`. An enveloped model already emitted
+    # `dimension(f, "length", role="height")` in the loop above; a model without one has no
+    # feature to name, so the replay simply lost the dimension — silently and lint-clean
+    # (#889). `overall_height()` is the verb for exactly that case.
+    if not any(f.kind == "envelope" for f in feats):
+        from draftwright.model.compiled import compile_dimensions
+
+        if compile_dimensions(model).ladder("overall_height") is not None:
+            body += [
+                "",
+                "# Overall height (from the bounding box — this part declares no envelope",
+                "# feature, so there is none to hang a dimension(...) intent on).",
+                "dwg.overall_height()",
+            ]
     if plan_sections(model, feature_hole_keys(model, a)) is not None:
         body += [
             "",

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -192,6 +192,9 @@ class _IntentRouting:
     len_ids: set
     slot_ids: set
     height_ladder_ids: set
+    #: `Drawing.overall_height()` intents — the bbox-fallback overall height, which has no
+    #: feature to hang a `dimension(...)` intent on (#889).
+    overall_height_ids: set
     step_position_ids: set
     explicit_envelope_height: bool
     user_dim_ids: set
@@ -1212,6 +1215,53 @@ class Drawing:
             self, feature, self._part_model, self._analysis, view=view, name=name, ctx=ctx
         )
 
+    def overall_height(self) -> list[str]:
+        """Add the part's **overall height** — the one dimension with no feature to name.
+
+        Every other add verb takes a feature, because every other dimension belongs to one.
+        The overall height usually does too: a model with an `EnvelopeFeature` carries a
+        `height` parameter, and `dimension(env, "length", role="height")` is the verb for it.
+
+        A model WITHOUT one still gets an overall height — the compiler falls back to the
+        bounding box, which is a decision only the compiler may make (`_compile_overall_height`).
+        There is then no feature to record an intent against, so an intent-level script had no
+        way to say "and the 46 mm overall height", and a generated script replayed without it,
+        silently and lint-clean (#889).
+
+        This verb is that line. It is deliberately NOT "draw it whenever the compiler approves
+        one": `auto_dims=False` means the verbs are the whole drawing, so a dimension nobody
+        recorded must not appear — record-then-finalize has to equal placing live.
+
+        Returns the placed names (empty when the compiler withholds the height — a Z-turned
+        part whose step chain already tiles it, or an X/Y rotational OD that conveys it).
+        """
+        if self._defer_intents:  # #426: record, don't place — finalize() drains it
+            self._intents.append(Intent("overall_height", None, {}))
+            return []
+        model, a = self._part_model, self._analysis
+        if model is None or a is None:
+            raise ValueError("overall_height(): no detected model — build the drawing first")
+        from draftwright._core import layout_frame
+        from draftwright.annotations._common import drain_corridors
+        from draftwright.annotations.from_model import render_height_ladder
+        from draftwright.model.compiled import RenderableDimensionPlan, compile_dimensions
+
+        before = set(self.annotations())
+        ctx = PlacementContext(registry=self._registry, coverage=self._coverage, items=self.items)
+        overall = compile_dimensions(model).ladder("overall_height")
+        if overall is not None:
+            # ONLY the overall height: passing the whole plan would also rebuild the step
+            # ladder, which is a different intent with its own verb.
+            render_height_ladder(
+                self,
+                RenderableDimensionPlan(ladders=(overall,)),
+                layout_frame(a),
+                ctx=ctx,
+                detail_view=self._build.detail_view,
+            )
+            drain_corridors(ctx, self)
+        return sorted(set(self.annotations()) - before)
+
     def furniture(self, feature, *, view=None) -> list[str]:
         """Add a hole/pattern's non-dimensional **sheet furniture** (#419) — centre marks
         (every member) plus a pattern's centre-cross (bolt circle) or pitch/grid dims.
@@ -1448,6 +1498,7 @@ class Drawing:
             and it.kwargs.get("param") == "length"
             and it.kwargs.get("role") in (None, "step_height")
         }
+        overall_height_ids = {id(it) for it in self._intents if it.kind == "overall_height"}
         explicit_envelope_height = any(
             routable
             and it.kind == "dimension"
@@ -1529,6 +1580,7 @@ class Drawing:
             len_ids=len_ids,
             slot_ids=slot_ids,
             height_ladder_ids=height_ladder_ids,
+            overall_height_ids=overall_height_ids,
             step_position_ids=step_position_ids,
             explicit_envelope_height=explicit_envelope_height,
             user_dim_ids=user_dim_ids,
@@ -1825,6 +1877,7 @@ class Drawing:
                 | r.len_ids
                 | r.slot_ids
                 | r.height_ladder_ids
+                | r.overall_height_ids  # drained by _s_height_ladder
                 | r.step_position_ids
                 | r.user_dim_ids
                 | r.rotational_ids  # drained by _s_rotational; no _replay_intent branch
@@ -1904,21 +1957,36 @@ class Drawing:
             # only REGISTERS ladder candidates; they place at the drain. Their intents
             # drop there (with step positions), NOT here — a raise before the drain
             # leaves them recorded so a retry rebuilds the batch (#639).
-            if r.height_ladder_ids:
-                assert a is not None and isinstance(model, PartModel)
-                from draftwright._core import layout_frame
-                from draftwright.model.compiled import compile_dimensions
+            # Two things share this renderer, and they are gated separately (#889).
+            #
+            # The step-height LADDER is a `step_level` feature's correlated rungs, so one
+            # recorded intent means "rebuild the whole chain". The OVERALL HEIGHT is envelope
+            # furniture — and on a part with NO `EnvelopeFeature` it comes from the compiler's
+            # bounding-box fallback, so there is no feature to record `dimension(env,
+            # "length", role="height")` against. `Drawing.overall_height()` is the verb for
+            # that case, and `r.overall_height_ids` is its intent.
+            #
+            # Deliberately NOT "draw it whenever the compiler approves one": `auto_dims=False`
+            # means the verbs below add everything, so injecting an automatic dimension nobody
+            # recorded breaks record-then-finalize == place-live, which is the whole contract
+            # of the deferred path (caught by `test_finalize_replay_equals_live_placement`).
+            if not (r.height_ladder_ids or r.overall_height_ids):
+                return
+            assert a is not None and isinstance(model, PartModel)
+            from draftwright._core import layout_frame
+            from draftwright.model.compiled import compile_dimensions
 
-                render_height_ladder(
-                    self,
-                    # `include_overall` is drawing state, so it is an input to the COMPILE
-                    # (whether the overall height is in the set) rather than something the
-                    # renderer decides after the fact.
-                    compile_dimensions(model, include_overall=not r.explicit_envelope_height),
-                    layout_frame(a),
-                    ctx=ctx,
-                    detail_view=self._build.detail_view,
-                )
+            render_height_ladder(
+                self,
+                # `include_overall` is drawing state, so it is an input to the COMPILE
+                # (whether the overall height is in the set) rather than something the
+                # renderer decides after the fact. An explicit `role="height"` intent draws it
+                # through the dimension path instead, so the compile must leave it out.
+                compile_dimensions(model, include_overall=not r.explicit_envelope_height),
+                layout_frame(a),
+                ctx=ctx,
+                detail_view=self._build.detail_view,
+            )
 
         def _s_step_positions():
             # Prismatic step positions (all shoulders) — registration-only, like the
@@ -2106,6 +2174,7 @@ class Drawing:
                 or r.user_dim_ids
                 or r.step_position_ids
                 or r.height_ladder_ids
+                or r.overall_height_ids
             ):
                 assert a is not None and isinstance(model, PartModel)  # either ⟹ routable
                 drain_and_reconcile(ctx, self)
@@ -2120,6 +2189,7 @@ class Drawing:
                     | queued_dim_ids
                     | r.step_position_ids
                     | r.height_ladder_ids
+                    | r.overall_height_ids
                 )
             ]
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1235,10 +1235,28 @@ class Drawing:
         Returns the placed names (empty when the compiler withholds the height — a Z-turned
         part whose step chain already tiles it, or an X/Y rotational OD that conveys it).
         """
+        model, a = self._part_model, self._analysis
+        # BEFORE the deferred/live split, so both routes refuse identically — the shape #925
+        # settled for `callout()`: a check on one side of that split makes the answer depend
+        # on whether you are inside `deferred()`.
+        if model is not None and any(f.kind == "envelope" for f in model.features):
+            # This verb exists ONLY for the featureless fallback. On an enveloped model the
+            # measurement already has a feature to name, and supporting both spellings gave
+            # two: live, `overall_height()` then `dimension(env, …, role="height")` drew the
+            # 30 mm height TWICE, while the reverse order and the deferred route drew it once
+            # (`explicit_envelope_height` removes the overall ladder from the compile). Order-
+            # dependent live and live ≠ deferred, from composing two public spellings of one
+            # measurement — the "three spellings of pin" problem (#906) in miniature (#934
+            # review). One measurement, one verb.
+            raise ValueError(
+                "overall_height(): this model declares an envelope, so its height has a "
+                'feature to name — use dimension(envelope, "length", role="height"). This '
+                "verb is for a model with NO envelope feature, where the height comes from "
+                "the bounding box and there is nothing to name."
+            )
         if self._defer_intents:  # #426: record, don't place — finalize() drains it
             self._intents.append(Intent("overall_height", None, {}))
             return []
-        model, a = self._part_model, self._analysis
         if model is None or a is None:
             raise ValueError("overall_height(): no detected model — build the drawing first")
         from draftwright._core import layout_frame

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1243,21 +1243,18 @@ class Drawing:
             raise ValueError("overall_height(): no detected model — build the drawing first")
         from draftwright._core import layout_frame
         from draftwright.annotations._common import drain_corridors
-        from draftwright.annotations.from_model import render_height_ladder
-        from draftwright.model.compiled import RenderableDimensionPlan, compile_dimensions
+        from draftwright.annotations.from_model import ladder_plan_for, render_height_ladder
+        from draftwright.model.compiled import compile_dimensions
 
         before = set(self.annotations())
         ctx = PlacementContext(registry=self._registry, coverage=self._coverage, items=self.items)
-        overall = compile_dimensions(model).ladder("overall_height")
-        if overall is not None:
-            # ONLY the overall height: passing the whole plan would also rebuild the step
-            # ladder, which is a different intent with its own verb.
+        # ONLY the overall height: the renderer also draws the step ladder, which is a
+        # different intent with its own verb. The drain projects the plan with the same
+        # helper, so the two routes cannot disagree about what was asked for (#934 review).
+        plan = ladder_plan_for(compile_dimensions(model), step_height=False, overall=True)
+        if plan.ladder("overall_height") is not None:
             render_height_ladder(
-                self,
-                RenderableDimensionPlan(ladders=(overall,)),
-                layout_frame(a),
-                ctx=ctx,
-                detail_view=self._build.detail_view,
+                self, plan, layout_frame(a), ctx=ctx, detail_view=self._build.detail_view
             )
             drain_corridors(ctx, self)
         return sorted(set(self.annotations()) - before)
@@ -1974,15 +1971,25 @@ class Drawing:
                 return
             assert a is not None and isinstance(model, PartModel)
             from draftwright._core import layout_frame
+            from draftwright.annotations.from_model import ladder_plan_for
             from draftwright.model.compiled import compile_dimensions
 
             render_height_ladder(
                 self,
+                # Projected to what was RECORDED. Passing the whole compiled plan once either
+                # intent was present meant `overall_height()` alone also rebuilt the step
+                # rungs — a dimension nobody asked for, and live/deferred divergence in the
+                # one change relying on their equivalence (#934 review).
+                #
                 # `include_overall` is drawing state, so it is an input to the COMPILE
                 # (whether the overall height is in the set) rather than something the
                 # renderer decides after the fact. An explicit `role="height"` intent draws it
                 # through the dimension path instead, so the compile must leave it out.
-                compile_dimensions(model, include_overall=not r.explicit_envelope_height),
+                ladder_plan_for(
+                    compile_dimensions(model, include_overall=not r.explicit_envelope_height),
+                    step_height=bool(r.height_ladder_ids),
+                    overall=bool(r.overall_height_ids),
+                ),
                 layout_frame(a),
                 ctx=ctx,
                 detail_view=self._build.detail_view,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9148,6 +9148,60 @@ class TestTurnedDiameters:
             deferred.overall_height()
         assert deferred.annotations() == live.annotations()
 
+    @pytest.mark.parametrize("deferred", [False, True], ids=["live", "deferred"])
+    def test_overall_height_is_refused_when_the_model_declares_an_envelope(self, deferred):
+        """One measurement, one verb.
+
+        `overall_height()` exists ONLY for the featureless fallback — a model with no
+        `EnvelopeFeature`, whose height comes from the bounding box and has nothing to name.
+        It did not enforce that, so on an enveloped model both public spellings were
+        available and composing them drew the height twice:
+
+            live,  overall_height() then dimension(env, …, role="height")  →  BOTH
+            live,  the reverse order                                       →  one
+            deferred, either order                                         →  one
+
+        Order-dependent live AND live ≠ deferred, from two spellings of one measurement —
+        the "three spellings of pin" problem (#906) in miniature (#934 review).
+
+        Refused before the deferred/live split, so both routes answer identically. That is
+        the shape #925 settled for `callout()`: a check on one side makes the answer depend
+        on whether you are inside `deferred()`.
+        """
+        from draftwright.model.declare import envelope
+
+        part = Box(80, 60, 30)
+        dwg = build_drawing(part, model=[envelope(part)], auto_dims=False)
+        with pytest.raises(ValueError, match="declares an envelope"):
+            if deferred:
+                with dwg.deferred():
+                    dwg.overall_height()
+            else:
+                dwg.overall_height()
+
+    @pytest.mark.parametrize("deferred", [False, True], ids=["live", "deferred"])
+    def test_an_enveloped_height_is_drawn_once_by_its_feature_verb(self, deferred):
+        """The false-positive half: refusing the second spelling must not cost the first.
+
+        The enveloped model's height is still dimensionable — through the feature that owns
+        it — and exactly once, on both routes."""
+        from draftwright.model.declare import envelope
+
+        part = Box(80, 60, 30)
+        dwg = build_drawing(part, model=[envelope(part)], auto_dims=False)
+        feature = dwg.model().features[0]
+        if deferred:
+            with dwg.deferred():
+                dwg.dimension(feature, "length", role="height")
+        else:
+            dwg.dimension(feature, "length", role="height")
+        heights = [
+            a.label
+            for n, a in dwg.iter_annotations()
+            if n.startswith(("dim_height", "dim_length"))
+        ]
+        assert heights == ["30"], f"the height should be drawn once, got {heights}"
+
     def test_the_overall_height_intent_is_commentable_not_injected(self):
         """The half that the first fix got wrong, and the reason there is a verb at all.
 
@@ -9160,7 +9214,12 @@ class TestTurnedDiameters:
         the property the whole intent-level script rests on (ADR 0016, "the script records
         intent").
         """
-        part = Box(80, 60, 12) - Pos(20, 10, 0) * Cylinder(4, 40)
+        # The verb's actual domain: a part with NO `EnvelopeFeature`, so the height comes
+        # from the bounding-box fallback and there is nothing to name. (An enveloped model
+        # refuses this verb and uses its feature instead — see the test above; this fixture
+        # asserted the property on an enveloped plate, which is the overlap itself.)
+        part = self._issue_881_y_step_flange()
+        assert not any(f.kind == "envelope" for f in build_drawing(part).model().features)
 
         silent = build_drawing(part, auto_dims=False)
         assert "dim_height" not in silent.annotations(), "not recorded ⇒ not drawn"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -6261,9 +6261,19 @@ class TestFeatureEdits:
         with dwg.deferred():
             dwg.dimension(step_level, "length", role="step_height")
 
-        assert "dim_height" in dwg.annotations()
         assert any(n.startswith("dim_step") for n in dwg.annotations())
         assert dwg._intents == []
+        # NOT `dim_height`. This asserted the opposite until #934: the drain handed
+        # `render_height_ladder` the whole compiled plan, so a step-height intent also drew
+        # the overall height. One intent draws one thing — the overall height has its own
+        # verb (`overall_height()`), and the conflation meant commenting either line out of a
+        # generated script need not have removed what it named.
+        #
+        # No replay regression rides on this. A part WITH an `EnvelopeFeature` — like this one
+        # — emits `dimension(f, "length", role="height")`, which sets `explicit_envelope_height`
+        # and takes the overall height out of the compile entirely, so the ladder never
+        # carried it there anyway. A part WITHOUT one now emits `dwg.overall_height()`.
+        assert "dim_height" not in dwg.annotations()
 
     def test_callout_adds_a_hole_leader_and_round_trips(self):
         # #414 / #400 Ph2: the callout add verb — detect-only build, then add the hole's
@@ -9044,6 +9054,99 @@ class TestTurnedDiameters:
             if "steplen" in name:
                 dwg.remove(name)
         assert "axial_length_missing" in {issue.code for issue in dwg.lint()}
+
+    @pytest.mark.parametrize(
+        ("overall", "step", "expect_height", "expect_rungs"),
+        [
+            (False, False, False, False),
+            (True, False, True, False),
+            (False, True, False, True),
+            (True, True, True, True),
+        ],
+        ids=["neither", "overall-only", "step-only", "both"],
+    )
+    def test_each_ladder_intent_draws_only_what_it_recorded(
+        self, overall, step, expect_height, expect_rungs
+    ):
+        """`render_height_ladder` draws TWO independent things, and the drain passed it the
+        whole compiled plan once EITHER intent was present.
+
+        So `overall_height()` alone also rebuilt the step rungs — a dimension nobody recorded,
+        and live/deferred divergence in the change that relies on their equivalence (#934
+        review). The converse held too: a step-height intent carried the overall height along,
+        so commenting out `dwg.overall_height()` in a generated script need not have removed it.
+
+        A model with BOTH approved ladders is required to see this at all. Every earlier
+        fixture exposes one, which is why cross-contamination was invisible: with a single
+        ladder, "pass everything" and "pass what was asked for" are the same plan.
+
+        Asserted on WHICH ladders appear, not how many marks: with both recorded, the strip
+        legitimately drops a rung for room, and pinning counts would make this test fail on
+        placement changes that have nothing to do with the property.
+        """
+        from draftwright.model.ir import Frame, PartModel, StepLevelFeature
+
+        part = Box(80, 60, 30)
+        model = PartModel(
+            bbox=part.bounding_box(),
+            orientation="prismatic",
+            features=[
+                StepLevelFeature(
+                    Frame((0, 0, 0), "z"),
+                    base=-15,
+                    levels=(-5, 5),
+                    shoulders=(("x", 0),),
+                    datum=(-40, -30, -15),
+                )
+            ],
+            datums=[],
+        )
+        dwg = build_drawing(part, model=model, auto_dims=False)
+        feature = dwg.model().features[0]
+        with dwg.deferred():
+            if overall:
+                dwg.overall_height()
+            if step:
+                dwg.dimension(feature, "length", role="step_height")
+
+        drawn = {n for n, _ in dwg.iter_annotations()}
+        assert ("dim_height" in drawn) is expect_height
+        assert any(n.startswith("dim_step") for n in drawn) is expect_rungs
+
+    def test_overall_height_live_and_deferred_agree_with_a_step_ladder_present(self):
+        """The equivalence, on the model that can break it.
+
+        `test_the_overall_height_intent_is_commentable_not_injected` uses a part with no
+        step_level, so its live and deferred results agreed even while the drain was drawing
+        every ladder it could find. The ladder itself is deferred-only by construction (a
+        correlated set, routed at the drain), so the overall height is the half where live and
+        deferred are both reachable — and therefore the half that can disagree."""
+        from draftwright.model.ir import Frame, PartModel, StepLevelFeature
+
+        part = Box(80, 60, 30)
+
+        def _model():
+            return PartModel(
+                bbox=part.bounding_box(),
+                orientation="prismatic",
+                features=[
+                    StepLevelFeature(
+                        Frame((0, 0, 0), "z"),
+                        base=-15,
+                        levels=(-5, 5),
+                        shoulders=(("x", 0),),
+                        datum=(-40, -30, -15),
+                    )
+                ],
+                datums=[],
+            )
+
+        live = build_drawing(part, model=_model(), auto_dims=False)
+        live.overall_height()
+        deferred = build_drawing(part, model=_model(), auto_dims=False)
+        with deferred.deferred():
+            deferred.overall_height()
+        assert deferred.annotations() == live.annotations()
 
     def test_the_overall_height_intent_is_commentable_not_injected(self):
         """The half that the first fix got wrong, and the reason there is a verb at all.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9045,6 +9045,77 @@ class TestTurnedDiameters:
                 dwg.remove(name)
         assert "axial_length_missing" in {issue.code for issue in dwg.lint()}
 
+    def test_the_overall_height_intent_is_commentable_not_injected(self):
+        """The half that the first fix got wrong, and the reason there is a verb at all.
+
+        Making the drain draw the overall height whenever the compiler approved one restored
+        #889's parity — and broke record-then-finalize == place-live, because `auto_dims=False`
+        means the recorded verbs ARE the drawing and an automatic dimension nobody asked for
+        appeared in the deferred result. `test_finalize_replay_equals_live_placement` caught it.
+
+        So it is an INTENT: absent unless recorded, which also makes it commentable, which is
+        the property the whole intent-level script rests on (ADR 0016, "the script records
+        intent").
+        """
+        part = Box(80, 60, 12) - Pos(20, 10, 0) * Cylinder(4, 40)
+
+        silent = build_drawing(part, auto_dims=False)
+        assert "dim_height" not in silent.annotations(), "not recorded ⇒ not drawn"
+
+        live = build_drawing(part, auto_dims=False)
+        assert live.overall_height() == ["dim_height"]
+
+        deferred = build_drawing(part, auto_dims=False)
+        with deferred.deferred():
+            deferred.overall_height()
+        assert deferred.annotations() == live.annotations(), "record-then-finalize == live"
+
+    def test_overall_height_round_trips_through_generated_script(self, tmp_path):
+        """#889: the replay dropped the automatic overall height, silently and lint-clean.
+
+        Two different things share `render_height_ladder`, and the drain gated BOTH on the
+        step-ladder intent. The step-height LADDER is a `step_level` feature's correlated
+        rungs, so one recorded intent meaning "rebuild the whole chain" is right. The OVERALL
+        HEIGHT is envelope furniture — and on a part with no `EnvelopeFeature` it comes from
+        the compiler's bounding-box fallback, so there is NO feature for a script to record an
+        intent against. It could never be replayed, only lost.
+
+        The Y-axis stepped flange is the case that exposes it: `step` features but no
+        `step_level`, so no ladder intent exists to carry the overall height along.
+
+        Asserted as full annotation-set parity rather than "dim_height is present", because
+        the acceptance is that replay matches the automatic drawing — and the risk on the
+        other side is duplicating the Y-step length chain, which a presence check would miss.
+        """
+        import runpy
+
+        from build123d import export_step
+
+        from draftwright.make_drawing import generate_script
+
+        part = self._issue_881_y_step_flange()
+        assert not any(f.kind == "envelope" for f in build_drawing(part).model().features), (
+            "the fixture must have NO envelope feature — the bbox fallback is the case "
+            "with no intent to record"
+        )
+        step = tmp_path / "flange.step"
+        export_step(part, str(step))
+
+        auto = build_drawing(part)
+        replayed = runpy.run_path(generate_script(str(step), out=str(tmp_path / "gen")))["dwg"]
+
+        automatic = {n for n, _ in auto.iter_annotations()}
+        replay = {n for n, _ in replayed.iter_annotations()}
+        assert "dim_height" in automatic, "the fixture must draw an overall height to lose"
+        assert replay == automatic, (
+            f"replay differs — missing {sorted(automatic - replay)}, "
+            f"extra {sorted(replay - automatic)}"
+        )
+        assert (
+            auto.get_annotation("dim_height").label == replayed.get_annotation("dim_height").label
+        )
+        assert not auto.lint_summary()["by_code"] and not replayed.lint_summary()["by_code"]
+
     @pytest.mark.parametrize(("axis_z", "rotation"), [(0.0, 90), (17.0, 90), (-11.0, -90)])
     def test_issue_892_short_y_step_chain_moves_to_enlarged_side_detail(self, axis_z, rotation):
         # P10-base axial profile: 3 | 5.5 | 3.5 mm along Y.  Centred labels crowd at


### PR DESCRIPTION
Closes #889.

## What was happening

The Y-axis stepped flange replayed without its 46 mm overall height — silently, and lint-clean on both drawings, which is why lint never surfaced it.

```
auto only     : ['dim_height']
generated only: []
```

## Root cause

**The overall height is the one dimension with no feature to name.**

A model with an `EnvelopeFeature` carries a `height` parameter, and `generate_script` already emits `dimension(f, "length", role="height")` for it. This part has **no envelope feature at all** — the height comes from the compiler's bounding-box fallback (`_compile_overall_height`), a decision only the compiler may make. So an intent-level script had no way to say *"and the 46 mm overall height"*. It could not be replayed, only lost.

`Drawing.overall_height()` is the verb for exactly that case. The emitter writes it only when the model has no envelope feature, so it never duplicates the existing height line.

## The first fix was wrong, and the existing suite caught it

I made the drain draw the overall height whenever the compiler approved one. That restored parity — and broke `test_finalize_replay_equals_live_placement`.

Under `auto_dims=False` the recorded verbs **are** the drawing, so injecting an automatic dimension nobody asked for meant record-then-finalize no longer equalled placing live. **That is this bug's mirror image**: I fixed a silent omission by creating a silent addition.

As an intent it is absent unless recorded — which preserves the live/deferred contract *and* makes it commentable, the property the whole intent-level script rests on (ADR 0016, "the script records intent").

I would have shipped the wrong fix on the targeted tests alone; the full tier is what caught it.

## Tests

- **Full annotation-set parity**, not "`dim_height` is present". The issue's acceptance has two halves — replay includes the height *and* does not duplicate the Y-step length chain — and a presence check only tests one. Canaried on `main`: `replay differs — missing ['dim_height'], extra []`.
- **Commentability / live-vs-deferred**: not recorded ⇒ not drawn; live == deferred. This is the assertion the first fix would have failed.
- The fixture asserts it has *no* envelope feature, so the test cannot silently drift onto the already-working path.

**2167 passed, 1 skipped** (full fast tier), all four lint checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)