### PR TITLE
Add the ADR 0017 recognition result shell

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from draftwright.compose import StripDepths
-    from draftwright.recognition import TurnedProfile
+    from draftwright.recognition import RecognitionResult, TurnedProfile
 
 from build123d import Align, BoundBox, Compound, Edge, Location, Mode, Shape, Text, Vector
 from build123d_drafting.helpers import (
@@ -822,6 +822,7 @@ class Analysis:
     """
 
     part: Shape
+    recognition: RecognitionResult
     bb: BoundBox
     x_size: float
     y_size: float
@@ -839,7 +840,7 @@ class Analysis:
     pads: list  # geometry-derived rectangular-pad coverage inventory (#885)
     z_diams: list[float]
     cross_diams: list[float]
-    cyls: tuple[list, list]
+    cyls: tuple[tuple, tuple]
     prof: TurnedProfile | None  # turned step profile (recognise_turned_steps), detected once
     od_diam: float | None
     is_rotational: bool

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -49,16 +49,8 @@ from draftwright.model.planner import plan_dimensions
 from draftwright.recognition import (
     TurnedProfile,
     analyse_cylinders,
+    build_recognition_result,
     full_cylinders,
-    recognise_bosses,
-    recognise_countersinks,
-    recognise_hole_patterns,
-    recognise_holes,
-    recognise_pocket_patterns,
-    recognise_pockets,
-    recognise_rectangular_pads,
-    recognise_slots,
-    recognise_turned_steps,
     step_level_zs,
 )
 
@@ -521,7 +513,13 @@ def _analyse(
     # recognise_face_levels admitted it). Prismatic and other parts keep the
     # general face-level scan, which recognise_turned_steps cannot replace (no
     # cylinders → no profile).
-    _turned = TurnedProfile.from_steps(recognise_turned_steps(part, cyls=(z_cyls, cross_cyls)))
+    recognition = build_recognition_result(part, cylinders=(z_cyls, cross_cyls))
+    # The aggregate owns the shared substrate from here on.  Rebind the local projection so
+    # model construction, Analysis and the finished BuildState all consume the same inventory
+    # object rather than parallel list/tuple wrappers that merely happen to contain equal data.
+    shared_cyls = recognition.cylinders
+    shared_z_cyls, _shared_cross_cyls = shared_cyls
+    _turned = TurnedProfile.from_steps(list(recognition.turned_steps))
     if _turned is not None and _turned.axis == "z":
         step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
     else:
@@ -537,15 +535,13 @@ def _analyse(
     _arrow_length = _draft_est.arrow_length
     _pad_around_text = _draft_est.pad_around_text
     layout_model = _coerce_layout_model(model, part, decorations)
-    holes = recognise_holes(part, cyls=(z_cyls, cross_cyls), csinks=recognise_countersinks(part))
-    patterns = recognise_hole_patterns(holes)
-    bosses = recognise_bosses(
-        part, cyls=(z_cyls, cross_cyls)
-    )  # detect once — the one inventory (#264)
-    slots = recognise_slots(part)
-    pockets = recognise_pockets(part)
-    pocket_patterns = recognise_pocket_patterns(pockets)
-    pads = recognise_rectangular_pads(part)
+    holes = list(recognition.holes)
+    patterns = list(recognition.hole_patterns)
+    bosses = list(recognition.bosses)
+    slots = list(recognition.slots)
+    pockets = list(recognition.pockets)
+    pocket_patterns = list(recognition.pocket_patterns)
+    pads = list(recognition.pads)
     # Build the IR once, up front, so page/scale selection sizes from the SAME feature
     # model the renderers use — detected and declared parts share one sizing path and no
     # recogniser record reaches the sheet estimators (ADR 0008; #584 WP1 A). A declared
@@ -556,7 +552,7 @@ def _analyse(
     # own callout, not a phantom merged "N×" (the renderer emits them separately too — the
     # old estimator over-reserved). This can shift a tightly-packed such part's layout.
     _bores = (
-        tuple(_sizing_bores(z_cyls, z_diams, od_diam, cx, cy))
+        tuple(_sizing_bores(shared_z_cyls, z_diams, od_diam, cx, cy))
         if is_rotational and od_axis == "z"
         else ()
     )
@@ -576,7 +572,7 @@ def _analyse(
             step_zs=step_zs,
             rotational=(od_diam, _bores, od_axis) if is_rotational else None,
             pmi=pmi_records,
-            cyls=(z_cyls, cross_cyls),
+            cyls=shared_cyls,
         )
     )
     sizing_groups = plan_dimensions(sizing_model)
@@ -713,6 +709,7 @@ def _analyse(
 
     return Analysis(
         part=part,
+        recognition=recognition,
         bb=bb,
         x_size=x_size,
         y_size=y_size,
@@ -730,7 +727,7 @@ def _analyse(
         pads=pads,
         z_diams=z_diams,
         cross_diams=cross_diams,
-        cyls=(z_cyls, cross_cyls),
+        cyls=shared_cyls,
         prof=_turned,
         od_diam=od_diam,
         is_rotational=is_rotational,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -418,6 +418,7 @@ def _assemble(
     # ADR 0005 §2 (#639): the ONE build-context attachment — analysis + finished model
     # in a single typed BuildState; the compat properties on Drawing read through it.
     dwg._build.analysis = a
+    dwg._build.recognition = a.recognition
     dwg._build.part_model = pm
     # Persist the caller's detail-view opt-in: on the auto_dims=False path the flag
     # reaches no pass here, but the finalize drain gates the prismatic detail

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -17,7 +17,10 @@ import tempfile
 import warnings
 from dataclasses import dataclass
 from dataclasses import field as dataclasses_field
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+if TYPE_CHECKING:
+    from draftwright.recognition import RecognitionResult
 
 # PEP 702 @deprecated. A `sys.version_info` guard (not try/except) so the type checker,
 # which targets the 3.10 floor, resolves the backport branch instead of `warnings.deprecated`
@@ -261,6 +264,7 @@ class BuildState:
     - ``analysis`` — the pipeline's :class:`Analysis` namespace.
     - ``part_model`` — the detected/declared ADR-0008 PartModel (read surface for
       semantic edits, #397).
+    - ``recognition`` — the ADR 0017 aggregate reused by model detection and critique.
     - ``view_edge_cache`` — lint's per-view edge bboxes, keyed on id(view shape)
       (helpers #143/#164).
     - ``ann_box_cache`` — lint's annotation bounding boxes (#602): identity- AND
@@ -278,6 +282,7 @@ class BuildState:
     """
 
     analysis: Analysis | None = None
+    recognition: RecognitionResult | None = None
     part_model: object | None = None
     view_edge_cache: dict = dataclasses_field(default_factory=dict)
     ann_box_cache: dict = dataclasses_field(default_factory=dict)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -571,6 +571,16 @@ class Drawing:
         """
         return self._part_model
 
+    def recognition(self) -> RecognitionResult | None:
+        """The ADR 0017 recognition inventory used to build this drawing.
+
+        This is the geometry-only evidence below the detected/declared :meth:`model` and
+        drafting policy.  It is an experimental, read-only result; ``None`` is possible only
+        for a bare ``Drawing`` that did not pass through :func:`build_drawing`.
+        """
+
+        return self._build.recognition
+
     # --- build-context compat properties (#639): one BuildState, thin views.
     # _part_model and the two caches are GETTER-ONLY by design (#691 review):
     # zero assignment sites exist in src/ or tests/, and a future wholesale

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -91,6 +91,7 @@ from draftwright.recognition.levels import (
 )
 from draftwright.recognition.pads import RaisedPad, recognise_rectangular_pads
 from draftwright.recognition.plates import Plate, recognise_plates
+from draftwright.recognition.result import RecognitionResult, build_recognition_result
 from draftwright.recognition.slots import (
     Pocket,
     PocketArray,
@@ -130,6 +131,7 @@ __all__ = [
     "StepShoulder",
     "TurnedProfile",
     "TurnedStep",
+    "RecognitionResult",
     "BevelReject",
     "analyse_cylinders",
     "classify_bevel",
@@ -155,5 +157,6 @@ __all__ = [
     "recognise_slot_patterns",
     "recognise_slots",
     "recognise_turned_steps",
+    "build_recognition_result",
     "full_cylinders",
 ]

--- a/src/draftwright/recognition/result.py
+++ b/src/draftwright/recognition/result.py
@@ -1,0 +1,75 @@
+"""Aggregate recognition result (ADR 0017).
+
+This is the orchestration boundary above the ADR 0013 recognisers.  It starts with the
+inventories already shared by analysis and model detection; later ADR 0017 slices add the
+remaining families, reconciliation, measurables and diagnostics without changing the
+individual recogniser contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from draftwright.recognition._features import (
+    analyse_cylinders,
+    recognise_bosses,
+    recognise_hole_patterns,
+    recognise_holes,
+)
+from draftwright.recognition.countersinks import recognise_countersinks
+from draftwright.recognition.pads import recognise_rectangular_pads
+from draftwright.recognition.slots import (
+    recognise_pocket_patterns,
+    recognise_pockets,
+    recognise_slots,
+)
+from draftwright.recognition.turned import recognise_turned_steps
+
+
+@dataclass(frozen=True)
+class RecognitionResult:
+    """The immutable feature inventory produced by one recognition orchestration run.
+
+    The aggregate is intentionally incomplete in its first migration slice: these are the
+    inventories that ``analysis`` already detected and injected into ``build_part_model``.
+    Keeping that boundary explicit lets subsequent families move here monotonically instead
+    of introducing a second, big-bang detector.
+    """
+
+    cylinders: tuple[tuple, tuple]
+    countersinks: tuple
+    holes: tuple
+    hole_patterns: tuple
+    bosses: tuple
+    slots: tuple
+    pockets: tuple
+    pocket_patterns: tuple
+    pads: tuple
+    turned_steps: tuple
+
+
+def build_recognition_result(part, *, cylinders=None) -> RecognitionResult:
+    """Run the initial shared recognition inventory exactly once for *part*.
+
+    Dependencies are computed by this orchestration layer and injected downstream: holes
+    reuse both the cylinder substrate and countersinks, while patterns reuse their accepted
+    member records.  No recogniser rediscovers one of those dependencies internally.
+    """
+
+    z_cyls, cross_cyls = cylinders if cylinders is not None else analyse_cylinders(part)
+    cyls = (z_cyls, cross_cyls)
+    countersinks = recognise_countersinks(part)
+    holes = recognise_holes(part, cyls=cyls, csinks=countersinks)
+    pockets = recognise_pockets(part)
+    return RecognitionResult(
+        cylinders=(tuple(z_cyls), tuple(cross_cyls)),
+        countersinks=tuple(countersinks),
+        holes=tuple(holes),
+        hole_patterns=tuple(recognise_hole_patterns(holes)),
+        bosses=tuple(recognise_bosses(part, cyls=cyls)),
+        slots=tuple(recognise_slots(part)),
+        pockets=tuple(pockets),
+        pocket_patterns=tuple(recognise_pocket_patterns(pockets)),
+        pads=tuple(recognise_rectangular_pads(part)),
+        turned_steps=tuple(recognise_turned_steps(part, cyls=cyls)),
+    )

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -491,6 +491,9 @@ def test_build_state_has_a_single_construction_and_fill_site():
         # and these guards caught it.
         "builder.py": [
             "_build.analysis",
+            # ADR 0017's recognition aggregate is filled beside analysis/model at this
+            # same single construction site; Drawing.recognition() is read-only.
+            "_build.recognition",
             "_build.part_model",
             "_build.detail_view",
             "_build.trace",

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -300,8 +300,8 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     (was: holes/patterns/slots 2×, turned steps 3×)."""
     from build123d import Cylinder, Pos, Rotation
 
-    import draftwright.analysis as anmod
     import draftwright.model.detect as dmod
+    import draftwright.recognition.result as rmod
     from draftwright import build_drawing
 
     counts: dict[str, int] = {}
@@ -311,7 +311,7 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
         "recognise_slots",
         "recognise_turned_steps",
     ):
-        for mod in (anmod, dmod):
+        for mod in (rmod, dmod):
             orig = getattr(mod, name)
 
             def wrap(*a, _orig=orig, _n=name, **k):

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -24,12 +24,13 @@ def test_recognition_result_is_frozen_and_owns_tuple_inventories():
         result.holes = ()
 
 
-def test_drawing_build_state_reuses_analysis_recognition_result():
+def test_built_drawing_exposes_its_recognition_result_without_private_state():
     drawing = build_drawing(_plate_with_holes())
 
-    assert drawing._build.recognition is drawing._build.analysis.recognition
-    assert tuple(drawing._build.analysis.holes) == drawing._build.recognition.holes
-    assert drawing._build.analysis.cyls is drawing._build.recognition.cylinders
+    result = drawing.recognition()
+    assert isinstance(result, RecognitionResult)
+    assert len(result.holes) == 2
+    assert result.cylinders
 
 
 def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -1,0 +1,76 @@
+"""ADR 0017 phase 1: one explicit recognition result."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.recognition import RecognitionResult, build_recognition_result
+
+
+def _plate_with_holes():
+    plate = Box(60, 40, 8)
+    return plate - Pos(-15, 0, 0) * Cylinder(3, 8) - Pos(15, 0, 0) * Cylinder(3, 8)
+
+
+def test_recognition_result_is_frozen_and_owns_tuple_inventories():
+    result = build_recognition_result(_plate_with_holes())
+
+    assert isinstance(result, RecognitionResult)
+    assert len(result.holes) == 2
+    assert isinstance(result.holes, tuple)
+    with pytest.raises(FrozenInstanceError):
+        result.holes = ()
+
+
+def test_drawing_build_state_reuses_analysis_recognition_result():
+    drawing = build_drawing(_plate_with_holes())
+
+    assert drawing._build.recognition is drawing._build.analysis.recognition
+    assert tuple(drawing._build.analysis.holes) == drawing._build.recognition.holes
+    assert drawing._build.analysis.cyls is drawing._build.recognition.cylinders
+
+
+def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
+    import draftwright.recognition.result as result_module
+
+    calls = {"cylinders": 0, "countersinks": 0, "holes": 0, "patterns": 0}
+    cylinders = ([{"axis": "z"}], [{"axis": "x"}])
+    countersinks = [object()]
+    holes = [object()]
+
+    def fake_cylinders(part):
+        calls["cylinders"] += 1
+        return cylinders
+
+    def fake_countersinks(part):
+        calls["countersinks"] += 1
+        return countersinks
+
+    def fake_holes(part, *, cyls=None, csinks=None):
+        calls["holes"] += 1
+        assert cyls[0] is cylinders[0] and cyls[1] is cylinders[1]
+        assert csinks is countersinks
+        return holes
+
+    def fake_patterns(records):
+        calls["patterns"] += 1
+        assert records is holes
+        return []
+
+    monkeypatch.setattr(result_module, "analyse_cylinders", fake_cylinders)
+    monkeypatch.setattr(result_module, "recognise_countersinks", fake_countersinks)
+    monkeypatch.setattr(result_module, "recognise_holes", fake_holes)
+    monkeypatch.setattr(result_module, "recognise_hole_patterns", fake_patterns)
+    monkeypatch.setattr(result_module, "recognise_bosses", lambda *args, **kwargs: [])
+    monkeypatch.setattr(result_module, "recognise_slots", lambda part: [])
+    monkeypatch.setattr(result_module, "recognise_pockets", lambda part: [])
+    monkeypatch.setattr(result_module, "recognise_pocket_patterns", lambda records: [])
+    monkeypatch.setattr(result_module, "recognise_rectangular_pads", lambda part: [])
+    monkeypatch.setattr(result_module, "recognise_turned_steps", lambda *args, **kwargs: [])
+
+    built = result_module.build_recognition_result(object())
+
+    assert calls == {"cylinders": 1, "countersinks": 1, "holes": 1, "patterns": 1}
+    assert built.holes == tuple(holes)


### PR DESCRIPTION
## What changed

- adds the first frozen `RecognitionResult` aggregate from ADR 0017;
- moves the inventories already shared by analysis/model detection behind one orchestration function;
- preserves the aggregate on `Analysis` and typed `BuildState`;
- makes the cylinder substrate the exact shared object consumed downstream;
- updates the existing detect-once guard to observe the new orchestration seam;
- adds counterexample guards for injected recogniser dependencies, immutable inventory containers, and build-state reuse.

## Why

Recognition state was an informal group of locals on `Analysis`. ADR 0017 requires one explicit result that can grow into the shared feature/measurable/diagnostic inventory. This is the minimal shell: it moves only families already detected in analysis and deliberately leaves reconciliation, semantic identities, requirements, and the remaining recogniser families for later slices of #1019/#1018.

The orchestration function is named `build_recognition_result`, not `recognise_*`, because ADR 0013 reserves that shape for individual feature recognisers returning deterministic lists of records.

## Compatibility

No drawing policy or intended output changes. Existing `Analysis` projections remain while consumers migrate. Declared-path and full inventory/cache completion remain tracked in #1019; this PR does not claim to close it.

## Validation

- `uv run ruff check src/draftwright tests/test_recognition_result.py tests/test_part_model.py`
- `uv run mypy src/draftwright`
- `uv run pytest -q tests/test_recognition_result.py tests/test_part_model.py tests/test_recogniser_contract.py tests/test_score.py tests/test_detect_once.py` (37 passed)

Part of #1019 and #1018.
