### PR TITLE
fix(#1015): a flat's opposite face must be on the same piece of stock

### DIFF
--- a/src/draftwright/recognition/flats.py
+++ b/src/draftwright/recognition/flats.py
@@ -145,7 +145,19 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
             if not _both_chord_ends_reach_od(verts, ax, d, nv, r):
                 continue  # one end abuts a slot floor, not the OD — a recess wall, not a flat
             cands.append(
-                {"axis": c["axis"], "n": nv, "s": s, "r": r, "at": pcv, "ax": ax, "dir": d}
+                {
+                    "axis": c["axis"],
+                    "n": nv,
+                    "s": s,
+                    "r": r,
+                    "at": pcv,
+                    "ax": ax,
+                    "dir": d,
+                    # Which piece of stock this face was matched to, for the opposition test
+                    # below. Internal to one recognition run — a same-run equality check, not
+                    # an identity that propagates — so the solid index is safe here.
+                    "stock": (c.get("solid_idx", 0), round(c["s_lo"], 3), round(c["s_hi"], 3)),
+                }
             )
             break
 
@@ -160,6 +172,13 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                 continue
             if not _same_axis_line(cand["ax"], cand["dir"], other["ax"]):
                 continue  # a lone flat on a *different* parallel shaft — not opposed
+            if other["stock"] != cand["stock"]:
+                # The same infinite axis is not the same piece of stock. Two lone D-flats on
+                # separate COAXIAL regions were each taken for the other's opposite face, so
+                # both got `across` = the sum of two unrelated chord offsets — a wrong number
+                # on the feature's only size parameter (#1015). The axial extent separates
+                # them; the axis line alone cannot.
+                continue
             dot = n[0] * other["n"][0] + n[1] * other["n"][1] + n[2] * other["n"][2]
             if abs(dot + 1.0) <= _ANTIPARALLEL_TOL:
                 opp = other

--- a/tests/test_flat_stock_opposition.py
+++ b/tests/test_flat_stock_opposition.py
@@ -1,0 +1,63 @@
+"""A flat's opposite face must be on the same piece of stock (#1015).
+
+``recognise_flats`` sizes each flat by looking for an *opponent* — an antiparallel face across
+the same axis. Finding one makes the size flat-to-flat (a double-D's A/F); finding none makes
+it flat-to-opposite-OD (a lone D's height). The search required the same infinite axis LINE and
+nothing more, so two lone D-flats on separate coaxial regions were each taken for the other's
+opposite face and both were sized as the sum of two unrelated chord offsets.
+
+``across`` is a flat's ONLY size parameter, so this is a wrong number on the drawing rather
+than a missing one — the part gets made to it.
+"""
+
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright.recognition import recognise_flats
+
+_C = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+
+def _lone_d(radius: float, offset: float, z: float):
+    """Round stock of *radius* with a SINGLE flat at signed *offset* from the axis, centred
+    at *z*. The cutter takes the material beyond the flat, on whichever side *offset* names.
+
+    One flat, not two: the bug needs a face whose true size is flat-to-opposite-OD, because a
+    double-D already finds its real opponent on its own stock.
+    """
+    beyond = 40 if offset >= 0 else -40
+    cutter = Pos(offset + beyond, 0, 0) * Box(80, 80, 60, align=_C)
+    return Pos(0, 0, z) * (Cylinder(radius, 40) - cutter)
+
+
+def _two_coaxial_lone_ds():
+    """Two lone-D regions on ONE axis, joined by a narrow waist, their flats on OPPOSITE sides
+    so each looks like the other's opponent.
+
+    ⌀40 with its flat 10 from the axis is 10 + 20 = 30 A/F.
+    ⌀24 with its flat 8 from the axis is 8 + 12 = 20 A/F.
+    Paired with each other they both read 10 + 8 = 18.
+    """
+    return _lone_d(20, 10, -30) + Cylinder(5, 60) + _lone_d(12, -8, 60)
+
+
+def test_lone_flats_on_separate_coaxial_stock_are_not_opposed():
+    flats = recognise_flats(_two_coaxial_lone_ds())
+    assert len(flats) == 2, "the fixture must produce exactly the two lone flats"
+    assert sorted(f.across for f in flats) == [20.0, 30.0]
+
+
+def test_the_two_faces_of_one_double_d_are_still_opposed():
+    """The other direction, and the property the fix most easily breaks: a genuine opposed
+    pair shares its stock, so it must still size flat-to-flat rather than falling back to
+    flat-to-OD (which would read 12.5 + 20 = 32.5 instead of 25)."""
+    part = Cylinder(20, 40) & Box(25, 60, 60, align=_C)
+    flats = recognise_flats(part)
+    assert len(flats) == 2
+    assert {f.across for f in flats} == {25.0}
+
+
+def test_a_lone_flat_on_a_single_stock_is_unchanged():
+    """No opponent anywhere: 10 from the axis of ⌀40 stock is 10 + 20 = 30 A/F. Guards against
+    a fix that suppresses opposition altogether."""
+    flats = recognise_flats(_lone_d(20, 10, 0))
+    assert [f.across for f in flats] == [30.0]


### PR DESCRIPTION
Closes #1015. Lifted out of #1011 (now draft) so a wrong number does not wait on that PR.

## The defect

`recognise_flats` sizes each flat by looking for an *opponent* — an antiparallel face across
the same axis. Finding one makes the size flat-to-flat (a double-D's A/F); finding none makes
it flat-to-opposite-OD (a lone D's height). The search required the same infinite axis **line**
and nothing more, so two lone D-flats on separate coaxial regions were each taken for the
other's opposite face.

```text
⌀40, flat 10 from the axis   → 10 + 20 = 30 A/F
⌀24, flat  8 from the axis   →  8 + 12 = 20 A/F
cross-paired                 → 10 +  8 = 18 A/F, for both
```

`across` is a flat's **only** size parameter, so this is a wrong number on the drawing rather
than a missing one — the part gets made to it. Nothing downstream catches it: `render_flats`
and any completeness check both consume the recogniser's value, so they agree with each other.

## The fix

Compare the matched cylinder's axial extent, which phase 1 already has in hand.

It stays **internal to one recognition run** — a same-run equality test between two candidates,
not an identity that propagates — so it makes no commitment about the stable feature identity
proposed in ADR 0017 §3, which rules out traversal-derived values for anything that does
propagate. That is deliberate: the same information exposed on the record *would* need to
satisfy §3, and this does not expose it.

## Verification

Canaried in both directions, because a fix that simply stopped opposing would also make the
reported symptom disappear:

| mutation | result |
|---|---|
| pair by axis line alone (the bug) | coaxial case red at exactly `[18.0, 18.0]` |
| never oppose | double-D case red at 32.5 instead of 25 |

Three tests: the coaxial pair, a genuine double-D that must still size flat-to-flat, and a lone
flat on single stock that must still size flat-to-OD.

Lint gates and smoke tier pass; full fast tier running (this changes recogniser output).

## Relationship to ADR 0017 (#1016)

Worth stating rather than leaving to be discovered: **§2's list of reconciliation examples
names this exact case** — "flats on parallel or coaxial stock regions". So this rule is one of
the bespoke exclusions that ADR would migrate into a named reconciliation stage, and it is
expected to move rather than live here permanently.

I think it should still land now:

- it is a correctness bug producing a wrong manufacturing dimension, not an architectural one;
- ADR 0017 explicitly does not require a big-bang migration, and says existing domain rules
  move into the stage incrementally;
- it creates no identity, no stage and no contract, so it prejudges nothing in the ADR;
- ten lines in one function move easily when the stage exists.

The alternative is shipping `18 A/F` for a part that is 30 until an architecture decision is
agreed *and* implemented.
