### PR TITLE
Bound annotation-dense detail placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **Annotation-dense detail placement no longer stalls the build** (#1065). Detail views
+  avoid every decomposed annotation shaft, witness, label and item footprint; CTC-02
+  supplies 571 such boxes. The free-rectangle search previously treated that set as tiny
+  and admitted roughly 34 billion candidate rectangles, exhausting the slow tier's
+  ten-minute test budget before export. A compressed-coordinate sweep preserves the same
+  deterministic winning rectangle while completing the real search in seconds.
+
 - **Through double-D bores are recognised and called out as first-class hole profiles**
   (#1061). Automatic and declared builds preserve the parent-circle diameter, A/F size,
   orientation and depth, and render one compound `DOUBLE-D ... A/F` bore callout. Physical

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -17,7 +17,7 @@ import functools
 import logging
 import math
 import re
-from bisect import bisect_right
+from bisect import bisect_left, bisect_right
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -539,6 +539,115 @@ def _legible_locations(positions, scale):
     return kept, n_too_close
 
 
+class _FreeRunIndex:
+    """Range-covered Y coordinates with the longest remaining free run.
+
+    Coordinate points are represented as zero-length cells between the ordinary
+    intervals.  That lets a degenerate obstacle split a gap exactly as the open
+    AABB overlap predicate does, without assigning the point any physical width.
+    """
+
+    def __init__(self, coordinates):
+        self.coordinates = coordinates
+        lengths = []
+        for i, value in enumerate(coordinates):
+            lengths.append(0.0)
+            if i + 1 < len(coordinates):
+                lengths.append(coordinates[i + 1] - value)
+        self._lengths = lengths
+        self._n = len(lengths)
+        size = 4 * self._n
+        self._cover = [0] * size
+        self._total = [0.0] * size
+        self._prefix = [0.0] * size
+        self._suffix = [0.0] * size
+        self._longest = [0.0] * size
+        self._all_free = [True] * size
+        self._build(1, 0, self._n)
+
+    def _build(self, node, lo, hi):
+        if hi - lo == 1:
+            length = self._lengths[lo]
+            self._total[node] = length
+            self._prefix[node] = length
+            self._suffix[node] = length
+            self._longest[node] = length
+            return
+        mid = (lo + hi) // 2
+        self._build(node * 2, lo, mid)
+        self._build(node * 2 + 1, mid, hi)
+        self._pull(node)
+
+    def _pull(self, node):
+        if self._cover[node]:
+            self._all_free[node] = False
+            self._prefix[node] = self._suffix[node] = self._longest[node] = 0.0
+            return
+        left, right = node * 2, node * 2 + 1
+        self._total[node] = self._total[left] + self._total[right]
+        self._all_free[node] = self._all_free[left] and self._all_free[right]
+        self._prefix[node] = self._prefix[left]
+        if self._all_free[left]:
+            self._prefix[node] += self._prefix[right]
+        self._suffix[node] = self._suffix[right]
+        if self._all_free[right]:
+            self._suffix[node] += self._suffix[left]
+        self._longest[node] = max(
+            self._longest[left],
+            self._suffix[left] + self._prefix[right],
+            self._longest[right],
+        )
+
+    @property
+    def longest(self):
+        return self._longest[1]
+
+    def block(self, lo, hi):
+        """Add one obstacle interval in coordinate space."""
+        first = bisect_left(self.coordinates, lo)
+        last = bisect_left(self.coordinates, hi)
+        if lo == hi:
+            unit_lo, unit_hi = 2 * first, 2 * first + 1
+        else:
+            # Block the open span but not its endpoints: touching an obstacle is
+            # permitted by the placement AABB predicate.
+            unit_lo, unit_hi = 2 * first + 1, 2 * last
+        self._block(1, 0, self._n, unit_lo, unit_hi)
+
+    def _block(self, node, lo, hi, block_lo, block_hi):
+        if block_lo <= lo and hi <= block_hi:
+            self._cover[node] += 1
+            self._pull(node)
+            return
+        mid = (lo + hi) // 2
+        if block_lo < mid:
+            self._block(node * 2, lo, mid, block_lo, block_hi)
+        if mid < block_hi:
+            self._block(node * 2 + 1, mid, hi, block_lo, block_hi)
+        self._pull(node)
+
+    def first_run(self, minimum):
+        """Lowest-Y free run at least *minimum* long."""
+        return self._first_run(1, 0, self._n, self.coordinates[0], minimum)
+
+    def _first_run(self, node, lo, hi, origin, minimum):
+        if hi - lo == 1:
+            return origin
+        left, right = node * 2, node * 2 + 1
+        mid = (lo + hi) // 2
+        if self._longest[left] >= minimum:
+            return self._first_run(left, lo, mid, origin, minimum)
+        if self._suffix[left] + self._prefix[right] >= minimum:
+            return origin + self._total[left] - self._suffix[left]
+        return self._first_run(
+            right,
+            mid,
+            hi,
+            origin + self._total[left],
+            minimum,
+        )
+
+
 def _largest_empty_rect(drawable, obstacles, *, target_size=None, warn: bool = True):
     """Largest axis-aligned empty rectangle in *drawable* avoiding *obstacles*.
 
@@ -549,10 +658,11 @@ def _largest_empty_rect(drawable, obstacles, *, target_size=None, warn: bool = T
     placing a wide or tall fixed-aspect footprint can supply its minimum
     ``(width, height)`` instead.
 
-    The obstacle set is tiny (front/plan/side views + title block), so a
-    gap-based search over candidate edges is both exact enough and cheap: every
-    maximal empty rectangle has edges drawn from the drawable bounds and the
-    obstacle bounds, so enumerating those cut lines finds the optimum.
+    Every maximal empty rectangle has edges drawn from the drawable bounds and
+    the obstacle bounds.  Sweep candidate X strips while adding their blocking Y
+    intervals to a compressed-coordinate free-run index.  This is equivalent to
+    enumerating every pair of Y edges, without the quartic blow-up when a detail
+    view includes hundreds of decomposed annotation segments (#1065).
     """
     target_w, target_h = target_size or (1.0, 1.0)
     if not (math.isfinite(target_w) and target_w > 0 and math.isfinite(target_h) and target_h > 0):
@@ -562,35 +672,51 @@ def _largest_empty_rect(drawable, obstacles, *, target_size=None, warn: bool = T
     xs = sorted({dx0, dx1, *(c for o in obstacles for c in (o[0], o[2]) if dx0 < c < dx1)})
     ys = sorted({dy0, dy1, *(c for o in obstacles for c in (o[1], o[3]) if dy0 < c < dy1)})
 
+    events = []
+    for ox0, oy0, ox1, oy1 in obstacles:
+        block_lo = max(dy0, oy0)
+        block_hi = min(dy1, oy1)
+        if block_hi < dy0 or block_lo > dy1:
+            continue
+        events.append((ox0, ox1, block_lo, block_hi))
+    events.sort(key=lambda event: event[0])
+
     # The score is min(width / target_w, height / target_h), so any candidate whose
     # width or height cannot exceed the corresponding scaled target cannot beat the
     # best found so far. This is the same exact prune as the square-default path,
     # normalized by the requested footprint.
     best = None
     best_score = 0.0
-    nx, ny = len(xs), len(ys)
+    nx = len(xs)
     for i in range(nx - 1):
         rx0 = xs[i]
         if xs[-1] - rx0 <= best_score * target_w:
             break  # widest strip from here on can't beat best (rx0 only grows)
+        free_y = _FreeRunIndex(ys)
+        event_index = 0
         for j in range(bisect_right(xs, rx0 + best_score * target_w), nx):
             rx1 = xs[j]
             width = rx1 - rx0
-            # only obstacles overlapping the x-strip [rx0, rx1] can block it
-            strip = [(o[1], o[3]) for o in obstacles if o[0] < rx1 and rx0 < o[2]]
-            for k in range(ny - 1):
-                ry0 = ys[k]
-                if ys[-1] - ry0 <= best_score * target_h:
-                    break  # tallest gap from here can't beat best (ry0 only grows)
-                for m in range(bisect_right(ys, ry0 + best_score * target_h), ny):
-                    ry1 = ys[m]
-                    if any(ry0 < oy1 and oy0 < ry1 for (oy0, oy1) in strip):
-                        continue
-                    height = ry1 - ry0
-                    score = min(width / target_w, height / target_h)
-                    if score > best_score:
-                        best_score = score
-                        best = (rx0, ry0, rx1, ry1)
+            while event_index < len(events) and events[event_index][0] < rx1:
+                _, ox1, block_lo, block_hi = events[event_index]
+                if rx0 < ox1:
+                    free_y.block(block_lo, block_hi)
+                event_index += 1
+
+            height = free_y.longest
+            score = min(width / target_w, height / target_h)
+            if score <= best_score:
+                continue
+
+            # If width caps the score, select the first global Y edge that makes
+            # the target fit.  Otherwise select the end of the first tallest gap.
+            # These are the same deterministic winners as the exhaustive search.
+            needed_height = min(width * target_h / target_w, height)
+            ry0 = free_y.first_run(needed_height)
+            edge = bisect_left(ys, ry0 + needed_height)
+            ry1 = ys[min(edge, len(ys) - 1)]
+            best_score = score
+            best = (rx0, ry0, rx1, ry1)
     if best is None:
         # No empty rectangle exists (obstacles cover the drawable area). This
         # is unreachable in practice — choose_scale always leaves a gap — but

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1385,6 +1385,42 @@ class TestIsoEmptyRect:
             100.0,
         )
 
+    def test_degenerate_obstacle_still_splits_a_gap(self):
+        from draftwright._core import _largest_empty_rect
+
+        assert _largest_empty_rect(
+            (0.0, 0.0, 10.0, 10.0),
+            [(5.0, 5.0, 5.0, 5.0)],
+        ) == (0.0, 0.0, 5.0, 5.0)
+
+    @pytest.mark.timeout(10)
+    def test_annotation_sized_obstacle_set_stays_bounded(self):
+        """Detail placement sees decomposed shafts, witnesses, and labels, not
+        merely four view hulls.  A CTC-02 build supplies 571 boxes; distinct
+        obstacle edges must not turn that ordinary occupancy into a quartic
+        candidate-rectangle search."""
+        from draftwright._core import _largest_empty_rect
+
+        drawable = (0.0, 0.0, 1000.0, 1000.0)
+        obstacles = []
+        for i in range(300):
+            x = 20.0 + i * 1.6
+            y = 20.0 + ((i * 137) % 600) * 1.5
+            obstacles.append((x, y, x + 0.7, y + 0.7))
+
+        result = _largest_empty_rect(
+            drawable,
+            obstacles,
+            target_size=(1635.0, 2752.0),
+            warn=False,
+        )
+
+        x0, y0, x1, y1 = result
+        assert x0 < x1 and y0 < y1
+        assert not any(
+            x0 < ox1 and ox0 < x1 and y0 < oy1 and oy0 < y1 for ox0, oy0, ox1, oy1 in obstacles
+        )
+
     @pytest.mark.parametrize(
         "target_size",
         [(float("nan"), 1.0), (0.0, 1.0), (1.0, float("nan")), (1.0, 0.0)],


### PR DESCRIPTION
Closes #1065.

## What changed

- replace the exhaustive X/Y candidate-rectangle enumeration with a deterministic X sweep over a compressed-coordinate free-run index;
- preserve target-aspect scoring, endpoint touching, degenerate obstacles, and the previous first-winner tie-break;
- add a dense 300-obstacle performance mutation plus a degenerate-obstacle semantic guard;
- record the release-blocking fix in the changelog.

## Root cause

#1057 enabled prismatic detail recovery by default. Detail placement correctly includes decomposed annotation occupancy, but `_largest_empty_rect` still assumed only four view/title-block obstacles. CTC-02 supplies 571 boxes, 659 X edges, and 563 Y edges, admitting roughly 34 billion candidate rectangles. Four consecutive `main` slow-tier runs timed out after 600 seconds inside that search.

The replacement maintains the same candidate-edge policy while tracking the longest free Y run under incrementally added X-strip obstacles. The real 571-box search takes 3.4 seconds locally.

## Validation

- exact result parity with the old algorithm across 10,000 randomized small inputs, including degenerate boxes and multiple target aspects;
- focused empty-rectangle suite: 10 passed;
- full fast tier: 2,918 passed, 1 skipped, 2 xfailed in 10m05s;
- full slow tier: 19 passed in 41m00s;
- affected CTC-02 standards test independently passed in 8m53s;
- Ruff, Ruff format, mypy, codespell, and `git diff --check` green.

## ADR consistency

This changes only deterministic box-math implementation. It preserves ADR 0004's local free-rectangle placement and fast composed-footprint policy, ADR 0014's complete annotation occupancy, and ADR 0015's pipeline boundaries.