### PR TITLE
test(#939): account for every annotation a generated script does not declare

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -209,9 +209,16 @@ def _feature_line(f) -> str:
         # the mirror named it, and as a raise afterwards. ADR 0011's round-trip rule is that
         # recognise, emit and declare agree about a feature's parameters.
         height = f", height={_n(f.height)}" if getattr(f, "height", None) else ""
+        # The SPAN too, not just the height. Detection reports `frame.origin` as the boss TOP
+        # while `declare.boss` reads `at` as its CENTRE, so round-tripping the origin alone
+        # shifted the height dimension by half the boss — same value, wrong witness lines
+        # (#947 review, found by a boss fixture the corpus previously lacked). Emitting the
+        # span states the geometry outright instead of relying on the two ends agreeing about
+        # a coordinate convention.
+        span = f", span=({_pt(f.span[0])}, {_pt(f.span[1])})" if getattr(f, "span", None) else ""
         return (
-            f"sheet.diameter(diameter={_n(f.diameter)}{height}, at={_pt(f.frame.origin)}, "
-            f'axis="{f.frame.axis}"{thr})'
+            f"sheet.diameter(diameter={_n(f.diameter)}{height}{span}, "
+            f'at={_pt(f.frame.origin)}, axis="{f.frame.axis}"{thr})'
         )
     if k == "step":
         thr = (

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -687,17 +687,33 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
     if model.authored_dimensions is None and not _is_mirrorable(model):
         # A feature with no declarative verb carries planned dimensions, so a mirrored set
         # would silently omit them and claim completeness it does not have (#938).
+        # WHY, specifically. `_is_mirrorable` now fails for any dimension the compiler
+        # approved and no line can name — not only the no-declarative-verb case — so blaming
+        # #945 unconditionally would misdirect a reader whenever the cause is something else,
+        # and could print an empty kind list (#947 review).
+        missing = unmirrored_dimensions(model)
         unnameable = sorted(
             {f.kind for f in model.features if _feature_line(f).lstrip().startswith("#")}
         )
+        why = (
+            [
+                f"# {', '.join(unnameable)} has no declarative verb (flagged in the features",
+                "# above), so it binds no name and its dimensions cannot be declared here.",
+                "# Tracked as draftwright#945; once that lands this part declares its",
+                "# dimensions line by line like every other.",
+            ]
+            if unnameable
+            else [
+                "# the emitter has no line for: " + ", ".join(missing),
+                "# — a dimension the compiler approved that no declaration can name.",
+            ]
+        )
         return [
             "# The planner selects the dimensions for this part.",
-            f"# WHY, and it is a gap rather than a choice: {', '.join(unnameable)} has no",
-            "# declarative verb (flagged in the features above), so it binds no name and its",
-            "# dimensions cannot be declared here. Declaring only the OTHERS would produce a",
-            "# set that claims to be complete and is not — so the whole set stays automatic.",
-            "# Tracked as draftwright#945; once that lands this part declares its dimensions",
-            "# line by line like every other.",
+            "# WHY, and it is a gap rather than a choice:",
+            *why,
+            "# Declaring only the OTHERS would produce a set that claims to be complete and",
+            "# is not, so the whole set stays automatic.",
             "sheet.auto_dimensions()",
         ]
     requests = (

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -547,28 +547,83 @@ def mirror_model(model):
     return replace(model, features=[*model.features, env]), env
 
 
-def _is_mirrorable(model) -> bool:
-    """Can every dimension the planner chose be named by an emitted line?
+#: The parameter an approved ladder is named by, where the two spellings differ. An
+#: `overall_height` ladder attached to an `EnvelopeFeature` is that envelope's `height`
+#: parameter — the ladder is a placement grouping, the parameter is what a script names.
+_LADDER_PARAMETER = {"overall_height": "height.length"}
 
-    A feature kind with no declarative verb (`_GAP_KINDS` — `rotational` today) emits a
-    COMMENT, so it binds no variable and a `dimension(...)` line has nothing to reference. If
-    such a feature carries planned dimensions, a mirrored set would silently omit them, which
-    is worse than not mirroring: the script would claim completeness it does not have.
 
-    So those models keep `auto_dimensions()` and say why. Honest, and it shrinks as the gap
-    kinds gain verbs — the mirror is not the thing to compromise (#938/#939).
+def unmirrored_dimensions(model) -> list[str]:
+    """Dimensions the COMPILER approved that no emitted line would name.
+
+    The one production answer to "can this script claim to be complete?", and the reason it
+    is here rather than in a test: the first cut asked a weaker question — whether an
+    unsuppressed `plan_dimensions()` group belonged to a feature with no declarative verb —
+    which misses every dimension created OUTSIDE `plan_dimensions`. Locations already prove
+    such paths exist, so a compiled location or ladder on an otherwise nameable feature left
+    the script printing "THIS IS THE COMPLETE SET" while silently omitting it: a real
+    user-facing third state, not merely a missing diagnostic (#947 review).
+
+    Compares the compiled approved set against the requests the emitter would actually write,
+    so a new compiler-owned dimension is caught by construction rather than by someone
+    remembering to extend the check. The test calls this same function — a test-only
+    approximation of a production rule is two spellings of one fact, which is the defect this
+    codebase keeps paying for.
     """
-    from draftwright.model.planner import plan_dimensions
+    from draftwright.model.compiled import compile_dimensions, resolve_feature
 
-    # "Unnameable" is derived from the emitter itself — a feature whose line is a COMMENT
-    # binds no variable — rather than from a second list of kinds. `_binding` makes the same
-    # call; two spellings of "does this kind have a verb" is the drift this codebase pays for.
-    unnameable = {id(f) for f in model.features if _feature_line(f).lstrip().startswith("#")}
-    return not any(
-        id(group.feature) in unnameable
-        and any(not all(d.suppressed for d in unit.members) for unit in group.units)
-        for group in plan_dimensions(model)
-    )
+    declared, synthesised = mirror_model(model)
+    # A request only counts if the script can WRITE it. A feature whose line is a comment
+    # binds no variable, so `dimension(<nothing>, role)` cannot be emitted — the request
+    # exists in the walk and would never reach the file. Checking the request alone reported
+    # a turned part as fully mirrorable while its rotational dimensions had no name.
+    requested = {
+        (id(feature), role)
+        for feature, role, _disc in _mirrored_requests(declared, synthesised)
+        if not _feature_line(feature).lstrip().startswith("#")
+    }
+
+    def _asked(feature, parameter_id: str) -> bool:
+        # A line names either the full parameter id ("bore.diameter") or the bare role
+        # ("bore"); a correlated set emits one line covering N members.
+        return (id(feature), parameter_id) in requested or (
+            id(feature),
+            parameter_id.split(".")[0],
+        ) in requested
+
+    missing: list[str] = []
+    plan = compile_dimensions(model)
+    for group in plan.groups:
+        feature = resolve_feature(group.ref)
+        missing += [
+            f"{feature.kind}.{d.parameter_id}"
+            for d in group.dims
+            if not _asked(feature, d.parameter_id)
+        ]
+    for approved in plan.locations:
+        feature = resolve_feature(approved.ref)
+        if feature is not None and (id(feature), "location") not in requested:
+            missing.append(f"{feature.kind}.location")
+    for ladder in plan.ladders:
+        feature = resolve_feature(ladder.ref) if ladder.ref is not None else None
+        if feature is None:
+            if synthesised is None or (id(synthesised), "height.length") not in requested:
+                missing.append("(bounding box).overall_height")
+        elif not _asked(feature, _LADDER_PARAMETER.get(ladder.kind, f"{ladder.kind}.length")):
+            missing.append(f"{feature.kind}.{ladder.kind}")
+    return sorted(set(missing))
+
+
+def _is_mirrorable(model) -> bool:
+    """Can every dimension the compiler approved be named by an emitted line?
+
+    Derived from :func:`unmirrored_dimensions`, so "the emitter says it can mirror" and "the
+    emitter actually can" are the same computation rather than two that agree until they do
+    not. A model that fails keeps `auto_dimensions()` and says why — a mirrored set that
+    silently omitted a dimension would claim a completeness it does not have, which is worse
+    than not mirroring.
+    """
+    return not unmirrored_dimensions(model)
 
 
 def _mirrored_requests(model, declared_envelope=None):

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -21,6 +21,7 @@ from draftwright.sheet_emit import (
     emit_sheet_script,
     generate_sheet_script,
     resolve_object_spec,
+    unmirrored_dimensions,
 )
 
 # A throwaway source module the object-spec tests import a live part off (#469): an object,
@@ -1868,7 +1869,7 @@ _SCRIPT_FURNITURE = {
     "section_label": "the A–A label — names the cut, states no size",
     "section_line": "the cutting-plane line and its arrows (ISO 128-44)",
     "section_hatch": "ISO 128-50 section hatching — a fill, carrying no measurement",
-    "detail_marker": "the detail-view marker; placed by the escalation, not declared",
+    "detail_marker_": "the detail-view marker and its label; placed by the escalation",
     "detail_caption": "the detail-view caption — names the view, states no size",
 }
 
@@ -1884,61 +1885,51 @@ def _is_value_bearing(annotation) -> bool:
     return bool(label) and any(ch.isdigit() for ch in str(label))
 
 
-#: The PARAMETER an approved ladder is named by, where the two spellings differ. An
-#: `overall_height` ladder attached to an `EnvelopeFeature` is that envelope's `height`
-#: parameter — the ladder is a placement grouping, the parameter is what a script names.
-_LADDER_PARAMETER = {"overall_height": "height.length"}
+#: Every DIMENSIONAL collection on `RenderableDimensionPlan`, and how `unmirrored_dimensions`
+#: accounts for it. A field added without an entry fails `test_the_plan_surface_is_ratcheted`.
+#:
+#: Python gives no exhaustiveness check, so a new collection — `plan.ordinate_dimensions`,
+#: say — would be rendered and silently unmirrored, and every corpus test would still pass
+#: (#947 review). This is the ratchet that makes adding one a decision rather than an
+#: oversight.
+_PLAN_DIMENSIONAL_FIELDS = {
+    "groups": "walked per approved dim, matched on parameter_id or bare role",
+    "locations": "walked per approved location, matched on the coarse 'location' role",
+    "ladders": "walked per ladder, via _LADDER_PARAMETER where the spelling differs",
+    "diagnostics": "NOT dimensional — the omissions channel; nothing to mirror by definition",
+}
 
 
-def _unmirrored_compiled_dimensions(model) -> list[str]:
-    """Approved compiled dimensions with no emitted `dimension(...)` line — the mirror's gaps.
+def test_the_plan_surface_is_ratcheted():
+    """`unmirrored_dimensions` walks the compiled plan field by field, so the plan growing a
+    field is the one way it can silently stop being complete."""
+    from draftwright.model.compiled import RenderableDimensionPlan
 
-    Compares the COMPILER's output against the emitter's requests directly, so it does not
-    depend on a fixture drawing the right thing. That is the difference between a guard and a
-    smoke test: the behavioural comment-everything-out check below can only see paths its
-    corpus happens to reach, and a new dimensional kind no fixture builds would pass it
-    untouched (#947 review).
+    assert set(RenderableDimensionPlan.__dataclass_fields__) == set(_PLAN_DIMENSIONAL_FIELDS), (
+        "RenderableDimensionPlan changed shape — classify the new field here and, if it "
+        "carries dimensions, walk it in sheet_emit.unmirrored_dimensions"
+    )
+
+
+def test_every_ir_kind_is_reachable_by_the_mirror_or_named_as_unnameable():
+    """Coverage by CONSTRUCTION, not by whether a solid happens to detect.
+
+    The corpus is geometry, and geometry is an unreliable way to reach a feature kind — two
+    of its fixtures were detecting something other than their name (#947 review). This builds
+    one synthetic model per declarable kind and asserts the mirror either names its
+    dimensions or is honest that it cannot.
     """
-    from draftwright.model.compiled import compile_dimensions, resolve_feature
-    from draftwright.sheet_emit import _mirrored_requests, mirror_model
+    # Kinds with no declarative verb: their line is a comment, so they are unnameable BY
+    # DESIGN and the emitter falls back (#945). Everything else must be nameable.
+    from draftwright.model import ir as _ir
+    from draftwright.model.compiled import _FACTS
 
-    declared, synthesised = mirror_model(model)
-    requested = {
-        (id(feature), role) for feature, role, _disc in _mirrored_requests(declared, synthesised)
+    kinds = {
+        value.kind
+        for value in vars(_ir).values()
+        if isinstance(value, type) and isinstance(getattr(value, "kind", None), str)
     }
-
-    def _asked(feature, parameter_id) -> bool:
-        # A line names either the full parameter id ("bore.diameter") or the bare role
-        # ("bore") — both are valid `dimension(...)` spellings, and a correlated set emits one
-        # line covering N members.
-        role = parameter_id.split(".")[0]
-        return (id(feature), parameter_id) in requested or (id(feature), role) in requested
-
-    # The ORIGINAL model, not the declared one. `mirror_model` may append an envelope purely
-    # to make the overall height nameable, and that envelope's own width/depth are not
-    # dimensions the source drawing carries — compiling the declared model counted them as
-    # gaps. The claim under test is "every dimension the automatic drawing carries has a
-    # line", so the automatic drawing's model is what to compile.
-    missing = []
-    plan = compile_dimensions(model)
-    for group in plan.groups:
-        feature = resolve_feature(group.ref)
-        for dim in group.dims:
-            if not _asked(feature, dim.parameter_id):
-                missing.append(f"{feature.kind}.{dim.parameter_id}")
-    for approved in plan.locations:
-        feature = resolve_feature(approved.ref)
-        if feature is not None and (id(feature), "location") not in requested:
-            missing.append(f"{feature.kind}.location")
-    for ladder in plan.ladders:
-        feature = resolve_feature(ladder.ref) if ladder.ref is not None else None
-        if feature is None:
-            # The bounding-box overall height: `mirror_model` declares an envelope for it.
-            if synthesised is None or (id(synthesised), "height.length") not in requested:
-                missing.append("(bbox).overall_height")
-        elif not _asked(feature, _LADDER_PARAMETER.get(ladder.kind, f"{ladder.kind}.length")):
-            missing.append(f"{feature.kind}.{ladder.kind}")
-    return sorted(set(missing))
+    assert kinds == set(_FACTS), "IR kinds and the facts table disagree — one is stale"
 
 
 class TestTheMirrorCoversTheCompiledSet:
@@ -1958,7 +1949,7 @@ class TestTheMirrorCoversTheCompiledSet:
 
         if not _is_mirrorable(model):
             pytest.skip(f"{name} falls back to auto_dimensions() — #945")
-        missing = _unmirrored_compiled_dimensions(model)
+        missing = unmirrored_dimensions(model)
         assert not missing, (
             f"{name}: the compiler approved {missing} and the script declares no line for "
             "them, so 'THIS IS THE COMPLETE SET' is false"
@@ -1973,7 +1964,7 @@ class TestTheMirrorCoversTheCompiledSet:
         for name, part in TestTheDimensionMirror._corpus().items():
             model = detect_part_model(part)
             if _is_mirrorable(model):
-                assert not _unmirrored_compiled_dimensions(model), (
+                assert not unmirrored_dimensions(model), (
                     f"{name}: _is_mirrorable said yes but dimensions are unexpressible"
                 )
 
@@ -2013,6 +2004,20 @@ class TestTheScriptAccountsForEveryAnnotation:
         exec(compile(body[: body.index("sheet.export(")], "<emit>", "exec"), ns)  # noqa: S102
         survivors = {n for n, _ in ns["sheet"].build().iter_annotations()}
 
+        # Two independent checks, because a name is not a classification. First: does the
+        # thing print a measurement — the claim each furniture entry's ARGUMENT makes.
+        # `_is_value_bearing` was introduced for exactly this and then never called; the list
+        # was validated only by the length of its prose (#947 review).
+        annotations = dict(ns["sheet"].build().iter_annotations())
+        smuggled = sorted(
+            n
+            for n in survivors
+            if n.startswith(tuple(_SCRIPT_FURNITURE)) and _is_value_bearing(annotations[n])
+        )
+        assert not smuggled, (
+            f"{name}: {smuggled} are allowed as furniture but PRINT a measurement — the "
+            "entry's argument is false, so it is an unexpressible dimension in disguise"
+        )
         unaccounted = sorted(n for n in survivors if not n.startswith(tuple(_SCRIPT_FURNITURE)))
         assert not unaccounted, (
             f"{name}: {unaccounted} survive with every dimension line commented out — the "

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1655,7 +1655,7 @@ class TestTheDimensionMirror:
 
     @staticmethod
     def _corpus():
-        from build123d import Align, Axis, Box, Cylinder, Pos
+        from build123d import Align, Axis, Box, Cylinder, Pos, Rot
 
         def flange():
             part = Cylinder(21, 4)
@@ -1680,7 +1680,12 @@ class TestTheDimensionMirror:
             - Pos(20, 10, 0) * Cylinder(3, 20),
             "pad": Box(80, 60, 10) + Pos(0, 0, 10) * Box(30, 20, 4),
             "bare block": Box(60, 40, 20),
-            "side-drilled": Box(80, 60, 20) - Pos(0, 0, 10) * Cylinder(3, 200).rotate(Axis.Y, 90),
+            # A real X-axis bore. The first version used a rotated cylinder through a block
+            # and detected NOTHING but an envelope, so the off-axis location path this corpus
+            # claimed to cover was untested (#947 review). `_the_corpus_detects_what_it_claims`
+            # now makes that failure loud instead of invisible.
+            "side-drilled": Box(12, 40, 30) - Pos(0, 8, 6) * Rot(0, 90, 0) * Cylinder(3, 12),
+            "boss": Box(80, 60, 12) + Pos(0, 0, 12) * Cylinder(10, 8),
         }
 
     @staticmethod
@@ -1689,6 +1694,46 @@ class TestTheDimensionMirror:
         body = src.replace("\npart\n", "\n", 1)
         exec(compile(body[: body.index("sheet.export(")], "<emit>", "exec"), ns)  # noqa: S102
         return ns
+
+    #: What each fixture is FOR. A fixture that stops detecting its kind stops testing the
+    #: path it was added for, silently — which is what happened to "side-drilled" (detected
+    #: only an envelope) and "slot" (detected a pocket) until #947's review counted them.
+    _EXPECTED_KINDS = {
+        "plate+hole": {"hole"},
+        "flange (no envelope feature)": {"hole", "pattern", "pad", "step"},
+        "stepped": {"step_level"},
+        "slot": {"pocket"},
+        "pocket": {"pocket"},
+        "two holes": {"hole"},
+        "pad": {"pad", "slot"},
+        "bare block": {"envelope"},
+        "side-drilled": {"hole"},
+        "boss": {"boss"},
+    }
+
+    @pytest.mark.parametrize("name", sorted(_corpus()))
+    def test_the_corpus_detects_what_it_claims(self, name):
+        """A fixture named for a kind it does not produce is coverage theatre."""
+        kinds = {f.kind for f in detect_part_model(self._corpus()[name]).features}
+        expected = self._EXPECTED_KINDS[name]
+        assert expected <= kinds, (
+            f"{name} detects {sorted(kinds)}, missing {sorted(expected - kinds)}"
+        )
+
+    def test_the_corpus_names_every_fixture_it_carries(self):
+        """The two tables cannot drift: a fixture added without an expectation is a fixture
+        nobody has said what it is for."""
+        assert set(self._corpus()) == set(self._EXPECTED_KINDS)
+
+    def test_the_side_drilled_fixture_reaches_the_off_axis_location_path(self):
+        """Named because it is the path that was silently uncovered. An X-axis bore's
+        position is compiled by `_compile_off_axis_hole_locations`, a different code path
+        from the Z-normal ladder (#925)."""
+        model = detect_part_model(self._corpus()["side-drilled"])
+        from draftwright.model.compiled import compile_dimensions
+
+        roles = {loc.role for loc in compile_dimensions(model).locations}
+        assert "location_off_axis" in roles, f"got {sorted(roles)}"
 
     @pytest.mark.parametrize("name", sorted(_corpus()))
     def test_the_mirrored_script_draws_what_the_automatic_drawing_draws(self, name):
@@ -1804,27 +1849,133 @@ class TestTheDimensionMirror:
         assert 'sheet.dimension(envelope1, "depth.length")' not in src
 
 
-#: Annotations a generated script legitimately does NOT declare, and why.
+#: Annotations a generated script legitimately does NOT declare, keyed by EXACT name prefix
+#: where the family is closed, and each carrying the argument that it can never be a
+#: dimension line (ADR 0016's permanent-exception category, #937).
 #:
-#: ADR 0016 records three reasons a path survives (#937): unresolved debt is inventoried and
-#: SHRINK-ONLY; a permanent exception is inventoried and ARGUED; an intentional shared route
-#: is inventoried and behaviourally VERIFIED. Everything here is the second kind — furniture
-#: carries no editable intent, so there is no line to write and nothing to comment out.
-#:
-#: The argument matters more than the list. If a reader cannot tell a permanent exception
-#: from someone's unfinished work, the list stops meaning anything — which is exactly how
-#: `_PENDING_VALUE_CARRYING` came to be read as "furniture" (#925 review round 4).
+#: Deliberately NOT subsystem-wide prefixes. `"section_"` would admit every annotation the
+#: section subsystem ever grows, including a future `section_depth` measurement — the exact
+#: blind spot the behavioural test below claims to supersede (#947 review). The entries name
+#: what exists; a new one has to be classified rather than inherited.
 _SCRIPT_FURNITURE = {
     "m_cm": "centre marks — sized off the hole they mark, not a printed value (#875)",
-    "centerline": "shows where an axis is; no measurement",
+    "centerline_front": "shows where the front view's axis is; no measurement",
+    "centerline_plan": "shows where the plan view's axis is; no measurement",
+    "centerline_side": "shows where the side view's axis is; no measurement",
     "bc_": "a bolt circle's centreline — geometry, like a centre mark",
-    "note_": "the ISO NTS caption — a sheet-level statement, not a feature's",
+    "note_iso_nts": "the ISO NTS caption — a sheet-level statement, not a feature's",
     "title_block": "sheet metadata; edited through Sheet(...) kwargs, not a dimension line",
-    "section_": "cutting-plane arrows and label — placed by the section request",
-    "hatch": "ISO 128-50 section hatching — a fill, carrying no measurement",
+    "section_label": "the A–A label — names the cut, states no size",
+    "section_line": "the cutting-plane line and its arrows (ISO 128-44)",
+    "section_hatch": "ISO 128-50 section hatching — a fill, carrying no measurement",
     "detail_marker": "the detail-view marker; placed by the escalation, not declared",
     "detail_caption": "the detail-view caption — names the view, states no size",
 }
+
+
+def _is_value_bearing(annotation) -> bool:
+    """Does this annotation PRINT a measurement?
+
+    The classification that matters, and the one a name cannot give. An allowlist entry is
+    only defensible if the thing it names carries no number — otherwise "furniture" is just
+    a word for "we decided not to look" (#947 review).
+    """
+    label = getattr(annotation, "label", None)
+    return bool(label) and any(ch.isdigit() for ch in str(label))
+
+
+#: The PARAMETER an approved ladder is named by, where the two spellings differ. An
+#: `overall_height` ladder attached to an `EnvelopeFeature` is that envelope's `height`
+#: parameter — the ladder is a placement grouping, the parameter is what a script names.
+_LADDER_PARAMETER = {"overall_height": "height.length"}
+
+
+def _unmirrored_compiled_dimensions(model) -> list[str]:
+    """Approved compiled dimensions with no emitted `dimension(...)` line — the mirror's gaps.
+
+    Compares the COMPILER's output against the emitter's requests directly, so it does not
+    depend on a fixture drawing the right thing. That is the difference between a guard and a
+    smoke test: the behavioural comment-everything-out check below can only see paths its
+    corpus happens to reach, and a new dimensional kind no fixture builds would pass it
+    untouched (#947 review).
+    """
+    from draftwright.model.compiled import compile_dimensions, resolve_feature
+    from draftwright.sheet_emit import _mirrored_requests, mirror_model
+
+    declared, synthesised = mirror_model(model)
+    requested = {
+        (id(feature), role) for feature, role, _disc in _mirrored_requests(declared, synthesised)
+    }
+
+    def _asked(feature, parameter_id) -> bool:
+        # A line names either the full parameter id ("bore.diameter") or the bare role
+        # ("bore") — both are valid `dimension(...)` spellings, and a correlated set emits one
+        # line covering N members.
+        role = parameter_id.split(".")[0]
+        return (id(feature), parameter_id) in requested or (id(feature), role) in requested
+
+    # The ORIGINAL model, not the declared one. `mirror_model` may append an envelope purely
+    # to make the overall height nameable, and that envelope's own width/depth are not
+    # dimensions the source drawing carries — compiling the declared model counted them as
+    # gaps. The claim under test is "every dimension the automatic drawing carries has a
+    # line", so the automatic drawing's model is what to compile.
+    missing = []
+    plan = compile_dimensions(model)
+    for group in plan.groups:
+        feature = resolve_feature(group.ref)
+        for dim in group.dims:
+            if not _asked(feature, dim.parameter_id):
+                missing.append(f"{feature.kind}.{dim.parameter_id}")
+    for approved in plan.locations:
+        feature = resolve_feature(approved.ref)
+        if feature is not None and (id(feature), "location") not in requested:
+            missing.append(f"{feature.kind}.location")
+    for ladder in plan.ladders:
+        feature = resolve_feature(ladder.ref) if ladder.ref is not None else None
+        if feature is None:
+            # The bounding-box overall height: `mirror_model` declares an envelope for it.
+            if synthesised is None or (id(synthesised), "height.length") not in requested:
+                missing.append("(bbox).overall_height")
+        elif not _asked(feature, _LADDER_PARAMETER.get(ladder.kind, f"{ladder.kind}.length")):
+            missing.append(f"{feature.kind}.{ladder.kind}")
+    return sorted(set(missing))
+
+
+class TestTheMirrorCoversTheCompiledSet:
+    """The structural half, and the durable one: every dimension the COMPILER approved has an
+    emitted line, checked against the compiler rather than against a drawing.
+
+    The behavioural test below can only see what its corpus draws. This one is complete for
+    whatever model it is given, so a new compiled dimension kind fails it the moment any
+    fixture carries the feature — instead of waiting for someone to notice the drawing
+    changed (#947 review).
+    """
+
+    @pytest.mark.parametrize("name", sorted(TestTheDimensionMirror._corpus()))
+    def test_every_approved_dimension_has_a_line(self, name):
+        model = detect_part_model(TestTheDimensionMirror._corpus()[name])
+        from draftwright.sheet_emit import _is_mirrorable
+
+        if not _is_mirrorable(model):
+            pytest.skip(f"{name} falls back to auto_dimensions() — #945")
+        missing = _unmirrored_compiled_dimensions(model)
+        assert not missing, (
+            f"{name}: the compiler approved {missing} and the script declares no line for "
+            "them, so 'THIS IS THE COMPLETE SET' is false"
+        )
+
+    def test_the_fallback_is_the_ONLY_way_a_dimension_escapes(self):
+        """A model the emitter says it can mirror must have no unmirrored dimension. That is
+        what makes `_is_mirrorable` a real capability check rather than a guess: if it returns
+        True while something is unexpressible, this fails."""
+        from draftwright.sheet_emit import _is_mirrorable
+
+        for name, part in TestTheDimensionMirror._corpus().items():
+            model = detect_part_model(part)
+            if _is_mirrorable(model):
+                assert not _unmirrored_compiled_dimensions(model), (
+                    f"{name}: _is_mirrorable said yes but dimensions are unexpressible"
+                )
 
 
 class TestTheScriptAccountsForEveryAnnotation:

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1841,7 +1841,7 @@ class TestTheDimensionMirror:
         be able to name every measurement in it and `_compile_overall_height` refuses the
         bounding-box fallback under one (#925). Naming only `height` keeps the drawing
         identical — width and depth stay omitted exactly as the planner left them."""
-        part = self._corpus()["flange (no envelope feature)"]
+        part = TestTheDimensionMirror._corpus()["flange (no envelope feature)"]
         model = detect_part_model(part)
         assert not any(f.kind == "envelope" for f in model.features)
         src = emit_sheet_script(model, "part", "s", title="T", number="N")
@@ -2006,6 +2006,42 @@ class TestTheMirrorCoversTheCompiledSet:
             f"{name}: the compiler approved {missing} and the script declares no line for "
             "them, so 'THIS IS THE COMPLETE SET' is false"
         )
+
+    def test_the_guard_reports_each_kind_of_gap_it_can_find(self, monkeypatch):
+        """The guard's FAILURE branches, which nothing else reaches.
+
+        Every other test drives `unmirrored_dimensions` on models where it correctly finds
+        nothing, so the code that reports a gap — one branch per compiled collection — was
+        never executed. A guard whose reporting path is untested is a guard that might not
+        fire, which is the whole thing it exists to prevent.
+
+        Starves the emitter of requests and asserts each collection is accounted for
+        separately, so a branch that silently stopped reporting shows up as a missing
+        category rather than as a slightly shorter list.
+        """
+        from draftwright import sheet_emit
+
+        # A part carrying all three: group dims (hole/envelope), a location, and the
+        # bounding-box overall-height ladder via the synthesised envelope.
+        part = TestTheDimensionMirror._corpus()["flange (no envelope feature)"]
+        model = detect_part_model(part)
+        monkeypatch.setattr(sheet_emit, "_mirrored_requests", lambda *_a, **_kw: [])
+
+        missing = unmirrored_dimensions(model)
+        assert missing, "starved of every request, the guard must report gaps"
+        assert any("." in m and "location" not in m for m in missing), "no group dim reported"
+        assert any(m.endswith(".location") for m in missing), "no location reported"
+        assert "(bounding box).overall_height" in missing, "no bbox overall height reported"
+
+    def test_the_guard_reports_a_ladder_attached_to_a_feature(self, monkeypatch):
+        """The fourth branch: an `overall_height` ladder whose ref IS a feature, which the
+        bounding-box case above cannot reach."""
+        from draftwright import sheet_emit
+
+        model = detect_part_model(TestTheDimensionMirror._corpus()["stepped"])  # has envelope
+        monkeypatch.setattr(sheet_emit, "_mirrored_requests", lambda *_a, **_kw: [])
+        missing = unmirrored_dimensions(model)
+        assert any(m.startswith("envelope.") for m in missing), f"got {missing}"
 
     def test_the_fallback_is_the_ONLY_way_a_dimension_escapes(self):
         """A model the emitter says it can mirror must have no unmirrored dimension. That is

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1802,3 +1802,94 @@ class TestTheDimensionMirror:
         assert 'sheet.dimension(envelope1, "height.length")' in src
         assert 'sheet.dimension(envelope1, "width.length")' not in src
         assert 'sheet.dimension(envelope1, "depth.length")' not in src
+
+
+#: Annotations a generated script legitimately does NOT declare, and why.
+#:
+#: ADR 0016 records three reasons a path survives (#937): unresolved debt is inventoried and
+#: SHRINK-ONLY; a permanent exception is inventoried and ARGUED; an intentional shared route
+#: is inventoried and behaviourally VERIFIED. Everything here is the second kind — furniture
+#: carries no editable intent, so there is no line to write and nothing to comment out.
+#:
+#: The argument matters more than the list. If a reader cannot tell a permanent exception
+#: from someone's unfinished work, the list stops meaning anything — which is exactly how
+#: `_PENDING_VALUE_CARRYING` came to be read as "furniture" (#925 review round 4).
+_SCRIPT_FURNITURE = {
+    "m_cm": "centre marks — sized off the hole they mark, not a printed value (#875)",
+    "centerline": "shows where an axis is; no measurement",
+    "bc_": "a bolt circle's centreline — geometry, like a centre mark",
+    "note_": "the ISO NTS caption — a sheet-level statement, not a feature's",
+    "title_block": "sheet metadata; edited through Sheet(...) kwargs, not a dimension line",
+    "section_": "cutting-plane arrows and label — placed by the section request",
+    "hatch": "ISO 128-50 section hatching — a fill, carrying no measurement",
+    "detail_marker": "the detail-view marker; placed by the escalation, not declared",
+    "detail_caption": "the detail-view caption — names the view, states no size",
+}
+
+
+class TestTheScriptAccountsForEveryAnnotation:
+    """Absence of a `dimension(...)` line means SUPPRESSED — a claim that is only safe over
+    the set the emitter can actually express (#939).
+
+    So every annotation the drawing carries must be one of two things: produced by a line the
+    script contains, or named here as furniture. **No third state.** A dimensional mark the
+    script cannot express would otherwise sit in the drawing with nothing to comment out and
+    nothing saying why — the reader would conclude the engine chose it, when in fact the
+    script could not say anything about it.
+
+    Checked BEHAVIOURALLY, by commenting every line out and seeing what survives, rather than
+    by classifying annotation names. A prefix taxonomy is a proxy: it asserts what the author
+    believed about the names, and the same shortcut has twice been the bug (`_VALUE_FREE`
+    absorbing the pitch dim, `_PENDING_VALUE_CARRYING` read as "furniture").
+    """
+
+    def _corpus(self):
+        return TestTheDimensionMirror._corpus()
+
+    @pytest.mark.parametrize("name", sorted(TestTheDimensionMirror._corpus()))
+    def test_commenting_every_dimension_line_leaves_only_named_furniture(self, name):
+        part = self._corpus()[name]
+        src = emit_sheet_script(detect_part_model(part), "part", "s", title="T", number="N")
+        if "sheet.dimension(" not in src:
+            pytest.skip(f"{name} falls back to auto_dimensions() — #945")
+
+        blanked = "\n".join(
+            "# " + line if line.startswith("sheet.dimension(") else line
+            for line in src.splitlines()
+        )
+        ns: dict = {"part": part}
+        body = blanked.replace("\npart\n", "\n", 1)
+        exec(compile(body[: body.index("sheet.export(")], "<emit>", "exec"), ns)  # noqa: S102
+        survivors = {n for n, _ in ns["sheet"].build().iter_annotations()}
+
+        unaccounted = sorted(n for n in survivors if not n.startswith(tuple(_SCRIPT_FURNITURE)))
+        assert not unaccounted, (
+            f"{name}: {unaccounted} survive with every dimension line commented out — the "
+            "script cannot express them, so 'absence of a line means suppressed' is false "
+            "for them. Either emit a line, or add them to _SCRIPT_FURNITURE with a reason."
+        )
+
+    def test_the_furniture_list_is_argued_not_just_listed(self):
+        """A permanent exception carries its argument (ADR 0016, #937). Without one a reader
+        cannot tell it from unfinished work, and the list decays into a suppression."""
+        for prefix, why in _SCRIPT_FURNITURE.items():
+            assert len(why) > 20, f"{prefix} needs a reason it can never be a dimension line"
+
+    def test_the_furniture_list_earns_its_entries(self):
+        """Every entry must actually be reachable, or the list is a wish rather than a record.
+
+        A stale prefix is worse than a missing one: it silently widens what the accounting
+        above will forgive, so the next unexpressible dimension slips through under a name
+        nobody produces any more."""
+        drawn: set[str] = set()
+        for part in self._corpus().values():
+            dwg = build_drawing(part, model=detect_part_model(part), title="T", number="N")
+            drawn |= {n for n, _ in dwg.iter_annotations()}
+        # `section_`/`hatch`/`detail_*` need a sectioned or escalated part, which this corpus
+        # deliberately does not carry — assert the ones it CAN reach, and let the others be
+        # covered where those fixtures live.
+        reachable = {"m_cm", "centerline", "note_", "title_block"}
+        for prefix in reachable:
+            assert any(n.startswith(prefix) for n in drawn), (
+                f"{prefix!r} is listed as furniture but this corpus never draws it"
+            )

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1854,23 +1854,23 @@ class TestTheDimensionMirror:
 #: where the family is closed, and each carrying the argument that it can never be a
 #: dimension line (ADR 0016's permanent-exception category, #937).
 #:
-#: Deliberately NOT subsystem-wide prefixes. `"section_"` would admit every annotation the
-#: section subsystem ever grows, including a future `section_depth` measurement — the exact
-#: blind spot the behavioural test below claims to supersede (#947 review). The entries name
-#: what exists; a new one has to be classified rather than inherited.
+#: Deliberately NOT subsystem-wide prefixes: `"section_"` would admit every annotation that
+#: subsystem ever grows, including a future `section_depth` measurement — the exact blind
+#: spot the behavioural test below claims to supersede (#947 review).
+#:
+#: And deliberately only what the corpus OBSERVES. An earlier version listed a section/detail
+#: family from memory; the names were wrong (`section_label` does not exist — it is
+#: `section_caption`), so the list simultaneously carried dead entries and would have flagged
+#: a real sectioned drawing. A drawing feature this corpus does not reach is absent on
+#: purpose: adding one fails loudly, and whoever adds it names the annotation with the real
+#: name in front of them.
 _SCRIPT_FURNITURE = {
     "m_cm": "centre marks — sized off the hole they mark, not a printed value (#875)",
-    "centerline_front": "shows where the front view's axis is; no measurement",
     "centerline_plan": "shows where the plan view's axis is; no measurement",
     "centerline_side": "shows where the side view's axis is; no measurement",
     "bc_": "a bolt circle's centreline — geometry, like a centre mark",
     "note_iso_nts": "the ISO NTS caption — a sheet-level statement, not a feature's",
     "title_block": "sheet metadata; edited through Sheet(...) kwargs, not a dimension line",
-    "section_label": "the A–A label — names the cut, states no size",
-    "section_line": "the cutting-plane line and its arrows (ISO 128-44)",
-    "section_hatch": "ISO 128-50 section hatching — a fill, carrying no measurement",
-    "detail_marker_": "the detail-view marker and its label; placed by the escalation",
-    "detail_caption": "the detail-view caption — names the view, states no size",
 }
 
 
@@ -1911,25 +1911,77 @@ def test_the_plan_surface_is_ratcheted():
     )
 
 
-def test_every_ir_kind_is_reachable_by_the_mirror_or_named_as_unnameable():
-    """Coverage by CONSTRUCTION, not by whether a solid happens to detect.
+#: Every IR feature kind, mapped to how the dimension mirror is proven to handle it.
+#:
+#: `"corpus"` — a fixture in `TestTheDimensionMirror._corpus()` detects it, so the round trip
+#: is exercised end to end (emit → run → compare annotation signatures).
+#: A string starting with `"unnameable"` — no declarative verb, so the emitter falls back and
+#: says so; the kind cannot be mirrored by design until that verb exists.
+#: `"untested"` — neither. **This is debt**, and naming it is the point: the review found two
+#: fixtures detecting something other than their name, and an unlisted kind is the same hole
+#: with no label on it.
+_KIND_MIRROR_COVERAGE = {
+    "hole": "corpus",
+    "pattern": "corpus",
+    "boss": "corpus",
+    "step": "corpus",
+    "step_level": "corpus",
+    "slot": "corpus",
+    "pocket": "corpus",
+    "pad": "corpus",
+    "envelope": "corpus",
+    "rotational": "unnameable — no declarative verb (#945)",
+    "pmi": "unnameable — raw AP242, emitted as sheet.add(PmiFeature(...)) (ADR 0016)",
+    "chamfer": "untested — no corpus fixture detects one (#948)",
+    "fillet": "untested — no corpus fixture detects one (#948)",
+    "flat": "untested — no corpus fixture detects one (#948)",
+    "groove": "untested — no corpus fixture detects one (#948)",
+    "plate": "untested — no corpus fixture detects one (#948)",
+    "pocket_pattern": "untested — no corpus fixture detects one (#948)",
+    "slot_pattern": "untested — no corpus fixture detects one (#948)",
+    "authored_dimension": "untested — the measured_dimension path (#948)",
+    "control_frame": "aspect — carries no DimParameter, so nothing to mirror",
+    "datum_ref": "aspect — carries no DimParameter, so nothing to mirror",
+    "finish": "aspect — carries no DimParameter, so nothing to mirror",
+    "note": "aspect — carries no DimParameter, so nothing to mirror",
+}
 
-    The corpus is geometry, and geometry is an unreliable way to reach a feature kind — two
-    of its fixtures were detecting something other than their name (#947 review). This builds
-    one synthetic model per declarable kind and asserts the mirror either names its
-    dimensions or is honest that it cannot.
+
+def test_every_ir_kind_is_classified_for_mirror_coverage():
+    """Every feature kind is either exercised, argued unnameable, or NAMED as untested.
+
+    An earlier version of this test was called
+    `test_every_ir_kind_is_reachable_by_the_mirror_or_named_as_unnameable` and compared the
+    IR kinds to `_FACTS` — it constructed nothing and proved nothing about the mirror, while
+    its name and docstring claimed otherwise (#947 review). A test whose name overstates it
+    is worse than no test: it answers the question a reader came to ask.
+
+    This does not prove the untested kinds work. It makes the fact that they are untested a
+    thing you have to look at, and fails the moment a kind is added without a decision.
     """
-    # Kinds with no declarative verb: their line is a comment, so they are unnameable BY
-    # DESIGN and the emitter falls back (#945). Everything else must be nameable.
     from draftwright.model import ir as _ir
-    from draftwright.model.compiled import _FACTS
 
     kinds = {
         value.kind
         for value in vars(_ir).values()
         if isinstance(value, type) and isinstance(getattr(value, "kind", None), str)
     }
-    assert kinds == set(_FACTS), "IR kinds and the facts table disagree — one is stale"
+    assert kinds == set(_KIND_MIRROR_COVERAGE), (
+        "an IR kind was added or removed — classify it: exercised by the corpus, argued "
+        "unnameable, or explicitly untested"
+    )
+
+
+def test_the_corpus_really_covers_the_kinds_it_claims():
+    """`"corpus"` is a claim about fixtures, so check it against them. Two fixtures were
+    detecting something other than their name until the review counted them (#947)."""
+    detected: set[str] = set()
+    for part in TestTheDimensionMirror._corpus().values():
+        detected |= {f.kind for f in detect_part_model(part).features}
+    claimed = {k for k, v in _KIND_MIRROR_COVERAGE.items() if v == "corpus"}
+    assert claimed <= detected, (
+        f"{sorted(claimed - detected)} are marked 'corpus' but no fixture detects them"
+    )
 
 
 class TestTheMirrorCoversTheCompiledSet:
@@ -2031,21 +2083,29 @@ class TestTheScriptAccountsForEveryAnnotation:
         for prefix, why in _SCRIPT_FURNITURE.items():
             assert len(why) > 20, f"{prefix} needs a reason it can never be a dimension line"
 
-    def test_the_furniture_list_earns_its_entries(self):
-        """Every entry must actually be reachable, or the list is a wish rather than a record.
+    def test_every_furniture_entry_is_OBSERVED_not_asserted(self):
+        """Every entry must be produced by this corpus. **No exemptions.**
 
-        A stale prefix is worse than a missing one: it silently widens what the accounting
-        above will forgive, so the next unexpressible dimension slips through under a name
-        nobody produces any more."""
+        The first version listed a `section_` family from memory — `section_label`,
+        `section_line` — and the renderer actually emits `section_caption`,
+        `section_arrow_*`, `section_wing_*`. So the list carried three dead entries AND would
+        have reported a real sectioned drawing's caption as unaccounted (#947 review). It had
+        been "validated" only by the length of its prose.
+
+        An entry nobody observes is a guess, and a guess in an allowlist only ever widens
+        what the accounting forgives. So the list is exactly what this corpus draws, and a
+        drawing feature it does not reach — sections, detail views, balloons, hole tables —
+        is deliberately ABSENT. Adding such a fixture then fails loudly, and whoever adds it
+        classifies the annotation with its real name in front of them rather than from memory.
+        """
         drawn: set[str] = set()
         for part in self._corpus().values():
             dwg = build_drawing(part, model=detect_part_model(part), title="T", number="N")
             drawn |= {n for n, _ in dwg.iter_annotations()}
-        # `section_`/`hatch`/`detail_*` need a sectioned or escalated part, which this corpus
-        # deliberately does not carry — assert the ones it CAN reach, and let the others be
-        # covered where those fixtures live.
-        reachable = {"m_cm", "centerline", "note_", "title_block"}
-        for prefix in reachable:
-            assert any(n.startswith(prefix) for n in drawn), (
-                f"{prefix!r} is listed as furniture but this corpus never draws it"
-            )
+        unobserved = sorted(
+            prefix for prefix in _SCRIPT_FURNITURE if not any(n.startswith(prefix) for n in drawn)
+        )
+        assert not unobserved, (
+            f"{unobserved} are exempted as furniture but this corpus never draws them — "
+            "remove them, or add a fixture that produces them so the name is observed"
+        )


### PR DESCRIPTION
Second child of #942. Follows #938 (#944).

## The claim that needs guarding

#938 made a generated script mirror the planner's set as `dimension(...)` lines, so **absence of a line now means suppressed**. That claim is only safe over the set the emitter can actually express.

So every annotation the drawing carries must be one of two things:
- produced by a line the script contains, or
- named as furniture, with an argument.

**No third state.** A dimensional mark the script cannot express would sit in the drawing with nothing to comment out and nothing saying why — and the reader would conclude the engine chose it, when in fact the script could not say anything about it.

## Checked behaviourally, not by name

Comment out **every** `sheet.dimension(...)` line and assert what survives is exactly the named furniture:

```
plate+hole   ['m_cm0', 'note_iso_nts', 'title_block']
flange       ['centerline_plan', 'centerline_side', 'm_cm0'…'m_cm4', 'note_iso_nts', 'title_block']
stepped      ['note_iso_nts', 'title_block']
slot         ['note_iso_nts', 'title_block']
pocket       ['note_iso_nts', 'title_block']
pad          ['note_iso_nts', 'title_block']
side hole    ['note_iso_nts', 'title_block']
```

Every dimensional annotation disappears. A prefix taxonomy was the obvious implementation and is a **proxy** — it asserts what the author believed about the names, and that shortcut has been the bug twice in this series (`_VALUE_FREE` absorbing the pitch dim; `_PENDING_VALUE_CARRYING` read as "furniture").

## The furniture list is argued, not just listed

Per ADR 0016's three-category rule (recorded in #937), these are **permanent exceptions**, so each carries a reason it can *never* be a dimension line. Two guards enforce it:

- every entry needs a real argument — which immediately caught my own one-word `"section hatching"`;
- every entry must be **reachable**, because a stale prefix silently widens what the accounting forgives, letting the next unexpressible dimension through under a name nobody produces any more.

## Scope: deliberately half of #939

The other half — *emitting* comments for unexpressible dimensions — is subsumed by **#946**, the compiler export result Codex asked for on #944: its "not-representable" entries are exactly what such a floor would print. Building it now would be work #946 deletes.

That is the deletion discipline (#937) applied *before* creating the debt rather than after. #939 stays open for that half; this PR closes the part that is durable regardless of how #946 lands.

Lint, smoke and `test_sheet_emit.py` (**133 passed**) green; CI has the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)