### PR TITLE
Expose AP242 PMI extraction gaps

### DIFF
--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -29,8 +29,11 @@ _LAZY = {
     "FeatureInfo": "draftwright.drawing",
     "Sheet": "draftwright.sheet",
     "lint_feature_coverage": "draftwright.linting",
+    "PmiExtractionReport": "draftwright.pmi",
     "PmiRecord": "draftwright.pmi",
+    "PmiSourceEntity": "draftwright.pmi",
     "extract_pmi": "draftwright.pmi",
+    "extract_pmi_report": "draftwright.pmi",
     "choose_scale": "draftwright.compose",
     # A warning category users are told to filter must be importable without reaching into a
     # private module (#1043 review) — and without paying for the CAD kernel. It lives in the
@@ -78,7 +81,13 @@ if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel co
     from draftwright.compose import choose_scale
     from draftwright.drawing import Drawing, FeatureInfo
     from draftwright.linting import lint_feature_coverage
-    from draftwright.pmi import PmiRecord, extract_pmi
+    from draftwright.pmi import (
+        PmiExtractionReport,
+        PmiRecord,
+        PmiSourceEntity,
+        extract_pmi,
+        extract_pmi_report,
+    )
     from draftwright.sheet import Sheet
 
 
@@ -93,11 +102,14 @@ __all__ = [
     "Drawing",
     "SoftDeprecationWarning",
     "FeatureInfo",
+    "PmiExtractionReport",
     "PmiRecord",
+    "PmiSourceEntity",
     "Sheet",
     "build_drawing",
     "choose_scale",
     "extract_pmi",
+    "extract_pmi_report",
     "lint_feature_coverage",
     "make_drawing",
 ]

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1015,7 +1015,10 @@ class Analysis:
     tolerance: str
     drawn_by: str
     out: str
-    pmi: list
+    # Canonical AP242 source census + extraction outcomes, or None when PMI was not requested
+    # (or the input is an in-memory Shape). Typed as object to keep the rank-1 core from
+    # importing rank-2 pmi; the compatibility `pmi` property below is its records projection.
+    pmi_report: object | None
     pmi_mode: str
     # Standing ISO 7200 title-block fields (#766) — defaulted, so they sit after the
     # non-default fields above. Defaults preserve the prior output: revision "A", the rest
@@ -1039,6 +1042,11 @@ class Analysis:
     # declared a model (ADR 0011) or on a manually-built Analysis — consumers fall
     # back to build_model(a).
     model: object | None = None
+
+    @property
+    def pmi(self) -> list:
+        """Successful PMI records, derived from the canonical extraction report."""
+        return list(getattr(self.pmi_report, "records", ()))
 
 
 _greedy_strip_ys = _greedy_strip_1d

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -532,14 +532,17 @@ def _analyse(
     part = _solids_body(part, src)
 
     # Semantic PMI extraction (AP242 only; separate read-only pass).
+    pmi_report = None
     pmi_records: list = []
     if pmi != "off" and not isinstance(step_file, Shape):
-        try:
-            from draftwright.pmi import extract_pmi
+        from draftwright.pmi import PmiExtractionReport, extract_pmi_report
 
-            pmi_records = extract_pmi(step_file)
+        try:
+            pmi_report = extract_pmi_report(step_file)
+            pmi_records = list(pmi_report.records)
         except Exception as exc:
             _log.warning("PMI extraction failed: %s", exc)
+            pmi_report = PmiExtractionReport(error=f"{type(exc).__name__}: {exc}")
 
     bb = part.bounding_box()
     x_size = bb.max.X - bb.min.X
@@ -885,7 +888,7 @@ def _analyse(
         projection=projection,
         zones=zones,
         out=out,
-        pmi=pmi_records,
+        pmi_report=pmi_report,
         pmi_mode=pmi,
         # The sizing model IS the render model when detection ran (identical inputs by
         # construction — #584 WP1 A); store it so the pipeline never detects twice

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -79,6 +79,7 @@ from draftwright.linting import (
     lint_feature_coverage,
     lint_flat_coverage,
     lint_location_coverage,
+    lint_pmi_extraction,
     lint_principal_profile_coverage,
     lint_prismatic_coverage,
     lint_profiled_bore_coverage,
@@ -122,6 +123,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "channel_width_dropped",
         "flat_dropped",
         "polygonal_boss_dropped",
+        "pmi_not_extracted",
         "placement_unsatisfiable",
         "pmi_dropped",
     }
@@ -2876,6 +2878,8 @@ class Drawing:
                     cyls,
                     recognition=recognition,
                 )
+        if physical and self._analysis is not None:
+            issues += lint_pmi_extraction(self._analysis.pmi_report, self._analysis.pmi_mode)
         issues += list(self._registry.issues)
         # Attach a ready-to-paste fix snippet where one is computable (#29).
         # str | None — None when no concrete repair can be inferred.
@@ -2928,6 +2932,7 @@ class Drawing:
                         if (s := getattr(i, "suggestion", None)) is not None
                         else {}
                     ),
+                    **({"source_ids": i.source_ids} if i.source_ids else {}),
                 }
                 for i in issues
             ],

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -29,6 +29,7 @@ from draftwright.linting.coverage import (
 )
 from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.issues import LintIssue
+from draftwright.linting.pmi_coverage import lint_pmi_extraction
 from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
 from draftwright.linting.slot_coverage import lint_slot_coverage
 from draftwright.linting.structural import lint_drawing
@@ -47,6 +48,7 @@ __all__ = [
     "lint_flat_coverage",
     "lint_slot_coverage",
     "lint_location_coverage",
+    "lint_pmi_extraction",
     "lint_principal_profile_coverage",
     "lint_profiled_bore_coverage",
     "lint_prismatic_coverage",

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -23,3 +23,7 @@ class LintIssue:
     # that do not hold semantic provenance. Kept internal/plain-tuple so adding it does not
     # turn LintIssue into a general requirement ledger (#1018 Gate 1).
     measurement_ids: tuple = ()
+    # External source-record identities implicated in this issue. Kept as plain strings and
+    # populated narrowly by source reconciliation such as AP242 PMI (#623); this does not
+    # introduce a second feature/measurement identity system.
+    source_ids: tuple[str, ...] = ()

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -1,0 +1,44 @@
+"""Source-to-extraction completeness for AP242 PMI (#623)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from draftwright.linting.issues import LintIssue
+from draftwright.pmi import PmiExtractionReport
+
+
+def lint_pmi_extraction(report: PmiExtractionReport | None, mode: str) -> list[LintIssue]:
+    """Report source PMI that did not survive extraction.
+
+    ``report`` mode is diagnostic, so its outcomes are informational. ``annotate`` promises
+    drawing output and therefore treats the same missing source requirement as an error.
+    Presentation-only labels are retained in the census but are not requirements.
+    """
+    if report is None or mode == "off":
+        return []
+
+    severity: Literal["error", "info"] = "error" if mode == "annotate" else "info"
+    issues = []
+    if report.error:
+        issues.append(
+            LintIssue(
+                severity=severity,
+                code="pmi_not_extracted",
+                message=f"AP242 PMI could not be inventoried: {report.error}",
+            )
+        )
+    issues.extend(
+        LintIssue(
+            severity=severity,
+            code="pmi_not_extracted",
+            message=(
+                f"AP242 {source.category} {source.source_id} was discovered but not "
+                f"extracted: {source.reason}"
+            ),
+            source_ids=(source.source_id,),
+        )
+        for source in report.sources
+        if source.outcome in ("not_extracted", "partially_extracted")
+    )
+    return issues

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -1,9 +1,9 @@
 """PMI (Product Manufacturing Information) extractor for AP242 STEP files.
 
 Reads semantic PMI from an ISO 10303-242 STEP file via a second
-``STEPCAFControl_Reader`` pass with ``SetGDTMode(True)``.  Returns a list of
-:class:`PmiRecord` objects that ``_annotate_pmi`` in ``make_drawing.py`` turns
-into drawing annotations.
+``STEPCAFControl_Reader`` pass with ``SetGDTMode(True)``. The canonical result is
+:class:`PmiExtractionReport`: it preserves every discovered source entity and its
+extraction outcome. :func:`extract_pmi` remains the compatible records-only projection.
 
 build123d's ``import_step`` already uses ``STEPCAFControl_Reader`` + an XCAF
 document (for names/colours/layers) but never enables GDT mode and discards
@@ -20,9 +20,9 @@ GeomTolerance, Datum).
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 _log = logging.getLogger(__name__)
 
@@ -35,8 +35,8 @@ try:
     from OCP.BRepBndLib import BRepBndLib
     from OCP.IFSelect import IFSelect_RetDone
     from OCP.STEPCAFControl import STEPCAFControl_Reader
-    from OCP.TCollection import TCollection_ExtendedString
-    from OCP.TDF import TDF_LabelSequence
+    from OCP.TCollection import TCollection_AsciiString, TCollection_ExtendedString
+    from OCP.TDF import TDF_LabelSequence, TDF_Tool
     from OCP.TDocStd import TDocStd_Document
     from OCP.XCAFDoc import (
         XCAFDoc_Dimension,
@@ -80,8 +80,10 @@ _DIM_TYPE: dict[int, str] = {
     31: "presentation",  # DimensionPresentation ← graphical only, skip
 }
 
-# Types whose GetValue() is a meaningful length/angle (skip label/presentation)
-_SKIP_TYPES = {30, 31}
+# Type 31 is graphical presentation only. Type 30 (CommonLabel) can carry authored meaning
+# despite having no numeric GetValue, so it must fail visibly until supported rather than be
+# discarded with presentation geometry (#623 review).
+_PRESENTATION_TYPES = {31}
 
 # prefix character for the label
 _DIM_PREFIX: dict[str, str] = {
@@ -113,7 +115,7 @@ _GTOL_TYPE: dict[int, str] = {
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class PmiRecord:
     """One semantic PMI annotation from an AP242 STEP file.
 
@@ -142,10 +144,39 @@ class PmiRecord:
     value: float
     upper_tol: float | None = None
     lower_tol: float | None = None
-    ref_pts: list[tuple[float, float, float]] = field(default_factory=list)
+    ref_pts: tuple[tuple[float, float, float], ...] = ()
     ref_bbox: tuple[float, float, float, float, float, float] | None = None
     dominant_axis: str = "?"
     label: str = ""
+    # Stable within the source XCAF document: category + TDF label entry. Blank only for
+    # hand-constructed compatibility records; extraction always fills it (#623).
+    source_id: str = ""
+
+
+PmiSourceCategory = Literal["dimension", "geometric_tolerance", "datum"]
+PmiExtractionOutcome = Literal[
+    "extracted", "partially_extracted", "presentation_only", "not_extracted"
+]
+
+
+@dataclass(frozen=True)
+class PmiSourceEntity:
+    """One source AP242 entity and the outcome of the extraction stage."""
+
+    source_id: str
+    category: PmiSourceCategory
+    type_code: int | None
+    outcome: PmiExtractionOutcome
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class PmiExtractionReport:
+    """The immutable source census and successful record projection from one XCAF pass."""
+
+    sources: tuple[PmiSourceEntity, ...] = ()
+    records: tuple[PmiRecord, ...] = ()
+    error: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -205,15 +236,148 @@ def _make_label(kind: str, value: float, upper_tol: float | None, lower_tol: flo
     return base
 
 
+def _label_entry(label) -> str:
+    """Return the stable TDF entry path for one XCAF source label."""
+    entry = TCollection_AsciiString()
+    TDF_Tool.Entry_s(label, entry)
+    return str(entry.ToCString())
+
+
+def _source_id(category: PmiSourceCategory, label) -> str:
+    return f"{category}:{_label_entry(label)}"
+
+
+def _dimension_without_record(source_id: str, type_code: int) -> PmiSourceEntity | None:
+    """Classify dimension labels that deliberately produce no extracted record."""
+    if type_code in _PRESENTATION_TYPES:
+        return PmiSourceEntity(
+            source_id=source_id,
+            category="dimension",
+            type_code=type_code,
+            outcome="presentation_only",
+            reason="graphical presentation is not a semantic requirement",
+        )
+    if type_code == 30:
+        return PmiSourceEntity(
+            source_id=source_id,
+            category="dimension",
+            type_code=type_code,
+            outcome="not_extracted",
+            reason="common-label dimension extraction is not implemented",
+        )
+    return None
+
+
+def _failure_reason(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _dimension_record(
+    label, obj, type_code: int, shape_tool, source_id: str
+) -> tuple[PmiRecord, tuple[str, ...]]:
+    """Convert one semantic XCAF dimension label, allowing its caller to record failures."""
+    partial_reasons = []
+    # Nominal value: scalar first, array fallback.
+    value = 0.0
+    try:
+        value = float(obj.GetValue())
+    except Exception:
+        try:
+            values = obj.GetValues()
+            if values is not None:
+                value = float(values.Value(values.Lower()))
+            else:
+                partial_reasons.append("nominal value is unavailable")
+        except Exception as exc:
+            partial_reasons.append(f"nominal value is unavailable ({_failure_reason(exc)})")
+
+    upper_tol: float | None = None
+    lower_tol: float | None = None
+    try:
+        candidate = float(obj.GetUpperTolValue())
+        if abs(candidate) > 1e-9:
+            upper_tol = candidate
+    except Exception:
+        pass
+    try:
+        candidate = float(obj.GetLowerTolValue())
+        if abs(candidate) > 1e-9:
+            lower_tol = candidate
+    except Exception:
+        pass
+
+    first_refs = TDF_LabelSequence()
+    second_refs = TDF_LabelSequence()
+    XCAFDoc_DimTolTool.GetRefShapeLabel_s(label, first_refs, second_refs)
+    points: list[tuple[float, float, float]] = []
+    boxes: list[tuple[float, float, float, float, float, float]] = []
+    reference_count = first_refs.Length() + second_refs.Length()
+    for refs in (first_refs, second_refs):
+        for index in range(1, refs.Length() + 1):
+            shape = shape_tool.GetShape_s(refs.Value(index))
+            if shape is None or shape.IsNull():
+                partial_reasons.append("one referenced shape is unavailable")
+                continue
+            try:
+                bbox = _shape_bbox(shape)
+                boxes.append(bbox)
+                points.append(_bbox_centroid(bbox))
+            except Exception as exc:
+                partial_reasons.append(
+                    f"one referenced shape could not be measured ({_failure_reason(exc)})"
+                )
+    if reference_count == 0:
+        partial_reasons.append("referenced geometry is unavailable")
+
+    # The outer edges of the referenced geometry give the correct measurement span (e.g.
+    # the two far sides of a diameter) rather than the shorter centroid-to-centroid distance.
+    ref_bbox = _merge_bboxes(boxes) if boxes else None
+    dominant_axis = _dominant_from_bbox(ref_bbox) if ref_bbox else "?"
+    kind = _DIM_TYPE.get(type_code, f"type{type_code}")
+    return (
+        PmiRecord(
+            kind=kind,
+            type_code=type_code,
+            value=value,
+            upper_tol=upper_tol,
+            lower_tol=lower_tol,
+            ref_pts=tuple(points),
+            ref_bbox=ref_bbox,
+            dominant_axis=dominant_axis,
+            label=_make_label(kind, value, upper_tol, lower_tol),
+            source_id=source_id,
+        ),
+        tuple(dict.fromkeys(partial_reasons)),
+    )
+
+
+def _geometric_tolerance_record(obj, type_code: int, source_id: str) -> PmiRecord:
+    """Convert the currently preserved subset of one XCAF geometric tolerance."""
+    value = float(obj.GetValue())
+    kind = _GTOL_TYPE.get(type_code, f"gtol{type_code}")
+    return PmiRecord(
+        kind=kind,
+        type_code=type_code,
+        value=value,
+        label=f"{kind} {value:.3g}" if value else kind,
+        source_id=source_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 
-def extract_pmi(step_file: str | Path) -> list[PmiRecord]:
-    """Extract semantic PMI from an AP242 STEP file.
+def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
+    """Inventory and extract semantic PMI from an AP242 STEP file in one XCAF pass.
 
-    Returns an empty list (with a log message) when:
+    The report retains one source outcome for every dimension, geometric tolerance and
+    datum label. Graphical presentation-only dimension labels are inventoried but are not
+    manufacturing requirements. Datums are currently reported as ``not_extracted`` rather
+    than disappearing from the records-only projection.
+
+    Returns an empty report (with a report-level error where applicable) when:
 
     - the file contains no GDT data;
     - OCP's GDT support is unavailable (``_PMI_AVAILABLE`` is False);
@@ -222,142 +386,175 @@ def extract_pmi(step_file: str | Path) -> list[PmiRecord]:
     Does **not** modify the solid geometry — purely a read-only second pass.
     """
     if not _PMI_AVAILABLE:
-        _log.debug("PMI extraction unavailable (OCP SetGDTMode not found)")
-        return []
+        reason = "OCP SetGDTMode is unavailable"
+        _log.debug("PMI extraction unavailable (%s)", reason)
+        return PmiExtractionReport(error=reason)
 
     path = str(step_file)
     doc = TDocStd_Document(TCollection_ExtendedString("XCAF"))
     reader = STEPCAFControl_Reader()
     reader.SetGDTMode(True)
     reader.SetNameMode(True)
-    status = reader.ReadFile(path)
+    try:
+        status = reader.ReadFile(path)
+    except Exception as exc:
+        reason = f"ReadFile failed: {_failure_reason(exc)}"
+        _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
+        return PmiExtractionReport(error=reason)
     if status != IFSelect_RetDone:
-        _log.warning(
-            "PMI extraction: ReadFile failed for %s (status=%s)", Path(step_file).name, status
-        )
-        return []
-    reader.Transfer(doc)
+        reason = f"ReadFile failed with status {status}"
+        _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
+        return PmiExtractionReport(error=reason)
+    try:
+        transferred = reader.Transfer(doc)
+    except Exception as exc:
+        reason = f"Transfer failed: {_failure_reason(exc)}"
+        _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
+        return PmiExtractionReport(error=reason)
+    if transferred is False:
+        reason = "Transfer failed"
+        _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
+        return PmiExtractionReport(error=reason)
 
     main = doc.Main()
     shape_tool = XCAFDoc_DocumentTool.ShapeTool_s(main)
     dt = XCAFDoc_DocumentTool.DimTolTool_s(main)
 
     records: list[PmiRecord] = []
+    sources: list[PmiSourceEntity] = []
 
     # ---- Dimensions --------------------------------------------------------
     dims = TDF_LabelSequence()
     dt.GetDimensionLabels(dims)
-    n_dims_ok = 0
-
-    for i in range(1, dims.Length() + 1):
-        lab = dims.Value(i)
+    for index in range(1, dims.Length() + 1):
+        label = dims.Value(index)
+        source_id = _source_id("dimension", label)
+        type_code: int | None = None
         try:
-            obj = XCAFDoc_Dimension.Set_s(lab).GetObject()
-            tc = int(obj.GetType())
-            if tc in _SKIP_TYPES:
+            obj = XCAFDoc_Dimension.Set_s(label).GetObject()
+            type_code = int(obj.GetType())
+            without_record = _dimension_without_record(source_id, type_code)
+            if without_record is not None:
+                sources.append(without_record)
                 continue
-
-            # Nominal value: scalar first, array fallback
-            val: float = 0.0
-            try:
-                val = float(obj.GetValue())
-            except Exception:
-                try:
-                    arr = obj.GetValues()
-                    if arr is not None:
-                        val = float(arr.Value(arr.Lower()))
-                except Exception:
-                    pass
-
-            # Tolerances
-            upper_tol: float | None = None
-            lower_tol: float | None = None
-            try:
-                u = float(obj.GetUpperTolValue())
-                if abs(u) > 1e-9:
-                    upper_tol = u
-            except Exception:
-                pass
-            try:
-                lo = float(obj.GetLowerTolValue())
-                if abs(lo) > 1e-9:
-                    lower_tol = lo
-            except Exception:
-                pass
-
-            # Referenced geometry → bboxes and centroids
-            f_seq = TDF_LabelSequence()
-            s_seq = TDF_LabelSequence()
-            XCAFDoc_DimTolTool.GetRefShapeLabel_s(lab, f_seq, s_seq)
-            pts: list[tuple[float, float, float]] = []
-            raw_bboxes: list[tuple[float, float, float, float, float, float]] = []
-            for seq in (f_seq, s_seq):
-                for k in range(1, seq.Length() + 1):
-                    shp = shape_tool.GetShape_s(seq.Value(k))
-                    if shp is not None and not shp.IsNull():
-                        try:
-                            bb6 = _shape_bbox(shp)
-                            raw_bboxes.append(bb6)
-                            pts.append(_bbox_centroid(bb6))
-                        except Exception:
-                            pass
-
-            # Combined bbox of all referenced shapes, used for witness placement.
-            # The outer edges of the referenced geometry give the correct measurement
-            # span (e.g., the two far sides of a ø35 bore) rather than the much
-            # shorter centroid-to-centroid distance.
-            ref_bbox = _merge_bboxes(raw_bboxes) if raw_bboxes else None
-            dom = _dominant_from_bbox(ref_bbox) if ref_bbox else "?"
-
-            kind = _DIM_TYPE.get(tc, f"type{tc}")
-            lbl = _make_label(kind, val, upper_tol, lower_tol)
-            records.append(
-                PmiRecord(
-                    kind=kind,
-                    type_code=tc,
-                    value=val,
-                    upper_tol=upper_tol,
-                    lower_tol=lower_tol,
-                    ref_pts=pts,
-                    ref_bbox=ref_bbox,
-                    dominant_axis=dom,
-                    label=lbl,
+            record, partial_reasons = _dimension_record(
+                label, obj, type_code, shape_tool, source_id
+            )
+        except Exception as exc:
+            sources.append(
+                PmiSourceEntity(
+                    source_id=source_id,
+                    category="dimension",
+                    type_code=type_code,
+                    outcome="not_extracted",
+                    reason=_failure_reason(exc),
                 )
             )
-            n_dims_ok += 1
-        except Exception as exc:
-            _log.debug("PMI dim[%d] skipped: %s", i, exc)
+            _log.debug("PMI %s not extracted: %s", source_id, exc)
+        else:
+            records.append(record)
+            sources.append(
+                PmiSourceEntity(
+                    source_id,
+                    "dimension",
+                    type_code,
+                    "partially_extracted" if partial_reasons else "extracted",
+                    "; ".join(partial_reasons),
+                )
+            )
 
     # ---- Geometric tolerances ----------------------------------------------
-    gts = TDF_LabelSequence()
-    dt.GetGeomToleranceLabels(gts)
-    n_gtol_ok = 0
-
-    for i in range(1, gts.Length() + 1):
-        lab = gts.Value(i)
+    tolerances = TDF_LabelSequence()
+    dt.GetGeomToleranceLabels(tolerances)
+    for index in range(1, tolerances.Length() + 1):
+        label = tolerances.Value(index)
+        source_id = _source_id("geometric_tolerance", label)
+        tolerance_type_code: int | None = None
         try:
-            obj = XCAFDoc_GeomTolerance.Set_s(lab).GetObject()
-            tc = int(obj.GetType())
-            val = float(obj.GetValue())
-            kind = _GTOL_TYPE.get(tc, f"gtol{tc}")
-            records.append(
-                PmiRecord(
-                    kind=kind,
-                    type_code=tc,
-                    value=val,
-                    label=f"{kind} {val:.3g}" if val else kind,
+            obj = XCAFDoc_GeomTolerance.Set_s(label).GetObject()
+            tolerance_type_code = int(obj.GetType())
+            record = _geometric_tolerance_record(obj, tolerance_type_code, source_id)
+        except Exception as exc:
+            sources.append(
+                PmiSourceEntity(
+                    source_id=source_id,
+                    category="geometric_tolerance",
+                    type_code=tolerance_type_code,
+                    outcome="not_extracted",
+                    reason=_failure_reason(exc),
                 )
             )
-            n_gtol_ok += 1
-        except Exception as exc:
-            _log.debug("PMI gtol[%d] skipped: %s", i, exc)
+            _log.debug("PMI %s not extracted: %s", source_id, exc)
+        else:
+            records.append(record)
+            sources.append(
+                PmiSourceEntity(
+                    source_id,
+                    "geometric_tolerance",
+                    tolerance_type_code,
+                    "partially_extracted",
+                    "only the characteristic type is preserved; value and references are incomplete",
+                )
+            )
+
+    # ---- Datums ------------------------------------------------------------
+    # XCAF discovers these entities, but the current extractor creates no record for them.
+    # Keeping each source identity and explicit failure is the first #623 vertical slice;
+    # datum concept lowering follows separately rather than hiding the entire category.
+    datums = TDF_LabelSequence()
+    dt.GetDatumLabels(datums)
+    for index in range(1, datums.Length() + 1):
+        source_id = _source_id("datum", datums.Value(index))
+        sources.append(
+            PmiSourceEntity(
+                source_id=source_id,
+                category="datum",
+                type_code=None,
+                outcome="not_extracted",
+                reason="datum extraction is not implemented",
+            )
+        )
+
+    semantic_dimensions = sum(
+        source.category == "dimension" and source.outcome != "presentation_only"
+        for source in sources
+    )
+    extracted_dimensions = sum(
+        source.category == "dimension" and source.outcome == "extracted" for source in sources
+    )
+    partial_dimensions = sum(
+        source.category == "dimension" and source.outcome == "partially_extracted"
+        for source in sources
+    )
+    presentation_dimensions = sum(
+        source.category == "dimension" and source.outcome == "presentation_only"
+        for source in sources
+    )
+    partial_tolerances = sum(
+        source.category == "geometric_tolerance" and source.outcome == "partially_extracted"
+        for source in sources
+    )
 
     _log.info(
-        "PMI extracted from %s: %d/%d dims, %d/%d gtols",
+        "PMI extracted from %s: %d/%d complete semantic dims (%d partial, "
+        "%d presentation-only), "
+        "0/%d complete gtols (%d partial), 0/%d datums",
         Path(step_file).name,
-        n_dims_ok,
-        dims.Length(),
-        n_gtol_ok,
-        gts.Length(),
+        extracted_dimensions,
+        semantic_dimensions,
+        partial_dimensions,
+        presentation_dimensions,
+        tolerances.Length(),
+        partial_tolerances,
+        datums.Length(),
     )
-    return records
+    return PmiExtractionReport(sources=tuple(sources), records=tuple(records))
+
+
+def extract_pmi(step_file: str | Path) -> list[PmiRecord]:
+    """Return the successful-record projection of :func:`extract_pmi_report`.
+
+    This compatibility surface deliberately remains a list. Callers that need to know what
+    the source contained or why a record is absent must use :func:`extract_pmi_report`.
+    """
+    return list(extract_pmi_report(step_file).records)

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -1,12 +1,14 @@
 """Tests for PMI extraction and annotation (Phase 1–3)."""
 
+from collections import Counter
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from build123d import Box, export_step
 
-from draftwright import build_drawing, extract_pmi
-from draftwright.pmi import _PMI_AVAILABLE, PmiRecord
+from draftwright import build_drawing, extract_pmi, extract_pmi_report
+from draftwright.pmi import _PMI_AVAILABLE, PmiExtractionReport, PmiRecord
 
 FIXTURES = Path(__file__).parent / "fixtures"
 CTC01 = FIXTURES / "nist_ctc_01_asme1_ap242.stp"
@@ -19,18 +21,23 @@ pytestmark = pytest.mark.skipif(not _PMI_AVAILABLE, reason="OCP GDT support not 
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(scope="module")
+def ctc01_extraction_report():
+    return extract_pmi_report(CTC01)
+
+
 class TestExtractPmi:
-    def test_nist_ctc01_returns_records(self):
-        recs = extract_pmi(CTC01)
+    def test_nist_ctc01_returns_records(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         assert len(recs) > 0
 
-    def test_nist_ctc01_dim_count(self):
-        recs = extract_pmi(CTC01)
+    def test_nist_ctc01_dim_count(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         dims = [r for r in recs if r.kind not in ("gtol", "datum")]
         assert len(dims) >= 8, f"expected ≥8 dim records, got {len(dims)}"
 
-    def test_nist_ctc01_gtol_count(self):
-        recs = extract_pmi(CTC01)
+    def test_nist_ctc01_gtol_count(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         gtols = [
             r
             for r in recs
@@ -54,26 +61,26 @@ class TestExtractPmi:
         ]
         assert len(gtols) >= 4
 
-    def test_usable_dims_have_positive_value(self):
-        recs = extract_pmi(CTC01)
+    def test_usable_dims_have_positive_value(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         usable = [r for r in recs if r.value > 0 and len(r.ref_pts) >= 2]
         assert len(usable) >= 4, f"expected ≥4 usable dims, got {len(usable)}"
 
-    def test_diameter_labels_prefixed(self):
-        recs = extract_pmi(CTC01)
+    def test_diameter_labels_prefixed(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         diameters = [r for r in recs if r.kind == "diameter" and r.value > 0]
         assert len(diameters) >= 1
         for d in diameters:
             assert d.label.startswith("ø"), f"diameter label missing ø: {d.label!r}"
 
-    def test_ref_pts_are_3d_tuples(self):
-        recs = extract_pmi(CTC01)
+    def test_ref_pts_are_3d_tuples(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         for r in recs:
             for pt in r.ref_pts:
                 assert len(pt) == 3, f"ref_pt should be 3-tuple, got {pt!r}"
 
-    def test_dominant_axis_set(self):
-        recs = extract_pmi(CTC01)
+    def test_dominant_axis_set(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         usable = [r for r in recs if r.value > 0 and len(r.ref_pts) >= 2]
         axes = {r.dominant_axis for r in usable}
         assert axes - {"X", "Y", "Z", "?"} == set()
@@ -86,10 +93,252 @@ class TestExtractPmi:
         recs = extract_pmi(step)
         assert recs == []
 
-    def test_records_are_pmi_record_instances(self):
-        recs = extract_pmi(CTC01)
+    def test_records_are_pmi_record_instances(self, ctc01_extraction_report):
+        recs = ctc01_extraction_report.records
         for r in recs:
             assert isinstance(r, PmiRecord)
+
+    def test_records_only_api_remains_a_list_projection(self, ctc01_extraction_report):
+        assert extract_pmi(CTC01) == list(ctc01_extraction_report.records)
+
+    def test_report_preserves_the_complete_ctc01_source_denominator(self, ctc01_extraction_report):
+        report = ctc01_extraction_report
+        assert isinstance(report, PmiExtractionReport)
+        assert len(report.sources) == 38
+        assert len({source.source_id for source in report.sources}) == 38
+        assert Counter((source.category, source.outcome) for source in report.sources) == Counter(
+            {
+                ("dimension", "extracted"): 12,
+                ("dimension", "presentation_only"): 9,
+                ("geometric_tolerance", "partially_extracted"): 6,
+                ("datum", "not_extracted"): 11,
+            }
+        )
+        assert {record.source_id for record in report.records} == {
+            source.source_id
+            for source in report.sources
+            if source.outcome in ("extracted", "partially_extracted")
+        }
+
+    def test_non_record_dimension_types_fail_closed(self):
+        import draftwright.pmi as pmi_module
+
+        presentation = pmi_module._dimension_without_record("dimension:p", 31)
+        common_label = pmi_module._dimension_without_record("dimension:c", 30)
+
+        assert presentation is not None and presentation.outcome == "presentation_only"
+        assert common_label is not None and common_label.outcome == "not_extracted"
+        assert "not implemented" in common_label.reason
+        assert pmi_module._dimension_without_record("dimension:d", 15) is None
+
+    def test_dimension_field_failures_are_explicit_partial_outcomes(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        class FakeSequence:
+            def __init__(self):
+                self.items = []
+
+            def Length(self):
+                return len(self.items)
+
+            def Value(self, index):
+                return self.items[index - 1]
+
+        class FakeArray:
+            def Lower(self):
+                return 1
+
+            def Value(self, _index):
+                return 12.0
+
+        class FakeObject:
+            def __init__(self, values):
+                self.values = values
+
+            def GetValue(self):
+                raise RuntimeError("scalar unavailable")
+
+            def GetValues(self):
+                if isinstance(self.values, Exception):
+                    raise self.values
+                return self.values
+
+            def GetUpperTolValue(self):
+                raise RuntimeError("no upper tolerance")
+
+            def GetLowerTolValue(self):
+                raise RuntimeError("no lower tolerance")
+
+        refs = []
+
+        def get_refs(_label, first, second):
+            first.items.extend(refs)
+            second.items.extend([])
+
+        monkeypatch.setattr(pmi_module, "TDF_LabelSequence", FakeSequence)
+        monkeypatch.setattr(
+            pmi_module,
+            "XCAFDoc_DimTolTool",
+            SimpleNamespace(GetRefShapeLabel_s=get_refs),
+        )
+        shape_tool = SimpleNamespace(GetShape_s=lambda ref: ref)
+
+        record, reasons = pmi_module._dimension_record(
+            object(), FakeObject(FakeArray()), 15, shape_tool, "dimension:a"
+        )
+        assert record.value == 12.0
+        assert reasons == ("referenced geometry is unavailable",)
+
+        refs[:] = [None]
+        _record, reasons = pmi_module._dimension_record(
+            object(), FakeObject(None), 15, shape_tool, "dimension:b"
+        )
+        assert reasons == (
+            "nominal value is unavailable",
+            "one referenced shape is unavailable",
+        )
+
+        refs[:] = [SimpleNamespace(IsNull=lambda: False)]
+        monkeypatch.setattr(
+            pmi_module,
+            "_shape_bbox",
+            lambda _shape: (_ for _ in ()).throw(RuntimeError("bbox failed")),
+        )
+        _record, reasons = pmi_module._dimension_record(
+            object(),
+            FakeObject(RuntimeError("array unavailable")),
+            15,
+            shape_tool,
+            "dimension:c",
+        )
+        assert "nominal value is unavailable (RuntimeError: array unavailable)" in reasons
+        assert "one referenced shape could not be measured (RuntimeError: bbox failed)" in reasons
+
+    def test_report_returns_structured_reader_failures(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        monkeypatch.setattr(pmi_module, "_PMI_AVAILABLE", False)
+        assert "SetGDTMode" in pmi_module.extract_pmi_report("missing.step").error
+
+        class FakeReader:
+            def __init__(self, *, status=1, transfer=True):
+                self.status = status
+                self.transfer = transfer
+
+            def SetGDTMode(self, _enabled):
+                pass
+
+            def SetNameMode(self, _enabled):
+                pass
+
+            def ReadFile(self, _path):
+                if isinstance(self.status, Exception):
+                    raise self.status
+                return self.status
+
+            def Transfer(self, _doc):
+                if isinstance(self.transfer, Exception):
+                    raise self.transfer
+                return self.transfer
+
+        monkeypatch.setattr(pmi_module, "_PMI_AVAILABLE", True)
+        monkeypatch.setattr(pmi_module, "IFSelect_RetDone", 1)
+        monkeypatch.setattr(pmi_module, "TCollection_ExtendedString", lambda value: value)
+        monkeypatch.setattr(pmi_module, "TDocStd_Document", lambda _name: object())
+
+        for reader, expected in (
+            (FakeReader(status=RuntimeError("read exploded")), "read exploded"),
+            (FakeReader(status=0), "ReadFile failed"),
+            (FakeReader(transfer=RuntimeError("transfer exploded")), "transfer exploded"),
+            (FakeReader(transfer=False), "Transfer failed"),
+        ):
+            monkeypatch.setattr(pmi_module, "STEPCAFControl_Reader", lambda: reader)
+            assert expected in pmi_module.extract_pmi_report("broken.step").error
+
+    def test_a_failed_conversion_does_not_disappear_from_the_source_denominator(
+        self, monkeypatch, ctc01_extraction_report
+    ):
+        import draftwright.pmi as pmi_module
+
+        target = next(
+            source.source_id
+            for source in ctc01_extraction_report.sources
+            if source.category == "dimension" and source.outcome == "extracted"
+        )
+        original = pmi_module._dimension_record
+
+        def fail_one(label, obj, type_code, shape_tool, source_id):
+            if source_id == target:
+                raise RuntimeError("mutation: conversion failed")
+            return original(label, obj, type_code, shape_tool, source_id)
+
+        monkeypatch.setattr(pmi_module, "_dimension_record", fail_one)
+        mutated = extract_pmi_report(CTC01)
+        failed = next(source for source in mutated.sources if source.source_id == target)
+
+        assert {source.source_id for source in mutated.sources} == {
+            source.source_id for source in ctc01_extraction_report.sources
+        }
+        assert len(mutated.records) == len(ctc01_extraction_report.records) - 1
+        assert failed.outcome == "not_extracted"
+        assert failed.reason == "RuntimeError: mutation: conversion failed"
+
+    def test_a_partial_conversion_keeps_both_its_source_and_record(
+        self, monkeypatch, ctc01_extraction_report
+    ):
+        import draftwright.pmi as pmi_module
+
+        target = next(
+            source.source_id
+            for source in ctc01_extraction_report.sources
+            if source.category == "dimension" and source.outcome == "extracted"
+        )
+        original = pmi_module._dimension_record
+
+        def partial_one(label, obj, type_code, shape_tool, source_id):
+            record, reasons = original(label, obj, type_code, shape_tool, source_id)
+            if source_id == target:
+                reasons = (*reasons, "mutation: one field was lost")
+            return record, reasons
+
+        monkeypatch.setattr(pmi_module, "_dimension_record", partial_one)
+        mutated = extract_pmi_report(CTC01)
+        partial = next(source for source in mutated.sources if source.source_id == target)
+
+        assert {source.source_id for source in mutated.sources} == {
+            source.source_id for source in ctc01_extraction_report.sources
+        }
+        assert {record.source_id for record in mutated.records} == {
+            record.source_id for record in ctc01_extraction_report.records
+        }
+        assert partial.outcome == "partially_extracted"
+        assert partial.reason == "mutation: one field was lost"
+
+    def test_a_failed_gtol_conversion_keeps_its_source_identity(
+        self, monkeypatch, ctc01_extraction_report
+    ):
+        import draftwright.pmi as pmi_module
+
+        target = next(
+            source.source_id
+            for source in ctc01_extraction_report.sources
+            if source.category == "geometric_tolerance"
+        )
+        original = pmi_module._geometric_tolerance_record
+
+        def fail_one(obj, type_code, source_id):
+            if source_id == target:
+                raise RuntimeError("mutation: gtol conversion failed")
+            return original(obj, type_code, source_id)
+
+        monkeypatch.setattr(pmi_module, "_geometric_tolerance_record", fail_one)
+        mutated = extract_pmi_report(CTC01)
+        failed = next(source for source in mutated.sources if source.source_id == target)
+
+        assert len(mutated.sources) == len(ctc01_extraction_report.sources)
+        assert len(mutated.records) == len(ctc01_extraction_report.records) - 1
+        assert failed.outcome == "not_extracted"
+        assert failed.reason == "RuntimeError: mutation: gtol conversion failed"
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +364,24 @@ class TestBuildDrawingPmi:
         dwg = build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="off")
         pmi_names = [n for n in dwg.annotations() if n.startswith("pmi_")]
         assert pmi_names == [], f"pmi='off' should add no pmi_ annotations, got {pmi_names}"
+        assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_extracted"]
+
+    def test_a_top_level_extraction_failure_cannot_become_no_pmi(self, tmp_path, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        step = tmp_path / "plain.step"
+        export_step(Box(40, 30, 20), str(step))
+
+        def fail(_step_file):
+            raise RuntimeError("mutation: XCAF pass failed")
+
+        monkeypatch.setattr(pmi_module, "extract_pmi_report", fail)
+        drawing = build_drawing(step, pmi="annotate")
+        issues = [issue for issue in drawing.lint() if issue.code == "pmi_not_extracted"]
+
+        assert len(issues) == 1
+        assert issues[0].severity == "error"
+        assert "RuntimeError: mutation: XCAF pass failed" in issues[0].message
 
     def test_pmi_report_extracts_but_does_not_annotate(self, tmp_path):
         """pmi='report' populates a._analysis.pmi but adds no drawing annotations."""
@@ -125,17 +392,37 @@ class TestBuildDrawingPmi:
         assert len(a.pmi) > 0, "pmi='report' should populate pmi records"
         pmi_names = [n for n in dwg.annotations() if n.startswith("pmi_")]
         assert pmi_names == [], "pmi='report' should not add drawing annotations"
+        issues = [issue for issue in dwg.lint() if issue.code == "pmi_not_extracted"]
+        assert len(issues) == 17
+        assert {issue.severity for issue in issues} == {"info"}
+        assert len({issue.source_ids for issue in issues}) == 17
 
     def test_pmi_annotate_adds_dims(self, ctc01_annotated):
         """pmi='annotate' adds at least one pmi_ dimension to the drawing."""
         pmi_names = [n for n in ctc01_annotated.annotations() if n.startswith("pmi_")]
         assert len(pmi_names) >= 1, f"expected ≥1 pmi_ annotation, got {pmi_names}"
 
-    def test_pmi_annotate_drawing_lint_clean(self, ctc01_annotated):
-        """Drawing with PMI annotations passes lint with no errors."""
-        issues = ctc01_annotated.lint()
-        errors = [i for i in issues if i.severity == "error"]
-        assert errors == [], f"lint errors with PMI: {[str(i) for i in errors]}"
+    def test_pmi_annotate_reports_each_incomplete_source_record(self, ctc01_annotated):
+        issues = [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_extracted"]
+        assert len(issues) == 17
+        assert {issue.severity for issue in issues} == {"error"}
+        assert len({issue.source_ids for issue in issues}) == 17
+        assert all(issue.source_ids[0] in issue.message for issue in issues)
+        assert (
+            sum("datum extraction is not implemented" in issue.message for issue in issues) == 11
+        )
+        assert (
+            sum("only the characteristic type is preserved" in issue.message for issue in issues)
+            == 6
+        )
+        summary = ctc01_annotated.lint_summary()
+        assert summary["passed"] is False
+        assert summary["by_code"]["pmi_not_extracted"] == 17
+        assert all(
+            "source_ids" in issue
+            for issue in summary["issues"]
+            if issue["code"] == "pmi_not_extracted"
+        )
 
     def test_pmi_annotate_exports_svg_dxf(self, ctc01_annotated):
         """build_drawing + export with PMI produces valid SVG and DXF files."""
@@ -177,12 +464,12 @@ class TestDeclaredModelPmi:
         assert [n for n in dwg.annotations() if n.startswith("pmi_")] == []
 
 
-def test_build_pmi_features_mirrors_detection():
+def test_build_pmi_features_mirrors_detection(ctc01_extraction_report):
     """build_pmi_features (shared by build_part_model and the declared-model synthesis) builds one
     imported drafting annotation per record; both callers construct them identically (#472)."""
     from draftwright.model import AuthoredDimension, PmiFeature, build_pmi_features
 
-    recs = extract_pmi(CTC01)
+    recs = ctc01_extraction_report.records
     dim_kinds = {
         "linear",
         "diameter",


### PR DESCRIPTION
## Summary

- make a frozen `PmiExtractionReport` the canonical result of the AP242 XCAF pass while preserving `extract_pmi()` as a list projection
- retain stable TDF source identities and explicit outcomes for every dimension, geometric tolerance, and datum label
- surface incomplete extraction as structured lint issues in `report` and `annotate` modes
- mutation-gate failed and partial dimension/GTOL conversion so records cannot disappear from the source denominator

## Why

The existing extractor returned only successful records. Unsupported datums, partial geometric tolerances, and caught conversion failures therefore became indistinguishable from PMI that never existed, allowing an incomplete AP242 drawing to appear lint-clean. This is the first source-to-extraction slice of #623; lowering and rendering reconciliation remain separate follow-ups.

## Compatibility

`extract_pmi()` still returns `list[PmiRecord]`, and `Analysis.pmi` remains a list projection. `PmiRecord` is now frozen and uses tuple reference points so the canonical report is transitively immutable; no repository caller mutates either surface.

## Validation

- `scripts/pr-check --full`
- 3,037 passed, 4 skipped, 2 xfailed
- 93.94% combined line/branch coverage
- 100% changed-source coverage (183/183 lines)

Refs #623