### PR TITLE
Cover principal profile rejection paths

### DIFF
--- a/tests/test_principal_profile_classifier.py
+++ b/tests/test_principal_profile_classifier.py
@@ -1,0 +1,122 @@
+"""Topology-level rejection cases for principal inner-profile coverage."""
+
+import pytest
+from build123d import GeomType, Vector
+
+from draftwright.linting.coverage import _supported_inner_profile
+
+
+class _Bounds:
+    def __init__(self, x0: float, y0: float, x1: float, y1: float):
+        self.min = Vector(x0, y0, 0)
+        self.max = Vector(x1, y1, 0)
+        self.size = Vector(x1 - x0, y1 - y0, 0)
+
+    def center(self):
+        return (self.min + self.max) / 2
+
+
+class _Edge:
+    def __init__(
+        self,
+        kind: GeomType,
+        bounds: _Bounds,
+        *,
+        radius: float | None = None,
+        centre: tuple[float, float] | None = None,
+        length: float = 1.0,
+    ):
+        self.geom_type = kind
+        self._bounds = bounds
+        self.length = length
+        if radius is not None:
+            self.radius = radius
+        if centre is not None:
+            self.arc_center = Vector(*centre)
+
+    def bounding_box(self):
+        return self._bounds
+
+
+class _Wire:
+    def __init__(self, edges: list[_Edge], bounds: _Bounds, *, length: float = 1.0):
+        self._edges = edges
+        self._bounds = bounds
+        self.length = length
+
+    def edges(self):
+        return self._edges
+
+    def bounding_box(self):
+        return self._bounds
+
+
+def _line(x0: float, y0: float, x1: float, y1: float) -> _Edge:
+    return _Edge(GeomType.LINE, _Bounds(x0, y0, x1, y1))
+
+
+def _arc(radius: float | None, centre: tuple[float, float]) -> _Edge:
+    return _Edge(GeomType.CIRCLE, _Bounds(0, 0, 0, 0), radius=radius, centre=centre)
+
+
+_OBROUND_LINES = [_line(2, 0, 8, 0), _line(2, 4, 8, 4)]
+_OBROUND_ARCS = [_arc(2, (2, 2)), _arc(2, (8, 2))]
+_ROUND_RECT_LINES = [
+    _line(2, 0, 10, 0),
+    _line(2, 10, 10, 10),
+    _line(0, 2, 0, 8),
+    _line(12, 2, 12, 8),
+]
+
+
+@pytest.mark.parametrize(
+    "wire",
+    [
+        _Wire([], _Bounds(0, 0, 0, 0)),
+        _Wire([_arc(None, (2, 2))], _Bounds(0, 0, 4, 4)),
+        _Wire([_line(0, 0, 4, 4)], _Bounds(0, 0, 4, 4)),
+        _Wire([_Edge(GeomType.ELLIPSE, _Bounds(0, 0, 6, 4))], _Bounds(0, 0, 6, 4)),
+        _Wire([_line(2, 0, 8, 0), *_OBROUND_ARCS], _Bounds(0, 0, 10, 4)),
+        _Wire(
+            [*_OBROUND_LINES, _arc(2, (2, 2)), _arc(1.5, (8, 2))],
+            _Bounds(0, 0, 10, 4),
+        ),
+        _Wire([*_OBROUND_LINES, _arc(None, (2, 2)), _arc(2, (8, 2))], _Bounds(0, 0, 10, 4)),
+        _Wire(
+            [_line(2, 1, 8, 1), _line(2, 3, 8, 3), *_OBROUND_ARCS],
+            _Bounds(0, 0, 10, 4),
+        ),
+        _Wire(
+            [*_OBROUND_LINES, _arc(2, (3, 2)), _arc(2, (8, 2))],
+            _Bounds(0, 0, 10, 4),
+        ),
+        _Wire(
+            [*_ROUND_RECT_LINES, *[_arc(5, point) for point in ((5, 5),) * 4]],
+            _Bounds(0, 0, 12, 10),
+        ),
+        _Wire(
+            [
+                *_ROUND_RECT_LINES[:2],
+                _line(2, 2, 2, 8),
+                _line(10, 2, 10, 8),
+                *[_arc(2, point) for point in ((2, 2), (2, 8), (10, 2), (10, 8))],
+            ],
+            _Bounds(0, 0, 12, 10),
+        ),
+    ],
+    ids=(
+        "empty",
+        "circle-without-radius",
+        "diagonal-linear-loop",
+        "unsupported-curve",
+        "mixed-edge-count",
+        "unequal-arc-radii",
+        "mixed-loop-arc-without-radius",
+        "lines-away-from-boundary",
+        "wrong-arc-centre",
+        "corner-radius-consumes-short-side",
+        "rounded-rectangle-lines-away-from-boundary",
+    ),
+)
+def test_unsupported_topologies_fail_closed(wire):
+    assert not _supported_inner_profile(wire, ("x", "y"), 1e-5)


### PR DESCRIPTION
## What changed

Adds topology-level tests for the principal inner-profile classifier introduced by #1059. The matrix covers empty and malformed loops, diagonal linear loops, unsupported curves, invalid line/arc counts, unequal or missing radii, misplaced boundary lines, incorrect arc centres, and degenerate rounded rectangles.

## Why

#1059 merged after its Actions matrix passed, but Codecov later reported `codecov/patch` at 81.75% and `codecov/project` at 91.58%. The accepted-profile and real-wheel tests covered the main behavior but left defensive rejection decisions unexercised.

This PR changes tests only. It restores proof for the fail-closed branches without changing runtime behavior.

## Validation

- `uv run pytest -q tests/test_principal_profile_classifier.py tests/test_issue_1058_wheel_profile.py` (23 passed)
- `uv run ruff check tests/test_principal_profile_classifier.py`
- `uv run ruff format --check tests/test_principal_profile_classifier.py`
- `uv run mypy src/draftwright tests/test_principal_profile_classifier.py`
- mutation check: changing the unsupported-curve decision to accept makes the named test fail