### PR TITLE
Reuse detected whole-part envelopes

### DIFF
--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1176,8 +1176,19 @@ class Sheet:
         return _Params(self, len(self._features) - 1)
 
     def envelope(self, obj=None) -> _Params:
-        """Declare the overall bounding dimensions. Defaults to the whole part."""
-        self._features.append(_envelope(obj if obj is not None else self._part))
+        """Declare the overall bounding dimensions. Defaults to the whole part.
+
+        The no-argument form reuses an equal whole-part envelope already seeded by
+        :meth:`from_part`; its returned handle therefore decorates and dimensions that
+        detected feature instead of appending a duplicate. An explicit *obj* remains a
+        distinct declaration, including when another envelope is already present.
+        """
+        feature = _envelope(obj if obj is not None else self._part)
+        if obj is None:
+            for index, existing in enumerate(self._features):
+                if existing == feature:
+                    return _Params(self, index)
+        self._features.append(feature)
         return _Params(self, len(self._features) - 1)
 
     # -- GD&T / finish aspects (ADR 0011 P2c, #479) ---------------------------

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -2012,6 +2012,9 @@ def test_the_declared_envelope_equals_the_detected_one():
             f for f in build_part_model(_solids_body(obj)).features if f.kind == "envelope"
         )
         declared = declare_envelope(obj)
+        assert detected == declared, (
+            f"{name}: exact equality is required for Sheet.envelope() to reuse detection"
+        )
         # EVERY field, not just the two that were wrong. The name says equal, so it compares
         # equal — `frame.axis`, `bbox_min` and `bbox_max` went unchecked in the first cut, and a
         # property test that inspects a subset is the shape both earlier bugs hid in.

--- a/tests/test_issue_1000_envelope_reuse.py
+++ b/tests/test_issue_1000_envelope_reuse.py
@@ -1,0 +1,90 @@
+"""Regression coverage for hybrid whole-part envelope declarations (#1000)."""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet, SoftDeprecationWarning
+
+
+def _envelopes(sheet: Sheet) -> list:
+    return [feature for feature in sheet.features if feature.kind == "envelope"]
+
+
+def test_from_part_no_arg_envelope_reuses_the_detected_feature_and_handle():
+    part = Box(30, 20, 5)
+    sheet = Sheet.from_part(part)
+    detected = _envelopes(sheet)
+    assert len(detected) == 1, "the fixture must start with detection's whole-part envelope"
+
+    whole = sheet.envelope()
+    whole.tolerance(0.05, on="width")
+    sheet.dimension(whole, "width.length")
+
+    model = sheet.model()
+    assert _envelopes(sheet) == detected, "the no-arg declaration must not append a duplicate"
+    assert len(model.authored_dimensions) == 1
+    assert model.authored_dimensions[0].feature is model.features[0]
+    assert model.authored_dimensions[0].role == "width.length"
+
+    decorations = list(model.decorations.items())
+    assert len(decorations) == 1
+    (feature, kind, role), tolerance = decorations[0]
+    assert feature is model.features[0], "the returned handle must retain the detected token"
+    assert (kind, role, tolerance) == ("length", "width", 0.05)
+
+
+def test_reused_envelope_does_not_create_phantom_suppressions():
+    sheet = Sheet.from_part(Box(30, 20, 5))
+    sheet.dimension(sheet.envelope(), "width.length")
+
+    rows = sheet.build().suppressions()
+    assert sorted(row["parameter_id"] for row in rows) == ["depth.length", "height.length"]
+    assert all(row["authored"] for row in rows)
+
+
+def test_plain_sheet_no_arg_envelope_still_declares_one():
+    with pytest.warns(SoftDeprecationWarning):
+        sheet = Sheet(Box(30, 20, 5)).auto_dimensions()
+
+    sheet.envelope()
+    assert len(_envelopes(sheet)) == 1
+
+
+def test_explicit_subobject_envelope_remains_a_distinct_declaration():
+    sheet = Sheet.from_part(Box(30, 20, 5))
+
+    sheet.envelope(Box(10, 8, 3))
+
+    assert [(feature.width, feature.depth, feature.height) for feature in _envelopes(sheet)] == [
+        (30.0, 20.0, 5.0),
+        (10.0, 8.0, 3.0),
+    ]
+
+
+def test_explicit_equal_object_remains_a_distinct_declaration():
+    part = Box(30, 20, 5)
+    sheet = Sheet.from_part(part)
+
+    sheet.envelope(part)
+
+    envelopes = _envelopes(sheet)
+    assert len(envelopes) == 2
+    assert envelopes[0] == envelopes[1], (
+        "the explicit-object form declares separately even when its geometry is whole-part equal"
+    )
+
+
+def test_no_arg_envelope_reuses_by_equality_not_kind():
+    sheet = Sheet.from_part(Box(30, 20, 5))
+    sheet.envelope(Box(10, 8, 3))
+    sheet.features.reverse()  # put the sub-envelope before the whole-part envelope
+
+    whole = sheet.envelope()
+    whole.tolerance(0.1, on="width")
+
+    assert len(_envelopes(sheet)) == 2
+    ((feature, kind, role), tolerance) = next(iter(sheet.model().decorations.items()))
+    assert feature.width == 30.0, "a kind-only lookup would bind the handle to the sub-envelope"
+    assert (kind, role, tolerance) == ("length", "width", 0.1)


### PR DESCRIPTION
Closes #1000

## What changed
- make no-argument `Sheet.envelope()` reuse an equal whole-part envelope already seeded by `Sheet.from_part()`
- preserve token identity so the returned handle decorates and dimensions the detected feature
- keep explicit `envelope(obj)` declarations distinct, including equal geometry
- add suppression-ledger and adversarial regressions for unconditional append, kind-only matching, and over-eager explicit deduplication

## Validation
- `uv run pytest -q tests/test_issue_1000_envelope_reuse.py` (6 passed)
- `uv run pytest -q tests/test_declare.py tests/test_sheet_identity_invariant.py tests/test_suppression_ledger.py` (334 passed)
- `scripts/pr-check --quick` (73 passed; static gates clean)

## Review evidence
- unconditional-append mutation fails the cardinality and suppression tests
- kind-only matching mutation binds the handle to a reordered sub-envelope and fails
- removing the no-argument gate deduplicates explicit equal geometry and fails