### PR TITLE
Prove flat completeness correspondence

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1117,10 +1117,19 @@ class PlacementContext:
             self._hole_feature_index = idx
         return self._hole_feature_index.get(tuple(round(c, 3) for c in location))
 
-    def record_issue(self, severity, code, message) -> None:
+    def record_issue(self, severity, code, message, *, measurement=None) -> None:
         """Record a build-time lint issue on the run's registry (#639). Replaces the passes'
         old `dwg._record_build_issue`."""
-        self.registry.record_issue(LintIssue(severity=severity, code=code, message=message))
+        ids: tuple
+        if measurement is None:
+            ids = ()
+        elif isinstance(measurement, (list, tuple)):
+            ids = tuple(item for item in measurement if item is not None)
+        else:
+            ids = (measurement,)
+        self.registry.record_issue(
+            LintIssue(severity=severity, code=code, message=message, measurement_ids=ids)
+        )
 
     def reset_issues(self) -> None:
         self.registry.reset_issues()

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1529,7 +1529,10 @@ def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False
                 break
         else:
             ctx.record_issue(
-                "warning", drop_code, f"{noun} callout {label} not placed (no clear room)"
+                "warning",
+                drop_code,
+                f"{noun} callout {label} not placed (no clear room)",
+                measurement=measurement,
             )
             if ev is not None:
                 ev["items"].append(

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -76,6 +76,7 @@ from draftwright.linting import (
     lint_declaration_reconciliation,
     lint_drawing,
     lint_feature_coverage,
+    lint_flat_coverage,
     lint_location_coverage,
     lint_prismatic_coverage,
 )
@@ -99,6 +100,10 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "pocket_not_located",
         "unrecognised_defining_geometry",
         "axial_length_missing",
+        "flat_requirement_suppressed",
+        "flat_requirement_dropped",
+        "flat_requirement_missing",
+        "flat_requirement_unverifiable",
         "missing_principal_dimension",
         "label_vs_measured",
         "dim_inside_part",
@@ -2714,7 +2719,7 @@ class Drawing:
             bosses: list | None
             pads: list | None
             pockets: list | None
-            recognition: object | None
+            recognition: RecognitionResult | None
             prof_kw: dict
             if a is not None and a.recognition is not None:
                 cyls = a.cyls
@@ -2796,6 +2801,14 @@ class Drawing:
                 bbox=a.bb if a is not None else None,
                 features=getattr(model, "features", ()) if model is not None else (),
                 recognition=recognition,
+            )
+            issues += lint_flat_coverage(
+                self.part,
+                recognition=recognition,
+                features=getattr(model, "features", ()) if model is not None else (),
+                registry=self._registry,
+                omissions=self._build.omissions,
+                assembly=self.assembly,
             )
             # Reverse direction (#487): a DECLARED feature with no matching geometry (a stale
             # phantom callout). Only for a caller-supplied model — detection can't over-declare.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -101,7 +101,6 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "unrecognised_defining_geometry",
         "axial_length_missing",
         "flat_requirement_suppressed",
-        "flat_requirement_dropped",
         "flat_requirement_missing",
         "flat_requirement_unverifiable",
         "missing_principal_dimension",
@@ -113,6 +112,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "plate_thickness_dropped",
         "step_position_dropped",
         "chamfer_dropped",
+        "flat_dropped",
         "placement_unsatisfiable",
         "pmi_dropped",
     }

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -25,12 +25,18 @@ from draftwright.linting.coverage import (
     lint_location_coverage,
     lint_prismatic_coverage,
 )
+from draftwright.linting.flat_coverage import (
+    FlatRequirementOutcome,
+    flat_requirement_outcomes,
+    lint_flat_coverage,
+)
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import lint_drawing
 from draftwright.linting.suggest import _suggest_fix
 
 __all__ = [
     "CoverageState",
+    "FlatRequirementOutcome",
     "LintIssue",
     "_suggest_fix",
     "lint_axial_coverage",
@@ -38,6 +44,8 @@ __all__ = [
     "lint_declaration_reconciliation",
     "lint_drawing",
     "lint_feature_coverage",
+    "flat_requirement_outcomes",
+    "lint_flat_coverage",
     "lint_location_coverage",
     "lint_prismatic_coverage",
 ]

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -25,18 +25,13 @@ from draftwright.linting.coverage import (
     lint_location_coverage,
     lint_prismatic_coverage,
 )
-from draftwright.linting.flat_coverage import (
-    FlatRequirementOutcome,
-    flat_requirement_outcomes,
-    lint_flat_coverage,
-)
+from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import lint_drawing
 from draftwright.linting.suggest import _suggest_fix
 
 __all__ = [
     "CoverageState",
-    "FlatRequirementOutcome",
     "LintIssue",
     "_suggest_fix",
     "lint_axial_coverage",
@@ -44,7 +39,6 @@ __all__ = [
     "lint_declaration_reconciliation",
     "lint_drawing",
     "lint_feature_coverage",
-    "flat_requirement_outcomes",
     "lint_flat_coverage",
     "lint_location_coverage",
     "lint_prismatic_coverage",

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -1,0 +1,185 @@
+"""Semantic completeness for machined-flat A/F requirements (#1018 Gate 1).
+
+Physical ground truth comes from the shared recognition result. Engine outcomes are joined
+through the existing IR ``FlatFeature`` and compiler ``DimensionId``; labels, leader tips,
+projected geometry, annotation names, and page coordinates are never evidence.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Literal
+
+from draftwright.linting.issues import LintIssue
+from draftwright.recognition import RecognitionResult
+
+FlatRequirementState = Literal["placed", "suppressed", "dropped", "missing", "unverifiable"]
+
+
+@dataclass(frozen=True, order=True)
+class _FlatRequirementKey:
+    axis: str
+    axis_line: tuple[float, float]
+    stock_span: tuple[float, float]
+    across: float
+
+
+@dataclass(frozen=True)
+class FlatRequirementOutcome:
+    """The observable engine outcome of one physical A/F requirement."""
+
+    axis: str
+    axis_line: tuple[float, float]
+    stock_span: tuple[float, float]
+    across: float
+    state: FlatRequirementState
+
+
+def _rounded_pair(values) -> tuple[float, float]:
+    first, second = values
+    return (round(float(first), 3), round(float(second), 3))
+
+
+def _key(flat) -> _FlatRequirementKey:
+    return _FlatRequirementKey(
+        axis=flat.axis,
+        axis_line=_rounded_pair(flat.axis_line),
+        stock_span=_rounded_pair(flat.stock_span),
+        across=round(float(flat.across), 3),
+    )
+
+
+def _matches(measurement, feature, parameter: str) -> bool:
+    """Match a compiler identity without coupling linting to the model package."""
+    return (
+        getattr(measurement, "feature", None) == feature
+        and getattr(measurement, "parameter", None) == parameter
+    )
+
+
+def flat_requirement_outcomes(
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+) -> list[FlatRequirementOutcome]:
+    """Follow each recognised flat requirement to an explicit engine outcome.
+
+    Two faces of one double-D/hex share a requirement; parallel or disjoint coaxial stock
+    does not. The grouping key is exactly the stock identity carried by recognition and the
+    IR, plus the measured A/F value. If that exact recognition-to-IR correspondence is absent,
+    the result is ``unverifiable`` rather than a fuzzy match.
+    """
+    if recognition is None:
+        return []
+    if not isinstance(recognition, RecognitionResult):
+        raise TypeError(
+            "flat_requirement_outcomes() requires the run's RecognitionResult; "
+            f"got {type(recognition).__name__}"
+        )
+
+    physical: set[_FlatRequirementKey] = {_key(flat) for flat in recognition.flats}
+    if not physical:
+        return []
+
+    # Linting's ADR 0015 carve-out forbids importing the model package. The model remains
+    # downstream evidence, not the physical inventory, and is read through the same duck-typed
+    # boundary as the other coverage checks.
+    ir_by_requirement: dict[_FlatRequirementKey, list] = defaultdict(list)
+    for feature in features:
+        if getattr(feature, "kind", None) == "flat":
+            ir_by_requirement[_key(feature)].append(feature)
+
+    placed = {
+        measurement for name in registry.names() for measurement in registry.measurement_of(name)
+    }
+    authored_suppressions = {
+        (omission.feature, omission.parameter_id)
+        for omission in omissions
+        if omission.feature is not None and omission.authored
+    }
+    dropped = {
+        measurement
+        for issue in registry.issues
+        if issue.code == "flat_dropped"
+        for measurement in getattr(issue, "measurement_ids", ())
+    }
+
+    outcomes: list[FlatRequirementOutcome] = []
+    for requirement in sorted(physical):
+        matched = ir_by_requirement.get(requirement, [])
+        if not matched:
+            state: FlatRequirementState = "unverifiable"
+        else:
+            expected = [(feature, "flat.length") for feature in matched]
+            if any(
+                _matches(measurement, *requirement_id)
+                for requirement_id in expected
+                for measurement in placed
+            ):
+                state = "placed"
+            elif all(requirement_id in authored_suppressions for requirement_id in expected):
+                state = "suppressed"
+            elif any(
+                _matches(measurement, *requirement_id)
+                for requirement_id in expected
+                for measurement in dropped
+            ):
+                state = "dropped"
+            else:
+                associated_names = {
+                    name for feature in matched for name in registry.names_for_feature(feature)
+                }
+                state = (
+                    "unverifiable"
+                    if any(not registry.measurement_of(name) for name in associated_names)
+                    else "missing"
+                )
+        outcomes.append(
+            FlatRequirementOutcome(
+                axis=requirement.axis,
+                axis_line=requirement.axis_line,
+                stock_span=requirement.stock_span,
+                across=requirement.across,
+                state=state,
+            )
+        )
+    return outcomes
+
+
+def lint_flat_coverage(
+    part,
+    *,
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+    assembly=None,
+) -> list[LintIssue]:
+    """Report every recognised A/F requirement that is not semantically placed."""
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    severity: Literal["info", "warning"] = "info" if assembly else "warning"
+    issues: list[LintIssue] = []
+    for outcome in flat_requirement_outcomes(recognition, features, registry, omissions):
+        if outcome.state == "placed":
+            continue
+        stock = (
+            f"{outcome.axis.upper()} stock at axis line {outcome.axis_line}, "
+            f"span {outcome.stock_span}"
+        )
+        messages = {
+            "suppressed": "was deliberately omitted by the authored dimension set",
+            "dropped": "was approved but its callout was dropped during placement",
+            "missing": "has no placed, suppressed, or dropped A/F measurement outcome",
+            "unverifiable": "cannot be joined to measurement provenance without guessing",
+        }
+        issues.append(
+            LintIssue(
+                severity=severity,
+                code=f"flat_requirement_{outcome.state}",
+                message=f"machined flat {outcome.across:g} A/F on {stock} {messages[outcome.state]}",
+            )
+        )
+    return issues

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -50,6 +50,14 @@ def _key(flat) -> _FlatRequirementKey:
     )
 
 
+def _source_point(flat) -> tuple[float, float, float]:
+    point = getattr(flat, "at", None)
+    if point is None:
+        point = flat.frame.origin
+    x, y, z = point
+    return (round(float(x), 3), round(float(y), 3), round(float(z), 3))
+
+
 def _matches(measurement, feature, parameter: str) -> bool:
     """Match a compiler identity without coupling linting to the model package."""
     return (
@@ -67,8 +75,8 @@ def flat_requirement_outcomes(
     """Follow each recognised flat requirement to an explicit engine outcome.
 
     Two faces of one double-D/hex share a requirement; parallel or disjoint coaxial stock
-    does not. The grouping key is exactly the stock identity carried by recognition and the
-    IR, plus the measured A/F value. If that exact recognition-to-IR correspondence is absent,
+    does not. Stock identity plus A/F defines that physical grouping; each group's recognised
+    3-D face anchors then join to IR exactly. If that record-to-IR correspondence is absent,
     the result is ``unverifiable`` rather than a fuzzy match.
     """
     if recognition is None:
@@ -79,7 +87,9 @@ def flat_requirement_outcomes(
             f"got {type(recognition).__name__}"
         )
 
-    physical: set[_FlatRequirementKey] = {_key(flat) for flat in recognition.flats}
+    physical: dict[_FlatRequirementKey, set[tuple[float, float, float]]] = defaultdict(set)
+    for flat in recognition.flats:
+        physical[_key(flat)].add(_source_point(flat))
     if not physical:
         return []
 
@@ -88,8 +98,11 @@ def flat_requirement_outcomes(
     # boundary as the other coverage checks.
     ir_by_requirement: dict[_FlatRequirementKey, list] = defaultdict(list)
     for feature in features:
-        if getattr(feature, "kind", None) == "flat":
-            ir_by_requirement[_key(feature)].append(feature)
+        if getattr(feature, "kind", None) != "flat":
+            continue
+        requirement = _key(feature)
+        if _source_point(feature) in physical.get(requirement, ()):
+            ir_by_requirement[requirement].append(feature)
 
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -170,13 +170,16 @@ def lint_flat_coverage(
     omissions=(),
     assembly=None,
 ) -> list[LintIssue]:
-    """Report every recognised A/F requirement that is not semantically placed."""
+    """Report uncovered A/F requirements without duplicating placement-drop issues."""
     if assembly is None:
         assembly = len(part.solids()) > 1
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     issues: list[LintIssue] = []
     for outcome in flat_requirement_outcomes(recognition, features, registry, omissions):
-        if outcome.state == "placed":
+        # `flat_dropped` is already a user-facing build issue. Its measurement identity is
+        # what proves this outcome; emitting a second warning here would score one defect
+        # twice, contrary to the existing coverage/drop de-duplication contract.
+        if outcome.state in {"placed", "dropped"}:
             continue
         stock = (
             f"{outcome.axis.upper()} stock at axis line {outcome.axis_line}, "
@@ -184,7 +187,6 @@ def lint_flat_coverage(
         )
         messages = {
             "suppressed": "was deliberately omitted by the authored dimension set",
-            "dropped": "was approved but its callout was dropped during placement",
             "missing": "has no placed, suppressed, or dropped A/F measurement outcome",
             "unverifiable": "cannot be joined to measurement provenance without guessing",
         }

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -19,3 +19,7 @@ class LintIssue:
     # A ready-to-paste fix snippet, attached by Drawing.lint() via _suggest_fix
     # (#29); None when no concrete repair can be inferred.
     suggestion: str | None = None
+    # Compiler measurement identities implicated in a build-time outcome. Empty for checks
+    # that do not hold semantic provenance. Kept internal/plain-tuple so adding it does not
+    # turn LintIssue into a general requirement ledger (#1018 Gate 1).
+    measurement_ids: tuple = ()

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -14,7 +14,8 @@ import pytest
 from build123d import Align, Box, Cylinder, Pos
 
 from draftwright import Sheet, build_drawing
-from draftwright.linting import LintIssue, flat_requirement_outcomes
+from draftwright.linting import LintIssue
+from draftwright.linting.flat_coverage import flat_requirement_outcomes
 from draftwright.recognition import recognise_flats
 from draftwright.registry import AnnotationRegistry
 

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -151,6 +151,26 @@ def test_authored_omission_is_suppressed_not_missing():
     assert _flat_codes(dwg) == ["flat_requirement_suppressed"]
 
 
+def test_a_planner_omission_is_not_authored_suppression():
+    dwg = build_drawing(_double_d())
+    recognition = dwg.recognition()
+    assert recognition is not None
+    features = dwg.model().features
+    omissions = tuple(
+        SimpleNamespace(feature=feature, parameter_id="flat.length", authored=False)
+        for feature in features
+        if feature.kind == "flat"
+    )
+
+    outcomes = flat_requirement_outcomes(
+        recognition,
+        features,
+        AnnotationRegistry(),
+        omissions,
+    )
+    assert [outcome.state for outcome in outcomes] == ["missing"]
+
+
 def test_forced_placement_failure_is_dropped_not_missing():
     dwg = build_drawing(_flatted_shaft(), page="A4", scale=2.0)
     issues = dwg.lint()

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -153,11 +153,20 @@ def test_authored_omission_is_suppressed_not_missing():
 
 def test_forced_placement_failure_is_dropped_not_missing():
     dwg = build_drawing(_flatted_shaft(), page="A4", scale=2.0)
-    drop = next(issue for issue in dwg.lint() if issue.code == "flat_dropped")
+    issues = dwg.lint()
+    drop = next(issue for issue in issues if issue.code == "flat_dropped")
     assert len(drop.measurement_ids) == 2, (
         "the placement outcome must retain the grouped compiler identities"
     )
-    assert _flat_codes(dwg) == ["flat_requirement_dropped"]
+    recognition = dwg.recognition()
+    assert recognition is not None
+    outcomes = flat_requirement_outcomes(recognition, dwg.model().features, dwg.registry)
+    assert [outcome.state for outcome in outcomes] == ["dropped"]
+    assert [
+        issue.code
+        for issue in issues
+        if issue.code in {"flat_dropped", "flat_requirement_dropped"}
+    ] == ["flat_dropped"], "one placement failure must not be reported and scored twice"
 
     # Mutation: a generic `flat_dropped` code is not semantic evidence by itself.
     dwg.registry.reset_issues()

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -1,0 +1,194 @@
+"""Flat completeness follows semantic provenance, never presentation (#1018 Gate 1).
+
+The discovery branch #1011 tried to recover "does this annotation define this flat?" from
+labels, leader tips, projected chords, and stock radii. These tests start at the opposite end:
+physical requirements come from the shared recognition result, and engine outcomes are joined
+through the IR feature and compiler-owned ``DimensionId`` already stored in the annotation
+registry.
+"""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting import LintIssue, flat_requirement_outcomes
+from draftwright.recognition import recognise_flats
+from draftwright.registry import AnnotationRegistry
+
+
+def _double_d():
+    """One Z-axis stock region with two opposed faces: one physical A/F requirement."""
+    return (
+        Cylinder(15, 40) - Pos(12.5, 0, 0) * Box(10, 40, 50) - Pos(-12.5, 0, 0) * Box(10, 40, 50)
+    )
+
+
+def _lone_d():
+    return Cylinder(15, 40) - Pos(12.5, 0, 0) * Box(10, 40, 50)
+
+
+def _two_parallel_lobes():
+    return _lone_d() + Pos(100, 0, 0) * _lone_d()
+
+
+def _two_coaxial_regions():
+    return _lone_d() + Pos(0, 0, 80) * _lone_d()
+
+
+def _flatted_shaft():
+    """The #1011 drop fixture: a stepped shaft truncated to one 25 mm double-D."""
+    part = Cylinder(20, 40) + Pos(0, 0, 30) * Cylinder(12, 20)
+    return part & Box(
+        25,
+        60,
+        100,
+        align=(Align.CENTER, Align.CENTER, Align.CENTER),
+    )
+
+
+def _flat_callout(dwg) -> str:
+    names = [name for name in dwg.annotations() if name.startswith("m_flat_")]
+    assert len(names) == 1, f"fixture needs one placed flat callout, got {names}"
+    return names[0]
+
+
+def _flat_codes(dwg) -> list[str]:
+    return [issue.code for issue in dwg.lint() if issue.code.startswith("flat_requirement_")]
+
+
+def _outcomes_without_annotations(part):
+    dwg = build_drawing(part)
+    recognition = dwg.recognition()
+    assert recognition is not None
+    return flat_requirement_outcomes(
+        recognition,
+        dwg.model().features,
+        AnnotationRegistry(),
+    )
+
+
+def _declared_flat_drawing(*, suppress: bool = False):
+    part = _double_d()
+    recognised = recognise_flats(part)
+    sheet = Sheet(part)
+    for flat in recognised:
+        sheet.flat(
+            axis=flat.axis,
+            across=flat.across,
+            at=flat.at,
+            axis_line=flat.axis_line,
+            stock_span=flat.stock_span,
+        )
+    if suppress:
+        envelope = sheet.envelope()
+        sheet.dimension(envelope, "width.length")
+    else:
+        sheet.auto_dimensions()
+    return sheet.build()
+
+
+def test_a_placed_engine_callout_satisfies_the_recognised_requirement():
+    dwg = build_drawing(_double_d())
+    name = _flat_callout(dwg)
+    assert len(dwg.measurement_keys(name)) == 2, (
+        "a double-D callout must retain both compiler measurement ids; otherwise a clean "
+        "coverage result would have no semantic evidence"
+    )
+    assert _flat_codes(dwg) == []
+
+
+def test_removing_the_callout_produces_missing():
+    dwg = build_drawing(_double_d())
+    dwg.remove(_flat_callout(dwg))
+    assert _flat_codes(dwg) == ["flat_requirement_missing"]
+
+
+def test_free_text_quoting_the_size_does_not_certify_the_requirement():
+    dwg = build_drawing(_double_d())
+    dwg.remove(_flat_callout(dwg))
+    dwg.note("25 A/F", (20, 20), view="plan")
+    assert _flat_codes(dwg) == ["flat_requirement_missing"]
+
+
+def test_severing_measurement_provenance_is_unverifiable_not_placed():
+    """The targeted mutation: keep the real callout and its feature ownership, but remove
+    only its compiler measurement identity. A guard that inspects label/type/tip stays green;
+    a semantic guard must change from placed to unverifiable."""
+    dwg = build_drawing(_double_d())
+    name = _flat_callout(dwg)
+    identity = dwg.registry.identity_of(name)
+    identity["measurement"] = ()
+    dwg.registry.reapply(name, identity)
+
+    assert _flat_codes(dwg) == ["flat_requirement_unverifiable"]
+
+
+def test_stock_identity_defines_requirement_cardinality_without_page_matching():
+    double_d = _outcomes_without_annotations(_double_d())
+    parallel = _outcomes_without_annotations(_two_parallel_lobes())
+    coaxial = _outcomes_without_annotations(_two_coaxial_regions())
+
+    assert [outcome.state for outcome in double_d] == ["missing"], (
+        "two faces on one stock region are one physical A/F requirement"
+    )
+    assert [outcome.state for outcome in parallel] == ["missing", "missing"], (
+        "equal flats on distinct parallel axis lines are two requirements"
+    )
+    assert [outcome.state for outcome in coaxial] == ["missing", "missing"], (
+        "equal flats on disjoint spans of one axis line are two requirements"
+    )
+
+
+def test_authored_omission_is_suppressed_not_missing():
+    dwg = _declared_flat_drawing(suppress=True)
+    assert not [name for name in dwg.annotations() if name.startswith("m_flat_")], (
+        "precondition: the authored set omitted the A/F measurement"
+    )
+    assert _flat_codes(dwg) == ["flat_requirement_suppressed"]
+
+
+def test_forced_placement_failure_is_dropped_not_missing():
+    dwg = build_drawing(_flatted_shaft(), page="A4", scale=2.0)
+    drop = next(issue for issue in dwg.lint() if issue.code == "flat_dropped")
+    assert len(drop.measurement_ids) == 2, (
+        "the placement outcome must retain the grouped compiler identities"
+    )
+    assert _flat_codes(dwg) == ["flat_requirement_dropped"]
+
+    # Mutation: a generic `flat_dropped` code is not semantic evidence by itself.
+    dwg.registry.reset_issues()
+    dwg.registry.record_issue(replace(drop, measurement_ids=()))
+    assert _flat_codes(dwg) == ["flat_requirement_missing"]
+
+
+def test_a_recognised_requirement_missing_from_the_declared_ir_is_unverifiable():
+    sheet = Sheet(_double_d())
+    envelope = sheet.envelope()
+    sheet.dimension(envelope, "width.length")
+    dwg = sheet.build()
+
+    assert _flat_codes(dwg) == ["flat_requirement_unverifiable"]
+
+
+def test_automatic_and_declared_paths_agree_when_provenance_is_complete():
+    automatic = build_drawing(_double_d())
+    declared = _declared_flat_drawing()
+
+    assert _flat_callout(automatic)
+    assert _flat_callout(declared)
+    assert _flat_codes(automatic) == _flat_codes(declared) == []
+    assert declared.recognition() is not None, "declared critique must cache its one aggregate"
+
+
+def test_a_caller_assembled_empty_inventory_cannot_silence_coverage():
+    with pytest.raises(TypeError, match="RecognitionResult"):
+        flat_requirement_outcomes(SimpleNamespace(flats=()), (), AnnotationRegistry())
+
+
+def test_measurement_provenance_keeps_lint_issue_positional_compatibility():
+    issue = LintIssue("warning", "message", None, "code", "suggestion")
+    assert issue.suggestion == "suggestion"
+    assert issue.measurement_ids == ()

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -174,6 +174,25 @@ def test_a_recognised_requirement_missing_from_the_declared_ir_is_unverifiable()
     assert _flat_codes(dwg) == ["flat_requirement_unverifiable"]
 
 
+def test_requirement_identity_without_source_record_correspondence_is_unverifiable():
+    part = _double_d()
+    sheet = Sheet(part)
+    for flat in recognise_flats(part):
+        shifted_at = (flat.at[0], flat.at[1] + 1.0, flat.at[2])
+        sheet.flat(
+            axis=flat.axis,
+            across=flat.across,
+            at=shifted_at,
+            axis_line=flat.axis_line,
+            stock_span=flat.stock_span,
+        )
+    sheet.auto_dimensions()
+    dwg = sheet.build()
+
+    assert _flat_callout(dwg), "precondition: the stale declaration still rendered a callout"
+    assert _flat_codes(dwg) == ["flat_requirement_unverifiable"]
+
+
 def test_automatic_and_declared_paths_agree_when_provenance_is_complete():
     automatic = build_drawing(_double_d())
     declared = _declared_flat_drawing()


### PR DESCRIPTION
## Summary

Implements ADR 0017 / #1018 Gate 1 as one flat-specific end-to-end slice.

- builds the physical A/F requirement inventory from the run's `RecognitionResult`
- groups the two faces of one double-D/hex definition while keeping parallel axis lines and disjoint coaxial stock spans distinct
- joins each recognised face to IR by its existing exact model-space anchor, then follows existing compiler `DimensionId` provenance
- distinguishes `placed`, authored `suppressed`, placement `dropped`, `missing`, and `unverifiable` without inspecting labels, leaders, projected geometry, annotation names, or page coordinates
- carries compiler measurement identities on the existing machined-callout drop issue so a drop can be attributed semantically without emitting a duplicate warning

## What Gate 1 established

The existing flat stock identity, source anchor, `DimensionId`, compiler omission diagnostics, and ADR 0010 registry seam are sufficient for this slice. The only missing downstream fact was the measurement identity already held by the renderer when placement failed.

This PR deliberately does **not** introduce global feature/requirement/annotation identity types, a shared requirements module, a general outcome ledger, or reconciliation machinery. The flat outcome model stays internal until Gate 2 shows whether a reusable contract has earned a public abstraction.

## Adversarial coverage

The mutations prove that:

- one double-D is one requirement; equal flats on parallel or disjoint coaxial stock are independent
- removing a real callout becomes `missing`
- free text saying `25 A/F` cannot certify coverage
- severing only annotation measurement provenance becomes `unverifiable`
- the right stock identity with the wrong recognised face anchor is `unverifiable`
- an authored omission becomes `suppressed`, while a planner omission remains `missing`
- a forced placement failure becomes `dropped`; deleting its measurement provenance changes the outcome
- one placement failure remains one user-facing `flat_dropped` issue rather than being scored twice
- a caller-assembled empty recognition proxy is rejected
- automatic and declared paths agree when provenance is complete
- the existing `LintIssue` positional constructor remains compatible

## Review iterations

1. Added bare/compound measurement normalization and fixed type/format findings.
2. Removed an ADR 0015 import-boundary violation by keeping recognition as physical truth and duck-typing downstream IR evidence.
3. Rejected empty recognition proxies and made drop measurement provenance mutation-tested.
4. Preserved `LintIssue` positional compatibility and kept the flat outcome model out of package API.
5. Required exact recognition-record anchors rather than certifying on requirement identity alone.
6. De-duplicated placement-drop diagnostics and added the negative non-authored-omission mutation.

No substantive findings remain; the residual observations are refactoring/editorial nits.

## Validation

- Full local fast matrix: `2737 passed, 1 skipped, 2 xfailed` before the final two targeted mutations
- Latest focused semantic/import/recognition suites: green
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
- `uv run codespell src/ tests/ docs/`
- GitHub CI on `75a229e`: lint plus all 15 Ubuntu/macOS/Windows Python 3.10-3.14 jobs green; slow workflow skipped by policy

Part of #1018. Supersedes the presentation-matching approach from #1011.