### PR TITLE
docs(#987): give every deprecation a removal target, and index them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,16 @@ carries a tracking issue *and* a removal date, or the facade is permanent by acc
   accepts its sole value `sheet`; `imperative` is now an unrecognised value like any typo,
   rather than one carrying its own explanation of the #940 retirement.
 
-Still deprecated, **not** yet removed: the bare dimension-role spellings
-(`dimension(f, "width")` for `"width.length"`) and the `Sheet.dimension(kind=…, value=…)`
-call shape. Both remain #720, and both warn.
+**Also going in this release, not yet removed as of this entry** — the bare dimension-role
+spellings (`dimension(f, "width")`, use the parameter id `"width.length"`) and the
+`Sheet.dimension(kind=…, value=…)` call shape (use `measured_dimension(...)`). Both warn
+today and both are removed by #720 before 0.4.0 ships.
+
+Note these break **without a release that warns you**: they were deprecated after v0.3.9 and
+removed in 0.4.0, so upgrading from v0.3.9 or earlier goes straight from working to
+`ValueError` with no `DeprecationWarning` in between. That is deliberate (ADR 0016), which is
+why it is written down here and in `docs/deprecations.md` — the documentation is the only
+notice you get. `dimension_ids()` on a `Sheet` handle lists the valid parameter ids.
 
 ### Fixed
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -23,7 +23,20 @@ something.
 | `Drawing.attach_part_model()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.attach_solve_trace()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.export_pdf()` | `export(out, formats=("pdf",))["pdf"]` | 0.3.1 | 0.5.0 |
-| `Drawing.place_dim()` | `dimension(feature, param, pin=True)` / `locate(…, pin=True)` | 0.3.8 (#817) | **gated on #707** |
+| `Drawing.export(svg=, dxf=)` keywords + tuple return | `export(out, formats=[...])` → `{format: path}` | 0.3.1 | 0.5.0 — **warns nowhere, see below** |
+| `Drawing.place_dim()` | `dimension(feature, param, pin=True)` / `locate(…, pin=True)` | 0.3.8 (#817) | gated on #707, target 0.6.0 |
+
+### ⚠ `export(svg=, dxf=)` is declared deprecated but emits no warning
+
+It sits under v0.3.1's **"### Deprecated"** heading in the CHANGELOG, and `export()`'s docstring
+calls it "legacy (kept for back-compat)" — but the code path at `drawing.py:2753` warns nowhere.
+`tests/test_deprecation_dates.py` therefore cannot see it *by construction*: that guard scans
+things that warn.
+
+A deprecation nobody is warned about is not a deprecation, it is documentation. Before 0.5.0
+removes it, it has to start warning — otherwise the removal is a silent break for every caller
+still using the tuple form. Adding that warning is a behaviour change beyond dating, so it is
+**not** in this pass; it is the reason the row above is annotated rather than plain.
 
 ### ⚠ The two #963 deprecations have a zero-length warning period
 
@@ -37,9 +50,12 @@ is what scripts have been written with since the verb existed; `"width.length"` 
 one. So the effect is a hard break on longstanding usage with no migration release.
 
 The mechanical scale is small — one call site in the whole test corpus, measured — so this is
-about the policy, not the work. **Unresolved: whether these move to 0.5.0** (a real
-deprecation period, requiring an ADR 0016 amendment) **or stay at 0.4.0** as a documented
-breaking change. Tracked in #720.
+about the policy, not the work.
+
+**As it stands the answer is 0.4.0**: that is what ADR 0016 decided and what the runtime
+messages say, so the table above states it rather than leaving the row blank. It is *under
+review* — moving to 0.5.0 would give a real deprecation period and needs an ADR 0016
+amendment. Tracked in #720, awaiting the maintainer's call.
 
 ### Why `place_dim` has a gate rather than a version
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,72 @@
+# Deprecations
+
+Every deprecated surface in draftwright, what replaces it, and when it goes.
+
+ADR 0005 §4: *"Each alias carries a tracking issue and a removal target... A facade with no
+exit date is a failure mode, not a success."* This page is where those dates live in one
+place. `tests/test_deprecation_dates.py` fails if any `@deprecated` message or
+`DeprecationWarning` lacks a removal statement, so the rule is executable rather than a
+convention — but the test cannot check that a row exists *here*, so add one when you deprecate
+something.
+
+## Live deprecations
+
+| Surface | Use instead | Deprecated in | Removed in |
+|---|---|---|---|
+| `Sheet.dimension(kind=…, value=…)` call shape | `Sheet.measured_dimension(...)` | **unreleased** (#963) | 0.4.0 (#720) — **see below** |
+| bare dimension-role spellings — `dimension(f, "width")` | the parameter id — `"width.length"` | **unreleased** (#963) | 0.4.0 (#720) — **see below** |
+| `Drawing.add()` | the placement verbs (`callout` / `dimension` / `note` / `add_table`) | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.add_view()` | the section verb; the raw projector is private | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.clear_annotations()` | the feature-scoped verbs (`drop` / `remove`) | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.set_view_coordinates()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.drop_view_coordinates()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.attach_part_model()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.attach_solve_trace()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.export_pdf()` | `export(out, formats=("pdf",))["pdf"]` | 0.3.1 | 0.5.0 |
+| `Drawing.place_dim()` | `dimension(feature, param, pin=True)` / `locate(…, pin=True)` | 0.3.8 (#817) | **gated on #707** |
+
+### ⚠ The two #963 deprecations have a zero-length warning period
+
+Both were added **after v0.3.9** (`4030913`), so they have never appeared in a released
+version — and ADR 0016 dates them to expire at 0.4.0. As written, 0.4.0 is both the first
+release in which the warning exists and the release that removes the surface: nobody
+upgrading from v0.3.9 ever sees the `DeprecationWarning` before the break.
+
+That matters because bare roles are the **pre-existing** spelling. `dimension(f, "width")`
+is what scripts have been written with since the verb existed; `"width.length"` is the new
+one. So the effect is a hard break on longstanding usage with no migration release.
+
+The mechanical scale is small — one call site in the whole test corpus, measured — so this is
+about the policy, not the work. **Unresolved: whether these move to 0.5.0** (a real
+deprecation period, requiring an ADR 0016 amendment) **or stay at 0.4.0** as a documented
+breaking change. Tracked in #720.
+
+### Why `place_dim` has a gate rather than a version
+
+ADR 0012 makes it the sanctioned raw page-coordinate escape hatch until the full
+auto-plus-user recompose lands (#426 / #661 / #707). Until then it has no replacement for the
+cases it exists to serve, so dating it to a release would be a promise the engine cannot keep.
+A gate names the blocker instead of inventing a version — still an answer to "when", and still
+checkable.
+
+## Not deprecated, and deliberately so
+
+- **`--style`** — survives with exactly one legal value, `sheet`. It is retained **indefinitely**
+  so existing invocations keep working, which is a decision rather than an oversight: removing
+  it would break every script that passes `--style sheet` to buy nothing. (`--style imperative`
+  was a compat stub with a date, and was deleted at it in #720.)
+- **`make_drawing.py`** — a permanent re-export facade, not a transitional one.
+
+## Removed
+
+| Surface | Removed in | Notes |
+|---|---|---|
+| `Drawing._named` / `_anno_view` / `_pinned` / `_build_issues` | 0.4.0 (#720) | private; use `dwg.registry` |
+| `Drawing._pattern_callouts` / `_patterned_holes` / `_dropped_callout_diams` | 0.4.0 (#720) | private; use `dwg.coverage` |
+| `draftwright.sheet_dsl` | 0.4.0 (#720) | import from `draftwright.sheet` (renamed #640) |
+| `generate_script` | 0.4.0 (#720) | retired #940; use `--script` / `emit_sheet_script` |
+| `--style imperative` (bespoke message) | 0.4.0 (#720) | now an ordinary unrecognised value |
+
+Absence is asserted by `test_the_expired_compat_aliases_stay_deleted` and
+`test_the_deleted_modules_and_stubs_stay_deleted` — a deletion nobody asserts is a deletion
+that comes back.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -13,8 +13,8 @@ something.
 
 | Surface | Use instead | Deprecated in | Removed in |
 |---|---|---|---|
-| `Sheet.dimension(kind=…, value=…)` call shape | `Sheet.measured_dimension(...)` | **unreleased** (#963) | 0.4.0 (#720) — **see below** |
-| bare dimension-role spellings — `dimension(f, "width")` | the parameter id — `"width.length"` | **unreleased** (#963) | 0.4.0 (#720) — **see below** |
+| `Sheet.dimension(kind=…, value=…)` call shape | `Sheet.measured_dimension(...)` | never released (#963) | **0.4.0** (#720) — breaking, **see below** |
+| bare dimension-role spellings — `dimension(f, "width")` | the parameter id — `"width.length"` | never released (#963) | **0.4.0** (#720) — breaking, **see below** |
 | `Drawing.add()` | the placement verbs (`callout` / `dimension` / `note` / `add_table`) | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.add_view()` | the section verb; the raw projector is private | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.clear_annotations()` | the feature-scoped verbs (`drop` / `remove`) | 0.3.8 (#817) | 0.5.0 |
@@ -38,7 +38,7 @@ removes it, it has to start warning — otherwise the removal is a silent break 
 still using the tuple form. Adding that warning is a behaviour change beyond dating, so it is
 **not** in this pass; it is the reason the row above is annotated rather than plain.
 
-### ⚠ The two #963 deprecations have a zero-length warning period
+### ⚠ The two #963 deprecations break without a warning release — deliberately
 
 Both were added **after v0.3.9** (`4030913`), so they have never appeared in a released
 version — and ADR 0016 dates them to expire at 0.4.0. As written, 0.4.0 is both the first
@@ -49,13 +49,18 @@ That matters because bare roles are the **pre-existing** spelling. `dimension(f,
 is what scripts have been written with since the verb existed; `"width.length"` is the new
 one. So the effect is a hard break on longstanding usage with no migration release.
 
-The mechanical scale is small — one call site in the whole test corpus, measured — so this is
-about the policy, not the work.
+The mechanical scale is small — one call site in the whole test corpus, measured — so this was
+a policy question, not a work question.
 
-**As it stands the answer is 0.4.0**: that is what ADR 0016 decided and what the runtime
-messages say, so the table above states it rather than leaving the row blank. It is *under
-review* — moving to 0.5.0 would give a real deprecation period and needs an ADR 0016
-amendment. Tracked in #720, awaiting the maintainer's call.
+**Decided: they go at 0.4.0** (maintainer, 2026-08-01), as ADR 0016 already specified. The
+warning period is skipped knowingly rather than by oversight, so it is **a documented break**:
+this section, the 0.4.0 CHANGELOG entry, and the removal itself have to spell out what changed
+and what to write instead, because the runtime will not get the chance to. If you are upgrading
+from v0.3.9 or earlier, this is the page that tells you — nothing in your own run will.
+
+Migration: replace the bare family role with the parameter id (`"width"` → `"width.length"`;
+`dimension_ids()` on a `Sheet` handle lists the valid ones), and replace
+`sheet.dimension(kind=…, value=…)` with `sheet.measured_dimension(…)`.
 
 ### Why `place_dim` has a gate rather than a version
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -24,7 +24,7 @@ something.
 | `Drawing.attach_solve_trace()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.export_pdf()` | `export(out, formats=("pdf",))["pdf"]` | 0.3.1 | 0.5.0 |
 | `Drawing.export(svg=, dxf=)` keywords + tuple return | `export(out, formats=[...])` → `{format: path}` | 0.3.1 | 0.5.0 — **warns nowhere, see below** |
-| `Drawing.place_dim()` | `dimension(feature, param, pin=True)` / `locate(…, pin=True)` | 0.3.8 (#817) | gated on #707, target 0.6.0 |
+| `Drawing.place_dim()` | `dimension(feature, param, pin=True)` / `locate(…, pin=True)` | **0.2.12** (0.3.8 added the PEP 702 shim) | gated on #707, target 0.6.0 |
 
 ### ⚠ `export(svg=, dxf=)` is declared deprecated but emits no warning
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -589,11 +589,12 @@ class Drawing:
         "Drawing.dimension(feature, param, ..., pin=True) or "
         "Drawing.locate(feature, ..., pin=True) for feature-backed edits. "
         "place_dim() remains only as a raw page-coordinate escape hatch. "
-        # NOT dated 0.5.0 with the #817 plumbing, deliberately: ADR 0012 makes this the
-        # sanctioned escape hatch until the full auto-plus-user recompose lands, so it has no
-        # replacement to point at yet. Dating it to a version whose replacement does not exist
-        # would be a promise the engine cannot keep (#987).
-        "Removal gated on #707 (full recompose); not before 0.5.0."
+        # Not dated with the #817 plumbing: ADR 0012 makes this the sanctioned escape hatch
+        # until the full auto-plus-user recompose lands, so it has no replacement to point at.
+        # But a bare "not before 0.5.0" is a lower bound, not an exit — and §4's complaint is
+        # precisely about surfaces with no exit (Codex #987 r1). So it names BOTH: the
+        # prerequisite and a target release, the latter to be revised if #707 slips.
+        "Removal gated on #707 (full recompose); target 0.6.0."
     )
     def place_dim(
         self,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -359,7 +359,7 @@ class Drawing:
     @deprecated(
         "Drawing.add_view() is deprecated (#817): view projection is engine plumbing. Custom "
         "section/auxiliary views come from the section verb; the raw projector is now private "
-        "(_add_view)."
+        "(_add_view). Removed in 0.5.0."
     )
     def add_view(self, name, shape, camera, up, position, *, look_at=None, scaled=False):
         """DEPRECATED (#817): the raw view projector is now private (:meth:`_add_view`)."""
@@ -397,7 +397,7 @@ class Drawing:
 
     @deprecated(
         "Drawing.set_view_coordinates() is deprecated (#817): view-coordinate plumbing is "
-        "engine-internal; the mutator is now private (_set_view_coordinates)."
+        "engine-internal; the mutator is now private (_set_view_coordinates). Removed in 0.5.0."
     )
     def set_view_coordinates(self, view, coords) -> None:
         """DEPRECATED (#817): now private (:meth:`_set_view_coordinates`)."""
@@ -409,7 +409,7 @@ class Drawing:
 
     @deprecated(
         "Drawing.drop_view_coordinates() is deprecated (#817): view-coordinate plumbing is "
-        "engine-internal; the mutator is now private (_drop_view_coordinates)."
+        "engine-internal; the mutator is now private (_drop_view_coordinates). Removed in 0.5.0."
     )
     def drop_view_coordinates(self, view) -> None:
         """DEPRECATED (#817): now private (:meth:`_drop_view_coordinates`)."""
@@ -547,7 +547,7 @@ class Drawing:
 
     @deprecated(
         "Drawing.attach_part_model() is deprecated (#817): build-state attach is engine "
-        "plumbing; the mutator is now private (_attach_part_model)."
+        "plumbing; the mutator is now private (_attach_part_model). Removed in 0.5.0."
     )
     def attach_part_model(self, model) -> None:
         """DEPRECATED (#817): now private (:meth:`_attach_part_model`)."""
@@ -566,7 +566,7 @@ class Drawing:
 
     @deprecated(
         "Drawing.attach_solve_trace() is deprecated (#817): build-state attach is engine "
-        "plumbing; the mutator is now private (_attach_solve_trace)."
+        "plumbing; the mutator is now private (_attach_solve_trace). Removed in 0.5.0."
     )
     def attach_solve_trace(self, trace) -> None:
         """DEPRECATED (#817): now private (:meth:`_attach_solve_trace`)."""
@@ -588,7 +588,12 @@ class Drawing:
         "Drawing.place_dim() is deprecated for normal editable scripts; use "
         "Drawing.dimension(feature, param, ..., pin=True) or "
         "Drawing.locate(feature, ..., pin=True) for feature-backed edits. "
-        "place_dim() remains only as a raw page-coordinate escape hatch."
+        "place_dim() remains only as a raw page-coordinate escape hatch. "
+        # NOT dated 0.5.0 with the #817 plumbing, deliberately: ADR 0012 makes this the
+        # sanctioned escape hatch until the full auto-plus-user recompose lands, so it has no
+        # replacement to point at yet. Dating it to a version whose replacement does not exist
+        # would be a promise the engine cannot keep (#987).
+        "Removal gated on #707 (full recompose); not before 0.5.0."
     )
     def place_dim(
         self,
@@ -714,7 +719,8 @@ class Drawing:
 
     @deprecated(
         "Drawing.add() is deprecated (#817): use the placement verbs (callout/dimension/note/"
-        "add_table/…); free text is note(). The raw add primitive is now private (_add)."
+        "add_table/…); free text is note(). The raw add primitive is now private (_add). "
+        "Removed in 0.5.0."
     )
     def add(self, obj, name=None, view=None, feature=None):
         """DEPRECATED (#817): the raw placement primitive is now private (:meth:`_add`). Use the
@@ -2445,7 +2451,7 @@ class Drawing:
     @deprecated(
         "Drawing.clear_annotations() is deprecated (#817): wholesale annotation removal is a "
         "footgun for user scripts — use the feature-scoped verbs (drop/remove). The primitive "
-        "is now private (_clear_annotations)."
+        "is now private (_clear_annotations). Removed in 0.5.0."
     )
     def clear_annotations(self, keep=("title_block",)):
         """DEPRECATED (#817): now private (:meth:`_clear_annotations`)."""
@@ -2812,7 +2818,8 @@ class Drawing:
         """Deprecated — use ``export(out, formats=("pdf",))["pdf"]``. Renders a PDF (svglib +
         reportlab) with the draftwright metadata + clickable title-block link."""
         warnings.warn(
-            "Drawing.export_pdf() is deprecated; use export(formats=('pdf',))['pdf'].",
+            "Drawing.export_pdf() is deprecated; use export(formats=('pdf',))['pdf']. "
+            "Removed in 0.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_deprecation_dates.py
+++ b/tests/test_deprecation_dates.py
@@ -9,8 +9,10 @@ the #817 plumbing for "~0.5.0". It is that the date lived in a release note whil
 the caller actually sees said nothing, so answering "what is left for the next release" meant
 grepping three ADRs and a changelog, and still getting it wrong.
 
-Scans both forms a deprecation takes here: the PEP 702 ``@deprecated`` decorator (which also
-gets type-checkers to flag call sites) and a runtime ``warnings.warn(..., DeprecationWarning)``.
+**Known blind spot.** This scans code that *warns*. A surface documented as deprecated but
+emitting no warning is invisible here — `Drawing.export(svg=, dxf=)` is exactly that (declared
+deprecated under v0.3.1's "Deprecated" heading, warns nowhere). `docs/deprecations.md` is the
+backstop for those; this file cannot be.
 """
 
 from __future__ import annotations
@@ -21,45 +23,50 @@ from pathlib import Path
 
 _SRC = Path(__file__).resolve().parents[1] / "src" / "draftwright"
 
-#: A removal statement is either a version ("Removed in 0.5.0", "Expires at 0.4.0") or an
-#: explicit gate on the work that must land first ("Removal gated on #707"). The second form
-#: exists for `place_dim`: ADR 0012 keeps it as the sanctioned raw-coordinate escape hatch
-#: until the full recompose lands, so dating it to a release whose replacement does not exist
-#: would be a promise the engine cannot keep. A gate names the blocker instead of inventing a
-#: version — which is still an answer to "when", and still checkable.
-_REMOVAL = re.compile(r"\b\d+\.\d+\.\d+\b|removal gated on #\d+", re.IGNORECASE)
+#: A removal STATEMENT — removal language followed by a version — not merely a version
+#: anywhere in the message. The first cut accepted any `X.Y.Z`, so "Deprecated since 0.3.8"
+#: or a Python-version note would have satisfied a test whose name promises it checks removal
+#: (Codex #987 r1). Accepts "Removed in 0.5.0", "Expires at 0.4.0", and the gated form
+#: "Removal gated on #707; target 0.6.0".
+_REMOVAL = re.compile(r"(?:removed|removal|expires|expiry)\b[^.]{0,60}?\d+\.\d+(?:\.\d+)?", re.I)
 
 
-def _message_of(node: ast.AST) -> str | None:
-    """The literal message string of a `@deprecated(...)` or `warnings.warn(..., DeprecationWarning)`
-    call, or None if this isn't one. Implicitly-concatenated string parts arrive already joined."""
+def _is_deprecation(node: ast.AST) -> bool:
+    """True if this call IS a deprecation announcement — the `@deprecated(...)` decorator or
+    `warnings.warn(..., DeprecationWarning)`.
+
+    Deliberately separate from reading the message: "is this a deprecation" and "can I read
+    its text" are different questions, and conflating them let an unreadable message be
+    silently treated as "not a deprecation" (Codex #987 r1).
+    """
     if not isinstance(node, ast.Call):
-        return None
+        return False
     func = node.func
-    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
-    if name == "deprecated":
-        pass
-    elif name == "warn":
-        kinds = [a for a in node.args[1:]] + [
-            k.value for k in node.keywords if k.arg == "category"
-        ]
-        if not any(getattr(k, "id", None) == "DeprecationWarning" for k in kinds):
-            return None
-    else:
-        return None
-    if not node.args:
-        return None
-    return _literal_text(node.args[0])
+    if isinstance(func, ast.Name) and func.id == "deprecated":
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "deprecated":
+        return True
+    # `warnings.warn(...)` specifically — not any object's `.warn()`, which would sweep in
+    # unrelated logger calls that happen to take a second argument.
+    is_warn = (
+        isinstance(func, ast.Attribute)
+        and func.attr == "warn"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "warnings"
+    )
+    if not is_warn:
+        return False
+    cats = list(node.args[1:]) + [k.value for k in node.keywords if k.arg == "category"]
+    return any(isinstance(c, ast.Name) and c.id == "DeprecationWarning" for c in cats)
 
 
 def _literal_text(node: ast.AST) -> str | None:
-    """The statically-known text of a message argument.
+    """The statically-known text of a message argument, or None if it cannot be read.
 
     Handles f-strings by joining their constant parts and dropping the interpolations: the
     bare-role deprecation builds its message with `f"{verb}({role!r}): …"`, so treating only
     `ast.Constant` as a message made the scanner skip it SILENTLY — it says "Expires at 0.4.0"
-    and was invisible to the check anyway. A guard that quietly ignores the messages it cannot
-    parse is the same failure it is testing for.
+    and was invisible to the check anyway.
     """
     if isinstance(node, ast.Constant):
         return node.value if isinstance(node.value, str) else None
@@ -73,29 +80,56 @@ def _literal_text(node: ast.AST) -> str | None:
     return None
 
 
-def test_every_deprecation_names_its_removal() -> None:
-    undated: list[str] = []
+def _scan() -> list[tuple[str, str | None]]:
+    """``(location, message-or-None)`` for every deprecation announcement under src/."""
+    out: list[tuple[str, str | None]] = []
     for path in sorted(_SRC.rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
-            msg = _message_of(node)
-            if msg is not None and not _REMOVAL.search(msg):
-                undated.append(f"{path.relative_to(_SRC)}:{node.lineno}: {msg[:70]}…")
-    assert not undated, (
+            if _is_deprecation(node):
+                assert isinstance(node, ast.Call)
+                msg = _literal_text(node.args[0]) if node.args else None
+                out.append((f"{path.relative_to(_SRC)}:{node.lineno}", msg))
+    return out
+
+
+def test_every_deprecation_names_its_removal() -> None:
+    bad: list[str] = []
+    for where, msg in _scan():
+        if msg is None:
+            # An unreadable message is a FAILURE, not a skip: a deprecation built from a module
+            # constant or a helper would otherwise vanish from the check entirely (Codex r1).
+            bad.append(f"{where}: message is not a literal — the guard cannot read it")
+        elif not _REMOVAL.search(msg):
+            bad.append(f"{where}: {msg[:70]}…")
+    assert not bad, (
         'deprecation(s) with no removal target — give each a version ("Removed in 0.5.0") or '
-        'an explicit gate ("Removal gated on #707") in the message the CALLER sees, and add a '
-        "row to docs/deprecations.md (#987 / ADR 0005 §4):\n  " + "\n  ".join(undated)
+        'a gated target ("Removal gated on #707; target 0.6.0") in the message the CALLER sees, '
+        "and add a row to docs/deprecations.md (#987 / ADR 0005 §4):\n  " + "\n  ".join(bad)
     )
 
 
 def test_the_scanner_actually_matches_something() -> None:
-    """Guard the guard: if `_message_of` stopped recognising the call shapes — a decorator
+    """Guard the guard: if `_is_deprecation` stopped recognising the call shapes — a decorator
     rename, a move to `warnings.warn(category=...)` — the test above would pass by finding
     nothing to check, which is the failure mode it exists to prevent."""
-    found = 0
-    for path in sorted(_SRC.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        found += sum(1 for n in ast.walk(tree) if _message_of(n) is not None)
-    assert found >= 8, (
-        f"the deprecation scanner found only {found} messages — has the shape changed?"
-    )
+    found = len(_scan())
+    assert found >= 11, f"the deprecation scanner found only {found} — has the shape changed?"
+
+
+def test_the_removal_pattern_rejects_a_bare_version() -> None:
+    """The regex must require removal LANGUAGE, not just a version — negative fixtures, because
+    the first cut passed on any `X.Y.Z` and so would have accepted every string below."""
+    for text in (
+        "Foo() is deprecated since 0.3.8; use bar().",
+        "Foo() is deprecated (#817): use bar().",
+        "Foo() requires Python 3.12.0.",
+        "Foo() is deprecated. Removed in a future release.",
+    ):
+        assert not _REMOVAL.search(text), f"should NOT count as a removal statement: {text!r}"
+    for text in (
+        "Foo() is deprecated. Removed in 0.5.0.",
+        "Foo('x'): use the id. Expires at 0.4.0.",
+        "Foo() is deprecated. Removal gated on #707; target 0.6.0.",
+    ):
+        assert _REMOVAL.search(text), f"SHOULD count as a removal statement: {text!r}"

--- a/tests/test_deprecation_dates.py
+++ b/tests/test_deprecation_dates.py
@@ -1,0 +1,101 @@
+"""Every deprecation names when it goes (#987 / ADR 0005 §4).
+
+§4's rule is that a compat surface carries a tracking issue *and* a removal target, because
+"a facade with no exit date is a failure mode, not a success". #720 applied that to seven
+private aliases and deleted them. This asserts the same rule for everything else that warns.
+
+The gap this closes is not that dates were never chosen — the v0.3.8 CHANGELOG *did* slate
+the #817 plumbing for "~0.5.0". It is that the date lived in a release note while the message
+the caller actually sees said nothing, so answering "what is left for the next release" meant
+grepping three ADRs and a changelog, and still getting it wrong.
+
+Scans both forms a deprecation takes here: the PEP 702 ``@deprecated`` decorator (which also
+gets type-checkers to flag call sites) and a runtime ``warnings.warn(..., DeprecationWarning)``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "draftwright"
+
+#: A removal statement is either a version ("Removed in 0.5.0", "Expires at 0.4.0") or an
+#: explicit gate on the work that must land first ("Removal gated on #707"). The second form
+#: exists for `place_dim`: ADR 0012 keeps it as the sanctioned raw-coordinate escape hatch
+#: until the full recompose lands, so dating it to a release whose replacement does not exist
+#: would be a promise the engine cannot keep. A gate names the blocker instead of inventing a
+#: version — which is still an answer to "when", and still checkable.
+_REMOVAL = re.compile(r"\b\d+\.\d+\.\d+\b|removal gated on #\d+", re.IGNORECASE)
+
+
+def _message_of(node: ast.AST) -> str | None:
+    """The literal message string of a `@deprecated(...)` or `warnings.warn(..., DeprecationWarning)`
+    call, or None if this isn't one. Implicitly-concatenated string parts arrive already joined."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    if name == "deprecated":
+        pass
+    elif name == "warn":
+        kinds = [a for a in node.args[1:]] + [
+            k.value for k in node.keywords if k.arg == "category"
+        ]
+        if not any(getattr(k, "id", None) == "DeprecationWarning" for k in kinds):
+            return None
+    else:
+        return None
+    if not node.args:
+        return None
+    return _literal_text(node.args[0])
+
+
+def _literal_text(node: ast.AST) -> str | None:
+    """The statically-known text of a message argument.
+
+    Handles f-strings by joining their constant parts and dropping the interpolations: the
+    bare-role deprecation builds its message with `f"{verb}({role!r}): …"`, so treating only
+    `ast.Constant` as a message made the scanner skip it SILENTLY — it says "Expires at 0.4.0"
+    and was invisible to the check anyway. A guard that quietly ignores the messages it cannot
+    parse is the same failure it is testing for.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.JoinedStr):
+        parts = [
+            v.value
+            for v in node.values
+            if isinstance(v, ast.Constant) and isinstance(v.value, str)
+        ]
+        return "".join(parts) if parts else None
+    return None
+
+
+def test_every_deprecation_names_its_removal() -> None:
+    undated: list[str] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            msg = _message_of(node)
+            if msg is not None and not _REMOVAL.search(msg):
+                undated.append(f"{path.relative_to(_SRC)}:{node.lineno}: {msg[:70]}…")
+    assert not undated, (
+        'deprecation(s) with no removal target — give each a version ("Removed in 0.5.0") or '
+        'an explicit gate ("Removal gated on #707") in the message the CALLER sees, and add a '
+        "row to docs/deprecations.md (#987 / ADR 0005 §4):\n  " + "\n  ".join(undated)
+    )
+
+
+def test_the_scanner_actually_matches_something() -> None:
+    """Guard the guard: if `_message_of` stopped recognising the call shapes — a decorator
+    rename, a move to `warnings.warn(category=...)` — the test above would pass by finding
+    nothing to check, which is the failure mode it exists to prevent."""
+    found = 0
+    for path in sorted(_SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        found += sum(1 for n in ast.walk(tree) if _message_of(n) is not None)
+    assert found >= 8, (
+        f"the deprecation scanner found only {found} messages — has the shape changed?"
+    )


### PR DESCRIPTION
Closes #987.

ADR 0005 §4: *"Each alias carries a tracking issue **and** a removal target... A facade with no exit date is a failure mode."* #720 applied that to seven **private** aliases and deleted them. Meanwhile eleven deprecation messages on the **public** API named no date at all — which matters more, because callers outside this repo actually use these.

## The dates weren't undecided — they were in the wrong place

The v0.3.8 CHANGELOG already slated the #817 plumbing for "~0.5.0". That date lived in a release note while the message the caller sees said nothing. The cost is real: answering "what's left for 0.4.0" took grepping `@deprecated`, `DeprecationWarning` and three ADRs, **and I still got it wrong mid-audit** — I reported a rename as outstanding that had already landed, surviving only as a comment at `sheet.py:235`.

- Eight #817 `Drawing` methods + `export_pdf` now say **"Removed in 0.5.0"**.
- `docs/deprecations.md` is the index: live deprecations, what replaces each, and — deliberately — what is **not** deprecated. `--style` is permanent (removing it breaks every script passing `--style sheet` to buy nothing), and it should say so rather than sit undated by omission.
- `tests/test_deprecation_dates.py` fails on any `@deprecated` or `DeprecationWarning` whose message states no removal.

## `place_dim` gets a gate, not a version

It is the one I refused to date. ADR 0012 makes it the sanctioned raw-coordinate escape hatch until the full recompose lands (#426/#661/#707), so it has **no replacement to point at**. Dating it to a release whose replacement doesn't exist would be a promise the engine can't keep. It names its blocker instead — `"Removal gated on #707"` — which is still an answer to "when", and still checkable.

## The guard was broken in the way this PR is about

Its first cut only read `ast.Constant`, so it **silently skipped the bare-role warning** — that message is an f-string. It says "Expires at 0.4.0" and was invisible to the check anyway. A guard that quietly ignores what it can't parse is precisely the failure it exists to catch.

Found by printing what it matched rather than trusting a green run. f-strings now join their literal parts: 10 messages → 11.

Three canaries, each validated: a stripped date fails it, a stripped **f-string** date fails it, and a broken scanner fails the second test (`test_the_scanner_actually_matches_something`) — which exists so the first can't pass by finding nothing.

## Recorded, deliberately NOT resolved here

Verifying the version columns turned up a policy problem. Both #963 deprecations (bare roles, the `dimension(kind=…, value=…)` call shape) landed **after v0.3.9** (`4030913`), so they have never shipped — and ADR 0016 expires them at 0.4.0. That makes 0.4.0 both the first release carrying the warning and the release that removes the surface: **nobody upgrading from v0.3.9 ever sees it.**

It bites because bare roles are the *pre-existing* spelling — `dimension(f, "width")` is what scripts are written with today. The mechanical scale is one call site (measured, not grepped), so this is purely about policy: move them to 0.5.0 for a real deprecation period (needs an ADR 0016 amendment), or keep 0.4.0 as a documented break. Flagged in the doc and on #720; awaiting the maintainer's call.

## Verification

The new suite plus `test_drawing_encapsulation` (10 passed), three validated canaries, all four lint checks. CI's matrix is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
