### PR TITLE
feat(#996): per-feature completeness check — BLOCKED on #1009

### DIFF
--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -16,6 +16,11 @@ Import the public surface from here, not the submodules.
 
 from __future__ import annotations
 
+from draftwright.linting.completeness import (
+    FeatureVerdict,
+    completeness_summary,
+    feature_completeness,
+)
 from draftwright.linting.coverage import (
     CoverageState,
     lint_axial_coverage,
@@ -31,8 +36,11 @@ from draftwright.linting.suggest import _suggest_fix
 
 __all__ = [
     "CoverageState",
+    "FeatureVerdict",
     "LintIssue",
     "_suggest_fix",
+    "completeness_summary",
+    "feature_completeness",
     "lint_axial_coverage",
     "lint_boss_height_coverage",
     "lint_declaration_reconciliation",

--- a/src/draftwright/linting/completeness.py
+++ b/src/draftwright/linting/completeness.py
@@ -51,23 +51,52 @@ COVERED = "covered"
 UNCOVERED = "uncovered"
 UNCHECKED = "unchecked"
 
-#: kind -> (size parameter ids, location parameter ids). A recognised kind absent from here
-#: answers ``unchecked``, by design — see the module docstring.
+#: kind -> (size parameter ids, location parameter ids) for a feature with nothing special
+#: about it. A recognised kind absent from here answers ``unchecked``, by design.
 #:
-#: The ids are the compiler's own `parameter_id`s, read off real builds rather than guessed,
-#: because a typo here would silently mean "never covered" and read as a real finding.
-_REQUIRED: dict[str, tuple[frozenset, frozenset]] = {
+#: The ids are the compiler's own `parameter_id`s. Every one of them is asserted to appear in
+#: a real build's ledger by `test_every_required_id_is_one_the_compiler_actually_emits` —
+#: because the first cut wrote `location_slot.location` where the compiler emits
+#: `location_slot.length`, which made EVERY slot report its location missing, and nothing
+#: caught it. A hand-maintained string table without a ratchet is an unenforced claim.
+#:
+#: (The two location ids disagree in form — `location_pocket.location` against
+#: `location_slot.length` — which looks like an engine inconsistency rather than a deliberate
+#: distinction. Recorded as a side issue rather than papered over here.)
+_BASE_REQUIRED: dict[str, tuple[frozenset, frozenset]] = {
     "pocket": (
         frozenset({"pocket_width.length", "pocket_length.length", "pocket_depth.length"}),
         frozenset({"location_pocket.location"}),
     ),
     "slot": (
         frozenset({"slot_width.length", "slot_length.length"}),
-        frozenset({"location_slot.location"}),
+        frozenset({"location_slot.length"}),
     ),
     "chamfer": (frozenset({"chamfer.length"}), frozenset()),
     "fillet": (frozenset({"fillet.radius"}), frozenset()),
 }
+
+
+def _requirements(kind: str, feat):
+    """What *this* feature needs — a function of the RECORD, not of its kind.
+
+    Kind alone cannot express a per-feature requirement, and that is not academic: a pocket
+    whose walls are flush with the stock edges is located by those edges, so the planner
+    correctly emits no location dimension for it. A kind-only table demanded one anyway and
+    reported a correct drawing as defective (Codex #1007 r1) — the same fabricated-defect
+    class this module has now produced four ways.
+
+    ``edge_anchored`` is a **recogniser** fact, sitting on the record, so consulting it is not
+    the plan-sourcing the ADR 0015 carve-out forbids. That is the distinction: reading what
+    the geometry IS stays honest; reading what the planner DECIDED would not.
+    """
+    base = _BASE_REQUIRED.get(kind)
+    if base is None:
+        return None
+    size, location = base
+    if getattr(feat, "edge_anchored", False):
+        return size, frozenset()  # the stock edges locate it; no location dim is owed
+    return size, location
 
 
 @dataclass(frozen=True)
@@ -160,14 +189,22 @@ def feature_completeness(part, dwg, *, analysis=None, tol: float = 0.6) -> list[
     drawn = _drawn_by_feature(dwg)
     out: list[FeatureVerdict] = []
     for kind, feats in _inventory(part, analysis):
-        want = _REQUIRED.get(kind)
+        anchors = [_anchor(f) for f in feats]
         for feat in feats:
+            want = _requirements(kind, feat)
             anchor = _anchor(feat)
             if anchor is None:
                 # No anchor means the join cannot run, so nothing can be concluded either
                 # way. Reported as its own key so the feature still APPEARS — a feature
                 # missing from the report reads as "nothing to say about it".
                 out.append(FeatureVerdict(kind, f"{kind}@?", UNCHECKED, UNCHECKED))
+                continue
+            # Two same-kind features within *tol* of each other cannot be told apart by this
+            # join, so a complete neighbour would lend its ids to an incomplete one and the
+            # incomplete one would read covered (Codex #1007 r1). Ambiguity resolves to
+            # UNKNOWN, never to a union — the module's polarity rule, applied to the join.
+            if sum(1 for other in anchors if other is not None and _near(other, anchor, tol)) > 1:
+                out.append(FeatureVerdict(kind, _key(kind, anchor), UNCHECKED, UNCHECKED))
                 continue
             mine = tuple(
                 sorted(
@@ -191,12 +228,20 @@ def _near(a, b, tol: float) -> bool:
 
 
 def _inventory(part, analysis):
-    """``(kind, records)`` for every recognised feature kind.
+    """``(kind, records)`` for the feature kinds this module enumerates.
 
-    Every kind the recognisers produce is listed, including those with no rule yet, so the
-    unchecked set is REAL. Enumerating only the kinds this module can judge would make the
-    report agree with itself by construction — the self-confirming shape the ADR 0015
-    carve-out prevents, one level up.
+    **Not yet every recognised kind.** Hole patterns, pocket/slot patterns, countersinks,
+    plates, face levels, step shoulders and turned steps are absent, so a part dominated by
+    those produces a sparse report. Said plainly because the first version claimed "every
+    recognised feature kind" while omitting all eight — and a report that looks authoritative
+    while silently skipping most of a part is the exact false confidence this epic exists to
+    remove. Tracked as #1008.
+
+    Listing kinds with no rule yet is still deliberate: they answer ``unchecked``, so the
+    report does not agree with itself by construction.
+
+    ``analysis`` is reused where the build already computed an inventory (five of the nine);
+    the rest are recognised here, so this is only partly ADR 0015's one-inventory rule.
     """
     from draftwright.recognition import (
         recognise_bosses,
@@ -247,9 +292,20 @@ def completeness_summary(verdicts) -> dict:
 
 
 def _by_kind(verdicts) -> dict:
+    """``kind -> {complete, undefined, unchecked}`` counting FEATURES.
+
+    The first cut incremented once for size and once for location, so one fully covered
+    pocket read ``{"covered": 2}`` while the surrounding API described feature counts — and
+    the test asserted the field against itself, so it could never have said otherwise
+    (Codex #1007 r1).
+    """
     out: dict = {}
     for v in verdicts:
-        row = out.setdefault(v.kind, {COVERED: 0, UNCOVERED: 0, UNCHECKED: 0})
-        for verdict in (v.size, v.location):
-            row[verdict] += 1
+        row = out.setdefault(v.kind, {"complete": 0, "undefined": 0, "unchecked": 0})
+        if v.complete:
+            row["complete"] += 1
+        elif v.undefined:
+            row["undefined"] += 1
+        else:
+            row["unchecked"] += 1
     return out

--- a/src/draftwright/linting/completeness.py
+++ b/src/draftwright/linting/completeness.py
@@ -1,0 +1,240 @@
+"""Manufacturing completeness — is every recognised feature actually defined? (#996 WP1)
+
+`lint_feature_coverage` asks one narrow question: does every part **diameter** have a
+callout. Four of the five real-part case studies behind #996 (#909/#914/#916/#917/#918)
+produce a drawing you could not manufacture from *and lint clean*, because nobody asks "does
+this pocket have a size" or "does anything say where it is".
+
+This module asks that of **every recognised feature**, and returns a per-feature verdict
+rather than a count.
+
+## The two sides come from opposite places, on purpose
+
+**Requirements** come from **recognition** — the geometry. Never from the dimensioning IR.
+That is the ADR 0015 lint/coverage carve-out (pinned by `tests/test_import_boundaries.py`),
+and its rationale is this epic in one line:
+
+    sourcing coverage from the plan would be circular — a feature the planner omitted would
+    never be flagged
+
+#916, #917 and #918 are all *recognised, never planned*. Ask the plan what ought to be
+dimensioned and those three become invisible by construction, which is exactly why they lint
+clean today.
+
+**Coverage** comes from the finished drawing, via the measurement identity each annotation
+now carries (#1002): `Drawing.measurement_keys()` says which `(feature, parameter)` a placed
+annotation actually draws. That is an exact answer, and it is the reason this check is
+possible at all — the first attempt matched dimension *witness geometry* instead and
+reported a fully-dimensioned pocket as undefined twice over, because its size is a leader
+callout with no witnesses and its location dims did not land where the geometry predicted.
+
+Reading identity off the drawing is not the circularity the carve-out forbids: the drawing
+is the artefact under test, and `measurement_keys` returns plain dicts, not IR objects.
+
+## Three verdicts, not two
+
+``covered`` / ``uncovered`` / ``unchecked``. The third carries the weight.
+
+This epic has now made the same mistake three times (#1001 r1 and r2, #1002 r3): narrowing
+what counts as a measurement to reduce noise, and thereby turning noise into silence. A kind
+with no rule in :data:`_REQUIRED`, or one whose renderer records no identity yet
+(#926 hole callouts, #754, #1004, #1005), must answer **"I cannot tell"** — never "fine".
+So the unchecked count is visible pressure to close those, rather than a gap that reads as a
+pass. :func:`completeness_summary` reports it as its own number for the same reason.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+COVERED = "covered"
+UNCOVERED = "uncovered"
+UNCHECKED = "unchecked"
+
+#: kind -> (size parameter ids, location parameter ids). A recognised kind absent from here
+#: answers ``unchecked``, by design — see the module docstring.
+#:
+#: The ids are the compiler's own `parameter_id`s, read off real builds rather than guessed,
+#: because a typo here would silently mean "never covered" and read as a real finding.
+_REQUIRED: dict[str, tuple[frozenset, frozenset]] = {
+    "pocket": (
+        frozenset({"pocket_width.length", "pocket_length.length", "pocket_depth.length"}),
+        frozenset({"location_pocket.location"}),
+    ),
+    "slot": (
+        frozenset({"slot_width.length", "slot_length.length"}),
+        frozenset({"location_slot.location"}),
+    ),
+    "chamfer": (frozenset({"chamfer.length"}), frozenset()),
+    "fillet": (frozenset({"fillet.radius"}), frozenset()),
+}
+
+
+@dataclass(frozen=True)
+class FeatureVerdict:
+    """One recognised feature's completeness, as plain data.
+
+    ``key`` is geometry-derived (``kind@(x,y,z)``) so it survives a rebuild — the property
+    `Drawing.suppressions()` needs for the same reason: a bare kind name makes two pockets
+    indistinguishable, and *which one* is undefined is the whole question.
+    """
+
+    kind: str
+    key: str
+    size: str
+    location: str
+    drawn: tuple = ()
+
+    @property
+    def complete(self) -> bool:
+        """Both defined. ``unchecked`` is NOT complete — an unanswered question is not a
+        pass, and collapsing the two is the failure this module exists to avoid."""
+        return self.size == COVERED and self.location == COVERED
+
+    @property
+    def undefined(self) -> bool:
+        """Something is positively missing, as opposed to unknown."""
+        return UNCOVERED in (self.size, self.location)
+
+
+def _origin(feature_key: str) -> tuple | None:
+    """The ``(x, y, z)`` out of a ``kind@(x,y,z)/axis[...]`` ledger key."""
+    if "@(" not in feature_key:
+        return None
+    inner = feature_key.split("@(", 1)[1].split(")", 1)[0]
+    try:
+        return tuple(float(v) for v in inner.split(","))
+    except ValueError:
+        return None
+
+
+def _drawn_by_feature(dwg) -> list[tuple[str, tuple, str]]:
+    """``(kind, origin, parameter_id)`` for every measurement the drawing actually draws."""
+    out = []
+    for name, _ann in dwg.iter_annotations():
+        for key in dwg.measurement_keys(name):
+            feature = key["feature"]
+            origin = _origin(feature)
+            if origin is not None:
+                out.append((feature.split("@", 1)[0], origin, key["parameter_id"]))
+    return out
+
+
+def _anchor(feat) -> tuple:
+    """A geometry-derived point identifying *feat*, matching the IR's frame origin."""
+    location = getattr(feat, "location", None)
+    if location is not None:
+        return tuple(location)[:3]
+    frame = getattr(feat, "frame", None)
+    if frame is not None:
+        return tuple(frame.origin)[:3]
+    wa, la = getattr(feat, "width_axis", None), getattr(feat, "long_axis", None)
+    if wa is not None and la is not None:
+        da = next(a for a in "xyz" if a not in (wa, la))
+        coords = {wa: feat.w_center, la: (feat.lo + feat.hi) / 2, da: getattr(feat, "d_hi", 0.0)}
+        return (coords["x"], coords["y"], coords["z"])
+    return (0.0, 0.0, 0.0)
+
+
+def _key(kind: str, point) -> str:
+    x, y, z = point
+    return f"{kind}@({x:.3f},{y:.3f},{z:.3f})"
+
+
+def feature_completeness(part, dwg, *, analysis=None, tol: float = 0.6) -> list[FeatureVerdict]:
+    """A verdict per recognised feature: is a defining size drawn, and a location?
+
+    Reads the recognised inventory off *analysis* when the caller has one (the build already
+    paid for it — ADR 0015's one-inventory rule) and recognises directly otherwise, so the
+    check judges any producer rather than only this engine's own builds.
+    """
+    drawn = _drawn_by_feature(dwg)
+    out: list[FeatureVerdict] = []
+    for kind, feats in _inventory(part, analysis):
+        want = _REQUIRED.get(kind)
+        for feat in feats:
+            anchor = _anchor(feat)
+            mine = tuple(
+                sorted(
+                    parameter
+                    for d_kind, origin, parameter in drawn
+                    if d_kind == kind and _near(origin, anchor, tol)
+                )
+            )
+            if want is None:
+                size = location = UNCHECKED
+            else:
+                size_ids, location_ids = want
+                size = COVERED if size_ids <= set(mine) else UNCOVERED
+                location = COVERED if location_ids <= set(mine) else UNCOVERED
+            out.append(FeatureVerdict(kind, _key(kind, anchor), size, location, mine))
+    return out
+
+
+def _near(a, b, tol: float) -> bool:
+    return len(a) == len(b) and all(abs(p - q) <= tol for p, q in zip(a, b, strict=True))
+
+
+def _inventory(part, analysis):
+    """``(kind, records)`` for every recognised feature kind.
+
+    Every kind the recognisers produce is listed, including those with no rule yet, so the
+    unchecked set is REAL. Enumerating only the kinds this module can judge would make the
+    report agree with itself by construction — the self-confirming shape the ADR 0015
+    carve-out prevents, one level up.
+    """
+    from draftwright.recognition import (
+        recognise_bosses,
+        recognise_chamfers,
+        recognise_fillets,
+        recognise_flats,
+        recognise_grooves,
+        recognise_holes,
+        recognise_pockets,
+        recognise_rectangular_pads,
+        recognise_slots,
+    )
+
+    def _from(name, fn):
+        got = getattr(analysis, name, None) if analysis is not None else None
+        return got if got is not None else fn()
+
+    return [
+        ("hole", _from("holes", lambda: recognise_holes(part))),
+        ("slot", _from("slots", lambda: recognise_slots(part))),
+        ("pocket", _from("pockets", lambda: recognise_pockets(part))),
+        ("pad", _from("pads", lambda: recognise_rectangular_pads(part))),
+        ("boss", _from("bosses", lambda: recognise_bosses(part))),
+        ("chamfer", recognise_chamfers(part)),
+        ("fillet", recognise_fillets(part)),
+        ("flat", recognise_flats(part)),
+        ("groove", recognise_grooves(part)),
+    ]
+
+
+def completeness_summary(verdicts) -> dict:
+    """Counts by verdict — the blast-radius measurement #996 WP1 asks for first.
+
+    ``unchecked`` is its own number and is folded into neither side. Reporting "83% complete"
+    while a third of the features were never examined is the kind of confidence this epic
+    exists to remove.
+    """
+    verdicts = list(verdicts)
+    judged = [v for v in verdicts if not (v.size == UNCHECKED and v.location == UNCHECKED)]
+    return {
+        "features": len(verdicts),
+        "judged": len(judged),
+        "complete": sum(1 for v in judged if v.complete),
+        "undefined": sum(1 for v in judged if v.undefined),
+        "unchecked": len(verdicts) - len(judged),
+        "by_kind": _by_kind(verdicts),
+    }
+
+
+def _by_kind(verdicts) -> dict:
+    out: dict = {}
+    for v in verdicts:
+        row = out.setdefault(v.kind, {COVERED: 0, UNCOVERED: 0, UNCHECKED: 0})
+        for verdict in (v.size, v.location):
+            row[verdict] += 1
+    return out

--- a/src/draftwright/linting/completeness.py
+++ b/src/draftwright/linting/completeness.py
@@ -120,11 +120,20 @@ def _drawn_by_feature(dwg) -> list[tuple[str, tuple, str]]:
     return out
 
 
-def _anchor(feat) -> tuple:
-    """A geometry-derived point identifying *feat*, matching the IR's frame origin."""
-    location = getattr(feat, "location", None)
-    if location is not None:
-        return tuple(location)[:3]
+def _anchor(feat) -> tuple | None:
+    """A geometry-derived point identifying *feat*, matching the IR's frame origin.
+
+    ``None`` when no field yields one — and that is load-bearing. The first cut fell back to
+    ``(0, 0, 0)``, so all four chamfers on a box collapsed onto one key, matched none of the
+    four drawn identities, and were reported **undefined**. Measured on a part whose chamfers
+    are all correctly dimensioned: four fabricated alarms, from the checker rather than the
+    drawing. An unmatchable feature is *unknown*, never *undefined* — the same polarity rule
+    the rest of this module is built on, applied to the join itself.
+    """
+    for field in ("location", "at"):
+        point = getattr(feat, field, None)
+        if point is not None:
+            return tuple(point)[:3]
     frame = getattr(feat, "frame", None)
     if frame is not None:
         return tuple(frame.origin)[:3]
@@ -133,7 +142,7 @@ def _anchor(feat) -> tuple:
         da = next(a for a in "xyz" if a not in (wa, la))
         coords = {wa: feat.w_center, la: (feat.lo + feat.hi) / 2, da: getattr(feat, "d_hi", 0.0)}
         return (coords["x"], coords["y"], coords["z"])
-    return (0.0, 0.0, 0.0)
+    return None
 
 
 def _key(kind: str, point) -> str:
@@ -154,6 +163,12 @@ def feature_completeness(part, dwg, *, analysis=None, tol: float = 0.6) -> list[
         want = _REQUIRED.get(kind)
         for feat in feats:
             anchor = _anchor(feat)
+            if anchor is None:
+                # No anchor means the join cannot run, so nothing can be concluded either
+                # way. Reported as its own key so the feature still APPEARS — a feature
+                # missing from the report reads as "nothing to say about it".
+                out.append(FeatureVerdict(kind, f"{kind}@?", UNCHECKED, UNCHECKED))
+                continue
             mine = tuple(
                 sorted(
                     parameter

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -5,7 +5,7 @@ wrongnesses had the same shape: the checker inventing a defect rather than findi
 is the failure mode this whole epic is about, so they are canaries, not decoration.
 """
 
-from build123d import Axis, Box, Cylinder, Pos, chamfer
+from build123d import Axis, Box, Cylinder, Pos, chamfer, fillet
 
 from draftwright import build_drawing
 from draftwright.linting.completeness import (
@@ -125,6 +125,109 @@ def test_unchecked_is_never_folded_into_either_side():
         "complete": 1,
         "undefined": 1,
         "unchecked": 1,
-        "by_kind": summary["by_kind"],
+        "by_kind": summary["by_kind"],  # asserted properly in test_by_kind_counts_features
     }
     assert summary["complete"] + summary["undefined"] == summary["judged"]
+
+
+def _ledger_ids(part):
+    dwg = build_drawing(part)
+    return {k["parameter_id"] for n, _a in dwg.iter_annotations() for k in dwg.measurement_keys(n)}
+
+
+def test_every_required_id_is_one_the_compiler_actually_emits():
+    """Fail-closed ratchet on the id vocabulary — the guard that was missing.
+
+    `_BASE_REQUIRED` named `location_slot.location`; the compiler emits
+    `location_slot.length`. So EVERY slot in every drawing reported its location missing, and
+    nothing caught it — the docstring above the table even warned that a typo there "would
+    silently mean never covered and read as a real finding", which is precisely what it did.
+
+    A hand-maintained string table with no ratchet is an unenforced claim. This builds real
+    parts and asserts every id the table demands is one the compiler genuinely mints.
+    """
+    from draftwright.linting.completeness import _BASE_REQUIRED
+
+    emitted = set()
+    for part in (
+        Box(60, 30, 10) - Box(30, 8, 20),  # slot
+        Box(80, 60, 20) - Pos(0, 0, 12) * Box(30, 20, 10),  # pocket
+        chamfer(Box(60, 40, 20).edges().filter_by(Axis.Z), 3),
+        fillet(Box(60, 40, 20).edges().filter_by(Axis.Z), 5),
+    ):
+        emitted |= _ledger_ids(part)
+
+    demanded = {i for size, loc in _BASE_REQUIRED.values() for i in (size | loc)}
+    assert demanded <= emitted, (
+        f"these ids are demanded but no build emits them: {sorted(demanded - emitted)}. "
+        "A required id the compiler never mints means that feature can NEVER read covered."
+    )
+
+
+def test_a_real_slot_reads_covered_on_both_axes():
+    """The regression finding 1 produced: no slot could ever read location-covered, and
+    there was no slot integration test despite slots being one of four judged kinds."""
+    part = Box(60, 30, 10) - Box(30, 8, 20)
+    dwg = build_drawing(part)
+    (slot,) = _verdicts(part, dwg, "slot")
+    assert (slot.size, slot.location) == (COVERED, COVERED)
+
+
+def test_an_edge_anchored_pocket_owes_no_location_dimension():
+    """Requirements are a function of the RECORD, not the kind.
+
+    A pocket flush with the stock edges is located by them, so the planner emits no location
+    dimension — correctly. The kind-only table demanded one and reported this correct drawing
+    as defective. `edge_anchored` is a recogniser fact, so reading it stays inside the ADR
+    0015 carve-out.
+    """
+    from draftwright.recognition import recognise_pockets
+
+    part = Box(80, 60, 20) - Pos(25, 20, 12) * Box(30, 20, 10)
+    assert any(getattr(p, "edge_anchored", False) for p in recognise_pockets(part)), (
+        "fixture must actually be edge-anchored or this proves nothing"
+    )
+    dwg = build_drawing(part)
+    (pocket,) = _verdicts(part, dwg, "pocket")
+    assert pocket.location == COVERED, "nothing is owed, so nothing is missing"
+    assert pocket.complete
+
+
+def test_two_indistinguishable_features_are_unchecked_not_merged():
+    """A complete neighbour must not lend its ids to an incomplete one.
+
+    The join matches on kind plus a point within *tol*, so two same-kind features inside that
+    cube cannot be separated. Merging their ids would let one cover the other; the honest
+    answer is that neither can be judged.
+    """
+    from draftwright.linting import completeness
+
+    class _Feat:
+        def __init__(self, at):
+            self.at = at
+
+    part = Box(60, 40, 20)
+    dwg = build_drawing(part)
+    original = completeness._inventory
+    try:
+        completeness._inventory = lambda p, a: [
+            ("chamfer", [_Feat((0.0, 0.0, 0.0)), _Feat((0.1, 0.0, 0.0))])
+        ]
+        verdicts = feature_completeness(part, dwg, tol=0.6)
+    finally:
+        completeness._inventory = original
+    assert len(verdicts) == 2
+    assert all(v.size == UNCHECKED and v.location == UNCHECKED for v in verdicts)
+
+
+def test_by_kind_counts_features_not_axes():
+    """One fully covered pocket is ONE complete feature, not two covered axes."""
+    verdicts = [
+        FeatureVerdict("pocket", "pocket@(0,0,0)", COVERED, COVERED),
+        FeatureVerdict("pocket", "pocket@(9,0,0)", UNCOVERED, COVERED),
+        FeatureVerdict("hole", "hole@(2,0,0)", UNCHECKED, UNCHECKED),
+    ]
+    assert completeness_summary(verdicts)["by_kind"] == {
+        "pocket": {"complete": 1, "undefined": 1, "unchecked": 0},
+        "hole": {"complete": 0, "undefined": 0, "unchecked": 1},
+    }

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,0 +1,130 @@
+"""Manufacturing-completeness check (#996 WP1 step 3).
+
+Two of these tests exist because the module was wrong in that exact way first, and both
+wrongnesses had the same shape: the checker inventing a defect rather than finding one. That
+is the failure mode this whole epic is about, so they are canaries, not decoration.
+"""
+
+from build123d import Axis, Box, Cylinder, Pos, chamfer
+
+from draftwright import build_drawing
+from draftwright.linting.completeness import (
+    COVERED,
+    UNCHECKED,
+    UNCOVERED,
+    FeatureVerdict,
+    completeness_summary,
+    feature_completeness,
+)
+
+
+def _pocketed():
+    return Box(80, 60, 20) - Pos(0, 0, 12) * Box(30, 20, 10)
+
+
+def _verdicts(part, dwg, kind):
+    return [v for v in feature_completeness(part, dwg) if v.kind == kind]
+
+
+def test_a_fully_dimensioned_pocket_reads_covered():
+    """The regression that killed the first implementation.
+
+    It matched dimension WITNESS GEOMETRY, and reported this pocket undefined on both axes —
+    while the drawing carried its width, length and depth on one compound `m_pocket_*` leader
+    (which has no witnesses at all) and its position on `m_locx`/`m_locy`. A checker that
+    reports a correct drawing as defective is worse than no checker.
+    """
+    part = _pocketed()
+    dwg = build_drawing(part)
+    (pocket,) = _verdicts(part, dwg, "pocket")
+    assert (pocket.size, pocket.location) == (COVERED, COVERED)
+    assert "pocket_depth.length" in pocket.drawn  # the leader's compound id, not a witness
+
+
+def test_removing_the_size_callout_is_reported():
+    """The other direction — a check that never fires is worthless.
+
+    Drops the compound callout and nothing else, so `location` must stay covered: the check
+    has to discriminate the two, not collapse to one per-feature boolean.
+    """
+    part = _pocketed()
+    dwg = build_drawing(part)
+    for name, _ann in list(dwg.iter_annotations()):
+        if name.startswith("m_pocket"):
+            dwg.remove(name)
+    (pocket,) = _verdicts(part, dwg, "pocket")
+    assert pocket.size == UNCOVERED
+    assert pocket.location == COVERED, "only the size was removed"
+    assert pocket.undefined and not pocket.complete
+
+
+def test_four_chamfers_are_four_features_and_all_are_covered():
+    """`_anchor` fell back to ``(0, 0, 0)`` for records with no ``.location``/``.frame``, so
+    all four chamfers collapsed onto ONE key, matched none of the four identities actually
+    drawn for them, and were reported undefined — four fabricated alarms on a part that is
+    correctly dimensioned. Chamfer and Fillet anchor on ``.at``.
+
+    Asserts four DISTINCT keys, not just four verdicts: the collapse is the defect, and four
+    identical keys would satisfy a count.
+    """
+    part = chamfer(Box(60, 40, 20).edges().filter_by(Axis.Z), 3)
+    dwg = build_drawing(part)
+    chamfers = _verdicts(part, dwg, "chamfer")
+    assert len(chamfers) == 4
+    assert len({v.key for v in chamfers}) == 4, "one key per chamfer, not one for all four"
+    assert all(v.size == COVERED for v in chamfers)
+    assert all(v.location == COVERED for v in chamfers), "a chamfer needs no location dim"
+
+
+def test_a_feature_with_no_derivable_anchor_is_unchecked_not_undefined():
+    """No anchor means the join cannot run, so nothing can be concluded — and the honest
+    answer is *unknown*. Reporting it as undefined is how the four fabricated chamfer alarms
+    happened; this pins the polarity at the join itself."""
+
+    class _Anchorless:  # no location / at / frame / width_axis
+        pass
+
+    from draftwright.linting import completeness
+
+    part = _pocketed()
+    dwg = build_drawing(part)
+    original = completeness._inventory
+    try:
+        completeness._inventory = lambda p, a: [("pocket", [_Anchorless()])]
+        (verdict,) = feature_completeness(part, dwg)
+    finally:
+        completeness._inventory = original
+    assert (verdict.size, verdict.location) == (UNCHECKED, UNCHECKED)
+    assert not verdict.undefined, "unknown is not a defect"
+    assert not verdict.complete, "and it is not a pass either"
+
+
+def test_a_hole_is_listed_but_unchecked_while_its_renderer_records_no_identity():
+    """Hole callouts are on the legacy pre-compiled-plan surface (#926) and record nothing,
+    so a hole's size cannot be judged. It must still APPEAR — a feature missing from the
+    report reads as "nothing to say about it", which is the silence this epic exists to
+    remove. Delete this test when #926 lands; the hole should then be judged."""
+    part = Box(80, 60, 10) - Pos(20, 10, 0) * Cylinder(4, 20)
+    dwg = build_drawing(part)
+    (hole,) = _verdicts(part, dwg, "hole")
+    assert (hole.size, hole.location) == (UNCHECKED, UNCHECKED)
+
+
+def test_unchecked_is_never_folded_into_either_side():
+    """Reporting "83% complete" while a third of the features were never examined is exactly
+    the false confidence #996 exists to remove, so the summary keeps three numbers."""
+    verdicts = [
+        FeatureVerdict("pocket", "pocket@(0,0,0)", COVERED, COVERED),
+        FeatureVerdict("slot", "slot@(1,0,0)", UNCOVERED, COVERED),
+        FeatureVerdict("hole", "hole@(2,0,0)", UNCHECKED, UNCHECKED),
+    ]
+    summary = completeness_summary(verdicts)
+    assert summary == {
+        "features": 3,
+        "judged": 2,
+        "complete": 1,
+        "undefined": 1,
+        "unchecked": 1,
+        "by_kind": summary["by_kind"],
+    }
+    assert summary["complete"] + summary["undefined"] == summary["judged"]


### PR DESCRIPTION
**Draft — do not merge. Blocked on #1009.**

WP1 step 3 of #996: for every recognised feature, is a defining size drawn and a location? Requirements from the recognisers (never the IR — the ADR 0015 carve-out), coverage from the #1002 measurement identity, three verdicts (`covered` / `uncovered` / `unchecked`).

## Why it is blocked

Two adversarial rounds found **six distinct fabricated-defect classes** — the checker inventing defects rather than finding them. Full table on #1009. The two P0s were each reproduced on independent real parts:

- **patterns**: the compiler collapses 3+ members into one `pocket_pattern`/`slot_pattern`, while the checker lists members and requires an exact kind match — so a fully dimensioned array of three slots yields **three fabricated defects**;
- **off-centre slots**: a lone `SlotFeature.frame` sits at the part bbox centre on the transverse axes by design, while the checker anchors on the true centroid — so **no off-centre slot can ever match**. The slot test in this branch used a *centred* subtraction, so it passed by construction.

There is also a false negative that is **inherent, not a gap**: a pocket's X and Y location dims share one identity, so deleting either still reads `location='covered'`. That needs directional identity (#883).

## The root cause

The check hand-reconstructs a correspondence between recogniser records and compiler identities. That correspondence is genuinely non-trivial — grouping, deliberate frame conventions, cardinality — and every approximation of it has invented defects. **#1009** specifies what is actually needed.

## What is sound and worth keeping

- coverage read from measurement identity rather than witness geometry (the first cut matched witnesses and called a fully-dimensioned pocket undefined — its size is a leader, which has no witnesses);
- the three-verdict polarity: `unchecked` is never folded into either side;
- the fail-closed id ratchet, which catches a required id the compiler never mints;
- per-record requirements, so an edge-anchored pocket is not asked for location dims it correctly lacks.

## Also withdrawn

The blast-radius measurement reported on #996 ("12 judged, 0 undefined") **is withdrawn** — it was produced by this instrument, and neither a slot nor an edge-anchored pocket was in the sample. #996's "measure before choosing severity" step is still open.

## Related

#1008 (the kind inventory covers 9 of ~17), #1009 (the correspondence model), #883 (per-member location identity).