### PR TITLE
feat(#1025): split step shoulders into shared evidence and per-consumer projection

### DIFF
--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -647,6 +647,7 @@ def _analyse(
             # branch `recognition` is non-None by construction (it is the not-declared arm).
             slot_patterns=list(recognition.slot_patterns) if recognition else None,
             grooves=list(recognition.grooves) if recognition else None,
+            risers=list(recognition.risers) if recognition else None,
             flats=list(recognition.flats) if recognition else None,
             pockets=pockets,
             pocket_patterns=pocket_patterns,

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -583,12 +583,11 @@ def _analyse(
     else:
         recognition = build_recognition_result(part, cylinders=(z_cyls, cross_cyls))
         _turned = TurnedProfile.from_steps(list(recognition.turned_steps))
-        if _turned is not None and _turned.axis == "z":
-            step_zs = [z for z in _turned.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
-        else:
-            # The aggregate's own area-filtered extraction (#578 review; hoisted there by
-            # #1022 so critique on the declared path reads one value rather than rescanning).
-            step_zs = list(recognition.step_levels)
+        # The aggregate's own rule (#578 review; hoisted there by #1022, shared with critique
+        # by #1025). Both callers deriving this separately let lint project over a different
+        # ladder than the model was sized from — which is exactly the divergence one waist is
+        # supposed to prevent.
+        step_zs = recognition.step_ladder(bb)
     # The aggregate owns the shared substrate from here on.  Rebind the local projection so
     # model construction, Analysis and the finished BuildState all consume the same inventory
     # object rather than parallel list/tuple wrappers that merely happen to contain equal data.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -217,6 +217,7 @@ def build_model(a: Analysis):
         # #1024 collapses that duplication.
         slot_patterns=a.recognition.slot_patterns,
         grooves=a.recognition.grooves,
+        risers=a.recognition.risers,
         flats=a.recognition.flats,
         pockets=a.recognition.pockets,
         pocket_patterns=a.recognition.pocket_patterns,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2713,12 +2713,16 @@ class Drawing:
             bosses: list | None
             pads: list | None
             pockets: list | None
-            step_zs: list | None
+            recognition: object | None
             prof_kw: dict
             if a is not None and a.recognition is not None:
                 cyls = a.cyls
                 holes, patterns, bosses = a.holes, a.patterns, a.bosses
-                pads, pockets, step_zs = a.pads, a.pockets, a.step_zs
+                pads, pockets = a.pads, a.pockets
+                # The whole aggregate, not a level set: coverage projects the shared riser
+                # evidence over recognition's OWN levels, so no caller can narrow the
+                # shoulder inventory (#1025).
+                recognition = a.recognition
                 prof_kw = {"prof": a.prof}
             elif a is not None:
                 # A DECLARED build recognised nothing (#1022), so `a.holes` and friends are
@@ -2732,13 +2736,12 @@ class Drawing:
                 bosses = list(rec.bosses)
                 pads = list(rec.pads)
                 pockets = list(rec.pockets)
-                # NOT `a.step_zs`: that is declaration-sourced on this path, and critique
-                # taking its inventory from the model is what ADR 0015 forbids — it would
-                # make lint blind to exactly the geometry a sparse declaration omitted, which
-                # is the case `unrecognised_defining_geometry` exists to report. The
-                # aggregate's geometry-sourced ladder is the right answer, and reading it here
-                # rather than passing `None` is what stops coverage rescanning it every lint.
-                step_zs = list(rec.step_levels)
+                # The aggregate, NOT anything off `Analysis`: its levels and risers are
+                # geometry-sourced, where the declared `Analysis` carries what the author
+                # declared. Critique taking its inventory from the model is what ADR 0015
+                # forbids — it would make lint blind to exactly the geometry a sparse
+                # declaration omitted, the case `unrecognised_defining_geometry` reports.
+                recognition = rec
                 # `a.prof` IS declaration-sourced, and here that is right rather than a
                 # shortcut: axial critique judges the declared profile's dimensioning, so a
                 # declared turned part keeps it without the aggregate.
@@ -2748,7 +2751,7 @@ class Drawing:
                     self._cyl_cache = analyse_cylinders(self.part)
                 cyls = self._cyl_cache
                 holes = patterns = bosses = None
-                pads = pockets = step_zs = None
+                pads = pockets = recognition = None
                 prof_kw = {}
             issues += lint_feature_coverage(
                 self.part,
@@ -2791,7 +2794,7 @@ class Drawing:
                 pockets=pockets,
                 bbox=a.bb if a is not None else None,
                 features=getattr(model, "features", ()) if model is not None else (),
-                step_zs=step_zs,
+                recognition=recognition,
             )
             # Reverse direction (#487): a DECLARED feature with no matching geometry (a stale
             # phantom callout). Only for a caller-supplied model — detection can't over-declare.

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -28,17 +28,17 @@ from build123d_drafting.helpers import CenterMark, Dimension, TitleBlock
 from draftwright._core import _DIAM_RE, _END_ON, HoleRef, _axis_letter, _fmt, _xyz
 from draftwright.linting.issues import LintIssue
 from draftwright.recognition import (
+    RecognitionResult,
     TurnedProfile,
     analyse_cylinders,
+    build_recognition_result,
     feature_diameters,
     project_step_shoulders,
     recognise_hole_patterns,
     recognise_holes,
     recognise_pockets,
     recognise_rectangular_pads,
-    recognise_risers,
     recognise_turned_steps,
-    step_level_zs,
 )
 
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
@@ -608,9 +608,19 @@ def lint_prismatic_coverage(
     # clean absence is indistinguishable from a clean part, so it is closed by construction:
     # `recognition` is the run's aggregate, and an absent one is re-derived from the solid
     # rather than defaulted to something narrower.
+    # Fail-closed on the TYPE, not just the name: `recognition=` replaced the old `step_zs=`,
+    # and a duck-typed stand-in (`SimpleNamespace(risers=(), step_levels=())`) would silence
+    # this check exactly as `step_zs=[]` did — the same false-negative door wearing a new
+    # parameter (Codex #1031 r1). Only recognition's own frozen result is accepted.
+    if recognition is not None and not isinstance(recognition, RecognitionResult):
+        raise TypeError(
+            f"lint_prismatic_coverage(recognition=) takes the run's RecognitionResult, got "
+            f"{type(recognition).__name__}. A completeness check must not accept a "
+            "caller-assembled inventory: an empty stand-in silences it."
+        )
+    _rec = build_recognition_result(part) if recognition is None else recognition
     source_shoulders = project_step_shoulders(
-        recognise_risers(part) if recognition is None else recognition.risers,
-        levels=step_level_zs(part) if recognition is None else list(recognition.step_levels),
+        _rec.risers, levels=_rec.step_ladder(bbox if bbox is not None else part.bounding_box())
     )
     model_shoulders = {
         (axis, round(pos, 3))

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -31,11 +31,12 @@ from draftwright.recognition import (
     TurnedProfile,
     analyse_cylinders,
     feature_diameters,
+    project_step_shoulders,
     recognise_hole_patterns,
     recognise_holes,
     recognise_pockets,
     recognise_rectangular_pads,
-    recognise_step_shoulders,
+    recognise_risers,
     recognise_turned_steps,
     step_level_zs,
 )
@@ -419,7 +420,7 @@ def lint_prismatic_coverage(
     assembly=None,
     tol: float = 0.6,
     features=(),
-    step_zs=None,
+    recognition=None,
 ) -> list:
     """Report undefined raised-pad footprints and blind-pocket locations.
 
@@ -600,8 +601,16 @@ def lint_prismatic_coverage(
                 message=f"{unlocated} blind pocket(s) have no complete X/Y location scheme",
             )
         )
-    source_shoulders = recognise_step_shoulders(
-        part, levels=step_level_zs(part) if step_zs is None else step_zs
+    # BOTH halves come from recognition, never from a caller argument (#1025). The old
+    # `step_zs=` parameter fully determined the answer — `step_zs=[]` yielded no shoulders, so
+    # `missing_transitions` was structurally zero and this check could never fire. The engine
+    # never passed that, but a false-negative door in a completeness check is the one place a
+    # clean absence is indistinguishable from a clean part, so it is closed by construction:
+    # `recognition` is the run's aggregate, and an absent one is re-derived from the solid
+    # rather than defaulted to something narrower.
+    source_shoulders = project_step_shoulders(
+        recognise_risers(part) if recognition is None else recognition.risers,
+        levels=step_level_zs(part) if recognition is None else list(recognition.step_levels),
     )
     model_shoulders = {
         (axis, round(pos, 3))

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -684,7 +684,7 @@ def _read_step_levels(
     for a single-level rebate, mirroring ``model/detect.py``), the ``datum`` (bbox min corner
     the positions measure from) and ``at`` (the frame anchor — bbox centre X/Y at ``base``,
     matching ``detect.py`` so an object round-trips to the same IR)."""
-    from draftwright.recognition import recognise_step_shoulders, step_level_zs
+    from draftwright.recognition import project_step_shoulders, recognise_risers, step_level_zs
 
     # Solids only, for the same reason as `envelope()` (#977): this takes the WHOLE part, so a
     # STEP import hands it PMI presentation geometry too. Measuring the compound put CTC01's
@@ -695,8 +695,15 @@ def _read_step_levels(
     bb = obj.bounding_box()
     base = round(bb.min.Z, 3)
     levels = tuple(sorted(round(z, 3) for z in step_level_zs(obj)))
+    # Scans `obj`, not the build's part — a declared step_level reads the object the author
+    # handed it, which is a different solid from the one the aggregate recognised (#1025). So
+    # this is the one consumer that legitimately keeps its own scan, in the same sense
+    # `hole(cylinder)` reads a diameter off the cylinder you passed.
     shoulders = (
-        tuple((s.axis, s.position) for s in recognise_step_shoulders(obj, levels=list(levels)))
+        tuple(
+            (s.axis, s.position)
+            for s in project_step_shoulders(recognise_risers(obj), levels=list(levels))
+        )
         if len(levels) == 1
         else ()
     )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -62,12 +62,14 @@ from draftwright.recognition import (
     PocketGrid,
     RaisedPad,
     RectGrid,
+    RiserEvidence,
     Slot,
     SlotArray,
     SlotGrid,
     StepShoulder,
     TurnedProfile,
     TurnedStep,
+    project_step_shoulders,
     recognise_bosses,
     recognise_chamfers,
     recognise_countersinks,
@@ -80,9 +82,9 @@ from draftwright.recognition import (
     recognise_pocket_patterns,
     recognise_pockets,
     recognise_rectangular_pads,
+    recognise_risers,
     recognise_slot_patterns,
     recognise_slots,
-    recognise_step_shoulders,
     recognise_turned_steps,
 )
 
@@ -555,6 +557,7 @@ _ORCHESTRATED_RECORDS: dict[type, str] = {
     CounterSink: "a nested sub-record of HoleRecord — rides on the hole callout, never a top-level feature",
     FaceLevel: "aggregated into a single StepLevelFeature step ladder (one feature per part, not per level)",
     StepShoulder: "aggregated into StepLevelFeature.shoulders (in-plane step positions, not a standalone feature)",
+    RiserEvidence: "pre-projection evidence (#1025) — projected to StepShoulder per consumer, never converted directly",
 }
 
 
@@ -582,6 +585,7 @@ def build_part_model(
     bosses=None,
     slots=None,
     slot_patterns=None,
+    risers=None,
     grooves=None,
     flats=None,
     pockets=None,
@@ -811,8 +815,16 @@ def build_part_model(
         if _levels:
             # Every profile transition needs an in-plane station. Heights alone do
             # not reconstruct a multi-level staircase or a slanted run (#897).
+            # Projected over the run's riser evidence, not a fresh scan (#1025). `_levels`
+            # is the OWNERSHIP-FILTERED set — plate and pocket floors removed — which is a
+            # model decision and stays here; the evidence underneath is shared with critique,
+            # which projects the same risers over its own unfiltered levels.
             _shoulders = tuple(
-                (s.axis, s.position) for s in recognise_step_shoulders(part, levels=list(_levels))
+                (s.axis, s.position)
+                for s in project_step_shoulders(
+                    recognise_risers(part) if risers is None else risers,
+                    levels=list(_levels),
+                )
             )
             features.append(
                 StepLevelFeature(

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -15,7 +15,7 @@ A *feature* recogniser takes one of two shapes:
 
 - **Part-based** — ``recognise_<feature>(part, *, <tuning / injected deps>) -> list[record]``
   (``recognise_holes(part, *, cyls=None)``, ``recognise_chamfers(part, *, tol=...)``,
-  ``recognise_step_shoulders(part, *, levels)``). Everything after ``part`` is
+  ``recognise_risers(part, *, tol=...)``). Everything after ``part`` is
   **keyword-only** — both tuning and any injected inventory. A recogniser **never
   re-recognises a dependency internally**; the caller (``detect.py`` / ``analysis.py``)
   owns the single inventory and threads it (one inventory, ADR 0008 Am5).
@@ -53,6 +53,13 @@ query), and deliberately keep their names. Likewise the **shared single-face rea
 ``floor_face_anchor``, ``step_level_zs``, #704): helpers shared with the declared
 front-end, not recognisers — they traffic in build123d/OCP objects,
 so a future ADR 0013 Phase-2 package extraction would keep them internal, not surface.
+
+``project_step_shoulders`` is likewise not a recogniser but its mirror image: a **pure
+projection** over :func:`recognise_risers`' records, with no ``part`` and no geometry access
+at all (#1025). It carries the ``project_`` verb rather than ``recognise_`` precisely so the
+manifest does not have to decide whether the aggregate owns it — it owns the evidence, and
+each consumer projects. A function that cannot look at a solid cannot become a second
+recognition site.
 """
 
 from __future__ import annotations
@@ -84,9 +91,11 @@ from draftwright.recognition.flats import Flat, recognise_flats
 from draftwright.recognition.grooves import Groove, floor_face_anchor, recognise_grooves
 from draftwright.recognition.levels import (
     FaceLevel,
+    RiserEvidence,
     StepShoulder,
+    project_step_shoulders,
     recognise_face_levels,
-    recognise_step_shoulders,
+    recognise_risers,
     step_level_zs,
 )
 from draftwright.recognition.pads import RaisedPad, recognise_rectangular_pads
@@ -128,6 +137,7 @@ __all__ = [
     "Slot",
     "SlotArray",
     "SlotGrid",
+    "RiserEvidence",
     "StepShoulder",
     "TurnedProfile",
     "TurnedStep",
@@ -138,8 +148,9 @@ __all__ = [
     "cone_rims",
     "fillet_anchor",
     "floor_face_anchor",
+    "project_step_shoulders",
     "recognise_face_levels",
-    "recognise_step_shoulders",
+    "recognise_risers",
     "step_level_zs",
     "feature_diameters",
     "recognise_bosses",

--- a/src/draftwright/recognition/levels.py
+++ b/src/draftwright/recognition/levels.py
@@ -40,6 +40,36 @@ class StepShoulder(Record):
     position: float
 
 
+@dataclass(frozen=True, order=True)
+class RiserEvidence(Record):
+    """One candidate step riser, recognised WITHOUT reference to any level set (#1025).
+
+    :func:`recognise_risers` scans the solid once and emits these; each consumer then calls
+    :func:`project_step_shoulders` with the level set *it* cares about. The split exists
+    because the scan is the cost and the levels are only a filter: model construction
+    projects over levels filtered by plate and pocket ownership, while critique must project
+    over the unfiltered ones (ADR 0015 forbids lint taking its inventory from the model). One
+    scan, two answers — rather than one scan per asker.
+
+    ``z_lo``/``z_hi`` are the riser face's vertical extent, kept raw so the level test stays
+    in the projection. ``lo_at_envelope``/``hi_at_envelope`` pre-answer the part of the
+    oblique tie-test that does NOT depend on levels — whether that end sits on the part's top
+    or bottom — so the projection needs the levels and nothing else about the solid.
+
+    ``order=True`` for a deterministic recogniser return, per ADR 0013.
+    """
+
+    vertical: bool
+    axis: str
+    positions: tuple[float, ...]
+    other_axis: str
+    other_positions: tuple[float, ...]
+    z_lo: float
+    z_hi: float
+    lo_at_envelope: bool
+    hi_at_envelope: bool
+
+
 def recognise_face_levels(
     part, *, tol: float = 0.5, min_area_frac: float = 0.0
 ) -> list[FaceLevel]:
@@ -99,16 +129,26 @@ def step_level_zs(part, *, tol: float = 0.6) -> list[float]:
     ]
 
 
-def recognise_step_shoulders(
-    part, *, levels, min_area_frac: float = 0.15, tol: float = 0.5
-) -> list[StepShoulder]:
-    """Return the in-plane positions of a prismatic part's step shoulders — the
-    ``(axis, position)`` where a step/rebate changes height (#555).
+def recognise_risers(
+    part, *, min_area_frac: float = 0.15, tol: float = 0.5
+) -> list[RiserEvidence]:
+    """Scan *part* once for candidate step risers, independent of any level set (#1025).
 
-    ``recognise_face_levels`` recovers the step *heights* (Z); this recovers *where along
-    the part* each shoulder sits, so a stepped block is fully constrained (two different
-    shoulder positions no longer draw the same sheet). A shoulder is either a
-    vertical riser or an endpoint of a full-span slanted transition. The latter's
+    This is the expensive half of the old ``recognise_step_shoulders``: the full
+    ``part.faces()`` walk and every geometric gate that does not need levels — planarity,
+    in-plane axis, the full-span test that separates a step from a pad or blind pocket, the
+    interior-position test, the structural-ramp size floor and the area floor.
+
+    What it deliberately does NOT do is decide which candidates rise from a *recognised*
+    level; that is :func:`project_step_shoulders`, because the answer differs per consumer
+    and re-scanning per consumer is the cost ADR 0017 exists to remove.
+
+    See :class:`RiserEvidence`. Returns a sorted, deduplicated list.
+
+    ``recognise_face_levels`` recovers the step *heights* (Z); the projection over this
+    evidence recovers *where along the part* each shoulder sits, so a stepped block is fully
+    constrained (two different shoulder positions no longer draw the same sheet). A shoulder
+    is either a vertical riser or an endpoint of a full-span slanted transition. The latter's
     two stations, together with the adjacent height levels, define the ramp without
     a redundant angle dimension (#897).
 
@@ -120,17 +160,12 @@ def recognise_step_shoulders(
     larger than *tol* is not recognised — the alternative, loosening the span test,
     re-admits pads/pockets, so the full-span sharp-edged step is the recognised class
     (partial/filleted-end steps are a future refinement).
-
-    Returns a sorted, deduplicated list. Empty when *levels* is empty (no step) or no
-    riser qualifies.
     """
-    if not levels:
-        return []
     bb = part.bounding_box()
     ext = {"x": bb.max.X - bb.min.X, "y": bb.max.Y - bb.min.Y, "z": bb.max.Z - bb.min.Z}
     lo = {"x": bb.min.X, "y": bb.min.Y}
     hi = {"x": bb.max.X, "y": bb.max.Y}
-    out: list[StepShoulder] = []
+    out: list[RiserEvidence] = []
     for f in part.faces():
         s = BRepAdaptor_Surface(f.wrapped)
         if s.GetType() != GeomAbs_Plane:
@@ -168,8 +203,8 @@ def recognise_step_shoulders(
             pos = loc.X() if axis == "x" else loc.Y()
             if not (lo[axis] + tol < pos < hi[axis] - tol):
                 continue  # interior only — an envelope face is not a shoulder
-            if not any(abs(fb.min.Z - z) < tol for z in levels):
-                continue  # rises from a step level (not a through slot's wall)
+            # The "rises from a step level" test lives in project_step_shoulders — it is the
+            # one gate whose answer depends on which level set the asker holds (#1025).
             positions = (pos,)
         else:
             # A genuine oblique profile face contributes both transition
@@ -178,12 +213,6 @@ def recognise_step_shoulders(
             # both the ramp and its width (#897).
             if abs(nv.Z) <= 0.01 or fb.max.Z - fb.min.Z <= tol:
                 continue
-            structural_zs = (*levels, bb.min.Z, bb.max.Z)
-            if not all(
-                any(abs(z - structural_z) < tol for structural_z in structural_zs)
-                for z in (fb.min.Z, fb.max.Z)
-            ):
-                continue  # drafted/incidental face not tied to recognised profile levels
             axis_positions = (
                 fb.min.X if axis == "x" else fb.min.Y,
                 fb.max.X if axis == "x" else fb.max.Y,
@@ -207,14 +236,60 @@ def recognise_step_shoulders(
         )
         if cross <= 0 or props.Mass() < area_floor:
             continue  # a large riser, not an incidental feature face
-        out.extend(
-            StepShoulder(axis, round(pos, 3))
-            for pos in positions
-            if lo[axis] + tol < pos < hi[axis] - tol
+        out.append(
+            RiserEvidence(
+                vertical=vertical,
+                axis=axis,
+                positions=tuple(
+                    round(pos, 3) for pos in positions if lo[axis] + tol < pos < hi[axis] - tol
+                ),
+                other_axis=other,
+                other_positions=tuple(
+                    round(pos, 3)
+                    for pos in other_positions
+                    if lo[other] + tol < pos < hi[other] - tol
+                ),
+                z_lo=fb.min.Z,
+                z_hi=fb.max.Z,
+                # The level-independent half of the oblique tie-test: an end sitting on the
+                # part's top or bottom is structural whatever the level set says.
+                lo_at_envelope=abs(fb.min.Z - bb.min.Z) < tol or abs(fb.min.Z - bb.max.Z) < tol,
+                hi_at_envelope=abs(fb.max.Z - bb.min.Z) < tol or abs(fb.max.Z - bb.max.Z) < tol,
+            )
         )
-        out.extend(
-            StepShoulder(other, round(pos, 3))
-            for pos in other_positions
-            if lo[other] + tol < pos < hi[other] - tol
-        )
+    return sorted(set(out))
+
+
+def project_step_shoulders(risers, *, levels, tol: float = 0.5) -> list[StepShoulder]:
+    """Project :func:`recognise_risers` evidence onto *levels* — the pure half (#1025).
+
+    A candidate riser counts as a step shoulder only if it rises from a level the caller
+    recognises: a vertical riser's foot must sit on one, and an oblique ramp's two ends must
+    each sit on one or on the part envelope. That is the whole level dependency, and it is
+    the whole reason the old ``recognise_step_shoulders`` could not be hoisted into the
+    shared aggregate — its answer depends on who is asking.
+
+    Model construction passes levels filtered by plate and pocket ownership; critique passes
+    the unfiltered geometry ladder, because ADR 0015 forbids lint taking its inventory from
+    the model. Both project the same evidence; neither rescans the solid.
+
+    No *part* argument, by construction: this cannot look at geometry, so it cannot become a
+    second recognition site. Returns a sorted, deduplicated list; empty when *levels* is empty
+    (a part with no recognised step has no shoulders to locate).
+    """
+    if not levels:
+        return []
+
+    def tied(z: float, at_envelope: bool) -> bool:
+        return at_envelope or any(abs(z - level) < tol for level in levels)
+
+    out: list[StepShoulder] = []
+    for r in risers:
+        if r.vertical:
+            if not any(abs(r.z_lo - level) < tol for level in levels):
+                continue  # rises from a step level (not a through slot's wall)
+        elif not (tied(r.z_lo, r.lo_at_envelope) and tied(r.z_hi, r.hi_at_envelope)):
+            continue  # drafted/incidental face not tied to recognised profile levels
+        out.extend(StepShoulder(r.axis, pos) for pos in r.positions)
+        out.extend(StepShoulder(r.other_axis, pos) for pos in r.other_positions)
     return sorted(set(out))

--- a/src/draftwright/recognition/levels.py
+++ b/src/draftwright/recognition/levels.py
@@ -68,6 +68,14 @@ class RiserEvidence(Record):
     z_hi: float
     lo_at_envelope: bool
     hi_at_envelope: bool
+    #: The tolerance this evidence was scanned with, so the projection matches it by default.
+    #: Without this the split silently broke a non-default ``tol``: the old one-stage call used
+    #: one value for the geometric gates AND the level ties, whereas ``recognise_risers(part,
+    #: tol=0.1)`` followed by a bare ``project_step_shoulders(...)`` mixed 0.1 with the
+    #: projection's own default (Codex #1031 r1). Carried on the record rather than passed
+    #: separately because a caller who has the evidence should not have to remember how it was
+    #: produced.
+    tol: float = 0.5
 
 
 def recognise_face_levels(
@@ -255,12 +263,13 @@ def recognise_risers(
                 # part's top or bottom is structural whatever the level set says.
                 lo_at_envelope=abs(fb.min.Z - bb.min.Z) < tol or abs(fb.min.Z - bb.max.Z) < tol,
                 hi_at_envelope=abs(fb.max.Z - bb.min.Z) < tol or abs(fb.max.Z - bb.max.Z) < tol,
+                tol=tol,
             )
         )
     return sorted(set(out))
 
 
-def project_step_shoulders(risers, *, levels, tol: float = 0.5) -> list[StepShoulder]:
+def project_step_shoulders(risers, *, levels, tol: float | None = None) -> list[StepShoulder]:
     """Project :func:`recognise_risers` evidence onto *levels* — the pure half (#1025).
 
     A candidate riser counts as a step shoulder only if it rises from a level the caller
@@ -276,9 +285,18 @@ def project_step_shoulders(risers, *, levels, tol: float = 0.5) -> list[StepShou
     No *part* argument, by construction: this cannot look at geometry, so it cannot become a
     second recognition site. Returns a sorted, deduplicated list; empty when *levels* is empty
     (a part with no recognised step has no shoulders to locate).
+
+    *tol* defaults to the tolerance the evidence was scanned with, so a two-stage call is
+    equivalent to the old single-stage one at ANY tolerance, not just the default. Pass it
+    explicitly only to project more or less tightly than the scan deliberately.
     """
     if not levels:
         return []
+    risers = list(risers)
+    if not risers:
+        return []
+    if tol is None:
+        tol = risers[0].tol
 
     def tied(z: float, at_envelope: bool) -> bool:
         return at_envelope or any(abs(z - level) < tol for level in levels)

--- a/src/draftwright/recognition/result.py
+++ b/src/draftwright/recognition/result.py
@@ -28,7 +28,7 @@ from draftwright.recognition.slots import (
     recognise_slot_patterns,
     recognise_slots,
 )
-from draftwright.recognition.turned import recognise_turned_steps
+from draftwright.recognition.turned import TurnedProfile, recognise_turned_steps
 
 #: The families this aggregate runs, exactly once, per orchestration.
 MIGRATED: frozenset[str] = frozenset(
@@ -158,6 +158,23 @@ class RecognitionResult:
     #: which risers count depends on the level set the asker holds, and that is the whole
     #: reason this family could not be hoisted until the scan and the filter were separated.
     risers: tuple
+
+    def step_ladder(self, bb) -> list[float]:
+        """The effective step ladder for *bb*: turned shoulders for a Z-turned part, else the
+        prismatic face levels (#1025).
+
+        ONE rule, two callers. ``_analyse`` computes the ladder page/scale selection converges
+        on, and critique needs the same set to decide which risers count — but they derived it
+        separately, so lint could silently project over a different ladder than the model was
+        built from (Codex #1031 r3). Both now call this.
+
+        Geometry-only, so it is a legitimate source for critique under ADR 0015: it reads the
+        aggregate's own recognition, never the model.
+        """
+        prof = TurnedProfile.from_steps(list(self.turned_steps))
+        if prof is not None and prof.axis == "z":
+            return [z for z in prof.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
+        return list(self.step_levels)
 
 
 def build_recognition_result(part, *, cylinders=None) -> RecognitionResult:

--- a/src/draftwright/recognition/result.py
+++ b/src/draftwright/recognition/result.py
@@ -20,7 +20,7 @@ from draftwright.recognition._features import (
 from draftwright.recognition.countersinks import recognise_countersinks
 from draftwright.recognition.flats import recognise_flats
 from draftwright.recognition.grooves import recognise_grooves
-from draftwright.recognition.levels import step_level_zs
+from draftwright.recognition.levels import recognise_risers, step_level_zs
 from draftwright.recognition.pads import recognise_rectangular_pads
 from draftwright.recognition.slots import (
     recognise_pocket_patterns,
@@ -48,6 +48,7 @@ MIGRATED: frozenset[str] = frozenset(
         "recognise_pocket_patterns",
         "recognise_pockets",
         "recognise_rectangular_pads",
+        "recognise_risers",
         "recognise_slot_patterns",
         "recognise_slots",
         "recognise_turned_steps",
@@ -76,7 +77,10 @@ class Deferral(Enum):
 
     ``CALLER_SPECIFIC_INPUT`` — an input other than the part decides the answer and the
     callers pass different ones, so there is no single per-build value for a frozen
-    aggregate to hold.
+    aggregate to hold.  Its last holder left in #1025, which showed the reason is usually a
+    *shape* problem rather than a fact about the feature: the scan did not depend on the
+    caller's input, only the filter did, so separating the two gave the aggregate something
+    single-valued to own.  Prefer that split before reaching for this member again.
 
     ``NO_INDEPENDENT_CONSUMER`` — reached only through one shared helper, so there is
     nothing to cache for.  Unlike the others, not scheduled to change.
@@ -109,14 +113,16 @@ class Deferred:
 #: family can be deferred for that reason again; what does not survive is a *deferral*
 #: justified by a cost that no longer exists.
 #:
-#: What is left binds on the AUTOMATIC path, which #1022 did not touch: the classification
-#: gate (#1028) and the one recogniser whose answer depends on which caller is asking
-#: (#1025).
+#: ``CALLER_SPECIFIC_INPUT`` is gone too (#1025): ``recognise_step_shoulders`` split into a
+#: level-free scan the aggregate owns (``recognise_risers``) and a pure
+#: ``project_step_shoulders`` each consumer applies with its own level set.
+#:
+#: What is left is one reason on the AUTOMATIC path, which #1022 did not touch: the
+#: classification gate (#1028).
 DEFERRED: dict[str, Deferred] = {
     "recognise_chamfers": Deferred(Deferral.CLASSIFICATION_GATED, blocker=1028),
     "recognise_fillets": Deferred(Deferral.CLASSIFICATION_GATED, blocker=1028),
     "recognise_plates": Deferred(Deferral.CLASSIFICATION_GATED, blocker=1028),
-    "recognise_step_shoulders": Deferred(Deferral.CALLER_SPECIFIC_INPUT, blocker=1025),
 }
 
 
@@ -146,8 +152,12 @@ class RecognitionResult:
     #: The interior prismatic step Z-levels (:func:`step_level_zs` — ``recognise_face_levels``
     #: behind its area filter). A float tuple rather than records because both consumers want
     #: the gated levels, not the faces: sizing converges page/scale on them, and critique feeds
-    #: them to ``recognise_step_shoulders`` as the geometry's own ladder (#1022).
+    #: them to ``project_step_shoulders`` as the geometry's own ladder (#1022).
     step_levels: tuple[float, ...]
+    #: Candidate step risers, scanned once and projected per consumer (#1025). NOT shoulders:
+    #: which risers count depends on the level set the asker holds, and that is the whole
+    #: reason this family could not be hoisted until the scan and the filter were separated.
+    risers: tuple
 
 
 def build_recognition_result(part, *, cylinders=None) -> RecognitionResult:
@@ -181,4 +191,5 @@ def build_recognition_result(part, *, cylinders=None) -> RecognitionResult:
         pads=tuple(recognise_rectangular_pads(part)),
         turned_steps=tuple(recognise_turned_steps(part, cyls=cyls)),
         step_levels=tuple(step_level_zs(part)),
+        risers=tuple(recognise_risers(part)),
     )

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -384,7 +384,7 @@ def test_lint_projects_the_shared_riser_evidence_and_rescans_nothing():
     )
 
 
-def test_the_critique_cannot_be_handed_a_narrower_shoulder_inventory():
+def test_the_critique_rejects_an_assembled_shoulder_inventory():
     """A completeness check must not accept an argument that can silence it.
 
     ``lint_prismatic_coverage`` used to take ``step_zs=``, and it *fully determined* the
@@ -399,7 +399,20 @@ def test_the_critique_cannot_be_handed_a_narrower_shoulder_inventory():
     caller can narrow it. A duck-typed `SimpleNamespace(risers=(), step_levels=())` silenced
     the check exactly as `step_zs=[]` had — the same door wearing a new parameter name (Codex
     #1031 r1). So the behavioural half is the one with teeth: an assembled stand-in is
-    REJECTED, and only recognition's own frozen result is accepted.
+    REJECTED.
+
+    **What this does NOT establish**, deliberately named rather than implied: the type check
+    proves neither provenance nor correspondence with *part*. A caller can still pass
+    ``build_recognition_result(some_other_solid)``, or construct a valid frozen result with
+    empty inventories, and this function will use it (Codex #1031 r2). That is true of every
+    injected inventory in the engine — `holes=`, `pockets=`, `pads=` — and is the accepted
+    cost of ADR 0008 Amdt 5 dependency injection, not something specific to this parameter.
+    Closing it needs an unforgeable association between an aggregate and its solid, which is
+    tracked separately (#1032); singling out this one parameter would be inconsistent and
+    would still not make the check fail-closed.
+
+    So the test is named for what it does: it rejects an ASSEMBLED inventory, which is the
+    accidental form. It does not claim to reject a mismatched genuine one.
     """
     params = inspect.signature(lint_prismatic_coverage).parameters
     assert "step_zs" not in params, (
@@ -508,10 +521,21 @@ def test_one_ladder_rule_serves_sizing_and_critique():
     # vacuous and would pass with the consolidation removed (verified: it did).
     with counting_calls({"ladder": RecognitionResult.step_ladder}) as calls:
         drawing = build_drawing(part)
+        sizing = dict(calls)
+        calls.clear()
+        drawing.lint()
+        critique = dict(calls)
 
-    assert calls.get("ladder"), (
+    assert sizing.get("ladder"), (
         "the build never called RecognitionResult.step_ladder — sizing is deriving its own "
         "ladder again, which is the drift this consolidation removes"
+    )
+    # Both consumers, asserted separately. Counting across the whole build satisfied the
+    # assertion from `_analyse`'s call alone, so critique could revert to the raw face levels
+    # and this guard would stay green — the regression it names, undetected (Codex #1031 r2).
+    assert critique.get("ladder"), (
+        "lint never called RecognitionResult.step_ladder — critique is projecting risers over "
+        "a different ladder than the model was sized from"
     )
     lengths = sorted(n for n in drawing.annotations() if n.startswith("m_steplen"))
     assert len(lengths) == 2, f"expected one length per turned segment, got {lengths}"

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -15,15 +15,18 @@ Counted by code object (``conftest.counting_calls``) rather than by patching mod
 see that helper for why a binding-level spy cannot be trusted for this claim.
 """
 
+import inspect
 from contextlib import contextmanager
 
 import pytest
-from build123d import Box, Cylinder, Pos, Rot
+from build123d import Align, Box, Cylinder, Pos, Rot
 from conftest import counting_calls
 
 import draftwright.recognition as recognition
 from draftwright import Sheet, build_drawing
 from draftwright.compose import _est_right_strip_depth, _n_right_strip_boss_heights
+from draftwright.linting.coverage import lint_prismatic_coverage
+from draftwright.recognition import project_step_shoulders, recognise_risers, step_level_zs
 from draftwright.recognition.result import DEFERRED, MIGRATED
 
 
@@ -103,8 +106,7 @@ def test_exporting_a_declared_drawing_pays_for_one_aggregate_and_no_more(tmp_pat
     assert first.get("recognise_holes") == 1, (
         "the first export's lint-and-log found no inventory to judge against"
     )
-    rescanned = {n: c for n, c in second.items() if n != "recognise_step_shoulders"}
-    assert not rescanned, f"a second export re-recognised {rescanned}"
+    assert dict(second) == {}, f"a second export re-recognised {dict(second)}"
 
 
 def test_a_detected_build_still_recognises_each_family_once():
@@ -125,10 +127,9 @@ def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
     """A declared drawing has no inventory to judge against, so the first *explicit* physical
     lint builds one — once, and cached in the typed ``BuildState``.
 
-    ``recognise_step_shoulders`` is exempt: it is the ``CALLER_SPECIFIC_INPUT`` deferral, and
-    it rescans on every lint until #1025 splits it. Budgeting it is the honest form; a
-    lint-side memo to silence it would make critique a second recognition owner, which is what
-    ADR 0017 exists to remove.
+    No exemptions since #1025: the last family that rescanned per lint
+    (``recognise_step_shoulders``) split into evidence the aggregate owns plus a pure
+    projection, so repeated critique now recognises nothing at all.
     """
     _, sheet = _declared_plate_sheet()
     drawing = sheet.build()
@@ -145,9 +146,8 @@ def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
         "the first physical lint of a declared drawing must obtain one aggregate — without it "
         "coverage judges against an empty inventory and reports every real feature as missing"
     )
-    rescanned = {n: c for n, c in later.items() if n != "recognise_step_shoulders"}
-    assert not rescanned, (
-        f"two further lints re-ran {rescanned} — the aggregate is supposed to be built once "
+    assert dict(later) == {}, (
+        f"two further lints re-ran {dict(later)} — the aggregate is supposed to be built once "
         "and reused, so a second scan is a cache that is not being hit"
     )
     # Counting alone would pass an implementation whose later lints reuse the aggregate and
@@ -347,3 +347,80 @@ def test_a_turned_model_reserves_no_boss_height_slots():
     sheet.step(c)
 
     assert _n_right_strip_boss_heights(sheet.build().model()) == 0
+
+
+def _rebated_block():
+    """A full-span step: one riser, one interior level, one shoulder to locate."""
+    return Box(60, 40, 20, align=(Align.MIN,) * 3) - Pos(30, 0, 10) * Box(
+        30, 40, 10, align=(Align.MIN,) * 3
+    )
+
+
+def test_lint_projects_the_shared_riser_evidence_and_rescans_nothing():
+    """#1025's headline: the last per-lint rescan is gone.
+
+    ``recognise_step_shoulders`` did a full face scan on every critique pass, because its
+    answer depended on the caller's level set and ADR 0015 forbids lint taking that from the
+    model. Splitting the scan (``recognise_risers``) from the filter
+    (``project_step_shoulders``) gives the aggregate something single-valued to own, and each
+    consumer projects. This is phase 0's third guard for epic #1018.
+    """
+    drawing = build_drawing(_rebated_block())
+
+    with _counting_every_family() as counts:
+        drawing.lint()
+        drawing.lint()
+
+    assert dict(counts) == {}, (
+        f"linting a built drawing recognised {dict(counts)} — critique is supposed to judge "
+        "against the build's inventory, not scan the solid again"
+    )
+
+
+def test_the_critique_cannot_be_handed_a_narrower_shoulder_inventory():
+    """A completeness check must not accept an argument that can silence it.
+
+    ``lint_prismatic_coverage`` used to take ``step_zs=``, and it *fully determined* the
+    shoulder answer: ``step_zs=[]`` produced no shoulders, so ``missing_transitions`` was
+    structurally zero and ``unrecognised_defining_geometry`` could never fire. The engine
+    never passed that — ``Analysis.step_zs`` is a pure function of the solid — but a
+    false-negative door in a completeness check is the one place a clean absence is
+    indistinguishable from a clean part.
+
+    Asserted on the SIGNATURE, not on behaviour: the door is closed by there being no
+    parameter to open it with. A caller may pass the whole recognition aggregate, which is
+    recognition's own answer and not narrowable to a subset the caller chose.
+    """
+    params = inspect.signature(lint_prismatic_coverage).parameters
+
+    assert "step_zs" not in params, (
+        "lint_prismatic_coverage grew back a caller-supplied level set — that argument "
+        "decides the shoulder answer, so a caller passing [] silences the check entirely"
+    )
+    assert "step_shoulders" not in params, (
+        "the critique must recognise its own shoulder inventory rather than accept one"
+    )
+    assert "recognition" in params, (
+        "the critique needs the aggregate to project, or it falls back to rescanning"
+    )
+
+
+def test_the_two_consumers_project_the_same_evidence_differently():
+    """The split's whole point: one scan, two answers.
+
+    Model construction filters levels by plate and pocket ownership; critique must not (ADR
+    0015 — lint's inventory cannot come from the model). If the projection ignored its
+    ``levels`` argument, both would agree and the deferral this replaced would have been
+    pointless. A projection that discriminates is what makes one shared scan sufficient.
+    """
+    part = _rebated_block()
+    risers = recognise_risers(part)
+    assert risers, "fixture stopped producing riser evidence"
+
+    everything = project_step_shoulders(risers, levels=step_level_zs(part))
+    nothing = project_step_shoulders(risers, levels=[])
+    unrelated = project_step_shoulders(risers, levels=[999.0])
+
+    assert everything, "the real level set produced no shoulders"
+    assert nothing == [], "an empty level set must locate no shoulder"
+    assert unrelated == [], "a level no riser sits on must locate no shoulder"

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -17,6 +17,7 @@ see that helper for why a binding-level spy cannot be trusted for this claim.
 
 import inspect
 from contextlib import contextmanager
+from types import SimpleNamespace
 
 import pytest
 from build123d import Align, Box, Cylinder, Pos, Rot
@@ -26,7 +27,13 @@ import draftwright.recognition as recognition
 from draftwright import Sheet, build_drawing
 from draftwright.compose import _est_right_strip_depth, _n_right_strip_boss_heights
 from draftwright.linting.coverage import lint_prismatic_coverage
-from draftwright.recognition import project_step_shoulders, recognise_risers, step_level_zs
+from draftwright.recognition import (
+    RecognitionResult,
+    build_recognition_result,
+    project_step_shoulders,
+    recognise_risers,
+    step_level_zs,
+)
 from draftwright.recognition.result import DEFERRED, MIGRATED
 
 
@@ -387,12 +394,14 @@ def test_the_critique_cannot_be_handed_a_narrower_shoulder_inventory():
     false-negative door in a completeness check is the one place a clean absence is
     indistinguishable from a clean part.
 
-    Asserted on the SIGNATURE, not on behaviour: the door is closed by there being no
-    parameter to open it with. A caller may pass the whole recognition aggregate, which is
-    recognition's own answer and not narrowable to a subset the caller chose.
+    The signature half is necessary but NOT sufficient, which the first cut of this test got
+    wrong: asserting that a `recognition=` parameter exists says nothing about whether a
+    caller can narrow it. A duck-typed `SimpleNamespace(risers=(), step_levels=())` silenced
+    the check exactly as `step_zs=[]` had — the same door wearing a new parameter name (Codex
+    #1031 r1). So the behavioural half is the one with teeth: an assembled stand-in is
+    REJECTED, and only recognition's own frozen result is accepted.
     """
     params = inspect.signature(lint_prismatic_coverage).parameters
-
     assert "step_zs" not in params, (
         "lint_prismatic_coverage grew back a caller-supplied level set — that argument "
         "decides the shoulder answer, so a caller passing [] silences the check entirely"
@@ -400,8 +409,16 @@ def test_the_critique_cannot_be_handed_a_narrower_shoulder_inventory():
     assert "step_shoulders" not in params, (
         "the critique must recognise its own shoulder inventory rather than accept one"
     )
-    assert "recognition" in params, (
-        "the critique needs the aggregate to project, or it falls back to rescanning"
+
+    part = _rebated_block()
+    empty_stand_in = SimpleNamespace(risers=(), step_levels=())
+    with pytest.raises(TypeError, match="RecognitionResult"):
+        lint_prismatic_coverage(part, [], features=(), recognition=empty_stand_in)
+
+    # And the real thing still works — the guard rejects impostors, not the parameter.
+    assert isinstance(
+        lint_prismatic_coverage(part, [], features=(), recognition=build_recognition_result(part)),
+        list,
     )
 
 
@@ -424,3 +441,77 @@ def test_the_two_consumers_project_the_same_evidence_differently():
     assert everything, "the real level set produced no shoulders"
     assert nothing == [], "an empty level set must locate no shoulder"
     assert unrelated == [], "a level no riser sits on must locate no shoulder"
+
+
+def test_a_two_stage_call_matches_the_old_one_stage_one_at_any_tolerance():
+    """The split must not change what a NON-default tolerance means.
+
+    The old `recognise_step_shoulders(part, levels=..., tol=t)` used one `t` for the geometric
+    gates and the level ties. Split naively, `recognise_risers(part, tol=0.1)` followed by a
+    bare `project_step_shoulders(...)` mixed 0.1 with the projection's own default — so a
+    riser 0.3 mm off a level was rejected before and accepted after (Codex #1031 r1). The
+    evidence carries the tolerance it was scanned with, so the natural two-stage call stays
+    equivalent.
+    """
+    part = _rebated_block()
+
+    for tol in (0.1, 0.5, 2.0):
+        risers = recognise_risers(part, tol=tol)
+        assert all(r.tol == tol for r in risers), "evidence lost the tolerance it was scanned with"
+        # The bare projection must behave as if it had been told `tol` explicitly.
+        assert project_step_shoulders(risers, levels=[10.4]) == project_step_shoulders(
+            risers, levels=[10.4], tol=tol
+        ), f"tol={tol}: the bare projection did not inherit the scan's tolerance"
+
+    # And the inheritance is load-bearing, not incidental: a level 0.3mm off is inside the
+    # loose scan's tolerance and outside the tight one's.
+    loose = project_step_shoulders(recognise_risers(part, tol=0.5), levels=[10.3])
+    tight = project_step_shoulders(recognise_risers(part, tol=0.1), levels=[10.3])
+    assert loose != tight, "fixture no longer distinguishes the two tolerances"
+
+
+def _turned_shaft_with_blind_bore():
+    """A Z-turned shaft whose blind-bore floor is a horizontal face level but NOT an OD
+    shoulder — so the two candidate ladders genuinely differ."""
+    part = Cylinder(20, 30) + Pos(0, 0, 30) * Cylinder(14, 30)
+    return part - Pos(0, 0, 45) * Cylinder(6, 30)
+
+
+def test_one_ladder_rule_serves_sizing_and_critique():
+    """Sizing and critique must converge on the SAME step ladder.
+
+    For a Z-turned part the ladder is the turned profile's shoulders, not the raw horizontal
+    face levels — that distinction exists because a blind bore's flat floor is a face level
+    and is emphatically not an OD shoulder. `_analyse` had that rule; critique derived its own
+    level set separately, so lint could project risers over a different ladder than the model
+    was sized from (Codex #1031 r3). `RecognitionResult.step_ladder` is now the one rule both
+    call.
+
+    The fixture is chosen so the two candidate sets actually differ; on an ordinary prismatic
+    part they coincide and this would assert nothing.
+    """
+    part = _turned_shaft_with_blind_bore()
+    rec = build_recognition_result(part)
+    bb = part.bounding_box()
+
+    ladder = rec.step_ladder(bb)
+    assert ladder != list(rec.step_levels), (
+        "fixture stopped exercising the divergence — the turned ladder and the raw face "
+        "levels coincide here, so this test would pass with the rule removed"
+    )
+    assert 30.0 not in ladder, "the blind-bore floor leaked into the turned ladder"
+    assert 30.0 in rec.step_levels, "fixture no longer produces the bore floor as a face level"
+
+    # And sizing goes through that same rule rather than re-deriving it. Asserted by counting
+    # the call, because on a turned part `step_zs` feeds only the strip reservation — there is
+    # no rendered rung to read the difference off, so a behavioural assertion here would be
+    # vacuous and would pass with the consolidation removed (verified: it did).
+    with counting_calls({"ladder": RecognitionResult.step_ladder}) as calls:
+        drawing = build_drawing(part)
+
+    assert calls.get("ladder"), (
+        "the build never called RecognitionResult.step_ladder — sizing is deriving its own "
+        "ladder again, which is the drift this consolidation removes"
+    )
+    lengths = sorted(n for n in drawing.annotations() if n.startswith("m_steplen"))
+    assert len(lengths) == 2, f"expected one length per turned segment, got {lengths}"

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -52,16 +52,25 @@ def _record_types_in(annot) -> set[type]:
     return set()
 
 
+#: Prefixes of the public functions that emit records into the IR. ``project_`` joined
+#: ``recognise_`` in #1025: ``project_step_shoulders`` produces ``StepShoulder``, which reaches
+#: ``StepLevelFeature.shoulders`` exactly as a recogniser's record would. Deriving the universe
+#: from ``recognise_`` alone would have quietly dropped that type from the completeness guard
+#: the moment it moved behind a projection — and left a future ``project_*`` record type with
+#: no home and no test saying so.
+_RECORD_EMITTING_PREFIXES = ("recognise_", "project_")
+
+
 def _recogniser_record_universe() -> set[type]:
     """The authoritative set of record types, derived MECHANICALLY from the public
-    ``recognise_*`` return annotations (not a hand-maintained list). This is what makes
-    the completeness guard genuinely fail-closed: add ``recognise_threads() ->
+    record-emitting functions' return annotations (not a hand-maintained list). This is what
+    makes the completeness guard genuinely fail-closed: add ``recognise_threads() ->
     list[ThreadRecord]`` and ``ThreadRecord`` enters this universe automatically, so the
     partition test below fails until it is given a home — matching the ADR 0013 claim
     that a new recogniser cannot silently emit features with no converter."""
     universe: set[type] = set()
     for name in dir(recognition):
-        if not name.startswith("recognise_"):
+        if not name.startswith(_RECORD_EMITTING_PREFIXES):
             continue
         fn = getattr(recognition, name)
         # Fail loud, not open: an unresolvable return annotation must surface as a test

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -42,6 +42,7 @@ from draftwright.recognition import (
     StepShoulder,
     TurnedStep,
     analyse_cylinders,
+    project_step_shoulders,
     recognise_bosses,
     recognise_chamfers,
     recognise_countersinks,
@@ -54,9 +55,9 @@ from draftwright.recognition import (
     recognise_plates,
     recognise_pocket_patterns,
     recognise_pockets,
+    recognise_risers,
     recognise_slot_patterns,
     recognise_slots,
-    recognise_step_shoulders,
     recognise_turned_steps,
 )
 from draftwright.recognition._record import Record
@@ -222,7 +223,16 @@ def _records_from_recognisers():
         ("recognise_grooves", recognise_grooves(grooved)),
         ("recognise_plates", recognise_plates(_l_bracket())),
         ("recognise_face_levels", recognise_face_levels(stepped)),
-        ("recognise_step_shoulders", recognise_step_shoulders(stepped, levels=levels)),
+        ("recognise_risers", recognise_risers(stepped)),
+        # `StepShoulder` stopped being a recogniser return in #1025 — it is now what
+        # `project_step_shoulders` derives from riser evidence. It stays in this roster
+        # because the record contract (frozen, JSON-serialisable, no leaked build123d object)
+        # binds a projection's output exactly as it binds a recogniser's; dropping it would
+        # retire the only coverage of that type on the grounds that it moved.
+        (
+            "project_step_shoulders",
+            project_step_shoulders(recognise_risers(stepped), levels=levels),
+        ),
         ("recognise_turned_steps", recognise_turned_steps(_turned_shaft())),
     ]:
         for r in recs:
@@ -277,7 +287,7 @@ def test_part_based_recognisers_are_keyword_only_after_part():
         recognise_grooves,
         recognise_plates,
         recognise_face_levels,
-        recognise_step_shoulders,
+        recognise_risers,
         recognise_turned_steps,
     ):
         params = list(inspect.signature(fn).parameters.values())

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -38,6 +38,7 @@ from draftwright.recognition import (
     recognise_pocket_patterns,
     recognise_pockets,
     recognise_rectangular_pads,
+    recognise_risers,
     recognise_slot_patterns,
     recognise_slots,
     recognise_turned_steps,
@@ -87,6 +88,16 @@ def _padded_plate():
     return Box(120, 90, 16) + Pos(0, -30, 10) * Box(30, 20, 4)
 
 
+def _stepped_block():
+    """A full-span step — the shape `recognise_risers` exists to find (#1025).
+
+    None of the other fixtures produce a riser: a pad, a pocket and a bolt circle all have
+    BOUNDED walls, which the full-span test deliberately rejects, so without this the
+    aggregate's `risers` field would be compared () to () everywhere.
+    """
+    return Box(80, 40, 10) + Pos(-20, 0, 10) * Box(40, 40, 12)
+
+
 #: Between them these cover every RecognitionResult field with a NON-EMPTY inventory, which
 #: is what makes the equality assertions in the oracle below discriminating rather than
 #: comparing () to ().
@@ -99,6 +110,7 @@ _ORACLE_FIXTURES = [
     ("pocket grid", _pocket_grid_plate),
     ("stepped shaft", _stepped_shaft),
     ("padded plate", _padded_plate),
+    ("stepped block", _stepped_block),
 ]
 
 
@@ -279,6 +291,7 @@ def _expected_inventory(part) -> dict:
         "pads": tuple(recognise_rectangular_pads(part)),
         "turned_steps": tuple(recognise_turned_steps(part, cyls=cyls)),
         "step_levels": tuple(step_level_zs(part)),
+        "risers": tuple(recognise_risers(part)),
     }
 
 
@@ -317,21 +330,17 @@ def test_the_aggregate_carries_what_its_recognisers_returned():
     )
 
 
-#: How many times a family may run during ONE automatic build. Anything absent budgets 1.
-#: The single entry is the DEFERRED family with two callers that may ask different questions
-#: (see ``recognition.result.DEFERRED``) — model construction with ownership-filtered levels,
-#: and the critique with unfiltered ones. On this fixture the two level sets happen to
-#: coincide, so the second scan is pure waste rather than a second answer; the budget records
-#: the deferral's real price and pins it so it cannot quietly rise.
-_BUILD_CALL_BUDGET = {"recognise_step_shoulders": 2}
+#: How many times a family may run during ONE automatic build. Anything absent budgets 1, and
+#: the map is now EMPTY: #1025 split the last family that needed a second scan into
+#: ``recognise_risers`` plus a pure projection, so no family has a reason to run twice.
+#: An entry appearing here again needs a reason, not a bigger number.
+_BUILD_CALL_BUDGET: dict[str, int] = {}
 
-#: How many times a family may run during ONE ``lint()`` of an already-built drawing. The
-#: single entry is the same deferral: the critique recognises its own shoulder inventory on
-#: every pass, because ADR 0015 forbids it taking one from the model and there is nowhere
-#: below both ``model/`` and ``linting/`` for a shared answer to live. #1025 makes it a
-#: projection over the aggregate's evidence and this budget goes to zero. Anything else
-#: appearing here is lint growing a scan it did not have.
-_LINT_CALL_BUDGET = {"recognise_step_shoulders": 1}
+#: How many times a family may run during ONE ``lint()`` of an already-built drawing. EMPTY
+#: since #1025: critique projects the aggregate's riser evidence over its own levels instead
+#: of rescanning, so linting a built drawing now recognises NOTHING. That is phase 0's third
+#: guard. Any entry here is lint growing back a recognition owner.
+_LINT_CALL_BUDGET: dict[str, int] = {}
 
 
 @contextmanager

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -132,6 +132,9 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
     )
     monkeypatch.setattr(result_module, "recognise_grooves", cyl_consumer("grooves", []))
     monkeypatch.setattr(result_module, "recognise_flats", cyl_consumer("flats", []))
+    # #1025: the level-free riser scan. Takes the part only — the level set that used to
+    # make this family caller-specific now lives in `project_step_shoulders`.
+    monkeypatch.setattr(result_module, "recognise_risers", counted("risers", []))
 
     built = result_module.build_recognition_result(object())
 
@@ -152,6 +155,7 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
         "slot_patterns",
         "grooves",
         "flats",
+        "risers",
     }, f"the orchestration ran a different set of families: {sorted(calls)}"
     assert set(calls.values()) == {1}, f"a family ran more than once: {calls}"
     assert built.holes == tuple(holes)
@@ -209,6 +213,7 @@ def test_injecting_the_aggregate_builds_the_same_model_as_detecting(name, build)
         pocket_patterns=list(rec.pocket_patterns),
         pads=list(rec.pads),
         step_zs=list(rec.step_levels),
+        risers=list(rec.risers),
         cyls=rec.cylinders,
     )
 

--- a/tests/test_slanted_blind_step.py
+++ b/tests/test_slanted_blind_step.py
@@ -23,7 +23,7 @@ from build123d import (
 from draftwright import build_drawing
 from draftwright.model.declare import envelope
 from draftwright.recognition import levels as levels_module
-from draftwright.recognition.levels import recognise_step_shoulders
+from draftwright.recognition.levels import project_step_shoulders, recognise_risers
 from draftwright.recognition.slots import _Face, _recognise_corner_notches
 
 
@@ -181,8 +181,8 @@ def test_oblique_degenerate_and_small_bounded_faces_are_rejected(monkeypatch):
     shallow = Face((1.0, 0.0, 0.02), _box(2, 3, 0, 10, 24.75, 25))
     small = Face((1.0, 0.0, 0.5), _box(2, 3, 0, 2, 20, 25))
 
-    assert recognise_step_shoulders(Part(shallow), levels=[24.75]) == []
-    assert recognise_step_shoulders(Part(small), levels=[20]) == []
+    assert project_step_shoulders(recognise_risers(Part(shallow)), levels=[24.75]) == []
+    assert project_step_shoulders(recognise_risers(Part(small)), levels=[20]) == []
 
 
 def test_completeness_lint_can_report_transitions_without_blind_recesses(


### PR DESCRIPTION
Closes #1025. Branches off `main` (after #1030 merged).

## The shape of the problem

`recognise_step_shoulders(part, *, levels)` did a full `part.faces()` scan and used `levels` only to *select* which risers qualified. The scan was the cost; the level set was a projection parameter.

That mattered because the two consumers legitimately pass different level sets — model construction filters by plate and pocket ownership, critique must not (ADR 0015 forbids lint taking its inventory from the model). So the family could not be hoisted into the aggregate, and **lint rescanned the solid on every pass**.

#1021 read that as a property of the feature and budgeted the rescan. It is really a property of the function's *shape*.

## The split

- **`recognise_risers(part)`** — the scan and every level-independent gate: planarity, in-plane axis, the full-span test that separates a step from a pad or blind pocket, the interior-position test, the structural-ramp size floor, the area floor. Owned by the aggregate, run once per build.
- **`project_step_shoulders(risers, *, levels)`** — the filter. **No `part` argument by construction**, so it cannot become a second recognition site even by accident.

`RiserEvidence` carries `lo_at_envelope`/`hi_at_envelope` so the level-free half of the oblique tie-test is precomputed; the projection then needs the levels and nothing else about the solid.

## Measured

| | before | after |
|---|---|---|
| automatic build | 16 families, `recognise_step_shoulders` **twice** | 17 families, **once each** |
| lint of a built drawing | 1 scan **per pass** | **0** |
| declared build | 0 | 0 |

Linting now recognises nothing. That is **epic #1018's phase-0 third guard**, and the last of the three.

## Manifest

`DEFERRED` loses its `CALLER_SPECIFIC_INPUT` entry — down to the three `CLASSIFICATION_GATED` families (#1028). The enum member survives with a note that this reason is usually a *shape* problem rather than a fact about the feature: the scan never depended on the caller, only the filter did. Prefer the split before reaching for that member again.

## Folded in: a false-negative door

`lint_prismatic_coverage` took `step_zs=`, and that argument **fully determined** the shoulder answer: `step_zs=[]` yielded no shoulders, so `missing_transitions` was structurally zero and `unrecognised_defining_geometry` could never fire. The engine never passed that — but a completeness check is the one place a clean absence is indistinguishable from a clean part.

The parameter is gone. The guard asserts on the **signature**, not on behaviour: the door is closed by there being nothing to open it with.

## Two things worth reviewer attention

**`declare.step_level` keeps its own scan, deliberately.** It reads the object the author handed it — a different solid from the one the aggregate recognised — in the same sense `hole(cylinder)` reads a diameter off the cylinder you passed. Not an oversight.

**The record-type universe now derives from `project_*` as well as `recognise_*`.** `StepShoulder` is emitted by a projection now; deriving from `recognise_` alone would have silently dropped it from the completeness guard the moment it moved, and left a future `project_*` record type with no home and no test saying so. `RiserEvidence` gets a documented home in `_ORCHESTRATED_RECORDS`.

## Verification

- 68 passed across the recognition, contract, registry and guard suites; 1286 passed across the broad consumer suites on the previous revision.
- Four lint gates clean.
- **Five mutations, each producing a red guard**: reintroducing `step_zs=` → signature guard; making lint rescan → count guards; making the projection ignore its levels → discrimination guard; dropping `RiserEvidence`'s home → partition guard; narrowing the universe back to `recognise_` → partition guard.
- Full tier not run locally by instruction; CI covers it.

## Issue corrections

#1025's body has been corrected in three places where it described work that #1021's reshape never landed: the `CoverageState.step_shoulders` memo, the `critique_step_shoulders` fallback and the ADR 0017 §6 amendment do not exist, and `test_the_critique_takes_no_shoulder_inventory` was cited as an existing guard but had never been written. The split's argument is unaffected — it was never justified by the memo's existence. This PR writes the missing guard for real.

Parent: #1018. Remaining sibling: #1028.
