### PR TITLE
feat(#1022): a declared build recognises nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,18 +388,31 @@ Current ADRs:
   deferral is a `Deferral` reason **code** plus the issue that removes it, not a paragraph:
   prose in a constant CI reads goes stale silently, and the first cut's did. The why-trail
   lives in the blocking issue.
-  Four things are still open, in this order. **#1022** — the ADR 0011 declared-path gate:
-  a declared build still recognises, and gating it is *not* just skipping the call, because
-  page/scale selection reads `step_zs` and the turned profile off that recognition even
-  when the model was declared, so sizing has to source them from the declaration first; the
-  same issue owns the one lazily-built `BuildState` aggregate a declared drawing needs when
-  physical critique *is* asked for. **#1025** — `recognise_step_shoulders` splits into raw
+  **#1022** landed the **ADR 0011 declared-path gate**: a declared build now recognises
+  **nothing**. It was not one `if` — sizing sources the turned profile and step ladder from
+  the declaration (`_declared_turned_profile` / `_declared_step_zs` in `analysis.py`), and
+  the lint→repair loop stopped asking for the feature-coverage half it never used
+  (`Drawing.lint(physical=False)`; repair acts on `dim_inside_part` alone, ADR 0002).
+  Critique on that path still needs an inventory, so `BuildState.ensure_recognition()` builds
+  one lazily, once — in the typed build state, not a lint- or `Drawing`-side memo, which
+  would make critique a second recognition owner. Exporting a declared drawing pays for that
+  one aggregate by design: `export` logs the coverage critique, and suppressing it to reach
+  "zero" would trade a user-facing diagnostic for a benchmark number. Two consequences worth
+  knowing: lint takes `step_zs`/`pads`/`pockets` from the **aggregate**, never from
+  `Analysis` on the declared path (ADR 0015 — critique must not inventory from the model);
+  and `recognise_face_levels` migrated into the aggregate as `step_levels`, its
+  `NO_INDEPENDENT_CONSUMER` deferral having stopped being true the moment declared-path
+  critique needed the geometry ladder. The gate also exposed a latent strip-sizing bug on
+  *both* paths: `_est_right_strip_depth` counted ladder steps only, while boss heights share
+  that strip — detected builds hid it in the ladder's slack (`_n_right_strip_boss_heights`,
+  `compose.py`).
+  Three things are still open, in this order. **#1025** — `recognise_step_shoulders` splits into raw
   riser evidence in the aggregate plus a pure projection per consumer, because its `levels=`
   input differs between model construction (filtered by plate and pocket ownership) and
   critique (unfiltered — ADR 0015 forbids lint taking its inventory from the model); until
   then lint rescans on every pass, budgeted rather than memoised, since a lint-owned memo
   would be a second recognition owner. **#1026** — migrate the three `BUILD_MODEL_ONLY`
-  families #1022 unblocks, and shrink the manifest. **#1028** — the classification gate is
+  families #1022 has now unblocked, and shrink the manifest. **#1028** — the classification gate is
   a *different* blocker on the automatic path, untouched by #1022: `chamfers`/`fillets`/
   `plates` migrate only once the orchestration itself carries the part classification, so
   hoisting them stops meaning "scan every turned build for a discarded result". Beyond the

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -822,7 +822,12 @@ class Analysis:
     """
 
     part: Shape
-    recognition: RecognitionResult
+    #: The ADR 0017 aggregate, or ``None`` on a DECLARED build — which recognises nothing
+    #: (ADR 0011 / #1022).  ``None`` means "not detected", never "detected and empty": a
+    #: consumer needing an inventory on that path must go through the lazy
+    #: ``Drawing._recognition()``, which builds one on demand rather than reading an absence
+    #: as an answer.
+    recognition: RecognitionResult | None
     bb: BoundBox
     x_size: float
     y_size: float

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -44,14 +44,15 @@ from draftwright.compose import (
     choose_scale,
 )
 from draftwright.model import build_part_model
-from draftwright.model.ir import Datum, PartModel, StepFeature
+from draftwright.model.ir import Datum, PartModel, StepFeature, StepLevelFeature
 from draftwright.model.planner import plan_dimensions
 from draftwright.recognition import (
+    RecognitionResult,
     TurnedProfile,
+    TurnedStep,
     analyse_cylinders,
     build_recognition_result,
     full_cylinders,
-    step_level_zs,
 )
 
 _log = logging.getLogger(__name__)
@@ -140,6 +141,57 @@ def _coerce_layout_model(model, part, decorations=None) -> PartModel | None:
         features=features,
         datums=[datum],
         decorations=decorations or {},
+    )
+
+
+def _declared_turned_profile(model: PartModel) -> TurnedProfile | None:
+    """The turned profile a DECLARED model states, or ``None`` if it declares no steps.
+
+    The detected path aggregates ``recognise_turned_steps``; a declared model already carries
+    the same information as :class:`StepFeature`\\ s, so this reads it rather than scanning the
+    solid for it (#1022).  ``span`` is the pair of axial end-points the declaration fixed, so
+    ``lo``/``hi`` need no geometry — a declared step's extent is what the author said it is.
+
+    Mixed-axis steps are a malformed declaration, not a recoverable one:
+    :meth:`TurnedProfile.from_steps` raises, and it is allowed to reach the caller here for
+    the same reason it does on the detected path.
+    """
+    steps = [f for f in model.features if isinstance(f, StepFeature)]
+    if not steps:
+        return None
+    axis_i = "xyz".index(steps[0].frame.axis)
+    return TurnedProfile.from_steps(
+        [
+            TurnedStep(
+                axis=f.frame.axis,
+                lo=min(f.span[0][axis_i], f.span[1][axis_i]),
+                hi=max(f.span[0][axis_i], f.span[1][axis_i]),
+                diameter=f.diameter,
+            )
+            for f in steps
+        ]
+    )
+
+
+def _declared_step_zs(model: PartModel, prof: TurnedProfile | None, bb) -> list[float]:
+    """The step Z-levels page/scale selection converges on, sourced from the declaration.
+
+    Mirrors the detected path's two branches exactly — a Z-axis turned profile contributes its
+    interior shoulders, anything else the prismatic height ladder — with the ladder read off a
+    declared :class:`StepLevelFeature` instead of re-scanning face levels (#1022).  The 0.6 mm
+    end-exclusion is the detected path's, kept identical so a declared build selects the same
+    page as the equivalent detected one.
+    """
+    if prof is not None and prof.axis == "z":
+        return [z for z in prof.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
+    return sorted(
+        {
+            z
+            for f in model.features
+            if isinstance(f, StepLevelFeature)
+            for z in f.levels
+            if bb.min.Z + 0.6 < z < bb.max.Z - 0.6
+        }
     )
 
 
@@ -513,17 +565,39 @@ def _analyse(
     # recognise_face_levels admitted it). Prismatic and other parts keep the
     # general face-level scan, which recognise_turned_steps cannot replace (no
     # cylinders → no profile).
-    recognition = build_recognition_result(part, cylinders=(z_cyls, cross_cyls))
+    # ADR 0011 / ADR 0017 §6: a declared model skips detection (#1022).  The gate has to sit
+    # here, ABOVE the aggregate, which is why `_coerce_layout_model` moved up from its old
+    # place below — it is pure (IR in, IR out) and reads nothing this block computes.
+    layout_model = _coerce_layout_model(model, part, decorations)
+    recognition: RecognitionResult | None
+    _turned: TurnedProfile | None
+    step_zs: list[float]
+    if layout_model is not None:
+        # Sizing must source `prof` and `step_zs` from the DECLARATION here. Taking them from
+        # a recognition that has been gated away would silently change page/scale selection,
+        # and leaving `prof=None` would silently disable axial critique for a declared turned
+        # part — both are failures the gate must not introduce (#1022).
+        recognition = None
+        _turned = _declared_turned_profile(layout_model)
+        step_zs = _declared_step_zs(layout_model, _turned, bb)
+    else:
+        recognition = build_recognition_result(part, cylinders=(z_cyls, cross_cyls))
+        _turned = TurnedProfile.from_steps(list(recognition.turned_steps))
+        if _turned is not None and _turned.axis == "z":
+            step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
+        else:
+            # The aggregate's own area-filtered extraction (#578 review; hoisted there by
+            # #1022 so critique on the declared path reads one value rather than rescanning).
+            step_zs = list(recognition.step_levels)
     # The aggregate owns the shared substrate from here on.  Rebind the local projection so
     # model construction, Analysis and the finished BuildState all consume the same inventory
     # object rather than parallel list/tuple wrappers that merely happen to contain equal data.
-    shared_cyls = recognition.cylinders
+    # A declared build has no aggregate, but `analyse_cylinders` already ran in
+    # `_classify_geometry` — it is substrate, not a recogniser, so reusing it gates nothing.
+    shared_cyls = (
+        recognition.cylinders if recognition is not None else (tuple(z_cyls), tuple(cross_cyls))
+    )
     shared_z_cyls, _shared_cross_cyls = shared_cyls
-    _turned = TurnedProfile.from_steps(list(recognition.turned_steps))
-    if _turned is not None and _turned.axis == "z":
-        step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
-    else:
-        step_zs = step_level_zs(part)  # shared area-filtered extraction (#578 review)
 
     # Pass 1 (two-pass layout, #131): measure annotation strip depths before
     # view positions are fixed.  font_size=3.0 is a fixed page-mm constant so
@@ -534,14 +608,17 @@ def _analyse(
     _draft_est = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
     _arrow_length = _draft_est.arrow_length
     _pad_around_text = _draft_est.pad_around_text
-    layout_model = _coerce_layout_model(model, part, decorations)
-    holes = list(recognition.holes)
-    patterns = list(recognition.hole_patterns)
-    bosses = list(recognition.bosses)
-    slots = list(recognition.slots)
-    pockets = list(recognition.pockets)
-    pocket_patterns = list(recognition.pocket_patterns)
-    pads = list(recognition.pads)
+    # Empty on the declared path — NOT "this part has no holes", but "nothing was detected".
+    # Every consumer that would read them as an inventory is either skipped there
+    # (`build_part_model`, `build_model`) or goes through the lazy aggregate instead
+    # (critique — see `Drawing._recognition`), so the two never get confused.
+    holes = list(recognition.holes) if recognition else []
+    patterns = list(recognition.hole_patterns) if recognition else []
+    bosses = list(recognition.bosses) if recognition else []
+    slots = list(recognition.slots) if recognition else []
+    pockets = list(recognition.pockets) if recognition else []
+    pocket_patterns = list(recognition.pocket_patterns) if recognition else []
+    pads = list(recognition.pads) if recognition else []
     # Build the IR once, up front, so page/scale selection sizes from the SAME feature
     # model the renderers use — detected and declared parts share one sizing path and no
     # recogniser record reaches the sheet estimators (ADR 0008; #584 WP1 A). A declared

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -196,6 +196,14 @@ def build_model(a: Analysis):
     its bore set is empty.
     """
     _bores = tuple(_concentric_bore_diams(a)) if a.is_rotational and a.od_axis == "z" else ()
+    # This is the DETECTED path's model construction — `_auto_annotate` calls it only when the
+    # caller declared no model, and a detected build always has the aggregate. On the declared
+    # path `a.recognition` is None (#1022) and there is nothing here to build from, so an
+    # absent aggregate means the caller reached this from somewhere it should not have.
+    assert a.recognition is not None, (
+        "build_model needs the recognition aggregate, which a declared build does not have — "
+        "the declared path uses the caller's model (dwg.model()) instead of building one."
+    )
     return build_part_model(
         a.part,
         holes=a.holes,

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -58,16 +58,43 @@ from draftwright.model.callout import hole_callout_spec
 _log = logging.getLogger(__name__)
 
 
-def _est_right_strip_depth(n_steps: int) -> float:
+def _est_right_strip_depth(n_steps: int, n_extra: int = 0) -> float:
     """Depth needed to the right of the front view.
 
-    Always includes dim_height (1 slot).  *n_steps* dim_step slots follow if
-    any step levels are present.  Returns the minimum corridor width (from view
-    edge to outer_limit) that makes all those allocations succeed.
+    Always includes dim_height (1 slot).  *n_steps* dim_step slots follow if any step levels
+    are present, and *n_extra* covers the strip's OTHER occupants — see
+    :func:`_n_right_strip_boss_heights`.  Returns the minimum corridor width (from view edge
+    to outer_limit) that makes all those allocations succeed.
     """
-    n = 1 + max(n_steps, 0)  # dim_height + one slot per step dim
+    n = 1 + max(n_steps, 0) + max(n_extra, 0)  # dim_height + one slot per step / other dim
     # gap + dim_height + (n-1) step slots each preceded by one spacing
     return float(_STRIP_GAP + _SLOT_DIM_HEIGHT + (n - 1) * (_STRIP_SPACING + _SLOT_DIM_STEP))
+
+
+def _n_right_strip_boss_heights(model) -> int:
+    """How many boss-height dims will contend for the front view's right strip (#1022).
+
+    ``render_boss_heights`` puts a Z-axis boss's height there, sharing the strip with the step
+    ladder — but the depth estimate counted only ladder steps, so the strip was sized for one
+    occupant class and solved for two.  On a DETECTED build that stayed invisible: the ladder
+    reserved enough slack that the boss height fitted in it.  Gating recognition off the
+    declared path (#1022) removed that accident — a declared model that states a boss but no
+    height ladder reserved one slot, needed two, and the height was dropped silently.
+
+    Mirrors ``render_boss_heights``' own guards: a turned model (any declared step) renders no
+    boss heights at all, and only the Z-axis ones land right — X/Y bosses go to the *above*
+    strips.  A rotational part that declares a Z boss over-reserves by one slot; that is the
+    conservative direction, and the same call the authored-Z-dim branch below makes.
+    """
+    if any(getattr(f, "kind", None) == "step" for f in model.features):
+        return 0
+    return sum(
+        1
+        for f in model.features
+        if getattr(f, "kind", None) == "boss"
+        and getattr(f, "height", None) is not None
+        and f.frame.axis == "z"
+    )
 
 
 def _est_pv_below_depth() -> float:
@@ -348,7 +375,9 @@ def _compose_anno_boxes(
     (#584 WP1 A); ``bore_callout_width`` is the planner-derived callout width the
     caller measured with :func:`_est_planned_bore_callout_width`.
     """
-    boxes = [AnnoBox("right", _est_right_strip_depth(n_steps))]  # FV right dim ladder
+    n_boss_h = _n_right_strip_boss_heights(model)
+    # FV right dim ladder + the boss heights that share the strip with it
+    boxes = [AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h))]
     bore_depth = bore_callout_width
     if bore_depth > 0:
         # elbow clearance + leader-to-label gap, as in _measure_strips
@@ -370,7 +399,9 @@ def _compose_anno_boxes(
     )
     if z_authored:
         slot = _SLOT_DIM_STEP + _STRIP_SPACING
-        boxes.append(AnnoBox("right", _est_right_strip_depth(n_steps) + z_authored * slot))
+        boxes.append(
+            AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h) + z_authored * slot)
+        )
         boxes.append(AnnoBox("left", _STRIP_GAP + z_authored * slot))
     above = _est_pv_above_depth(model, font_size, pad_around_text)
     if above > 0:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2954,6 +2954,11 @@ class Drawing:
                 raise ValueError(
                     f"unknown export format(s) {unknown}; choose from {self._EXPORT_FORMATS}"
                 )
+            # Beside the format check, not down at the PNG render: EVERY reason this call
+            # cannot succeed belongs before the work, or the "validate first" rule holds for
+            # whichever argument someone remembered (Codex #1029 r2).
+            if "png" in want and dpi <= 0:
+                raise ValueError(f"png export needs dpi > 0, got {dpi}")
 
         # AFTER validation, for the same reason validation precedes the deprecation warning
         # above: a call that is about to raise should not first do the work. On a declared
@@ -3012,8 +3017,6 @@ class Drawing:
 
         # --- formats=... → {format: path} (requested order); normalised + validated above ---
         assert want is not None  # formats is not None on this branch
-        if "png" in want and dpi <= 0:
-            raise ValueError(f"png export needs dpi > 0, got {dpi}")
         want_set = set(want)
         paths: dict[str, str] = {}
         # Intermediates — the SVG behind a PDF/PNG, the PDF behind a PNG — go to a temp dir when

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -591,8 +591,13 @@ class Drawing:
         """The ADR 0017 recognition inventory used to build this drawing.
 
         This is the geometry-only evidence below the detected/declared :meth:`model` and
-        drafting policy.  It is an experimental, read-only result; ``None`` is possible only
-        for a bare ``Drawing`` that did not pass through :func:`build_drawing`.
+        drafting policy.  It is an experimental, read-only result.
+
+        ``None`` for a bare ``Drawing`` that did not pass through :func:`build_drawing`, and
+        for a **declared** build that has not yet been critiqued — that path recognises
+        nothing (ADR 0011 / #1022) and only builds an aggregate when something asks for
+        physical critique.  So ``None`` here means "nothing has needed recognition yet", never
+        "this part has no features".
         """
 
         return self._build.recognition

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2932,8 +2932,6 @@ class Drawing:
             if out.endswith("." + _ext):
                 out = out[: -(len(_ext) + 1)]
                 break
-        self._lint_and_log()
-
         # Normalise ONCE, here, before anything reads it. `formats` may be a one-shot iterable,
         # and the mixed-API warning below used to build its message with `tuple(formats)` —
         # which consumed a generator, leaving the export loop nothing to iterate: it warned
@@ -2951,6 +2949,12 @@ class Drawing:
                 raise ValueError(
                     f"unknown export format(s) {unknown}; choose from {self._EXPORT_FORMATS}"
                 )
+
+        # AFTER validation, for the same reason validation precedes the deprecation warning
+        # above: a call that is about to raise should not first do the work. On a declared
+        # drawing this critique builds the recognition aggregate (#1022), so a mistyped format
+        # used to scan the whole solid and only then report the typo.
+        self._lint_and_log()
 
         # `formats=` wins over the legacy booleans, which means `export(out, formats=("svg",),
         # svg=False)` writes the SVG the caller just switched off — silently, since the legacy

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -82,7 +82,7 @@ from draftwright.linting import (
 from draftwright.projection import (
     project_view_geometry,
 )
-from draftwright.recognition import analyse_cylinders
+from draftwright.recognition import analyse_cylinders, build_recognition_result
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing
 
@@ -301,6 +301,22 @@ class BuildState:
         boxes together — a rolled-back drawing must re-measure everything."""
         self.view_edge_cache.clear()
         self.ann_box_cache.clear()
+
+    def ensure_recognition(self, part) -> RecognitionResult:
+        """The run's recognition aggregate, recognising *part* once if nothing has yet.
+
+        A declared build performs no recognition (ADR 0011 / #1022), so critique on that path
+        has no inventory to judge against and must produce one.  It is built **here**, in the
+        typed build state, and at most once per drawing: a lint-side or ``Drawing``-side memo
+        would make critique a second recognition owner, which is exactly what ADR 0017 exists
+        to remove (and what review of #1021 rejected).
+
+        On a detected build ``recognition`` is already filled by the builder, so this returns
+        it and recognises nothing.
+        """
+        if self.recognition is None:
+            self.recognition = build_recognition_result(part)
+        return self.recognition
 
 
 class Drawing:
@@ -2629,11 +2645,19 @@ class Drawing:
         return repair_drawing(self, max_iter)
 
     # -- output ---------------------------------------------------------------
-    def lint(self):
+    def lint(self, *, physical: bool = True):
         """Lint all annotations against all views; returns the list of issues.
 
         When :attr:`part` is set, also runs :func:`lint_feature_coverage`.
         Build-time drops recorded via :meth:`_record_build_issue` are included.
+
+        ``physical=False`` asks for the **placement** critique only — geometry/standards
+        checks over what is on the sheet — and skips the feature-coverage half that needs a
+        recognition inventory of the solid. That is what the repair loop wants (it acts on
+        ``dim_inside_part`` and nothing else, ADR 0002), and on a declared build it is the
+        difference between exporting a drawing and recognising the part to no purpose
+        (#1022). The default stays the full critique: a caller asking "is this drawing
+        right?" means both halves.
         """
         # Drawable area (page minus the standard margin), passed explicitly to
         # lint_drawing for bounds checks — draftwright owns linting now and no
@@ -2673,7 +2697,7 @@ class Drawing:
                     view_edge_cache=self._view_edge_cache,
                     ann_box_cache=self._ann_box_cache,
                 )
-        if self.part is not None:
+        if self.part is not None and physical:
             # Reuse the single feature inventory from the build (#244) when present,
             # so lint does not re-detect holes/patterns/turned-steps; fall back to
             # detecting when there is no analysis (a manually-built Drawing, or lint
@@ -2682,16 +2706,44 @@ class Drawing:
             holes: list | None
             patterns: list | None
             bosses: list | None
+            pads: list | None
+            pockets: list | None
+            step_zs: list | None
             prof_kw: dict
-            if a is not None:
+            if a is not None and a.recognition is not None:
                 cyls = a.cyls
                 holes, patterns, bosses = a.holes, a.patterns, a.bosses
+                pads, pockets, step_zs = a.pads, a.pockets, a.step_zs
+                prof_kw = {"prof": a.prof}
+            elif a is not None:
+                # A DECLARED build recognised nothing (#1022), so `a.holes` and friends are
+                # empty because nothing looked — not because the part has none. Feeding that
+                # emptiness to coverage would report every real hole as uncovered, so critique
+                # recognises here instead: once per drawing, owned by BuildState.
+                rec = self._build.ensure_recognition(self.part)
+                cyls = rec.cylinders
+                holes = list(rec.holes)
+                patterns = list(rec.hole_patterns)
+                bosses = list(rec.bosses)
+                pads = list(rec.pads)
+                pockets = list(rec.pockets)
+                # NOT `a.step_zs`: that is declaration-sourced on this path, and critique
+                # taking its inventory from the model is what ADR 0015 forbids — it would
+                # make lint blind to exactly the geometry a sparse declaration omitted, which
+                # is the case `unrecognised_defining_geometry` exists to report. The
+                # aggregate's geometry-sourced ladder is the right answer, and reading it here
+                # rather than passing `None` is what stops coverage rescanning it every lint.
+                step_zs = list(rec.step_levels)
+                # `a.prof` IS declaration-sourced, and here that is right rather than a
+                # shortcut: axial critique judges the declared profile's dimensioning, so a
+                # declared turned part keeps it without the aggregate.
                 prof_kw = {"prof": a.prof}
             else:
                 if self._cyl_cache is None:
                     self._cyl_cache = analyse_cylinders(self.part)
                 cyls = self._cyl_cache
                 holes = patterns = bosses = None
+                pads = pockets = step_zs = None
                 prof_kw = {}
             issues += lint_feature_coverage(
                 self.part,
@@ -2730,11 +2782,11 @@ class Drawing:
                 self.part,
                 self,
                 assembly=self.assembly,
-                pads=a.pads if a is not None else None,
-                pockets=a.pockets if a is not None else None,
+                pads=pads,
+                pockets=pockets,
                 bbox=a.bb if a is not None else None,
                 features=getattr(model, "features", ()) if model is not None else (),
-                step_zs=a.step_zs if a is not None else None,
+                step_zs=step_zs,
             )
             # Reverse direction (#487): a DECLARED feature with no matching geometry (a stale
             # phantom callout). Only for a caller-supplied model — detection can't over-declare.

--- a/src/draftwright/recognition/result.py
+++ b/src/draftwright/recognition/result.py
@@ -18,6 +18,7 @@ from draftwright.recognition._features import (
     recognise_holes,
 )
 from draftwright.recognition.countersinks import recognise_countersinks
+from draftwright.recognition.levels import step_level_zs
 from draftwright.recognition.pads import recognise_rectangular_pads
 from draftwright.recognition.slots import (
     recognise_pocket_patterns,
@@ -31,6 +32,12 @@ MIGRATED: frozenset[str] = frozenset(
     {
         "recognise_bosses",
         "recognise_countersinks",
+        # Reached through `step_level_zs`, the area-filtered gate over it — which is the form
+        # both consumers want, so the aggregate stores that rather than the raw levels. It was
+        # deferred NO_INDEPENDENT_CONSUMER until #1022 gave it one: critique on the declared
+        # path needs the geometry ladder, and rescanning it per lint is what the deferral's
+        # reason had stopped covering.
+        "recognise_face_levels",
         "recognise_hole_patterns",
         "recognise_holes",
         "recognise_pocket_patterns",
@@ -104,7 +111,6 @@ DEFERRED: dict[str, Deferred] = {
     "recognise_flats": Deferred(Deferral.BUILD_MODEL_ONLY, blocker=1022),
     "recognise_slot_patterns": Deferred(Deferral.BUILD_MODEL_ONLY, blocker=1022),
     "recognise_step_shoulders": Deferred(Deferral.CALLER_SPECIFIC_INPUT, blocker=1025),
-    "recognise_face_levels": Deferred(Deferral.NO_INDEPENDENT_CONSUMER),
 }
 
 
@@ -128,6 +134,11 @@ class RecognitionResult:
     pocket_patterns: tuple
     pads: tuple
     turned_steps: tuple
+    #: The interior prismatic step Z-levels (:func:`step_level_zs` — ``recognise_face_levels``
+    #: behind its area filter). A float tuple rather than records because both consumers want
+    #: the gated levels, not the faces: sizing converges page/scale on them, and critique feeds
+    #: them to ``recognise_step_shoulders`` as the geometry's own ladder (#1022).
+    step_levels: tuple[float, ...]
 
 
 def build_recognition_result(part, *, cylinders=None) -> RecognitionResult:
@@ -154,4 +165,5 @@ def build_recognition_result(part, *, cylinders=None) -> RecognitionResult:
         pocket_patterns=tuple(recognise_pocket_patterns(pockets)),
         pads=tuple(recognise_rectangular_pads(part)),
         turned_steps=tuple(recognise_turned_steps(part, cyls=cyls)),
+        step_levels=tuple(step_level_zs(part)),
     )

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -61,10 +61,18 @@ def _repair_dim_inside_part(dwg, issue) -> bool:
 
 def repair_drawing(dwg, max_iter: int = 3):
     """Close the lint→repair loop; see :meth:`Drawing.repair` for the contract.
-    Returns *dwg* for chaining."""
+    Returns *dwg* for chaining.
+
+    Lints ``physical=False`` — the placement critique only. This loop acts on
+    ``_REPAIRABLE_CODES`` (``dim_inside_part``) and nothing else, so the feature-coverage
+    half was computed and discarded on every iteration; on a declared build it also forced
+    the recognition ADR 0011 says that path skips (#1022). It makes the net-worsened
+    comparison below stricter too: coverage issues cannot change from re-placing a
+    dimension, so counting them only diluted the ratio.
+    """
     flipped: set = set()
     for _ in range(max_iter):
-        before = dwg.lint()
+        before = dwg.lint(physical=False)
         if not before:
             break
         snap_annotations = list(dwg.items)
@@ -83,7 +91,7 @@ def repair_drawing(dwg, max_iter: int = 3):
                     changed = True
         if not changed:
             break
-        if len(dwg.lint()) > len(before):
+        if len(dwg.lint(physical=False)) > len(before):
             # The repairs net-worsened the sheet — undo this pass and stop.
             dwg.items[:] = snap_annotations
             dwg.registry.restore(snap_registry)

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -189,15 +189,17 @@ def test_the_lazy_aggregate_is_owned_by_the_build_state():
     """
     _, sheet = _declared_plate_sheet()
     drawing = sheet.build()
-    assert drawing._build.recognition is None, "a declared build should not have recognised yet"
+    assert drawing.recognition() is None, "a declared build should not have recognised yet"
 
     drawing.lint()
 
-    assert drawing._build.recognition is not None, "the aggregate did not land in BuildState"
-    assert drawing._analysis.recognition is None, (
-        "Analysis is frozen and built before critique — a filled `recognition` here would mean "
-        "the lazy aggregate had been written back into the sizing-time inventory"
-    )
+    first = drawing.recognition()
+    assert first is not None, "the aggregate did not land in BuildState"
+    # Read through `Drawing.recognition()`, the public accessor over ``BuildState.recognition``
+    # — reaching into `_build` here would be the test-side private read #741 ratchets, and the
+    # claim is about the aggregate being reachable and stable, which the accessor states.
+    drawing.lint()
+    assert drawing.recognition() is first, "a second lint replaced the aggregate"
 
 
 def test_repair_asks_for_the_placement_critique_only():
@@ -229,22 +231,25 @@ def test_a_declared_turned_part_keeps_axial_critique():
     critique for every declared turned part — a gate that quietly removes a check is worse
     than the scan it saves.
 
-    Asserted by making the check FIRE, not merely by finding a profile: a `prof` that is
-    present but wrong would pass the weaker assertion.
+    Asserted through what the profile PRODUCES rather than by reading it off ``Analysis``: one
+    step-length dimension per declared segment, and the check firing when they are removed. A
+    ``prof`` that is present but wrong — one step, or the wrong axis — passes "is not None"
+    and fails both of these.
     """
     a, b, c = _turned_shaft_parts()
     sheet = Sheet(a + b + c).auto_dimensions()
     sheet.step(a)
     sheet.step(b)
     sheet.step(c)
-    drawing = sheet.build()
+    with _counting_every_family() as counts:
+        drawing = sheet.build()
+    assert dict(counts) == {}, f"the declared turned path recognised {dict(counts)}"
 
-    assert drawing._analysis.recognition is None, "the declared turned path still recognised"
-    prof = drawing._analysis.prof
-    assert prof is not None and prof.axis == "x", (
-        "a declared turned shaft lost its profile — sizing and axial critique both read it"
+    lengths = sorted(n for n in drawing.annotations() if n.startswith("m_steplen"))
+    assert len(lengths) == 3, (
+        f"expected one step-length dim per declared segment, got {lengths} — the declared "
+        "profile reached the renderer with the wrong step count or axis"
     )
-    assert len(prof.steps) == 3, f"declared profile has {len(prof.steps)} steps, expected 3"
     assert not [i for i in drawing.lint() if i.code == "axial_length_missing"]
 
     for name in [n for n in drawing.annotations() if n.startswith("m_steplen")][:2]:
@@ -279,7 +284,11 @@ def test_a_declared_boss_height_is_reserved_room_in_the_right_strip():
     sheet.pocket(pocket)
     drawing = sheet.build()
 
-    assert drawing._analysis.step_zs == [], (
+    # The fixture only exercises the case while it declares NO height ladder: with one, the
+    # ladder's own slots would hide the missing boss-height slot exactly as they do on the
+    # detected path. Asserted off the declared model rather than `Analysis.step_zs`, which
+    # says the same thing one derivation later and is a test-side private read (#741).
+    assert not [f for f in drawing.model().features if f.kind == "step_level"], (
         "fixture no longer exercises the case — it needs a declared boss with NO declared "
         "height ladder, so the strip's only reserved slot is the envelope height"
     )

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -160,9 +160,22 @@ def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
     assert third_issues == first_issues, "the third lint disagreed with the first"
 
 
-def test_a_rejected_export_does_not_recognise_first():
-    """``export`` validates its formats, then lints. It used to lint first, so a mistyped
-    format scanned the whole solid and only then reported the typo.
+#: Every way ``export`` can reject a call outright, with the message it rejects it by.
+#: Parametrised rather than written once because the first fix covered only the unknown-format
+#: path and left the `dpi` check where it was — a second review round found the parallel path
+#: still recognising. A rejection reason added here without moving its check ahead of
+#: ``_lint_and_log`` fails, which is the property that generalises.
+_REJECTED_EXPORTS = [
+    ({"formats": ("bogus",)}, "unknown export format"),
+    ({"formats": ("png",), "dpi": 0}, "dpi > 0"),
+    ({"formats": ("png",), "dpi": -150}, "dpi > 0"),
+]
+
+
+@pytest.mark.parametrize(("kwargs", "message"), _REJECTED_EXPORTS)
+def test_a_rejected_export_does_not_recognise_first(kwargs, message):
+    """``export`` validates, then lints. It used to lint first, so a call that could not
+    possibly succeed scanned the whole solid and only then reported the fault.
 
     Harmless while the critique was free — on a detected build the inventory already exists —
     but #1022 made it the trigger for the lazy aggregate, so a broken call started paying for
@@ -173,12 +186,12 @@ def test_a_rejected_export_does_not_recognise_first():
     drawing = sheet.build()
 
     with _counting_every_family() as counts:
-        with pytest.raises(ValueError, match="unknown export format"):
-            drawing.export("out", formats=("bogus",))
+        with pytest.raises(ValueError, match=message):
+            drawing.export("out", **kwargs)
 
     assert dict(counts) == {}, (
-        f"a rejected export recognised {dict(counts)} before raising — the call was never "
-        "going to produce a drawing to critique"
+        f"a rejected export ({kwargs}) recognised {dict(counts)} before raising — the call "
+        "was never going to produce a drawing to critique"
     )
 
 

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -35,6 +35,16 @@ def _counting_every_family():
         yield counts
 
 
+def _issue_keys(issues) -> tuple:
+    """A stable, order-insensitive representation of a lint result.
+
+    Sorted because the issue list is assembled from several checks and their relative order is
+    not part of the contract; message included because two issues of one code differ only
+    there (which hole, which shoulder).
+    """
+    return tuple(sorted((i.code, i.severity, i.message) for i in issues))
+
+
 def _prismatic_plate():
     return Box(80, 60, 20) - Pos(0, 0, 0) * Cylinder(5, 20)
 
@@ -124,11 +134,11 @@ def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
     drawing = sheet.build()
 
     with _counting_every_family() as counts:
-        drawing.lint()
+        first_issues = _issue_keys(drawing.lint())
         first = dict(counts)
         counts.clear()
-        drawing.lint()
-        drawing.lint()
+        second_issues = _issue_keys(drawing.lint())
+        third_issues = _issue_keys(drawing.lint())
         later = dict(counts)
 
     assert first.get("recognise_holes") == 1, (
@@ -139,6 +149,36 @@ def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
     assert not rescanned, (
         f"two further lints re-ran {rescanned} — the aggregate is supposed to be built once "
         "and reused, so a second scan is a cache that is not being hit"
+    )
+    # Counting alone would pass an implementation whose later lints reuse the aggregate and
+    # return LESS — placement issues only, or nothing. "Obtains no new aggregate" and "returns
+    # the same answer" are separate claims and the second is the one a user would notice.
+    assert second_issues == first_issues, (
+        "the second lint of a declared drawing disagreed with the first while recognising "
+        f"nothing new: {sorted(set(first_issues) ^ set(second_issues))}"
+    )
+    assert third_issues == first_issues, "the third lint disagreed with the first"
+
+
+def test_a_rejected_export_does_not_recognise_first():
+    """``export`` validates its formats, then lints. It used to lint first, so a mistyped
+    format scanned the whole solid and only then reported the typo.
+
+    Harmless while the critique was free — on a detected build the inventory already exists —
+    but #1022 made it the trigger for the lazy aggregate, so a broken call started paying for
+    recognition it could never use. Same reasoning the surrounding code already applies to the
+    deprecation warning: report the fault that matters before doing the work.
+    """
+    _, sheet = _declared_plate_sheet()
+    drawing = sheet.build()
+
+    with _counting_every_family() as counts:
+        with pytest.raises(ValueError, match="unknown export format"):
+            drawing.export("out", formats=("bogus",))
+
+    assert dict(counts) == {}, (
+        f"a rejected export recognised {dict(counts)} before raising — the call was never "
+        "going to produce a drawing to critique"
     )
 
 

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -1,0 +1,287 @@
+"""A declared build recognises nothing; critique on that path recognises once (#1022).
+
+ADR 0011 says a caller-supplied ``PartModel`` skips detection, and ADR 0017 §6 restates it for
+the aggregate. Neither held: ``_analyse`` ran ``build_recognition_result`` before it knew
+whether a model had been declared, so a declared build recognised the full inventory and threw
+most of it away.
+
+The gate is not one ``if``. Page and scale selection read the turned profile and the step-level
+ladder off that recognition, so sizing had to source them from the declaration first; and the
+lint→repair loop asked for the full critique on every iteration while acting only on
+``dim_inside_part``, which forced the recognition back in through the side door. Both halves
+are guarded here, because either one alone leaves the acceptance unmet.
+
+Counted by code object (``conftest.counting_calls``) rather than by patching module bindings —
+see that helper for why a binding-level spy cannot be trusted for this claim.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+from build123d import Box, Cylinder, Pos, Rot
+from conftest import counting_calls
+
+import draftwright.recognition as recognition
+from draftwright import Sheet, build_drawing
+from draftwright.compose import _est_right_strip_depth, _n_right_strip_boss_heights
+from draftwright.recognition.result import DEFERRED, MIGRATED
+
+
+@contextmanager
+def _counting_every_family():
+    with counting_calls(
+        {name: getattr(recognition, name) for name in MIGRATED | DEFERRED.keys()}
+    ) as counts:
+        yield counts
+
+
+def _prismatic_plate():
+    return Box(80, 60, 20) - Pos(0, 0, 0) * Cylinder(5, 20)
+
+
+def _declared_plate_sheet():
+    part = _prismatic_plate()
+    sheet = Sheet(part).auto_dimensions()
+    sheet.envelope()
+    sheet.hole(Pos(0, 0, 0) * Cylinder(5, 20))
+    return part, sheet
+
+
+def _turned_shaft_parts():
+    """Three coaxial segments, each longer than it is wide so the axis is unambiguous."""
+    a = Pos(-42.5, 0, 0) * Rot(0, 90, 0) * Cylinder(9, 25)
+    b = Pos(-10, 0, 0) * Rot(0, 90, 0) * Cylinder(15, 40)
+    c = Pos(25, 0, 0) * Rot(0, 90, 0) * Cylinder(11, 30)
+    return a, b, c
+
+
+def test_a_declared_build_recognises_nothing():
+    """The headline acceptance. Includes the repair loop, which runs inside ``build_drawing``
+    and used to force a full critique — gating ``_analyse`` alone left this at ten families,
+    every one reached through ``repair() -> lint()`` rather than through detection.
+    """
+    _, sheet = _declared_plate_sheet()
+    with _counting_every_family() as counts:
+        sheet.build()
+
+    assert dict(counts) == {}, (
+        f"a declared build recognised {dict(counts)}. ADR 0011 says a caller-supplied model "
+        "skips detection — every one of these scanned a solid whose features the caller had "
+        "already stated."
+    )
+
+
+def test_exporting_a_declared_drawing_pays_for_one_aggregate_and_no_more(tmp_path):
+    """``export`` calls ``_lint_and_log``, whose warnings the user reads — so exporting *is*
+    asking for physical critique, and the lazy aggregate is the honest price.
+
+    Deliberately not "export recognises nothing": the alternative was making ``_lint_and_log``
+    skip coverage, which would stop every export on BOTH paths from reporting coverage
+    problems. That trades a real diagnostic for a benchmark number. What must hold is that the
+    price is paid once — a second export reuses the aggregate.
+    """
+    _, sheet = _declared_plate_sheet()
+    drawing = sheet.build()
+
+    with _counting_every_family() as counts:
+        drawing.export(str(tmp_path / "first"), formats=("svg",))
+        first = dict(counts)
+        counts.clear()
+        drawing.export(str(tmp_path / "second"), formats=("svg",))
+        second = dict(counts)
+
+    assert first.get("recognise_holes") == 1, (
+        "the first export's lint-and-log found no inventory to judge against"
+    )
+    rescanned = {n: c for n, c in second.items() if n != "recognise_step_shoulders"}
+    assert not rescanned, f"a second export re-recognised {rescanned}"
+
+
+def test_a_detected_build_still_recognises_each_family_once():
+    """The gate must not fire on the automatic path — the counterexample that stops
+    :func:`test_a_declared_build_and_export_recognises_nothing` from being satisfied by
+    breaking recognition outright."""
+    with _counting_every_family() as counts:
+        build_drawing(_prismatic_plate())
+
+    assert counts, "a detected build recognised nothing — the gate fired on the wrong path"
+    for family in MIGRATED:
+        assert counts.get(family) == 1, (
+            f"{family} ran {counts.get(family, 0)}× on the detected path, not once"
+        )
+
+
+def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
+    """A declared drawing has no inventory to judge against, so the first *explicit* physical
+    lint builds one — once, and cached in the typed ``BuildState``.
+
+    ``recognise_step_shoulders`` is exempt: it is the ``CALLER_SPECIFIC_INPUT`` deferral, and
+    it rescans on every lint until #1025 splits it. Budgeting it is the honest form; a
+    lint-side memo to silence it would make critique a second recognition owner, which is what
+    ADR 0017 exists to remove.
+    """
+    _, sheet = _declared_plate_sheet()
+    drawing = sheet.build()
+
+    with _counting_every_family() as counts:
+        drawing.lint()
+        first = dict(counts)
+        counts.clear()
+        drawing.lint()
+        drawing.lint()
+        later = dict(counts)
+
+    assert first.get("recognise_holes") == 1, (
+        "the first physical lint of a declared drawing must obtain one aggregate — without it "
+        "coverage judges against an empty inventory and reports every real feature as missing"
+    )
+    rescanned = {n: c for n, c in later.items() if n != "recognise_step_shoulders"}
+    assert not rescanned, (
+        f"two further lints re-ran {rescanned} — the aggregate is supposed to be built once "
+        "and reused, so a second scan is a cache that is not being hit"
+    )
+
+
+def test_the_lazy_aggregate_is_owned_by_the_build_state():
+    """ADR 0017 §6: one owner. ``Drawing._cyl_cache`` is the existing violation (#1023) and
+    this must not add a second — the aggregate lands in ``BuildState``, which is where a
+    finished drawing already keeps its build context.
+    """
+    _, sheet = _declared_plate_sheet()
+    drawing = sheet.build()
+    assert drawing._build.recognition is None, "a declared build should not have recognised yet"
+
+    drawing.lint()
+
+    assert drawing._build.recognition is not None, "the aggregate did not land in BuildState"
+    assert drawing._analysis.recognition is None, (
+        "Analysis is frozen and built before critique — a filled `recognition` here would mean "
+        "the lazy aggregate had been written back into the sizing-time inventory"
+    )
+
+
+def test_repair_asks_for_the_placement_critique_only():
+    """Repair acts on ``dim_inside_part`` and nothing else (ADR 0002), so it has no use for
+    the feature-coverage half — and asking for it is what forced recognition back onto the
+    declared path after ``_analyse`` was gated.
+    """
+    seen: list[bool] = []
+    drawing = build_drawing(Box(60, 40, 20))
+    real_lint = drawing.lint
+
+    def spy(*, physical=True):
+        seen.append(physical)
+        return real_lint(physical=physical)
+
+    drawing.lint = spy
+    drawing.repair()
+
+    assert seen, "repair did not lint at all"
+    assert not any(seen), (
+        f"repair requested the physical critique ({seen}) — it acts only on placement codes, "
+        "so the coverage half is computed and discarded every iteration"
+    )
+
+
+def test_a_declared_turned_part_keeps_axial_critique():
+    """``Analysis.prof`` feeds ``lint_axial_coverage``. Gating recognition without a
+    declaration-sourced replacement would leave it ``None`` and silently disable axial
+    critique for every declared turned part — a gate that quietly removes a check is worse
+    than the scan it saves.
+
+    Asserted by making the check FIRE, not merely by finding a profile: a `prof` that is
+    present but wrong would pass the weaker assertion.
+    """
+    a, b, c = _turned_shaft_parts()
+    sheet = Sheet(a + b + c).auto_dimensions()
+    sheet.step(a)
+    sheet.step(b)
+    sheet.step(c)
+    drawing = sheet.build()
+
+    assert drawing._analysis.recognition is None, "the declared turned path still recognised"
+    prof = drawing._analysis.prof
+    assert prof is not None and prof.axis == "x", (
+        "a declared turned shaft lost its profile — sizing and axial critique both read it"
+    )
+    assert len(prof.steps) == 3, f"declared profile has {len(prof.steps)} steps, expected 3"
+    assert not [i for i in drawing.lint() if i.code == "axial_length_missing"]
+
+    for name in [n for n in drawing.annotations() if n.startswith("m_steplen")][:2]:
+        drawing.remove(name)
+
+    assert [i for i in drawing.lint() if i.code == "axial_length_missing"], (
+        "removing two step-length dims produced no axial_length_missing — the declared "
+        "profile is present but critique is not actually judging against it"
+    )
+
+
+def test_a_declared_boss_height_is_reserved_room_in_the_right_strip():
+    """A boss height shares the front view's right strip with the step ladder, but the depth
+    estimate counted only ladder steps — the strip was sized for one occupant class and solved
+    for two.
+
+    On a detected build the ladder's own reservation absorbed the boss height, so the defect
+    was invisible. A declared model that states a boss and no ladder reserved one slot, needed
+    two, and the height was dropped — silently, because ``render_boss_heights`` sets
+    ``on_drop`` to a no-op so the omission is reported once by lint rather than twice.
+    """
+    wall, length, width, height = 3.0, 90, 64, 38
+    pocket = Pos(0, 0, -wall) * Box(length - 2 * wall, width - 2 * wall, height)
+    boss = Pos(0, 0, height / 2 + 5) * Cylinder(14, 10)
+    bore = Pos(0, 0, 15) * Cylinder(6, 40)
+    cover = Box(length, width, height) - pocket + boss - bore
+
+    sheet = Sheet(cover, title="C").auto_dimensions()
+    sheet.envelope()
+    sheet.boss(boss)
+    sheet.hole(bore).through()
+    sheet.pocket(pocket)
+    drawing = sheet.build()
+
+    assert drawing._analysis.step_zs == [], (
+        "fixture no longer exercises the case — it needs a declared boss with NO declared "
+        "height ladder, so the strip's only reserved slot is the envelope height"
+    )
+    assert [n for n in drawing.annotations() if n.startswith("m_bossheight_")], (
+        "the declared boss height was dropped: the right strip reserved a slot for the "
+        "envelope height only, leaving the boss height nowhere to go"
+    )
+    assert drawing.lint_summary()["by_code"].get("boss_height_missing", 0) == 0
+
+
+def test_the_right_strip_estimate_counts_boss_heights():
+    """The unit behind the case above: an extra occupant is an extra slot."""
+    assert _est_right_strip_depth(0, 1) > _est_right_strip_depth(0, 0)
+    assert _est_right_strip_depth(2, 1) == _est_right_strip_depth(3, 0)
+
+
+@pytest.mark.parametrize(
+    ("declare", "expected", "why"),
+    [
+        (lambda s, boss: s.boss(boss), 1, "a Z-axis boss with a height lands in the right strip"),
+        (lambda s, boss: None, 0, "no boss declared, no slot"),
+    ],
+)
+def test_only_the_bosses_that_land_right_are_counted(declare, expected, why):
+    """Mirrors ``render_boss_heights``' own guards rather than reserving for every boss —
+    over-reserving costs page space on every build that has one."""
+    boss = Pos(0, 0, 15) * Cylinder(14, 10)
+    sheet = Sheet(Box(90, 64, 20) + boss).auto_dimensions()
+    sheet.envelope()
+    declare(sheet, boss)
+    model = sheet.build().model()
+
+    assert _n_right_strip_boss_heights(model) == expected, why
+
+
+def test_a_turned_model_reserves_no_boss_height_slots():
+    """``render_boss_heights`` returns early for a turned part, so reserving for one there
+    would be dead page space."""
+    a, b, c = _turned_shaft_parts()
+    sheet = Sheet(a + b + c).auto_dimensions()
+    sheet.step(a)
+    sheet.step(b)
+    sheet.step(c)
+
+    assert _n_right_strip_boss_heights(sheet.build().model()) == 0

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8369,7 +8369,8 @@ class TestRepair:
             message="Dim 'OSC': annotation bbox overlaps part outline by 40%",
             code="dim_inside_part",
         )
-        dwg.lint = lambda: [issue]
+        # `physical=` because repair asks for the placement critique only (#1022).
+        dwg.lint = lambda **kw: [issue]
         dwg.repair(max_iter=5)
         # Flipped exactly once → ends on "below", not back to "above".
         assert dwg.get_annotation("x")._dw_spec.side == "below"
@@ -8408,7 +8409,7 @@ class TestRepair:
         )
         calls = {"n": 0}
 
-        def fake_lint():
+        def fake_lint(**kw):  # repair lints physical=False (#1022)
             calls["n"] += 1
             return [overlap]
 

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -38,6 +38,7 @@ from draftwright.recognition import (
     recognise_rectangular_pads,
     recognise_slots,
     recognise_turned_steps,
+    step_level_zs,
 )
 from draftwright.recognition.result import DEFERRED, MIGRATED, Deferral
 
@@ -229,27 +230,19 @@ def test_a_classification_gated_reason_is_true_of_the_build():
 def test_the_migrated_families_are_the_ones_the_orchestration_actually_runs():
     """Guards the manifest against the failure that makes it worthless: a name listed as
     MIGRATED that ``build_recognition_result`` never calls. Checked by *running* the
-    orchestration with each family instrumented, not by reading its source."""
-    called: dict[str, int] = {}
-    originals = {name: getattr(result_module, name) for name in MIGRATED}
+    orchestration with each family instrumented, not by reading its source.
 
-    def spy(name, orig):
-        def wrapper(*args, **kwargs):
-            called[name] = called.get(name, 0) + 1
-            return orig(*args, **kwargs)
-
-        return wrapper
-
-    for name, orig in originals.items():
-        setattr(result_module, name, spy(name, orig))
-    try:
-        # A part carrying every migrated feature kind would be enormous; the claim under test
-        # is that the ORCHESTRATION invokes each family, which holds for any solid — a family
-        # that finds nothing was still asked.
+    Counted by code object rather than by patching ``result_module``'s bindings. The binding
+    form was not merely fragile here, it was wrong: #1022 migrated ``recognise_face_levels``,
+    which the orchestration reaches INDIRECTLY through ``step_level_zs``, so there is no name
+    on this module to patch and the spy raised ``AttributeError``. A family is migrated if the
+    orchestration calls it, not if it happens to be called by a line in this file.
+    """
+    # A part carrying every migrated feature kind would be enormous; the claim under test
+    # is that the ORCHESTRATION invokes each family, which holds for any solid — a family
+    # that finds nothing was still asked.
+    with counting_calls({name: getattr(recognition, name) for name in MIGRATED}) as called:
         result_module.build_recognition_result(Box(40, 30, 10))
-    finally:
-        for name, orig in originals.items():
-            setattr(result_module, name, orig)
 
     assert set(called) == MIGRATED, (
         f"listed as migrated but never called: {sorted(MIGRATED - set(called))}"
@@ -279,6 +272,7 @@ def _expected_inventory(part) -> dict:
         "pocket_patterns": tuple(recognise_pocket_patterns(pockets)),
         "pads": tuple(recognise_rectangular_pads(part)),
         "turned_steps": tuple(recognise_turned_steps(part, cyls=cyls)),
+        "step_levels": tuple(step_level_zs(part)),
     }
 
 
@@ -402,66 +396,32 @@ def test_an_automatic_build_runs_each_family_exactly_once_and_lint_runs_no_migra
         )
 
 
-#: What a declared build recognises today, per family. A ratchet baseline, not a target:
-#: ADR 0011 says a declared model skips detection, and #1022 takes every entry here to zero.
-#: Pinned per family rather than as a total because a total permits SUBSTITUTION — one
-#: family dropping out while another appears leaves the count unmoved and the guard silent,
-#: which is precisely the quiet migration this test exists to catch.
-_DECLARED_BUILD_BASELINE = {
-    "recognise_bosses": 1,
-    "recognise_countersinks": 1,
-    "recognise_face_levels": 1,
-    "recognise_hole_patterns": 1,
-    "recognise_holes": 1,
-    "recognise_pocket_patterns": 1,
-    "recognise_pockets": 1,
-    "recognise_rectangular_pads": 1,
-    "recognise_slots": 1,
-    "recognise_step_shoulders": 1,
-    "recognise_turned_steps": 1,
-}
+def test_a_declared_build_recognises_nothing():
+    """ADR 0011 / ADR 0017 §6, now a pass mark rather than a ratchet (#1022).
 
+    This started life as ``test_a_declared_build_does_not_grow_new_recognition``, pinning
+    eleven families per build so the debt could only shrink. #1022 took all eleven to zero:
+    ``_analyse`` gates the aggregate on whether a model was declared, sizing sources the
+    turned profile and step ladder from the declaration, and the repair loop stopped asking
+    for the feature-coverage half of lint it never used.
 
-def test_a_declared_build_does_not_grow_new_recognition():
-    """A ratchet on the ADR 0011 / ADR 0017 §6 debt, not a pass mark.
+    Zero rather than a budget, because there is no longer a family with a reason to run here
+    — anything appearing is a new consumer that has not been threaded through the
+    declaration, and it should have to justify itself in review rather than nudge a number.
 
-    A declared build is supposed to perform **no** recognition, and today it performs a
-    lot — page and scale selection read ``step_zs`` and the turned profile off the
-    aggregate even when the model was declared, so the gate needs sizing reworked first
-    (#1022). What this pins is the *direction of travel*: the manifest forces a
-    MIGRATED/DEFERRED decision for each new family but has no opinion on which way that
-    decision loads this path, so without a ratchet here every future migration quietly makes
-    the declared path do more work and no test says a word.
-
-    It earned its keep by catching a regression in the PR that introduced it: an earlier
-    revision migrated three ``BUILD_MODEL_ONLY`` families and took this path from 11 to 14
-    for no detected-path saving at all. They are deferred instead.
-
-    Monotone per family, not by cardinality. Counting ``len(ran) <= 11`` and
-    ``sum(ran.values()) <= 11`` — the form this replaces — is satisfied by substitution: drop
-    one family, add another, and 11/11 still holds while the declared path is doing entirely
-    different work. Each entry may only go DOWN, to absent, which is what #1022 does to all
-    of them at once.
+    Detected-path coverage lives in
+    :func:`test_an_automatic_build_runs_each_family_exactly_once_and_lint_runs_no_migrated_one`,
+    which is what stops this being satisfiable by breaking recognition outright.
     """
     with _counting_every_family() as ran:
         sheet = Sheet(Box(80, 60, 20)).auto_dimensions()
         sheet.envelope()
         sheet.build()
 
-    added = sorted(set(ran) - set(_DECLARED_BUILD_BASELINE))
-    assert not added, (
-        f"a declared build now recognises {added}, which it did not before. ADR 0011 says a "
-        "declared model skips detection — this baseline is a ratchet on the way to zero "
-        "(#1022), so a family may leave it but none may join."
-    )
-    grew = {
-        n: (c, _DECLARED_BUILD_BASELINE[n])
-        for n, c in ran.items()
-        if c > _DECLARED_BUILD_BASELINE[n]
-    }
-    assert not grew, (
-        f"a declared build now calls {grew} (actual, baseline) — a family called more often "
-        "is new work on this path just as surely as a new family is."
+    assert dict(ran) == {}, (
+        f"a declared build recognised {dict(ran)}. ADR 0011 says a caller-supplied model "
+        "skips detection — each of these scanned a solid whose features the caller had "
+        "already stated, and threw the answer away."
     )
 
 

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -119,6 +119,10 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
     )
     monkeypatch.setattr(result_module, "recognise_rectangular_pads", counted("pads", []))
     monkeypatch.setattr(result_module, "recognise_turned_steps", cyl_consumer("turned_steps", []))
+    # `step_level_zs` is the area-filtered gate over `recognise_face_levels`, migrated into the
+    # aggregate by #1022 so declared-path critique reads one ladder instead of rescanning per
+    # lint. It takes the part only — no injected substrate to assert identity on.
+    monkeypatch.setattr(result_module, "step_level_zs", counted("step_levels", [4.0, 9.0]))
 
     built = result_module.build_recognition_result(object())
 
@@ -135,6 +139,8 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
         "pocket_patterns",
         "pads",
         "turned_steps",
+        "step_levels",
     }, f"the orchestration ran a different set of families: {sorted(calls)}"
     assert set(calls.values()) == {1}, f"a family ran more than once: {calls}"
     assert built.holes == tuple(holes)
+    assert built.step_levels == (4.0, 9.0)


### PR DESCRIPTION
Closes #1022. Stacked on nothing — branches off `main`.

## What held it up

ADR 0011 says a caller-supplied `PartModel` skips detection; ADR 0017 §6 restates it for the aggregate. Neither held — `_analyse` ran `build_recognition_result` before it knew whether a model had been declared.

The issue predicted the gate would not be one `if`, and that was right, but not complete. Four things had to move:

**Sizing.** Page/scale selection read `prof` and `step_zs` off the recognition even for a declared model. `_declared_turned_profile` / `_declared_step_zs` source them from the declaration, mirroring the detected path's two branches (including the 0.6 mm end-exclusion) so selection is unchanged.

**The repair loop.** Gating `_analyse` alone left the declared build at *ten* families — all reached through `build_drawing` → `repair()` → `lint()`. Repair acts on `dim_inside_part` and nothing else (ADR 0002) but requested the full critique every iteration. `Drawing.lint(physical=False)` asks for the placement half. That also tightens repair's own net-worsened check: coverage issues cannot change from re-placing a dimension, so counting them only diluted the ratio.

**Critique's inventory.** On the declared path `a.holes` is empty because nothing looked, not because the part has none — feeding that to coverage reports every real hole as uncovered. `BuildState.ensure_recognition()` builds one lazily, at most once, in the typed build state. A lint-side or `Drawing`-side memo would make critique a second recognition owner, which is what ADR 0017 exists to remove and what #1021's review rejected.

**ADR 0015.** Lint takes `step_zs`/`pads`/`pockets` from that aggregate, never from `Analysis` on the declared path. My first cut got this wrong and four tests caught it: critique inventorying from the model made lint blind to exactly the geometry a sparse declaration omits — the case `unrecognised_defining_geometry` exists to report.

## Measured, not asserted from the source

| | before | after |
|---|---|---|
| declared build | 10 recognisers | **0** |
| first critique on a declared drawing | — | 1 aggregate |
| repeated critique | — | 0 (bar the `recognise_step_shoulders` deferral, #1025) |
| detected build | 16 | 16 |

## Two calls worth reviewing

**Export pays for one aggregate, deliberately.** `export` calls `_lint_and_log`, whose warnings users read. Making it skip coverage would stop *every* export on *both* paths from reporting coverage problems — trading a real diagnostic for a benchmark number. So "build/export without physical critique invokes zero" is met by build; export legitimately buys one aggregate, and the guard asserts once-and-no-more rather than restating the acceptance.

**`recognise_face_levels` migrates into the aggregate** as `step_levels`. Its `NO_INDEPENDENT_CONSUMER` deferral stopped being true the moment declared-path critique needed the geometry ladder; without the migration lint rescanned it once per pass. `DEFERRED` is down to seven. This is the manifest doing its job — a deferral whose stated reason expired.

## A latent bug on both paths

`_est_right_strip_depth` reserved one slot per ladder step, but `render_boss_heights` puts every Z-axis boss height in that same strip — sized for one occupant class, solved for two. Detected builds hid it inside the ladder's slack. A declared model with a boss and no ladder reserved one slot, needed two, and dropped the height **silently** (`on_drop` is a no-op there so lint reports the omission once rather than twice). `_n_right_strip_boss_heights` counts the real occupants, mirroring the renderer's own guards (turned models render none; X/Y bosses go to the *above* strips).

This changes detected-path reservations wherever a Z boss has a height. That is the fix working, not a side effect — ADR 0004 drops byte-identity — but it is the widest-blast-radius edit here and deserves the most scrutiny.

Known conservative gap: `is_rotational` is geometry-derived and not visible to the composer, so a rotational part declaring a Z boss over-reserves by one slot. Safe direction, and the same call the authored-Z-dim branch already makes.

## Verification

- Targeted: 1221 passed across the eleven affected suites; recognition suites re-run green after the last fix. **Full tier not run** (per instruction) — CI covers it.
- Four gates clean: ruff check, ruff format, mypy, codespell.
- **Mutation-validated**: reverting the gate → 7 red; reverting the repair split → 5 red; reverting the strip sizing → the boss-height guard red.
- `test_a_declared_build_does_not_grow_new_recognition` → `test_a_declared_build_recognises_nothing`: the #1021 ratchet reached its target.
- `test_the_migrated_families_are_the_ones_the_orchestration_actually_runs` moves off module-binding spies onto `counting_calls`. Migrating a family reached *indirectly* (via `step_level_zs`) made the old spy raise `AttributeError` rather than fail — the blind spot #1027 was written to close, still present in that one test.

Unblocks #1026.
