### PR TITLE
docs: fix two README examples that no longer run on 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ from draftwright import build_drawing
 
 dwg = build_drawing(part, title="Mounting Plate")
 issues = dwg.lint()                       # list[LintIssue] — coverage, page bounds, ISO
-svg_path, dxf_path = dwg.export("my_part")
+paths = dwg.export("my_part", formats=("svg", "dxf"))   # {"svg": ..., "dxf": ...}
 ```
+
+`export()` with no `formats=` returns the old `(svg, dxf)` tuple; that shape is deprecated
+and removed in 0.5.0 (see [docs/deprecations.md](docs/deprecations.md)).
 
 ### Declarative drawings — reference features, declare intent
 
@@ -93,6 +96,9 @@ plate = Box(120, 80, 20)
 bore = Pos(0, 0, 0) * Cylinder(4, 20)
 
 sheet = Sheet(plate - bore, title="Plate", number="DWG-002")
+sheet.auto_dimensions()                                   # the planner's set (ADR 0016:
+                                                          # a build must say where its
+                                                          # dimensions come from)
 sheet.envelope()
 sheet.datum("A", plate.faces().sort_by()[-1])             # datum A on the top face
 hole = sheet.hole(bore).finish("1.6").note("M3x0.5 TAP")  # ⌀8 bore, Ra 1.6, tapped


### PR DESCRIPTION
Noticed while generating a Sheet script from the README example: the README teaches an export shape that 0.4.0 deprecated. Executing the rest of the blocks found a worse one.

## The declarative example was broken

`README.md`'s flagship `Sheet` example — the one demonstrating the declarative surface — **raised** for anyone following it on 0.4.0:

```
ValueError: this sheet does not say where its dimensions come from.
```

ADR 0016 (#874) made declaring a dimension source mandatory; the example was never updated. Adds `sheet.auto_dimensions()`.

The planner's set is the right choice here specifically: that example demonstrates declaring **aspects** — surface finish, datum, GD&T position — not authoring a dimension set. An authored set would change what it is showing.

## The Drawing example used the deprecated export shape

`svg_path, dxf_path = dwg.export("my_part")` is the legacy tuple form, which warns as of #987 and is removed in 0.5.0. Now passes `formats=("svg", "dxf")` and reads the dict, with a note on what the old shape is and where it is documented.

## How they were found

By **executing** the README's python blocks, not reading them — with the export deprecation promoted to an error. Blocks 0, 1 and 2 now all pass under that filter.

Blocks 5 and 6 raise `NameError` standalone; that is correct and not a defect — they are continuation fragments that assume the imports above them.

Docs only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)