### PR TITLE
Place independent flat callouts in clear margin

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1792,27 +1792,37 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
         # First-AUTHORED tolerance wins (planner/model order, not spatial — see the
         # fillet pass / render_diameters precedent, Codex review).
         tol = next((pd.tolerance for _, pd in members if pd.tolerance is not None), None)
-        # The margin fallback is specifically for several independent pieces of stock in the
-        # same aggregate view (#1034).  Do not enable it for a lone flat: today that includes
-        # slanted stock, whose aligned-only identity is not canonical and must remain reported
-        # as dropped until both halves of #1036 are fixed together.
-        candidate_factory = (
-            _flat_candidates if sum(key[0] == axis for key in collapse) > 1 else _corner_candidates
-        )
+        axis_aligned = all(g.facts.axis_aligned for g, _ in members)
+        if not axis_aligned:
+            # Slanted stock's two-coordinate axis_line is not canonical (#1036). It used to
+            # drop accidentally when alone but could render when several slanted stocks made
+            # the aggregate view large enough. An empty candidate set makes the unsupported
+            # state deterministic and still records one attributed flat_dropped outcome.
+            candidates = ()
+        else:
+            # The margin fallback is specifically for several independent pieces of aligned
+            # stock in the same aggregate view (#1034). Ordinary single/double-D stock keeps
+            # the established centre-out placement first and unchanged.
+            candidate_factory = (
+                _flat_candidates
+                if sum(key[0] == axis for key in collapse) > 1
+                else _corner_candidates
+            )
+            candidates = candidate_factory(
+                dwg,
+                view,
+                vb,
+                [g.facts for g, _ in ordered],
+                reach,
+                provenances=[g.ref for g, _ in ordered],
+            )
         jobs.append(
             (
                 f"m_flat_{axis}{gi}",
                 view,
                 vb,
                 _flat_label(members[0][1].value_text, _tol_suffix(tol, draft)),
-                candidate_factory(
-                    dwg,
-                    view,
-                    vb,
-                    [g.facts for g, _ in ordered],
-                    reach,
-                    provenances=[g.ref for g, _ in ordered],
-                ),
+                candidates,
                 tuple(pd.id for _, pd in ordered),  # the grouped callout draws every member
             )
         )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1492,6 +1492,36 @@ def _corner_candidates(dwg, view, vb, members, reach, *, provenances=None):
         yield (tip, elbow, owner)
 
 
+def _flat_candidates(dwg, view, vb, members, reach, *, provenances):
+    """Keep the established centre-out lead first, then try true margin escapes.
+
+    A flat is a corner feature on its own stock, but not necessarily on the aggregate view:
+    parallel stock can put an inner lobe well inside ``vb``.  The old single candidate moved
+    only *reach* from that lobe and left the label intersecting the aggregate silhouette.
+    ``_radial_candidates`` advances to the view boundary before adding the same reach, so its
+    fallbacks use available margin without changing the preferred placement of ordinary flats.
+    """
+    members = list(members)
+    provenances = list(provenances)
+    yield from _corner_candidates(
+        dwg,
+        view,
+        vb,
+        members,
+        reach,
+        provenances=provenances,
+    )
+    for member, provenance in zip(members, provenances):
+        yield from _radial_candidates(
+            dwg,
+            view,
+            vb,
+            member,
+            reach,
+            provenance=provenance,
+        )
+
+
 def _leader_callout_pass(dwg, a, jobs, *, noun, drop_code, ctx, geom_clear=False) -> int:
     """Place one machined-feature leader callout per job (#637). A *job* is
     ``(name, view, vb, label, candidates, measurement)`` where *candidates* yields ``(tip,
@@ -1762,13 +1792,20 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
         # First-AUTHORED tolerance wins (planner/model order, not spatial — see the
         # fillet pass / render_diameters precedent, Codex review).
         tol = next((pd.tolerance for _, pd in members if pd.tolerance is not None), None)
+        # The margin fallback is specifically for several independent pieces of stock in the
+        # same aggregate view (#1034).  Do not enable it for a lone flat: today that includes
+        # slanted stock, whose aligned-only identity is not canonical and must remain reported
+        # as dropped until both halves of #1036 are fixed together.
+        candidate_factory = (
+            _flat_candidates if sum(key[0] == axis for key in collapse) > 1 else _corner_candidates
+        )
         jobs.append(
             (
                 f"m_flat_{axis}{gi}",
                 view,
                 vb,
                 _flat_label(members[0][1].value_text, _tol_suffix(tol, draft)),
-                _corner_candidates(
+                candidate_factory(
                     dwg,
                     view,
                     vb,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -253,10 +253,11 @@ _FACTS: dict[str, tuple[str, ...]] = {
     # changes output, and a migration that claims byte-identity is the wrong place for it.
     "chamfer": ("frame", "axis", "leg2", "angle"),
     "fillet": ("frame", "axis"),
-    # `axis_line` is STRUCTURE, not a measurement: it says which piece of stock a flat
-    # belongs to, so the renderer can tell a double-D's two faces from two parallel
-    # lobes (#1013). The drawing never prints it.
-    "flat": ("frame", "axis", "axis_line", "stock_span"),
+    # `axis_line`/`stock_span` are STRUCTURE, not measurements: they say which piece of stock
+    # a flat belongs to, so the renderer can tell a double-D's two faces from two parallel
+    # lobes (#1013). `axis_aligned` gates a placement capability whose slanted identity is not
+    # canonical yet (#1036). The drawing prints none of them.
+    "flat": ("frame", "axis", "axis_line", "stock_span", "axis_aligned"),
     "groove": ("frame", "axis"),
     "plate": ("frame", "axis"),
     # Raw AP242 PMI is the documented non-generated exception: its source-authored label

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -498,7 +498,14 @@ def _read_flat_face(face) -> Point:
 
 
 def flat(
-    obj=None, *, axis=None, across=None, at=None, axis_line=None, stock_span=None
+    obj=None,
+    *,
+    axis=None,
+    across=None,
+    at=None,
+    axis_line=None,
+    stock_span=None,
+    axis_aligned=True,
 ) -> FlatFeature:
     """A machined flat on round stock (#148b). Either ``flat(flat_face)`` — the planar face
     supplies the leader point ``at`` (``axis=`` and ``across=`` still required, being
@@ -523,6 +530,7 @@ def flat(
         across=round(across, 3),
         axis_line=_stock_pair(axis_line),
         stock_span=_stock_pair(stock_span),
+        axis_aligned=axis_aligned,
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -512,6 +512,7 @@ def _convert_flat(flat: Flat, ctx: ConvContext) -> FlatFeature:
         across=flat.across,
         axis_line=flat.axis_line,
         stock_span=flat.stock_span,
+        axis_aligned=flat.axis_aligned,
     )
 
 

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -649,6 +649,10 @@ class FlatFeature:
     #: The owning stock's axial extent — with ``axis_line``, the stock identity. Coaxial
     #: stacked stock shares an axis line, so that alone merged independent definitions.
     stock_span: tuple[float, float] = (0.0, 0.0)
+    #: False for stock whose real cylinder direction is not the named principal ``axis``.
+    #: Its aligned-only ``axis_line`` is not canonical, so margin fallback must not make its
+    #: callout render before #1036 fixes identity and rendering together.
+    axis_aligned: bool = True
     kind: ClassVar[str] = "flat"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/recognition/flats.py
+++ b/src/draftwright/recognition/flats.py
@@ -50,6 +50,7 @@ _MIN_FLAT_DEPTH = 0.5
 # line (not merely the same axis letter) within these mm tolerances.
 _OD_REACH_TOL = 0.1
 _AXIS_LINE_TOL = 0.1
+_AXIS_ALIGNED_TOL = 1e-3
 
 
 def _both_chord_ends_reach_od(verts, ax, dv, nv, r):
@@ -126,6 +127,10 @@ class Flat(Record):
     #: recogniser's internal ``stock`` tuple also carries a solid index, which is a same-run
     #: equality check and deliberately NOT propagated: it is not stable across runs.
     stock_span: tuple[float, float] = (0.0, 0.0)
+    #: Whether the owning cylinder follows the named principal axis. Placement may use
+    #: aggregate-view margin fallbacks only for aligned stock: slanted stock's two-coordinate
+    #: ``axis_line`` is not a canonical identity (#1036).
+    axis_aligned: bool = True
 
 
 def recognise_flats(part, *, cyls=None) -> list[Flat]:
@@ -182,6 +187,7 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                     "at": pcv,
                     "ax": ax,
                     "dir": d,
+                    "axis_aligned": _is_axis_aligned(c["axis"], d),
                     # Which piece of stock this face was matched to, for the opposition test
                     # below. Internal to one recognition run — a same-run equality check, not
                     # an identity that propagates — so the solid index is safe here.
@@ -220,6 +226,7 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                 at=(round(cand["at"][0], 3), round(cand["at"][1], 3), round(cand["at"][2], 3)),
                 axis_line=cand["axis_line"],
                 stock_span=cand["stock_span"],
+                axis_aligned=cand["axis_aligned"],
             )
         )
     return sorted(out, key=lambda fl: (fl.axis, fl.at))
@@ -247,3 +254,16 @@ def _axis_line(axis: str, ax) -> tuple[float, float]:
     """
     keep = [i for i, letter in enumerate("xyz") if letter != axis]
     return (round(ax[keep[0]], 3), round(ax[keep[1]], 3))
+
+
+def _is_axis_aligned(axis: str, direction) -> bool:
+    """Whether *direction* follows the principal axis named by *axis*.
+
+    This is deliberately a capability bit, not a line identity. It prevents a placement
+    fallback from making slanted A/F callouts visible before #1036 carries the canonical
+    direction + perpendicular-foot identity needed to group them safely.
+    """
+    idx = "xyz".index(axis)
+    return abs(abs(direction[idx]) - 1.0) <= _AXIS_ALIGNED_TOL and all(
+        abs(direction[j]) <= _AXIS_ALIGNED_TOL for j in range(3) if j != idx
+    )

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -382,9 +382,10 @@ def _feature_line(f, part_envelope=None) -> str:
         # collapsing into one callout, and a script that omits them regenerates the very
         # drawing the detection was fixing (Codex #1035 r1). The declared defaults reproduce
         # pre-#1013 grouping, so silence here is not neutral — it is the old bug.
+        alignment = "" if f.axis_aligned else ", axis_aligned=False"
         return (
             f'sheet.flat(axis="{f.axis}", across={_n(f.across)}, at={_pt(f.frame.origin)}, '
-            f"axis_line={_pt(f.axis_line)}, stock_span={_pt(f.stock_span)})"
+            f"axis_line={_pt(f.axis_line)}, stock_span={_pt(f.stock_span)}{alignment})"
         )
     if k == "groove":
         return (

--- a/tests/test_flat_stock_identity.py
+++ b/tests/test_flat_stock_identity.py
@@ -44,6 +44,7 @@ def test_the_record_distinguishes_one_stock_from_two():
 
     assert len(dd) == 2 and len(lobes) == 2, "both fixtures should yield two flat records"
     assert {f.axis for f in dd} == {"z"} and {f.axis for f in lobes} == {"z"}
+    assert all(f.axis_aligned for f in [*dd, *lobes])
 
     assert len({f.axis_line for f in dd}) == 1, (
         "a double-D's two faces are one piece of stock — they must share an axis line, or the "
@@ -184,6 +185,7 @@ def test_slanted_stock_is_an_acknowledged_limitation_not_a_silent_wrong_answer()
         "a (0.707, 0, 0.707) axis is classified by its dominant component; if that changed, "
         "the slanted-identity reasoning in _axis_line needs rechecking"
     )
+    assert not flats[0].axis_aligned, "the renderer needs an explicit slanted-stock guard"
 
     dwg = build_drawing(slant)
     assert not [n for n in dwg.annotations() if n.startswith("m_flat_")], (
@@ -194,3 +196,10 @@ def test_slanted_stock_is_an_acknowledged_limitation_not_a_silent_wrong_answer()
     assert [i for i in dwg.lint() if i.code == "flat_dropped"], (
         "the slanted flat is neither drawn nor reported — that would be a silent omission"
     )
+
+    # The multi-stock fallback from #1034 must not defeat the guard merely because there are
+    # now two non-canonical stock groups (the adversarial counterexample to the first cut).
+    two_slants = slant + Pos(0, 60, 0) * slant
+    multi = build_drawing(two_slants)
+    assert not [n for n in multi.annotations() if n.startswith("m_flat_")]
+    assert len([i for i in multi.lint() if i.code == "flat_dropped"]) == 2

--- a/tests/test_flat_stock_identity.py
+++ b/tests/test_flat_stock_identity.py
@@ -64,30 +64,24 @@ def test_a_double_d_still_gets_exactly_one_callout():
     assert not [i for i in dwg.lint() if i.code == "flat_dropped"]
 
 
-def test_two_parallel_lobes_are_two_definitions_and_a_lost_one_is_reported():
-    """The defect: the sheet used to carry one callout for two independent definitions, with
-    nothing saying so.
+def test_two_parallel_lobes_place_two_independent_definitions():
+    """Each stock needs its own placed A/F definition (#1034).
 
-    The engine now plans both. Placing them both is a corridor-capacity problem and is NOT
-    what this fix is about (#1034) — what matters here is that the second definition exists
-    and its loss is REPORTED rather than absorbed by a grouping key. A completeness failure
-    that is visible is the whole point; the previous behaviour was a clean-looking drawing
-    that was wrong.
+    The left lobe's flat is not on the aggregate plan-view boundary.  A single centre-out
+    candidate therefore leaves its label intersecting the aggregate view box even though
+    there is clear margin above it.  Removing the margin-escape candidates must make this
+    test fail with one placed callout plus one ``flat_dropped`` issue.
     """
     dwg = build_drawing(_two_parallel_lobes())
 
     callouts = sorted(n for n in dwg.annotations() if n.startswith("m_flat_"))
     dropped = [i for i in dwg.lint() if i.code == "flat_dropped"]
 
-    assert len(callouts) + len(dropped) == 2, (
-        f"two lobes are two A/F definitions; the drawing accounts for "
-        f"{len(callouts)} placed + {len(dropped)} reported. Before #1013 this was one "
-        "callout and no report — the second lobe simply vanished."
-    )
-    assert dropped, (
-        "the unplaced definition must be reported. Silently drawing one callout for two "
-        "lobes is the exact defect: a sheet that looks complete and is not"
-    )
+    assert len(callouts) == 2, f"two lobes need two placed A/F definitions, got {callouts}"
+    assert not dropped, f"available plan-view margin must prevent a placement drop: {dropped}"
+    assert not [
+        i for i in dwg.lint() if i.code in {"annotation_overlap", "leader_crosses_silhouette"}
+    ]
 
 
 def _coaxial_separated_stocks():

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -569,6 +569,23 @@ class TestEmit:
         redeclared = eval(line, {"__builtins__": {}}, env)  # noqa: S307
         assert redeclared.axis == det.axis and redeclared.across == det.across
         assert redeclared.frame.origin == pytest.approx(det.frame.origin)
+        assert redeclared.axis_line == det.axis_line and redeclared.stock_span == det.stock_span
+        assert redeclared.axis_aligned == det.axis_aligned
+
+    def test_slanted_flat_round_trips_the_alignment_guard(self):
+        from build123d import Rot
+
+        from draftwright.model import flat as declare_flat
+        from draftwright.sheet_emit import _feature_line
+
+        part = Rot(0, 45, 0) * (Cylinder(10, 40) - Pos(8, 0, 0) * Box(10, 40, 60))
+        det = next(f for f in build_drawing(part, number="X").model().features if f.kind == "flat")
+        assert det.axis_aligned is False
+        line = _feature_line(det)
+        assert "axis_aligned=False" in line
+        env = {"sheet": type("S", (), {"flat": staticmethod(declare_flat)})()}
+        redeclared = eval(line, {"__builtins__": {}}, env)  # noqa: S307
+        assert redeclared.axis_aligned is False
 
     def test_groove_emits_the_groove_verb(self):
         # #148c: a detected turned groove emits `sheet.groove(...)` — the emit surface for the


### PR DESCRIPTION
## What

Place both independent A/F callouts for aligned parallel or coaxial stock when clear aggregate-view margin exists.

The old flat leader offered only a centre-out candidate from each local stock face. An inner lobe can sit well inside the aggregate view bounds, so its label intersected the aggregate silhouette and was dropped despite clear margin. Flat placement now preserves that established candidate first, then offers boundary-aware radial escapes for multiple independent aligned stock groups on the same axis.

This also makes the existing slanted-stock limitation deterministic. Recognition carries a narrow `axis_aligned` capability through the IR and emitted declaration; non-aligned flats receive no placement candidates and retain attributed `flat_dropped` outcomes until #1036 supplies canonical direction identity and rendering together.

## Evidence

The two-lobe fixture now has:

- two `m_flat_*` callouts;
- no `flat_dropped`;
- no `annotation_overlap`;
- no `leader_crosses_silhouette`.

Parallel gaps of 60, 100, and 160 mm and separated coaxial stock all place both definitions. Ordinary single-stock and double-D flats keep their original candidate order.

## Adversarial review

1. The first cut enabled margin fallbacks for every flat. A lone slanted stock then rendered despite its non-canonical identity, so fallback was restricted to multiple stock groups.
2. A two-slanted-stock counterexample showed that aggregate view growth could also make the old preferred candidates clear. That exposed a pre-existing accidental guard, not a safe capability boundary. The final implementation derives `axis_aligned` during recognition, threads and round-trips it, and fails closed with one attributed drop per unsupported definition.
3. Final contract review exercised automatic and declared non-aligned builds. Both omit the callout and report `flat_dropped`. No substantive findings remain; naming and eventual replacement by #1036's full direction identity are nits/follow-up scope.

## Validation

- `pytest tests/test_flat_stock_identity.py tests/test_flat_completeness.py tests/test_sheet_emit.py tests/test_declare.py tests/test_compiled_plan_boundary.py tests/test_recognition_manifest.py tests/test_recogniser_contract.py tests/test_detect_registry.py tests/test_parameter_id.py`  
  `702 passed, 2 xfailed`
- Pre-review full suite: `2766 passed, 1 skipped, 19 deselected, 2 xfailed`
- `ruff check src tests`
- `ruff format --check src tests`
- `mypy src/draftwright`
- `codespell`

Closes #1034.