### PR TITLE
Close AP242 PMI mode accounting

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1015,11 +1015,16 @@ class Analysis:
     tolerance: str
     drawn_by: str
     out: str
-    # Canonical AP242 source census + extraction outcomes, or None when PMI was not requested
-    # (or the input is an in-memory Shape). Typed as object to keep the rank-1 core from
-    # importing rank-2 pmi; the compatibility `pmi` property below is its records projection.
+    # Canonical AP242 source census + extraction outcomes for a STEP input, including off mode
+    # (which inventories but does not lower records); None for an in-memory Shape. Typed as
+    # object to keep the rank-1 core from importing rank-2 pmi; the compatibility `pmi` property
+    # below is its records projection.
     pmi_report: object | None
     pmi_mode: str
+    # True when the caller omitted `pmi` and the public default selected off. Kept separate
+    # from the effective mode so the ignored-PMI diagnostic can distinguish that default from
+    # an explicit opt-out without widening the three-mode renderer contract (#623).
+    pmi_defaulted: bool
     # Standing ISO 7200 title-block fields (#766) — defaulted, so they sit after the
     # non-default fields above. Defaults preserve the prior output: revision "A", the rest
     # blank (the TitleBlock helper's own defaults).

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -502,7 +502,7 @@ def _analyse(
     out,
     scale=None,
     page=None,
-    pmi="off",
+    pmi=None,
     model=None,
     decorations=None,
     material="",
@@ -531,15 +531,21 @@ def _analyse(
         src = str(step_file)
     part = _solids_body(part, src)
 
-    # Semantic PMI extraction (AP242 only; separate read-only pass).
+    pmi_defaulted = pmi is None
+    pmi_mode = "off" if pmi_defaulted else pmi
+
+    # Semantic PMI census (AP242 only; separate read-only pass). Even off mode inventories a
+    # STEP source so it can say authored PMI was ignored; it deliberately does not feed those
+    # records into the IR. In-memory Shapes have no AP242 document to inspect.
     pmi_report = None
     pmi_records: list = []
-    if pmi != "off" and not isinstance(step_file, Shape):
+    if not isinstance(step_file, Shape):
         from draftwright.pmi import PmiExtractionReport, extract_pmi_report
 
         try:
             pmi_report = extract_pmi_report(step_file)
-            pmi_records = list(pmi_report.records)
+            if pmi_mode != "off":
+                pmi_records = list(pmi_report.records)
         except Exception as exc:
             _log.warning("PMI extraction failed: %s", exc)
             pmi_report = PmiExtractionReport(error=f"{type(exc).__name__}: {exc}")
@@ -889,7 +895,8 @@ def _analyse(
         zones=zones,
         out=out,
         pmi_report=pmi_report,
-        pmi_mode=pmi,
+        pmi_mode=pmi_mode,
+        pmi_defaulted=pmi_defaulted,
         # The sizing model IS the render model when detection ran (identical inputs by
         # construction — #584 WP1 A); store it so the pipeline never detects twice
         # (ADR 0008 Amdt 5, #602). A declared model (layout_model) is NOT stored: the

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -763,7 +763,7 @@ def build_drawing(
     page: str | tuple | None = None,
     auto_dims: bool = True,
     detail_view: bool = True,
-    pmi: Literal["off", "report", "annotate"] = "off",
+    pmi: Literal["off", "report", "annotate"] | None = None,
     repair: bool = True,
     assembly: bool | None = None,
     model: Sequence[Feature] | PartModel | None = None,
@@ -797,6 +797,11 @@ def build_drawing(
         detail_view: automatically recover crowded prismatic step dimensions in an
             enlarged detail view. Default ``True``; pass ``False`` to leave them on the
             parent view only and report ``step_dim_dropped`` when they do not fit.
+        pmi: AP242 PMI handling. ``None`` (the default) behaves as ``"off"`` but retains
+            that it was defaulted so a source containing authored PMI can say annotation is
+            disabled by default. Explicit ``"off"`` produces no PMI annotations or per-record
+            failures but reports the ignored source inventory; ``"report"`` inventories and
+            lowers without rendering; ``"annotate"`` also requires render outcomes.
         repair: run the bounded lint→repair loop (:meth:`Drawing.repair`) after
             placement to fix mechanically-clear violations (a dim on the wrong
             side, two overlapping labels). Default ``True``; a no-op on a clean
@@ -934,7 +939,7 @@ def make_drawing(
     page: str | tuple | None = None,
     auto_dims: bool = True,
     detail_view: bool = True,
-    pmi: Literal["off", "report", "annotate"] = "off",
+    pmi: Literal["off", "report", "annotate"] | None = None,
     assembly: bool | None = None,
     material: str = "",
     date: str = "",

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -132,10 +132,10 @@ def main(
         help="--script flavour: only 'sheet' (the declarative Sheet script, one line per "
         "feature). Retained for scripts that pass it",
     ),
-    pmi: PmiMode = typer.Option(
-        PmiMode.off,
+    pmi: PmiMode | None = typer.Option(
+        None,
         help=(
-            "AP242 PMI handling: 'off' ignore; 'report' log extracted PMI without "
+            "AP242 PMI handling (default: off): 'off' ignore; 'report' log extracted PMI without "
             "annotating; 'annotate' add PMI-derived dimensions to the drawing"
         ),
     ),
@@ -217,7 +217,7 @@ def main(
                 frame=frame,
                 zones=zones,
                 projection=projection or None,
-                pmi=pmi.value,
+                pmi=pmi.value if pmi is not None else "off",
                 formats=tuple(formats),
             )
         print(py_path)
@@ -232,7 +232,7 @@ def main(
         drawn_by=drawn_by,
         scale=scale,
         page=page,
-        pmi=pmi.value,
+        pmi=pmi.value if pmi is not None else None,
         material=material,
         date=date,
         revision=revision,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -80,12 +80,14 @@ from draftwright.linting import (
     lint_flat_coverage,
     lint_location_coverage,
     lint_pmi_extraction,
+    lint_pmi_ignored,
     lint_pmi_lowering,
     lint_pmi_rendering,
     lint_principal_profile_coverage,
     lint_prismatic_coverage,
     lint_profiled_bore_coverage,
     lint_slot_coverage,
+    pmi_stage_summary,
 )
 from draftwright.projection import (
     project_view_geometry,
@@ -2883,6 +2885,11 @@ class Drawing:
                     recognition=recognition,
                 )
         if physical and self._analysis is not None:
+            issues += lint_pmi_ignored(
+                self._analysis.pmi_report,
+                self._analysis.pmi_mode,
+                defaulted=self._analysis.pmi_defaulted,
+            )
             issues += lint_pmi_extraction(self._analysis.pmi_report, self._analysis.pmi_mode)
             issues += lint_pmi_lowering(
                 self._analysis.pmi_report,
@@ -2914,6 +2921,8 @@ class Drawing:
         - ``geometry_issues`` — count of standards/geometry-correctness issues
           as opposed to pure layout (see ``_GEOMETRY_AWARE_CODES``);
         - ``issues`` — the full list, each as a plain dict.
+        - ``pmi`` — when source PMI exists, source-to-render stage counts derived from the
+          extraction report, final IR, annotation registry, and structured placement drops.
         """
         issues = self.lint()
         errors = sum(1 for i in issues if i.severity == "error")
@@ -2925,6 +2934,16 @@ class Drawing:
         score = max(
             0.0,
             1.0 - errors * _SCORE_ERROR_PENALTY - warnings * _SCORE_WARNING_PENALTY,
+        )
+        pmi = (
+            pmi_stage_summary(
+                self._analysis.pmi_report,
+                getattr(self._part_model, "features", ()),
+                self._registry,
+                self._analysis.pmi_mode,
+            )
+            if self._analysis is not None
+            else None
         )
         return {
             "passed": errors == 0,
@@ -2950,6 +2969,7 @@ class Drawing:
                 }
                 for i in issues
             ],
+            **({"pmi": pmi} if pmi is not None else {}),
         }
 
     # The output formats export() understands. PDF renders from the SVG, PNG from the PDF —

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -31,8 +31,10 @@ from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.pmi_coverage import (
     lint_pmi_extraction,
+    lint_pmi_ignored,
     lint_pmi_lowering,
     lint_pmi_rendering,
+    pmi_stage_summary,
 )
 from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
 from draftwright.linting.slot_coverage import lint_slot_coverage
@@ -52,9 +54,11 @@ __all__ = [
     "lint_flat_coverage",
     "lint_slot_coverage",
     "lint_location_coverage",
+    "lint_pmi_ignored",
     "lint_pmi_extraction",
     "lint_pmi_lowering",
     "lint_pmi_rendering",
+    "pmi_stage_summary",
     "lint_principal_profile_coverage",
     "lint_profiled_bore_coverage",
     "lint_prismatic_coverage",

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -2,10 +2,86 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Literal
 
 from draftwright.linting.issues import LintIssue
 from draftwright.pmi import PmiExtractionReport
+
+
+def _source_category_counts(report: PmiExtractionReport) -> dict[str, int]:
+    return dict(sorted(Counter(source.category for source in report.sources).items()))
+
+
+def lint_pmi_ignored(
+    report: PmiExtractionReport | None, mode: str, *, defaulted: bool
+) -> list[LintIssue]:
+    """Report one source-level event when off mode deliberately ignores authored PMI."""
+    if report is None or mode != "off" or not report.sources:
+        return []
+
+    counts = _source_category_counts(report)
+    names = {
+        "dimension": "dimension",
+        "geometric_tolerance": "geometric tolerance",
+        "datum": "datum",
+    }
+    inventory = ", ".join(
+        f"{count} {names[category]}{'s' if count != 1 else ''}"
+        for category, count in counts.items()
+    )
+    reason = "PMI annotation is disabled by default" if defaulted else "pmi='off' was selected"
+    return [
+        LintIssue(
+            severity="info",
+            code="pmi_present_but_ignored",
+            message=(
+                f"AP242 PMI is present but ignored because {reason} ({inventory}); "
+                "use --pmi report to inspect it or --pmi annotate to place supported PMI"
+            ),
+        )
+    ]
+
+
+def pmi_stage_summary(
+    report: PmiExtractionReport | None, features, registry, mode: str
+) -> dict[str, object] | None:
+    """Derive source-to-render stage counts from the canonical report, IR, and registry.
+
+    The counts are stage inventories, not an additive funnel: presentation-only source labels
+    are inventoried but produce no extracted record, while a partially extracted record still
+    reached the extraction stage. Distinct source IDs keep every count per source entity.
+    """
+    if report is None or not report.sources:
+        return None
+
+    extracted = {record.source_id for record in report.records if record.source_id}
+    lowered_features = [
+        feature
+        for feature in features
+        if getattr(feature, "source_id", "") in extracted
+        and getattr(feature, "kind", None) != "pmi"
+    ]
+    lowered = {feature.source_id for feature in lowered_features}
+    rendered = {
+        feature.source_id for feature in lowered_features if registry.names_for_feature(feature)
+    }
+    dropped = {
+        source_id
+        for issue in registry.issues
+        if getattr(issue, "code", None) == "pmi_dropped"
+        for source_id in getattr(issue, "source_ids", ())
+        if source_id in lowered
+    }
+    return {
+        "mode": mode,
+        "sources": len(report.sources),
+        "by_category": _source_category_counts(report),
+        "extracted": len(extracted),
+        "lowered": len(lowered),
+        "rendered": len(rendered),
+        "dropped": len(dropped),
+    }
 
 
 def lint_pmi_extraction(report: PmiExtractionReport | None, mode: str) -> list[LintIssue]:

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -1,4 +1,4 @@
-"""Tests for PMI extraction and annotation (Phase 1–3)."""
+"""Tests for AP242 PMI extraction, lowering, rendering, and mode reconciliation."""
 
 from collections import Counter
 from pathlib import Path
@@ -12,6 +12,7 @@ from draftwright.pmi import _PMI_AVAILABLE, PmiExtractionReport, PmiRecord
 
 FIXTURES = Path(__file__).parent / "fixtures"
 CTC01 = FIXTURES / "nist_ctc_01_asme1_ap242.stp"
+CTC01_AP203 = FIXTURES / "nist_ctc_01_asme1_ap203.stp"
 
 pytestmark = pytest.mark.skipif(not _PMI_AVAILABLE, reason="OCP GDT support not available")
 
@@ -373,14 +374,53 @@ def _single_source_dimension_drawing():
 
 
 class TestBuildDrawingPmi:
-    def test_pmi_off_leaves_drawing_unchanged(self, tmp_path):
-        """pmi='off' produces an identical drawing to not passing pmi at all."""
+    def test_explicit_pmi_off_reports_one_ignored_inventory_without_render_failures(
+        self, tmp_path
+    ):
         stem = str(tmp_path / "ctc01_no_pmi")
         dwg = build_drawing(str(CTC01), out=stem, title="CTC-01", number="NIST-01", pmi="off")
         pmi_names = [n for n in dwg.annotations() if n.startswith("pmi_")]
         assert pmi_names == [], f"pmi='off' should add no pmi_ annotations, got {pmi_names}"
-        assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_extracted"]
-        assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_rendered"]
+        issues = dwg.lint()
+        ignored = [issue for issue in issues if issue.code == "pmi_present_but_ignored"]
+        assert len(ignored) == 1
+        assert ignored[0].severity == "info"
+        assert "pmi='off' was selected" in ignored[0].message
+        assert "21 dimensions" in ignored[0].message
+        assert "6 geometric tolerances" in ignored[0].message
+        assert "11 datums" in ignored[0].message
+        assert "--pmi report" in ignored[0].message
+        assert "--pmi annotate" in ignored[0].message
+        assert not [issue for issue in issues if issue.code.startswith("pmi_not_")]
+
+        assert dwg.lint_summary()["pmi"] == {
+            "mode": "off",
+            "sources": 38,
+            "by_category": {"datum": 11, "dimension": 21, "geometric_tolerance": 6},
+            "extracted": 18,
+            "lowered": 0,
+            "rendered": 0,
+            "dropped": 0,
+        }
+
+    def test_default_pmi_off_says_annotation_is_disabled_by_default(self, tmp_path, caplog):
+        drawing = build_drawing(CTC01, out=str(tmp_path / "ctc01_default"))
+        ignored = [issue for issue in drawing.lint() if issue.code == "pmi_present_but_ignored"]
+
+        assert len(ignored) == 1
+        assert "PMI annotation is disabled by default" in ignored[0].message
+        assert "pmi='off' was selected" not in ignored[0].message
+        assert not [name for name in drawing.annotations() if name.startswith("pmi_")]
+
+        caplog.clear()
+        drawing.export(formats=("svg",))
+        assert sum("pmi_present_but_ignored" in record.message for record in caplog.records) == 1
+
+    def test_default_pmi_probe_keeps_ap203_quiet(self, tmp_path):
+        drawing = build_drawing(CTC01_AP203, out=str(tmp_path / "ctc01_ap203"))
+
+        assert not [issue for issue in drawing.lint() if issue.code.startswith("pmi_")]
+        assert "pmi" not in drawing.lint_summary()
 
     def test_a_top_level_extraction_failure_cannot_become_no_pmi(self, tmp_path, monkeypatch):
         import draftwright.pmi as pmi_module
@@ -417,6 +457,15 @@ class TestBuildDrawingPmi:
         assert {issue.severity for issue in lowering} == {"info"}
         assert len({issue.source_ids for issue in lowering}) == 10
         assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_rendered"]
+        assert dwg.lint_summary()["pmi"] == {
+            "mode": "report",
+            "sources": 38,
+            "by_category": {"datum": 11, "dimension": 21, "geometric_tolerance": 6},
+            "extracted": 18,
+            "lowered": 8,
+            "rendered": 0,
+            "dropped": 0,
+        }
 
     def test_pmi_annotate_adds_dims(self, ctc01_annotated):
         """pmi='annotate' adds at least one pmi_ dimension to the drawing."""
@@ -487,6 +536,15 @@ class TestBuildDrawingPmi:
         assert rendered.isdisjoint(dropped)
         assert rendered | dropped == {feature.source_id for feature in authored}
         assert not [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_rendered"]
+        assert ctc01_annotated.lint_summary()["pmi"] == {
+            "mode": "annotate",
+            "sources": 38,
+            "by_category": {"datum": 11, "dimension": 21, "geometric_tolerance": 6},
+            "extracted": 18,
+            "lowered": 8,
+            "rendered": 6,
+            "dropped": 2,
+        }
 
     def test_a_deleted_render_dispatch_is_reported_by_source_identity(self, monkeypatch):
         import draftwright.annotations.from_model as from_model
@@ -559,6 +617,48 @@ class TestBuildDrawingPmi:
         """All pmi_ annotation names in the drawing are unique."""
         pmi_names = [n for n in ctc01_annotated.annotations() if n.startswith("pmi_")]
         assert len(pmi_names) == len(set(pmi_names)), f"duplicate pmi names: {pmi_names}"
+
+
+def test_pmi_summary_is_derived_from_registry_outcomes():
+    from draftwright.linting import LintIssue, pmi_stage_summary
+    from draftwright.pmi import PmiSourceEntity
+
+    drawing = _single_source_dimension_drawing()
+    feature = next(
+        feature
+        for feature in drawing.model().features
+        if feature.source_id == "dimension:mutation"
+    )
+    report = PmiExtractionReport(
+        sources=(PmiSourceEntity("dimension:mutation", "dimension", 1, "extracted"),),
+        records=(PmiRecord("linear", 1, 20, source_id="dimension:mutation"),),
+    )
+
+    placed = pmi_stage_summary(report, drawing.model().features, drawing.registry, "annotate")
+    (annotation_name,) = drawing.registry.names_for_feature(feature)
+    drawing.remove(annotation_name)
+    missing = pmi_stage_summary(report, drawing.model().features, drawing.registry, "annotate")
+    drawing.registry.record_issue(
+        LintIssue(
+            severity="warning",
+            code="pmi_dropped",
+            message="mutation: solver rejected the candidate",
+            source_ids=("dimension:mutation",),
+        )
+    )
+    dropped = pmi_stage_summary(report, drawing.model().features, drawing.registry, "annotate")
+
+    assert placed == {
+        "mode": "annotate",
+        "sources": 1,
+        "by_category": {"dimension": 1},
+        "extracted": 1,
+        "lowered": 1,
+        "rendered": 1,
+        "dropped": 0,
+    }
+    assert missing["rendered"] == 0 and missing["dropped"] == 0
+    assert dropped["rendered"] == 0 and dropped["dropped"] == 1
 
 
 class TestDeclaredModelPmi:

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1096,6 +1096,30 @@ class TestLooksLikeSpec:
 
 
 class TestCli:
+    def test_cli_preserves_default_vs_explicit_pmi_off(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+
+        import draftwright.builder as builder_module
+        from draftwright.cli import app
+
+        seen = []
+
+        class DrawingStub:
+            def export(self, *, formats):
+                return {name: str(tmp_path / f"out.{name}") for name in formats}
+
+        def build_stub(**kwargs):
+            seen.append(kwargs["pmi"])
+            return DrawingStub()
+
+        monkeypatch.setattr(builder_module, "build_drawing", build_stub)
+        defaulted = CliRunner().invoke(app, ["part.step"])
+        explicit = CliRunner().invoke(app, ["part.step", "--pmi", "off"])
+
+        assert defaulted.exit_code == 0, defaulted.output
+        assert explicit.exit_code == 0, explicit.output
+        assert seen == [None, "off"]
+
     def test_style_sheet_routes_to_the_declarative_emitter(self, tmp_path):
         from typer.testing import CliRunner
 


### PR DESCRIPTION
## Summary

- inventory AP242 PMI even when the effective mode is `off`, without lowering or rendering it
- distinguish default-off from an explicit opt-out and emit one structured `pmi_present_but_ignored` info with category counts and next actions
- derive source/extracted/lowered/rendered/dropped counts in `lint_summary` from the extraction report, final IR, ADR 0010 registry, and structured drops
- keep report free of render requirements, annotate fully reconciled, and AP203 quiet

## Evidence

CTC01 now reports the following stage census:

| mode | sources | extracted | lowered | rendered | dropped |
|---|---:|---:|---:|---:|---:|
| off | 38 | 18 | 0 | 0 | 0 |
| report | 38 | 18 | 8 | 0 | 0 |
| annotate | 38 | 18 | 8 | 6 | 2 |

The mutation gate removes a registry-owned annotation and then records a placement drop; the derived summary moves from rendered to missing to dropped without any maintained counter.

A real default CLI export emits one `pmi_present_but_ignored` line with 21 dimensions, 6 geometric tolerances, 11 datums, and both `--pmi report` / `--pmi annotate` actions. AP203 emits no PMI issue or summary section.

## Probe cost

After the geometry import, the separate XCAF census measured about 0.13-0.14 s on both CTC01 AP242 and AP203. Three no-annotation CTC01 builds on the branch took 2.034 s, 2.085 s, and 1.989 s; the baseline range was 1.785-2.828 s, so the probe did not produce a measurable whole-build regression beyond run-to-run noise.

## Validation

- `scripts/pr-check --full`: 3,046 passed, 4 skipped, 2 xfailed
- combined line/branch coverage: 94.01%
- changed source coverage: 100% (28/28)
- emitter/CLI/import-boundary/private-access/summary regression set: 380 passed, 2 xfailed
- real default CLI export inspected
- final-commit static gate and focused mutation/output/CLI tests: green

Closes #623.
