### PR TITLE
feat(#996): expose the compiler's suppression ledger

### DIFF
--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -244,7 +244,15 @@ def _declared_feature_keys(groups, a: Analysis) -> set:
 
 
 def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
-    """Add the standard automatic dimensions, centrelines, and title block."""
+    """Add the standard automatic dimensions, centrelines, and title block.
+
+    Returns the compiler's omission diagnostics — every measurement it considered and did not
+    approve, with the rule that stopped it (#996). RETURNED rather than written onto the
+    drawing: #830 removed the last engine caller that reached for `dwg._attach_*`, and
+    `builder._assemble` is BuildState's single fill site (ADR 0005 §2 / #639). Handing them
+    back keeps both true — the record outlives the build without `annotations/` touching the
+    drawing's privates.
+    """
     # Per-run placement scratch (detail requests / escalations / corridor batch) + references to
     # the drawing's build-state stores (registry/coverage), threaded to the passes instead of hung
     # on the Drawing (ADR 0005 §2, #639). Fresh each auto-pass; the corridor batch is drained once
@@ -623,6 +631,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # The escalations live only on this per-run ctx (#639), discarded when _auto_annotate
     # returns — so nothing carries stale drops into a later deferred edit (#440), and there is
     # no drawing-level list to clear.
+    return _compiled.diagnostics
 
 
 def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -487,11 +487,14 @@ def _assemble(
     # what #830's single-construction rule exists to stop, and the guard caught the first
     # attempt at exactly that.
     if _diagnostics is None:
-        _model_for_audit = dwg.model()
-        if _model_for_audit is not None:
-            from draftwright.model.compiled import compile_dimensions
+        from draftwright.model.compiled import compile_dimensions
 
-            _diagnostics = compile_dimensions(_model_for_audit).diagnostics
+        # No `is not None` guard on the model: `_build.part_model` is filled unconditionally
+        # above, so the guard was unreachable — and its fallback was a silent empty ledger,
+        # which is the precise failure this whole surface exists to remove. If a future path
+        # ever reaches here without a model, that should raise where it happens rather than
+        # produce a confident "nothing was suppressed" (#996).
+        _diagnostics = compile_dimensions(dwg.model()).diagnostics
     dwg._build.omissions = tuple(_diagnostics or ())
     return dwg
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -445,7 +445,10 @@ def _assemble(
         _fv_ol = a.fv_zones.right.outer_limit
         _pv_ol = a.pv_zones.right.outer_limit
         _sv_ol = a.sv_zones.right.outer_limit
-        _auto_annotate(dwg, a, detail_view=detail_view)
+        # BuildState's single fill site owns the omission ledger too (#996 / ADR 0005 §2):
+        # the orchestrator returns it rather than writing a drawing private, so `annotations/`
+        # stays off the state bus (#639/#830) and `suppressions()` has something to read.
+        dwg._build.omissions = tuple(_auto_annotate(dwg, a, detail_view=detail_view) or ())
         _fit_iso_view(dwg, a)
         _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
         _final_iso_x_lim = _ix0 - 4

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -437,6 +437,7 @@ def _assemble(
     dwg._add_view("side", part_s, (cxs + dist, cys, czs), (0, 0, 1), (a.SV_X, a.SV_Y), scaled=True)
     _project_iso(dwg, a, a.SCALE, shape_s=part_s)
 
+    _diagnostics = None  # the audit ledger; filled once at the end of this function (#996)
     if auto_dims:
         # Snapshot outer_limits before _auto_annotate tightens them against the
         # initial (possibly overflowing) iso.  After _fit_iso_view rescales the
@@ -445,10 +446,10 @@ def _assemble(
         _fv_ol = a.fv_zones.right.outer_limit
         _pv_ol = a.pv_zones.right.outer_limit
         _sv_ol = a.sv_zones.right.outer_limit
-        # BuildState's single fill site owns the omission ledger too (#996 / ADR 0005 §2):
-        # the orchestrator returns it rather than writing a drawing private, so `annotations/`
-        # stays off the state bus (#639/#830) and `suppressions()` has something to read.
-        dwg._build.omissions = tuple(_auto_annotate(dwg, a, detail_view=detail_view) or ())
+        # The orchestrator RETURNS the omission ledger rather than writing a drawing private,
+        # so `annotations/` stays off the state bus (#639/#830). Filled at the single site
+        # below, not here — see there (#996 / ADR 0005 §2).
+        _diagnostics = _auto_annotate(dwg, a, detail_view=detail_view)
         _fit_iso_view(dwg, a)
         _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
         _final_iso_x_lim = _ix0 - 4
@@ -473,6 +474,25 @@ def _assemble(
             _add_zone_grid(dwg, a)
         if a.projection:  # projection-method glyph (#769) — auto path adds it via the orchestrator
             _add_projection_symbol(dwg, a)
+
+    # The audit ledger, filled at ONE site for both paths (#996 / ADR 0005 §2).
+    #
+    # It is not a by-product of rendering. The auto path gets it from `_auto_annotate`'s
+    # return; `auto_dims=False` draws no automatic dimensions, so it compiles for the
+    # diagnostics alone — the plan is discarded, only the record kept. That branch reported an
+    # EMPTY ledger while the compiler really had suppressed measurements, which is precisely
+    # the false confidence this surface exists to remove (Codex #996 r1).
+    #
+    # Assigned once rather than in each branch: two fill sites for one BuildState field is
+    # what #830's single-construction rule exists to stop, and the guard caught the first
+    # attempt at exactly that.
+    if _diagnostics is None:
+        _model_for_audit = dwg.model()
+        if _model_for_audit is not None:
+            from draftwright.model.compiled import compile_dimensions
+
+            _diagnostics = compile_dimensions(_model_for_audit).diagnostics
+    dwg._build.omissions = tuple(_diagnostics or ())
     return dwg
 
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -211,13 +211,26 @@ class _IntentRouting:
     slot_pattern_ids: set
 
 
+#: Size scalars appended to a feature key when present, in this order. Position alone is not
+#: identity: two holes at ONE origin with different bores keyed the same, and that is exactly
+#: the coincident-dedup case where the ledger most needs to say which instance lost its
+#: location (Codex #996 r4). Rounded, so float noise from a rebuild does not change the key.
+_KEY_SCALARS = ("diameter", "depth", "width", "length", "radius")
+
+
 def feature_key(f) -> str | None:
     """A stable, plain-data identity for a feature in the audit ledger (#996).
 
-    ``kind@(x,y,z)/axis``. The type name alone made two holes indistinguishable, so a diff of
-    two builds could not say which one lost a measurement, or whether a suppression had moved
-    between instances (Codex #996 r1). Derived from the geometry, so it also survives a
-    rebuild that reorders the feature list — list position would not.
+    ``kind@(x,y,z)/axis`` plus whichever of :data:`_KEY_SCALARS` the feature carries. The type
+    name alone made two holes indistinguishable, so a diff of two builds could not say which
+    one lost a measurement, or whether a suppression had moved between instances (Codex r1).
+    Derived from the geometry, so it survives a rebuild that reorders the feature list — list
+    position would not.
+
+    **Its limit, stated rather than implied:** two features of one kind sharing an origin,
+    an axis *and* every scalar above are indistinguishable here. They are the same measurement
+    to the compiler, so nothing in the ledger could separate them — but a caller diffing builds
+    should know the key is a description, not a handle.
     """
     if f is None:
         return None
@@ -230,7 +243,13 @@ def feature_key(f) -> str | None:
     if origin is None:
         return f"{kind}/{axis}" if axis else kind
     x, y, z = (float(v) for v in (origin[0], origin[1], origin[2]))
-    return f"{kind}@({x:.3f},{y:.3f},{z:.3f})/{axis}"
+    sizes = [
+        f"{name}={float(v):.3f}"
+        for name in _KEY_SCALARS
+        if isinstance(v := getattr(f, name, None), (int, float))
+    ]
+    tail = ("[" + ",".join(sizes) + "]") if sizes else ""
+    return f"{kind}@({x:.3f},{y:.3f},{z:.3f})/{axis}{tail}"
 
 
 @dataclass

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -242,6 +242,13 @@ class BuildState:
     ann_box_cache: dict = dataclasses_field(default_factory=dict)
     trace: Any = None
     detail_view: bool = False
+    #: The compiler's :class:`~draftwright.model.compiled.Omission` records — every
+    #: measurement it considered and did not approve, with the rule that stopped it (#996).
+    #: The compiled plan was a local in the orchestrator: built, read by the renderers, and
+    #: dropped. So the one place recording WHY a dimension is absent did not outlive the
+    #: build, and absence had to be inferred from a finished sheet — which is how a wrong
+    #: suppression rule produced four issue reports before anyone found the rule (#997).
+    omissions: tuple = ()
 
     def clear_geometry_caches(self) -> None:
         """The one invalidation seam (finalize rollback): view edges + annotation
@@ -557,6 +564,36 @@ class Drawing:
         """Attach the built PartModel so ``model()`` and feature edits see it. Lets the
         orchestrator hand the model back without an ``annotations/`` attribute write (#639)."""
         self._build.part_model = model
+
+    def suppressions(self) -> list[dict]:
+        """Every measurement the compiler considered and did not approve, and why.
+
+        The **audit read** (#996). A finished drawing shows what was drawn; this shows what
+        was *not*, separated into the two cases that mean opposite things:
+
+        - ``authored`` — the script's own omission, under ADR 0016's rule that an authored
+          set means omission is suppression. Recoverable by adding a ``dimension(...)`` line.
+        - otherwise — a **planner rule** decided it, and ``reason`` names which.
+
+        The second is the one worth auditing. A rule that fires where it should not produces
+        a drawing that is silently under-defined and lints clean, which is how #997's square
+        rule generated four separate issue reports without any of them naming the cause. An
+        absent dimension is only defensible if something can say which rule removed it; this
+        is that something.
+
+        Returns plain dicts (``feature``/``parameter_id``/``value``/``reason``/``authored``)
+        so a harness, a script or an LLM can diff two builds without importing IR types.
+        """
+        return [
+            {
+                "feature": type(o.feature).__name__ if o.feature is not None else None,
+                "parameter_id": o.parameter_id,
+                "value": o.value,
+                "reason": o.reason,
+                "authored": o.authored,
+            }
+            for o in self._build.omissions
+        ]
 
     @property
     def solve_trace(self):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -211,6 +211,28 @@ class _IntentRouting:
     slot_pattern_ids: set
 
 
+def feature_key(f) -> str | None:
+    """A stable, plain-data identity for a feature in the audit ledger (#996).
+
+    ``kind@(x,y,z)/axis``. The type name alone made two holes indistinguishable, so a diff of
+    two builds could not say which one lost a measurement, or whether a suppression had moved
+    between instances (Codex #996 r1). Derived from the geometry, so it also survives a
+    rebuild that reorders the feature list — list position would not.
+    """
+    if f is None:
+        return None
+    kind = getattr(f, "kind", None) or type(f).__name__
+    frame = getattr(f, "frame", None)
+    if frame is None:
+        return kind
+    origin = getattr(frame, "origin", None)
+    axis = getattr(frame, "axis", "")
+    if origin is None:
+        return f"{kind}/{axis}" if axis else kind
+    x, y, z = (float(v) for v in (origin[0], origin[1], origin[2]))
+    return f"{kind}@({x:.3f},{y:.3f},{z:.3f})/{axis}"
+
+
 @dataclass
 class BuildState:
     """The build context a finished :class:`Drawing` carries (ADR 0005 §2 / #639).
@@ -581,12 +603,17 @@ class Drawing:
         absent dimension is only defensible if something can say which rule removed it; this
         is that something.
 
-        Returns plain dicts (``feature``/``parameter_id``/``value``/``reason``/``authored``)
-        so a harness, a script or an LLM can diff two builds without importing IR types.
+        Returns plain dicts so a harness, a script or an LLM can diff two builds without
+        importing IR types. ``feature`` is a **stable key**, not just the type name: a bare
+        ``"HoleFeature"`` made two holes indistinguishable, so a diff could not say *which*
+        one lost its location, or whether a suppression had moved between instances (Codex
+        #996 r1). The key is ``kind@(x,y,z)/axis``, which survives a rebuild because it is
+        derived from the geometry rather than from list position.
         """
+
         return [
             {
-                "feature": type(o.feature).__name__ if o.feature is not None else None,
+                "feature": feature_key(o.feature),
                 "parameter_id": o.parameter_id,
                 "value": o.value,
                 "reason": o.reason,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1062,5 +1062,30 @@ def compile_dimensions(
         groups=tuple(groups_out),
         ladders=tuple(ladders),
         locations=tuple(locations),
-        diagnostics=tuple(omissions + height_omissions + location_omissions + group_omissions),
+        diagnostics=_dedupe_omissions(
+            omissions + height_omissions + location_omissions + group_omissions
+        ),
     )
+
+
+def _dedupe_omissions(omissions: list[Omission]) -> tuple[Omission, ...]:
+    """One row per (feature, parameter, reason) — the audit reports facts, not sightings.
+
+    An authored set records the overall height twice: once by `_compile_overall_height`'s
+    bespoke branch and once by the general group traversal, since the envelope's `height`
+    parameter is in its group too. Both are correct about the same fact, and a duplicated row
+    makes a consumer over-count suppressions and a build-diff show churn that did not happen
+    (#996 — the lead Codex was chasing when its run timed out).
+
+    Keyed on the FEATURE's identity rather than the object, so two distinct features that
+    share a kind and reason still get a row each.
+    """
+    seen: set[tuple[int, str, str]] = set()
+    out: list[Omission] = []
+    for o in omissions:
+        key = (id(o.feature), o.parameter_id, o.reason)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(o)
+    return tuple(out)

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1063,29 +1063,32 @@ def compile_dimensions(
         ladders=tuple(ladders),
         locations=tuple(locations),
         diagnostics=_dedupe_omissions(
-            omissions + height_omissions + location_omissions + group_omissions
+            omissions, height_omissions, location_omissions, group_omissions
         ),
     )
 
 
-def _dedupe_omissions(omissions: list[Omission]) -> tuple[Omission, ...]:
-    """One row per (feature, parameter, reason) — the audit reports facts, not sightings.
+def _dedupe_omissions(*sources: list[Omission]) -> tuple[Omission, ...]:
+    """Drop only the omissions two DIFFERENT compilers reported about one fact.
 
-    An authored set records the overall height twice: once by `_compile_overall_height`'s
-    bespoke branch and once by the general group traversal, since the envelope's `height`
-    parameter is in its group too. Both are correct about the same fact, and a duplicated row
-    makes a consumer over-count suppressions and a build-diff show churn that did not happen
-    (#996 — the lead Codex was chasing when its run timed out).
+    An authored set records the overall height twice — `_compile_overall_height`'s bespoke
+    branch and the general group traversal both notice it, since the envelope's `height`
+    parameter is in its group too. That duplication makes a consumer over-count suppressions
+    and a build-diff show churn that did not happen.
 
-    Keyed on the FEATURE's identity rather than the object, so two distinct features that
-    share a kind and reason still get a row each.
+    But a repetition *within* one source is not a duplicate. `_compile_off_axis_hole_locations`
+    deliberately emits one omission per member, and every member of a grouped hole shares the
+    same `HoleFeature` — so a naive key of (feature, parameter, reason) collapses four real
+    member facts into one and silently loses positions. Losing a real row is worse than the
+    duplicate it was meant to fix (Codex #996 r6).
+
+    Hence: cross-source only. Each source keeps its own repetitions; a key already seen in an
+    EARLIER source is dropped from a later one.
     """
     seen: set[tuple[int, str, str]] = set()
     out: list[Omission] = []
-    for o in omissions:
-        key = (id(o.feature), o.parameter_id, o.reason)
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append(o)
+    for source in sources:
+        keys_here = {(id(o.feature), o.parameter_id, o.reason) for o in source}
+        out += [o for o in source if (id(o.feature), o.parameter_id, o.reason) not in seen]
+        seen |= keys_here
     return tuple(out)

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -798,12 +798,17 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
     for pd in plan_locations(model):
         feature = pd.feature
         span = pd.param.span
-        assert span is not None  # plan_locations always sets the datum → ref span
         if pd.suppressed:
+            # Before the span assert, deliberately: a suppressed entry records WHY a position
+            # is absent and needs no geometry. When the model has no `datum_xy` there is no
+            # datum → ref span to build one from, so requiring it here turned that diagnostic
+            # into an AssertionError — a silent hole replaced by a crash, which is worse for
+            # the caller it was meant to help (#996).
             omissions.append(
                 Omission(feature, pd.param.parameter_id, None, pd.reason or "suppressed")
             )
             continue
+        assert span is not None  # an APPROVED location always carries its datum → ref span
         axis = feature.frame.axis if feature is not None else None
         if isinstance(feature, PocketFeature) and axis != "z":
             # A non-Z pocket's two in-plane coordinates are drawn as TWO dims in its end-on

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1085,10 +1085,17 @@ def _dedupe_omissions(*sources: list[Omission]) -> tuple[Omission, ...]:
     Hence: cross-source only. Each source keeps its own repetitions; a key already seen in an
     EARLIER source is dropped from a later one.
     """
-    seen: set[tuple[int, str, str]] = set()
+
+    def key(o: Omission) -> tuple[int, str, object, str]:
+        # `value` is in the key deliberately. Two sources reporting one parameter with
+        # DIFFERENT values are not one fact reported twice — they are two compilers
+        # disagreeing, and an audit should surface that rather than silently keep whichever
+        # source happens to run first.
+        return (id(o.feature), o.parameter_id, o.value, o.reason)
+
+    seen: set[tuple[int, str, object, str]] = set()
     out: list[Omission] = []
     for source in sources:
-        keys_here = {(id(o.feature), o.parameter_id, o.reason) for o in source}
-        out += [o for o in source if (id(o.feature), o.parameter_id, o.reason) not in seen]
-        seen |= keys_here
+        out += [o for o in source if key(o) not in seen]
+        seen |= {key(o) for o in source}
     return tuple(out)

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1091,7 +1091,14 @@ def _dedupe_omissions(*sources: list[Omission]) -> tuple[Omission, ...]:
         # DIFFERENT values are not one fact reported twice — they are two compilers
         # disagreeing, and an audit should surface that rather than silently keep whichever
         # source happens to run first.
-        return (id(o.feature), o.parameter_id, o.value, o.reason)
+        #
+        # ROUNDED, because these values carry real float jitter: an X-turned envelope reports
+        # its height as 20.000000000000007 by one route and 20.0 by another. Keying on the raw
+        # float would split a genuine duplicate back into two rows on noise, re-creating the
+        # over-reporting this function exists to remove. A disagreement that matters differs by
+        # far more than a micron.
+        v = round(o.value, 6) if isinstance(o.value, float) else o.value
+        return (id(o.feature), o.parameter_id, v, o.reason)
 
     seen: set[tuple[int, str, object, str]] = set()
     out: list[Omission] = []

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -491,8 +491,31 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
         refs = kept
     unique: list[tuple[Point, str, Feature]] = []
     for r, role, feat in refs:
-        if not any(abs(r[0] - u[0]) < 0.5 and abs(r[1] - u[1]) < 0.5 for u, _, _ in unique):
+        clash = next(
+            (u for u, _, _ in unique if abs(r[0] - u[0]) < 0.5 and abs(r[1] - u[1]) < 0.5),
+            None,
+        )
+        if clash is None:
             unique.append((r, role, feat))
+        else:
+            # Record the rejection instead of dropping it silently (#996). This is a RULE
+            # deciding a measurement is redundant — the same category as the suppressions
+            # above — but it used to filter before the compiler saw the candidate, so no
+            # `Omission` existed and the audit could not see it. An audit that claims
+            # completeness while a suppression path is invisible is worse than none, because
+            # its silence reads as "nothing was suppressed" (Codex #996 r1).
+            omitted.append(
+                _plan(
+                    r,
+                    role,
+                    feat,
+                    suppressed=True,
+                    reason=(
+                        f"coincident with a location already dimensioned at "
+                        f"({clash[0]:.3f}, {clash[1]:.3f})"
+                    ),
+                )
+            )
     return [_plan(r, role, feat) for r, role, feat in unique] + omitted
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -423,7 +423,30 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
     """
     datum = next((d for d in model.datums if d.id == "datum_xy"), None)
     if datum is None:
-        return []
+        # No datum to measure from — but every otherwise-eligible feature still HAD a location
+        # to lose, so say so rather than returning nothing (#996, Codex r3).
+        #
+        # This bare `return []` broke the same guarantee as the edge-anchored pocket:
+        # `_check_authored_targets` accepts `dimension(hole, "location")` on feature
+        # eligibility alone, so an author could name a position, pass validation, and get
+        # neither the dimension nor a word about why. It bites a caller-supplied `PartModel`
+        # (ADR 0011), which `build_drawing` preserves verbatim — datums included, or not.
+        #
+        # Deliberately NOT fixed by defaulting a datum into model coercion: that would hide
+        # malformed compiler input behind a plausible drawing instead of reporting it.
+        return [
+            PlannedDimension(
+                param=DimParameter(kind="location", role=role, value=0.0, span=None, refs=()),
+                convention="location",
+                suppressed=True,
+                reason="no datum_xy in the model to measure the position from",
+                datum=None,
+                feature=f,
+            )
+            for f in model.features
+            for role in (location_role(f),)
+            if role is not None and location_datum(f) == "datum_xy"
+        ]
     dx, dy, dz = datum.at
     # (ref_point, role): role distinguishes a hole ref from a pattern ref — the
     # renderer's concentric-bore exclusion applies to holes only (a bolt circle on

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -431,6 +431,10 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
     # (ref_point, role, source feature): the feature is carried so the renderer can
     # record provenance on the placed location dim (ADR 0010).
     refs: list[tuple[Point, str, Feature]] = []
+    # Features whose location a RULE declined before a reference point existed. They have no
+    # ref to plan from, so they cannot go through `refs`, but they were considered — and an
+    # audit that cannot see them reads their absence as "nothing was suppressed" (#996).
+    dropped: list[tuple[Feature, str, str]] = []
     for f in model.features:
         # Which features get a `datum_xy` position — including the orientation rule (the
         # hole/pattern/pad ladder is Z-normal; a pocket's two in-plane coordinates belong
@@ -450,8 +454,19 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
             elif f.members:
                 near = min(f.members, key=lambda m: (m[0] - dx) ** 2 + (m[1] - dy) ** 2)
                 refs.append((near, role, f))
+            else:
+                # A non-bolt-circle pattern with no members has no point to locate FROM.
+                # Recorded rather than skipped (#996): this feature passed the eligibility
+                # check two lines up, so its location was considered and then dropped.
+                dropped.append((f, role, "pattern has no members to locate from"))
         elif isinstance(f, PocketFeature):
             if f.edge_anchored:
+                # The pocket's position is conveyed by the edge it is anchored to, so no
+                # datum location is planned. A RULE decision, and it used to `continue`
+                # silently — so an authored `dimension(pocket, "location")` that
+                # `_check_authored_targets` had ACCEPTED produced nothing at all, with no
+                # diagnostic to say why (Codex #996 r2).
+                dropped.append((f, role, "edge-anchored; the edge conveys the position"))
                 continue
             # A recognised pocket frame may be anchored at an opening corner;
             # location furniture defines the in-plane centre, which is expressed
@@ -516,6 +531,10 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
                     ),
                 )
             )
+    omitted += [
+        _plan(feat.frame.origin, role, feat, suppressed=True, reason=why)
+        for feat, role, why in dropped
+    ]
     return [_plan(r, role, feat) for r, role, feat in unique] + omitted
 
 

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -495,7 +495,7 @@ def test_build_state_has_a_single_construction_and_fill_site():
             "_build.detail_view",
             "_build.trace",
             "_build.omissions",
-        ],
+        ],  # omissions: ONE assignment covering both the auto and auto_dims=False paths
         # drawing.py still writes _build.trace via the deprecated attach_solve_trace
         # shim/primitive (kept until 0.5.0) — no engine caller reaches it now. The
         # recorder also participates in finalize()'s #647 transaction: finalize

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -484,11 +484,17 @@ def test_build_state_has_a_single_construction_and_fill_site():
         # _build.trace: the #736 solve-trace recorder now rides BuildState filled
         # directly at the one construction site (#830 — the engine constructs the
         # build state, it does not mutate a live Drawing through attach_solve_trace).
+        # _build.omissions: the compiler's suppression ledger (#996). `_auto_annotate`
+        # RETURNS it and builder fills it here, rather than `annotations/` writing a drawing
+        # private — #830 removed the last engine caller that did that, and this new field is
+        # not an excuse to reintroduce the pattern. The first cut of #996 did exactly that
+        # and these guards caught it.
         "builder.py": [
             "_build.analysis",
             "_build.part_model",
             "_build.detail_view",
             "_build.trace",
+            "_build.omissions",
         ],
         # drawing.py still writes _build.trace via the deprecated attach_solve_trace
         # shim/primitive (kept until 0.5.0) — no engine caller reaches it now. The

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -346,6 +346,7 @@ class TestStepPosition:
         intents_before = len(dwg._intents)
         coverage_before = dwg.coverage.snapshot()
         issues_before = dwg.registry.issues
+        suppressions_before = dwg.suppressions()
 
         calls = {"n": 0}
         real = _common.drain_corridors
@@ -371,6 +372,12 @@ class TestStepPosition:
         assert len(dwg._intents) == intents_before
         assert dwg.coverage.snapshot() == coverage_before  # coverage restored (#647 review)
         assert dwg.registry.issues == issues_before  # the mid-drain issue rolled out too
+        # The audit ledger (#996) is NOT part of the transaction, and that is the guarantee
+        # rather than an oversight: finalize recompiles the same immutable model and never
+        # writes _build.omissions, so there is nothing to roll back. Asserted explicitly
+        # (Codex #996 r4) so a future stage that DOES write it has to notice this and add it
+        # to the snapshot set above.
+        assert dwg.suppressions() == suppressions_before
 
         monkeypatch.undo()
         dwg.finalize()  # clean retry — the shoulder position places exactly once (no duplicate)

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -302,6 +302,23 @@ def test_the_dedup_keeps_repetitions_within_one_source():
         [Omission(feature, "height.length", 30.0, "authored")],
     )
     assert len(disagreeing) == 2, "a value disagreement must not be deduped away"
+
+    # ...but float NOISE is not a disagreement. These values carry real jitter — an X-turned
+    # envelope reports its height as 20.000000000000007 by one route and 20.0 by another — so
+    # the key rounds. Keying on the raw float would split a genuine duplicate back into two
+    # rows on noise, re-creating the over-reporting this function exists to remove.
+    jittered = _dedupe_omissions(
+        [Omission(feature, "height.length", 20.0, "authored")],
+        [Omission(feature, "height.length", 20.000000000000007, "authored")],
+    )
+    assert len(jittered) == 1, "float jitter must not read as two compilers disagreeing"
+
+    # And an omission with no value at all (most location rows) still dedupes.
+    valueless = _dedupe_omissions(
+        [Omission(feature, "location.location", None, "r")],
+        [Omission(feature, "location.location", None, "r")],
+    )
+    assert len(valueless) == 1
     assert [o.value for o in positions] == [20.0, 12.0, 50.0, 18.0], (
         "one compiler reporting four members is four facts, not one"
     )

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -293,6 +293,15 @@ def test_the_dedup_keeps_repetitions_within_one_source():
     heights = [o for o in rows if o.parameter_id == "height.length"]
     positions = [o for o in rows if o.parameter_id == "location.location"]
     assert len(heights) == 1, "two compilers reporting one fact is a duplicate"
+
+    # ...but two compilers DISAGREEING is not one fact. `value` is in the dedup key, so a
+    # differing measurement survives as its own row instead of the earlier source silently
+    # winning — an audit should surface a disagreement between compilers, not hide it.
+    disagreeing = _dedupe_omissions(
+        [Omission(feature, "height.length", 25.0, "authored")],
+        [Omission(feature, "height.length", 30.0, "authored")],
+    )
+    assert len(disagreeing) == 2, "a value disagreement must not be deduped away"
     assert [o.value for o in positions] == [20.0, 12.0, 50.0, 18.0], (
         "one compiler reporting four members is four facts, not one"
     )

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -246,6 +246,29 @@ def test_a_model_with_no_datum_records_the_locations_it_cannot_measure():
     assert rows, "the missing-datum diagnostic must reach Drawing.suppressions()"
 
 
+def test_one_row_per_fact_not_per_sighting():
+    """An authored set records the overall height TWICE — `_compile_overall_height`'s bespoke
+    branch and the general group traversal both notice it, since the envelope's `height`
+    parameter is in its group too.
+
+    Both are right about the same fact. A duplicated row makes a consumer over-count
+    suppressions, and a build-diff show churn that never happened — the false signal this
+    audit exists to remove. (The lead Codex was chasing when its final run timed out; found
+    by counting rows rather than reading them.)
+    """
+    from collections import Counter
+
+    sheet = Sheet(Box(120, 80, 25) - Pos(0, 0, 15) * Box(30, 20, 12), title="T", number="N")
+    sheet.dimension(sheet.envelope(), "width.length")  # authored: everything else omitted
+    rows = sheet.build().suppressions()
+
+    keys = [(r["feature"], r["parameter_id"], r["reason"]) for r in rows]
+    dupes = {k: n for k, n in Counter(keys).items() if n > 1}
+    assert not dupes, f"the same omission reported more than once: {dupes}"
+    # ...and the fact itself survives the dedup rather than being dropped with its twin.
+    assert any(r["parameter_id"] == "height.length" for r in rows)
+
+
 def test_the_ledger_is_plain_data():
     """A harness, a generated script or an LLM has to diff two builds without importing IR
     types — that is the whole point of an audit surface — so the rows are plain dicts."""

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -363,3 +363,18 @@ def test_the_feature_key_distinguishes_two_instances_of_one_kind():
         HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 6.0, depth=None, through=True)
     ), "the same geometry must key the same across builds — that is what a diff relies on"
     assert feature_key(None) is None  # a model-level omission has no feature
+
+    # The key is TOTAL by design. Every concrete IR feature carries a frame with a required
+    # origin, so these fallbacks are unreachable today — but `feature_key` runs once per
+    # ledger row, and one odd feature raising would take the whole audit read down with it.
+    # A degraded-but-honest key beats an exception here, which is the opposite trade to the
+    # builder's model guard (removed, because ITS fallback was a silent empty ledger).
+    class _NoFrame:
+        kind = "mystery"
+
+    class _NoOrigin:
+        kind = "mystery"
+        frame = type("F", (), {"origin": None, "axis": "z"})()
+
+    assert feature_key(_NoFrame()) == "mystery"
+    assert feature_key(_NoOrigin()) == "mystery/z"

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -109,6 +109,49 @@ def test_the_coincident_location_dedup_records_its_rejection():
     assert "10.000" in suppressed[0].reason and "5.000" in suppressed[0].reason
 
 
+def test_an_edge_anchored_pocket_records_why_it_has_no_location():
+    """The second completeness hole, same shape as the dedup one (Codex #996 r2).
+
+    An edge-anchored pocket passes the location eligibility check and is then `continue`d
+    out of the loop — a rule decision, silently. Worse than a missing audit row: an authored
+    `dimension(pocket, "location")` that `_check_authored_targets` had ACCEPTED produced
+    nothing at all, breaking that check's guarantee that an accepted entry cannot silently
+    yield nothing.
+
+    Found by asking the reviewer, twice, for *other* paths that drop a measurement without an
+    `Omission` — a completeness claim is only worth what the search behind it was.
+    """
+    from build123d import Box as _Box
+
+    from draftwright.model import Datum, Frame, PartModel, PocketFeature
+    from draftwright.model.planner import plan_locations
+
+    bbox = _Box(80, 50, 20).bounding_box()
+    pocket = PocketFeature(
+        frame=Frame((10.0, 5.0, 20.0), "z"),
+        width_axis="y",
+        long_axis="x",
+        width=10.0,
+        length=20.0,
+        depth=6.0,
+        w_center=5.0,
+        lo=0.0,
+        hi=20.0,
+        edge_anchored=True,
+    )
+    model = PartModel(
+        bbox=bbox,
+        orientation="prismatic",
+        features=[pocket],
+        datums=[Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))],
+    )
+
+    planned = plan_locations(model)
+    assert len(planned) == 1, "the skipped location must be recorded, not dropped"
+    assert planned[0].suppressed
+    assert "edge-anchored" in planned[0].reason
+
+
 def test_the_ledger_is_plain_data():
     """A harness, a generated script or an LLM has to diff two builds without importing IR
     types — that is the whole point of an audit surface — so the rows are plain dicts."""

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -152,6 +152,56 @@ def test_an_edge_anchored_pocket_records_why_it_has_no_location():
     assert "edge-anchored" in planned[0].reason
 
 
+def test_a_pattern_with_no_members_records_why_it_has_no_location():
+    """The third silent drop, found by sweeping the loop rather than waiting for a report.
+
+    A non-bolt-circle pattern with no members has no point to locate FROM, so it fell through
+    the elif chain. Like the edge-anchored pocket, it had already passed the eligibility check
+    — considered, then dropped, with nothing to show for it.
+    """
+    from build123d import Box as _Box
+
+    from draftwright.model import Datum, Frame, HoleFeature, PartModel, PatternFeature
+    from draftwright.model.planner import plan_locations
+
+    bbox = _Box(80, 50, 20).bounding_box()
+    member = HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 6.0, depth=None, through=True)
+    model = PartModel(
+        bbox=bbox,
+        orientation="prismatic",
+        features=[
+            PatternFeature(
+                Frame((10.0, 5.0, 10.0), "z"),
+                pattern="linear",
+                count=2,
+                member=member,
+                members=(),
+            )
+        ],
+        datums=[Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))],
+    )
+    planned = plan_locations(model)
+    assert [p.suppressed for p in planned] == [True]
+    assert "no members" in planned[0].reason
+
+
+def test_the_ledger_is_filled_when_auto_dimensions_are_off():
+    """`auto_dims=False` reported an EMPTY ledger while the compiler really had suppressed
+    measurements (Codex #996 r1) — the fill sat inside the auto branch.
+
+    That is the worst failure this surface can have: not a wrong answer but a confident empty
+    one, on a supported path. Both paths must agree about what the compiler decided, because
+    the compiler decided the same thing either way; only the rendering differs.
+    """
+    part = Rot(0, 90, 0) * Cylinder(10, 40)
+    auto = build_drawing(part, number="X", auto_dims=True).suppressions()
+    manual = build_drawing(part, number="X", auto_dims=False).suppressions()
+
+    assert manual, "auto_dims=False must not report an empty ledger"
+    assert [r["parameter_id"] for r in auto] == [r["parameter_id"] for r in manual]
+    assert [r["reason"] for r in auto] == [r["reason"] for r in manual]
+
+
 def test_the_ledger_is_plain_data():
     """A harness, a generated script or an LLM has to diff two builds without importing IR
     types — that is the whole point of an audit surface — so the rows are plain dicts."""

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -1,0 +1,81 @@
+"""`Drawing.suppressions()` — the audit read (#996 WP1).
+
+A finished drawing shows what was drawn. Nothing showed what was **not**, or why, because the
+compiled plan carrying that record was a local in the orchestrator: built, consumed by the
+renderers, discarded. So an absent dimension could only be inferred from the sheet, and
+inference cannot tell "correctly omitted" from "a suppression rule is wrong".
+
+That gap has a measured cost. #997's square-footprint rule suppressed BOTH envelope extents on
+a square part and fired on parts up to 5% off square. The drawing was silent, lint was clean,
+and it produced **four separate issue reports** (#916, #917, #918, and the shape of #909) none
+of which named the cause. What finally identified it was building one part twice with a single
+property changed and diffing the dimensions — the manual form of this read.
+
+The distinction this surface has to preserve is ADR 0016's: an **authored** omission is the
+script's own (omission means suppression, recoverable with a `dimension(...)` line), while a
+rule suppression is the engine's decision and must name the rule. They look identical on paper
+and mean opposite things.
+"""
+
+from __future__ import annotations
+
+from build123d import Box, Cylinder, Pos, Rot
+
+from draftwright import Sheet, build_drawing
+
+
+def _by_param(dwg) -> dict[str, dict]:
+    return {o["parameter_id"]: o for o in dwg.suppressions()}
+
+
+def test_a_rule_suppression_names_the_rule_that_made_it():
+    """The X-turned rotational rule is a *correct* suppression — the OD conveys the cross-axis
+    extent, so restating it would double-dimension. The point is not that it fires, but that
+    the drawing can now say it fired and why."""
+    dwg = build_drawing(Rot(0, 90, 0) * Cylinder(10, 40), number="X")
+    led = _by_param(dwg)
+
+    assert "depth.length" in led, "the suppressed extent must appear in the ledger"
+    entry = led["depth.length"]
+    assert entry["authored"] is False, "a planner rule, not the script's omission"
+    assert "rotational OD" in entry["reason"], f"unattributed suppression: {entry['reason']!r}"
+
+    # ...and the drawing really is missing it, so the ledger describes the sheet rather than
+    # some parallel bookkeeping.
+    assert "m_env_depth" not in dwg.annotations()
+
+
+def test_a_part_with_nothing_suppressed_has_an_empty_ledger():
+    """No false positives: a plain prismatic plate states its extents and the audit is quiet.
+
+    This is also the #997 regression from the audit's side — a square plate reported two rule
+    suppressions before that fix, and the ledger is where that would now be visible.
+    """
+    assert build_drawing(Box(60, 40, 20), number="X").suppressions() == []
+    assert build_drawing(Box(50, 50, 30), number="X").suppressions() == []
+
+
+def test_an_authored_omission_is_distinguished_from_a_rule_suppression():
+    """ADR 0016: omission from an authored set is the AUTHOR's decision. Conflating it with a
+    rule suppression would make the audit unusable — every authored script would look like the
+    engine dropping dimensions."""
+    sheet = Sheet(Box(80, 50, 20) - Pos(10, 5, 0) * Cylinder(4, 30), title="T", number="N")
+    hole = sheet.hole(diameter=8, at=(10, 5, 10), axis="z", depth=20)
+    sheet.dimension(hole, "bore.diameter")  # authored set: everything else is omitted
+    dwg = sheet.build()
+
+    authored = [o for o in dwg.suppressions() if o["authored"]]
+    assert authored, "an authored set that omits measurements must record them as authored"
+    assert all(o["reason"] for o in dwg.suppressions()), "every omission carries a reason"
+
+
+def test_the_ledger_is_plain_data():
+    """A harness, a generated script or an LLM has to diff two builds without importing IR
+    types — that is the whole point of an audit surface — so the rows are plain dicts."""
+    dwg = build_drawing(Rot(0, 90, 0) * Cylinder(10, 40), number="X")
+    rows = dwg.suppressions()
+    assert rows and all(isinstance(r, dict) for r in rows)
+    assert set(rows[0]) == {"feature", "parameter_id", "value", "reason", "authored"}
+    import json
+
+    json.dumps(rows)  # must round-trip; a harness will serialise these

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -202,6 +202,41 @@ def test_the_ledger_is_filled_when_auto_dimensions_are_off():
     assert [r["reason"] for r in auto] == [r["reason"] for r in manual]
 
 
+def test_a_model_with_no_datum_records_the_locations_it_cannot_measure():
+    """The fourth hole, and the third round in a row to find one (Codex #996 r3).
+
+    `plan_locations` returned `[]` outright when the model carried no `datum_xy`. Every
+    otherwise-eligible feature still HAD a position to lose, so the drawing simply had no
+    locations and the audit said nothing.
+
+    It breaks the same guarantee as the edge-anchored pocket: `_check_authored_targets`
+    accepts `dimension(hole, "location")` on feature eligibility alone, so an author could
+    name a position, pass validation, and receive neither the dimension nor a reason. It bites
+    a caller-supplied `PartModel` (ADR 0011), which `build_drawing` preserves verbatim —
+    datums included, or not.
+
+    Not fixed by defaulting a datum into model coercion: that would hide malformed compiler
+    input behind a plausible-looking drawing rather than reporting it.
+    """
+    from build123d import Box as _Box
+
+    from draftwright.model import Frame, HoleFeature, PartModel
+    from draftwright.model.planner import plan_locations
+
+    bbox = _Box(80, 50, 20).bounding_box()
+    model = PartModel(
+        bbox=bbox,
+        orientation="prismatic",
+        features=[HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 6.0, depth=None, through=True)],
+        datums=[],  # the point: a model that never got a datum_xy
+    )
+
+    planned = plan_locations(model)
+    assert [p.suppressed for p in planned] == [True], "an unmeasurable location must be recorded"
+    assert "no datum_xy" in planned[0].reason
+    assert planned[0].datum is None  # there is none — the row says so rather than inventing one
+
+
 def test_the_ledger_is_plain_data():
     """A harness, a generated script or an LLM has to diff two builds without importing IR
     types — that is the whole point of an audit surface — so the rows are plain dicts."""

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -273,7 +273,14 @@ def test_the_feature_key_distinguishes_two_instances_of_one_kind():
     b = HoleFeature(Frame((10.2, 5.1, 18.0), "z"), 4.0, depth=5.0, through=False)
 
     assert feature_key(a) != feature_key(b), "two distinct holes must not share a key"
-    assert feature_key(a) == "hole@(10.000,5.000,10.000)/z"
+
+    # Position alone is not identity. Two holes at ONE origin with different bores keyed the
+    # same — and that is precisely the coincident-dedup case, where the ledger most needs to
+    # say which instance lost its location (Codex #996 r4).
+    same_spot_wide = HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 6.0, depth=None, through=True)
+    same_spot_narrow = HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 4.0, depth=8.0, through=False)
+    assert feature_key(same_spot_wide) != feature_key(same_spot_narrow)
+    assert feature_key(a) == "hole@(10.000,5.000,10.000)/z[diameter=6.000]"
     assert feature_key(a) == feature_key(
         HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 6.0, depth=None, through=True)
     ), "the same geometry must key the same across builds — that is what a diff relies on"

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -236,6 +236,15 @@ def test_a_model_with_no_datum_records_the_locations_it_cannot_measure():
     assert "no datum_xy" in planned[0].reason
     assert planned[0].datum is None  # there is none — the row says so rather than inventing one
 
+    # ...and it survives the FULL build, not just the planner. The unit assertions above all
+    # passed while `build_drawing` raised AssertionError on this very model: `_compile_locations`
+    # asserted a datum → ref span before checking `suppressed`, so the diagnostic that closed
+    # the hole crashed the build instead — a silent omission traded for a hard failure.
+    # Testing the planner in isolation could not see that; the public path is the contract.
+    drawing = build_drawing(_Box(80, 50, 20), model=model, number="X")
+    rows = [r for r in drawing.suppressions() if "no datum_xy" in r["reason"]]
+    assert rows, "the missing-datum diagnostic must reach Drawing.suppressions()"
+
 
 def test_the_ledger_is_plain_data():
     """A harness, a generated script or an LLM has to diff two builds without importing IR

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -69,6 +69,46 @@ def test_an_authored_omission_is_distinguished_from_a_rule_suppression():
     assert all(o["reason"] for o in dwg.suppressions()), "every omission carries a reason"
 
 
+def test_the_coincident_location_dedup_records_its_rejection():
+    """Completeness: a rule that drops a measurement must produce an `Omission`.
+
+    `plan_locations` dedups references within 0.5 of one another. That filter ran *before*
+    the compiler saw the candidate, so the rejection produced no diagnostic at all and the
+    audit could not see it (Codex #996 r1). An audit claiming completeness while a
+    suppression path is invisible is worse than no audit — its silence reads as "nothing was
+    suppressed", which is the exact false confidence this surface exists to remove.
+
+    Unit-level on purpose: the dedup compares feature *origins* in X/Y, so provoking it from
+    real geometry needs two features stacked at one plan position, and the fixture would then
+    be testing recognition rather than the rule.
+    """
+    from build123d import Box as _Box
+
+    from draftwright.model import Datum, Frame, HoleFeature, PartModel
+    from draftwright.model.planner import plan_locations
+
+    bbox = _Box(80, 50, 20).bounding_box()
+    datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
+    near, also_near = (10.0, 5.0, 10.0), (10.2, 5.1, 18.0)  # within the 0.5 window in X/Y
+    model = PartModel(
+        bbox=bbox,
+        orientation="prismatic",
+        features=[
+            HoleFeature(Frame(near, "z"), 6.0, depth=None, through=True),
+            HoleFeature(Frame(also_near, "z"), 4.0, depth=5.0, through=False),
+        ],
+        datums=[datum],
+    )
+
+    planned = plan_locations(model)
+    suppressed = [p for p in planned if p.suppressed]
+    assert len(suppressed) == 1, "the deduped reference must be recorded, not dropped"
+    # ...and it names the winner, so an auditor can see WHICH location absorbed it rather
+    # than only that something vanished.
+    assert "coincident" in suppressed[0].reason
+    assert "10.000" in suppressed[0].reason and "5.000" in suppressed[0].reason
+
+
 def test_the_ledger_is_plain_data():
     """A harness, a generated script or an LLM has to diff two builds without importing IR
     types — that is the whole point of an audit surface — so the rows are plain dicts."""
@@ -79,3 +119,25 @@ def test_the_ledger_is_plain_data():
     import json
 
     json.dumps(rows)  # must round-trip; a harness will serialise these
+
+
+def test_the_feature_key_distinguishes_two_instances_of_one_kind():
+    """A diff has to say WHICH feature lost a measurement.
+
+    The key was the class name, so two holes both read `"HoleFeature"` and a diff could not
+    tell whether the same hole was suppressed in both builds, or whether a suppression had
+    moved between instances (Codex #996 r1). It is derived from the geometry now, so it also
+    survives a rebuild that reorders the feature list — list position would not.
+    """
+    from draftwright.drawing import feature_key
+    from draftwright.model import Frame, HoleFeature
+
+    a = HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 6.0, depth=None, through=True)
+    b = HoleFeature(Frame((10.2, 5.1, 18.0), "z"), 4.0, depth=5.0, through=False)
+
+    assert feature_key(a) != feature_key(b), "two distinct holes must not share a key"
+    assert feature_key(a) == "hole@(10.000,5.000,10.000)/z"
+    assert feature_key(a) == feature_key(
+        HoleFeature(Frame((10.0, 5.0, 10.0), "z"), 6.0, depth=None, through=True)
+    ), "the same geometry must key the same across builds — that is what a diff relies on"
+    assert feature_key(None) is None  # a model-level omission has no feature

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -269,6 +269,35 @@ def test_one_row_per_fact_not_per_sighting():
     assert any(r["parameter_id"] == "height.length" for r in rows)
 
 
+def test_the_dedup_keeps_repetitions_within_one_source():
+    """The dedup must not eat genuine per-member facts (Codex #996 r6).
+
+    `_compile_off_axis_hole_locations` emits one omission per member, and every member of a
+    grouped hole shares the SAME `HoleFeature` — so a key of (feature, parameter, reason) is
+    identical across members. Keyed that way, four real member positions collapsed to one and
+    vanished from the audit. Losing a real row is worse than the duplicate it was meant to fix.
+
+    So the dedup is cross-SOURCE only: two different compilers reporting one fact is a
+    duplicate; one compiler reporting four members is four facts. My first test asserted only
+    the envelope case and passed while this was broken.
+    """
+    from draftwright.model.compiled import Omission, _dedupe_omissions
+
+    feature = object()  # one feature, as a grouped hole's members share theirs
+    bespoke = [Omission(feature, "height.length", 25.0, "authored")]
+    members = [Omission(feature, "location.location", v, "r") for v in (20.0, 12.0, 50.0, 18.0)]
+    general = [Omission(feature, "height.length", 25.0, "authored")]  # the same fact again
+
+    rows = _dedupe_omissions(bespoke, members, general)
+
+    heights = [o for o in rows if o.parameter_id == "height.length"]
+    positions = [o for o in rows if o.parameter_id == "location.location"]
+    assert len(heights) == 1, "two compilers reporting one fact is a duplicate"
+    assert [o.value for o in positions] == [20.0, 12.0, 50.0, 18.0], (
+        "one compiler reporting four members is four facts, not one"
+    )
+
+
 def test_the_ledger_is_plain_data():
     """A harness, a generated script or an LLM has to diff two builds without importing IR
     types — that is the whole point of an audit surface — so the rows are plain dicts."""


### PR DESCRIPTION
**WP1 step 1** of #996 (manufacturing-completeness). Makes the engine able to say what it did *not* dimension, and which rule decided that.

## The gap

`Omission` already records the feature, parameter, value **and the reason string**. But the compiled plan carrying it was a local in `_auto_annotate`: built, read by the renderers, discarded. So the one thing that knew *why* a dimension was absent did not outlive the build, and absence could only be inferred from a finished sheet.

Inference cannot separate **"correctly omitted"** from **"a suppression rule is wrong"**. That distinction is the whole audit.

## Validated against the bug that motivated it

#997's square rule suppressed both envelope extents on a square part, and fired on parts up to 5% off square. The drawing was silent, lint was clean, and it produced **four issue reports** — #916, #917, #918 and the shape of #909 — none of which named the cause. What eventually found it was building one part twice with a single property changed and diffing the dimensions.

I reintroduced the deleted rule and ran the new read against it:

```
50x50: dims=[]  lint=0          ← the sheet is silent, lint agrees
   LEDGER: width.length | square footprint (single overall dim suffices)
   LEDGER: depth.length | square footprint (single overall dim suffices)

100x95: dims=[]  lint=0
   LEDGER: width.length | square footprint (single overall dim suffices)   ← on a part that is not square
```

Four reports' worth of mystery, reduced to one named rule firing twice.

## Shape

`Drawing.suppressions()` returns plain dicts — `feature` / `parameter_id` / `value` / `reason` / `authored` — so a harness, a generated script or an LLM can diff two builds without importing IR types. That diff is WP1 step 2; this is what it reads.

`authored` preserves ADR 0016's distinction: an omission from an authored set is the *script's* decision and is recoverable with a `dimension(...)` line; anything else is the engine's, and names its rule. They look identical on a sheet and mean opposite things.

## I built it wrong first, and the guards caught it

I copied the `_attach_part_model` seam and wrote the ledger onto the drawing **from the orchestrator** — which is exactly what #830 removed the last caller of, as the comment six lines above my edit says. Three guards fired at once:

- `test_no_engine_module_touches_drawing_privates`
- `test_private_reads_are_a_documented_shrinking_allowlist`
- `test_build_state_has_a_single_construction_and_fill_site`

Correct seam: `_auto_annotate` **returns** the diagnostics and `builder._assemble` — BuildState's single fill site — attaches them. The roster entry records why, so the next BuildState field does not repeat it.

Second time today a copied pattern was wrong in its new context (the other: `Sheet.export` forwarding `formats=None` into a deprecated path). Worth the guards existing.

## Verification

Full suite **2615 passed**, 0 failures. Four new tests including a canary: removing the attachment fails three of them. All four lint checks.

## Next

**Step 2 — the differential harness.** Perturb a part along one property, diff the ledgers, and report any dimension that vanishes without a geometric reason. That is the step where the audit starts *finding* things rather than recording them.

One limit stated plainly so this is not oversold: the ledger catches **wrong suppression**, not **absent recognition**. A feature that never reaches the IR has no ledger entry — #909 needs a different instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
