### PR TITLE
Prove slot and pattern completeness correspondence

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -137,7 +137,7 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
     )
 
 
-def _record_slot_drop(ctx, dwg, kind, idx, view, feat):
+def _record_slot_drop(ctx, dwg, kind, idx, view, feat, measurement=None):
     """Record a slot dim the layout could not place (#135).
 
     Info severity — a dim with no clear room is dropped as "place what fits",
@@ -152,6 +152,7 @@ def _record_slot_drop(ctx, dwg, kind, idx, view, feat):
         "info",
         f"{noun}_dim_dropped",
         f"{noun}{idx} {kind} dim not placed (no room beside the {view})",
+        measurement=measurement,
     )
     ctx.escalations.append(
         Escalation(kind=noun, view=view, feature=feat, reason=f"no room beside the {view}")
@@ -379,7 +380,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                         trace_label=f"slot_{_fsd}_fallthrough",
                     ):
                         return  # placed on the opposite strip
-                    _record_slot_drop(ctx, dwg, _dw, idx, vw[0], _feat)
+                    _record_slot_drop(ctx, dwg, _dw, idx, vw[0], _feat, approved.id)
 
                 if vw[0] == "front":
                     ctx.post_drain.append(_retry)
@@ -441,7 +442,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
             ):
                 count += 1
             else:
-                _record_slot_drop(ctx, dwg, "width", i, name, s)
+                _record_slot_drop(ctx, dwg, "width", i, name, s, wpd.id)
         if lpd is not None:
             if _place(
                 s.long_axis,
@@ -455,7 +456,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
             ):
                 count += 1
             else:
-                _record_slot_drop(ctx, dwg, "length", i, name, s)
+                _record_slot_drop(ctx, dwg, "length", i, name, s, lpd.id)
         # Pads are located by the compiled location set on both axes; slots retain their
         # historical single-axis position dimension here.
         pos = slot_positions.get(g.ref)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -543,7 +543,10 @@ def _location_candidate(
     def _drop(nm):
         edge = "plan view" if view == "plan" else "side view"
         ctx.record_issue(
-            "warning", "location_ref_dropped", f"{nm} not placed (no room above the {edge})"
+            "warning",
+            "location_ref_dropped",
+            f"{nm} not placed (no room above the {edge})",
+            measurement=measurement,
         )
         ctx.escalations.append(Escalation("location", view, nm, "strip_full"))
 
@@ -618,7 +621,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         # `loc.id` rides along as the measurement identity (#1002): the compiler already
         # minted it for this very entry, so the renderer records WHICH measurement it drew
         # rather than leaving the audit to infer it from the annotation's name.
-        refs.append((rx, ry, resolve_feature(loc.ref), loc.id))
+        refs.append((rx, ry, resolve_feature(loc.ref), loc.id, loc.discriminator))
     if not refs:
         return 0
     pinned_set = set(pinned or ())
@@ -647,21 +650,29 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                 u[3] = u[3] or r[2] in pinned_set
                 # Collapsing coincident Xs into one dim must ACCUMULATE what it draws
                 # (#1002 r4): the survivor genuinely measures every collapsed feature's X.
-                if r[3] is not None and r[3] not in u[4]:
+                if r[4] in (None, "x") and r[3] is not None and r[3] not in u[4]:
                     u[4].append(r[3])
                 break
         else:
             x_refs.append(
-                [r[0], r[1], r[2], r[2] in pinned_set, [r[3]] if r[3] is not None else []]
+                [
+                    r[0],
+                    r[1],
+                    r[2],
+                    r[2] in pinned_set,
+                    [r[3]] if r[3] is not None and r[4] in (None, "x") else [],
+                ]
             )
     _x_drawable = {r[0] for r in x_refs if abs(r[0] - datum_x) * a.SCALE >= 1.0}
     _kept_x, _n_x_close = _legible_locations(_x_drawable, a.SCALE)
     if _n_x_close:
+        dropped_x = [r for r in x_refs if r[0] in _x_drawable and r[0] not in set(_kept_x)]
         ctx.record_issue(
             "warning",
             "location_ref_dropped",
             f"{_n_x_close} X location dim(s) too closely spaced to dimension legibly "
             "(use a detail view)",
+            measurement=tuple(mid for ref in dropped_x for mid in ref[4]),
         )
         ctx.escalations.append(Escalation("location", "plan", None, "illegible"))
     _kept_x_set = set(_kept_x)
@@ -736,21 +747,29 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         for u in y_refs:
             if abs(r[1] - u[1]) < 0.5:
                 u[3] = u[3] or r[2] in pinned_set
-                if r[3] is not None and r[3] not in u[4]:
+                if r[4] in (None, "y") and r[3] is not None and r[3] not in u[4]:
                     u[4].append(r[3])  # accumulate, as in the X loop (#1002 r4)
                 break
         else:
             y_refs.append(
-                [r[0], r[1], r[2], r[2] in pinned_set, [r[3]] if r[3] is not None else []]
+                [
+                    r[0],
+                    r[1],
+                    r[2],
+                    r[2] in pinned_set,
+                    [r[3]] if r[3] is not None and r[4] in (None, "y") else [],
+                ]
             )
     _y_drawable = {r[1] for r in y_refs if abs(r[1] - datum_y) * a.SCALE >= 1.0}
     _kept_y, _n_y_close = _legible_locations(_y_drawable, a.SCALE)
     if _n_y_close:
+        dropped_y = [r for r in y_refs if r[1] in _y_drawable and r[1] not in set(_kept_y)]
         ctx.record_issue(
             "warning",
             "location_ref_dropped",
             f"{_n_y_close} Y location dim(s) too closely spaced to dimension legibly "
             "(use a detail view)",
+            measurement=tuple(mid for ref in dropped_y for mid in ref[4]),
         )
         ctx.escalations.append(Escalation("location", "side", None, "illegible"))
     _kept_y_set = set(_kept_y)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1157,9 +1157,7 @@ def _add_grid_pitch_dims(
     ):
         pu, pv = plane_axes(actual_feature.frame.axis)
         angle = math.radians(actual_feature.angle or 0.0)
-        column_world = tuple(
-            math.cos(angle) * pu[k] + math.sin(angle) * pv[k] for k in range(3)
-        )
+        column_world = tuple(math.cos(angle) * pu[k] + math.sin(angle) * pv[k] for k in range(3))
         origin = actual_feature.frame.origin
         page_origin = to_page(origin)
         page_column = to_page(tuple(origin[k] + column_world[k] for k in range(3)))
@@ -1194,7 +1192,9 @@ def _add_grid_pitch_dims(
         span = along(hi) - along(lo)
         n = round(span / pitch_page) + 1
         if column_page is not None:
-            discriminator = "col" if abs(u[0] * column_page[0] + u[1] * column_page[1]) > 0.7 else "row"
+            discriminator = (
+                "col" if abs(u[0] * column_page[0] + u[1] * column_page[1]) > 0.7 else "row"
+            )
             pitch = by_discriminator[discriminator]
         else:
             # Selection fallback is numeric; the LABEL remains the compiler's own text.
@@ -1645,6 +1645,18 @@ def render_slot_patterns(dwg, plan, a, *, ctx, only=None) -> int:
         # misleading spec, Codex #848 r3). Distinct name prefix (dim_slotpat_pitch) so a plan-view
         # slot pattern and hole/pocket pattern do not collide.
         if name not in placed_names:
+            for dimension in (
+                (g.dim(role="pitch"),)
+                if g.facts.pattern == "linear"
+                else tuple(d for d in g.dims if d.role == "grid_pitch")
+            ):
+                if dimension is not None:
+                    ctx.record_issue(
+                        "warning",
+                        "slot_dim_dropped",
+                        "slot pattern pitch not placed because its grouped callout dropped",
+                        measurement=dimension.id,
+                    )
             continue
         feat = g.facts
         members = feat.members or (feat.frame.origin,)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -33,6 +33,7 @@ from draftwright._core import (
     _iso_bbox,
     _log,
 )
+from draftwright._geometry import plane_axes
 from draftwright.annotations._common import (
     CROSSABLE_TYPES,
     CorridorCandidate,
@@ -1019,6 +1020,7 @@ def _add_furniture(
             to_page,
             f"dim_pitch_{view}{j}",
             feature=feat,
+            measurement=pitch.id,
             ctx=ctx,
         )
     elif feat.pattern == "grid":
@@ -1101,6 +1103,7 @@ def _add_grid_pitch_dims(
     *,
     ctx,
     name_prefix="dim_pitch",
+    drop_code=None,
 ):
     """Both pitch dimensions of a rectangular grid — one along each lattice axis,
     each labelled ``(n-1)× pitch`` (#92).  The two axes are recovered as the two
@@ -1136,6 +1139,35 @@ def _add_grid_pitch_dims(
     l2, bx, by = basis2
     u2 = (bx / l2, by / l2)
 
+    # The two pitch values are not identities: on a square-pitch grid they are equal. Map
+    # recovered page axes to the IR's row/column lattice basis instead. `angle` names the
+    # column direction in the plane_axes frame; the perpendicular direction is the row.
+    # Keep the numeric fallback for bare helper callers with no semantic pattern feature.
+    actual_feature = resolve_feature(feature)
+    by_discriminator = {
+        entry.discriminator: entry
+        for entry in nominals
+        if getattr(entry, "discriminator", None) in {"row", "col"}
+    }
+    column_page = None
+    if (
+        actual_feature is not None
+        and getattr(actual_feature, "pattern", None) == "grid"
+        and {"row", "col"} <= set(by_discriminator)
+    ):
+        pu, pv = plane_axes(actual_feature.frame.axis)
+        angle = math.radians(actual_feature.angle or 0.0)
+        column_world = tuple(
+            math.cos(angle) * pu[k] + math.sin(angle) * pv[k] for k in range(3)
+        )
+        origin = actual_feature.frame.origin
+        page_origin = to_page(origin)
+        page_column = to_page(tuple(origin[k] + column_world[k] for k in range(3)))
+        dx, dy = page_column[0] - page_origin[0], page_column[1] - page_origin[1]
+        norm = math.hypot(dx, dy)
+        if norm > 1e-9:
+            column_page = (dx / norm, dy / norm)
+
     def _axis_dim(u, pitch_page, sub):
         perp = (-u[1], u[0])
 
@@ -1161,9 +1193,12 @@ def _add_grid_pitch_dims(
         hi = max(line, key=along)
         span = along(hi) - along(lo)
         n = round(span / pitch_page) + 1
-        # Label with the approved pitch entry nearest this axis' page step. Selection is
-        # numeric, the LABEL is the compiler's own text — the two are different jobs.
-        pitch = min(nominals, key=lambda e: abs(e.value - pitch_page / a.SCALE))
+        if column_page is not None:
+            discriminator = "col" if abs(u[0] * column_page[0] + u[1] * column_page[1]) > 0.7 else "row"
+            pitch = by_discriminator[discriminator]
+        else:
+            # Selection fallback is numeric; the LABEL remains the compiler's own text.
+            pitch = min(nominals, key=lambda e: abs(e.value - pitch_page / a.SCALE))
         _place_pitch_dim(
             dwg,
             a,
@@ -1175,6 +1210,8 @@ def _add_grid_pitch_dims(
             to_page,
             f"{name_prefix}_{view}{j}_{sub}",
             feature=feature,
+            measurement=pitch.id,
+            drop_code=drop_code,
             ctx=ctx,
         )
 
@@ -1183,7 +1220,20 @@ def _add_grid_pitch_dims(
 
 
 def _place_pitch_dim(
-    dwg, a: Analysis, view, loc1, loc2, n, pitch_text, to_page, name, feature=None, *, ctx
+    dwg,
+    a: Analysis,
+    view,
+    loc1,
+    loc2,
+    n,
+    pitch_text,
+    to_page,
+    name,
+    feature=None,
+    measurement=None,
+    drop_code=None,
+    *,
+    ctx,
 ):
     """Pitch dimension between two hole-centre *locations* ``loc1``→``loc2``, labelled
     ``(n-1)× pitch``, placed just outside the view on the side of the row's
@@ -1293,7 +1343,8 @@ def _place_pitch_dim(
             _clear_and_validate(off, side_vec, page_box, obstacles),
             name,
             view=view,
-            feature=feature,
+            feature=resolve_feature(feature),
+            measurement=measurement,
         )
 
     # Place onto the zone strip for the chosen side (#374): each side is its own strip, so the
@@ -1400,10 +1451,18 @@ def _place_pitch_dim(
                 _clear_and_validate(offset, side_vec, page_box, obstacles, probe),
                 name,
                 view=view,
-                feature=feature,
+                feature=resolve_feature(feature),
+                measurement=measurement,
             )
             return
     _log.info("Pitch dimension for the %s× %s array skipped (no room)", n, pitch_text)
+    if drop_code is not None:
+        ctx.record_issue(
+            "warning",
+            drop_code,
+            f"slot pattern pitch {pitch_text} not placed (no clear room beside the {view})",
+            measurement=measurement,
+        )
 
 
 def render_pocket_patterns(dwg, plan, a, *, ctx, only=None) -> int:
@@ -1500,6 +1559,7 @@ def render_pocket_patterns(dwg, plan, a, *, ctx, only=None) -> int:
                 to_page,
                 f"dim_pocketpat_pitch_{view}{i}",
                 feature=g.ref,
+                measurement=pitch.id,
                 ctx=ctx,
             )
         elif feat.pattern == "grid" and len(grid) == 2:
@@ -1606,6 +1666,8 @@ def render_slot_patterns(dwg, plan, a, *, ctx, only=None) -> int:
                 to_page,
                 f"dim_slotpat_pitch_{view}{i}",
                 feature=g.ref,
+                measurement=pitch.id,
+                drop_code="slot_dim_dropped",
                 ctx=ctx,
             )
         elif feat.pattern == "grid" and len(grid) == 2:
@@ -1620,6 +1682,7 @@ def render_slot_patterns(dwg, plan, a, *, ctx, only=None) -> int:
                 feature=g.ref,
                 ctx=ctx,
                 name_prefix="dim_slotpat_pitch",
+                drop_code="slot_dim_dropped",
             )
     return placed
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1099,8 +1099,8 @@ def _add_grid_pitch_dims(
     members,
     nominals,  # the approved grid_pitch entries, one per lattice axis
     to_page,
-    feature=None,
     *,
+    feature,
     ctx,
     name_prefix="dim_pitch",
     drop_code=None,
@@ -1142,29 +1142,21 @@ def _add_grid_pitch_dims(
     # The two pitch values are not identities: on a square-pitch grid they are equal. Map
     # recovered page axes to the IR's row/column lattice basis instead. `angle` names the
     # column direction in the plane_axes frame; the perpendicular direction is the row.
-    # Keep the numeric fallback for bare helper callers with no semantic pattern feature.
     actual_feature = resolve_feature(feature)
     by_discriminator = {
         entry.discriminator: entry
         for entry in nominals
         if getattr(entry, "discriminator", None) in {"row", "col"}
     }
-    column_page = None
-    if (
-        actual_feature is not None
-        and getattr(actual_feature, "pattern", None) == "grid"
-        and {"row", "col"} <= set(by_discriminator)
-    ):
-        pu, pv = plane_axes(actual_feature.frame.axis)
-        angle = math.radians(actual_feature.angle or 0.0)
-        column_world = tuple(math.cos(angle) * pu[k] + math.sin(angle) * pv[k] for k in range(3))
-        origin = actual_feature.frame.origin
-        page_origin = to_page(origin)
-        page_column = to_page(tuple(origin[k] + column_world[k] for k in range(3)))
-        dx, dy = page_column[0] - page_origin[0], page_column[1] - page_origin[1]
-        norm = math.hypot(dx, dy)
-        if norm > 1e-9:
-            column_page = (dx / norm, dy / norm)
+    pu, pv = plane_axes(actual_feature.frame.axis)
+    angle = math.radians(actual_feature.angle or 0.0)
+    column_world = tuple(math.cos(angle) * pu[k] + math.sin(angle) * pv[k] for k in range(3))
+    origin = actual_feature.frame.origin
+    page_origin = to_page(origin)
+    page_column = to_page(tuple(origin[k] + column_world[k] for k in range(3)))
+    dx, dy = page_column[0] - page_origin[0], page_column[1] - page_origin[1]
+    norm = math.hypot(dx, dy)
+    column_page = (dx / norm, dy / norm)
 
     def _axis_dim(u, pitch_page, sub):
         perp = (-u[1], u[0])
@@ -1191,14 +1183,10 @@ def _add_grid_pitch_dims(
         hi = max(line, key=along)
         span = along(hi) - along(lo)
         n = round(span / pitch_page) + 1
-        if column_page is not None:
-            discriminator = (
-                "col" if abs(u[0] * column_page[0] + u[1] * column_page[1]) > 0.7 else "row"
-            )
-            pitch = by_discriminator[discriminator]
-        else:
-            # Selection fallback is numeric; the LABEL remains the compiler's own text.
-            pitch = min(nominals, key=lambda e: abs(e.value - pitch_page / a.SCALE))
+        discriminator = (
+            "col" if abs(u[0] * column_page[0] + u[1] * column_page[1]) > 0.7 else "row"
+        )
+        pitch = by_discriminator[discriminator]
         _place_pitch_dim(
             dwg,
             a,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -79,6 +79,7 @@ from draftwright.linting import (
     lint_flat_coverage,
     lint_location_coverage,
     lint_prismatic_coverage,
+    lint_slot_coverage,
 )
 from draftwright.projection import (
     project_view_geometry,
@@ -2803,6 +2804,14 @@ class Drawing:
                 recognition=recognition,
             )
             issues += lint_flat_coverage(
+                self.part,
+                recognition=recognition,
+                features=getattr(model, "features", ()) if model is not None else (),
+                registry=self._registry,
+                omissions=self._build.omissions,
+                assembly=self.assembly,
+            )
+            issues += lint_slot_coverage(
                 self.part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -27,6 +27,7 @@ from draftwright.linting.coverage import (
 )
 from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.issues import LintIssue
+from draftwright.linting.slot_coverage import lint_slot_coverage
 from draftwright.linting.structural import lint_drawing
 from draftwright.linting.suggest import _suggest_fix
 
@@ -40,6 +41,7 @@ __all__ = [
     "lint_drawing",
     "lint_feature_coverage",
     "lint_flat_coverage",
+    "lint_slot_coverage",
     "lint_location_coverage",
     "lint_prismatic_coverage",
 ]

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -1,0 +1,290 @@
+"""Semantic completeness for lone-slot and slot-pattern requirements (#1018 Gate 2).
+
+Recognition owns physical cardinality: pattern members are removed from the lone-slot
+inventory and represented by one pattern requirement. Engine outcomes are joined through
+exact slot geometry, IR features, compiler measurement ids, and the annotation registry.
+Presentation is never evidence.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Literal
+
+from draftwright.linting.issues import LintIssue
+from draftwright.recognition import RecognitionResult
+
+SlotRequirementState = Literal["placed", "suppressed", "dropped", "missing", "unverifiable"]
+SlotSourceKind = Literal["slot", "slot_pattern"]
+
+
+@dataclass(frozen=True)
+class SlotRequirementOutcome:
+    """The observable engine outcome of one physical slot measurement."""
+
+    source_kind: SlotSourceKind
+    source_at: tuple[float, float, float]
+    member_count: int
+    parameter_id: str
+    state: SlotRequirementState
+
+
+def _rounded(value) -> float:
+    return round(float(value), 3)
+
+
+def _point(value) -> tuple[float, float, float]:
+    x, y, z = value
+    return (_rounded(x), _rounded(y), _rounded(z))
+
+
+def _slot_key(slot) -> tuple:
+    """The slot facts both recognition and IR retain; deliberately excludes frame origin."""
+    return (
+        slot.width_axis,
+        slot.long_axis,
+        _rounded(slot.width),
+        _rounded(slot.length),
+        _rounded(slot.w_center),
+        _rounded(slot.lo),
+        _rounded(slot.hi),
+    )
+
+
+def _slot_source_at(slot) -> tuple[float, float, float]:
+    location = getattr(slot, "location", None)
+    if location is not None:
+        return _point(location)
+    coord = {
+        slot.long_axis: (slot.lo + slot.hi) / 2,
+        slot.width_axis: slot.w_center,
+    }
+    depth_axis = next(axis for axis in "xyz" if axis not in coord)
+    coord[depth_axis] = getattr(slot.frame, "origin")["xyz".index(depth_axis)]
+    return _point((coord["x"], coord["y"], coord["z"]))
+
+
+def _pattern_key(pattern) -> tuple:
+    source_members = getattr(pattern, "slots", None)
+    if source_members is not None:
+        members = tuple(sorted(_slot_source_at(slot) for slot in source_members))
+        member = source_members[0]
+        pitch = getattr(pattern, "pitch", None)
+        grid = (
+            getattr(pattern, "row_pitch", None),
+            getattr(pattern, "col_pitch", None),
+        )
+        pattern_kind = "grid" if grid[0] is not None else "linear"
+    else:
+        members = tuple(sorted(_point(point) for point in pattern.members))
+        member = pattern.member
+        pitch = getattr(pattern, "pitch", None)
+        grid = getattr(pattern, "grid", None) or (None, None)
+        pattern_kind = pattern.pattern
+    direction = getattr(pattern, "direction", None)
+    return (
+        pattern_kind,
+        len(members),
+        _slot_key(member),
+        members,
+        None if pitch is None else _rounded(pitch),
+        None if direction is None else _point(direction),
+        tuple(None if value is None else _rounded(value) for value in grid),
+        getattr(pattern, "rows", None),
+        getattr(pattern, "cols", None),
+        None if getattr(pattern, "angle", None) is None else _rounded(pattern.angle),
+    )
+
+
+def _pattern_source_at(pattern) -> tuple[float, float, float]:
+    center = getattr(pattern, "center", None)
+    if center is not None:
+        return _point(center)
+    slots = getattr(pattern, "slots", None)
+    if slots:
+        points = [_slot_source_at(slot) for slot in slots]
+        return (
+            _rounded(sum(point[0] for point in points) / len(points)),
+            _rounded(sum(point[1] for point in points) / len(points)),
+            _rounded(sum(point[2] for point in points) / len(points)),
+        )
+    return _point(pattern.frame.origin)
+
+
+def _parameter_ids(feature, *, pattern: bool) -> tuple[str, ...] | None:
+    """Derive the compiler vocabulary from the matched feature, not a parallel id table."""
+    parameters = tuple(feature.parameters())
+    by_role: dict[str, list[str]] = defaultdict(list)
+    for parameter in parameters:
+        by_role[parameter.role].append(parameter.parameter_id)
+
+    required_roles = ["slot_width", "slot_length"]
+    if pattern:
+        if feature.pattern == "linear":
+            required_roles.append("pitch")
+        elif feature.pattern == "grid":
+            required_roles.extend(("grid_pitch", "grid_pitch"))
+        else:
+            return None
+    else:
+        stem = getattr(feature, "LOCATION_STEM", None)
+        if stem is None:
+            return None
+        by_role[stem].append(f"{stem}.length")
+        required_roles.append(stem)
+
+    expected_counts = {role: required_roles.count(role) for role in set(required_roles)}
+    if any(len(by_role.get(role, ())) != count for role, count in expected_counts.items()):
+        return None
+    ids = [parameter.parameter_id for parameter in parameters if parameter.role in expected_counts]
+    if not pattern:
+        ids.append(f"{feature.LOCATION_STEM}.length")
+    return tuple(ids)
+
+
+def _matches(measurement, feature, parameter: str) -> bool:
+    return (
+        getattr(measurement, "feature", None) == feature
+        and getattr(measurement, "parameter", None) == parameter
+    )
+
+
+def _state(feature, parameter, *, placed, suppressed, dropped, registry):
+    if any(_matches(measurement, feature, parameter) for measurement in placed):
+        return "placed"
+    if (feature, parameter) in suppressed:
+        return "suppressed"
+    if any(_matches(measurement, feature, parameter) for measurement in dropped):
+        return "dropped"
+    associated = registry.names_for_feature(feature)
+    if any(not registry.measurement_of(name) for name in associated):
+        return "unverifiable"
+    return "missing"
+
+
+def slot_requirement_outcomes(
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+) -> list[SlotRequirementOutcome]:
+    """Follow each recognised lone slot or grouped pattern to compiler/placement outcomes."""
+    if recognition is None:
+        return []
+    if not isinstance(recognition, RecognitionResult):
+        raise TypeError(
+            "slot_requirement_outcomes() requires the run's RecognitionResult; "
+            f"got {type(recognition).__name__}"
+        )
+
+    pattern_members = {member for pattern in recognition.slot_patterns for member in pattern.slots}
+    sources: list[tuple[SlotSourceKind, object, tuple, tuple[float, float, float], int]] = [
+        ("slot", slot, _slot_key(slot), _slot_source_at(slot), 1)
+        for slot in recognition.slots
+        if slot not in pattern_members
+    ]
+    sources.extend(
+        (
+            "slot_pattern",
+            pattern,
+            _pattern_key(pattern),
+            _pattern_source_at(pattern),
+            len(pattern.slots),
+        )
+        for pattern in recognition.slot_patterns
+    )
+    if not sources:
+        return []
+
+    source_counts: dict[tuple[str, tuple], int] = defaultdict(int)
+    for kind, _source, key, _at, _count in sources:
+        source_counts[(kind, key)] += 1
+    ir_by_key: dict[tuple[str, tuple], list] = defaultdict(list)
+    for feature in features:
+        feature_kind = getattr(feature, "kind", None)
+        if feature_kind == "slot":
+            ir_by_key[(feature_kind, _slot_key(feature))].append(feature)
+        elif feature_kind == "slot_pattern":
+            ir_by_key[(feature_kind, _pattern_key(feature))].append(feature)
+
+    placed = {
+        measurement for name in registry.names() for measurement in registry.measurement_of(name)
+    }
+    suppressed = {
+        (omission.feature, omission.parameter_id)
+        for omission in omissions
+        if omission.feature is not None and omission.authored
+    }
+    dropped = {
+        measurement
+        for issue in registry.issues
+        for measurement in getattr(issue, "measurement_ids", ())
+    }
+
+    outcomes: list[SlotRequirementOutcome] = []
+    for kind, _source, key, at, member_count in sources:
+        matches = ir_by_key.get((kind, key), ())
+        feature = matches[0] if len(matches) == source_counts[(kind, key)] == 1 else None
+        parameter_ids = _parameter_ids(feature, pattern=kind == "slot_pattern") if feature else None
+        if parameter_ids is None:
+            # The association or required compiler vocabulary is not provable. Keep the
+            # physical item visible as one unchecked outcome rather than inventing ids.
+            outcomes.append(
+                SlotRequirementOutcome(kind, at, member_count, "?", "unverifiable")
+            )
+            continue
+        outcomes.extend(
+            SlotRequirementOutcome(
+                kind,
+                at,
+                member_count,
+                parameter,
+                _state(
+                    feature,
+                    parameter,
+                    placed=placed,
+                    suppressed=suppressed,
+                    dropped=dropped,
+                    registry=registry,
+                ),
+            )
+            for parameter in parameter_ids
+        )
+    return outcomes
+
+
+def lint_slot_coverage(
+    part,
+    *,
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+    assembly=None,
+) -> list[LintIssue]:
+    """Report uncovered slot requirements without duplicating placement-drop issues."""
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    severity: Literal["info", "warning"] = "info" if assembly else "warning"
+    messages = {
+        "suppressed": "was deliberately omitted by the authored dimension set",
+        "missing": "has no placed, suppressed, or dropped measurement outcome",
+        "unverifiable": "cannot be joined to measurement provenance without guessing",
+    }
+    issues = []
+    for outcome in slot_requirement_outcomes(recognition, features, registry, omissions):
+        if outcome.state in {"placed", "dropped"}:
+            continue
+        noun = "slot" if outcome.source_kind == "slot" else f"{outcome.member_count}-slot pattern"
+        issues.append(
+            LintIssue(
+                severity=severity,
+                code=f"slot_requirement_{outcome.state}",
+                message=(
+                    f"{noun} at {outcome.source_at} measurement {outcome.parameter_id} "
+                    f"{messages[outcome.state]}"
+                ),
+            )
+        )
+    return issues

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -52,6 +52,42 @@ def _slot_key(slot) -> tuple:
     )
 
 
+def _slot_spec_key(slot) -> tuple:
+    """The representative facts a pattern consumes; its member position is inert."""
+    return (
+        slot.width_axis,
+        slot.long_axis,
+        _rounded(slot.width),
+        _rounded(slot.length),
+    )
+
+
+def _unoriented_direction(value) -> tuple[float, float, float] | None:
+    if value is None:
+        return None
+    x, y, z = (float(component) for component in value)
+    norm = (x * x + y * y + z * z) ** 0.5
+    if norm == 0:
+        return None
+    direction = (x / norm, y / norm, z / norm)
+    first = next((component for component in direction if abs(component) > 1e-9), 1.0)
+    if first < 0:
+        direction = tuple(-component for component in direction)
+    return _point(direction)
+
+
+def _pattern_direction(value, members) -> tuple[float, float, float] | None:
+    """Canonicalise an explicit axis or derive the default axis from its member line."""
+    if value is None and len(members) >= 2:
+        value = tuple(members[-1][i] - members[0][i] for i in range(3))
+    return _unoriented_direction(value)
+
+
+def _grid_angle(value) -> float | None:
+    """A rectangular lattice is unchanged by reversing both of its basis directions."""
+    return None if value is None else _rounded(float(value) % 180.0)
+
+
 def _slot_source_at(slot) -> tuple[float, float, float]:
     location = getattr(slot, "location", None)
     if location is not None:
@@ -86,14 +122,14 @@ def _pattern_key(pattern) -> tuple:
     return (
         pattern_kind,
         len(members),
-        _slot_key(member),
+        _slot_spec_key(member),
         members,
         None if pitch is None else _rounded(pitch),
-        None if direction is None else _point(direction),
+        _pattern_direction(direction, members),
         tuple(None if value is None else _rounded(value) for value in grid),
         getattr(pattern, "rows", None),
         getattr(pattern, "cols", None),
-        None if getattr(pattern, "angle", None) is None else _rounded(pattern.angle),
+        _grid_angle(getattr(pattern, "angle", None)),
     )
 
 
@@ -127,6 +163,9 @@ def _parameter_ids(feature, *, pattern: bool) -> tuple[str, ...] | None:
             required_roles.extend(("grid_pitch", "grid_pitch"))
         else:
             return None
+        location_stem = getattr(feature, "LOCATION_STEM", None)
+        if feature.frame.axis != "z" or location_stem is None:
+            return None
     else:
         stem = getattr(feature, "LOCATION_STEM", None)
         if stem is None:
@@ -138,7 +177,9 @@ def _parameter_ids(feature, *, pattern: bool) -> tuple[str, ...] | None:
     if any(len(by_role.get(role, ())) != count for role, count in expected_counts.items()):
         return None
     ids = [parameter.parameter_id for parameter in parameters if parameter.role in expected_counts]
-    if not pattern:
+    if pattern:
+        ids.extend(f"{feature.LOCATION_STEM}.location.{axis}" for axis in ("x", "y"))
+    else:
         ids.append(f"{feature.LOCATION_STEM}.length")
     return tuple(ids)
 
@@ -226,13 +267,13 @@ def slot_requirement_outcomes(
     for kind, _source, key, at, member_count in sources:
         matches = ir_by_key.get((kind, key), ())
         feature = matches[0] if len(matches) == source_counts[(kind, key)] == 1 else None
-        parameter_ids = _parameter_ids(feature, pattern=kind == "slot_pattern") if feature else None
+        parameter_ids = (
+            _parameter_ids(feature, pattern=kind == "slot_pattern") if feature else None
+        )
         if parameter_ids is None:
             # The association or required compiler vocabulary is not provable. Keep the
             # physical item visible as one unchecked outcome rather than inventing ids.
-            outcomes.append(
-                SlotRequirementOutcome(kind, at, member_count, "?", "unverifiable")
-            )
+            outcomes.append(SlotRequirementOutcome(kind, at, member_count, "?", "unverifiable"))
             continue
         outcomes.extend(
             SlotRequirementOutcome(

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -63,8 +63,6 @@ def _slot_spec_key(slot) -> tuple:
 
 
 def _unoriented_direction(value) -> tuple[float, float, float] | None:
-    if value is None:
-        return None
     x, y, z = (float(component) for component in value)
     norm = (x * x + y * y + z * z) ** 0.5
     if norm == 0:
@@ -78,27 +76,18 @@ def _unoriented_direction(value) -> tuple[float, float, float] | None:
 
 def _pattern_direction(value, members) -> tuple[float, float, float] | None:
     """Canonicalise an explicit axis or derive the default axis from its member line."""
-    if value is None and len(members) >= 2:
+    if value is None:
         value = tuple(members[-1][i] - members[0][i] for i in range(3))
     return _unoriented_direction(value)
 
 
-def _grid_angle(value) -> float | None:
+def _grid_angle(value) -> float:
     """A rectangular lattice is unchanged by reversing both of its basis directions."""
-    return None if value is None else _rounded(float(value) % 180.0)
+    return _rounded(float(value or 0.0) % 180.0)
 
 
 def _slot_source_at(slot) -> tuple[float, float, float]:
-    location = getattr(slot, "location", None)
-    if location is not None:
-        return _point(location)
-    coord = {
-        slot.long_axis: (slot.lo + slot.hi) / 2,
-        slot.width_axis: slot.w_center,
-    }
-    depth_axis = next(axis for axis in "xyz" if axis not in coord)
-    coord[depth_axis] = getattr(slot.frame, "origin")["xyz".index(depth_axis)]
-    return _point((coord["x"], coord["y"], coord["z"]))
+    return _point(slot.location)
 
 
 def _pattern_key(pattern) -> tuple:
@@ -125,11 +114,11 @@ def _pattern_key(pattern) -> tuple:
         _slot_spec_key(member),
         members,
         None if pitch is None else _rounded(pitch),
-        _pattern_direction(direction, members),
+        _pattern_direction(direction, members) if pattern_kind == "linear" else None,
         tuple(None if value is None else _rounded(value) for value in grid),
         getattr(pattern, "rows", None),
         getattr(pattern, "cols", None),
-        _grid_angle(getattr(pattern, "angle", None)),
+        _grid_angle(getattr(pattern, "angle", None)) if pattern_kind == "grid" else None,
     )
 
 
@@ -137,15 +126,12 @@ def _pattern_source_at(pattern) -> tuple[float, float, float]:
     center = getattr(pattern, "center", None)
     if center is not None:
         return _point(center)
-    slots = getattr(pattern, "slots", None)
-    if slots:
-        points = [_slot_source_at(slot) for slot in slots]
-        return (
-            _rounded(sum(point[0] for point in points) / len(points)),
-            _rounded(sum(point[1] for point in points) / len(points)),
-            _rounded(sum(point[2] for point in points) / len(points)),
-        )
-    return _point(pattern.frame.origin)
+    points = [_slot_source_at(slot) for slot in pattern.slots]
+    return (
+        _rounded(sum(point[0] for point in points) / len(points)),
+        _rounded(sum(point[1] for point in points) / len(points)),
+        _rounded(sum(point[2] for point in points) / len(points)),
+    )
 
 
 def _parameter_ids(feature, *, pattern: bool) -> tuple[str, ...] | None:
@@ -159,10 +145,8 @@ def _parameter_ids(feature, *, pattern: bool) -> tuple[str, ...] | None:
     if pattern:
         if feature.pattern == "linear":
             required_roles.append("pitch")
-        elif feature.pattern == "grid":
+        else:  # exact source correspondence already proved this is the physical grid
             required_roles.extend(("grid_pitch", "grid_pitch"))
-        else:
-            return None
         location_stem = getattr(feature, "LOCATION_STEM", None)
         if feature.frame.axis != "z" or location_stem is None:
             return None

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -62,6 +62,7 @@ from draftwright.model.ir import (
     Point,
     RotationalFeature,
     SlotFeature,
+    SlotPatternFeature,
     StepLevelFeature,
 )
 from draftwright.model.planner import (
@@ -801,18 +802,52 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
     for pd in plan_locations(model):
         feature = pd.feature
         span = pd.param.span
+        directional_slot_pattern = (
+            isinstance(feature, SlotPatternFeature) and feature.frame.axis == "z"
+        )
         if pd.suppressed:
             # Before the span assert, deliberately: a suppressed entry records WHY a position
             # is absent and needs no geometry. When the model has no `datum_xy` there is no
             # datum → ref span to build one from, so requiring it here turned that diagnostic
             # into an AssertionError — a silent hole replaced by a crash, which is worse for
             # the caller it was meant to help (#996).
-            omissions.append(
-                Omission(feature, pd.param.parameter_id, None, pd.reason or "suppressed")
+            parameter_ids = (
+                tuple(f"{pd.param.parameter_id}.{axis}" for axis in ("x", "y"))
+                if directional_slot_pattern
+                else (pd.param.parameter_id,)
+            )
+            omissions.extend(
+                Omission(feature, parameter_id, None, pd.reason or "suppressed")
+                for parameter_id in parameter_ids
             )
             continue
         assert span is not None  # an APPROVED location always carries its datum → ref span
         axis = feature.frame.axis if feature is not None else None
+        if directional_slot_pattern:
+            assert isinstance(feature, SlotPatternFeature)
+            # One authored `location` intent, two independently observable page dimensions.
+            # Keeping distinct ids is what lets completeness detect deletion of X while Y
+            # remains placed; a shared set member would make that false negative structural.
+            for measured_axis in ("x", "y"):
+                index = "xyz".index(measured_axis)
+                value = abs(span[1][index] - span[0][index])
+                approved.append(
+                    ApprovedDimension(
+                        id=_dim_id(feature, f"{pd.param.parameter_id}.{measured_axis}"),
+                        value_text=_fmt(value),
+                        value=value,
+                        # `render_locations` groups both axes from this full datum→ref
+                        # relationship; narrowing one copy would erase the other datum
+                        # coordinate before the renderer separates X from Y.
+                        span=span,
+                        ref=FeatureRef(feature),
+                        kind="location",
+                        role=pd.param.role,
+                        discriminator=measured_axis,
+                        axis=axis,
+                    )
+                )
+            continue
         if isinstance(feature, PocketFeature) and axis != "z":
             # A non-Z pocket's two in-plane coordinates are drawn as TWO dims in its end-on
             # view (`render_slots`), so they are approved as two entries carrying their own

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -531,6 +531,11 @@ class SlotPatternFeature:
     dim(s). ``frame.axis`` is the slot's THROUGH axis (the one neither width nor long), so the
     callout reads in the view normal to it (the same view the member slots' dims read in)."""
 
+    #: The compiled stem for the pattern's datum location (#1018 Gate 2). A Z-normal slot
+    #: pattern is located in X and Y; the compiler gives those page dimensions distinct
+    #: discriminators so one direction cannot certify the other.
+    LOCATION_STEM: ClassVar[str] = "location_slot_pattern"
+
     frame: Frame
     pattern: str  # "linear" | "grid"
     count: int

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -36,6 +36,7 @@ from draftwright.model.ir import (
     PocketPatternFeature,
     Point,
     SlotFeature,
+    SlotPatternFeature,
 )
 
 #: The `reason` marking a measurement the AUTHORED set left out — the author's own
@@ -352,6 +353,7 @@ _LOCATABLE: tuple[type, ...] = (
     PocketPatternFeature,
     PadFeature,
     SlotFeature,
+    SlotPatternFeature,
 )
 
 
@@ -386,9 +388,9 @@ def location_datum(feature) -> str | None:
         return "datum_xy"  # every orientation: its two in-plane coordinates
     if isinstance(feature, HoleFeature):
         return "datum_xy" if feature.frame.axis == "z" else "bbox"
-    # Patterns, pocket-patterns and pads: the plan-X / side-Y ladder only, so Z-normal only.
-    # A fall-through, not a fourth `isinstance` + `return None`: membership above is by
-    # exact type, so those three are all that can reach here and the extra arm was
+    # Patterns, pocket/slot-patterns and pads: the plan-X / side-Y ladder only, so Z-normal
+    # only. A fall-through, not another `isinstance` + `return None`: membership above is by
+    # exact type, so those four are all that can reach here and the extra arm was
     # unreachable — dead code that read as defensive and showed up as the one uncovered
     # line in the patch.
     return "datum_xy" if feature.frame.axis == "z" else None

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -712,14 +712,6 @@ def test_every_direct_placement_records_identity_or_says_why_not():
         # Named individually rather than waved at, because each is a real hole in the
         # audit's attribution and each needs its own plumbing.
         ("from_model.py", "_draw_step_chain"): "step-chain segs carry no id (#1004)",
-        (
-            "holes.py",
-            "_place_pitch_dim",
-        ): "pattern pitch dims carry no id (#1005)",
-        (
-            "holes.py",
-            "_place_pitch_dim._place",
-        ): "pattern pitch dims carry no id (#1005)",
         ("holes.py", "_off_axis_queue"): "side-hole location candidates, no id map (#1005)",
         # -- identity arrives by another route --------------------------------------
         ("from_model.py", "_reroute_crossing_diameters"): "reapplies the saved identity",

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 from build123d import Box, Pos
 
-from draftwright import Sheet, build_drawing
+from draftwright import Drawing, Sheet, build_drawing
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
 from draftwright.model import slot
 from draftwright.model.compiled import compile_dimensions
@@ -338,43 +338,21 @@ def test_pattern_placement_failures_retain_each_failed_measurement():
 
 
 def test_grouped_callout_failure_marks_its_orphaned_pattern_pitches(monkeypatch):
-    from draftwright.annotations import holes as hole_renderers
+    annotations = Drawing.annotations
 
-    original = hole_renderers._leader_callout_pass
+    def without_grouped_slot_callout(drawing):
+        return [name for name in annotations(drawing) if not name.startswith("m_slotpat")]
 
-    def drop_callouts(_dwg, _analysis, jobs, *, noun, drop_code, ctx, geom_clear=False):
-        if noun != "slot pattern":
-            return original(
-                _dwg,
-                _analysis,
-                jobs,
-                noun=noun,
-                drop_code=drop_code,
-                ctx=ctx,
-                geom_clear=geom_clear,
-            )
-        assert geom_clear is False
-        for _name, _view, _bounds, label, _candidates, measurement in jobs:
-            ctx.record_issue(
-                "warning",
-                drop_code,
-                f"{noun} callout {label} not placed (forced test failure)",
-                measurement=measurement,
-            )
-        return 0
-
-    monkeypatch.setattr(hole_renderers, "_leader_callout_pass", drop_callouts)
+    monkeypatch.setattr(Drawing, "annotations", without_grouped_slot_callout)
     dwg = build_drawing(_slot_grid())
 
     dropped = {
         measurement.parameter
         for issue in dwg.registry.issues
-        if issue.code in {"slot_dropped", "slot_dim_dropped"}
+        if issue.code == "slot_dim_dropped"
         for measurement in issue.measurement_ids
     }
     assert dropped == {
-        "slot_width.length",
-        "slot_length.length",
         "grid_pitch.length.row",
         "grid_pitch.length.col",
     }

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -1,8 +1,14 @@
 """Slot completeness follows semantic provenance, never presentation (#1018 Gate 2)."""
 
+from dataclasses import replace
+
+import pytest
 from build123d import Box, Pos
 
-from draftwright import build_drawing
+from draftwright import Sheet, build_drawing
+from draftwright.linting.slot_coverage import slot_requirement_outcomes
+from draftwright.model import slot
+from draftwright.recognition import recognise_slots
 
 
 def _off_centre_slot():
@@ -17,8 +23,56 @@ def _slot_grid():
     return part
 
 
+def _equal_pitch_slot_grid():
+    part = Box(176, 136, 20)
+    for x in (-17, 17):
+        for y in (-34, 0, 34):
+            part -= Pos(x, y, 0) * Box(24, 8, 20)
+    return part
+
+
+def _slot_row():
+    part = Box(60, 180, 20)
+    for y in (-45, -15, 15, 45):
+        part -= Pos(0, y, 0) * Box(30, 8, 20)
+    return part
+
+
 def _slot_requirement_codes(dwg):
     return [issue.code for issue in dwg.lint() if issue.code.startswith("slot_requirement_")]
+
+
+def _outcomes(dwg):
+    dwg.lint()  # declared critique obtains and caches its recognition aggregate here
+    return slot_requirement_outcomes(
+        dwg.recognition(),
+        dwg.model().features,
+        dwg.registry,
+        dwg._build.omissions,
+    )
+
+
+def _declared_slot_drawing(*, suppress=False, w_shift=0.0):
+    part = _off_centre_slot()
+    (source,) = recognise_slots(part)
+    sheet = Sheet(part)
+    handle = sheet.slot(
+        width=source.width,
+        length=source.length,
+        long_axis=source.long_axis,
+        width_axis=source.width_axis,
+        depth_axis=source.depth_axis,
+        w_center=source.w_center + w_shift,
+        lo=source.lo,
+        hi=source.hi,
+        at=source.location,
+    )
+    if suppress:
+        envelope = sheet.envelope()
+        sheet.dimension(envelope, "width.length")
+    else:
+        sheet.auto_dimensions()
+    return sheet.build(), handle
 
 
 def test_removing_an_off_centre_slots_location_is_detected():
@@ -43,6 +97,12 @@ def test_removing_an_off_centre_slots_location_is_detected():
     dwg.remove(location_name)
 
     assert _slot_requirement_codes(dwg) == ["slot_requirement_missing"]
+    states = {outcome.parameter_id: outcome.state for outcome in _outcomes(dwg)}
+    assert states == {
+        "slot_width.length": "placed",
+        "slot_length.length": "placed",
+        "location_slot.length": "missing",
+    }
 
 
 def test_grid_pitch_annotations_retain_distinct_directional_provenance():
@@ -51,12 +111,188 @@ def test_grid_pitch_annotations_retain_distinct_directional_provenance():
     pitch_names = sorted(name for name in dwg.annotations() if "slotpat_pitch" in name)
     assert len(pitch_names) == 2
 
-    pitch_ids = {
+    pitch_by_id = {
+        dwg.measurement_keys(name)[0]["parameter_id"]: name
+        for name in pitch_names
+    }
+    assert set(pitch_by_id) == {"grid_pitch.length.row", "grid_pitch.length.col"}
+
+    dwg.remove(pitch_by_id["grid_pitch.length.row"])
+    assert _slot_requirement_codes(dwg) == ["slot_requirement_missing"]
+    outcomes = {outcome.parameter_id: outcome.state for outcome in _outcomes(dwg)}
+    assert outcomes["grid_pitch.length.row"] == "missing"
+    assert outcomes["grid_pitch.length.col"] == "placed"
+
+
+def test_equal_grid_pitches_do_not_collapse_directional_identity():
+    """Equal numeric values must still retain row/column identity."""
+    dwg = build_drawing(_equal_pitch_slot_grid())
+    pitch_names = [name for name in dwg.annotations() if "slotpat_pitch" in name]
+    assert len(pitch_names) == 2
+    assert {
         dwg.measurement_keys(name)[0]["parameter_id"]
         for name in pitch_names
         if dwg.measurement_keys(name)
-    }
-    assert pitch_ids == {"grid_pitch.length.row", "grid_pitch.length.col"}
+    } == {"grid_pitch.length.row", "grid_pitch.length.col"}
 
-    dwg.remove(pitch_names[0])
+
+def test_one_recognised_grid_is_one_requirement_with_compound_provenance():
+    dwg = build_drawing(_slot_grid())
+    outcomes = _outcomes(dwg)
+    assert [(outcome.source_kind, outcome.member_count) for outcome in outcomes] == [
+        ("slot_pattern", 6),
+    ] * 4
+    assert {outcome.parameter_id for outcome in outcomes} == {
+        "slot_width.length",
+        "slot_length.length",
+        "grid_pitch.length.row",
+        "grid_pitch.length.col",
+    }
+    assert {outcome.state for outcome in outcomes} == {"placed"}
+
+    (callout,) = [name for name in dwg.annotations() if name.startswith("m_slotpat")]
+    assert {key["parameter_id"] for key in dwg.measurement_keys(callout)} == {
+        "slot_width.length",
+        "slot_length.length",
+    }
+    dwg.remove(callout)
+    missing = [outcome for outcome in _outcomes(dwg) if outcome.state == "missing"]
+    assert {outcome.parameter_id for outcome in missing} == {
+        "slot_width.length",
+        "slot_length.length",
+    }
+    assert all(outcome.member_count == 6 for outcome in missing)
+
+
+def test_linear_pattern_pitch_retains_its_compiler_identity():
+    dwg = build_drawing(_slot_row())
+    (pitch,) = [name for name in dwg.annotations() if "slotpat_pitch" in name]
+    assert [key["parameter_id"] for key in dwg.measurement_keys(pitch)] == ["pitch.length"]
+    assert {outcome.state for outcome in _outcomes(dwg)} == {"placed"}
+
+
+def test_severing_pitch_provenance_is_unverifiable_not_placed():
+    dwg = build_drawing(_slot_grid())
+    pitch = next(name for name in dwg.annotations() if "slotpat_pitch" in name)
+    parameter = dwg.measurement_keys(pitch)[0]["parameter_id"]
+    identity = dwg.registry.identity_of(pitch)
+    identity["measurement"] = ()
+    dwg.registry.reapply(pitch, identity)
+
+    outcome = next(item for item in _outcomes(dwg) if item.parameter_id == parameter)
+    assert outcome.state == "unverifiable"
+    assert _slot_requirement_codes(dwg) == ["slot_requirement_unverifiable"]
+
+
+def test_matching_free_text_does_not_certify_a_slot_location():
+    dwg = build_drawing(_off_centre_slot())
+    slot = next(feature for feature in dwg.model().features if feature.kind == "slot")
+    location = next(
+        name
+        for name in dwg.registry.names_for_feature(slot)
+        if any(key["parameter_id"] == "location_slot.length" for key in dwg.measurement_keys(name))
+    )
+    label = dwg.get_annotation(location).label
+    dwg.remove(location)
+    dwg.note(label, (20, 20), view="plan")
+
     assert _slot_requirement_codes(dwg) == ["slot_requirement_missing"]
+
+
+def test_authored_omission_is_suppressed_not_missing():
+    dwg, _handle = _declared_slot_drawing(suppress=True)
+    outcomes = _outcomes(dwg)
+    assert [outcome.state for outcome in outcomes] == ["suppressed"] * 3
+    assert _slot_requirement_codes(dwg) == ["slot_requirement_suppressed"] * 3
+
+
+def test_a_real_placement_failure_retains_the_dropped_measurement():
+    dwg = build_drawing(_off_centre_slot(), page="A4", scale=1.5)
+    (drop,) = [issue for issue in dwg.lint() if issue.code == "slot_dim_dropped"]
+    assert len(drop.measurement_ids) == 1
+    dropped_parameter = drop.measurement_ids[0].parameter
+    outcome = next(item for item in _outcomes(dwg) if item.parameter_id == dropped_parameter)
+    assert outcome.state == "dropped"
+    assert "slot_requirement_dropped" not in _slot_requirement_codes(dwg)
+
+    dwg.registry.reset_issues()
+    dwg.registry.record_issue(replace(drop, measurement_ids=()))
+    outcome = next(item for item in _outcomes(dwg) if item.parameter_id == dropped_parameter)
+    assert outcome.state == "missing"
+
+
+def test_stale_declared_geometry_is_unverifiable_without_a_nearest_match():
+    dwg, _handle = _declared_slot_drawing(w_shift=1.0)
+    assert [name for name in dwg.annotations() if name.startswith("m_slot")]
+    outcomes = _outcomes(dwg)
+    assert len(outcomes) == 1
+    assert outcomes[0].state == "unverifiable"
+
+
+def test_duplicate_ir_candidates_are_unverifiable_not_merged():
+    dwg = build_drawing(_slot_grid())
+    pattern = next(feature for feature in dwg.model().features if feature.kind == "slot_pattern")
+    outcomes = slot_requirement_outcomes(
+        dwg.recognition(),
+        (pattern, pattern),
+        dwg.registry,
+        dwg._build.omissions,
+    )
+    assert len(outcomes) == 1
+    assert outcomes[0].state == "unverifiable"
+
+
+def test_automatic_and_declared_paths_agree_despite_their_frame_conventions():
+    automatic = build_drawing(_off_centre_slot())
+    declared, _handle = _declared_slot_drawing()
+    auto_slot = next(feature for feature in automatic.model().features if feature.kind == "slot")
+    declared_slot = next(feature for feature in declared.model().features if feature.kind == "slot")
+    assert auto_slot.frame.origin != declared_slot.frame.origin
+
+    auto_states = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(automatic)]
+    declared_states = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(declared)]
+    assert auto_states == declared_states
+    assert declared.recognition() is not None
+
+
+def test_detected_and_declared_grids_have_the_same_grouped_outcomes():
+    part = _slot_grid()
+    automatic = build_drawing(part)
+    (source,) = automatic.recognition().slot_patterns
+    source_member = source.slots[0]
+    member = slot(
+        width=source_member.width,
+        length=source_member.length,
+        long_axis=source_member.long_axis,
+        width_axis=source_member.width_axis,
+        depth_axis=source_member.depth_axis,
+        w_center=source_member.w_center,
+        lo=source_member.lo,
+        hi=source_member.hi,
+        at=source_member.location,
+    )
+    sheet = Sheet(part).auto_dimensions()
+    sheet.slot_pattern(
+        member,
+        kind="grid",
+        count=len(source.slots),
+        grid=(source.row_pitch, source.col_pitch),
+        rows=source.rows,
+        cols=source.cols,
+        angle=source.angle,
+        at=source.center,
+    )
+    declared = sheet.build()
+
+    expected = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(automatic)]
+    actual = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(declared)]
+    assert actual == expected
+
+
+def test_a_caller_assembled_empty_inventory_cannot_silence_slot_coverage():
+    from types import SimpleNamespace
+
+    from draftwright.registry import AnnotationRegistry
+
+    with pytest.raises(TypeError, match="RecognitionResult"):
+        slot_requirement_outcomes(SimpleNamespace(slots=(), slot_patterns=()), (), AnnotationRegistry())

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -8,6 +8,7 @@ from build123d import Box, Pos
 from draftwright import Sheet, build_drawing
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
 from draftwright.model import slot
+from draftwright.model.compiled import compile_dimensions
 from draftwright.recognition import recognise_slots
 
 
@@ -38,6 +39,21 @@ def _slot_row():
     return part
 
 
+def _slot_column():
+    part = Box(180, 60, 20)
+    for x in (-45, -15, 15, 45):
+        part -= Pos(x, 0, 0) * Box(8, 30, 20)
+    return part
+
+
+def _off_axis_slot_grid():
+    part = Box(20, 176, 136)
+    for y in (-22, 22):
+        for z in (-34, 0, 34):
+            part -= Pos(0, y, z) * Box(20, 24, 8)
+    return part
+
+
 def _slot_requirement_codes(dwg):
     return [issue.code for issue in dwg.lint() if issue.code.startswith("slot_requirement_")]
 
@@ -48,7 +64,7 @@ def _outcomes(dwg):
         dwg.recognition(),
         dwg.model().features,
         dwg.registry,
-        dwg._build.omissions,
+        compile_dimensions(dwg.model()).diagnostics,
     )
 
 
@@ -89,10 +105,7 @@ def test_removing_an_off_centre_slots_location_is_detected():
     (location_name,) = [
         name
         for name in dwg.registry.names_for_feature(slot)
-        if any(
-            key["parameter_id"] == "location_slot.length"
-            for key in dwg.measurement_keys(name)
-        )
+        if any(key["parameter_id"] == "location_slot.length" for key in dwg.measurement_keys(name))
     ]
     dwg.remove(location_name)
 
@@ -111,10 +124,7 @@ def test_grid_pitch_annotations_retain_distinct_directional_provenance():
     pitch_names = sorted(name for name in dwg.annotations() if "slotpat_pitch" in name)
     assert len(pitch_names) == 2
 
-    pitch_by_id = {
-        dwg.measurement_keys(name)[0]["parameter_id"]: name
-        for name in pitch_names
-    }
+    pitch_by_id = {dwg.measurement_keys(name)[0]["parameter_id"]: name for name in pitch_names}
     assert set(pitch_by_id) == {"grid_pitch.length.row", "grid_pitch.length.col"}
 
     dwg.remove(pitch_by_id["grid_pitch.length.row"])
@@ -122,6 +132,25 @@ def test_grid_pitch_annotations_retain_distinct_directional_provenance():
     outcomes = {outcome.parameter_id: outcome.state for outcome in _outcomes(dwg)}
     assert outcomes["grid_pitch.length.row"] == "missing"
     assert outcomes["grid_pitch.length.col"] == "placed"
+
+
+def test_pattern_location_keeps_x_and_y_measurement_identity_distinct():
+    dwg = build_drawing(_slot_grid())
+    locations = {
+        key["parameter_id"]: name
+        for name in dwg.annotations()
+        for key in dwg.measurement_keys(name)
+        if key["parameter_id"].startswith("location_slot_pattern.")
+    }
+    assert set(locations) == {
+        "location_slot_pattern.location.x",
+        "location_slot_pattern.location.y",
+    }
+
+    dwg.remove(locations["location_slot_pattern.location.x"])
+    states = {outcome.parameter_id: outcome.state for outcome in _outcomes(dwg)}
+    assert states["location_slot_pattern.location.x"] == "missing"
+    assert states["location_slot_pattern.location.y"] == "placed"
 
 
 def test_equal_grid_pitches_do_not_collapse_directional_identity():
@@ -141,12 +170,14 @@ def test_one_recognised_grid_is_one_requirement_with_compound_provenance():
     outcomes = _outcomes(dwg)
     assert [(outcome.source_kind, outcome.member_count) for outcome in outcomes] == [
         ("slot_pattern", 6),
-    ] * 4
+    ] * 6
     assert {outcome.parameter_id for outcome in outcomes} == {
         "slot_width.length",
         "slot_length.length",
         "grid_pitch.length.row",
         "grid_pitch.length.col",
+        "location_slot_pattern.location.x",
+        "location_slot_pattern.location.y",
     }
     assert {outcome.state for outcome in outcomes} == {"placed"}
 
@@ -206,6 +237,47 @@ def test_authored_omission_is_suppressed_not_missing():
     assert _slot_requirement_codes(dwg) == ["slot_requirement_suppressed"] * 3
 
 
+def test_authored_pattern_omission_suppresses_both_location_directions():
+    part = _slot_grid()
+    detected = build_drawing(part)
+    (source,) = detected.recognition().slot_patterns
+    source_member = source.slots[0]
+    member = slot(
+        width=source_member.width,
+        length=source_member.length,
+        long_axis=source_member.long_axis,
+        width_axis=source_member.width_axis,
+        depth_axis=source_member.depth_axis,
+        w_center=source_member.w_center,
+        lo=source_member.lo,
+        hi=source_member.hi,
+        at=source_member.location,
+    )
+    sheet = Sheet(part)
+    sheet.slot_pattern(
+        member,
+        kind="grid",
+        count=len(source.slots),
+        grid=(source.row_pitch, source.col_pitch),
+        rows=source.rows,
+        cols=source.cols,
+        angle=source.angle,
+        at=source.center,
+    )
+    envelope = sheet.envelope()
+    sheet.dimension(envelope, "width.length")
+    outcomes = _outcomes(sheet.build())
+
+    assert {outcome.parameter_id for outcome in outcomes if outcome.state == "suppressed"} == {
+        "slot_width.length",
+        "slot_length.length",
+        "grid_pitch.length.row",
+        "grid_pitch.length.col",
+        "location_slot_pattern.location.x",
+        "location_slot_pattern.location.y",
+    }
+
+
 def test_a_real_placement_failure_retains_the_dropped_measurement():
     dwg = build_drawing(_off_centre_slot(), page="A4", scale=1.5)
     (drop,) = [issue for issue in dwg.lint() if issue.code == "slot_dim_dropped"]
@@ -219,6 +291,18 @@ def test_a_real_placement_failure_retains_the_dropped_measurement():
     dwg.registry.record_issue(replace(drop, measurement_ids=()))
     outcome = next(item for item in _outcomes(dwg) if item.parameter_id == dropped_parameter)
     assert outcome.state == "missing"
+
+
+def test_pattern_placement_failures_retain_each_failed_measurement():
+    dwg = build_drawing(_slot_grid(), page="A4", scale=1.0)
+    outcomes = _outcomes(dwg)
+    dropped = {outcome.parameter_id for outcome in outcomes if outcome.state == "dropped"}
+    assert dropped == {
+        "grid_pitch.length.row",
+        "location_slot_pattern.location.x",
+        "location_slot_pattern.location.y",
+    }
+    assert not [outcome for outcome in outcomes if outcome.state == "missing"]
 
 
 def test_stale_declared_geometry_is_unverifiable_without_a_nearest_match():
@@ -236,9 +320,18 @@ def test_duplicate_ir_candidates_are_unverifiable_not_merged():
         dwg.recognition(),
         (pattern, pattern),
         dwg.registry,
-        dwg._build.omissions,
+        compile_dimensions(dwg.model()).diagnostics,
     )
     assert len(outcomes) == 1
+    assert outcomes[0].state == "unverifiable"
+
+
+def test_off_axis_pattern_location_is_unverifiable_not_assumed_complete():
+    dwg = build_drawing(_off_axis_slot_grid())
+    outcomes = _outcomes(dwg)
+    assert len(outcomes) == 1
+    assert outcomes[0].source_kind == "slot_pattern"
+    assert outcomes[0].member_count == 6
     assert outcomes[0].state == "unverifiable"
 
 
@@ -246,7 +339,9 @@ def test_automatic_and_declared_paths_agree_despite_their_frame_conventions():
     automatic = build_drawing(_off_centre_slot())
     declared, _handle = _declared_slot_drawing()
     auto_slot = next(feature for feature in automatic.model().features if feature.kind == "slot")
-    declared_slot = next(feature for feature in declared.model().features if feature.kind == "slot")
+    declared_slot = next(
+        feature for feature in declared.model().features if feature.kind == "slot"
+    )
     assert auto_slot.frame.origin != declared_slot.frame.origin
 
     auto_states = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(automatic)]
@@ -255,7 +350,7 @@ def test_automatic_and_declared_paths_agree_despite_their_frame_conventions():
     assert declared.recognition() is not None
 
 
-def test_detected_and_declared_grids_have_the_same_grouped_outcomes():
+def test_detected_and_equivalently_rotated_declared_grids_have_the_same_outcomes():
     part = _slot_grid()
     automatic = build_drawing(part)
     (source,) = automatic.recognition().slot_patterns
@@ -279,8 +374,79 @@ def test_detected_and_declared_grids_have_the_same_grouped_outcomes():
         grid=(source.row_pitch, source.col_pitch),
         rows=source.rows,
         cols=source.cols,
-        angle=source.angle,
+        angle=source.angle + 180.0,
         at=source.center,
+    )
+    declared = sheet.build()
+
+    expected = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(automatic)]
+    actual = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(declared)]
+    assert actual == expected
+
+
+def test_declared_linear_pattern_accepts_another_member_and_reversed_axis():
+    """Representative position and direction sign do not change the physical pattern."""
+    part = _slot_row()
+    automatic = build_drawing(part)
+    (source,) = automatic.recognition().slot_patterns
+    source_member = source.slots[-1]
+    member = slot(
+        width=source_member.width,
+        length=source_member.length,
+        long_axis=source_member.long_axis,
+        width_axis=source_member.width_axis,
+        depth_axis=source_member.depth_axis,
+        w_center=source_member.w_center,
+        lo=source_member.lo,
+        hi=source_member.hi,
+        at=source_member.location,
+    )
+    center = tuple(
+        sum(slot.location[i] for slot in source.slots) / len(source.slots) for i in range(3)
+    )
+    sheet = Sheet(part).auto_dimensions()
+    sheet.slot_pattern(
+        member,
+        kind="linear",
+        count=len(source.slots),
+        pitch=source.pitch,
+        direction=tuple(-value for value in source.direction),
+        at=center,
+    )
+    declared = sheet.build()
+
+    expected = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(automatic)]
+    actual = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(declared)]
+    assert actual == expected
+
+
+def test_declared_linear_pattern_accepts_its_implicit_default_axis():
+    """Omitting the default +X axis is representation, not different geometry."""
+    part = _slot_column()
+    automatic = build_drawing(part)
+    (source,) = automatic.recognition().slot_patterns
+    source_member = source.slots[0]
+    member = slot(
+        width=source_member.width,
+        length=source_member.length,
+        long_axis=source_member.long_axis,
+        width_axis=source_member.width_axis,
+        depth_axis=source_member.depth_axis,
+        w_center=source_member.w_center,
+        lo=source_member.lo,
+        hi=source_member.hi,
+        at=source_member.location,
+    )
+    center = tuple(
+        sum(item.location[i] for item in source.slots) / len(source.slots) for i in range(3)
+    )
+    sheet = Sheet(part).auto_dimensions()
+    sheet.slot_pattern(
+        member,
+        kind="linear",
+        count=len(source.slots),
+        pitch=source.pitch,
+        at=center,
     )
     declared = sheet.build()
 
@@ -295,4 +461,6 @@ def test_a_caller_assembled_empty_inventory_cannot_silence_slot_coverage():
     from draftwright.registry import AnnotationRegistry
 
     with pytest.raises(TypeError, match="RecognitionResult"):
-        slot_requirement_outcomes(SimpleNamespace(slots=(), slot_patterns=()), (), AnnotationRegistry())
+        slot_requirement_outcomes(
+            SimpleNamespace(slots=(), slot_patterns=()), (), AnnotationRegistry()
+        )

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -1,6 +1,7 @@
 """Slot completeness follows semantic provenance, never presentation (#1018 Gate 2)."""
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 from build123d import Box, Pos
@@ -28,6 +29,14 @@ def _equal_pitch_slot_grid():
     part = Box(176, 136, 20)
     for x in (-17, 17):
         for y in (-34, 0, 34):
+            part -= Pos(x, y, 0) * Box(24, 8, 20)
+    return part
+
+
+def _default_angle_slot_grid():
+    part = Box(176, 136, 20)
+    for x in (-34, 0, 34):
+        for y in (-22, 22):
             part -= Pos(x, y, 0) * Box(24, 8, 20)
     return part
 
@@ -89,6 +98,29 @@ def _declared_slot_drawing(*, suppress=False, w_shift=0.0):
     else:
         sheet.auto_dimensions()
     return sheet.build(), handle
+
+
+def _pattern_proxy(pattern, *, parameters, location_stem="location_slot_pattern"):
+    values = {
+        name: getattr(pattern, name)
+        for name in (
+            "frame",
+            "pattern",
+            "count",
+            "member",
+            "members",
+            "pitch",
+            "direction",
+            "grid",
+            "rows",
+            "cols",
+            "angle",
+        )
+    }
+    values.update(kind="slot_pattern", parameters=parameters)
+    if location_stem is not None:
+        values["LOCATION_STEM"] = location_stem
+    return SimpleNamespace(**values)
 
 
 def test_removing_an_off_centre_slots_location_is_detected():
@@ -305,6 +337,49 @@ def test_pattern_placement_failures_retain_each_failed_measurement():
     assert not [outcome for outcome in outcomes if outcome.state == "missing"]
 
 
+def test_grouped_callout_failure_marks_its_orphaned_pattern_pitches(monkeypatch):
+    from draftwright.annotations import holes as hole_renderers
+
+    original = hole_renderers._leader_callout_pass
+
+    def drop_callouts(_dwg, _analysis, jobs, *, noun, drop_code, ctx, geom_clear=False):
+        if noun != "slot pattern":
+            return original(
+                _dwg,
+                _analysis,
+                jobs,
+                noun=noun,
+                drop_code=drop_code,
+                ctx=ctx,
+                geom_clear=geom_clear,
+            )
+        assert geom_clear is False
+        for _name, _view, _bounds, label, _candidates, measurement in jobs:
+            ctx.record_issue(
+                "warning",
+                drop_code,
+                f"{noun} callout {label} not placed (forced test failure)",
+                measurement=measurement,
+            )
+        return 0
+
+    monkeypatch.setattr(hole_renderers, "_leader_callout_pass", drop_callouts)
+    dwg = build_drawing(_slot_grid())
+
+    dropped = {
+        measurement.parameter
+        for issue in dwg.registry.issues
+        if issue.code in {"slot_dropped", "slot_dim_dropped"}
+        for measurement in issue.measurement_ids
+    }
+    assert dropped == {
+        "slot_width.length",
+        "slot_length.length",
+        "grid_pitch.length.row",
+        "grid_pitch.length.col",
+    }
+
+
 def test_stale_declared_geometry_is_unverifiable_without_a_nearest_match():
     dwg, _handle = _declared_slot_drawing(w_shift=1.0)
     assert [name for name in dwg.annotations() if name.startswith("m_slot")]
@@ -324,6 +399,42 @@ def test_duplicate_ir_candidates_are_unverifiable_not_merged():
     )
     assert len(outcomes) == 1
     assert outcomes[0].state == "unverifiable"
+
+
+def test_zero_declared_linear_direction_is_unverifiable():
+    dwg = build_drawing(_slot_row())
+    pattern = next(feature for feature in dwg.model().features if feature.kind == "slot_pattern")
+
+    outcomes = slot_requirement_outcomes(
+        dwg.recognition(),
+        (replace(pattern, direction=(0.0, 0.0, 0.0)),),
+        dwg.registry,
+    )
+    assert [(outcome.parameter_id, outcome.state) for outcome in outcomes] == [
+        ("?", "unverifiable")
+    ]
+
+
+def test_missing_pattern_location_vocabulary_is_unverifiable():
+    dwg = build_drawing(_slot_grid())
+    pattern = next(feature for feature in dwg.model().features if feature.kind == "slot_pattern")
+    proxy = _pattern_proxy(pattern, parameters=pattern.parameters, location_stem=None)
+
+    outcomes = slot_requirement_outcomes(dwg.recognition(), (proxy,), dwg.registry)
+    assert [(outcome.parameter_id, outcome.state) for outcome in outcomes] == [
+        ("?", "unverifiable")
+    ]
+
+
+def test_incomplete_pattern_measurement_vocabulary_is_unverifiable():
+    dwg = build_drawing(_slot_grid())
+    pattern = next(feature for feature in dwg.model().features if feature.kind == "slot_pattern")
+    proxy = _pattern_proxy(pattern, parameters=lambda: pattern.parameters()[:-1])
+
+    outcomes = slot_requirement_outcomes(dwg.recognition(), (proxy,), dwg.registry)
+    assert [(outcome.parameter_id, outcome.state) for outcome in outcomes] == [
+        ("?", "unverifiable")
+    ]
 
 
 def test_off_axis_pattern_location_is_unverifiable_not_assumed_complete():
@@ -375,6 +486,40 @@ def test_detected_and_equivalently_rotated_declared_grids_have_the_same_outcomes
         rows=source.rows,
         cols=source.cols,
         angle=source.angle + 180.0,
+        at=source.center,
+    )
+    declared = sheet.build()
+
+    expected = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(automatic)]
+    actual = [(outcome.parameter_id, outcome.state) for outcome in _outcomes(declared)]
+    assert actual == expected
+
+
+def test_declared_grid_accepts_the_implicit_zero_degree_angle():
+    part = _default_angle_slot_grid()
+    automatic = build_drawing(part)
+    (source,) = automatic.recognition().slot_patterns
+    assert source.angle == 0.0
+    source_member = source.slots[0]
+    member = slot(
+        width=source_member.width,
+        length=source_member.length,
+        long_axis=source_member.long_axis,
+        width_axis=source_member.width_axis,
+        depth_axis=source_member.depth_axis,
+        w_center=source_member.w_center,
+        lo=source_member.lo,
+        hi=source_member.hi,
+        at=source_member.location,
+    )
+    sheet = Sheet(part).auto_dimensions()
+    sheet.slot_pattern(
+        member,
+        kind="grid",
+        count=len(source.slots),
+        grid=(source.row_pitch, source.col_pitch),
+        rows=source.rows,
+        cols=source.cols,
         at=source.center,
     )
     declared = sheet.build()
@@ -456,11 +601,17 @@ def test_declared_linear_pattern_accepts_its_implicit_default_axis():
 
 
 def test_a_caller_assembled_empty_inventory_cannot_silence_slot_coverage():
-    from types import SimpleNamespace
-
     from draftwright.registry import AnnotationRegistry
 
     with pytest.raises(TypeError, match="RecognitionResult"):
         slot_requirement_outcomes(
             SimpleNamespace(slots=(), slot_patterns=()), (), AnnotationRegistry()
         )
+
+
+def test_absent_recognition_and_a_valid_empty_inventory_are_both_quiet():
+    from draftwright.registry import AnnotationRegistry
+
+    dwg = build_drawing(Box(60, 40, 20))
+    assert slot_requirement_outcomes(None, (), AnnotationRegistry()) == []
+    assert slot_requirement_outcomes(dwg.recognition(), (), AnnotationRegistry()) == []

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -1,0 +1,62 @@
+"""Slot completeness follows semantic provenance, never presentation (#1018 Gate 2)."""
+
+from build123d import Box, Pos
+
+from draftwright import build_drawing
+
+
+def _off_centre_slot():
+    return Box(100, 70, 10) - Pos(22, -11, 0) * Box(30, 8, 20)
+
+
+def _slot_grid():
+    part = Box(176, 136, 20)
+    for x in (-22, 22):
+        for y in (-34, 0, 34):
+            part -= Pos(x, y, 0) * Box(24, 8, 20)
+    return part
+
+
+def _slot_requirement_codes(dwg):
+    return [issue.code for issue in dwg.lint() if issue.code.startswith("slot_requirement_")]
+
+
+def test_removing_an_off_centre_slots_location_is_detected():
+    """The recogniser centroid and IR frame differ on the transverse axis by design.
+
+    Removing only the compiler-identified location dimension must therefore be found through
+    semantic slot correspondence, not a fuzzy kind-plus-frame-origin join.
+    """
+    dwg = build_drawing(_off_centre_slot())
+    (slot,) = [feature for feature in dwg.model().features if feature.kind == "slot"]
+    assert slot.frame.origin[1] == 0.0
+    assert dwg.recognition().slots[0].location[1] == -11.0
+
+    (location_name,) = [
+        name
+        for name in dwg.registry.names_for_feature(slot)
+        if any(
+            key["parameter_id"] == "location_slot.length"
+            for key in dwg.measurement_keys(name)
+        )
+    ]
+    dwg.remove(location_name)
+
+    assert _slot_requirement_codes(dwg) == ["slot_requirement_missing"]
+
+
+def test_grid_pitch_annotations_retain_distinct_directional_provenance():
+    """One placed pitch direction must not satisfy the other by set membership."""
+    dwg = build_drawing(_slot_grid())
+    pitch_names = sorted(name for name in dwg.annotations() if "slotpat_pitch" in name)
+    assert len(pitch_names) == 2
+
+    pitch_ids = {
+        dwg.measurement_keys(name)[0]["parameter_id"]
+        for name in pitch_names
+        if dwg.measurement_keys(name)
+    }
+    assert pitch_ids == {"grid_pitch.length.row", "grid_pitch.length.col"}
+
+    dwg.remove(pitch_names[0])
+    assert _slot_requirement_codes(dwg) == ["slot_requirement_missing"]


### PR DESCRIPTION
## What

Completes ADR 0017 Gate 2 with semantic slot and slot-pattern completeness outcomes.

- lone off-centre slots join recognition to IR from exact model-space slot facts, without treating the deliberately bbox-centred IR frame as the recognition location;
- recognised pattern members collapse to one physical pattern source and one compound set of outcomes, rather than one defect per member;
- compiler/registry identities distinguish width, length, each grid/linear pitch, and each pattern datum-location direction;
- outcomes distinguish `placed`, authored `suppressed`, placement `dropped`, `missing`, and `unverifiable`;
- ambiguous, stale, off-axis, malformed, or provenance-free association remains unchecked instead of being guessed;
- renderer drop paths retain the measurement identities they already hold.

No label, leader-tip, witness, projected-position, annotation-name, page-coordinate, or numeric-value inference certifies engine output. No general identity framework, requirements module, reconciliation stage, or outcome ledger is introduced.

## Evidence

The slice covers:

- off-centre 1:1 correspondence despite recognition/IR frame conventions;
- grid and linear N:1 correspondence;
- distinct row/column pitch IDs even when both pitches have the same numeric value;
- distinct X/Y pattern-location IDs, with deletion of either direction detected independently;
- grouped callout provenance for member count plus size requirements;
- automatic/declared parity, including reversed/default linear axes and equivalent/default grid angles;
- authored suppression, real placement drops, stale declarations, duplicate IR matches, off-axis patterns, incomplete vocabularies, and severed provenance.

Targeted mutations were run for the original silent location deletion and missing pitch IDs, directional set collapse, equal-pitch numeric matching, grouped-member overcounting, lost drop identities, fuzzy source joins, presentation certification, direction-sign/default representation, and grid-angle periodicity. Each mutation made its named guard fail.

## Adversarial review

Six substantive rounds found and fixed:

1. representative-member position and linear direction sign overconstrained an otherwise exact pattern join;
2. pattern datum location was absent from the compiler vocabulary, so pitch alone could look complete;
3. corridor, legibility, callout, and pitch-drop paths discarded approved measurement IDs;
4. equivalent default axes and `angle + 180°` declarations failed correspondence, and tests breached the public Drawing audit boundary;
5. Codecov exposed an ambiguous numeric grid-pitch fallback and untested grouped-drop paths; the fallback was removed and fail-closed cases were pinned;
6. the full suite rejected a private renderer monkeypatch, so the forced-drop test now uses the public `Drawing.annotations()` seam.

Only typing/readability nits remain. There are no human review comments, requested changes, or unresolved threads.

## Validation

- Gate 2 semantic suite: 26 passed
- shared hole/pocket/slot pattern, location, strip, compiler, and audit suites: 204 passed
- private import/attribute ratchets: 4 passed
- full local suite before the final test-only seam correction: 2,765 passed, 1 guard failure, 1 skipped, 2 expected xfails; the failed guard and its companion ratchets then passed directly
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/draftwright/`
- `uv run codespell src tests docs`

GitHub CI is green on `f711086`: lint, all 15 Ubuntu/macOS/Windows Python 3.10-3.14 fast-test jobs, and both Codecov gates passed. Patch coverage is 97.34%; project coverage rose from 91.47% to 91.60%. The slow workflow was skipped by policy.

Closes the Gate 2 slice of #1018; does not close the epic.

