### PR TITLE
Prove repeating radial profile evidence

### DIFF
--- a/docs/research/1062-repeating-radial-profile-evidence.md
+++ b/docs/research/1062-repeating-radial-profile-evidence.md
@@ -1,0 +1,103 @@
+# Repeating Radial Profile Evidence (#1062)
+
+> **Status:** discovery decision, 2026-08-07. The executable evidence is in
+> `tests/test_issue_1058_wheel_profile.py`. No automatic gear semantics are approved by
+> this note.
+
+## Decision
+
+The wheel fixture proves a **closed 13-fold repeating radial outer profile** about its Z
+axis. It does not prove that the profile is a gear, nor does it establish module, pressure
+angle, helix angle, backlash, tooth thickness, quality grade, or manufacturing process.
+
+Keep `unrecognised_defining_geometry` for this part. Do not add an automatic `GearFeature`,
+emit a gear callout, or treat outside/root diameters and repeat count as a complete
+manufacturing definition. The useful next boundary is:
+
+1. reusable geometry-only correspondence for a repeating radial profile; and
+2. a separately designed, explicit declaration of gear requirements and their drawing
+   presentation.
+
+The second may consume the first to check that declared tooth count and axis correspond to
+the solid. Recognition must not manufacture the declaration.
+
+## Pinned Evidence
+
+| Item | Observed fact |
+|---|---|
+| Fixture | `tests/fixtures/issue_1058_wheel_rh.step` |
+| SHA-256 | `4911c06426f0ceeedc198416e058aabc1c1a6a65e9e766eca7efed5484a27cda` |
+| STEP form | AP214, one solid, generic product name `SOLID` |
+| Overall bounds | X -3.8000001..3.7733322; Y -3.8000001..3.8000001; Z -3.8500001..3.8500001 mm |
+| Principal outer boundaries | two, at the opposed Z limits |
+| Boundary topology | one closed 52-edge outer wire on each end face |
+| Edge inventory | 13 circular edges and 39 B-splines |
+| Circular edges | radius 3.8 mm, common XY centre (0, 0) |
+| Rotational correspondence | four complete 13-edge orbits under `2*pi/13` rotation |
+| Orbit roles | one circular-tip orbit and three B-spline orbits |
+
+Both end faces prove the same correspondence despite different edge start and traversal.
+The STEP header and entities contain no gear name, PMI, standard, or parameter metadata.
+
+## What The Proof Establishes
+
+The test samples every curve in each outer wire, then requires a one-to-one mapping of every
+curve under one sector rotation. Curve type, length, and sampled geometry must agree within
+the fixed tolerance. The mapping must be bijective, each orbit must contain exactly 13
+curves, and every endpoint must belong to one connected degree-two cycle.
+
+This is stronger than the existing lint hint. `_radial_outer_arc_count` reports 13 equal,
+equally spaced arcs on a common circle, but explicitly does not claim that the 39 intervening
+B-splines repeat. The complete-wire proof closes that geometric gap without widening the
+semantic claim.
+
+The following mutations fail:
+
+- retaining only the 13 common-circle arcs;
+- altering one intervening B-spline sample while leaving all arcs unchanged;
+- breaking one endpoint so the outer wire is open;
+- changing one sector boundary while preserving a closed cycle; and
+- relying on the wire's original start edge or traversal direction.
+
+The changed-intervening-curve mutation is the decisive guard: an arc-count implementation
+would still pass it.
+
+## Why This Is Not Gear Recognition
+
+Many manufactured profiles can be cyclic without being gears. Even if a human recognises
+the fixture's purpose, the B-rep alone does not uniquely identify the generating standard or
+the requirements needed to reproduce and inspect it. Fitting a plausible standard from 13
+tips and a diameter would turn a guess into normative drawing output.
+
+A truthful technical drawing therefore needs explicit requirements supplied by the author,
+usually including at least the gear system/type, tooth count, module or diametral pitch,
+pressure angle, reference geometry, and the applicable accuracy or inspection requirement.
+The exact public surface and table/callout form need a standards-backed design slice; this
+discovery does not invent them.
+
+## ADR Fit
+
+- **ADR 0013:** the proven repeat is lower-tier, geometry-only evidence. `gear` is an
+  application semantic and must not be smuggled into the recognition record.
+- **ADR 0015:** any future automatic record must enter through the compiler's existing
+  recognition waist. A declared gear requirement belongs on the declared path.
+- **ADR 0017:** if productionised, one orchestration owns the correspondence evidence and
+  consumers project from it. The mutation precedes trust in the guard, and a new identity
+  scheme is not justified by this single case.
+- **ADR 0011:** explicit author intent is the appropriate source for requirements that the
+  B-rep cannot establish.
+
+No ADR amendment is required. No placement decision is made, so ADR 0014 is unaffected.
+
+## Follow-up Slices
+
+1. **Productionise repeating-profile evidence when a consumer is ready.** Extract the pure
+   full-wire correspondence into recognition, add it to the one orchestration, and use it for
+   physical critique and declared-profile correspondence. Do not clear completeness merely
+   because the repeat exists.
+2. **Design declared gear requirements.** Start from the applicable drawing/gear standards
+   and define the minimum honest declaration, validation, IR, and table/callout output. Include
+   a mismatch diagnostic when declared count or axis disagrees with geometric evidence.
+3. **Only then assess automatic assistance.** Recognition may prefill proven geometric facts
+   such as axis and repeat count for user confirmation. It may not infer the normative gear
+   specification.

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -1,9 +1,10 @@
 """Evidence-backed recognition and coverage for the double-D wheel profile (#1058)."""
 
 from collections import Counter
+from dataclasses import dataclass, replace
 from hashlib import sha256
 from inspect import signature
-from math import asin, sqrt
+from math import asin, cos, hypot, pi, sin, sqrt
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -47,12 +48,15 @@ from draftwright.recognition.profiled_bores import (
     DoubleDProfile,
     double_d_bores_from_openings,
     double_d_profile,
+    principal_boundary_plane,
 )
 from draftwright.sheet_emit import _feature_line, _hole_line, emit_sheet_script
 
 _WHEEL = Path(__file__).parent / "fixtures" / "issue_1058_wheel_rh.step"
 _SHA256 = "4911c06426f0ceeedc198416e058aabc1c1a6a65e9e766eca7efed5484a27cda"
 _CENTER = (Align.CENTER, Align.CENTER, Align.CENTER)
+_RADIAL_REPEAT_COUNT = 13
+_CORRESPONDENCE_TOL = 1e-5
 
 
 def _double_d_bore():
@@ -170,6 +174,136 @@ def _profile_evidence(case="valid"):
     return _ProfileWire([*lines, *arcs], size=size)
 
 
+@dataclass(frozen=True)
+class _CurveEvidence:
+    """A traversal-neutral sample of one real outer-wire edge for #1062 discovery."""
+
+    kind: GeomType
+    length: float
+    points: tuple[tuple[float, float], ...]
+
+
+def _sample_outer_wire(face, *, samples=9) -> tuple[_CurveEvidence, ...]:
+    evidence = []
+    for edge in face.outer_wire().edges():
+        points = []
+        for index in range(samples):
+            point = edge.position_at(index / (samples - 1))
+            points.append((float(point.X), float(point.Y)))
+        evidence.append(
+            _CurveEvidence(
+                kind=edge.geom_type,
+                length=float(edge.length),
+                points=tuple(points),
+            )
+        )
+    return tuple(evidence)
+
+
+def _distance(a, b) -> float:
+    return hypot(a[0] - b[0], a[1] - b[1])
+
+
+def _one_closed_cycle(edges: tuple[_CurveEvidence, ...], tol: float) -> bool:
+    """Every endpoint has degree two and every edge belongs to one connected component."""
+    if not edges:
+        return False
+    nodes: list[tuple[float, float]] = []
+    incident: list[list[int]] = []
+    edge_nodes = []
+    for edge_index, edge in enumerate(edges):
+        endpoints = []
+        for point in (edge.points[0], edge.points[-1]):
+            matches = [index for index, node in enumerate(nodes) if _distance(point, node) <= tol]
+            if len(matches) > 1:
+                return False
+            if matches:
+                node_index = matches[0]
+            else:
+                node_index = len(nodes)
+                nodes.append(point)
+                incident.append([])
+            incident[node_index].append(edge_index)
+            endpoints.append(node_index)
+        if endpoints[0] == endpoints[1]:
+            return False
+        edge_nodes.append(tuple(endpoints))
+    if any(len(edge_ids) != 2 for edge_ids in incident):
+        return False
+
+    reached_edges = set()
+    frontier = [0]
+    while frontier:
+        edge_index = frontier.pop()
+        if edge_index in reached_edges:
+            continue
+        reached_edges.add(edge_index)
+        frontier.extend(
+            neighbour
+            for node_index in edge_nodes[edge_index]
+            for neighbour in incident[node_index]
+            if neighbour not in reached_edges
+        )
+    return len(reached_edges) == len(edges)
+
+
+def _rotate(point, angle, centre):
+    x, y = point[0] - centre[0], point[1] - centre[1]
+    return (
+        centre[0] + x * cos(angle) - y * sin(angle),
+        centre[1] + x * sin(angle) + y * cos(angle),
+    )
+
+
+def _curves_match(source, target, *, angle, centre, tol) -> bool:
+    if source.kind != target.kind or abs(source.length - target.length) > tol:
+        return False
+    rotated = tuple(_rotate(point, angle, centre) for point in source.points)
+    return any(
+        max(_distance(a, b) for a, b in zip(rotated, candidate, strict=True)) <= tol
+        for candidate in (target.points, tuple(reversed(target.points)))
+    )
+
+
+def _cyclic_edge_orbits(edges, *, centre, repeat_count, tol):
+    """Prove the complete closed wire maps bijectively under one repeat rotation."""
+    edges = tuple(edges)
+    if (
+        len(edges) <= repeat_count
+        or len(edges) % repeat_count
+        or not _one_closed_cycle(edges, tol)
+    ):
+        return None
+    angle = 2 * pi / repeat_count
+    mapping = []
+    for edge in edges:
+        matches = [
+            index
+            for index, candidate in enumerate(edges)
+            if _curves_match(edge, candidate, angle=angle, centre=centre, tol=tol)
+        ]
+        if len(matches) != 1:
+            return None
+        mapping.append(matches[0])
+    if len(set(mapping)) != len(edges):
+        return None
+
+    unseen = set(range(len(edges)))
+    orbits = []
+    while unseen:
+        start = min(unseen)
+        orbit = []
+        current = start
+        while current not in orbit:
+            orbit.append(current)
+            current = mapping[current]
+        if current != start or len(orbit) != repeat_count:
+            return None
+        unseen -= set(orbit)
+        orbits.append(tuple(orbit))
+    return tuple(orbits)
+
+
 @pytest.fixture(scope="module")
 def wheel_part():
     return import_step(str(_WHEEL))
@@ -178,6 +312,11 @@ def wheel_part():
 @pytest.fixture(scope="module")
 def wheel_drawing():
     return build_drawing(_WHEEL)
+
+
+def _wheel_end_faces(part):
+    bbox = part.bounding_box()
+    return [face for face in part.faces() if principal_boundary_plane(face, bbox)]
 
 
 def test_real_wheel_fixture_proves_the_double_d_profile(wheel_part):
@@ -207,6 +346,147 @@ def test_real_wheel_fixture_proves_the_double_d_profile(wheel_part):
         assert 1.75 != pytest.approx(min(bb.size.X, bb.size.Y) / 2), (
             "a true obround cap radius is half its short extent; this is a double-D"
         )
+
+
+def test_real_wheel_proves_complete_thirteen_sector_correspondence(wheel_part):
+    end_faces = _wheel_end_faces(wheel_part)
+    assert len(end_faces) == 2
+    boundaries = [principal_boundary_plane(face, wheel_part.bounding_box()) for face in end_faces]
+    assert [boundary[0] for boundary in boundaries if boundary] == ["z", "z"]
+    assert sorted(boundary[2] for boundary in boundaries if boundary) == pytest.approx(
+        [-3.8500001, 3.8500001]
+    )
+    for face in end_faces:
+        edges = list(face.outer_wire().edges())
+        assert Counter(edge.geom_type for edge in edges) == Counter(
+            {GeomType.BSPLINE: 39, GeomType.CIRCLE: 13}
+        )
+        circles = [edge for edge in edges if edge.geom_type == GeomType.CIRCLE]
+        assert [edge.radius for edge in circles] == pytest.approx([3.8] * 13)
+        assert [(edge.arc_center.X, edge.arc_center.Y) for edge in circles] == pytest.approx(
+            [(0.0, 0.0)] * 13,
+            abs=1e-6,
+        )
+
+        evidence = _sample_outer_wire(face)
+        orbits = _cyclic_edge_orbits(
+            evidence,
+            centre=(0.0, 0.0),
+            repeat_count=_RADIAL_REPEAT_COUNT,
+            tol=_CORRESPONDENCE_TOL,
+        )
+        assert orbits is not None
+        assert [len(orbit) for orbit in orbits] == [13, 13, 13, 13]
+        assert Counter(evidence[orbit[0]].kind for orbit in orbits) == Counter(
+            {GeomType.BSPLINE: 3, GeomType.CIRCLE: 1}
+        )
+
+
+def test_full_profile_correspondence_ignores_start_and_traversal(wheel_part):
+    evidence = _sample_outer_wire(_wheel_end_faces(wheel_part)[0])
+    shifted = evidence[7:] + evidence[:7]
+    reversed_traversal = tuple(
+        replace(edge, points=tuple(reversed(edge.points))) for edge in reversed(evidence)
+    )
+
+    for candidate in (shifted, reversed_traversal):
+        assert (
+            _cyclic_edge_orbits(
+                candidate,
+                centre=(0.0, 0.0),
+                repeat_count=_RADIAL_REPEAT_COUNT,
+                tol=_CORRESPONDENCE_TOL,
+            )
+            is not None
+        )
+
+
+def test_common_circle_arcs_alone_do_not_prove_full_sector_correspondence(wheel_part):
+    evidence = _sample_outer_wire(_wheel_end_faces(wheel_part)[0])
+    arcs = tuple(edge for edge in evidence if edge.kind == GeomType.CIRCLE)
+    assert len(arcs) == 13
+    assert (
+        _cyclic_edge_orbits(
+            arcs,
+            centre=(0.0, 0.0),
+            repeat_count=_RADIAL_REPEAT_COUNT,
+            tol=_CORRESPONDENCE_TOL,
+        )
+        is None
+    )
+
+
+def test_one_changed_intervening_curve_breaks_full_sector_correspondence(wheel_part):
+    evidence = list(_sample_outer_wire(_wheel_end_faces(wheel_part)[0]))
+    changed_index = next(
+        index for index, edge in enumerate(evidence) if edge.kind == GeomType.BSPLINE
+    )
+    changed = evidence[changed_index]
+    points = list(changed.points)
+    x, y = points[len(points) // 2]
+    points[len(points) // 2] = (x + 0.01, y)
+    evidence[changed_index] = replace(changed, points=tuple(points))
+
+    assert len([edge for edge in evidence if edge.kind == GeomType.CIRCLE]) == 13
+    assert (
+        _cyclic_edge_orbits(
+            evidence,
+            centre=(0.0, 0.0),
+            repeat_count=_RADIAL_REPEAT_COUNT,
+            tol=_CORRESPONDENCE_TOL,
+        )
+        is None
+    )
+
+
+def test_an_open_outer_cycle_cannot_prove_sector_correspondence(wheel_part):
+    evidence = list(_sample_outer_wire(_wheel_end_faces(wheel_part)[0]))
+    changed = evidence[0]
+    points = list(changed.points)
+    x, y = points[0]
+    points[0] = (x + 0.01, y)
+    evidence[0] = replace(changed, points=tuple(points))
+
+    assert not _one_closed_cycle(tuple(evidence), tol=_CORRESPONDENCE_TOL)
+    assert (
+        _cyclic_edge_orbits(
+            evidence,
+            centre=(0.0, 0.0),
+            repeat_count=_RADIAL_REPEAT_COUNT,
+            tol=_CORRESPONDENCE_TOL,
+        )
+        is None
+    )
+
+
+def test_one_unequal_sector_pitch_breaks_correspondence_even_when_closed(wheel_part):
+    evidence = list(_sample_outer_wire(_wheel_end_faces(wheel_part)[0]))
+    endpoint = evidence[0].points[0]
+    partners = [
+        (edge_index, point_index)
+        for edge_index, edge in enumerate(evidence[1:], start=1)
+        for point_index in (0, -1)
+        if _distance(endpoint, edge.points[point_index]) <= 1e-8
+    ]
+    assert len(partners) == 1
+
+    moved = _rotate(endpoint, 0.01, centre=(0.0, 0.0))
+    for edge_index, point_index in ((0, 0), partners[0]):
+        edge = evidence[edge_index]
+        points = list(edge.points)
+        points[point_index] = moved
+        evidence[edge_index] = replace(edge, points=tuple(points))
+
+    assert _one_closed_cycle(tuple(evidence), tol=_CORRESPONDENCE_TOL)
+    assert (
+        _cyclic_edge_orbits(
+            evidence,
+            centre=(0.0, 0.0),
+            repeat_count=_RADIAL_REPEAT_COUNT,
+            tol=_CORRESPONDENCE_TOL,
+        )
+        is None
+    )
 
 
 def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawing):


### PR DESCRIPTION
## Summary

- prove complete 13-fold outer-wire correspondence on the pinned wheel STEP fixture
- mutation-gate arcs-only, altered-spline, open-cycle, unequal-pitch, start-edge, and traversal cases
- record the evidence boundary: repeating radial geometry is proven; gear semantics and parameters are not

## Product impact

This is a bounded discovery decision. It leaves runtime recognition and `unrecognised_defining_geometry` unchanged, and defines separate follow-ups for reusable geometric correspondence and explicit declared gear requirements.

## Validation

- `scripts/pr-check --full`
- 3,028 passed, 4 skipped, 2 xfailed
- 93.75% combined line and branch coverage
- changed-source coverage: no production source lines changed

Closes #1062
