### PR TITLE
feat(#966): a feature declares its location stem (slot/pocket/hole paths)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -91,6 +91,7 @@ from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
     HoleFeature,
     PatternFeature,
+    PocketFeature,
     SlotFeature,
 )
 
@@ -195,7 +196,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
     pocket_locations = {
         (loc.ref, loc.discriminator): loc
         for loc in plan.locations
-        if loc.role == "location_pocket" and loc.discriminator is not None
+        if loc.role == PocketFeature.LOCATION_STEM and loc.discriminator is not None
     }
     # A slot's own position dim — datum→near-end along its long axis. Compiled, not
     # computed from `a.bb`: it prints a number, so an authored set that does not name the
@@ -605,7 +606,11 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         # filter). A pattern ref (role "location_pattern" — e.g. a bolt-circle
         # centre) is NOT filtered, even on the axis. A renderer-side filter only ever
         # REMOVES an approved entry (a drop), so it does not breach the boundary.
-        if loc.role == "location" and a.is_rotational and _concentric_with_axis(a, rx, ry):
+        if (
+            loc.role == HoleFeature.LOCATION_STEM
+            and a.is_rotational
+            and _concentric_with_axis(a, rx, ry)
+        ):
             continue
         # Provenance (ADR 0010): the located feature. `resolve_feature` is the sanctioned
         # seam for exactly this — the corridor's feature map keys drop()/annotations_of().

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -87,7 +87,12 @@ from draftwright.layout import StripCandidate, plan_strip
 from draftwright.model.callout import _first as _first
 from draftwright.model.callout import hole_callout_spec as hole_callout_spec
 from draftwright.model.compiled import FeatureRef, resolve_feature
-from draftwright.model.ir import AUTHORED_DIMENSION_KINDS, HoleFeature, PatternFeature
+from draftwright.model.ir import (
+    AUTHORED_DIMENSION_KINDS,
+    HoleFeature,
+    PatternFeature,
+    SlotFeature,
+)
 
 
 def callout_from_spec(spec, draft, count) -> HoleCallout | None:
@@ -195,7 +200,12 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
     # A slot's own position dim — datum→near-end along its long axis. Compiled, not
     # computed from `a.bb`: it prints a number, so an authored set that does not name the
     # slot's location must not get one (#925).
-    slot_positions = {loc.ref: loc for loc in plan.locations if loc.role == "location_slot"}
+    # Derived, not spelled: the name is a CONTRACT between the compiler that mints it and
+    # this renderer that reads it, and until #966 neither end derived it — so renaming the
+    # declaration silently dropped every slot location dim rather than renaming it.
+    slot_positions = {
+        loc.ref: loc for loc in plan.locations if loc.role == SlotFeature.LOCATION_STEM
+    }
     draft = dwg.draft
     tier = draft.font_size + 2 * draft.pad_around_text
     views = {

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -581,7 +581,10 @@ def _approved_off_axis_holes(plan) -> list[_OffHole]:
     """
     holes: dict[tuple, _OffHole] = {}
     for entry in plan.locations:
-        if entry.role != "location_off_axis":
+        # Derived, not spelled: the role is a CONTRACT between the compiler that mints it
+        # and this filter that reads it. A literal here is a second owner — renaming the
+        # declaration would make every side-hole position dim vanish (#966).
+        if entry.role != HoleFeature.LOCATION_OFF_AXIS_STEM:
             continue
         assert entry.span is not None  # off-axis entries always carry datum → member
         member = entry.span[1]

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -297,7 +297,11 @@ def add_feature_location(
         rx, ry = _span(loc)[1][0], _span(loc)[1][1]
         # A rotational part's on-axis *hole* is located by the centreline, not a
         # position dim (matches render_locations); a pattern ref is never filtered.
-        if loc.role == "location" and a.is_rotational and _concentric_with_axis(a, rx, ry):
+        if (
+            loc.role == HoleFeature.LOCATION_STEM
+            and a.is_rotational
+            and _concentric_with_axis(a, rx, ry)
+        ):
             continue
         # Coincident X (or Y) across this feature's own members → one dim, not a stack
         # of identical position dims (matches render_locations' x_refs/y_refs dedup).

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -944,7 +944,7 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
         datum = float(getattr(bb.min, f.long_axis.upper()))
         value = f.lo - datum
         if authored_location_omitted(model, f):
-            omissions.append(Omission(f, "location_slot.length", value, _AUTHORED_OMISSION))
+            omissions.append(Omission(f, f"{f.LOCATION_STEM}.length", value, _AUTHORED_OMISSION))
             continue
         start = list(f.frame.origin)
         end = list(f.frame.origin)
@@ -952,13 +952,13 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
         end["xyz".index(f.long_axis)] = f.lo
         approved.append(
             ApprovedDimension(
-                id=_dim_id(f, "location_slot.length"),
+                id=_dim_id(f, f"{f.LOCATION_STEM}.length"),
                 value_text=_fmt(value),
                 value=value,
                 span=((start[0], start[1], start[2]), (end[0], end[1], end[2])),
                 ref=FeatureRef(f),
                 kind="length",
-                role="location_slot",
+                role=f.LOCATION_STEM,  # the feature owns its name (#966)
                 axis=f.long_axis,
             )
         )

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -941,7 +941,13 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
     omissions: list[Omission] = []
     bb: Any = model.bbox
     for f in model.features:
-        if not isinstance(f, SlotFeature):
+        # Eligibility through `location_datum`, matching `_compile_off_axis_hole_locations`
+        # — a bare `isinstance` was a second, laxer answer to "is this locatable": it
+        # accepted a SlotFeature SUBCLASS, which inherits `LOCATION_STEM`, so the subclass
+        # minted its position under the parent's name while the planner (exact type)
+        # refused to plan one. The collision the declaration exists to prevent, reached by
+        # the one path that did not ask (Codex #1010 r4).
+        if not isinstance(f, SlotFeature) or location_datum(f) != "bbox":
             continue
         datum = float(getattr(bb.min, f.long_axis.upper()))
         value = f.lo - datum

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -901,20 +901,22 @@ def _compile_off_axis_hole_locations(
                 value = abs(member[index] - datum)
                 if omitted:
                     omissions.append(
-                        Omission(f, f"location_off_axis.{meas}", value, _AUTHORED_OMISSION)
+                        Omission(
+                            f, f"{f.LOCATION_OFF_AXIS_STEM}.{meas}", value, _AUTHORED_OMISSION
+                        )
                     )
                     continue
                 start = list(member)
                 start[index] = datum
                 approved.append(
                     ApprovedDimension(
-                        id=_dim_id(f, f"location_off_axis.{meas}"),
+                        id=_dim_id(f, f"{f.LOCATION_OFF_AXIS_STEM}.{meas}"),
                         value_text=_fmt(value),
                         value=value,
                         span=((start[0], start[1], start[2]), member),
                         ref=FeatureRef(f),
                         kind="length",
-                        role="location_off_axis",
+                        role=f.LOCATION_OFF_AXIS_STEM,  # the feature owns its name (#966)
                         discriminator=meas,
                         axis=f.frame.axis,
                     )

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -210,6 +210,13 @@ class HoleFeature:
     compound callout. ``cbore``/``spotface`` are ``(diameter, depth)`` or ``None``
     (plain tuples — the IR stays decoupled from the recogniser's types)."""
 
+    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
+    #: beside the feature, rather than in a table in the planner: the stem was per-type
+    #: there but the SUFFIX was chosen at each mint site, which is how
+    #: `location_pocket.location` and `location_slot.length` came to disagree. One
+    #: declaration site, one spelling.
+    LOCATION_STEM: ClassVar[str] = "location"
+
     frame: Frame
     diameter: float
     depth: float | None
@@ -287,6 +294,13 @@ class PatternFeature:
     pattern-defining dims (BCD / pitch / grid pitches). The member holes are NOT
     emitted individually (the engine's grouped ``n× ø`` callout)."""
 
+    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
+    #: beside the feature, rather than in a table in the planner: the stem was per-type
+    #: there but the SUFFIX was chosen at each mint site, which is how
+    #: `location_pocket.location` and `location_slot.length` came to disagree. One
+    #: declaration site, one spelling.
+    LOCATION_STEM: ClassVar[str] = "location_pattern"
+
     frame: Frame
     pattern: str  # "bolt_circle" | "linear" | "grid"
     count: int
@@ -355,6 +369,13 @@ class SlotFeature:
     in-plane geometry so the renderer can place the size + position dims in the
     view the two axes span (the recogniser's `Slot`, normalised into the IR)."""
 
+    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
+    #: beside the feature, rather than in a table in the planner: the stem was per-type
+    #: there but the SUFFIX was chosen at each mint site, which is how
+    #: `location_pocket.location` and `location_slot.length` came to disagree. One
+    #: declaration site, one spelling.
+    LOCATION_STEM: ClassVar[str] = "location_slot"
+
     frame: Frame
     width_axis: str
     long_axis: str
@@ -382,6 +403,13 @@ class PocketFeature:
     in-plane geometry (width/length/position) mirrors a slot so the renderer places
     the callout in the view the two in-plane axes span (the recogniser's `Pocket`,
     normalised into the IR)."""
+
+    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
+    #: beside the feature, rather than in a table in the planner: the stem was per-type
+    #: there but the SUFFIX was chosen at each mint site, which is how
+    #: `location_pocket.location` and `location_slot.length` came to disagree. One
+    #: declaration site, one spelling.
+    LOCATION_STEM: ClassVar[str] = "location_pocket"
 
     frame: Frame
     width_axis: str
@@ -421,6 +449,13 @@ class PadFeature:
     prismatic level ladder, avoiding double-dimensioning the same Z rise.
     """
 
+    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
+    #: beside the feature, rather than in a table in the planner: the stem was per-type
+    #: there but the SUFFIX was chosen at each mint site, which is how
+    #: `location_pocket.location` and `location_slot.length` came to disagree. One
+    #: declaration site, one spelling.
+    LOCATION_STEM: ClassVar[str] = "location_pad"
+
     frame: Frame
     width_axis: str
     long_axis: str
@@ -452,6 +487,13 @@ class PocketPatternFeature:
     the ``(n-1)× pitch`` dim(s). ``frame.axis`` is the opening-normal (depth) axis, so the
     callout reads in the view normal to it (``_END_ON`` z→plan / x→side / y→front — the
     same map `render_pockets` uses)."""
+
+    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
+    #: beside the feature, rather than in a table in the planner: the stem was per-type
+    #: there but the SUFFIX was chosen at each mint site, which is how
+    #: `location_pocket.location` and `location_slot.length` came to disagree. One
+    #: declaration site, one spelling.
+    LOCATION_STEM: ClassVar[str] = "location_pocket_pattern"
 
     frame: Frame
     pattern: str  # "linear" | "grid"

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -211,11 +211,22 @@ class HoleFeature:
     (plain tuples — the IR stays decoupled from the recogniser's types)."""
 
     #: The compiled stem this feature's position is minted under (#966). Declared HERE,
-    #: beside the feature, rather than in a table in the planner: the stem was per-type
-    #: there but the SUFFIX was chosen at each mint site, which is how
-    #: `location_pocket.location` and `location_slot.length` came to disagree. One
-    #: declaration site, one spelling.
+    #: beside the feature, rather than in a table in the planner, because the planner's
+    #: table was one of TWO owners: the mint sites in `model/compiled.py` and the readers
+    #: in `annotations/` spelled the same name again as a literal, so renaming the table
+    #: made a dimension VANISH rather than change name. One owner of the stem.
+    #:
+    #: The SUFFIX is still chosen at each mint site, which is how
+    #: `location_pocket.location` and `location_slot.length` came to disagree — that half
+    #: of #966 is not fixed here. This declaration owns the stem and nothing more.
     LOCATION_STEM: ClassVar[str] = "location"
+
+    #: The stem a SIDE-DRILLED bore's two positions are minted under — a separate
+    #: measurement from the Z-normal ladder above (bounding-box datum, one entry per
+    #: measured axis, compiled in `_compile_off_axis_hole_locations`), so it is a separate
+    #: declaration rather than a suffix rule over `LOCATION_STEM`. Declared for the same
+    #: reason: compiler and renderer both read it instead of restating the literal.
+    LOCATION_OFF_AXIS_STEM: ClassVar[str] = "location_off_axis"
 
     frame: Frame
     diameter: float
@@ -294,11 +305,8 @@ class PatternFeature:
     pattern-defining dims (BCD / pitch / grid pitches). The member holes are NOT
     emitted individually (the engine's grouped ``n× ø`` callout)."""
 
-    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
-    #: beside the feature, rather than in a table in the planner: the stem was per-type
-    #: there but the SUFFIX was chosen at each mint site, which is how
-    #: `location_pocket.location` and `location_slot.length` came to disagree. One
-    #: declaration site, one spelling.
+    #: The compiled stem this feature's position is minted under — see
+    #: :attr:`HoleFeature.LOCATION_STEM` for why it is declared here (#966).
     LOCATION_STEM: ClassVar[str] = "location_pattern"
 
     frame: Frame
@@ -369,11 +377,8 @@ class SlotFeature:
     in-plane geometry so the renderer can place the size + position dims in the
     view the two axes span (the recogniser's `Slot`, normalised into the IR)."""
 
-    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
-    #: beside the feature, rather than in a table in the planner: the stem was per-type
-    #: there but the SUFFIX was chosen at each mint site, which is how
-    #: `location_pocket.location` and `location_slot.length` came to disagree. One
-    #: declaration site, one spelling.
+    #: The compiled stem this feature's position is minted under — see
+    #: :attr:`HoleFeature.LOCATION_STEM` for why it is declared here (#966).
     LOCATION_STEM: ClassVar[str] = "location_slot"
 
     frame: Frame
@@ -404,11 +409,8 @@ class PocketFeature:
     the callout in the view the two in-plane axes span (the recogniser's `Pocket`,
     normalised into the IR)."""
 
-    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
-    #: beside the feature, rather than in a table in the planner: the stem was per-type
-    #: there but the SUFFIX was chosen at each mint site, which is how
-    #: `location_pocket.location` and `location_slot.length` came to disagree. One
-    #: declaration site, one spelling.
+    #: The compiled stem this feature's position is minted under — see
+    #: :attr:`HoleFeature.LOCATION_STEM` for why it is declared here (#966).
     LOCATION_STEM: ClassVar[str] = "location_pocket"
 
     frame: Frame
@@ -449,11 +451,8 @@ class PadFeature:
     prismatic level ladder, avoiding double-dimensioning the same Z rise.
     """
 
-    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
-    #: beside the feature, rather than in a table in the planner: the stem was per-type
-    #: there but the SUFFIX was chosen at each mint site, which is how
-    #: `location_pocket.location` and `location_slot.length` came to disagree. One
-    #: declaration site, one spelling.
+    #: The compiled stem this feature's position is minted under — see
+    #: :attr:`HoleFeature.LOCATION_STEM` for why it is declared here (#966).
     LOCATION_STEM: ClassVar[str] = "location_pad"
 
     frame: Frame
@@ -488,11 +487,8 @@ class PocketPatternFeature:
     callout reads in the view normal to it (``_END_ON`` z→plan / x→side / y→front — the
     same map `render_pockets` uses)."""
 
-    #: The compiled stem this feature's position is minted under (#966). Declared HERE,
-    #: beside the feature, rather than in a table in the planner: the stem was per-type
-    #: there but the SUFFIX was chosen at each mint site, which is how
-    #: `location_pocket.location` and `location_slot.length` came to disagree. One
-    #: declaration site, one spelling.
+    #: The compiled stem this feature's position is minted under — see
+    #: :attr:`HoleFeature.LOCATION_STEM` for why it is declared here (#966).
     LOCATION_STEM: ClassVar[str] = "location_pocket_pattern"
 
     frame: Frame

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -386,13 +386,12 @@ def location_datum(feature) -> str | None:
         return "datum_xy"  # every orientation: its two in-plane coordinates
     if isinstance(feature, HoleFeature):
         return "datum_xy" if feature.frame.axis == "z" else "bbox"
-    # Patterns and pads: the plan-X / side-Y ladder only, so Z-normal only. Spelled as an
-    # explicit isinstance rather than a fall-through, so the narrowing is visible to a
-    # reader and to mypy — the membership guard above is a tuple variable and narrows to
-    # nothing.
-    if isinstance(feature, PatternFeature | PadFeature | PocketPatternFeature):
-        return "datum_xy" if feature.frame.axis == "z" else None
-    return None
+    # Patterns, pocket-patterns and pads: the plan-X / side-Y ladder only, so Z-normal only.
+    # A fall-through, not a fourth `isinstance` + `return None`: membership above is by
+    # exact type, so those three are all that can reach here and the extra arm was
+    # unreachable — dead code that read as defensive and showed up as the one uncovered
+    # line in the patch.
+    return "datum_xy" if feature.frame.axis == "z" else None
 
 
 #: The role every authored entry uses to name a location, whatever the per-kind role above.

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -339,6 +339,12 @@ def _datum_for(model: PartModel, param: DimParameter) -> Datum | None:
 #: mint site kept the old name while the declaration said something else — the same
 #: two-owners defect in a new place (Codex #1010 r2). A membership set plus a live read
 #: cannot go stale.
+#:
+#: Membership is by EXACT type, not `isinstance`, matching the `dict[type, str]` this
+#: replaced and `model/detect.py`'s exact-type converter registry. A subclass of a
+#: locatable feature is a new kind: it inherits `LOCATION_STEM`, so accepting it would
+#: mint its position under its PARENT's name and collide with it in the ledger. Declaring
+#: its own stem (and joining this tuple) is the way in.
 _LOCATABLE: tuple[type, ...] = (
     HoleFeature,
     PatternFeature,
@@ -372,7 +378,7 @@ _LOCATABLE: tuple[type, ...] = (
 def location_datum(feature) -> str | None:
     """``"datum_xy"``, ``"bbox"``, or ``None`` — where *feature*'s position is measured
     from, or that it has none. See :data:`_LOCATABLE`."""
-    if not isinstance(feature, _LOCATABLE):
+    if type(feature) not in _LOCATABLE:
         return None
     if isinstance(feature, SlotFeature):
         return "bbox"  # near-end offset along its long axis, in its own view

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -148,7 +148,7 @@ class AddressableDimension:
     `plan_locations` returns a flat cross-feature list of bare `PlannedDimension`s, deduped
     by ref point, that never enters a `DimensionGroup`.
 
-    That no longer means a location is unaddressable. :data:`_LOCATION_ROLE` gives each
+    That no longer means a location is unaddressable. each feature's own `LOCATION_STEM` gives
     locatable kind a role, which is what `sheet.dimension(bore, "location")` names and what
     an authored set omits (#925) — one unit per feature. The finer question **#883** asks
     (is a grouped hole's location one unit or one per member? does a deduped coincident ref
@@ -331,26 +331,22 @@ def _datum_for(model: PartModel, param: DimParameter) -> Datum | None:
 #: a location was unnameable — it had no `DimParameter`, so an authored set could neither
 #: include nor exclude it, and every location was drawn regardless of what the script
 #: declared. A dimension the author cannot address is a dimension the author cannot omit.
-#: Feature type -> compiled location stem, DERIVED from each feature's own
-#: `LOCATION_STEM` declaration (#966) rather than restated here. The stem used to be
-#: written in this table while the SUFFIX was chosen at each mint site, which is how
-#: `location_pocket.location` and `location_slot.length` came to disagree — two spellings
-#: for one concept, because no single place owned the name.
+#: The feature types whose position the planner plans. The NAME is not restated here — it
+#: is read from each feature's own `LOCATION_STEM` declaration at call time (#966).
 #:
-#: Kept as a mapping so existing callers are unchanged; it is now a projection of the
-#: declarations, not a second source. `test_every_locatable_feature_declares_its_stem`
-#: fails if a feature that plans a location does not declare one.
-_LOCATION_ROLE: dict[type, str] = {
-    cls: cls.LOCATION_STEM
-    for cls in (
-        HoleFeature,
-        PatternFeature,
-        PocketFeature,
-        PocketPatternFeature,
-        PadFeature,
-        SlotFeature,
-    )
-}
+#: A dict comprehension over the declarations was the first attempt, and it was an
+#: import-time SNAPSHOT: renaming a declaration afterwards left the snapshot stale, so the
+#: mint site kept the old name while the declaration said something else — the same
+#: two-owners defect in a new place (Codex #1010 r2). A membership set plus a live read
+#: cannot go stale.
+_LOCATABLE: tuple[type, ...] = (
+    HoleFeature,
+    PatternFeature,
+    PocketFeature,
+    PocketPatternFeature,
+    PadFeature,
+    SlotFeature,
+)
 
 
 #: Which DATUM each kind's position is measured from, per orientation — and therefore
@@ -375,8 +371,8 @@ _LOCATION_ROLE: dict[type, str] = {
 #: today's engine and the author gets an error instead of a blank drawing.
 def location_datum(feature) -> str | None:
     """``"datum_xy"``, ``"bbox"``, or ``None`` — where *feature*'s position is measured
-    from, or that it has none. See :data:`_LOCATION_ROLE`."""
-    if type(feature) not in _LOCATION_ROLE:
+    from, or that it has none. See :data:`_LOCATABLE`."""
+    if not isinstance(feature, _LOCATABLE):
         return None
     if isinstance(feature, SlotFeature):
         return "bbox"  # near-end offset along its long axis, in its own view
@@ -384,8 +380,13 @@ def location_datum(feature) -> str | None:
         return "datum_xy"  # every orientation: its two in-plane coordinates
     if isinstance(feature, HoleFeature):
         return "datum_xy" if feature.frame.axis == "z" else "bbox"
-    # Patterns and pads: the plan-X / side-Y ladder only, so Z-normal only.
-    return "datum_xy" if feature.frame.axis == "z" else None
+    # Patterns and pads: the plan-X / side-Y ladder only, so Z-normal only. Spelled as an
+    # explicit isinstance rather than a fall-through, so the narrowing is visible to a
+    # reader and to mypy — the membership guard above is a tuple variable and narrows to
+    # nothing.
+    if isinstance(feature, PatternFeature | PadFeature | PocketPatternFeature):
+        return "datum_xy" if feature.frame.axis == "z" else None
+    return None
 
 
 #: The role every authored entry uses to name a location, whatever the per-kind role above.
@@ -405,7 +406,7 @@ def location_role(feature) -> str | None:
     authored vocabulary cannot accept a target no compiler will produce."""
     if location_datum(feature) is None:
         return None
-    return _LOCATION_ROLE.get(type(feature))
+    return getattr(type(feature), "LOCATION_STEM", None)  # live read, never a snapshot
 
 
 def plan_locations(model: PartModel) -> list[PlannedDimension]:

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -331,19 +331,25 @@ def _datum_for(model: PartModel, param: DimParameter) -> Datum | None:
 #: a location was unnameable — it had no `DimParameter`, so an authored set could neither
 #: include nor exclude it, and every location was drawn regardless of what the script
 #: declared. A dimension the author cannot address is a dimension the author cannot omit.
+#: Feature type -> compiled location stem, DERIVED from each feature's own
+#: `LOCATION_STEM` declaration (#966) rather than restated here. The stem used to be
+#: written in this table while the SUFFIX was chosen at each mint site, which is how
+#: `location_pocket.location` and `location_slot.length` came to disagree — two spellings
+#: for one concept, because no single place owned the name.
+#:
+#: Kept as a mapping so existing callers are unchanged; it is now a projection of the
+#: declarations, not a second source. `test_every_locatable_feature_declares_its_stem`
+#: fails if a feature that plans a location does not declare one.
 _LOCATION_ROLE: dict[type, str] = {
-    HoleFeature: "location",
-    PatternFeature: "location_pattern",
-    PocketFeature: "location_pocket",
-    PocketPatternFeature: "location_pocket_pattern",
-    PadFeature: "location_pad",
-    # A slot's position is datum-referenced too, but from the BOUNDING BOX along its long
-    # axis rather than from `datum_xy`, and it is drawn in the slot's own view. So it is
-    # addressable here (an authored set can name or omit it) while `plan_locations` skips
-    # it — the span is compiled in `model/compiled._compile_slot_positions`, which has the
-    # bbox. Listing it in one table with the rest is what keeps "which features have a
-    # position" a single answer.
-    SlotFeature: "location_slot",
+    cls: cls.LOCATION_STEM
+    for cls in (
+        HoleFeature,
+        PatternFeature,
+        PocketFeature,
+        PocketPatternFeature,
+        PadFeature,
+        SlotFeature,
+    )
 }
 
 

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -10,7 +10,6 @@ import dataclasses
 
 import pytest
 
-from draftwright.model import PartModel
 from draftwright.model.planner import _LOCATION_ROLE, location_datum, location_role
 
 pytestmark = pytest.mark.smoke
@@ -69,14 +68,57 @@ def test_stems_are_unique_so_two_features_cannot_share_a_name():
     assert len(stems) == len(set(stems)), f"duplicate location stems: {stems}"
 
 
-def test_location_role_still_answers_none_where_no_location_is_planned():
-    """`location_role` derives from `location_datum`, so the authored vocabulary cannot
-    accept a target no compiler will produce. Declaring a stem must not change that."""
-    from draftwright.model import Frame, HoleFeature
+def test_a_real_build_mints_the_slot_location_from_the_declaration():
+    """The assertion the first cut was missing (Codex #1010 r1).
+
+    Every other test here compares the planner table with the declaration — table against
+    table. None of them touched a compiled plan, so **all of them passed while the
+    declaration was decorative**: the mint site in `compiled.py` still held its own
+    hardcoded `"location_slot.length"`, and renaming the declaration changed no output at
+    all. A vocabulary nothing consumes is not a vocabulary.
+
+    So this mutates the declaration and asserts a REAL build's ledger follows it.
+    """
+    from build123d import Box
+
+    from draftwright import build_drawing
+    from draftwright.model import SlotFeature
+
+    def _slot_ids(dwg):
+        return {
+            key["parameter_id"]
+            for name, _a in dwg.iter_annotations()
+            for key in dwg.measurement_keys(name)
+            if key["feature"].startswith("slot")
+        }
+
+    part = Box(60, 30, 10) - Box(30, 8, 20)
+    assert "location_slot.length" in _slot_ids(build_drawing(part))
+
+    original = SlotFeature.LOCATION_STEM
+    try:
+        SlotFeature.LOCATION_STEM = "location_canary"
+        mutated = _slot_ids(build_drawing(part))
+    finally:
+        SlotFeature.LOCATION_STEM = original
+
+    assert "location_canary.length" in mutated, (
+        "the compiled ledger ignored the declaration — the mint site still owns the name"
+    )
+    assert "location_slot.length" not in mutated
+
+
+def test_location_role_answers_for_an_eligible_feature_and_none_for_an_ineligible_one():
+    """Both directions, unlike the first cut — which was named "...answers none where no
+    location is planned" and then asserted the opposite on a feature that IS locatable,
+    ending with `assert model is not None`, which cannot fail after ordinary construction."""
+    from draftwright.model import Frame, HoleFeature, PatternFeature
 
     side = HoleFeature(Frame((0.0, 0.0, 0.0), "x"), 6.0, depth=None, through=True)
-    assert location_datum(side) == "bbox"
+    assert location_datum(side) == "bbox"  # eligible, from the bounding box
     assert location_role(side) == "location"
 
-    model = PartModel(bbox=None, orientation=None, features=[side])
-    assert model is not None  # the feature is constructible in a model, not just standalone
+    member = HoleFeature(Frame((0.0, 0.0, 0.0), "x"), 6.0, depth=None, through=True)
+    off_axis = PatternFeature(Frame((0.0, 0.0, 0.0), "x"), "linear", 3, member)
+    assert location_datum(off_axis) is None, "an off-axis pattern has never been drawn"
+    assert location_role(off_axis) is None, "so the vocabulary must not accept it"

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -9,8 +9,9 @@ tests pin the declaration as the one source, fail-closed.
 import dataclasses
 
 import pytest
+from build123d import Box, Cylinder, Pos
 
-from draftwright.model.planner import _LOCATION_ROLE, location_datum, location_role
+from draftwright.model.planner import _LOCATABLE, location_datum, location_role
 
 pytestmark = pytest.mark.smoke
 
@@ -32,11 +33,35 @@ def _feature_classes():
     ]
 
 
-def test_the_planner_table_is_a_projection_not_a_second_source():
-    """Every entry must equal the feature's own declaration. A table that could drift from
-    the declaration would recreate the exact defect this issue exists to remove."""
-    for cls, stem in _LOCATION_ROLE.items():
-        assert stem == cls.LOCATION_STEM, f"{cls.__name__}: table says {stem!r}"
+def test_the_planner_holds_membership_but_never_a_name():
+    """There is no second copy of the name to drift, because there is no copy at all.
+
+    The first cut kept `_LOCATION_ROLE`, a `dict[type, str]` built by comprehension from the
+    declarations. It read as derived, but it was an import-time SNAPSHOT: renaming a
+    declaration afterwards left it stale, so the mint site went on using the old name while
+    the declaration said otherwise — two owners again, one layer down (Codex #1010 r2).
+
+    `_LOCATABLE` answers only WHICH features have a position; `location_role` reads the name
+    live. This asserts the planner holds no name strings, so the snapshot cannot come back.
+    """
+    import draftwright.model.planner as planner
+
+    assert all(isinstance(cls, type) for cls in _LOCATABLE), "membership only, not names"
+
+    # No module-level container may hold a location stem: that is what a snapshot looks
+    # like. `LOCATION_ROLE` is exempt — it is the AUTHORING role (what a script writes),
+    # a different vocabulary from the compiled stems (see #966).
+    stems = {cls.LOCATION_STEM for cls in _LOCATABLE}
+    for name in dir(planner):
+        if name == "LOCATION_ROLE" or name.startswith("__"):
+            continue
+        value = getattr(planner, name)
+        if isinstance(value, dict):
+            assert not (stems & set(map(str, value.values()))), f"planner.{name} caches stems"
+        elif isinstance(value, (set, frozenset, list, tuple)):
+            assert not (stems & {v for v in value if isinstance(v, str)}), (
+                f"planner.{name} caches stems"
+            )
 
 
 def test_every_locatable_feature_declares_its_stem():
@@ -45,7 +70,7 @@ def test_every_locatable_feature_declares_its_stem():
     here rather than silently inventing a spelling at the mint site."""
     missing = [
         cls.__name__
-        for cls in _LOCATION_ROLE
+        for cls in _LOCATABLE
         if not isinstance(getattr(cls, "LOCATION_STEM", None), str)
     ]
     assert missing == [], f"locatable features with no LOCATION_STEM declaration: {missing}"
@@ -56,7 +81,7 @@ def test_a_declared_stem_is_never_silently_unused():
     name nobody mints — the stale half of the vocabulary problem, and exactly what a
     hand-maintained list hides."""
     declared = {c.__name__ for c in _feature_classes() if hasattr(c, "LOCATION_STEM")}
-    routed = {c.__name__ for c in _LOCATION_ROLE}
+    routed = {c.__name__ for c in _LOCATABLE}
     assert declared == routed, (
         f"declared but never routed: {sorted(declared - routed)}; "
         f"routed but not declared: {sorted(routed - declared)}"
@@ -64,48 +89,64 @@ def test_a_declared_stem_is_never_silently_unused():
 
 
 def test_stems_are_unique_so_two_features_cannot_share_a_name():
-    stems = [c.LOCATION_STEM for c in _LOCATION_ROLE]
+    stems = [c.LOCATION_STEM for c in _LOCATABLE]
     assert len(stems) == len(set(stems)), f"duplicate location stems: {stems}"
 
 
-def test_a_real_build_mints_the_slot_location_from_the_declaration():
-    """The assertion the first cut was missing (Codex #1010 r1).
+@pytest.mark.parametrize(
+    ("kind", "feature_name", "build"),
+    [
+        ("slot", "SlotFeature", lambda: Box(60, 30, 10) - Box(30, 8, 20)),
+        ("pocket", "PocketFeature", lambda: Box(80, 60, 20) - Pos(0, 0, 12) * Box(30, 20, 10)),
+        ("hole", "HoleFeature", lambda: Box(80, 60, 10) - Pos(20, 10, 0) * Cylinder(4, 20)),
+    ],
+)
+def test_a_real_build_mints_each_location_from_its_declaration(kind, feature_name, build):
+    """Rename the declaration; the real build's ledger must follow.
 
-    Every other test here compares the planner table with the declaration — table against
-    table. None of them touched a compiled plan, so **all of them passed while the
-    declaration was decorative**: the mint site in `compiled.py` still held its own
-    hardcoded `"location_slot.length"`, and renaming the declaration changed no output at
-    all. A vocabulary nothing consumes is not a vocabulary.
+    **Parametrised over every kind whose readers this work has touched**, deliberately. The
+    first cut tested the slot alone and its prose claimed canonical ownership generally
+    (Codex #1010 r2) — which is the recurring defect in this branch's history: verify the
+    path just changed, then describe the result more broadly than was tested.
 
-    So this mutates the declaration and asserts a REAL build's ledger follows it.
+    This is the assertion that matters, because the name is a CONTRACT between the compiler
+    that mints it and the renderer that reads it. When only one end derived it, renaming did
+    not rename the dimension — it made the dimension VANISH, since the two ends disagreed
+    about what to look for. So a passing rename proves both ends follow the declaration.
     """
-    from build123d import Box
-
+    import draftwright.model as model_pkg
     from draftwright import build_drawing
-    from draftwright.model import SlotFeature
 
-    def _slot_ids(dwg):
+    feature_cls = getattr(model_pkg, feature_name)
+
+    def _ids(dwg):
         return {
             key["parameter_id"]
             for name, _a in dwg.iter_annotations()
             for key in dwg.measurement_keys(name)
-            if key["feature"].startswith("slot")
+            if key["feature"].startswith(kind)
         }
 
-    part = Box(60, 30, 10) - Box(30, 8, 20)
-    assert "location_slot.length" in _slot_ids(build_drawing(part))
-
-    original = SlotFeature.LOCATION_STEM
-    try:
-        SlotFeature.LOCATION_STEM = "location_canary"
-        mutated = _slot_ids(build_drawing(part))
-    finally:
-        SlotFeature.LOCATION_STEM = original
-
-    assert "location_canary.length" in mutated, (
-        "the compiled ledger ignored the declaration — the mint site still owns the name"
+    part = build()
+    original = feature_cls.LOCATION_STEM
+    baseline = _ids(build_drawing(part))
+    assert any(i.startswith(f"{original}.") for i in baseline), (
+        f"fixture must actually draw a {kind} location, or the rename proves nothing"
     )
-    assert "location_slot.length" not in mutated
+
+    try:
+        feature_cls.LOCATION_STEM = "location_canary"
+        mutated = _ids(build_drawing(part))
+    finally:
+        feature_cls.LOCATION_STEM = original
+
+    assert any(i.startswith("location_canary.") for i in mutated), (
+        f"{kind}: renaming the declaration did not rename the minted id — a reader or a "
+        "mint site still owns the name"
+    )
+    assert not any(i.startswith(f"{original}.") for i in mutated), (
+        f"{kind}: the old name survived the rename, so something holds a parallel copy"
+    )
 
 
 def test_location_role_answers_for_an_eligible_feature_and_none_for_an_ineligible_one():

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -341,9 +341,14 @@ def test_the_on_axis_bore_skip_reads_the_declaration_on_both_surfaces():
     copies of the comparison. With a stale literal the reader stops recognising the renamed
     role, the skip does not fire, and a redundant position dim appears on a part whose bore
     is located by its centreline.
+
+    The precondition is that the COMPILER approved a position for this bore — otherwise both
+    readers receive nothing and drawing nothing is free. That is the meaningful check here,
+    and a stronger one than asking the analysis whether the part is rotational.
     """
     from draftwright import build_drawing
     from draftwright.model import HoleFeature
+    from draftwright.model.compiled import compile_dimensions
 
     part = Cylinder(20, 40) - Cylinder(6, 60)
     original = HoleFeature.LOCATION_STEM
@@ -357,11 +362,17 @@ def test_the_on_axis_bore_skip_reads_the_declaration_on_both_surfaces():
             if key["feature"].startswith("hole")
         }
         dwg = build_drawing(part, auto_dims=False)
-        hole = next(f for f in dwg.model().features if isinstance(f, HoleFeature))
-        assert dwg._analysis.is_rotational, "fixture must be rotational to reach the skip"
+        model = dwg.model()
+        hole = next(f for f in model.features if isinstance(f, HoleFeature))
+        approved = [loc.id.parameter for loc in compile_dimensions(model).locations]
         names = dwg.locate(hole)
     finally:
         HoleFeature.LOCATION_STEM = original
+
+    assert any(p.startswith("location_canary.") for p in approved), (
+        f"the compiler approved {approved} — with no position to skip, neither reader is "
+        "reached and this test proves nothing"
+    )
 
     assert auto_ids == set(), (
         f"the auto pass drew {sorted(auto_ids)} for an on-axis bore on a rotational part — "

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -93,7 +93,43 @@ def test_stems_are_unique_so_two_features_cannot_share_a_name():
     assert len(stems) == len(set(stems)), f"duplicate location stems: {stems}"
 
 
-def test_a_subclass_is_not_silently_locatable():
+def _locatable_instances():
+    """One instance per locatable kind, with geometry the compiler actually mints for.
+
+    Written out rather than generated from field introspection: a constructor that guesses
+    values fails silently on whichever kind it guesses wrong, and a silent failure here is
+    indistinguishable from the defect under test. `members` on the pattern and `datum_xy` on
+    the model are both load-bearing for exactly that reason — without either, every case
+    below mints nothing and the whole parametrisation passes while proving nothing.
+    """
+    from draftwright.model import (
+        Frame,
+        HoleFeature,
+        PadFeature,
+        PatternFeature,
+        PocketFeature,
+        PocketPatternFeature,
+        SlotFeature,
+    )
+
+    z = Frame((10.0, 10.0, 0.0), "z")
+    hole = HoleFeature(z, 6.0, depth=None, through=True)
+    pocket = PocketFeature(z, "y", "x", 8.0, 20.0, 4.0, 10.0, 4.0, 24.0)
+    members = ((5.0, 10.0, 0.0), (15.0, 10.0, 0.0), (25.0, 10.0, 0.0))
+    return [
+        pytest.param(hole, id="hole"),
+        pytest.param(PatternFeature(z, "linear", 3, hole, members, pitch=10.0), id="pattern"),
+        pytest.param(pocket, id="pocket"),
+        pytest.param(
+            PocketPatternFeature(z, "linear", 3, pocket, members, pitch=10.0), id="pocket_pattern"
+        ),
+        pytest.param(PadFeature(z, "y", "x", 8.0, 20.0, 10.0, 4.0, 24.0, 0.0, 5.0), id="pad"),
+        pytest.param(SlotFeature(z, "y", "x", 8.0, 20.0, 10.0, 4.0, 24.0), id="slot"),
+    ]
+
+
+@pytest.mark.parametrize("feature", _locatable_instances())
+def test_a_subclass_is_not_silently_locatable(feature):
     """Membership is by EXACT type, as the `dict[type, str]` this replaced was.
 
     An `isinstance` check reads as the friendlier spelling and is wrong here: a subclass
@@ -102,17 +138,43 @@ def test_a_subclass_is_not_silently_locatable():
     prevent. It is also a behaviour change from main, and the review that caught it
     (Codex #1010 r3) caught it as an *undocumented* one. Declaring its own stem and joining
     `_LOCATABLE` is the way in.
+
+    Parametrised over **every** locatable kind, asserting on the COMPILED PLAN rather than
+    on `location_role` alone, and asserting the PARENT mints first — because the first cut
+    did none of the three. It tested a `HoleFeature` subclass and inferred the policy
+    generally, while `_compile_slot_positions` reached its mint site through a bare
+    `isinstance` and never asked: a slot subclass the planner refused minted
+    `location_slot.length` anyway (Codex #1010 r4). And the same test without the
+    parent-mints assertion was **vacuous for five of six kinds** — the model it built had no
+    `datum_xy`, so nothing was minted for anyone and every case passed.
     """
-    from draftwright.model import Frame, HoleFeature
+    from build123d import Box
 
-    @dataclasses.dataclass(frozen=True)
-    class DowelHole(HoleFeature):
-        pass
+    from draftwright.model import Datum, PartModel
+    from draftwright.model.compiled import compile_dimensions
 
-    sub = DowelHole(Frame((10.0, 10.0, 0.0), "z"), 6.0, depth=None, through=True)
-    assert sub.LOCATION_STEM == HoleFeature.LOCATION_STEM, "inherits its parent's name"
+    sub_cls = dataclasses.dataclass(frozen=True)(
+        type(f"Custom{type(feature).__name__}", (type(feature),), {})
+    )
+    sub = sub_cls(**{f.name: getattr(feature, f.name) for f in dataclasses.fields(feature)})
+    assert sub_cls.LOCATION_STEM == type(feature).LOCATION_STEM, "inherits its parent's name"
     assert location_datum(sub) is None, "so it must not be planned under that name"
     assert location_role(sub) is None
+
+    bb = Box(60, 60, 20).bounding_box()
+    datums = [Datum(id="datum_xy", kind="point", at=(bb.min.X, bb.min.Y, bb.min.Z))]
+
+    def _minted(f):
+        return [
+            loc.id.parameter
+            for loc in compile_dimensions(PartModel(bb, None, [f], datums)).locations
+        ]
+
+    assert _minted(feature), "the parent must mint here, or the subclass minting nothing is free"
+    assert _minted(sub) == [], (
+        f"a {sub_cls.__name__} the planner refused still minted {_minted(sub)} — a compiler "
+        "reached its mint site without asking the eligibility question"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -1,0 +1,82 @@
+"""The location half of the dimension vocabulary is declared, not restated (#966).
+
+`location_pocket.location` and `location_slot.length` — two spellings for one concept —
+arose because the stem was written in a planner table while the suffix was chosen at each
+mint site. No single place owned the name, so nothing could notice they disagreed. These
+tests pin the declaration as the one source, fail-closed.
+"""
+
+import dataclasses
+
+import pytest
+
+from draftwright.model import PartModel
+from draftwright.model.planner import _LOCATION_ROLE, location_datum, location_role
+
+pytestmark = pytest.mark.smoke
+
+
+def _feature_classes():
+    """Every IR feature type exported by `model`.
+
+    NOT by walking `Feature.__subclasses__()`: `Feature` is a runtime-checkable Protocol, so
+    the feature dataclasses satisfy it structurally and inherit nothing. That walk returned
+    an EMPTY list, which silently made the bidirectional check below vacuous — a discovery
+    mechanism that finds nothing proves nothing.
+    """
+    import draftwright.model as model
+
+    return [
+        obj
+        for name in dir(model)
+        if isinstance(obj := getattr(model, name), type) and dataclasses.is_dataclass(obj)
+    ]
+
+
+def test_the_planner_table_is_a_projection_not_a_second_source():
+    """Every entry must equal the feature's own declaration. A table that could drift from
+    the declaration would recreate the exact defect this issue exists to remove."""
+    for cls, stem in _LOCATION_ROLE.items():
+        assert stem == cls.LOCATION_STEM, f"{cls.__name__}: table says {stem!r}"
+
+
+def test_every_locatable_feature_declares_its_stem():
+    """Fail-closed: a feature the planner will plan a location for must declare the name
+    that location is minted under. Adding a locatable feature without a declaration fails
+    here rather than silently inventing a spelling at the mint site."""
+    missing = [
+        cls.__name__
+        for cls in _LOCATION_ROLE
+        if not isinstance(getattr(cls, "LOCATION_STEM", None), str)
+    ]
+    assert missing == [], f"locatable features with no LOCATION_STEM declaration: {missing}"
+
+
+def test_a_declared_stem_is_never_silently_unused():
+    """The other direction. A feature declaring a stem that the planner never consults is a
+    name nobody mints — the stale half of the vocabulary problem, and exactly what a
+    hand-maintained list hides."""
+    declared = {c.__name__ for c in _feature_classes() if hasattr(c, "LOCATION_STEM")}
+    routed = {c.__name__ for c in _LOCATION_ROLE}
+    assert declared == routed, (
+        f"declared but never routed: {sorted(declared - routed)}; "
+        f"routed but not declared: {sorted(routed - declared)}"
+    )
+
+
+def test_stems_are_unique_so_two_features_cannot_share_a_name():
+    stems = [c.LOCATION_STEM for c in _LOCATION_ROLE]
+    assert len(stems) == len(set(stems)), f"duplicate location stems: {stems}"
+
+
+def test_location_role_still_answers_none_where_no_location_is_planned():
+    """`location_role` derives from `location_datum`, so the authored vocabulary cannot
+    accept a target no compiler will produce. Declaring a stem must not change that."""
+    from draftwright.model import Frame, HoleFeature
+
+    side = HoleFeature(Frame((0.0, 0.0, 0.0), "x"), 6.0, depth=None, through=True)
+    assert location_datum(side) == "bbox"
+    assert location_role(side) == "location"
+
+    model = PartModel(bbox=None, orientation=None, features=[side])
+    assert model is not None  # the feature is constructible in a model, not just standalone

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -93,26 +93,86 @@ def test_stems_are_unique_so_two_features_cannot_share_a_name():
     assert len(stems) == len(set(stems)), f"duplicate location stems: {stems}"
 
 
+def test_a_subclass_is_not_silently_locatable():
+    """Membership is by EXACT type, as the `dict[type, str]` this replaced was.
+
+    An `isinstance` check reads as the friendlier spelling and is wrong here: a subclass
+    INHERITS `LOCATION_STEM`, so accepting it would mint its position under its parent's
+    stem — two features minting one name, which is the collision the declaration exists to
+    prevent. It is also a behaviour change from main, and the review that caught it
+    (Codex #1010 r3) caught it as an *undocumented* one. Declaring its own stem and joining
+    `_LOCATABLE` is the way in.
+    """
+    from draftwright.model import Frame, HoleFeature
+
+    @dataclasses.dataclass(frozen=True)
+    class DowelHole(HoleFeature):
+        pass
+
+    sub = DowelHole(Frame((10.0, 10.0, 0.0), "z"), 6.0, depth=None, through=True)
+    assert sub.LOCATION_STEM == HoleFeature.LOCATION_STEM, "inherits its parent's name"
+    assert location_datum(sub) is None, "so it must not be planned under that name"
+    assert location_role(sub) is None
+
+
 @pytest.mark.parametrize(
     ("kind", "feature_name", "build"),
     [
-        ("slot", "SlotFeature", lambda: Box(60, 30, 10) - Box(30, 8, 20)),
-        ("pocket", "PocketFeature", lambda: Box(80, 60, 20) - Pos(0, 0, 12) * Box(30, 20, 10)),
-        ("hole", "HoleFeature", lambda: Box(80, 60, 10) - Pos(20, 10, 0) * Cylinder(4, 20)),
+        pytest.param("slot", "SlotFeature", lambda: Box(60, 30, 10) - Box(30, 8, 20), id="slot"),
+        pytest.param(
+            "pocket",
+            "PocketFeature",
+            lambda: Box(80, 60, 20) - Pos(0, 0, 12) * Box(30, 20, 10),
+            id="pocket-z",
+        ),
+        # A pocket in a VERTICAL face, whose position compiles to two discriminated entries
+        # and is read back by a second branch in `from_model`. Added because mutating that
+        # branch to a literal left the Z-normal case above green — the reader it guards was
+        # never reached, and a fixture that does not reach a path says nothing about it.
+        pytest.param(
+            "pocket",
+            "PocketFeature",
+            lambda: Box(80, 60, 40) - Pos(38, 0, 5) * Box(10, 20, 15),
+            id="pocket-x",
+        ),
+        pytest.param(
+            "hole",
+            "HoleFeature",
+            lambda: Box(80, 60, 10) - Pos(20, 10, 0) * Cylinder(4, 20),
+            id="hole-z",
+        ),
+        pytest.param(
+            "pattern",
+            "PatternFeature",
+            lambda: (
+                Box(80, 80, 10)
+                - Pos(25, 25, 0) * Cylinder(3, 20)
+                - Pos(-25, 25, 0) * Cylinder(3, 20)
+                - Pos(25, -25, 0) * Cylinder(3, 20)
+                - Pos(-25, -25, 0) * Cylinder(3, 20)
+            ),
+            id="pattern-z",
+        ),
     ],
 )
 def test_a_real_build_mints_each_location_from_its_declaration(kind, feature_name, build):
     """Rename the declaration; the real build's ledger must follow.
 
-    **Parametrised over every kind whose readers this work has touched**, deliberately. The
-    first cut tested the slot alone and its prose claimed canonical ownership generally
-    (Codex #1010 r2) — which is the recurring defect in this branch's history: verify the
-    path just changed, then describe the result more broadly than was tested.
-
     This is the assertion that matters, because the name is a CONTRACT between the compiler
     that mints it and the renderer that reads it. When only one end derived it, renaming did
     not rename the dimension — it made the dimension VANISH, since the two ends disagreed
-    about what to look for. So a passing rename proves both ends follow the declaration.
+    about what to look for.
+
+    **Scope, stated as narrowly as the evidence.** What passing proves: for a *slot*, a
+    *pocket in each of its two compiled shapes*, a *Z-normal hole* and a *Z-normal pattern*,
+    on an automatic `build_drawing`, both the mint site and the reader derive the stem from
+    the declaration. It does **not** cover `PadFeature` or `PocketPatternFeature` (no fixture
+    here draws either's position), nor the two paths outside this parametrisation — the
+    side-drilled bore's own stem and the `locate()` edit verb, each canaried separately
+    below. Every case here was added after mutating the reader it guards and watching this
+    test go red; the two that were assumed instead (`pocket-x`, `locate()`) had both been
+    green against a broken reader. The recurring defect in this branch is to verify the one
+    path just changed and then describe the result more broadly than was tested.
     """
     import draftwright.model as model_pkg
     from draftwright import build_drawing
@@ -146,6 +206,108 @@ def test_a_real_build_mints_each_location_from_its_declaration(kind, feature_nam
     )
     assert not any(i.startswith(f"{original}.") for i in mutated), (
         f"{kind}: the old name survived the rename, so something holds a parallel copy"
+    )
+
+
+def test_the_side_drilled_path_mints_from_its_own_declaration():
+    """The off-axis bore, which the canary above does not reach.
+
+    Its two positions are a different measurement from the Z-normal ladder — bounding-box
+    datum, one entry per measured axis — so they carry their own declaration,
+    `LOCATION_OFF_AXIS_STEM`, rather than a suffix rule over `LOCATION_STEM`. Before this
+    the name was a literal in the compiler and the same literal in `holes.py`'s filter: the
+    branch's own two-owners defect, still open at r3.
+
+    Asserted at TWO levels because they fail differently, and asserting one would miss the
+    other: the compiled ids show the *mint* followed the rename; the drawn `dim_loc_*`
+    annotations surviving it show the *reader* did. A reader still holding the literal
+    matches nothing, so the dims vanish while the compiled ids look perfect.
+
+    Not via `measurement_keys` like the canary above — the off-axis dims record no
+    measurement identity yet (#1005), so that ledger is empty here and an assertion over it
+    would pass vacuously.
+    """
+    from build123d import Rot
+
+    from draftwright import build_drawing
+    from draftwright.builder import detect_part_model
+    from draftwright.model import HoleFeature
+    from draftwright.model.compiled import compile_dimensions
+
+    part = Box(12, 40, 30) - Pos(0, 8, 6) * Rot(0, 90, 0) * Cylinder(3, 12)
+    model = detect_part_model(part)
+    original = HoleFeature.LOCATION_OFF_AXIS_STEM
+
+    def _params():
+        return {loc.id.parameter for loc in compile_dimensions(model).locations}
+
+    def _drawn():
+        return {n for n, _a in build_drawing(part).iter_annotations() if n.startswith("dim_loc_")}
+
+    baseline_params, baseline_drawn = _params(), _drawn()
+    assert any(p.startswith(f"{original}.") for p in baseline_params), (
+        "fixture must reach the off-axis compiler, or the rename proves nothing"
+    )
+    assert baseline_drawn, "fixture must actually DRAW the off-axis positions"
+
+    try:
+        HoleFeature.LOCATION_OFF_AXIS_STEM = "location_canary"
+        mutated_params, mutated_drawn = _params(), _drawn()
+    finally:
+        HoleFeature.LOCATION_OFF_AXIS_STEM = original
+
+    assert {p for p in mutated_params if p.startswith("location_canary.")} == {
+        p.replace(original, "location_canary") for p in baseline_params
+    }, "the off-axis mint site still owns the name"
+    assert mutated_drawn == baseline_drawn, (
+        "renaming the declaration dropped the side-hole position dims — the renderer holds "
+        "a literal copy of the role and now matches nothing"
+    )
+
+
+def test_the_on_axis_bore_skip_reads_the_declaration_on_both_surfaces():
+    """The two readers that compare the role in order to NOT draw something.
+
+    A ROTATIONAL part with an on-axis bore, deliberately: that is the one branch where
+    `render_locations` (the auto pass) and `Drawing.locate()` (the edit verb) consult the
+    role at all — each skips the position dim because the centreline already locates the
+    bore. On a plate neither comparison is reached, so a plate fixture says nothing about
+    these readers however plausible it reads. This test's first cut used one and a stale
+    literal sailed straight through it.
+
+    So the observable is the SKIP, asserted on both surfaces because they hold separate
+    copies of the comparison. With a stale literal the reader stops recognising the renamed
+    role, the skip does not fire, and a redundant position dim appears on a part whose bore
+    is located by its centreline.
+    """
+    from draftwright import build_drawing
+    from draftwright.model import HoleFeature
+
+    part = Cylinder(20, 40) - Cylinder(6, 60)
+    original = HoleFeature.LOCATION_STEM
+    try:
+        HoleFeature.LOCATION_STEM = "location_canary"
+        auto = build_drawing(part)
+        auto_ids = {
+            key["parameter_id"]
+            for n, _a in auto.iter_annotations()
+            for key in auto.measurement_keys(n)
+            if key["feature"].startswith("hole")
+        }
+        dwg = build_drawing(part, auto_dims=False)
+        hole = next(f for f in dwg.model().features if isinstance(f, HoleFeature))
+        assert dwg._analysis.is_rotational, "fixture must be rotational to reach the skip"
+        names = dwg.locate(hole)
+    finally:
+        HoleFeature.LOCATION_STEM = original
+
+    assert auto_ids == set(), (
+        f"the auto pass drew {sorted(auto_ids)} for an on-axis bore on a rotational part — "
+        "`render_locations` no longer recognises the renamed role"
+    )
+    assert names == [], (
+        f"locate() placed {names} for the same bore — the edit surface holds a literal copy "
+        "of the role"
     )
 
 


### PR DESCRIPTION
First slice of #966. Each feature declares the stem its position is minted under; the compiler that mints the id and the renderers that read it back both derive it from that one declaration.

## What this establishes

Declaration ownership of the location **stem**, proven by renaming the declaration against real builds and asserting both the minted ids and the drawn annotations follow. Every mint site and reader, each verified by mutation:

| site | canaried by |
|---|---|
| slot mint (`model/compiled`) + `from_model` slot reader | `[slot]` |
| Z-normal pocket mint | `[pocket-z]` |
| non-Z pocket mint + `from_model` discriminated-pocket reader | `[pocket-x]` |
| Z-hole and Z-pattern mint (via `planner.location_role`) | `[hole-z]`, `[pattern-z]` |
| side-drilled mint + `holes.py` off-axis filter | `test_the_side_drilled_path_mints_from_its_own_declaration` |
| `render_locations` and `Drawing.locate()` on-axis-bore skip | `test_the_on_axis_bore_skip_reads_the_declaration_on_both_surfaces` |
| exact-type eligibility, all six locatable kinds | `test_a_subclass_is_not_silently_locatable` |

Every row was checked by editing the protected code back to a string literal and confirming the named test goes red. **Four were green against broken code before that check** — which is the point of doing it:

- the discriminated-pocket branch (a Z-normal fixture never reaches it);
- the on-axis skip, on *both* surfaces (a plate fixture never reaches either);
- `_compile_slot_positions` (found by review, not by the guard — see below);
- and the subclass guard itself, whose first rewrite built a `PartModel` with no `datum_xy`, so five of six kinds minted nothing for the **parent** either and every case passed for free.

## What it does not establish

- **The suffixes still differ** — `location_pocket.location` vs `location_slot.length`. The stem is owned; the suffix is still chosen at each mint site. That is the remaining half of #966, and `ir.py` now says so rather than claiming "one declaration site, one spelling".
- The off-axis canary observes compiled ids and drawn annotations, not `measurement_keys`: those dims record no measurement identity yet (**#1005**), so a ledger assertion would pass vacuously.

## The review defects, closed

1. **Undocumented behaviour change (r3).** `isinstance(feature, _LOCATABLE)` accepted subclasses where the `dict[type, str]` it replaced did not. Exact membership restored and documented as deliberate: a subclass inherits `LOCATION_STEM`, so accepting it would mint its position under its parent's name.
2. **Off-axis compilation (r3)** now comes under the declaration, via a second stem (`LOCATION_OFF_AXIS_STEM`) rather than a suffix rule — the bbox-datum, per-axis positions are a different measurement from the Z-normal ladder, so a separate declaration is the honest shape.
3. **The canary's overclaim (r3)** — fixed by widening the evidence rather than the prose, then stating the scope as narrowly as what was mutated.
4. **The `ir.py` comment (r3)** — corrected.
5. **`_compile_slot_positions` bypassed the eligibility rule (r4).** It selected slots with a bare `isinstance`, so a `SlotFeature` subclass the planner refused still minted `location_slot.length` — the exact collision fix 1 claimed to prevent, reached by the one compiler that never asked. Eligibility now comes from `location_datum`, matching `_compile_off_axis_hole_locations`; the guard is parametrised over all six kinds and asserts on the compiled plan.

Two further fixes came from CI rather than review: the on-axis canary read `dwg._analysis` (tripping the #741 private-read ratchet) and now asserts the compiler approved a position instead — a stronger precondition; and `location_datum`'s trailing `isinstance` arm plus `return None`, which exact-type membership made unreachable, is gone. It was the branch's one uncovered patch line, and the narrowing it claimed to give mypy was never needed (the parameter is untyped).

Codex rounds 5 and 6: no findings.

## Verification

Full fast tier under coverage: **2672 passed, 1 skipped, 2 xfailed**; no uncovered line remains in this branch's diff. ruff check, ruff format, mypy, codespell clean.
