### PR TITLE
Fit detail views to aspect-specific sheet space

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -539,55 +539,55 @@ def _legible_locations(positions, scale):
     return kept, n_too_close
 
 
-def _largest_empty_rect(drawable, obstacles, *, warn: bool = True):
+def _largest_empty_rect(drawable, obstacles, *, target_size=None, warn: bool = True):
     """Largest axis-aligned empty rectangle in *drawable* avoiding *obstacles*.
 
     *drawable* and each obstacle are ``(x0, y0, x1, y1)`` page-mm boxes.  Returns
     the empty sub-rectangle of *drawable* (overlapping no obstacle) that maximises
-    the side of the largest square it can hold — i.e. ``min(width, height)`` — so
-    the (near-square) iso view can be scaled up as far as possible.
+    the uniform scale of *target_size*. The default ``(1, 1)`` maximises the side
+    of the largest square it can hold, preserving the iso-view policy. A caller
+    placing a wide or tall fixed-aspect footprint can supply its minimum
+    ``(width, height)`` instead.
 
     The obstacle set is tiny (front/plan/side views + title block), so a
     gap-based search over candidate edges is both exact enough and cheap: every
     maximal empty rectangle has edges drawn from the drawable bounds and the
     obstacle bounds, so enumerating those cut lines finds the optimum.
     """
+    target_w, target_h = target_size or (1.0, 1.0)
+    if target_w <= 0 or target_h <= 0:
+        raise ValueError("target_size must contain positive dimensions")
+
     dx0, dy0, dx1, dy1 = drawable
     xs = sorted({dx0, dx1, *(c for o in obstacles for c in (o[0], o[2]) if dx0 < c < dx1)})
     ys = sorted({dy0, dy1, *(c for o in obstacles for c in (o[1], o[3]) if dy0 < c < dy1)})
 
-    # The score is min(width, height), so any candidate whose width OR height is
-    # ``<= best_score`` cannot beat the best found so far. Because ``xs``/``ys`` are
-    # sorted and ``best_score`` only grows, we skip those candidates outright rather
-    # than enumerate-then-reject them: ``break`` the outer loop once even its widest
-    # candidate is too small, and ``bisect`` the inner loop's start past every pair
-    # narrower than ``best_score``. This is an exact prune — skipped candidates could
-    # never satisfy ``score > best_score`` — so the result (and its tie-breaking) is
-    # identical to the naive quadruple loop, but the detail-view caller (which passes
-    # every placed-annotation footprint, not just the handful of views) no longer
-    # triggers an O(N⁴) blow-up (#661).
+    # The score is min(width / target_w, height / target_h), so any candidate whose
+    # width or height cannot exceed the corresponding scaled target cannot beat the
+    # best found so far. This is the same exact prune as the square-default path,
+    # normalized by the requested footprint.
     best = None
     best_score = 0.0
     nx, ny = len(xs), len(ys)
     for i in range(nx - 1):
         rx0 = xs[i]
-        if xs[-1] - rx0 <= best_score:
+        if xs[-1] - rx0 <= best_score * target_w:
             break  # widest strip from here on can't beat best (rx0 only grows)
-        for j in range(bisect_right(xs, rx0 + best_score), nx):
+        for j in range(bisect_right(xs, rx0 + best_score * target_w), nx):
             rx1 = xs[j]
             width = rx1 - rx0
             # only obstacles overlapping the x-strip [rx0, rx1] can block it
             strip = [(o[1], o[3]) for o in obstacles if o[0] < rx1 and rx0 < o[2]]
             for k in range(ny - 1):
                 ry0 = ys[k]
-                if ys[-1] - ry0 <= best_score:
+                if ys[-1] - ry0 <= best_score * target_h:
                     break  # tallest gap from here can't beat best (ry0 only grows)
-                for m in range(bisect_right(ys, ry0 + best_score), ny):
+                for m in range(bisect_right(ys, ry0 + best_score * target_h), ny):
                     ry1 = ys[m]
                     if any(ry0 < oy1 and oy0 < ry1 for (oy0, oy1) in strip):
                         continue
                     height = ry1 - ry0
-                    score = width if width < height else height
+                    score = min(width / target_w, height / target_h)
                     if score > best_score:
                         best_score = score
                         best = (rx0, ry0, rx1, ry1)

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -555,8 +555,13 @@ def _largest_empty_rect(drawable, obstacles, *, target_size=None, warn: bool = T
     obstacle bounds, so enumerating those cut lines finds the optimum.
     """
     target_w, target_h = target_size or (1.0, 1.0)
-    if target_w <= 0 or target_h <= 0:
-        raise ValueError("target_size must contain positive dimensions")
+    if not (
+        math.isfinite(target_w)
+        and target_w > 0
+        and math.isfinite(target_h)
+        and target_h > 0
+    ):
+        raise ValueError("target_size must contain finite positive dimensions")
 
     dx0, dy0, dx1, dy1 = drawable
     xs = sorted({dx0, dx1, *(c for o in obstacles for c in (o[0], o[2]) if dx0 < c < dx1)})

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -555,12 +555,7 @@ def _largest_empty_rect(drawable, obstacles, *, target_size=None, warn: bool = T
     obstacle bounds, so enumerating those cut lines finds the optimum.
     """
     target_w, target_h = target_size or (1.0, 1.0)
-    if not (
-        math.isfinite(target_w)
-        and target_w > 0
-        and math.isfinite(target_h)
-        and target_h > 0
-    ):
+    if not (math.isfinite(target_w) and target_w > 0 and math.isfinite(target_h) and target_h > 0):
         raise ValueError("target_size must contain finite positive dimensions")
 
     dx0, dy0, dx1, dy1 = drawable

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -420,6 +420,11 @@ def _render_detail(
         if detail_scale >= req.scale_needed:
             break
 
+    min_detail_scale = max(req.scale_needed, a.SCALE * 1.2 + 1e-6)
+    if not math.isfinite(min_detail_scale):
+        _log.info("Detail %s skipped (non-finite scale required)", letter)
+        return False
+
     # Crop to the band along req.axis (two fuzzy cuts). Solids only — a mixed
     # compound (PMI curves) cannot be cut.
     solids = a.part.solids()
@@ -468,10 +473,6 @@ def _render_detail(
     def _pads(s):  # annotation bands may depend on the scale (the prismatic ladder)
         return req.pads(s) if req.pads is not None else (0.0, req.pad_top)
 
-    min_detail_scale = max(req.scale_needed, a.SCALE * 1.2 + 1e-6)
-    if not math.isfinite(min_detail_scale):
-        _log.info("Detail %s skipped (non-finite scale required)", letter)
-        return False
     min_pad_right, min_pad_top = _pads(min_detail_scale)
     min_footprint = (
         view_w * min_detail_scale + min_pad_right,

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -456,7 +456,30 @@ def _render_detail(
         _log.warning("Detail %s skipped (boolean crop produced no solid)", letter)
         return False
 
-    # Placement: largest empty rectangle avoiding placed views + the title block.
+    # Footprint = the projected cropped band + the request's annotation pads (the
+    # dim ladder/chain) + the caption row. Rectangle selection must know that aspect:
+    # the iso helper's square-default optimum can reject a wide, short detail even
+    # when a different empty rectangle fits it (#915).
+    cb = cropped.bounding_box()
+    view_w = cb.max.Y - cb.min.Y if req.source_view == "side" else cb.max.X - cb.min.X
+    view_h = cb.max.Z - cb.min.Z
+    cap_h = 8.0
+
+    def _pads(s):  # annotation bands may depend on the scale (the prismatic ladder)
+        return req.pads(s) if req.pads is not None else (0.0, req.pad_top)
+
+    min_detail_scale = max(req.scale_needed, a.SCALE * 1.2 + 1e-6)
+    if not math.isfinite(min_detail_scale):
+        _log.info("Detail %s skipped (non-finite scale required)", letter)
+        return False
+    min_pad_right, min_pad_top = _pads(min_detail_scale)
+    min_footprint = (
+        view_w * min_detail_scale + min_pad_right,
+        view_h * min_detail_scale + min_pad_top + a.DIM_PAD + cap_h,
+    )
+
+    # Placement: best empty rectangle for this footprint, avoiding placed views
+    # and the title block.
     drawable = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
     obstacles = []
     for vis, hid in dwg.views.values():
@@ -473,18 +496,8 @@ def _render_detail(
     obstacles.append(
         (a.PAGE_W - a.TB_W - _TB_CLEAR, a.margin, a.PAGE_W - _TB_CLEAR, _TB_CLEAR + _TB_H)
     )
-    rx0, ry0, rx1, ry1 = _largest_empty_rect(drawable, obstacles)
+    rx0, ry0, rx1, ry1 = _largest_empty_rect(drawable, obstacles, target_size=min_footprint)
     rect_w, rect_h = rx1 - rx0, ry1 - ry0
-
-    # Footprint = the projected cropped band + the request's annotation pads (the
-    # dim ladder/chain) + the caption row. Shrink the scale to fit if necessary.
-    cb = cropped.bounding_box()
-    view_w = cb.max.Y - cb.min.Y if req.source_view == "side" else cb.max.X - cb.min.X
-    view_h = cb.max.Z - cb.min.Z
-    cap_h = 8.0
-
-    def _pads(s):  # annotation bands may depend on the scale (the prismatic ladder)
-        return req.pads(s) if req.pads is not None else (0.0, req.pad_top)
 
     def _fits(s):
         pr, pt = _pads(s)
@@ -493,7 +506,6 @@ def _render_detail(
     # Fit continuously enough not to jump over a viable scale.  Subtracting a
     # whole sheet scale skipped 3:1 on a 2:1 sheet (4→2), even when 3:1 both fit
     # and exceeded the requested legibility scale (#897).
-    min_detail_scale = max(req.scale_needed, a.SCALE * 1.2 + 1e-6)
     fit_step = a.SCALE * 0.5
     while detail_scale - fit_step >= min_detail_scale and not _fits(detail_scale):
         detail_scale -= fit_step

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -276,7 +276,9 @@ def _fit_iso_view(dwg, a: Analysis, annotate: bool = True):
     fill the zone can be computed from the measured extents without iteration.
 
     - Overflow (needed < 1): shrink with 2 % safety margin.
-    - Under-fill (needed > 1): grow to 90 % of zone, leaving breathing room.
+    - Under-fill (needed > 1): grow to 90 % of zone, leaving breathing room, unless an
+      enlarged detail has claimed sheet space after the iso zone was composed. In that case
+      the orientation-only iso stays at the truthful sheet scale.
     - Within 5 % of sheet scale: leave as-is (no NTS label).
     """
     # Use the precomputed iso zone (largest empty rectangle).  A section view
@@ -308,6 +310,12 @@ def _fit_iso_view(dwg, a: Analysis, annotate: bool = True):
         if extent > 0
     ]
     needed = min(ratios, default=1.0)
+    has_detail = any(name.startswith("detail_") for name in dwg.views)
+    if needed >= 1.0 and has_detail:
+        # Detail views are defining content and resolve against the sheet-scale iso. Growing
+        # that iso afterwards can invade an aspect-specific detail rectangle (#915). Keep the
+        # already-fitting orientation view at its current scale.
+        return
     if needed >= 1.0:
         # Iso fits; grow to 90 % of zone — leaves comfortable breathing room.
         margin_pct = 0.90

--- a/tests/test_issue_915_dense_case.py
+++ b/tests/test_issue_915_dense_case.py
@@ -40,3 +40,17 @@ def test_issue_915_hole_callouts_share_one_spacing_solve():
     step_drops = [issue for issue in issues if issue.code == "step_dim_dropped"]
     assert len(step_drops) == 1
     assert "5 step height(s)" in step_drops[0].message
+
+
+def test_issue_915_wide_detail_uses_a_matching_empty_region():
+    """A1 has enough wide, short space even though its largest square is too narrow."""
+    dwg = build_drawing(_ISSUE_915, page="A1", scale=0.5, detail_view=True)
+
+    assert "detail_a" in dwg.views
+    labels = [
+        annotation.label
+        for name, annotation in dwg.iter_annotations()
+        if name.startswith("dim_detail_a_step")
+    ]
+    assert labels == ["10", "13", "20", "30", "40", "57", "60", "65"]
+    assert dwg.lint() == []

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1371,6 +1371,20 @@ class TestIsoEmptyRect:
         g = _layout_geometry(20, 20, 20, 1.0, 297.0, 210.0, 120.0, None)
         assert g.iso_valid is True
 
+    def test_target_aspect_can_choose_a_wide_short_gap_over_the_largest_square(self):
+        from draftwright._core import _largest_empty_rect
+
+        drawable = (0.0, 0.0, 100.0, 100.0)
+        obstacles = [(40.0, 0.0, 100.0, 70.0)]
+
+        assert _largest_empty_rect(drawable, obstacles) == (0.0, 0.0, 40.0, 70.0)
+        assert _largest_empty_rect(drawable, obstacles, target_size=(60.0, 20.0)) == (
+            0.0,
+            70.0,
+            100.0,
+            100.0,
+        )
+
 
 class TestScaleMinimum:
     """An explicit scale below the legibility floor is honoured with a warning (#489);
@@ -5593,6 +5607,9 @@ class TestDetailView:
         assert any(n.startswith("dim_detail_a_step") for n in dwg.annotations())
         # Drawn at a larger scale than the sheet.
         assert dwg.coords("detail_a")._scale > a.SCALE
+        # The detail resolves against the sheet-scale iso. That orientation aid must not then
+        # grow into the defining detail after placement (#915).
+        assert dwg.coords("iso")._scale == pytest.approx(a.SCALE)
         # Absolute step heights use the part base as their datum. The detail
         # must include that datum so neither witness endpoint floats outside
         # the visible crop.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1385,6 +1385,16 @@ class TestIsoEmptyRect:
             100.0,
         )
 
+    @pytest.mark.parametrize(
+        "target_size",
+        [(float("nan"), 1.0), (0.0, 1.0), (1.0, float("nan")), (1.0, 0.0)],
+    )
+    def test_target_aspect_requires_two_finite_positive_dimensions(self, target_size):
+        from draftwright._core import _largest_empty_rect
+
+        with pytest.raises(ValueError, match="finite positive dimensions"):
+            _largest_empty_rect((0.0, 0.0, 10.0, 10.0), [], target_size=target_size)
+
 
 class TestScaleMinimum:
     """An explicit scale below the legibility floor is honoured with a warning (#489);
@@ -5591,6 +5601,23 @@ class TestDetailView:
         assert "detail_a" not in dwg.views
         assert "detail_caption" not in dwg.annotations()
         assert not any(n.startswith("dim_detail") for n in dwg.annotations())
+
+    def test_non_finite_requested_scale_is_rejected_before_geometry_work(self):
+        from types import SimpleNamespace
+
+        from draftwright._core import DetailRequest
+        from draftwright.annotations.sections import _render_detail
+
+        req = DetailRequest(axis="z", lo=0.0, hi=1.0, scale_needed=float("inf"), redraw=lambda: 1)
+
+        assert not _render_detail(
+            None,
+            SimpleNamespace(SCALE=1.0),
+            req,
+            "detail_a",
+            "A",
+            ctx=None,
+        )
 
     def test_crowded_shoulders_get_a_detail_view_when_requested(self):
         from draftwright._core import _legible_steps


### PR DESCRIPTION
## Summary

- let the shared empty-rectangle search optimize for a caller's target footprint while preserving the ISO view's square-default behavior
- choose detail placement from its minimum legible projected view, dimension pads, and caption footprint
- prevent a fitting orientation-only ISO view from growing into a defining detail after placement
- require the real #915 case to place all eight approved step-height rungs with clean lint on A1 at 1:2

## Root cause

The real case requires a wide, short detail footprint. On A1, 163 empty rectangles can hold its minimum 448.7 x 191.3 mm footprint, but the detailer reused `_largest_empty_rect` in its ISO-specific mode. That helper maximized `min(width, height)`, selected a 367 x 437 mm near-square region, and rejected the detail as too narrow.

The helper now optionally scores `min(width / target_width, height / target_height)`. Its default target remains `(1, 1)`, including historical iteration and tie behavior, so ordinary ISO composition is unchanged.

## Adversarial findings

1. Removing only the detailer's `target_size` argument restores `detail_unplaceable` on the real case and fails before the label assertions.
2. The expanded cleanliness corpus found a real follow-on regression: a crowded turned detail placed legally against the sheet-scale ISO, then the builder enlarged the ISO into it. Once a defining detail exists, a fitting ISO now remains at its current truthful scale; overflowing ISOs may still shrink.
3. The real guard requires the exact ordered eight labels, not a set, so dropping, duplicating, or fabricating a rung fails.
4. Codecov exposed untested validation paths. Non-finite requested scales now fail before geometry work, and aspect dimensions must be finite and positive; branch-complete tests cover both coordinates.
5. A separate exhaustive oracle matched the normalized pruning result over 1,000 randomized obstacle/aspect cases.

## Scope

This is one rung of #915's escalation, not closure. A1 at 1:2 now places all eight compiler-approved step-height rungs and reports clean lint.

A2 remains unplaceable under the current request. Investigation found that this is not yet evidence for page/view recomposition: `FaceLevel` / `StepLevelFeature` retains each Z value but not the supporting face's in-plane span, and the compiler consequently gives every height the same envelope-edge witness station. The detail request therefore falls back to the full 170 mm front width. The next slice must first test and retain exact per-level geometric support; only a still-infeasible correspondent crop would justify recomposition.

This PR does not silently crop away measured geometry, reduce the requested detail scale, claim per-level geometric correspondence, or claim A2 complete.

## Verification

- rendered A1 output inspected: full-width front detail at 2.5:1, all eight approved labels present, lint empty
- detail/compiled-plan parity set: 46 passed
- layout, strip, script-detail, and real-case set: 129 passed
- focused ISO/detail cleanliness after the adversarial fix: 23 passed
- input-validation delta: 9 passed
- normalized rectangle pruning: 1,000 randomized cases matched exhaustive search
- repository-wide Ruff check and format check pass
- local full fast suite on the implementation head: 2,792 passed, 1 skipped, 19 deselected, 2 expected failures
- final-head GitHub CI: lint plus all 15 Ubuntu/macOS/Windows Python 3.10-3.14 lanes passed; slow workflow skipped by policy
- Codecov: 100% of modified coverable lines; project coverage 91.62% to 91.63%

Progresses #915.
