### PR TITLE
Reconcile AP242 PMI render outcomes

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1130,13 +1130,7 @@ class PlacementContext:
             ids = tuple(item for item in measurement if item is not None)
         else:
             ids = (measurement,)
-        source_ids: tuple[str, ...]
-        if source is None:
-            source_ids = ()
-        elif isinstance(source, (list, tuple)):
-            source_ids = tuple(str(item) for item in source if item)
-        else:
-            source_ids = (str(source),) if source else ()
+        source_ids = (str(source),) if source else ()
         self.registry.record_issue(
             LintIssue(
                 severity=severity,

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1120,7 +1120,7 @@ class PlacementContext:
             self._hole_feature_index = idx
         return self._hole_feature_index.get(tuple(round(c, 3) for c in location))
 
-    def record_issue(self, severity, code, message, *, measurement=None) -> None:
+    def record_issue(self, severity, code, message, *, measurement=None, source=None) -> None:
         """Record a build-time lint issue on the run's registry (#639). Replaces the passes'
         old `dwg._record_build_issue`."""
         ids: tuple
@@ -1130,8 +1130,21 @@ class PlacementContext:
             ids = tuple(item for item in measurement if item is not None)
         else:
             ids = (measurement,)
+        source_ids: tuple[str, ...]
+        if source is None:
+            source_ids = ()
+        elif isinstance(source, (list, tuple)):
+            source_ids = tuple(str(item) for item in source if item)
+        else:
+            source_ids = (str(source),) if source else ()
         self.registry.record_issue(
-            LintIssue(severity=severity, code=code, message=message, measurement_ids=ids)
+            LintIssue(
+                severity=severity,
+                code=code,
+                message=message,
+                measurement_ids=ids,
+                source_ids=source_ids,
+            )
         )
 
     def reset_issues(self) -> None:

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3900,7 +3900,10 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
     else:
         view = "front" if ax in ("X", "Z") else "side"
     ctx.record_issue(
-        "warning", "pmi_dropped", f"PMI {label!r} not placed (no room beside the {view})"
+        "warning",
+        "pmi_dropped",
+        f"PMI {label!r} not placed (no room beside the {view})",
+        source=getattr(rec, "source_id", ""),
     )
     ctx.escalations.append(
         Escalation(kind="pmi", view=view, feature=rec, reason="no room beside the view")
@@ -3918,6 +3921,18 @@ def _record_pmi_unrenderable(dwg, label, rec, *, ctx):
         "authored_dim_degenerate",
         f"authored dimension {label!r} has degenerate reference geometry (needs two "
         "distinct reference points spanning a legible distance)",
+        source=getattr(rec, "source_id", ""),
+    )
+
+
+def _record_pmi_no_candidate(ctx, label, rec):
+    """Record authored PMI for which the renderer could not form any placement candidate."""
+    source_id = getattr(rec, "source_id", "")
+    ctx.record_issue(
+        "error" if source_id else "warning",
+        "pmi_not_rendered",
+        f"authored dimension {label!r} produced no viable render candidate",
+        source=source_id,
     )
 
 
@@ -4221,6 +4236,7 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
         info = _bore_info(rec)
         if info is None:
             _log.debug("PMI dim[%d] diam: no ref_bbox, skip", idx)
+            _record_pmi_no_candidate(ctx, label, rec)
             return False
         bore_axis, cx_f, cy_f, cz_f = info
         # Resolved axis (handles _bore_info's '?' degenerate-bbox fallback); the diameter
@@ -4346,8 +4362,11 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
 
     if placed:
         return True
-    _log.info("PMI dim[%d] %s %.3g → no viable strip", idx, ax, rec.value)
-    _record_pmi_drop(ctx, dwg, ax, label, rec)
+    # No candidate reached the shared solve. Source reconciliation reports this as
+    # ``pmi_not_rendered``; ``pmi_dropped`` is reserved for a queued candidate rejected by
+    # placement capacity, via ``_pmi_queue_options``'s on-drop callback (#623).
+    _log.info("PMI dim[%d] %s %.3g → no viable render candidate", idx, ax, rec.value)
+    _record_pmi_no_candidate(ctx, label, rec)
     return False
 
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -81,6 +81,7 @@ from draftwright.linting import (
     lint_location_coverage,
     lint_pmi_extraction,
     lint_pmi_lowering,
+    lint_pmi_rendering,
     lint_principal_profile_coverage,
     lint_prismatic_coverage,
     lint_profiled_bore_coverage,
@@ -106,6 +107,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "pocket_not_located",
         "unrecognised_defining_geometry",
         "pmi_not_lowered",
+        "pmi_not_rendered",
         "axial_length_missing",
         "flat_requirement_suppressed",
         "flat_requirement_missing",
@@ -2885,6 +2887,11 @@ class Drawing:
             issues += lint_pmi_lowering(
                 self._analysis.pmi_report,
                 getattr(self._part_model, "features", ()),
+                self._analysis.pmi_mode,
+            )
+            issues += lint_pmi_rendering(
+                getattr(self._part_model, "features", ()),
+                self._registry,
                 self._analysis.pmi_mode,
             )
         issues += list(self._registry.issues)

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -29,7 +29,11 @@ from draftwright.linting.coverage import (
 )
 from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.issues import LintIssue
-from draftwright.linting.pmi_coverage import lint_pmi_extraction, lint_pmi_lowering
+from draftwright.linting.pmi_coverage import (
+    lint_pmi_extraction,
+    lint_pmi_lowering,
+    lint_pmi_rendering,
+)
 from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
 from draftwright.linting.slot_coverage import lint_slot_coverage
 from draftwright.linting.structural import lint_drawing
@@ -50,6 +54,7 @@ __all__ = [
     "lint_location_coverage",
     "lint_pmi_extraction",
     "lint_pmi_lowering",
+    "lint_pmi_rendering",
     "lint_principal_profile_coverage",
     "lint_profiled_bore_coverage",
     "lint_prismatic_coverage",

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -76,3 +76,44 @@ def lint_pmi_lowering(report: PmiExtractionReport | None, features, mode: str) -
             )
         )
     return issues
+
+
+def lint_pmi_rendering(features, registry, mode: str) -> list[LintIssue]:
+    """Report source-bearing typed PMI that produced no annotation or placement drop.
+
+    ADR 0010's registry is the existing annotation-to-feature provenance owner. A placement
+    rejection is already a structured ``pmi_dropped`` build issue, so this reconciliation is
+    derived from those two outcomes rather than maintained in a parallel ledger.
+    """
+    if mode != "annotate":
+        return []
+
+    by_source: dict[str, list[object]] = {}
+    for feature in features:
+        source_id = getattr(feature, "source_id", "")
+        if source_id and getattr(feature, "kind", None) == "authored_dimension":
+            by_source.setdefault(source_id, []).append(feature)
+
+    dropped = {
+        source_id
+        for issue in registry.issues
+        if getattr(issue, "code", None) == "pmi_dropped"
+        for source_id in getattr(issue, "source_ids", ())
+    }
+    already_reported = {
+        source_id
+        for issue in registry.issues
+        if getattr(issue, "code", None) == "pmi_not_rendered"
+        for source_id in getattr(issue, "source_ids", ())
+    }
+    return [
+        LintIssue(
+            severity="error",
+            code="pmi_not_rendered",
+            message=f"AP242 source {source_id} reached typed drafting IR but produced no annotation",
+            source_ids=(source_id,),
+        )
+        for source_id, source_features in by_source.items()
+        if source_id not in dropped | already_reported
+        and not any(registry.names_for_feature(feature) for feature in source_features)
+    ]

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -688,6 +688,7 @@ def test_render_pmi_reports_unrecognized_bore_axis_as_not_rendered_without_crash
     from draftwright.linting import lint_pmi_rendering
     from draftwright.model import AuthoredDimension
     from draftwright.model.ir import Frame
+    from draftwright.registry import AnnotationRegistry
 
     dwg = build_drawing(Box(40, 30, 20), number="X")
     bogus = AuthoredDimension(
@@ -704,7 +705,8 @@ def test_render_pmi_reports_unrecognized_bore_axis_as_not_rendered_without_crash
     # The pmi_dropped lint now routes through the ctx's registry/coverage (#639); wire them to
     # the drawing's so the drop lands on dwg's build issues.
     ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
-    n = render_pmi(dwg, model, dwg._analysis, ctx=ctx)  # must not raise
+    analysis = dwg._analysis
+    n = render_pmi(dwg, model, analysis, ctx=ctx)  # must not raise
     assert n == 0
     assert not any(i.code == "pmi_dropped" for i in dwg.registry.issues)
     recorded = [issue for issue in dwg.registry.issues if issue.code == "pmi_not_rendered"]
@@ -714,19 +716,8 @@ def test_render_pmi_reports_unrecognized_bore_axis_as_not_rendered_without_crash
     issues = lint_pmi_rendering(model.features, dwg.registry, "annotate")
     assert issues == []
 
-
-def test_render_pmi_keeps_a_source_less_missing_bore_bbox_visible():
-    from build123d import Box
-
-    from draftwright import build_drawing
-    from draftwright.annotations._common import PlacementContext
-    from draftwright.annotations.from_model import render_pmi
-    from draftwright.linting import CoverageState
-    from draftwright.model import AuthoredDimension
-    from draftwright.model.ir import Frame
-    from draftwright.registry import AnnotationRegistry
-
-    dwg = build_drawing(Box(40, 30, 20), number="X")
+    # Removing the false capacity label must not make a source-less malformed declaration
+    # disappear either. Reuse the same analysis so this test does not widen private test reads.
     record = AuthoredDimension(
         frame=Frame((0.0, 0.0, 0.0), "z"),
         dimension_kind="diameter",
@@ -736,9 +727,9 @@ def test_render_pmi_keeps_a_source_less_missing_bore_bbox_visible():
         ref_pts=((0.0, 0.0, 0.0), (5.0, 0.0, 0.0)),
     )
     registry = AnnotationRegistry()
-    ctx = PlacementContext(registry=registry, coverage=CoverageState())
+    source_less_ctx = PlacementContext(registry=registry, coverage=dwg.coverage)
 
-    assert render_pmi(dwg, SimpleNamespace(features=[record]), dwg._analysis, ctx=ctx) == 0
+    assert render_pmi(dwg, SimpleNamespace(features=[record]), analysis, ctx=source_less_ctx) == 0
     assert [(issue.severity, issue.code, issue.source_ids) for issue in registry.issues] == [
         ("warning", "pmi_not_rendered", ()),
     ]

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -357,6 +357,21 @@ def ctc01_annotated(tmp_path_factory):
     return build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="annotate")
 
 
+def _single_source_dimension_drawing():
+    from draftwright import Sheet
+
+    sheet = Sheet(Box(40, 30, 20), title="PMI render mutation").authored_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=20,
+        label="20",
+        dominant_axis="X",
+        ref_pts=[(-10, -15, 0), (10, -15, 0)],
+        source_id="dimension:mutation",
+    )
+    return sheet.build()
+
+
 class TestBuildDrawingPmi:
     def test_pmi_off_leaves_drawing_unchanged(self, tmp_path):
         """pmi='off' produces an identical drawing to not passing pmi at all."""
@@ -365,6 +380,7 @@ class TestBuildDrawingPmi:
         pmi_names = [n for n in dwg.annotations() if n.startswith("pmi_")]
         assert pmi_names == [], f"pmi='off' should add no pmi_ annotations, got {pmi_names}"
         assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_extracted"]
+        assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_rendered"]
 
     def test_a_top_level_extraction_failure_cannot_become_no_pmi(self, tmp_path, monkeypatch):
         import draftwright.pmi as pmi_module
@@ -400,6 +416,7 @@ class TestBuildDrawingPmi:
         assert len(lowering) == 10
         assert {issue.severity for issue in lowering} == {"info"}
         assert len({issue.source_ids for issue in lowering}) == 10
+        assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_rendered"]
 
     def test_pmi_annotate_adds_dims(self, ctc01_annotated):
         """pmi='annotate' adds at least one pmi_ dimension to the drawing."""
@@ -441,6 +458,94 @@ class TestBuildDrawingPmi:
         assert len(raw_source_ids) == 10
         assert {issue.severity for issue in issues} == {"error"}
         assert {issue.source_ids[0] for issue in issues} == raw_source_ids
+
+    def test_pmi_annotate_accounts_for_each_typed_dimension_at_the_render_seam(
+        self, ctc01_annotated
+    ):
+        from draftwright.model import AuthoredDimension
+
+        authored = [
+            feature
+            for feature in ctc01_annotated.model().features
+            if isinstance(feature, AuthoredDimension)
+        ]
+        rendered = {
+            feature.source_id
+            for feature in authored
+            if ctc01_annotated.registry.names_for_feature(feature)
+        }
+        dropped = {
+            source_id
+            for issue in ctc01_annotated.registry.issues
+            if issue.code == "pmi_dropped"
+            for source_id in issue.source_ids
+        }
+
+        assert len(authored) == 8
+        assert len(rendered) == 6
+        assert len(dropped) == 2
+        assert rendered.isdisjoint(dropped)
+        assert rendered | dropped == {feature.source_id for feature in authored}
+        assert not [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_rendered"]
+
+    def test_a_deleted_render_dispatch_is_reported_by_source_identity(self, monkeypatch):
+        import draftwright.annotations.from_model as from_model
+        from draftwright.linting import lint_pmi_rendering
+
+        original = from_model._renderable_pmi_records
+        monkeypatch.setattr(
+            from_model,
+            "_renderable_pmi_records",
+            lambda records: [
+                record for record in original(records) if record.source_id != "dimension:mutation"
+            ],
+        )
+        drawing = _single_source_dimension_drawing()
+        feature = next(
+            feature
+            for feature in drawing.model().features
+            if feature.source_id == "dimension:mutation"
+        )
+        issues = lint_pmi_rendering(drawing.model().features, drawing.registry, "annotate")
+
+        assert feature in original([feature])
+        assert drawing.registry.names_for_feature(feature) == []
+        assert not [issue for issue in drawing.registry.issues if issue.code == "pmi_dropped"]
+        assert [(issue.code, issue.severity, issue.source_ids) for issue in issues] == [
+            ("pmi_not_rendered", "error", ("dimension:mutation",))
+        ]
+
+    def test_a_forced_placement_drop_is_not_reported_as_missing_render_dispatch(self, monkeypatch):
+        import draftwright.annotations._common as common
+        import draftwright.annotations.from_model as from_model
+        from draftwright.linting import lint_pmi_rendering
+
+        original = common.place_strip_candidates
+
+        def reject_source_candidate(*args, **kwargs):
+            features = kwargs.get("features", {})
+            if any(
+                getattr(feature, "source_id", "") == "dimension:mutation"
+                for feature in features.values()
+            ):
+                return list(args[4])
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(common, "place_strip_candidates", reject_source_candidate)
+        monkeypatch.setattr(from_model, "place_strip_candidates", reject_source_candidate)
+        drawing = _single_source_dimension_drawing()
+        feature = next(
+            feature
+            for feature in drawing.model().features
+            if feature.source_id == "dimension:mutation"
+        )
+        drops = [issue for issue in drawing.registry.issues if issue.code == "pmi_dropped"]
+
+        assert drawing.registry.names_for_feature(feature) == []
+        assert [(issue.severity, issue.source_ids) for issue in drops] == [
+            ("warning", ("dimension:mutation",))
+        ]
+        assert lint_pmi_rendering(drawing.model().features, drawing.registry, "annotate") == []
 
     def test_pmi_annotate_exports_svg_dxf(self, ctc01_annotated):
         """build_drawing + export with PMI produces valid SVG and DXF files."""
@@ -569,10 +674,10 @@ def test_a_supported_dimension_routed_to_raw_ir_is_reported_by_source_identity(
     assert target.source_id in issue.message
 
 
-def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
+def test_render_pmi_reports_unrecognized_bore_axis_as_not_rendered_without_crashing():
     # #638 review: the bore ø/R placement became a `_bore[axis]` table lookup. A diameter
-    # record whose dominant_axis doesn't resolve to X/Y/Z must still drop gracefully — as the
-    # old Z/X/Y if-chain did by falling through — not KeyError-crash the whole build.
+    # record whose dominant_axis doesn't resolve to X/Y/Z must report the missing renderer,
+    # not claim placement capacity rejected it or KeyError-crash the whole build.
     from types import SimpleNamespace
 
     from build123d import Box
@@ -580,6 +685,7 @@ def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
     from draftwright import build_drawing
     from draftwright.annotations._common import PlacementContext
     from draftwright.annotations.from_model import render_pmi
+    from draftwright.linting import lint_pmi_rendering
     from draftwright.model import AuthoredDimension
     from draftwright.model.ir import Frame
 
@@ -592,6 +698,7 @@ def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
         dominant_axis="Q",  # not X/Y/Z → matches no bore config
         ref_bbox=(0.0, 0.0, 0.0, 5.0, 1.0, 1.0),
         ref_pts=((0.0, 0.0, 0.0), (5.0, 0.0, 0.0)),
+        source_id="dimension:bogus-axis",
     )
     model = SimpleNamespace(features=[bogus])
     # The pmi_dropped lint now routes through the ctx's registry/coverage (#639); wire them to
@@ -599,4 +706,39 @@ def test_render_pmi_drops_unrecognized_bore_axis_without_crashing():
     ctx = PlacementContext(registry=dwg.registry, coverage=dwg.coverage)
     n = render_pmi(dwg, model, dwg._analysis, ctx=ctx)  # must not raise
     assert n == 0
-    assert any(i.code == "pmi_dropped" for i in dwg.registry.issues)  # graceful drop recorded
+    assert not any(i.code == "pmi_dropped" for i in dwg.registry.issues)
+    recorded = [issue for issue in dwg.registry.issues if issue.code == "pmi_not_rendered"]
+    assert [(issue.severity, issue.source_ids) for issue in recorded] == [
+        ("error", ("dimension:bogus-axis",))
+    ]
+    issues = lint_pmi_rendering(model.features, dwg.registry, "annotate")
+    assert issues == []
+
+
+def test_render_pmi_keeps_a_source_less_missing_bore_bbox_visible():
+    from build123d import Box
+
+    from draftwright import build_drawing
+    from draftwright.annotations._common import PlacementContext
+    from draftwright.annotations.from_model import render_pmi
+    from draftwright.linting import CoverageState
+    from draftwright.model import AuthoredDimension
+    from draftwright.model.ir import Frame
+    from draftwright.registry import AnnotationRegistry
+
+    dwg = build_drawing(Box(40, 30, 20), number="X")
+    record = AuthoredDimension(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        dimension_kind="diameter",
+        value=5.0,
+        label="ø5",
+        dominant_axis="Z",
+        ref_pts=((0.0, 0.0, 0.0), (5.0, 0.0, 0.0)),
+    )
+    registry = AnnotationRegistry()
+    ctx = PlacementContext(registry=registry, coverage=CoverageState())
+
+    assert render_pmi(dwg, SimpleNamespace(features=[record]), dwg._analysis, ctx=ctx) == 0
+    assert [(issue.severity, issue.code, issue.source_ids) for issue in registry.issues] == [
+        ("warning", "pmi_not_rendered", ()),
+    ]


### PR DESCRIPTION
## Summary

- reconcile source-bearing authored PMI against ADR 0010's annotation registry
- report typed PMI that produces no annotation as `pmi_not_rendered`
- carry source IDs on `pmi_dropped` and distinguish solver rejection from no viable render candidate
- keep report/off modes free of per-record rendering requirements

## Evidence

CTC01's eight typed authored dimensions now reconcile to six registry-owned annotations and two structured placement drops.

The mutation pair proves the stage boundary:

- deleting one render dispatch produces `pmi_not_rendered` for that source ID
- forcing that same source through placement rejection produces `pmi_dropped`, not `pmi_not_rendered`

A source-less malformed authored dimension remains visibly diagnosed rather than disappearing after the false capacity label was removed.

## Validation

- `scripts/pr-check --full`: 3,042 passed, 4 skipped, 2 xfailed
- combined line/branch coverage: 93.98%
- changed source coverage: 100% (21/21)
- impacted regression set: 452 passed, 2 xfailed
- static analysis, formatting, mypy, and codespell: green

Part of #623. This PR deliberately leaves mode-level ignored-PMI diagnostics and summary stage counts to the fourth slice.
