### PR TITLE
fix(#1013): a flat carries its stock identity, so parallel lobes stop collapsing

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1710,9 +1710,16 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
         )
         if pd is None:
             continue
-        collapse.setdefault((g.facts.axis, round(pd.value, 3)), []).append((g, pd))
+        # Grouped by the stock's AXIS LINE as well as the size (#1013). Two same-sized flats
+        # on one axis line are the two faces of one double-D — one A/F definition, one
+        # callout. On DIFFERENT axis lines they are separate lobes, each needing its own: the
+        # axis letter alone cannot tell those apart, so a part with two parallel 25 A/F lobes
+        # used to get one callout and leave the second undefined on the sheet.
+        collapse.setdefault((g.facts.axis, g.facts.axis_line, round(pd.value, 3)), []).append(
+            (g, pd)
+        )
     jobs = []
-    for gi, ((axis, _across), members) in enumerate(sorted(collapse.items())):
+    for gi, ((axis, _axis_line, _across), members) in enumerate(sorted(collapse.items())):
         if only is not None:
             # #426 Ph2b subset (finalize): filter members AFTER enumerating the collapse so gi
             # stays the full-drawing group index (Codex #811) — see render_fillets.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1710,16 +1710,21 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
         )
         if pd is None:
             continue
-        # Grouped by the stock's AXIS LINE as well as the size (#1013). Two same-sized flats
-        # on one axis line are the two faces of one double-D — one A/F definition, one
-        # callout. On DIFFERENT axis lines they are separate lobes, each needing its own: the
-        # axis letter alone cannot tell those apart, so a part with two parallel 25 A/F lobes
-        # used to get one callout and leave the second undefined on the sheet.
-        collapse.setdefault((g.facts.axis, g.facts.axis_line, round(pd.value, 3)), []).append(
-            (g, pd)
-        )
+        # Grouped by the STOCK IDENTITY as well as the size (#1013). Two same-sized flats on
+        # one piece of stock are the two faces of one double-D — one A/F definition, one
+        # callout. On different stock they are independent, each needing its own; the axis
+        # letter alone cannot tell those apart, so a part with two parallel 25 A/F lobes used
+        # to get one callout and leave the second undefined on the sheet.
+        #
+        # Identity is the axis line AND the axial span, because neither alone is enough:
+        # parallel lobes share a span but not a line, and coaxial stacked stock shares a line
+        # but not a span. Grouping on the line alone merged the coaxial case silently — the
+        # same defect this fix is about, one arrangement over (Codex #1035 r1).
+        collapse.setdefault(
+            (g.facts.axis, g.facts.axis_line, g.facts.stock_span, round(pd.value, 3)), []
+        ).append((g, pd))
     jobs = []
-    for gi, ((axis, _axis_line, _across), members) in enumerate(sorted(collapse.items())):
+    for gi, ((axis, _line, _span, _across), members) in enumerate(sorted(collapse.items())):
         if only is not None:
             # #426 Ph2b subset (finalize): filter members AFTER enumerating the collapse so gi
             # stays the full-drawing group index (Codex #811) — see render_fillets.

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -252,7 +252,10 @@ _FACTS: dict[str, tuple[str, ...]] = {
     # changes output, and a migration that claims byte-identity is the wrong place for it.
     "chamfer": ("frame", "axis", "leg2", "angle"),
     "fillet": ("frame", "axis"),
-    "flat": ("frame", "axis"),
+    # `axis_line` is STRUCTURE, not a measurement: it says which piece of stock a flat
+    # belongs to, so the renderer can tell a double-D's two faces from two parallel
+    # lobes (#1013). The drawing never prints it.
+    "flat": ("frame", "axis", "axis_line"),
     "groove": ("frame", "axis"),
     "plate": ("frame", "axis"),
     # Raw AP242 PMI is the documented non-generated exception: its source-authored label

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -255,7 +255,7 @@ _FACTS: dict[str, tuple[str, ...]] = {
     # `axis_line` is STRUCTURE, not a measurement: it says which piece of stock a flat
     # belongs to, so the renderer can tell a double-D's two faces from two parallel
     # lobes (#1013). The drawing never prints it.
-    "flat": ("frame", "axis", "axis_line"),
+    "flat": ("frame", "axis", "axis_line", "stock_span"),
     "groove": ("frame", "axis"),
     "plate": ("frame", "axis"),
     # Raw AP242 PMI is the documented non-generated exception: its source-authored label

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -497,7 +497,9 @@ def _read_flat_face(face) -> Point:
     return (round(c.X, 4), round(c.Y, 4), round(c.Z, 4))
 
 
-def flat(obj=None, *, axis=None, across=None, at=None, axis_line=None) -> FlatFeature:
+def flat(
+    obj=None, *, axis=None, across=None, at=None, axis_line=None, stock_span=None
+) -> FlatFeature:
     """A machined flat on round stock (#148b). Either ``flat(flat_face)`` — the planar face
     supplies the leader point ``at`` (``axis=`` and ``across=`` still required, being
     unrecoverable from a plane) — or fully explicit ``flat(axis="z", across=15, at=(x, y,
@@ -519,13 +521,20 @@ def flat(obj=None, *, axis=None, across=None, at=None, axis_line=None) -> FlatFe
         frame=Frame(origin=at, axis=axis),
         axis=axis,
         across=round(across, 3),
-        axis_line=(0.0, 0.0)
-        if axis_line is None
-        else (
-            round(axis_line[0], 3),
-            round(axis_line[1], 3),
-        ),
+        axis_line=_stock_pair(axis_line),
+        stock_span=_stock_pair(stock_span),
     )
+
+
+def _stock_pair(v) -> tuple[float, float]:
+    """A rounded ``(a, b)`` stock-identity pair, or the origin default when unstated.
+
+    Both halves of a flat's stock identity round the same way, so they share this — an
+    earlier cut inlined only one and left ``stock_span=`` accepted-and-ignored, which the
+    #964 emit-fidelity oracle caught: a parameter that silently does nothing is worse than
+    an absent one, because the caller has no way to tell.
+    """
+    return (0.0, 0.0) if v is None else (round(v[0], 3), round(v[1], 3))
 
 
 def _read_groove_face(face) -> tuple[str, float, float, Point]:

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -497,7 +497,7 @@ def _read_flat_face(face) -> Point:
     return (round(c.X, 4), round(c.Y, 4), round(c.Z, 4))
 
 
-def flat(obj=None, *, axis=None, across=None, at=None) -> FlatFeature:
+def flat(obj=None, *, axis=None, across=None, at=None, axis_line=None) -> FlatFeature:
     """A machined flat on round stock (#148b). Either ``flat(flat_face)`` — the planar face
     supplies the leader point ``at`` (``axis=`` and ``across=`` still required, being
     unrecoverable from a plane) — or fully explicit ``flat(axis="z", across=15, at=(x, y,
@@ -510,7 +510,22 @@ def flat(obj=None, *, axis=None, across=None, at=None) -> FlatFeature:
     axis = _norm_axis(axis)
     _require_positive(across=across)
     _require_point("at", at)
-    return FlatFeature(frame=Frame(origin=at, axis=axis), axis=axis, across=round(across, 3))
+    # `axis_line` cannot be derived from `at`: a double-D's two faces have DIFFERENT face
+    # centres but ONE axis line, so deriving it would split every declared double-D in two.
+    # Defaulting to the origin line means all declared flats on an axis group together, which
+    # is exactly the pre-#1013 behaviour — so a single-stock declaration is unaffected. A part
+    # with parallel lobes has to say so, because nothing in a flat's own geometry says it.
+    return FlatFeature(
+        frame=Frame(origin=at, axis=axis),
+        axis=axis,
+        across=round(across, 3),
+        axis_line=(0.0, 0.0)
+        if axis_line is None
+        else (
+            round(axis_line[0], 3),
+            round(axis_line[1], 3),
+        ),
+    )
 
 
 def _read_groove_face(face) -> tuple[str, float, float, Point]:

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -507,7 +507,10 @@ def _convert_fillet(fl: Fillet, ctx: ConvContext) -> FilletFeature:
 def _convert_flat(flat: Flat, ctx: ConvContext) -> FlatFeature:
     at = flat.at
     return FlatFeature(
-        frame=Frame((at[0], at[1], at[2]), flat.axis), axis=flat.axis, across=flat.across
+        frame=Frame((at[0], at[1], at[2]), flat.axis),
+        axis=flat.axis,
+        across=flat.across,
+        axis_line=flat.axis_line,
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -511,6 +511,7 @@ def _convert_flat(flat: Flat, ctx: ConvContext) -> FlatFeature:
         axis=flat.axis,
         across=flat.across,
         axis_line=flat.axis_line,
+        stock_span=flat.stock_span,
     )
 
 

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -641,6 +641,9 @@ class FlatFeature:
     #: share an A/F definition only if they share this; the axis letter alone cannot tell a
     #: double-D's two faces from two parallel lobes (#1013).
     axis_line: tuple[float, float] = (0.0, 0.0)
+    #: The owning stock's axial extent — with ``axis_line``, the stock identity. Coaxial
+    #: stacked stock shares an axis line, so that alone merged independent definitions.
+    stock_span: tuple[float, float] = (0.0, 0.0)
     kind: ClassVar[str] = "flat"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -637,6 +637,10 @@ class FlatFeature:
     frame: Frame
     axis: str
     across: float
+    #: The stock's axis line — see :class:`~draftwright.recognition.flats.Flat`. Two flats
+    #: share an A/F definition only if they share this; the axis letter alone cannot tell a
+    #: double-D's two faces from two parallel lobes (#1013).
+    axis_line: tuple[float, float] = (0.0, 0.0)
     kind: ClassVar[str] = "flat"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/recognition/flats.py
+++ b/src/draftwright/recognition/flats.py
@@ -113,6 +113,19 @@ class Flat(Record):
     #: ADR 0013's rule for a record that looks too thin: the fix is the record. The
     #: recogniser already had the owning cylinder in hand, so this costs nothing to carry.
     axis_line: tuple[float, float] = (0.0, 0.0)
+    #: The owning stock's axial extent ``(lo, hi)`` along ``axis``.
+    #:
+    #: The axis line alone is NOT stock identity, and this code already knew it: #1015 taught
+    #: the opposition test that "the same infinite axis is not the same piece of stock", and
+    #: the same holds for grouping. Two D-shafts stacked coaxially with a gap share an axis
+    #: line, so grouping on that alone merged two independent A/F definitions into one callout
+    #: — the very defect #1013 set out to fix, in a coaxial arrangement instead of a parallel
+    #: one (Codex #1035 r1).
+    #:
+    #: Together with ``axis_line`` this is the stock identity. Purely geometric — the
+    #: recogniser's internal ``stock`` tuple also carries a solid index, which is a same-run
+    #: equality check and deliberately NOT propagated: it is not stable across runs.
+    stock_span: tuple[float, float] = (0.0, 0.0)
 
 
 def recognise_flats(part, *, cyls=None) -> list[Flat]:
@@ -162,6 +175,7 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                 {
                     "axis": c["axis"],
                     "axis_line": _axis_line(c["axis"], ax),
+                    "stock_span": (round(c["s_lo"], 3), round(c["s_hi"], 3)),
                     "n": nv,
                     "s": s,
                     "r": r,
@@ -205,6 +219,7 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                 across=round(across, 3),
                 at=(round(cand["at"][0], 3), round(cand["at"][1], 3), round(cand["at"][2], 3)),
                 axis_line=cand["axis_line"],
+                stock_span=cand["stock_span"],
             )
         )
     return sorted(out, key=lambda fl: (fl.axis, fl.at))

--- a/src/draftwright/recognition/flats.py
+++ b/src/draftwright/recognition/flats.py
@@ -230,6 +230,20 @@ def _axis_line(axis: str, ax) -> tuple[float, float]:
 
     Rounded to the same 3 dp as every other coordinate a record carries, so two faces on one
     piece of stock compare equal rather than differing in float noise.
+
+    **Axis-ALIGNED stock only, and deliberately so.** Dropping the dominant axis letter's
+    coordinate identifies a line only when the axis is along X, Y or Z. For a slanted
+    cylinder — ``analyse_cylinders`` classifies one by its dominant component, so a
+    ``(0.707, 0, 0.707)`` axis reads as ``"x"`` — this is neither canonical (the value depends
+    on WHICH point along the axis the cylinder record reports) nor sufficient (two different
+    slanted directions through one point encode identically). A canonical key would be the
+    perpendicular foot from the origin plus the direction, as :func:`_same_axis_line` already
+    computes for the opposition test.
+
+    That is not done here because slanted flats do not render at all today: the callout is
+    dropped (`flat_dropped`) before identity matters, so a canonical key would fix a
+    component of an already-broken path with no observable improvement. #1036 covers both
+    halves together. The narrow claim this function makes is the one it can keep.
     """
     keep = [i for i, letter in enumerate("xyz") if letter != axis]
     return (round(ax[keep[0]], 3), round(ax[keep[1]], 3))

--- a/src/draftwright/recognition/flats.py
+++ b/src/draftwright/recognition/flats.py
@@ -99,6 +99,20 @@ class Flat(Record):
     axis: str
     across: float
     at: tuple[float, float, float]
+    #: The stock's axis LINE — the two coordinates perpendicular to ``axis``, in xyz order
+    #: with the axis component dropped (z → (x, y); x → (y, z); y → (x, z)).
+    #:
+    #: The axis letter alone cannot say whether two flats belong to the same piece of round
+    #: stock, and that is the one thing both consumers need (#1013). Two faces at
+    #: ``(-12.5, 0, 0)`` and ``(12.5, 0, 0)`` are one double-D — one A/F definition. Two at
+    #: ``(0, 0, 0)`` and ``(100, 0, 0)`` are two parallel lobes — two independent ones. From
+    #: ``axis``/``across``/``at`` those are the same shape of data, so the renderer collapsed
+    #: the second case into one callout and coverage, mirroring it, called the result
+    #: complete.
+    #:
+    #: ADR 0013's rule for a record that looks too thin: the fix is the record. The
+    #: recogniser already had the owning cylinder in hand, so this costs nothing to carry.
+    axis_line: tuple[float, float] = (0.0, 0.0)
 
 
 def recognise_flats(part, *, cyls=None) -> list[Flat]:
@@ -147,6 +161,7 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
             cands.append(
                 {
                     "axis": c["axis"],
+                    "axis_line": _axis_line(c["axis"], ax),
                     "n": nv,
                     "s": s,
                     "r": r,
@@ -189,6 +204,17 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                 axis=cand["axis"],
                 across=round(across, 3),
                 at=(round(cand["at"][0], 3), round(cand["at"][1], 3), round(cand["at"][2], 3)),
+                axis_line=cand["axis_line"],
             )
         )
     return sorted(out, key=lambda fl: (fl.axis, fl.at))
+
+
+def _axis_line(axis: str, ax) -> tuple[float, float]:
+    """The two coordinates of *ax* perpendicular to *axis* — the stock's axis line (#1013).
+
+    Rounded to the same 3 dp as every other coordinate a record carries, so two faces on one
+    piece of stock compare equal rather than differing in float noise.
+    """
+    keep = [i for i, letter in enumerate("xyz") if letter != axis]
+    return (round(ax[keep[0]], 3), round(ax[keep[1]], 3))

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -377,7 +377,15 @@ def _feature_line(f, part_envelope=None) -> str:
     if k == "fillet":
         return f'sheet.fillet(axis="{f.axis}", radius={_n(f.radius)}, at={_pt(f.frame.origin)})'
     if k == "flat":
-        return f'sheet.flat(axis="{f.axis}", across={_n(f.across)}, at={_pt(f.frame.origin)})'
+        # `axis_line`/`stock_span` are the stock identity (#1013). Emitted ALWAYS, not only
+        # when non-default: they are what stops two same-sized flats on separate stock
+        # collapsing into one callout, and a script that omits them regenerates the very
+        # drawing the detection was fixing (Codex #1035 r1). The declared defaults reproduce
+        # pre-#1013 grouping, so silence here is not neutral — it is the old bug.
+        return (
+            f'sheet.flat(axis="{f.axis}", across={_n(f.across)}, at={_pt(f.frame.origin)}, '
+            f"axis_line={_pt(f.axis_line)}, stock_span={_pt(f.stock_span)})"
+        )
     if k == "groove":
         return (
             f'sheet.groove(axis="{f.axis}", width={_n(f.width)}, '

--- a/tests/test_flat_stock_identity.py
+++ b/tests/test_flat_stock_identity.py
@@ -9,7 +9,7 @@ undefined on the sheet with nothing reporting it.
 ADR 0013's rule for a record that looks too thin is that the fix is the record.
 """
 
-from build123d import Box, Cylinder, Pos
+from build123d import Box, Cylinder, Pos, Rot
 
 from draftwright import build_drawing
 from draftwright.model.declare import flat as declare_flat
@@ -171,3 +171,32 @@ def test_a_declared_flat_defaults_to_one_stock():
 
     far = declare_flat(axis="z", across=25, at=(100, 0, 0), axis_line=(100.0, 0.0))
     assert far.axis_line != a.axis_line, "an explicit axis line must separate declared lobes"
+
+
+def test_slanted_stock_is_an_acknowledged_limitation_not_a_silent_wrong_answer():
+    """`axis_line` identifies AXIS-ALIGNED stock. For a slanted axis it is neither canonical
+    nor sufficient — see `_axis_line`'s docstring and #1036.
+
+    This pins the reason that gap is tolerable rather than urgent: a slanted flat produces no
+    callout at all, so the identity never gets to be wrong in a drawing. The test exists so
+    that if slanted rendering is ever fixed, this fails and the identity gap surfaces with
+    it — rather than the two being fixed months apart with a wrong callout in between.
+    """
+    slant = Rot(0, 45, 0) * (Cylinder(10, 40) - Pos(8, 0, 0) * Box(10, 40, 60))
+
+    flats = recognise_flats(slant)
+    assert flats, "fixture stopped producing a slanted flat — it no longer pins anything"
+    assert flats[0].axis == "x", (
+        "a (0.707, 0, 0.707) axis is classified by its dominant component; if that changed, "
+        "the slanted-identity reasoning in _axis_line needs rechecking"
+    )
+
+    dwg = build_drawing(slant)
+    assert not [n for n in dwg.annotations() if n.startswith("m_flat_")], (
+        "a slanted flat now RENDERS. The identity key it is grouped by is not canonical for "
+        "slanted axes (#1036) — fix that before shipping slanted A/F callouts, or two "
+        "patches of one shaft may draw two callouts and two shafts may draw one."
+    )
+    assert [i for i in dwg.lint() if i.code == "flat_dropped"], (
+        "the slanted flat is neither drawn nor reported — that would be a silent omission"
+    )

--- a/tests/test_flat_stock_identity.py
+++ b/tests/test_flat_stock_identity.py
@@ -1,0 +1,106 @@
+"""A flat's stock identity — two parallel lobes are not one double-D (#1013).
+
+`Flat` recorded `axis` (the letter), `across` and `at`, and nothing that said which piece of
+round stock a flat belonged to. From that record, two faces of one double-D and two flats on
+two parallel lobes are the same shape of data, so `render_flats` grouped by
+`(axis, across)` and collapsed both cases into a single callout — leaving the second lobe
+undefined on the sheet with nothing reporting it.
+
+ADR 0013's rule for a record that looks too thin is that the fix is the record.
+"""
+
+from build123d import Box, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.model.declare import flat as declare_flat
+from draftwright.recognition import recognise_flats
+
+
+def _lobe():
+    """One D-flat on round stock, axis Z, centred on the origin line."""
+    return Cylinder(15, 40) - Pos(12.5, 0, 0) * Box(10, 40, 50)
+
+
+def _double_d():
+    """ONE piece of stock, two opposed faces — one A/F definition."""
+    return (
+        Cylinder(15, 40) - Pos(12.5, 0, 0) * Box(10, 40, 50) - Pos(-12.5, 0, 0) * Box(10, 40, 50)
+    )
+
+
+def _two_parallel_lobes(gap: float = 100.0):
+    """TWO pieces of stock, same size flat on each — two independent A/F definitions."""
+    return _lobe() + Pos(gap, 0, 0) * _lobe()
+
+
+def test_the_record_distinguishes_one_stock_from_two():
+    """The counterexample the record could not express before.
+
+    Both fixtures produce two `Flat` records with equal `axis` and equal `across`. Only the
+    axis line separates them, which is exactly why the letter alone was not enough.
+    """
+    dd = recognise_flats(_double_d())
+    lobes = recognise_flats(_two_parallel_lobes())
+
+    assert len(dd) == 2 and len(lobes) == 2, "both fixtures should yield two flat records"
+    assert {f.axis for f in dd} == {"z"} and {f.axis for f in lobes} == {"z"}
+
+    assert len({f.axis_line for f in dd}) == 1, (
+        "a double-D's two faces are one piece of stock — they must share an axis line, or the "
+        "renderer will draw two A/F callouts for one definition"
+    )
+    assert len({f.axis_line for f in lobes}) == 2, (
+        "two parallel lobes are two pieces of stock — separate axis lines, or the renderer "
+        "collapses them and the second lobe goes undefined"
+    )
+
+
+def test_a_double_d_still_gets_exactly_one_callout():
+    """The collapse is correct for the case it was written for, and must survive the fix."""
+    dwg = build_drawing(_double_d())
+
+    callouts = sorted(n for n in dwg.annotations() if n.startswith("m_flat_"))
+    assert len(callouts) == 1, f"a double-D is ONE A/F definition, got {callouts}"
+    assert not [i for i in dwg.lint() if i.code == "flat_dropped"]
+
+
+def test_two_parallel_lobes_are_two_definitions_and_a_lost_one_is_reported():
+    """The defect: the sheet used to carry one callout for two independent definitions, with
+    nothing saying so.
+
+    The engine now plans both. Placing them both is a corridor-capacity problem and is NOT
+    what this fix is about (#1034) — what matters here is that the second definition exists
+    and its loss is REPORTED rather than absorbed by a grouping key. A completeness failure
+    that is visible is the whole point; the previous behaviour was a clean-looking drawing
+    that was wrong.
+    """
+    dwg = build_drawing(_two_parallel_lobes())
+
+    callouts = sorted(n for n in dwg.annotations() if n.startswith("m_flat_"))
+    dropped = [i for i in dwg.lint() if i.code == "flat_dropped"]
+
+    assert len(callouts) + len(dropped) == 2, (
+        f"two lobes are two A/F definitions; the drawing accounts for "
+        f"{len(callouts)} placed + {len(dropped)} reported. Before #1013 this was one "
+        "callout and no report — the second lobe simply vanished."
+    )
+    assert dropped, (
+        "the unplaced definition must be reported. Silently drawing one callout for two "
+        "lobes is the exact defect: a sheet that looks complete and is not"
+    )
+
+
+def test_a_declared_flat_defaults_to_one_stock():
+    """`axis_line` cannot be derived from `at`: a double-D's two faces have different face
+    centres but one axis line, so deriving it would split every declared double-D in two.
+
+    The default is the origin line — all declared flats on an axis group together, which is
+    the pre-#1013 behaviour, so a single-stock declaration is unaffected. A declarer with
+    parallel lobes states them, because nothing in a flat's own geometry says it.
+    """
+    a = declare_flat(axis="z", across=25, at=(-12.5, 0, 0))
+    b = declare_flat(axis="z", across=25, at=(12.5, 0, 0))
+    assert a.axis_line == b.axis_line, "two declared faces of one double-D must not split"
+
+    far = declare_flat(axis="z", across=25, at=(100, 0, 0), axis_line=(100.0, 0.0))
+    assert far.axis_line != a.axis_line, "an explicit axis line must separate declared lobes"

--- a/tests/test_flat_stock_identity.py
+++ b/tests/test_flat_stock_identity.py
@@ -90,6 +90,73 @@ def test_two_parallel_lobes_are_two_definitions_and_a_lost_one_is_reported():
     )
 
 
+def _coaxial_separated_stocks():
+    """TWO pieces of stock stacked on ONE axis with a gap — same axis line, different spans."""
+    lobe = Cylinder(15, 30) - Pos(12.5, 0, 0) * Box(10, 40, 50)
+    return lobe + Pos(0, 0, 80) * lobe
+
+
+def test_coaxial_separated_stock_is_two_definitions_not_one():
+    """The axis line alone is NOT stock identity, and this code already knew it.
+
+    #1015 taught the opposition test that "the same infinite axis is not the same piece of
+    stock"; grouping needed the same lesson. Two D-shafts stacked coaxially with a gap share
+    an axis line, so the first cut of #1013 merged them into one callout with no report —
+    the very defect it set out to fix, one arrangement over (Codex #1035 r1).
+
+    The axial span separates them. Neither half suffices alone: parallel lobes share a span
+    but not a line; coaxial stock shares a line but not a span.
+    """
+    flats = recognise_flats(_coaxial_separated_stocks())
+    assert len(flats) == 2, "fixture should yield one flat per stock"
+    assert len({f.axis_line for f in flats}) == 1, (
+        "fixture no longer exercises the case — these must SHARE an axis line, or the "
+        "parallel-lobe fix would separate them and this proves nothing"
+    )
+    assert len({f.stock_span for f in flats}) == 2, (
+        "coaxial stock must be told apart by its axial span"
+    )
+
+    dwg = build_drawing(_coaxial_separated_stocks())
+    callouts = [n for n in dwg.annotations() if n.startswith("m_flat_")]
+    dropped = [i for i in dwg.lint() if i.code == "flat_dropped"]
+    assert len(callouts) + len(dropped) == 2, (
+        f"two coaxial stocks are two A/F definitions; got {len(callouts)} placed + "
+        f"{len(dropped)} reported. One callout and no report is the silent defect."
+    )
+
+
+def test_the_emitted_script_carries_the_stock_identity(tmp_path):
+    """A detected two-lobe part must not round-trip into a collapsed one-lobe declaration.
+
+    `sheet.flat(...)` omitted the identity, and the declared defaults reproduce pre-#1013
+    grouping — so an emitted script regenerated exactly the drawing the detection had just
+    fixed. Silence is not neutral here; it is the old bug (Codex #1035 r1).
+
+    CLAUDE.md requires a feature to round-trip recognise + emit + declare, and this is the
+    emit leg.
+    """
+    from build123d import export_step
+
+    from draftwright.sheet_emit import generate_sheet_script
+
+    step = str(tmp_path / "lobes.step")
+    export_step(_two_parallel_lobes(), step)
+    generate_sheet_script(step, out=str(tmp_path / "lobes"))
+    script = (tmp_path / "lobes.py").read_text()
+
+    flat_lines = [ln for ln in script.splitlines() if "sheet.flat(" in ln]
+    assert len(flat_lines) == 2, f"expected one declaration per lobe, got {flat_lines}"
+    for ln in flat_lines:
+        assert "axis_line=" in ln and "stock_span=" in ln, (
+            f"emitted flat drops its stock identity, so the script regenerates the collapse: {ln}"
+        )
+    # And the two lobes are declared as DIFFERENT stock, not merely annotated.
+    assert "axis_line=(0, 0)" in script and "axis_line=(100, 0)" in script, (
+        "both lobes emitted the same axis line — the script would collapse them again"
+    )
+
+
 def test_a_declared_flat_defaults_to_one_stock():
     """`axis_line` cannot be derived from `at`: a double-D's two faces have different face
     centres but one axis line, so deriving it would split every declared double-D in two.


### PR DESCRIPTION
Closes #1013. First slice of epic #1018 phase 2 — geometry-derived stock identity.

## The defect

`Flat` recorded `axis` (the letter), `across` and `at`, and nothing that said **which piece of round stock** a flat belonged to. From that record these are indistinguishable:

- two faces at `(-12.5, 0, 0)` and `(12.5, 0, 0)` — one double-D, **one** A/F definition;
- two faces at `(0, 0, 0)` and `(100, 0, 0)` — two parallel lobes, **two** definitions.

`render_flats` grouped by `(axis, across)`, so a part with two same-sized lobes got **one** callout and the second lobe went undefined on the sheet — with nothing reporting it.

## The fix is the record

ADR 0013 is explicit about this case, and `FaceLevel` and `TurnedStep` have had the same treatment. `Flat` and `FlatFeature` now carry `axis_line` — the two coordinates perpendicular to the axis — and the renderer groups by it. The recogniser already had the owning cylinder in hand at the match point, so it costs nothing to carry.

## A bug the compiled-plan boundary caught, and my first fix hid

Worth surfacing, because it is exactly the failure mode ADR 0016 Amendment 1's fact allowlist exists to prevent.

My first cut read the fact as `getattr(g.facts, "axis_line", (0.0, 0.0))`. The compiled plan **refuses** facts renderers are not allowed to read — but the `getattr` default swallowed that refusal, both groups fell back to the same value, and the behaviour did not change at all. A defensive default defeated a deliberate guard.

`axis_line` is now declared as **structure** in `_FACTS["flat"]` (it says which stock a flat belongs to; the drawing never prints it), and the access is direct so an unlisted fact fails loudly.

## Behaviour

| case | before | after |
|---|---|---|
| single D-flat | 1 callout | unchanged, lint clean |
| double-D | 1 callout | unchanged, lint clean |
| two parallel lobes | **1 callout, silently incomplete** | 1 placed + 1 **reported** (`flat_dropped`) |

The last row is the improvement. Finding a second anchor is a corridor-capacity question — filed as **#1034**, deliberately not done here, because changing placement alongside recognition makes any regression ambiguous between the two. A completeness failure that is *visible* beats a clean-looking drawing that is wrong.

The guard asserts `placed + reported == 2`, so tightening #1034 to two placed callouts sharpens an assertion rather than rewriting the test.

## The declared path

`declare.flat` takes an optional `axis_line=`, defaulting to the origin line. It **cannot** be derived from `at`: a double-D's two faces have different face centres but one axis line, so deriving it would split every declared double-D in two. The default reproduces pre-#1013 grouping, so single-stock declarations are unaffected; a declarer with parallel lobes states them, because nothing in a flat's own geometry says it.

## Scope note

The coverage half of #1013 is **not** here. `lint_flat_coverage` lives on #1011, which is still an open PR, so it does not exist on `main`. It should group by `axis_line` when that lands.

## Verification

- 1357 passed across ten suites; four gates clean.
- **Mutations, each red**: reverting the renderer grouping to `(axis, across)`; dropping `axis_line` from the compiled-plan fact allowlist.
- Full tier not run locally by instruction; CI covers it.

Parent: #1018 (phase 2). Related: #1011, #1034.
