### PR TITLE
Recognise milled features within physical solids

### DIFF
--- a/src/draftwright/recognition/pads.py
+++ b/src/draftwright/recognition/pads.py
@@ -24,13 +24,8 @@ class RaisedPad(Record):
     z1: float
 
 
-def recognise_rectangular_pads(part, *, tol: float = 0.2) -> list[RaisedPad]:
-    """Return rectangular horizontal faces that are bounded in plan and raised.
-
-    A candidate is a planar +Z face whose area fills its XY bounding rectangle
-    and is bounded on both in-plane axes. Full-span steps are excluded;
-    non-rectangular pocket floors and perforated plate faces fail the area test.
-    """
+def _recognise_rectangular_pads_one(part, *, tol: float) -> list[RaisedPad]:
+    """Recognise pads using one solid's faces and bounds."""
     bb = part.bounding_box()
     raw_tops: list[tuple[float, float, float, float, float]] = []
     for face in part.faces():
@@ -136,3 +131,18 @@ def recognise_rectangular_pads(part, *, tol: float = 0.2) -> list[RaisedPad]:
             abs(other.z1 - pad.z0) <= tol and touches_plan(pad, other) for other in raw_regions
         )
     )
+
+
+def recognise_rectangular_pads(part, *, tol: float = 0.2) -> list[RaisedPad]:
+    """Return bounded rectangular raised faces independently per solid.
+
+    A candidate is a planar +Z face whose area fills its XY bounding rectangle
+    and is bounded on both in-plane axes. Full-span steps are excluded;
+    non-rectangular pocket floors and perforated plate faces fail the area test.
+    Body-local walls and bounds prevent a detached component from being treated
+    as a pad raised from another component (#958).
+    """
+    solids = list(part.solids())
+    sources = solids if len(solids) > 1 else [part]
+    pads = [pad for solid in sources for pad in _recognise_rectangular_pads_one(solid, tol=tol)]
+    return sorted(pads)

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -774,15 +774,8 @@ def _recognise_obround_from_ends(part, faces, *, blind: bool = False):
     return out
 
 
-def recognise_slots(part) -> list[Slot]:
-    """Recognise enclosed through-slots with rectangular walls in *part*.
-
-    Returns a list of :class:`Slot`, one per physical feature, in a
-    deterministic order (co-located candidate pairs are merged, keeping the
-    narrower width).  See the module docstring for the recognition predicate and
-    its (deliberately narrow) scope. Obround slots too stubby for their flat walls
-    to pair are recovered from their end caps (#816).
-    """
+def _recognise_slots_one(part) -> list[Slot]:
+    """Recognise slots using one solid's faces and bounds."""
     faces = _planar_faces(part)
     pbb = part.bounding_box()
     part_ext = {a: getattr(pbb.size, "XYZ"[_AXES[a]]) for a in "xyz"}
@@ -808,6 +801,24 @@ def recognise_slots(part) -> list[Slot]:
     # Recombine arms of a crossing channel split by the intersection (#604), then extend any
     # radiused-end (obround) slot to its overall length (#613).
     return _extend_obround_ends(_collapse_collinear(_merge(candidates), part), part)
+
+
+def recognise_slots(part) -> list[Slot]:
+    """Recognise enclosed through-slots independently within each solid in *part*.
+
+    Returns a list of :class:`Slot`, one per physical feature, in a
+    deterministic order (co-located candidate pairs within a solid are merged,
+    keeping the narrower width). See the module docstring for the recognition
+    predicate and its deliberately narrow scope. Obround slots too stubby for
+    their flat walls to pair are recovered from their end caps (#816).
+
+    A compound is scanned per solid so faces from separate components cannot
+    combine into a fictitious slot across the gap between them (#958).
+    """
+    solids = list(part.solids())
+    sources = solids if len(solids) > 1 else [part]
+    slots = [slot for solid in sources for slot in _recognise_slots_one(solid)]
+    return sorted(slots, key=lambda slot: (slot.width, _region_center(slot)))
 
 
 def _same_channel_line(a: Slot, b: Slot):
@@ -1049,15 +1060,8 @@ def _channel_candidate(fa, fb, faces, part_ext, part_bounds) -> Channel | None:
     return candidate if isinstance(candidate, Channel) else None
 
 
-def recognise_pockets(part) -> list[Pocket]:
-    """Blind rectangular recesses — floored slots/pockets (#148a).
-
-    The blind counterpart of :func:`recognise_slots`: the same facing-rectangular-wall
-    candidate scan, but keeping the pairs a floor caps.  The depth (open-face-to-floor
-    extent) is read from the axis the floor is normal to — see :func:`_pocket_candidate` —
-    not from a size heuristic, so a pocket deeper than it is long is dimensioned correctly.
-    A "blind slot" (elongated) and a "pocket" (near-square) are the same floored feature,
-    dimensioned width × length × depth."""
+def _recognise_pockets_one(part) -> list[Pocket]:
+    """Recognise pockets using one solid's faces and bounds."""
     faces = _planar_faces(part)
     pbb = part.bounding_box()
     part_ext = {a: getattr(pbb.size, "XYZ"[_AXES[a]]) for a in "xyz"}
@@ -1079,13 +1083,24 @@ def recognise_pockets(part) -> list[Pocket]:
     return _extend_obround_ends(_merge(candidates), part)
 
 
-def recognise_channels(part) -> list[Channel]:
-    """Full-span floored rectangular channels, open at both longitudinal ends.
+def recognise_pockets(part) -> list[Pocket]:
+    """Recognise blind rectangular recesses independently within each solid.
 
-    This is deliberately separate from :func:`recognise_pockets`: a channel's length
-    and depth participate in the surrounding envelope/plate scheme, while only its
-    wall-to-wall width is an independent defining measurement.
+    The blind counterpart of :func:`recognise_slots`: the same facing-rectangular-wall
+    candidate scan, but keeping the pairs a floor caps. The depth (open-face-to-floor
+    extent) is read from the axis the floor is normal to -- see
+    :func:`_pocket_candidate` -- not from a size heuristic, so a pocket deeper than it
+    is long is dimensioned correctly. A compound is scanned per solid so separate
+    components cannot supply walls or floors for one fictitious recess (#958).
     """
+    solids = list(part.solids())
+    sources = solids if len(solids) > 1 else [part]
+    pockets = [pocket for solid in sources for pocket in _recognise_pockets_one(solid)]
+    return sorted(pockets, key=lambda pocket: (pocket.width, _region_center(pocket)))
+
+
+def _recognise_channels_one(part) -> list[Channel]:
+    """Recognise channels using one solid's faces and bounds."""
     faces = _planar_faces(part)
     pbb = part.bounding_box()
     part_ext = {a: getattr(pbb.size, "XYZ"[_AXES[a]]) for a in "xyz"}
@@ -1109,6 +1124,23 @@ def recognise_channels(part) -> list[Channel]:
                     candidates.append(channel)
     return sorted(
         set(candidates),
+        key=lambda c: (c.long_axis, c.width_axis, c.lo, c.hi, c.w_center, c.width),
+    )
+
+
+def recognise_channels(part) -> list[Channel]:
+    """Recognise full-span floored channels independently within each solid.
+
+    This is deliberately separate from :func:`recognise_pockets`: a channel's length
+    and depth participate in the surrounding envelope/plate scheme, while only its
+    wall-to-wall width is an independent defining measurement. Body-local bounds prove
+    that the channel reaches the ends of the same solid whose faces bound it (#958).
+    """
+    solids = list(part.solids())
+    sources = solids if len(solids) > 1 else [part]
+    channels = [channel for solid in sources for channel in _recognise_channels_one(solid)]
+    return sorted(
+        channels,
         key=lambda c: (c.long_axis, c.width_axis, c.lo, c.hi, c.w_center, c.width),
     )
 

--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -1060,6 +1060,21 @@ def _channel_candidate(fa, fb, faces, part_ext, part_bounds) -> Channel | None:
     return candidate if isinstance(candidate, Channel) else None
 
 
+def _channel_sort_key(channel: Channel):
+    """Geometry-only order, including depth to break cross-solid traversal ties."""
+    return (
+        channel.long_axis,
+        channel.width_axis,
+        channel.lo,
+        channel.hi,
+        channel.w_center,
+        channel.width,
+        channel.d_lo,
+        channel.d_hi,
+        channel.open_sign,
+    )
+
+
 def _recognise_pockets_one(part) -> list[Pocket]:
     """Recognise pockets using one solid's faces and bounds."""
     faces = _planar_faces(part)
@@ -1124,7 +1139,7 @@ def _recognise_channels_one(part) -> list[Channel]:
                     candidates.append(channel)
     return sorted(
         set(candidates),
-        key=lambda c: (c.long_axis, c.width_axis, c.lo, c.hi, c.w_center, c.width),
+        key=_channel_sort_key,
     )
 
 
@@ -1139,10 +1154,7 @@ def recognise_channels(part) -> list[Channel]:
     solids = list(part.solids())
     sources = solids if len(solids) > 1 else [part]
     channels = [channel for solid in sources for channel in _recognise_channels_one(solid)]
-    return sorted(
-        channels,
-        key=lambda c: (c.long_axis, c.width_axis, c.lo, c.hi, c.w_center, c.width),
-    )
+    return sorted(channels, key=_channel_sort_key)
 
 
 def _recognise_corner_notches(faces: list[_Face], pbb, tol: float = 0.5) -> list[Pocket]:

--- a/tests/test_issue_958_cross_solid_recognition.py
+++ b/tests/test_issue_958_cross_solid_recognition.py
@@ -131,3 +131,20 @@ def test_real_channels_on_separate_bodies_are_each_preserved():
 
     assert all(len(recognise_channels(solid)) == 1 for solid in part.solids())
     assert len(recognise_channels(part)) == 2
+
+
+def test_channel_order_does_not_depend_on_compound_child_order():
+    channelled = (
+        Box(50, 50, 12)
+        + Pos(0, -18.75, 15) * Box(50, 12.5, 18)
+        + Pos(0, 18.75, 15) * Box(50, 12.5, 18)
+    )
+    upper = Pos(0, 0, 60) * channelled
+
+    lower_first = recognise_channels(Compound(children=[channelled, upper]))
+    upper_first = recognise_channels(Compound(children=[upper, channelled]))
+    assert lower_first == upper_first
+    assert [(channel.d_lo, channel.d_hi) for channel in lower_first] == [
+        (6.0, 24.0),
+        (66.0, 84.0),
+    ]

--- a/tests/test_issue_958_cross_solid_recognition.py
+++ b/tests/test_issue_958_cross_solid_recognition.py
@@ -1,0 +1,133 @@
+"""#958: recognition evidence must belong to one physical solid."""
+
+from build123d import Box, Compound, Pos
+
+from draftwright import build_drawing
+from draftwright.recognition import (
+    RaisedPad,
+    recognise_channels,
+    recognise_pockets,
+    recognise_rectangular_pads,
+    recognise_slots,
+)
+
+
+def _detached_pad_compound():
+    return Compound(
+        children=[
+            Box(80, 60, 10),
+            Pos(0, 0, 10) * Box(30, 20, 4),
+        ]
+    )
+
+
+def _three_body_wall_pair():
+    return Compound(
+        children=[
+            Box(80, 60, 10),
+            Pos(0, 0, 10) * Box(30, 20, 4),
+            Pos(0, -10.5, 6.5) * Box(30, 1, 3),
+        ]
+    )
+
+
+def _three_body_full_span_wall_pair():
+    return Compound(
+        children=[
+            Box(30, 60, 10),
+            Pos(0, 0, 10) * Box(30, 20, 4),
+            Pos(0, -10.5, 6.5) * Box(30, 1, 3),
+        ]
+    )
+
+
+def test_detached_body_does_not_create_slot_evidence():
+    part = _detached_pad_compound()
+    assert len(part.solids()) == 2
+    assert all(recognise_slots(solid) == [] for solid in part.solids())
+    assert recognise_slots(part) == []
+
+
+def test_detached_body_does_not_create_pad_evidence():
+    part = _detached_pad_compound()
+    assert len(part.solids()) == 2
+    assert all(recognise_rectangular_pads(solid) == [] for solid in part.solids())
+    assert recognise_rectangular_pads(part) == []
+
+
+def test_detached_body_does_not_emit_plausible_but_false_dimensions():
+    drawing = build_drawing(_detached_pad_compound())
+
+    assert not [feature for feature in drawing.model().features if feature.kind in {"slot", "pad"}]
+    assert not [name for name in drawing.annotations() if name.startswith(("m_slot", "m_pad"))]
+
+
+def test_attached_pad_remains_recognised_once():
+    part = Box(80, 60, 10) + Pos(0, 0, 7) * Box(30, 20, 4)
+    assert len(part.solids()) == 1
+    assert recognise_slots(part) == []
+    assert recognise_rectangular_pads(part) == [RaisedPad(-15, 15, -10, 10, 5, 9)]
+
+    drawing = build_drawing(part)
+    assert [feature.kind for feature in drawing.model().features].count("pad") == 1
+    assert {
+        name: drawing.get_annotation(name).label
+        for name in drawing.annotations()
+        if name.startswith("m_pad")
+    } == {"m_pad0_width": "20", "m_pad0_length": "30"}
+    assert not [name for name in drawing.annotations() if name.startswith("m_slot")]
+    assert drawing.lint() == []
+
+
+def test_faces_from_three_bodies_do_not_form_a_pocket():
+    part = _three_body_wall_pair()
+    assert len(part.solids()) == 3
+    assert all(recognise_pockets(solid) == [] for solid in part.solids())
+    assert recognise_pockets(part) == []
+
+
+def test_faces_from_three_bodies_do_not_form_a_channel():
+    part = _three_body_full_span_wall_pair()
+    assert len(part.solids()) == 3
+    assert all(recognise_channels(solid) == [] for solid in part.solids())
+    assert recognise_channels(part) == []
+
+
+def test_real_slots_on_separate_bodies_are_each_preserved():
+    slotted = Box(60, 30, 10) - Box(30, 8, 20)
+    part = Compound(children=[slotted, Pos(0, 60, 0) * slotted])
+
+    slots = recognise_slots(part)
+    assert len(slots) == 2
+    assert [(slot.width, slot.length, slot.w_center) for slot in slots] == [
+        (8.0, 30.0, 0.0),
+        (8.0, 30.0, 60.0),
+    ]
+
+
+def test_real_pads_on_separate_bodies_are_each_preserved():
+    padded = Box(80, 60, 10) + Pos(0, 0, 7) * Box(30, 20, 4)
+    part = Compound(children=[padded, Pos(120, 0, 0) * padded])
+
+    assert all(len(recognise_rectangular_pads(solid)) == 1 for solid in part.solids())
+    assert len(recognise_rectangular_pads(part)) == 2
+
+
+def test_real_pockets_on_separate_bodies_are_each_preserved():
+    pocketed = Box(80, 60, 20) - Pos(0, 0, 6) * Box(30, 20, 8)
+    part = Compound(children=[pocketed, Pos(120, 0, 0) * pocketed])
+
+    assert all(len(recognise_pockets(solid)) == 1 for solid in part.solids())
+    assert len(recognise_pockets(part)) == 2
+
+
+def test_real_channels_on_separate_bodies_are_each_preserved():
+    channelled = (
+        Box(50, 50, 12)
+        + Pos(0, -18.75, 15) * Box(50, 12.5, 18)
+        + Pos(0, 18.75, 15) * Box(50, 12.5, 18)
+    )
+    part = Compound(children=[channelled, Pos(0, 100, 0) * channelled])
+
+    assert all(len(recognise_channels(solid)) == 1 for solid in part.solids())
+    assert len(recognise_channels(part)) == 2

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7919,7 +7919,10 @@ class TestFindSlots:
         # faces sit at w_center ± width/2; only the inward-normal test in _has_side_walls rejects them.
         d1 = Pos(0, -10, 0) * Cylinder(4, 30) & Pos(0, -12, 0) * Box(20, 4, 40)
         d2 = Pos(0, 10, 0) * Cylinder(4, 30) & Pos(0, 12, 0) * Box(20, 4, 40)
-        assert recognise_slots(Box(8, 40, 21) - d1 - d2) == []
+        split = Box(8, 40, 21) - d1 - d2
+        part = split + Pos(0, 0, 11) * Box(8, 40, 1)
+        assert len(part.solids()) == 1  # the exterior bridge keeps the predicate body-local (#958)
+        assert recognise_slots(part) == []
 
     def test_stubby_blind_obround_pocket_is_recognised_not_a_slot(self):
         # #837: the blind counterpart of the stubby through-slot — a floored obround pocket whose

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1961,12 +1961,15 @@ class TestTheDimensionMirror:
             "plate+hole": Box(80, 50, 8) - Pos(-20, 0, 0) * Cylinder(4, 20),
             "flange (no envelope feature)": flange(),
             "stepped": Box(40, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20),
-            "slot": Box(80, 60, 12) - Pos(10, 0, 6) * Box(30, 8, 10),
+            "slot": Box(80, 60, 12) - Pos(10, 0, 0) * Box(30, 8, 20),
             "pocket": Box(80, 60, 20) - Pos(0, 0, 14) * Box(30, 20, 14),
             "two holes": Box(80, 50, 8)
             - Pos(-20, 0, 0) * Cylinder(4, 20)
             - Pos(20, 10, 0) * Cylinder(3, 20),
-            "pad": Box(80, 60, 10) + Pos(0, 0, 10) * Box(30, 20, 4),
+            # Box is centre-aligned by default: z=7 joins the pad's -2..2 span to
+            # the base's -5..5 top. z=10 leaves a 3 mm gap and used to exercise
+            # the cross-solid phantom recognition fixed by #958.
+            "pad": Box(80, 60, 10) + Pos(0, 0, 7) * Box(30, 20, 4),
             "bare block": Box(60, 40, 20),
             # A real X-axis bore. The first version used a rotated cylinder through a block
             # and detected NOTHING but an envelope, so the off-axis location path this corpus
@@ -2016,10 +2019,10 @@ class TestTheDimensionMirror:
         "plate+hole": {"hole"},
         "flange (no envelope feature)": {"hole", "pattern", "pad", "step"},
         "stepped": {"step_level"},
-        "slot": {"pocket"},
+        "slot": {"slot"},
         "pocket": {"pocket"},
         "two holes": {"hole"},
-        "pad": {"pad", "slot"},
+        "pad": {"pad"},
         "bare block": {"envelope"},
         "side-drilled": {"hole"},
         "boss": {"boss"},
@@ -3003,7 +3006,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
             "fillet": _chamfered_corner(bd_fillet, 3),
             "flat": Cylinder(10, 30) - Pos(10, 0, 0) * Box(10, 40, 40),
             "groove": Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(8, 4)),
-            "pad": Box(80, 60, 10) + Pos(0, 0, 10) * Box(30, 20, 4),
+            "pad": Box(80, 60, 10) + Pos(0, 0, 7) * Box(30, 20, 4),
             "channel": Box(50, 50, 12)
             + Pos(0, -18.75, 15) * Box(50, 12.5, 18)
             + Pos(0, 18.75, 15) * Box(50, 12.5, 18),


### PR DESCRIPTION
## Summary

- scan slots, pockets, channels, and rectangular pads independently within each physical solid
- preserve the public once-per-family recognition boundary and deterministic aggregate ordering
- correct dimension-mirror fixtures that relied on a detached-pad phantom to claim slot coverage
- preserve genuine features on every body while keeping cross-body derived pattern ownership in #1073

## Adversarial review

- aggregate-scan mutations for all four families are killed by independent physical counterexamples
- attached one-solid pad remains one pad, no slot, dimensioned once, and lint-clean
- genuine slots, pads, pockets, and channels on two separate bodies remain two records
- ADR 0013/0015/0017 review found no boundary change: records remain geometry-only and each public family is still called once

## Validation

- `scripts/pr-check --quick`
- 60 focused recognition/manifest/contract tests
- 460 broad slot, pocket, model, Sheet emit tests after correcting the latent corpus fixtures
- #958 regression file: 10 passed
- full fast tier: 2927 passed, 1 skipped, 2 xfailed; only failure was the known coverage-sensitive 10 s layout performance guard tracked in #1071
- changed production lines: 100% diff coverage

Closes #958
Closes #1074
Refs #1073
Refs #1071