### PR TITLE
feat(#941): report two dimensions that state the same measurement

### DIFF
--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -710,8 +710,8 @@ one exists today:
    different features measuring the same span.
 3. **A redundancy lint** — for over-dimensioning that is neither identical nor coincident,
    e.g. carrying both a pattern's per-hole locations *and* the pitch that determines them.
-   **This does not exist**: the current codes are `*_dropped` and `feature_not_dimensioned`;
-   nothing reports duplicate or redundant dimensioning. Adding it is part of this work.
+   **Landed as `redundant_dimension` (#941, 2026-07-31)**, but narrower than written here,
+   because the motivating example turned out not to occur — see the amendment below.
 
 ### Dimensions are sheet-level; the view is derived placement
 
@@ -1089,7 +1089,8 @@ second with the single-source-of-truth of the first — over the identified set,
   editable line, so the intent-mirror property holds; the two verbs stay distinct precisely
   because one references and the other restates.
 - **A duplicate/redundancy lint code joins `linting/structural.py`** — the third protection
-  layer; nothing reports redundant dimensioning today.
+  layer; nothing reports redundant dimensioning today. **Done** (#941): `redundant_dimension`,
+  severity `warning`, reporting the pair rather than picking a winner.
 - **`--style imperative` retires once the declarative mirror reaches its coverage**, leaving
   one generated output. The low-level `Drawing` verbs stay a hand-use API but stop being a
   generated surface (ADR 0001 §3), and the generated file deliberately loses its
@@ -1149,6 +1150,7 @@ second with the single-source-of-truth of the first — over the identified set,
    not yet mirrorable.
 5. **Redundancy lint.** The third duplicate-protection layer — report over-dimensioning that
    is neither identical nor coincident (a pattern's per-hole locations *and* its pitch).
+   **Landed** (#941), rescoped — the pattern example does not occur; see the amendment.
 6. **Retire `--style imperative`** once the mirror reaches its reconstruction coverage
    (rotational, the ladders, off-axis `locate`, machined callouts, pocket / slot patterns),
    leaving the declarative script as the single generated output. **Landed** (#940). The
@@ -1156,6 +1158,43 @@ second with the single-source-of-truth of the first — over the identified set,
    regressions asserted only against the imperative script (#555, #881, #889, #133) were
    retargeted onto the Sheet script and hold as full parity, and every part family in the
    round-trip corpus emits, runs and lints clean through it.
+
+## Amendment 2 — the redundancy lint is an authored-path check, because the planner cannot over-dimension (2026-07-31)
+
+Phase 5 asked whether redundancy is a lint or a planner rule. Measuring the planner's output
+before writing anything (#941) answered it, and rescoped the phase:
+
+- **The planner cannot close a dimension chain.** Every span it approves along an axis is
+  measured from a **common datum** — on a stepped block, `step_height` z(−20→10) and
+  `overall_height` z(−20→20) share a start; `step_position` x(−30→10) and the envelope width
+  x(−30→30) likewise. The derived remainders are simply left unstated, which is correct
+  datum dimensioning. A suppression rule in `plan_dimensions` would have nothing to suppress.
+- **The motivating example does not occur.** A linear pattern draws its pitch **plus one
+  origin location**, not per-hole locations *and* pitch. Those are complementary: the pitch
+  gives the spacing, the location gives where the array sits.
+- **The referential authored path cannot create redundancy either.** `dimension(feature, role)`
+  selects a *subset* of the addressable set, and a subset of a non-redundant set is
+  non-redundant.
+- **The materialised path can, and did.** `measured_dimension(...)` (and imported AP242 PMI,
+  the same IR kind) carries its own value and reference points and is checked against nothing.
+  Restating an approved measurement drew it twice, lint-clean.
+
+So `redundant_dimension` reports only what it can prove — same orientation, same measured
+length, coincident extent along the measuring axis — and does **not** attempt the general
+over-dimensioning question. It names the pair and chooses no winner: ISO 129 keeps the
+functionally significant dimension, which is a judgement about the part.
+
+**The planner-rule half of phase 5 already exists, ad hoc, and is unsound.**
+`_compile_overall_height` suppresses the overall height with the reasons "Z-turned (the step
+chain tiles the height)" and "rotational OD conveys the height". Those *are* redundancy rules
+in the planner. #955 records that they fire on a premise placement can invalidate: when the
+step chain drops at placement, nothing conveys the height, and a rule meant to prevent
+over-dimensioning leaves the drawing under-dimensioned. Fixing that is worth more than adding
+a second planner rule here.
+
+On its first corpus sweep the new check found one true positive in twenty parts — a plate
+with a pad dimensions the same 30 mm span twice, as the pad's length and as a
+mis-recognised slot's (#958).
 
 ## Open questions
 

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -710,8 +710,9 @@ one exists today:
    different features measuring the same span.
 3. **A redundancy lint** — for over-dimensioning that is neither identical nor coincident,
    e.g. carrying both a pattern's per-hole locations *and* the pitch that determines them.
-   **Landed as `redundant_dimension` (#941, 2026-07-31)**, but narrower than written here,
-   because the motivating example turned out not to occur — see the amendment below.
+   **Landed as `redundant_dimension` (#941, 2026-07-31)**, narrower than written here: the
+   motivating pattern example does not occur, and the check compares rather than prevents —
+   see Amendment 2.
 
 ### Dimensions are sheet-level; the view is derived placement
 
@@ -1159,42 +1160,54 @@ second with the single-source-of-truth of the first — over the identified set,
    retargeted onto the Sheet script and hold as full parity, and every part family in the
    round-trip corpus emits, runs and lints clean through it.
 
-## Amendment 2 — the redundancy lint is an authored-path check, because the planner cannot over-dimension (2026-07-31)
+## Amendment 2 — redundancy is reported, not planned away; the planner is not immune (2026-07-31)
 
 Phase 5 asked whether redundancy is a lint or a planner rule. Measuring the planner's output
-before writing anything (#941) answered it, and rescoped the phase:
+before writing anything (#941) narrowed the question, and reviewing the result corrected the
+first answer — recorded here in the order it happened, because the correction is the useful part.
 
-- **The planner cannot close a dimension chain.** Every span it approves along an axis is
-  measured from a **common datum** — on a stepped block, `step_height` z(−20→10) and
-  `overall_height` z(−20→20) share a start; `step_position` x(−30→10) and the envelope width
-  x(−30→30) likewise. The derived remainders are simply left unstated, which is correct
-  datum dimensioning. A suppression rule in `plan_dimensions` would have nothing to suppress.
-- **The motivating example does not occur.** A linear pattern draws its pitch **plus one
-  origin location**, not per-hole locations *and* pitch. Those are complementary: the pitch
-  gives the spacing, the location gives where the array sits.
-- **The referential authored path cannot create redundancy either.** `dimension(feature, role)`
-  selects a *subset* of the addressable set, and a subset of a non-redundant set is
-  non-redundant.
-- **The materialised path can, and did.** `measured_dimension(...)` (and imported AP242 PMI,
-  the same IR kind) carries its own value and reference points and is checked against nothing.
-  Restating an approved measurement drew it twice, lint-clean.
+**What measurement established.** Ordinary datum ladders do not close chains. Every span the
+planner approves along a *feature's own* axis is measured from a common datum — on a stepped
+block, `step_height` z(−20→10) and `overall_height` z(−20→20) share a start; `step_position`
+x(−30→10) and the envelope width x(−30→30) likewise. The derived remainders are simply left
+unstated, which is correct datum dimensioning. And the issue's motivating example does not
+occur: a linear pattern draws its pitch **plus one origin location**, not per-hole locations
+*and* pitch — those are complementary. (Pattern kinds differ in what they draw; slot patterns
+emit pitch with no origin location at all, which is a separate gap, #960.)
 
-So `redundant_dimension` reports only what it can prove — same orientation, same measured
-length, coincident extent along the measuring axis — and does **not** attempt the general
-over-dimensioning question. It names the pair and chooses no winner: ISO 129 keeps the
-functionally significant dimension, which is a judgement about the part.
+**What that did NOT establish, contrary to this amendment's first draft.** "The planner cannot
+over-dimension" was too strong, and its own supporting example refutes it (#959 review). #958
+is an *automatic* drawing in which a pad and a mis-recognised slot carry the identical x span
+and both get dimensioned. The recognition defect is upstream, but the planner still accepted
+two roles on two features naming the same span and emitted both. So:
 
-**The planner-rule half of phase 5 already exists, ad hoc, and is unsound.**
+- Two roles on two different features **can** name the same span; nothing in the planner
+  prevents it.
+- Therefore the referential authored path is not immune either — it selects a subset of the
+  addressable set, and that set is not guaranteed redundancy-free.
+- The materialised path (`measured_dimension`, imported AP242 PMI) is simply the *easiest*
+  way to produce it, since it carries its own value and reference points and is checked
+  against nothing.
+
+**Decision.** Report, do not plan away. `redundant_dimension` (severity `warning`) reports a
+pair that measures the same world axis over the same extent, names both annotations, and picks
+no winner: ISO 129 keeps the functionally significant dimension, which is a judgement about the
+part, and guessing produces a plausible wrong drawing (#630/#631). The check is comparison-only
+and deliberately narrow; it does not attempt the general over-dimensioning question.
+
+A planner-side suppression rule is **not** ruled out by this, and phase 5 should not be read as
+having decided against one. The evidence says a rule keyed on *datum ladders* would have nothing
+to catch, not that no planner rule could help — #958's pad/slot pair is exactly the shape a
+planner-side "two roles, one span" rule would resolve at the waist. What argues for lint first is
+that the pair's correct resolution is a drafting judgement, so a report is useful even once a
+planner rule exists.
+
+**The planner-rule half also already exists, ad hoc, and is unsound.**
 `_compile_overall_height` suppresses the overall height with the reasons "Z-turned (the step
-chain tiles the height)" and "rotational OD conveys the height". Those *are* redundancy rules
-in the planner. #955 records that they fire on a premise placement can invalidate: when the
-step chain drops at placement, nothing conveys the height, and a rule meant to prevent
-over-dimensioning leaves the drawing under-dimensioned. Fixing that is worth more than adding
-a second planner rule here.
-
-On its first corpus sweep the new check found one true positive in twenty parts — a plate
-with a pad dimensions the same 30 mm span twice, as the pad's length and as a
-mis-recognised slot's (#958).
+chain tiles the height)" and "rotational OD conveys the height" — redundancy rules in the
+planner. #955 records that they fire on a premise placement can invalidate: when the step chain
+drops at placement, nothing conveys the height, and a rule meant to prevent over-dimensioning
+leaves the drawing under-dimensioned. Fixing that is worth more than adding a second rule.
 
 ## Open questions
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -107,6 +107,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "chamfer_dropped",
         "placement_unsatisfiable",
         "pmi_dropped",
+        "redundant_dimension",
     }
 )
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -75,7 +75,9 @@ from draftwright.linting import (
     lint_feature_coverage,
     lint_location_coverage,
     lint_prismatic_coverage,
+    lint_redundant_dimensions,
 )
+from draftwright.linting.structural import _ann_box as _annotation_box
 from draftwright.projection import (
     project_view_geometry,
 )
@@ -2540,6 +2542,47 @@ class Drawing:
         self.items = [o for o in self.items if id(o) in kept_ids]
         return removed
 
+    def _redundancy_entries(self):
+        """``(name, view, length, lo, hi, horizontal, label)`` per drawn dimension (#941).
+
+        Assembled HERE rather than inside `lint_drawing` because the redundancy check needs
+        two things a bare annotation cannot supply: its registry NAME, so the report says
+        which two to look at rather than quoting two identical labels, and its VIEW, so the
+        world axis it measures is known rather than inferred from page geometry.
+
+        Non-sheet-scale annotations (the enlarged detail view, #42) are excluded: the same
+        measurement drawn again at detail scale has a different page length and extent, so
+        it is neither comparable to its sheet-scale twin nor to anything else here. That
+        makes a detail-view repeat a known blind spot rather than a wrong answer.
+        """
+        entries = []
+        for name, obj in self.iter_annotations():
+            if getattr(obj, "measured_length", None) is None:
+                continue
+            if getattr(obj, "_dw_scale", self.scale) != self.scale:
+                continue
+            view = self.view_of(name)
+            if view is None:
+                continue
+            box = _annotation_box(obj, self._ann_box_cache)
+            if box is None:
+                continue
+            min_x, min_y, max_x, max_y = box
+            horizontal = (max_x - min_x) >= (max_y - min_y)
+            lo, hi = (min_x, max_x) if horizontal else (min_y, max_y)
+            entries.append(
+                (
+                    name,
+                    view,
+                    float(obj.measured_length),
+                    lo,
+                    hi,
+                    horizontal,
+                    str(getattr(obj, "label", "")),
+                )
+            )
+        return entries
+
     def _record_build_issue(self, severity, code, message):
         """Record a lint issue discovered during construction (e.g. an
         annotation the layout had to drop). Surfaced by :meth:`lint` so a
@@ -2617,6 +2660,8 @@ class Drawing:
                     view_edge_cache=self._view_edge_cache,
                     ann_box_cache=self._ann_box_cache,
                 )
+        issues += lint_redundant_dimensions(self._redundancy_entries())
+
         if self.part is not None:
             # Reuse the single feature inventory from the build (#244) when present,
             # so lint does not re-detect holes/patterns/turned-steps; fall back to

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -26,10 +26,11 @@ from draftwright.linting.coverage import (
     lint_prismatic_coverage,
 )
 from draftwright.linting.issues import LintIssue
-from draftwright.linting.structural import lint_drawing
+from draftwright.linting.structural import lint_drawing, lint_redundant_dimensions
 from draftwright.linting.suggest import _suggest_fix
 
 __all__ = [
+    "lint_redundant_dimensions",
     "CoverageState",
     "LintIssue",
     "_suggest_fix",

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -264,6 +264,8 @@ def lint_drawing(
         elif getattr(item, "measured_length", None) is not None:
             _lint_dim(item, part_bbox, issues, drawing_scale, box_cache)
 
+    _lint_redundant_dims(items, issues, box_cache)
+
     # Pairwise label-overlap check. The compare-box for a label-less item is an
     # *optimal* bounding_box() — expensive, and previously recomputed for both
     # items of every pair (O(n²): ~200 s on an 83-hole part). Compute each
@@ -817,6 +819,80 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
                         f"{overlap / dim_area * 100:.0f}% — offset sign may place it inside the view"
                     ),
                     code="dim_inside_part",
+                )
+            )
+
+
+#: Page-mm slack for calling two dimension extents "the same". Generous next to placement
+#: precision (sub-micron) and far tighter than any real pair of distinct measurements.
+_REDUNDANT_TOL_MM = 0.15
+
+
+def _dim_measure(item, box_cache):
+    """What a dimension MEASURES, as page geometry: ``(orientation, length, lo, hi)``.
+
+    ``lo``/``hi`` bound it along its own measuring axis. That axis is the whole trick — two
+    dimensions of the same length that measure different things sit at different places
+    along it, and two that measure the same thing coincide there even when they are drawn
+    on different views, because the orthographic views are aligned (a plan-view width and a
+    front-view width share the page's x band by construction). So no view mapping is
+    needed, and none is guessed at. Returns None for anything unmeasurable.
+    """
+    bb = _ann_box(item, box_cache)
+    length = getattr(item, "measured_length", None)
+    if bb is None or length is None:
+        return None
+    min_x, min_y, max_x, max_y = bb
+    horizontal = (max_x - min_x) >= (max_y - min_y)
+    lo, hi = (min_x, max_x) if horizontal else (min_y, max_y)
+    return ("h" if horizontal else "v", float(length), lo, hi)
+
+
+def _lint_redundant_dims(items, issues, box_cache) -> None:
+    """Report two dimensions that state the SAME measurement (#941, ADR 0016 phase 5).
+
+    The engine's two existing duplicate protections do not cover this. Value/identity dedup
+    needs the same identity, and the corridor solve's coincident-span dedup compares
+    candidates within a solve — so a measurement that arrives from a *different producer*
+    passes both. The demonstrated case is a materialised
+    ``Sheet.measured_dimension(...)`` (or imported AP242 PMI, which is the same IR kind)
+    restating a measurement the planner already approved: both get drawn, and nothing said
+    anything.
+
+    Deliberately narrow. It reports only the case it can prove — same orientation, same
+    measured length, coincident extent along the measuring axis — and NOT the general
+    over-dimensioning question. The planner's own output cannot close a dimension chain:
+    every span it emits along an axis is measured from a common datum, so the derived
+    remainders are simply left unstated (verified across the drawing corpus, #941). A
+    checker for redundancy the planner cannot produce would be a rule with nothing to
+    catch.
+
+    It does not choose a winner either. Which of two redundant dimensions to keep is a
+    drafting judgement — ISO 129 prefers the functional one — and guessing produces a
+    plausible wrong drawing, which this codebase ranks below a visible message
+    (#630/#631). Severity ``warning``: the drawing is valid, the dimensioning is not.
+    """
+    measured = []
+    for item in items:
+        m = _dim_measure(item, box_cache)
+        if m is not None:
+            measured.append((m, _item_label(item)))
+
+    for i, (a, label_a) in enumerate(measured):
+        for b, label_b in measured[i + 1 :]:
+            if a[0] != b[0] or abs(a[1] - b[1]) > _REDUNDANT_TOL_MM:
+                continue
+            if abs(a[2] - b[2]) > _REDUNDANT_TOL_MM or abs(a[3] - b[3]) > _REDUNDANT_TOL_MM:
+                continue
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    message=(
+                        f"Dims '{label_a}' and '{label_b}' state the same measurement "
+                        f"— they span the same extent along the same axis. Drop one; ISO 129 "
+                        f"keeps the functionally significant dimension"
+                    ),
+                    code="redundant_dimension",
                 )
             )
 

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -264,8 +264,6 @@ def lint_drawing(
         elif getattr(item, "measured_length", None) is not None:
             _lint_dim(item, part_bbox, issues, drawing_scale, box_cache)
 
-    _lint_redundant_dims(items, issues, box_cache)
-
     # Pairwise label-overlap check. The compare-box for a label-less item is an
     # *optimal* bounding_box() — expensive, and previously recomputed for both
     # items of every pair (O(n²): ~200 s on an 83-hole part). Compute each
@@ -827,74 +825,68 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
 #: precision (sub-micron) and far tighter than any real pair of distinct measurements.
 _REDUNDANT_TOL_MM = 0.15
 
-
-def _dim_measure(item, box_cache):
-    """What a dimension MEASURES, as page geometry: ``(orientation, length, lo, hi)``.
-
-    ``lo``/``hi`` bound it along its own measuring axis. That axis is the whole trick — two
-    dimensions of the same length that measure different things sit at different places
-    along it, and two that measure the same thing coincide there even when they are drawn
-    on different views, because the orthographic views are aligned (a plan-view width and a
-    front-view width share the page's x band by construction). So no view mapping is
-    needed, and none is guessed at. Returns None for anything unmeasurable.
-    """
-    bb = _ann_box(item, box_cache)
-    length = getattr(item, "measured_length", None)
-    if bb is None or length is None:
-        return None
-    min_x, min_y, max_x, max_y = bb
-    horizontal = (max_x - min_x) >= (max_y - min_y)
-    lo, hi = (min_x, max_x) if horizontal else (min_y, max_y)
-    return ("h" if horizontal else "v", float(length), lo, hi)
+#: ``(view, orientation) -> the WORLD axis the dimension measures.`` Two dimensions are only
+#: comparable when they measure the same world axis, and page geometry alone cannot say which
+#: — a vertical dim means Z on the front view and Y on the plan. An earlier form of this check
+#: compared page extents and argued that view alignment made the mapping unnecessary; that was
+#: unsound (#959 review). It happened not to misfire on any corpus part, but the safety came
+#: from where the packer put the views, not from the data, so it is stated explicitly instead.
+_VIEW_AXIS = {
+    ("front", "h"): "x",
+    ("front", "v"): "z",
+    ("plan", "h"): "x",
+    ("plan", "v"): "y",
+    ("side", "h"): "y",
+    ("side", "v"): "z",
+}
 
 
-def _lint_redundant_dims(items, issues, box_cache) -> None:
+def lint_redundant_dimensions(entries) -> list[LintIssue]:
     """Report two dimensions that state the SAME measurement (#941, ADR 0016 phase 5).
+
+    *entries* are ``(name, view, length, lo, hi, horizontal, label)`` — the caller resolves
+    them, because this module is duck-typed on a bare annotation list and a `Dimension`
+    exposes neither its name nor its view. ``lo``/``hi`` bound the dimension along its own
+    measuring axis in page mm; ``length`` is the measured length.
 
     The engine's two existing duplicate protections do not cover this. Value/identity dedup
     needs the same identity, and the corridor solve's coincident-span dedup compares
-    candidates within a solve — so a measurement that arrives from a *different producer*
-    passes both. The demonstrated case is a materialised
-    ``Sheet.measured_dimension(...)`` (or imported AP242 PMI, which is the same IR kind)
-    restating a measurement the planner already approved: both get drawn, and nothing said
-    anything.
+    candidates *within* a solve — so a measurement arriving from a different producer passes
+    both. The demonstrated case is a materialised ``Sheet.measured_dimension(...)`` (or
+    imported AP242 PMI, the same IR kind) restating a measurement the planner already
+    approved: both drawn, nothing said.
 
-    Deliberately narrow. It reports only the case it can prove — same orientation, same
-    measured length, coincident extent along the measuring axis — and NOT the general
-    over-dimensioning question. The planner's own output cannot close a dimension chain:
-    every span it emits along an axis is measured from a common datum, so the derived
-    remainders are simply left unstated (verified across the drawing corpus, #941). A
-    checker for redundancy the planner cannot produce would be a rule with nothing to
-    catch.
-
-    It does not choose a winner either. Which of two redundant dimensions to keep is a
-    drafting judgement — ISO 129 prefers the functional one — and guessing produces a
-    plausible wrong drawing, which this codebase ranks below a visible message
-    (#630/#631). Severity ``warning``: the drawing is valid, the dimensioning is not.
+    Deliberately narrow — same world axis, same measured length, coincident extent. It does
+    NOT attempt the general over-dimensioning question, and it does not pick a winner: which
+    of two redundant dimensions to keep is a drafting judgement (ISO 129 prefers the
+    functional one), and guessing produces a plausible wrong drawing, which this codebase
+    ranks below a visible message (#630/#631). Severity ``warning``: the drawing is valid,
+    the dimensioning is not.
     """
-    measured = []
-    for item in items:
-        m = _dim_measure(item, box_cache)
-        if m is not None:
-            measured.append((m, _item_label(item)))
-
-    for i, (a, label_a) in enumerate(measured):
-        for b, label_b in measured[i + 1 :]:
-            if a[0] != b[0] or abs(a[1] - b[1]) > _REDUNDANT_TOL_MM:
+    issues: list[LintIssue] = []
+    axed = [
+        (name, _VIEW_AXIS[(view, "h" if horizontal else "v")], length, lo, hi, label)
+        for name, view, length, lo, hi, horizontal, label in entries
+        if (view, "h" if horizontal else "v") in _VIEW_AXIS
+    ]
+    for i, (name_a, axis_a, len_a, lo_a, hi_a, label_a) in enumerate(axed):
+        for name_b, axis_b, len_b, lo_b, hi_b, label_b in axed[i + 1 :]:
+            if axis_a != axis_b or abs(len_a - len_b) > _REDUNDANT_TOL_MM:
                 continue
-            if abs(a[2] - b[2]) > _REDUNDANT_TOL_MM or abs(a[3] - b[3]) > _REDUNDANT_TOL_MM:
+            if abs(lo_a - lo_b) > _REDUNDANT_TOL_MM or abs(hi_a - hi_b) > _REDUNDANT_TOL_MM:
                 continue
             issues.append(
                 LintIssue(
                     severity="warning",
                     message=(
-                        f"Dims '{label_a}' and '{label_b}' state the same measurement "
-                        f"— they span the same extent along the same axis. Drop one; ISO 129 "
-                        f"keeps the functionally significant dimension"
+                        f"Dims {name_a!r} ({label_a!r}) and {name_b!r} ({label_b!r}) state the "
+                        f"same measurement — the same {axis_a.upper()} extent. Drop one; "
+                        f"ISO 129 keeps the functionally significant dimension"
                     ),
                     code="redundant_dimension",
                 )
             )
+    return issues
 
 
 def _lint_leader(item, issues, box_cache=None, warned=None) -> None:

--- a/src/draftwright/linting/suggest.py
+++ b/src/draftwright/linting/suggest.py
@@ -107,9 +107,10 @@ def _suggest_fix(issue, dwg) -> str | None:
         # drafting judgement about the part, not something the geometry says.
         return (
             "# Two dimensions say the same thing. Keep the functionally significant one\n"
-            "# (ISO 129) and drop the other. In a generated Sheet script, comment out its\n"
-            "# line; on a live drawing:\n"
-            '# dwg.drop("<the redundant annotation name>")'
+            "# (ISO 129) and drop the other. The message names both; on a live drawing\n"
+            "# remove the one you do not want BY NAME (drop() takes a feature, not a name):\n"
+            '# dwg.remove("<the redundant annotation name>")\n'
+            "# In a generated Sheet script, comment out the dimension line instead."
         )
 
     if code == "plate_thickness_dropped":

--- a/src/draftwright/linting/suggest.py
+++ b/src/draftwright/linting/suggest.py
@@ -101,6 +101,17 @@ def _suggest_fix(issue, dwg) -> str | None:
             "dwg = build_drawing(part, detail_view=True)"
         )
 
+    if code == "redundant_dimension":
+        # Two dimensions state the same measurement (#941). The engine deliberately does
+        # not pick a winner — ISO 129 keeps the functionally significant one, which is a
+        # drafting judgement about the part, not something the geometry says.
+        return (
+            "# Two dimensions say the same thing. Keep the functionally significant one\n"
+            "# (ISO 129) and drop the other. In a generated Sheet script, comment out its\n"
+            "# line; on a live drawing:\n"
+            '# dwg.drop("<the redundant annotation name>")'
+        )
+
     if code == "plate_thickness_dropped":
         # A recognised plate/wall thickness had no room in its target strip (#559).
         return (

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -560,3 +560,59 @@ class TestLeaderCrossesSilhouette:
         arc = Edge.make_circle(5)
         edges = [(arc, _shape_box2d(arc))]
         assert _leader_shaft_hits_edges((-10.0, 0.0), (10.0, 0.0), edges)
+
+
+class TestRedundantDimension:
+    """#941 (ADR 0016 phase 5): two dimensions that state the SAME measurement.
+
+    The engine's existing duplicate protections do not cover this — value/identity dedup
+    needs the same identity, and the corridor solve's coincident-span dedup compares
+    candidates within one solve — so a measurement arriving from a different producer
+    passes both. See `_lint_redundant_dims` for why the check is deliberately narrow.
+    """
+
+    def _codes(self, items):
+        return [i.code for i in lint_drawing(items)]
+
+    def test_two_dims_over_the_same_span_are_reported(self, draft):
+        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
+        b = Dimension((-20, 0, 0), (20, 0, 0), "above", 16, draft, label="40")
+        issues = [i for i in lint_drawing([a, b]) if i.code == "redundant_dimension"]
+        assert len(issues) == 1
+        assert issues[0].severity == "warning"
+        # Names the pair, so the fix is a line to remove rather than a puzzle (#941).
+        assert "'40'" in issues[0].message
+
+    def test_one_dim_alone_is_clean(self, draft):
+        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
+        assert "redundant_dimension" not in self._codes([a])
+
+    def test_same_length_at_a_different_position_is_not_redundant(self, draft):
+        """The discriminator. Two 40s measuring DIFFERENT spans is ordinary dimensioning —
+        it is coincidence of value, not of measurement, and flagging it would make the
+        check useless on any part with repeated feature sizes."""
+        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
+        b = Dimension((30, 0, 0), (70, 0, 0), "above", 8, draft, label="40")
+        assert "redundant_dimension" not in self._codes([a, b])
+
+    def test_different_lengths_over_overlapping_spans_are_not_redundant(self, draft):
+        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
+        b = Dimension((-20, 0, 0), (0, 0, 0), "above", 16, draft, label="20")
+        assert "redundant_dimension" not in self._codes([a, b])
+
+    def test_perpendicular_dims_are_not_redundant(self, draft):
+        """A 40-wide and a 40-tall dimension are not the same measurement, even though
+        both are 40 and both touch the same corner."""
+        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
+        b = Dimension((-20, -20, 0), (-20, 20, 0), "left", 8, draft, label="40")
+        assert "redundant_dimension" not in self._codes([a, b])
+
+    def test_three_dims_over_one_span_report_every_pair(self, draft):
+        """Reporting per PAIR rather than per span is deliberate: the author has to decide
+        which to keep, and needs to see each conflict named."""
+        dims = [
+            Dimension((-20, 0, 0), (20, 0, 0), "above", off, draft, label="40")
+            for off in (8, 16, 24)
+        ]
+        issues = [i for i in lint_drawing(dims) if i.code == "redundant_dimension"]
+        assert len(issues) == 3

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -24,7 +24,7 @@ from build123d_drafting import (
     place_dims,
 )
 
-from draftwright.linting import lint_drawing
+from draftwright.linting import lint_drawing, lint_redundant_dimensions
 
 
 @pytest.fixture
@@ -565,54 +565,100 @@ class TestLeaderCrossesSilhouette:
 class TestRedundantDimension:
     """#941 (ADR 0016 phase 5): two dimensions that state the SAME measurement.
 
-    The engine's existing duplicate protections do not cover this — value/identity dedup
-    needs the same identity, and the corridor solve's coincident-span dedup compares
-    candidates within one solve — so a measurement arriving from a different producer
-    passes both. See `_lint_redundant_dims` for why the check is deliberately narrow.
+    `lint_redundant_dimensions` takes resolved entries rather than annotations, because the
+    check needs each dimension's registry NAME (so the report says which two to look at)
+    and its VIEW (so the world axis is known rather than inferred from page geometry). See
+    `Drawing._redundancy_entries` for the caller.
     """
 
-    def _codes(self, items):
-        return [i.code for i in lint_drawing(items)]
+    @staticmethod
+    def _entry(name, view, length, lo, hi, horizontal=True, label=None):
+        return (name, view, length, lo, hi, horizontal, label or str(length))
 
-    def test_two_dims_over_the_same_span_are_reported(self, draft):
-        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
-        b = Dimension((-20, 0, 0), (20, 0, 0), "above", 16, draft, label="40")
-        issues = [i for i in lint_drawing([a, b]) if i.code == "redundant_dimension"]
+    def _codes(self, entries):
+        return [i.code for i in lint_redundant_dimensions(entries)]
+
+    def test_two_dims_over_the_same_span_are_reported(self):
+        issues = lint_redundant_dimensions(
+            [
+                self._entry("m_env_width", "plan", 40, -20, 20),
+                self._entry("pmi_x_0", "front", 40, -20, 20),
+            ]
+        )
         assert len(issues) == 1
         assert issues[0].severity == "warning"
-        # Names the pair, so the fix is a line to remove rather than a puzzle (#941).
-        assert "'40'" in issues[0].message
+        # Names the PAIR. Quoting two identical labels ("Dims '40' and '40'") tells the
+        # reader nothing about which two annotations to look at (#959 review).
+        assert "'m_env_width'" in issues[0].message
+        assert "'pmi_x_0'" in issues[0].message
+        assert "X extent" in issues[0].message
 
-    def test_one_dim_alone_is_clean(self, draft):
-        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
-        assert "redundant_dimension" not in self._codes([a])
+    def test_one_dim_alone_is_clean(self):
+        assert not self._codes([self._entry("a", "front", 40, -20, 20)])
 
-    def test_same_length_at_a_different_position_is_not_redundant(self, draft):
+    def test_same_length_at_a_different_position_is_not_redundant(self):
         """The discriminator. Two 40s measuring DIFFERENT spans is ordinary dimensioning —
-        it is coincidence of value, not of measurement, and flagging it would make the
-        check useless on any part with repeated feature sizes."""
-        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
-        b = Dimension((30, 0, 0), (70, 0, 0), "above", 8, draft, label="40")
-        assert "redundant_dimension" not in self._codes([a, b])
+        coincidence of value, not of measurement. Flagging it would make the check useless
+        on any part with repeated feature sizes."""
+        assert not self._codes(
+            [
+                self._entry("a", "front", 40, -20, 20),
+                self._entry("b", "front", 40, 30, 70),
+            ]
+        )
 
-    def test_different_lengths_over_overlapping_spans_are_not_redundant(self, draft):
-        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
-        b = Dimension((-20, 0, 0), (0, 0, 0), "above", 16, draft, label="20")
-        assert "redundant_dimension" not in self._codes([a, b])
+    def test_different_lengths_over_overlapping_spans_are_not_redundant(self):
+        assert not self._codes(
+            [
+                self._entry("a", "front", 40, -20, 20),
+                self._entry("b", "front", 20, -20, 0),
+            ]
+        )
 
-    def test_perpendicular_dims_are_not_redundant(self, draft):
-        """A 40-wide and a 40-tall dimension are not the same measurement, even though
-        both are 40 and both touch the same corner."""
-        a = Dimension((-20, 0, 0), (20, 0, 0), "above", 8, draft, label="40")
-        b = Dimension((-20, -20, 0), (-20, 20, 0), "left", 8, draft, label="40")
-        assert "redundant_dimension" not in self._codes([a, b])
+    def test_the_same_page_extent_on_a_different_WORLD_axis_is_not_redundant(self):
+        """The reason the view is threaded in at all (#959 review). A vertical dimension
+        means Z on the front view and Y on the plan; identical page geometry in those two
+        views is two different measurements. An earlier form compared page extents only and
+        argued view alignment made the mapping unnecessary — unsound, and this is the case
+        that proves it."""
+        assert not self._codes(
+            [
+                self._entry("front_v", "front", 40, -20, 20, horizontal=False),
+                self._entry("plan_v", "plan", 40, -20, 20, horizontal=False),
+            ]
+        )
 
-    def test_three_dims_over_one_span_report_every_pair(self, draft):
-        """Reporting per PAIR rather than per span is deliberate: the author has to decide
-        which to keep, and needs to see each conflict named."""
-        dims = [
-            Dimension((-20, 0, 0), (20, 0, 0), "above", off, draft, label="40")
-            for off in (8, 16, 24)
-        ]
-        issues = [i for i in lint_drawing(dims) if i.code == "redundant_dimension"]
-        assert len(issues) == 3
+    def test_the_same_world_axis_across_views_IS_redundant(self):
+        """The converse, and the case that matters: front-vertical and side-vertical both
+        measure Z, so the same extent there is the same measurement stated twice."""
+        assert self._codes(
+            [
+                self._entry("front_v", "front", 40, -20, 20, horizontal=False),
+                self._entry("side_v", "side", 40, -20, 20, horizontal=False),
+            ]
+        ) == ["redundant_dimension"]
+
+    def test_perpendicular_dims_are_not_redundant(self):
+        assert not self._codes(
+            [
+                self._entry("a", "front", 40, -20, 20),
+                self._entry("b", "front", 40, -20, 20, horizontal=False),
+            ]
+        )
+
+    def test_an_unknown_view_is_skipped_not_guessed(self):
+        """A detail view or an unplaced annotation has no entry in the axis table. It is
+        dropped rather than assigned a guessed axis — a wrong warning is worse than a
+        missed one for a check whose whole value is that it is trustworthy."""
+        assert not self._codes(
+            [
+                self._entry("a", "detail_a", 40, -20, 20),
+                self._entry("b", "detail_a", 40, -20, 20),
+            ]
+        )
+
+    def test_three_dims_over_one_span_report_every_pair(self):
+        """Per PAIR rather than per span: the author decides which to keep, and needs each
+        conflict named."""
+        entries = [self._entry(f"d{i}", "front", 40, -20, 20) for i in range(3)]
+        assert len(lint_redundant_dimensions(entries)) == 3

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -38,3 +38,88 @@ def test_dropped_diams_append_read_reset():
     assert c.dropped_diams == [8.0, 5.0]
     c.reset_dropped()
     assert c.dropped_diams == []
+
+
+class TestRedundantDimensionEndToEnd:
+    """#941: the case the check exists for, on a real build rather than stand-ins.
+
+    `measured_dimension` (and imported AP242 PMI, the same IR kind) carries its own value
+    and reference points and is not checked against the planner's approved set. Restating a
+    measurement the planner already draws produced two dimensions saying the same thing,
+    with nothing reporting it — which is what settled #941's open question: redundancy is
+    reachable from the authored/materialised path, not from the planner, whose spans are
+    all measured from a common datum and so cannot close a chain.
+    """
+
+    @staticmethod
+    def _plate():
+        from build123d import Box
+
+        return Box(40, 20, 10)
+
+    def _codes(self, dwg):
+        return [i for i in dwg.lint() if i.code == "redundant_dimension"]
+
+    def test_restating_an_approved_measurement_is_reported(self):
+        from draftwright import Sheet
+
+        sheet = Sheet.from_part(self._plate(), title="T", number="N").auto_dimensions()
+        # The envelope width the planner already approves, stated again by hand.
+        sheet.measured_dimension(
+            kind="linear",
+            value=40,
+            label="40",
+            dominant_axis="X",
+            ref_bbox=(-20, -10, -5, 20, 10, 5),
+            ref_pts=[(-20, 0, 0), (20, 0, 0)],
+        )
+        dwg = sheet.build()
+
+        drawn = {n for n, o in dwg.iter_annotations() if getattr(o, "label", None)}
+        assert {"m_env_width", "pmi_x_0"} <= drawn  # guard: both really are drawn
+        issues = self._codes(dwg)
+        assert len(issues) == 1, [i.message for i in issues]
+        assert issues[0].severity == "warning"
+
+    def test_the_same_part_without_the_restatement_is_clean(self):
+        """The control. Without this, the test above would pass on a check that fires on
+        every drawing."""
+        from draftwright import Sheet
+
+        dwg = Sheet.from_part(self._plate(), title="T", number="N").auto_dimensions().build()
+        assert not self._codes(dwg)
+
+    def test_the_planner_alone_does_not_over_dimension(self):
+        """#941's open question, as an executable answer: the automatic path emits no
+        redundant pair. Every span it approves along an axis is measured from a common
+        datum, so the derived remainders are left unstated. If a planner change starts
+        producing redundancy, this fails and the "lint, not a planner rule" conclusion
+        recorded on #941 has to be revisited.
+
+        The pad fixture is deliberately absent — it DOES report, and correctly: its pad
+        and its (mis-recognised) slot carry the identical x span, so the drawing states
+        that 30 mm twice. Tracked as #958 rather than papered over here.
+        """
+        from build123d import Box, Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        corpus = {
+            "plate": Box(80, 50, 8),
+            "plate+hole": Box(80, 50, 8) - Pos(-20, 0, 0) * Cylinder(4, 20),
+            "two holes": Box(80, 50, 8)
+            - Pos(-20, 0, 0) * Cylinder(4, 20)
+            - Pos(20, 10, 0) * Cylinder(3, 20),
+            "stepped": Box(40, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20),
+            "pocket": Box(80, 60, 20) - Pos(0, 0, 14) * Box(30, 20, 14),
+            "boss": Box(80, 60, 12) + Pos(0, 0, 12) * Cylinder(10, 8),
+            "turned shaft": Cylinder(15, 20) + Pos(0, 0, 17.5) * Cylinder(10, 15),
+            "bored flange": Cylinder(40, 8) - Cylinder(8, 20),
+        }
+        noisy = {
+            name: [
+                i.message for i in build_drawing(part).lint() if i.code == "redundant_dimension"
+            ]
+            for name, part in corpus.items()
+        }
+        assert not any(noisy.values()), {k: v for k, v in noisy.items() if v}

--- a/tests/test_linting.py
+++ b/tests/test_linting.py
@@ -80,6 +80,8 @@ class TestRedundantDimensionEndToEnd:
         issues = self._codes(dwg)
         assert len(issues) == 1, [i.message for i in issues]
         assert issues[0].severity == "warning"
+        # Names both annotations, so the reader knows which two to look at.
+        assert "'m_env_width'" in issues[0].message and "'pmi_x_0'" in issues[0].message
 
     def test_the_same_part_without_the_restatement_is_clean(self):
         """The control. Without this, the test above would pass on a check that fires on
@@ -89,16 +91,16 @@ class TestRedundantDimensionEndToEnd:
         dwg = Sheet.from_part(self._plate(), title="T", number="N").auto_dimensions().build()
         assert not self._codes(dwg)
 
-    def test_the_planner_alone_does_not_over_dimension(self):
-        """#941's open question, as an executable answer: the automatic path emits no
-        redundant pair. Every span it approves along an axis is measured from a common
-        datum, so the derived remainders are left unstated. If a planner change starts
-        producing redundancy, this fails and the "lint, not a planner rule" conclusion
-        recorded on #941 has to be revisited.
+    def test_ordinary_datum_ladders_do_not_over_dimension(self):
+        """The measured half of #941's open question: on these parts the automatic path
+        emits no redundant pair, because every span it approves along a feature's own axis
+        is measured from a common datum and the derived remainders are left unstated.
 
-        The pad fixture is deliberately absent — it DOES report, and correctly: its pad
-        and its (mis-recognised) slot carry the identical x span, so the drawing states
-        that 30 mm twice. Tracked as #958 rather than papered over here.
+        Named for what it actually shows. It does NOT show that the planner cannot
+        over-dimension — #958 is an automatic drawing that does, where a pad and a
+        mis-recognised slot carry the identical x span and both get dimensioned. That
+        fixture is deliberately absent here and the exclusion is stated rather than silent;
+        add it back when #958 is fixed. ADR 0016 Amendment 2 records the corrected claim.
         """
         from build123d import Box, Cylinder, Pos
 


### PR DESCRIPTION
Closes #941. Child of #942 (ADR 0016 phase 5) — the **last** child of the epic.

## The open question, settled with measurements

The issue said to settle "is redundancy a lint or a planner rule?" before implementing. I
measured the planner's actual output. The answer is neither option as posed, and it rescoped
the work — full evidence in [this comment](https://github.com/pzfreo/draftwright/issues/941#issuecomment-5139291120).

**The planner cannot over-dimension.** Every span it approves along an axis is measured from
a **common datum**:

```
step_height     z -20 → 10      overall_height  z -20 → 20
step_position   x -30 → 10      m_env_width     x -30 → 30
```

Common-datum spans cannot close a chain — which is the thing ISO 129 warns about. The derived
remainders (10 and 20) are left unstated, which is correct datum dimensioning. A suppression
rule in `plan_dimensions` would have nothing to suppress.

**The motivating example does not occur.** A 3-hole linear pattern draws `2× 40` **plus one
origin location** — not per-hole locations *and* pitch. Pitch gives spacing, location gives
where the array sits. Complementary, not redundant.

**The referential authored path can't create redundancy either** — `dimension(feature, role)`
picks a *subset* of the addressable set, and a subset of a non-redundant set is non-redundant.

**The materialised path can, and did.** `measured_dimension(...)` (and imported AP242 PMI, the
same IR kind) carries its own value and ref points and is checked against nothing:

```
m_env_width  '40'
pmi_x_0      '40'      <-- the same measurement, twice
lint: {}               <-- reported by nothing
```

## What this adds

`redundant_dimension`, severity `warning`, in `linting/structural.py`. It reports only what it
can prove — same orientation, same measured length, coincident extent along the measuring axis.

No view mapping is needed or guessed at: the orthographic views are aligned, so a plan-view
width and a front-view width share the page's x band by construction.

It **names the pair and picks no winner**. ISO 129 keeps the functionally significant
dimension, which is a judgement about the part; guessing produces a plausible wrong drawing,
which this codebase ranks below a visible message (#630/#631). A `_suggest_fix` snippet says so.

## It found a real defect on its first sweep

One true positive across 20 parts: `Box(80,60,10) + Pos(0,0,10)*Box(30,20,4)` states the same
30 mm span twice — as the pad's length and as a mis-recognised slot's. Identical `long_axis`,
`lo`, `hi`. Filed as **#958**, and excluded from the no-false-positive corpus **by name with the
reason**, so the exclusion is visible rather than a silent gap.

## Deliberately NOT done

No new planner suppression rule. That half of phase 5 **already exists**, ad hoc, in
`_compile_overall_height` ("Z-turned (the step chain tiles the height)"). #955 records that it
is *unsound* rather than missing — it fires on a premise placement can invalidate, so when the
chain drops nothing conveys the height. Fixing that beats adding a second one.

## Tests

- 6 unit tests on the check's discriminators: same length at a *different* position is not
  redundant (value coincidence ≠ measurement coincidence), different lengths over overlapping
  spans, perpendicular dims, three-over-one-span reports every pair.
- End-to-end: the restatement is reported; the same part without it is clean (the control);
  and `test_the_planner_alone_does_not_over_dimension` makes the "lint, not a planner rule"
  conclusion **executable** — if a planner change starts producing redundancy, it fails and the
  conclusion gets revisited.

## Verification

- `ruff check` / `ruff format --check` / `mypy` / `codespell` clean
- smoke 54 passed
- lint suites + emitter + layout-hypothesis: 309 passed
- `test_make_drawing.py` + `test_e2e_standards.py`: 717 passed (no fallout from the new code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)