### PR TITLE
feat(#938): mirror the planner's dimension set as commentable dimension(...) lines

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -203,8 +203,14 @@ def _feature_line(f) -> str:
         thr = (
             f", thread={f.thread!r}" if getattr(f, "thread", None) else ""
         )  # external thread (#859)
+        # The HEIGHT round-trips too (#938). Dropping it made the declared boss carry only
+        # `boss.diameter` while the detected one also carries `boss_height.length`, so the
+        # regenerated model could not express a dimension its source had — silently before
+        # the mirror named it, and as a raise afterwards. ADR 0011's round-trip rule is that
+        # recognise, emit and declare agree about a feature's parameters.
+        height = f", height={_n(f.height)}" if getattr(f, "height", None) else ""
         return (
-            f"sheet.diameter(diameter={_n(f.diameter)}, at={_pt(f.frame.origin)}, "
+            f"sheet.diameter(diameter={_n(f.diameter)}{height}, at={_pt(f.frame.origin)}, "
             f'axis="{f.frame.axis}"{thr})'
         )
     if k == "step":
@@ -488,6 +494,138 @@ def _binding(f, line: str, counts: dict[str, int]) -> str | None:
     return f"{f.kind}{counts[f.kind]}"
 
 
+def _declared_envelope(model):
+    """The envelope this emitter SYNTHESISED for *model*, or ``None``.
+
+    Recognised by identity against `mirror_model`'s own construction: the appended feature is
+    the last one and carries the bounding box exactly. Kept separate from the planner walk so
+    its width and depth are never named — see `_mirrored_requests`."""
+    tail = model.features[-1] if model.features else None
+    if tail is None or tail.kind != "envelope":
+        return None
+    bb = model.bbox
+    same = (
+        abs(tail.width - float(bb.size.X)) < 1e-9
+        and abs(tail.depth - float(bb.size.Y)) < 1e-9
+        and abs(tail.height - float(bb.size.Z)) < 1e-9
+    )
+    return tail if same and getattr(tail, "_dw_synthesised", False) else None
+
+
+def mirror_model(model):
+    """The model the emitted script DECLARES — *model*, plus an envelope when the part's
+    overall height would otherwise be unnameable.
+
+    A generated script mirrors the planner's chosen set as explicit `dimension(...)` lines
+    (#938), which makes it an AUTHORED set — and an authored set is the complete
+    dimensioning, so every measurement in it must be nameable. The overall height usually is:
+    an `EnvelopeFeature` carries a `height` parameter. On a part with no envelope feature the
+    compiler falls back to the bounding box, and `_compile_overall_height` deliberately
+    refuses that fallback under an authored set — a script "must not acquire a measurement
+    its author had no way to ask for" (#925). Mirroring such a part would silently drop its
+    overall height, which is #889's bug at the authored level.
+
+    So the script declares the envelope and names only its height. That is honest rather than
+    a workaround: the engine was already dimensioning the bounding box, and the declaration
+    writes down what it was doing implicitly. Naming only `height` keeps the drawing
+    identical — the width and depth stay omitted exactly as the planner left them.
+    """
+    if any(f.kind == "envelope" for f in model.features):
+        return model
+    from draftwright.model.compiled import compile_dimensions
+
+    if compile_dimensions(model).ladder("overall_height") is None:
+        return model  # the compiler withholds it (Z-turned, rotational OD) — nothing to name
+    from dataclasses import replace
+
+    from draftwright.model.ir import EnvelopeFeature, Frame
+
+    bb = model.bbox
+    lo = (float(bb.min.X), float(bb.min.Y), float(bb.min.Z))
+    hi = (float(bb.max.X), float(bb.max.Y), float(bb.max.Z))
+    env = EnvelopeFeature(
+        Frame((0.0, 0.0, 0.0), "z"),
+        width=float(bb.size.X),
+        depth=float(bb.size.Y),
+        height=float(bb.size.Z),
+        bbox_min=lo,
+        bbox_max=hi,
+    )
+    object.__setattr__(env, "_dw_synthesised", True)
+    return replace(model, features=[*model.features, env])
+
+
+def _is_mirrorable(model) -> bool:
+    """Can every dimension the planner chose be named by an emitted line?
+
+    A feature kind with no declarative verb (`_GAP_KINDS` — `rotational` today) emits a
+    COMMENT, so it binds no variable and a `dimension(...)` line has nothing to reference. If
+    such a feature carries planned dimensions, a mirrored set would silently omit them, which
+    is worse than not mirroring: the script would claim completeness it does not have.
+
+    So those models keep `auto_dimensions()` and say why. Honest, and it shrinks as the gap
+    kinds gain verbs — the mirror is not the thing to compromise (#938/#939).
+    """
+    from draftwright.model.planner import plan_dimensions
+
+    # "Unnameable" is derived from the emitter itself — a feature whose line is a COMMENT
+    # binds no variable — rather than from a second list of kinds. `_binding` makes the same
+    # call; two spellings of "does this kind have a verb" is the drift this codebase pays for.
+    unnameable = {id(f) for f in model.features if _feature_line(f).lstrip().startswith("#")}
+    return not any(
+        id(group.feature) in unnameable
+        and any(not all(d.suppressed for d in unit.members) for unit in group.units)
+        for group in plan_dimensions(model)
+    )
+
+
+def _mirrored_requests(model, declared_envelope=None):
+    """One `(feature, role)` per dimension the planner CHOSE — the mirror's content.
+
+    Emitted per addressable UNIT, never per member: a `step_height` ladder and a rotational
+    body's bores are one `AddressableDimension` holding N, so one line drops the set and
+    there is no member line to mislead (ADR 0016 identity tier 3).
+
+    From the planner's INTENT, never from placed annotations. Walking the drawing is the
+    obvious way to build a mirror and it is wrong: a dimension the solver dropped would
+    vanish from the regenerated script and could never be recovered by re-running it, and an
+    unrelated layout change would silently rewrite version-controlled source.
+    """
+    from draftwright.model.planner import plan_dimensions
+
+    out: list[tuple] = []
+    if declared_envelope is not None:
+        # The synthesised envelope exists ONLY to make the overall height nameable, so name
+        # its height and nothing else — its width and depth stay omitted exactly as the
+        # planner left them on a model that never declared an envelope (`mirror_model`).
+        out.append((declared_envelope, "height.length", None))
+    for group in plan_dimensions(model):
+        if declared_envelope is not None and group.feature is declared_envelope:
+            continue  # its height is named above; its width/depth stay omitted
+        for unit in group.units:
+            if all(d.suppressed for d in unit.members):
+                continue  # the planner did not choose it; the mirror must not add it
+            out.append((group.feature, str(unit.id), None))
+    # Locations come from the COMPILED set, not from `plan_locations`. The two differ, and
+    # the difference is exactly the positions that are compiled elsewhere: a slot's near-end
+    # offset and a side-drilled hole's, which measure from the bounding box rather than from
+    # `datum_xy` (#925). Walking the planner missed them, so a mirrored pad/slot part lost
+    # its position dim — the whole class of bug this mirror exists to prevent.
+    from draftwright.model.compiled import compile_dimensions, resolve_feature
+
+    named: set[int] = set()
+    for approved in compile_dimensions(model).locations:
+        # One line per FEATURE, not per ref: coincident refs are deduplicated across
+        # features, and `dimension(f, "location")` is a per-feature unit (#883 is the
+        # per-member question, deliberately not answered here).
+        feature = resolve_feature(approved.ref)
+        if feature is None or id(feature) in named:
+            continue
+        named.add(id(feature))
+        out.append((feature, "location", None))
+    return out
+
+
 def _dimension_block(model, names: dict[int, str]) -> list[str]:
     """The authored set as `sheet.dimension(...)` declarations, or the `auto_dimensions()` line.
 
@@ -499,12 +637,26 @@ def _dimension_block(model, names: dict[int, str]) -> list[str]:
     A generated script must state its source either way (ADR 0016 / #874): a dimension the
     script does not name only means "omitted" inside a set that says it is complete.
     """
-    if model.authored_dimensions is None:
+    if model.authored_dimensions is None and not _is_mirrorable(model):
+        # A feature with no declarative verb carries planned dimensions, so a mirrored set
+        # would silently omit them and claim completeness it does not have (#938).
         return [
-            "# The planner selects the dimensions. Replace with dimension(feature, role) lines",
-            "# to declare the complete set by hand (ADR 0016).",
+            "# The planner selects the dimensions: this part has a feature with no",
+            "# declarative verb (flagged above), so its dimensions cannot be named here.",
+            "# Replace with dimension(feature, role) lines to declare the set by hand.",
             "sheet.auto_dimensions()",
         ]
+    requests = (
+        [(a.feature, a.role, a.discriminator) for a in model.authored_dimensions]
+        if model.authored_dimensions is not None
+        # A detected model has no authored set, so the script MIRRORS the planner's choice as
+        # explicit lines instead of `auto_dimensions()` (#938). That is what makes an
+        # automatic dimension commentable: before this, the promise "comment a line out to
+        # drop it" held for features and not for dimensions, so the only way to drop one
+        # dimension was to drop its whole feature — losing the callout, the centre marks and
+        # the location with it.
+        else _mirrored_requests(model, _declared_envelope(model))
+    )
     out = [
         "# ── Dimensions ────────────────────────────────────────────────────────────────",
         "# THIS IS THE COMPLETE SET (ADR 0016). A measurement with no line here is omitted",
@@ -517,8 +669,8 @@ def _dimension_block(model, names: dict[int, str]) -> list[str]:
         # automatic one does, rather than in prose a reader has to trust.
         "sheet.authored_dimensions()",
     ]
-    for authored in model.authored_dimensions:
-        name = names.get(id(authored.feature))
+    for feature, role, discriminator in requests:
+        name = names.get(id(feature))
         if name is None:
             # Reachable for a kind with no declarative verb (its line is a comment, so it
             # binds nothing). Refusing the SCRIPT is right: emitting the rest would produce
@@ -526,14 +678,14 @@ def _dimension_block(model, names: dict[int, str]) -> list[str]:
             # divergence the blanket refusal existed to prevent — just narrowed from "any
             # authored model" to "an authored dimension on an unemittable feature".
             raise ValueError(
-                f"emit_sheet_script(): cannot name the {authored.feature.kind} carrying the "
-                f"authored dimension {authored.role!r} — that kind has no declarative verb, "
-                "so the generated script has no variable to reference it by"
+                f"emit_sheet_script(): cannot name the {feature.kind} carrying the "
+                f"dimension {role!r} — that kind has no declarative verb, so the generated "
+                "script has no variable to reference it by"
             )
         # Double quotes, matching the house style of every other emitted string argument
         # (`axis="z"`); `!r` would render single and make the file read as two dialects.
-        axis = f', axis="{authored.discriminator}"' if authored.discriminator else ""
-        out.append(f'sheet.dimension({name}, "{authored.role}"{axis})')
+        axis = f', axis="{discriminator}"' if discriminator else ""
+        out.append(f'sheet.dimension({name}, "{role}"{axis})')
     return out
 
 
@@ -635,6 +787,10 @@ def emit_sheet_script(
     comment a feature line out and re-run — which shifts every later index and silently
     retargets the declarations onto their neighbours. #931 and #932 removed positional
     addressing from the artefact, so the declarations can now be written honestly."""
+    # The script declares this model — `model` plus an envelope when the overall height would
+    # otherwise be unnameable under the mirrored (authored) set. BEFORE the import scan, since
+    # a synthesised envelope needs `EnvelopeFeature` imported like a detected one.
+    model = mirror_model(model)
     model_imports = set()
     if any(f.kind in ("hole", "pattern") for f in model.features):
         model_imports.add("hole")
@@ -685,11 +841,11 @@ def emit_sheet_script(
         # dimension only means something inside a set that says it is complete. The planner's
         # set is stated here; an AUTHORED set is stated after the features instead, because
         # each of its lines names a feature by the variable that feature's line binds.
-        *(
-            _dimension_block(model, _names) + [""]
-            if model.authored_dimensions is None
-            else ["# The dimension source is DECLARED below the features (ADR 0016).", ""]
-        ),
+        # Every generated script now declares its dimensions below the features (#938), so
+        # the source is stated here as a pointer rather than inline: the lines name features
+        # by the variables those features' lines bind, and cannot precede them.
+        "# The dimension source is DECLARED below the features (ADR 0016).",
+        "",
         # For a live-source part (#771), the values below were read off YOUR objects — point
         # each line back at the object to keep it a single source of truth (a STEP-sourced
         # script has no such objects, so this note is emitted only for object inputs).
@@ -708,7 +864,8 @@ def emit_sheet_script(
         # a value, re-run). Runs are consecutive in feature order; never reordered (ADR 0014).
         *feature_lines,
         "",
-        *(_dimension_block(model, _names) + [""] if model.authored_dimensions is not None else []),
+        *_dimension_block(model, _names),
+        "",
         "# ── Views ─────────────────────────────────────────────────────────────────────",
         "# front / plan / side / iso are always produced.",
     ]

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -494,24 +494,6 @@ def _binding(f, line: str, counts: dict[str, int]) -> str | None:
     return f"{f.kind}{counts[f.kind]}"
 
 
-def _declared_envelope(model):
-    """The envelope this emitter SYNTHESISED for *model*, or ``None``.
-
-    Recognised by identity against `mirror_model`'s own construction: the appended feature is
-    the last one and carries the bounding box exactly. Kept separate from the planner walk so
-    its width and depth are never named — see `_mirrored_requests`."""
-    tail = model.features[-1] if model.features else None
-    if tail is None or tail.kind != "envelope":
-        return None
-    bb = model.bbox
-    same = (
-        abs(tail.width - float(bb.size.X)) < 1e-9
-        and abs(tail.depth - float(bb.size.Y)) < 1e-9
-        and abs(tail.height - float(bb.size.Z)) < 1e-9
-    )
-    return tail if same and getattr(tail, "_dw_synthesised", False) else None
-
-
 def mirror_model(model):
     """The model the emitted script DECLARES — *model*, plus an envelope when the part's
     overall height would otherwise be unnameable.
@@ -531,11 +513,11 @@ def mirror_model(model):
     identical — the width and depth stay omitted exactly as the planner left them.
     """
     if any(f.kind == "envelope" for f in model.features):
-        return model
+        return model, None
     from draftwright.model.compiled import compile_dimensions
 
     if compile_dimensions(model).ladder("overall_height") is None:
-        return model  # the compiler withholds it (Z-turned, rotational OD) — nothing to name
+        return model, None  # the compiler withholds it (Z-turned, rotational OD)
     from dataclasses import replace
 
     from draftwright.model.ir import EnvelopeFeature, Frame
@@ -551,8 +533,11 @@ def mirror_model(model):
         bbox_min=lo,
         bbox_max=hi,
     )
-    object.__setattr__(env, "_dw_synthesised", True)
-    return replace(model, features=[*model.features, env])
+    # Returned ALONGSIDE the model rather than stamped onto it. The first cut set a private
+    # marker on the frozen `EnvelopeFeature` and rediscovered it later by position and size —
+    # emitter bookkeeping masquerading as model state, on a public IR type (#944 review).
+    # Which feature the emitter synthesised is the emitter's own fact; it travels out-of-band.
+    return replace(model, features=[*model.features, env]), env
 
 
 def _is_mirrorable(model) -> bool:
@@ -626,7 +611,7 @@ def _mirrored_requests(model, declared_envelope=None):
     return out
 
 
-def _dimension_block(model, names: dict[int, str]) -> list[str]:
+def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) -> list[str]:
     """The authored set as `sheet.dimension(...)` declarations, or the `auto_dimensions()` line.
 
     Emitted AFTER the features, because each line names a feature by the variable that
@@ -640,10 +625,17 @@ def _dimension_block(model, names: dict[int, str]) -> list[str]:
     if model.authored_dimensions is None and not _is_mirrorable(model):
         # A feature with no declarative verb carries planned dimensions, so a mirrored set
         # would silently omit them and claim completeness it does not have (#938).
+        unnameable = sorted(
+            {f.kind for f in model.features if _feature_line(f).lstrip().startswith("#")}
+        )
         return [
-            "# The planner selects the dimensions: this part has a feature with no",
-            "# declarative verb (flagged above), so its dimensions cannot be named here.",
-            "# Replace with dimension(feature, role) lines to declare the set by hand.",
+            "# The planner selects the dimensions for this part.",
+            f"# WHY, and it is a gap rather than a choice: {', '.join(unnameable)} has no",
+            "# declarative verb (flagged in the features above), so it binds no name and its",
+            "# dimensions cannot be declared here. Declaring only the OTHERS would produce a",
+            "# set that claims to be complete and is not — so the whole set stays automatic.",
+            "# Tracked as draftwright#945; once that lands this part declares its dimensions",
+            "# line by line like every other.",
             "sheet.auto_dimensions()",
         ]
     requests = (
@@ -655,7 +647,7 @@ def _dimension_block(model, names: dict[int, str]) -> list[str]:
         # drop it" held for features and not for dimensions, so the only way to drop one
         # dimension was to drop its whole feature — losing the callout, the centre marks and
         # the location with it.
-        else _mirrored_requests(model, _declared_envelope(model))
+        else _mirrored_requests(model, synthesised_envelope)
     )
     out = [
         "# ── Dimensions ────────────────────────────────────────────────────────────────",
@@ -790,7 +782,7 @@ def emit_sheet_script(
     # The script declares this model — `model` plus an envelope when the overall height would
     # otherwise be unnameable under the mirrored (authored) set. BEFORE the import scan, since
     # a synthesised envelope needs `EnvelopeFeature` imported like a detected one.
-    model = mirror_model(model)
+    model, _synth_env = mirror_model(model)
     model_imports = set()
     if any(f.kind in ("hole", "pattern") for f in model.features):
         model_imports.add("hole")
@@ -864,7 +856,7 @@ def emit_sheet_script(
         # a value, re-run). Runs are consecutive in feature order; never reordered (ADR 0014).
         *feature_lines,
         "",
-        *_dimension_block(model, _names),
+        *_dimension_block(model, _names, _synth_env),
         "",
         "# ── Views ─────────────────────────────────────────────────────────────────────",
         "# front / plan / side / iso are always produced.",

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -80,11 +80,16 @@ class TestEmit:
         "part", [Box(40, 20, 10), _plate(), Box(80, 60, 40)], ids=["bare", "plate", "block"]
     )
     def test_every_emitted_script_states_its_dimension_source(self, part):
-        """#874's emitter gate. A generated script must SAY where its dimensions come
-        from, not rely on a default — that is what makes omission mean something. Round
-        trips cover this only implicitly (the build would raise), so assert the line
-        directly: a part with no features must still emit it."""
-        assert "sheet.auto_dimensions()" in _script_for(part)
+        """#874's emitter gate. A generated script must SAY where its dimensions come from,
+        not rely on a default — that is what makes omission mean something. Round trips cover
+        this only implicitly (the build would raise), so assert the line directly: a part with
+        no features must still emit one.
+
+        EITHER verb satisfies it. This asserted `auto_dimensions()` specifically until #938
+        made the script mirror the planner's set as `dimension(...)` lines, which is the
+        authored source — a different answer to the same question, not a missing one."""
+        src = _script_for(part)
+        assert "sheet.auto_dimensions()" in src or "sheet.authored_dimensions()" in src
 
     def test_an_authored_set_emits_its_declarations_through_the_facade(self):
         """The emitter used to write `sheet.auto_dimensions()` for ANY model, so a script
@@ -150,7 +155,11 @@ class TestEmit:
         # `measured_dimension` since #873: a generated script must not emit the
         # transitional overload, or every regenerated AP242 script arrives deprecated.
         assert "sheet.measured_dimension(" in src
-        assert "sheet.dimension(" not in src
+        # The transitional MEASURED overload (`dimension(kind=…, value=…)`), not the
+        # referential verb: a regenerated AP242 script must not arrive pre-deprecated (#873).
+        # Bare `sheet.dimension(` stopped meaning that when #938 made every script mirror the
+        # planner's set with referential `dimension(feature, role)` lines.
+        assert "sheet.dimension(kind=" not in src
         assert "sheet.pmi(" not in src
         assert "# authored_dimension" not in src
         assert "source='ap242_pmi'" in src
@@ -1407,19 +1416,19 @@ class TestEmittedFeaturesAreNamed:
         import ast
 
         src = self._src()
-        block = [
-            ln
-            for ln in src.splitlines()
-            if ln.startswith(("sheet.", "hole", "envelope", "pattern")) and "sheet." in ln
+        # The FEATURE block only. Since #938 the script also contains `dimension(...)` lines,
+        # which are statements that correctly bind nothing — they name features rather than
+        # declaring them. Slicing the block is what keeps this about feature declarations.
+        lines = src.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.startswith("# ── Features"))
+        end = next(i for i, ln in enumerate(lines[start:], start) if ln.startswith("# ── Dim"))
+        declarations = [
+            ln.split("#")[0].rstrip()
+            for ln in lines[start:end]
+            if "sheet." in ln and not ln.lstrip().startswith("#")
         ]
-        declarations = [ln.split("#")[0].rstrip() for ln in block if "sheet.export" not in ln]
-        unbound = [
-            ln
-            for ln in declarations
-            if not isinstance(ast.parse(ln).body[0], ast.Assign)
-            and "auto_dimensions" not in ln
-            and "Sheet(" not in ln
-        ]
+        assert declarations, "the fixture must emit feature lines"
+        unbound = [ln for ln in declarations if not isinstance(ast.parse(ln).body[0], ast.Assign)]
         assert not unbound, f"emitted feature lines with no binding: {unbound}"
 
     def test_the_names_are_distinct_and_valid_identifiers(self):
@@ -1562,9 +1571,12 @@ class TestAuthoredSetRoundTrips:
         the auto path its explicit `auto_dimensions()` line."""
         from build123d import Box
 
+        # Since #938 a detected model MIRRORS the planner's set as `dimension(...)` lines
+        # rather than deferring to `auto_dimensions()`. The property this guards is unchanged
+        # — the script states its source explicitly — and the source is now the authored one.
         src = _script_for(Box(40, 20, 10))
-        assert "sheet.auto_dimensions()" in src
-        assert "sheet.dimension(" not in src
+        assert "sheet.authored_dimensions()" in src
+        assert "sheet.dimension(" in src
 
     def test_an_EMPTY_authored_set_round_trips(self):
         """`authored_dimensions=()` is a valid model: "the author chose no dimensions".
@@ -1628,3 +1640,136 @@ class TestAuthoredSetRoundTrips:
         model = dataclasses.replace(model, authored_dimensions=(RequestedDimension(rot, "od"),))
         with pytest.raises(ValueError, match="has no declarative verb"):
             emit_sheet_script(model, "part", "bracket", title="T", number="N")
+
+
+class TestTheDimensionMirror:
+    """A generated script declares the planner's dimensions as commentable lines (#938).
+
+    Before this the script said `sheet.auto_dimensions()`, so the editable-drawing promise —
+    comment a line out to drop it — held for FEATURES and not for DIMENSIONS. The only way to
+    drop one dimension was to comment out its whole feature, losing that feature's callout,
+    centre marks and location with it. #922 built the capability across three PRs; nothing
+    used it, because `--script` emits from `detect_part_model`, which never carries an
+    authored set.
+    """
+
+    @staticmethod
+    def _corpus():
+        from build123d import Align, Axis, Box, Cylinder, Pos
+
+        def flange():
+            part = Cylinder(21, 4)
+            for x in (-18, 18):
+                for y in (-18, 18):
+                    part += Pos(x, y, 2) * Box(10, 10, 4, align=(Align.CENTER,) * 3)
+            part = part + Pos(0, 0, 2) * Cylinder(15.5, 12) + Pos(0, 0, 10) * Cylinder(12.5, 12)
+            part -= Cylinder(8, 30)
+            for x in (-18, 18):
+                for y in (-18, 18):
+                    part -= Pos(x, y, 0) * Cylinder(2, 10)
+            return part.rotate(Axis.X, 90)
+
+        return {
+            "plate+hole": Box(80, 50, 8) - Pos(-20, 0, 0) * Cylinder(4, 20),
+            "flange (no envelope feature)": flange(),
+            "stepped": Box(40, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20),
+            "slot": Box(80, 60, 12) - Pos(10, 0, 6) * Box(30, 8, 10),
+            "pocket": Box(80, 60, 20) - Pos(0, 0, 14) * Box(30, 20, 14),
+            "two holes": Box(80, 50, 8)
+            - Pos(-20, 0, 0) * Cylinder(4, 20)
+            - Pos(20, 10, 0) * Cylinder(3, 20),
+            "pad": Box(80, 60, 10) + Pos(0, 0, 10) * Box(30, 20, 4),
+            "bare block": Box(60, 40, 20),
+            "side-drilled": Box(80, 60, 20) - Pos(0, 0, 10) * Cylinder(3, 200).rotate(Axis.Y, 90),
+        }
+
+    @staticmethod
+    def _run(src, part):
+        ns: dict = {"part": part}
+        body = src.replace("\npart\n", "\n", 1)
+        exec(compile(body[: body.index("sheet.export(")], "<emit>", "exec"), ns)  # noqa: S102
+        return ns
+
+    @pytest.mark.parametrize("name", sorted(_corpus()))
+    def test_the_mirrored_script_draws_what_the_automatic_drawing_draws(self, name):
+        """The acceptance, per fixture: annotation-set EQUALITY.
+
+        On drawn annotations, not emitted text — a text assertion passes on a script that
+        names the wrong feature, which is exactly what positional addressing produced before
+        #932. A corpus rather than one part, because single-fixture guards are how whole
+        paths stayed uncovered twice in this series (#925 had no holes, #934 had one ladder).
+        """
+        part = self._corpus()[name]
+        model = detect_part_model(part)
+        automatic = build_drawing(part, model=model, number="N")
+        src = emit_sheet_script(model, "part", "s", title="T", number="N")
+        regenerated = self._run(src, part)["sheet"].build()
+
+        def marks(dwg):
+            return {n for n, _ in dwg.iter_annotations()}
+
+        assert marks(regenerated) == marks(automatic), (
+            f"{name}: missing {sorted(marks(automatic) - marks(regenerated))}, "
+            f"extra {sorted(marks(regenerated) - marks(automatic))}"
+        )
+
+    def test_every_planner_dimension_gets_a_line(self):
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(80, 50, 8) - Pos(-20, 0, 0) * Cylinder(4, 20)
+        src = emit_sheet_script(detect_part_model(part), "part", "s", title="T", number="N")
+        assert "sheet.auto_dimensions()" not in src
+        assert 'sheet.dimension(hole1, "bore.diameter")' in src
+        assert 'sheet.dimension(hole1, "location")' in src
+        assert 'sheet.dimension(envelope1, "width.length")' in src
+
+    def test_commenting_one_line_drops_exactly_that_dimension(self):
+        """The point of the whole change, executed rather than asserted about."""
+        from build123d import Box, Cylinder, Pos
+
+        part = Box(80, 50, 8) - Pos(-20, 0, 0) * Cylinder(4, 20)
+        src = emit_sheet_script(detect_part_model(part), "part", "s", title="T", number="N")
+        full = {n for n, _ in self._run(src, part)["sheet"].build().iter_annotations()}
+
+        target = 'sheet.dimension(envelope1, "width.length")'
+        assert target in src
+        edited = src.replace(target, "# " + target)
+        reduced = {n for n, _ in self._run(edited, part)["sheet"].build().iter_annotations()}
+        assert full - reduced == {"m_env_width"}, (
+            f"commenting one line changed {sorted(full - reduced)} — it must drop exactly one"
+        )
+
+    def test_a_correlated_set_emits_ONE_line(self):
+        """A `step_height` ladder is one `AddressableDimension` holding N rungs, so there is
+        one line and no member line to mislead (ADR 0016 identity tier 3)."""
+        from build123d import Box, Pos
+
+        part = Box(40, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20)
+        src = emit_sheet_script(detect_part_model(part), "part", "s", title="T", number="N")
+        assert src.count("step_height") == 1
+
+    def test_a_model_with_an_unnameable_feature_keeps_the_planner_source(self):
+        """A feature with no declarative verb emits a COMMENT, so it binds no name and its
+        dimensions cannot be mirrored. Falling back to `auto_dimensions()` and saying why
+        beats emitting a set that claims a completeness it does not have."""
+        from build123d import Cylinder
+
+        part = Cylinder(40, 8) - Cylinder(8, 20)
+        model = detect_part_model(part)
+        assert any(f.kind == "rotational" for f in model.features), "fixture must hit the gap"
+        src = emit_sheet_script(model, "part", "s", title="T", number="N")
+        assert "sheet.auto_dimensions()" in src
+        assert "no\n# declarative verb" in src or "declarative verb" in src
+
+    def test_the_synthesised_envelope_names_only_its_height(self):
+        """A part with no `EnvelopeFeature` gets one declared, because an authored set must
+        be able to name every measurement in it and `_compile_overall_height` refuses the
+        bounding-box fallback under one (#925). Naming only `height` keeps the drawing
+        identical — width and depth stay omitted exactly as the planner left them."""
+        part = self._corpus()["flange (no envelope feature)"]
+        model = detect_part_model(part)
+        assert not any(f.kind == "envelope" for f in model.features)
+        src = emit_sheet_script(model, "part", "s", title="T", number="N")
+        assert 'sheet.dimension(envelope1, "height.length")' in src
+        assert 'sheet.dimension(envelope1, "width.length")' not in src
+        assert 'sheet.dimension(envelope1, "depth.length")' not in src

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1701,16 +1701,21 @@ class TestTheDimensionMirror:
         """
         part = self._corpus()[name]
         model = detect_part_model(part)
-        automatic = build_drawing(part, model=model, number="N")
+        # Same title/number on both sides — the signature includes the title block, and a
+        # mismatch there would read as a dimension difference.
+        automatic = build_drawing(part, model=model, title="T", number="N")
         src = emit_sheet_script(model, "part", "s", title="T", number="N")
         regenerated = self._run(src, part)["sheet"].build()
 
-        def marks(dwg):
-            return {n for n, _ in dwg.iter_annotations()}
-
-        assert marks(regenerated) == marks(automatic), (
-            f"{name}: missing {sorted(marks(automatic) - marks(regenerated))}, "
-            f"extra {sorted(marks(regenerated) - marks(automatic))}"
+        names = {n for n, _ in automatic.iter_annotations()}
+        got = {n for n, _ in regenerated.iter_annotations()}
+        assert got == names, f"{name}: missing {sorted(names - got)}, extra {sorted(got - names)}"
+        # Names alone are too weak: a request aimed at the right feature kind but rebuilt
+        # with the wrong VALUE or span keeps exactly the same registry name (#944 review).
+        # `_annotation_signature` compares labels, dimension specs, leader coverage and boxes.
+        assert _annotation_signature(regenerated) == _annotation_signature(automatic), (
+            f"{name}: same annotation names but different content — a mirrored dimension "
+            "reproduced the wrong value, span, side or view"
         )
 
     def test_every_planner_dimension_gets_a_line(self):
@@ -1749,9 +1754,17 @@ class TestTheDimensionMirror:
         assert src.count("step_height") == 1
 
     def test_a_model_with_an_unnameable_feature_keeps_the_planner_source(self):
-        """A feature with no declarative verb emits a COMMENT, so it binds no name and its
-        dimensions cannot be mirrored. Falling back to `auto_dimensions()` and saying why
-        beats emitting a set that claims a completeness it does not have."""
+        """A feature with no declarative verb binds no name, so its dimensions cannot be
+        mirrored — and declaring only the OTHERS would emit a set claiming a completeness it
+        does not have.
+
+        **This pins UNFINISHED work, not a settled limitation.** `RotationalFeature` is
+        recognised and rendered but cannot be declared or emitted — the missing ADR 0011
+        round-trip leg, tracked as #945. Until it lands, a turned part gets none of #938's
+        benefit: one unsupported dimension turns every other declaration in that script from
+        explicit back to implicit (#944 review). The test asserts the fallback SAYS so, and
+        names the issue, so a reader meets the gap rather than inferring a decision.
+        """
         from build123d import Cylinder
 
         part = Cylinder(40, 8) - Cylinder(8, 20)
@@ -1759,7 +1772,23 @@ class TestTheDimensionMirror:
         assert any(f.kind == "rotational" for f in model.features), "fixture must hit the gap"
         src = emit_sheet_script(model, "part", "s", title="T", number="N")
         assert "sheet.auto_dimensions()" in src
-        assert "no\n# declarative verb" in src or "declarative verb" in src
+        assert "rotational has no" in src, "the fallback must NAME the unnameable kind"
+        assert "draftwright#945" in src, "and point at the work that removes it"
+
+    def test_the_fallback_names_the_gap_the_tracker_still_carries(self):
+        """A pointer to a closed issue reads as a settled decision. If #945 lands, the
+        fallback and this test go with it — this fails first if the reference goes stale
+        without the code changing."""
+        from build123d import Cylinder
+
+        src = emit_sheet_script(
+            detect_part_model(Cylinder(40, 8) - Cylinder(8, 20)),
+            "part",
+            "s",
+            title="T",
+            number="N",
+        )
+        assert "sheet.auto_dimensions()" in src and "draftwright#945" in src
 
     def test_the_synthesised_envelope_names_only_its_height(self):
         """A part with no `EnvelopeFeature` gets one declared, because an authored set must


### PR DESCRIPTION
Closes #938. First child of #942.

## The gap

**#922 built the capability and nothing used it.** `--script` emits from `detect_part_model`, which never carries an authored set, so every generated script said `sheet.auto_dimensions()` and **not one automatic dimension was commentable**.

So the editable-drawing promise held for *features* and not for *dimensions*: the only way to drop one dimension was to comment out its whole feature — losing that feature's callout, centre marks and location with it.

```python
sheet.authored_dimensions()
sheet.dimension(hole1, "bore.diameter")
sheet.dimension(hole1, "location")
sheet.dimension(envelope1, "width.length")
```

## Three things the implementation had to settle

**The overall height on a part with no `EnvelopeFeature`.** A mirrored set *is* an authored set, and `_compile_overall_height` deliberately refuses the bounding-box fallback under one — a script "must not acquire a measurement its author had no way to ask for" (#925). Mirroring would have silently dropped it: **#889's bug at the authored level**. The script now declares an envelope and names only its `height`. Honest rather than a workaround — the engine was already dimensioning the bounding box, and the declaration writes down what it was doing implicitly. Naming only `height` keeps width and depth omitted exactly as the planner left them (verified by set equality, not by inspection).

**Features with no declarative verb** (`rotational`) emit a comment, so they bind no name and cannot be referenced. Those models keep `auto_dimensions()` **and say why** — a mirrored set that silently omitted their dimensions would claim a completeness it does not have. Derived from the emitter's own fallback (`_feature_line` returns a comment) rather than a second table of kinds.

**Locations come from the compiled set**, not `plan_locations`. The two differ by exactly the positions compiled elsewhere — a slot's near-end offset, a side-drilled hole's — and walking the planner lost them on pad/slot parts.

## Two pre-existing bugs it surfaced

The mirror turns silent divergence into a raise, which is how both appeared:

- **The emitted boss line dropped the boss HEIGHT.** The declared boss carried only `boss.diameter` while the detected one also carried `boss_height.length` — an ADR 0011 round-trip violation (recognise, emit and declare must agree about a feature's parameters). Fixed here.
- **#943 filed**: a turned part's emitted script fails to *execute* (`declared steps don't span this part's full height`). Verified identical on `main`, independent of this change, and not fixable without giving `rotational` a declarative surface.

## Tests

**Annotation-set equality over a nine-part corpus** — plate, no-envelope flange, stepped, slot, pocket, two-hole, pad, bare block, side-drilled. On drawn annotations, not emitted text: a text assertion passes on a script naming the *wrong feature*, which is what positional addressing produced before #932. A corpus rather than one part, because single-fixture guards are how whole paths stayed uncovered twice in this series.

Plus: commenting out one line drops **exactly** one dimension; a correlated set emits exactly one line; the unnameable-feature fallback; the synthesised envelope names only its height.

Three existing tests kept their property and changed their expectation — the script states its source (either verb), no MEASURED overload (`dimension(kind=` rather than the bare substring), feature lines bind names (scoped to the feature block).

Lint, smoke and `test_sheet_emit.py` (**121 passed**) green; CI has the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)