### PR TITLE
test(#948): make the mirror-coverage roster verify its own claims

### DIFF
--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2103,15 +2103,37 @@ def test_the_plan_surface_is_ratcheted():
     )
 
 
+#: The route vocabulary. A value is a route, optionally followed by ``" — <reason>"``; the
+#: route itself must be one of these, so a typo or an invented classification fails
+#: `test_every_route_in_the_roster_is_one_of_the_known_ones` rather than passing as prose.
+#:
+#: Checked exactly, not by prefix: `startswith("corpus")` accepted `"corpus nonsense"`, and a
+#: roster whose whole purpose is to verify its own claims should not take a claim's word for
+#: what route it is on (Codex review of #973).
+_MIRROR_ROUTES = ("corpus", "declared", "aspect", "unnameable")
+
+
+def _route_of(value: str) -> str:
+    """The route a `_KIND_MIRROR_COVERAGE` value names, without its reason."""
+    return value.split("—")[0].strip()
+
+
 #: Every IR feature kind, mapped to how the dimension mirror is proven to handle it.
 #:
-#: `"corpus"` — a fixture in `TestTheDimensionMirror._corpus()` detects it, so the round trip
-#: is exercised end to end (emit → run → compare annotation signatures).
-#: A string starting with `"unnameable"` — no declarative verb, so the emitter falls back and
-#: says so; the kind cannot be mirrored by design until that verb exists.
-#: `"untested"` — neither. **This is debt**, and naming it is the point: the review found two
-#: fixtures detecting something other than their name, and an unlisted kind is the same hole
-#: with no label on it.
+#: `"corpus"` — some fixture in `TestTheDimensionMirror._corpus()` owns an approved dimension
+#: of this kind, so the round trip is exercised end to end (emit → run → compare signatures).
+#: Checked against the COMPILER, not against detection: recognising a feature that yields no
+#: approved dimension leaves the mirror untouched however cleanly it is recognised (#948).
+#: `"declared"` — nothing detects it, so it is reached through the declared route instead;
+#: `test_the_declared_route_reaches_the_kind_that_claims_it` builds that model and requires
+#: the emitter to write its line.
+#: `"aspect"` — carries no DimParameter, so there is nothing for the mirror to reproduce.
+#: `"unnameable"` — no declarative verb, so the emitter falls back and says so; the kind
+#: cannot be mirrored by design until that verb exists.
+#:
+#: There is deliberately no "untested" route any more: #948 closed the last of them, and every
+#: route above now carries an obligation a test enforces. Re-introducing one would mean adding
+#: it to `_MIRROR_ROUTES` and saying, in the open, that it requires nothing.
 _KIND_MIRROR_COVERAGE = {
     "hole": "corpus",
     "pattern": "corpus",
@@ -2169,6 +2191,23 @@ def test_every_ir_kind_is_classified_for_mirror_coverage():
     )
 
 
+def test_every_route_in_the_roster_is_one_of_the_known_ones():
+    """A route is a vocabulary, not free text.
+
+    Without this, a value only has to LOOK like a classification: `"corpus nonsense"` passed a
+    prefix test, and a misspelt `"asspect"` would have matched no obligation at all and so been
+    required to satisfy nothing — the fail-open this roster exists to prevent, one level up
+    (Codex review of #973).
+    """
+    unknown = {
+        k: v for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) not in _MIRROR_ROUTES
+    }
+    assert not unknown, (
+        f"{unknown} name routes outside {_MIRROR_ROUTES} — a route with no obligation requires "
+        "nothing, which is what an unclassified kind already was"
+    )
+
+
 def _kinds_the_mirror_dimensions() -> set[str]:
     """Feature kinds some corpus fixture contributes an APPROVED dimension for.
 
@@ -2200,7 +2239,7 @@ def test_the_corpus_really_covers_the_kinds_it_claims():
     detection-only form would have called that covered.
     """
     dimensioned = _kinds_the_mirror_dimensions()
-    claimed = {k for k, v in _KIND_MIRROR_COVERAGE.items() if v.startswith("corpus")}
+    claimed = {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == "corpus"}
     assert claimed <= dimensioned, (
         f"{sorted(claimed - dimensioned)} are marked 'corpus' but no corpus fixture yields "
         "an approved dimension owned by that kind — the mirror never exercises them"
@@ -2241,7 +2280,7 @@ def test_the_declared_route_reaches_the_kind_that_claims_it():
     what proves the values then survive re-running that line; this is what stops the roster
     claiming a route nothing travels (#948).
     """
-    declared = {k for k, v in _KIND_MIRROR_COVERAGE.items() if v == "declared"}
+    declared = {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == "declared"}
     assert declared, "the 'declared' route has no kinds — delete it rather than leave it empty"
     _part, model = _declared_measurement_model()
     reached = {f.kind for f in model.features}
@@ -2263,7 +2302,7 @@ def test_every_kind_the_corpus_dimensions_is_claimed_as_corpus():
     understated = {
         k
         for k in dimensioned
-        if k in _KIND_MIRROR_COVERAGE and not _KIND_MIRROR_COVERAGE[k].startswith("corpus")
+        if k in _KIND_MIRROR_COVERAGE and _route_of(_KIND_MIRROR_COVERAGE[k]) != "corpus"
     }
     assert not understated, (
         f"{sorted(understated)} are dimensioned by a corpus fixture but the roster claims "

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2111,37 +2111,11 @@ def test_the_plan_surface_is_ratcheted():
 #: review rounds for on #967, and not applying it here was this roster stopping one step
 #: short: `aspect` and `unnameable` passed the vocabulary check while obliging nothing, so any
 #: kind parked under either escaped verification entirely (Codex review of #973, round 2).
-_MIRROR_ROUTE_OBLIGATIONS = {
-    # Some corpus fixture owns an approved dimension of this kind, so the mirror round trip
-    # runs for it. Asked of the compiler: recognising a feature that yields no approved
-    # dimension leaves the mirror untouched however cleanly it is recognised.
-    "corpus": lambda kinds, facts: (
-        kinds - facts["dimensioned"],
-        "no corpus fixture yields an approved dimension owned by that kind",
-    ),
-    # Nothing detects it, so it is reached by declaring it instead — and the emitter writes it.
-    "declared": lambda kinds, facts: (
-        kinds - facts["declarable"],
-        "building the declared model does not produce them, or the emitter writes no line",
-    ),
-    # No DimParameter, so there is nothing for the mirror to reproduce. Checked by CONSTRUCTING
-    # one and asking it — the claim is about the kind's own content, so a condition on the
-    # corpus cannot establish it. "The corpus does not dimension it" was the first cut and was
-    # near-vacuous: any kind absent from the corpus satisfied it, so a dimension-bearing kind
-    # could sit here untouched (Codex review of #973, round 3).
-    "aspect": lambda kinds, facts: (
-        {k for k in kinds if facts["parameterised"].get(k, True)},
-        "an instance of that kind reports DimParameters, so there IS something to mirror",
-    ),
-}
-
-#: There is deliberately no `unnameable` route. `pmi` was its only member and is `declared` —
-#: the emitter serialises it and the script reconstructs it. An empty route is a spelling
-#: waiting to be misused, so it is gone rather than kept for symmetry; a genuinely unmirrorable
-#: kind would add it back WITH an obligation, which is now the only way to add one at all.
-
-#: Derived, never hand-written — see above.
-_MIRROR_ROUTES = tuple(_MIRROR_ROUTE_OBLIGATIONS)
+#: The route vocabulary. A value is a route, optionally followed by ``" — <reason>"``.
+#:
+#: There is deliberately no `unnameable` route: `pmi` was its only member and is `declared` —
+#: the emitter serialises it and the generated script reconstructs it (#973 r3).
+_MIRROR_ROUTES = ("corpus", "declared", "aspect")
 
 
 def _route_of(value: str) -> str:
@@ -2278,54 +2252,29 @@ def _declared_measurement_model():
 #: assumed. Every aspect class defines the method — they satisfy the `Feature` protocol — so
 #: `hasattr` proves nothing and the call is the only real check.
 def _aspect_instances():
+    """One instance per aspect kind, for asking `parameters()` directly.
+
+    Minimal on purpose. An earlier cut built MAXIMAL samples and ratcheted them against
+    `dataclasses.fields`, to catch an aspect class gaining a dimension-bearing option. It could
+    not: `default_factory` fields are invisible to that comparison, and "different from the
+    default" is not "the dimension-bearing branch ran" — `measurement=0.0` against a `> 0` gate
+    passes it. No generic comparison of dataclass values proves branch coverage, so the
+    machinery bought a specific canary and an overstated claim (Codex review of #973, round 5).
+    All four implementations return `[]` unconditionally today; if one becomes conditional, its
+    semantics need a purpose-built test rather than a generic one anticipating it.
+    """
     from draftwright.model.ir import ControlFrame, DatumRef, Finish, Frame, Note
 
     frame = Frame((0.0, 0.0, 0.0), "z")
-    # MAXIMAL, and ratcheted by `test_the_aspect_samples_leave_no_field_at_its_default`: a
-    # sample that leaves an optional field unset cannot exercise a `parameters()` branch gated
-    # on that field, so `Note` gaining a dimension-bearing option would report no parameters
-    # and keep its `aspect` route with every guard green (Codex review of #973, round 4).
-    common = {"frame": frame, "view": "front", "side": "top", "origin": object()}
+    common = {"frame": frame, "view": "front", "side": "top"}
     return {
         "control_frame": ControlFrame(
-            **common,
-            characteristic="position",
-            tolerance="0.1",
-            datums=("A",),
-            diameter=True,
-            modifier="M",
+            **common, characteristic="position", tolerance="0.1", datums=("A",)
         ),
         "datum_ref": DatumRef(**common, letter="A"),
         "finish": Finish(**common, ra="1.6"),
         "note": Note(**common, text="TYP"),
     }
-
-
-def test_the_aspect_samples_leave_no_field_at_its_default():
-    """The `aspect` obligation asks a CONSTRUCTED instance, so the instance has to be maximal.
-
-    A hand-written sample cannot exercise a `parameters()` branch gated on a field it does not
-    set — and a field it does not set is exactly what a new IR option looks like. Comparing
-    against `dataclasses.fields` makes IR growth fail here, at the sample, rather than silently
-    widening the exemption it feeds (#973 r4).
-    """
-    import dataclasses
-
-    for kind, obj in _aspect_instances().items():
-        at_default = [
-            f.name
-            for f in dataclasses.fields(obj)
-            if f.default is not dataclasses.MISSING and getattr(obj, f.name) == f.default
-        ]
-        assert not at_default, (
-            f"{kind}: the sample leaves {at_default} at the class default, so any "
-            "`parameters()` branch gated on those fields is unexercised — populate them"
-        )
-
-
-def _parameterised_kinds() -> dict[str, bool]:
-    """kind -> whether an instance of it reports any `DimParameter`."""
-    return {k: bool(v.parameters()) for k, v in _aspect_instances().items()}
 
 
 def _declared_models():
@@ -2352,64 +2301,56 @@ def _declarable_kinds() -> set[str]:
     return reached
 
 
-def test_every_kind_is_on_a_route_that_exists():
-    """The partition is TOTAL — every kind sits on a route the obligations define.
+def _kinds_on(route: str) -> set[str]:
+    return {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == route}
 
-    Parametrising the obligation test over routes covers every route; it does not cover every
-    KIND. A kind spelled with a route that no longer exists belongs to no parametrisation and
-    is therefore checked by nothing at all. Deleting this guard as "subsumed" while
-    consolidating is exactly how that happened, and a canary reverting `pmi` to the removed
-    `unnameable` route passed until this came back (#973 r3).
-    """
+
+def test_every_kind_is_on_a_route_that_exists():
+    """The partition is TOTAL. A kind naming a route that does not exist is on no route, so
+    none of the checks below look at it — which is what an unclassified kind already was. A
+    canary reverting `pmi` to the removed `unnameable` route passed until this existed."""
     stranded = {
         k: v for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) not in _MIRROR_ROUTES
     }
-    assert not stranded, (
-        f"{stranded} name routes outside {_MIRROR_ROUTES}; a kind on no route has no "
-        "obligation, which is what an unclassified kind already was"
+    assert not stranded, f"{stranded} name routes outside {_MIRROR_ROUTES}"
+
+
+def test_corpus_kinds_own_an_approved_dimension():
+    """`"corpus"` means the mirror round trip RUNS for that kind, and the mirror reproduces
+    approved dimensions — so ask the compiler, not detection. A fixture recognising a chamfer
+    that yields no approved dimension leaves the mirror untouched (#948)."""
+    missing = _kinds_on("corpus") - _kinds_the_mirror_dimensions()
+    assert not missing, (
+        f"{sorted(missing)} are marked 'corpus' but no corpus fixture yields an approved "
+        "dimension owned by that kind — the mirror never exercises them"
     )
 
 
-@pytest.mark.parametrize("route", _MIRROR_ROUTES)
-def test_every_kind_meets_the_obligation_of_the_route_it_claims(route):
-    """Each route's claim, enforced by the obligation that defines it.
-
-    Parametrised over the DERIVED vocabulary, so adding a route without an obligation is not
-    a weaker test — it is an impossible one. That is the difference between this and the
-    version Codex rejected, where `aspect` and `unnameable` were accepted spellings that
-    obliged nothing, and any kind parked under either was verified by nothing at all (#973 r2).
-    """
-    facts = {
-        "dimensioned": _kinds_the_mirror_dimensions(),
-        "declarable": _declarable_kinds(),
-        "parameterised": _parameterised_kinds(),
-    }
-    kinds = {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == route}
-    failing, why = _MIRROR_ROUTE_OBLIGATIONS[route](kinds, facts)
-    assert not failing, f"{sorted(failing)} claim the '{route}' route, but {why}"
+def test_declared_kinds_are_reachable_and_emitted():
+    """`"declared"` means detection cannot reach it, so a declared model does — and the emitter
+    writes it. Both halves: a kind the emitter silently drops is not declarable however cleanly
+    the model carries it."""
+    missing = _kinds_on("declared") - _declarable_kinds()
+    assert not missing, (
+        f"{sorted(missing)} claim the declared route, but building the declared model does not "
+        "produce them, or the emitter writes no line for them"
+    )
 
 
-def test_each_obligation_can_actually_fail():
-    """The obligations, applied to a roster that is wrong on purpose.
-
-    An obligation that returns nothing whatever it is given is the failure this whole table
-    exists to prevent, and it is invisible while the real roster is correct — the shape that
-    took seven rounds to kill on #967. Every route is checked, so a future one cannot be added
-    inert."""
-    facts = {
-        "dimensioned": {"hole"},
-        "declarable": {"authored_dimension"},
-        "parameterised": {"hole": True},
-    }
-    wrong = {
-        "corpus": {"note"},  # not dimensioned
-        "declared": {"note"},  # not declarable
-        "aspect": {"hole"},  # reports DimParameters, so not dimensionless
-    }
-    assert set(wrong) == set(_MIRROR_ROUTE_OBLIGATIONS), "a route has no failing example here"
-    for route, kinds in wrong.items():
-        failing, _why = _MIRROR_ROUTE_OBLIGATIONS[route](kinds, facts)
-        assert failing, f"the '{route}' obligation accepts {kinds} — it requires nothing"
+def test_aspect_kinds_report_no_dimension_parameters():
+    """`"aspect"` means the kind carries no DimParameter, so there is nothing to mirror. Asked
+    of an instance, because every aspect class DEFINES `parameters()` — they satisfy the
+    `Feature` protocol — so its presence proves nothing and the call is the only real check."""
+    samples = _aspect_instances()
+    aspects = _kinds_on("aspect")
+    assert aspects <= set(samples), (
+        f"{sorted(aspects - set(samples))} claim the aspect route with no sample to ask"
+    )
+    bearing = {k for k in aspects if samples[k].parameters()}
+    assert not bearing, (
+        f"{sorted(bearing)} are marked 'aspect' but report DimParameters, so there IS "
+        "something for the mirror to reproduce"
+    )
 
 
 def test_every_kind_the_corpus_dimensions_is_claimed_as_corpus():

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2281,15 +2281,46 @@ def _aspect_instances():
     from draftwright.model.ir import ControlFrame, DatumRef, Finish, Frame, Note
 
     frame = Frame((0.0, 0.0, 0.0), "z")
-    common = {"frame": frame, "view": "front", "side": "top"}
+    # MAXIMAL, and ratcheted by `test_the_aspect_samples_leave_no_field_at_its_default`: a
+    # sample that leaves an optional field unset cannot exercise a `parameters()` branch gated
+    # on that field, so `Note` gaining a dimension-bearing option would report no parameters
+    # and keep its `aspect` route with every guard green (Codex review of #973, round 4).
+    common = {"frame": frame, "view": "front", "side": "top", "origin": object()}
     return {
         "control_frame": ControlFrame(
-            **common, characteristic="position", tolerance="0.1", datums=("A",), diameter=True
+            **common,
+            characteristic="position",
+            tolerance="0.1",
+            datums=("A",),
+            diameter=True,
+            modifier="M",
         ),
         "datum_ref": DatumRef(**common, letter="A"),
         "finish": Finish(**common, ra="1.6"),
         "note": Note(**common, text="TYP"),
     }
+
+
+def test_the_aspect_samples_leave_no_field_at_its_default():
+    """The `aspect` obligation asks a CONSTRUCTED instance, so the instance has to be maximal.
+
+    A hand-written sample cannot exercise a `parameters()` branch gated on a field it does not
+    set — and a field it does not set is exactly what a new IR option looks like. Comparing
+    against `dataclasses.fields` makes IR growth fail here, at the sample, rather than silently
+    widening the exemption it feeds (#973 r4).
+    """
+    import dataclasses
+
+    for kind, obj in _aspect_instances().items():
+        at_default = [
+            f.name
+            for f in dataclasses.fields(obj)
+            if f.default is not dataclasses.MISSING and getattr(obj, f.name) == f.default
+        ]
+        assert not at_default, (
+            f"{kind}: the sample leaves {at_default} at the class default, so any "
+            "`parameters()` branch gated on those fields is unexercised — populate them"
+        )
 
 
 def _parameterised_kinds() -> dict[str, bool]:

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2124,21 +2124,21 @@ _MIRROR_ROUTE_OBLIGATIONS = {
         kinds - facts["declarable"],
         "building the declared model does not produce them, or the emitter writes no line",
     ),
-    # No DimParameter, so there is nothing for the mirror to reproduce. The obligation is that
-    # the corpus does NOT dimension it: a kind the compiler approves a dimension for plainly
-    # has something to mirror, whatever the roster says.
+    # No DimParameter, so there is nothing for the mirror to reproduce. Checked by CONSTRUCTING
+    # one and asking it — the claim is about the kind's own content, so a condition on the
+    # corpus cannot establish it. "The corpus does not dimension it" was the first cut and was
+    # near-vacuous: any kind absent from the corpus satisfied it, so a dimension-bearing kind
+    # could sit here untouched (Codex review of #973, round 3).
     "aspect": lambda kinds, facts: (
-        kinds & facts["dimensioned"],
-        "the compiler approves a dimension owned by that kind, so it is not dimensionless",
-    ),
-    # No declarative verb — `sheet.add(...)` of a raw record is not one — so the emitter cannot
-    # mirror it by design. Same obligation as `aspect` for the same reason: if the corpus
-    # dimensions it, the claim is false however it is worded.
-    "unnameable": lambda kinds, facts: (
-        kinds & facts["dimensioned"],
-        "the compiler approves a dimension owned by that kind, so the mirror does reach it",
+        {k for k in kinds if facts["parameterised"].get(k, True)},
+        "an instance of that kind reports DimParameters, so there IS something to mirror",
     ),
 }
+
+#: There is deliberately no `unnameable` route. `pmi` was its only member and is `declared` —
+#: the emitter serialises it and the script reconstructs it. An empty route is a spelling
+#: waiting to be misused, so it is gone rather than kept for symmetry; a genuinely unmirrorable
+#: kind would add it back WITH an obligation, which is now the only way to add one at all.
 
 #: Derived, never hand-written — see above.
 _MIRROR_ROUTES = tuple(_MIRROR_ROUTE_OBLIGATIONS)
@@ -2176,7 +2176,14 @@ _KIND_MIRROR_COVERAGE = {
     "pad": "corpus",
     "envelope": "corpus",
     "rotational": "corpus",
-    "pmi": "unnameable — raw AP242, emitted as sheet.add(PmiFeature(...)) (ADR 0016)",
+    # `declared`, not `unnameable`: the emitter SERIALISES every raw record as
+    # `sheet.add(PmiFeature(...))`, and the generated script names, reconstructs and
+    # executes it. Whether `sheet.add` is as fluent as a feature verb is an API-quality
+    # question; it does not make the kind unnameable, and `_FIDELITY_ROUTE` below has
+    # classified this exact behaviour as declared since #962. Calling it unnameable here
+    # contradicted that, and rewording the reason would have kept the false claim
+    # (Codex review of #973, round 3).
+    "pmi": "declared — raw AP242, emitted as sheet.add(PmiFeature(...)) (ADR 0016)",
     "chamfer": "corpus",
     "fillet": "corpus",
     "flat": "corpus",
@@ -2267,13 +2274,69 @@ def _declared_measurement_model():
     return part, sheet.model()
 
 
+#: One constructed instance per aspect kind, so `parameters()` can be ASKED rather than
+#: assumed. Every aspect class defines the method — they satisfy the `Feature` protocol — so
+#: `hasattr` proves nothing and the call is the only real check.
+def _aspect_instances():
+    from draftwright.model.ir import ControlFrame, DatumRef, Finish, Frame, Note
+
+    frame = Frame((0.0, 0.0, 0.0), "z")
+    common = {"frame": frame, "view": "front", "side": "top"}
+    return {
+        "control_frame": ControlFrame(
+            **common, characteristic="position", tolerance="0.1", datums=("A",), diameter=True
+        ),
+        "datum_ref": DatumRef(**common, letter="A"),
+        "finish": Finish(**common, ra="1.6"),
+        "note": Note(**common, text="TYP"),
+    }
+
+
+def _parameterised_kinds() -> dict[str, bool]:
+    """kind -> whether an instance of it reports any `DimParameter`."""
+    return {k: bool(v.parameters()) for k, v in _aspect_instances().items()}
+
+
+def _declared_models():
+    """`(kind, model, expected_line)` for each model that reaches a kind detection cannot.
+
+    Both are executed by `TestTheDeclaredModelMatchesTheDetectedOne`'s declared corpus too;
+    named here so the roster's obligation and those round trips travel the same route.
+    """
+    _part, measured = _declared_measurement_model()
+    yield "authored_dimension", measured, "sheet.measured_dimension("
+    _part, pmi = TestTheDeclaredModelMatchesTheDetectedOne._declared_corpus()["raw pmi"]()
+    yield "pmi", pmi, "sheet.add(PmiFeature("
+
+
 def _declarable_kinds() -> set[str]:
-    """Kinds the DECLARED route actually reaches: present on the declared model, and written
-    by the emitter. Both halves, because a kind the emitter silently drops is not declarable
+    """Kinds the DECLARED route actually reaches: present on a declared model, AND written by
+    the emitter. Both halves, because a kind the emitter silently drops is not declarable
     however cleanly the model carries it."""
-    _part, model = _declared_measurement_model()
-    src = emit_sheet_script(model, "part", "s", title="T", number="N")
-    return {f.kind for f in model.features if "sheet.measured_dimension(" in src}
+    reached = set()
+    for kind, model, line in _declared_models():
+        src = emit_sheet_script(model, "part", "s", title="T", number="N")
+        if line in src and any(f.kind == kind for f in model.features):
+            reached.add(kind)
+    return reached
+
+
+def test_every_kind_is_on_a_route_that_exists():
+    """The partition is TOTAL — every kind sits on a route the obligations define.
+
+    Parametrising the obligation test over routes covers every route; it does not cover every
+    KIND. A kind spelled with a route that no longer exists belongs to no parametrisation and
+    is therefore checked by nothing at all. Deleting this guard as "subsumed" while
+    consolidating is exactly how that happened, and a canary reverting `pmi` to the removed
+    `unnameable` route passed until this came back (#973 r3).
+    """
+    stranded = {
+        k: v for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) not in _MIRROR_ROUTES
+    }
+    assert not stranded, (
+        f"{stranded} name routes outside {_MIRROR_ROUTES}; a kind on no route has no "
+        "obligation, which is what an unclassified kind already was"
+    )
 
 
 @pytest.mark.parametrize("route", _MIRROR_ROUTES)
@@ -2285,7 +2348,11 @@ def test_every_kind_meets_the_obligation_of_the_route_it_claims(route):
     version Codex rejected, where `aspect` and `unnameable` were accepted spellings that
     obliged nothing, and any kind parked under either was verified by nothing at all (#973 r2).
     """
-    facts = {"dimensioned": _kinds_the_mirror_dimensions(), "declarable": _declarable_kinds()}
+    facts = {
+        "dimensioned": _kinds_the_mirror_dimensions(),
+        "declarable": _declarable_kinds(),
+        "parameterised": _parameterised_kinds(),
+    }
     kinds = {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == route}
     failing, why = _MIRROR_ROUTE_OBLIGATIONS[route](kinds, facts)
     assert not failing, f"{sorted(failing)} claim the '{route}' route, but {why}"
@@ -2298,12 +2365,15 @@ def test_each_obligation_can_actually_fail():
     exists to prevent, and it is invisible while the real roster is correct — the shape that
     took seven rounds to kill on #967. Every route is checked, so a future one cannot be added
     inert."""
-    facts = {"dimensioned": {"hole"}, "declarable": {"authored_dimension"}}
+    facts = {
+        "dimensioned": {"hole"},
+        "declarable": {"authored_dimension"},
+        "parameterised": {"hole": True},
+    }
     wrong = {
         "corpus": {"note"},  # not dimensioned
         "declared": {"note"},  # not declarable
-        "aspect": {"hole"},  # dimensioned, so not dimensionless
-        "unnameable": {"hole"},  # dimensioned, so the mirror does reach it
+        "aspect": {"hole"},  # reports DimParameters, so not dimensionless
     }
     assert set(wrong) == set(_MIRROR_ROUTE_OBLIGATIONS), "a route has no failing example here"
     for route, kinds in wrong.items():

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2103,14 +2103,45 @@ def test_the_plan_surface_is_ratcheted():
     )
 
 
-#: The route vocabulary. A value is a route, optionally followed by ``" — <reason>"``; the
-#: route itself must be one of these, so a typo or an invented classification fails
-#: `test_every_route_in_the_roster_is_one_of_the_known_ones` rather than passing as prose.
+#: Each route, mapped to what claiming it OBLIGES — as code, given the measured facts.
+#: Returns the kinds on that route which fail the obligation, plus how to say so.
 #:
-#: Checked exactly, not by prefix: `startswith("corpus")` accepted `"corpus nonsense"`, and a
-#: roster whose whole purpose is to verify its own claims should not take a claim's word for
-#: what route it is on (Codex review of #973).
-_MIRROR_ROUTES = ("corpus", "declared", "aspect", "unnameable")
+#: The vocabulary is DERIVED from this table (`_MIRROR_ROUTES` below), so a route cannot be
+#: spelled unless it requires something. That is the lesson `_ROUTE_OBLIGATIONS` paid seven
+#: review rounds for on #967, and not applying it here was this roster stopping one step
+#: short: `aspect` and `unnameable` passed the vocabulary check while obliging nothing, so any
+#: kind parked under either escaped verification entirely (Codex review of #973, round 2).
+_MIRROR_ROUTE_OBLIGATIONS = {
+    # Some corpus fixture owns an approved dimension of this kind, so the mirror round trip
+    # runs for it. Asked of the compiler: recognising a feature that yields no approved
+    # dimension leaves the mirror untouched however cleanly it is recognised.
+    "corpus": lambda kinds, facts: (
+        kinds - facts["dimensioned"],
+        "no corpus fixture yields an approved dimension owned by that kind",
+    ),
+    # Nothing detects it, so it is reached by declaring it instead — and the emitter writes it.
+    "declared": lambda kinds, facts: (
+        kinds - facts["declarable"],
+        "building the declared model does not produce them, or the emitter writes no line",
+    ),
+    # No DimParameter, so there is nothing for the mirror to reproduce. The obligation is that
+    # the corpus does NOT dimension it: a kind the compiler approves a dimension for plainly
+    # has something to mirror, whatever the roster says.
+    "aspect": lambda kinds, facts: (
+        kinds & facts["dimensioned"],
+        "the compiler approves a dimension owned by that kind, so it is not dimensionless",
+    ),
+    # No declarative verb — `sheet.add(...)` of a raw record is not one — so the emitter cannot
+    # mirror it by design. Same obligation as `aspect` for the same reason: if the corpus
+    # dimensions it, the claim is false however it is worded.
+    "unnameable": lambda kinds, facts: (
+        kinds & facts["dimensioned"],
+        "the compiler approves a dimension owned by that kind, so the mirror does reach it",
+    ),
+}
+
+#: Derived, never hand-written — see above.
+_MIRROR_ROUTES = tuple(_MIRROR_ROUTE_OBLIGATIONS)
 
 
 def _route_of(value: str) -> str:
@@ -2191,23 +2222,6 @@ def test_every_ir_kind_is_classified_for_mirror_coverage():
     )
 
 
-def test_every_route_in_the_roster_is_one_of_the_known_ones():
-    """A route is a vocabulary, not free text.
-
-    Without this, a value only has to LOOK like a classification: `"corpus nonsense"` passed a
-    prefix test, and a misspelt `"asspect"` would have matched no obligation at all and so been
-    required to satisfy nothing — the fail-open this roster exists to prevent, one level up
-    (Codex review of #973).
-    """
-    unknown = {
-        k: v for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) not in _MIRROR_ROUTES
-    }
-    assert not unknown, (
-        f"{unknown} name routes outside {_MIRROR_ROUTES} — a route with no obligation requires "
-        "nothing, which is what an unclassified kind already was"
-    )
-
-
 def _kinds_the_mirror_dimensions() -> set[str]:
     """Feature kinds some corpus fixture contributes an APPROVED dimension for.
 
@@ -2227,23 +2241,6 @@ def _kinds_the_mirror_dimensions() -> set[str]:
             if feature is not None:
                 covered.add(feature.kind)
     return covered
-
-
-def test_the_corpus_really_covers_the_kinds_it_claims():
-    """`"corpus"` is a claim about fixtures, so check it against them. Two fixtures were
-    detecting something other than their name until the review counted them (#947).
-
-    Strengthened from detection to DIMENSIONING (#948): the roster names mirror coverage, and
-    the mirror reproduces approved dimensions. A kind whose fixture yields no approved
-    dimension is not mirrored by that fixture however cleanly it is recognised, and the
-    detection-only form would have called that covered.
-    """
-    dimensioned = _kinds_the_mirror_dimensions()
-    claimed = {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == "corpus"}
-    assert claimed <= dimensioned, (
-        f"{sorted(claimed - dimensioned)} are marked 'corpus' but no corpus fixture yields "
-        "an approved dimension owned by that kind — the mirror never exercises them"
-    )
 
 
 def _declared_measurement_model():
@@ -2270,28 +2267,48 @@ def _declared_measurement_model():
     return part, sheet.model()
 
 
-def test_the_declared_route_reaches_the_kind_that_claims_it():
-    """`"declared"` is a claim too, so give it an obligation rather than a sentence.
-
-    The entry it replaced was prose that no guard could check, and which happened to escape
-    the corpus check on an exact-string comparison. This builds the declared model and
-    requires both halves of the claim: the kind exists on it, and the emitter writes a line
-    that declares it. `test_a_measured_dimension_round_trips_through_the_emitted_script` is
-    what proves the values then survive re-running that line; this is what stops the roster
-    claiming a route nothing travels (#948).
-    """
-    declared = {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == "declared"}
-    assert declared, "the 'declared' route has no kinds — delete it rather than leave it empty"
+def _declarable_kinds() -> set[str]:
+    """Kinds the DECLARED route actually reaches: present on the declared model, and written
+    by the emitter. Both halves, because a kind the emitter silently drops is not declarable
+    however cleanly the model carries it."""
     _part, model = _declared_measurement_model()
-    reached = {f.kind for f in model.features}
-    assert declared <= reached, (
-        f"{sorted(declared - reached)} claim the declared route, but building the declared "
-        "model does not produce them"
-    )
     src = emit_sheet_script(model, "part", "s", title="T", number="N")
-    assert "sheet.measured_dimension(" in src, (
-        "the declared model emits no measured_dimension line, so the route is unwritable"
-    )
+    return {f.kind for f in model.features if "sheet.measured_dimension(" in src}
+
+
+@pytest.mark.parametrize("route", _MIRROR_ROUTES)
+def test_every_kind_meets_the_obligation_of_the_route_it_claims(route):
+    """Each route's claim, enforced by the obligation that defines it.
+
+    Parametrised over the DERIVED vocabulary, so adding a route without an obligation is not
+    a weaker test — it is an impossible one. That is the difference between this and the
+    version Codex rejected, where `aspect` and `unnameable` were accepted spellings that
+    obliged nothing, and any kind parked under either was verified by nothing at all (#973 r2).
+    """
+    facts = {"dimensioned": _kinds_the_mirror_dimensions(), "declarable": _declarable_kinds()}
+    kinds = {k for k, v in _KIND_MIRROR_COVERAGE.items() if _route_of(v) == route}
+    failing, why = _MIRROR_ROUTE_OBLIGATIONS[route](kinds, facts)
+    assert not failing, f"{sorted(failing)} claim the '{route}' route, but {why}"
+
+
+def test_each_obligation_can_actually_fail():
+    """The obligations, applied to a roster that is wrong on purpose.
+
+    An obligation that returns nothing whatever it is given is the failure this whole table
+    exists to prevent, and it is invisible while the real roster is correct — the shape that
+    took seven rounds to kill on #967. Every route is checked, so a future one cannot be added
+    inert."""
+    facts = {"dimensioned": {"hole"}, "declarable": {"authored_dimension"}}
+    wrong = {
+        "corpus": {"note"},  # not dimensioned
+        "declared": {"note"},  # not declarable
+        "aspect": {"hole"},  # dimensioned, so not dimensionless
+        "unnameable": {"hole"},  # dimensioned, so the mirror does reach it
+    }
+    assert set(wrong) == set(_MIRROR_ROUTE_OBLIGATIONS), "a route has no failing example here"
+    for route, kinds in wrong.items():
+        failing, _why = _MIRROR_ROUTE_OBLIGATIONS[route](kinds, facts)
+        assert failing, f"the '{route}' obligation accepts {kinds} — it requires nothing"
 
 
 def test_every_kind_the_corpus_dimensions_is_claimed_as_corpus():

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1678,24 +1678,12 @@ class TestAuthoredSetRoundTrips:
         it carries its own value, label, tolerances and reference points, so what must
         survive emit-and-re-run is that materialised content, not a role name.
         """
-        from draftwright import Sheet, build_drawing
+        from draftwright import build_drawing
 
-        def authored(part):
-            sheet = Sheet(part, title="T", number="N").auto_dimensions()
-            sheet.measured_dimension(
-                kind="linear",
-                value=40,
-                label="40",
-                dominant_axis="X",
-                ref_bbox=(-20, -10, -5, 20, 10, 5),
-                ref_pts=[(-20, 0, 0), (20, 0, 0)],
-                upper_tol=0.1,
-                lower_tol=0.0,
-            )
-            return sheet.model()
-
-        part = Box(40, 20, 10)
-        model = authored(part)
+        # The same model `test_the_declared_route_reaches_the_kind_that_claims_it` checks the
+        # roster against, so the route the roster names and the route proven to round-trip
+        # cannot drift apart (#948).
+        part, model = _declared_measurement_model()
         direct = build_drawing(part, model=model, number="N")
         src = emit_sheet_script(model, "part", "authored", title="T", number="N")
         assert "sheet.measured_dimension(" in src
@@ -2143,7 +2131,12 @@ _KIND_MIRROR_COVERAGE = {
     "plate": "corpus",
     "pocket_pattern": "corpus",
     "slot_pattern": "corpus",
-    "authored_dimension": "corpus (declared route — nothing detects one)",
+    # NOT "corpus": nothing detects an imported AP242 measurement or a hand-written
+    # `measured_dimension`, so no detection fixture can reach it. It said "corpus (declared
+    # route — nothing detects one)", which read as covered while escaping the corpus check
+    # entirely — the string did not equal "corpus", so the guard skipped it and nothing
+    # verified the claim (#948). Its own route, with its own obligation, below.
+    "authored_dimension": "declared",
     "control_frame": "aspect — carries no DimParameter, so nothing to mirror",
     "datum_ref": "aspect — carries no DimParameter, so nothing to mirror",
     "finish": "aspect — carries no DimParameter, so nothing to mirror",
@@ -2176,15 +2169,105 @@ def test_every_ir_kind_is_classified_for_mirror_coverage():
     )
 
 
+def _kinds_the_mirror_dimensions() -> set[str]:
+    """Feature kinds some corpus fixture contributes an APPROVED dimension for.
+
+    Asked of the compiler, not of detection. A fixture can detect a chamfer perfectly and
+    still leave the mirror unexercised for it, because what the mirror reproduces is the
+    approved dimension SET — so "a fixture detects this kind" was never the claim
+    `_KIND_MIRROR_COVERAGE` makes (#948).
+    """
+    from draftwright.model.compiled import compile_dimensions, resolve_feature
+
+    covered: set[str] = set()
+    for part in TestTheDimensionMirror._corpus().values():
+        model = detect_part_model(part)
+        plan = compile_dimensions(model)
+        for owner in (*plan.groups, *plan.locations, *plan.ladders):
+            feature = resolve_feature(owner.ref) if owner.ref is not None else None
+            if feature is not None:
+                covered.add(feature.kind)
+    return covered
+
+
 def test_the_corpus_really_covers_the_kinds_it_claims():
     """`"corpus"` is a claim about fixtures, so check it against them. Two fixtures were
-    detecting something other than their name until the review counted them (#947)."""
-    detected: set[str] = set()
-    for part in TestTheDimensionMirror._corpus().values():
-        detected |= {f.kind for f in detect_part_model(part).features}
-    claimed = {k for k, v in _KIND_MIRROR_COVERAGE.items() if v == "corpus"}
-    assert claimed <= detected, (
-        f"{sorted(claimed - detected)} are marked 'corpus' but no fixture detects them"
+    detecting something other than their name until the review counted them (#947).
+
+    Strengthened from detection to DIMENSIONING (#948): the roster names mirror coverage, and
+    the mirror reproduces approved dimensions. A kind whose fixture yields no approved
+    dimension is not mirrored by that fixture however cleanly it is recognised, and the
+    detection-only form would have called that covered.
+    """
+    dimensioned = _kinds_the_mirror_dimensions()
+    claimed = {k for k, v in _KIND_MIRROR_COVERAGE.items() if v.startswith("corpus")}
+    assert claimed <= dimensioned, (
+        f"{sorted(claimed - dimensioned)} are marked 'corpus' but no corpus fixture yields "
+        "an approved dimension owned by that kind — the mirror never exercises them"
+    )
+
+
+def _declared_measurement_model():
+    """`(part, model)` for a model carrying an `authored_dimension` — the one IR kind
+    detection cannot reach.
+
+    Module level so the roster guard and the round-trip test build the SAME thing — two
+    spellings of one fact is the defect this file keeps paying for.
+    """
+    from draftwright import Sheet
+
+    part = Box(40, 20, 10)
+    sheet = Sheet(part, title="T", number="N").auto_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=40,
+        label="40",
+        dominant_axis="X",
+        ref_bbox=(-20, -10, -5, 20, 10, 5),
+        ref_pts=[(-20, 0, 0), (20, 0, 0)],
+        upper_tol=0.1,
+        lower_tol=0.0,
+    )
+    return part, sheet.model()
+
+
+def test_the_declared_route_reaches_the_kind_that_claims_it():
+    """`"declared"` is a claim too, so give it an obligation rather than a sentence.
+
+    The entry it replaced was prose that no guard could check, and which happened to escape
+    the corpus check on an exact-string comparison. This builds the declared model and
+    requires both halves of the claim: the kind exists on it, and the emitter writes a line
+    that declares it. `test_a_measured_dimension_round_trips_through_the_emitted_script` is
+    what proves the values then survive re-running that line; this is what stops the roster
+    claiming a route nothing travels (#948).
+    """
+    declared = {k for k, v in _KIND_MIRROR_COVERAGE.items() if v == "declared"}
+    assert declared, "the 'declared' route has no kinds — delete it rather than leave it empty"
+    _part, model = _declared_measurement_model()
+    reached = {f.kind for f in model.features}
+    assert declared <= reached, (
+        f"{sorted(declared - reached)} claim the declared route, but building the declared "
+        "model does not produce them"
+    )
+    src = emit_sheet_script(model, "part", "s", title="T", number="N")
+    assert "sheet.measured_dimension(" in src, (
+        "the declared model emits no measured_dimension line, so the route is unwritable"
+    )
+
+
+def test_every_kind_the_corpus_dimensions_is_claimed_as_corpus():
+    """The converse, so the roster cannot understate either. A kind the corpus already
+    exercises should say so rather than sit under a weaker route — otherwise the next reader
+    adds a redundant fixture, or worse, argues an exemption for something already covered."""
+    dimensioned = _kinds_the_mirror_dimensions()
+    understated = {
+        k
+        for k in dimensioned
+        if k in _KIND_MIRROR_COVERAGE and not _KIND_MIRROR_COVERAGE[k].startswith("corpus")
+    }
+    assert not understated, (
+        f"{sorted(understated)} are dimensioned by a corpus fixture but the roster claims "
+        "something weaker for them"
     )
 
 


### PR DESCRIPTION
Closes #948. Part of epic #964.

## The issue was already satisfied — but not for the reason the roster gave

#948 asked for round-trip fixtures for eight IR kinds marked `"untested"` in
`_KIND_MIRROR_COVERAGE`. All eight acquired coverage *after* it was filed:

- **seven** (`chamfer`, `fillet`, `flat`, `groove`, `plate`, `pocket_pattern`, `slot_pattern`)
  got mirror-corpus fixtures in #957;
- **`authored_dimension`** got a declared-route round trip, whose whole-feature structural
  equality landed in #967.

I checked the seven are genuinely *exercised* rather than merely detected — each yields real
emitted lines (`dimension(chamfer1, "chamfer.length")`, `dimension(groove1, "groove.diameter")`,
`dimension(slot_pattern1, "pitch.length")`, …). Adding more fixtures would have been redundant.

## What was wrong: two fail-opens in the roster

**1. The guard checked detection, not dimensioning.** `_KIND_MIRROR_COVERAGE` names *mirror*
coverage, and the mirror reproduces the compiler's approved dimension set. The check asked only
whether a fixture *detected* the kind — so a fixture recognising a chamfer that yields no
approved dimension would have counted as covered while the mirror never touched it. It now asks
the compiler, via the same `compile_dimensions`/`resolve_feature` path `unmirrored_dimensions`
uses in production.

**2. `authored_dimension` escaped the guard entirely.** Its value was the prose string
`"corpus (declared route — nothing detects one)"`, and the guard compared `v == "corpus"` — so it
was silently excluded and *nothing* verified the claim. Deleting the test that covers it would
have gone unnoticed.

It now has a real route, `"declared"`, with an obligation: build the declared model, require the
kind on it, require the emitter to write the line. The round-trip test builds that *same* model
via a shared helper, so the route the roster names and the route proven to round-trip cannot
drift apart. A converse guard stops the roster understating a covered kind too.

## Verification

**Canaries — all three fire:**

| mutation | result |
|---|---|
| revert `authored_dimension` to the old prose string (i.e. main's actual state) | 2 failed |
| claim an aspect kind as `corpus` | 1 failed |
| understate a covered kind as `declared` | 2 failed |

- Full fast tier: **2564 passed, 1 skipped, 2 xfailed** (the #883 order pair).
- ruff check / ruff format / mypy / codespell clean. No stray artefacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)