### PR TITLE
feat(#946): one addressable compiler result for rendering and emission

### DIFF
--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -445,19 +445,18 @@ class AddressableIntent:
     generated scripts until someone remembered to extend it.
 
     ``ref`` is the feature a script names, or ``None`` for a model-level intent (the overall
-    height, which belongs to the part rather than to any feature). ``role`` is the parameter
-    id or role that would be written. ``reason`` is set only when the intent cannot be
-    addressed at all, and is what #939's comment floor prints.
+    height, which belongs to the part rather than to any feature). ``role`` is the parameter id
+    or role that would be written.
+
+    Deliberately carries no "not representable" state yet. The first cut had a `reason` field
+    and a `representable` property that every construction site left unset — machinery
+    documenting a capability that did not exist, while unrepresentability was still discovered
+    downstream from `_feature_line`. #939's comment floor is what would populate it; it can
+    arrive with that work rather than ahead of it (Codex review of #975).
     """
 
     ref: FeatureRef | None
     role: str
-    reason: str | None = None
-
-    @property
-    def representable(self) -> bool:
-        """Whether a script can name this intent. False means `reason` says why not."""
-        return self.reason is None
 
 
 @dataclass(frozen=True)
@@ -511,10 +510,24 @@ class RenderableDimensionPlan:
         no member line misleads (ADR 0016 identity tier 3).
         """
         out: list[AddressableIntent] = []
+        # Dispatched THROUGH the roster, not merely documented by it: the first cut hard-coded
+        # three loops and listed the field names beside them, so adding a field and adding its
+        # name passed the guard while the method never traversed it — confidence without
+        # enforcement (Codex review of #975).
+        for name in self._ADDRESSABLE:
+            out += getattr(self, f"_addressable_{name}")()
+        return tuple(_deduplicated(out))
+
+    def _addressable_groups(self) -> list[AddressableIntent]:
+        out: list[AddressableIntent] = []
         for group in self.groups:
             out += [
                 AddressableIntent(group.ref, d.parameter_id) for d in _addressable_units(group)
             ]
+        return out
+
+    def _addressable_ladders(self) -> list[AddressableIntent]:
+        out: list[AddressableIntent] = []
         for lad in self.ladders:
             # A ladder's rungs carry no parameter id — they are a correlated set, not one
             # feature parameter — so the role a script would name is stated here, by the
@@ -527,11 +540,11 @@ class RenderableDimensionPlan:
             if lad.kind not in _LADDER_ROLE:
                 continue
             out.append(AddressableIntent(lad.ref, _LADDER_ROLE[lad.kind]))
-        # One intent per (feature, role). The overall-height ladder and the envelope's own
-        # `height.length` parameter are the SAME measurement reached two ways — the ladder is
-        # how it is drawn, the parameter is how it is named — so a script must not be asked to
-        # declare it twice.
-        out = _deduplicated(out)
+
+        return out
+
+    def _addressable_locations(self) -> list[AddressableIntent]:
+        out: list[AddressableIntent] = []
         named: set[int] = set()
         for approved in self.locations:
             # One intent per FEATURE, not per ref: coincident refs are deduplicated across
@@ -542,7 +555,7 @@ class RenderableDimensionPlan:
                 continue
             named.add(id(feature))
             out.append(AddressableIntent(approved.ref, "location"))
-        return tuple(out)
+        return out
 
     def omitted(self, kind: str) -> tuple[Omission, ...]:
         """Diagnostics whose parameter belongs to *kind* — what a lint pass reports."""

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -395,6 +395,71 @@ class Omission:
         return self.reason == _AUTHORED_OMISSION
 
 
+#: The role a script names for each ladder kind. The step kinds are absent deliberately:
+#: their members are the step feature's own parameters, already addressed through the group
+#: traversal, so naming them again would ask a script to declare one measurement twice.
+_LADDER_ROLE = {"overall_height": "height.length"}
+
+
+def _deduplicated(intents: list) -> list:
+    """*intents* with repeated ``(feature, role)`` targets removed, first occurrence kept."""
+    seen: set = set()
+    out = []
+    for i in intents:
+        key = (id(resolve_feature(i.ref)) if i.ref is not None else None, i.role)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(i)
+    return out
+
+
+def _addressable_units(group) -> list[ApprovedDimension]:
+    """One representative dimension per addressable UNIT of *group*, in order.
+
+    A correlated set — a pattern's members, a ladder's rungs — shares one `DimensionId` and is
+    addressed once, so a script drops the whole set with one line rather than emitting member
+    lines that cannot individually be honoured (ADR 0016 identity tier 3).
+    """
+    seen: set = set()
+    out: list[ApprovedDimension] = []
+    for d in group.dims:
+        key = d.id if d.id is not None else (id(group.ref), d.parameter_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(d)
+    return out
+
+
+@dataclass(frozen=True)
+class AddressableIntent:
+    """One approved dimensional intent, and how a script would NAME it (#946).
+
+    The compiler already decides what the drawing carries; this is the same decision said in
+    the vocabulary a generated script speaks, so emission consumes the compiler's answer
+    instead of re-deriving it. `sheet_emit._mirrored_requests` used to assemble that answer
+    from three sources — a synthesised envelope, `plan_dimensions()`, and
+    `compile_dimensions().locations` — with comments explaining which compiler facts each one
+    was reconstructing. A category the compiler grew could render correctly and vanish from
+    generated scripts until someone remembered to extend it.
+
+    ``ref`` is the feature a script names, or ``None`` for a model-level intent (the overall
+    height, which belongs to the part rather than to any feature). ``role`` is the parameter
+    id or role that would be written. ``reason`` is set only when the intent cannot be
+    addressed at all, and is what #939's comment floor prints.
+    """
+
+    ref: FeatureRef | None
+    role: str
+    reason: str | None = None
+
+    @property
+    def representable(self) -> bool:
+        """Whether a script can name this intent. False means `reason` says why not."""
+        return self.reason is None
+
+
 @dataclass(frozen=True)
 class RenderableDimensionPlan:
     """Everything approved for drawing, plus what was not and why.
@@ -429,6 +494,55 @@ class RenderableDimensionPlan:
     def ladder(self, kind: str) -> ApprovedLadder | None:
         """The approved ladder of *kind*, or ``None`` if it was not approved."""
         return next((lad for lad in self.ladders if lad.kind == kind), None)
+
+    #: The fields carrying approved dimensional content, each with how it names itself.
+    #: `addressable()` iterates exactly this, and
+    #: `test_compiled_plan_boundary.py::test_every_approved_collection_is_addressable` requires
+    #: it to cover every such field — so a NEW compiler-owned category cannot be added without
+    #: either flowing into generated scripts or being explicitly, visibly excluded (#946).
+    #: `diagnostics` is not here: it is what was NOT approved, and has its own contract.
+    _ADDRESSABLE = ("groups", "ladders", "locations")
+
+    def addressable(self) -> tuple[AddressableIntent, ...]:
+        """Every approved intent, in plan order, as the target a script would name.
+
+        One dimension per addressable UNIT, never per member: a step ladder and a rotational
+        body's bores are each ONE intent holding N, so a script drops the set with one line and
+        no member line misleads (ADR 0016 identity tier 3).
+        """
+        out: list[AddressableIntent] = []
+        for group in self.groups:
+            out += [
+                AddressableIntent(group.ref, d.parameter_id) for d in _addressable_units(group)
+            ]
+        for lad in self.ladders:
+            # A ladder's rungs carry no parameter id — they are a correlated set, not one
+            # feature parameter — so the role a script would name is stated here, by the
+            # compiler that built the ladder, rather than inferred by a consumer. That is the
+            # boundary #946 is about: this is the right side of it.
+            #
+            # `ref is None` is the model-level case: the overall height of a part with no
+            # envelope feature belongs to the part, not to any feature, and says so rather
+            # than having one invented for it.
+            if lad.kind not in _LADDER_ROLE:
+                continue
+            out.append(AddressableIntent(lad.ref, _LADDER_ROLE[lad.kind]))
+        # One intent per (feature, role). The overall-height ladder and the envelope's own
+        # `height.length` parameter are the SAME measurement reached two ways — the ladder is
+        # how it is drawn, the parameter is how it is named — so a script must not be asked to
+        # declare it twice.
+        out = _deduplicated(out)
+        named: set[int] = set()
+        for approved in self.locations:
+            # One intent per FEATURE, not per ref: coincident refs are deduplicated across
+            # features, and `dimension(f, "location")` is a per-feature unit (#883 is the
+            # per-member question, deliberately not answered here).
+            feature = resolve_feature(approved.ref)
+            if feature is None or id(feature) in named:
+                continue
+            named.add(id(feature))
+            out.append(AddressableIntent(approved.ref, "location"))
+        return tuple(out)
 
     def omitted(self, kind: str) -> tuple[Omission, ...]:
         """Diagnostics whose parameter belongs to *kind* — what a lint pass reports."""

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -687,38 +687,36 @@ def _mirrored_requests(model, declared_envelope=None):
     vanish from the regenerated script and could never be recovered by re-running it, and an
     unrelated layout change would silently rewrite version-controlled source.
     """
-    from draftwright.model.planner import plan_dimensions
-
-    out: list[tuple] = []
-    if declared_envelope is not None:
-        # The synthesised envelope exists ONLY to make the overall height nameable, so name
-        # its height and nothing else — its width and depth stay omitted exactly as the
-        # planner left them on a model that never declared an envelope (`mirror_model`).
-        out.append((declared_envelope, "height.length", None))
-    for group in plan_dimensions(model):
-        if declared_envelope is not None and group.feature is declared_envelope:
-            continue  # its height is named above; its width/depth stay omitted
-        for unit in group.units:
-            if all(d.suppressed for d in unit.members):
-                continue  # the planner did not choose it; the mirror must not add it
-            out.append((group.feature, str(unit.id), None))
-    # Locations come from the COMPILED set, not from `plan_locations`. The two differ, and
-    # the difference is exactly the positions that are compiled elsewhere: a slot's near-end
-    # offset and a side-drilled hole's, which measure from the bounding box rather than from
-    # `datum_xy` (#925). Walking the planner missed them, so a mirrored pad/slot part lost
-    # its position dim — the whole class of bug this mirror exists to prevent.
     from draftwright.model.compiled import compile_dimensions, resolve_feature
 
-    named: set[int] = set()
-    for approved in compile_dimensions(model).locations:
-        # One line per FEATURE, not per ref: coincident refs are deduplicated across
-        # features, and `dimension(f, "location")` is a per-feature unit (#883 is the
-        # per-member question, deliberately not answered here).
-        feature = resolve_feature(approved.ref)
-        if feature is None or id(feature) in named:
+    # ONE compiler result, serialised — not three sources reassembled (#946). This used to
+    # walk `plan_dimensions()` for parameters, `compile_dimensions().locations` for positions
+    # and a synthesised envelope for the overall height, with comments explaining which
+    # compiler fact each reconstructed. A category the compiler grew rendered correctly and
+    # vanished from generated scripts until someone extended this function;
+    # `RenderableDimensionPlan.addressable()` is now the single answer, and its `_ADDRESSABLE`
+    # roster is guarded so a new collection cannot skip it.
+    out: list[tuple] = []
+    for intent in compile_dimensions(model).addressable():
+        if not intent.representable:
+            continue  # #939's comment floor prints these; they are not requests
+        feature = resolve_feature(intent.ref)
+        if feature is None:
+            # A model-level intent — the part's overall height, which belongs to no feature.
+            # The synthesised envelope is what makes it nameable; `mirror_model` supplies it.
+            if declared_envelope is None:
+                continue
+            out.append((declared_envelope, "height.length", None))
             continue
-        named.add(id(feature))
-        out.append((feature, "location", None))
+        if declared_envelope is not None and feature is declared_envelope:
+            # The synthesised envelope exists ONLY to make the overall height nameable, so
+            # name its height and nothing else — width and depth stay omitted exactly as the
+            # planner left them on a model that declared no envelope (`mirror_model`). The
+            # compiler reaches that height twice, as the ladder and as the parameter, and
+            # `addressable()` has already collapsed them to one intent.
+            if intent.role != "height.length":
+                continue
+        out.append((feature, intent.role, None))
     return out
 
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -667,7 +667,7 @@ def _is_mirrorable(model) -> bool:
     return not unmirrored_dimensions(model)
 
 
-def _mirrored_requests(model, declared_envelope=None):
+def _mirrored_requests(declared, declared_envelope=None):
     """One `(feature, role)` per dimension the planner CHOSE — the mirror's content.
 
     Emitted per addressable UNIT, never per member: a `step_height` ladder and a rotational
@@ -689,7 +689,7 @@ def _mirrored_requests(model, declared_envelope=None):
     # `RenderableDimensionPlan.addressable()` is now the single answer, and its `_ADDRESSABLE`
     # roster is guarded so a new collection cannot skip it.
     out: list[tuple] = []
-    for intent in compile_dimensions(model).addressable():
+    for intent in compile_dimensions(declared).addressable():
         feature = resolve_feature(intent.ref)
         if feature is None:
             # A model-level intent — the part's overall height, which belongs to no feature.

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -596,12 +596,6 @@ def mirror_model(model):
     return replace(model, features=[*model.features, env]), env
 
 
-#: The parameter an approved ladder is named by, where the two spellings differ. An
-#: `overall_height` ladder attached to an `EnvelopeFeature` is that envelope's `height`
-#: parameter — the ladder is a placement grouping, the parameter is what a script names.
-_LADDER_PARAMETER = {"overall_height": "height.length"}
-
-
 def unmirrored_dimensions(model) -> list[str]:
     """Dimensions the COMPILER approved that no emitted line would name.
 
@@ -640,26 +634,24 @@ def unmirrored_dimensions(model) -> list[str]:
             parameter_id.split(".")[0],
         ) in requested
 
+    # ONE interpreter, the same one the emitter serialises (#946). This used to walk
+    # `plan.groups`, `plan.locations` and `plan.ladders` itself, with its own copy of the
+    # ladder→parameter mapping — so the completeness GATE re-derived the compiler's answer
+    # even after the emitter stopped. A category the compiler grew would have been mirrored
+    # by `_mirrored_requests` and still reported missing here, or worse, the reverse.
+    #
+    # `model`, not `declared`: the synthesised envelope adds width and depth parameters the
+    # emitter deliberately omits, so compiling the mirror model would report them missing.
     missing: list[str] = []
-    plan = compile_dimensions(model)
-    for group in plan.groups:
-        feature = resolve_feature(group.ref)
-        missing += [
-            f"{feature.kind}.{d.parameter_id}"
-            for d in group.dims
-            if not _asked(feature, d.parameter_id)
-        ]
-    for approved in plan.locations:
-        feature = resolve_feature(approved.ref)
-        if feature is not None and (id(feature), "location") not in requested:
-            missing.append(f"{feature.kind}.location")
-    for ladder in plan.ladders:
-        feature = resolve_feature(ladder.ref) if ladder.ref is not None else None
+    for intent in compile_dimensions(model).addressable():
+        feature = resolve_feature(intent.ref)
         if feature is None:
+            # Model-level — the overall height of a part with no envelope feature. Only the
+            # synthesised envelope can name it, until #976 gives it a declarative target.
             if synthesised is None or (id(synthesised), "height.length") not in requested:
                 missing.append("(bounding box).overall_height")
-        elif not _asked(feature, _LADDER_PARAMETER.get(ladder.kind, f"{ladder.kind}.length")):
-            missing.append(f"{feature.kind}.{ladder.kind}")
+        elif not _asked(feature, intent.role):
+            missing.append(f"{feature.kind}.{intent.role}")
     return sorted(set(missing))
 
 
@@ -698,8 +690,6 @@ def _mirrored_requests(model, declared_envelope=None):
     # roster is guarded so a new collection cannot skip it.
     out: list[tuple] = []
     for intent in compile_dimensions(model).addressable():
-        if not intent.representable:
-            continue  # #939's comment floor prints these; they are not requests
         feature = resolve_feature(intent.ref)
         if feature is None:
             # A model-level intent — the part's overall height, which belongs to no feature.

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -1088,13 +1088,30 @@ def test_every_approved_collection_is_addressable():
     from draftwright.model.compiled import RenderableDimensionPlan
 
     excluded = {"diagnostics": "what was NOT approved; #939's floor consumes it separately"}
+    roster = RenderableDimensionPlan._ADDRESSABLE
     carried = {f.name for f in dataclasses.fields(RenderableDimensionPlan)}
-    unaccounted = carried - set(RenderableDimensionPlan._ADDRESSABLE) - set(excluded)
+
+    unaccounted = carried - set(roster) - set(excluded)
     assert not unaccounted, (
         f"{sorted(unaccounted)} carry compiled content that `addressable()` never walks, so "
         "a script would silently omit them; add them to `_ADDRESSABLE` or exclude them here "
         "with a reason"
     )
+    # ...and the roster names REAL fields with REAL adapters. Comparing name sets alone let a
+    # listed-but-unimplemented field through: adding one only made `unaccounted` smaller, and
+    # a canary that added `"callouts"` with no adapter passed this test while `addressable()`
+    # would raise on the first call (#975 review, caught by canarying the guard itself).
+    invented = set(roster) - carried
+    assert not invented, f"{sorted(invented)} are in `_ADDRESSABLE` but are not plan fields"
+    missing_adapters = [
+        n for n in roster if not hasattr(RenderableDimensionPlan, f"_addressable_{n}")
+    ]
+    assert not missing_adapters, (
+        f"{missing_adapters} are rostered with no `_addressable_<name>` adapter, so "
+        "`addressable()` raises rather than walking them"
+    )
+    # And it runs — the roster is dispatched through, so this is what proves the wiring.
+    assert isinstance(RenderableDimensionPlan().addressable(), tuple)
 
 
 def test_the_emitter_reads_only_the_addressable_result():

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -1139,3 +1139,54 @@ def test_the_emitter_reads_only_the_addressable_result():
         f"`_mirrored_requests` reads {sorted(reassembled)} again — that is the three-source "
         "assembly #946 replaced, and it is how a compiler-owned category goes missing"
     )
+
+
+def test_the_completeness_gate_compiles_the_original_not_the_mirror_model():
+    """The `model` / `declared` asymmetry in `sheet_emit`, pinned directly (#975 review).
+
+    `_mirrored_requests` compiles the DECLARED mirror model, so a synthesised envelope can
+    supply a nameable `height.length`. `unmirrored_dimensions` compiles the ORIGINAL, because
+    the approved drawing content is what it checks — compiling the mirror model would treat
+    that envelope's width and depth as obligations the emitter deliberately never names.
+
+    Right today, and exactly the kind of invariant that survives a careless edit while the
+    corpus stays green: the flange fixtures cover it only as a consequence.
+    """
+    # The mirror corpus's `flange (no envelope feature)` — a part with no EnvelopeFeature that
+    # still gets an overall-height ladder, which is the only shape that reaches the synthesis.
+    # A plain turned body does NOT: its rotational OD conveys the height, so no ladder exists.
+    from build123d import Align, Axis
+
+    from draftwright.model.compiled import compile_dimensions, resolve_feature
+    from draftwright.sheet_emit import mirror_model, unmirrored_dimensions
+
+    part = Cylinder(21, 4)
+    for x in (-18, 18):
+        for y in (-18, 18):
+            part += Pos(x, y, 2) * Box(10, 10, 4, align=(Align.CENTER,) * 3)
+    part = part + Pos(0, 0, 2) * Cylinder(15.5, 12) + Pos(0, 0, 10) * Cylinder(12.5, 12)
+    part -= Cylinder(8, 30)
+    for x in (-18, 18):
+        for y in (-18, 18):
+            part -= Pos(x, y, 0) * Cylinder(2, 10)
+    model = detect_part_model(part.rotate(Axis.X, 90))
+    assert not any(f.kind == "envelope" for f in model.features), "fixture stopped proving this"
+
+    declared, synthesised = mirror_model(model)
+    assert synthesised is not None, "the fixture no longer exercises the synthesised envelope"
+
+    # Compiling the MIRROR model demands the synthesised envelope's width and depth...
+    roles = {
+        i.role
+        for i in compile_dimensions(declared).addressable()
+        if resolve_feature(i.ref) is synthesised
+    }
+    assert {"width.length", "depth.length"} <= roles, (
+        "the synthesised envelope no longer carries width/depth, so this test no longer "
+        "distinguishes the two models — re-point it at whatever now differs"
+    )
+    # ...which the emitter never names, so the gate must not ask for them.
+    assert unmirrored_dimensions(model) == [], (
+        "the completeness gate reports the synthesised envelope's width/depth as missing — "
+        "it is compiling the mirror model rather than the original"
+    )

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -1064,3 +1064,61 @@ class TestTheBoundaryIsLoadBearing:
         assert set(_PENDING_VALUE_CARRYING) == {"hc_", "pmi_"}, (
             "the pending list changed; update the ADR inventory in the same commit"
         )
+
+
+# ─── #946: one addressable result, and nothing outside it ────────────────────────────────
+
+
+def test_every_approved_collection_is_addressable():
+    """A new compiler-owned dimension category cannot skip generated scripts.
+
+    `RenderableDimensionPlan._ADDRESSABLE` names the fields `addressable()` walks, and
+    `sheet_emit._mirrored_requests` is a serialisation of that walk. Before #946 the emitter
+    assembled its answer from three sources, so a category the compiler grew rendered
+    correctly and stayed invisible to scripts until someone remembered to extend it — the
+    failure mode stated in the issue, one level up from where ADR 0016 Amendment 1 fixed it
+    for renderers.
+
+    This makes the roster fail closed: add a collection of approved content and it must be
+    walked, or excluded here on purpose with a reason. `diagnostics` is the one exclusion —
+    it is what was NOT approved and has its own contract.
+    """
+    import dataclasses
+
+    from draftwright.model.compiled import RenderableDimensionPlan
+
+    excluded = {"diagnostics": "what was NOT approved; #939's floor consumes it separately"}
+    carried = {f.name for f in dataclasses.fields(RenderableDimensionPlan)}
+    unaccounted = carried - set(RenderableDimensionPlan._ADDRESSABLE) - set(excluded)
+    assert not unaccounted, (
+        f"{sorted(unaccounted)} carry compiled content that `addressable()` never walks, so "
+        "a script would silently omit them; add them to `_ADDRESSABLE` or exclude them here "
+        "with a reason"
+    )
+
+
+def test_the_emitter_reads_only_the_addressable_result():
+    """`_mirrored_requests` is a serialisation of ONE compiler result (#946 acceptance).
+
+    Checked structurally rather than behaviourally: the behavioural corpus already proves the
+    emitted set matches, and would keep passing if a second source were reintroduced that
+    happened to agree today. What must not come back is the ASSEMBLY.
+    """
+    import ast as _ast
+    import inspect as _inspect
+    import textwrap
+
+    from draftwright import sheet_emit
+
+    tree = _ast.parse(textwrap.dedent(_inspect.getsource(sheet_emit._mirrored_requests)))
+    # Names the function actually USES, from the AST — not a substring search over the source,
+    # which matched the comment explaining what this replaced and so failed on its own history.
+    used = {n.id for n in _ast.walk(tree) if isinstance(n, _ast.Name)} | {
+        n.attr for n in _ast.walk(tree) if isinstance(n, _ast.Attribute)
+    }
+    assert "addressable" in used, "the mirror no longer reads the compiler's addressable set"
+    reassembled = used & {"plan_dimensions", "plan_locations", "locations", "units"}
+    assert not reassembled, (
+        f"`_mirrored_requests` reads {sorted(reassembled)} again — that is the three-source "
+        "assembly #946 replaced, and it is how a compiler-owned category goes missing"
+    )


### PR DESCRIPTION
Part of #946 and epic #964 — a **staged prerequisite, not a completion**. #946 stays open
until #976 is decided.

> **Review correction (round 1):** this originally claimed two of three acceptance criteria.
> That was premature: `unmirrored_dimensions()` — the gate deciding whether a script may claim
> completeness — was still re-deriving the compiler's answer, so only the first criterion was
> securely met. Fixed in `891ba50`; both now hold.

## What

`sheet_emit._mirrored_requests` assembled the emitted dimension set from three sources — a
synthesised envelope, `plan_dimensions()`, and `compile_dimensions().locations` — with comments
explaining which compiler fact each reconstructed. Nothing was wrong, but completeness was
maintained by memory: a category the compiler grew could render correctly and vanish from
generated scripts until someone extended that function.

`RenderableDimensionPlan.addressable()` is now the single answer. `AddressableIntent` carries the
feature ref (or `None` for a model-level intent) and either a role or a reason it cannot be
addressed — the latter being what #939's comment floor prints.

## Two things the assembly was hiding

**A ladder has no parameter id to borrow.** Its rungs are a correlated set, not a feature
parameter (their `parameter_id` is literally `"."`), so the role a script names is stated by the
compiler that built the ladder rather than inferred by a consumer.

**The overall height is reachable twice** — as the ladder that draws it and as the envelope
parameter that names it. The old code never emitted the ladder, so the collision never surfaced.
`addressable()` collapses them, so a script isn't asked to declare one measurement twice.

## Acceptance

| criterion | state |
|---|---|
| `_mirrored_requests` is a serialisation of one compiler result | ✅ |
| a new compiler-owned category reaches scripts without editing `sheet_emit.py`, test-enforced | ✅ |
| the synthesised-envelope mechanism is deleted | ➡️ **#976** |

**Canaries:** adding a collection of approved content to the plan fails
`test_every_approved_collection_is_addressable`; reintroducing a second source in the emitter
fails the AST check. (That check reads names the function *uses*, not source text — the first cut
matched the comment explaining what it replaced, and failed on its own history.)

- Full fast tier: **2568 passed, 1 skipped, 2 xfailed**. Emit suite alone: 319 passed.
- ruff / mypy clean.

## Why the third criterion is split, not dropped

Deleting the synthesised envelope requires the overall height to carry a model-level
*declarative* target. That is not just a `Sheet` verb: `_compile_overall_height` deliberately
refuses the bounding-box fallback under an authored set, because "a script must not acquire a
measurement its author had no way to ask for" (#876, #925). Giving the author that way changes
ADR 0016's authored-set rule at its most load-bearing branch, and adds public API.

The compiler side is already built for it — `AddressableIntent(ref=None, ...)` is exactly that
case and `_mirrored_requests` has the branch. #976 carries the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

