### PR TITLE
test(#974): remove the misleading route comment

### DIFF
--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2171,19 +2171,30 @@ def test_the_plan_surface_is_ratcheted():
     )
 
 
-#: Each route, mapped to what claiming it OBLIGES — as code, given the measured facts.
-#: Returns the kinds on that route which fail the obligation, plus how to say so.
+#: The route vocabulary. A value in `_KIND_MIRROR_COVERAGE` is a route, optionally followed
+#: by ``" — <reason>"``.
 #:
-#: The vocabulary is DERIVED from this table (`_MIRROR_ROUTES` below), so a route cannot be
-#: spelled unless it requires something. That is the lesson `_ROUTE_OBLIGATIONS` paid seven
-#: review rounds for on #967, and not applying it here was this roster stopping one step
-#: short: `aspect` and `unnameable` passed the vocabulary check while obliging nothing, so any
-#: kind parked under either escaped verification entirely (Codex review of #973, round 2).
-#: The route vocabulary. A value is a route, optionally followed by ``" — <reason>"``.
+#: Hand-written, and checked rather than derived. An earlier cut derived it from a table of
+#: obligation callables so a route could not be spelled unless it required something; #973's
+#: last review judged that framework over-engineered — it tested the taxonomy more than the
+#: mirror — and it was cut back to the three direct tests below. This comment claimed the
+#: derived property for several commits after the table it named was deleted, which is the
+#: over-claiming those same reviews kept finding (#974).
+#:
+#: What replaces it is `_ROUTE_CHECKS`: every route must name the test that enforces it, so
+#: adding a route without a check fails rather than silently exempting every kind on it.
 #:
 #: There is deliberately no `unnameable` route: `pmi` was its only member and is `declared` —
 #: the emitter serialises it and the generated script reconstructs it (#973 r3).
 _MIRROR_ROUTES = ("corpus", "declared", "aspect")
+
+#: route -> the test that enforces what claiming it means. Names, not callables: the point is
+#: that a reader can follow the claim to the check, and that adding a route without one fails.
+_ROUTE_CHECKS = {
+    "corpus": "test_corpus_kinds_own_an_approved_dimension",
+    "declared": "test_declared_kinds_are_reachable_and_emitted",
+    "aspect": "test_aspect_kinds_report_no_dimension_parameters",
+}
 
 
 def _route_of(value: str) -> str:
@@ -3328,3 +3339,23 @@ def test_the_generated_script_imports_exactly_what_it_uses(name, tmp_path):
         text=True,
     )
     assert r.returncode == 0, f"{name}: generated script has unused imports\n{r.stdout}"
+
+
+def test_every_route_names_a_check_that_exists():
+    """A route with no check exempts every kind on it — silently, and by construction.
+
+    This is the property an earlier cut got by DERIVING the vocabulary from a table of
+    obligation callables. That framework was judged over-engineered (#973 r5) and cut, but the
+    comment kept claiming the property for several commits after the table was gone. So the
+    claim is small and true now: every route names its test, and the test exists in this module
+    (#974).
+    """
+    missing_checks = set(_MIRROR_ROUTES) - set(_ROUTE_CHECKS)
+    assert not missing_checks, (
+        f"{sorted(missing_checks)} are routes with no entry in `_ROUTE_CHECKS`, so nothing "
+        "verifies what claiming them means"
+    )
+    stale = set(_ROUTE_CHECKS) - set(_MIRROR_ROUTES)
+    assert not stale, f"{sorted(stale)} name checks for routes that no longer exist"
+    absent = [t for t in _ROUTE_CHECKS.values() if t not in globals()]
+    assert not absent, f"{absent} are named as route checks but not defined in this module"

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2174,27 +2174,29 @@ def test_the_plan_surface_is_ratcheted():
 #: The route vocabulary. A value in `_KIND_MIRROR_COVERAGE` is a route, optionally followed
 #: by ``" — <reason>"``.
 #:
-#: Hand-written, and checked rather than derived. An earlier cut derived it from a table of
+#: Hand-written, and NOT derived — which is the whole of what follows. An earlier cut derived
 #: obligation callables so a route could not be spelled unless it required something; #973's
 #: last review judged that framework over-engineered — it tested the taxonomy more than the
 #: mirror — and it was cut back to the three direct tests below. This comment claimed the
 #: derived property for several commits after the table it named was deleted, which is the
 #: over-claiming those same reviews kept finding (#974).
 #:
-#: What replaces it is `_ROUTE_CHECKS`: every route must name the test that enforces it, so
-#: adding a route without a check fails rather than silently exempting every kind on it.
+#: Nothing replaces that enforcement, and this says so rather than implying otherwise. The
+#: three routes are checked by three named tests below — `test_corpus_kinds_own_an_approved_
+#: dimension`, `test_declared_kinds_are_reachable_and_emitted`,
+#: `test_aspect_kinds_report_no_dimension_parameters` — and keeping this tuple in step with them
+#: is MANUAL. Adding a fourth route without writing its check would exempt every kind on it
+#: silently.
 #:
+#: A `_ROUTE_CHECKS` map from route to test NAME was tried and removed: it verified only that a
+#: name existed in `globals()`, so a new route could point at an existing test that examines a
+#: different route entirely — the same fail-open, now wearing a guard (#984 review). Claiming
+#: less is better than a check that reads like enforcement and is not. Making it real means the
+#: derived-obligation design in `_ROUTE_OBLIGATIONS` below, which #973's last review cut here as
+#: over-engineered; that tension is genuine and stays recorded on #974.
 #: There is deliberately no `unnameable` route: `pmi` was its only member and is `declared` —
 #: the emitter serialises it and the generated script reconstructs it (#973 r3).
 _MIRROR_ROUTES = ("corpus", "declared", "aspect")
-
-#: route -> the test that enforces what claiming it means. Names, not callables: the point is
-#: that a reader can follow the claim to the check, and that adding a route without one fails.
-_ROUTE_CHECKS = {
-    "corpus": "test_corpus_kinds_own_an_approved_dimension",
-    "declared": "test_declared_kinds_are_reachable_and_emitted",
-    "aspect": "test_aspect_kinds_report_no_dimension_parameters",
-}
 
 
 def _route_of(value: str) -> str:
@@ -3339,23 +3341,3 @@ def test_the_generated_script_imports_exactly_what_it_uses(name, tmp_path):
         text=True,
     )
     assert r.returncode == 0, f"{name}: generated script has unused imports\n{r.stdout}"
-
-
-def test_every_route_names_a_check_that_exists():
-    """A route with no check exempts every kind on it — silently, and by construction.
-
-    This is the property an earlier cut got by DERIVING the vocabulary from a table of
-    obligation callables. That framework was judged over-engineered (#973 r5) and cut, but the
-    comment kept claiming the property for several commits after the table was gone. So the
-    claim is small and true now: every route names its test, and the test exists in this module
-    (#974).
-    """
-    missing_checks = set(_MIRROR_ROUTES) - set(_ROUTE_CHECKS)
-    assert not missing_checks, (
-        f"{sorted(missing_checks)} are routes with no entry in `_ROUTE_CHECKS`, so nothing "
-        "verifies what claiming them means"
-    )
-    stale = set(_ROUTE_CHECKS) - set(_MIRROR_ROUTES)
-    assert not stale, f"{sorted(stale)} name checks for routes that no longer exist"
-    absent = [t for t in _ROUTE_CHECKS.values() if t not in globals()]
-    assert not absent, f"{absent} are named as route checks but not defined in this module"

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1746,7 +1746,7 @@ class TestAuthoredSetRoundTrips:
         """
         from draftwright import build_drawing
 
-        # The same model `test_the_declared_route_reaches_the_kind_that_claims_it` checks the
+        # The same model `test_declared_kinds_are_reachable_and_emitted` checks the
         # roster against, so the route the roster names and the route proven to round-trip
         # cannot drift apart (#948).
         part, model = _declared_measurement_model()
@@ -2171,31 +2171,11 @@ def test_the_plan_surface_is_ratcheted():
     )
 
 
-#: The route vocabulary. A value in `_KIND_MIRROR_COVERAGE` is a route, optionally followed
-#: by ``" — <reason>"``.
+#: The route vocabulary. A value in `_KIND_MIRROR_COVERAGE` is one of these, optionally
+#: followed by ``" — <reason>"``.
 #:
-#: Hand-written, and NOT derived — which is the whole of what follows. An earlier cut derived
-#: obligation callables so a route could not be spelled unless it required something; #973's
-#: last review judged that framework over-engineered — it tested the taxonomy more than the
-#: mirror — and it was cut back to the three direct tests below. This comment claimed the
-#: derived property for several commits after the table it named was deleted, which is the
-#: over-claiming those same reviews kept finding (#974).
-#:
-#: Nothing replaces that enforcement, and this says so rather than implying otherwise. The
-#: three routes are checked by three named tests below — `test_corpus_kinds_own_an_approved_
-#: dimension`, `test_declared_kinds_are_reachable_and_emitted`,
-#: `test_aspect_kinds_report_no_dimension_parameters` — and keeping this tuple in step with them
-#: is MANUAL. Adding a fourth route without writing its check would exempt every kind on it
-#: silently.
-#:
-#: A `_ROUTE_CHECKS` map from route to test NAME was tried and removed: it verified only that a
-#: name existed in `globals()`, so a new route could point at an existing test that examines a
-#: different route entirely — the same fail-open, now wearing a guard (#984 review). Claiming
-#: less is better than a check that reads like enforcement and is not. Making it real means the
-#: derived-obligation design in `_ROUTE_OBLIGATIONS` below, which #973's last review cut here as
-#: over-engineered; that tension is genuine and stays recorded on #974.
-#: There is deliberately no `unnameable` route: `pmi` was its only member and is `declared` —
-#: the emitter serialises it and the generated script reconstructs it (#973 r3).
+#: Nothing enforces that a route has a check. Adding one here without writing its test
+#: would exempt every kind on it, silently — #974.
 _MIRROR_ROUTES = ("corpus", "declared", "aspect")
 
 
@@ -2210,16 +2190,15 @@ def _route_of(value: str) -> str:
 #: of this kind, so the round trip is exercised end to end (emit → run → compare signatures).
 #: Checked against the COMPILER, not against detection: recognising a feature that yields no
 #: approved dimension leaves the mirror untouched however cleanly it is recognised (#948).
-#: `"declared"` — nothing detects it, so it is reached through the declared route instead;
-#: `test_the_declared_route_reaches_the_kind_that_claims_it` builds that model and requires
-#: the emitter to write its line.
+#: `"declared"` — nothing detects it, so it is reached through the declared route instead.
+#: `test_declared_kinds_are_reachable_and_emitted` builds that model and requires the
+#: emitter to write its line; the premise that nothing detects it is a claim about the
+#: detectors that no test here checks.
 #: `"aspect"` — carries no DimParameter, so there is nothing for the mirror to reproduce.
-#: `"unnameable"` — no declarative verb, so the emitter falls back and says so; the kind
-#: cannot be mirrored by design until that verb exists.
 #:
-#: There is deliberately no "untested" route any more: #948 closed the last of them, and every
-#: route above now carries an obligation a test enforces. Re-introducing one would mean adding
-#: it to `_MIRROR_ROUTES` and saying, in the open, that it requires nothing.
+#: No `"unnameable"` route: `pmi` was its only member and is `declared` — the emitter
+#: serialises it and the generated script reconstructs it (#973 r3). No `"untested"` route
+#: either; #948 closed the last of them.
 _KIND_MIRROR_COVERAGE = {
     "hole": "corpus",
     "pattern": "corpus",


### PR DESCRIPTION
Removes a comment that was never true. **Does not** close #974 — the enforcement it described is
still unbuilt, and that issue stays open for it.

## The comment

The note above `_MIRROR_ROUTES` said the vocabulary was *derived* from a table of obligations, so
a route could not be spelled unless it required something.

```
b30439c  added _MIRROR_ROUTE_OBLIGATIONS   ← on the #973 branch
0a7d7ad  removed it (the trim)             ← same branch
50dbc27  squash-merged                     ← main never contained the table
```

The table lived for two commits on a branch. The trim removed it and left the comment; the squash
landed **only the comment**. So main has carried a note describing code no reader could ever have
found — not a regression, a claim that was never true here.

## Why nothing replaces it

Two attempts were rejected on review, correctly:

- a `route → test name` map verified only that a name existed in `globals()`, so a new route could
  point at a test examining a different route — the same hole, wearing a guard;
- a rewritten comment saying "three tests check three routes" was still stronger than the truth,
  since each test checks a predicate **narrower** than its route's meaning.

What remains says only what is true:

> Nothing enforces that a route has a check. Adding one here without writing its test would exempt
> every kind on it, silently — #974.

## Scope

**Net: 12 insertions, 20 deletions.** No behaviour change, no new checks.

Building the real enforcement is #974's remaining work, deliberately not attempted here: two
reviews disagree about whether it is worth it (#973 r5 called the framework over-engineered;
#984's review says nothing weaker enforces anything), and that should be settled before someone
builds it rather than during.

- Emit suite: **340 passed, 2 xfailed**. Full fast tier green before the final trim.
- ruff / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
