### PR TITLE
test: count recogniser calls by code object, closing the substrate guard's blind spot

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,10 +33,21 @@ def counting_calls(functions: Mapping[str, Callable[..., object]]):
     blind spots must not open one.
 
     The hook is thread-local — only the calling thread is measured, which is what the tests
-    want. Any profiler already installed is **chained**, not suspended: `sys.setprofile`
-    holds one function, so an outer profiler (a nested ``counting_calls``, a plugin) would
-    otherwise go blind for the duration and never know. Coverage is unaffected either way —
-    it drives ``sys.settrace``/``sys.monitoring``, a separate mechanism.
+    want. A Python-level profiler already installed is **chained**, not suspended:
+    ``sys.setprofile`` holds one function, so an outer profiler (a nested ``counting_calls``,
+    a plugin) would otherwise go blind for the duration and never know.
+
+    A C-level profiler cannot be chained, and this refuses to run rather than pretend.
+    Under cProfile on Python <= 3.11, ``sys.getprofile()`` returns the ``Profile`` object,
+    which is not callable: chaining to it raises ``TypeError`` mid-context, and so does
+    restoring it on the way out. (On 3.12+ cProfile moved to ``sys.monitoring``, so
+    ``getprofile()`` is ``None`` and there is nothing to collide with.) Refusing on entry is
+    the same fail-closed choice as the duplicate-code-object check above: the alternatives
+    are a crash from inside a context manager, or counts taken with the outer profiler
+    silently switched off.
+
+    Coverage is unaffected throughout — it drives ``sys.settrace``/``sys.monitoring``, a
+    separate mechanism.
     """
     by_code: dict = {}
     for name, fn in functions.items():
@@ -50,6 +61,13 @@ def counting_calls(functions: Mapping[str, Callable[..., object]]):
         by_code[code] = name
     counts: dict[str, int] = {}
     previous = sys.getprofile()
+    if previous is not None and not callable(previous):
+        raise RuntimeError(
+            f"a non-callable profiler is installed ({type(previous).__name__}) — a C-level "
+            "profiler such as cProfile on Python <= 3.11. counting_calls can neither chain "
+            "to it nor restore it, so it refuses rather than crash mid-context or return "
+            "counts taken with the outer profiler silently switched off."
+        )
 
     def hook(frame, event, arg):
         if event == "call":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,12 @@ guard (#1019) counts recogniser families the same way.
 """
 
 import sys
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 
 
 @contextmanager
-def counting_calls(functions: dict):
+def counting_calls(functions: Mapping[str, Callable[..., object]]):
     """Count invocations of *functions* (``{name: callable}``) by CODE OBJECT.
 
     Counted with a profile hook rather than by installing spies over the modules that
@@ -26,20 +27,38 @@ def counting_calls(functions: dict):
     caller got hold of the function, so this closes all of those forms at once and needs no
     list of modules to keep in step with the source.
 
-    The hook is thread-local (only the calling thread is measured, which is what the tests
-    want) and saves/restores any profiler already installed, so it composes with a coverage
-    run — ``coverage`` drives ``sys.settrace``/``sys.monitoring``, a separate mechanism.
+    Two functions may share one code object (two closures off the same factory), and then
+    a call to either is indistinguishable from a call to the other. Rejected rather than
+    silently attributed to whichever name came last: a helper that exists to remove silent
+    blind spots must not open one.
+
+    The hook is thread-local — only the calling thread is measured, which is what the tests
+    want. Any profiler already installed is **chained**, not suspended: `sys.setprofile`
+    holds one function, so an outer profiler (a nested ``counting_calls``, a plugin) would
+    otherwise go blind for the duration and never know. Coverage is unaffected either way —
+    it drives ``sys.settrace``/``sys.monitoring``, a separate mechanism.
     """
-    by_code = {fn.__code__: name for name, fn in functions.items()}
+    by_code: dict = {}
+    for name, fn in functions.items():
+        code = fn.__code__
+        if code in by_code:
+            raise ValueError(
+                f"{name!r} and {by_code[code]!r} share one code object "
+                f"({code.co_name} at {code.co_filename}:{code.co_firstlineno}), so their "
+                "calls cannot be told apart. Count them separately."
+            )
+        by_code[code] = name
     counts: dict[str, int] = {}
+    previous = sys.getprofile()
 
     def hook(frame, event, arg):
         if event == "call":
             name = by_code.get(frame.f_code)
             if name is not None:
                 counts[name] = counts.get(name, 0) + 1
+        if previous is not None:
+            previous(frame, event, arg)
 
-    previous = sys.getprofile()
     sys.setprofile(hook)
     try:
         yield counts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Shared test helpers.
+
+``counting_calls`` is here rather than in one suite because more than one needs it:
+``test_detect_once`` counts the shared cylinder substrate, and the ADR 0017 manifest
+guard (#1019) counts recogniser families the same way.
+"""
+
+import sys
+from contextlib import contextmanager
+
+
+@contextmanager
+def counting_calls(functions: dict):
+    """Count invocations of *functions* (``{name: callable}``) by CODE OBJECT.
+
+    Counted with a profile hook rather than by installing spies over the modules that
+    import the name. That choice is the whole point, and it was arrived at the hard way:
+    four successive review rounds each closed one more *binding form* the spy approach
+    could not see — first the modules nobody had listed, then aliased imports
+    (``as _rescan``), and the next rung would have been a function held in a container, a
+    class attribute, a closure cell or a default argument. Patching bindings can only ever
+    cover the forms someone has thought of, and a missed form is silent: the call happens,
+    the count does not move, and the guard reports success.
+
+    A code object cannot be re-bound. Every call reaches the same ``__code__``, however the
+    caller got hold of the function, so this closes all of those forms at once and needs no
+    list of modules to keep in step with the source.
+
+    The hook is thread-local (only the calling thread is measured, which is what the tests
+    want) and saves/restores any profiler already installed, so it composes with a coverage
+    run — ``coverage`` drives ``sys.settrace``/``sys.monitoring``, a separate mechanism.
+    """
+    by_code = {fn.__code__: name for name, fn in functions.items()}
+    counts: dict[str, int] = {}
+
+    def hook(frame, event, arg):
+        if event == "call":
+            name = by_code.get(frame.f_code)
+            if name is not None:
+                counts[name] = counts.get(name, 0) + 1
+
+    previous = sys.getprofile()
+    sys.setprofile(hook)
+    try:
+        yield counts
+    finally:
+        sys.setprofile(previous)

--- a/tests/test_counting_calls.py
+++ b/tests/test_counting_calls.py
@@ -1,0 +1,91 @@
+"""The shared call-counting helper's own contract (#1027).
+
+``counting_calls`` exists to remove silent blind spots from the recogniser guards, so its
+two ways of *being* a blind spot get counterexamples of their own: an outer profiler going
+dark for the duration, and two functions sharing one code object.
+"""
+
+import sys
+
+import pytest
+from conftest import counting_calls
+
+
+def _target():
+    return "t"
+
+
+def _other():
+    return "o"
+
+
+def _closure_factory(n):
+    """Two calls return two function objects that share ONE code object."""
+
+    def made():
+        return n
+
+    return made
+
+
+def test_an_outer_profiler_still_sees_calls_made_inside():
+    """``sys.setprofile`` holds exactly one function, so installing the hook replaces
+    whatever was there. Restoring it afterwards is not enough — an outer profiler that is
+    blind for the duration reports a call count that is silently short, which is the exact
+    failure mode this helper was written to end.
+    """
+    seen: list[str] = []
+
+    def outer(frame, event, arg):
+        if event == "call":
+            seen.append(frame.f_code.co_name)
+
+    sys.setprofile(outer)
+    try:
+        with counting_calls({"target": _target}) as counts:
+            _target()
+            inside = sys.getprofile()
+        restored = sys.getprofile()
+    finally:
+        sys.setprofile(None)
+
+    assert counts == {"target": 1}
+    assert "_target" in seen, "the outer profiler went blind inside counting_calls"
+    assert inside is not outer, "the hook was never installed"
+    assert restored is outer, "the outer profiler was not restored"
+
+
+def test_counting_two_functions_that_share_a_code_object_is_refused():
+    """Two closures off one factory have the same ``__code__``, so a call to either is
+    indistinguishable from a call to the other. The dict comprehension this replaces kept
+    whichever name came last and attributed both to it — a wrong count reported as a
+    successful one.
+    """
+    first, second = _closure_factory(1), _closure_factory(2)
+    assert first.__code__ is second.__code__, "fixture no longer shares a code object"
+
+    with pytest.raises(ValueError, match="share one code object"):
+        with counting_calls({"first": first, "second": second}):
+            pass  # pragma: no cover — the raise happens on entry
+
+
+def test_the_refusal_leaves_the_profiler_untouched():
+    """Validation runs before the hook is installed, so a refused call cannot leave the
+    interpreter profiling into a context that has already unwound."""
+    first, second = _closure_factory(1), _closure_factory(2)
+    before = sys.getprofile()
+
+    with pytest.raises(ValueError):
+        with counting_calls({"first": first, "second": second}):
+            pass  # pragma: no cover
+
+    assert sys.getprofile() is before
+
+
+def test_distinct_functions_are_counted_separately():
+    with counting_calls({"target": _target, "other": _other}) as counts:
+        _target()
+        _target()
+        _other()
+
+    assert counts == {"target": 2, "other": 1}

--- a/tests/test_counting_calls.py
+++ b/tests/test_counting_calls.py
@@ -40,6 +40,7 @@ def test_an_outer_profiler_still_sees_calls_made_inside():
         if event == "call":
             seen.append(frame.f_code.co_name)
 
+    before = sys.getprofile()
     sys.setprofile(outer)
     try:
         with counting_calls({"target": _target}) as counts:
@@ -47,7 +48,9 @@ def test_an_outer_profiler_still_sees_calls_made_inside():
             inside = sys.getprofile()
         restored = sys.getprofile()
     finally:
-        sys.setprofile(None)
+        # Restore what was there, not None: clobbering an outer profiler for the rest of the
+        # session is the same defect this test exists to catch, committed by the test.
+        sys.setprofile(before)
 
     assert counts == {"target": 1}
     assert "_target" in seen, "the outer profiler went blind inside counting_calls"
@@ -89,3 +92,26 @@ def test_distinct_functions_are_counted_separately():
         _other()
 
     assert counts == {"target": 2, "other": 1}
+
+
+def test_a_c_level_profiler_is_refused_rather_than_crashed_into(monkeypatch):
+    """Under cProfile on Python <= 3.11, ``sys.getprofile()`` returns the ``Profile``
+    object, which is **not callable**. Chaining to it raises ``TypeError`` from inside the
+    context, and so does restoring it on exit — verified on 3.10, where both paths blow up.
+
+    ``sys.setprofile`` rejects non-callables, so the object cannot be installed for real
+    here; the guard reads ``sys.getprofile()``, which is what is faked.
+    """
+
+    class _NotCallable:
+        pass
+
+    monkeypatch.setattr(sys, "getprofile", lambda: _NotCallable())
+    installed = []
+    monkeypatch.setattr(sys, "setprofile", lambda fn: installed.append(fn))
+
+    with pytest.raises(RuntimeError, match="non-callable profiler"):
+        with counting_calls({"target": _target}):
+            pass  # pragma: no cover — the raise happens on entry
+
+    assert not installed, "the hook was installed before the profiler was checked"

--- a/tests/test_detect_once.py
+++ b/tests/test_detect_once.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import pytest
 from build123d import Axis, Box, fillet
+from conftest import counting_calls
 
 from draftwright import build_drawing
 
@@ -67,26 +68,22 @@ def test_generate_script_detects_once(fillet_counter, tmp_path):
 
 
 @pytest.fixture
-def cyls_counter(monkeypatch):
-    """Count ``analyse_cylinders`` scans everywhere the name is import-bound —
-    patching only ``_features`` would miss the recognisers' own bindings."""
-    import draftwright.analysis as analysis
-    import draftwright.drawing as drawing
+def cyls_counter():
+    """Count ``analyse_cylinders`` scans by CODE OBJECT (see ``conftest.counting_calls``).
+
+    Not by patching the modules that bind the name. #1019 spent four review rounds on that
+    approach and each round found one more binding form it could not see — modules nobody
+    had listed (``recognition.result`` and ``linting.coverage``, both on live paths), then
+    aliased imports, and next would have been a function held in a container or a closure.
+    Every miss is silent: the rescan happens and the count does not move.
+
+    Yields a live dict, so the count is read AFTER the work — matching the previous
+    fixture's ``calls["n"]`` shape.
+    """
     import draftwright.recognition._features as _features
-    import draftwright.recognition.flats as flats
-    import draftwright.recognition.grooves as grooves
-    import draftwright.recognition.turned as turned
 
-    calls = {"n": 0}
-    real = _features.analyse_cylinders
-
-    def counting(part):
-        calls["n"] += 1
-        return real(part)
-
-    for mod in (_features, analysis, drawing, flats, grooves, turned):
-        monkeypatch.setattr(mod, "analyse_cylinders", counting)
-    return calls
+    with counting_calls({"n": _features.analyse_cylinders}) as counts:
+        yield counts
 
 
 def test_cylinder_scan_runs_once_per_build(cyls_counter):
@@ -97,8 +94,9 @@ def test_cylinder_scan_runs_once_per_build(cyls_counter):
     # scan count regresses.
     dwg = build_drawing(_filleted())
     dwg.lint()
-    assert cyls_counter["n"] == 1, (
-        f"analyse_cylinders ran {cyls_counter['n']}× in one build+lint — a recogniser "
+    scans = cyls_counter.get("n", 0)
+    assert scans == 1, (
+        f"analyse_cylinders ran {scans}× in one build+lint — a recogniser "
         f"or lint path is re-scanning instead of sharing the one Analysis scan (#703)"
     )
 


### PR DESCRIPTION
Split out of #1021 at review request: an isolated test-quality change, independent of
#1019's deliverable.

## The gap

`test_cylinder_scan_runs_once_per_build` (#703) guards that one build + lint scans the
solid for cylinders exactly once. It did that by monkeypatching `analyse_cylinders` across
a hand-kept list of modules — and the list had fallen behind the source. Neither
`recognition/result.py` nor `linting/coverage.py` was on it, and both bind the name **by
value** on live paths. So dropping the substrate injection from `build_recognition_result`
makes the aggregate re-scan every solid on every build, with the **entire fast tier green**.

Verified both directions on this branch:

| fixture | injection removed from `build_recognition_result` |
|---|---|
| old (module patch list) | **4 passed** |
| new (code object) | **1 failed**, 3 passed |

## Why not just add the two missing modules

Because that is a rung, not the fix. Five review rounds on #1021 climbed exactly this
ladder: modules nobody had listed → an *aliased* import (`as _rescan`) → a function held in
a **dict**. The next rungs are a class attribute, a closure cell, a default argument, a
`partial`, a late import. A patch list can only cover the binding forms someone thought of,
and every miss is silent — the call happens, the count does not move, the guard reports
success. CLAUDE.md §8: if the same class of bug appears twice, reconsider the approach.

A **code object** cannot be re-bound. Every call reaches the same `__code__` however the
caller got hold of the function, so counting with a profile hook closes container / class
attribute / closure / default arg / partial / alias / late import at once, and needs no
module list kept in step with the source.

The hook is thread-local and saves/restores any profiler already installed, so it composes
with a `--cov` run (coverage drives `sys.settrace`/`sys.monitoring`, a separate mechanism).
Verified under `--cov`.

`counting_calls` lands in `tests/conftest.py` rather than in the one suite because the ADR
0017 manifest guard (#1019) counts recogniser families the same way.

No source changes. Part of epic #1018.
