### PR TITLE
chore: bump version to 0.4.1.dev0 after the 0.4.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.0"
+version = "0.4.1.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.0"
+version = "0.4.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
Post-release housekeeping. **0.4.0 is published** — [PyPI](https://pypi.org/project/draftwright/0.4.0/) has both the wheel and the sdist, and the [release](https://github.com/pzfreo/draftwright/releases/tag/v0.4.0) is tagged at `19acc7d`.

The release workflow's `bump-version` job normally does this itself, but it pushes straight to `main` and branch protection declines it:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
 ! [remote rejected] main -> main (protected branch hook declined)
```

Expected — no PAT is configured. `publish-pypi` succeeded; only this last step could not land, so it comes as a PR.

**Why it shouldn't wait.** `publish.yml` builds every push to `main` as `${base}.dev${run_number}` for TestPyPI. With `main` still reading `0.4.0`, the next merge would publish `0.4.0.devN` — a version that sorts *below* the released `0.4.0` while containing work that comes *after* it.

`uv.lock` regenerated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)