### PR TITLE
feat(#976): emit sheet.envelope() for the whole-part envelope

### DIFF
--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -28,6 +28,7 @@ fixtures (#472).
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -971,6 +972,17 @@ def emit_sheet_script(
     from draftwright.model.declare import _envelope_from_bbox
 
     feature_lines, _names = _feature_block(model.features, _envelope_from_bbox(model.bbox))
+    # Narrowed to what the BODY actually names. The set above is derived from feature kinds,
+    # which over-imports the moment a kind stops emitting a constructor: since #976 a
+    # whole-part envelope emits `sheet.envelope()`, so `EnvelopeFeature` and `Frame` were
+    # imported and never used, and a user linting their own generated script got F401 on line
+    # three. Deriving from the emitted text cannot over-import by construction, and cannot
+    # under-import either — a name absent from the body is a name the body does not need.
+    _body = "\n".join(feature_lines)
+    # Called as a NAME, not merely present as a substring: `hole` occurs inside `sheet.hole(`,
+    # so a substring test keeps the import for every script that uses the fluent verb and needs
+    # no constructor — which is four of the nineteen corpus fixtures.
+    model_imports = {n for n in model_imports if re.search(rf"(?<![.\w]){n}\s*\(", _body)}
     lines = [
         _HEADER,
         "from draftwright import Sheet",

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -199,13 +199,33 @@ def _raw_pmi_line(f) -> str:
     )
 
 
-def _feature_line(f) -> str:
+def _feature_line(f, part_envelope=None) -> str:
+    """The declaration for one feature.
+
+    *part_envelope* is the whole-part `EnvelopeFeature` when the caller knows it, so an
+    envelope that IS that one can emit the verb instead of six baked numbers (#976). Optional
+    because two callers only ask whether the line is a comment, and passing it there would be
+    noise; omitting it simply keeps the explicit form.
+    """
     k = f.kind
     if k == "authored_dimension":
         return _measured_dimension_line(f)
     if k == "pmi":
         return _raw_pmi_line(f)
     if k == "envelope":
+        if part_envelope is not None and f == part_envelope:
+            # `sheet.envelope()` defaults to the whole part and now measures its SOLIDS with a
+            # centred frame (#977/#976), so for the whole-part envelope it reconstructs exactly
+            # this feature — verified on the CTC-01 STEP seam, where the raw import is
+            # 1170 × 650 and the part is 800 × 450. Restating six numbers the object already
+            # carries is what ADR 0011 exists to avoid.
+            #
+            # Guarded by equality rather than assumed: an envelope declared on a SUB-OBJECT is
+            # not the part, and the bare verb would silently measure something else — the exact
+            # shape of the four defects #977 closed.
+            return "sheet.envelope()   # envelope " + (
+                f"{_n(f.width)} × {_n(f.height)} × {_n(f.depth)}"
+            )
         return (
             "sheet.add(EnvelopeFeature("
             f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
@@ -803,7 +823,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
     return out
 
 
-def _feature_block(features) -> tuple[list[str], dict[int, str]]:
+def _feature_block(features, part_envelope=None) -> tuple[list[str], dict[int, str]]:
     """The emitted feature lines plus ``{id(feature): binding}`` for the names they bind.
 
     The map is RETURNED rather than recomputed by the dimension block, which needs the same
@@ -829,7 +849,7 @@ def _feature_block(features) -> tuple[list[str], dict[int, str]]:
         summary = _run_summary(run)
         out.append(f"#   {section}" + (f" · {summary}" if summary else "") + " ─────")
         for f in run:
-            line = _feature_line(f)
+            line = _feature_line(f, part_envelope)
             name = _binding(f, line, counts)
             if name is not None:
                 names[id(f)] = name
@@ -948,7 +968,9 @@ def emit_sheet_script(
         ctor.append("zones=True")
     if projection:
         ctor.append(f"projection={projection!r}")
-    feature_lines, _names = _feature_block(model.features)
+    from draftwright.model.declare import _envelope_from_bbox
+
+    feature_lines, _names = _feature_block(model.features, _envelope_from_bbox(model.bbox))
     lines = [
         _HEADER,
         "from draftwright import Sheet",

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -126,7 +126,7 @@ class TestEmit:
         src = _script_for(_plate())
         assert "sheet = Sheet(part, title='T', number='N')" in src
         assert "sheet.hole(diameter=8" in src  # the ⌀8 holes
-        assert "sheet.add(EnvelopeFeature(" in src
+        assert "sheet.envelope()" in src  # #976: the whole-part envelope emits the verb
         assert src.rstrip().endswith("drawing.export('drawing', formats=('pdf',))")
 
     def test_the_script_names_the_drawing_before_exporting_it(self):
@@ -188,19 +188,61 @@ class TestEmit:
             f"lint() between build and export did not return usable issues: {issues!r}"
         )
 
+    def test_only_the_whole_part_envelope_emits_the_bare_verb(self):
+        """`sheet.envelope()` measures the whole part, so only the whole-part envelope may use
+        it (#976).
+
+        An envelope declared on a SUB-OBJECT is a different measurement, and substituting the
+        bare verb there would silently emit a script that measures something else — the exact
+        shape of the four defects #977 closed. The substitution is guarded by equality against
+        `_envelope_from_bbox(model.bbox)`, and this is what proves the guard discriminates
+        rather than always firing.
+        """
+        import dataclasses
+
+        from draftwright.model.declare import envelope as declare_envelope
+
+        part = _plate()
+        model = detect_part_model(part)
+        whole = _script_for(part)
+        assert "sheet.envelope()" in whole, "the whole-part envelope should emit the verb"
+
+        sub = declare_envelope(Box(20, 20, 10))
+        swapped = dataclasses.replace(
+            model, features=[sub if f.kind == "envelope" else f for f in model.features]
+        )
+        src = emit_sheet_script(swapped, "part", "drawing", title="T", number="N")
+        line = next(ln for ln in src.splitlines() if "envelope" in ln and " = " in ln)
+        assert "sheet.envelope()" not in line, (
+            f"a sub-object envelope emitted the bare verb ({line.strip()}), which measures the "
+            "whole part instead — the declaration would silently change what it means"
+        )
+        assert "EnvelopeFeature(" in line and "width=20" in line
+
     def test_step_seam_preserves_detected_ctc01_envelope(self, tmp_path):
-        # #536: build123d.import_step reports CTC01's raw bbox as 1170 × 650, but the
-        # detector's solid-body envelope is 800 × 450. The generated STEP-seam script
-        # must preserve the detected EnvelopeFeature literally instead of remeasuring
-        # the raw imported object with sheet.envelope().
+        # #536: `build123d.import_step` reports CTC01's raw bbox as 1170 × 650 while the
+        # detector's solid-body envelope is 800 × 450, so a STEP-seam script must declare the
+        # PART. This originally asserted `"sheet.envelope()" not in src` and baked the detected
+        # numbers, because the verb remeasured the raw import and got 1170.
+        #
+        # INVERTED, not deleted (#976). #977 fixed the verb to measure solids and #980 centred
+        # its frame, so `sheet.envelope()` now reconstructs the detected envelope exactly — the
+        # measurement bug the old assertion guarded no longer exists. What #536 actually
+        # protects is unchanged and still checked below: the script must not carry 1170.
         step = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap203.stp"
         py = generate_sheet_script(str(step), out=str(tmp_path / "ctc01"))
         src = Path(py).read_text(encoding="utf-8")
-        assert "sheet.envelope()" not in src
-        assert "sheet.add(EnvelopeFeature(" in src
-        assert "width=800" in src
-        assert "depth=450" in src
-        assert "1170" not in src
+        assert "sheet.envelope()" in src, "the whole-part envelope should emit the verb"
+        assert "1170" not in src, "the raw import's bbox leaked into the script"
+        assert "650" not in src
+
+        # ...and the verb genuinely rebuilds 800 × 450, rather than merely not saying 1170.
+        ns: dict = {}
+        exec(compile(src[: src.index("drawing = sheet.build()")], "<emit>", "exec"), ns)  # noqa: S102
+        env = next(f for f in ns["sheet"].model().features if f.kind == "envelope")
+        assert (round(env.width), round(env.depth)) == (800, 450), (
+            f"the re-run declares {env.width} × {env.depth}, not the part's 800 × 450"
+        )
 
     @pytest.mark.skipif(not _PMI_AVAILABLE, reason="OCP GDT support not available")
     def test_step_seam_emits_ap242_pmi_as_sheet_dimensions(self, tmp_path):
@@ -1811,7 +1853,9 @@ class TestAuthoredSetRoundTrips:
             mp.setattr(
                 sheet_emit,
                 "_feature_line",
-                lambda f: "# envelope — no declarative verb" if f is env else real(f),
+                lambda f, part_envelope=None: (
+                    "# envelope — no declarative verb" if f is env else real(f, part_envelope)
+                ),
             )
             with pytest.raises(ValueError, match="has no declarative verb"):
                 emit_sheet_script(model, "part", "bracket", title="T", number="N")

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -219,6 +219,30 @@ class TestEmit:
         )
         assert "EnvelopeFeature(" in line and "width=20" in line
 
+    def test_a_declared_whole_part_envelope_also_emits_the_verb(self):
+        """Provenance is immaterial — the guard is equality, not "did detection make this".
+
+        A user who called `sheet.envelope()` themselves produces the same `EnvelopeFeature` the
+        detector would, so the emitted script may say so. Documented because the guard READS
+        like a detection check and is not one: what it asks is whether this envelope is the
+        whole part, which a declared one can equally be (#982 review).
+        """
+        import dataclasses
+
+        from draftwright.model.declare import envelope as declare_envelope
+
+        part = _plate()
+        model = detect_part_model(part)
+        declared = declare_envelope(part)  # what a hand-written sheet.envelope() would build
+        swapped = dataclasses.replace(
+            model, features=[declared if f.kind == "envelope" else f for f in model.features]
+        )
+        src = emit_sheet_script(swapped, "part", "drawing", title="T", number="N")
+        assert "sheet.envelope()" in src, (
+            "a declared whole-part envelope did not emit the verb, so the guard is testing "
+            "provenance rather than equality"
+        )
+
     def test_step_seam_preserves_detected_ctc01_envelope(self, tmp_path):
         # #536: `build123d.import_step` reports CTC01's raw bbox as 1170 × 650 while the
         # detector's solid-body envelope is 800 × 450, so a STEP-seam script must declare the
@@ -3269,3 +3293,38 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
                 f"{name}: {original.kind}.members came back in a different order — "
                 f"{rebuilt.members!r} rather than {original.members!r}"
             )
+
+
+@pytest.mark.parametrize("name", sorted(TestTheDimensionMirror._corpus()))
+def test_the_generated_script_imports_exactly_what_it_uses(name, tmp_path):
+    """A generated script is source a user edits and lints, so it must not arrive with unused
+    imports (#982 review).
+
+    The import set was derived from feature KINDS, which over-imports the moment a kind stops
+    emitting a constructor — #976 made a whole-part envelope emit `sheet.envelope()`, leaving
+    `EnvelopeFeature` and `Frame` imported and unused. It is derived from the emitted body now,
+    matching each name as a CALL: a substring test keeps `hole` for every script that uses
+    `sheet.hole(...)` and needs no constructor, which is four of these fixtures and was true
+    before #976 too.
+
+    Module level because `TestTheDimensionMirror` is defined below `TestEmit`, and a
+    class-body parametrize cannot see a name declared later in the file.
+    """
+    import subprocess
+    import sys
+
+    src = emit_sheet_script(
+        detect_part_model(TestTheDimensionMirror._corpus()[name]),
+        "part",
+        "drawing",
+        title="T",
+        number="N",
+    )
+    script = tmp_path / "generated.py"
+    script.write_text(src, encoding="utf-8")
+    r = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", "--select", "F401", "--isolated", str(script)],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, f"{name}: generated script has unused imports\n{r.stdout}"


### PR DESCRIPTION
Closes #976, and completes **#946's third acceptance criterion**.

## What

Generated scripts stop restating six numbers the object already carries:

```python
envelope1 = sheet.envelope()   # envelope 800 × 150 × 450
```

instead of `sheet.add(EnvelopeFeature(frame=..., width=800, height=150, depth=450,
bbox_min=..., bbox_max=...))`.

That is ADR 0011's point — the size lives on the object — and it is only possible now because
**#977** made the verb measure solids and **#980** centred its frame, so it reconstructs the
detected envelope exactly. Verified on the CTC-01 STEP seam: the script emits the verb and
rebuilds the part's **800 × 450**, not the raw import's 1170 × 650.

## The guard is the substance

`sheet.envelope()` measures the **whole part**, so the substitution happens only when the
feature equals `_envelope_from_bbox(model.bbox)`. An envelope declared on a **sub-object** keeps
the explicit form — substituting there would emit a script that silently measures something
else, which is the shape of all four defects #977 closed.

| canary | result |
|---|---|
| always substitute | fails on the sub-object case |
| never substitute | fails on the whole-part case |

## #536 is inverted, not deleted

It required `"sheet.envelope()" not in src` because the verb remeasured the raw import. That bug
is gone, so the assertion now protects the opposite — but **what #536 actually guards is
unchanged and still checked**: the script must not carry 1170, and the re-run must genuinely
rebuild 800 × 450 rather than merely avoid saying the wrong number.

## Two test-side breakages worth noting

The targeted runs missed both; the full tier caught them.

- A `MonkeyPatch` stub for `_feature_line` still had the old one-argument signature. Widening a
  signature moves the *fakes* too, and nothing type-checks a monkeypatch.
- An assertion pinned the baked form this replaces.

## Verification

- Full fast tier: **2574 passed, 1 skipped, 2 xfailed**. Emit suite: 320 passed.
- ruff / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)