### PR TITLE
Recover Z-turned height when step chain drops

### DIFF
--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -41,6 +41,10 @@ The part-drawing engine is a **compiler**:
   dimensioning planner (model/planner.py)   │  plan_dimensions → DimensionGroup
   plan_locations / plan_sections            │  per feature; convention + view +
                                             ▼  model-level suppression + datum
+  compile_dimensions() → RenderableDimensionPlan
+        approved groups / ladders / locations / contingencies + omission diagnostics
+                                            │
+                                            ▼
   render-intents → the IR render layer (annotations/from_model.py, holes.py)
                                             │
   shared layout / projection / export  (ADR 0014 placement, ADR 0004 pack,

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -1309,3 +1309,30 @@ silently acquiring an obligation.
 Incidentally the softer label is the louder signal: `DeprecationWarning` is filtered by
 default in notebooks, several test runners and library-internal call paths, whereas a
 `UserWarning` shows unconditionally.
+
+## Amendment 5 — placement may release a compiler-approved contingency (2026-08-07)
+
+**A plan may carry an approved alternative that stays inactive unless the primary
+representation places no marks.** The alternative is dimensional content, not permission for
+a renderer to derive content after placement.
+
+#955 supplied the concrete case. A Z-turned part normally states its axial extent through the
+step-length chain, so the overall height is omitted. Whether that chain survives is known only
+at placement: a crowded chain can be dropped transactionally. The compiler cannot predict the
+drop, while the renderer must not recover the height from the bounding box. Treating either
+layer as the owner breaks Amendment 1's WHAT/WHERE split.
+
+`RenderableDimensionPlan.contingencies` therefore carries the compiler-built
+`ApprovedLadder` for the overall height, paired with the primary representation and its
+inactive diagnostic. The orchestrator observes only the primary renderer's placement result:
+when the complete chain places zero marks, it releases the already-approved ladder and removes
+the now-stale omission. `render_height_ladder` receives an ordinary approved entry and remains
+unable to read the model or bounding box. If the released height also cannot fit, that is an
+ordinary placement drop, not suppression.
+
+Three constraints keep this from becoming a conditional-suppression flag under another name:
+
+- an authored omission prevents the contingency from being compiled at all;
+- a surviving primary leaves the fallback inactive and the omission diagnostic intact;
+- contingencies are addressable, so a generated authored `Sheet` script carries the fallback
+  intent and makes the same runtime selection as the detected build.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -37,6 +37,7 @@ from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import PlacementContext
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.from_model import (
+    ladder_plan_for,
     render_boss_diameters,
     render_boss_heights,
     render_centermarks,
@@ -345,6 +346,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # ladder, the shoulders and the detail escalation each hold a separately
     # derived decision — three chances to disagree about one drawing.
     _compiled = compile_dimensions(_model, groups=_groups)
+    # Placement may release compiler-approved alternatives. Keep that runtime selection
+    # separate from the immutable base plan consumed by every ordinary stage.
+    _runtime_plan = _compiled
 
     # Hole callouts, location dims, and the section view fire on *feature
     # presence*, independent of the turned/prismatic class (#10): the
@@ -526,8 +530,20 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # X-turned head queues an enlarged detail request (#304/#307) instead of
         # cramming; the envelope dim along the turning axis was suppressed so the chain
         # does not double-dimension the length.
+        nonlocal _runtime_plan
         if a.prof is not None:
-            render_step_lengths(dwg, _compiled, ctx=ctx)
+            placed = render_step_lengths(dwg, _compiled, ctx=ctx)
+            if placed == 0:
+                released = _runtime_plan.release_contingency("step_length")
+                if released is not _runtime_plan:
+                    _runtime_plan = released
+                    render_height_ladder(
+                        dwg,
+                        ladder_plan_for(_runtime_plan, step_height=False, overall=True),
+                        layout_frame(a),
+                        ctx=ctx,
+                        detail_view=detail_view,
+                    )
 
     def _s_off_axis_along():
         # Side-drilled (X/Y-axis) hole HEIGHT locations — queued after the mandatory
@@ -658,7 +674,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # The escalations live only on this per-run ctx (#639), discarded when _auto_annotate
     # returns — so nothing carries stale drops into a later deferred edit (#440), and there is
     # no drawing-level list to clear.
-    return _compiled.diagnostics
+    return _runtime_plan.diagnostics
 
 
 def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx):

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -1135,8 +1135,6 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
 
 def _overall_axial_extent_is_dimensioned(part, dwg, prof, tol: float = 0.6) -> bool:
     """Whether a profile-view dimension witnesses the turned profile's two outer ends."""
-    if not prof.shoulders:
-        return False
     view = "side" if prof.axis == "y" else "front"
     use_x = prof.axis in ("x", "y")
 

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -1133,6 +1133,32 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
     return len(covered_steps)
 
 
+def _overall_axial_extent_is_dimensioned(part, dwg, prof, tol: float = 0.6) -> bool:
+    """Whether a profile-view dimension witnesses the turned profile's two outer ends."""
+    if not prof.shoulders:
+        return False
+    view = "side" if prof.axis == "y" else "front"
+    use_x = prof.axis in ("x", "y")
+
+    def projected(station: float) -> float:
+        c = part.bounding_box().center()
+        point = [c.X, c.Y, c.Z]
+        point["xyz".index(prof.axis)] = station
+        x, y, *_ = dwg.at(view, *point)
+        return float(x if use_x else y)
+
+    lo, hi = projected(min(prof.shoulders)), projected(max(prof.shoulders))
+    for _name, annotation in dwg.annotations_in_view(view):
+        if not isinstance(annotation, Dimension):
+            continue
+        coords = {(x if use_x else y) for x, y in _dim_vertices(annotation)}
+        if any(abs(value - lo) <= tol for value in coords) and any(
+            abs(value - hi) <= tol for value in coords
+        ):
+            return True
+    return False
+
+
 def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     """Report a stepped turned part whose axial step lengths are undimensioned.
 
@@ -1167,6 +1193,18 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     # leaves its band uncovered, so a genuine gap still fires (reconcile rendered, not intent).
     covered += sum(1 for name in dwg.annotations() if name.startswith(f"m_groove_{prof.axis}"))
     if covered >= n:
+        return []
+    # #955: when placement drops the complete chain, its specific warning already says the
+    # shoulders remain unresolved. If the compiler-approved overall fallback survived, the
+    # generic "axial length absent" warning would duplicate that diagnosis even though the
+    # part's total extent is now stated. The drop is a required half of this condition: an
+    # authored drawing that chooses only the overall extent still lacks shoulder locations
+    # and must continue to receive ``axial_length_missing``.
+    registry = getattr(dwg, "registry", None)
+    chain_drop_reported = any(
+        issue.code == "step_dim_dropped" for issue in getattr(registry, "issues", ())
+    )
+    if chain_drop_reported and _overall_axial_extent_is_dimensioned(part, dwg, prof):
         return []
     return [
         LintIssue(

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -49,7 +49,7 @@ completeness:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from draftwright._geometry import _fmt
@@ -412,6 +412,22 @@ class Omission:
         return self.reason == _AUTHORED_OMISSION
 
 
+@dataclass(frozen=True)
+class ApprovedContingency:
+    """Compiler-approved content released only when its primary representation places none.
+
+    The fallback is dimensional content, not a renderer recipe: it is the same
+    :class:`ApprovedLadder` the renderer would receive on the ordinary path. ``inactive`` is
+    the planner diagnostic that remains truthful while the primary survives and is removed
+    when the fallback is released. Placement decides only whether the primary survived; it
+    never derives the fallback measurement.
+    """
+
+    primary: str
+    fallback: ApprovedLadder
+    inactive: Omission
+
+
 #: The role a script names for each ladder kind. The step kinds are absent deliberately:
 #: their members are the step feature's own parameters, already addressed through the group
 #: traversal, so naming them again would ask a script to declare one measurement twice.
@@ -497,6 +513,10 @@ class RenderableDimensionPlan:
     #: `span` is ``(datum, located point)`` and `axis` is the feature's frame axis — the
     #: two things the renderer needs and cannot derive.
     locations: tuple[ApprovedDimension, ...] = ()
+    #: Approved alternatives that are not drawn with their primary representation. They are
+    #: addressable because a generated authored script must carry the fallback intent even
+    #: when the automatic build did not need to release it.
+    contingencies: tuple[ApprovedContingency, ...] = ()
     diagnostics: tuple[Omission, ...] = field(default=())
 
     def of_kind(self, *kinds: str) -> tuple[ApprovedGroup, ...]:
@@ -511,13 +531,34 @@ class RenderableDimensionPlan:
         """The approved ladder of *kind*, or ``None`` if it was not approved."""
         return next((lad for lad in self.ladders if lad.kind == kind), None)
 
+    def contingency(self, primary: str) -> ApprovedContingency | None:
+        """The approved fallback for *primary*, or ``None`` when none was compiled."""
+        return next((item for item in self.contingencies if item.primary == primary), None)
+
+    def release_contingency(self, primary: str) -> RenderableDimensionPlan:
+        """Return a plan in which *primary*'s already-approved fallback is active.
+
+        Releasing removes the inactive planner diagnostic. A fallback that later fails to fit
+        is a placement drop and is reported by the renderer, not as a stale suppression.
+        """
+        selected = tuple(item for item in self.contingencies if item.primary == primary)
+        if not selected:
+            return self
+        inactive_ids = {id(item.inactive) for item in selected}
+        return replace(
+            self,
+            ladders=(*self.ladders, *(item.fallback for item in selected)),
+            contingencies=tuple(item for item in self.contingencies if item.primary != primary),
+            diagnostics=tuple(item for item in self.diagnostics if id(item) not in inactive_ids),
+        )
+
     #: The fields carrying approved dimensional content, each with how it names itself.
     #: `addressable()` iterates exactly this, and
     #: `test_compiled_plan_boundary.py::test_every_approved_collection_is_addressable` requires
     #: it to cover every such field — so a NEW compiler-owned category cannot be added without
     #: either flowing into generated scripts or being explicitly, visibly excluded (#946).
     #: `diagnostics` is not here: it is what was NOT approved, and has its own contract.
-    _ADDRESSABLE = ("groups", "ladders", "locations")
+    _ADDRESSABLE = ("groups", "ladders", "locations", "contingencies")
 
     def addressable(self) -> tuple[AddressableIntent, ...]:
         """Every approved intent, in plan order, as the target a script would name.
@@ -572,6 +613,14 @@ class RenderableDimensionPlan:
                 continue
             named.add(id(feature))
             out.append(AddressableIntent(approved.ref, "location"))
+        return out
+
+    def _addressable_contingencies(self) -> list[AddressableIntent]:
+        out: list[AddressableIntent] = []
+        for item in self.contingencies:
+            ladder = item.fallback
+            if ladder.kind in _LADDER_ROLE:
+                out.append(AddressableIntent(ladder.ref, _LADDER_ROLE[ladder.kind]))
         return out
 
     def omitted(self, kind: str) -> tuple[Omission, ...]:
@@ -739,8 +788,8 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
 
 
 def _compile_overall_height(
-    model: PartModel, marked, *, include_overall: bool
-) -> tuple[ApprovedLadder | None, list[Omission]]:
+    model: PartModel, marked, *, include_overall: bool, step_chain_approved: bool
+) -> tuple[ApprovedLadder | None, ApprovedContingency | None, list[Omission]]:
     """The part's overall height — the envelope's ``height`` parameter, drawn in the
     front-view right strip rather than below a view, which is why it rides the ladder.
 
@@ -758,29 +807,11 @@ def _compile_overall_height(
     bb: Any = model.bbox  # build123d BoundBox
     rot = next((f for f in model.features if isinstance(f, RotationalFeature)), None)
     if not include_overall:
-        return None, []
-    if model.orientation == "z":
-        return None, [
-            Omission(
-                env,
-                "height.length",
-                float(bb.size.Z),
-                "Z-turned (the step chain tiles the height)",
-            )
-        ]
-    if rot is not None and rot.frame.axis in ("x", "y"):
-        return None, [
-            Omission(
-                env,
-                "height.length",
-                float(bb.size.Z),
-                f"rotational OD ({rot.frame.axis}-axis) conveys the height",
-            )
-        ]
+        return None, None, []
+    mark = marked.get((id(env), "height.length")) if env is not None else None
     if env is not None:
-        mark = marked.get((id(env), "height.length"))
-        if mark is not None:
-            return None, [Omission(env, "height.length", mark[0], mark[1])]
+        if mark is not None and mark[1] == _AUTHORED_OMISSION:
+            return None, None, [Omission(env, "height.length", mark[0], mark[1])]
     elif model.authored_dimensions is not None:
         # No `EnvelopeFeature`, so the height falls back to the bounding box and no
         # parameter anywhere names it. An AUTHORED set is the drawing's complete
@@ -788,29 +819,58 @@ def _compile_overall_height(
         # for: declaring `.envelope()` is how the overall height becomes nameable (#876).
         # This is the one place the fallback lives, so refusing it is one branch rather
         # than a rule every renderer has to remember.
-        return None, [
-            Omission(None, "height.length", float(bb.size.Z), "not in the authored dimension set")
-        ]
+        return (
+            None,
+            None,
+            [
+                Omission(
+                    None, "height.length", float(bb.size.Z), "not in the authored dimension set"
+                )
+            ],
+        )
     value = float(env.height) if env is not None else float(bb.size.Z)
     env_ref = FeatureRef(env) if env is not None else None
     x, y = float(bb.max.X), float(bb.min.Y)
-    return (
-        ApprovedLadder(
-            "overall_height",
-            (
-                ApprovedDimension(
-                    id=_dim_id(env, "height.length"),
-                    value_text=_fmt(value),
-                    value=value,
-                    span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
-                    ref=env_ref,
-                    rendered_label=_fmt(value),
-                ),
+    ladder = ApprovedLadder(
+        "overall_height",
+        (
+            ApprovedDimension(
+                id=_dim_id(env, "height.length"),
+                value_text=_fmt(value),
+                value=value,
+                span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
+                ref=env_ref,
+                rendered_label=_fmt(value),
             ),
-            ref=env_ref,
         ),
-        [],
+        ref=env_ref,
     )
+    if model.orientation == "z":
+        if step_chain_approved:
+            inactive = Omission(
+                env,
+                "height.length",
+                value,
+                "Z-turned (the step chain tiles the height)",
+            )
+            return None, ApprovedContingency("step_length", ladder, inactive), [inactive]
+        return ladder, None, []
+    if rot is not None and rot.frame.axis in ("x", "y"):
+        return (
+            None,
+            None,
+            [
+                Omission(
+                    env,
+                    "height.length",
+                    value,
+                    f"rotational OD ({rot.frame.axis}-axis) conveys the height",
+                )
+            ],
+        )
+    if mark is not None:
+        return None, None, [Omission(env, "height.length", mark[0], mark[1])]
+    return ladder, None, []
 
 
 def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[Omission]]:
@@ -1120,9 +1180,33 @@ def compile_dimensions(
             )
     marked = _suppressed_dims(model, planned)
     ladders, omissions = _compile_step_ladders(model, marked)
-    overall, height_omissions = _compile_overall_height(
-        model, marked, include_overall=include_overall
+    groups_out, group_omissions = _compile_groups(planned)
+    step_chain_approved = any(
+        group.feature_kind == "step"
+        and group.facts.frame.axis == "z"
+        and group.dim(kind="length") is not None
+        for group in groups_out
     )
+    overall, contingency, height_omissions = _compile_overall_height(
+        model,
+        marked,
+        include_overall=include_overall,
+        step_chain_approved=step_chain_approved,
+    )
+    height_ladder = overall or (contingency.fallback if contingency is not None else None)
+    if height_ladder is not None:
+        # The bespoke compiler can deliberately override the planner's old Z-turn
+        # suppression, either as direct content or as a contingency. Its diagnostic is the
+        # canonical one, so do not retain the general traversal's duplicate (whose legacy
+        # wording differs and would survive value/reason deduplication).
+        overall_feature = resolve_feature(height_ladder.ref)
+        group_omissions = [
+            omission
+            for omission in group_omissions
+            if not (
+                omission.feature is overall_feature and omission.parameter_id == "height.length"
+            )
+        ]
     if overall is not None:
         ladders.append(overall)
     locations, location_omissions = _compile_locations(model)
@@ -1132,11 +1216,11 @@ def compile_dimensions(
     off_axis, off_axis_omissions = _compile_off_axis_hole_locations(model)
     locations.extend(off_axis)
     location_omissions.extend(off_axis_omissions)
-    groups_out, group_omissions = _compile_groups(planned)
     return RenderableDimensionPlan(
         groups=tuple(groups_out),
         ladders=tuple(ladders),
         locations=tuple(locations),
+        contingencies=(contingency,) if contingency is not None else (),
         diagnostics=_dedupe_omissions(
             omissions, height_omissions, location_omissions, group_omissions
         ),

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -619,8 +619,10 @@ class RenderableDimensionPlan:
         out: list[AddressableIntent] = []
         for item in self.contingencies:
             ladder = item.fallback
-            if ladder.kind in _LADDER_ROLE:
-                out.append(AddressableIntent(ladder.ref, _LADDER_ROLE[ladder.kind]))
+            # Contingencies are approved dimensional content, so silently ignoring an
+            # unregistered kind would let generated scripts lose it. Indexing is deliberately
+            # fail-closed, matching the addressability ratchet on the containing plan.
+            out.append(AddressableIntent(ladder.ref, _LADDER_ROLE[ladder.kind]))
         return out
 
     def omitted(self, kind: str) -> tuple[Omission, ...]:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -663,7 +663,8 @@ def mirror_model(model):
         return model, None
     from draftwright.model.compiled import compile_dimensions
 
-    if compile_dimensions(model).ladder("overall_height") is None:
+    plan = compile_dimensions(model)
+    if plan.ladder("overall_height") is None and plan.contingency("step_length") is None:
         return model, None  # the compiler withholds it (Z-turned, rotational OD)
     from dataclasses import replace
 

--- a/tests/refactor_golden/grooved_shaft.json
+++ b/tests/refactor_golden/grooved_shaft.json
@@ -28,6 +28,24 @@
     },
     {
       "geom_bbox": [
+        54.0,
+        55.0,
+        62.0,
+        115.1
+      ],
+      "label": "60",
+      "label_bbox": [
+        58.9,
+        83.4,
+        61.1,
+        86.6
+      ],
+      "name": "dim_height",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
         30.0,
         119.0,
         50.1,
@@ -119,7 +137,7 @@
       "step-length chain dropped: turned shoulders too closely spaced to dimension at this scale (use a detail view)"
     ]
   ],
-  "item_count": 7,
+  "item_count": 8,
   "views": {
     "front": [
       30.0,

--- a/tests/test_issue_955_height_contingency.py
+++ b/tests/test_issue_955_height_contingency.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from dataclasses import replace
 
 import pytest
-from build123d import Align, Cylinder, Pos
+from build123d import Align, Box, Cylinder, Pos
 
 from draftwright import Sheet, build_drawing
 from draftwright.builder import detect_part_model
-from draftwright.model.compiled import compile_dimensions
+from draftwright.model.compiled import (
+    ApprovedContingency,
+    ApprovedLadder,
+    Omission,
+    RenderableDimensionPlan,
+    compile_dimensions,
+)
 from draftwright.model.ir import EnvelopeFeature, Frame, RequestedDimension, StepFeature
+from draftwright.model.planner import plan_dimensions
 
 
 def _crowded_grooved_shaft():
@@ -54,6 +61,22 @@ def test_the_compiler_owns_the_z_turned_height_contingency():
     assert _height_rows(released) == []
 
 
+def test_an_unregistered_contingency_kind_fails_closed():
+    inactive = Omission(None, "height.length", 1.0, "inactive")
+    plan = RenderableDimensionPlan(
+        contingencies=(
+            ApprovedContingency(
+                "primary",
+                ApprovedLadder("unregistered", ()),
+                inactive,
+            ),
+        )
+    )
+
+    with pytest.raises(KeyError, match="unregistered"):
+        plan.addressable()
+
+
 def test_an_authored_omission_never_becomes_a_contingency():
     model = detect_part_model(_crowded_grooved_shaft())
     envelope = _envelope_for(model)
@@ -89,6 +112,31 @@ def test_z_turned_without_an_approved_chain_gets_the_height_directly():
     assert overall is not None
     assert overall.rungs[0].value == pytest.approx(60)
     assert _height_rows(plan) == []
+
+
+def test_an_unrelated_planner_suppression_still_withholds_height():
+    model = detect_part_model(Box(40, 30, 20))
+    groups = []
+    for group in plan_dimensions(model):
+        units = tuple(
+            replace(
+                unit,
+                members=tuple(
+                    replace(pd, suppressed=True, reason="test policy")
+                    if pd.param.parameter_id == "height.length"
+                    else pd
+                    for pd in unit.members
+                ),
+            )
+            for unit in group.units
+        )
+        groups.append(replace(group, units=units))
+
+    plan = compile_dimensions(model, groups=groups)
+
+    assert plan.ladder("overall_height") is None
+    assert plan.contingency("step_length") is None
+    assert [o.reason for o in _height_rows(plan)] == ["test policy"]
 
 
 @pytest.mark.timeout(120)

--- a/tests/test_issue_955_height_contingency.py
+++ b/tests/test_issue_955_height_contingency.py
@@ -1,0 +1,147 @@
+"""#955: a dropped Z-turned step chain releases a compiler-approved overall height."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from build123d import Align, Cylinder, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright.builder import detect_part_model
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.ir import EnvelopeFeature, Frame, RequestedDimension, StepFeature
+
+
+def _crowded_grooved_shaft():
+    shaft = Cylinder(12, 60, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    shaft -= Pos(0, 0, 30) * (
+        Cylinder(12, 4, align=(Align.CENTER, Align.CENTER, Align.MIN))
+        - Cylinder(9, 4, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    )
+    return shaft
+
+
+def _height_rows(plan):
+    return [o for o in plan.diagnostics if o.parameter_id == "height.length"]
+
+
+def _envelope_for(model):
+    bb = model.bbox
+    center = bb.center()
+    return EnvelopeFeature(
+        Frame((center.X, center.Y, center.Z), "z"),
+        width=float(bb.size.X),
+        height=float(bb.size.Z),
+        depth=float(bb.size.Y),
+        bbox_min=(float(bb.min.X), float(bb.min.Y), float(bb.min.Z)),
+        bbox_max=(float(bb.max.X), float(bb.max.Y), float(bb.max.Z)),
+    )
+
+
+def test_the_compiler_owns_the_z_turned_height_contingency():
+    plan = compile_dimensions(detect_part_model(_crowded_grooved_shaft()))
+
+    assert plan.ladder("overall_height") is None
+    contingency = plan.contingency("step_length")
+    assert contingency is not None
+    assert contingency.fallback.kind == "overall_height"
+    assert contingency.fallback.rungs[0].value == pytest.approx(60)
+    assert [o.reason for o in _height_rows(plan)] == ["Z-turned (the step chain tiles the height)"]
+
+    released = plan.release_contingency("step_length")
+    assert released.ladder("overall_height") == contingency.fallback
+    assert _height_rows(released) == []
+
+
+def test_an_authored_omission_never_becomes_a_contingency():
+    model = detect_part_model(_crowded_grooved_shaft())
+    envelope = _envelope_for(model)
+    steps = [feature for feature in model.features if isinstance(feature, StepFeature)]
+    model = replace(
+        model,
+        features=[*model.features, envelope],
+        authored_dimensions=tuple(RequestedDimension(step, "step.length") for step in steps),
+    )
+
+    plan = compile_dimensions(model)
+
+    assert len(plan.of_kind("step")) == 2
+    assert all(group.dim(kind="length") is not None for group in plan.of_kind("step"))
+    assert plan.contingency("step_length") is None
+    assert plan.ladder("overall_height") is None
+    assert len(_height_rows(plan)) == 1
+    assert _height_rows(plan)[0].authored
+
+
+def test_z_turned_without_an_approved_chain_gets_the_height_directly():
+    model = detect_part_model(_crowded_grooved_shaft())
+    model = replace(
+        model,
+        features=[feature for feature in model.features if not isinstance(feature, StepFeature)]
+        + [_envelope_for(model)],
+    )
+
+    plan = compile_dimensions(model)
+
+    assert plan.contingency("step_length") is None
+    overall = plan.ladder("overall_height")
+    assert overall is not None
+    assert overall.rungs[0].value == pytest.approx(60)
+    assert _height_rows(plan) == []
+
+
+@pytest.mark.timeout(120)
+def test_a_dropped_chain_releases_the_height_and_clears_the_planner_omission():
+    drawing = build_drawing(_crowded_grooved_shaft(), number="X")
+    labels = {
+        label
+        for _, annotation in drawing.iter_annotations()
+        if (label := getattr(annotation, "label", None))
+    }
+    codes = drawing.lint_summary()["by_code"]
+
+    assert "60" in labels
+    assert "dim_height" in drawing.annotations()
+    assert codes.get("axial_length_missing", 0) == 0
+    assert codes.get("step_dim_dropped") == 1
+    assert not [row for row in drawing.suppressions() if row["parameter_id"] == "height.length"]
+
+
+@pytest.mark.timeout(120)
+def test_a_surviving_z_chain_does_not_release_a_redundant_height():
+    drawing = build_drawing(
+        Cylinder(12, 30, align=(Align.CENTER, Align.CENTER, Align.MIN))
+        + Pos(0, 0, 30) * Cylinder(8, 30, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    )
+
+    assert any(name.startswith("m_steplen") for name in drawing.annotations())
+    assert "dim_height" not in drawing.annotations()
+    assert [
+        row["reason"] for row in drawing.suppressions() if row["parameter_id"] == "height.length"
+    ] == ["Z-turned (the step chain tiles the height)"]
+
+
+@pytest.mark.timeout(120)
+def test_an_authored_overall_height_does_not_claim_the_shoulders_are_located():
+    sheet = Sheet.from_part(_crowded_grooved_shaft())
+    envelope = sheet.envelope()
+    sheet.dimension(envelope, "height.length")
+
+    drawing = sheet.build()
+    codes = drawing.lint_summary()["by_code"]
+
+    assert "dim_height" in drawing.annotations()
+    assert codes.get("step_dim_dropped", 0) == 0
+    assert codes.get("axial_length_missing") == 1
+
+
+@pytest.mark.timeout(120)
+def test_an_unplaceable_fallback_is_a_drop_not_a_stale_suppression():
+    drawing = build_drawing(_crowded_grooved_shaft(), page="90x70", scale=4.0, repair=False)
+    codes = drawing.lint_summary()["by_code"]
+
+    assert "dim_height" not in drawing.annotations()
+    assert codes.get("placement_unsatisfiable", 0) >= 1
+    assert codes.get("axial_length_missing") == 1
+    assert not [row for row in drawing.suppressions() if row["parameter_id"] == "height.length"]

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2157,6 +2157,23 @@ class TestTheDimensionMirror:
         assert 'sheet.dimension(envelope1, "width.length")' not in src
         assert 'sheet.dimension(envelope1, "depth.length")' not in src
 
+    def test_a_withheld_model_level_height_does_not_synthesise_an_envelope(self):
+        from dataclasses import replace
+
+        from build123d import Align, Rotation
+
+        part = Rotation(0, 90, 0) * Cylinder(10, 30, align=(Align.CENTER, Align.CENTER, Align.MIN))
+        model = detect_part_model(part)
+        model = replace(
+            model, features=[feature for feature in model.features if feature.kind != "envelope"]
+        )
+        assert not any(feature.kind == "envelope" for feature in model.features)
+
+        mirrored, synthesised = mirror_model(model)
+
+        assert mirrored is model
+        assert synthesised is None
+
 
 #: Annotations a generated script legitimately does NOT declare, keyed by EXACT name prefix
 #: where the family is closed, and each carrying the argument that it can never be a

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -23,6 +23,7 @@ from draftwright.sheet_emit import (
     _member_hole_str,
     emit_sheet_script,
     generate_sheet_script,
+    mirror_model,
     resolve_object_spec,
     unmirrored_dimensions,
 )
@@ -3269,10 +3270,15 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
         exec(compile(src[: src.index("drawing = sheet.build()")], "<emit>", "exec"), ns)  # noqa: S102
         declared = ns["sheet"].model()
 
-        by_kind_detected = [f for f in detected.features if f.kind != "authored_dimension"]
+        mirrored, synthesised = mirror_model(detected)
+        extra = [f.kind for f in mirrored.features][len(detected.features) :]
+        assert extra == (["envelope"] if synthesised is not None else []), (
+            f"{name}: the mirror introduced an unexpected feature set {extra}"
+        )
+        by_kind_detected = [f for f in mirrored.features if f.kind != "authored_dimension"]
         by_kind_declared = [f for f in declared.features if f.kind != "authored_dimension"]
         assert [f.kind for f in by_kind_declared] == [f.kind for f in by_kind_detected], (
-            f"{name}: the script declares a different set of feature kinds"
+            f"{name}: the script declares a different set of feature kinds from its mirror"
         )
 
         for original, rebuilt in zip(by_kind_detected, by_kind_declared):

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1397,12 +1397,11 @@ class TestRoundTripParity:
         moment that output was declared rather than detected.
 
         Signature parity alone would also be satisfied by two identically BLANK drawings, so
-        this pins the content on both sides as well — including the part that is still wrong.
+        this pins the content on both sides as well.
         This shaft's shoulders sit 4 mm apart, which fails the legibility gate, which drops the
-        whole step chain; the overall height was already suppressed at compile time on the
-        premise that chain would convey it, so nothing states the 60 mm. That is #955, it
-        predates this fix and affects the detected path identically, and it is asserted here
-        rather than glossed: when #955 lands this test must fail and be updated."""
+        whole step chain. #955 recovers the overall height from a compiler-approved contingency
+        while retaining the specific chain-drop diagnostic; direct and generated-script builds
+        must make that same runtime selection."""
         from build123d import Align
 
         shaft = Cylinder(12, 60, align=(Align.CENTER, Align.CENTER, Align.MIN))
@@ -1419,17 +1418,14 @@ class TestRoundTripParity:
             assert any(n.startswith("m_groove") for n in names), (which, names)
             assert "4 WIDE × ø18" in labels, (which, labels)
             assert "ø24" in labels, (which, labels)
-            # The #955 gap, stated: no height, and lint says so on both paths. These four
-            # assertions are expected to fail when #955 lands — that is deliberate. Replace
-            # them with the height's presence then, and check parity still holds; do not
-            # relax them, or the fixture stops describing the drawing it produces. (Asserting
-            # only the lint codes would not decouple this: they change when #955 lands too.)
-            gap = f"{which}: #955 fixed? see the note above — update, don't relax."
-            assert "dim_height" not in names, (gap, names)
-            assert "60" not in labels, (gap, labels)
+            assert "dim_height" in names, (which, names)
+            assert "60" in labels, (which, labels)
             codes = dwg.lint_summary()["by_code"]
-            assert codes.get("axial_length_missing") == 1, (gap, codes)
-            assert codes.get("step_dim_dropped") == 1, (gap, codes)
+            assert codes.get("axial_length_missing", 0) == 0, (which, codes)
+            assert codes.get("step_dim_dropped") == 1, (which, codes)
+            assert not [
+                row for row in dwg.suppressions() if row["parameter_id"] == "height.length"
+            ], (which, dwg.suppressions())
 
     def test_pocket_pattern_parity(self, tmp_path, monkeypatch):
         """#957 review: the emitted script named `pocket` without importing it, so a
@@ -2209,6 +2205,8 @@ _PLAN_DIMENSIONAL_FIELDS = {
     "locations": "walked per approved location, matched on the coarse 'location' role",
     "ladders": "walked per ladder; the compiler states the role it is named by "
     "(`_LADDER_ROLE`), so the emitter no longer carries its own copy (#975)",
+    "contingencies": "walked as approved alternative ladders; generated authored scripts "
+    "must retain a fallback even when the automatic build leaves it inactive",
     "diagnostics": "NOT dimensional — the omissions channel; nothing to mirror by definition",
 }
 


### PR DESCRIPTION
## Summary

- compile a distinct overall-height contingency when an approved Z-turned step chain is the primary representation
- release that already-approved ladder only when the complete chain places zero marks, while preserving ordinary placement-drop behavior if the fallback also cannot fit
- keep authored omission authoritative, approve height directly when no step chain exists, and mirror the contingency into generated `Sheet` scripts
- remove the inactive suppression when the fallback is released and avoid duplicating the generic axial warning when the specific chain-drop diagnostic remains
- record the contingent-plan refinement in ADR 0016 and update ADR 0015's compiler shape

## Root cause

The compiler suppressed Z-turned overall height on the assumption that the step chain tiled the axial extent. The chain's transactional legibility decision happens later at placement, so a crowded chain could place zero marks after the only available overall height had already been withheld. Letting the renderer derive `60` from the bounding box would violate ADR 0016's compiled-plan boundary.

The compiler now owns both representations. Placement reports whether the primary survived, and the orchestrator selects the compiler-approved alternative without inventing dimensional content.

## Validation

- `scripts/pr-check --quick`
- focused compiler, suppression-ledger, renderer-seam, emitter parity, axial-coverage, and #955 regression suites
- detected and generated-declared paths both render `60`, clear `axial_length_missing`, retain `step_dim_dropped`, and expose no stale height suppression
- controls cover a surviving chain, authored height omission with both step lengths still approved, no approved chain, authored overall-only incompleteness, and an unplaceable fallback

## Adversarial review

The following mutations each failed independently before being reverted:

- release the fallback when any chain marks survive
- create the contingency despite authored height omission
- leave the inactive suppression after release
- retain the legacy envelope suppression when no approved chain exists

Closes #955
