### PR TITLE
fix(#977): declare the envelope from the part, not the PMI geometry

### DIFF
--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -11,7 +11,12 @@ drawing grab-bag (ADR 0008; #584 WP2). This module imports nothing from
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
+
+from build123d import Compound
+
+_log = logging.getLogger(__name__)
 
 # Axis letter -> the orthographic view a feature on that axis reads end-on in.
 _END_ON = {"x": "side", "y": "front", "z": "plan"}
@@ -42,6 +47,26 @@ class HoleRef:
     def of(cls, loc) -> HoleRef:
         x, y, z = _xyz(loc)
         return cls(round(x, 3), round(y, 3), round(z, 3))
+
+
+def _solids_body(part, src: str = "part"):
+    """The part reduced to just its solids — the geometry the drawing is *of*.
+
+    AP242 STEP files (and hand-built Compounds) can carry non-solid geometry beside
+    the solid — PMI presentation wires, leader curves, construction edges/sketches —
+    which, left in, draw as phantom rectangles in every view and inflate the bounding
+    box, corrupting the scale choice and the envelope dimensions. Shared by
+    :func:`_analyse` and :meth:`draftwright.Sheet.model` (#453) so the model a caller
+    *inspects* is wrapped from the exact same body the engine *draws*."""
+    solids = part.solids()
+    if not solids:
+        return part
+    body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
+    if body.bounding_box().size != part.bounding_box().size or len(part.edges()) != len(
+        body.edges()
+    ):
+        _log.info("Dropping non-solid geometry from %s (PMI presentation data)", src)
+    return body
 
 
 def _axis_letter(obj) -> str:

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -33,6 +33,7 @@ from draftwright._core import (
     _legible_steps,
     _Projector,
 )
+from draftwright._geometry import _solids_body
 from draftwright.compose import (
     StripDepths,
     _build_zones,
@@ -315,26 +316,6 @@ def _converge_step_sizing(
 # set minimum corridor widths, and by _fits() (Phase 3) for consistent sheet
 # selection.
 # ---------------------------------------------------------------------------
-
-
-def _solids_body(part, src: str = "part"):
-    """The part reduced to just its solids — the geometry the drawing is *of*.
-
-    AP242 STEP files (and hand-built Compounds) can carry non-solid geometry beside
-    the solid — PMI presentation wires, leader curves, construction edges/sketches —
-    which, left in, draw as phantom rectangles in every view and inflate the bounding
-    box, corrupting the scale choice and the envelope dimensions. Shared by
-    :func:`_analyse` and :meth:`draftwright.Sheet.model` (#453) so the model a caller
-    *inspects* is wrapped from the exact same body the engine *draws*."""
-    solids = part.solids()
-    if not solids:
-        return part
-    body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
-    if body.bounding_box().size != part.bounding_box().size or len(part.edges()) != len(
-        body.edges()
-    ):
-        _log.info("Dropping non-solid geometry from %s (PMI presentation data)", src)
-    return body
 
 
 @dataclass(frozen=True)

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import math
 import warnings
 
-from draftwright._geometry import plane_axes
+from draftwright._geometry import _solids_body, plane_axes
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
     AuthoredDimension,
@@ -1442,8 +1442,19 @@ def slot_pattern(
 
 def envelope(obj) -> EnvelopeFeature:
     """The overall bounding box of *obj* as width (X) / height (Z) / depth (Y),
-    matching the detector's prismatic envelope."""
-    bb = obj.bounding_box()
+    matching the detector's prismatic envelope.
+
+    Measured on the SOLIDS, not on *obj* as handed in. An AP242 STEP import is a compound of
+    the part plus its PMI presentation geometry — annotation planes, leader curves — and
+    measuring the whole thing declared CTC01 as 1170 × 650 where the part is 800 × 450: an
+    envelope 370 mm too wide, silently, in anything a user declared by hand (#977).
+
+    `_solids_body` is the engine's existing answer to that, already used by `_analyse` and
+    `Sheet.model` so a caller inspects the body the engine draws (#453). Sharing it is what
+    makes the docstring's "matching the detector's" claim true rather than aspirational; the
+    detected path was always right, and it is this declared verb that was measuring the file.
+    """
+    bb = _solids_body(obj).bounding_box()
     c = bb.center()
     return EnvelopeFeature(
         frame=Frame((c.X, c.Y, bb.min.Z), "z"),

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -686,6 +686,12 @@ def _read_step_levels(
     matching ``detect.py`` so an object round-trips to the same IR)."""
     from draftwright.recognition import recognise_step_shoulders, step_level_zs
 
+    # Solids only, for the same reason as `envelope()` (#977): this takes the WHOLE part, so a
+    # STEP import hands it PMI presentation geometry too. Measuring the compound put CTC01's
+    # datum at (-590, -325) and its anchor at (-5, 0) instead of (-400, -225) and (0, 0) —
+    # every step position off by the annotation overhang. The recognisers get the same body, or
+    # they would read levels off geometry the drawing is not of.
+    obj = _solids_body(obj)
     bb = obj.bounding_box()
     base = round(bb.min.Z, 3)
     levels = tuple(sorted(round(z, 3) for z in step_level_zs(obj)))

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -48,7 +48,7 @@ from collections.abc import MutableSequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, overload
 
-from draftwright.analysis import _solids_body
+from draftwright._geometry import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
 from draftwright.model import DimensionParameterId, Feature

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1863,3 +1863,37 @@ class TestRotationalDeclaration:
             rotational(od=-1)
         with pytest.raises(ValueError):
             rotational(od=30, bores=(0,))
+
+
+def test_declared_envelope_measures_the_part_not_the_pmi_geometry():
+    """`sheet.envelope()` on a STEP import declares the PART, not the file (#977).
+
+    An AP242 STEP file is a compound of the solid plus its PMI presentation geometry —
+    annotation planes, leader curves. Measuring the whole thing declared CTC01 as 1170 × 650
+    where the part is 800 × 450: an envelope 370 mm too wide, silently, in any hand-written
+    declaration.
+
+    Uses the STEP fixture directly because NO build123d-object fixture reproduces it — for
+    those the raw bbox and the solid bbox are equal, which is exactly why the corpus never
+    caught this and why an object-based test here would prove nothing.
+    """
+    from pathlib import Path
+
+    from build123d import import_step
+
+    from draftwright import Sheet
+
+    step = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap203.stp"
+    obj = import_step(str(step))
+    raw = obj.bounding_box()
+    assert round(raw.size.X) == 1170, (
+        "the fixture no longer carries non-solid geometry, so it cannot distinguish the two "
+        "measurements — re-point this test at one that does"
+    )
+
+    sheet = Sheet(obj, title="T", number="N").auto_dimensions()
+    env = sheet.features[sheet.envelope()._i]
+    assert (round(env.width), round(env.depth), round(env.height)) == (800, 450, 150), (
+        f"declared envelope is {env.width} x {env.depth} x {env.height}; it is measuring the "
+        "imported compound (PMI presentation geometry included) rather than the solid body"
+    )

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1897,3 +1897,32 @@ def test_declared_envelope_measures_the_part_not_the_pmi_geometry():
         f"declared envelope is {env.width} x {env.depth} x {env.height}; it is measuring the "
         "imported compound (PMI presentation geometry included) rather than the solid body"
     )
+
+
+def test_declared_step_levels_measure_the_part_not_the_pmi_geometry():
+    """`step_level(part)` has the same exposure as `envelope()` — it takes the WHOLE part.
+
+    Confirmed on the CTC01 fixture: measuring the imported compound put the datum at
+    (-590, -325) and the frame anchor at (-5, 0), where the part's are (-400, -225) and (0, 0).
+    Every step position would then be offset by the annotation overhang.
+
+    Found by auditing the sibling verbs after #977 rather than by a failing drawing — the
+    declared path had no STEP-based coverage, so nothing was going to report it.
+    """
+    from pathlib import Path
+
+    from build123d import import_step
+
+    from draftwright.model.declare import step_level
+
+    step = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap203.stp"
+    obj = import_step(str(step))
+    assert round(obj.bounding_box().size.X) == 1170, "fixture no longer carries PMI geometry"
+
+    feat = step_level(obj)
+    assert (round(feat.datum[0]), round(feat.datum[1])) == (-400, -225), (
+        f"datum {feat.datum} is measured off the imported compound, not the solid body"
+    )
+    assert (round(feat.frame.origin[0]), round(feat.frame.origin[1])) == (0, 0), (
+        f"frame anchor {feat.frame.origin} is measured off the imported compound"
+    )


### PR DESCRIPTION
Closes #977.

## The bug

`Sheet.envelope()` measured whatever object it was handed. An AP242 STEP import is a compound of
the solid **plus its PMI presentation geometry** — annotation planes, leader curves — so:

```
raw import bbox : 1170.0 x 650.0 x 150.0   <- what sheet.envelope() declared
solids only     :  800.0 x 450.0 x 150.0   <- the part; what the drawing is of
```

An envelope **370 mm too wide**, silently, in anything a user declared by hand. The docstring
claimed it matched "the detector's prismatic envelope"; it did not.

## The fix

The engine already had the answer: `_solids_body` exists because that geometry "inflates the
bounding box, corrupting the scale choice and the envelope dimensions", and `_analyse` /
`Sheet.model` both use it so a caller inspects the body the engine draws (#453). The declared
verb was the one path that didn't.

Moved `_solids_body` from `analysis` (DAG rank 3) down to `_geometry` (rank 0) so `analysis`,
`sheet` and `model/declare` share **one** implementation. `model/` may not import `analysis`, so
the alternative was a copy in the model layer — two spellings of one fact.

## How it was found

By asking why the emitter bakes envelope numbers instead of emitting the verb. Everything around
this bug was built to route *around* it rather than notice it:

- #536 added a test asserting an emitted script must **not** use `sheet.envelope()`;
- the emitter bakes detected numbers to sidestep it;
- #946 called that baking a workaround;
- and I had concluded the baking was necessary.

All locally correct, all downstream of one line measuring the wrong object. Credit to the
framing that separated "the part's bounding box" from "everything in the file, including PMI".

## Verification

- `sheet.envelope()` on CTC01 now declares **800 × 450 × 150**.
- **Canary:** reverting the one-line change reproduces 1170 × 650 exactly.
- The test uses the STEP fixture *directly* and asserts it still carries non-solid geometry
  before relying on it. No build123d-object fixture reproduces this — their raw and solid boxes
  are equal — which is why a 17-fixture corpus check agreed with the opposite conclusion earlier.
- Full fast tier: **2570 passed, 1 skipped, 2 xfailed**. ruff / mypy clean.

## Knock-on

With the verb correct, #536's "the emitted script must not use `sheet.envelope()`" assertion may
no longer be justified, which could shrink #976 from API surgery to a small change. To be tested
after this lands, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)