### PR TITLE
docs: establish trust and coverage delivery project

### DIFF
--- a/docs/plans/2026-08-trust-and-coverage-plan.md
+++ b/docs/plans/2026-08-trust-and-coverage-plan.md
@@ -1,0 +1,140 @@
+# Trust and coverage delivery plan
+
+- **Window:** 2026-08-03 to 2026-10-02
+- **Status:** Active
+- **Live execution:** [Draftwright: Trustworthy Manufacturing Drawings](https://github.com/users/pzfreo/projects/3)
+- **Outcome milestone:** [Trustworthy manufacturing drawings](https://github.com/pzfreo/draftwright/milestone/4)
+- **Strategy:** [Product backlog roadmap](product-backlog-roadmap.md)
+
+## Objective
+
+Make draftwright trustworthy before making it broader: prevent known silent
+incompleteness, prove the fixes with independent evidence, then expand
+manufacturing coverage through the same compiler and lint contracts.
+
+By 2 October, the selected real and synthetic fixtures should either produce a
+complete drawing or a specific diagnostic for every known unsupported defining
+feature. A clean lint result must never be the consequence of failed recognition.
+
+## Product outcomes
+
+1. The current duplicate, missing, and unlocated-dimension defects are fixed and
+   mutation-guarded.
+2. Polygonal bosses reach recognition, drafting IR, annotation, and independent
+   coverage lint without claiming unsupported manufacturing semantics.
+3. AP242 PMI records are reconciled from source through lowering and rendering;
+   missing or fragmented output is diagnosed independently.
+4. The editable declared surface preserves source identity where it can do so
+   unambiguously.
+5. Users can find current API documentation, and accumulated releasable work does
+   not sit on `main` without an explicit weekly release decision.
+
+## Non-goals
+
+- Do not turn ADR 0017's unproven later phases into a programme without a driving
+  defect or experiment.
+- Do not infer gear standards, intent, or parameters from suggestive geometry.
+- Do not expand annotation placement or declaration APIs by bypassing the shared
+  solve.
+- Do not use the milestone as a container for unrelated cleanup.
+
+## Delivery sequence
+
+The sequence is outcome-led. An iteration boundary is a review point, not a reason
+to merge work that lacks evidence. Work that exceeds one reviewable PR is split
+before implementation.
+
+| Iteration | Primary outcome | Planned issues | Exit evidence |
+| --- | --- | --- | --- |
+| W1, 3-9 Aug | Stabilise and release | [#1067](https://github.com/pzfreo/draftwright/issues/1067) | Full local and hosted tiers green; v0.4.1 installed from the registry |
+| W2, 10-16 Aug | Remove known false/duplicate completeness output | [#958](https://github.com/pzfreo/draftwright/issues/958), [#1000](https://github.com/pzfreo/draftwright/issues/1000) | Reduced fixtures and adversarial mutations fail before each fix and pass after it |
+| W3, 17-23 Aug | Make turned-height placement truthful | [#955](https://github.com/pzfreo/draftwright/issues/955), [#1004](https://github.com/pzfreo/draftwright/issues/1004) | Overall height is suppressed only when the surviving chain measures it |
+| W4, 24-30 Aug | Establish polygonal-boss evidence | [#676](https://github.com/pzfreo/draftwright/issues/676) | Recognition record and rejection mutations prove what geometry establishes |
+| W5, 31 Aug-6 Sep | Complete polygonal-boss vertical slice | [#676](https://github.com/pzfreo/draftwright/issues/676); discovery [#1062](https://github.com/pzfreo/draftwright/issues/1062) | Across-flats/corners definition renders and missing output lints independently; gear discovery ends in a decision |
+| W6, 7-13 Sep | Reconcile source PMI | [#623](https://github.com/pzfreo/draftwright/issues/623) | Source, lowered, rendered, missing, and suppressed outcomes are distinguishable |
+| W7, 14-20 Sep | Lower selected AP242 PMI | [#62](https://github.com/pzfreo/draftwright/issues/62), [#675](https://github.com/pzfreo/draftwright/issues/675) | Values and references lower to shared IR; paired tolerances render as one semantic requirement |
+| W8, 21-27 Sep | Preserve declared source identity | [#1041](https://github.com/pzfreo/draftwright/issues/1041) | Unique matches emit references; ambiguous matches fail safe to numeric declarations |
+| W9, 28 Sep-2 Oct | Document and release the outcome | [#846](https://github.com/pzfreo/draftwright/issues/846) | Browsable API reference is published; milestone evidence and release decision recorded |
+
+## Control points
+
+Continue from trust fixes into coverage only when:
+
+- the fast and slow tiers are green on `main`;
+- the selected defect mutations prove each guard is load-bearing;
+- no known fixture receives a clean lint result after recognition loses a defining
+  feature; and
+- release v0.4.1 has either shipped or has a recorded blocker and owner.
+
+Continue from polygonal bosses into AP242 PMI only when the new feature has one
+owned recognition path, semantic measurement identity, and independent coverage
+critique. Do not accept emitted text or an empty recognition result as evidence.
+
+## Project operating model
+
+The GitHub Project is the source of truth for live execution state. This document
+changes only when outcomes, sequence, gates, or operating rules change.
+
+### Fields
+
+- `Status`: Backlog, Ready, In progress, In review, Blocked, Done.
+- `Horizon`: Now, Next, Later, Parked.
+- `Iteration`: weekly, 3 August through 2 October.
+- `Size`: S, M, or L; split work larger than L before it enters Now.
+- Native `Assignees`, `Milestone`, and `Labels` retain ownership, outcome, priority,
+  area, and workstream metadata.
+
+### Views
+
+- **Current Delivery:** Now and Next, board by status.
+- **Eight-Week Roadmap:** committed items on the iteration timeline.
+- **Triage:** items missing a horizon.
+- **Trust Bugs:** open correctness work in `stream:trust`.
+- **Coverage Milestone:** the active outcome milestone.
+- **Parked:** explicitly deferred product expansion.
+
+### WIP and entry rules
+
+- Keep at most two delivery items and one bounded discovery in Now.
+- An item enters Now only with an owner, iteration, acceptance evidence, and an
+  unblocked next action.
+- Next holds no more than five validated follow-ons. Later is the default for
+  accepted backlog. Parked requires a reason to resume.
+- `Blocked` requires a named dependency or decision and is reviewed after seven
+  days. A blocked item does not retain a scarce Now slot by default.
+- Close an issue only when its acceptance evidence is linked. Done is automated
+  from closure; merged PRs are not a substitute for closing the outcome issue.
+
+### Cadence
+
+- **Daily while delivering:** move status and link the implementing PR.
+- **Friday:** run `scripts/project-audit`, review blocked work and WIP, choose the
+  next iteration, and record a Project status update.
+- **At each iteration boundary:** decide whether to release; record the decision
+  even when no release is cut.
+- **At milestone close:** compare the product outcome with evidence, not issue
+  count, and record any scope change here.
+
+GitHub's native Project workflows set newly added items to Backlog, move closed
+items to Done, add linked issues, and complete merged PRs. Initial backlog import
+is complete. New top-level issues still require triage into the Project; the Triage
+view and weekly audit make omissions visible.
+
+## Risks and responses
+
+| Risk | Response |
+| --- | --- |
+| Architecture work resumes without a user-visible defect | Keep it in Later until an issue supplies the failing fixture and acceptance evidence |
+| Recognition gains names unsupported by B-rep evidence | Separate geometric inventory from declared manufacturing semantics; require rejection mutations |
+| Slow CI lengthens every review loop | Keep reduced fixtures in the fast tier and run the slow tier at PR and release gates |
+| The Project becomes another stale tracker | One live source, weekly audit, WIP limits, and status updates; no duplicate session ledger |
+| Scope expands past one maintainer's capacity | Pull only from Next when a Now slot clears; replan rather than carry hidden WIP |
+
+## Decision log
+
+- **2026-08-05:** ADR 0017 phase 1 is treated as evidence to test, not automatic
+  authority to execute phases 2-6.
+- **2026-08-07:** GitHub Project 3 replaces issue #758 as the live execution layer.
+  Repository plans retain strategy, outcome gates, and durable decisions.
+- **2026-08-07:** The former Coverage expansion milestone is consolidated into one
+  time-bound trust-and-coverage outcome so correctness remains ahead of breadth.

--- a/docs/plans/2026-08-trust-and-coverage-plan.md
+++ b/docs/plans/2026-08-trust-and-coverage-plan.md
@@ -115,6 +115,11 @@ changes only when outcomes, sequence, gates, or operating rules change.
 - **At milestone close:** compare the product outcome with evidence, not issue
   count, and record any scope change here.
 
+`scripts/project-audit` requires `gh` authenticated with a classic token carrying
+Project read access. GitHub's user-owned Project item endpoint does not accept the
+repository `GITHUB_TOKEN`, so the audit is a named weekly maintainer control rather
+than a scheduled Action that would silently skip or require a broad stored token.
+
 GitHub's native Project workflows set newly added items to Backlog, move closed
 items to Done, add linked issues, and complete merged PRs. Initial backlog import
 is complete. New top-level issues still require triage into the Project; the Triage

--- a/docs/plans/product-backlog-roadmap.md
+++ b/docs/plans/product-backlog-roadmap.md
@@ -1,9 +1,11 @@
 # Product backlog roadmap
 
-- **Status:** Active delivery plan
-- **Last reviewed:** 2026-07-26
-- **Live tracker:** [#758 — trustworthy drawing pipeline and backlog
-  burn-down](https://github.com/pzfreo/draftwright/issues/758)
+- **Status:** Active product strategy
+- **Last reviewed:** 2026-08-07
+- **Live execution:** [Draftwright: Trustworthy Manufacturing
+  Drawings](https://github.com/users/pzfreo/projects/3)
+- **Current delivery plan:** [Trust and coverage, August-October
+  2026](2026-08-trust-and-coverage-plan.md)
 
 ## Product promise
 
@@ -12,13 +14,14 @@ deterministic drawing or clearly reports why it cannot. Work that undermines
 completeness, parity, deterministic diagnosis, or truthful lint outranks new
 surface area.
 
-This document records delivery intent and prioritisation. ADRs remain the source
-of architectural decisions; GitHub issues remain the source of live work status.
-Historical issue state and completed-task ledgers do not belong here.
+This document records the product promise and durable prioritisation rules. ADRs
+remain the source of architectural decisions, the dated delivery plan records the
+current outcome and gates, and the GitHub Project is the source of live work
+status. Historical issue state and completed-task ledgers do not belong here.
 
 ## Operating model
 
-- At most four implementation issues are active, one in each workstream.
+- At most two delivery issues and one bounded discovery are in **Now**.
 - An umbrella coordinates work but is never assigned as an implementation task.
 - A bug that produces a clean but incomplete drawing outranks a visible failure.
 - Every bug fix gains a reduced fast-tier fixture where practical.
@@ -28,22 +31,23 @@ Historical issue state and completed-task ledgers do not belong here.
 - Speculative features stay parked until they have a named user, milestone, or
   experiment.
 
-Scheduling uses `roadmap:now`, `roadmap:next`, `roadmap:later`, and
-`roadmap:parked`. Severity continues to use the existing `priority:P0`–`P3`
-labels. Workstreams use `stream:*`; `blocked` records an external dependency or
-decision that prevents progress.
+Scheduling uses the Project's `Horizon` and `Iteration` fields. Severity continues
+to use the existing `priority:P0`-`P3` labels. Workstreams use `stream:*`;
+`Blocked` records an external dependency or decision that prevents progress. The
+former `roadmap:*` labels are retired after migration because duplicate scheduling
+state is a drift source.
 
 ## Workstreams and current WIP
 
 | Workstream | Objective | Now | Next |
 | --- | --- | --- | --- |
-| Trust and correctness | Never certify or silently emit an incomplete drawing | [#863](https://github.com/pzfreo/draftwright/issues/863) thread-blind ⌀ dedup on the incremental paths | [#812](https://github.com/pzfreo/draftwright/issues/812)-class emit gaps as found |
-| Reliability and diagnostics | Make failures fast, reproducible, and representative | No active implementation | [#826](https://github.com/pzfreo/draftwright/issues/826) dependency/static-security/secret scanning |
-| Architecture | Remove boundaries that make correctness work risky | No active implementation — Milestone 2 exited | [#830](https://github.com/pzfreo/draftwright/issues/830) residual state-bus seam review |
-| Manufacturing coverage | Expand independently verified feature coverage | [#676](https://github.com/pzfreo/draftwright/issues/676) polygonal boss recognition | [#675](https://github.com/pzfreo/draftwright/issues/675) paired bilateral PMI tolerances |
+| Trust and correctness | Never certify or silently emit an incomplete drawing | [#958](https://github.com/pzfreo/draftwright/issues/958) duplicate pad/phantom-slot span | [#1000](https://github.com/pzfreo/draftwright/issues/1000), [#955](https://github.com/pzfreo/draftwright/issues/955), [#1004](https://github.com/pzfreo/draftwright/issues/1004) |
+| Reliability and diagnostics | Make failures fast, reproducible, and representative | [#1067](https://github.com/pzfreo/draftwright/issues/1067) v0.4.1 and weekly release decision | No additional item until a Now slot clears |
+| Architecture | Remove boundaries only when they block a product outcome | No active implementation | Pull only from a failing product slice |
+| Manufacturing coverage | Expand independently verified feature coverage | No active implementation until the trust gate clears | [#676](https://github.com/pzfreo/draftwright/issues/676), then [#623](https://github.com/pzfreo/draftwright/issues/623) |
 
-The table is intentionally small. The live roadmap issue records ownership,
-blockers, and session-to-session movement.
+The table is intentionally small. The Project records ownership, blockers, and
+movement; the dated delivery plan records the multi-week sequence and gates.
 
 ## Milestone 1 — Trustworthy 0.3.x
 
@@ -58,7 +62,7 @@ not-reproducible. Focus moves to Milestone 2.
 Off-milestone quality polish shipped afterwards in **v0.3.7** (turned ⌀ leader
 placement — centre-on-feature, the `leader_crosses_silhouette` lint, and
 clear-side re-routing of body-crossing leaders); it did not change milestone scope
-or exit criteria. See the live tracker (#758) for the delivered ledger.
+or exit criteria. See the archived tracker (#758) for the delivered ledger.
 
 ### Outcome
 
@@ -131,15 +135,25 @@ package/test boundaries no longer encourage reach-through or cyclic ownership.
 - The builder/CLI/emitter import graph is acyclic.
 - Test-side private reads have a shrink-only guard and a documented residual.
 
-## Milestone 3 — Coverage expansion
+## Active milestone — Trustworthy manufacturing drawings
+
+**Target: 2026-10-02.** The former open-ended Coverage expansion milestone is
+consolidated into this time-bound outcome. Correctness fixes lead; manufacturing
+coverage follows only after the trust gate in the current delivery plan.
 
 ### Outcome
 
-Important manufacturing features are recognised or imported, lowered into
-drafting concepts, rendered, and checked by independent coverage lint.
+Known silent or misleading incompleteness is removed, then selected manufacturing
+features are recognised or imported, lowered into drafting concepts, rendered,
+and checked by independent coverage lint.
 
 ### Initial scope
 
+- [#958](https://github.com/pzfreo/draftwright/issues/958),
+  [#1000](https://github.com/pzfreo/draftwright/issues/1000),
+  [#955](https://github.com/pzfreo/draftwright/issues/955), and
+  [#1004](https://github.com/pzfreo/draftwright/issues/1004) — current trust
+  defects and their measurement-identity enabler.
 - [#676](https://github.com/pzfreo/draftwright/issues/676) — polygonal boss
   recognition and across-flats/corners definition.
 - [#675](https://github.com/pzfreo/draftwright/issues/675) — paired, grouped
@@ -180,33 +194,15 @@ both exited):
 
 At the start of a delivery session:
 
-1. Read this roadmap and the latest handoff on the live tracker.
-2. Verify the four **Now** slots against current `main` and issue state.
+1. Read the current delivery plan and open the Project's Current Delivery view.
+2. Verify the three **Now** slots against current `main` and issue state.
 3. Resume the first unblocked issue; do not pull **Next** work while its stream's
    **Now** item remains active.
 
-At the end of a delivery session, add this comment to the live tracker:
+At the end of a delivery session, update issue and Project status directly. On
+Friday, run `scripts/project-audit` and publish a short Project status update with
+completed evidence, current blockers, the next iteration, and any scope decision.
 
-```markdown
-## Session handoff — YYYY-MM-DD
-
-Completed:
-- #123 — outcome and PR
-
-Evidence:
-- tests, checks, or user-visible result
-
-Current:
-- #456 — state and blocker
-
-Next:
-1. #789
-2. #790
-
-Roadmap changes:
-- why anything moved between Now, Next, Later, or Parked
-```
-
-Review the backlog weekly. Update this document only when product promise,
-milestone scope, exit criteria, or operating rules change; record routine issue
-movement on the live tracker.
+Review the backlog weekly. Update this document only when the product promise or
+operating rules change; update the dated plan when its outcome, sequence, gates,
+or milestone scope changes.

--- a/scripts/project-audit
+++ b/scripts/project-audit
@@ -55,7 +55,7 @@ gh api --paginate --slurp \
             size: ([.fields[]? | select(.name == "Size") | .value.name.raw][0] // ""),
             status: ([.fields[]? | select(.name == "Status") | .value.name.raw][0] // ""),
             title: (.content.title // "Draft item"),
-            updated: (.content.updated_at // "1970-01-01T00:00:00Z")
+            updated: (.updated_at // "1970-01-01T00:00:00Z")
         }
     ]}' >"$items_file"
 

--- a/scripts/project-audit
+++ b/scripts/project-audit
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_number="${1:-3}"
+owner="${2:-pzfreo}"
+repository="${3:-draftwright}"
+now_epoch="$(date +%s)"
+items_file="$(mktemp)"
+fields_file="$(mktemp)"
+open_issues_file="$(mktemp)"
+trap 'rm -f "$items_file" "$fields_file" "$open_issues_file"' EXIT
+
+for command in gh jq; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        printf 'project-audit: required command not found: %s\n' "$command" >&2
+        exit 2
+    fi
+done
+
+gh api \
+    "users/$owner/projectsV2/$project_number/fields?per_page=100" \
+    >"$fields_file"
+
+field_ids="$(
+    jq -r \
+        '[.[] | select(.name == "Status" or .name == "Horizon" or .name == "Iteration") | .id]
+         | join(",")' \
+        "$fields_file"
+)"
+if [[ "$(tr ',' '\n' <<<"$field_ids" | wc -l | tr -d ' ')" != "3" ]]; then
+    printf 'project-audit: Status, Horizon, and Iteration fields are required.\n' >&2
+    exit 2
+fi
+
+gh api --paginate --slurp \
+    "users/$owner/projectsV2/$project_number/items?per_page=100&fields=$field_ids" \
+    | jq '{items: [
+        .[][]
+        | {
+            assignees: [.content.assignees[]?.login],
+            content: {
+                number: .content.number,
+                url: .content.html_url
+            },
+            horizon: ([.fields[]? | select(.name == "Horizon") | .value.name.raw][0] // ""),
+            iteration: ([.fields[]? | select(.name == "Iteration") | .value.title.raw][0] // ""),
+            labels: [.content.labels[]?.name],
+            status: ([.fields[]? | select(.name == "Status") | .value.name.raw][0] // ""),
+            title: (.content.title // "Draft item"),
+            updated: (.content.updated_at // "1970-01-01T00:00:00Z")
+        }
+    ]}' >"$items_file"
+
+gh api --paginate --slurp \
+    "repos/$owner/$repository/issues?state=open&per_page=100" \
+    | jq '[
+        .[][]
+        | select(has("pull_request") | not)
+        | {number, title, url: .html_url}
+    ]' >"$open_issues_file"
+
+failures=0
+
+missing_items="$(
+    jq -r \
+        --slurpfile project "$items_file" \
+        '.[] as $issue
+         | select(any($project[0].items[]; .content.url == $issue.url) | not)
+         | "#\($issue.number) \($issue.title)"' \
+        "$open_issues_file"
+)"
+if [[ -n "$missing_items" ]]; then
+    printf 'Open repository issues missing from the Project:\n%s\n' \
+        "$missing_items" >&2
+    failures=$((failures + 1))
+fi
+
+report_items() {
+    local heading="$1"
+    local filter="$2"
+    local matches
+
+    matches="$(jq -r "$filter | \"#\(.content.number // \"draft\") \(.title)\"" "$items_file")"
+    if [[ -n "$matches" ]]; then
+        printf '%s\n%s\n' "$heading" "$matches" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+now_count="$(
+    jq '[.items[] | select(.horizon == "Now" and .status != "Done")] | length' \
+        "$items_file"
+)"
+if (( now_count > 3 )); then
+    printf 'WIP limit: %s items are in Now; maximum is 3.\n' "$now_count" >&2
+    failures=$((failures + 1))
+fi
+
+delivery_now_count="$(
+    jq '[.items[]
+         | select(.horizon == "Now" and .status != "Done")
+         | select(any(.labels[]?; . == "design") | not)]
+        | length' \
+        "$items_file"
+)"
+if (( delivery_now_count > 2 )); then
+    printf 'WIP limit: %s delivery items are in Now; maximum is 2.\n' \
+        "$delivery_now_count" >&2
+    failures=$((failures + 1))
+fi
+
+discovery_now_count="$(
+    jq '[.items[]
+         | select(.horizon == "Now" and .status != "Done")
+         | select(any(.labels[]?; . == "design"))]
+        | length' \
+        "$items_file"
+)"
+if (( discovery_now_count > 1 )); then
+    printf 'WIP limit: %s discovery items are in Now; maximum is 1.\n' \
+        "$discovery_now_count" >&2
+    failures=$((failures + 1))
+fi
+
+next_count="$(
+    jq '[.items[] | select(.horizon == "Next" and .status != "Done")] | length' \
+        "$items_file"
+)"
+if (( next_count > 5 )); then
+    printf 'Queue limit: %s items are in Next; maximum is 5.\n' "$next_count" >&2
+    failures=$((failures + 1))
+fi
+
+active_count="$(
+    jq '[.items[] | select(.status == "In progress" or .status == "In review")]
+        | length' \
+        "$items_file"
+)"
+if (( active_count > 3 )); then
+    printf 'WIP limit: %s items are In progress or In review; maximum is 3.\n' \
+        "$active_count" >&2
+    failures=$((failures + 1))
+fi
+
+report_items \
+    'Active items missing a Horizon:' \
+    '.items[] | select((.status // "") != "Done" and (.horizon // "") == "")'
+
+report_items \
+    'In-progress or in-review items outside Now:' \
+    '.items[]
+     | select(.status == "In progress" or .status == "In review")
+     | select(.horizon != "Now")'
+
+report_items \
+    'Now items missing owner, iteration, priority, area, or stream:' \
+    '.items[]
+     | select(.horizon == "Now" and .status != "Done")
+     | select(
+         ((.assignees // []) | length) == 0
+         or (.iteration // "") == ""
+         or (any(.labels[]?; startswith("priority:")) | not)
+         or (any(.labels[]?; startswith("area:")) | not)
+         or (any(.labels[]?; startswith("stream:")) | not)
+       )'
+
+report_items \
+    'Next items missing owner, priority, area, or stream:' \
+    '.items[]
+     | select(.horizon == "Next" and .status != "Done")
+     | select(
+         ((.assignees // []) | length) == 0
+         or (any(.labels[]?; startswith("priority:")) | not)
+         or (any(.labels[]?; startswith("area:")) | not)
+         or (any(.labels[]?; startswith("stream:")) | not)
+       )'
+
+report_items \
+    'Blocked items not updated for seven days:' \
+    ".items[]
+     | select(.status == \"Blocked\")
+     | select((.updated // \"1970-01-01T00:00:00Z\" | fromdateiso8601) < ($now_epoch - 604800))"
+
+if (( failures > 0 )); then
+    printf 'project-audit: %s policy check(s) failed.\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'project-audit: Project %s/%s satisfies the delivery policies.\n' \
+    "$owner" "$project_number"

--- a/scripts/project-audit
+++ b/scripts/project-audit
@@ -23,12 +23,19 @@ gh api \
 
 field_ids="$(
     jq -r \
-        '[.[] | select(.name == "Status" or .name == "Horizon" or .name == "Iteration") | .id]
+        '[.[]
+          | select(
+              .name == "Status"
+              or .name == "Horizon"
+              or .name == "Iteration"
+              or .name == "Size"
+            )
+          | .id]
          | join(",")' \
         "$fields_file"
 )"
-if [[ "$(tr ',' '\n' <<<"$field_ids" | wc -l | tr -d ' ')" != "3" ]]; then
-    printf 'project-audit: Status, Horizon, and Iteration fields are required.\n' >&2
+if [[ "$(tr ',' '\n' <<<"$field_ids" | wc -l | tr -d ' ')" != "4" ]]; then
+    printf 'project-audit: Status, Horizon, Iteration, and Size fields are required.\n' >&2
     exit 2
 fi
 
@@ -45,6 +52,7 @@ gh api --paginate --slurp \
             horizon: ([.fields[]? | select(.name == "Horizon") | .value.name.raw][0] // ""),
             iteration: ([.fields[]? | select(.name == "Iteration") | .value.title.raw][0] // ""),
             labels: [.content.labels[]?.name],
+            size: ([.fields[]? | select(.name == "Size") | .value.name.raw][0] // ""),
             status: ([.fields[]? | select(.name == "Status") | .value.name.raw][0] // ""),
             title: (.content.title // "Draft item"),
             updated: (.content.updated_at // "1970-01-01T00:00:00Z")
@@ -153,23 +161,14 @@ report_items \
      | select(.horizon != "Now")'
 
 report_items \
-    'Now items missing owner, iteration, priority, area, or stream:' \
+    'Committed items missing owner, iteration, size, priority, area, or stream:' \
     '.items[]
-     | select(.horizon == "Now" and .status != "Done")
+     | select(.status != "Done")
+     | select(.horizon == "Now" or .horizon == "Next" or .iteration != "")
      | select(
          ((.assignees // []) | length) == 0
          or (.iteration // "") == ""
-         or (any(.labels[]?; startswith("priority:")) | not)
-         or (any(.labels[]?; startswith("area:")) | not)
-         or (any(.labels[]?; startswith("stream:")) | not)
-       )'
-
-report_items \
-    'Next items missing owner, priority, area, or stream:' \
-    '.items[]
-     | select(.horizon == "Next" and .status != "Done")
-     | select(
-         ((.assignees // []) | length) == 0
+         or (.size // "") == ""
          or (any(.labels[]?; startswith("priority:")) | not)
          or (any(.labels[]?; startswith("area:")) | not)
          or (any(.labels[]?; startswith("stream:")) | not)


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: delivery state was split between a stale roadmap table, an open tracker issue, labels, and milestones; the backlog had no enforceable WIP or sequencing model.
- Fixture/reproducer: the 2026-08-07 tracker audit found 100+ open issues, no `roadmap:now` item, one `roadmap:next` item, and completed milestones still open.
- Before/after result: GitHub Project 3 is now the live execution layer with every open issue imported; the repository records the outcome, sequence, gates, and decision history.
- Mutation that makes the guard fail: remove an open issue from the Project, exceed Now/Next WIP, move active work outside Now, or remove required Now/Next metadata; `scripts/project-audit` exits non-zero.

## Contract and scope

- Smallest contract this change tests: live execution has one structured source of truth and its WIP/membership invariants are independently auditable.
- Relevant ADRs: ADR 0017 informs the evidence and mutation gates; no architectural decision changes.
- Explicitly deferred: GitHub exposes auto-add workflow configuration only in the Project UI. The audit detects any top-level issue omitted before the weekly review.

## Validation

- [x] `scripts/pr-check --quick`
- [ ] `scripts/pr-check` before final review
- [x] The named mutation was observed failing before the implementation passed it
- [x] Automatic, declared, and generated-script paths were checked where affected — N/A, planning/tooling only
- [x] Recognition and repeated-lint call counts were checked where affected — N/A, planning/tooling only
- [x] `scripts/project-audit` passes against the live Project

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] New prerequisites were split or the work was explicitly reclassified as discovery

Supersedes #758.