### PR TITLE
fix(#976): the synthesised envelope shares the declared construction

### DIFF
--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1467,10 +1467,10 @@ def envelope(obj) -> EnvelopeFeature:
     makes the docstring's "matching the detector's" claim true rather than aspirational; the
     detected path was always right, and it is this declared verb that was measuring the file.
     """
-    return envelope_from_bbox(_solids_body(obj).bounding_box())
+    return _envelope_from_bbox(_solids_body(obj).bounding_box())
 
 
-def envelope_from_bbox(bb) -> EnvelopeFeature:
+def _envelope_from_bbox(bb) -> EnvelopeFeature:
     """An :class:`EnvelopeFeature` for an already-measured bounding box.
 
     The construction, split from the measurement so the two callers cannot drift: `envelope()`

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1467,7 +1467,18 @@ def envelope(obj) -> EnvelopeFeature:
     makes the docstring's "matching the detector's" claim true rather than aspirational; the
     detected path was always right, and it is this declared verb that was measuring the file.
     """
-    bb = _solids_body(obj).bounding_box()
+    return envelope_from_bbox(_solids_body(obj).bounding_box())
+
+
+def envelope_from_bbox(bb) -> EnvelopeFeature:
+    """An :class:`EnvelopeFeature` for an already-measured bounding box.
+
+    The construction, split from the measurement so the two callers cannot drift: `envelope()`
+    measures a build123d object, and `sheet_emit.mirror_model` has only a `PartModel` and its
+    bbox. The emitter used to hand-roll this and hardcoded the frame origin to (0, 0, 0), which
+    is the bbox centre only for a part centred on the origin — on the corpus flange it was 6 mm
+    out in Y, disagreeing with both the detector and this verb (#976).
+    """
     c = bb.center()
     return EnvelopeFeature(
         frame=Frame((c.X, c.Y, c.Z), "z"),

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -25,7 +25,6 @@ from draftwright.model.ir import (
     BossFeature,
     ChamferFeature,
     Datum,
-    EnvelopeFeature,
     Feature,
     FilletFeature,
     FlatFeature,
@@ -733,17 +732,13 @@ def build_part_model(
         # (a boss whose diameter fills the footprint is the body, dimensioned by its
         # OD, not a box).
         if not _is_round(bbox, bosses_d):
-            c = bbox.center()
-            features.append(
-                EnvelopeFeature(
-                    frame=Frame((c.X, c.Y, c.Z), "z"),
-                    width=bbox.size.X,
-                    height=bbox.size.Z,
-                    depth=bbox.size.Y,
-                    bbox_min=(bbox.min.X, bbox.min.Y, bbox.min.Z),
-                    bbox_max=(bbox.max.X, bbox.max.Y, bbox.max.Z),
-                )
-            )
+            # The same construction the declared verb and the emitter's synthesis use.
+            # Detection was the REFERENCE the other two were fixed to match (#977/#976); with
+            # three independent producers, "matches the detector" was a property to re-verify
+            # rather than one the code held. Now there is one spelling.
+            from draftwright.model.declare import _envelope_from_bbox
+
+            features.append(_envelope_from_bbox(bbox))
 
     # Plate/wall thicknesses on a multi-plate prismatic (#559) — the thin extent of a
     # slab that no other prismatic dim recovers (a wall along X/Y, or a Z base plate too

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -576,19 +576,14 @@ def mirror_model(model):
         return model, None  # the compiler withholds it (Z-turned, rotational OD)
     from dataclasses import replace
 
-    from draftwright.model.ir import EnvelopeFeature, Frame
+    from draftwright.model.declare import envelope_from_bbox
 
-    bb = model.bbox
-    lo = (float(bb.min.X), float(bb.min.Y), float(bb.min.Z))
-    hi = (float(bb.max.X), float(bb.max.Y), float(bb.max.Z))
-    env = EnvelopeFeature(
-        Frame((0.0, 0.0, 0.0), "z"),
-        width=float(bb.size.X),
-        depth=float(bb.size.Y),
-        height=float(bb.size.Z),
-        bbox_min=lo,
-        bbox_max=hi,
-    )
+    # The SAME construction `sheet.envelope()` uses, not a copy. Hand-rolling it here hardcoded
+    # the frame origin to (0, 0, 0) — the bbox centre only for a part centred on the origin, and
+    # 6 mm out in Y on the corpus flange — so the synthesised envelope disagreed with both the
+    # detector and the declared verb. That is the fourth instance of #977's signature: a
+    # constructed envelope that does not match what detection would produce (#976).
+    env = envelope_from_bbox(model.bbox)
     # Returned ALONGSIDE the model rather than stamped onto it. The first cut set a private
     # marker on the frozen `EnvelopeFeature` and rediscovered it later by position and size —
     # emitter bookkeeping masquerading as model state, on a public IR type (#944 review).

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -576,14 +576,14 @@ def mirror_model(model):
         return model, None  # the compiler withholds it (Z-turned, rotational OD)
     from dataclasses import replace
 
-    from draftwright.model.declare import envelope_from_bbox
+    from draftwright.model.declare import _envelope_from_bbox
 
     # The SAME construction `sheet.envelope()` uses, not a copy. Hand-rolling it here hardcoded
     # the frame origin to (0, 0, 0) — the bbox centre only for a part centred on the origin, and
     # 6 mm out in Y on the corpus flange — so the synthesised envelope disagreed with both the
     # detector and the declared verb. That is the fourth instance of #977's signature: a
     # constructed envelope that does not match what detection would produce (#976).
-    env = envelope_from_bbox(model.bbox)
+    env = _envelope_from_bbox(model.bbox)
     # Returned ALONGSIDE the model rather than stamped onto it. The first cut set a private
     # marker on the frozen `EnvelopeFeature` and rediscovered it later by position and size —
     # emitter bookkeeping masquerading as model state, on a public IR type (#944 review).

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1977,3 +1977,40 @@ def test_the_declared_envelope_equals_the_detected_one():
                 )
             else:
                 assert want == got, f"{name}: {f.name} {got!r} != {want!r}"
+
+
+def test_the_synthesised_envelope_is_centred_like_a_detected_one():
+    """The emitter's synthesis matches detection too — the fourth producer of this feature.
+
+    `mirror_model` hand-rolled an `EnvelopeFeature` with `Frame((0, 0, 0))`, which is the bbox
+    centre only for a part centred on the origin. The corpus flange is not: its bbox spans
+    (-23,-16,-23) to (23,4,23), centre (0, -6, 0), so the synthesised frame was 6 mm out in Y.
+
+    Pinned directly. The emit suite proves behavioural parity, which is why nothing caught this
+    — the frame does not move a dimension, it moves what a GD&T frame or note would target.
+    """
+    from build123d import Align, Axis, Box, Cylinder, Pos
+
+    from draftwright.model.detect import build_part_model
+    from draftwright.sheet_emit import mirror_model
+
+    part = Cylinder(21, 4)
+    for x in (-18, 18):
+        for y in (-18, 18):
+            part += Pos(x, y, 2) * Box(10, 10, 4, align=(Align.CENTER,) * 3)
+    part = part + Pos(0, 0, 2) * Cylinder(15.5, 12) + Pos(0, 0, 10) * Cylinder(12.5, 12)
+    part -= Cylinder(8, 30)
+    for x in (-18, 18):
+        for y in (-18, 18):
+            part -= Pos(x, y, 0) * Cylinder(2, 10)
+
+    model = build_part_model(part.rotate(Axis.X, 90))
+    _declared, synthesised = mirror_model(model)
+    assert synthesised is not None, "the fixture no longer reaches the synthesis path"
+
+    bb = model.bbox
+    centre = (bb.center().X, bb.center().Y, bb.center().Z)
+    assert all(abs(a - b) < 1e-6 for a, b in zip(synthesised.frame.origin, centre)), (
+        f"synthesised frame {synthesised.frame.origin} is not the bbox centre {centre} — it is "
+        "hardcoded rather than measured, so it only matches for a part centred on the origin"
+    )


### PR DESCRIPTION
Part of #976 (and #946's third criterion). The **fourth** instance of #977's signature.

## The bug

`sheet_emit.mirror_model` hand-rolled its `EnvelopeFeature` and hardcoded the frame origin:

```python
env = EnvelopeFeature(Frame((0.0, 0.0, 0.0), "z"), ...)
```

That is the bbox centre only for a part centred on the origin. On the corpus flange — bbox
`(-23,-16,-23) … (23,4,23)`, centre `(0, -6, 0)` — it was **6 mm out in Y**, disagreeing with
both the detector and the verb #980 had just aligned.

## The fix

`declare.envelope()` splits into measurement and construction:

- `envelope(obj)` — measures a build123d object (solids only, #977)
- `envelope_from_bbox(bb)` — builds the feature

The emitter has only a `PartModel` and its bbox, which is *why* it carried a copy: it could not
call the verb. It can call the construction, so the copy is gone.

That is the pattern behind all four instances of this class: **the same fact spelled twice and
drifting.** Each fix has removed a spelling rather than corrected a copy.

## Measured, deliberately not built here

The emitted line **can** become `sheet.envelope()`:

| case | baked | verb |
|---|---|---|
| CTC-01 STEP seam | 55 annotations | 55, no differences |
| 17 corpus fixtures | — | all identical |

So #536's `"sheet.envelope()" not in src` assertion is obsolete — it guarded a measurement bug
#977 removed — and should be **inverted, not deleted**, so the reason stays recorded.

It needs a guard first: an envelope declared on a **sub-object** is not the whole part, and
substituting the bare verb there would silently change what is measured — precisely the bug
shape this series has been closing. #976 carries the measurement and the remaining steps in
order.

## Verification

- Full fast tier: **2572 passed, 1 skipped, 2 xfailed**. Emit suite alone: 319 passed.
- ruff / mypy clean.
- The declared/detected property test from #980 continues to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)