### PR TITLE
Preserve step-detail measurement provenance

### DIFF
--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -759,7 +759,7 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
     # source view would have.
     levels = [r.span[1][2] for r in rungs]
     datum_z = rungs[0].span[0][2]
-    label_of = {r.span[1][2]: r.final_label for r in rungs}
+    rung_by_level = {r.span[1][2]: r for r in rungs}
     has_shoulders = plan.ladder("step_position") is not None
     z0, z1 = min(levels), max(levels)
     pad = 0.08 * (z1 - z0) + 1.0
@@ -834,7 +834,8 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
         source_x_by_z = {r.span[1][2]: r.span[1][0] for r in supported}
         placed = 0
         for i, z in enumerate(det_kept):
-            label = label_of[z]  # the compiler's label, not a second derivation
+            rung = rung_by_level[z]
+            label = rung.final_label  # the compiler's label, not a second derivation
             try:
                 if has_level_supports:
                     source_x = source_x_by_z[z]
@@ -862,7 +863,11 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
                     )
                 det_dim._dw_scale = detail_scale  # detail scale, for label-vs-measured lint (#42)
                 ctx.place(
-                    det_dim, f"dim_{view}_step{i}", view=view
+                    det_dim,
+                    f"dim_{view}_step{i}",
+                    view=view,
+                    feature=rung.id.feature if rung.id is not None else None,
+                    measurement=rung.id,
                 )  # view-scoped name (#307 review)
                 ladder += step_pad
                 placed += 1

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -697,10 +697,6 @@ def test_every_direct_placement_records_identity_or_says_why_not():
         ("sections.py", "_add_section_letters"): "the 'A' identification letters",
         ("sections.py", "_add_cutting_plane_arrows"): "ISO 128-44 arrows are not dimensions",
         ("sections.py", "_render_detail"): "detail-view geometry, caption and circle",
-        (
-            "sections.py",
-            "_request_prismatic_detail.redraw",
-        ): "re-renders the section geometry, not a dimension",
         # -- hole callouts: still on the legacy surface (#926) ----------------------
         ("holes.py", "add_feature_callout"): "hole callouts are pre-compiled-plan (#926)",
         ("holes.py", "_place_queue"): "hole callouts are pre-compiled-plan (#926)",

--- a/tests/test_issue_909_sloped_profile.py
+++ b/tests/test_issue_909_sloped_profile.py
@@ -7,7 +7,9 @@ import pytest
 from build123d import import_step
 
 from draftwright import Drawing, build_drawing
+from draftwright.drawing import feature_key
 from draftwright.model import PadFeature
+from draftwright.model.compiled import compile_dimensions
 from draftwright.recognition import RaisedPad, recognise_rectangular_pads
 from draftwright.sheet_emit import generate_sheet_script
 
@@ -62,6 +64,31 @@ def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
     }
     assert "26" in detail_labels
     assert drawing.lint() == []
+
+
+def test_case_study_detail_rungs_keep_their_compiled_measurement_identity():
+    drawing = build_drawing(_ISSUE_909, detail_view=True)
+    step = next(feature for feature in drawing.model().features if feature.kind == "step_level")
+    detail_names = {name for name in drawing.annotations() if name.startswith("dim_detail_a_step")}
+    ladder = compile_dimensions(drawing.model()).ladder("step_height")
+    assert ladder is not None
+    rung_by_label = {rung.final_label: rung for rung in ladder.rungs}
+
+    assert detail_names
+    for name in detail_names:
+        rung = rung_by_label[drawing.get_annotation(name).label]
+        assert rung.id is not None
+        assert drawing.measurement_keys(name) == [
+            {
+                "feature": feature_key(rung.id.feature),
+                "parameter_id": rung.id.parameter,
+            }
+        ]
+    assert detail_names <= set(drawing.annotations_of(step))
+
+    removed = set(drawing.drop(step))
+    assert detail_names <= removed
+    assert not detail_names & set(drawing.annotations())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -119,6 +119,21 @@ def test_generated_script_matches_direct_detail_view(crowded_step, tmp_path):
 
     assert _detail_signature(scripted) == _detail_signature(direct)
 
+    def detail_measurements(drawing):
+        step = next(
+            feature for feature in drawing.model().features if feature.kind == "step_level"
+        )
+        names = {name for name in drawing.annotations() if name.startswith("dim_detail_a_step")}
+        assert names <= set(drawing.annotations_of(step))
+        return {
+            drawing.get_annotation(name).label: drawing.measurement_keys(name) for name in names
+        }
+
+    direct_measurements = detail_measurements(direct)
+    assert direct_measurements
+    assert all(direct_measurements.values())
+    assert detail_measurements(scripted) == direct_measurements
+
 
 @pytest.mark.timeout(300)
 def test_generated_script_matches_two_direct_detail_views(tmp_path):


### PR DESCRIPTION
## Summary

- register each enlarged prismatic detail rung against the approved compiled measurement it draws
- attribute those detail annotations to the source step-level feature, so `annotations_of()` and `drop(feature)` remain complete
- remove the audit ratchet exemption that incorrectly classified detail dimensions as non-measurement geometry
- pin the contract against the real #909 STEP artifact without requiring the duplicate main-view rung to survive

## Evidence

On current `main`, `dim_detail_a_step0` and `dim_detail_a_step1` render the approved 21 mm and 26 mm rungs but both return `[]` from `measurement_keys()` and neither belongs to the step feature.

Mutations removing `measurement=` and `feature=` fail independently. The first is caught by both the real-artifact assertion and the direct-placement inventory; the second is caught by semantic ownership and `drop(feature)`.

## Validation

- formatter, Ruff, mypy, codespell
- 64 focused tests covering #909, the audit differential, detail script parity, #915 dense details, and slanted-profile details

Part of #909 and #996. This PR does not decide whether detail views should be automatic or whether the main-view 21 mm rung should remain duplicated.