### PR TITLE
docs(ADR 0016): record the deletion discipline — the rule that actually held

### DIFF
--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -153,9 +153,9 @@ reach (`_staircase()` has no holes, which is how two dimensional paths stayed ou
 boundary unnoticed); the source ratchet covers every path whether a fixture walks it or not.
 It is shrink-only, and each survivor carries a written reason.
 
-**Designating an owner means DELETING the alternative reader, not redirecting the caller.**
-The rule that most reliably held while this ADR was implemented, and the one that explains
-why some fixes stuck and others did not:
+**Once a semantic owner is designated, parallel INFERENCE paths must be deleted, not
+redirected.** The rule that most reliably held while this ADR was implemented, and the one
+that explains why some fixes stuck and others did not:
 
 - #921 fixed eight renderers to check `suppressed`. The ninth leaked.
 - #923 **deleted the field**. No renderer has leaked it since — `ApprovedDimension` has
@@ -165,10 +165,25 @@ why some fixes stuck and others did not:
 
 A redirect leaves the trap armed: the next author reaches for the reader that still exists,
 because it still exists. Fixing N call sites is O(N) work that must be repeated for every
-new call site; removing the thing they call is O(1) and permanent. So when this ADR names a
-single source of truth, the same change removes the other way to get the same answer —
-and if it cannot yet be removed, it is NAMED as pending (`_PENDING_VALUE_CARRYING`,
-`_FMT_BUDGET`, `_SAME_PATH_AS_ENVELOPE`) rather than left to be discovered.
+new call site; deleting the thing they call is O(1) and permanent.
+
+**Scoped to competing readers of one semantic fact — not to compatibility forwarding.** Two
+ways to *ask* for an answer is an API convenience and this codebase keeps several on purpose
+(`make_drawing`'s facade, the `sheet_dsl` alias, `dimension`'s transitional overload). Two
+ways to *decide* an answer is the defect: `location_role` and `plan_locations` and the
+off-axis pass each independently concluding whether a hole has a position. A forwarding shim
+computes nothing, so it cannot disagree; a second inference path exists precisely to
+conclude, and will.
+
+When a parallel path cannot yet be deleted, it is named — and the two ways of naming one are
+different mechanisms that should not be confused:
+
+- **Unresolved debt** is inventoried AND **shrink-only**, so it can only ever get smaller:
+  `_PENDING_VALUE_CARRYING`, `_FMT_BUDGET`.
+- **An intentional shared route** is inventoried AND **behaviourally verified**, so the
+  listing stays a checked claim rather than an assertion: `_SAME_PATH_AS_ENVELOPE`, whose
+  members are proven by `test_the_same_path_verbs_really_share_the_route` to reach their
+  handle by the same two lines `envelope` does.
 
 The corollary is why this ADR keeps producing *tables* rather than checks: a check must be
 remembered at each site, a table is consulted from one. `location_datum`, `_FACTS` and

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -153,6 +153,27 @@ reach (`_staircase()` has no holes, which is how two dimensional paths stayed ou
 boundary unnoticed); the source ratchet covers every path whether a fixture walks it or not.
 It is shrink-only, and each survivor carries a written reason.
 
+**Designating an owner means DELETING the alternative reader, not redirecting the caller.**
+The rule that most reliably held while this ADR was implemented, and the one that explains
+why some fixes stuck and others did not:
+
+- #921 fixed eight renderers to check `suppressed`. The ninth leaked.
+- #923 **deleted the field**. No renderer has leaked it since — `ApprovedDimension` has
+  nothing to forget.
+- #925 removed `_ir_off_axis_holes` rather than leaving it beside `_approved_off_axis_holes`;
+  #933 removed the emitter's blanket refusal rather than adding a flag beside it.
+
+A redirect leaves the trap armed: the next author reaches for the reader that still exists,
+because it still exists. Fixing N call sites is O(N) work that must be repeated for every
+new call site; removing the thing they call is O(1) and permanent. So when this ADR names a
+single source of truth, the same change removes the other way to get the same answer —
+and if it cannot yet be removed, it is NAMED as pending (`_PENDING_VALUE_CARRYING`,
+`_FMT_BUDGET`, `_SAME_PATH_AS_ENVELOPE`) rather than left to be discovered.
+
+The corollary is why this ADR keeps producing *tables* rather than checks: a check must be
+remembered at each site, a table is consulted from one. `location_datum`, `_FACTS` and
+`_LOCATION_ROLE` are each the deletion of a rule that had been restated in three places.
+
 **Hole callouts (`hc_`) remain on the legacy surface.** They honour `suppressed` at every
 term (`model/callout.py` checks it for each segment, head and dependent), so this is a
 structural gap rather than a behavioural one — but "the renderer checks" is exactly the

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -175,13 +175,20 @@ off-axis pass each independently concluding whether a hole has a position. A for
 computes nothing, so it cannot disagree; a second inference path exists precisely to
 conclude, and will.
 
-When a parallel path cannot yet be deleted, it is named — and the two ways of naming one are
-different mechanisms that should not be confused:
+A path that is not deleted is named, and there are **three** reasons a path survives. They
+are different mechanisms, trustworthy for different reasons, and conflating them is how a
+list stops meaning anything:
 
-- **Unresolved debt** is inventoried AND **shrink-only**, so it can only ever get smaller:
-  `_PENDING_VALUE_CARRYING`, `_FMT_BUDGET`.
-- **An intentional shared route** is inventoried AND **behaviourally verified**, so the
-  listing stays a checked claim rather than an assertion: `_SAME_PATH_AS_ENVELOPE`, whose
+- **Unresolved debt** — inventoried AND **shrink-only**, so it can only ever get smaller.
+  `_FMT_BUDGET`, and the `hc_` member of `_PENDING_VALUE_CARRYING` (#926).
+- **A permanent exception** — inventoried AND **argued**, because it will never shrink and a
+  reader must be able to tell that from a pending item. The `pmi_` member of
+  `_PENDING_VALUE_CARRYING`, and `render_pmi` / `render_gdt` in the contract table above:
+  they render author-supplied text rather than inferring a generated measurement, so there
+  is no inference path to delete. *(That those two live in one tuple named "pending" is
+  itself the conflation this paragraph warns about — folded into #926.)*
+- **An intentional shared route** — inventoried AND **behaviourally verified**, so the
+  listing stays a checked claim rather than an assertion. `_SAME_PATH_AS_ENVELOPE`, whose
   members are proven by `test_the_same_path_verbs_really_share_the_route` to reach their
   handle by the same two lines `envelope` does.
 


### PR DESCRIPTION
Docs only, no behaviour change.

## Why

During the #925 review you asked how to prevent the recurring defect shape. I named three mechanisms. Two shipped — the label-provenance ratchet (#925) and the exhaustive authored-role sweep (#928). The third I described as *"costs nothing, write it into ADR 0016 as a one-line rule"* — and then never did. A tracker audit caught it.

It is the mechanism that most reliably held, and the one that explains why some fixes stuck and others did not.

## The rule

**Designating an owner means DELETING the alternative reader, not redirecting the caller.**

| | |
|---|---|
| #921 | fixed eight renderers to check `suppressed` — **the ninth leaked** |
| #923 | **deleted the field** — none has leaked since; `ApprovedDimension` has nothing to forget |
| #925 | removed `_ir_off_axis_holes` rather than leaving it beside `_approved_off_axis_holes` |
| #933 | removed the emitter's blanket refusal rather than adding a flag beside it |

A redirect leaves the trap armed: the next author reaches for the reader that still exists, *because it still exists*. Fixing N call sites is O(N) work repeated for every new call site; removing the thing they call is O(1) and permanent.

And when it cannot yet be removed, it is **named as pending** — `_PENDING_VALUE_CARRYING`, `_FMT_BUDGET`, `_SAME_PATH_AS_ENVELOPE` — rather than left to be rediscovered.

## The corollary

Recorded because it otherwise reads as a stylistic habit: this ADR keeps producing **tables rather than checks**, because a check must be remembered at each site while a table is consulted from one. `location_datum`, `_FACTS` and `_LOCATION_ROLE` are each the deletion of a rule that had been restated in three places.

Sits beside the existing "two ratchets, on the symptom and on the cause" paragraph, so the three prevention mechanisms are documented together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)