### PR TITLE
feat(#720)!: remove the bare dimension-role spelling and the call-shape shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,23 @@ carries a tracking issue *and* a removal date, or the facade is permanent by acc
   accepts its sole value `sheet`; `imperative` is now an unrecognised value like any typo,
   rather than one carrying its own explanation of the #940 retirement.
 
-**Also going in this release, not yet removed as of this entry** — the bare dimension-role
-spellings (`dimension(f, "width")`, use the parameter id `"width.length"`) and the
-`Sheet.dimension(kind=…, value=…)` call shape (use `measured_dimension(...)`). Both warn
-today and both are removed by #720 before 0.4.0 ships.
+- **Bare dimension-role spellings** — `sheet.dimension(f, "width")`. Use the parameter id,
+  `"width.length"`; `dimension_ids()` on a handle lists the valid ones. The bare role is the
+  *family* spelling: it selects every parameter carrying it, which is how
+  `dimension(step, "step")` quietly declared two measurements. In an authored set, where
+  omission means suppression, silently declaring an extra one is the mirror image of the rule
+  — so it now raises rather than resolving. (A *discriminated* bare role, used with `axis=`,
+  is unaffected: that is how variants like `grid_pitch.length.row` are addressed, and it never
+  warned.)
+- **The `Sheet.dimension(kind=…, value=…)` call shape** — use `Sheet.measured_dimension(...)`.
+  `dimension` is now solely the ADR 0016 referential verb: it names a feature and a parameter
+  id and reads the value off the geometry.
 
-Note these break **without a release that warns you**: they were deprecated after v0.3.9 and
-removed in 0.4.0, so upgrading from v0.3.9 or earlier goes straight from working to
-`ValueError` with no `DeprecationWarning` in between. That is deliberate (ADR 0016), which is
-why it is written down here and in `docs/deprecations.md` — the documentation is the only
-notice you get. `dimension_ids()` on a `Sheet` handle lists the valid parameter ids.
+Those last two break **without a release that warns you**. They were deprecated after v0.3.9
+and removed in 0.4.0, so the `DeprecationWarning` never appeared in a released version —
+upgrading from v0.3.9 or earlier goes straight from working to a raise. That is deliberate
+(ADR 0016); this entry and `docs/deprecations.md` are the only notice you get, so both
+failures name their replacement rather than raising about argument counts.
 
 ### Fixed
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -56,13 +56,23 @@ Migration — replace the bare family role with the parameter id (`"width"` → 
 `sheet.dimension(kind=…, value=…)` with `sheet.measured_dimension(…)`. Both failures name
 their replacement rather than raising about argument counts.
 
-**Note on scale.** Before doing it, this section said "one call site in the whole test corpus,
-measured". That was the count of *bare-role calls*, and it was right — but the removal also
-touched four tests that existed to pin the deprecated behaviour itself (warn-and-normalise,
-the warning's `stacklevel`, the legacy form reaching the emitter). Those were rewritten to
-assert the refusal, not deleted: a removal nobody asserts is a removal that comes back. Worth
-recording, because "one call site" is the sort of measurement that reads as "trivial" and
-under-counts the tests written *about* the thing being removed.
+**Note on scale — and on how the estimate was wrong.** Before doing it, this section said
+"one call site in the whole test corpus, measured". That was wrong twice over.
+
+The measurement counted `DeprecationWarning`s emitted by a *selection* of test files, not the
+corpus — so it reported the one call site in the files it happened to run and missed nine more
+in `tests/test_add_dimension.py` and `tests/test_compiled_plan_boundary.py`, which it never
+executed. A count is only corpus-wide if it was taken corpus-wide, and "measured" made it
+sound like it had been. What found the rest was running the whole suite.
+
+It also counted only *calls*, missing four tests that existed to pin the deprecated behaviour
+itself (warn-and-normalise for both verbs, the warning's `stacklevel`, the legacy spelling
+reaching the emitter). Those were rewritten to assert the refusal rather than deleted: a
+removal nobody asserts is a removal that comes back.
+
+The true scope was ten call sites across three files plus four rewritten tests. Recorded
+because the failure mode generalises: a number attached to the word "measured" gets trusted
+in place of the thing it was supposed to measure.
 
 ### Why `place_dim` has a gate rather than a version
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -13,8 +13,6 @@ something.
 
 | Surface | Use instead | Deprecated in | Removed in |
 |---|---|---|---|
-| `Sheet.dimension(kind=…, value=…)` call shape | `Sheet.measured_dimension(...)` | never released (#963) | **0.4.0** (#720) — breaking, **see below** |
-| bare dimension-role spellings — `dimension(f, "width")` | the parameter id — `"width.length"` | never released (#963) | **0.4.0** (#720) — breaking, **see below** |
 | `Drawing.add()` | the placement verbs (`callout` / `dimension` / `note` / `add_table`) | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.add_view()` | the section verb; the raw projector is private | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.clear_annotations()` | the feature-scoped verbs (`drop` / `remove`) | 0.3.8 (#817) | 0.5.0 |
@@ -38,29 +36,33 @@ removes it, it has to start warning — otherwise the removal is a silent break 
 still using the tuple form. Adding that warning is a behaviour change beyond dating, so it is
 **not** in this pass; it is the reason the row above is annotated rather than plain.
 
-### ⚠ The two #963 deprecations break without a warning release — deliberately
+### ⚠ The two #963 removals broke without a warning release — deliberately
 
-Both were added **after v0.3.9** (`4030913`), so they have never appeared in a released
-version — and ADR 0016 dates them to expire at 0.4.0. As written, 0.4.0 is both the first
-release in which the warning exists and the release that removes the surface: nobody
-upgrading from v0.3.9 ever sees the `DeprecationWarning` before the break.
+Both deprecations were added **after v0.3.9** (`4030913`) and removed in 0.4.0, so the
+`DeprecationWarning` never appeared in a released version — and no longer exists at all.
+Upgrading from v0.3.9 or earlier goes straight from working to a raise.
 
-That matters because bare roles are the **pre-existing** spelling. `dimension(f, "width")`
-is what scripts have been written with since the verb existed; `"width.length"` is the new
-one. So the effect is a hard break on longstanding usage with no migration release.
+That matters because the bare role is the **pre-existing** spelling: `dimension(f, "width")`
+is what scripts were written with, and `"width.length"` is the new one. So this is a hard
+break on longstanding usage with no migration release.
 
-The mechanical scale is small — one call site in the whole test corpus, measured — so this was
-a policy question, not a work question.
+**Decided: 0.4.0** (maintainer, 2026-08-01), as ADR 0016 already specified. The warning period
+is skipped knowingly rather than by oversight, which makes it **a documented break**: this
+page, the 0.4.0 CHANGELOG entry, and the raise itself have to carry what the runtime cannot.
+Nothing in your own run will tell you.
 
-**Decided: they go at 0.4.0** (maintainer, 2026-08-01), as ADR 0016 already specified. The
-warning period is skipped knowingly rather than by oversight, so it is **a documented break**:
-this section, the 0.4.0 CHANGELOG entry, and the removal itself have to spell out what changed
-and what to write instead, because the runtime will not get the chance to. If you are upgrading
-from v0.3.9 or earlier, this is the page that tells you — nothing in your own run will.
-
-Migration: replace the bare family role with the parameter id (`"width"` → `"width.length"`;
+Migration — replace the bare family role with the parameter id (`"width"` → `"width.length"`;
 `dimension_ids()` on a `Sheet` handle lists the valid ones), and replace
-`sheet.dimension(kind=…, value=…)` with `sheet.measured_dimension(…)`.
+`sheet.dimension(kind=…, value=…)` with `sheet.measured_dimension(…)`. Both failures name
+their replacement rather than raising about argument counts.
+
+**Note on scale.** Before doing it, this section said "one call site in the whole test corpus,
+measured". That was the count of *bare-role calls*, and it was right — but the removal also
+touched four tests that existed to pin the deprecated behaviour itself (warn-and-normalise,
+the warning's `stacklevel`, the legacy form reaching the emitter). Those were rewritten to
+assert the refusal, not deleted: a removal nobody asserts is a removal that comes back. Worth
+recording, because "one call site" is the sort of measurement that reads as "trivial" and
+under-counts the tests written *about* the thing being removed.
 
 ### Why `place_dim` has a gate rather than a version
 
@@ -87,6 +89,12 @@ checkable.
 | `draftwright.sheet_dsl` | 0.4.0 (#720) | import from `draftwright.sheet` (renamed #640) |
 | `generate_script` | 0.4.0 (#720) | retired #940; use `--script` / `emit_sheet_script` |
 | `--style imperative` (bespoke message) | 0.4.0 (#720) | now an ordinary unrecognised value |
+| bare dimension-role spellings — `dimension(f, "width")` | 0.4.0 (#720) | **breaking, never warned in a release** — use the id (`"width.length"`); `dimension_ids()` lists them |
+| `Sheet.dimension(kind=…, value=…)` call shape | 0.4.0 (#720) | **breaking, never warned in a release** — use `measured_dimension(...)` |
+
+The last two raise with the replacement named, rather than resolving or `TypeError`-ing about
+argument counts, because that message is the only notice this break gets — see the section
+above on why the warning period is deliberately absent.
 
 Absence is asserted by `test_the_expired_compat_aliases_stay_deleted` and
 `test_the_deleted_modules_and_stubs_stay_deleted` — a deletion nobody asserts is a deletion

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -46,7 +46,7 @@ import math
 import warnings
 from collections.abc import MutableSequence
 from dataclasses import replace
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING
 
 from draftwright._geometry import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
@@ -86,6 +86,11 @@ from draftwright.model.declare import read_countersink as _read_countersink
 from draftwright.model.ir import RequestedDimension
 from draftwright.model.planner import LOCATION_ROLE as _LOCATION_ROLE
 from draftwright.model.planner import location_role as _location_role
+
+#: "Not supplied" for `Sheet.dimension`'s positional parameters. They cannot simply be
+#: required: a keyword-only legacy call has to reach the removal message rather than die on
+#: "missing 2 required positional arguments" (#720).
+_UNSET = object()
 
 
 def _parse_datums(to) -> tuple[str, ...]:
@@ -810,66 +815,41 @@ class Sheet:
     #: intersection of what only a measured call can supply.
     _MEASURED_KEYWORDS = frozenset({"kind", "value", "label", "dominant_axis", "ref_pts"})
 
-    @overload
-    def dimension(
-        self, feature, role: DimensionParameterId, *, axis: str | None = ...
-    ) -> DimensionIntent: ...
-
-    @overload
     def dimension(
         self,
+        feature=_UNSET,
+        role: DimensionParameterId = _UNSET,  # type: ignore[assignment]
         *,
-        kind: str,
-        value: float,
-        label: str,
-        dominant_axis: str,
-        ref_pts,
-        ref_bbox=...,
-        at=...,
-        axis: str | None = ...,
-        upper_tol: float | None = ...,
-        lower_tol: float | None = ...,
-        source: str = ...,
-        source_kind: str | None = ...,
-    ) -> _Params: ...
+        axis: str | None = None,
+        **removed,
+    ):
+        """`dimension(feature, role)` — the ADR 0016 referential verb. See
+        :meth:`_authored_dimension` for the semantics.
 
-    def dimension(self, *args, **kw):
-        """Transitional overload for the pre-#873 spelling of :meth:`measured_dimension`.
+        The signature is the real one again (#720): the transitional call-shape dispatch to
+        :meth:`measured_dimension` was removed at 0.4.0, so `dimension` means one thing. That
+        restores what the `@overload` pair existed to provide — completion and type-checking on
+        the verb scripts are actually written in (#963) — without the dual shape.
 
-        The two ``@overload`` stubs above are what an editor and mypy see. Without them the
-        runtime signature is ``(*args, **kw)`` — so the referential form, which is the whole
-        ADR 0016 authoring surface, offered no completion and no checking on the very verb
-        scripts are written in (#963). They also make the transitional dual shape legible:
-        one call form takes a feature and a role, the other restates a measurement.
-
-        They are **call-shape** overloads, not per-feature ones, and the difference matters
-        to anyone reading the completion list: ``feature`` is untyped and every feature gets
-        the same flat vocabulary, so an editor will offer ``pocket_width.length`` on a hole.
-        Narrowing that needs handle types that can express a per-feature vocabulary, which
-        `pocket()`, `slot()`, `pad()` and `envelope()` cannot today — they all return
-        `_Params`. The runtime resolver remains the authority; this is guidance, not a
-        complete static model of what a given feature carries (#965 review).
-
-        A **transitional overload, not a deprecation wrapper**, because the name is *reused*
-        rather than retired: ADR 0016 gives ``dimension`` the referential meaning — name a
-        feature and a role, carry no number — on both :class:`Sheet` and ``Drawing``. A plain
-        rename would leave old keyword calls raising ``TypeError`` from the new signature's
-        argument list rather than saying what happened, which is the worst of both.
-
-        So this dispatches on how it was called, for one release. It expires at 0.4.0 with the
-        ADR 0005 §4 alias removals (#720).
+        ``feature``/``role`` default to a sentinel rather than being required so that a
+        keyword-only legacy call (`dimension(kind=…, value=…)`) reaches the message below
+        instead of a bare "missing 2 required positional arguments". The old shape never
+        appeared in a release, so this refusal is the only notice it gets — a documented
+        break (`docs/deprecations.md`).
         """
-        if self._MEASURED_KEYWORDS & set(kw):
-            warnings.warn(
-                "Sheet.dimension(kind=…, value=…) is now Sheet.measured_dimension(...) — "
-                "`dimension` is becoming the referential verb that names a feature and a role "
-                "and reads the value off the geometry (ADR 0016). This overload expires at "
-                "0.4.0.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return self.measured_dimension(*args, **kw)
-        return self._authored_dimension(*args, **kw)
+        if removed:
+            legacy = sorted(self._MEASURED_KEYWORDS & set(removed))
+            if legacy:
+                raise TypeError(
+                    f"Sheet.dimension({', '.join(f'{k}=…' for k in legacy)}) was removed at "
+                    "0.4.0 (#720) — use Sheet.measured_dimension(...) for a measurement that "
+                    "restates a value. `dimension` is the referential verb: it names a feature "
+                    "and a parameter id and reads the value off the geometry (ADR 0016)."
+                )
+            raise TypeError(f"dimension() got unexpected keyword(s) {sorted(removed)}")
+        if feature is _UNSET or role is _UNSET:
+            raise TypeError("dimension() requires a feature and a parameter id")
+        return self._authored_dimension(feature, role, axis=axis)
 
     def _authored_dimension(self, feature, role: DimensionParameterId, *, axis: str | None = None):
         """`dimension(feature, role)` — declare one member of the COMPLETE authored set.
@@ -1553,21 +1533,22 @@ class Sheet:
             return token, target, exact.discriminator, role
         discriminated = any(p.discriminator for p in matching)
         if bare and not discriminated:
-            warnings.warn(
+            # Deprecated in #963, REMOVED at 0.4.0 (#720). This warned for one development
+            # cycle but never appeared in a release, so the break is documented rather than
+            # warned — see docs/deprecations.md and the 0.4.0 CHANGELOG. Raising (not
+            # normalising) is the point: an authored set means omission is suppression, and a
+            # spelling that selects the whole family is how `dimension(step, "step")` quietly
+            # declared two measurements the author never named.
+            raise ValueError(
                 f"{verb}({role!r}): name the measurement by its id, {bases[0]!r}. The bare "
-                "role is the family spelling and is deprecated (#963) — it is what let "
-                "`dimension(step, 'step')` declare two dimensions silently. Expires at 0.4.0.",
-                DeprecationWarning,
-                # `add_dimension` calls here directly; `dimension` goes through the
-                # transitional dispatcher AND `_authored_dimension`, so it is two frames
-                # further out. A shared constant pointed the warning at draftwright's own
-                # source instead of the caller's line (#965 review).
-                stacklevel=4 if verb == "dimension" else 3,
+                "role is the family spelling, not one of its measurements; it was removed at "
+                "0.4.0 (#720). dimension_ids() lists the valid ids for a feature."
             )
         # A discriminated parameter keeps the BARE role: its full id carries the variant
         # (`grid_pitch.length.row`), which `axis=` supplies separately, so normalising to the
-        # id here would hand the planner a spelling that matches no parameter.
-        canonical = bases[0] if (bare and not discriminated) else role
+        # id here would hand the planner a spelling that matches no parameter. This is NOT the
+        # removed spelling — it is how variants are addressed, and it never warned.
+        canonical = role
         discs = {p.discriminator for p in matching}
         if len(discs) > 1 and axis is None:
             raise ValueError(

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -822,14 +822,20 @@ class Sheet:
         *,
         axis: str | None = None,
         **removed,
-    ):
+    ) -> DimensionIntent:
         """`dimension(feature, role)` — the ADR 0016 referential verb. See
         :meth:`_authored_dimension` for the semantics.
 
         The signature is the real one again (#720): the transitional call-shape dispatch to
         :meth:`measured_dimension` was removed at 0.4.0, so `dimension` means one thing. That
-        restores what the `@overload` pair existed to provide — completion and type-checking on
-        the verb scripts are actually written in (#963) — without the dual shape.
+        restores most of what the `@overload` pair provided — the parameter names and the
+        `DimensionIntent` return a caller sees (#963) — without the dual shape.
+
+        One thing it does NOT restore: `**removed` means a type checker accepts any keyword
+        rather than rejecting an unknown one (Codex #720 r1). That is the price of catching the
+        legacy call at runtime to name its replacement; the alternative is a static error whose
+        text is about argument counts. Worth revisiting once the break is old news, at which
+        point `**removed` can go and the signature becomes exact.
 
         ``feature``/``role`` default to a sentinel rather than being required so that a
         keyword-only legacy call (`dimension(kind=…, value=…)`) reaches the message below
@@ -851,7 +857,9 @@ class Sheet:
             raise TypeError("dimension() requires a feature and a parameter id")
         return self._authored_dimension(feature, role, axis=axis)
 
-    def _authored_dimension(self, feature, role: DimensionParameterId, *, axis: str | None = None):
+    def _authored_dimension(
+        self, feature, role: DimensionParameterId, *, axis: str | None = None
+    ) -> DimensionIntent:
         """`dimension(feature, role)` — declare one member of the COMPLETE authored set.
 
         Referential, like every ADR 0016 intent: it names a feature and a role and carries no

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -386,7 +386,7 @@ class TestSheetSurface:
         part = Rot(0, 90, 0) * Cylinder(4, 20) + Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)
         sheet = Sheet(part, title="T", number="N")
         sheet.step(diameter=8, length=20, at=(0, 0, 0), axis="x")
-        sheet.dimension(sheet.envelope(), "width")
+        sheet.dimension(sheet.envelope(), "width.length")
         dwg = sheet.build()
         step = next(f for f in dwg.model().features if f.kind == "step")
 
@@ -993,7 +993,7 @@ class TestOmittedDimensionsDoNotRender:
 
     def test_an_omitted_overall_height_is_not_drawn(self):
         sheet = Sheet(self._plate(), title="T", number="N")
-        sheet.dimension(sheet.envelope(), "width")
+        sheet.dimension(sheet.envelope(), "width.length")
         assert "dim_height" not in _names(sheet.build())
 
     def test_the_authored_overall_height_is_drawn(self):
@@ -1021,7 +1021,7 @@ class TestOmittedDimensionsDoNotRender:
         part = self._staircase()
         sheet = Sheet(part, title="T", number="N")
         sheet.step_level(part)
-        sheet.dimension(sheet.envelope(), "width")
+        sheet.dimension(sheet.envelope(), "width.length")
         assert self._rungs(sheet.build()) == []
 
     def test_a_correlated_set_is_addressed_whole(self):
@@ -1032,7 +1032,7 @@ class TestOmittedDimensionsDoNotRender:
         part = self._staircase()
         authored = Sheet(part, title="T", number="N")
         authored.step_level(part)
-        authored.dimension(authored.features[-1], "step_height")
+        authored.dimension(authored.features[-1], "step_height.length")
         auto = Sheet(part, title="T", number="N")
         auto.step_level(part)
         auto.auto_dimensions()
@@ -1044,7 +1044,7 @@ class TestOmittedDimensionsDoNotRender:
         part = self._shouldered()
         sheet = Sheet(part, title="T", number="N")
         sheet.step_level(part)
-        sheet.dimension(sheet.features[-1], "step_height")
+        sheet.dimension(sheet.features[-1], "step_height.length")
         assert self._shoulders(sheet.build()) == [], "step_position was not authored"
         assert self._rungs(sheet.build()), "but its sibling set on the same feature was"
 
@@ -1052,7 +1052,7 @@ class TestOmittedDimensionsDoNotRender:
         part = self._shouldered()
         sheet = Sheet(part, title="T", number="N")
         sheet.step_level(part)
-        sheet.dimension(sheet.features[-1], "step_position")
+        sheet.dimension(sheet.features[-1], "step_position.length")
         assert self._shoulders(sheet.build())
 
     def test_an_unaddressable_overall_height_is_refused_not_drawn(self):
@@ -1150,9 +1150,9 @@ class TestOmittedDimensionsDoNotRender:
             sheet.dimension(sheet.features[-1], role)
             return _names(sheet.build())
 
-        od_only = _built("od")
+        od_only = _built("od.diameter")
         assert "dim_od" in od_only and "ldr_z0" not in od_only
-        bore_only = _built("bore")
+        bore_only = _built("bore.diameter")
         assert "ldr_z0" in bore_only and "dim_od" not in bore_only
 
 

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -659,7 +659,7 @@ class TestAPositionIsADimension:
             return {n for n, _ in sheet.build().iter_annotations()}
 
         assert not [n for n in build(["bore.diameter"]) if n.startswith("dim_pitch")]
-        assert [n for n in build(["pitch"]) if n.startswith("dim_pitch")], (
+        assert [n for n in build(["pitch.length"]) if n.startswith("dim_pitch")], (
             "the script named the pitch and the drawing has no pitch dim"
         )
 

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1657,6 +1657,27 @@ class TestAuthoredDimension:
         # The referential form is unaffected — same verb, the one meaning it now has.
         assert not [f for f in sheet.features if f.kind == "authored_dimension"]
 
+    def test_the_other_two_argument_errors_are_still_legible(self):
+        """`dimension` takes `**removed` so a keyword-only legacy call reaches its message
+        rather than dying on "missing 2 required positional arguments". That catch-all has two
+        other exits, and both were added WITHOUT tests — codecov caught it (#720 review).
+
+        They matter because `**removed` swallows what a normal signature would reject: an
+        ordinary typo must still say it is a typo, and a call with no arguments must still say
+        what it wanted, or the compat catch-all degrades every unrelated mistake."""
+        from draftwright.sheet import Sheet
+
+        sheet = Sheet(Box(40, 20, 10), title="P").auto_dimensions()
+        env = sheet.envelope()
+
+        # A keyword that is neither valid nor legacy: reported as unexpected, and named.
+        with pytest.raises(TypeError, match="unexpected keyword"):
+            sheet.dimension(env, "width.length", nonesuch=1)
+
+        # No arguments at all: says what it needs, rather than a bare "unexpected keyword".
+        with pytest.raises(TypeError, match="requires a feature and a parameter id"):
+            sheet.dimension()
+
     def test_validates_without_the_facade(self):
         from draftwright.model import measured_dimension
 

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1631,33 +1631,22 @@ class TestAuthoredDimension:
         via_facade = next(f for f in sheet.features if f.kind == "authored_dimension")
         assert measured_dimension(**self._KW) == via_facade
 
-    def test_the_transitional_overload_still_reaches_the_same_feature(self):
-        """#873 REUSES the name `dimension` rather than retiring it, so an old keyword call
-        cannot be left to fail with a `TypeError` from the new signature's argument list. It
-        warns and delegates for one release, and must build the identical feature."""
-        from draftwright.model import measured_dimension
+    def test_the_measured_call_shape_is_refused_by_name(self):
+        """#720 removed the transitional dispatch at 0.4.0, so `dimension` means one thing.
+
+        These two tests previously asserted that the measured keywords WARNED and delegated.
+        The reason that shim existed is the reason this test replaces rather than deletes
+        them: #873 reused the name `dimension` instead of retiring it, so an old keyword call
+        must not be left to fail with a `TypeError` about missing positional arguments. It now
+        fails by NAMING the replacement — which is the only notice this break gets, since the
+        deprecation never appeared in a release (docs/deprecations.md)."""
         from draftwright.sheet import Sheet
 
         sheet = Sheet(Box(40, 20, 10), title="P").auto_dimensions()
-        with pytest.warns(DeprecationWarning, match="measured_dimension"):
+        with pytest.raises(TypeError, match="measured_dimension"):
             sheet.dimension(**self._KW)
-        assert next(f for f in sheet.features if f.kind == "authored_dimension") == (
-            measured_dimension(**self._KW)
-        )
-
-    def test_the_overload_still_routes_the_measured_form(self):
-        """This replaces a test asserting that `dimension(feature, role)` was NOT yet the
-        referential verb — "the referential form is #874. Until then…". #874 has landed, so
-        that assertion is superseded; what still needs pinning is the transitional overload
-        underneath it, which dispatches on the measured keywords so a pre-rename call says
-        what happened instead of raising a TypeError about missing arguments."""
-        import warnings
-
-        from draftwright.sheet import Sheet
-
-        sheet = Sheet(Box(40, 20, 10), title="P").auto_dimensions()
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        # ...and it says which keywords it is talking about, not just "unexpected keyword".
+        with pytest.raises(TypeError, match=r"kind=…"):
             sheet.dimension(
                 kind="linear",
                 value=40,
@@ -1665,9 +1654,8 @@ class TestAuthoredDimension:
                 dominant_axis="X",
                 ref_pts=[(-20, 0, 0), (20, 0, 0)],
             )
-        assert any("measured_dimension" in str(w.message) for w in caught), (
-            "the measured form must route to measured_dimension with a deprecation notice"
-        )
+        # The referential form is unaffected — same verb, the one meaning it now has.
+        assert not [f for f in sheet.features if f.kind == "authored_dimension"]
 
     def test_validates_without_the_facade(self):
         from draftwright.model import measured_dimension

--- a/tests/test_deprecation_dates.py
+++ b/tests/test_deprecation_dates.py
@@ -109,12 +109,24 @@ def test_every_deprecation_names_its_removal() -> None:
     )
 
 
+#: The number of deprecation announcements the scanner must still find. Lower it ONLY when a
+#: deprecation was genuinely removed, and say which — the point is that a silent drop means the
+#: scanner broke, not that the codebase got cleaner. Was 11 until #720 removed the two #963
+#: warnings (the bare dimension-role spelling and the `dimension(kind=…, value=…)` call shape)
+#: at 0.4.0; those are now raises, which carry no removal date to check.
+_EXPECTED_DEPRECATIONS = 9
+
+
 def test_the_scanner_actually_matches_something() -> None:
     """Guard the guard: if `_is_deprecation` stopped recognising the call shapes — a decorator
     rename, a move to `warnings.warn(category=...)` — the test above would pass by finding
     nothing to check, which is the failure mode it exists to prevent."""
     found = len(_scan())
-    assert found >= 11, f"the deprecation scanner found only {found} — has the shape changed?"
+    assert found >= _EXPECTED_DEPRECATIONS, (
+        f"the deprecation scanner found only {found}, expected at least "
+        f"{_EXPECTED_DEPRECATIONS} — either a deprecation was removed (lower the constant and "
+        "note which) or the scanner stopped recognising a call shape"
+    )
 
 
 def test_the_removal_pattern_rejects_a_bare_version() -> None:

--- a/tests/test_dimension_role_vocabulary.py
+++ b/tests/test_dimension_role_vocabulary.py
@@ -17,6 +17,8 @@ import ast
 from pathlib import Path
 from typing import get_args
 
+import pytest
+
 from draftwright.model import DimensionParameterId
 
 _IR = Path(__file__).resolve().parents[1] / "src" / "draftwright" / "model" / "ir.py"
@@ -179,34 +181,35 @@ class TestTheCanonicalSpellingIsEnforced:
         sheet.dimension(step, "step.length")
         assert sheet._authored[-1]["role"] == "step.length"
 
-    def test_a_singleton_family_warns_and_is_normalised(self):
-        import warnings
+    def test_a_singleton_family_is_refused(self):
+        """#720 removed the bare family spelling at 0.4.0. It previously warned and normalised
+        to the id; it now raises, because in an authored set — where omission is suppression —
+        a spelling that selects the whole family declares measurements the author never named.
 
+        Refusing rather than normalising is what makes the two rules consistent: `step` already
+        raised for naming two measurements, and `bore` silently resolving was the same defect
+        hidden by there happening to be only one."""
         sheet, hole = self._hole_sheet()
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            sheet.dimension(hole, "bore")  # type: ignore[call-overload]
-        assert sheet._authored[-1]["role"] == "bore.diameter"
-        assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        with pytest.raises(ValueError, match="bore.diameter"):
+            sheet.dimension(hole, "bore")  # type: ignore[arg-type]
+        assert not sheet._authored, "a refused spelling must not record an authored dimension"
 
-    def test_the_warning_points_at_the_caller_not_at_draftwright(self):
-        """A deprecation reported against the library's own source tells the reader nothing
-        about which of their lines to change. `dimension` reaches the resolver two frames
-        deeper than `add_dimension` (through the transitional dispatcher and
-        `_authored_dimension`), so one shared stacklevel cannot serve both — and asserting
-        only that a warning EXISTS does not catch it (#965 review)."""
-        import warnings
+    def test_the_refusal_names_the_spelling_to_use_for_both_verbs(self):
+        """Was `test_the_warning_points_at_the_caller_not_at_draftwright`, which pinned the
+        stacklevel of the deprecation — `dimension` reached the resolver two frames deeper
+        than `add_dimension`, so one shared value could not serve both (#965 review).
 
+        A raise has no stacklevel to get wrong: the traceback ends at the caller's line by
+        construction. What survives is the intent — the failure has to tell you which line to
+        change AND what to write there — so this now asserts the message carries both the
+        rejected spelling and the id that replaces it, for each verb."""
         for verb in ("dimension", "add_dimension"):
             sheet, hole = self._hole_sheet(verb)
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                getattr(sheet, verb)(hole, "bore")  # type: ignore[call-overload]
-            dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-            assert dep, verb
-            assert Path(dep[0].filename).name == Path(__file__).name, (
-                f"{verb}: warning blamed {dep[0].filename}, not the calling test"
-            )
+            with pytest.raises(ValueError) as exc:
+                getattr(sheet, verb)(hole, "bore")
+            msg = str(exc.value)
+            assert "'bore'" in msg and "bore.diameter" in msg, f"{verb}: unhelpful — {msg}"
+            assert "dimension_ids()" in msg, f"{verb}: does not say how to find valid ids"
 
     def test_the_handles_answer_what_they_can_be_asked_for(self):
         """`dimension_ids()` is the runtime half of the discoverability #963 is about, and it lists
@@ -224,16 +227,15 @@ class TestTheCanonicalSpellingIsEnforced:
         for role in hole.dimension_ids():
             sheet.dimension(hole, role)  # every listed role must actually resolve
 
-    def test_add_dimension_normalises_identically(self):
-        """The two verbs address a measurement through one resolver, so normalisation must
-        not be something only the authored path gets."""
-        import warnings
-
+    def test_add_dimension_refuses_identically(self):
+        """The two verbs address a measurement through ONE resolver, so the refusal must not
+        be something only the authored path gets — as normalisation had to not be, before
+        #720 replaced it with a refusal. A second copy of the addressing logic is how the
+        callout reading drifted in #875."""
         sheet, hole = self._hole_sheet("add_dimension")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            sheet.add_dimension(hole, "bore")  # type: ignore[call-overload]
-        assert sheet._added_dimensions[-1]["role"] == "bore.diameter"
+        with pytest.raises(ValueError, match="bore.diameter"):
+            sheet.add_dimension(hole, "bore")
+        assert not sheet._added_dimensions, "a refused spelling must not record a dimension"
 
     def test_the_canonical_spelling_is_silent(self):
         """A deprecation that fires on the recommended spelling trains people to ignore it."""
@@ -324,21 +326,24 @@ class TestTheCanonicalSpellingIsEnforced:
         sheet.dimension(pattern, "grid_pitch", axis="row")
         assert sheet._authored[-1]["role"] == "grid_pitch"
 
-    def test_a_legacy_spelling_reaches_the_script_canonically(self):
-        """Why normalisation is at the facade rather than only in the error message: the
-        emitter writes what was stored, so before this an emitted script's dialect depended
-        on how its source model was authored."""
-        import warnings
+    def test_the_script_can_only_be_written_in_the_canonical_spelling(self):
+        """The emitter writes what was stored, so an emitted script's dialect used to depend on
+        how its source model was authored — which is what normalisation at the facade fixed.
 
+        #720 removes the other dialect entirely, so this now asserts the stronger property: the
+        canonical id round-trips, and the bare family spelling cannot reach a script at all
+        because it cannot be stored in the first place."""
         from draftwright.sheet_emit import emit_sheet_script
 
         sheet, hole = self._hole_sheet()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            sheet.dimension(hole, "bore")  # type: ignore[call-overload]
+        sheet.dimension(hole, "bore.diameter")
         src = emit_sheet_script(sheet.model(), "part", "s", title="T", number="N")
         assert '"bore.diameter"' in src
         assert '"bore")' not in src
+
+        sheet2, hole2 = self._hole_sheet()
+        with pytest.raises(ValueError):
+            sheet2.dimension(hole2, "bore")  # never gets as far as the emitter
 
     def test_the_generated_header_advertises_a_route_that_runs(self):
         """The header first pointed at `feature.parameters()`, which raises on the facade

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -116,7 +116,7 @@ class TestEmit:
         from draftwright.sheet_emit import emit_sheet_script
 
         sheet = Sheet(Box(90, 60, 20), title="T", number="N")
-        sheet.dimension(sheet.envelope(), "width")
+        sheet.dimension(sheet.envelope(), "width.length")
         src = emit_sheet_script(
             sheet.model(), "part = Box(90, 60, 20)", "s", title="T", number="N"
         )


### PR DESCRIPTION
**BREAKING.** Part 2 of #720, at the 0.4.0 date the maintainer confirmed. This is the last functional change before the release.

## What goes

**Bare family roles now raise.** `dimension(f, "width")` selected *every* parameter carrying that role — which is how `dimension(step, "step")` quietly declared two measurements. In an authored set, whose whole semantics is that omission means suppression, silently declaring an extra one is the mirror image of the rule.

Refusing is what makes the two halves consistent: a bare role naming *two* measurements already raised, and `bore` resolving silently was the same defect hidden by there happening to be only one.

**`Sheet.dimension(kind=…, value=…)` is refused by name.**

## Scope is narrower than "remove bare roles"

A **discriminated** bare role is retained. `grid_pitch` + `axis="row"` is how variants like `grid_pitch.length.row` are addressed; it never warned and is not the deprecated spelling. Only `bare and not discriminated` went — the exact case the warning fired on.

## Why the call shape is refused rather than just deleted

Deleting the dispatch outright leaves callers with `TypeError: _authored_dimension() got an unexpected keyword 'kind'` — naming a **private** method. So `dimension` regains its real signature (restoring the completion and type-checking the `@overload` pair existed to give, without the dual shape) and rejects the old keywords with a message pointing at `measured_dimension`.

That is argument validation, not a surviving shim. The sentinel defaults are there so a keyword-only legacy call reaches the message instead of dying on *"missing 2 required positional arguments"* — the precise failure the original overload was written to avoid.

## Four tests rewritten, none deleted

They existed to pin the deprecated behaviour: warn-and-normalise (both verbs), the warning's `stacklevel`, and the legacy spelling reaching the emitter. Each now asserts the refusal instead. **A removal nobody asserts is a removal that comes back.**

The `stacklevel` one is the interesting case — it pinned that the warning blamed the caller's line rather than draftwright's own source. A raise has no stacklevel to get wrong, but the *intent* survives: tell me which line to change **and** what to write there. It is now `test_the_refusal_names_the_spelling_to_use_for_both_verbs`, asserting the message carries the rejected spelling, its replacement, and `dimension_ids()`.

## Two things my own tooling caught

- The `test_deprecation_dates` ratchet from #987 fired on the drop from 11 deprecations to 9. Updated **with the reason**, since a silent drop is supposed to mean the scanner broke rather than that the codebase got tidier.
- `docs/deprecations.md` said *"one call site in the whole test corpus, measured"*. That counted bare-role **calls** correctly, but under-counted the tests written **about** the thing being removed. The note now says so — "one call site" reads as trivial and isn't.

## The break has no warning release, deliberately

Both were deprecated after v0.3.9 and removed in 0.4.0, so the `DeprecationWarning` never appeared in a released version and no longer exists. Upgrading from v0.3.9 goes straight from working to a raise. Confirmed as a **documented break**, so the CHANGELOG, `docs/deprecations.md` and the raise messages carry what the runtime cannot.

## Verification

`test_dimension_role_vocabulary` + `test_declare` (206), the Sheet suites + script parity (536 — the sole failure was the ratchet above, now fixed), smoke (51), and all four lint checks. CI's matrix is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
