### PR TITLE
Send only omitted step rungs to detail views

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -59,6 +59,8 @@ class Escalation:
         reason:   why placement failed — ``"strip_full" | "illegible" | "corridor_blocked" | "no_room"``.
         remedies: ranked candidate remedies the resolver may pick, e.g.
                   ``("group_balloon", "table", "detail", "drop")``. Empty = resolver's default ladder.
+        targets:  opaque approved items the failed placement could not draw. Empty for
+                  escalations whose remedy reconstructs a whole feature/group.
     """
 
     kind: str
@@ -66,6 +68,7 @@ class Escalation:
     feature: object
     reason: str
     remedies: tuple[str, ...] = field(default_factory=tuple)
+    targets: tuple[object, ...] = field(default_factory=tuple)
 
 
 def _never_aborts(method):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3218,6 +3218,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             frame.scale,
             allow_short=has_shoulders,
         )
+        kept_level_set = set(kept_z)
         if n_close:
             # With the explicit detail opt-in the enlarged view owns the omitted rungs.
             # Report the source-view drop only when no recovery was requested; a failed
@@ -3233,9 +3234,15 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             # `_request_prismatic_detail` (sections.py) consumes this instead of recomputing
             # the legibility gate.
             ctx.escalations.append(
-                Escalation(kind="step", view="front", feature=step, reason="illegible")
+                Escalation(
+                    kind="step",
+                    view="front",
+                    feature=step,
+                    reason="illegible",
+                    targets=tuple(rung for rung in rungs if rung.span[1][2] not in kept_level_set),
+                )
             )
-        kept = [r for r in rungs if r.span[1][2] in set(kept_z)]
+        kept = [r for r in rungs if r.span[1][2] in kept_level_set]
         for col, rung in enumerate(kept):
             # A short structural rise needs external arrows, whose ink would swamp the usual
             # right-hand ladder; it goes to the left strip below (#565).

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -739,8 +739,9 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
     X-turned crowded-head block + `DetailRequest` this docstring's sibling,
     `render_step_lengths`, already has.
 
-    The redraw re-draws the step-height ladder in the detail view at the
-    enlarged scale — from the **compiled plan**, like the source-view ladder.
+    The redraw draws only the approved rungs the source-view spacing gate omitted,
+    at the enlarged scale. The escalation carries those exact compiled objects; this
+    resolver does not re-decide which rungs failed.
 
     That was the last dimensional bypass of ADR 0016's boundary (#923 review). This
     function used to re-derive the step feature from ``dwg.model()`` and rebuild the ladder
@@ -749,22 +750,30 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
     renderer while its escalation reconstructed the same content left the rule true only of
     the path anyone happened to look at."""
     rung_set = plan.ladder("step_height")
-    rungs = list(rung_set.rungs) if rung_set is not None else []
-    if len(rungs) < 2:
+    approved_rungs = list(rung_set.rungs) if rung_set is not None else []
+    if len(approved_rungs) < 2:
         return
-    if not any(e.kind == "step" and e.reason == "illegible" for e in ctx.escalations):
+    escalation = next(
+        (e for e in ctx.escalations if e.kind == "step" and e.reason == "illegible"),
+        None,
+    )
+    if escalation is None:
+        return
+    rungs = [rung for rung in approved_rungs if rung in escalation.targets]
+    if not rungs:
         return
     # Both ends off the approved span, never the bounding box: the span is the compiler's
     # statement of what each rung measures, and the detail must measure the same thing the
     # source view would have.
+    approved_levels = [r.span[1][2] for r in approved_rungs]
     levels = [r.span[1][2] for r in rungs]
-    datum_z = rungs[0].span[0][2]
+    datum_z = approved_rungs[0].span[0][2]
     rung_by_level = {r.span[1][2]: r for r in rungs}
     has_shoulders = plan.ladder("step_position") is not None
-    z0, z1 = min(levels), max(levels)
+    z0, z1 = min(approved_levels), max(approved_levels)
     pad = 0.08 * (z1 - z0) + 1.0
     band_lo, band_hi = max(a.bb.min.Z, z0 - pad), min(a.bb.max.Z, z1 + pad)
-    s_zs = sorted(levels)
+    s_zs = sorted(approved_levels)
     min_gap = min(b - aa for aa, b in zip(s_zs, s_zs[1:]))
     # World→page scale that renders the closest gap at the legibility floor — no sheet
     # factor (detail_scale is itself an absolute world→page scale). (#307 review)
@@ -781,8 +790,8 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
     # treating that synthetic station as crop evidence would cut away the measured face. One
     # millimetre gives the fuzzy booleans context without scaling the crop back toward the full
     # 170 mm envelope that made the A2 detail unplaceable (#915).
-    supported = [r for r in rungs if r.span is not None and r.support_bounds is not None]
-    has_level_supports = len(supported) == len(rungs)
+    supported = [r for r in approved_rungs if r.span is not None and r.support_bounds is not None]
+    has_level_supports = len(supported) == len(approved_rungs)
     x_stations = sorted({r.span[1][0] for r in supported}) if has_level_supports else []
     crop_xs = (
         (max(a.bb.min.X, x_stations[0] - 1.0), min(a.bb.max.X, x_stations[-1] + 1.0))
@@ -795,7 +804,7 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
         return (
             len(
                 _legible_steps(
-                    levels,
+                    approved_levels,
                     datum_z,
                     detail_scale,
                     allow_short=has_shoulders,

--- a/tests/test_issue_909_sloped_profile.py
+++ b/tests/test_issue_909_sloped_profile.py
@@ -62,7 +62,14 @@ def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
         for name, annotation in drawing.iter_annotations()
         if name.startswith("dim_detail_a_step")
     }
-    assert "26" in detail_labels
+    main_labels = {
+        annotation.label
+        for name, annotation in drawing.iter_annotations()
+        if name.startswith("dim_step")
+    }
+    assert main_labels == {"21"}
+    assert detail_labels == {"26"}
+    assert main_labels.isdisjoint(detail_labels)
     assert drawing.lint() == []
 
 

--- a/tests/test_issue_909_sloped_profile.py
+++ b/tests/test_issue_909_sloped_profile.py
@@ -57,19 +57,19 @@ def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
         "pad_length.length",
         "location_pad.location",
     }
-    detail_labels = {
+    detail_labels = Counter(
         annotation.label
         for name, annotation in drawing.iter_annotations()
         if name.startswith("dim_detail_a_step")
-    }
-    main_labels = {
+    )
+    main_labels = Counter(
         annotation.label
         for name, annotation in drawing.iter_annotations()
         if name.startswith("dim_step")
-    }
-    assert main_labels == {"21"}
-    assert detail_labels == {"26"}
-    assert main_labels.isdisjoint(detail_labels)
+    )
+    assert main_labels == Counter({"21": 1})
+    assert detail_labels == Counter({"26": 1})
+    assert not main_labels & detail_labels
     assert drawing.lint() == []
 
 

--- a/tests/test_issue_915_dense_case.py
+++ b/tests/test_issue_915_dense_case.py
@@ -56,7 +56,7 @@ def test_issue_915_wide_detail_uses_a_matching_empty_region():
         for name, annotation in dwg.iter_annotations()
         if name.startswith("dim_detail_a_step")
     ]
-    assert labels == ["10", "13", "20", "30", "40", "57", "60", "65"]
+    assert labels == ["13", "20", "40", "60", "65"]
     assert dwg.lint() == []
 
 
@@ -101,7 +101,7 @@ def test_issue_915_a2_detail_uses_each_levels_supporting_geometry():
         for name, annotation in dwg.iter_annotations()
         if name.startswith("dim_detail_a_step")
     }
-    assert list(detail_dims) == ["10", "13", "20", "30", "40", "57", "60", "65"]
+    assert list(detail_dims) == ["13", "20", "40", "60", "65"]
     for label, dimension in detail_dims.items():
         expected = dwg.at("detail_a", *rungs[label].span[1])
         assert dimension._dw_spec.p2[:2] == pytest.approx(expected[:2])

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5707,8 +5707,24 @@ class TestDetailView:
         _request_prismatic_detail(None, a, ctx=no_escalation, plan=plan)
         assert no_escalation.detail_requests == []
 
+        ladder = plan.ladder("step_height")
+        assert ladder is not None
+        empty_escalation = PlacementContext(
+            escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")]
+        )
+        _request_prismatic_detail(None, a, ctx=empty_escalation, plan=plan)
+        assert empty_escalation.detail_requests == []
+
         with_escalation = PlacementContext(
-            escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")],
+            escalations=[
+                Escalation(
+                    kind="step",
+                    view="front",
+                    feature=None,
+                    reason="illegible",
+                    targets=(ladder.rungs[-1],),
+                )
+            ],
         )
         _request_prismatic_detail(None, a, ctx=with_escalation, plan=plan)
         assert len(with_escalation.detail_requests) == 1
@@ -5746,7 +5762,15 @@ class TestDetailView:
             SCALE=1.0,
         )
         ctx = PlacementContext(
-            escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")]
+            escalations=[
+                Escalation(
+                    kind="step",
+                    view="front",
+                    feature=None,
+                    reason="illegible",
+                    targets=(rungs[-1],),
+                )
+            ]
         )
 
         _request_prismatic_detail(None, analysis, ctx=ctx, plan=plan)
@@ -5787,7 +5811,15 @@ class TestDetailView:
             SCALE=1.0,
         )
         ctx = PlacementContext(
-            escalations=[Escalation(kind="step", view="front", feature=None, reason="illegible")]
+            escalations=[
+                Escalation(
+                    kind="step",
+                    view="front",
+                    feature=None,
+                    reason="illegible",
+                    targets=rungs,
+                )
+            ]
         )
 
         _request_prismatic_detail(None, analysis, ctx=ctx, plan=plan)
@@ -5815,7 +5847,7 @@ class TestDetailView:
             annotation.label
             for name, annotation in on.iter_annotations()
             if name.startswith("dim_detail_a_step")
-        ] == ["35", "38"]
+        ] == ["38"]
 
     def test_plain_part_gets_no_detail_view(self):
         dwg = build_drawing(Box(60, 40, 20))

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -6,6 +6,7 @@ queues and resolves detail requests like the auto pass); the remaining xfails
 capture the still-open gaps — side-drilled location dims and rotational furniture.
 """
 
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -139,19 +140,19 @@ def test_generated_script_matches_direct_detail_view(crowded_step, tmp_path):
 
         ladder = compile_dimensions(drawing.model()).ladder("step_height")
         assert ladder is not None
-        approved = {rung.final_label for rung in ladder.rungs}
-        parent = {
+        approved = Counter(rung.final_label for rung in ladder.rungs)
+        parent = Counter(
             annotation.label
             for name, annotation in drawing.annotations_in_view("front")
             if name.startswith("dim_step")
-        }
-        detail = {
+        )
+        detail = Counter(
             annotation.label
             for name, annotation in drawing.annotations_in_view("detail_a")
             if name.startswith("dim_detail_a_step")
-        }
-        assert parent.isdisjoint(detail)
-        assert parent | detail == approved
+        )
+        assert not parent & detail
+        assert parent + detail == approved
         return parent, detail
 
     assert step_partition(scripted) == step_partition(direct)

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -134,6 +134,28 @@ def test_generated_script_matches_direct_detail_view(crowded_step, tmp_path):
     assert all(direct_measurements.values())
     assert detail_measurements(scripted) == direct_measurements
 
+    def step_partition(drawing):
+        from draftwright.model.compiled import compile_dimensions
+
+        ladder = compile_dimensions(drawing.model()).ladder("step_height")
+        assert ladder is not None
+        approved = {rung.final_label for rung in ladder.rungs}
+        parent = {
+            annotation.label
+            for name, annotation in drawing.annotations_in_view("front")
+            if name.startswith("dim_step")
+        }
+        detail = {
+            annotation.label
+            for name, annotation in drawing.annotations_in_view("detail_a")
+            if name.startswith("dim_detail_a_step")
+        }
+        assert parent.isdisjoint(detail)
+        assert parent | detail == approved
+        return parent, detail
+
+    assert step_partition(scripted) == step_partition(direct)
+
 
 @pytest.mark.timeout(300)
 def test_generated_script_matches_two_direct_detail_views(tmp_path):

--- a/tests/test_slanted_blind_step.py
+++ b/tests/test_slanted_blind_step.py
@@ -6,6 +6,7 @@ vendoring the uploaded customer STEP file.
 
 from __future__ import annotations
 
+from collections import Counter
 from types import SimpleNamespace
 
 import pytest
@@ -86,19 +87,19 @@ def test_slanted_blind_step_gets_reconstructable_dimension_plan(slanted_blind_st
     assert {"m_pocket_xy0", "m_pocket_xy1"} <= names
     assert "detail_a" in dwg.views
 
-    detail_labels = {
+    detail_labels = Counter(
         str(getattr(ann, "label", ""))
         for name, ann in dwg.annotations_in_view("detail_a")
         if name.startswith("dim_detail_a_step")
-    }
-    main_labels = {
+    )
+    main_labels = Counter(
         str(getattr(ann, "label", ""))
         for name, ann in dwg.annotations_in_view("front")
         if name.startswith("dim_step")
-    }
-    assert "14" in main_labels
-    assert "19" in detail_labels
-    assert main_labels.isdisjoint(detail_labels)
+    )
+    assert main_labels["14"] == 1
+    assert detail_labels["19"] == 1
+    assert not main_labels & detail_labels
     assert getattr(dwg.get_annotation("dim_height"), "label", None) == "25"
     assert not [i for i in dwg.lint() if i.severity in ("warning", "error")]
 

--- a/tests/test_slanted_blind_step.py
+++ b/tests/test_slanted_blind_step.py
@@ -91,7 +91,14 @@ def test_slanted_blind_step_gets_reconstructable_dimension_plan(slanted_blind_st
         for name, ann in dwg.annotations_in_view("detail_a")
         if name.startswith("dim_detail_a_step")
     }
-    assert {"14", "19"} <= detail_labels
+    main_labels = {
+        str(getattr(ann, "label", ""))
+        for name, ann in dwg.annotations_in_view("front")
+        if name.startswith("dim_step")
+    }
+    assert "14" in main_labels
+    assert "19" in detail_labels
+    assert main_labels.isdisjoint(detail_labels)
     assert getattr(dwg.get_annotation("dim_height"), "label", None) == "25"
     assert not [i for i in dwg.lint() if i.severity in ("warning", "error")]
 


### PR DESCRIPTION
## Summary

- carry the exact approved step rungs omitted by the parent-view spacing gate on the existing escalation
- redraw only those omitted rungs in the enlarged detail, while retaining the full ladder as crop, scale, and layout context
- fail closed when a synthetic/broken escalation supplies no approved targets
- remove redundant parent/detail definitions in #909, #915, the slanted-profile control, and the generic shelled-cover detail

## Evidence

Closed issue #42 defines the contract as feeding dropped dimensions into the detail view. Current main redraws the complete approved ladder:

- #909: parent `21`; detail `21, 26`
- #915: parent `10, 30, 57`; detail all eight levels
- shelled cover: parent `35`; detail `35, 38`
- slanted profile: parent `14`; detail includes `14, 19`

This PR makes the two view sets disjoint without changing scale, crop context, placement, lint, or compiled measurement provenance.

## Adversarial review so far

- ignoring the payload redraws the full ladder and fails #909 plus the empty-payload guard
- sending kept rather than omitted targets redraws `21` and loses `26`
- narrowing crop/padding to the omitted set reflows #909 and introduces lint; the implementation retains the full ladder as layout context
- a no-target escalation queues no detail instead of reconstructing content

## Validation

- formatter, Ruff, mypy, codespell
- 124 focused tests across escalation, solve trace, #909, #915, slanted profiles, and generated-Sheet parity

Part of #909 and #996. Automatic detail selection remains out of scope.