### PR TITLE
Render slanted flats with canonical stock identity

### DIFF
--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -12,6 +12,7 @@ drawing grab-bag (ADR 0008; #584 WP2). This module imports nothing from
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 
 from build123d import Compound
@@ -106,6 +107,102 @@ def plane_axes(axis) -> tuple[tuple[float, float, float], tuple[float, float, fl
 def _axis_letter_of(axis) -> str:
     """Letter of a bare 3-vector's dominant component (:func:`_axis_letter` takes an object)."""
     return max(zip("xyz", axis, strict=True), key=lambda t: abs(t[1]))[0]
+
+
+def _axis_direction_components(axis: str, direction=None):
+    """Validate a direction and return ``(raw, norm, dominant_index)``."""
+    if axis not in "xyz" or len(axis) != 1:
+        raise ValueError("axis must be 'x', 'y', or 'z'")
+    if direction is None:
+        direction = tuple(1.0 if letter == axis else 0.0 for letter in "xyz")
+    try:
+        raw = tuple(float(component) for component in direction)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("axis_direction must be a 3-vector") from exc
+    if len(raw) != 3:
+        raise ValueError("axis_direction must be a 3-vector")
+    if not all(math.isfinite(component) for component in raw):
+        raise ValueError("axis_direction must contain only finite values")
+    norm = math.hypot(*raw)
+    if norm <= 1e-12:
+        raise ValueError("axis_direction must be non-zero")
+    idx = "xyz".index(axis)
+    if abs(raw[idx]) + norm * 1e-9 < max(abs(component) for component in raw):
+        raise ValueError(f"axis_direction's dominant component must match axis={axis!r}")
+    return raw, norm, idx
+
+
+def _normalised_axis_direction(axis: str, direction=None) -> tuple[float, float, float]:
+    """Full-precision unit direction used for geometric projection."""
+    raw, norm, idx = _axis_direction_components(axis, direction)
+    sign = -1.0 if raw[idx] < 0 else 1.0
+    return (
+        sign * raw[0] / norm,
+        sign * raw[1] / norm,
+        sign * raw[2] / norm,
+    )
+
+
+def _canonical_axis_direction(axis: str, direction=None) -> tuple[float, float, float]:
+    """Return a stable unit direction whose named dominant component is positive.
+
+    ``axis`` remains the orthographic routing hint used by the IR. ``direction`` is the
+    actual geometric axis needed to distinguish slanted stock lines; omitting it means the
+    corresponding principal axis. Six decimal places preserve direction while keeping
+    recognition/declaration identities stable across round trips.
+    """
+    raw, norm, idx = _axis_direction_components(axis, direction)
+    sign = -1.0 if raw[idx] < 0 else 1.0
+    # A previously canonical six-decimal vector is close enough to unit length that
+    # normalising it again can move the last digit. Preserve it to make emit -> declare
+    # idempotent; arbitrary vectors are still normalised on first entry.
+    unit = (
+        tuple(sign * component for component in raw)
+        if abs(norm - 1.0) <= 2e-6
+        else _normalised_axis_direction(axis, raw)
+    )
+    rounded = tuple(0.0 if abs(component) < 0.5e-6 else round(component, 6) for component in unit)
+    return (rounded[0], rounded[1], rounded[2])
+
+
+def _canonical_axis_span(axis: str, direction, span) -> tuple[float, float]:
+    """Express an axial extent along the canonical positive direction."""
+    raw, _norm, idx = _axis_direction_components(axis, direction)
+    lo, hi = (float(value) for value in span)
+    if raw[idx] < 0:
+        lo, hi = -hi, -lo
+    return (round(lo, 3), round(hi, 3))
+
+
+def _axis_line_coordinates(axis: str, point, direction=None) -> tuple[float, float]:
+    """Canonical in-plane coordinates of a 3-D axis line.
+
+    The perpendicular foot from the origin makes the result invariant to which point on the
+    line a geometry kernel reports. The named dominant coordinate is omitted; together with
+    the direction it is recoverable from the foot's perpendicularity, so two numbers retain
+    the aligned-stock representation while remaining sufficient for slanted stock.
+    """
+    px, py, pz = (float(component) for component in point)
+    # Use the unrounded unit vector here. Rounding before projection amplifies angular error
+    # into millimetres when the reported axis point is tens of metres from the origin.
+    vector = _normalised_axis_direction(axis, direction)
+    along = px * vector[0] + py * vector[1] + pz * vector[2]
+    foot = tuple(component - along * delta for component, delta in zip((px, py, pz), vector))
+    keep = [i for i, letter in enumerate("xyz") if letter != axis]
+    coordinates = tuple(round(foot[i], 3) for i in keep)
+    return (
+        0.0 if coordinates[0] == 0 else coordinates[0],
+        0.0 if coordinates[1] == 0 else coordinates[1],
+    )
+
+
+def _axis_direction_is_aligned(axis: str, direction, *, tol: float = 1e-3) -> bool:
+    """Whether a canonical direction follows the principal axis named by ``axis``."""
+    vector = _canonical_axis_direction(axis, direction)
+    idx = "xyz".index(axis)
+    return abs(vector[idx] - 1.0) <= tol and all(
+        abs(vector[j]) <= tol for j in range(3) if j != idx
+    )
 
 
 def _fmt(v: float) -> str:

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1774,10 +1774,19 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
         # but not a span. Grouping on the line alone merged the coaxial case silently — the
         # same defect this fix is about, one arrangement over (Codex #1035 r1).
         collapse.setdefault(
-            (g.facts.axis, g.facts.axis_line, g.facts.stock_span, round(pd.value, 3)), []
+            (
+                g.facts.axis,
+                g.facts.axis_direction,
+                g.facts.axis_line,
+                g.facts.stock_span,
+                round(pd.value, 3),
+            ),
+            [],
         ).append((g, pd))
     jobs = []
-    for gi, ((axis, _line, _span, _across), members) in enumerate(sorted(collapse.items())):
+    for gi, ((axis, _direction, _line, _span, _across), members) in enumerate(
+        sorted(collapse.items())
+    ):
         if only is not None:
             # #426 Ph2b subset (finalize): filter members AFTER enumerating the collapse so gi
             # stays the full-drawing group index (Codex #811) — see render_fillets.
@@ -1792,30 +1801,18 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
         # First-AUTHORED tolerance wins (planner/model order, not spatial — see the
         # fillet pass / render_diameters precedent, Codex review).
         tol = next((pd.tolerance for _, pd in members if pd.tolerance is not None), None)
-        axis_aligned = all(g.facts.axis_aligned for g, _ in members)
-        if not axis_aligned:
-            # Slanted stock's two-coordinate axis_line is not canonical (#1036). It used to
-            # drop accidentally when alone but could render when several slanted stocks made
-            # the aggregate view large enough. An empty candidate set makes the unsupported
-            # state deterministic and still records one attributed flat_dropped outcome.
-            candidates = ()
-        else:
-            # The margin fallback is specifically for several independent pieces of aligned
-            # stock in the same aggregate view (#1034). Ordinary single/double-D stock keeps
-            # the established centre-out placement first and unchanged.
-            candidate_factory = (
-                _flat_candidates
-                if sum(key[0] == axis for key in collapse) > 1
-                else _corner_candidates
-            )
-            candidates = candidate_factory(
-                dwg,
-                view,
-                vb,
-                [g.facts for g, _ in ordered],
-                reach,
-                provenances=[g.ref for g, _ in ordered],
-            )
+        # The established centre-out positions remain first. Boundary-aware fallbacks are
+        # now safe for every flat because direction + perpendicular line position + span make
+        # aligned and slanted stock groups canonical (#1036); they also cover a lone flat
+        # under local placement pressure, not only #1034's multiple-stock case.
+        candidates = _flat_candidates(
+            dwg,
+            view,
+            vb,
+            [g.facts for g, _ in ordered],
+            reach,
+            provenances=[g.ref for g, _ in ordered],
+        )
         jobs.append(
             (
                 f"m_flat_{axis}{gi}",

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Literal
 
+from draftwright._geometry import _canonical_axis_direction
 from draftwright.linting.issues import LintIssue
 from draftwright.recognition import RecognitionResult
 
@@ -20,6 +21,7 @@ FlatRequirementState = Literal["placed", "suppressed", "dropped", "missing", "un
 @dataclass(frozen=True, order=True)
 class _FlatRequirementKey:
     axis: str
+    axis_direction: tuple[float, float, float]
     axis_line: tuple[float, float]
     stock_span: tuple[float, float]
     across: float
@@ -30,6 +32,7 @@ class FlatRequirementOutcome:
     """The observable engine outcome of one physical A/F requirement."""
 
     axis: str
+    axis_direction: tuple[float, float, float]
     axis_line: tuple[float, float]
     stock_span: tuple[float, float]
     across: float
@@ -44,6 +47,7 @@ def _rounded_pair(values) -> tuple[float, float]:
 def _key(flat) -> _FlatRequirementKey:
     return _FlatRequirementKey(
         axis=flat.axis,
+        axis_direction=_canonical_axis_direction(flat.axis, getattr(flat, "axis_direction", None)),
         axis_line=_rounded_pair(flat.axis_line),
         stock_span=_rounded_pair(flat.stock_span),
         across=round(float(flat.across), 3),
@@ -74,10 +78,11 @@ def flat_requirement_outcomes(
 ) -> list[FlatRequirementOutcome]:
     """Follow each recognised flat requirement to an explicit engine outcome.
 
-    Two faces of one double-D/hex share a requirement; parallel or disjoint coaxial stock
-    does not. Stock identity plus A/F defines that physical grouping; each group's recognised
-    3-D face anchors then join to IR exactly. If that record-to-IR correspondence is absent,
-    the result is ``unverifiable`` rather than a fuzzy match.
+    Two faces of one double-D/hex share a requirement; parallel, differently-directed, or
+    disjoint coaxial stock does not. Direction + line + span identity and A/F define that
+    physical grouping; each group's recognised 3-D face anchors then join to IR exactly. If
+    that record-to-IR correspondence is absent, the result is ``unverifiable`` rather than a
+    fuzzy match.
     """
     if recognition is None:
         return []
@@ -152,6 +157,7 @@ def flat_requirement_outcomes(
         outcomes.append(
             FlatRequirementOutcome(
                 axis=requirement.axis,
+                axis_direction=requirement.axis_direction,
                 axis_line=requirement.axis_line,
                 stock_span=requirement.stock_span,
                 across=requirement.across,
@@ -182,7 +188,8 @@ def lint_flat_coverage(
         if outcome.state in {"placed", "dropped"}:
             continue
         stock = (
-            f"{outcome.axis.upper()} stock at axis line {outcome.axis_line}, "
+            f"{outcome.axis.upper()} stock along {outcome.axis_direction} at axis line "
+            f"{outcome.axis_line}, "
             f"span {outcome.stock_span}"
         )
         messages = {

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -253,11 +253,10 @@ _FACTS: dict[str, tuple[str, ...]] = {
     # changes output, and a migration that claims byte-identity is the wrong place for it.
     "chamfer": ("frame", "axis", "leg2", "angle"),
     "fillet": ("frame", "axis"),
-    # `axis_line`/`stock_span` are STRUCTURE, not measurements: they say which piece of stock
-    # a flat belongs to, so the renderer can tell a double-D's two faces from two parallel
-    # lobes (#1013). `axis_aligned` gates a placement capability whose slanted identity is not
-    # canonical yet (#1036). The drawing prints none of them.
-    "flat": ("frame", "axis", "axis_line", "stock_span", "axis_aligned"),
+    # These are STRUCTURE, not measurements: together they say which piece of stock a flat
+    # belongs to, so the renderer can tell one double-D's two faces from independent aligned
+    # or slanted regions (#1013/#1036). The drawing prints none of them.
+    "flat": ("frame", "axis", "axis_line", "stock_span", "axis_direction"),
     "groove": ("frame", "axis"),
     "plate": ("frame", "axis"),
     # Raw AP242 PMI is the documented non-generated exception: its source-authored label

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -505,13 +505,14 @@ def flat(
     at=None,
     axis_line=None,
     stock_span=None,
-    axis_aligned=True,
+    axis_direction=None,
 ) -> FlatFeature:
     """A machined flat on round stock (#148b). Either ``flat(flat_face)`` — the planar face
     supplies the leader point ``at`` (``axis=`` and ``across=`` still required, being
     unrecoverable from a plane) — or fully explicit ``flat(axis="z", across=15, at=(x, y,
-    z))``. Called out ``{across} A/F`` (across flats). An object supplies the ``at`` default;
-    any explicit keyword overrides (#451)."""
+    z))``. ``axis_direction=`` carries a non-principal stock direction; ``axis_line=`` and
+    ``stock_span=`` then complete its geometric identity. Called out ``{across} A/F`` (across
+    flats). An object supplies the ``at`` default; any explicit keyword overrides (#451)."""
     if obj is not None:
         at = _read_flat_face(obj) if at is None else at
     if across is None or axis is None or at is None:
@@ -530,7 +531,7 @@ def flat(
         across=round(across, 3),
         axis_line=_stock_pair(axis_line),
         stock_span=_stock_pair(stock_span),
-        axis_aligned=axis_aligned,
+        axis_direction=axis_direction,
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -512,7 +512,7 @@ def _convert_flat(flat: Flat, ctx: ConvContext) -> FlatFeature:
         across=flat.across,
         axis_line=flat.axis_line,
         stock_span=flat.stock_span,
-        axis_aligned=flat.axis_aligned,
+        axis_direction=flat.axis_direction,
     )
 
 

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -23,7 +23,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, runtime_checkable
 
-from draftwright._geometry import _fmt
+from draftwright._geometry import (
+    _axis_direction_is_aligned,
+    _canonical_axis_direction,
+    _canonical_axis_span,
+    _fmt,
+)
 
 if TYPE_CHECKING:
     from draftwright.fits import FitClass
@@ -642,18 +647,36 @@ class FlatFeature:
     frame: Frame
     axis: str
     across: float
-    #: The stock's axis line — see :class:`~draftwright.recognition.flats.Flat`. Two flats
-    #: share an A/F definition only if they share this; the axis letter alone cannot tell a
-    #: double-D's two faces from two parallel lobes (#1013).
+    #: The stock axis line's canonical in-plane position — see
+    #: :class:`~draftwright.recognition.flats.Flat`. Two flats share an A/F definition only if
+    #: they share direction, line and span; the axis letter alone cannot tell a double-D's
+    #: two faces from two parallel or slanted regions (#1013/#1036).
     axis_line: tuple[float, float] = (0.0, 0.0)
-    #: The owning stock's axial extent — with ``axis_line``, the stock identity. Coaxial
-    #: stacked stock shares an axis line, so that alone merged independent definitions.
+    #: The owning stock's axial extent along ``axis_direction``. Coaxial stacked stock shares
+    #: a direction and line, so those alone merged independent definitions.
     stock_span: tuple[float, float] = (0.0, 0.0)
-    #: False for stock whose real cylinder direction is not the named principal ``axis``.
-    #: Its aligned-only ``axis_line`` is not canonical, so margin fallback must not make its
-    #: callout render before #1036 fixes identity and rendering together.
-    axis_aligned: bool = True
+    #: Real stock direction, canonicalised with the named dominant component positive. With
+    #: the perpendicular-foot ``axis_line`` and axial ``stock_span``, this distinguishes
+    #: slanted stock regions without presentation inference (#1036).
+    axis_direction: Point | None = None
     kind: ClassVar[str] = "flat"
+
+    def __post_init__(self) -> None:
+        direction = self.axis_direction
+        object.__setattr__(
+            self,
+            "stock_span",
+            _canonical_axis_span(self.axis, direction, self.stock_span),
+        )
+        object.__setattr__(
+            self,
+            "axis_direction",
+            _canonical_axis_direction(self.axis, direction),
+        )
+
+    @property
+    def axis_aligned(self) -> bool:
+        return _axis_direction_is_aligned(self.axis, self.axis_direction)
 
     def parameters(self) -> list[DimParameter]:
         return [DimParameter("length", "flat", self.across)]

--- a/src/draftwright/recognition/flats.py
+++ b/src/draftwright/recognition/flats.py
@@ -33,6 +33,12 @@ from dataclasses import dataclass
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.GeomAbs import GeomAbs_Plane
 
+from draftwright._geometry import (
+    _axis_direction_is_aligned,
+    _axis_line_coordinates,
+    _canonical_axis_direction,
+    _canonical_axis_span,
+)
 from draftwright.recognition._features import analyse_cylinders
 from draftwright.recognition._record import Record
 
@@ -50,7 +56,6 @@ _MIN_FLAT_DEPTH = 0.5
 # line (not merely the same axis letter) within these mm tolerances.
 _OD_REACH_TOL = 0.1
 _AXIS_LINE_TOL = 0.1
-_AXIS_ALIGNED_TOL = 1e-3
 
 
 def _both_chord_ends_reach_od(verts, ax, dv, nv, r):
@@ -80,10 +85,12 @@ def _both_chord_ends_reach_od(verts, ax, dv, nv, r):
     return lo_r is not None and lo_r >= r - _OD_REACH_TOL and hi_r >= r - _OD_REACH_TOL
 
 
-def _same_axis_line(a_ax, a_dir, b_ax):
+def _same_axis_line(axis, a_ax, a_dir, b_ax, b_dir):
     """Two radial flats are opposed across one shaft only if their turning axes are the *same
     line* — the vector between the axis points has no component perpendicular to the shared
     direction. Guards against pairing lone flats on two distinct parallel shafts."""
+    if _canonical_axis_direction(axis, a_dir) != _canonical_axis_direction(axis, b_dir):
+        return False
     vx, vy, vz = b_ax[0] - a_ax[0], b_ax[1] - a_ax[1], b_ax[2] - a_ax[2]
     adot = vx * a_dir[0] + vy * a_dir[1] + vz * a_dir[2]
     px, py, pz = vx - adot * a_dir[0], vy - adot * a_dir[1], vz - adot * a_dir[2]
@@ -100,8 +107,10 @@ class Flat(Record):
     axis: str
     across: float
     at: tuple[float, float, float]
-    #: The stock's axis LINE — the two coordinates perpendicular to ``axis``, in xyz order
-    #: with the axis component dropped (z → (x, y); x → (y, z); y → (x, z)).
+    #: The stock axis line's perpendicular foot from the origin, stored as the two coordinates
+    #: other than dominant ``axis`` (z → (x, y); x → (y, z); y → (x, z)). With
+    #: ``axis_direction`` the omitted coordinate is recoverable, so this is canonical for
+    #: aligned and slanted lines (#1036).
     #:
     #: The axis letter alone cannot say whether two flats belong to the same piece of round
     #: stock, and that is the one thing both consumers need (#1013). Two faces at
@@ -114,7 +123,7 @@ class Flat(Record):
     #: ADR 0013's rule for a record that looks too thin: the fix is the record. The
     #: recogniser already had the owning cylinder in hand, so this costs nothing to carry.
     axis_line: tuple[float, float] = (0.0, 0.0)
-    #: The owning stock's axial extent ``(lo, hi)`` along ``axis``.
+    #: The owning stock's axial extent ``(lo, hi)`` along ``axis_direction``.
     #:
     #: The axis line alone is NOT stock identity, and this code already knew it: #1015 taught
     #: the opposition test that "the same infinite axis is not the same piece of stock", and
@@ -123,14 +132,32 @@ class Flat(Record):
     #: — the very defect #1013 set out to fix, in a coaxial arrangement instead of a parallel
     #: one (Codex #1035 r1).
     #:
-    #: Together with ``axis_line`` this is the stock identity. Purely geometric — the
-    #: recogniser's internal ``stock`` tuple also carries a solid index, which is a same-run
-    #: equality check and deliberately NOT propagated: it is not stable across runs.
+    #: Together with ``axis_direction`` and ``axis_line`` this is the stock identity. Purely
+    #: geometric — the recogniser's internal ``stock`` tuple also carries a solid index,
+    #: which is a same-run equality check and deliberately NOT propagated: it is not stable
+    #: across runs.
     stock_span: tuple[float, float] = (0.0, 0.0)
-    #: Whether the owning cylinder follows the named principal axis. Placement may use
-    #: aggregate-view margin fallbacks only for aligned stock: slanted stock's two-coordinate
-    #: ``axis_line`` is not a canonical identity (#1036).
-    axis_aligned: bool = True
+    #: The real cylinder direction, with the named dominant component positive. Together
+    #: with the perpendicular-foot ``axis_line`` and ``stock_span`` this is the canonical
+    #: stock-region identity ADR 0017 section 3 requires (#1036).
+    axis_direction: tuple[float, float, float] | None = None
+
+    def __post_init__(self) -> None:
+        direction = self.axis_direction
+        object.__setattr__(
+            self,
+            "stock_span",
+            _canonical_axis_span(self.axis, direction, self.stock_span),
+        )
+        object.__setattr__(
+            self,
+            "axis_direction",
+            _canonical_axis_direction(self.axis, direction),
+        )
+
+    @property
+    def axis_aligned(self) -> bool:
+        return _axis_direction_is_aligned(self.axis, self.axis_direction)
 
 
 def recognise_flats(part, *, cyls=None) -> list[Flat]:
@@ -179,7 +206,7 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
             cands.append(
                 {
                     "axis": c["axis"],
-                    "axis_line": _axis_line(c["axis"], ax),
+                    "axis_line": _axis_line(c["axis"], ax, d),
                     "stock_span": (round(c["s_lo"], 3), round(c["s_hi"], 3)),
                     "n": nv,
                     "s": s,
@@ -187,7 +214,7 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                     "at": pcv,
                     "ax": ax,
                     "dir": d,
-                    "axis_aligned": _is_axis_aligned(c["axis"], d),
+                    "axis_direction": d,
                     # Which piece of stock this face was matched to, for the opposition test
                     # below. Internal to one recognition run — a same-run equality check, not
                     # an identity that propagates — so the solid index is safe here.
@@ -205,7 +232,9 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
         for j, other in enumerate(cands):
             if j == i or other["axis"] != cand["axis"]:
                 continue
-            if not _same_axis_line(cand["ax"], cand["dir"], other["ax"]):
+            if not _same_axis_line(
+                cand["axis"], cand["ax"], cand["dir"], other["ax"], other["dir"]
+            ):
                 continue  # a lone flat on a *different* parallel shaft — not opposed
             if other["stock"] != cand["stock"]:
                 # The same infinite axis is not the same piece of stock. Two lone D-flats on
@@ -226,44 +255,21 @@ def recognise_flats(part, *, cyls=None) -> list[Flat]:
                 at=(round(cand["at"][0], 3), round(cand["at"][1], 3), round(cand["at"][2], 3)),
                 axis_line=cand["axis_line"],
                 stock_span=cand["stock_span"],
-                axis_aligned=cand["axis_aligned"],
+                axis_direction=cand["axis_direction"],
             )
         )
     return sorted(out, key=lambda fl: (fl.axis, fl.at))
 
 
-def _axis_line(axis: str, ax) -> tuple[float, float]:
-    """The two coordinates of *ax* perpendicular to *axis* — the stock's axis line (#1013).
+def _axis_line(axis: str, ax, direction=None) -> tuple[float, float]:
+    """Canonical in-plane coordinates of the stock's axis line (#1013, #1036).
 
     Rounded to the same 3 dp as every other coordinate a record carries, so two faces on one
     piece of stock compare equal rather than differing in float noise.
 
-    **Axis-ALIGNED stock only, and deliberately so.** Dropping the dominant axis letter's
-    coordinate identifies a line only when the axis is along X, Y or Z. For a slanted
-    cylinder — ``analyse_cylinders`` classifies one by its dominant component, so a
-    ``(0.707, 0, 0.707)`` axis reads as ``"x"`` — this is neither canonical (the value depends
-    on WHICH point along the axis the cylinder record reports) nor sufficient (two different
-    slanted directions through one point encode identically). A canonical key would be the
-    perpendicular foot from the origin plus the direction, as :func:`_same_axis_line` already
-    computes for the opposition test.
-
-    That is not done here because slanted flats do not render at all today: the callout is
-    dropped (`flat_dropped`) before identity matters, so a canonical key would fix a
-    component of an already-broken path with no observable improvement. #1036 covers both
-    halves together. The narrow claim this function makes is the one it can keep.
+    The stored point is the perpendicular foot from the origin, so it is invariant to which
+    point along the line OCP reports. The dominant coordinate is omitted; ``axis_direction``
+    makes it recoverable and distinguishes different slanted directions through one foot.
+    Aligned stock therefore retains its existing two-coordinate representation.
     """
-    keep = [i for i, letter in enumerate("xyz") if letter != axis]
-    return (round(ax[keep[0]], 3), round(ax[keep[1]], 3))
-
-
-def _is_axis_aligned(axis: str, direction) -> bool:
-    """Whether *direction* follows the principal axis named by *axis*.
-
-    This is deliberately a capability bit, not a line identity. It prevents a placement
-    fallback from making slanted A/F callouts visible before #1036 carries the canonical
-    direction + perpendicular-foot identity needed to group them safely.
-    """
-    idx = "xyz".index(axis)
-    return abs(abs(direction[idx]) - 1.0) <= _AXIS_ALIGNED_TOL and all(
-        abs(direction[j]) <= _AXIS_ALIGNED_TOL for j in range(3) if j != idx
-    )
+    return _axis_line_coordinates(axis, ax, direction)

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -47,6 +47,12 @@ def _pt(p) -> str:
     return "(" + ", ".join(str(_n(c)) for c in p) + ")"
 
 
+def _direction(p) -> str:
+    """A direction vector needs angular precision, not the 3 dp used for mm coordinates."""
+    values = (round(float(component), 6) for component in p)
+    return "(" + ", ".join(str(int(v)) if v == int(v) else str(v) for v in values) + ")"
+
+
 def _pts_arg(points) -> str:
     return "[" + ", ".join(_pt(p) for p in points) + "]"
 
@@ -382,10 +388,15 @@ def _feature_line(f, part_envelope=None) -> str:
         # collapsing into one callout, and a script that omits them regenerates the very
         # drawing the detection was fixing (Codex #1035 r1). The declared defaults reproduce
         # pre-#1013 grouping, so silence here is not neutral — it is the old bug.
-        alignment = "" if f.axis_aligned else ", axis_aligned=False"
+        principal = tuple(1.0 if letter == f.axis else 0.0 for letter in "xyz")
+        direction = (
+            ""
+            if f.axis_direction == principal
+            else f", axis_direction={_direction(f.axis_direction)}"
+        )
         return (
             f'sheet.flat(axis="{f.axis}", across={_n(f.across)}, at={_pt(f.frame.origin)}, '
-            f"axis_line={_pt(f.axis_line)}, stock_span={_pt(f.stock_span)}{alignment})"
+            f"axis_line={_pt(f.axis_line)}, stock_span={_pt(f.stock_span)}{direction})"
         )
     if k == "groove":
         return (

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -555,6 +555,24 @@ class TestFlat:
         f = flat(axis="z", across=15, at=(5, 0, 0))
         assert isinstance(f, FlatFeature)
         assert f.axis == "z" and f.across == 15 and f.frame.origin == pytest.approx((5, 0, 0))
+        assert f.axis_direction == (0.0, 0.0, 1.0) and f.axis_aligned
+
+    def test_direction_is_normalised_and_canonical(self):
+        f = flat(
+            axis="x",
+            across=13,
+            at=(3, 0, -3),
+            stock_span=(-20, 10),
+            axis_direction=(-1, 0, -1),
+        )
+        assert f.axis_direction == pytest.approx((2**-0.5, 0.0, 2**-0.5), abs=1e-6)
+        assert f.stock_span == (-10.0, 20.0)
+        assert not f.axis_aligned
+
+    @pytest.mark.parametrize("direction", [(0, 0, 0), (0, 1, 0), (1, 0), (float("nan"), 0, 0)])
+    def test_rejects_invalid_direction(self, direction):
+        with pytest.raises(ValueError, match="axis_direction"):
+            flat(axis="x", across=13, at=(3, 0, -3), axis_direction=direction)
 
     def test_reads_at_off_the_planar_face(self):
         # The object flavour reads the leader point off the planar flat face; axis/across

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -16,7 +16,9 @@ from build123d import Align, Box, Cylinder, Pos
 from draftwright import Sheet, build_drawing
 from draftwright.linting import LintIssue
 from draftwright.linting.flat_coverage import flat_requirement_outcomes
+from draftwright.model.declare import flat as declare_flat
 from draftwright.recognition import recognise_flats
+from draftwright.recognition.flats import Flat
 from draftwright.registry import AnnotationRegistry
 
 
@@ -82,6 +84,7 @@ def _declared_flat_drawing(*, suppress: bool = False):
             at=flat.at,
             axis_line=flat.axis_line,
             stock_span=flat.stock_span,
+            axis_direction=flat.axis_direction,
         )
     if suppress:
         envelope = sheet.envelope()
@@ -143,6 +146,49 @@ def test_stock_identity_defines_requirement_cardinality_without_page_matching():
     )
 
 
+def test_direction_is_a_load_bearing_part_of_slanted_requirement_identity():
+    """Two directions through one perpendicular foot are different stock lines.
+
+    This deliberately holds axis letter, line coordinates, span and A/F equal. Removing
+    direction from the key collapses the two physical requirements into one and must fail.
+    """
+    drawing = build_drawing(_double_d())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    directions = ((1.0, 0.0, 1.0), (1.0, 0.0, -1.0))
+    points = ((3.0, 0.0, -3.0), (3.0, 0.0, 3.0))
+    records = tuple(
+        Flat(
+            axis="x",
+            across=13.0,
+            at=point,
+            axis_line=(0.0, 0.0),
+            stock_span=(-20.0, 20.0),
+            axis_direction=direction,
+        )
+        for point, direction in zip(points, directions, strict=True)
+    )
+    features = tuple(
+        declare_flat(
+            axis=record.axis,
+            across=record.across,
+            at=record.at,
+            axis_line=record.axis_line,
+            stock_span=record.stock_span,
+            axis_direction=record.axis_direction,
+        )
+        for record in records
+    )
+
+    outcomes = flat_requirement_outcomes(
+        replace(recognition, flats=records),
+        features,
+        AnnotationRegistry(),
+    )
+    assert [outcome.state for outcome in outcomes] == ["missing", "missing"]
+    assert len({outcome.axis_direction for outcome in outcomes}) == 2
+
+
 def test_authored_omission_is_suppressed_not_missing():
     dwg = _declared_flat_drawing(suppress=True)
     assert not [name for name in dwg.annotations() if name.startswith("m_flat_")], (
@@ -172,7 +218,7 @@ def test_a_planner_omission_is_not_authored_suppression():
 
 
 def test_forced_placement_failure_is_dropped_not_missing():
-    dwg = build_drawing(_flatted_shaft(), page="A4", scale=2.0)
+    dwg = build_drawing(_flatted_shaft(), page="A4", scale=3.0)
     issues = dwg.lint()
     drop = next(issue for issue in issues if issue.code == "flat_dropped")
     assert len(drop.measurement_ids) == 2, (
@@ -214,6 +260,7 @@ def test_requirement_identity_without_source_record_correspondence_is_unverifiab
             at=shifted_at,
             axis_line=flat.axis_line,
             stock_span=flat.stock_span,
+            axis_direction=flat.axis_direction,
         )
     sheet.auto_dimensions()
     dwg = sheet.build()

--- a/tests/test_flat_stock_identity.py
+++ b/tests/test_flat_stock_identity.py
@@ -9,11 +9,13 @@ undefined on the sheet with nothing reporting it.
 ADR 0013's rule for a record that looks too thin is that the fix is the record.
 """
 
+import pytest
 from build123d import Box, Cylinder, Pos, Rot
 
 from draftwright import build_drawing
 from draftwright.model.declare import flat as declare_flat
 from draftwright.recognition import recognise_flats
+from draftwright.recognition.flats import _axis_line, _same_axis_line
 
 
 def _lobe():
@@ -168,14 +170,13 @@ def test_a_declared_flat_defaults_to_one_stock():
     assert far.axis_line != a.axis_line, "an explicit axis line must separate declared lobes"
 
 
-def test_slanted_stock_is_an_acknowledged_limitation_not_a_silent_wrong_answer():
-    """`axis_line` identifies AXIS-ALIGNED stock. For a slanted axis it is neither canonical
-    nor sufficient — see `_axis_line`'s docstring and #1036.
+def test_slanted_stock_has_canonical_identity_and_a_placed_definition():
+    """A slanted flat's A/F callout is safe only after its stock key carries direction.
 
-    This pins the reason that gap is tolerable rather than urgent: a slanted flat produces no
-    callout at all, so the identity never gets to be wrong in a drawing. The test exists so
-    that if slanted rendering is ever fixed, this fails and the identity gap surfaces with
-    it — rather than the two being fixed months apart with a wrong callout in between.
+    The OCP axis point for this fixture is ``(-14.142, 0, -14.142)``. Dropping X from that
+    point produced ``(0, -14.142)``, a key that changed with the chosen point along the line.
+    The perpendicular foot is the origin, so the canonical in-plane coordinates are
+    ``(0, 0)`` and direction distinguishes other lines through that foot (#1036).
     """
     slant = Rot(0, 45, 0) * (Cylinder(10, 40) - Pos(8, 0, 0) * Box(10, 40, 60))
 
@@ -185,21 +186,55 @@ def test_slanted_stock_is_an_acknowledged_limitation_not_a_silent_wrong_answer()
         "a (0.707, 0, 0.707) axis is classified by its dominant component; if that changed, "
         "the slanted-identity reasoning in _axis_line needs rechecking"
     )
-    assert not flats[0].axis_aligned, "the renderer needs an explicit slanted-stock guard"
+    assert flats[0].axis_direction == pytest.approx((2**-0.5, 0.0, 2**-0.5), abs=1e-6)
+    assert flats[0].axis_line == (0.0, 0.0), (
+        "the line key used OCP's arbitrary point rather than the perpendicular foot"
+    )
+    assert not flats[0].axis_aligned
 
     dwg = build_drawing(slant)
-    assert not [n for n in dwg.annotations() if n.startswith("m_flat_")], (
-        "a slanted flat now RENDERS. The identity key it is grouped by is not canonical for "
-        "slanted axes (#1036) — fix that before shipping slanted A/F callouts, or two "
-        "patches of one shaft may draw two callouts and two shafts may draw one."
-    )
-    assert [i for i in dwg.lint() if i.code == "flat_dropped"], (
-        "the slanted flat is neither drawn nor reported — that would be a silent omission"
-    )
+    callouts = [n for n in dwg.annotations() if n.startswith("m_flat_")]
+    assert callouts == ["m_flat_x0"]
+    assert len(dwg.measurement_keys(callouts[0])) == 1
+    assert not [
+        issue
+        for issue in dwg.lint()
+        if issue.code in {"flat_dropped", "annotation_overlap", "leader_crosses_silhouette"}
+        or issue.code.startswith("flat_requirement_")
+    ]
 
-    # The multi-stock fallback from #1034 must not defeat the guard merely because there are
-    # now two non-canonical stock groups (the adversarial counterexample to the first cut).
+    # Translation perpendicular to the slanted direction changes the canonical line position,
+    # so the two physical requirements remain two rendered definitions.
     two_slants = slant + Pos(0, 60, 0) * slant
     multi = build_drawing(two_slants)
-    assert not [n for n in multi.annotations() if n.startswith("m_flat_")]
-    assert len([i for i in multi.lint() if i.code == "flat_dropped"]) == 2
+    assert len([n for n in multi.annotations() if n.startswith("m_flat_")]) == 2
+    assert not [i for i in multi.lint() if i.code == "flat_dropped"]
+
+
+def test_a_slanted_double_d_is_still_one_physical_definition():
+    slanted_double_d = Rot(0, 45, 0) * _double_d()
+    flats = recognise_flats(slanted_double_d)
+    assert len(flats) == 2 and len({f.axis_direction for f in flats}) == 1
+    assert len({(f.axis_line, f.stock_span) for f in flats}) == 1
+
+    dwg = build_drawing(slanted_double_d)
+    callouts = [n for n in dwg.annotations() if n.startswith("m_flat_")]
+    assert len(callouts) == 1 and len(dwg.measurement_keys(callouts[0])) == 2
+    assert not [i for i in dwg.lint() if i.code == "flat_dropped"]
+
+
+def test_slanted_line_geometry_is_directional_and_point_invariant():
+    direction = (2**-0.5, 0.0, 2**-0.5)
+    first = (-14142.135624, 60.0, -14142.135624)
+    second = tuple(first[i] + 40000 * direction[i] for i in range(3))
+    assert _axis_line("x", first, direction) == _axis_line("x", second, direction) == (60.0, 0.0)
+
+    # A perpendicular foot alone is not a line: a different direction through it must not
+    # make two faces opponents. Removing the direction comparison makes this assertion fail.
+    assert not _same_axis_line(
+        "x",
+        (0.0, 0.0, 0.0),
+        direction,
+        (0.0, 0.0, 0.0),
+        (2**-0.5, 0.0, -(2**-0.5)),
+    )

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -570,9 +570,10 @@ class TestEmit:
         assert redeclared.axis == det.axis and redeclared.across == det.across
         assert redeclared.frame.origin == pytest.approx(det.frame.origin)
         assert redeclared.axis_line == det.axis_line and redeclared.stock_span == det.stock_span
+        assert redeclared.axis_direction == det.axis_direction
         assert redeclared.axis_aligned == det.axis_aligned
 
-    def test_slanted_flat_round_trips_the_alignment_guard(self):
+    def test_slanted_flat_round_trips_its_canonical_stock_identity(self):
         from build123d import Rot
 
         from draftwright.model import flat as declare_flat
@@ -582,10 +583,38 @@ class TestEmit:
         det = next(f for f in build_drawing(part, number="X").model().features if f.kind == "flat")
         assert det.axis_aligned is False
         line = _feature_line(det)
-        assert "axis_aligned=False" in line
+        assert "axis_direction=(0.707107, 0, 0.707107)" in line
+        assert "axis_line=(0, 0)" in line
         env = {"sheet": type("S", (), {"flat": staticmethod(declare_flat)})()}
         redeclared = eval(line, {"__builtins__": {}}, env)  # noqa: S307
-        assert redeclared.axis_aligned is False
+        assert redeclared.axis_direction == det.axis_direction
+        assert redeclared.axis_line == det.axis_line and redeclared.stock_span == det.stock_span
+
+        redrawn = build_drawing(part, model=[redeclared], number="X")
+        assert [n for n in redrawn.annotations() if n.startswith("m_flat_")] == ["m_flat_x0"]
+        assert not [
+            i
+            for i in redrawn.lint()
+            if i.code == "flat_dropped" or i.code.startswith("flat_requirement_")
+        ]
+
+    def test_flat_direction_round_trip_is_not_coordinate_precision(self):
+        from draftwright.model import flat as declare_flat
+        from draftwright.sheet_emit import _feature_line
+
+        feature = declare_flat(
+            axis="x",
+            across=13,
+            at=(3, 0, -3),
+            axis_line=(0, 0),
+            stock_span=(-20, 20),
+            axis_direction=(0.907331, -0.059575, 0.416176),
+        )
+        line = _feature_line(feature)
+        assert "axis_direction=(0.907331, -0.059575, 0.416176)" in line
+        env = {"sheet": type("S", (), {"flat": staticmethod(declare_flat)})()}
+        redeclared = eval(line, {"__builtins__": {}}, env)  # noqa: S307
+        assert redeclared.axis_direction == feature.axis_direction
 
     def test_groove_emits_the_groove_verb(self):
         # #148c: a detected turned groove emits `sheet.groove(...)` — the emit surface for the


### PR DESCRIPTION
## What

Render recognised slanted machined flats without making their stock grouping ambiguous.

A flat stock region is now identified by:

- the real axis direction, canonicalised with its dominant component positive;
- the axis line's perpendicular foot from the origin, retaining the existing two in-plane coordinates;
- the axial span expressed along that canonical direction.

That identity travels recognition → IR → compiled facts → completeness correspondence → emitted declaration. Flat placement keeps the established centre-out candidates first, then uses the boundary-aware fallbacks from #1034 for aligned and slanted stock alike.

The temporary `axis_aligned` field from #1046 is no longer stored state. It remains a derived convenience property; `axis_direction` is the source of truth.

## Observable result

The normal-scale #1036 fixture now has:

- one recognised slanted flat requirement;
- one placed `m_flat_x0=13 A/F` callout;
- compiler measurement provenance on that callout;
- no `flat_dropped`, completeness gap, overlap, or silhouette-crossing issue.

Two parallel slanted stocks produce two definitions. A slanted double-D still produces one grouped definition with both measurement identities.

## Adversarial review

1. **Precision at real-case scale.** Computing the perpendicular foot from a six-decimal direction can amplify angular rounding at 40-metre coordinates. Geometric projection now uses the full-precision unit vector; only the stable identity is rounded.
2. **Emitter fidelity.** The generic point formatter kept three decimals, which is drawing-coordinate precision rather than angular precision. Axis directions now emit at six decimals, and canonicalisation is idempotent across emit → declare.
3. **Opposition still ignored direction.** The recogniser's old same-line check projected positions along one direction but never verified the other cylinder shared it. Different slanted lines through one foot could still pair as opposing faces. It now compares canonical directions first.
4. **Direction sign and span.** Reversing a supplied direction now reverses and reorders its axial span, so equivalent unoriented axes retain one identity.
5. **Load-bearing mutations.** Replacing the completeness direction with the principal axis collapses two requirements to one; removing the recogniser direction comparison treats different lines as one. Both named guards fail under mutation and pass restored.

Only naming/compatibility nits remain.

## Validation

- Expanded recognition/IR/emit/declare/completeness suite: `722 passed, 2 xfailed`
- Targeted restored mutation guards: `2 passed`
- `ruff format --check src tests`
- `ruff check src tests`
- `mypy src/draftwright`
- `codespell src tests docs`

Closes #1036.