### PR TITLE
chore: bump version to 0.4.2.dev0 after release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.1"
+version = "0.4.2.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.1"
+version = "0.4.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },


### PR DESCRIPTION
## Outcome

Restore the post-release development version after v0.4.1. The release workflow produced this exact two-line change, then branch protection correctly rejected its direct push; #779 tracks replacing that push with a PR.

Without this bump, later main pushes are rewritten as `0.4.1.devN` for TestPyPI, which sorts below the released v0.4.1 while containing newer code.

## Adversarial review

One pass compared the workflow's logged intended version, the previous release convention, project metadata, lock metadata, built wheel/sdist, and CLI output. No substantive findings remain.

- only `pyproject.toml` and the editable package row in `uv.lock` change;
- both move `0.4.1 -> 0.4.2.dev0`;
- no dependency markers or resolutions changed;
- this does not close #779 because the automation still attempts a protected direct push.

## Validation

- [x] `uv lock --check`
- [x] wheel and sdist build as `0.4.2.dev0`
- [x] wheel METADATA and `draftwright --version` report `0.4.2.dev0`
- [x] `scripts/pr-check --quick` (73 passed)
- [ ] hosted matrix and Codecov

Refs #779 and #1067.
