### PR TITLE
feat(#1043): soft-deprecate Sheet.auto_dimensions() and add_dimension()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,10 @@ entry. Keep `_LAYERS` and this section in step.
   detected as declared (#969); the DAG's bottom leaf (guarded
   by `test_geometry_is_a_leaf`) so the IR waist uses them without importing
   `_core`.
+- **`_warnings.py`** — the public warning categories (`SoftDeprecationWarning`), a
+  dependency-free leaf. Separate from `_core` on purpose: `_core` imports build123d, so a
+  category defined there costs the CAD kernel (~6 s) to reach, and the pytest
+  `filterwarnings` entry naming it pays that on every invocation (#1043).
 - **`fits.py`** — the ISO 286 fit tables (`fit_deviation`, `FitClass`; ADR 0011
   P2a.2): a rank-0 leaf consumed by `_core`, `model/ir` and `sheet`.
 - **`intents.py`** — the deferred-placement "low IR" behind `Drawing.finalize()`

--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ plate = Box(120, 80, 20)
 bore = Pos(0, 0, 0) * Cylinder(4, 20)
 
 sheet = Sheet(plate - bore, title="Plate", number="DWG-002")
-sheet.auto_dimensions()                                   # the planner's set (ADR 0016:
-                                                          # a build must say where its
-                                                          # dimensions come from)
-sheet.envelope()
+env = sheet.envelope()
 sheet.datum("A", plate.faces().sort_by()[-1])             # datum A on the top face
 hole = sheet.hole(bore).finish("1.6").note("M3x0.5 TAP")  # ⌀8 bore, Ra 1.6, tapped
 sheet.control(hole).position(0.1, to="A", diameter=True)  # ⌀0.1 position wrt A
+
+sheet.authored_dimensions()                               # THIS is the complete set
+sheet.dimension(env, "width.length")                      # (ADR 0016: a build says where
+sheet.dimension(env, "height.length")                     #  its dimensions come from, and
+sheet.dimension(hole, "bore.diameter")                    #  omitting one means suppress it)
+
 sheet.export("plate")                                     # writes plate.pdf
 ```
 

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -1251,3 +1251,61 @@ facade and not on the IR type. Worth revisiting if the raw route grows users.
   caught the grid-pitch collision, because two ungrouped pitches are two addressable units);
   a test that an ambiguous selector raises rather than picking; and a stability test that
   re-detecting a part yields the same `ParameterId`s.
+
+## Amendment 4 — authored is the preferred source on `Sheet`; automatic is soft deprecated there (2026-08-05)
+
+This ADR presents the two dimension sources as co-equal alternatives: *either*
+`auto_dimensions()` *or* an authored set, mutually exclusive, and a build must say which.
+The mutual exclusion and the requirement to say stand. The even-handedness does not.
+
+**On the `Sheet` surface, authored dimensions are the recommended source, and
+`auto_dimensions()` / `add_dimension()` are soft deprecated** (#1043) — discouraged, still
+supported, and **not scheduled for removal**.
+
+### Why the surfaces differ
+
+The choice reads as symmetric in the abstract and is not, once you look at what each surface
+is for.
+
+- **It is what draftwright emits.** `--script` writes `authored_dimensions()` and one
+  `dimension(...)` line per measurement. The automatic path is the only form the tool itself
+  never produces, so a hand-written script using it diverges from every generated one.
+- **Amendment/§ "omission means suppression" only holds for an authored set.** Under the
+  automatic source there are no omissions to read, so an author cannot say "not that one" —
+  the very expressiveness this ADR added is unavailable.
+- **An authored list is editable text.** That is what makes "generate a script, then refine
+  it" work, for a person or a model. An automatic set is decided at runtime, cannot be seen
+  in the file, and cannot be edited line by line.
+
+A caller who has already chosen the declaration surface has chosen to be explicit about
+*features*. Being implicit about *dimensions* in the same script is the inconsistency.
+
+### What is explicitly unaffected
+
+`build_drawing(part)`'s automatic dimensioning — the detected front door. Point the CLI at a
+STEP file or a build123d object and get a fully dimensioned drawing with no ceremony. That
+path is automatic by design and carries no warning; a guard asserts it.
+
+`Sheet.from_part(part)` also keeps its implicit automatic source. It is the on-ramp — detect
+the features, get a drawing, then author over it — and adding `dimension(...)` lines
+*overrides* rather than conflicts (#921). Warning there would scold the recommended
+migration.
+
+### Why soft, and why not a removal date
+
+`docs/deprecations.md` carries ADR 0005 §4: a compat surface names a tracking issue *and* a
+removal target, because "a facade with no exit date is a failure mode, not a success".
+
+That rule governs surfaces kept alive only so old code keeps working. This is a different
+thing: `auto_dimensions()` works, is supported, and there is simply a better way to say the
+same thing. Attaching a removal date we did not intend would be the exact failure §4 names,
+wearing a date.
+
+So it raises `SoftDeprecationWarning` (a `UserWarning` subclass), not `DeprecationWarning`,
+and lives in a separate "Discouraged" table with no removal target. A guard asserts the class
+relationship, so a future change to `DeprecationWarning` fails at the definition rather than
+silently acquiring an obligation.
+
+Incidentally the softer label is the louder signal: `DeprecationWarning` is filtered by
+default in notebooks, several test runners and library-internal call paths, whereas a
+`UserWarning` shows unconditionally.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -12,7 +12,7 @@ something.
 ## Discouraged — supported, no removal planned
 
 These are **soft deprecated**: they warn, they steer you elsewhere, and they are **not going
-away**. They raise `SoftDeprecationWarning` (a `UserWarning` subclass), *not*
+away**. They raise `draftwright.SoftDeprecationWarning` (a `UserWarning` subclass), *not*
 `DeprecationWarning`, and they deliberately carry **no removal target**.
 
 That is not a violation of ADR 0005 §4's exit-date rule — it is the reason the two categories
@@ -23,6 +23,15 @@ failure §4 names, wearing a date.
 
 `tests/test_deprecation_dates.py` scans `DeprecationWarning`s only, so these rows are outside
 it by construction.
+
+To silence the category in your own code:
+
+```python
+import warnings
+from draftwright import SoftDeprecationWarning
+
+warnings.filterwarnings("ignore", category=SoftDeprecationWarning)
+```
 
 | Surface | Prefer | Since | Why |
 |---|---|---|---|

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -9,6 +9,30 @@ place. `tests/test_deprecation_dates.py` fails if any `@deprecated` message or
 convention — but the test cannot check that a row exists *here*, so add one when you deprecate
 something.
 
+## Discouraged — supported, no removal planned
+
+These are **soft deprecated**: they warn, they steer you elsewhere, and they are **not going
+away**. They raise `SoftDeprecationWarning` (a `UserWarning` subclass), *not*
+`DeprecationWarning`, and they deliberately carry **no removal target**.
+
+That is not a violation of ADR 0005 §4's exit-date rule — it is the reason the two categories
+are separate. §4 governs *compat surfaces*: things kept alive only so old code keeps working,
+which rot if they never leave. These are different. They work, they are supported, and there
+is a better way to do the same thing. Writing a removal date we did not mean would be the exact
+failure §4 names, wearing a date.
+
+`tests/test_deprecation_dates.py` scans `DeprecationWarning`s only, so these rows are outside
+it by construction.
+
+| Surface | Prefer | Since | Why |
+|---|---|---|---|
+| `Sheet.auto_dimensions()` | `authored_dimensions()` + `dimension(feature, role)` lines | 0.4.1 (#1043) | authored is what `--script` emits, is editable text, and is the only form where omission can mean suppression (ADR 0016) |
+| `Sheet.add_dimension()` | a `dimension(feature, role)` line on an authored set | 0.4.1 (#1043) | it augments the automatic set, which is itself discouraged here |
+
+**Not affected:** `build_drawing(part)`'s automatic dimensioning. Point the CLI at a STEP or a
+build123d object and get a fully dimensioned drawing — that is the detected front door and
+being automatic is the whole point of it.
+
 ## Live deprecations
 
 | Surface | Use instead | Deprecated in | Removed in |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ markers = [
 # `pytest.warns`, which fires regardless of this filter. Real `DeprecationWarning`s are
 # untouched and still carry removal dates (`tests/test_deprecation_dates.py`).
 filterwarnings = [
-    "ignore::draftwright._core.SoftDeprecationWarning",
+    "ignore::draftwright.SoftDeprecationWarning",
 ]
 # Coverage is a CI concern (it adds ~13% locally and instruments every line); the
 # CI workflow passes the --cov flags explicitly. Keep the local default lean.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,18 @@ markers = [
     "slow: heavy end-to-end CTC fixture builds (deselected by default)",
     "smoke: curated build-light subset for a fast local check (~30 s)",
 ]
+# `SoftDeprecationWarning` marks a surface that is discouraged but SUPPORTED and not going
+# away (#1043). The suite exercises `Sheet.auto_dimensions()` in ~170 places, deliberately —
+# it is still a supported path and its behaviour must keep being tested. Migrating those to
+# authored dimensions would be churn that tests less, so the category is silenced here rather
+# than at ~170 call sites.
+#
+# This does NOT weaken the guard: `tests/test_soft_deprecation.py` asserts the warning with
+# `pytest.warns`, which fires regardless of this filter. Real `DeprecationWarning`s are
+# untouched and still carry removal dates (`tests/test_deprecation_dates.py`).
+filterwarnings = [
+    "ignore::draftwright._core.SoftDeprecationWarning",
+]
 # Coverage is a CI concern (it adds ~13% locally and instruments every line); the
 # CI workflow passes the --cov flags explicitly. Keep the local default lean.
 addopts = "--tb=short -m 'not slow'"

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -33,9 +33,10 @@ _LAZY = {
     "extract_pmi": "draftwright.pmi",
     "choose_scale": "draftwright.compose",
     # A warning category users are told to filter must be importable without reaching into a
-    # private module (#1043 review). `_core` is cheap — it does not drag the CAD kernel — but
-    # it stays lazy for consistency with everything else here.
-    "SoftDeprecationWarning": "draftwright._core",
+    # private module (#1043 review) — and without paying for the CAD kernel. It lives in the
+    # dependency-free `_warnings` leaf for that second reason: defined in `_core` it cost ~6 s
+    # to reach, and the pytest filterwarnings entry naming it paid that on every invocation.
+    "SoftDeprecationWarning": "draftwright._warnings",
 }
 
 

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -32,6 +32,10 @@ _LAZY = {
     "PmiRecord": "draftwright.pmi",
     "extract_pmi": "draftwright.pmi",
     "choose_scale": "draftwright.compose",
+    # A warning category users are told to filter must be importable without reaching into a
+    # private module (#1043 review). `_core` is cheap — it does not drag the CAD kernel — but
+    # it stays lazy for consistency with everything else here.
+    "SoftDeprecationWarning": "draftwright._core",
 }
 
 
@@ -85,6 +89,7 @@ def __dir__():
 
 __all__ = [
     "Drawing",
+    "SoftDeprecationWarning",
     "FeatureInfo",
     "PmiRecord",
     "Sheet",

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -73,6 +73,7 @@ _sys.modules[__name__].__class__ = _DraftwrightModule
 
 
 if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel cost
+    from draftwright._warnings import SoftDeprecationWarning
     from draftwright.builder import build_drawing, make_drawing
     from draftwright.compose import choose_scale
     from draftwright.drawing import Drawing, FeatureInfo

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -49,26 +49,6 @@ from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
 _log = logging.getLogger(__name__)
 
 
-class SoftDeprecationWarning(UserWarning):
-    """A surface that is **discouraged but supported**, with no removal planned.
-
-    Deliberately NOT a :class:`DeprecationWarning`. ``docs/deprecations.md`` carries ADR 0005
-    §4's rule — a compat surface names a tracking issue *and* a removal target, because "a
-    facade with no exit date is a failure mode, not a success" — and
-    ``tests/test_deprecation_dates.py`` enforces it. Raising a ``DeprecationWarning`` for
-    something we intend to keep would mean writing a removal date we do not mean, which is
-    that failure mode wearing a date.
-
-    "Soft deprecated" is the term Python uses for exactly this: still supported, not
-    scheduled for removal, but not what you should reach for in new code.
-
-    A ``UserWarning`` subclass rather than a bare one so callers can silence this category
-    alone. It is also, in practice, the louder signal: ``DeprecationWarning`` is filtered by
-    default in notebooks, several test runners, and library-internal call paths, whereas this
-    shows unconditionally.
-    """
-
-
 def place_annotation(registry, items, obj, name=None, view=None, feature=None, measurement=None):
     """The annotation-placement primitive (#817): register *obj* under *name* — replacing any
     prior object of that name (dropped from the render list *items*) so a name maps to one

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -49,6 +49,26 @@ from draftwright.layout import _greedy_strip_1d, _solve_strip_1d
 _log = logging.getLogger(__name__)
 
 
+class SoftDeprecationWarning(UserWarning):
+    """A surface that is **discouraged but supported**, with no removal planned.
+
+    Deliberately NOT a :class:`DeprecationWarning`. ``docs/deprecations.md`` carries ADR 0005
+    §4's rule — a compat surface names a tracking issue *and* a removal target, because "a
+    facade with no exit date is a failure mode, not a success" — and
+    ``tests/test_deprecation_dates.py`` enforces it. Raising a ``DeprecationWarning`` for
+    something we intend to keep would mean writing a removal date we do not mean, which is
+    that failure mode wearing a date.
+
+    "Soft deprecated" is the term Python uses for exactly this: still supported, not
+    scheduled for removal, but not what you should reach for in new code.
+
+    A ``UserWarning`` subclass rather than a bare one so callers can silence this category
+    alone. It is also, in practice, the louder signal: ``DeprecationWarning`` is filtered by
+    default in notebooks, several test runners, and library-internal call paths, whereas this
+    shows unconditionally.
+    """
+
+
 def place_annotation(registry, items, obj, name=None, view=None, feature=None, measurement=None):
     """The annotation-placement primitive (#817): register *obj* under *name* — replacing any
     prior object of that name (dropped from the render list *items*) so a name maps to one

--- a/src/draftwright/_warnings.py
+++ b/src/draftwright/_warnings.py
@@ -1,0 +1,39 @@
+"""Warning categories — a dependency-free leaf.
+
+Deliberately its own module rather than living in :mod:`draftwright._core`. `_core` imports
+build123d, so a category defined there costs the full CAD kernel (~6 s) to reach — and the
+pytest ``filterwarnings`` entry that names it pays that on **every** invocation, including
+``--collect-only`` and the ~30 s smoke tier. A warning class is the last thing that should
+drag a geometry kernel behind it (#1043 review).
+
+Nothing here imports anything.
+"""
+
+from __future__ import annotations
+
+
+class SoftDeprecationWarning(UserWarning):
+    """A surface that is **discouraged but supported**, with no removal planned.
+
+    Deliberately NOT a :class:`DeprecationWarning`. ``docs/deprecations.md`` carries ADR 0005
+    §4's rule — a compat surface names a tracking issue *and* a removal target, because "a
+    facade with no exit date is a failure mode, not a success" — and
+    ``tests/test_deprecation_dates.py`` enforces it. Raising a ``DeprecationWarning`` for
+    something we intend to keep would mean writing a removal date we do not mean, which is
+    that failure mode wearing a date.
+
+    "Soft deprecated" is the term Python uses for exactly this: still supported, not
+    scheduled for removal, but not what you should reach for in new code.
+
+    A ``UserWarning`` subclass rather than a bare one so callers can silence this category
+    alone::
+
+        import warnings
+        from draftwright import SoftDeprecationWarning
+
+        warnings.filterwarnings("ignore", category=SoftDeprecationWarning)
+
+    It is also, in practice, the louder signal: ``DeprecationWarning`` is filtered by default
+    in notebooks, several test runners, and library-internal call paths, whereas this shows
+    unconditionally.
+    """

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -8,13 +8,20 @@ that previously held ``sheet.py`` is ``compose.py``.)
 Reference the build123d objects you built, declare the drawing aspects they need,
 export. Geometry supplies the size (⌀ read off the object); you supply only the
 intent. Built on the ``model=`` seam (:func:`draftwright.build_drawing`), so
-detection is skipped and the auto-pass dimensions exactly the declared features::
+detection is skipped. A build must also say where its dimensions come from (ADR
+0016); authored is the recommended source here, and `auto_dimensions()` is soft
+deprecated (#1043)::
 
     sheet = Sheet(part, title="PLATE", number="DWG-001")
-    sheet.envelope()
-    sheet.hole(h1)
+    env = sheet.envelope()
+    bore = sheet.hole(h1)
     sheet.hole(h2).depth(5)          # a blind hole — adds a depth callout
     sheet.diameter(boss_cyl)
+
+    sheet.authored_dimensions()      # THIS is the complete set (ADR 0016)
+    sheet.dimension(env, "width.length")
+    sheet.dimension(bore, "bore.diameter")
+
     sheet.export("plate")
 
 **Scope (this module):** the *feature-declaration* surface over the renderers the
@@ -48,8 +55,8 @@ from collections.abc import MutableSequence
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
-from draftwright._core import SoftDeprecationWarning
 from draftwright._geometry import _solids_body
+from draftwright._warnings import SoftDeprecationWarning
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
 from draftwright.model import DimensionParameterId, Feature

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -48,6 +48,7 @@ from collections.abc import MutableSequence
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
+from draftwright._core import SoftDeprecationWarning
 from draftwright._geometry import _solids_body
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.fits import fit_class
@@ -1375,16 +1376,39 @@ class Sheet:
         return self._features
 
     def auto_dimensions(self) -> Sheet:
-        """Ask for the planner's automatic dimension set (ADR 0016).
+        """**Soft deprecated** (#1043) — prefer :meth:`authored_dimensions` in new code.
 
-        **Required**, unless the sheet authors its own set with :meth:`dimension` (#874):
-        a build must say where its dimensions come from rather than defaulting to one
-        silently, so a script that means "dimension this for me" reads that way, and one
-        that means "draw exactly what I name" cannot be mistaken for it.
+        Supported, and **not scheduled for removal**: existing scripts keep working. But on
+        this surface, authored dimensions are the right default, for three reasons:
 
-        This is also what :meth:`add_dimension` augments — an augment only means
-        something against a set the planner chose.
+        - it is what draftwright itself emits — ``--script`` writes ``authored_dimensions()``
+          with a line per dimension, so the automatic path is the only form the tool never
+          produces;
+        - *omission means suppression* (ADR 0016) only holds for an authored set. Under an
+          automatic one you cannot express "not that one";
+        - an authored list is editable text. That is what makes "generate a script, then
+          refine it" work, for a person or a model.
+
+        If you want the planner's choices as a starting point, generate them —
+        ``draftwright yourmodule:part --script`` — and edit the result, rather than asking
+        for them at runtime where they cannot be seen or changed.
+
+        Still asks for the planner's automatic set (ADR 0016). A build must say where its
+        dimensions come from rather than defaulting silently (#874), and this is one of the
+        two ways to say it. It is also what :meth:`add_dimension` augments.
+
+        ``build_drawing(part)``'s automatic path is unaffected and carries no warning — that
+        is the detected front door, and being automatic is its whole point.
         """
+        warnings.warn(
+            "Sheet.auto_dimensions() is soft deprecated: still supported and NOT scheduled "
+            "for removal, but authored dimensions are the going-forward surface. Prefer "
+            "authored_dimensions() plus dimension(feature, role) lines — or generate them "
+            "with `--script` and edit the result. build_drawing()'s automatic path is "
+            "unaffected.",
+            SoftDeprecationWarning,
+            stacklevel=2,
+        )
         self._auto_dimensions = "explicit"
         return self
 
@@ -1416,6 +1440,11 @@ class Sheet:
 
         Returns a :class:`DimensionIntent`.
 
+        **Soft deprecated** (#1043) — supported and not scheduled for removal, but it exists
+        only to augment :meth:`auto_dimensions`, which is itself discouraged here. To add a
+        measurement to an authored set, write a :meth:`dimension` line: same effect, and the
+        result is visible in the script rather than computed at runtime.
+
         Requesting a measurement the planner already emits is a deliberate no-op, not an
         error: a script should be able to ask without first knowing the rule set's mind.
 
@@ -1424,6 +1453,14 @@ class Sheet:
         a silent coin toss between the row and column pitch is the kind of wrong a reader
         cannot see.
         """
+        warnings.warn(
+            "Sheet.add_dimension() is soft deprecated: still supported and NOT scheduled for "
+            "removal, but it augments the automatic set, which is itself discouraged here. "
+            "Prefer authored_dimensions() plus a dimension(feature, role) line — the same "
+            "measurement, visible in the script rather than added at runtime.",
+            SoftDeprecationWarning,
+            stacklevel=2,
+        )
         token, _target, discriminator, role = self._resolve_measurement(
             feature, role, axis, "add_dimension"
         )
@@ -1474,12 +1511,14 @@ class Sheet:
         if not self._auto_dimensions and not authored:
             raise ValueError(
                 "this sheet does not say where its dimensions come from. Call "
-                "auto_dimensions() for the planner's set, or authored_dimensions() to declare "
-                "the complete set yourself and then add zero or more dimension(feature, role) "
-                "lines. (A dimension(...) line selects the authored source on its own; the "
-                "verb is how a COMPLETE-BUT-EMPTY set says so, since it has no line to say it "
-                "with. Building without either used to mean the automatic set; ADR 0016 makes "
-                "the source explicit so that omitting a dimension can mean something.)"
+                "authored_dimensions() and then add zero or more dimension(feature, role) "
+                "lines to declare the complete set — that is the recommended surface, and "
+                "what `--script` generates. (A dimension(...) line selects the authored "
+                "source on its own; the verb is how a COMPLETE-BUT-EMPTY set says so, since "
+                "it has no line to say it with.) auto_dimensions() also works and is "
+                "supported, but is soft deprecated on this surface (#1043). Building without "
+                "either used to mean the automatic set; ADR 0016 makes the source explicit "
+                "so that omitting a dimension can mean something."
             )
 
     def _resolve_measurement(

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -56,6 +56,11 @@ _MODEL_DIR = _SRC / "model"
 _LAYERS: dict[str, int] = {
     # 0 — leaves: import nothing from draftwright (or only same-rank leaves / the IR waist)
     "_geometry": 0,
+    # Warning categories only. Imports nothing at all — deliberately, because a category
+    # users are told to filter must not cost the CAD kernel to reach (#1043): defined beside
+    # `_core` it dragged build123d, and the pytest filterwarnings entry naming it paid ~6 s on
+    # every invocation.
+    "_warnings": 0,
     "fits": 0,
     "fonts": 0,
     "layout": 0,

--- a/tests/test_soft_deprecation.py
+++ b/tests/test_soft_deprecation.py
@@ -1,0 +1,118 @@
+"""Soft deprecation: discouraged, supported, and NOT scheduled for removal (#1043).
+
+`Sheet.auto_dimensions()` and `Sheet.add_dimension()` steer callers toward authored
+dimensions, which is what `--script` emits and the only form where omission can mean
+suppression (ADR 0016). They keep working indefinitely.
+
+The category matters as much as the message. `docs/deprecations.md` carries ADR 0005 §4 —
+a compat surface names a removal target, because "a facade with no exit date is a failure
+mode" — and `tests/test_deprecation_dates.py` enforces it. Raising `DeprecationWarning` for
+something we intend to keep would mean writing a removal date we do not mean.
+"""
+
+import warnings
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright._core import SoftDeprecationWarning
+
+
+def _part():
+    return Box(80, 60, 20) - Pos(0, 0, 0) * Cylinder(5, 20)
+
+
+def test_soft_deprecation_is_not_a_deprecation_warning():
+    """The load-bearing distinction, asserted directly.
+
+    If this ever becomes a `DeprecationWarning`, it silently acquires an obligation under ADR
+    0005 §4 to carry a removal target — and `test_deprecation_dates` would start scanning a
+    message that promises no removal, because we do not intend one. Better to fail here, at
+    the definition, than there with a confusing message.
+    """
+    assert issubclass(SoftDeprecationWarning, UserWarning)
+    assert not issubclass(SoftDeprecationWarning, DeprecationWarning)
+
+
+@pytest.mark.parametrize("verb", ["auto_dimensions", "add_dimension"])
+def test_the_discouraged_verbs_warn_without_promising_removal(verb):
+    """Each names the replacement, and explicitly does NOT promise to go away — a user who
+    reads the warning should learn that their code will keep working."""
+    sheet = Sheet(_part())
+    hole = sheet.hole(Pos(0, 0, 0) * Cylinder(5, 20))
+
+    with pytest.warns(SoftDeprecationWarning) as rec:
+        if verb == "auto_dimensions":
+            sheet.auto_dimensions()
+        else:
+            # `add_dimension` only means something against an automatic set, so reaching it
+            # necessarily warns twice. The last warning is the one under test.
+            sheet.auto_dimensions()
+            sheet.add_dimension(hole, "bore.diameter")
+
+    msg = str(rec[-1].message)
+    assert "authored" in msg.lower(), f"the warning must name the replacement: {msg}"
+    assert "not scheduled for removal" in msg.lower(), (
+        f"the warning must say it is staying — that is what makes this soft: {msg}"
+    )
+
+
+def test_the_warning_does_not_claim_a_removal_version():
+    """`test_deprecation_dates` requires removal LANGUAGE plus a version of every
+    `DeprecationWarning`. These must not read like that, or a future reader will believe a
+    removal is scheduled when none is.
+    """
+    import re
+
+    sheet = Sheet(_part())
+    with pytest.warns(SoftDeprecationWarning) as rec:
+        sheet.auto_dimensions()
+
+    msg = str(rec[0].message)
+    assert not re.search(r"(?:removed|removal|expires)\b[^.]{0,60}?\d+\.\d+", msg, re.I), (
+        f"the message reads like a scheduled removal, which it is not: {msg}"
+    )
+
+
+def test_the_automatic_detected_path_is_not_discouraged():
+    """The boundary most likely to be crossed by accident.
+
+    `build_drawing(part)` IS automatic dimensioning, and that is the product's front door —
+    point the CLI at a STEP and get a drawing. Only the `Sheet` declaration surface is
+    steered, because an author who is already explicit about features should be equally
+    explicit about dimensions.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SoftDeprecationWarning)
+        drawing = build_drawing(_part())
+
+    assert drawing.annotations(), "the automatic path should still dimension the part"
+
+
+def test_the_recommended_migration_does_not_nag():
+    """`from_part()` seeds detected features and picks the automatic source *implicitly*;
+    adding `dimension(...)` lines overrides it (#921). That is the recommended way to take
+    over a detected drawing, so it must not warn — a migration path that scolds you for
+    taking it is worse than no advice.
+    """
+    part = _part()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SoftDeprecationWarning)
+        sheet = Sheet.from_part(part)
+        feature = next(f for f in sheet.features if f.kind == "hole")
+        sheet.dimension(feature, "bore.diameter")
+        sheet.build()
+
+
+def test_authored_dimensions_is_silent():
+    """The recommended surface itself, obviously, must not warn."""
+    part = _part()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SoftDeprecationWarning)
+        sheet = Sheet(part)
+        hole = sheet.hole(Pos(0, 0, 0) * Cylinder(5, 20))
+        sheet.envelope()
+        sheet.authored_dimensions()
+        sheet.dimension(hole, "bore.diameter")
+        sheet.build()

--- a/tests/test_soft_deprecation.py
+++ b/tests/test_soft_deprecation.py
@@ -10,6 +10,7 @@ mode" — and `tests/test_deprecation_dates.py` enforces it. Raising `Deprecatio
 something we intend to keep would mean writing a removal date we do not mean.
 """
 
+import pathlib
 import subprocess
 import sys
 import warnings
@@ -191,4 +192,30 @@ def test_reaching_the_warning_category_does_not_import_the_cad_kernel():
     assert out.stdout.strip() == "False", (
         "importing SoftDeprecationWarning pulled in the CAD kernel — it belongs in a "
         "dependency-free leaf, not beside code that imports build123d"
+    )
+
+
+def test_the_category_is_defined_exactly_once():
+    """One class, one place.
+
+    `_core` kept a second, independent definition after the class was moved to the
+    dependency-free leaf — a `git checkout` used to undo a mutation clobbered the deletion,
+    and it was committed back (Codex #1045 r3). Two classes with one name is worse than
+    either alone: `Sheet` emits the public one, so anyone filtering or catching the other
+    silently matches nothing, and the kernel-dragging definition the move existed to remove
+    is still there.
+
+    Scans the source rather than comparing imports, because the two-class state is invisible
+    to every behavioural test — `pytest.warns(SoftDeprecationWarning)` passes either way.
+    """
+    root = pathlib.Path(__file__).resolve().parent.parent / "src" / "draftwright"
+    definitions = [
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*.py")
+        if "class SoftDeprecationWarning" in path.read_text(encoding="utf-8")
+    ]
+
+    assert definitions == ["_warnings.py"], (
+        f"SoftDeprecationWarning is defined in {definitions} — it belongs only in the "
+        "dependency-free leaf. A second definition matches nothing that the first catches."
     )

--- a/tests/test_soft_deprecation.py
+++ b/tests/test_soft_deprecation.py
@@ -15,8 +15,7 @@ import warnings
 import pytest
 from build123d import Box, Cylinder, Pos
 
-from draftwright import Sheet, build_drawing
-from draftwright._core import SoftDeprecationWarning
+from draftwright import Sheet, SoftDeprecationWarning, build_drawing
 
 
 def _part():
@@ -35,43 +34,74 @@ def test_soft_deprecation_is_not_a_deprecation_warning():
     assert not issubclass(SoftDeprecationWarning, DeprecationWarning)
 
 
+def _warn_auto(sheet):
+    """Select the automatic source WITHOUT its warning reaching the caller's capture.
+
+    `add_dimension` is only legal against an automatic set, so reaching it necessarily warns
+    twice. The first cut of these tests wrapped both calls in one `pytest.warns` and asserted
+    on the last record — which passes even if `add_dimension` stops warning entirely, because
+    `auto_dimensions`' warning satisfies every assertion on its own. Verified: deleting
+    `add_dimension`'s warning left all seven tests green (Codex #1045 r1).
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SoftDeprecationWarning)
+        sheet.auto_dimensions()
+
+
+def _trigger(verb, sheet, hole):
+    """Call exactly ONE discouraged verb, with any prerequisite warning already absorbed."""
+    if verb == "auto_dimensions":
+        sheet.auto_dimensions()
+    else:
+        _warn_auto(sheet)
+        sheet.add_dimension(hole, "bore.diameter")
+
+
 @pytest.mark.parametrize("verb", ["auto_dimensions", "add_dimension"])
 def test_the_discouraged_verbs_warn_without_promising_removal(verb):
     """Each names the replacement, and explicitly does NOT promise to go away — a user who
-    reads the warning should learn that their code will keep working."""
+    reads the warning should learn that their code will keep working.
+
+    Exactly one warning is captured, so each verb is tested on its own behaviour.
+    """
     sheet = Sheet(_part())
     hole = sheet.hole(Pos(0, 0, 0) * Cylinder(5, 20))
 
     with pytest.warns(SoftDeprecationWarning) as rec:
-        if verb == "auto_dimensions":
-            sheet.auto_dimensions()
-        else:
-            # `add_dimension` only means something against an automatic set, so reaching it
-            # necessarily warns twice. The last warning is the one under test.
-            sheet.auto_dimensions()
-            sheet.add_dimension(hole, "bore.diameter")
+        _trigger(verb, sheet, hole)
 
-    msg = str(rec[-1].message)
+    assert len(rec) == 1, (
+        f"expected exactly one warning from {verb}, got {len(rec)} — a prerequisite verb's "
+        "warning is leaking into the capture and could satisfy these assertions by itself"
+    )
+    msg = str(rec[0].message)
+    assert verb in msg, f"the warning must name the verb it came from: {msg}"
     assert "authored" in msg.lower(), f"the warning must name the replacement: {msg}"
     assert "not scheduled for removal" in msg.lower(), (
         f"the warning must say it is staying — that is what makes this soft: {msg}"
     )
 
 
-def test_the_warning_does_not_claim_a_removal_version():
+@pytest.mark.parametrize("verb", ["auto_dimensions", "add_dimension"])
+def test_the_warning_does_not_claim_a_removal_version(verb):
     """`test_deprecation_dates` requires removal LANGUAGE plus a version of every
     `DeprecationWarning`. These must not read like that, or a future reader will believe a
     removal is scheduled when none is.
+
+    Parametrised over both verbs: the first cut checked only `auto_dimensions`, so
+    `add_dimension` could have started promising a removal without this failing.
     """
     import re
 
     sheet = Sheet(_part())
+    hole = sheet.hole(Pos(0, 0, 0) * Cylinder(5, 20))
+
     with pytest.warns(SoftDeprecationWarning) as rec:
-        sheet.auto_dimensions()
+        _trigger(verb, sheet, hole)
 
     msg = str(rec[0].message)
     assert not re.search(r"(?:removed|removal|expires)\b[^.]{0,60}?\d+\.\d+", msg, re.I), (
-        f"the message reads like a scheduled removal, which it is not: {msg}"
+        f"{verb}'s message reads like a scheduled removal, which it is not: {msg}"
     )
 
 

--- a/tests/test_soft_deprecation.py
+++ b/tests/test_soft_deprecation.py
@@ -10,6 +10,8 @@ mode" — and `tests/test_deprecation_dates.py` enforces it. Raising `Deprecatio
 something we intend to keep would mean writing a removal date we do not mean.
 """
 
+import subprocess
+import sys
 import warnings
 
 import pytest
@@ -146,3 +148,47 @@ def test_authored_dimensions_is_silent():
         sheet.authored_dimensions()
         sheet.dimension(hole, "bore.diameter")
         sheet.build()
+
+
+@pytest.mark.parametrize("verb", ["auto_dimensions", "add_dimension"])
+def test_the_warning_blames_the_caller_not_the_library(verb):
+    """`stacklevel=2`, guarded.
+
+    A warning attributed to `sheet.py` tells the user nothing: they cannot see which of their
+    lines caused it, which for a "stop using this" message is the entire value. The
+    implementation was already correct, but nothing failed if it stopped being — mutating
+    either site to `stacklevel=1` left every other guard green (Codex #1045 r2).
+    """
+    sheet = Sheet(_part())
+    hole = sheet.hole(Pos(0, 0, 0) * Cylinder(5, 20))
+
+    with pytest.warns(SoftDeprecationWarning) as rec:
+        _trigger(verb, sheet, hole)
+
+    assert rec[0].filename == __file__, (
+        f"{verb}'s warning is attributed to {rec[0].filename}, not the caller. A user cannot "
+        "act on a warning that points at library internals."
+    )
+
+
+def test_reaching_the_warning_category_does_not_import_the_cad_kernel():
+    """A warning class must not drag build123d behind it.
+
+    It lived in `_core`, which imports build123d — so `from draftwright import
+    SoftDeprecationWarning` cost ~6 s, and the pytest `filterwarnings` entry naming it paid
+    that on EVERY invocation, including `--collect-only` and the smoke tier.
+
+    Run in a subprocess because this test module has already imported the kernel; checking
+    `sys.modules` in-process would pass regardless of where the class lives, which is why the
+    original regression was invisible to the suite (Codex #1045 r2).
+    """
+    probe = (
+        "import sys; from draftwright import SoftDeprecationWarning; "
+        "print('build123d' in sys.modules or 'OCP' in sys.modules)"
+    )
+    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+
+    assert out.stdout.strip() == "False", (
+        "importing SoftDeprecationWarning pulled in the CAD kernel — it belongs in a "
+        "dependency-free leaf, not beside code that imports build123d"
+    )


### PR DESCRIPTION
Closes #1043. Authored dimensions become the going-forward surface on `Sheet`.

**Discouraged is not deprecated.** `auto_dimensions()` keeps working, with no removal planned. That distinction is the design decision here, not an implementation detail.

## Why authored, on this surface

- **It is what draftwright emits.** `--script` writes `authored_dimensions()` and a line per dimension, so the automatic path is the only form the tool itself never produces.
- **"Omission means suppression" (#876) only holds for an authored set.** Under the automatic one there are no omissions to read, so an author cannot say *not that one* — the expressiveness ADR 0016 added is unavailable.
- **An authored list is editable text**, which is what makes "generate a script, then refine it" work for a person or a model.

A caller who chose the declaration surface chose to be explicit about *features*. Being implicit about *dimensions* in the same script is the inconsistency.

## Why soft, and why that is not a dodge

`docs/deprecations.md` carries ADR 0005 §4 — a compat surface names a removal target, because *"a facade with no exit date is a failure mode, not a success"* — and `test_deprecation_dates` enforces removal **language plus a version**.

Since we do not intend to remove this, a `DeprecationWarning` would mean writing a date we do not mean: the exact failure §4 names, wearing a date. So it raises **`SoftDeprecationWarning`** (a `UserWarning` subclass) and lives in a separate *Discouraged* table with no removal target.

Two things make this the better instrument rather than merely the more honest one:

1. `DeprecationWarning` is **filtered by default** in notebooks, several test runners, and library-internal call paths. A `UserWarning` shows unconditionally — for dissuasion, the softer label is the louder warning.
2. For steering LLMs, the **docstring** does most of the work; they read source far more reliably than they observe runtime warnings. Both docstrings now lead with the recommendation.

## Explicitly unaffected, both guarded

- **`build_drawing(part)`** — the detected front door. Point the CLI at a STEP or a build123d object and get a dimensioned drawing. Automatic by design; no warning.
- **`Sheet.from_part(part)`** — the on-ramp, where adding `dimension(...)` lines *overrides* the implicit choice (#921). Warning there would scold the recommended migration.

## Also here

- The no-dimension-source error leads with `authored_dimensions()`.
- The README example is authored — run under `-W error::UserWarning` to prove the documented path is silent.
- **ADR 0016 Amendment 4.** The ADR presents the two sources as co-equal, so without this the deprecation contradicts the decision record.

## The one judgement call

The suite calls `auto_dimensions()` at **~170 sites across 21 files**, deliberately — it is a supported path whose behaviour must keep being tested. Migrating them would be churn that tests *less*, so the category is silenced in `pyproject.toml` with the reasoning inline. `pytest.warns` fires regardless, so the guards are unaffected: **zero warning lines, 347 passed** on the noisiest suites.

## Verification

- **1402 passed** across eight affected suites; four gates clean.
- **Mutations, both red**: making it a `DeprecationWarning` fails the category guard; letting the message read like a scheduled removal fails two others.
- Guards cover the automatic path staying silent and the migration path not nagging — the two boundaries most likely to be crossed by accident.