### PR TITLE
Order nullable audit suppression rows

### DIFF
--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -101,6 +101,16 @@ def _rows(dwg) -> set[tuple]:
     return {(r["feature"], r["parameter_id"], r["reason"]) for r in dwg.suppressions()}
 
 
+def _suppression_sort_key(row: tuple) -> tuple:
+    """Total presentation order for public suppression rows, whose feature is nullable."""
+    feature, parameter, reason = row
+    return (
+        (feature is not None, feature or ""),
+        parameter,
+        (reason is not None, reason or ""),
+    )
+
+
 def _correspondence(feature, parameter) -> tuple:
     """The cross-build key: ``(feature KIND, parameter_id)``.
 
@@ -164,8 +174,8 @@ def diff_builds(before, after) -> dict:
     changed = {n: (v, after_dims[n]) for n, v in before_dims.items() if after_dims.get(n, v) != v}
 
     before_rows, after_rows = _rows(before), _rows(after)
-    gained_supp = sorted(after_rows - before_rows)
-    lost_supp = sorted(before_rows - after_rows)
+    gained_supp = sorted(after_rows - before_rows, key=_suppression_sort_key)
+    lost_supp = sorted(before_rows - after_rows, key=_suppression_sort_key)
 
     # A name present in BOTH builds that now draws a DIFFERENT measurement (#1002) — the
     # module's worst blind spot closed. An annotation name is an engine-assigned slot, so a

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -17,9 +17,9 @@ keeps it honest about the real `Drawing` surface.
 
 from __future__ import annotations
 
-from build123d import Box, BuildPart, Cylinder, Hole, Locations, Rot
+from build123d import Box, BuildPart, Cylinder, Hole, Locations, Pos, Rot
 
-from draftwright import build_drawing
+from draftwright import Sheet, build_drawing
 from draftwright.audit import diff_builds, explain
 
 
@@ -418,6 +418,32 @@ def test_it_works_on_real_drawings():
     assert "m_env_depth" in diff["dimensions_lost"], "the turned part states no depth"
     reasons = " ".join(r for _, _, r in diff["suppressions_gained"])
     assert "rotational OD" in reasons, "and the ledger says which rule took it"
+
+
+def test_real_mixed_featureless_and_feature_suppressions_have_a_total_order():
+    """#1077: an authored set can omit both a featureless overall dimension and a
+    feature-owned one. Those public ledger rows carry ``feature=None`` and ``feature=str``;
+    sorting the raw tuples crashes before the audit can report the loss.
+
+    Exercise both directions: gained suppressions in the authored build and lost
+    suppressions in the inverse comparison must preserve the public values unchanged.
+    """
+    part = Rot(0, 90, 0) * Cylinder(4, 20) + Pos(15, 0, 0) * Rot(0, 90, 0) * Cylinder(6, 10)
+    automatic = Sheet.from_part(part).build()
+    sheet = Sheet.from_part(part)
+    steps = [feature for feature in sheet.features if feature.kind == "step"]
+    assert len(steps) == 2
+    sheet.dimension(steps[0], "step.length")
+    authored = sheet.build()
+
+    forward = diff_builds(automatic, authored)
+    assert forward["dimensions_lost"]["m_steplen1"] == "10"
+    assert forward["candidate_explanations"]["m_steplen1"] == ["not in the authored dimension set"]
+    assert any(feature is None for feature, _parameter, _reason in forward["suppressions_gained"])
+
+    reverse = diff_builds(authored, automatic)
+    assert reverse["suppressions_lost"] == forward["suppressions_gained"]
+    assert any(feature is None for feature, _parameter, _reason in reverse["suppressions_lost"])
 
 
 def test_a_real_build_records_which_measurement_its_location_dims_draw():


### PR DESCRIPTION
## Summary

- order suppression ledger deltas with an explicit nullable-aware key
- preserve the public tuple values, including featureless `feature=None` omissions
- cover both gained and lost suppression directions with a real authored two-step drawing

## Why

`diff_builds()` sorted raw `(feature, parameter_id, reason)` tuples. An authored drawing can omit both the featureless overall height and feature-owned step measurements, so Python attempted to compare `None` with `str` and crashed before reporting the dimension loss.

The key is presentation-only. Set comparison, public row values, correspondence, and attribution behavior are unchanged.

## Adversarial review

- restoring raw tuple sorting fails with the original `TypeError`
- filtering featureless rows fails the retained-row assertion
- applying the key only to gained suppressions fails the inverse comparison
- no compiler, renderer, registry, or placement code changes

## Validation

- `scripts/pr-check --quick` (73 passed)
- audit/authored-dimension/strict-golden suites (169 passed, 1 skipped)
- focused audit coverage 97.7%
- full mypy and Ruff
- three mutation checks above

Closes #1077.
Refs #1004, #955.