### PR TITLE
feat(#1002): record which measurement an annotation draws

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -49,18 +49,21 @@ from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
 _log = logging.getLogger(__name__)
 
 
-def place_annotation(registry, items, obj, name=None, view=None, feature=None):
+def place_annotation(registry, items, obj, name=None, view=None, feature=None, measurement=None):
     """The annotation-placement primitive (#817): register *obj* under *name* — replacing any
     prior object of that name (dropped from the render list *items*) so a name maps to one
     object — append it to *items*, and record its owning *view* + source *feature* in *registry*.
     Shared by :meth:`Drawing._add` and :meth:`PlacementContext.place` so the render passes place
-    annotations without reaching into the ``Drawing``. Returns *obj*."""
+    annotations without reaching into the ``Drawing``. Returns *obj*.
+
+    *measurement* is the `DimensionId` *obj* draws, where the caller holds one (#1002) —
+    one axis finer than *feature*, since a feature has several measurements."""
     displaced = registry.named(name) if name is not None else None
     if displaced is not None:
         items.remove(displaced)
     annotate(obj, name)
     items.append(obj)
-    registry.add(obj, name, view, feature)
+    registry.add(obj, name, view, feature, measurement)
     return obj
 
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -840,6 +840,11 @@ class CorridorCandidate:
     # The source IR feature this dim was rendered for — recorded as provenance when the
     # dim is placed at drain (ADR 0010). ``None`` leaves the annotation feature-less.
     feature: object | None = None
+    # The `DimensionId` this candidate draws, where the renderer holds an
+    # `ApprovedDimension` to take it from (#1002). Peer to `feature` and recorded the same
+    # way at drain, one axis finer: `feature` says which hole, this says which of its
+    # measurements. ``None`` for a candidate whose renderer places directly (#754).
+    measurement: object | None = None
     # Real stacking-axis + perpendicular footprint ``(w, h)`` in page-mm, or ``None`` to
     # use the dimension default ``(tier, tier)``. Wide/tall occupants (a GD&T feature
     # control frame is ~24×6 mm) set this so the strip solve reserves their true extent
@@ -943,6 +948,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
     # A migrated renderer passes the opaque handle through; `resolve_feature` is a
     # no-op for the unmigrated ones that still pass the feature itself.
     feats = {c.name: resolve_feature(c.feature) for c in kept if c.feature is not None}
+    meas = {c.name: c.measurement for c in kept if c.measurement is not None}
     sizes = {c.name: c.size for c in kept if c.size is not None}  # real footprint (#61)
     forbid = {c.name: c.forbid for c in kept if c.forbid is not None}  # title-block box (#481)
     prio = {c.name: c.priority for c in kept if c.priority}  # over-capacity survival rank (#357)
@@ -960,6 +966,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             tier,
             ctx=ctx,
             features=feats,
+            measurements=meas,
             sizes=sizes,
             forbid=forbid,
             priorities=prio,
@@ -986,6 +993,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
                 footprints=foots,
                 corner_reserves=corner_reserves,
                 features=feats,
+                measurements=meas,
                 sizes=sizes,
                 forbid=forbid,
                 priorities=prio,
@@ -1079,7 +1087,7 @@ class PlacementContext:
     # per-ctx (per-run) index is correct (mirrors the old ``Drawing._hole_feature_index``).
     _hole_feature_index: Any = field(default=None, repr=False)
 
-    def place(self, obj, name=None, view=None, feature=None):
+    def place(self, obj, name=None, view=None, feature=None, measurement=None):
         """Place an annotation onto the drawing through this context (#817) — the render passes'
         door to the placement primitive, so a pass never reaches into the ``Drawing`` (ADR 0005
         §2). Registers *obj* under *name* (owning *view* + source *feature*) and appends it to the
@@ -1090,7 +1098,7 @@ class PlacementContext:
                 "with items=dwg.items (the orchestrator and Drawing verbs already do; a unit test "
                 "calling a render helper must pass it too)."
             )
-        return place_annotation(self.registry, self.items, obj, name, view, feature)
+        return place_annotation(self.registry, self.items, obj, name, view, feature, measurement)
 
     def feature_of_hole_at(self, location):
         """The IR hole/pattern feature whose member sits at model-space *location*, or ``None``
@@ -1195,6 +1203,7 @@ def place_strip_candidates(
     ctx,
     force=False,
     features=None,
+    measurements=None,
     sizes=None,
     forbid=None,
     priorities=None,
@@ -1502,7 +1511,13 @@ def place_strip_candidates(
         for name, dim in placed:
             # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
             # dims — `features` maps this batch's names to their source IR feature.
-            ctx.place(dim, name, view=view, feature=(features or {}).get(name))
+            ctx.place(
+                dim,
+                name,
+                view=view,
+                feature=(features or {}).get(name),
+                measurement=(measurements or {}).get(name),
+            )
     if tp is not None:
         tp["unplaced"] = [n for n, _ in todo]
         trace.end_pass(tp)  # folds a standalone pass's items; no-op when corridor-nested

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -629,9 +629,15 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         for u in x_refs:
             if abs(r[0] - u[0]) < 0.5:
                 u[3] = u[3] or r[2] in pinned_set
+                # Collapsing coincident Xs into one dim must ACCUMULATE what it draws
+                # (#1002 r4): the survivor genuinely measures every collapsed feature's X.
+                if r[3] is not None and r[3] not in u[4]:
+                    u[4].append(r[3])
                 break
         else:
-            x_refs.append([r[0], r[1], r[2], r[2] in pinned_set, r[3]])
+            x_refs.append(
+                [r[0], r[1], r[2], r[2] in pinned_set, [r[3]] if r[3] is not None else []]
+            )
     _x_drawable = {r[0] for r in x_refs if abs(r[0] - datum_x) * a.SCALE >= 1.0}
     _kept_x, _n_x_close = _legible_locations(_x_drawable, a.SCALE)
     if _n_x_close:
@@ -650,7 +656,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     # pass carving around the other and interleaving. No alternate view for a plan-X
     # location, so a corridor-blocked dim is force-kept (policy B), not relocated; only a
     # physically full strip drops (→ location_ref_dropped, escalates the hole table).
-    for i, (rx, ry, feat, pin_ref, mid) in enumerate(
+    for i, (rx, ry, feat, pin_ref, mids) in enumerate(
         sorted(x_refs, key=lambda r: abs(r[0] - datum_x))
     ):
         if abs(rx - datum_x) * a.SCALE < 1.0:
@@ -661,10 +667,14 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         # dimension and annotations_of never over-claims it (review #406, ADR 0010).
         _shared_x = any(abs(o[0] - rx) < 0.5 and o[2] != feat for o in refs)
         _xfeat = None if _shared_x else feat
-        # The measurement id follows the feature for the same reason (#1002), and more
-        # strictly: a shared dim genuinely IS both features' X location, so naming one of
-        # them would be a false attribution the audit then reports as exact.
-        _xmid = None if _shared_x else mid
+        # The measurement does NOT follow the feature (#1002 r4). Feature-unowned is an
+        # ADR 0010 *ownership* rule — it stops drop(feature) stripping a sibling's dim. It
+        # says nothing about what the dim measures, and a shared dim measures BOTH features'
+        # X location. The first cut dropped the id here as though naming one feature were the
+        # only option; recording all of them is both true and exactly what the tuple-valued
+        # channel exists for (ADR 0016 / #886). Discarding it made the audit blind on an
+        # ordinary dedup path.
+        _xmid = tuple(mids)
         register_corridor(
             ctx,
             ("plan", "above"),
@@ -710,9 +720,13 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         for u in y_refs:
             if abs(r[1] - u[1]) < 0.5:
                 u[3] = u[3] or r[2] in pinned_set
+                if r[3] is not None and r[3] not in u[4]:
+                    u[4].append(r[3])  # accumulate, as in the X loop (#1002 r4)
                 break
         else:
-            y_refs.append([r[0], r[1], r[2], r[2] in pinned_set, r[3]])
+            y_refs.append(
+                [r[0], r[1], r[2], r[2] in pinned_set, [r[3]] if r[3] is not None else []]
+            )
     _y_drawable = {r[1] for r in y_refs if abs(r[1] - datum_y) * a.SCALE >= 1.0}
     _kept_y, _n_y_close = _legible_locations(_y_drawable, a.SCALE)
     if _n_y_close:
@@ -728,9 +742,9 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     # Cap the side-above strip below the iso view so Y-location dims never run under it
     # (the carve respects outer_limit); the dim_pitch_side dims are obstacles the carve
     # avoids structurally, retiring the old manual allocate(10.0) reservation + cursor.
-    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _feat, _pin, _mid in y_refs):
+    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _feat, _pin, _mids in y_refs):
         a.sv_zones.above.outer_limit = min(a.sv_zones.above.outer_limit, iso_y0 - 4)
-    for i, (rx, ry, feat, pin_ref, mid) in enumerate(
+    for i, (rx, ry, feat, pin_ref, mids) in enumerate(
         sorted(y_refs, key=lambda r: abs(r[1] - datum_y))
     ):
         if abs(ry - datum_y) * a.SCALE < 1.0:
@@ -739,7 +753,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         # Shared-Y location dim → unowned (see the X loop; review #406).
         _shared_y = any(abs(o[1] - ry) < 0.5 and o[2] != feat for o in refs)
         _yfeat = None if _shared_y else feat
-        _ymid = None if _shared_y else mid  # see the X loop (#1002)
+        _ymid = tuple(mids)  # every collapsed feature's Y — see the X loop (#1002 r4)
         register_corridor(
             ctx,
             ("side", "above"),

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1220,7 +1220,13 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                 if thr:
                     label += f" {thr}"
                 name = f"m_dia_y{start_y + i}"
-                jobs.append((name, "front", vb, label, candidates))
+                # One ø callout stands for every step sharing this diameter, so it draws
+                # each of their diameter dims (#1002). Empty when a group planned none —
+                # recorded as unknown, which is the honest answer, not a guessed id.
+                mids = tuple(
+                    pd.id for gp in feature_groups for pd in gp.dims if pd.kind == "diameter"
+                )
+                jobs.append((name, "front", vb, label, candidates, mids))
                 covered_by_name[name] = dia
             placed += _leader_callout_pass(
                 dwg,
@@ -1439,8 +1445,12 @@ def _corner_candidates(dwg, view, vb, members, reach, *, provenances=None):
 
 def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False) -> int:
     """Place one machined-feature leader callout per job (#637). A *job* is
-    ``(name, view, vb, label, candidates)`` where *candidates* yields ``(tip, elbow,
-    feature)`` lead positions to try in order. Places the first Leader whose label lands clear
+    ``(name, view, vb, label, candidates, measurement)`` where *candidates* yields ``(tip,
+    elbow, feature)`` lead positions to try in order and *measurement* is the tuple of
+    `DimensionId`s the callout's label draws — several, because these callouts are compound:
+    a pocket prints width × length × depth, a groove width × ⌀ (#1002 r3, which found the
+    whole machined-feature group recording nothing at all).
+    Places the first Leader whose label lands clear
     (:func:`_label_lands_clear`, with *geom_clear* passed through), attributed to that
     candidate's feature; if none of a job's candidates land, records ``<noun> callout … not
     placed`` as ``<drop_code>`` lint (never a silent drop). Obstacles are recomputed per job
@@ -1455,7 +1465,7 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
     ev = trace.pass_event(f"{noun}_callouts") if trace is not None and jobs else None
     page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
     n = 0
-    for name, view, vb, label, candidates in jobs:
+    for name, view, vb, label, candidates, measurement in jobs:
         obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
         tried = 0
         for tip, elbow, feature in candidates:
@@ -1464,8 +1474,15 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
             if _label_lands_clear(ldr, obstacles, vb, page, geom_clear=geom_clear):
                 # Compiled renderers carry opaque FeatureRefs so they cannot recover
                 # measurements from the source feature. Provenance is the one seam
-                # where the registry intentionally needs the source object itself.
-                ctx.place(ldr, name, view=view, feature=resolve_feature(feature))
+                # where the registry intentionally needs the source object itself —
+                # the measurements come down the job, from the planner (#1002).
+                ctx.place(
+                    ldr,
+                    name,
+                    view=view,
+                    feature=resolve_feature(feature),
+                    measurement=measurement,
+                )
                 if ev is not None:
                     ev["items"].append(
                         {
@@ -1545,6 +1562,7 @@ def render_chamfers(dwg, plan, a, *, ctx, only=None) -> int:
                 vb,
                 _chamfer_label(pd.value_text, pd.value, ch) + _tol_suffix(pd.tolerance, draft),
                 _corner_candidates(dwg, view, vb, [ch], reach, provenances=[g.ref]),
+                (pd.id,),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="chamfer", drop_code="chamfer_dropped", ctx=ctx)
@@ -1621,6 +1639,9 @@ def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
                     reach,
                     provenances=[g.ref for g, _ in ordered],
                 ),
+                # One `n× R` callout stands for EVERY collapsed member, so it draws all of
+                # their radii — the tuple storage exists for exactly this (#1002).
+                tuple(pd.id for _, pd in ordered),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped", ctx=ctx)
@@ -1691,6 +1712,7 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
                     reach,
                     provenances=[g.ref for g, _ in ordered],
                 ),
+                tuple(pd.id for _, pd in ordered),  # the grouped callout draws every member
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="flat", drop_code="flat_dropped", ctx=ctx)
@@ -1868,6 +1890,7 @@ def render_pockets(dwg, plan, a, *, ctx, only=None) -> int:
                     dsfx=_tol_suffix(dpd.tolerance, draft),
                 ),
                 _radial_candidates(dwg, view, vb, pk, reach, provenance=g.ref),
+                (wpd.id, lpd.id, dpd.id),  # width × length × depth, one callout (#1002)
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="pocket", drop_code="pocket_dropped", ctx=ctx)
@@ -1924,6 +1947,7 @@ def render_grooves(dwg, plan, a, *, ctx, only=None) -> int:
                     dsfx=_tol_suffix(dpd.tolerance, draft),
                 ),
                 _radial_candidates(dwg, view, vb, gr, reach, provenance=g.ref),
+                (wpd.id, dpd.id),  # one callout, two measurements (#1002)
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="groove", drop_code="groove_dropped", ctx=ctx)
@@ -1987,6 +2011,7 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
                 _radial_candidates(
                     dwg, view, vb, b, reach, rim=dia / 2 * a.SCALE, provenance=g.ref
                 ),
+                (dpd.id,),
             )
         )
     return _leader_callout_pass(

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1329,7 +1329,7 @@ def _reroute_crossing_diameters(dwg, *, ctx) -> int:
             _pt(tip[ax], fb[rad] - gap),
             _pt(tip[ax], fb[rad + 2] + gap),
         )
-        feat = dwg.registry.feature_of(name)
+        ident = dwg.registry.identity_of(name)  # every axis, as a unit (#1002)
         old = dwg.remove(name)  # remove first so obstacles exclude the leader being replaced
         placed_it = False
         try:
@@ -1349,14 +1349,16 @@ def _reroute_crossing_diameters(dwg, *, ctx) -> int:
                 box = _anno_box(cand)
                 if box is None or not _within_page(box) or _box_hits(box, obstacles):
                     continue
-                ctx.place(cand, name, view="front", feature=feat)
+                ctx.place(cand, name, view="front")
+                dwg.registry.reapply(name, ident)  # the re-routed leader draws the same thing
                 rerouted += 1
                 placed_it = True
                 break
         except Exception:  # noqa: BLE001 — a re-route error must never lose the leader
             placed_it = False
         if not placed_it and dwg.get_annotation(name) is None:
-            ctx.place(old, name, view="front", feature=feat)  # restore (Phase-1 flags it)
+            ctx.place(old, name, view="front")  # restore (Phase-1 flags it)
+            dwg.registry.reapply(name, ident)
     return rerouted
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -319,6 +319,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                         tier,
                         ctx=ctx,
                         features={cname: s},
+                        measurements={cname: approved.id},  # #1002
                         trace=ctx.trace,
                         trace_label=f"slot_{side}",
                     ):
@@ -362,6 +363,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                         tier,
                         ctx=ctx,
                         features={cname: _feat},
+                        measurements={cname: approved.id},  # #1002
                         trace=ctx.trace,
                         trace_label=f"slot_{_fsd}_fallthrough",
                     ):
@@ -397,6 +399,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                     ),
                     on_place=lambda nm: None,
                     on_drop=_far_or_drop,
+                    measurement=approved.id,  # #1002
                     dedup=(
                         (vw[0], round(meas_proj(raw_lo), 1), round(meas_proj(raw_hi), 1))
                         if is_pos
@@ -2168,12 +2171,17 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
         def _foot(pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl):
             return dim_footprint(pa, pb, side, pos - edge, draft, lbl)
 
-        def _drop(nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=g.ref):  # noqa: B008
+        def _drop(nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=g.ref, mid=pd.id):  # noqa: B008
             # Opposite-strip fallthrough (mirrors the GD&T #481 pattern), DEFERRED to
             # ctx.post_drain so it runs after EVERY corridor has drained (#684 review):
             # a mid-drain carve could occupy a corner a later sibling's force candidate
             # needs; post-drain, carve_free_position sees all placed annotations.
-            def _retry(nm=nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=feat):
+            # `mid` is bound as a DEFAULT like every sibling here: `pd` is the enclosing
+            # loop's variable and these retries run post-drain, so reading it live would
+            # record the LAST plate's identity on every one of them (#1002).
+            def _retry(
+                nm=nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=feat, mid=mid
+            ):
                 for view2, side2, strip2, axis2, qa, qb, edge2 in alt or ():
                     if strip2 is None:
                         continue
@@ -2199,7 +2207,7 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
                             or real[3] > page[3]
                         ):
                             continue
-                        ctx.place(dim, nm, view=view2, feature=feat)
+                        ctx.place(dim, nm, view=view2, feature=feat, measurement=mid)
                         return
                 ctx.record_issue(
                     "warning",
@@ -2233,6 +2241,7 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
                 on_drop=_drop,
                 force=True,
                 feature=g.ref,  # opaque provenance handle
+                measurement=pd.id,  # #1002
                 footprint=_foot,  # analytical measure — no probe build (#602)
             ),
         )
@@ -3105,6 +3114,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 on_drop=_drop_left,
                 force=True,
                 feature=step,
+                measurement=rung.id,  # #1002
                 footprint=lambda pos, zbase=zbase, ztop=ztop, label=label: dim_footprint(
                     (left_edge, zbase, 0),
                     (left_edge, ztop, 0),
@@ -3227,6 +3237,7 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
                 force=True,
                 # The opaque provenance handle, passed straight through.
                 feature=ladder.ref,
+                measurement=rung.id,  # #1002
             ),
         )
         n += 1

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -509,6 +509,7 @@ def _location_candidate(
     distance,
     build,
     feature=None,
+    measurement=None,
     pinned=False,
     footprint=None,
 ):
@@ -543,6 +544,7 @@ def _location_candidate(
         priority=PRIORITY.MANDATORY if pinned else PRIORITY.AUTO,
         force=True,
         feature=feature,  # provenance (ADR 0010): the located hole/pattern
+        measurement=measurement,  # which of its measurements this is (#1002)
         footprint=footprint,  # analytical measure — no probe build (#602)
     )
 
@@ -594,7 +596,10 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
             continue
         # Provenance (ADR 0010): the located feature. `resolve_feature` is the sanctioned
         # seam for exactly this — the corridor's feature map keys drop()/annotations_of().
-        refs.append((rx, ry, resolve_feature(loc.ref)))
+        # `loc.id` rides along as the measurement identity (#1002): the compiler already
+        # minted it for this very entry, so the renderer records WHICH measurement it drew
+        # rather than leaving the audit to infer it from the annotation's name.
+        refs.append((rx, ry, resolve_feature(loc.ref), loc.id))
     if not refs:
         return 0
     pinned_set = set(pinned or ())
@@ -623,7 +628,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                 u[3] = u[3] or r[2] in pinned_set
                 break
         else:
-            x_refs.append([r[0], r[1], r[2], r[2] in pinned_set])
+            x_refs.append([r[0], r[1], r[2], r[2] in pinned_set, r[3]])
     _x_drawable = {r[0] for r in x_refs if abs(r[0] - datum_x) * a.SCALE >= 1.0}
     _kept_x, _n_x_close = _legible_locations(_x_drawable, a.SCALE)
     if _n_x_close:
@@ -642,14 +647,21 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     # pass carving around the other and interleaving. No alternate view for a plan-X
     # location, so a corridor-blocked dim is force-kept (policy B), not relocated; only a
     # physically full strip drops (→ location_ref_dropped, escalates the hole table).
-    for i, (rx, ry, feat, pin_ref) in enumerate(sorted(x_refs, key=lambda r: abs(r[0] - datum_x))):
+    for i, (rx, ry, feat, pin_ref, mid) in enumerate(
+        sorted(x_refs, key=lambda r: abs(r[0] - datum_x))
+    ):
         if abs(rx - datum_x) * a.SCALE < 1.0:
             continue  # on the datum edge — nothing to dimension
         n += 1
         # A single X-location dim shared by two *distinct* features at this X belongs to
         # neither exclusively — leave it unowned so drop() cannot over-strip a sibling's
         # dimension and annotations_of never over-claims it (review #406, ADR 0010).
-        _xfeat = None if any(abs(o[0] - rx) < 0.5 and o[2] != feat for o in refs) else feat
+        _shared_x = any(abs(o[0] - rx) < 0.5 and o[2] != feat for o in refs)
+        _xfeat = None if _shared_x else feat
+        # The measurement id follows the feature for the same reason (#1002), and more
+        # strictly: a shared dim genuinely IS both features' X location, so naming one of
+        # them would be a false attribution the audit then reports as exact.
+        _xmid = None if _shared_x else mid
         register_corridor(
             ctx,
             ("plan", "above"),
@@ -673,6 +685,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                     label=_fmt(_rx - datum_x),
                 ),
                 feature=_xfeat,
+                measurement=_xmid,
                 pinned=pin_ref,
                 footprint=lambda pos, _rx=rx, _ry=ry: dim_footprint(
                     (PX(datum_x), PY(_ry), 0),
@@ -696,7 +709,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                 u[3] = u[3] or r[2] in pinned_set
                 break
         else:
-            y_refs.append([r[0], r[1], r[2], r[2] in pinned_set])
+            y_refs.append([r[0], r[1], r[2], r[2] in pinned_set, r[3]])
     _y_drawable = {r[1] for r in y_refs if abs(r[1] - datum_y) * a.SCALE >= 1.0}
     _kept_y, _n_y_close = _legible_locations(_y_drawable, a.SCALE)
     if _n_y_close:
@@ -712,14 +725,18 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     # Cap the side-above strip below the iso view so Y-location dims never run under it
     # (the carve respects outer_limit); the dim_pitch_side dims are obstacles the carve
     # avoids structurally, retiring the old manual allocate(10.0) reservation + cursor.
-    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _feat, _pin in y_refs):
+    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _feat, _pin, _mid in y_refs):
         a.sv_zones.above.outer_limit = min(a.sv_zones.above.outer_limit, iso_y0 - 4)
-    for i, (rx, ry, feat, pin_ref) in enumerate(sorted(y_refs, key=lambda r: abs(r[1] - datum_y))):
+    for i, (rx, ry, feat, pin_ref, mid) in enumerate(
+        sorted(y_refs, key=lambda r: abs(r[1] - datum_y))
+    ):
         if abs(ry - datum_y) * a.SCALE < 1.0:
             continue
         n += 1
         # Shared-Y location dim → unowned (see the X loop; review #406).
-        _yfeat = None if any(abs(o[1] - ry) < 0.5 and o[2] != feat for o in refs) else feat
+        _shared_y = any(abs(o[1] - ry) < 0.5 and o[2] != feat for o in refs)
+        _yfeat = None if _shared_y else feat
+        _ymid = None if _shared_y else mid  # see the X loop (#1002)
         register_corridor(
             ctx,
             ("side", "above"),
@@ -743,6 +760,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                     label=_fmt(_ry - datum_y),
                 ),
                 feature=_yfeat,
+                measurement=_ymid,
                 pinned=pin_ref,
                 footprint=lambda pos, _ry=ry: dim_footprint(
                     (SX(datum_y), SZ(a.bb.max.Z), 0),
@@ -2026,6 +2044,7 @@ def render_boss_heights(dwg, plan, a, *, ctx) -> int:
                 on_drop=lambda _nm: None,
                 force=True,
                 feature=g.ref,
+                measurement=pd.id,
                 footprint=footprint,
             ),
         )
@@ -2236,7 +2255,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         return 0
     n = 0
 
-    def _queue(name, strip, view, tier, distance, build, footprint=None):
+    def _queue(name, strip, view, tier, distance, build, footprint=None, measurement=None):
         register_corridor(
             ctx,
             (view, "below"),
@@ -2252,6 +2271,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                 on_drop=lambda _nm: None,
                 priority=_MANDATORY_OVERALL_PRIORITY,
                 force=True,
+                measurement=measurement,  # which envelope extent this is (#1002)
                 footprint=footprint,  # analytical measure — no probe build (#602)
             ),
         )
@@ -2278,6 +2298,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.value_text: dim_footprint(
                 (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v
             ),
+            measurement=width.id,
         )
         n += 1
     depth = env.dim(role="depth")
@@ -2302,6 +2323,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.value_text: dim_footprint(
                 (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v
             ),
+            measurement=depth.id,
         )
         n += 1
     return n
@@ -2902,7 +2924,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     has_shoulders = plan.ladder("step_position") is not None
     short_rungs: list = []
 
-    # The chain, inner→outer: (name, page-z top, label, tier size, drop message).
+    # The chain, inner→outer: (name, page-z span, label, tier size, drop message, dim id).
     chain: list = []
     if rung_set is not None and rung_set.representative:
         (rep,) = rungs
@@ -2913,6 +2935,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 rep.final_label,
                 _SLOT_DIM_STEP,
                 "representative step-height dimension dropped (front-view right strip full)",
+                rep.id,
             )
         )
     elif rungs:
@@ -2956,6 +2979,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                     rung.final_label,
                     _SLOT_DIM_STEP,
                     "step-height dimension dropped (front-view right strip full)",
+                    rung.id,
                 )
             )
 
@@ -2969,12 +2993,13 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 height.final_label,
                 _SLOT_DIM_HEIGHT,
                 "overall height dimension dropped (front-view right strip full)",
+                height.id,
             )
         )
 
     names = [c[0] for c in chain]
     solved: dict[str, float] = {}
-    for k, (name, zbase, ztop, label, _tsize, drop_msg) in enumerate(chain):
+    for k, (name, zbase, ztop, label, _tsize, drop_msg, mid) in enumerate(chain):
 
         def _build(pos, name=name, zbase=zbase, ztop=ztop, label=label, k=k):
             base = edge2
@@ -3032,6 +3057,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 # than tying with them at 0 and losing on the generated key (#894).
                 priority=_PRINCIPAL_CHAIN_PRIORITY,
                 feature=step if name != "dim_height" else None,
+                measurement=mid,  # the rung's own compiled id (#1002)
                 footprint=_foot,
             ),
         )

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -270,7 +270,7 @@ def add_feature_location(
     def _uniq(prefix: str) -> str:
         return f"{prefix}{_first_free_index(prefix, ctx.registry)}"
 
-    def _place(view: str, strip, p1, p2, baseline, label: str) -> str:
+    def _place(view: str, strip, p1, p2, baseline, label: str, mid=None) -> str:
         perp = (min(p1, p2), max(p1, p2))
         pos = carve_free_position(dwg, strip, view, "y", tier, perp) if strip is not None else None
         if pos is None:  # strip full / absent — fall back just above the view
@@ -284,6 +284,7 @@ def add_feature_location(
             nm,
             view=view,
             feature=feature,
+            measurement=mid,  # the compiled location this dim draws (#1002)
         )
         if pin:
             dwg.pin(nm)
@@ -314,6 +315,7 @@ def add_feature_location(
                     PX(rx),
                     PY(ry),
                     _fmt(rx - dx),
+                    loc.id,
                 )
             )
         if (
@@ -330,6 +332,7 @@ def add_feature_location(
                     SX(ry),
                     SZ(a.bb.max.Z),
                     _fmt(ry - dy),
+                    loc.id,
                 )
             )
     return names
@@ -1452,6 +1455,7 @@ def render_pocket_patterns(dwg, plan, a, *, ctx, only=None) -> int:
                 vb,
                 label,
                 _radial_candidates(dwg, view, vb, feat, reach, provenance=g.ref),
+                (wpd.id, lpd.id, dpd.id),  # width × length × depth, one callout (#1002)
             )
         )
         furniture.append((i, g, view, name))
@@ -1561,6 +1565,7 @@ def render_slot_patterns(dwg, plan, a, *, ctx, only=None) -> int:
                 vb,
                 label,
                 _radial_candidates(dwg, view, vb, feat, reach, provenance=g.ref),
+                (wpd.id, lpd.id),  # width × length, one callout (#1002)
             )
         )
         furniture.append((i, g, view, name))

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -736,7 +736,10 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
         replaced = {
             n: o for n, o in list(dwg.iter_annotations()) if ctx.coverage.is_scattered_hole_doc(n)
         }
-        replaced_view = {n: dwg.view_of(n) for n in replaced}
+        # Identity as a UNIT (#1002). This captured the view alone, so a restored dim came
+        # back stripped of the feature provenance added in #398 and of the measurement id
+        # added here — the audit would then read it as "nothing claims it" (Codex r2).
+        replaced_identity = {n: dwg.registry.identity_of(n) for n in replaced}
         for n in replaced:
             dwg.remove(n)
 
@@ -754,7 +757,8 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):
             # drop lint, so the sheet is never left with neither. The pattern
             # balloons below are unaffected — nothing of theirs was removed.
             for n, obj in replaced.items():
-                ctx.place(obj, n, view=replaced_view.get(n))
+                ctx.place(obj, n)
+                dwg.registry.reapply(n, replaced_identity[n])
             ctx.record_issue("warning", "table_dropped", "hole table did not fit the sheet")
         else:
             # One entry per hole (with repeats) so the coverage *count* check sees

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -618,9 +618,7 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
             # room. The corridor solve now places dim_height when it fits — so on a
             # no-room prismatic detail, demote it DELIBERATELY (same outcome, now
             # explicit and logged) and retry the detail once.
-            hview = dwg.view_of(hname)
-            hfeat = dwg.registry.feature_of(hname)
-            hpinned = dwg.registry.is_pinned(hname)
+            ident = dwg.registry.identity_of(hname)
             hobj = dwg.remove(hname)
             placed = _render_detail(dwg, a, req, f"detail_{letter.lower()}", letter, ctx=ctx)
             if placed:
@@ -633,12 +631,11 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
                 # remove() also forgot the feature provenance + pin (#89), so restore
                 # them (user review): without the feature the restored dim drops off
                 # annotations_of(envelope) / drop(feature), and a later finalize's
-                # _overall_height_name can no longer rediscover it. (hpinned is
-                # defensive — _overall_height_name never returns a pinned name — but
-                # keeps this remove/re-add correct in isolation.)
-                ctx.place(hobj, hname, view=hview, feature=hfeat)
-                if hpinned:
-                    dwg.pin(hname)
+                # _overall_height_name can no longer rediscover it. Restored as one
+                # unit (#1002) — enumerating the axes here is what left the measurement
+                # behind when it was added (Codex r2).
+                ctx.place(hobj, hname)
+                dwg.registry.reapply(hname, ident)
         if placed:
             n_placed += 1
         elif req.kind == "prismatic-steps":

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -16,12 +16,20 @@ A placed annotation carries measurement identity only where the renderer recorde
 (#1002) — otherwise its name is an engine-assigned registry slot, not a handle on what it
 measures. **Identity is partial, and every limit below is a consequence of where it is
 missing.** Which renderers record it is not described here in prose, because a prose
-description of that set was wrong the first time it was written: it named only the
-direct-placing group while four compiled-plan renderers were also silently dropping their
-ids (Codex #1002 r1). `tests/test_audit_differential.py` enumerates the set mechanically and
-fails when a renderer forgets, so **that test is the answer**, not this paragraph. The
-standing exceptions are hole callouts (on the legacy surface, #926), PMI (from STEP, never
-compiled), GD&T frames (not measurements) and the direct-placing rotational group (#754).
+description of that set has now been wrong TWICE: first it named only the direct-placing
+group while four compiled-plan renderers dropped their ids (Codex r1), then it listed a
+four-item exception set while the entire shared machined-feature renderer — chamfers,
+fillets, flats, pockets, grooves, boss diameters — recorded nothing (Codex r3). The prose
+was believable both times, which is the point.
+
+The answer lives in `tests/test_audit_differential.py`, whose ratchet scans both placement
+paths (corridor candidates and direct `ctx.place`) across the whole `annotations/` package,
+and whose EXEMPT map IS the exception inventory — every entry carrying its reason, and a
+stale entry failing so the list cannot outlive the gaps it describes. Read that, not this
+paragraph. At the time of writing the gaps are hole callouts (legacy surface, #926), PMI
+(from STEP, never compiled), GD&T frames (not measurements), the direct-placing rotational
+group (#754), the turned step-length chain (#1004) and the pattern pitch/side-hole
+placers (#1005).
 
 Even where identity IS recorded, matching it across two builds is approximate. The ledger's
 key embeds the feature's origin and scalars, so it cannot join two builds that differ — the
@@ -132,10 +140,11 @@ def diff_builds(before, after) -> dict:
     - ``suppressions_gained`` / ``suppressions_lost`` — ledger rows as
       ``(feature, parameter_id, reason)``.
     - ``candidate_explanations`` — ``{lost name: [reason, ...]}``, a **hint** at which
-      newly-gained suppression might account for a loss, by parameter stem.
+      newly-gained suppression might account for a loss, joined on ``(feature kind,
+      parameter_id)`` where the renderer recorded identity, and absent where it did not.
 
-    The hint does not subtract from ``dimensions_lost``. An annotation carries no feature
-    identity, so the match cannot be trusted, and a weak match that cancels an alarm is worse
+    The hint does not subtract from ``dimensions_lost``. The join is by feature KIND, so it
+    cannot separate two features of one kind, and a weak match that cancels an alarm is worse
     than no match at all — it manufactures the confidence this epic exists to remove.
     """
     before_dims, after_dims = _measurements(before), _measurements(after)

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -12,21 +12,23 @@ actually found: not from the four issue reports describing its symptoms, but fro
 
 ## What this cannot do, stated first
 
-A placed annotation carries **no measurement identity** — its name is an engine-assigned
-registry slot, not a handle on what it measures. Three consequences, all real:
+A placed annotation carries measurement identity only where the renderer recorded one
+(#1002) — otherwise its name is an engine-assigned registry slot, not a handle on what it
+measures. **Identity is partial, and every limit below is a consequence of where it is
+missing**, not of its absence everywhere: the renderers that consume the compiled plan record
+a `DimensionId`; the ones that place directly (the rotational OD/bore group, #754) do not.
 
-- **A replaced measurement can hide completely.** Move a hole and `m_locx0` goes from `70` to
-  `90`: a different measurement reused the slot, and this reports it as a *change*. Worse, if
-  the replacement happens to render the same label, **every result map is empty** — the
-  substitution is wholly invisible. So a clean diff does **not** establish that the
-  measurements were preserved; it establishes only that nothing observable at this resolution
-  moved (Codex #1001).
-- **A loss cannot be attributed to a suppression with confidence.** Feature provenance is
-  PARTIAL, not absent: ``registry.feature_of(name)`` returns the owning feature for a hole
-  callout, centre mark or location, and ``None`` for an envelope dim (measured). And even a
-  known feature does not identify *which* of its measurements an annotation is. So a candidate
-  explanation is a *hint*, never a verdict — though tightening it to feature identity where
-  provenance exists is a real improvement available today (#1002).
+- **A replaced measurement hides where identity is unrecorded.** Move a hole and `m_locx0`
+  goes from `70` to `90`: a different measurement reused the slot. With identity recorded
+  that is caught and reported as ``measurements_substituted``. Without it the old hole
+  remains — and if the replacement renders the same label, **every result map is empty**. So
+  a clean diff still does not establish that the measurements were preserved; it establishes
+  that nothing observable at this resolution moved (Codex #1001).
+- **A loss is attributed only where identity exists.** Where it does, the join to the ledger
+  is exact — the same ``(feature, parameter_id)`` key both halves use. Where it does not, the
+  loss reads "nothing claims it" whether or not a rule removed it: unknown, deliberately,
+  rather than guessed. The first cut inferred attribution from annotation NAMES by substring
+  and cancelled real alarms with unrelated suppressions.
 - **An unnamed annotation is invisible.** ``Drawing.annotations()`` returns only *named*
   annotations by contract, so anything placed without a name cannot be compared here at all.
 - **A hole callout's CONTENT is invisible; only its presence is seen.** It renders as a
@@ -34,9 +36,8 @@ registry slot, not a handle on what it measures. Three consequences, all real:
   the object. Measured: changing a bore from ⌀8 to ⌀12 produces an identical diff. So a lost
   callout is reported, and a callout that starts saying something different is not.
 
-Closing these needs stable MEASUREMENT identity on a placed annotation — feature provenance
-alone is not enough, and is in any case only partial today.
-Until then this is a **triage aid, not a proof** — and deliberately shaped so its weakest part
+Closing the rest needs the remaining renderers to record identity too (#754), and a callout to
+expose its own text. Until then this is a **triage aid, not a proof** — and shaped so its weakest part
 cannot silence its strongest: a candidate suppression annotates a loss, it never removes it.
 An earlier cut let a weak substring match cancel the alarm outright, so any newly-suppressed
 ``width.*`` excused every lost annotation whose name contained "width", across unrelated
@@ -80,6 +81,12 @@ def _rows(dwg) -> set[tuple]:
     return {(r["feature"], r["parameter_id"], r["reason"]) for r in dwg.suppressions()}
 
 
+def _identity(dwg, name):
+    """``(feature, parameter_id)`` for *name*, or ``None`` where the renderer recorded none."""
+    key = dwg.measurement_key(name) if hasattr(dwg, "measurement_key") else None
+    return None if key is None else (key["feature"], key["parameter_id"])
+
+
 def diff_builds(before, after) -> dict:
     """Compare two finished drawings: what was drawn, and what the compiler declined.
 
@@ -111,12 +118,43 @@ def diff_builds(before, after) -> dict:
     gained_supp = sorted(after_rows - before_rows)
     lost_supp = sorted(before_rows - after_rows)
 
+    # A name present in BOTH builds that now draws a DIFFERENT measurement (#1002) — the
+    # module's worst blind spot closed. An annotation name is an engine-assigned slot, so a
+    # substitution under the same name (and, if the labels agree, under the same label)
+    # previously produced an entirely empty diff.
+    #
+    # BOTH halves of the id are compared, and the two mean different things — `explain`
+    # ranks them apart rather than this splitting them into two maps:
+    #
+    # - the PARAMETER changed → the name draws a different kind of measurement. Always an
+    #   alarm. Rare in practice, because a slot is usually reused by its own pass.
+    # - the FEATURE changed → the name draws the same measurement OF SOMETHING ELSE.
+    #   Reported, not alarmed: `feature_key` is positional, so any experiment that moves a
+    #   feature legitimately changes it. Alarming on that would fire on every perturbation.
+    #
+    # Comparing the parameter alone would have been nearly inert: a hole's X and Y location
+    # dims share ONE id (`location.location`), because `location` is addressable per feature
+    # and per-member identity is still open (ADR 0016 / #883). So an X↔Y swap is invisible
+    # here whichever half is compared — a limit of the compiler's addressing granularity,
+    # not of this comparison.
+    substituted: dict[str, tuple] = {}
+    for name in set(before_dims) & set(after_dims):
+        b_id, a_id = _identity(before, name), _identity(after, name)
+        if b_id is not None and a_id is not None and b_id != a_id:
+            substituted[name] = (b_id, a_id)
+
+    # Attribution, exact where identity exists. The first cut matched a suppression's
+    # parameter stem against the annotation's NAME by substring, so a newly-suppressed
+    # `width.length` claimed every lost annotation whose name contained "width" — across
+    # unrelated features (Codex #1001 r1). With identity recorded the join is on the same
+    # `(feature, parameter_id)` key both halves use, and a mismatch stays unexplained.
     candidates: dict[str, list[str]] = {}
     for name in lost:
+        ident = _identity(before, name)
+        if ident is None:
+            continue  # unknown identity — no attribution rather than a guessed one
         hits = [
-            reason
-            for _feature, parameter, reason in gained_supp
-            if parameter and str(parameter).split(".")[0] in name
+            reason for feature, parameter, reason in gained_supp if (feature, parameter) == ident
         ]
         if hits:
             candidates[name] = hits
@@ -125,6 +163,7 @@ def diff_builds(before, after) -> dict:
         "dimensions_lost": lost,
         "dimensions_gained": gained,
         "dimensions_changed": changed,
+        "measurements_substituted": substituted,
         "suppressions_gained": gained_supp,
         "suppressions_lost": lost_supp,
         "candidate_explanations": candidates,
@@ -147,6 +186,17 @@ def explain(diff: dict) -> list[str]:
         hint = candidates.get(name)
         why = f" — possibly: {'; '.join(hint)}" if hint else " — nothing claims it"
         out.append(f"LOST: {name} ({label}){why}")
+    # A name that silently changed what it measures is a measurement lost and another
+    # gained, disguised as neither (#1002) — so a changed PARAMETER ranks with the losses.
+    # A changed FEATURE goes below them: it is the expected result of moving a feature, and
+    # ranking it as an alarm would bury the real ones in every perturbation study.
+    subs = sorted(diff.get("measurements_substituted", {}).items())
+    for name, (was, now) in subs:
+        if was[1] != now[1]:
+            out.append(f"SUBSTITUTED: {name} now draws {now[1]}, was {was[1]}")
+    for name, (was, now) in subs:
+        if was[1] == now[1]:
+            out.append(f"reattributed: {name} ({now[1]}) now measures {now[0]}, was {was[0]}")
     for feature, parameter, reason in diff["suppressions_gained"]:
         out.append(f"suppressed: {parameter} on {feature} — {reason}")
     for name, label in sorted(diff["dimensions_gained"].items()):

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -15,8 +15,18 @@ actually found: not from the four issue reports describing its symptoms, but fro
 A placed annotation carries measurement identity only where the renderer recorded one
 (#1002) — otherwise its name is an engine-assigned registry slot, not a handle on what it
 measures. **Identity is partial, and every limit below is a consequence of where it is
-missing**, not of its absence everywhere: the renderers that consume the compiled plan record
-a `DimensionId`; the ones that place directly (the rotational OD/bore group, #754) do not.
+missing.** Which renderers record it is not described here in prose, because a prose
+description of that set was wrong the first time it was written: it named only the
+direct-placing group while four compiled-plan renderers were also silently dropping their
+ids (Codex #1002 r1). `tests/test_audit_differential.py` enumerates the set mechanically and
+fails when a renderer forgets, so **that test is the answer**, not this paragraph. The
+standing exceptions are hole callouts (on the legacy surface, #926), PMI (from STEP, never
+compiled), GD&T frames (not measurements) and the direct-placing rotational group (#754).
+
+Even where identity IS recorded, matching it across two builds is approximate. The ledger's
+key embeds the feature's origin and scalars, so it cannot join two builds that differ — the
+join uses `_correspondence` instead, which keeps the feature's KIND and drops its
+coordinates. Two features of one kind are therefore not separated.
 
 - **A replaced measurement hides where identity is unrecorded.** Move a hole and `m_locx0`
   goes from `70` to `90`: a different measurement reused the slot. With identity recorded
@@ -24,11 +34,12 @@ a `DimensionId`; the ones that place directly (the rotational OD/bore group, #75
   remains — and if the replacement renders the same label, **every result map is empty**. So
   a clean diff still does not establish that the measurements were preserved; it establishes
   that nothing observable at this resolution moved (Codex #1001).
-- **A loss is attributed only where identity exists.** Where it does, the join to the ledger
-  is exact — the same ``(feature, parameter_id)`` key both halves use. Where it does not, the
-  loss reads "nothing claims it" whether or not a rule removed it: unknown, deliberately,
-  rather than guessed. The first cut inferred attribution from annotation NAMES by substring
-  and cancelled real alarms with unrelated suppressions.
+- **A loss is attributed only where identity exists, and only by kind.** Where identity is
+  recorded the join is on ``(feature kind, parameter_id)`` — precise enough to separate an
+  envelope's width from a slot's, not precise enough to separate two slots. Where it is not
+  recorded the loss reads "nothing claims it" whether or not a rule removed it: unknown,
+  deliberately, rather than guessed. The first cut inferred attribution from annotation
+  NAMES by substring and cancelled real alarms with unrelated suppressions.
 - **An unnamed annotation is invisible.** ``Drawing.annotations()`` returns only *named*
   annotations by contract, so anything placed without a name cannot be compared here at all.
 - **A hole callout's CONTENT is invisible; only its presence is seen.** It renders as a
@@ -81,10 +92,28 @@ def _rows(dwg) -> set[tuple]:
     return {(r["feature"], r["parameter_id"], r["reason"]) for r in dwg.suppressions()}
 
 
-def _identity(dwg, name):
-    """``(feature, parameter_id)`` for *name*, or ``None`` where the renderer recorded none."""
-    key = dwg.measurement_key(name) if hasattr(dwg, "measurement_key") else None
-    return None if key is None else (key["feature"], key["parameter_id"])
+def _correspondence(feature, parameter) -> tuple:
+    """The cross-build key: ``(feature KIND, parameter_id)``.
+
+    The full ledger key is ``(feature_key, parameter_id)``, and `feature_key` embeds the
+    feature's ORIGIN AND SCALARS — by design, so two holes in one drawing are distinct. That
+    makes it useless for comparing two DIFFERENT builds, which is the only thing this module
+    does: widen a box 40→50 and the envelope's key changes, so an exact join finds nothing
+    and every real suppression reads "nothing claims it" (Codex #1002 r1, reproduced).
+
+    The kind survives the perturbation; the parameter is already stable. Weaker than full
+    identity — two features of one kind share a key — but a weak key that MATCHES ACROSS
+    BUILDS beats an exact key that cannot. It is safe here precisely because attribution
+    only ever annotates a loss; nothing downstream cancels an alarm on it.
+    """
+    return (str(feature).split("@")[0], parameter)
+
+
+def _identities(dwg, name) -> set[tuple]:
+    """Cross-build correspondence keys for everything *name* draws; empty if unrecorded."""
+    if not hasattr(dwg, "measurement_keys"):
+        return set()
+    return {_correspondence(k["feature"], k["parameter_id"]) for k in dwg.measurement_keys(name)}
 
 
 def diff_builds(before, after) -> dict:
@@ -123,38 +152,36 @@ def diff_builds(before, after) -> dict:
     # substitution under the same name (and, if the labels agree, under the same label)
     # previously produced an entirely empty diff.
     #
-    # BOTH halves of the id are compared, and the two mean different things — `explain`
-    # ranks them apart rather than this splitting them into two maps:
+    # Compared on the CORRESPONDENCE key, so a `width.length` on an envelope that merely got
+    # wider is not a substitution. An earlier cut compared the full ledger key and reported
+    # every envelope dim of every perturbed build as "reattributed" — three noise lines on a
+    # three-dimension drawing, in the one experiment this module exists to run.
     #
-    # - the PARAMETER changed → the name draws a different kind of measurement. Always an
-    #   alarm. Rare in practice, because a slot is usually reused by its own pass.
-    # - the FEATURE changed → the name draws the same measurement OF SOMETHING ELSE.
-    #   Reported, not alarmed: `feature_key` is positional, so any experiment that moves a
-    #   feature legitimately changes it. Alarming on that would fire on every perturbation.
-    #
-    # Comparing the parameter alone would have been nearly inert: a hole's X and Y location
-    # dims share ONE id (`location.location`), because `location` is addressable per feature
-    # and per-member identity is still open (ADR 0016 / #883). So an X↔Y swap is invisible
-    # here whichever half is compared — a limit of the compiler's addressing granularity,
-    # not of this comparison.
+    # A hole's X and Y location dims share ONE id (`location.location`), because `location`
+    # is addressable per feature and per-member identity is still open (ADR 0016 / #883), so
+    # an X↔Y swap is invisible here. That is the compiler's addressing granularity, not a
+    # limit of this comparison.
     substituted: dict[str, tuple] = {}
     for name in set(before_dims) & set(after_dims):
-        b_id, a_id = _identity(before, name), _identity(after, name)
-        if b_id is not None and a_id is not None and b_id != a_id:
-            substituted[name] = (b_id, a_id)
+        b_ids, a_ids = _identities(before, name), _identities(after, name)
+        if b_ids and a_ids and b_ids != a_ids:
+            substituted[name] = (sorted(b_ids), sorted(a_ids))
 
-    # Attribution, exact where identity exists. The first cut matched a suppression's
-    # parameter stem against the annotation's NAME by substring, so a newly-suppressed
-    # `width.length` claimed every lost annotation whose name contained "width" — across
-    # unrelated features (Codex #1001 r1). With identity recorded the join is on the same
-    # `(feature, parameter_id)` key both halves use, and a mismatch stays unexplained.
+    # Attribution, on the cross-build correspondence key. The first cut matched a
+    # suppression's parameter stem against the annotation's NAME by substring, so a
+    # newly-suppressed `width.length` claimed every lost annotation whose name contained
+    # "width" — across unrelated features (Codex #1001 r1). The second joined on the exact
+    # ledger key, which cannot match across two builds at all (Codex #1002 r1). This joins
+    # on what the two builds genuinely share: the feature's kind and the parameter.
     candidates: dict[str, list[str]] = {}
     for name in lost:
-        ident = _identity(before, name)
-        if ident is None:
+        idents = _identities(before, name)
+        if not idents:
             continue  # unknown identity — no attribution rather than a guessed one
         hits = [
-            reason for feature, parameter, reason in gained_supp if (feature, parameter) == ident
+            reason
+            for feature, parameter, reason in gained_supp
+            if _correspondence(feature, parameter) in idents
         ]
         if hits:
             candidates[name] = hits
@@ -187,16 +214,9 @@ def explain(diff: dict) -> list[str]:
         why = f" — possibly: {'; '.join(hint)}" if hint else " — nothing claims it"
         out.append(f"LOST: {name} ({label}){why}")
     # A name that silently changed what it measures is a measurement lost and another
-    # gained, disguised as neither (#1002) — so a changed PARAMETER ranks with the losses.
-    # A changed FEATURE goes below them: it is the expected result of moving a feature, and
-    # ranking it as an alarm would bury the real ones in every perturbation study.
-    subs = sorted(diff.get("measurements_substituted", {}).items())
-    for name, (was, now) in subs:
-        if was[1] != now[1]:
-            out.append(f"SUBSTITUTED: {name} now draws {now[1]}, was {was[1]}")
-    for name, (was, now) in subs:
-        if was[1] == now[1]:
-            out.append(f"reattributed: {name} ({now[1]}) now measures {now[0]}, was {was[0]}")
+    # gained, disguised as neither (#1002) — so it ranks with the losses.
+    for name, (was, now) in sorted(diff.get("measurements_substituted", {}).items()):
+        out.append(f"SUBSTITUTED: {name} now draws {now}, was {was}")
     for feature, parameter, reason in diff["suppressions_gained"]:
         out.append(f"suppressed: {parameter} on {feature} — {reason}")
     for name, label in sorted(diff["dimensions_gained"].items()):

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -34,7 +34,9 @@ placers (#1005).
 Even where identity IS recorded, matching it across two builds is approximate. The ledger's
 key embeds the feature's origin and scalars, so it cannot join two builds that differ — the
 join uses `_correspondence` instead, which keeps the feature's KIND and drops its
-coordinates. Two features of one kind are therefore not separated.
+coordinates. Two features of one kind are therefore not separated: a same-count swap of one
+slot's width for another's is invisible (**#1006**). Multiplicity IS compared — as a multiset,
+so a grouped callout dropping a member is caught — but a like-for-like exchange is not.
 
 - **A replaced measurement hides where identity is unrecorded.** Move a hole and `m_locx0`
   goes from `70` to `90`: a different measurement reused the slot. With identity recorded
@@ -67,6 +69,8 @@ nothing from the engine, so the thing it measures can never come to depend on it
 """
 
 from __future__ import annotations
+
+from collections import Counter
 
 #: Sheet FURNITURE — the annotation types that carry no measurement. Everything else counts.
 #:
@@ -117,11 +121,21 @@ def _correspondence(feature, parameter) -> tuple:
     return (str(feature).split("@")[0], parameter)
 
 
-def _identities(dwg, name) -> set[tuple]:
-    """Cross-build correspondence keys for everything *name* draws; empty if unrecorded."""
+def _identities(dwg, name) -> Counter:
+    """Cross-build correspondence keys for everything *name* draws; empty if unrecorded.
+
+    A **multiset**, not a set (Codex #1002 r5). The whole reason the registry stores a tuple
+    is that one annotation can draw several measurements — a grouped ``4× R5`` fillet callout
+    draws four. Deduplicating them here threw that away: a grouped callout dropping from four
+    members to three keeps the same *distinct* key, so the change vanished and every result
+    map came back empty. The counts survive the cross-build key even though the coordinates
+    do not, so multiplicity is exactly the part of the tuple worth keeping.
+    """
     if not hasattr(dwg, "measurement_keys"):
-        return set()
-    return {_correspondence(k["feature"], k["parameter_id"]) for k in dwg.measurement_keys(name)}
+        return Counter()
+    return Counter(
+        _correspondence(k["feature"], k["parameter_id"]) for k in dwg.measurement_keys(name)
+    )
 
 
 def diff_builds(before, after) -> dict:
@@ -174,7 +188,7 @@ def diff_builds(before, after) -> dict:
     for name in set(before_dims) & set(after_dims):
         b_ids, a_ids = _identities(before, name), _identities(after, name)
         if b_ids and a_ids and b_ids != a_ids:
-            substituted[name] = (sorted(b_ids), sorted(a_ids))
+            substituted[name] = (sorted(b_ids.elements()), sorted(a_ids.elements()))
 
     # Attribution, on the cross-build correspondence key. The first cut matched a
     # suppression's parameter stem against the annotation's NAME by substring, so a

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -641,6 +641,24 @@ class Drawing:
             for o in self._build.omissions
         ]
 
+    def measurement_key(self, name) -> dict | None:
+        """Which measurement the annotation *name* draws, or ``None`` if unrecorded (#1002).
+
+        The mirror of :meth:`suppressions` and deliberately the SAME key shape —
+        ``{"feature": <stable key>, "parameter_id": ...}`` — so a drawn measurement and a
+        suppressed one are directly comparable. Without it the two halves of the audit could
+        only be joined by matching an engine-assigned annotation name against a parameter id
+        by substring, which attributed losses to unrelated suppressions (Codex #1001 r1).
+
+        ``None`` means the renderer did not record an identity, **not** that the annotation
+        measures nothing: the direct-placing renderers (#754) record none. Treat presence as
+        exact and absence as unknown.
+        """
+        mid = self._registry.measurement_of(name)
+        if mid is None:
+            return None
+        return {"feature": feature_key(mid.feature), "parameter_id": mid.parameter}
+
     @property
     def solve_trace(self):
         """The opt-in solve-trace recorder threaded through this build (#736), or

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -641,23 +641,29 @@ class Drawing:
             for o in self._build.omissions
         ]
 
-    def measurement_key(self, name) -> dict | None:
-        """Which measurement the annotation *name* draws, or ``None`` if unrecorded (#1002).
+    def measurement_keys(self, name) -> list[dict]:
+        """Which measurements the annotation *name* draws — possibly none (#1002).
 
-        The mirror of :meth:`suppressions` and deliberately the SAME key shape —
+        The mirror of :meth:`suppressions` and deliberately the SAME row shape —
         ``{"feature": <stable key>, "parameter_id": ...}`` — so a drawn measurement and a
         suppressed one are directly comparable. Without it the two halves of the audit could
         only be joined by matching an engine-assigned annotation name against a parameter id
         by substring, which attributed losses to unrelated suppressions (Codex #1001 r1).
 
-        ``None`` means the renderer did not record an identity, **not** that the annotation
-        measures nothing: the direct-placing renderers (#754) record none. Treat presence as
-        exact and absence as unknown.
+        A **list**, because one annotation can draw several independently suppressible
+        measurements — a compound hole callout renders bore diameter, depth and counterbore
+        together (ADR 0016 / #886). Empty means the renderer recorded nothing, **not** that
+        the annotation measures nothing. Which renderers record it is enforced by the ratchet
+        in `tests/test_audit_differential.py`; treat presence as exact and absence as unknown.
+
+        Exact **within** a build. Across two builds the key cannot match directly, because
+        `feature_key` embeds coordinates and scalars a differential deliberately changes —
+        `draftwright.audit` joins on the feature's kind instead.
         """
-        mid = self._registry.measurement_of(name)
-        if mid is None:
-            return None
-        return {"feature": feature_key(mid.feature), "parameter_id": mid.parameter}
+        return [
+            {"feature": feature_key(mid.feature), "parameter_id": mid.parameter}
+            for mid in self._registry.measurement_of(name)
+        ]
 
     @property
     def solve_trace(self):

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -30,6 +30,21 @@ draftwright and carries no behaviour beyond the bookkeeping moved out of
 from __future__ import annotations
 
 
+def _as_ids(measurement) -> tuple:
+    """Normalise a caller's *measurement* to a tuple of ids (#1002).
+
+    Renderers that draw exactly one measurement pass the bare `DimensionId` they already
+    hold; a compound renderer passes a sequence. Accepting both keeps the common call site
+    honest — ``measurement=pd.id`` — without the storage pretending the relationship is
+    one-to-one, which ADR 0016 says it is not.
+    """
+    if measurement is None:
+        return ()
+    if isinstance(measurement, (list, tuple)):
+        return tuple(m for m in measurement if m is not None)
+    return (measurement,)
+
+
 class AnnotationRegistry:
     """Single owner of annotation identity, ownership, pins, and build issues."""
 
@@ -42,13 +57,20 @@ class AnnotationRegistry:
         # so a repack/repair preserves provenance. Absent for part-level marks (title
         # block, section arrows) that belong to no single feature.
         self._anno_feature: dict = {}
-        # name -> the `DimensionId` this annotation draws (#1002). One axis finer than
-        # _anno_feature, and the distinction is the point: a hole has a diameter, a depth
-        # and two locations, so knowing the FEATURE still does not say WHICH of its
-        # measurements an annotation is. This is the same `(feature, parameter)` key the
-        # compiler already mints for the compiled plan and `Drawing.suppressions()`
-        # reports, so an annotation and a suppression become comparable without matching
-        # on names — see `draftwright.audit`, whose substring hint this replaces.
+        # name -> the `DimensionId`s this annotation draws, as a TUPLE (#1002). One axis
+        # finer than _anno_feature, and the distinction is the point: a hole has a
+        # diameter, a depth and two locations, so knowing the FEATURE still does not say
+        # WHICH of its measurements an annotation is. Same `(feature, parameter)` key the
+        # compiler mints for the compiled plan and `Drawing.suppressions()` reports, so an
+        # annotation and a suppression become comparable without matching on names.
+        #
+        # A TUPLE rather than one id, from the start, because the relationship really is
+        # one-to-many: a compound hole callout renders bore diameter, depth, counterbore
+        # diameter and depth as ONE annotation, each independently suppressible. ADR 0016
+        # states this outright — the channel "has to become `name → tuple[DimensionId,
+        # ...]` before per-dimension resolution is possible at all" (#886). Storing one id
+        # would have to be widened again later, and worse, would make the audit's
+        # "exact when present" promise false for a callout's other measurements.
         self._anno_measurement: dict = {}
         self._pinned: set = set()
         self._build_issues: list = []
@@ -79,15 +101,16 @@ class AnnotationRegistry:
         """The source IR feature *name* was rendered for, or ``None`` (#398)."""
         return self._anno_feature.get(name)
 
-    def measurement_of(self, name):
-        """The `DimensionId` *name* draws, or ``None`` (#1002).
+    def measurement_of(self, name) -> tuple:
+        """The `DimensionId`s *name* draws, as a tuple — possibly empty (#1002).
 
-        ``None`` means *unknown*, never *not a measurement*: provenance is threaded from the
-        renderers that hold an `ApprovedDimension`, and the ones that place directly (the
-        rotational OD/bore group, #754) still answer ``None``. Read it as a hint that is
-        exact when present, and absent otherwise — never as a claim that the annotation
-        measures nothing."""
-        return self._anno_measurement.get(name)
+        Empty means *unknown*, never *measures nothing*: identity is threaded from the
+        renderers that hold an `ApprovedDimension`, and the rest answer empty. Which
+        renderers those are is enumerated and enforced by the ratchet in
+        `tests/test_audit_differential.py` rather than described here — the prose version of
+        that set was wrong when first written (Codex #1002 r1)."""
+        ids: tuple = self._anno_measurement.get(name, ())
+        return ids
 
     def names_for_feature(self, feature) -> list:
         """Every annotation name owned by *feature* (matched by value equality, so a
@@ -168,9 +191,10 @@ class AnnotationRegistry:
             # Same rule again, and it matters MORE here (#1002): a stale measurement id is
             # worse than none, because the audit trusts it as exact. A replacement under
             # this name draws whatever the new caller says it draws — including nothing
-            # identifiable, which must clear the old id rather than inherit it.
-            if measurement is not None:
-                self._anno_measurement[name] = measurement
+            # identifiable, which must clear the old ids rather than inherit them.
+            ids = _as_ids(measurement)
+            if ids:
+                self._anno_measurement[name] = ids
             else:
                 self._anno_measurement.pop(name, None)
         return displaced

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -42,6 +42,14 @@ class AnnotationRegistry:
         # so a repack/repair preserves provenance. Absent for part-level marks (title
         # block, section arrows) that belong to no single feature.
         self._anno_feature: dict = {}
+        # name -> the `DimensionId` this annotation draws (#1002). One axis finer than
+        # _anno_feature, and the distinction is the point: a hole has a diameter, a depth
+        # and two locations, so knowing the FEATURE still does not say WHICH of its
+        # measurements an annotation is. This is the same `(feature, parameter)` key the
+        # compiler already mints for the compiled plan and `Drawing.suppressions()`
+        # reports, so an annotation and a suppression become comparable without matching
+        # on names — see `draftwright.audit`, whose substring hint this replaces.
+        self._anno_measurement: dict = {}
         self._pinned: set = set()
         self._build_issues: list = []
 
@@ -70,6 +78,16 @@ class AnnotationRegistry:
     def feature_of(self, name):
         """The source IR feature *name* was rendered for, or ``None`` (#398)."""
         return self._anno_feature.get(name)
+
+    def measurement_of(self, name):
+        """The `DimensionId` *name* draws, or ``None`` (#1002).
+
+        ``None`` means *unknown*, never *not a measurement*: provenance is threaded from the
+        renderers that hold an `ApprovedDimension`, and the ones that place directly (the
+        rotational OD/bore group, #754) still answer ``None``. Read it as a hint that is
+        exact when present, and absent otherwise — never as a claim that the annotation
+        measures nothing."""
+        return self._anno_measurement.get(name)
 
     def names_for_feature(self, feature) -> list:
         """Every annotation name owned by *feature* (matched by value equality, so a
@@ -105,6 +123,7 @@ class AnnotationRegistry:
             "named": dict(self._named),
             "anno_view": dict(self._anno_view),
             "anno_feature": dict(self._anno_feature),
+            "anno_measurement": dict(self._anno_measurement),
             "pinned": set(self._pinned),
         }
 
@@ -116,10 +135,12 @@ class AnnotationRegistry:
         self._anno_view.update(snap["anno_view"])
         self._anno_feature.clear()
         self._anno_feature.update(snap.get("anno_feature", {}))
+        self._anno_measurement.clear()
+        self._anno_measurement.update(snap.get("anno_measurement", {}))
         self._pinned.clear()
         self._pinned.update(snap["pinned"])
 
-    def add(self, obj, name, view, feature=None):
+    def add(self, obj, name, view, feature=None, measurement=None):
         """Register *obj* under *name* and record its owning *view* (and source *feature*).
 
         Returns the object previously registered under *name* (so the caller can
@@ -144,6 +165,14 @@ class AnnotationRegistry:
                 self._anno_feature[name] = feature
             else:
                 self._anno_feature.pop(name, None)
+            # Same rule again, and it matters MORE here (#1002): a stale measurement id is
+            # worse than none, because the audit trusts it as exact. A replacement under
+            # this name draws whatever the new caller says it draws — including nothing
+            # identifiable, which must clear the old id rather than inherit it.
+            if measurement is not None:
+                self._anno_measurement[name] = measurement
+            else:
+                self._anno_measurement.pop(name, None)
         return displaced
 
     def remove(self, name):
@@ -153,6 +182,7 @@ class AnnotationRegistry:
             self._pinned.discard(name)  # a removed name carries no pin (#89)
             self._anno_view.pop(name, None)
             self._anno_feature.pop(name, None)
+            self._anno_measurement.pop(name, None)
         return obj
 
     def clear(self, keep) -> dict:
@@ -164,6 +194,7 @@ class AnnotationRegistry:
         self._pinned &= keep_set  # drop pins for cleared names (#89)
         self._anno_view = {n: v for n, v in self._anno_view.items() if n in keep_set}
         self._anno_feature = {n: f for n, f in self._anno_feature.items() if n in keep_set}
+        self._anno_measurement = {n: m for n, m in self._anno_measurement.items() if n in keep_set}
         return kept_named
 
     # -- pins -----------------------------------------------------------------

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -163,6 +163,59 @@ class AnnotationRegistry:
         self._pinned.clear()
         self._pinned.update(snap["pinned"])
 
+    def identity_of(self, name) -> dict:
+        """Every per-name identity axis bound to *name*, as one opaque restorable value.
+
+        A remove-then-re-add transaction (the callout re-route, the hole-table fallback, the
+        detail-view retry) has to put back everything the name carried. All three sites
+        hand-rolled that axis by axis, and every axis added since broke the sites nobody
+        updated: the hole-table fallback still restored view alone, losing the feature added
+        in #398; the detail-view retry carried view/feature/pin but not the measurement added
+        here (Codex #1002 r2). Reading and reapplying the axes as a UNIT, in the class that
+        owns them, is the only version of this a *fourth* axis cannot silently break.
+
+        The keys mirror the ``_anno_*`` map names on purpose — that is what lets
+        ``test_registry`` compare the two mechanically and fail when an axis is added without
+        being covered here.
+        """
+        return {
+            "view": self._anno_view.get(name),
+            "feature": self._anno_feature.get(name),
+            "measurement": self._anno_measurement.get(name, ()),
+            "pinned": name in self._pinned,
+        }
+
+    def reapply(self, name, identity) -> None:
+        """Rebind *identity* (from :meth:`identity_of`) to *name* — the write half.
+
+        Authoritative, not additive: an axis absent from *identity* is CLEARED, so a restore
+        can never leave *name* wearing metadata from whatever briefly held the slot.
+
+        Restores the pin too. :meth:`add` deliberately drops it, because a same-name add is a
+        fresh object that has not earned the user's pin (#89) — but a restore puts the SAME
+        object back, and dropping the user's ADR 0012 pin because an engine-internal fallback
+        round-tripped it is a bug. The detail-view retry already re-pinned by hand; this makes
+        the other two agree.
+        """
+        view, feature = identity.get("view"), identity.get("feature")
+        if view is not None:
+            self._anno_view[name] = view
+        else:
+            self._anno_view.pop(name, None)
+        if feature is not None:
+            self._anno_feature[name] = feature
+        else:
+            self._anno_feature.pop(name, None)
+        ids = _as_ids(identity.get("measurement"))
+        if ids:
+            self._anno_measurement[name] = ids
+        else:
+            self._anno_measurement.pop(name, None)
+        if identity.get("pinned"):
+            self._pinned.add(name)
+        else:
+            self._pinned.discard(name)
+
     def add(self, obj, name, view, feature=None, measurement=None):
         """Register *obj* under *name* and record its owning *view* (and source *feature*).
 

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -17,7 +17,7 @@ keeps it honest about the real `Drawing` surface.
 
 from __future__ import annotations
 
-from build123d import Box, Cylinder, Rot
+from build123d import Box, BuildPart, Cylinder, Hole, Locations, Rot
 
 from draftwright import build_drawing
 from draftwright.audit import diff_builds, explain
@@ -31,10 +31,12 @@ class _FakeDrawing:
         dims: dict[str, str],
         suppressions: list[dict] | None = None,
         types: dict[str, str] | None = None,
+        identities: dict[str, tuple] | None = None,
     ):
         self._dims = dims
         self._supp = suppressions or []
         self._types = types or {}
+        self._ids = identities or {}
 
     def annotations(self):
         return {n: self._types.get(n, "Dimension") for n in self._dims}
@@ -44,6 +46,10 @@ class _FakeDrawing:
 
     def suppressions(self):
         return list(self._supp)
+
+    def measurement_key(self, name):
+        ident = self._ids.get(name)
+        return None if ident is None else {"feature": ident[0], "parameter_id": ident[1]}
 
 
 def _supp(parameter, reason, feature="envelope@(0,0,0)/z"):
@@ -63,7 +69,11 @@ def test_a_loss_a_rule_accounts_for_is_not_unexplained():
     suffices)" and can ask whether a 50x50 part should really have no plan size. The
     measurement is gone, but nothing is hidden.
     """
-    before = _FakeDrawing({"m_env_width": "50", "m_env_depth": "40", "dim_height": "30"})
+    env = "envelope@(0,0,0)/z"
+    before = _FakeDrawing(
+        {"m_env_width": "50", "m_env_depth": "40", "dim_height": "30"},
+        identities={"m_env_width": (env, "width.length"), "m_env_depth": (env, "depth.length")},
+    )
     after = _FakeDrawing(
         {"dim_height": "30"},
         [_supp("width.length", "square footprint"), _supp("depth.length", "square footprint")],
@@ -214,25 +224,93 @@ def test_an_unknown_annotation_type_counts_as_a_measurement():
     assert "title_block" not in lost, "known furniture is still excluded"
 
 
-def test_a_same_name_same_label_replacement_is_invisible():
-    """The limit the module documents, pinned so the documentation cannot quietly drift from
-    the behaviour (Codex #1001 r2).
+def test_a_same_name_same_label_replacement_is_invisible_without_identity():
+    """The limit the module documents, pinned so the documentation cannot drift from the
+    behaviour (Codex #1001 r2) — now scoped to where it actually still applies.
 
     A name is a registry slot. If a different measurement takes the slot AND renders the same
-    label, every result map is empty — the substitution is wholly invisible. A clean diff
-    therefore does not establish that the measurements were preserved.
+    label, every result map is empty. #1002 closed this for annotations whose renderer records
+    a `DimensionId` (see the test below); it remains true for the renderers that record none —
+    the rotational OD/bore group, #754 — so a clean diff still does not establish that the
+    measurements were preserved.
 
-    Asserting a KNOWN BLIND SPOT, not desired behaviour. It fails the day #1002 gives
-    annotations real identity, which is exactly when someone should come back and delete it.
+    Asserting a KNOWN BLIND SPOT, not desired behaviour. Delete it when every renderer records
+    identity.
     """
-    before = _FakeDrawing({"m_locx0": "70"})
-    after = _FakeDrawing({"m_locx0": "70"})  # different measurement, same slot, same text
+    before = _FakeDrawing({"dim_od": "40"})  # no identity: the direct-placing renderers
+    after = _FakeDrawing({"dim_od": "40"})  # different measurement, same slot, same text
 
     diff = diff_builds(before, after)
     assert diff["dimensions_lost"] == {}
     assert diff["dimensions_gained"] == {}
     assert diff["dimensions_changed"] == {}
+    assert diff["measurements_substituted"] == {}
     assert explain(diff) == [], "invisible — and the docstring says so rather than implying it"
+
+
+def test_a_same_name_same_label_replacement_is_caught_with_identity():
+    """The blind spot above, closed wherever the renderer recorded what it drew (#1002).
+
+    Same name, same label, so every other map in the diff is empty — the only thing that
+    differs is what the annotation IS. This is the case the module previously could not see at
+    all, and the reason measurement identity was worth threading.
+    """
+    before = _FakeDrawing({"m_x0": "70"}, identities={"m_x0": ("hole@(10,5,5)/z", "location")})
+    after = _FakeDrawing({"m_x0": "70"}, identities={"m_x0": ("slot@(10,5,5)/z", "width.length")})
+
+    diff = diff_builds(before, after)
+    assert diff["dimensions_lost"] == {} and diff["dimensions_changed"] == {}
+    assert diff["measurements_substituted"] == {
+        "m_x0": (("hole@(10,5,5)/z", "location"), ("slot@(10,5,5)/z", "width.length"))
+    }
+    assert explain(diff)[0].startswith("SUBSTITUTED: m_x0"), "a changed parameter is an alarm"
+
+
+def test_the_same_measurement_of_a_moved_feature_is_reported_not_alarmed():
+    """A perturbation study MOVES features, so `feature_key` legitimately changes on every
+    run. Ranking that as an alarm would bury the real losses under one line per moved feature
+    — the failure mode `explain`'s ordering exists to prevent.
+
+    So a changed feature with an unchanged parameter is reported below the alarms, not as one.
+    """
+    before = _FakeDrawing({"m_x0": "70"}, identities={"m_x0": ("hole@(10,5,5)/z", "location")})
+    after = _FakeDrawing({"m_x0": "90"}, identities={"m_x0": ("hole@(30,5,5)/z", "location")})
+
+    lines = explain(diff_builds(before, after))
+    assert not any(line.startswith("SUBSTITUTED") for line in lines)
+    assert any(line.startswith("reattributed: m_x0") for line in lines)
+
+
+def test_a_suppression_on_another_feature_does_not_explain_this_loss():
+    """The canary for the attribution fix (#1002).
+
+    The first cut matched a suppression's parameter STEM against the annotation's NAME by
+    substring, so a newly-suppressed `width.length` on ANY feature claimed every lost
+    annotation whose name contained "width" (Codex #1001 r1). Here the stem matches the name
+    and the parameter matches exactly — only the feature differs, which is precisely what a
+    name-based match cannot see. The loss must stay unexplained.
+    """
+    before = _FakeDrawing(
+        {"m_width0": "20"}, identities={"m_width0": ("slot@(0,0,0)/z", "width.length")}
+    )
+    after = _FakeDrawing({}, [_supp("width.length", "coincident", feature="slot@(99,0,0)/z")])
+
+    diff = diff_builds(before, after)
+    assert "m_width0" in diff["dimensions_lost"]
+    assert diff["candidate_explanations"] == {}, "a different feature's rule explains nothing"
+    assert explain(diff)[0].endswith("nothing claims it")
+
+
+def test_a_suppression_on_the_same_measurement_does_explain_the_loss():
+    """The other half: an exact `(feature, parameter_id)` match IS the attribution, and the
+    hint still annotates the loss rather than removing it."""
+    ident = ("slot@(0,0,0)/z", "width.length")
+    before = _FakeDrawing({"m_width0": "20"}, identities={"m_width0": ident})
+    after = _FakeDrawing({}, [_supp("width.length", "coincident", feature="slot@(0,0,0)/z")])
+
+    diff = diff_builds(before, after)
+    assert diff["candidate_explanations"] == {"m_width0": ["coincident"]}
+    assert "m_width0" in diff["dimensions_lost"], "explained, still not cancelled"
 
 
 def test_a_labelless_callout_loss_is_still_detected():
@@ -295,3 +373,73 @@ def test_it_works_on_real_drawings():
     assert "m_env_depth" in diff["dimensions_lost"], "the turned part states no depth"
     reasons = " ".join(r for _, _, r in diff["suppressions_gained"])
     assert "rotational OD" in reasons, "and the ledger says which rule took it"
+
+
+def test_a_real_build_records_which_measurement_its_location_dims_draw():
+    """End-to-end (#1002): the duck types above encode what `diff_builds` *reads*, so they
+    cannot show that the engine actually WRITES any of it. This does.
+
+    Two things matter and both are asserted: identity reaches the registry from a real render
+    pass, and it is the SAME key shape `suppressions()` reports — that shared shape is the
+    whole point, since it is what lets a drawn measurement and a suppressed one be compared
+    without matching engine-assigned names by substring.
+    """
+    with BuildPart() as p:
+        Box(50, 40, 10)
+        with Locations((10, 5, 0)):
+            Hole(4)
+    dwg = build_drawing(p.part)
+
+    keyed = {n: dwg.measurement_key(n) for n in dwg.annotations()}
+    identified = {n: k for n, k in keyed.items() if k is not None}
+    assert identified, "the compiled-plan renderers must record what they drew"
+    for name, key in identified.items():
+        assert set(key) == {"feature", "parameter_id"}, f"{name}: the ledger's key shape"
+
+    # The two threaded groups, named rather than counted: a count would keep passing if a
+    # renderer stopped recording and another started.
+    assert identified["m_locx0"]["feature"].startswith("hole@"), "located hole"
+    assert identified["m_env_width"]["feature"].startswith("envelope@"), "overall extent"
+
+    assert dwg.measurement_key("title_block") is None, "furniture measures nothing"
+    # Not yet threaded, and asserted so the gap is visible rather than assumed closed: the
+    # hole callout is on the legacy surface (#926) and the direct-placing group is #754.
+    assert dwg.measurement_key("hc_plan0") is None, "callouts still record none (#926)"
+
+
+def test_identity_survives_the_repair_loops_snapshot_and_restore():
+    """A repair pass may roll back a worse placement by restoring a registry snapshot. The
+    view and feature tags are snapshotted for exactly this reason — a restore that dropped
+    them would leave provenance referencing names the rollback removed.
+
+    Measurement identity is a peer of those and must round-trip the same way. A stale or
+    missing id is worse here than elsewhere: the audit treats a recorded id as EXACT.
+    """
+    from draftwright.registry import AnnotationRegistry
+
+    reg = AnnotationRegistry()
+    obj = object()
+    reg.add(obj, "m_x0", "plan", feature="f", measurement="mid")
+    snap = reg.snapshot()
+
+    reg.add(object(), "m_x0", "plan", feature="g", measurement="other")
+    assert reg.measurement_of("m_x0") == "other"
+
+    reg.restore(snap)
+    assert reg.measurement_of("m_x0") == "mid", "a rollback restores what was drawn"
+
+
+def test_re_adding_a_name_without_an_identity_clears_the_old_one():
+    """The rule the view and feature tags already follow, and it matters more here: a
+    replacement draws whatever the new caller says it draws, including nothing identifiable.
+
+    Inheriting the displaced annotation's id would hand the audit a STALE identity it then
+    treats as exact — worse than the honest `None` that reads as "unknown".
+    """
+    from draftwright.registry import AnnotationRegistry
+
+    reg = AnnotationRegistry()
+    reg.add(object(), "m_x0", "plan", feature="f", measurement="mid")
+    reg.add(object(), "m_x0", "plan")
+
+    assert reg.measurement_of("m_x0") is None, "cleared, not inherited"

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -48,8 +48,16 @@ class _FakeDrawing:
         return list(self._supp)
 
     def measurement_keys(self, name):
+        # A LIST of identities, because a real annotation can draw several (a grouped `4× R5`
+        # fillet callout draws four). The first cut returned at most one, so the differential
+        # tests could not express the compound case at all — and did not notice the audit
+        # collapsing tuples to a set (Codex #1002 r5). A single `(feature, parameter)` pair is
+        # still accepted for the many one-measurement cases.
         ident = self._ids.get(name)
-        return [] if ident is None else [{"feature": ident[0], "parameter_id": ident[1]}]
+        if ident is None:
+            return []
+        pairs = ident if isinstance(ident, list) else [ident]
+        return [{"feature": f, "parameter_id": p} for f, p in pairs]
 
 
 def _supp(parameter, reason, feature="envelope@(0,0,0)/z"):
@@ -435,8 +443,17 @@ def test_a_real_build_records_which_measurement_its_location_dims_draw():
             assert set(key) == {"feature", "parameter_id"}, f"{name}: the ledger's key shape"
 
     # The two threaded groups, named rather than counted: a count would keep passing if a
-    # renderer stopped recording and another started.
+    # renderer stopped recording and another started. And the PARAMETER is asserted, not just
+    # the feature (Codex #1002 r5): checking only the feature prefix would let an envelope
+    # renderer record its *depth* under `m_env_width` and still pass, which is precisely the
+    # mis-threading the audit would then report as exact.
+    assert identified["m_locx0"] == [
+        {"feature": identified["m_locx0"][0]["feature"], "parameter_id": "location.location"}
+    ]
     assert identified["m_locx0"][0]["feature"].startswith("hole@"), "located hole"
+    assert identified["m_env_width"][0]["parameter_id"] == "width.length"
+    assert identified["m_env_depth"][0]["parameter_id"] == "depth.length"
+    assert identified["dim_height"][0]["parameter_id"] == "height.length"
     assert identified["m_env_width"][0]["feature"].startswith("envelope@"), "overall extent"
 
     assert dwg.measurement_keys("title_block") == [], "furniture measures nothing"
@@ -518,6 +535,32 @@ def test_a_bare_id_and_a_sequence_are_both_accepted():
     assert reg.measurement_of("c") == (), "a sequence of nothing is still unknown"
 
 
+def test_a_grouped_callout_losing_a_member_is_a_substitution():
+    """Multiplicity is part of the identity (Codex #1002 r5).
+
+    A `4× R5` fillet callout collapses four equal fillets into one annotation drawing four
+    measurements. Lose one and it becomes `3× R5` — same name, same feature kind, same
+    parameter. Comparing DISTINCT keys made that invisible: every result map came back empty
+    while a measurement had silently left the drawing, which is the exact failure this module
+    exists to prevent. A multiset sees it.
+    """
+    fillet_a = "fillet@(-28,-18,0)/z[radius=5.000]"
+    fillet_b = "fillet@(-28,18,0)/z[radius=5.000]"
+    before = _FakeDrawing(
+        {"m_fillet_z0": "4× R5"},
+        identities={"m_fillet_z0": [(fillet_a, "fillet.radius"), (fillet_b, "fillet.radius")]},
+    )
+    after = _FakeDrawing(
+        {"m_fillet_z0": "4× R5"},  # label unchanged too — identity is the only signal
+        identities={"m_fillet_z0": [(fillet_a, "fillet.radius")]},
+    )
+
+    diff = diff_builds(before, after)
+    assert diff["dimensions_lost"] == {} and diff["dimensions_changed"] == {}
+    assert "m_fillet_z0" in diff["measurements_substituted"], "a dropped member is a change"
+    assert any(line.startswith("SUBSTITUTED") for line in explain(diff))
+
+
 def test_a_location_dim_two_features_share_records_both_measurements():
     """The dedup path, which the single-hole canary never reached (#1002 r4).
 
@@ -558,7 +601,7 @@ def test_a_real_build_records_identity_for_the_machined_feature_callouts():
     ADR 0016 requires the channel to carry (#886), exercised end to end rather than asserted
     on the registry in isolation.
     """
-    from build123d import Axis, Box, chamfer, fillet
+    from build123d import Axis, Box, Mode, chamfer, fillet
 
     part = Box(60, 40, 20)
     chamfered = build_drawing(chamfer(part.edges().filter_by(Axis.Z), 3))
@@ -571,6 +614,20 @@ def test_a_real_build_records_identity_for_the_machined_feature_callouts():
     assert len(grouped) == 4, "one grouped callout, four collapsed members"
     assert {k["parameter_id"] for k in grouped} == {"fillet.radius"}
     assert len({k["feature"] for k in grouped}) == 4, "four distinct fillets, not one repeated"
+
+    # A pocket is the compound case with DISTINCT parameters, so it is the one that would
+    # expose a swapped width/depth id — the failure a presence-only check cannot see.
+    with BuildPart() as pk:
+        Box(80, 60, 20)
+        with Locations((0, 0, 10)):
+            Box(30, 20, 6, mode=Mode.SUBTRACT)
+    pocket = build_drawing(pk.part).measurement_keys("m_pocket_yx0")
+    assert [k["parameter_id"] for k in pocket] == [
+        "pocket_width.length",
+        "pocket_length.length",
+        "pocket_depth.length",
+    ], "width, length and depth in the order the label prints them"
+    assert {k["feature"].split("@")[0] for k in pocket} == {"pocket"}
 
 
 def _records_a_measurement(call) -> bool:

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -518,6 +518,33 @@ def test_a_bare_id_and_a_sequence_are_both_accepted():
     assert reg.measurement_of("c") == (), "a sequence of nothing is still unknown"
 
 
+def test_a_location_dim_two_features_share_records_both_measurements():
+    """The dedup path, which the single-hole canary never reached (#1002 r4).
+
+    Two distinct holes at the same X collapse to ONE `m_locx0`. That dim is deliberately
+    feature-*unowned* so `drop(feature)` cannot strip a sibling's dimension (ADR 0010) — but
+    the first cut let the measurement follow the feature and recorded nothing, conflating an
+    ownership rule with an identity one. A shared dim measures BOTH holes' X, and the
+    tuple-valued channel exists to say so (ADR 0016 / #886).
+
+    Asserted end to end because no source scan can see it: the renderer passes a variable, so
+    `measurement=_xmid` satisfies the syntax ratchet whether or not it holds anything.
+    """
+    with BuildPart() as p:
+        Box(60, 50, 10)
+        with Locations((10, 5, 0)):
+            Hole(3)
+        with Locations((10, 15, 0)):
+            Hole(5)
+    dwg = build_drawing(p.part)
+
+    assert dwg.registry.feature_of("m_locx0") is None, "shared dim stays unowned (ADR 0010)"
+    keys = dwg.measurement_keys("m_locx0")
+    assert len(keys) == 2, "it measures BOTH holes' X location, not neither"
+    assert {k["parameter_id"] for k in keys} == {"location.location"}
+    assert len({k["feature"] for k in keys}) == 2, "two distinct holes, not one repeated"
+
+
 def test_a_real_build_records_identity_for_the_machined_feature_callouts():
     """Behavioural counterpart to the two syntax ratchets (#1002 r3).
 

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -47,9 +47,9 @@ class _FakeDrawing:
     def suppressions(self):
         return list(self._supp)
 
-    def measurement_key(self, name):
+    def measurement_keys(self, name):
         ident = self._ids.get(name)
-        return None if ident is None else {"feature": ident[0], "parameter_id": ident[1]}
+        return [] if ident is None else [{"feature": ident[0], "parameter_id": ident[1]}]
 
 
 def _supp(parameter, reason, feature="envelope@(0,0,0)/z"):
@@ -69,14 +69,26 @@ def test_a_loss_a_rule_accounts_for_is_not_unexplained():
     suffices)" and can ask whether a 50x50 part should really have no plan size. The
     measurement is gone, but nothing is hidden.
     """
-    env = "envelope@(0,0,0)/z"
+    # The two builds describe DIFFERENT geometry — that is the whole point of a
+    # differential — so the feature keys differ in their scalars. An exact join on the
+    # ledger key finds nothing here and reports "nothing claims it" for a suppression that
+    # plainly does claim it (Codex #1002 r1, reproduced on a real build). The cross-build
+    # correspondence key is what makes this match.
+    before_env = "envelope@(0,0,0)/z[depth=40.000,width=50.000]"
+    after_env = "envelope@(0,0,0)/z[depth=50.000,width=50.000]"
     before = _FakeDrawing(
         {"m_env_width": "50", "m_env_depth": "40", "dim_height": "30"},
-        identities={"m_env_width": (env, "width.length"), "m_env_depth": (env, "depth.length")},
+        identities={
+            "m_env_width": (before_env, "width.length"),
+            "m_env_depth": (before_env, "depth.length"),
+        },
     )
     after = _FakeDrawing(
         {"dim_height": "30"},
-        [_supp("width.length", "square footprint"), _supp("depth.length", "square footprint")],
+        [
+            _supp("width.length", "square footprint", feature=after_env),
+            _supp("depth.length", "square footprint", feature=after_env),
+        ],
     )
 
     diff = diff_builds(before, after)
@@ -261,44 +273,69 @@ def test_a_same_name_same_label_replacement_is_caught_with_identity():
     diff = diff_builds(before, after)
     assert diff["dimensions_lost"] == {} and diff["dimensions_changed"] == {}
     assert diff["measurements_substituted"] == {
-        "m_x0": (("hole@(10,5,5)/z", "location"), ("slot@(10,5,5)/z", "width.length"))
+        "m_x0": ([("hole", "location")], [("slot", "width.length")])
     }
-    assert explain(diff)[0].startswith("SUBSTITUTED: m_x0"), "a changed parameter is an alarm"
+    assert explain(diff)[0].startswith("SUBSTITUTED: m_x0"), "a real substitution is an alarm"
 
 
-def test_the_same_measurement_of_a_moved_feature_is_reported_not_alarmed():
-    """A perturbation study MOVES features, so `feature_key` legitimately changes on every
-    run. Ranking that as an alarm would bury the real losses under one line per moved feature
-    — the failure mode `explain`'s ordering exists to prevent.
+def test_moving_a_feature_is_not_a_substitution():
+    """A perturbation study MOVES features, and `feature_key` embeds the origin and the
+    scalars — so the full ledger key changes on every run of the experiment this module
+    exists to run.
 
-    So a changed feature with an unchanged parameter is reported below the alarms, not as one.
+    Comparing that key reported EVERY dimension of EVERY perturbed feature as changed
+    identity: on a real 50x40 -> 50x50 box, three noise lines on a three-dimension drawing
+    (Codex #1002 r1). The correspondence key is the fix — same hole, same measurement, so
+    nothing is reported but the value change.
     """
     before = _FakeDrawing({"m_x0": "70"}, identities={"m_x0": ("hole@(10,5,5)/z", "location")})
     after = _FakeDrawing({"m_x0": "90"}, identities={"m_x0": ("hole@(30,5,5)/z", "location")})
 
-    lines = explain(diff_builds(before, after))
-    assert not any(line.startswith("SUBSTITUTED") for line in lines)
-    assert any(line.startswith("reattributed: m_x0") for line in lines)
+    diff = diff_builds(before, after)
+    assert diff["measurements_substituted"] == {}, "the same measurement, moved"
+    assert explain(diff) == ["changed: m_x0 70 -> 90"]
 
 
-def test_a_suppression_on_another_feature_does_not_explain_this_loss():
-    """The canary for the attribution fix (#1002).
+def test_a_suppression_on_a_different_kind_of_feature_does_not_explain_this_loss():
+    """The canary for the attribution fix (#1002), on the shape the historical bug had.
 
     The first cut matched a suppression's parameter STEM against the annotation's NAME by
-    substring, so a newly-suppressed `width.length` on ANY feature claimed every lost
-    annotation whose name contained "width" (Codex #1001 r1). Here the stem matches the name
-    and the parameter matches exactly — only the feature differs, which is precisely what a
-    name-based match cannot see. The loss must stay unexplained.
+    substring, so an ENVELOPE `width.length` suppression claimed a lost SLOT width — the
+    stem "width" appears in the name (Codex #1001 r1). Identity separates them because the
+    feature kinds differ, which is exactly what a name-based match cannot see.
     """
     before = _FakeDrawing(
-        {"m_width0": "20"}, identities={"m_width0": ("slot@(0,0,0)/z", "width.length")}
+        {"m_slot_width0": "20"},
+        identities={"m_slot_width0": ("slot@(0,0,0)/z", "width.length")},
+    )
+    after = _FakeDrawing({}, [_supp("width.length", "square footprint", feature="envelope@z")])
+
+    diff = diff_builds(before, after)
+    assert "m_slot_width0" in diff["dimensions_lost"]
+    assert diff["candidate_explanations"] == {}, "another KIND's rule explains nothing"
+    assert explain(diff)[0].endswith("nothing claims it")
+
+
+def test_two_features_of_one_kind_are_not_separated_by_the_cross_build_key():
+    """The price of matching across builds, asserted rather than left to be discovered.
+
+    The cross-build key is `(feature KIND, parameter_id)` — it must be, because the full
+    ledger key embeds coordinates and scalars that any perturbation changes. So a rule that
+    fired on a DIFFERENT slot still reads as a candidate explanation for this one.
+
+    Tolerable only because attribution never cancels an alarm: the loss is still reported,
+    with a hint that may be the wrong slot. Narrowing it needs a cross-build feature
+    correspondence the engine does not have (ADR 0016 leaves a durable `FeatureId` open).
+    """
+    before = _FakeDrawing(
+        {"m_slot0_width": "20"},
+        identities={"m_slot0_width": ("slot@(0,0,0)/z", "width.length")},
     )
     after = _FakeDrawing({}, [_supp("width.length", "coincident", feature="slot@(99,0,0)/z")])
 
     diff = diff_builds(before, after)
-    assert "m_width0" in diff["dimensions_lost"]
-    assert diff["candidate_explanations"] == {}, "a different feature's rule explains nothing"
-    assert explain(diff)[0].endswith("nothing claims it")
+    assert diff["candidate_explanations"] == {"m_slot0_width": ["coincident"]}, "same kind"
+    assert "m_slot0_width" in diff["dimensions_lost"], "hinted, never cancelled"
 
 
 def test_a_suppression_on_the_same_measurement_does_explain_the_loss():
@@ -390,21 +427,22 @@ def test_a_real_build_records_which_measurement_its_location_dims_draw():
             Hole(4)
     dwg = build_drawing(p.part)
 
-    keyed = {n: dwg.measurement_key(n) for n in dwg.annotations()}
-    identified = {n: k for n, k in keyed.items() if k is not None}
+    keyed = {n: dwg.measurement_keys(n) for n in dwg.annotations()}
+    identified = {n: k for n, k in keyed.items() if k}
     assert identified, "the compiled-plan renderers must record what they drew"
-    for name, key in identified.items():
-        assert set(key) == {"feature", "parameter_id"}, f"{name}: the ledger's key shape"
+    for name, keys in identified.items():
+        for key in keys:
+            assert set(key) == {"feature", "parameter_id"}, f"{name}: the ledger's key shape"
 
     # The two threaded groups, named rather than counted: a count would keep passing if a
     # renderer stopped recording and another started.
-    assert identified["m_locx0"]["feature"].startswith("hole@"), "located hole"
-    assert identified["m_env_width"]["feature"].startswith("envelope@"), "overall extent"
+    assert identified["m_locx0"][0]["feature"].startswith("hole@"), "located hole"
+    assert identified["m_env_width"][0]["feature"].startswith("envelope@"), "overall extent"
 
-    assert dwg.measurement_key("title_block") is None, "furniture measures nothing"
+    assert dwg.measurement_keys("title_block") == [], "furniture measures nothing"
     # Not yet threaded, and asserted so the gap is visible rather than assumed closed: the
     # hole callout is on the legacy surface (#926) and the direct-placing group is #754.
-    assert dwg.measurement_key("hc_plan0") is None, "callouts still record none (#926)"
+    assert dwg.measurement_keys("hc_plan0") == [], "callouts still record none (#926)"
 
 
 def test_identity_survives_the_repair_loops_snapshot_and_restore():
@@ -423,10 +461,10 @@ def test_identity_survives_the_repair_loops_snapshot_and_restore():
     snap = reg.snapshot()
 
     reg.add(object(), "m_x0", "plan", feature="g", measurement="other")
-    assert reg.measurement_of("m_x0") == "other"
+    assert reg.measurement_of("m_x0") == ("other",)
 
     reg.restore(snap)
-    assert reg.measurement_of("m_x0") == "mid", "a rollback restores what was drawn"
+    assert reg.measurement_of("m_x0") == ("mid",), "a rollback restores what was drawn"
 
 
 def test_re_adding_a_name_without_an_identity_clears_the_old_one():
@@ -442,4 +480,109 @@ def test_re_adding_a_name_without_an_identity_clears_the_old_one():
     reg.add(object(), "m_x0", "plan", feature="f", measurement="mid")
     reg.add(object(), "m_x0", "plan")
 
-    assert reg.measurement_of("m_x0") is None, "cleared, not inherited"
+    assert reg.measurement_of("m_x0") == (), "cleared, not inherited"
+
+
+def test_an_annotation_can_draw_several_measurements():
+    """The registry stores a TUPLE, and the relationship really is one-to-many: a compound
+    hole callout renders bore diameter, depth and counterbore as ONE annotation, each
+    independently suppressible.
+
+    ADR 0016 states this outright — the provenance channel "has to become
+    `name -> tuple[DimensionId, ...]` before per-dimension resolution is possible at all"
+    (#886). Storing one id would make the audit's "exact when present" promise false for
+    every other measurement the annotation carries, so the storage models it from the start
+    even though today's threaded renderers each supply exactly one.
+    """
+    from draftwright.registry import AnnotationRegistry
+
+    reg = AnnotationRegistry()
+    reg.add(object(), "hc0", "plan", measurement=["bore.diameter", "bore.depth"])
+
+    assert reg.measurement_of("hc0") == ("bore.diameter", "bore.depth")
+
+
+def test_a_bare_id_and_a_sequence_are_both_accepted():
+    """The common renderer draws one measurement and passes the `DimensionId` it already
+    holds — `measurement=pd.id`. Normalising at the boundary keeps that call site honest
+    without the storage pretending the relationship is one-to-one."""
+    from draftwright.registry import AnnotationRegistry
+
+    reg = AnnotationRegistry()
+    reg.add(object(), "a", "plan", measurement="one")
+    reg.add(object(), "b", "plan", measurement=("one", "two"))
+    reg.add(object(), "c", "plan", measurement=[None])
+
+    assert reg.measurement_of("a") == ("one",)
+    assert reg.measurement_of("b") == ("one", "two")
+    assert reg.measurement_of("c") == (), "a sequence of nothing is still unknown"
+
+
+def test_every_compiled_plan_dimensional_renderer_records_identity():
+    """The ratchet Codex asked for (#1002 r1): enumerate the renderers, do not spot-check.
+
+    The first cut threaded three renderers and documented the remaining gap as "the
+    direct-placing rotational group" — while slots, plate thicknesses, short step rungs and
+    the step-position ladder all held an `ApprovedDimension.id` and silently dropped it. The
+    documentation invited a reader to treat the unknown set as narrowly bounded when it was
+    not, which is the failure this whole epic exists to stop.
+
+    So this asserts the SOURCE, not one part's output: every `CorridorCandidate` built in the
+    IR render layer either passes a measurement or sits in EXEMPT with a reason. A renderer
+    added later that forgets fails here instead of quietly widening the unknown set again.
+    """
+    import ast
+    import pathlib
+
+    # Keyed by enclosing function so it survives edits above it, unlike a line number.
+    EXEMPT = {
+        # The shared location factory: its callers pass `measurement=` in, and it forwards.
+        "_location_candidate": "receives the id as a parameter",
+        # PMI comes from STEP AP242 extraction, not from the compiled plan — there is no
+        # ApprovedDimension and so no DimensionId to record.
+        "_pmi_queue_options": "PMI records are not compiled dimensions",
+        # GD&T frames are standalone IR features (ControlFrame/DatumRef/Finish, ADR 0011),
+        # placed as corridor candidates but carrying no dimensional measurement.
+        "render_gdt": "a control frame is not a measurement",
+    }
+
+    src = pathlib.Path("src/draftwright/annotations/from_model.py").read_text()
+    tree = ast.parse(src)
+    owner = {}
+    for fn in ast.walk(tree):
+        if isinstance(fn, ast.FunctionDef):
+            for line in range(fn.lineno, (fn.end_lineno or fn.lineno) + 1):
+                # Innermost wins: nested defs are visited after their parent's range is set
+                # only if they are narrower, so prefer the smallest enclosing span.
+                prev = owner.get(line)
+                if prev is None or (fn.end_lineno - fn.lineno) < (prev[1] - prev[0]):
+                    owner[line] = (fn.lineno, fn.end_lineno or fn.lineno, fn.name)
+
+    unrecorded = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call) and getattr(node.func, "id", None) == "CorridorCandidate"
+        ):
+            continue
+        if "measurement" in {k.arg for k in node.keywords}:
+            continue
+        # Attribute to the nearest ENCLOSING top-level renderer that EXEMPT can name.
+        names = {
+            o[2]
+            for line, o in owner.items()
+            if o[0] <= node.lineno <= o[1] and line == node.lineno
+        }
+        enclosing = {
+            fn.name
+            for fn in ast.walk(tree)
+            if isinstance(fn, ast.FunctionDef) and fn.lineno <= node.lineno <= (fn.end_lineno or 0)
+        }
+        if enclosing & set(EXEMPT):
+            continue
+        unrecorded.append((node.lineno, sorted(names or enclosing)))
+
+    assert not unrecorded, (
+        f"CorridorCandidate records no measurement identity at {unrecorded}. "
+        "Pass measurement=<the ApprovedDimension>.id, or add the renderer to EXEMPT "
+        "with the reason it carries no compiled measurement."
+    )

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -518,71 +518,179 @@ def test_a_bare_id_and_a_sequence_are_both_accepted():
     assert reg.measurement_of("c") == (), "a sequence of nothing is still unknown"
 
 
-def test_every_compiled_plan_dimensional_renderer_records_identity():
-    """The ratchet Codex asked for (#1002 r1): enumerate the renderers, do not spot-check.
+def test_a_real_build_records_identity_for_the_machined_feature_callouts():
+    """Behavioural counterpart to the two syntax ratchets (#1002 r3).
 
-    The first cut threaded three renderers and documented the remaining gap as "the
-    direct-placing rotational group" — while slots, plate thicknesses, short step rungs and
-    the step-position ladder all held an `ApprovedDimension.id` and silently dropped it. The
-    documentation invited a reader to treat the unknown set as narrowly bounded when it was
-    not, which is the failure this whole epic exists to stop.
+    The shared `_leader_callout_pass` renders chamfers, fillets, flats, pockets, grooves and
+    boss diameters, and recorded nothing for any of them while the module docstring listed a
+    four-item exception set. Source scans alone would not have caught that — the keyword was
+    simply absent from a path nothing scanned — so this reads a real build's output.
 
-    So this asserts the SOURCE, not one part's output: every `CorridorCandidate` built in the
-    IR render layer either passes a measurement or sits in EXEMPT with a reason. A renderer
-    added later that forgets fails here instead of quietly widening the unknown set again.
+    The fillet case is the important one: four equal fillets collapse to ONE `4× R5` callout,
+    so the annotation genuinely draws four measurements. That is the one-to-many relationship
+    ADR 0016 requires the channel to carry (#886), exercised end to end rather than asserted
+    on the registry in isolation.
+    """
+    from build123d import Axis, Box, chamfer, fillet
+
+    part = Box(60, 40, 20)
+    chamfered = build_drawing(chamfer(part.edges().filter_by(Axis.Z), 3))
+    keys = chamfered.measurement_keys("m_chamfer_z0")
+    assert [k["parameter_id"] for k in keys] == ["chamfer.length"]
+    assert keys[0]["feature"].startswith("chamfer@")
+
+    filleted = build_drawing(fillet(part.edges().filter_by(Axis.Z), 5))
+    grouped = filleted.measurement_keys("m_fillet_z0")
+    assert len(grouped) == 4, "one grouped callout, four collapsed members"
+    assert {k["parameter_id"] for k in grouped} == {"fillet.radius"}
+    assert len({k["feature"] for k in grouped}) == 4, "four distinct fillets, not one repeated"
+
+
+def _records_a_measurement(call) -> bool:
+    """True when *call* passes a ``measurement=`` that could actually carry an id.
+
+    A literal satisfies the keyword while recording nothing — ``measurement=None`` and
+    ``measurement=()`` both leave the annotation unidentified — so testing only that the
+    KEYWORD IS PRESENT yields a ratchet that cannot fail, which is precisely what the first
+    cut did (Codex #1002 r3). Constants and the empty-tuple literal are rejected; a name,
+    attribute or call is accepted.
+
+    Syntax, not dataflow: a variable that happens to hold ``None`` still passes here. That
+    limit is stated rather than papered over — the behavioural counterpart is
+    `test_a_real_build_records_which_measurement_its_location_dims_draw`, which reads a real
+    build's output rather than its source.
+    """
+    import ast
+
+    for kw in call.keywords:
+        if kw.arg != "measurement":
+            continue
+        if isinstance(kw.value, ast.Constant):
+            return False
+        return not (isinstance(kw.value, ast.Tuple) and not kw.value.elts)
+    return False
+
+
+def test_every_direct_placement_records_identity_or_says_why_not():
+    """The `ctx.place(...)` paths — the half the candidate ratchet never saw (#1002 r3).
+
+    The first ratchet scanned `CorridorCandidate(...)` only, so the shared machined-feature
+    renderer `_leader_callout_pass` — chamfers, fillets, flats, pockets, grooves, boss
+    diameters — placed with no identity at all while `audit.py` told readers the only gaps
+    were hole callouts, PMI, GD&T and the rotational group. The claim was false, and nothing
+    could have caught it.
+
+    Scanned across the WHOLE `annotations/` package, not one module. The first version of
+    this ratchet read `from_model.py` alone and so missed the two pattern-callout producers
+    in `holes.py` — the same mistake one level up, caught only because the tuple arity change
+    broke them at runtime. A guard narrower than its claim is the recurring defect here.
+
+    Every direct place in the package now either records a measurement or is listed below
+    with the reason it carries none. **The EXEMPT map IS the exception inventory** `audit.py`
+    refuses to restate in prose — and a stale entry fails too, so it cannot rot into a list
+    of excuses for renderers that have since been fixed.
+
+    Its reach ends at the placement site. `_leader_callout_pass` receives identity down a job
+    tuple, so a *producer* that passed `()` would satisfy this while recording nothing — the
+    job-tuple arity catches a dropped element, and
+    `test_a_real_build_records_identity_for_the_machined_feature_callouts` catches an empty
+    one for the kinds it builds. Stated because a canary for that case did NOT fire here.
     """
     import ast
     import pathlib
 
-    # Keyed by enclosing function so it survives edits above it, unlike a line number.
     EXEMPT = {
-        # The shared location factory: its callers pass `measurement=` in, and it forwards.
-        "_location_candidate": "receives the id as a parameter",
-        # PMI comes from STEP AP242 extraction, not from the compiled plan — there is no
-        # ApprovedDimension and so no DimensionId to record.
-        "_pmi_queue_options": "PMI records are not compiled dimensions",
-        # GD&T frames are standalone IR features (ControlFrame/DatumRef/Finish, ADR 0011),
-        # placed as corridor candidates but carrying no dimensional measurement.
-        "render_gdt": "a control frame is not a measurement",
+        # -- furniture: nothing here measures anything ------------------------------
+        ("from_model.py", "render_centermarks"): "a centre mark measures nothing",
+        (
+            "from_model.py",
+            "render_local_turned_centerlines._place",
+        ): "centrelines are furniture",
+        ("holes.py", "add_feature_furniture"): "centre marks are furniture",
+        ("holes.py", "_add_furniture"): "bolt-circle centre-cross is furniture",
+        ("balloons.py", "_render_balloon"): "a balloon tags a hole, it does not measure it",
+        ("sections.py", "_add_section_view"): "section geometry + its caption",
+        ("sections.py", "_add_section_letters"): "the 'A' identification letters",
+        ("sections.py", "_add_cutting_plane_arrows"): "ISO 128-44 arrows are not dimensions",
+        ("sections.py", "_render_detail"): "detail-view geometry, caption and circle",
+        (
+            "sections.py",
+            "_request_prismatic_detail.redraw",
+        ): "re-renders the section geometry, not a dimension",
+        # -- hole callouts: still on the legacy surface (#926) ----------------------
+        ("holes.py", "add_feature_callout"): "hole callouts are pre-compiled-plan (#926)",
+        ("holes.py", "_place_queue"): "hole callouts are pre-compiled-plan (#926)",
+        # -- the direct-placing rotational group (#754) -----------------------------
+        ("from_model.py", "render_rotational"): "direct-placing rotational group (#754)",
+        ("from_model.py", "_diameter_row_below"): "direct-placing rotational group (#754)",
+        ("from_model.py", "_diameter_column_left"): "direct-placing rotational group (#754)",
+        # -- gaps that ARE measurements, with the id not yet plumbed ----------------
+        # Named individually rather than waved at, because each is a real hole in the
+        # audit's attribution and each needs its own plumbing.
+        ("from_model.py", "_draw_step_chain"): "step-chain segs carry no id (#1004)",
+        (
+            "holes.py",
+            "_place_pitch_dim",
+        ): "pattern pitch dims carry no id (#1005)",
+        (
+            "holes.py",
+            "_place_pitch_dim._place",
+        ): "pattern pitch dims carry no id (#1005)",
+        ("holes.py", "_off_axis_queue"): "side-hole location candidates, no id map (#1005)",
+        # -- identity arrives by another route --------------------------------------
+        ("from_model.py", "_reroute_crossing_diameters"): "reapplies the saved identity",
+        ("orchestrator.py", "_maybe_tabulate_holes"): "reapplies the saved identity",
+        ("sections.py", "_resolve_details"): "reapplies the saved identity",
+        # -- not a measurement (ADR 0011) -------------------------------------------
+        ("from_model.py", "_drop._retry"): "GD&T relaxed-side retry places a control frame",
+        ("from_model.py", "_pmi_queue_options"): "PMI records are not compiled dimensions",
+        ("from_model.py", "render_gdt"): "a control frame is not a measurement",
     }
 
-    src = pathlib.Path("src/draftwright/annotations/from_model.py").read_text()
-    tree = ast.parse(src)
-    owner = {}
-    for fn in ast.walk(tree):
-        if isinstance(fn, ast.FunctionDef):
-            for line in range(fn.lineno, (fn.end_lineno or fn.lineno) + 1):
-                # Innermost wins: nested defs are visited after their parent's range is set
-                # only if they are narrower, so prefer the smallest enclosing span.
-                prev = owner.get(line)
-                if prev is None or (fn.end_lineno - fn.lineno) < (prev[1] - prev[0]):
-                    owner[line] = (fn.lineno, fn.end_lineno or fn.lineno, fn.name)
+    unrecorded, used = [], set()
+    for path in sorted(pathlib.Path("src/draftwright/annotations").glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        fns = [f for f in ast.walk(tree) if isinstance(f, ast.FunctionDef)]
 
-    unrecorded = []
-    for node in ast.walk(tree):
-        if not (
-            isinstance(node, ast.Call) and getattr(node.func, "id", None) == "CorridorCandidate"
-        ):
-            continue
-        if "measurement" in {k.arg for k in node.keywords}:
-            continue
-        # Attribute to the nearest ENCLOSING top-level renderer that EXEMPT can name.
-        names = {
-            o[2]
-            for line, o in owner.items()
-            if o[0] <= node.lineno <= o[1] and line == node.lineno
-        }
-        enclosing = {
-            fn.name
-            for fn in ast.walk(tree)
-            if isinstance(fn, ast.FunctionDef) and fn.lineno <= node.lineno <= (fn.end_lineno or 0)
-        }
-        if enclosing & set(EXEMPT):
-            continue
-        unrecorded.append((node.lineno, sorted(names or enclosing)))
+        def enclosing(line, fns=fns):
+            """The DOTTED path of enclosing functions, e.g. ``locate._place``.
+
+            Bare names are not unique: `holes.py` has two nested `_place` helpers, one for
+            location dims and one for pitch dims, so a single `("holes.py", "_place")` entry
+            exempted both — and silently covered the one that had just been fixed. Caught by
+            a canary that failed to fire, which is the only way that class of hole shows up.
+            """
+            chain = sorted(
+                (f for f in fns if f.lineno <= line <= (f.end_lineno or 0)),
+                key=lambda f: f.end_lineno - f.lineno,
+                reverse=True,
+            )
+            return ".".join(f.name for f in chain[-2:]) if chain else "?"
+
+        for node in ast.walk(tree):
+            is_place = (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "place"
+            )
+            is_cand = isinstance(node, ast.Call) and getattr(node.func, "id", None) == (
+                "CorridorCandidate"
+            )
+            if not (is_place or is_cand) or _records_a_measurement(node):
+                continue
+            key = (path.name, enclosing(node.lineno))
+            if key in EXEMPT:
+                used.add(key)
+                continue
+            unrecorded.append((path.name, node.lineno, key[1]))
 
     assert not unrecorded, (
-        f"CorridorCandidate records no measurement identity at {unrecorded}. "
-        "Pass measurement=<the ApprovedDimension>.id, or add the renderer to EXEMPT "
-        "with the reason it carries no compiled measurement."
+        f"these place an annotation with no measurement identity: {unrecorded}. "
+        "Pass measurement=<the ApprovedDimension>.id, or add the enclosing renderer to "
+        "EXEMPT with the reason it carries no compiled measurement."
+    )
+    assert set(EXEMPT) == used, (
+        f"stale EXEMPT entries — these renderers no longer need an exemption: "
+        f"{sorted(set(EXEMPT) - used)}. Delete them, or the inventory becomes a list of "
+        "excuses for code that has since been fixed."
     )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -131,3 +131,96 @@ def test_snapshot_restore_round_trips_view_and_pin_metadata():
     assert r.view_of("d2") == "plan"  # NOT the repaired "side"
     assert r.view_of("d3") is None  # its stale view entry is gone
     assert r.is_pinned("d1") and not r.is_pinned("d3")  # pins restored exactly
+
+
+def test_identity_of_reapply_round_trips_every_axis():
+    # The remove/re-add transactions (callout re-route, hole-table fallback, detail-view
+    # retry) restore through this pair. It must carry the measurement id too: a restored
+    # dim that has lost it reads as "nothing claims it" to the audit — a false negative in
+    # exactly the tool this identity exists to feed (#1002, Codex r2).
+    r = AnnotationRegistry()
+    obj, feat = object(), object()
+    r.add(obj, "d1", "front", feature=feat, measurement=("bore.depth",))
+    r.pin("d1")
+    ident = r.identity_of("d1")
+
+    removed = r.remove("d1")
+    assert r.identity_of("d1") == {  # gone in every axis, not just the object
+        "view": None,
+        "feature": None,
+        "measurement": (),
+        "pinned": False,
+    }
+
+    r.add(removed, "d1", None)  # the bare re-place the call sites do …
+    r.reapply("d1", ident)  # … then the identity, as a unit
+    assert r.view_of("d1") == "front"
+    assert r.feature_of("d1") is feat
+    assert r.measurement_of("d1") == ("bore.depth",)
+    assert r.is_pinned("d1")
+
+
+def test_reapply_clears_axes_the_identity_does_not_carry():
+    # Authoritative, not additive: a restore must never leave the name wearing metadata
+    # from whatever briefly held the slot.
+    r = AnnotationRegistry()
+    r.add(object(), "d1", "plan", feature=object(), measurement=("width.length",))
+    r.pin("d1")
+    r.reapply("d1", {"view": "front", "feature": None, "measurement": (), "pinned": False})
+    assert r.view_of("d1") == "front"
+    assert r.feature_of("d1") is None
+    assert r.measurement_of("d1") == ()
+    assert not r.is_pinned("d1")
+
+
+def test_identity_of_covers_every_per_name_axis():
+    """Ratchet: a FOURTH identity axis cannot be added and then silently forgotten.
+
+    That is the defect this pair exists to end — `_anno_feature` (#398) and
+    `_anno_measurement` (#1002) were each added without updating every restore site, and
+    each loss was found by a reviewer rather than by a test. The keys of `identity_of`
+    mirror the `_anno_*` map names so the two can be compared mechanically here.
+    """
+    r = AnnotationRegistry()
+    axes = {n for n in vars(r) if n.startswith("_anno_")}
+    ident = r.identity_of("nothing-registered")
+    assert {f"_anno_{k}" for k in ident if k != "pinned"} == axes
+    assert "pinned" in ident  # the non-`_anno_` axis, asserted explicitly
+
+
+def test_every_remove_and_restore_site_goes_through_the_identity_pair():
+    """Ratchet: the restore SITES, not just the primitive (Codex #1002 r2).
+
+    A registry-level round-trip cannot catch a call site that hand-rolls the axes — which is
+    precisely how this bug arrived three times. Any annotation pass that removes a name and
+    puts it back must read `identity_of` and write `reapply`; a pass that removes without
+    restoring says so here, with a reason.
+    """
+    import ast
+    import pathlib
+
+    # function name -> why it may remove without restoring identity
+    EXEMPT = {
+        "_clear_section_reservation": "deletes the reserved section marks outright; no restore"
+    }
+
+    root = pathlib.Path("src/draftwright/annotations")
+    offenders = []
+    for path in sorted(root.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            calls = {
+                n.func.attr
+                for n in ast.walk(fn)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+            }
+            if "remove" not in calls or fn.name in EXEMPT:
+                continue
+            if not {"identity_of", "reapply"} <= calls:
+                offenders.append(f"{path.name}:{fn.name}")
+    assert offenders == [], (
+        "these remove a named annotation without round-tripping its identity: "
+        + ", ".join(offenders)
+    )

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -240,7 +240,7 @@ class TestDiameterColumnOccupancy:
             def view_of(s, n):
                 return "front"
 
-            def add(s, ann, name, view, feature=None):
+            def add(s, ann, name, view, feature=None, measurement=None):
                 pass
 
         return _Dwg()

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -605,7 +605,7 @@ def test_place_strip_candidates_reserves_outermost_label_within_bounds():
         def view_of(s, n):
             return "plan"
 
-        def place(s, obj, name, view=None, feature=None):
+        def place(s, obj, name, view=None, feature=None, measurement=None):
             s.added.append((name, obj))
 
     strip = Strip(anchor=0.0, outer_limit=20.0, direction=1.0, gap=8.0, spacing=4.0)  # near=8
@@ -635,7 +635,7 @@ def test_place_strip_candidates_priority_survives_key_order():
         def view_of(s, n):
             return "plan"
 
-        def place(s, obj, name, view=None, feature=None):
+        def place(s, obj, name, view=None, feature=None, measurement=None):
             s.added.append((name, obj))
 
     def _run(priorities):
@@ -724,7 +724,7 @@ def test_place_strip_candidates_refills_after_late_forbid_rejection():
         def view_of(s, n):
             return "plan"
 
-        def place(s, obj, name, view=None, feature=None):
+        def place(s, obj, name, view=None, feature=None, measurement=None):
             s.added.append((name, obj))
 
     strip = Strip(anchor=0.0, outer_limit=13.0, direction=1.0, gap=0.0, spacing=4.0)
@@ -766,7 +766,7 @@ def test_place_strip_candidates_honors_per_candidate_natural_anchor():
         def view_of(s, n):
             return "plan"
 
-        def place(s, obj, name, view=None, feature=None):
+        def place(s, obj, name, view=None, feature=None, measurement=None):
             s.added.append((name, obj))
 
     strip = Strip(anchor=0.0, outer_limit=60.0, direction=1.0, gap=0.0, spacing=4.0)
@@ -818,7 +818,7 @@ def test_place_strip_candidates_ignores_perpendicular_disjoint_obstacle():
         def view_of(s, n):
             return "plan"
 
-        def place(s, o, n, view=None, feature=None):
+        def place(s, o, n, view=None, feature=None, measurement=None):
             s.added.append((n, o))
 
     # obstacle spans the whole strip in X but sits at y=[0,5]; the candidate dim is y=[30,40]


### PR DESCRIPTION
Closes part 2 of #1002 (epic #996, WP1).

## The problem

The audit's two halves could not be joined. `Drawing.suppressions()` keys a removed
measurement as `(feature, parameter_id)`. A placed annotation carried only an
engine-assigned registry name. So `audit` matched a suppression's **parameter stem against
the annotation's name by substring** — which attributed a lost slot width to an unrelated
envelope suppression (Codex #1001 r1), and left every same-name replacement invisible.

## What this does

`DimensionId` already exists, is frozen, compares structurally, and is already on every
`ApprovedDimension` — so this threads the identity the compiler mints rather than inventing
one. `CorridorCandidate.measurement` → `registry.add(..., measurement=)`, a peer of the ADR
0010 feature tag, snapshot/restored with it and cleared on replacement for the same reason.

Threaded at the compiled-plan renderers that hold an approved dim: **locations, envelope
extents, the height ladder.**

Two behaviour changes fall out:

- **Attribution is an exact `(feature, parameter_id)` join.** A rule on a *different*
  feature no longer explains this loss. Where identity is absent the loss reads "nothing
  claims it" — unknown rather than guessed.
- **`measurements_substituted`** reports a name that changed what it measures — the module's
  worst documented blind spot, previously a wholly empty diff.

## Two things I had to correct mid-way, both worth reading

**A design that was nearly inert.** I first compared the *parameter* half only, reasoning
that the feature half is positional and would change on every perturbation. Then I measured:
a hole's X and Y location dims share **one** id (`location.location`), because `location` is
addressable per feature and per-member identity is still open (ADR 0016 / #883). So
parameter-only comparison could almost never fire. Now both halves are compared and
`explain` ranks them apart — a changed parameter alarms, a changed feature is reported
*below* the alarms, since ranking it higher would fire on every perturbation study.

**A regression the tests caught.** Exact-only attribution initially made the #997 case
*worse*: envelope dims had no identity, so "square footprint" stopped explaining the lost
extents — the tool losing the very explanation that motivated it. That's what pushed the
envelope and height-ladder renderers into scope rather than locations alone.

## Coverage is partial, deliberately, and asserted

Hole callouts are on the legacy surface (#926); the rotational OD/bore group places directly
(#754). The end-to-end test asserts **both** the presence and the absence, so the gap stays
visible rather than assumed closed, and the module docstring says exactly which limits are
consequences of which gap.

## Canary

`test_a_suppression_on_another_feature_does_not_explain_this_loss` was run against the old
substring join and **fails** there — verified, not assumed.

## Verification

- 20 audit tests, plus registry / label-provenance / GD&T-placement / compiled-plan-boundary
  / add-dimension / make-drawing: **940 passed, 1 skipped**
- smoke: **51 passed**
- ruff check, ruff format, mypy, codespell: **clean**

## ADR fit

ADR 0010's provenance seam gains the finer axis it always implied ("even a known feature does
not identify *which* measurement"). ADR 0016's `DimensionId` is reused as-is rather than
duplicated. No import-layer change — `audit` stays a rank-0 leaf, reading the new
`Drawing.measurement_key()` on the public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
