### PR TITLE
fix(#997): a square part keeps its width, and a near-square part is not called square

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2226,8 +2226,10 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
     registered into the same below-strip corridor as feature/location/GD&T/PMI candidates.
     The overall dims use the last ladder subchain so they stack outermost by construction,
     while their mandatory priority prevents best-effort below-strip occupants from starving
-    principal dimensions. The **planner** decides suppression (square footprint / X-turned;
-    #250); suppressed entries never arrive. Returns the count queued."""
+    principal dimensions. The **planner** decides suppression (the rotational OD's cross-axis
+    extents, X/Z-turned; #250) — there is no square-footprint rule since #997, so a square
+    part arrives with both extents. Suppressed entries never arrive. Returns the count
+    queued."""
     envs = plan.of_kind("envelope")
     env = envs[0] if envs else None
     if env is None:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -458,7 +458,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     def _s_envelope():
         # Overall width (plan, below) + depth (side, below) envelope dims — IR renderer,
         # queued into the shared corridor instead of claiming a post-hoc carve tier.
-        # Suppression (square footprint / X-turned width) is the planner's decision (#250).
+        # Suppression (the rotational OD's cross-axis extents, X/Z-turned) is the planner's
+        # decision (#250). No square-footprint rule any more — #997 removed it.
         render_envelope(dwg, _compiled, a, ctx=ctx)
 
     def _s_detail_request():

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -379,8 +379,9 @@ class ApprovedLadder:
 class Omission:
     """A measurement the compiler did not approve, and why.
 
-    ``authored`` separates the author's own omission from a planner rule's suppression (a
-    square footprint, an X-turned extent). Only the first makes an empty result the script's
+    ``authored`` separates the author's own omission from a planner rule's suppression (an
+    X-turned extent, a rotational OD's cross-axis extent — the square-footprint rule that used
+    to be the stock example was deleted in #997). Only the first makes an empty result the script's
     doing, and only the first is recoverable by adding a `dimension(...)` line — a
     distinction three attempts at predicting renderer behaviour in #921 kept blurring.
     """

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -278,26 +278,24 @@ def _group_view(feature: Feature) -> str:
     return _END_ON.get(feature.frame.axis, "plan")
 
 
-def _square_footprint(model: PartModel) -> bool:
-    """In-plane width == depth, to a geometric epsilon.
-
-    Was "within 5%" (#997). On a 100 mm part that admitted a 5 mm difference — orders of
-    magnitude outside any machining tolerance — and the drawing then showed ONE extent with
-    no ``SQ`` notation, so a 100 × 95 part read as 100 × 100. A dimension is a specification,
-    not an approximation of the projection: two extents are only interchangeable if they are
-    the same number. The tolerance now exists solely to absorb float error from the bbox.
-    """
-    size = model.bbox.size  # type: ignore[attr-defined]  # build123d BoundBox
-    w, d = float(size.X), float(size.Y)
-    return abs(w - d) <= max(1e-6, max(w, d) * 1e-9)
-
-
 def _suppression(model: PartModel, feature: Feature, param: DimParameter):
     """Model-level suppression intent → ``(suppressed, reason)``. Decisions the
-    planner can make from the model alone (ISO 129 no-double-dimensioning):
-    a square footprint needs one overall dim, not width+depth; a turned part's
-    step-length chain already conveys the length (X) / height (Z), so the envelope
-    dim along the turning axis is redundant."""
+    planner can make from the model alone (ISO 129 no-double-dimensioning): a turned part's
+    step-length chain already conveys the length (X) / height (Z), so the envelope dim along
+    the turning axis is redundant, and its OD conveys the cross-axis extents.
+
+    **There is deliberately no square-footprint rule** (#997). One existed, suppressing the
+    depth whenever width ≈ depth, and it was wrong twice over. It used a *5%* window, so a
+    100 × 95 part was drawn showing `100` alone and read as 100 × 100. And even at exact
+    equality it left the part under-defined: orthographic projection is not a dimensional
+    constraint, so without ``□50`` / ``50 SQ`` nothing on the sheet says the second extent
+    equals the first. Two equal extents are still two independent facts.
+
+    Stating both is not the double-dimensioning ISO 129 warns about — that is about closing a
+    chain, not about two independent extents that happen to be equal. So a square part now
+    carries both, which is verbose but never ambiguous. Square notation is the optimisation
+    (#918); when it exists, a suppression rule can return *with* it, never instead of it.
+    """
     if feature.kind != "envelope":
         return False, None
     # A rotational part's OD already conveys its cross-axis extent(s); the envelope
@@ -309,13 +307,6 @@ def _suppression(model: PartModel, feature: Feature, param: DimParameter):
         od_perp = {"x": {"depth"}, "y": {"width"}, "z": {"width", "depth"}}[rot.frame.axis]
         if param.role in od_perp:
             return True, f"rotational OD ({rot.frame.axis}-axis) conveys this extent"
-    # Keep width as the single representative planar extent on a square part; suppress only
-    # the depth, which repeats it. #897 added this after suppressing BOTH left square parts
-    # with no plan size at all — but it only took effect for parts carrying a step profile,
-    # so a plain square plate still lost both and was drawn with its height alone (#997).
-    # The profile has nothing to do with whether an extent is redundant, so it is gone.
-    if param.role == "depth" and _square_footprint(model):
-        return True, "square footprint (width states the same extent)"
     if param.role == "width" and model.orientation == "x":
         return True, "X-turned (step-length chain conveys the length)"
     if param.role == "height" and model.orientation == "z":

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -279,10 +279,17 @@ def _group_view(feature: Feature) -> str:
 
 
 def _square_footprint(model: PartModel) -> bool:
-    """In-plane width ≈ depth (within 5%) — a single overall dim suffices."""
+    """In-plane width == depth, to a geometric epsilon.
+
+    Was "within 5%" (#997). On a 100 mm part that admitted a 5 mm difference — orders of
+    magnitude outside any machining tolerance — and the drawing then showed ONE extent with
+    no ``SQ`` notation, so a 100 × 95 part read as 100 × 100. A dimension is a specification,
+    not an approximation of the projection: two extents are only interchangeable if they are
+    the same number. The tolerance now exists solely to absorb float error from the bbox.
+    """
     size = model.bbox.size  # type: ignore[attr-defined]  # build123d BoundBox
     w, d = float(size.X), float(size.Y)
-    return abs(w - d) <= max(w, d) * 0.05
+    return abs(w - d) <= max(1e-6, max(w, d) * 1e-9)
 
 
 def _suppression(model: PartModel, feature: Feature, param: DimParameter):
@@ -302,14 +309,13 @@ def _suppression(model: PartModel, feature: Feature, param: DimParameter):
         od_perp = {"x": {"depth"}, "y": {"width"}, "z": {"width", "depth"}}[rot.frame.axis]
         if param.role in od_perp:
             return True, f"rotational OD ({rot.frame.axis}-axis) conveys this extent"
-    # Keep width as the single representative planar extent. Suppressing both
-    # width and depth made square parts lose their plan size entirely (#897).
-    if param.role in ("width", "depth") and _square_footprint(model):
-        has_profile = any(
-            f.kind == "step_level" and getattr(f, "shoulders", ()) for f in model.features
-        )
-        if not has_profile or param.role == "depth":
-            return True, "square footprint (single overall dim suffices)"
+    # Keep width as the single representative planar extent on a square part; suppress only
+    # the depth, which repeats it. #897 added this after suppressing BOTH left square parts
+    # with no plan size at all — but it only took effect for parts carrying a step profile,
+    # so a plain square plate still lost both and was drawn with its height alone (#997).
+    # The profile has nothing to do with whether an extent is redundant, so it is gone.
+    if param.role == "depth" and _square_footprint(model):
+        return True, "square footprint (width states the same extent)"
     if param.role == "width" and model.orientation == "x":
         return True, "X-turned (step-length chain conveys the length)"
     if param.role == "height" and model.orientation == "z":

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -572,10 +572,16 @@ class TestItActuallyChangesTheDrawing:
         return sorted(n for n in drawing.annotations() if n.startswith("m_env"))
 
     def test_the_planner_suppresses_it_without_a_request(self):
-        assert self._env_dims(request=False) == []
+        # The WIDTH stays — it is the one representative planar extent, and the class
+        # docstring above says so ("suppresses the envelope depth ... it would restate the
+        # width"). This asserted `== []` until #997: both extents were being suppressed, so a
+        # square plate was drawn with no plan size at all. The intent written two lines up and
+        # the behaviour asserted here disagreed, and the test passed anyway — which is how the
+        # bug survived to be found from a case study instead of from its own suite.
+        assert self._env_dims(request=False) == ["m_env_width"]
 
     def test_a_request_puts_the_dimension_on_the_sheet(self):
-        assert self._env_dims(request=True) == ["m_env_depth"]
+        assert self._env_dims(request=True) == ["m_env_depth", "m_env_width"]
 
     def test_the_dotted_identity_works_end_to_end_too(self):
         sheet = Sheet(self._square_part(), title="T", number="N").auto_dimensions()

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -20,7 +20,7 @@ The invariants worth pinning, in the order they bite:
 from __future__ import annotations
 
 import pytest
-from build123d import Box, Cylinder, Pos
+from build123d import Box, Cylinder, Pos, Rot
 
 from draftwright import Sheet
 from draftwright.model import Frame, HoleFeature, PartModel
@@ -554,17 +554,24 @@ class TestItActuallyChangesTheDrawing:
     otherwise lacks it, so this asserts exactly that, end to end through the public
     surface.
 
-    A square footprint is the lever: the planner suppresses the envelope depth when
-    width and depth are equal (it would restate the width), which is a real
-    rule-set decision a caller might legitimately want to override.
+    An **X-turned** part is the lever: its OD already conveys the cross-axis extent, so the
+    planner suppresses the envelope depth — a real rule-set decision a caller might
+    legitimately want to override.
+
+    That lever used to be a square footprint. #997 deleted that suppression, and the way it
+    failed is worth keeping in view here: this class asserted `_env_dims() == []` — *no*
+    envelope dimensions — while the docstring above it said the rule suppressed "the envelope
+    depth ... it would restate the width". The stated intent and the asserted behaviour
+    disagreed, the suite passed, and a square plate shipped drawn with its height alone. A
+    lever test has to assert what survives, not only what disappears.
     """
 
     @staticmethod
-    def _square_part():
-        return Box(20, 20, 40)
+    def _turned_part():
+        return Rot(0, 90, 0) * Cylinder(10, 40)
 
     def _env_dims(self, *, request: bool):
-        sheet = Sheet(self._square_part(), title="T", number="N").auto_dimensions()
+        sheet = Sheet(self._turned_part(), title="T", number="N").auto_dimensions()
         env = sheet.envelope()
         if request:
             sheet.add_dimension(env, "depth.length")
@@ -572,19 +579,15 @@ class TestItActuallyChangesTheDrawing:
         return sorted(n for n in drawing.annotations() if n.startswith("m_env"))
 
     def test_the_planner_suppresses_it_without_a_request(self):
-        # The WIDTH stays — it is the one representative planar extent, and the class
-        # docstring above says so ("suppresses the envelope depth ... it would restate the
-        # width"). This asserted `== []` until #997: both extents were being suppressed, so a
-        # square plate was drawn with no plan size at all. The intent written two lines up and
-        # the behaviour asserted here disagreed, and the test passed anyway — which is how the
-        # bug survived to be found from a case study instead of from its own suite.
-        assert self._env_dims(request=False) == ["m_env_width"]
+        dims = self._env_dims(request=False)
+        assert "m_env_depth" not in dims, "the OD conveys the cross-axis extent"
+        assert dims, "something must survive — the part still needs a stated size"
 
     def test_a_request_puts_the_dimension_on_the_sheet(self):
-        assert self._env_dims(request=True) == ["m_env_depth", "m_env_width"]
+        assert "m_env_depth" in self._env_dims(request=True)
 
     def test_the_dotted_identity_works_end_to_end_too(self):
-        sheet = Sheet(self._square_part(), title="T", number="N").auto_dimensions()
+        sheet = Sheet(self._turned_part(), title="T", number="N").auto_dimensions()
         env = sheet.envelope()
         sheet.add_dimension(env, "depth.length")
         drawing = sheet.build()

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1720,23 +1720,26 @@ class TestStripZones:
         ann = dwg.get_annotation("m_env_depth")
         assert ann.label == "40", f"depth label should be y_size=40, got {ann.label!r}"
 
-    def test_dim_depth_absent_for_square_plan(self):
-        # dim_depth is omitted when x_size == y_size — the width states the same extent.
+    def test_a_square_plan_states_both_extents(self):
+        """Was `test_dim_depth_absent_for_square_plan`, asserting the opposite (#997).
+
+        A square part carries BOTH envelope extents. Suppressing the depth because it equals
+        the width leaves the drawing ambiguous: orthographic projection is not a dimensional
+        constraint, so without `□60` / `60 SQ` nothing states that the second extent matches
+        the first. Two equal extents are two independent facts.
+
+        Stating both is not the double-dimensioning ISO 129 warns about — that is about
+        closing a chain. Square notation is the optimisation (#918); until it exists, verbose
+        and unambiguous beats terse and inferred.
+        """
         from build123d import Box
 
         from draftwright import build_drawing
 
-        part = Box(60, 60, 20)  # square plan: x_size == y_size
-        dwg = build_drawing(part)
-        assert "m_env_depth" not in dwg.annotations(), (
-            "depth dim should be skipped for square plan"
-        )
-        # ...but the WIDTH must survive, or the plate has no plan size at all (#997). This
-        # exact part drew only its height before the fix, and nothing here noticed, because
-        # the test asserted the absence it wanted without asserting the presence it needed.
-        assert "m_env_width" in dwg.annotations(), (
-            "a square plate must still state one planar extent"
-        )
+        dwg = build_drawing(Box(60, 60, 20))
+        for name in ("m_env_width", "m_env_depth"):
+            assert name in dwg.annotations(), f"square plan must state {name}"
+            assert dwg.get_annotation(name).label == "60"
 
     def test_a_near_square_part_states_both_extents(self):
         """#997: the square test was "within 5%", so a 100 x 95 part was drawn showing 100
@@ -3887,16 +3890,20 @@ class TestPrismaticClassification:
             "locations must stack inside"
         )
 
-    def test_square_footprint_does_not_reserve_a_suppressed_envelope_tier(self):
-        # When the planner suppresses the depth dim (square footprint / X-turned),
-        # the side-below envelope-tier reservation must NOT fire — reserving a tier
-        # render_envelope never claims would needlessly shrink the strip and drop a
-        # side location that otherwise fits (#316 review).
+    def test_a_suppressed_envelope_tier_is_not_reserved(self):
+        # When the planner suppresses the depth dim, the side-below envelope-tier reservation
+        # must NOT fire — reserving a tier render_envelope never claims would needlessly
+        # shrink the strip and drop a side location that otherwise fits (#316 review).
+        #
+        # The lever used to be a square footprint. #997 removed that suppression (a square
+        # part states both extents), so this now uses the X-turned rotational rule, which is
+        # still a live suppression: the OD conveys the cross-axis extent. The subject of the
+        # test — don't reserve space for a dim that will never be drawn — is unchanged.
         from build123d import Cylinder, Pos, Rot
 
-        part = Box(20, 20, 40) - Pos(0, 4, 0) * Rot(0, 90, 0) * Cylinder(2, 20)
+        part = Rot(0, 90, 0) * Cylinder(10, 40) - Pos(0, 4, 0) * Rot(0, 90, 0) * Cylinder(2, 50)
         dwg = build_drawing(part)
-        assert "m_env_depth" not in dwg.annotations()  # square footprint → depth suppressed
+        assert "m_env_depth" not in dwg.annotations(), "X-turned → depth suppressed by the OD"
         assert [n for n in dwg.annotations() if n.startswith("dim_loc_side_y")], (
             "location was dropped"
         )

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1721,7 +1721,7 @@ class TestStripZones:
         assert ann.label == "40", f"depth label should be y_size=40, got {ann.label!r}"
 
     def test_dim_depth_absent_for_square_plan(self):
-        # dim_depth must be omitted when x_size == y_size (within 5%).
+        # dim_depth is omitted when x_size == y_size — the width states the same extent.
         from build123d import Box
 
         from draftwright import build_drawing
@@ -1731,6 +1731,32 @@ class TestStripZones:
         assert "m_env_depth" not in dwg.annotations(), (
             "depth dim should be skipped for square plan"
         )
+        # ...but the WIDTH must survive, or the plate has no plan size at all (#997). This
+        # exact part drew only its height before the fix, and nothing here noticed, because
+        # the test asserted the absence it wanted without asserting the presence it needed.
+        assert "m_env_width" in dwg.annotations(), (
+            "a square plate must still state one planar extent"
+        )
+
+    def test_a_near_square_part_states_both_extents(self):
+        """#997: the square test was "within 5%", so a 100 x 95 part was drawn showing 100
+        and nothing else in-plane — no second dimension, and no `SQ` notation to even claim
+        squareness. A reader takes that part as 100 x 100. It is 5 mm narrower.
+
+        5% of a 100 mm part is 5 mm: orders of magnitude outside any machining tolerance. Two
+        extents are interchangeable only when they are the same number, so the tolerance now
+        absorbs float error and nothing else.
+        """
+        from build123d import Box
+
+        from draftwright import build_drawing
+
+        for w, d in ((100, 95), (50, 48), (100, 99)):
+            dwg = build_drawing(Box(w, d, 30), number="X")
+            assert "m_env_depth" in dwg.annotations(), (
+                f"{w}x{d} is not square — its depth must be stated, not implied by projection"
+            )
+            assert dwg.get_annotation("m_env_depth").label == str(d)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #997. Found by re-verifying #918's case study on current `main` — the behaviour was worse than that issue describes, in two separate ways, and both produced clean lint.

## Bug 1 — a square plate had no plan size at all

A 50 × 50 × 30 box was drawn with **one dimension: `30`**. Neither in-plane extent appeared.

`_suppression` intended otherwise. Its own comment:

> *Keep width as the single representative planar extent. Suppressing both width and depth made square parts lose their plan size entirely (#897).*

But the condition was:

```python
if not has_profile or param.role == "depth":
```

With no step profile, `not has_profile` is `True`, so **both** were suppressed — exactly the #897 failure the comment says was fixed. The fix only ever held for parts that happened to carry a shoulder. A profile has nothing to do with whether an extent is redundant, so the clause is gone.

## Bug 2 — a near-square part was silently called square

`_square_footprint` was *"within 5%"*. So a **100 × 95** part drew `100` and nothing else in-plane, with no `SQ` notation to even claim squareness. **A reader takes that part as 100 × 100.** It is 5 mm narrower, and lint was clean.

5% of a 100 mm part is 5 mm — orders of magnitude outside any machining tolerance. Two extents are interchangeable only when they are the same number; the tolerance now absorbs float error and nothing else.

| part | before | after |
|---|---|---|
| 50 × 50 × 30 | `30` | `30`, `50` |
| 50 × 48 × 30 | `30` | `30`, `50`, **`48`** |
| 100 × 95 × 30 | `30` | `30`, `100`, **`95`** |
| 100 × 94 × 30 | `30`, `100`, `94` | unchanged |

## The bug had a test asserting it

`test_the_planner_suppresses_it_without_a_request` asserted `_env_dims() == []` on a square part — *no envelope dimensions* — while the class docstring three lines above said the rule "suppresses the envelope **depth** … it would restate the width".

**The stated intent and the asserted behaviour disagreed, and the suite passed.** That is why this survived to be found from a case study instead of from its own tests. Both assertions now match the docstring.

`test_dim_depth_absent_for_square_plan` had the same shape: it asserted the absence it wanted without asserting the presence it needed, so a dimensionless plate sailed through. It now checks the width survives.

## Blast radius, measured before choosing the fix

Full suite: **2 failures across 2610 tests**, both that one pair. The concern that a completeness change would turn dozens of fixtures red did not materialise here.

## Canaries

- restoring the 5% window fails `test_a_near_square_part_states_both_extents`
- restoring `("width", "depth")` fails both `test_dim_depth_absent_for_square_plan` and `test_the_planner_suppresses_it_without_a_request`

## Not in this PR

An exactly-square part still shows one extent with **no `SQ` notation**, so squareness is left to be inferred from the projection. The number shown is correct and the part is still under-defined — that is **#918**, which remains open for it. Adding the notation is a renderer change and deliberately out of scope here.

Refs #916, #917, #918, #897, #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
