### PR TITLE
Expose AP242 PMI lowering gaps

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3949,7 +3949,10 @@ def _renderable_pmi_records(records):
     return [
         r
         for r in records
-        if r.pmi_kind in AUTHORED_DIMENSION_KINDS and r.value > 0 and len(r.ref_pts) >= 2
+        if r.kind == "authored_dimension"
+        and r.pmi_kind in AUTHORED_DIMENSION_KINDS
+        and r.value > 0
+        and len(r.ref_pts) >= 2
     ]
 
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -80,6 +80,7 @@ from draftwright.linting import (
     lint_flat_coverage,
     lint_location_coverage,
     lint_pmi_extraction,
+    lint_pmi_lowering,
     lint_principal_profile_coverage,
     lint_prismatic_coverage,
     lint_profiled_bore_coverage,
@@ -104,6 +105,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "pad_footprint_not_defined",
         "pocket_not_located",
         "unrecognised_defining_geometry",
+        "pmi_not_lowered",
         "axial_length_missing",
         "flat_requirement_suppressed",
         "flat_requirement_missing",
@@ -2880,6 +2882,11 @@ class Drawing:
                 )
         if physical and self._analysis is not None:
             issues += lint_pmi_extraction(self._analysis.pmi_report, self._analysis.pmi_mode)
+            issues += lint_pmi_lowering(
+                self._analysis.pmi_report,
+                getattr(self._part_model, "features", ()),
+                self._analysis.pmi_mode,
+            )
         issues += list(self._registry.issues)
         # Attach a ready-to-paste fix snippet where one is computable (#29).
         # str | None — None when no concrete repair can be inferred.

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -29,7 +29,7 @@ from draftwright.linting.coverage import (
 )
 from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.issues import LintIssue
-from draftwright.linting.pmi_coverage import lint_pmi_extraction
+from draftwright.linting.pmi_coverage import lint_pmi_extraction, lint_pmi_lowering
 from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
 from draftwright.linting.slot_coverage import lint_slot_coverage
 from draftwright.linting.structural import lint_drawing
@@ -49,6 +49,7 @@ __all__ = [
     "lint_slot_coverage",
     "lint_location_coverage",
     "lint_pmi_extraction",
+    "lint_pmi_lowering",
     "lint_principal_profile_coverage",
     "lint_profiled_bore_coverage",
     "lint_prismatic_coverage",

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -42,3 +42,37 @@ def lint_pmi_extraction(report: PmiExtractionReport | None, mode: str) -> list[L
         if source.outcome in ("not_extracted", "partially_extracted")
     )
     return issues
+
+
+def lint_pmi_lowering(report: PmiExtractionReport | None, features, mode: str) -> list[LintIssue]:
+    """Report extracted AP242 requirements that did not reach concept-shaped IR."""
+    if report is None or mode == "off":
+        return []
+
+    severity: Literal["error", "info"] = "error" if mode == "annotate" else "info"
+    by_source: dict[str, list[object]] = {}
+    for feature in features:
+        if source_id := getattr(feature, "source_id", ""):
+            by_source.setdefault(source_id, []).append(feature)
+
+    issues = []
+    for record in report.records:
+        if not record.source_id:
+            continue
+        lowered = by_source.get(record.source_id, ())
+        if lowered and any(getattr(feature, "kind", None) != "pmi" for feature in lowered):
+            continue
+        reason = (
+            f"remains a raw {record.kind!r} PMI fallback in the typed IR"
+            if lowered
+            else "did not produce a typed IR feature"
+        )
+        issues.append(
+            LintIssue(
+                severity=severity,
+                code="pmi_not_lowered",
+                message=f"AP242 source {record.source_id} {reason}",
+                source_ids=(record.source_id,),
+            )
+        )
+    return issues

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1912,12 +1912,15 @@ def measured_dimension(
     lower_tol: float | None = None,
     source: str = "sheet",
     source_kind: str | None = None,
+    source_id: str = "",
 ) -> AuthoredDimension:
     """A pre-authored drafting dimension from explicit measured values — the IR constructor
     behind :meth:`Sheet.measured_dimension` (#704: extracted so ``build_drawing(model=…)``
     callers can author one without the façade). Validates the kind against
     :data:`~draftwright.model.ir.AUTHORED_DIMENSION_KINDS`, needs ≥2 ``ref_pts``, and derives
-    ``at`` (the ``ref_bbox`` centre, else the ``ref_pts`` centroid) when not given."""
+    ``at`` (the ``ref_bbox`` centre, else the ``ref_pts`` centroid) when not given.
+    ``source_id`` preserves an external record identity; ordinary Sheet declarations leave it
+    blank."""
     _require_positive(value=value)
     dim_kind = str(kind).lower()
     if dim_kind not in AUTHORED_DIMENSION_KINDS:
@@ -1954,4 +1957,5 @@ def measured_dimension(
         ref_pts=pts,
         source=source,
         source_kind=source_kind or dim_kind,
+        source_id=str(source_id),
     )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -245,6 +245,7 @@ def build_pmi_features(pmi, bbox) -> list[AuthoredDimension | PmiFeature]:
                     ref_bbox=r.ref_bbox,
                     ref_pts=tuple(r.ref_pts),
                     source_kind=r.kind,
+                    source_id=r.source_id,
                 )
             )
             continue
@@ -257,6 +258,7 @@ def build_pmi_features(pmi, bbox) -> list[AuthoredDimension | PmiFeature]:
                 dominant_axis=r.dominant_axis,
                 ref_bbox=r.ref_bbox,
                 ref_pts=tuple(r.ref_pts),
+                source_id=r.source_id,
             )
         )
     return out

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1120,7 +1120,7 @@ class AuthoredDimension:
     PMI, but the drawing model sees an authored linear/diameter/radius/etc. dimension with
     baked label and referenced geometry. The normal dimension planner does not derive or
     duplicate it, so ``parameters()`` is empty; renderers consume it directly while keeping
-    the source/provenance fields for round-trip and diagnostics."""
+    the source/provenance fields, including ``source_id``, for round-trip and diagnostics."""
 
     frame: Frame
     dimension_kind: str  # "linear" | "diameter" | "radius" | "angular" | ...
@@ -1133,6 +1133,7 @@ class AuthoredDimension:
     ref_pts: tuple[Point, ...] = ()
     source: str = "ap242_pmi"
     source_kind: str | None = None
+    source_id: str = ""
     kind: ClassVar[str] = "authored_dimension"
 
     @property
@@ -1154,7 +1155,8 @@ class PmiFeature:
     Dimensional AP242 PMI should become :class:`AuthoredDimension`; GD&T/datum/surface
     records should eventually lower to ``ControlFrame`` / ``DatumRef`` / ``Finish``. This
     type remains as an explicit provenance-preserving escape hatch so unsupported records
-    are visible instead of silently lost."""
+    are visible instead of silently lost. ``source_id`` retains the external record identity
+    needed to report that missing concept lowering."""
 
     frame: Frame
     pmi_kind: str  # the PMI category: "linear" | "diameter" | "radius" | "angular" | ...
@@ -1163,6 +1165,7 @@ class PmiFeature:
     dominant_axis: str
     ref_bbox: tuple[float, float, float, float, float, float] | None = None
     ref_pts: tuple[Point, ...] = ()
+    source_id: str = ""
     kind: ClassVar[str] = "pmi"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -908,6 +908,7 @@ class Sheet:
         lower_tol: float | None = None,
         source: str = "sheet",
         source_kind: str | None = None,
+        source_id: str = "",
     ) -> _Params:
         """Declare a drafting dimension from explicit **measured** values.
 
@@ -921,6 +922,8 @@ class Sheet:
         may call the record PMI, but the editable script declares a dimension category, value,
         label, referenced model points, and optional structured tolerances. For ordinary
         geometry-backed edits prefer feature handles such as ``sheet.hole(...).tolerance(...)``.
+        ``source_id`` is the external record identity retained by generated imported-PMI scripts;
+        hand-authored dimensions normally leave it blank.
         Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
@@ -938,6 +941,7 @@ class Sheet:
                 lower_tol=lower_tol,
                 source=source,
                 source_kind=source_kind,
+                source_id=source_id,
             )
         )
         # A handle like every other declaration verb (#922). A measured dimension carries its

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -216,18 +216,21 @@ def _measured_dimension_line(f) -> str:
         kw.append(f"source={f.source!r}")
     if f.source_kind is not None and f.source_kind != f.dimension_kind:
         kw.append(f"source_kind={f.source_kind!r}")
+    if f.source_id:
+        kw.append(f"source_id={f.source_id!r}")
     # `measured_dimension` since #873 — a generated script must not emit the transitional
     # overload, or every regenerated AP242 script would arrive pre-deprecated.
     return "sheet.measured_dimension(" + ", ".join(kw) + ")"
 
 
 def _raw_pmi_line(f) -> str:
+    source_id = f", source_id={f.source_id!r}" if f.source_id else ""
     return (
         "sheet.add(PmiFeature("
         f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
         f"pmi_kind={f.pmi_kind!r}, value={_n(f.value)}, label={f.label!r}, "
         f"dominant_axis={f.dominant_axis!r}, ref_bbox={_bbox_arg(f.ref_bbox)}, "
-        f"ref_pts=tuple({_pts_arg(f.ref_pts)})"
+        f"ref_pts=tuple({_pts_arg(f.ref_pts)}){source_id}"
         "))   # raw AP242 PMI fallback; not yet lowered to a drafting concept"
     )
 

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -396,6 +396,10 @@ class TestBuildDrawingPmi:
         assert len(issues) == 17
         assert {issue.severity for issue in issues} == {"info"}
         assert len({issue.source_ids for issue in issues}) == 17
+        lowering = [issue for issue in dwg.lint() if issue.code == "pmi_not_lowered"]
+        assert len(lowering) == 10
+        assert {issue.severity for issue in lowering} == {"info"}
+        assert len({issue.source_ids for issue in lowering}) == 10
 
     def test_pmi_annotate_adds_dims(self, ctc01_annotated):
         """pmi='annotate' adds at least one pmi_ dimension to the drawing."""
@@ -423,6 +427,20 @@ class TestBuildDrawingPmi:
             for issue in summary["issues"]
             if issue["code"] == "pmi_not_extracted"
         )
+
+    def test_pmi_annotate_reports_each_raw_ir_fallback(self, ctc01_annotated):
+        from draftwright.model import PmiFeature
+
+        raw_source_ids = {
+            feature.source_id
+            for feature in ctc01_annotated.model().features
+            if isinstance(feature, PmiFeature)
+        }
+        issues = [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_lowered"]
+
+        assert len(raw_source_ids) == 10
+        assert {issue.severity for issue in issues} == {"error"}
+        assert {issue.source_ids[0] for issue in issues} == raw_source_ids
 
     def test_pmi_annotate_exports_svg_dxf(self, ctc01_annotated):
         """build_drawing + export with PMI produces valid SVG and DXF files."""
@@ -488,10 +506,12 @@ def test_build_pmi_features_mirrors_detection(ctc01_extraction_report):
     assert len(feats) == len(recs)
     authored = [f for f in feats if isinstance(f, AuthoredDimension)]
     raw = [f for f in feats if isinstance(f, PmiFeature)]
-    assert authored
-    assert raw  # GD&T/datum AP242 records are explicit raw fallbacks until concept lowering.
+    assert len(authored) == 8
+    # Four location dimensions and six geometric tolerances remain explicit raw fallbacks.
+    assert len(raw) == 10
     assert all(f.kind == "authored_dimension" for f in authored)
     assert all(f.kind == "pmi" for f in raw)
+    assert {feature.source_id for feature in feats} == {record.source_id for record in recs}
     # a dimensional PMI record's value/label ride onto its authored dimension verbatim
     assert {f.label for f in authored} >= {r.label for r in dims}
     for r in dims:
@@ -500,6 +520,53 @@ def test_build_pmi_features_mirrors_detection(ctc01_extraction_report):
             for f in authored
         )
     assert build_pmi_features(None, bbox) == []  # None/empty → no features
+
+
+def test_a_supported_dimension_routed_to_raw_ir_is_reported_by_source_identity(
+    ctc01_extraction_report, monkeypatch
+):
+    from dataclasses import replace
+
+    from build123d import import_step
+
+    import draftwright.model.detect as detect_module
+    from draftwright.annotations.from_model import _renderable_pmi_records
+    from draftwright.linting import lint_pmi_lowering
+    from draftwright.model import PmiFeature
+
+    target = next(record for record in ctc01_extraction_report.records if record.kind == "angular")
+    bbox = import_step(CTC01).bounding_box()
+    baseline = detect_module.build_pmi_features(ctc01_extraction_report.records, bbox)
+    compatibility_record = replace(target, source_id="")
+    compatibility_report = replace(ctc01_extraction_report, records=(compatibility_record,))
+    assert lint_pmi_lowering(compatibility_report, (), "annotate") == []
+    assert target.source_id not in {
+        issue.source_ids[0]
+        for issue in lint_pmi_lowering(ctc01_extraction_report, baseline, "annotate")
+    }
+    missing = [feature for feature in baseline if feature.source_id != target.source_id]
+    missing_issue = next(
+        issue
+        for issue in lint_pmi_lowering(ctc01_extraction_report, missing, "annotate")
+        if issue.source_ids == (target.source_id,)
+    )
+    assert "did not produce a typed IR feature" in missing_issue.message
+
+    monkeypatch.setattr(
+        detect_module,
+        "AUTHORED_DIMENSION_KINDS",
+        detect_module.AUTHORED_DIMENSION_KINDS - {"angular"},
+    )
+    mutated = detect_module.build_pmi_features(ctc01_extraction_report.records, bbox)
+    raw = next(feature for feature in mutated if feature.source_id == target.source_id)
+    issues = lint_pmi_lowering(ctc01_extraction_report, mutated, "annotate")
+    issue = next(issue for issue in issues if issue.source_ids == (target.source_id,))
+
+    assert isinstance(raw, PmiFeature)
+    assert raw not in _renderable_pmi_records(mutated)
+    assert issue.code == "pmi_not_lowered"
+    assert issue.severity == "error"
+    assert target.source_id in issue.message
 
 
 def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1816,8 +1816,9 @@ class TestAuthoredSetRoundTrips:
         # ...and the WHOLE feature, field by field. The four spot-checks above were what
         # `_FIDELITY_UNCOVERED` leaned on to exempt `authored_dimension` from the detected-route
         # oracle — and they missed `ref_pts`, `ref_bbox`, `frame`, `dimension_kind`,
-        # `dominant_axis`, `source` and `source_kind`, all of which the emitter writes. A review
-        # mutation moved every reference point by 1 mm and this test still passed (#967 r4).
+        # `dominant_axis`, `source`, `source_kind` and `source_id`, all of which the emitter
+        # writes. A review mutation moved every reference point by 1 mm and this test still
+        # passed (#967 r4).
         original = next(f for f in model.features if f.kind == "authored_dimension")
         assert _structurally_equal(original, feat), (
             f"the re-run declares a different measurement:\n  from {original}\n  to   {feat}"
@@ -2381,6 +2382,7 @@ def _declared_measurement_model():
         ref_pts=[(-20, 0, 0), (20, 0, 0)],
         upper_tol=0.1,
         lower_tol=0.0,
+        source_id="dimension:0:1:4:test",
     )
     return part, sheet.model()
 
@@ -3140,6 +3142,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
                 dominant_axis="X",
                 ref_bbox=(-30.0, -20.0, -10.0, 30.0, 20.0, 10.0),
                 ref_pts=((-30.0, 0.0, 0.0), (30.0, 0.0, 0.0)),
+                source_id="dimension:0:1:4:raw-test",
             )
             return part, dataclasses.replace(model, features=[*model.features, record])
 


### PR DESCRIPTION
## Summary

- carry stable AP242 source IDs from extracted records onto `AuthoredDimension` and raw `PmiFeature` IR, including emitted-script round trips
- derive `pmi_not_lowered` issues by reconciling source records with the finished IR
- distinguish eight CTC01 concept-shaped dimensions from four raw location dimensions and six raw geometric-tolerance fallbacks
- prevent raw PMI fallbacks from entering the authored-dimension renderer merely because their category looks dimensional
- mutation-gate both a deleted lowering result and a supported angular dimension routed to raw IR

## Why

After #1088, extraction failures were visible but a successful record could still lose its drafting concept during lowering. Raw `PmiFeature` was also not a load-bearing distinction: the renderer accepted it when `pmi_kind` matched a dimension category. This is the extraction-to-IR slice of #623; placement/render reconciliation follows separately.

## User impact

CTC01 now reports ten `pmi_not_lowered` outcomes by stable AP242 source identity: informational in `report` mode and errors in `annotate` mode. Successful authored dimensions remain rendered through the shared placement solve.

## Validation

- `scripts/pr-check --full`
- 3,039 passed, 4 skipped, 2 xfailed
- 93.94% combined line/branch coverage
- 100% changed-source coverage after the compatibility branch assertion
- focused PMI/emitter/import-boundary corpus: 405 passed, 2 xfailed

Refs #623