### PR TITLE
Record turned step measurement identity

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -19,6 +19,7 @@ once the holes epic landed (#251).
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass, replace
 from typing import Any
 
 from build123d_drafting import DatumFeature, FeatureControlFrame, SurfaceFinish, TextBlock
@@ -2603,7 +2604,35 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
     return n
 
 
-def _record_step_chain_drop(dwg, why: str, *, ctx) -> None:
+@dataclass(frozen=True)
+class _StepChainSegment:
+    """One step-length claim as it moves from part space through page projection.
+
+    The old positional tuples lost the compiled measurement id when they were rebuilt by
+    projection, repeat-run collapse, and detail redraws. Keeping the claim named makes those
+    transformations state explicitly whether they preserve, combine, or intentionally omit
+    identity (#1004).
+    """
+
+    pa: tuple[float, float, float]
+    pb: tuple[float, float, float]
+    value: float
+    tolerance: Any = None
+    measurements: tuple[Any, ...] = ()
+    label: str | None = None
+
+
+def _step_measurements(segs: list[_StepChainSegment]) -> tuple[Any, ...]:
+    """Stable union of the measurements represented by *segs*."""
+    result: list[Any] = []
+    for seg in segs:
+        for measurement in seg.measurements:
+            if measurement not in result:
+                result.append(measurement)
+    return tuple(result)
+
+
+def _record_step_chain_drop(dwg, why: str, *, ctx, measurement=()) -> None:
     """Record the ``step_dim_dropped`` lint warning when a turned step-length chain
     is dropped whole (#362). These drops were silent (debug log only) — the user got
     a drawing with no step-length dimensioning and no signal. Mirrors
@@ -2616,14 +2645,15 @@ def _record_step_chain_drop(dwg, why: str, *, ctx) -> None:
         "warning",
         "step_dim_dropped",
         f"step-length chain dropped: {why} at this scale (use a detail view)",
+        measurement=measurement,
     )
 
 
 def _draw_step_chain(
     dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True, *, ctx, start=0
 ) -> int:
-    """Place a turned step-length chain in *view* from *segs* — each ``(pa, pb,
-    value)`` already projected to *view*'s page coords, in axis order. Orientation is
+    """Place a turned step-length chain in *view* from structured *segs*, each already
+    projected to *view*'s page coords in axis order. Orientation is
     data (the projected span direction): horizontal → chain above the view, vertical
     → chain to the right. A uniform run collapses to one ``N× v`` dim (#230); else a
     per-segment chain, staggered into a near/far tier only when crowded (ISO 129-1,
@@ -2643,34 +2673,37 @@ def _draw_step_chain(
     x0, y0, x1, y1 = vb
     draft = dwg.draft
     gap = draft.font_size + 4 * draft.pad_around_text
-    horizontal = abs(segs[0][1][0] - segs[0][0][0]) >= abs(segs[0][1][1] - segs[0][0][1])
-    vals = [s[2] for s in segs]  # value is index 2 (segs are 4-tuples: pa, pb, value, tol)
-    labels = [s[4] if len(s) > 4 and s[4] is not None else _fmt(s[2]) for s in segs]
+    horizontal = abs(segs[0].pb[0] - segs[0].pa[0]) >= abs(segs[0].pb[1] - segs[0].pa[1])
+    vals = [seg.value for seg in segs]
+    labels = [seg.label if seg.label is not None else _fmt(seg.value) for seg in segs]
     mean_v = sum(vals) / len(vals)
     if (
         allow_collapse
-        and all(len(s) < 5 or s[4] is None for s in segs)
+        and all(seg.label is None for seg in segs)
         and len(segs) >= 3
         and (max(vals) - min(vals)) <= 0.10 * mean_v
     ):
         # A uniform run collapses to one "N× v" dim; a per-step ± would be a false claim on
         # N equal steps, so the collapse carries NO tolerance (#28 / P2a).
         label = f"{len(segs)}× {_fmt(mean_v)}"
-        xs = [p[0] for pa, pb, *_ in segs for p in (pa, pb)]
-        ys = [p[1] for pa, pb, *_ in segs for p in (pa, pb)]
+        xs = [p[0] for seg in segs for p in (seg.pa, seg.pb)]
+        ys = [p[1] for seg in segs for p in (seg.pa, seg.pb)]
         if horizontal:
             dim = _dim((min(xs), y1, 0), (max(xs), y1, 0), "above", gap, draft, label=label)
         else:
             dim = _dim((x1, min(ys), 0), (x1, max(ys), 0), "right", gap, draft, label=label)
         typ_name = f"{name_prefix}_typ" if start == 0 else f"{name_prefix}_typ{start}"
-        candidates = [(typ_name, dim)]
+        candidates = [(typ_name, dim, _step_measurements(segs))]
     else:
         tier_step = draft.font_size + 2 * draft.pad_around_text
         tiers = [0] * len(segs)
         if horizontal:
             cw = [
-                ((s[0][0] + s[1][0]) / 2, len(labels[i]) * draft.font_size * _EST_CHAR_WIDTH_EM)
-                for i, s in enumerate(segs)
+                (
+                    (seg.pa[0] + seg.pb[0]) / 2,
+                    len(labels[i]) * draft.font_size * _EST_CHAR_WIDTH_EM,
+                )
+                for i, seg in enumerate(segs)
             ]
 
             def _clear(items):
@@ -2686,7 +2719,10 @@ def _draw_step_chain(
             else:
                 _log.info("step-length chain skipped: too dense even when staggered")
                 _record_step_chain_drop(
-                    dwg, "shoulders too dense to dimension even when staggered", ctx=ctx
+                    dwg,
+                    "shoulders too dense to dimension even when staggered",
+                    ctx=ctx,
+                    measurement=_step_measurements(segs),
                 )
                 if ev is not None:
                     ev["items"].append(
@@ -2694,11 +2730,14 @@ def _draw_step_chain(
                     )
                 return 0
         else:
-            shoulder_ys = sorted({c for pa, pb, *_ in segs for c in (pa[1], pb[1])})
+            shoulder_ys = sorted({c for seg in segs for c in (seg.pa[1], seg.pb[1])})
             if any(b - a < tier_step for a, b in zip(shoulder_ys, shoulder_ys[1:])):
                 _log.info("step-length chain skipped: shoulders too close to dimension")
                 _record_step_chain_drop(
-                    dwg, "turned shoulders too closely spaced to dimension", ctx=ctx
+                    dwg,
+                    "turned shoulders too closely spaced to dimension",
+                    ctx=ctx,
+                    measurement=_step_measurements(segs),
                 )
                 if ev is not None:
                     ev["items"].append(
@@ -2712,37 +2751,50 @@ def _draw_step_chain(
 
         candidates = []
         for i, seg in enumerate(segs):
-            pa, pb, value, seg_tol, *_rest = seg
             if horizontal:
-                p1, p2, side = (pa[0], y1, 0), (pb[0], y1, 0), "above"
+                p1, p2, side = (seg.pa[0], y1, 0), (seg.pb[0], y1, 0), "above"
                 dist = gap + tiers[i] * tier_step
             else:
-                p1, p2, side = (x1, pa[1], 0), (x1, pb[1], 0), "right"
+                p1, p2, side = (x1, seg.pa[1], 0), (x1, seg.pb[1], 0), "right"
                 dist = gap
             candidates.append(
                 (
                     f"{name_prefix}{start + i}",
-                    _dim(p1, p2, side, dist, draft, label=labels[i], tolerance=seg_tol),
+                    _dim(
+                        p1,
+                        p2,
+                        side,
+                        dist,
+                        draft,
+                        label=labels[i],
+                        tolerance=seg.tolerance,
+                    ),
+                    seg.measurements,
                 )
             )
 
     # Room guard: if any dim would fall off the drawable page, place NONE.
     page = (_MARGIN, _MARGIN, dwg.page_w - _MARGIN, dwg.page_h - _MARGIN)
-    for _, dim in candidates:
+    for _, dim, _measurements in candidates:
         box = _anno_box(dim)
         if box is not None and not (
             page[0] <= box[0] and box[2] <= page[2] and page[1] <= box[1] and box[3] <= page[3]
         ):
-            _record_step_chain_drop(dwg, "a dimension would fall off the drawable page", ctx=ctx)
+            _record_step_chain_drop(
+                dwg,
+                "a dimension would fall off the drawable page",
+                ctx=ctx,
+                measurement=_step_measurements(segs),
+            )
             if ev is not None:
                 ev["items"].append(
                     {"name": name_prefix, "outcome": "dropped", "reason": "off_page"}
                 )
             return 0
-    for name, dim in candidates:
+    for name, dim, measurements in candidates:
         if detail_scale is not None:
             dim._dw_scale = detail_scale
-        ctx.place(dim, name, view=view)
+        ctx.place(dim, name, view=view, measurement=measurements)
         if ev is not None:
             b = _anno_box(dim)
             ev["items"].append(
@@ -2781,7 +2833,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     `DetailRequest` (#304/#307) is queued to break it down. If the detail later can't
     place, the block still locates the head extent and lint reports the un-located
     interior shoulders — never worse than the prior skip. Returns the count placed."""
-    rows = []  # (axis, a_world, b_world, value, tolerance) in axis order
+    rows: list[tuple[str, _StepChainSegment]] = []
     step_origins = []
     for g in plan.of_kind("step"):
         if g.facts.frame.axis not in ("x", "y", "z"):
@@ -2794,10 +2846,13 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
         rows.append(
             (
                 g.facts.frame.axis,
-                length.span[0],
-                length.span[1],
-                length.value,
-                length.tolerance,
+                _StepChainSegment(
+                    length.span[0],
+                    length.span[1],
+                    length.value,
+                    length.tolerance,
+                    (length.id,) if length.id is not None else (),
+                ),
             )
         )
         step_origins.append(g.facts.frame.origin)
@@ -2807,7 +2862,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     # only=None (auto-pass) → start=0, historical m_steplen naming, byte-identical. The
     # finalize path (only set) starts past existing m_steplen names (#426 naming seam).
     start = _next_steplen_start(ctx) if only is not None else 0
-    axes = {axis for axis, *_ in rows}
+    axes = {axis for axis, _seg in rows}
     if len(axes) != 1:
         _log.warning(
             "step-length chain has mixed axes; rendering each axis requires separate groups"
@@ -2815,9 +2870,9 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
         return 0
     turn_axis = next(iter(axes))
     view = "side" if turn_axis == "y" else "front"
-    bare_rows = [(a, b, v, t) for _axis, a, b, v, t in rows]
-    fsegs = [(dwg.at(view, *a), dwg.at(view, *b), v, t) for a, b, v, t in bare_rows]
-    horizontal = abs(fsegs[0][1][0] - fsegs[0][0][0]) >= abs(fsegs[0][1][1] - fsegs[0][0][1])
+    bare_rows = [seg for _axis, seg in rows]
+    fsegs = [replace(seg, pa=dwg.at(view, *seg.pa), pb=dwg.at(view, *seg.pb)) for seg in bare_rows]
+    horizontal = abs(fsegs[0].pb[0] - fsegs[0].pa[0]) >= abs(fsegs[0].pb[1] - fsegs[0].pa[1])
 
     # A Y-turned chain that would need near/far staggering is ambiguous in the
     # narrow side view: an interior far-tier segment reads like an overall
@@ -2826,29 +2881,27 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     if horizontal and turn_axis == "y" and len(fsegs) >= 2:
         label_widths = [
             _text_size(
-                _fmt(v) + _tol_suffix(t, draft),
+                _fmt(seg.value) + _tol_suffix(seg.tolerance, draft),
                 draft.font_size,
                 font=getattr(draft, "font", "Arial"),
             )[0]
-            for *_span, v, t in bare_rows
+            for seg in bare_rows
         ]
-        cw = sorted(
-            ((pa[0] + pb[0]) / 2, label_widths[i]) for i, (pa, pb, *_rest) in enumerate(fsegs)
-        )
+        cw = sorted(((seg.pa[0] + seg.pb[0]) / 2, label_widths[i]) for i, seg in enumerate(fsegs))
         labels_clear = all(
             c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
             for (c1, w1), (c2, w2) in zip(cw, cw[1:])
         )
         inside_arrows_fit = all(
-            abs(pb[0] - pa[0])
+            abs(seg.pb[0] - seg.pa[0])
             >= label_widths[i] + 2 * draft.arrow_length + 2 * draft.pad_around_text
-            for i, (pa, pb, *_rest) in enumerate(fsegs)
+            for i, seg in enumerate(fsegs)
         )
         # A long repeated-pitch tail can be stated once on the main view. This
         # removes several competing short labels and may make the remaining
         # isolated links readable without an enlarged detail (#881/#896).
-        ordered = sorted(fsegs, key=lambda seg: (seg[0][0] + seg[1][0]) / 2)
-        compact: list[tuple] = []
+        ordered = sorted(fsegs, key=lambda seg: (seg.pa[0] + seg.pb[0]) / 2)
+        compact: list[_StepChainSegment] = []
         collapsed = False
         j = 0
         while j < len(ordered):
@@ -2856,27 +2909,27 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
             k = j + 1
             while k < len(ordered):
                 prev, cur = repeat_run[-1], ordered[k]
-                contiguous = abs(max(prev[0][0], prev[1][0]) - min(cur[0][0], cur[1][0])) <= 1e-4
+                contiguous = abs(max(prev.pa[0], prev.pb[0]) - min(cur.pa[0], cur.pb[0])) <= 1e-4
                 if not (
                     contiguous
-                    and _fmt(cur[2]) == _fmt(repeat_run[0][2])
-                    and prev[3] is None
-                    and cur[3] is None
+                    and _fmt(cur.value) == _fmt(repeat_run[0].value)
+                    and prev.tolerance is None
+                    and cur.tolerance is None
                 ):
                     break
                 repeat_run.append(cur)
                 k += 1
             if len(repeat_run) >= 3:
-                xs = [p[0] for seg in repeat_run for p in seg[:2]]
-                y = repeat_run[0][0][1]
-                pitch = sum(seg[2] for seg in repeat_run) / len(repeat_run)
+                xs = [p[0] for seg in repeat_run for p in (seg.pa, seg.pb)]
+                y = repeat_run[0].pa[1]
+                pitch = sum(seg.value for seg in repeat_run) / len(repeat_run)
                 compact.append(
-                    (
+                    _StepChainSegment(
                         (min(xs), y, 0.0),
                         (max(xs), y, 0.0),
-                        sum(seg[2] for seg in repeat_run),
-                        None,
-                        f"{len(repeat_run)}× {_fmt(pitch)}",
+                        sum(seg.value for seg in repeat_run),
+                        measurements=_step_measurements(repeat_run),
+                        label=f"{len(repeat_run)}× {_fmt(pitch)}",
                     )
                 )
                 collapsed = True
@@ -2894,22 +2947,21 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                 start=start,
             )
         if not (labels_clear and inside_arrows_fit):
-            axis_lo = min(min(a[1], b[1]) for a, b, *_ in bare_rows)
-            axis_hi = max(max(a[1], b[1]) for a, b, *_ in bare_rows)
-            page_xs = [p[0] for pa, pb, *_ in fsegs for p in (pa, pb)]
-            page_y = fsegs[0][0][1]
+            axis_lo = min(min(seg.pa[1], seg.pb[1]) for seg in bare_rows)
+            axis_hi = max(max(seg.pa[1], seg.pb[1]) for seg in bare_rows)
+            page_xs = [p[0] for seg in fsegs for p in (seg.pa, seg.pb)]
+            page_y = fsegs[0].pa[1]
             block = [
-                (
+                _StepChainSegment(
                     (min(page_xs), page_y, 0.0),
                     (max(page_xs), page_y, 0.0),
                     axis_hi - axis_lo,
-                    None,
                 )
             ]
             scale_needed = max(
-                (w + 2 * draft.arrow_length + 2 * draft.pad_around_text) / row[2]
+                (w + 2 * draft.arrow_length + 2 * draft.pad_around_text) / row.value
                 for w, row in zip(label_widths, bare_rows)
-                if row[2] > 0
+                if row.value > 0
             )
 
             # Use the detected turning axis, not the sheet/bounding-box centroid:
@@ -2943,11 +2995,11 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                     return (px, py, 0.0)
 
                 dpairs = [
-                    ((_at(*a), _at(*b), v, t), label_widths[i])
-                    for i, (a, b, v, t) in enumerate(_rows)
+                    (replace(seg, pa=_at(*seg.pa), pb=_at(*seg.pb)), label_widths[i])
+                    for i, seg in enumerate(_rows)
                 ]
-                dpairs.sort(key=lambda item: (item[0][0][0] + item[0][1][0]) / 2)
-                dsegs: list[tuple] = []
+                dpairs.sort(key=lambda item: (item[0].pa[0] + item[0].pb[0]) / 2)
+                dsegs: list[_StepChainSegment] = []
                 detail_widths: list[float] = []
                 j = 0
                 while j < len(dpairs):
@@ -2958,29 +3010,29 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                         prev, _prev_width = run[-1]
                         cur, _cur_width = dpairs[k]
                         contiguous = (
-                            abs(max(prev[0][0], prev[1][0]) - min(cur[0][0], cur[1][0])) <= 1e-4
+                            abs(max(prev.pa[0], prev.pb[0]) - min(cur.pa[0], cur.pb[0])) <= 1e-4
                         )
                         # A repeated-pitch claim must be true at the drawing's
                         # displayed precision, not merely "within 10%".
-                        equal = _fmt(cur[2]) == _fmt(seg0[2])
-                        untoleranced = prev[3] is None and cur[3] is None
+                        equal = _fmt(cur.value) == _fmt(seg0.value)
+                        untoleranced = prev.tolerance is None and cur.tolerance is None
                         if not (contiguous and equal and untoleranced):
                             break
                         run.append(dpairs[k])
                         k += 1
                     if len(run) >= 3:
                         run_segs = [seg for seg, _width in run]
-                        xs = [p[0] for seg in run_segs for p in seg[:2]]
-                        y = run_segs[0][0][1]
-                        pitch = sum(seg[2] for seg in run_segs) / len(run_segs)
+                        xs = [p[0] for seg in run_segs for p in (seg.pa, seg.pb)]
+                        y = run_segs[0].pa[1]
+                        pitch = sum(seg.value for seg in run_segs) / len(run_segs)
                         label = f"{len(run_segs)}× {_fmt(pitch)}"
                         dsegs.append(
-                            (
+                            _StepChainSegment(
                                 (min(xs), y, 0.0),
                                 (max(xs), y, 0.0),
-                                sum(seg[2] for seg in run_segs),
-                                None,
-                                label,
+                                sum(seg.value for seg in run_segs),
+                                measurements=_step_measurements(run_segs),
+                                label=label,
                             )
                         )
                         detail_widths.append(
@@ -2999,8 +3051,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                 # both text clearance and full inside-arrow capacity at the actual
                 # fitted scale; returning zero transactionally drops the detail.
                 dcw = sorted(
-                    ((pa[0] + pb[0]) / 2, detail_widths[i])
-                    for i, (pa, pb, *_rest) in enumerate(dsegs)
+                    ((seg.pa[0] + seg.pb[0]) / 2, detail_widths[i]) for i, seg in enumerate(dsegs)
                 )
                 if not all(
                     c2 - c1 >= (w1 + w2) / 2 + draft.pad_around_text
@@ -3012,9 +3063,9 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                     )
                     return 0
                 if any(
-                    abs(pb[0] - pa[0])
+                    abs(seg.pb[0] - seg.pa[0])
                     < detail_widths[i] + 2 * draft.arrow_length + 2 * draft.pad_around_text
-                    for i, (pa, pb, *_rest) in enumerate(dsegs)
+                    for i, seg in enumerate(dsegs)
                 ):
                     _log.info(
                         "Y-chain detail rejected at scale %.3g: label + inside arrows "
@@ -3063,7 +3114,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     # (#307 review). The legible steps + blocks stay as the main chain.
     if horizontal and turn_axis == "x":
         floor_pg = 2 * draft.arrow_length
-        sub = [i for i, (pa, pb, *_) in enumerate(fsegs) if abs(pb[0] - pa[0]) < floor_pg]
+        sub = [i for i, seg in enumerate(fsegs) if abs(seg.pb[0] - seg.pa[0]) < floor_pg]
         runs: list[list[int]] = []
         for j in sub:
             (runs[-1].append(j) if runs and j == runs[-1][-1] + 1 else runs.append([j]))
@@ -3072,15 +3123,19 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
             blocks = []
             for run in heads:
                 ra = [bare_rows[i] for i in run]
-                hlo = min(min(a[0], b[0]) for a, b, *_ in ra)
-                hhi = max(max(a[0], b[0]) for a, b, *_ in ra)
-                minlen = min(r[2] for r in ra)  # value is index 2 (rows are 4-tuples: a,b,v,tol)
+                hlo = min(min(seg.pa[0], seg.pb[0]) for seg in ra)
+                hhi = max(max(seg.pa[0], seg.pb[0]) for seg in ra)
+                minlen = min(seg.value for seg in ra)
                 # World→page scale for the detail (no sheet factor — detail_scale is an
                 # absolute world→page scale). (#307 review)
                 scale_needed = _MIN_STEP_SEP_MM / minlen if minlen > 0 else float("inf")
                 # A head *block* is a synthetic span, not one toleranced step — carry no ± (None).
                 blocks.append(
-                    (dwg.at("front", hlo, 0, 0), dwg.at("front", hhi, 0, 0), hhi - hlo, None)
+                    _StepChainSegment(
+                        dwg.at("front", hlo, 0, 0),
+                        dwg.at("front", hhi, 0, 0),
+                        hhi - hlo,
+                    )
                 )
 
                 def _redraw(dwg, view, coords, detail_scale, _hw=ra):
@@ -3091,7 +3146,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                         px, py = coords.pp(x, y, z)
                         return (px, py, 0.0)
 
-                    hsegs = [(_at(*a), _at(*b), v, t) for a, b, v, t in _hw]
+                    hsegs = [replace(seg, pa=_at(*seg.pa), pb=_at(*seg.pb)) for seg in _hw]
                     return _draw_step_chain(
                         dwg, view, hsegs, f"dim_{view}_steplen", detail_scale, ctx=ctx
                     )
@@ -3110,7 +3165,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                 )
             head = {i for run in heads for i in run}
             main = [fsegs[i] for i in range(len(fsegs)) if i not in head] + blocks
-            main.sort(key=lambda s: s[0][0])
+            main.sort(key=lambda seg: seg.pa[0])
             # The chain now mixes head-block(s) with real steps — never collapse it to a
             # uniform "N× v" representative (a block is not a repeated step, #307 review).
             return _draw_step_chain(
@@ -3137,8 +3192,6 @@ def ladder_plan_for(plan, *, step_height: bool, overall: bool):
     `step_position` rides `step_height`: it is not content here, it is how those rungs are
     placed, so it is meaningless without them.
     """
-    from dataclasses import replace
-
     kinds = []
     if step_height:
         kinds += ["step_height", "step_position"]

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -25,11 +25,8 @@ was believable both times, which is the point.
 The answer lives in `tests/test_audit_differential.py`, whose ratchet scans both placement
 paths (corridor candidates and direct `ctx.place`) across the whole `annotations/` package,
 and whose EXEMPT map IS the exception inventory — every entry carrying its reason, and a
-stale entry failing so the list cannot outlive the gaps it describes. Read that, not this
-paragraph. At the time of writing the gaps are hole callouts (legacy surface, #926), PMI
-(from STEP, never compiled), GD&T frames (not measurements), the direct-placing rotational
-group (#754), the turned step-length chain (#1004) and the pattern pitch/side-hole
-placers (#1005).
+stale entry failing so the list cannot outlive the gaps it describes. Read that, not a
+second prose inventory here.
 
 Even where identity IS recorded, matching it across two builds is approximate. The ledger's
 key embeds the feature's origin and scalars, so it cannot join two builds that differ — the

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -707,7 +707,6 @@ def test_every_direct_placement_records_identity_or_says_why_not():
         # -- gaps that ARE measurements, with the id not yet plumbed ----------------
         # Named individually rather than waved at, because each is a real hole in the
         # audit's attribution and each needs its own plumbing.
-        ("from_model.py", "_draw_step_chain"): "step-chain segs carry no id (#1004)",
         ("holes.py", "_off_axis_queue"): "side-hole location candidates, no id map (#1005)",
         # -- identity arrives by another route --------------------------------------
         ("from_model.py", "_reroute_crossing_diameters"): "reapplies the saved identity",

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8818,6 +8818,18 @@ def _x_stepped_shaft():
     return Rotation(0, 90, 0) * (Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(8, 30))
 
 
+def _compiled_step_length_ids(dwg):
+    from draftwright.model.compiled import compile_dimensions
+
+    ids = {
+        dimension.id
+        for group in compile_dimensions(dwg.model()).of_kind("step")
+        if (dimension := group.dim(kind="length")) is not None
+    }
+    assert None not in ids
+    return ids
+
+
 class TestPrismaticBossDiameter:
     """#629: a boss on a PRISMATIC part gets its ø as a plan-view leader to the boss
     circle (names ``m_bossdia_*``), free to exit into clear margin — not the turned
@@ -9122,6 +9134,9 @@ class TestTurnedDiameters:
         assert step_labels >= {"8", "4"}
         assert "2" in step_labels or "4× 2" in step_labels
         assert {dwg.view_of(n) for n in dwg.annotations() if n.startswith("m_steplen")} == {"side"}
+        for name in (n for n in dwg.annotations() if n.startswith("m_steplen")):
+            expected = 4 if dwg.get_annotation(name).label == "4× 2" else 1
+            assert len(dwg.measurement_keys(name)) == expected
 
         # The central Y-axis bore shares the detected turned-profile axis. Its
         # centreline locates it; generic minimum-edge offsets would redundantly
@@ -9385,6 +9400,10 @@ class TestTurnedDiameters:
         assert {o.label for o in detail.values()} == {"3", "5.5", "3.5"}
         assert {dwg.view_of(n) for n in detail} == {"detail_a"}
         assert len({round(o._dw_spec.distance, 6) for o in detail.values()}) == 1
+        assert all(dwg.measurement_keys(name) == [] for name in main), (
+            "the aggregate block is not any one approved step measurement"
+        )
+        assert all(len(dwg.measurement_keys(name)) == 1 for name in detail)
 
         labels = sorted((o.label_bbox for o in detail.values()), key=lambda bb: bb[0])
         assert all(
@@ -9847,6 +9866,25 @@ class TestTurnedLengths:
         labels = {o.label for n, o in dwg.iter_annotations() if n.startswith("m_steplen")}
         assert labels == {"40", "30"}
 
+    @pytest.mark.parametrize(
+        "shaft",
+        [
+            pytest.param(_x_stepped_shaft(), id="x-turned"),
+            pytest.param(Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30), id="z-turned"),
+        ],
+    )
+    def test_each_step_length_records_its_measurement_identity(self, shaft):
+        dwg = build_drawing(shaft)
+        names = [name for name in dwg.annotations() if name.startswith("m_steplen")]
+        assert names
+        for name in names:
+            keys = dwg.measurement_keys(name)
+            assert len(keys) == 1, f"{name} must identify exactly the step length it draws"
+            assert keys[0]["feature"].startswith("step@")
+            assert keys[0]["parameter_id"] == "step.length"
+        recorded = {mid for name in names for mid in dwg.registry.measurement_of(name)}
+        assert recorded == _compiled_step_length_ids(dwg)
+
     def test_overall_width_suppressed_for_turned_part(self):
         # The complete chain conveys the overall length, so the envelope width dim
         # is dropped — no double dimensioning (ISO 129).
@@ -9886,6 +9924,12 @@ class TestTurnedLengths:
         steplen = {n: o.label for n, o in dwg.iter_annotations() if n.startswith("m_steplen")}
         assert steplen == {"m_steplen_typ": "4× 10"}, steplen
         assert "axial_length_missing" not in {i.code for i in dwg.lint()}
+
+        keys = dwg.measurement_keys("m_steplen_typ")
+        assert len(keys) == 4, "the collapsed annotation draws all four step lengths"
+        assert len({key["feature"] for key in keys}) == 4
+        assert {key["parameter_id"] for key in keys} == {"step.length"}
+        assert set(dwg.registry.measurement_of("m_steplen_typ")) == _compiled_step_length_ids(dwg)
 
     def test_prismatic_part_has_no_step_lengths(self):
         dwg = build_drawing(Box(80, 60, 20))
@@ -10011,8 +10055,13 @@ class TestTurnedLengths:
             z += ln
         dwg = build_drawing(Rotation(0, 90, 0) * shaft, scale=2.0)
         assert "detail_a" in dwg.views  # crowded head → enlarged detail
-        assert "25" in {o.label for n, o in dwg.iter_annotations() if n.startswith("m_steplen")}
-        assert len([n for n in dwg.annotations() if n.startswith("dim_detail_a_steplen")]) >= 3
+        main = {n: o for n, o in dwg.iter_annotations() if n.startswith("m_steplen")}
+        assert "25" in {o.label for o in main.values()}
+        block = next(name for name, obj in main.items() if obj.label != "25")
+        assert dwg.measurement_keys(block) == [], "the synthetic head extent is not one step"
+        detail = [n for n in dwg.annotations() if n.startswith("dim_detail_a_steplen")]
+        assert len(detail) >= 3
+        assert all(len(dwg.measurement_keys(name)) == 1 for name in detail)
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
 
     def test_two_sub_floor_runs_get_separate_non_colliding_details(self):

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -185,7 +185,7 @@ class TestStepChainDrop:
 
     def test_crowded_vertical_chain_records_the_drop(self):
         from draftwright.annotations._common import PlacementContext
-        from draftwright.annotations.from_model import _draw_step_chain
+        from draftwright.annotations.from_model import _draw_step_chain, _StepChainSegment
         from draftwright.registry import AnnotationRegistry
 
         dwg = self._stub_dwg()
@@ -195,13 +195,15 @@ class TestStepChainDrop:
         # far below tier_step (= font_size + 2*pad = 4). Values differ so the
         # uniform-collapse path is not taken. The chain is dropped whole.
         segs = [
-            ((80.0, 10.0, 0), (80.0, 10.1, 0), 5.0),
-            ((80.0, 10.1, 0), (80.0, 10.2, 0), 8.0),
+            _StepChainSegment((80.0, 10.0, 0), (80.0, 10.1, 0), 5.0, measurements=("step-a",)),
+            _StepChainSegment((80.0, 10.1, 0), (80.0, 10.2, 0), 8.0, measurements=("step-b",)),
         ]
         placed = _draw_step_chain(dwg, "front", segs, "m_steplen", ctx=ctx)
         assert placed == 0
         codes = [i.code for i in ctx.registry.issues]
         assert "step_dim_dropped" in codes, "silent drop no longer allowed (#362)"
+        drop = next(i for i in ctx.registry.issues if i.code == "step_dim_dropped")
+        assert drop.measurement_ids == ("step-a", "step-b")
         assert ctx.escalations == []  # _record_step_chain_drop records lint only, no Escalation
 
 

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -184,8 +184,10 @@ class TestStepChainDrop:
         return _Dwg()
 
     def test_crowded_vertical_chain_records_the_drop(self):
+        from types import SimpleNamespace
+
         from draftwright.annotations._common import PlacementContext
-        from draftwright.annotations.from_model import _draw_step_chain, _StepChainSegment
+        from draftwright.annotations.from_model import _draw_step_chain
         from draftwright.registry import AnnotationRegistry
 
         dwg = self._stub_dwg()
@@ -195,8 +197,22 @@ class TestStepChainDrop:
         # far below tier_step (= font_size + 2*pad = 4). Values differ so the
         # uniform-collapse path is not taken. The chain is dropped whole.
         segs = [
-            _StepChainSegment((80.0, 10.0, 0), (80.0, 10.1, 0), 5.0, measurements=("step-a",)),
-            _StepChainSegment((80.0, 10.1, 0), (80.0, 10.2, 0), 8.0, measurements=("step-b",)),
+            SimpleNamespace(
+                pa=(80.0, 10.0, 0),
+                pb=(80.0, 10.1, 0),
+                value=5.0,
+                tolerance=None,
+                measurements=("step-a",),
+                label=None,
+            ),
+            SimpleNamespace(
+                pa=(80.0, 10.1, 0),
+                pb=(80.0, 10.2, 0),
+                value=8.0,
+                tolerance=None,
+                measurements=("step-b",),
+                label=None,
+            ),
         ]
         placed = _draw_step_chain(dwg, "front", segs, "m_steplen", ctx=ctx)
         assert placed == 0


### PR DESCRIPTION
## Summary

- replace the turned step chain's positional tuples with a private structured segment that carries compiled measurement identities through projection and detail redraws
- record exact identities on ordinary dimensions, union all member identities on repeated-pitch marks, and attach affected identities to chain-drop diagnostics
- leave synthetic aggregate head/block spans deliberately unattributed, because they are not any one approved step measurement
- remove the direct-placement exemption and the duplicate prose inventory it made stale

## Why

`render_step_lengths` received `ApprovedDimension.id` but discarded it while converting the plan into bare geometry tuples. As a result the registry and `draftwright.audit` could not relate a placed or dropped step-length annotation to the compiled measurement it represented.

This remains renderer provenance only. It does not change recognition, compiler selection, labels, placement, or cross-build feature correspondence. Same-kind replacement remains #1006. The real omission review exposed the separate sorting crash in #1077.

## Adversarial review

- source-id removal is killed by X- and Z-turned exact-id tests
- retaining only the first id is killed for both the general uniform collapse and the Y-axis repeat collapse
- synthetic main-view blocks are asserted empty while their detail dimensions retain one exact id each
- existing strict placement goldens remain unchanged
- ADR 0010/0014/0015/0016 review found no new decision or alternate path

## Validation

- `scripts/pr-check --quick` (73 passed)
- 325 adjacent turned/render/audit/tolerance/declaration tests (324 passed, 1 skipped)
- `tests/test_refactor_golden.py` (14 passed)
- `mypy src/draftwright/`
- focused mutation checks for source, general collapse, and Y collapse identity loss

Closes #1004.
Refs #955, #1006, #1077.