### PR TITLE
docs: part classification is recognition, not sizing — correct the claim

### DIFF
--- a/src/draftwright/recognition/result.py
+++ b/src/draftwright/recognition/result.py
@@ -210,11 +210,20 @@ def build_recognition_result(
 
     *rotational* is the caller's geometric classification (``analysis._classify_geometry``).
     It gates the three families that only one part class consumes, so migrating them did not
-    mean scanning every turned build for a discarded result (#1028).  It stays an argument
-    rather than something recognised here: the rotational test reads bbox proportions and OD
-    offset, which is sizing's question about the part, not recognition's inventory of it —
-    deriving it below the IR would move drafting classification into ``recognition/``, an
-    explicit ADR 0017 non-goal.
+    mean scanning every turned build for a discarded result (#1028).
+
+    It is an argument for a SCOPING reason, not an architectural one, and #1037 removes it.
+    An earlier version of this docstring claimed the rotational test was "sizing's question,
+    not recognition's", and that deriving it here would move drafting classification into
+    ``recognition/``.  That is wrong: ``_is_rotational`` reads bbox proportions, the largest
+    external cylinder diameter and its concentricity — all geometric, all facts recovered
+    from the solid, and ``recognition/`` already uses bounding boxes and the cylinder
+    substrate freely.  Drafting *consumes* the classification for view selection exactly as
+    it consumes hole diameters; that does not make it drafting policy.
+
+    The real reason is that ``_classify_geometry`` lives in the analysis stage and moving it
+    was larger than #1028 warranted.  Until it moves, the gate is a property of this
+    orchestration only because a caller supplies the classification.
 
     The default is ``False`` — prismatic, so nothing is gated away.  A caller who has no
     classification (the lazy critique aggregate on a declared build) gets the COMPLETE


### PR DESCRIPTION
Docstring only, no behaviour change. Splitting it from #1037's actual work because the wrong claim is actively misleading and should not wait.

## What was wrong

`build_recognition_result` justified taking `rotational` as an argument like this:

> the rotational test reads bbox proportions and OD offset, which is sizing's question about the part, not recognition's inventory of it — deriving it below the IR would move drafting classification into `recognition/`, an explicit ADR 0017 non-goal.

I wrote that in #1028. It does not survive contact with the code:

```python
def _is_rotational(x_size, y_size, od_diam, od_axis_offset):
    envelope = max(x_size, y_size)
    return (abs(x_size - y_size) <= _SQUARENESS_TOL * envelope
            and od_diam >= _OD_FILL_MIN * envelope
            and od_axis_offset <= _OD_AXIS_TOL * envelope)
```

Bbox proportions, largest external cylinder diameter, concentricity. All geometric; all facts recovered from the solid. `recognition/` already uses `part.bounding_box()` freely (`recognise_risers`, `step_level_zs`, the flats chord tests), and `od_diam` comes from `analyse_cylinders`/`full_cylinders` — recognition substrate. So the stated obstacle does not exist.

Drafting *consumes* the classification for view selection and centrelines, exactly as it consumes hole diameters. That does not make it drafting policy.

## The real reason

Scoping. `_classify_geometry` lives in the analysis stage and moving it was larger than #1028 warranted. A fine decision with a bad justification written beside it — and the bad justification is what the next reader would have found.

The docstring now says that, names what the earlier claim got wrong so nobody re-derives it, and points at **#1037**, which does the move and drops the argument.

Raised in review discussion on #1035. Behaviour unchanged; 20 tests pass across the recognition suites, four gates clean.
