### PR TITLE
Speed up quality-gated iteration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Symptom and evidence
+
+- User-visible problem:
+- Fixture/reproducer:
+- Before/after result:
+- Mutation that makes the guard fail:
+
+## Contract and scope
+
+- Smallest contract this change tests:
+- Relevant ADRs:
+- Explicitly deferred:
+
+## Validation
+
+- [ ] `scripts/pr-check --quick`
+- [ ] `scripts/pr-check` before final review
+- [ ] The named mutation was observed failing before the implementation passed it
+- [ ] Automatic, declared, and generated-script paths were checked where affected
+- [ ] Recognition and repeated-lint call counts were checked where affected
+
+Use `N/A` with a reason for items that do not apply, such as fixture evidence on a docs-only PR.
+
+## Stop check
+
+- [ ] No two consecutive review rounds invalidated the same core association strategy
+- [ ] New prerequisites were split or the work was explicitly reclassified as discovery

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,11 @@ jobs:
         # 0.11 (cadquery-ocp-novtk — VTK dropped, and the only kernel with 3.13/3.14 wheels).
         # A few exact-position snapshots are skipped on 0.11 (see tests/_kernel.py).
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        # Ubuntu/Python 3.12 is the canonical coverage job below. Excluding it
+        # Ubuntu/Python 3.13 is the canonical coverage job below. Excluding it
         # here keeps the OS/Python matrix complete without running it twice.
         exclude:
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -67,7 +67,7 @@ jobs:
         # No --timeout here: it would override the 300 s set in
         # [tool.pytest.ini_options]. The heaviest test (full specimen-sheet SVG
         # export) can exceed 120 s on the slower macOS runners.
-        # Coverage is measured once by the canonical Ubuntu/Python 3.12 job below.
+        # Coverage is measured once by the canonical Ubuntu/Python 3.13 job below.
         # Instrumenting all fourteen compatibility jobs adds ~13% runtime without
         # producing another retained or uploaded report.
         run: >-
@@ -77,7 +77,7 @@ jobs:
   coverage:
     # The fifteenth OS/Python matrix entry, split out so only the one job that
     # uploads to Codecov receives an OIDC token and renders retained reports.
-    name: test (ubuntu-latest, 3.12)
+    name: test (ubuntu-latest, 3.13)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,7 +88,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -115,7 +115,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-linux-py3.12
+          name: coverage-linux-py3.13
           path: |
             coverage.xml
             htmlcov/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
     branches: [main]
   pull_request:
 
-# A PR needs results only for its latest head. Main runs are not cancelled because they own
-# the post-merge slow suite, which must not be starved during a burst of merges.
+# A PR needs results only for its latest head. Each main push gets a unique group because it
+# owns a post-merge slow-suite run that must survive later merges.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -106,9 +106,9 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           files: coverage.xml
-          # The repository's fail_under gate is authoritative; a third-party
-          # service outage must not block an otherwise valid change.
-          fail_ci_if_error: false
+          # Branch protection requires Codecov's project and patch checks. Fail this
+          # job too when the upload cannot produce those checks, rather than hanging.
+          fail_ci_if_error: true
           use_oidc: true
 
       - name: Upload coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# A PR needs results only for its latest head. Main runs are not cancelled because they own
+# the post-merge slow suite, which must not be starved during a burst of merges.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,17 +25,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      - name: Ruff lint
-        run: uv run ruff check src/ tests/
-
-      - name: Ruff format check
-        run: uv run ruff format --check src/ tests/
-
-      - name: Mypy
-        run: uv run mypy src/draftwright/
-
-      - name: Codespell
-        run: uv run codespell src/ tests/ docs/
+      - name: Static preflight
+        run: scripts/pr-check --static
 
   test:
     permissions:
@@ -70,12 +67,12 @@ jobs:
         # No --timeout here: it would override the 300 s set in
         # [tool.pytest.ini_options]. The heaviest test (full specimen-sheet SVG
         # export) can exceed 120 s on the slower macOS runners.
-        # Coverage runs in CI; it is kept out of the default addopts so local
-        # runs stay lean (see pyproject [tool.pytest.ini_options]).
+        # Coverage is measured once by the canonical Ubuntu/Python 3.12 job below.
+        # Instrumenting all fourteen compatibility jobs adds ~13% runtime without
+        # producing another retained or uploaded report.
         run: >-
           uv run pytest tests/ -n auto --dist loadscope
-          --cov=src/draftwright
-          --cov-report=term-missing
+          --durations=25
 
   coverage:
     # The fifteenth OS/Python matrix entry, split out so only the one job that
@@ -103,6 +100,7 @@ jobs:
           --cov-report=term-missing
           --cov-report=xml
           --cov-report=html:htmlcov
+          --durations=25
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ reports for 14 days. The other OS/Python jobs run the same tests without redunda
 coverage instrumentation. To reproduce the canonical run locally:
 
 ```
-uv run pytest tests/ -n auto --dist loadscope \
+uv run --python 3.13 pytest tests/ -n auto --dist loadscope \
   --cov=src/draftwright --cov-report=term-missing \
   --cov-report=xml --cov-report=html:htmlcov
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ before changing those areas.
 
 CI measures line and branch coverage on the full fast tier and enforces the
 `[tool.coverage.report] fail_under` floor in `pyproject.toml`. The canonical
-Linux/Python 3.12 job uploads to Codecov and retains the XML plus browsable HTML
+Linux/Python 3.13 job uploads to Codecov and retains the XML plus browsable HTML
 reports for 14 days. The other OS/Python jobs run the same tests without redundant
 coverage instrumentation. To reproduce the canonical run locally:
 
@@ -53,11 +53,13 @@ floor is 90%. Coverage thresholds are a ratchet: raise the floor after the canon
 job remains above the proposed value, and do not lower it to accommodate an untested
 change.
 
-`scripts/pr-check` additionally requires 92% line coverage over changed source lines,
-compared with `origin/main` by default. Set `BASE_REF` when the branch has another base.
-This is a local lower-bound analogue of Codecov's patch/project ratchet: it catches a
-poorly covered patch before the remote matrix, while the full-suite floor still guards
-the project as a whole.
+`scripts/pr-check` additionally requires 93% line coverage over changed source lines,
+compared with `origin/main` by default. Set `BASE_REF=upstream/main` for a fork, or when
+the branch has another base. Stage new files under `src/` first: Git does not include
+untracked files in a diff, so the command refuses to certify them invisibly.
+
+This local check catches low changed-line coverage before the remote matrix. It is not
+Codecov parity: branch partials and the project-coverage ratchet remain remote gates.
 
 ### Evidence-gated slices
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ dependency management.
 uv sync                       # install dependencies
 uv run pytest -m smoke        # quick "did I break something obvious" check (~30 s)
 uv run pytest                 # full fast tier
+scripts/pr-check --quick      # smoke tier plus every static PR gate
+scripts/pr-check              # final preflight: full coverage plus changed-line gate
 ```
 
 For a full local run, spread it across cores with
@@ -34,9 +36,10 @@ before changing those areas.
 ### Coverage
 
 CI measures line and branch coverage on the full fast tier and enforces the
-`[tool.coverage.report] fail_under` floor in `pyproject.toml` on every supported
-OS/Python combination. The canonical Linux/Python 3.12 job uploads to Codecov and
-retains the XML plus browsable HTML reports for 14 days. To reproduce that run locally:
+`[tool.coverage.report] fail_under` floor in `pyproject.toml`. The canonical
+Linux/Python 3.12 job uploads to Codecov and retains the XML plus browsable HTML
+reports for 14 days. The other OS/Python jobs run the same tests without redundant
+coverage instrumentation. To reproduce the canonical run locally:
 
 ```
 uv run pytest tests/ -n auto --dist loadscope \
@@ -46,14 +49,43 @@ uv run pytest tests/ -n auto --dist loadscope \
 
 The baseline recorded for #825 on Linux/Python 3.13 was **92.05% combined
 line-and-branch coverage** (93.90% statements and 86.89% branches); the initial
-floor is 90%. Coverage thresholds are a ratchet: raise the floor after the lowest
-result across the supported CI matrix remains above the proposed value, and do not
-lower it to accommodate an untested change.
+floor is 90%. Coverage thresholds are a ratchet: raise the floor after the canonical
+job remains above the proposed value, and do not lower it to accommodate an untested
+change.
+
+`scripts/pr-check` additionally requires 92% line coverage over changed source lines,
+compared with `origin/main` by default. Set `BASE_REF` when the branch has another base.
+This is a local lower-bound analogue of Codecov's patch/project ratchet: it catches a
+poorly covered patch before the remote matrix, while the full-suite floor still guards
+the project as a whole.
+
+### Evidence-gated slices
+
+Recognition, completeness, placement, and compiler work starts from a vertical slice,
+not an architecture phase. Before production code, record:
+
+1. a real or minimal fixture and its exact current false result;
+2. the desired user-visible and semantic result;
+3. the smallest contract being tested;
+4. a mutation that must make the proposed guard fail;
+5. the affected automatic, declared, generated-script, and repeated-lint paths;
+6. work deliberately left outside the slice.
+
+If two consecutive adversarial review rounds invalidate the same core association
+strategy, stop extending that approach. Preserve its fixtures, reclassify it as discovery,
+and split the missing upstream contract. A green suite is necessary, but it does not
+establish a semantic claim until the named mutation makes the guard fail.
+
+Test helpers follow the same evidence rule. Extract a structural assertion only after
+two slices use the same contract. Physical grouping, applicability, and correspondence
+keys stay family-specific unless a failing fixture proves otherwise.
 
 ## Pull requests
 
 - Branch off `main` and open a PR with a clear description of **why**.
-- Keep changes focused; add tests for new behaviour.
-- Make sure the fast test tier passes locally before pushing.
+- Keep changes focused; add a fixture, semantic oracle, and targeted mutation for new
+  behaviour rather than testing presentation proxies.
+- Use the PR template to record the slice and its stop condition.
+- Run `scripts/pr-check --quick` while iterating and `scripts/pr-check` before the final push.
 
 Questions or commercial-licensing enquiries: pzfreo@gmail.com.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ addopts = "--tb=short -m 'not slow'"
 [tool.coverage.run]
 source = ["src/draftwright"]
 omit = ["src/draftwright/__init__.py"]
+# Keep XML paths anchored at the repository root so local diff coverage and Codecov
+# measure the same changed source lines rather than relying on runner-specific paths.
+relative_files = true
 # Branch coverage makes the regression gate sensitive to untested decision paths,
 # which matter more than raw statement execution in the recognition/layout code.
 branch = true
@@ -106,8 +109,8 @@ branch = true
 [tool.coverage.report]
 # Baseline measured on the full fast tier on Linux/Python 3.13 (#825):
 # 92.05% combined line+branch coverage (93.90% statements, 86.89% branches).
-# Keep two points of cross-platform/kernel headroom; ratchet upward only after the
-# lowest CI matrix result has stayed above the proposed floor.
+# Keep two points of headroom; ratchet upward only after the canonical coverage job
+# has stayed above the proposed floor.
 fail_under = 90
 precision = 1
 exclude_lines = [

--- a/scripts/pr-check
+++ b/scripts/pr-check
@@ -29,6 +29,17 @@ case "$mode" in
             exit 2
         fi
 
+        untracked_sources=()
+        while IFS= read -r -d '' path; do
+            untracked_sources+=("$path")
+        done < <(git ls-files --others --exclude-standard -z -- src/)
+        if ((${#untracked_sources[@]})); then
+            printf 'Changed-line coverage cannot inspect untracked source files.\n' >&2
+            printf 'Stage these files before the full preflight:\n' >&2
+            printf '  %s\n' "${untracked_sources[@]}" >&2
+            exit 2
+        fi
+
         static_checks
         uv run pytest tests/ -n auto --dist loadscope \
             --cov=src/draftwright \
@@ -37,7 +48,7 @@ case "$mode" in
 
         uvx --from diff-cover==9.7.2 diff-cover coverage.xml \
             --compare-branch "$base_ref" \
-            --fail-under=92
+            --fail-under=93
         ;;
     *)
         printf 'Usage: %s [--quick|--static|--full]\n' "$0" >&2

--- a/scripts/pr-check
+++ b/scripts/pr-check
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+mode=${1:---full}
+
+static_checks() {
+    uv run ruff check src/ tests/
+    uv run ruff format --check src/ tests/
+    uv run mypy src/draftwright/
+    uv run codespell src/ tests/ docs/ scripts/ .github/ CONTRIBUTING.md
+}
+
+case "$mode" in
+    --static)
+        static_checks
+        ;;
+    --quick)
+        static_checks
+        uv run pytest tests/ -m smoke
+        ;;
+    --full)
+        base_ref=${BASE_REF:-origin/main}
+        if ! git rev-parse --verify "${base_ref}^{commit}" >/dev/null 2>&1; then
+            printf 'Cannot resolve BASE_REF=%s. Fetch it or set BASE_REF to a local commit.\n' \
+                "$base_ref" >&2
+            exit 2
+        fi
+
+        static_checks
+        uv run pytest tests/ -n auto --dist loadscope \
+            --cov=src/draftwright \
+            --cov-report=term-missing \
+            --cov-report=xml
+
+        uvx --from diff-cover==9.7.2 diff-cover coverage.xml \
+            --compare-branch "$base_ref" \
+            --fail-under=92
+        ;;
+    *)
+        printf 'Usage: %s [--quick|--static|--full]\n' "$0" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: semantic review and coverage feedback arrived only after a roughly 16-minute remote matrix, so failed iterations paid the full wait before exposing known classes of mistake.
- Fixture/reproducer: Epic #1018's adversarial-review history and both #1063 coverage artifacts; the first patch needed another full remote run after Codecov failed.
- Before/after result: contributors now have a one-command quick gate and a fail-closed full local gate; stale PR heads are cancelled, compatibility results arrive earlier, and canonical coverage moves from the measured 16:21 Python 3.12 path to the equivalent 7:15 Python 3.13 path.
- Mutations that make the guard fail: an unresolved `BASE_REF` and an untracked `src/` module both exit before tests; rejected #1063 head `0b939d6` fails the 93% changed-line floor while corrected head `c1e1569` passes at 96%.

## Contract and scope

- Smallest contract this change tests: local preflight mirrors the repository-owned static/full-suite floors, fails when Git cannot see new source, and provides a conservative changed-line warning before the branch is pushed.
- Relevant ADRs: no architectural decision changes; the contribution workflow generalises ADR 0017's evidence-gated, mutation-first lesson.
- Explicitly deferred: do not split test modules until repeated cross-platform duration reports identify a stable scheduling tail; do not add another recognition harness until a third slice demonstrates harmful shared duplication.

## Validation

- [x] `scripts/pr-check --quick` (73 passed on the final local amendment)
- [x] `scripts/pr-check` before final review (2,916 passed, 1 skipped, 2 xfailed; 93.64% combined coverage)
- [x] The named mutations were observed failing before the implementation passed them
- [x] Automatic, declared, and generated-script paths were checked where affected: N/A, infrastructure and contributor-process change only
- [x] Recognition and repeated-lint call counts were checked where affected: N/A, no recognition behavior changed
- [x] Workflow YAML parsing, shell syntax, clean-diff checks, missing-base failure, untracked-source failure, and rejected/corrected #1063 coverage replay

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] New prerequisites were split or the work was explicitly reclassified as discovery: no project dependency was added; `diff-cover` runs as an exact isolated `uvx` tool

## CI impact

- Retains all 15 Ubuntu/macOS/Windows Python 3.10-3.14 fast-test jobs and the post-merge slow suite.
- Keeps line and branch coverage, the project floor, Codecov, and retained reports on canonical Ubuntu/Python 3.13; Ubuntu/Python 3.12 remains a full compatibility job. Branch protection requires both Codecov project and patch checks.
- The same source baseline previously measured 93.65% coverage in 7:15 on 3.13 versus 93.64% in 16:21 on 3.12.
- Cancels obsolete pull-request heads only; every main push has a unique concurrency group so its slow safety net cannot be cancelled by a later merge.
- Reports the slowest 25 tests on every platform before any test-module split is proposed.

