### PR TITLE
feat(#996): a differential harness — diff two builds, flag what nothing claims

### DIFF
--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -26,6 +26,7 @@ nothing from the engine, so it can never become a dependency of the thing it mea
 
 from __future__ import annotations
 
+
 def _labelled(dwg) -> dict[str, str]:
     """``{annotation name: label}`` for every labelled annotation on a drawing."""
     out: dict[str, str] = {}

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -48,6 +48,11 @@ def diff_builds(before, after) -> dict:
     and a near-square one, a feature added, a dimension authored. Returns:
 
     - ``dimensions_lost`` / ``dimensions_gained`` — ``{name: label}``, by annotation name;
+    - ``dimensions_changed`` — ``{name: (before, after)}`` where the annotation survived but
+      its label did not. Reported but NOT alarmed: in a perturbation study a changed value is
+      the expected result of the change, so treating it as a finding would bury the losses in
+      noise. Silence was worse, though — an 80 mm width becoming 90 produced no output at all,
+      and a surface claiming to report "what was drawn" has to be able to see that;
     - ``suppressions_gained`` / ``suppressions_lost`` — ledger rows as
       ``(feature, parameter_id, reason)``;
     - ``unexplained_losses`` — the subset of ``dimensions_lost`` that **no** newly-gained
@@ -67,6 +72,7 @@ def diff_builds(before, after) -> dict:
     before_dims, after_dims = _labelled(before), _labelled(after)
     lost = {n: v for n, v in before_dims.items() if n not in after_dims}
     gained = {n: v for n, v in after_dims.items() if n not in before_dims}
+    changed = {n: (v, after_dims[n]) for n, v in before_dims.items() if after_dims.get(n, v) != v}
 
     before_rows, after_rows = _rows(before), _rows(after)
     gained_supp = sorted(after_rows - before_rows)
@@ -82,6 +88,7 @@ def diff_builds(before, after) -> dict:
     return {
         "dimensions_lost": lost,
         "dimensions_gained": gained,
+        "dimensions_changed": changed,
         "suppressions_gained": gained_supp,
         "suppressions_lost": lost_supp,
         "unexplained_losses": unexplained,
@@ -102,4 +109,6 @@ def explain(diff: dict) -> list[str]:
         out.append(f"suppressed: {parameter} on {feature} — {reason}")
     for name, label in sorted(diff["dimensions_gained"].items()):
         out.append(f"gained: {name} ({label})")
+    for name, (was, now) in sorted(diff.get("dimensions_changed", {}).items()):
+        out.append(f"changed: {name} {was} -> {now}")
     return out

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -1,38 +1,55 @@
 """audit — diff two builds and ask what went missing (#996 WP1 step 2).
 
 The suppression ledger (`Drawing.suppressions()`) says which rule removed a measurement. It
-answers *why* a dimension is absent, and it does so well — but only for absences some code
-path remembered to record. Three consecutive review rounds on #999 found a suppression that
-recorded nothing, each caught by a person hunting for it rather than by the ledger noticing
-its own gap. A completeness claim is worth exactly the last search behind it.
+answers *why* a dimension is absent — but only for absences some code path remembered to
+record. Three consecutive review rounds on #999 found suppression paths that recorded nothing,
+each caught by a person hunting for it rather than by the ledger noticing its own gap.
 
-**The differential does not depend on that.** Build a part twice, change one property, and
-compare: if a dimension present in one build is absent in the other, something removed it —
-whether or not anything wrote an `Omission`. It catches unknown-unknowns; the ledger reports
-known-knowns.
+**A diff does not depend on that.** If a dimension is present in one build and absent in
+another, something removed it, whether or not anything wrote it down. That is how #997 was
+actually found: not from the four issue reports describing its symptoms, but from `50x50` vs
+`50x40`.
 
-That is how #997 was actually found. Not by reading code, and not from four issue reports
-describing its symptoms, but from one comparison:
+## What this cannot do, stated first
 
-    50 x 50 -> no plan size at all
-    50 x 40 -> width and depth both stated
+A placed annotation carries **no measurement identity** — its name is an engine-assigned
+registry slot, not a handle on what it measures. Two consequences, both real:
 
-Two builds, one property changed, and the rule fell out. This module is that experiment,
-written down.
+- **A replaced measurement can hide as a changed one.** Move a hole and `m_locx0` goes from
+  `70` to `90`: a different measurement reused the slot. This reports it under
+  ``dimensions_changed``, which is honest but weaker than "the 70 measurement is gone".
+- **A loss cannot be attributed to a suppression with confidence.** The ledger row names a
+  feature; the annotation does not. So a candidate explanation is a *hint*, never a verdict.
+
+Closing either needs ADR 0010 provenance threaded from the planner to the placed annotation.
+Until then this is a **triage aid, not a proof** — and deliberately shaped so its weakest part
+cannot silence its strongest: a candidate suppression annotates a loss, it never removes it.
+An earlier cut let a weak substring match cancel the alarm outright, so any newly-suppressed
+``width.*`` excused every lost annotation whose name contained "width", across unrelated
+features (Codex #1001). That is the exact false confidence this epic exists to remove.
 
 A leaf by construction: it reads the public surface of two finished ``Drawing``s and imports
-nothing from the engine, so it can never become a dependency of the thing it measures.
+nothing from the engine, so the thing it measures can never come to depend on it.
 """
 
 from __future__ import annotations
 
+#: Annotation types that carry a MEASUREMENT. Everything else a drawing names — the title
+#: block, notes, centre marks — is furniture: it has a label, it changes between builds for
+#: reasons that are not dimensional, and counting it drowns the signal in exactly the noise
+#: this module exists to lift out (Codex #1001). `Leader` is in: a hole callout is dimensional
+#: content, it just renders as a leader.
+_DIMENSIONAL = frozenset({"Dimension", "Leader"})
 
-def _labelled(dwg) -> dict[str, str]:
-    """``{annotation name: label}`` for every labelled annotation on a drawing."""
+
+def _measurements(dwg) -> dict[str, str]:
+    """``{annotation name: label}`` for the DIMENSIONAL annotations only."""
     out: dict[str, str] = {}
-    for name in dwg.annotations():
+    for name, type_name in dwg.annotations().items():
+        if type_name not in _DIMENSIONAL:
+            continue
         label = getattr(dwg.get_annotation(name), "label", None)
-        if label is not None:
+        if label is not None and str(label) != "":
             out[name] = str(label)
     return out
 
@@ -44,32 +61,25 @@ def _rows(dwg) -> set[tuple]:
 def diff_builds(before, after) -> dict:
     """Compare two finished drawings: what was drawn, and what the compiler declined.
 
-    *before* and *after* are two builds you expect to differ in one property — a square part
-    and a near-square one, a feature added, a dimension authored. Returns:
+    *before* and *after* are two builds differing in one property — a square part and a
+    near-square one, a feature added, a dimension authored. Returns:
 
-    - ``dimensions_lost`` / ``dimensions_gained`` — ``{name: label}``, by annotation name;
+    - ``dimensions_lost`` / ``dimensions_gained`` — ``{name: label}``. **Every** loss appears
+      here; nothing filters this list. It is the alarm.
     - ``dimensions_changed`` — ``{name: (before, after)}`` where the annotation survived but
-      its label did not. Reported but NOT alarmed: in a perturbation study a changed value is
-      the expected result of the change, so treating it as a finding would bury the losses in
-      noise. Silence was worse, though — an 80 mm width becoming 90 produced no output at all,
-      and a surface claiming to report "what was drawn" has to be able to see that;
+      its label did not. Reported, not alarmed: in a perturbation study a changed value is the
+      expected result of the change, so ranking it with the losses would bury them in noise
+      the experiment itself creates.
     - ``suppressions_gained`` / ``suppressions_lost`` — ledger rows as
-      ``(feature, parameter_id, reason)``;
-    - ``unexplained_losses`` — the subset of ``dimensions_lost`` that **no** newly-gained
-      suppression accounts for.
+      ``(feature, parameter_id, reason)``.
+    - ``candidate_explanations`` — ``{lost name: [reason, ...]}``, a **hint** at which
+      newly-gained suppression might account for a loss, by parameter stem.
 
-    That last key is the point. A loss with a matching new suppression is a rule doing its
-    job, and the ledger names it. A loss with nothing claiming it is a measurement that left
-    the drawing without any part of the engine recording that it did — which is the class of
-    failure #997 belonged to, and the class the ledger alone cannot detect.
-
-    Matching is deliberately coarse: a lost annotation is "explained" when a gained
-    suppression mentions the same parameter stem (``m_env_depth`` ↔ ``depth.length``). It is a
-    triage signal for a human or a harness, not a proof — a precise link would need
-    provenance threaded from the planner to the placed annotation, which is ADR 0010's seam
-    and a much larger change than a comparison deserves.
+    The hint does not subtract from ``dimensions_lost``. An annotation carries no feature
+    identity, so the match cannot be trusted, and a weak match that cancels an alarm is worse
+    than no match at all — it manufactures the confidence this epic exists to remove.
     """
-    before_dims, after_dims = _labelled(before), _labelled(after)
+    before_dims, after_dims = _measurements(before), _measurements(after)
     lost = {n: v for n, v in before_dims.items() if n not in after_dims}
     gained = {n: v for n, v in after_dims.items() if n not in before_dims}
     changed = {n: (v, after_dims[n]) for n, v in before_dims.items() if after_dims.get(n, v) != v}
@@ -78,12 +88,15 @@ def diff_builds(before, after) -> dict:
     gained_supp = sorted(after_rows - before_rows)
     lost_supp = sorted(before_rows - after_rows)
 
-    stems = {str(row[1]).split(".")[0] for row in gained_supp if row[1]}
-    unexplained = {
-        name: label
-        for name, label in lost.items()
-        if not any(stem and stem in name for stem in stems)
-    }
+    candidates: dict[str, list[str]] = {}
+    for name in lost:
+        hits = [
+            reason
+            for _feature, parameter, reason in gained_supp
+            if parameter and str(parameter).split(".")[0] in name
+        ]
+        if hits:
+            candidates[name] = hits
 
     return {
         "dimensions_lost": lost,
@@ -91,20 +104,26 @@ def diff_builds(before, after) -> dict:
         "dimensions_changed": changed,
         "suppressions_gained": gained_supp,
         "suppressions_lost": lost_supp,
-        "unexplained_losses": unexplained,
+        "candidate_explanations": candidates,
     }
 
 
 def explain(diff: dict) -> list[str]:
     """The diff as lines a human or an LLM can read, most alarming first.
 
-    Ordering is the whole value: an unexplained loss is a possible engine defect, a explained
-    one is a rule working. Printing them together in dict order buries the first in the second
-    — which is how a wrong suppression stayed invisible across four issue reports.
+    Ordering is the value, not decoration. A lost dimension is a possible defect; a changed
+    one is usually the experiment working. Printed in dict order the first hides among the
+    second — which is how a wrong suppression stayed invisible across four issue reports.
+
+    Every loss gets a line. Where a suppression might account for it, that appears **on** the
+    line as a possibility, never instead of it.
     """
     out: list[str] = []
-    for name, label in sorted(diff["unexplained_losses"].items()):
-        out.append(f"UNEXPLAINED: {name} ({label}) vanished — no suppression claims it")
+    candidates = diff.get("candidate_explanations", {})
+    for name, label in sorted(diff["dimensions_lost"].items()):
+        hint = candidates.get(name)
+        why = f" — possibly: {'; '.join(hint)}" if hint else " — nothing claims it"
+        out.append(f"LOST: {name} ({label}){why}")
     for feature, parameter, reason in diff["suppressions_gained"]:
         out.append(f"suppressed: {parameter} on {feature} — {reason}")
     for name, label in sorted(diff["dimensions_gained"].items()):

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -25,6 +25,10 @@ registry slot, not a handle on what it measures. Three consequences, all real:
   feature; the annotation does not. So a candidate explanation is a *hint*, never a verdict.
 - **An unnamed annotation is invisible.** ``Drawing.annotations()`` returns only *named*
   annotations by contract, so anything placed without a name cannot be compared here at all.
+- **A hole callout's CONTENT is invisible; only its presence is seen.** It renders as a
+  ``Leader`` whose ``label`` is ``""`` — the text is built at draw time and never exposed on
+  the object. Measured: changing a bore from ⌀8 to ⌀12 produces an identical diff. So a lost
+  callout is reported, and a callout that starts saying something different is not.
 
 Closing either needs ADR 0010 provenance threaded from the planner to the placed annotation.
 Until then this is a **triage aid, not a proof** — and deliberately shaped so its weakest part

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -48,9 +48,13 @@ def _measurements(dwg) -> dict[str, str]:
     for name, type_name in dwg.annotations().items():
         if type_name not in _DIMENSIONAL:
             continue
+        # NO non-empty-label requirement. A hole callout renders as a `Leader` whose own
+        # `label` is "" — its text lives on an attached callout object, and on some paths
+        # nowhere readable at all. Requiring a label dropped those from the comparison
+        # entirely, so a vanished hole callout produced NO loss: the one thing this must
+        # never do (#996). Presence is the signal; the label is extra detail on it.
         label = getattr(dwg.get_annotation(name), "label", None)
-        if label is not None and str(label) != "":
-            out[name] = str(label)
+        out[name] = "" if label is None else str(label)
     return out
 
 

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -1,0 +1,104 @@
+"""audit — diff two builds and ask what went missing (#996 WP1 step 2).
+
+The suppression ledger (`Drawing.suppressions()`) says which rule removed a measurement. It
+answers *why* a dimension is absent, and it does so well — but only for absences some code
+path remembered to record. Three consecutive review rounds on #999 found a suppression that
+recorded nothing, each caught by a person hunting for it rather than by the ledger noticing
+its own gap. A completeness claim is worth exactly the last search behind it.
+
+**The differential does not depend on that.** Build a part twice, change one property, and
+compare: if a dimension present in one build is absent in the other, something removed it —
+whether or not anything wrote an `Omission`. It catches unknown-unknowns; the ledger reports
+known-knowns.
+
+That is how #997 was actually found. Not by reading code, and not from four issue reports
+describing its symptoms, but from one comparison:
+
+    50 x 50 -> no plan size at all
+    50 x 40 -> width and depth both stated
+
+Two builds, one property changed, and the rule fell out. This module is that experiment,
+written down.
+
+A leaf by construction: it reads the public surface of two finished ``Drawing``s and imports
+nothing from the engine, so it can never become a dependency of the thing it measures.
+"""
+
+from __future__ import annotations
+
+def _labelled(dwg) -> dict[str, str]:
+    """``{annotation name: label}`` for every labelled annotation on a drawing."""
+    out: dict[str, str] = {}
+    for name in dwg.annotations():
+        label = getattr(dwg.get_annotation(name), "label", None)
+        if label is not None:
+            out[name] = str(label)
+    return out
+
+
+def _rows(dwg) -> set[tuple]:
+    return {(r["feature"], r["parameter_id"], r["reason"]) for r in dwg.suppressions()}
+
+
+def diff_builds(before, after) -> dict:
+    """Compare two finished drawings: what was drawn, and what the compiler declined.
+
+    *before* and *after* are two builds you expect to differ in one property — a square part
+    and a near-square one, a feature added, a dimension authored. Returns:
+
+    - ``dimensions_lost`` / ``dimensions_gained`` — ``{name: label}``, by annotation name;
+    - ``suppressions_gained`` / ``suppressions_lost`` — ledger rows as
+      ``(feature, parameter_id, reason)``;
+    - ``unexplained_losses`` — the subset of ``dimensions_lost`` that **no** newly-gained
+      suppression accounts for.
+
+    That last key is the point. A loss with a matching new suppression is a rule doing its
+    job, and the ledger names it. A loss with nothing claiming it is a measurement that left
+    the drawing without any part of the engine recording that it did — which is the class of
+    failure #997 belonged to, and the class the ledger alone cannot detect.
+
+    Matching is deliberately coarse: a lost annotation is "explained" when a gained
+    suppression mentions the same parameter stem (``m_env_depth`` ↔ ``depth.length``). It is a
+    triage signal for a human or a harness, not a proof — a precise link would need
+    provenance threaded from the planner to the placed annotation, which is ADR 0010's seam
+    and a much larger change than a comparison deserves.
+    """
+    before_dims, after_dims = _labelled(before), _labelled(after)
+    lost = {n: v for n, v in before_dims.items() if n not in after_dims}
+    gained = {n: v for n, v in after_dims.items() if n not in before_dims}
+
+    before_rows, after_rows = _rows(before), _rows(after)
+    gained_supp = sorted(after_rows - before_rows)
+    lost_supp = sorted(before_rows - after_rows)
+
+    stems = {str(row[1]).split(".")[0] for row in gained_supp if row[1]}
+    unexplained = {
+        name: label
+        for name, label in lost.items()
+        if not any(stem and stem in name for stem in stems)
+    }
+
+    return {
+        "dimensions_lost": lost,
+        "dimensions_gained": gained,
+        "suppressions_gained": gained_supp,
+        "suppressions_lost": lost_supp,
+        "unexplained_losses": unexplained,
+    }
+
+
+def explain(diff: dict) -> list[str]:
+    """The diff as lines a human or an LLM can read, most alarming first.
+
+    Ordering is the whole value: an unexplained loss is a possible engine defect, a explained
+    one is a rule working. Printing them together in dict order buries the first in the second
+    — which is how a wrong suppression stayed invisible across four issue reports.
+    """
+    out: list[str] = []
+    for name, label in sorted(diff["unexplained_losses"].items()):
+        out.append(f"UNEXPLAINED: {name} ({label}) vanished — no suppression claims it")
+    for feature, parameter, reason in diff["suppressions_gained"]:
+        out.append(f"suppressed: {parameter} on {feature} — {reason}")
+    for name, label in sorted(diff["dimensions_gained"].items()):
+        out.append(f"gained: {name} ({label})")
+    return out

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -13,13 +13,18 @@ actually found: not from the four issue reports describing its symptoms, but fro
 ## What this cannot do, stated first
 
 A placed annotation carries **no measurement identity** — its name is an engine-assigned
-registry slot, not a handle on what it measures. Two consequences, both real:
+registry slot, not a handle on what it measures. Three consequences, all real:
 
-- **A replaced measurement can hide as a changed one.** Move a hole and `m_locx0` goes from
-  `70` to `90`: a different measurement reused the slot. This reports it under
-  ``dimensions_changed``, which is honest but weaker than "the 70 measurement is gone".
+- **A replaced measurement can hide completely.** Move a hole and `m_locx0` goes from `70` to
+  `90`: a different measurement reused the slot, and this reports it as a *change*. Worse, if
+  the replacement happens to render the same label, **every result map is empty** — the
+  substitution is wholly invisible. So a clean diff does **not** establish that the
+  measurements were preserved; it establishes only that nothing observable at this resolution
+  moved (Codex #1001).
 - **A loss cannot be attributed to a suppression with confidence.** The ledger row names a
   feature; the annotation does not. So a candidate explanation is a *hint*, never a verdict.
+- **An unnamed annotation is invisible.** ``Drawing.annotations()`` returns only *named*
+  annotations by contract, so anything placed without a name cannot be compared here at all.
 
 Closing either needs ADR 0010 provenance threaded from the planner to the placed annotation.
 Until then this is a **triage aid, not a proof** — and deliberately shaped so its weakest part
@@ -34,19 +39,23 @@ nothing from the engine, so the thing it measures can never come to depend on it
 
 from __future__ import annotations
 
-#: Annotation types that carry a MEASUREMENT. Everything else a drawing names — the title
-#: block, notes, centre marks — is furniture: it has a label, it changes between builds for
-#: reasons that are not dimensional, and counting it drowns the signal in exactly the noise
-#: this module exists to lift out (Codex #1001). `Leader` is in: a hole callout is dimensional
-#: content, it just renders as a leader.
-_DIMENSIONAL = frozenset({"Dimension", "Leader"})
+#: Sheet FURNITURE — the annotation types that carry no measurement. Everything else counts.
+#:
+#: A denylist, not an allowlist, and the polarity is the point (Codex #1001). An allowlist of
+#: {"Dimension", "Leader"} silently dropped `SafeDimension`, a real measurement-bearing class,
+#: and would drop every future dimensional type and subclass the same way. For a tool whose
+#: one job is not to hide a loss, an unknown type must fail toward NOISE — reported and
+#: dismissed by a reader — never toward silence. Adding a genuinely new furniture type here is
+#: a deliberate act; forgetting to add a new measurement type to an allowlist was an accident
+#: waiting to happen, and had already happened once.
+_FURNITURE = frozenset({"TitleBlock", "Note", "CenterMark"})
 
 
 def _measurements(dwg) -> dict[str, str]:
-    """``{annotation name: label}`` for the DIMENSIONAL annotations only."""
+    """``{annotation name: label}`` for everything that is not furniture."""
     out: dict[str, str] = {}
     for name, type_name in dwg.annotations().items():
-        if type_name not in _DIMENSIONAL:
+        if type_name in _FURNITURE:
             continue
         # NO non-empty-label requirement. A hole callout renders as a `Leader` whose own
         # `label` is "" — its text lives on an attached callout object, and on some paths
@@ -68,8 +77,9 @@ def diff_builds(before, after) -> dict:
     *before* and *after* are two builds differing in one property — a square part and a
     near-square one, a feature added, a dimension authored. Returns:
 
-    - ``dimensions_lost`` / ``dimensions_gained`` — ``{name: label}``. **Every** loss appears
-      here; nothing filters this list. It is the alarm.
+    - ``dimensions_lost`` / ``dimensions_gained`` — ``{name: label}``. Nothing *downstream*
+      filters this list; it is the alarm. It is not a completeness guarantee — see the
+      admission limits at the top of the module, which bound what reaches it at all.
     - ``dimensions_changed`` — ``{name: (before, after)}`` where the annotation survived but
       its label did not. Reported, not alarmed: in a perturbation study a changed value is the
       expected result of the change, so ranking it with the losses would bury them in noise

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -21,8 +21,12 @@ registry slot, not a handle on what it measures. Three consequences, all real:
   substitution is wholly invisible. So a clean diff does **not** establish that the
   measurements were preserved; it establishes only that nothing observable at this resolution
   moved (Codex #1001).
-- **A loss cannot be attributed to a suppression with confidence.** The ledger row names a
-  feature; the annotation does not. So a candidate explanation is a *hint*, never a verdict.
+- **A loss cannot be attributed to a suppression with confidence.** Feature provenance is
+  PARTIAL, not absent: ``registry.feature_of(name)`` returns the owning feature for a hole
+  callout, centre mark or location, and ``None`` for an envelope dim (measured). And even a
+  known feature does not identify *which* of its measurements an annotation is. So a candidate
+  explanation is a *hint*, never a verdict — though tightening it to feature identity where
+  provenance exists is a real improvement available today (#1002).
 - **An unnamed annotation is invisible.** ``Drawing.annotations()`` returns only *named*
   annotations by contract, so anything placed without a name cannot be compared here at all.
 - **A hole callout's CONTENT is invisible; only its presence is seen.** It renders as a
@@ -30,7 +34,8 @@ registry slot, not a handle on what it measures. Three consequences, all real:
   the object. Measured: changing a bore from ⌀8 to ⌀12 produces an identical diff. So a lost
   callout is reported, and a callout that starts saying something different is not.
 
-Closing either needs ADR 0010 provenance threaded from the planner to the placed annotation.
+Closing these needs stable MEASUREMENT identity on a placed annotation — feature provenance
+alone is not enough, and is in any case only partial today.
 Until then this is a **triage aid, not a proof** — and deliberately shaped so its weakest part
 cannot silence its strongest: a candidate suppression annotates a loss, it never removes it.
 An earlier cut let a weak substring match cancel the alarm outright, so any newly-suppressed

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -185,6 +185,56 @@ def test_sheet_furniture_is_not_a_measurement():
     )
 
 
+def test_an_unknown_annotation_type_counts_as_a_measurement():
+    """The filter is a DENYLIST, and the polarity is the point (Codex #1001 r2).
+
+    An allowlist of {"Dimension", "Leader"} silently dropped `SafeDimension` — a real
+    measurement-bearing class — and would drop every future dimensional type the same way. For
+    a tool whose one job is not to hide a loss, an unknown type must fail toward NOISE, which a
+    reader can dismiss, never toward silence, which nobody can.
+
+    This test deliberately does NOT use the implementation's own type names: it asserts that a
+    type the module has never heard of still counts. The previous version supplied the exact
+    strings the code checks and asserted their classification, which could only ever confirm
+    the implementation to itself.
+    """
+    before = _FakeDrawing(
+        {"sd0": "25", "whatever0": "9", "title_block": "DRAWING"},
+        types={
+            "sd0": "SafeDimension",
+            "whatever0": "SomeFutureDimensionKind",
+            "title_block": "TitleBlock",
+        },
+    )
+    after = _FakeDrawing({"title_block": "DRAWING"}, types={"title_block": "TitleBlock"})
+
+    lost = diff_builds(before, after)["dimensions_lost"]
+    assert "sd0" in lost, "SafeDimension is a measurement"
+    assert "whatever0" in lost, "an unknown type must fail toward noise, not silence"
+    assert "title_block" not in lost, "known furniture is still excluded"
+
+
+def test_a_same_name_same_label_replacement_is_invisible():
+    """The limit the module documents, pinned so the documentation cannot quietly drift from
+    the behaviour (Codex #1001 r2).
+
+    A name is a registry slot. If a different measurement takes the slot AND renders the same
+    label, every result map is empty — the substitution is wholly invisible. A clean diff
+    therefore does not establish that the measurements were preserved.
+
+    Asserting a KNOWN BLIND SPOT, not desired behaviour. It fails the day #1002 gives
+    annotations real identity, which is exactly when someone should come back and delete it.
+    """
+    before = _FakeDrawing({"m_locx0": "70"})
+    after = _FakeDrawing({"m_locx0": "70"})  # different measurement, same slot, same text
+
+    diff = diff_builds(before, after)
+    assert diff["dimensions_lost"] == {}
+    assert diff["dimensions_gained"] == {}
+    assert diff["dimensions_changed"] == {}
+    assert explain(diff) == [], "invisible — and the docstring says so rather than implying it"
+
+
 def test_a_labelless_callout_loss_is_still_detected():
     """A hole callout renders as a `Leader` whose own `label` is "" — its text lives on an
     attached callout object, and on some paths nowhere readable at all.

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -26,12 +26,18 @@ from draftwright.audit import diff_builds, explain
 class _FakeDrawing:
     """The three public reads `diff_builds` uses, and nothing else."""
 
-    def __init__(self, dims: dict[str, str], suppressions: list[dict] | None = None):
+    def __init__(
+        self,
+        dims: dict[str, str],
+        suppressions: list[dict] | None = None,
+        types: dict[str, str] | None = None,
+    ):
         self._dims = dims
         self._supp = suppressions or []
+        self._types = types or {}
 
     def annotations(self):
-        return dict.fromkeys(self._dims, "Dimension")
+        return {n: self._types.get(n, "Dimension") for n in self._dims}
 
     def get_annotation(self, name):
         return type("A", (), {"label": self._dims[name]})()
@@ -65,7 +71,9 @@ def test_a_loss_a_rule_accounts_for_is_not_unexplained():
 
     diff = diff_builds(before, after)
     assert set(diff["dimensions_lost"]) == {"m_env_width", "m_env_depth"}
-    assert diff["unexplained_losses"] == {}, "the ledger accounts for both"
+    # The ledger's account appears as a HINT on each loss — it does not remove the loss.
+    assert set(diff["candidate_explanations"]) == {"m_env_width", "m_env_depth"}
+    assert all(line.startswith("LOST") for line in explain(diff)[:2])
     assert any("square footprint" in line for line in explain(diff))
 
 
@@ -81,8 +89,9 @@ def test_a_loss_no_rule_claims_is_flagged():
     after = _FakeDrawing({"dim_height": "30"})  # m_locx0 gone, ledger silent
 
     diff = diff_builds(before, after)
-    assert diff["unexplained_losses"] == {"m_locx0": "33"}
-    assert explain(diff)[0].startswith("UNEXPLAINED"), "the alarm must lead the report"
+    assert diff["dimensions_lost"] == {"m_locx0": "33"}
+    assert diff["candidate_explanations"] == {}, "nothing in the ledger claims it"
+    assert explain(diff)[0] == "LOST: m_locx0 (33) — nothing claims it"
 
 
 def test_the_report_puts_the_alarm_first():
@@ -93,8 +102,8 @@ def test_the_report_puts_the_alarm_first():
     after = _FakeDrawing({"m_new": "12"}, [_supp("depth.length", "square footprint")])
 
     lines = explain(diff_builds(before, after))
-    assert lines[0].startswith("UNEXPLAINED")
-    assert sum(line.startswith("UNEXPLAINED") for line in lines) == 1
+    assert lines[0].startswith("LOST")
+    assert sum(line.startswith("LOST") for line in lines) == 2  # both losses alarm
 
 
 def test_a_changed_value_is_reported_but_not_alarmed():
@@ -116,7 +125,7 @@ def test_a_changed_value_is_reported_but_not_alarmed():
 
     lines = explain(diff)
     assert lines == ["changed: m_env_width 80 -> 90"]
-    assert not lines[0].startswith("UNEXPLAINED"), "a value change is not an alarm"
+    assert not lines[0].startswith("LOST"), "a value change is not an alarm"
 
 
 def test_a_loss_outranks_a_change_in_the_report():
@@ -126,8 +135,54 @@ def test_a_loss_outranks_a_change_in_the_report():
     after = _FakeDrawing({"m_env_width": "90"})
 
     lines = explain(diff_builds(before, after))
-    assert lines[0].startswith("UNEXPLAINED")
+    assert lines[0].startswith("LOST")
     assert lines[-1].startswith("changed:")
+
+
+def test_a_weak_hint_never_cancels_the_alarm():
+    """The dangerous direction, and the one my own tests could not have found (Codex #1001).
+
+    The first cut cancelled a loss outright when any newly-gained suppression's parameter stem
+    appeared in the lost annotation's name. Feature identity was discarded, so an unrelated
+    ENVELOPE `width.length` suppression silently excused a lost SLOT width — an alarm removed
+    by a coincidence of substrings.
+
+    An annotation carries no feature identity, so this match cannot be made reliable here; the
+    fix is that it no longer decides anything. It annotates the loss and the loss still shows.
+    """
+    before = _FakeDrawing({"m_slot_width0": "8"})
+    after = _FakeDrawing({}, [_supp("width.length", "square footprint", feature="envelope@z")])
+
+    diff = diff_builds(before, after)
+    assert diff["dimensions_lost"] == {"m_slot_width0": "8"}, "the loss must survive the hint"
+    assert explain(diff)[0].startswith("LOST: m_slot_width0")
+
+
+def test_sheet_furniture_is_not_a_measurement():
+    """A title block, a note and a centre mark all have labels and all change between builds
+    for reasons that are not dimensional. Counting them drowns the signal in the noise this
+    module exists to lift out (Codex #1001), so the diff filters on annotation TYPE."""
+    types = {
+        "title_block": "TitleBlock",
+        "note_iso_nts": "Note",
+        "m_cm0": "CenterMark",
+        "m_env_width": "Dimension",
+        "hc_plan0": "Leader",  # a hole callout IS dimensional content
+    }
+    dims = {
+        "title_block": "DRAWING",
+        "note_iso_nts": "ISO VIEW (NTS)",
+        "m_cm0": "x",
+        "m_env_width": "50",
+        "hc_plan0": "4x ø8 THRU",
+    }
+    before = _FakeDrawing(dims, types=types)
+    after = _FakeDrawing({"m_env_width": "50"}, types={"m_env_width": "Dimension"})
+
+    diff = diff_builds(before, after)
+    assert set(diff["dimensions_lost"]) == {"hc_plan0"}, (
+        "only the callout is a measurement; the title block, note and centre mark are furniture"
+    )
 
 
 def test_no_difference_reports_nothing():

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -97,6 +97,39 @@ def test_the_report_puts_the_alarm_first():
     assert sum(line.startswith("UNEXPLAINED") for line in lines) == 1
 
 
+def test_a_changed_value_is_reported_but_not_alarmed():
+    """A dimension can change without disappearing, and the first cut could not see it: an
+    80 mm width becoming 90 produced NO output at all, because the diff compared annotation
+    names and the name survived.
+
+    Reported now — a surface claiming to show "what was drawn" has to see a changed value. But
+    deliberately not an alarm: in a perturbation study a changed value is the expected result
+    of the perturbation, so ranking it with the losses would bury the signal in the noise the
+    experiment itself creates.
+    """
+    before = _FakeDrawing({"m_env_width": "80", "dim_height": "20"})
+    after = _FakeDrawing({"m_env_width": "90", "dim_height": "20"})
+
+    diff = diff_builds(before, after)
+    assert diff["dimensions_changed"] == {"m_env_width": ("80", "90")}
+    assert diff["dimensions_lost"] == {} and diff["dimensions_gained"] == {}
+
+    lines = explain(diff)
+    assert lines == ["changed: m_env_width 80 -> 90"]
+    assert not lines[0].startswith("UNEXPLAINED"), "a value change is not an alarm"
+
+
+def test_a_loss_outranks_a_change_in_the_report():
+    """Ordering again: a vanished dimension is a possible defect, a changed one is usually the
+    experiment working. The alarm must not sit below the noise."""
+    before = _FakeDrawing({"m_locx0": "33", "m_env_width": "80"})
+    after = _FakeDrawing({"m_env_width": "90"})
+
+    lines = explain(diff_builds(before, after))
+    assert lines[0].startswith("UNEXPLAINED")
+    assert lines[-1].startswith("changed:")
+
+
 def test_no_difference_reports_nothing():
     """No false positives: two identical builds produce an empty report, or the signal is
     noise and nobody reads it."""

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -256,6 +256,22 @@ def test_a_labelless_callout_loss_is_still_detected():
     assert explain(diff)[0].startswith("LOST: hc_plan0")
 
 
+def test_a_callout_content_change_is_a_documented_blind_spot():
+    """Presence is seen; CONTENT is not, for hole callouts.
+
+    A callout renders as a `Leader` whose `label` is "" — the text is built at draw time and
+    never exposed on the object. Measured on real builds: changing a bore from 8 to 12
+    produces an identical diff. Pinned as a KNOWN LIMIT so the docstring cannot drift from the
+    behaviour, and so the day the text becomes readable this test fails and someone deletes it.
+    """
+    before = _FakeDrawing({"hc_plan0": ""}, types={"hc_plan0": "Leader"})
+    after = _FakeDrawing({"hc_plan0": ""}, types={"hc_plan0": "Leader"})  # different bore
+
+    diff = diff_builds(before, after)
+    assert diff["dimensions_changed"] == {}, "no readable text, so no detectable change"
+    assert explain(diff) == []
+
+
 def test_no_difference_reports_nothing():
     """No false positives: two identical builds produce an empty report, or the signal is
     noise and nobody reads it."""

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -1,0 +1,122 @@
+"""`draftwright.audit` — diff two builds and ask what went missing (#996 WP1 step 2).
+
+The ledger says which rule removed a measurement, which is diagnosis. It cannot say that a
+measurement left without any rule recording it — three consecutive review rounds on #999 found
+suppression paths that recorded nothing, each caught by a person hunting for it rather than by
+the ledger noticing its own gap.
+
+The differential does not depend on anything having been recorded. If a dimension is present
+in one build and absent in another, something removed it. That is how #997 was actually found:
+not from four issue reports describing its symptoms, but from `50x50` vs `50x40`.
+
+Most of these tests use duck-typed stand-ins rather than real builds. The subject is the
+COMPARISON, and a real part would make the test about recognition instead — slower, and
+failing for reasons that have nothing to do with the thing under test. One end-to-end case
+keeps it honest about the real `Drawing` surface.
+"""
+
+from __future__ import annotations
+
+from build123d import Box, Cylinder, Rot
+
+from draftwright import build_drawing
+from draftwright.audit import diff_builds, explain
+
+
+class _FakeDrawing:
+    """The three public reads `diff_builds` uses, and nothing else."""
+
+    def __init__(self, dims: dict[str, str], suppressions: list[dict] | None = None):
+        self._dims = dims
+        self._supp = suppressions or []
+
+    def annotations(self):
+        return dict.fromkeys(self._dims, "Dimension")
+
+    def get_annotation(self, name):
+        return type("A", (), {"label": self._dims[name]})()
+
+    def suppressions(self):
+        return list(self._supp)
+
+
+def _supp(parameter, reason, feature="envelope@(0,0,0)/z"):
+    return {
+        "feature": feature,
+        "parameter_id": parameter,
+        "value": None,
+        "reason": reason,
+        "authored": False,
+    }
+
+
+def test_a_loss_a_rule_accounts_for_is_not_unexplained():
+    """The #997 shape, and the good case: a dimension vanished AND the ledger names why.
+
+    That is the audit working — a human reads "square footprint (single overall dim
+    suffices)" and can ask whether a 50x50 part should really have no plan size. The
+    measurement is gone, but nothing is hidden.
+    """
+    before = _FakeDrawing({"m_env_width": "50", "m_env_depth": "40", "dim_height": "30"})
+    after = _FakeDrawing(
+        {"dim_height": "30"},
+        [_supp("width.length", "square footprint"), _supp("depth.length", "square footprint")],
+    )
+
+    diff = diff_builds(before, after)
+    assert set(diff["dimensions_lost"]) == {"m_env_width", "m_env_depth"}
+    assert diff["unexplained_losses"] == {}, "the ledger accounts for both"
+    assert any("square footprint" in line for line in explain(diff))
+
+
+def test_a_loss_no_rule_claims_is_flagged():
+    """The alarm. A dimension left the drawing and NOTHING recorded that it did.
+
+    This is the class the ledger alone cannot detect, and the reason this module exists: the
+    coincident-location dedup dropped candidates before the compiler saw them, so no
+    `Omission` was ever written. A diff notices anyway, because it compares outcomes rather
+    than trusting the engine's account of itself.
+    """
+    before = _FakeDrawing({"m_locx0": "33", "dim_height": "30"})
+    after = _FakeDrawing({"dim_height": "30"})  # m_locx0 gone, ledger silent
+
+    diff = diff_builds(before, after)
+    assert diff["unexplained_losses"] == {"m_locx0": "33"}
+    assert explain(diff)[0].startswith("UNEXPLAINED"), "the alarm must lead the report"
+
+
+def test_the_report_puts_the_alarm_first():
+    """Ordering is the value, not decoration. An unexplained loss is a possible engine defect;
+    an explained one is a rule working. Interleaved in dict order, the first hides among the
+    second — which is how a wrong suppression survived four issue reports."""
+    before = _FakeDrawing({"m_locx0": "33", "m_env_depth": "40"})
+    after = _FakeDrawing({"m_new": "12"}, [_supp("depth.length", "square footprint")])
+
+    lines = explain(diff_builds(before, after))
+    assert lines[0].startswith("UNEXPLAINED")
+    assert sum(line.startswith("UNEXPLAINED") for line in lines) == 1
+
+
+def test_no_difference_reports_nothing():
+    """No false positives: two identical builds produce an empty report, or the signal is
+    noise and nobody reads it."""
+    dwg = _FakeDrawing({"m_env_width": "50"}, [_supp("depth.length", "rotational OD")])
+    diff = diff_builds(dwg, dwg)
+    assert diff["dimensions_lost"] == diff["dimensions_gained"] == {}
+    assert diff["suppressions_gained"] == diff["suppressions_lost"] == []
+    assert explain(diff) == []
+
+
+def test_it_works_on_real_drawings():
+    """One end-to-end case, so the duck types above cannot drift from the real surface.
+
+    An X-turned shaft suppresses its cross-axis extent via a LIVE rule (the OD conveys it), so
+    this exercises a genuine ledger entry rather than a fabricated one.
+    """
+    prismatic = build_drawing(Box(60, 40, 20), number="X")
+    turned = build_drawing(Rot(0, 90, 0) * Cylinder(10, 40), number="X")
+
+    diff = diff_builds(prismatic, turned)
+    assert "m_env_depth" in diff["dimensions_lost"], "the turned part states no depth"
+    reasons = " ".join(r for _, _, r in diff["suppressions_gained"])
+    assert "rotational OD" in reasons, "and the ledger says which rule took it"

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -185,6 +185,27 @@ def test_sheet_furniture_is_not_a_measurement():
     )
 
 
+def test_a_labelless_callout_loss_is_still_detected():
+    """A hole callout renders as a `Leader` whose own `label` is "" — its text lives on an
+    attached callout object, and on some paths nowhere readable at all.
+
+    The first cut required a non-empty label, so those were dropped from the comparison
+    entirely and a vanished hole callout produced NO loss. That is the single thing this
+    module must never do, and the type filter added to remove furniture is what introduced it.
+
+    Presence is the signal; the label is extra detail on it.
+    """
+    before = _FakeDrawing(
+        {"hc_plan0": "", "m_env_width": "90"},
+        types={"hc_plan0": "Leader", "m_env_width": "Dimension"},
+    )
+    after = _FakeDrawing({"m_env_width": "90"}, types={"m_env_width": "Dimension"})
+
+    diff = diff_builds(before, after)
+    assert "hc_plan0" in diff["dimensions_lost"], "a labelless callout still counts"
+    assert explain(diff)[0].startswith("LOST: hc_plan0")
+
+
 def test_no_difference_reports_nothing():
     """No false positives: two identical builds produce an empty report, or the signal is
     noise and nobody reads it."""

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -63,6 +63,10 @@ _LAYERS: dict[str, int] = {
     "intents": 0,
     "recognition": 0,
     "score": 0,  # census over recognition/ only — a leaf beside the recognisers (#704)
+    # audit: diffs two FINISHED drawings through their public reads (#996). A leaf by
+    # construction — it imports nothing from the engine, so the thing it measures can never
+    # come to depend on it.
+    "audit": 0,
     "model": 0,  # the ADR 0008 IR waist — depends only on rank-0 leaves (guarded below too)
     # 1 — the shared drawing/layout primitives
     "_core": 1,


### PR DESCRIPTION
**WP1 step 2** of #996. The ledger (#999) says *which rule* removed a measurement. This says *that a measurement left* — including when nothing recorded it.

## Why a diff, and not more ledger

Three consecutive review rounds on #999 found suppression paths that recorded no `Omission` at all. Each was caught by a person hunting for it, never by the ledger noticing its own gap. **A completeness claim is worth exactly the last search behind it**, and that search has been wrong three times.

A diff has no such dependency. If a dimension is present in one build and absent in another, something removed it — whether or not any code path remembered to write it down. The ledger reports known-knowns; the differential catches unknown-unknowns.

It is also how #997 was *actually* found. Not by reading code, and not from the four issue reports describing its symptoms, but from one comparison:

```
50 x 50  ->  no plan size at all
50 x 40  ->  width and depth both stated
```

This module is that experiment, written down.

## Shape

`diff_builds(before, after)` → what was drawn, what the compiler declined, and the key that matters:

**`unexplained_losses`** — dimensions that vanished with **no** newly-gained suppression accounting for them. A loss the ledger explains is a rule doing its job. A loss nothing claims is the class the ledger cannot detect.

`explain()` orders the report **alarm-first**, deliberately: an unexplained loss is a possible defect, an explained one is a rule working, and interleaved in dict order the first hides among the second — which is how a wrong suppression survived four issue reports.

## Verified against the real bug

With #997's rule temporarily reintroduced:

```
lost       : {'m_env_width': '50', 'm_env_depth': '40'}
unexplained: {}
--- report ---
  suppressed: depth.length on envelope@(...) — square footprint (single overall dim suffices)
  suppressed: width.length on envelope@(...) — square footprint (single overall dim suffices)
```

The diagnosis, automatically, from two builds. `unexplained` is empty here and that is **correct** — the ledger accounts for both, which is the tool distinguishing "a rule did this" from "nobody knows".

## Placement

A rank-0 leaf beside `score.py`: it reads the public surface of two finished `Drawing`s and imports nothing from the engine, so the thing it measures can never come to depend on it. Registered in `_LAYERS` with that rationale.

## Stated limits

The "explained" link is **stem matching** (`m_env_depth` ↔ `depth.length`) and the docstring says so. It is triage for a human or a harness, not proof. A precise link needs ADR 0010 provenance threaded from the planner to the placed annotation — a far larger change than a comparison deserves, and not one to smuggle in here.

## Tests

Five, mostly against duck-typed stand-ins: the subject is the **comparison**, and real parts would make the tests about recognition instead — slower, and failing for reasons unrelated to what is under test. One end-to-end case against real `Drawing`s keeps the stand-ins honest, using the live X-turned rotational rule rather than a fabricated ledger row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
