### PR TITLE
Recover crowded step dimensions automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- **Crowded prismatic step dimensions recover into an enlarged detail view by default**
+  (#909). The automatic `build_drawing` / `make_drawing` / CLI paths and generated
+  `Sheet` scripts now preserve the omitted dimensions instead of returning
+  `step_dim_dropped` unless the caller remembered `detail_view=True`. Pass
+  `detail_view=False` to retain the parent-view-only behavior and its lint warning.
+
 ## v0.4.0 — 2026-08-02
 
 **The compat-exit release.** Every surface whose documented removal target was 0.4.0 is gone,

--- a/docs/plans/right-first-time-roadmap.md
+++ b/docs/plans/right-first-time-roadmap.md
@@ -60,8 +60,8 @@ The three clusters that defined this arc are **complete and released**.
   (page-major ladder); iso growth capped at 1.3× sheet scale.
 - **#45 — TYP / representative dimensioning** (v0.1.9). A uniform step run is
   dimensioned once and labelled TYP.
-- **#42 — enlarged detail view (MVP)** (v0.1.9). Opt-in `detail_view=True`
-  re-draws crowded shoulders at a larger scale; per-view-scale lint.
+- **#42 — enlarged detail view (MVP)** (v0.1.9). Initially opt-in; automatic by default
+  after #909. Re-draws crowded shoulders at a larger scale; per-view-scale lint.
 
 ### Design record
 - **ADR 0001** — deterministic generation over an editable-code DSL.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3220,7 +3220,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
         )
         kept_level_set = set(kept_z)
         if n_close:
-            # With the explicit detail opt-in the enlarged view owns the omitted rungs.
+            # When detail recovery is enabled the enlarged view owns the omitted rungs.
             # Report the source-view drop only when no recovery was requested; a failed
             # detail records ``detail_unplaceable`` instead.
             if not detail_view:

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -496,8 +496,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         render_envelope(dwg, _compiled, a, ctx=ctx)
 
     def _s_detail_request():
-        # Prismatic step-height detail: queue it (only when build_drawing(detail_view=True))
-        # — resolved with every other detail request in the "details" stage (#307).
+        # Prismatic step-height detail: queue it when detail recovery is enabled (the
+        # build default; ``detail_view=False`` opts out), then resolve it with every other
+        # detail request in the "details" stage (#307).
         if detail_view:
             _request_prismatic_detail(dwg, a, ctx=ctx, plan=_compiled)
 

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -652,15 +652,15 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
         if placed:
             n_placed += 1
         elif req.kind == "prismatic-steps":
-            # (#630) The prismatic-steps request is the one queued only under the
-            # build_drawing(detail_view=True) opt-in (_request_prismatic_detail's gate),
-            # so a bail-out here means that opt-in produced nothing. Say so — with an
+            # (#630) The prismatic-steps request is queued when detail recovery is enabled
+            # (_request_prismatic_detail's gate), so a bail-out here means the requested
+            # recovery produced nothing. Say so — with an
             # actionable remedy — rather than returning a drawing byte-identical to
             # detail_view=False (a full-width crowded band, e.g. a shelled cover's stacked
             # face levels, can't be enlarged legibly and still fit alongside the main views).
             # The automatic turned-head requests (queued unconditionally by
-            # render_step_lengths) are NOT opt-in — their bail-out is the normal path (the
-            # main view locates the head/block inline), so they stay silent.
+            # render_step_lengths) are independent of that setting; their bail-out is the
+            # normal path (the main view locates the head/block inline), so they stay silent.
             ctx.record_issue(
                 "warning",
                 "detail_unplaceable",

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -420,7 +420,7 @@ def _assemble(
     dwg._build.analysis = a
     dwg._build.recognition = a.recognition
     dwg._build.part_model = pm
-    # Persist the caller's detail-view opt-in: on the auto_dims=False path the flag
+    # Persist the caller's detail-view setting: on the auto_dims=False path the flag
     # reaches no pass here, but the finalize drain gates the prismatic detail
     # request on it exactly as the auto pass does (#661).
     dwg._build.detail_view = detail_view
@@ -762,7 +762,7 @@ def build_drawing(
     scale: float | None = None,
     page: str | tuple | None = None,
     auto_dims: bool = True,
-    detail_view: bool = False,
+    detail_view: bool = True,
     pmi: Literal["off", "report", "annotate"] = "off",
     repair: bool = True,
     assembly: bool | None = None,
@@ -794,6 +794,9 @@ def build_drawing(
             note when the iso is rescaled off sheet scale) are still produced;
             add your own annotations before export. (Annotations added by the default can
             also be removed wholesale with :meth:`Drawing.clear_annotations`.)
+        detail_view: automatically recover crowded prismatic step dimensions in an
+            enlarged detail view. Default ``True``; pass ``False`` to leave them on the
+            parent view only and report ``step_dim_dropped`` when they do not fit.
         repair: run the bounded lint→repair loop (:meth:`Drawing.repair`) after
             placement to fix mechanically-clear violations (a dim on the wrong
             side, two overlapping labels). Default ``True``; a no-op on a clean
@@ -930,7 +933,7 @@ def make_drawing(
     scale: float | None = None,
     page: str | tuple | None = None,
     auto_dims: bool = True,
-    detail_view: bool = False,
+    detail_view: bool = True,
     pmi: Literal["off", "report", "annotate"] = "off",
     assembly: bool | None = None,
     material: str = "",
@@ -960,6 +963,8 @@ def make_drawing(
         auto_dims: pass ``False`` to skip the automatic dimensions,
             centrelines, and leaders (#74) — views, scale, page, and title
             block only.
+        detail_view: automatically add an enlarged view for crowded prismatic step
+            dimensions. Default ``True``; pass ``False`` to disable that recovery.
 
     Returns:
         Tuple of ``(svg_path, dxf_path)`` for the generated files.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -283,7 +283,7 @@ class BuildState:
     - ``trace`` — the opt-in solve-trace recorder (#736,
       :class:`~draftwright.annotations._common.SolveTrace`), or ``None`` (default:
       tracing off). Carried here so the finalize path traces like the auto pass.
-    - ``detail_view`` — the caller's ``build_drawing(detail_view=...)`` opt-in,
+    - ``detail_view`` — the resolved ``build_drawing(detail_view=...)`` setting,
       persisted so the finalize drain gates the prismatic detail request exactly
       as the auto pass does (#661) — on the ``auto_dims=False`` path the flag
       would otherwise be consumed nowhere.
@@ -1747,7 +1747,7 @@ class Drawing:
           register-only stages queue into the SHARED corridor (a slot position coincident
           with a hole location collapses to one dim, #345; pin/priority user dims join as
           first-class candidates, ADR 0012);
-        * **detail_request** — when the build opted in (``build_drawing(detail_view=True)``,
+        * **detail_request** — when detail recovery is enabled (the automatic default,
           persisted on ``BuildState``) and the ladder stage recorded a "step"/"illegible"
           escalation, the prismatic step-height detail is queued, exactly as the auto
           pass gates it (#661);
@@ -2115,8 +2115,7 @@ class Drawing:
 
         def _s_detail_request():
             # Prismatic step-height detail (#661): queue it exactly as the auto pass
-            # does — gated on the build's detail_view opt-in (persisted on BuildState;
-            # the auto path's build_drawing(detail_view=True) gate), firing only when
+            # does — gated on the build's persisted detail_view setting, firing only when
             # the ladder stage above recorded the "step"/"illegible" escalation
             # (_request_prismatic_detail's own check). Resolved in the "details" stage.
             if self._build.detail_view and routable:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1231,10 +1231,13 @@ class Sheet:
         return self
 
     def detail(self) -> Sheet:
-        """Request the enlarged **detail view** (#42/#307) — the ``build_drawing(detail_view=True)``
-        opt-in as a Sheet verb (#841). Adds a magnified crop of the step-height region when the
-        geometry warrants one (a no-op otherwise). Chainable. Not feature-targeted — for a blind
-        pocket's floor/depth prefer :meth:`section`."""
+        """Ensure enlarged **detail-view** recovery is enabled (#42/#307/#841).
+
+        Automatic builds enable it by default; this verb is useful after constructing a
+        ``Sheet(..., detail_view=False)`` or when an emitted declaration should state the
+        choice explicitly. Adds a magnified crop of the step-height region when warranted
+        (a no-op otherwise). Chainable. Not feature-targeted — for a blind pocket's
+        floor/depth prefer :meth:`section`."""
         self._opts["detail_view"] = True
         return self
 

--- a/tests/test_issue_909_sloped_profile.py
+++ b/tests/test_issue_909_sloped_profile.py
@@ -24,7 +24,7 @@ def test_touching_lower_ledges_do_not_hide_the_case_studys_raised_pad():
 
 
 def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
-    drawing = build_drawing(_ISSUE_909, detail_view=True)
+    drawing = build_drawing(_ISSUE_909)
     source = RaisedPad(-15.5, 15.5, 8.0, 24.7, 13.0, 20.0)
 
     recognition = drawing.recognition()
@@ -74,7 +74,7 @@ def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
 
 
 def test_case_study_detail_rungs_keep_their_compiled_measurement_identity():
-    drawing = build_drawing(_ISSUE_909, detail_view=True)
+    drawing = build_drawing(_ISSUE_909)
     step = next(feature for feature in drawing.model().features if feature.kind == "step_level")
     detail_names = {name for name in drawing.annotations() if name.startswith("dim_detail_a_step")}
     ladder = compile_dimensions(drawing.model()).ladder("step_height")

--- a/tests/test_issue_915_dense_case.py
+++ b/tests/test_issue_915_dense_case.py
@@ -12,7 +12,7 @@ _ISSUE_915 = Path(__file__).parent / "fixtures" / "issue_915_case_study_2.step"
 
 def test_issue_915_hole_callouts_share_one_spacing_solve():
     """Keep the real dense-plan failure distinct from its step-detail follow-up."""
-    dwg = build_drawing(_ISSUE_915, page="A2", scale=0.5)
+    dwg = build_drawing(_ISSUE_915, page="A2", scale=0.5, detail_view=False)
 
     assert Counter(feature.kind for feature in dwg.model().features) == Counter(
         {

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3161,6 +3161,30 @@ def test_cli_import_does_not_load_the_engine():
     )
 
 
+def test_cli_inherits_automatic_detail_default(monkeypatch):
+    """The CLI must not restore the historical opt-out while delegating to the engine."""
+    from typer.testing import CliRunner
+
+    import draftwright.builder as builder
+    from draftwright.cli import app
+
+    forwarded = []
+
+    class _Drawing:
+        def export(self, *, formats):
+            return {name: f"out.{name}" for name in formats}
+
+    def _build(*args, **kwargs):
+        forwarded.append(kwargs)
+        return _Drawing()
+
+    monkeypatch.setattr(builder, "build_drawing", _build)
+    result = CliRunner().invoke(app, ["part.step", "--format", "svg"])
+
+    assert result.exit_code == 0, result.output
+    assert "detail_view" not in forwarded[0], "omission deliberately inherits the True default"
+
+
 def test_lazy_public_api_preserves_make_drawing_identity():
     """The lazy package __init__ (#313) must still expose the public API, and
     `draftwright.make_drawing` must stay the FUNCTION even after the compat
@@ -5597,9 +5621,31 @@ def _crowded_shoulder_part():
 
 @pytest.mark.timeout(120)
 class TestDetailView:
-    def test_detail_view_off_by_default(self):
-        # detail_view=False (default) — no detail view even when shoulders are crowded.
-        dwg = build_drawing(_crowded_shoulder_part())
+    @pytest.mark.parametrize(
+        ("override", "expected"), [({}, True), ({"detail_view": False}, False)]
+    )
+    def test_make_drawing_forwards_default_and_explicit_opt_out(
+        self, monkeypatch, override, expected
+    ):
+        import draftwright.builder as builder
+
+        forwarded = []
+
+        class _Drawing:
+            def export(self, *, formats):
+                assert formats == ("svg", "dxf")
+                return {"svg": "out.svg", "dxf": "out.dxf"}
+
+        def _build(*args, **kwargs):
+            forwarded.append(kwargs["detail_view"])
+            return _Drawing()
+
+        monkeypatch.setattr(builder, "build_drawing", _build)
+        assert builder.make_drawing("part.step", **override) == ("out.svg", "out.dxf")
+        assert forwarded == [expected]
+
+    def test_detail_view_can_be_disabled_explicitly(self):
+        dwg = build_drawing(_crowded_shoulder_part(), detail_view=False)
         assert "detail_a" not in dwg.views
         assert "detail_caption" not in dwg.annotations()
         assert not any(n.startswith("dim_detail") for n in dwg.annotations())
@@ -5621,10 +5667,10 @@ class TestDetailView:
             ctx=None,
         )
 
-    def test_crowded_shoulders_get_a_detail_view_when_requested(self):
+    def test_crowded_shoulders_get_a_detail_view_automatically(self):
         from draftwright._core import _legible_steps
 
-        dwg = build_drawing(_crowded_shoulder_part(), detail_view=True)
+        dwg = build_drawing(_crowded_shoulder_part())
         a = dwg._analysis
         # Pin the trigger: the gate must actually drop at least one shoulder at
         # the chosen scale, otherwise the test is not exercising #42.
@@ -5858,7 +5904,7 @@ class TestDetailView:
 
     def test_finalize_places_and_rolls_back_a_detail_view(self, monkeypatch):
         # #661 + #647: the finalize drain queues + resolves detail requests like the
-        # auto pass (gated on the persisted detail_view opt-in). A raise in a LATER
+        # auto pass (gated on the persisted detail-view setting). A raise in a LATER
         # stage (tabulate) must roll a placed detail view back — views, coordinates,
         # and its annotations alike — so a retry starts clean and places it once.
         from draftwright.annotations import orchestrator as _orch
@@ -8318,7 +8364,7 @@ class TestLintSuggestions:
         assert dicts[0]["suggestion"]
 
     def test_step_dim_dropped_suggestion_mentions_detail_view(self):
-        dwg = build_drawing(_crowded_shoulder_part())
+        dwg = build_drawing(_crowded_shoulder_part(), detail_view=False)
         issues = [i for i in dwg.lint() if i.code == "step_dim_dropped"]
         assert issues, "crowded shoulders should drop a step dim"
         assert "detail_view=True" in issues[0].suggestion

--- a/tests/test_script_detail_parity.py
+++ b/tests/test_script_detail_parity.py
@@ -104,7 +104,7 @@ def _scripted_drawing(part, tmp_path, name, **build_settings):
 @pytest.mark.timeout(180)
 def test_direct_build_detail_fixture_really_triggers(crowded_step):
     """Guard the fixture: direct automatic output must contain a real detail."""
-    direct = build_drawing(str(crowded_step), detail_view=True)
+    direct = build_drawing(str(crowded_step))
 
     views, annotations = _detail_signature(direct)
     assert views == ("detail_a",)
@@ -114,9 +114,9 @@ def test_direct_build_detail_fixture_really_triggers(crowded_step):
 
 @pytest.mark.timeout(240)
 def test_generated_script_matches_direct_detail_view(crowded_step, tmp_path):
-    """Target behaviour: executing the script preserves the direct detail output."""
-    direct = build_drawing(str(crowded_step), detail_view=True)
-    scripted = _run_generated_script(crowded_step, tmp_path, "scripted", detail_view=True)
+    """Default direct and generated-Sheet builds recover the same detail output."""
+    direct = build_drawing(str(crowded_step))
+    scripted = _run_generated_script(crowded_step, tmp_path, "scripted")
 
     assert _detail_signature(scripted) == _detail_signature(direct)
 

--- a/tests/test_slanted_blind_step.py
+++ b/tests/test_slanted_blind_step.py
@@ -282,7 +282,7 @@ def test_unplaceable_short_step_records_left_strip_failure(monkeypatch):
 def test_crowded_step_warning_guides_to_detail_and_clears_after_recovery(
     slanted_blind_step,
 ):
-    plain = build_drawing(slanted_blind_step)
+    plain = build_drawing(slanted_blind_step, detail_view=False)
     dropped = [i for i in plain.lint() if i.code == "step_dim_dropped"]
     assert len(dropped) == 1
     assert "detail_view=True" in dropped[0].suggestion


### PR DESCRIPTION
## What changed

- make crowded prismatic step-detail recovery the default for `build_drawing` and `make_drawing`
- let the CLI and generated `Sheet` scripts inherit that default
- retain `detail_view=False` as an explicit parent-view-only opt-out
- update the public contract, changelog, and historical roadmap wording

## Why

The actual #909 STEP case now has a complete counted partition: the parent view carries `21`, the detail carries the omitted `26`, and lint is clean. Before this change, users of the fully automatic front door still received `step_dim_dropped` unless they knew to opt into the recovery that already existed. That left the issue acceptance path incomplete even after the recognition, provenance, and partition fixes in #1054-#1056.

## Impact

Crowded prismatic drawings may now gain an enlarged detail view without an extra argument. Plain parts remain unchanged. Callers that deliberately want the prior behavior can pass `detail_view=False` and retain the lint warning.

## Validation

- focused geometry/script matrix: 37 passed
- public-boundary matrix: 7 passed
- Ruff format/check and mypy: green
- adversarial mutations killed for the engine default, `make_drawing`, CLI delegation, explicit opt-out, and generated `Sheet` inheritance

Closes the automatic-detail acceptance slice of #909. Tracks the ADR 0017 evidence iteration in #996.