### PR TITLE
Preserve AP242 range tolerances

### DIFF
--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1910,6 +1910,8 @@ def measured_dimension(
     axis: str | None = None,
     upper_tol: float | None = None,
     lower_tol: float | None = None,
+    lower_bound: float | None = None,
+    upper_bound: float | None = None,
     source: str = "sheet",
     source_kind: str | None = None,
     source_id: str = "",
@@ -1919,8 +1921,9 @@ def measured_dimension(
     callers can author one without the façade). Validates the kind against
     :data:`~draftwright.model.ir.AUTHORED_DIMENSION_KINDS`, needs ≥2 ``ref_pts``, and derives
     ``at`` (the ``ref_bbox`` centre, else the ``ref_pts`` centroid) when not given.
-    ``source_id`` preserves an external record identity; ordinary Sheet declarations leave it
-    blank."""
+    ``lower_bound`` and ``upper_bound`` carry a limit range and must be supplied together; they
+    are mutually exclusive with deviation tolerances. ``source_id`` preserves an external
+    record identity; ordinary Sheet declarations leave it blank."""
     _require_positive(value=value)
     dim_kind = str(kind).lower()
     if dim_kind not in AUTHORED_DIMENSION_KINDS:
@@ -1936,6 +1939,19 @@ def measured_dimension(
     if dom not in ("X", "Y", "Z"):
         if not (dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None):
             raise ValueError("measured_dimension() dominant_axis must be X, Y, or Z")
+    if (lower_bound is None) != (upper_bound is None):
+        raise ValueError("measured_dimension() needs both lower_bound and upper_bound")
+    lower = None if lower_bound is None else float(lower_bound)
+    upper = None if upper_bound is None else float(upper_bound)
+    if lower is not None and upper is not None:
+        if lower > upper:
+            raise ValueError("measured_dimension() lower_bound must not exceed upper_bound")
+        if not lower <= float(value) <= upper:
+            raise ValueError("measured_dimension() value must lie within its range bounds")
+        if upper_tol is not None or lower_tol is not None:
+            raise ValueError(
+                "measured_dimension() cannot combine range bounds with deviation tolerances"
+            )
     if at is None:
         if bbox is not None:
             x0, y0, z0, x1, y1, z1 = bbox
@@ -1953,6 +1969,8 @@ def measured_dimension(
         dominant_axis=dom,
         upper_tol=upper_tol,
         lower_tol=lower_tol,
+        lower_bound=lower,
+        upper_bound=upper,
         ref_bbox=bbox,
         ref_pts=pts,
         source=source,

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -242,6 +242,8 @@ def build_pmi_features(pmi, bbox) -> list[AuthoredDimension | PmiFeature]:
                     dominant_axis=r.dominant_axis,
                     upper_tol=r.upper_tol,
                     lower_tol=r.lower_tol,
+                    lower_bound=r.lower_bound,
+                    upper_bound=r.upper_bound,
                     ref_bbox=r.ref_bbox,
                     ref_pts=tuple(r.ref_pts),
                     source_kind=r.kind,

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1118,9 +1118,11 @@ class AuthoredDimension:
 
     This is the concept-shaped IR for AP242 dimensional PMI: the source file may call it
     PMI, but the drawing model sees an authored linear/diameter/radius/etc. dimension with
-    baked label and referenced geometry. The normal dimension planner does not derive or
-    duplicate it, so ``parameters()`` is empty; renderers consume it directly while keeping
-    the source/provenance fields, including ``source_id``, for round-trip and diagnostics."""
+    baked label and referenced geometry. Deviation tolerances use ``upper_tol``/``lower_tol``;
+    limit dimensions use the mutually exclusive ``lower_bound``/``upper_bound`` pair. The
+    normal dimension planner does not derive or duplicate it, so ``parameters()`` is empty;
+    renderers consume it directly while keeping the source/provenance fields, including
+    ``source_id``, for round-trip and diagnostics."""
 
     frame: Frame
     dimension_kind: str  # "linear" | "diameter" | "radius" | "angular" | ...
@@ -1134,6 +1136,9 @@ class AuthoredDimension:
     source: str = "ap242_pmi"
     source_kind: str | None = None
     source_id: str = ""
+    # Appended to preserve positional construction of the original IR record.
+    lower_bound: float | None = None
+    upper_bound: float | None = None
     kind: ClassVar[str] = "authored_dimension"
 
     @property

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -126,6 +126,8 @@ class PmiRecord:
         value:          Nominal value in mm (or degrees for angular).
         upper_tol:      Upper tolerance in mm, or ``None``.
         lower_tol:      Lower tolerance in mm, or ``None``.
+        lower_bound:    Lower limit of a range dimension, in the same units as ``value``.
+        upper_bound:    Upper limit of a range dimension, in the same units as ``value``.
         ref_pts:        Bounding-box centroids of referenced geometry in global
                         STEP space (same coordinate frame as the imported solid).
         ref_bbox:       Combined axis-aligned bbox of ALL referenced shapes:
@@ -151,6 +153,9 @@ class PmiRecord:
     # Stable within the source XCAF document: category + TDF label entry. Blank only for
     # hand-constructed compatibility records; extraction always fills it (#623).
     source_id: str = ""
+    # Appended to preserve the positional compatibility of the original record fields.
+    lower_bound: float | None = None
+    upper_bound: float | None = None
 
 
 PmiSourceCategory = Literal["dimension", "geometric_tolerance", "datum"]
@@ -214,12 +219,22 @@ def _dominant_from_bbox(bbox: tuple[float, float, float, float, float, float]) -
     return dom[0] if dom[1] > 1e-6 else "?"
 
 
-def _make_label(kind: str, value: float, upper_tol: float | None, lower_tol: float | None) -> str:
-    """Format the annotation label with optional tolerance suffix."""
+def _make_label(
+    kind: str,
+    value: float,
+    upper_tol: float | None,
+    lower_tol: float | None,
+    *,
+    lower_bound: float | None = None,
+    upper_bound: float | None = None,
+) -> str:
+    """Format the annotation label with optional deviation or limit tolerance."""
     from draftwright._core import _fmt
 
     prefix = _DIM_PREFIX.get(kind, "")
     base = f"{prefix}{_fmt(value)}"
+    if lower_bound is not None and upper_bound is not None:
+        return f"{prefix}{_fmt(lower_bound)} - {prefix}{_fmt(upper_bound)}"
     # OCCT returns tolerances as positive magnitudes regardless of sign
     # convention.  upper_tol is always the + deviation; lower_tol is always
     # the - deviation stored as a positive magnitude.  We add explicit signs
@@ -299,12 +314,25 @@ def _dimension_record(
             upper_tol = candidate
     except Exception:
         pass
+
     try:
         candidate = float(obj.GetLowerTolValue())
         if abs(candidate) > 1e-9:
             lower_tol = candidate
     except Exception:
         pass
+
+    lower_bound: float | None = None
+    upper_bound: float | None = None
+    if obj.IsDimWithRange():
+        try:
+            lower_bound = float(obj.GetLowerBound())
+        except Exception as exc:
+            partial_reasons.append(f"lower range bound is unavailable ({_failure_reason(exc)})")
+        try:
+            upper_bound = float(obj.GetUpperBound())
+        except Exception as exc:
+            partial_reasons.append(f"upper range bound is unavailable ({_failure_reason(exc)})")
 
     first_refs = TDF_LabelSequence()
     second_refs = TDF_LabelSequence()
@@ -341,10 +369,19 @@ def _dimension_record(
             value=value,
             upper_tol=upper_tol,
             lower_tol=lower_tol,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
             ref_pts=tuple(points),
             ref_bbox=ref_bbox,
             dominant_axis=dominant_axis,
-            label=_make_label(kind, value, upper_tol, lower_tol),
+            label=_make_label(
+                kind,
+                value,
+                upper_tol,
+                lower_tol,
+                lower_bound=lower_bound,
+                upper_bound=upper_bound,
+            ),
             source_id=source_id,
         ),
         tuple(dict.fromkeys(partial_reasons)),

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -906,6 +906,8 @@ class Sheet:
         axis: str | None = None,
         upper_tol: float | None = None,
         lower_tol: float | None = None,
+        lower_bound: float | None = None,
+        upper_bound: float | None = None,
         source: str = "sheet",
         source_kind: str | None = None,
         source_id: str = "",
@@ -922,8 +924,10 @@ class Sheet:
         may call the record PMI, but the editable script declares a dimension category, value,
         label, referenced model points, and optional structured tolerances. For ordinary
         geometry-backed edits prefer feature handles such as ``sheet.hole(...).tolerance(...)``.
-        ``source_id`` is the external record identity retained by generated imported-PMI scripts;
-        hand-authored dimensions normally leave it blank.
+        ``lower_bound`` and ``upper_bound`` are the mutually exclusive alternative to
+        ``upper_tol``/``lower_tol`` for a limit range. ``source_id`` is the external record
+        identity retained by generated imported-PMI scripts; hand-authored dimensions normally
+        leave it blank.
         Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
@@ -939,6 +943,8 @@ class Sheet:
                 axis=axis,
                 upper_tol=upper_tol,
                 lower_tol=lower_tol,
+                lower_bound=lower_bound,
+                upper_bound=upper_bound,
                 source=source,
                 source_kind=source_kind,
                 source_id=source_id,

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -212,6 +212,10 @@ def _measured_dimension_line(f) -> str:
         kw.append(f"upper_tol={_n(f.upper_tol)}")
     if f.lower_tol is not None:
         kw.append(f"lower_tol={_n(f.lower_tol)}")
+    if f.lower_bound is not None:
+        kw.append(f"lower_bound={_n(f.lower_bound)}")
+    if f.upper_bound is not None:
+        kw.append(f"upper_bound={_n(f.upper_bound)}")
     if f.source != "sheet":
         kw.append(f"source={f.source!r}")
     if f.source_kind is not None and f.source_kind != f.dimension_kind:

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1773,6 +1773,19 @@ class TestAuthoredDimension:
             ({"dominant_axis": "W"}, "dominant_axis must be X, Y, or Z"),
             ({"kind": "liner"}, "kind must be one of"),
             ({"ref_pts": [(0, 0, 0)]}, "needs at least two ref_pts"),
+            ({"lower_bound": 39}, "needs both lower_bound and upper_bound"),
+            (
+                {"lower_bound": 41, "upper_bound": 39},
+                "lower_bound must not exceed upper_bound",
+            ),
+            (
+                {"lower_bound": 41, "upper_bound": 42},
+                "value must lie within its range bounds",
+            ),
+            (
+                {"lower_bound": 39, "upper_bound": 41},
+                "cannot combine range bounds with deviation tolerances",
+            ),
         ]
         for override, message in cases:
             with pytest.raises(ValueError, match=f"measured_dimension\\(\\) {message}"):

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -74,6 +74,28 @@ class TestExtractPmi:
         for d in diameters:
             assert d.label.startswith("ø"), f"diameter label missing ø: {d.label!r}"
 
+    def test_nist_range_diameters_keep_both_limits(self, ctc01_extraction_report):
+        """The two range-encoded CTC-01 requirements are distinct source dimensions.
+
+        Their XCAF objects carry a nominal value of 35 as well as explicit 34.8/35.2
+        bounds. Reading only ``GetValue()`` produces a plausible but wrong bare ``ø35``.
+        Pin the semantic fields and source identities from the NIST oracle so deleting the
+        range branch cannot leave a green extraction test (#675).
+        """
+        source_ids = {"dimension:0:1:4:25", "dimension:0:1:4:26"}
+        records = {
+            record.source_id: record
+            for record in ctc01_extraction_report.records
+            if record.source_id in source_ids
+        }
+
+        assert set(records) == source_ids
+        for record in records.values():
+            assert record.value == 35.0
+            assert (record.lower_bound, record.upper_bound) == (34.8, 35.2)
+            assert record.label == "ø34.8 - ø35.2"
+            assert record.upper_tol is None and record.lower_tol is None
+
     def test_ref_pts_are_3d_tuples(self, ctc01_extraction_report):
         recs = ctc01_extraction_report.records
         for r in recs:
@@ -153,8 +175,9 @@ class TestExtractPmi:
                 return 12.0
 
         class FakeObject:
-            def __init__(self, values):
+            def __init__(self, values, *, is_range=False):
                 self.values = values
+                self.is_range = is_range
 
             def GetValue(self):
                 raise RuntimeError("scalar unavailable")
@@ -169,6 +192,15 @@ class TestExtractPmi:
 
             def GetLowerTolValue(self):
                 raise RuntimeError("no lower tolerance")
+
+            def IsDimWithRange(self):
+                return self.is_range
+
+            def GetLowerBound(self):
+                raise RuntimeError("lower bound unavailable")
+
+            def GetUpperBound(self):
+                raise RuntimeError("upper bound unavailable")
 
         refs = []
 
@@ -214,6 +246,17 @@ class TestExtractPmi:
         )
         assert "nominal value is unavailable (RuntimeError: array unavailable)" in reasons
         assert "one referenced shape could not be measured (RuntimeError: bbox failed)" in reasons
+
+        refs.clear()
+        _record, reasons = pmi_module._dimension_record(
+            object(), FakeObject(FakeArray(), is_range=True), 15, shape_tool, "dimension:d"
+        )
+        assert (
+            "lower range bound is unavailable (RuntimeError: lower bound unavailable)" in reasons
+        )
+        assert (
+            "upper range bound is unavailable (RuntimeError: upper bound unavailable)" in reasons
+        )
 
     def test_report_returns_structured_reader_failures(self, monkeypatch):
         import draftwright.pmi as pmi_module
@@ -472,6 +515,24 @@ class TestBuildDrawingPmi:
         pmi_names = [n for n in ctc01_annotated.annotations() if n.startswith("pmi_")]
         assert len(pmi_names) >= 1, f"expected ≥1 pmi_ annotation, got {pmi_names}"
 
+    def test_pmi_annotate_renders_each_nist_range_requirement_with_both_limits(
+        self, ctc01_annotated
+    ):
+        from draftwright.model import AuthoredDimension
+
+        source_ids = {"dimension:0:1:4:25", "dimension:0:1:4:26"}
+        features = {
+            feature.source_id: feature
+            for feature in ctc01_annotated.model().features
+            if isinstance(feature, AuthoredDimension) and feature.source_id in source_ids
+        }
+        annotations = dict(ctc01_annotated.iter_annotations())
+
+        assert set(features) == source_ids
+        for feature in features.values():
+            (name,) = ctc01_annotated.registry.names_for_feature(feature)
+            assert annotations[name].label == "ø34.8 - ø35.2"
+
     def test_pmi_annotate_reports_each_incomplete_source_record(self, ctc01_annotated):
         issues = [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_extracted"]
         assert len(issues) == 17
@@ -717,11 +778,16 @@ def test_build_pmi_features_mirrors_detection(ctc01_extraction_report):
     assert all(f.kind == "authored_dimension" for f in authored)
     assert all(f.kind == "pmi" for f in raw)
     assert {feature.source_id for feature in feats} == {record.source_id for record in recs}
-    # a dimensional PMI record's value/label ride onto its authored dimension verbatim
+    # A dimensional PMI record's measured semantics ride onto its authored dimension verbatim.
     assert {f.label for f in authored} >= {r.label for r in dims}
     for r in dims:
         assert any(
-            f.label == r.label and f.upper_tol == r.upper_tol and f.lower_tol == r.lower_tol
+            f.source_id == r.source_id
+            and f.label == r.label
+            and f.upper_tol == r.upper_tol
+            and f.lower_tol == r.lower_tol
+            and f.lower_bound == r.lower_bound
+            and f.upper_bound == r.upper_bound
             for f in authored
         )
     assert build_pmi_features(None, bbox) == []  # None/empty → no features

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -319,6 +319,40 @@ class TestEmit:
         assert feat.source == "sheet"
         assert any(n.startswith("pmi_") for n in sheet.build().annotations())
 
+    def test_limit_dimension_round_trips_both_bounds(self):
+        """A generated AP242 script must not reduce a limit dimension to its nominal label."""
+        from draftwright import Sheet
+        from draftwright.sheet_emit import emit_sheet_script
+
+        part = Box(40, 20, 10)
+        sheet = Sheet(part, title="P").authored_dimensions()
+        sheet.measured_dimension(
+            kind="diameter",
+            value=35,
+            label="ø34.8 - ø35.2",
+            dominant_axis="Z",
+            ref_bbox=(-17.6, -17.6, -5, 17.6, 17.6, 5),
+            ref_pts=[(-17.6, 0, 0), (17.6, 0, 0)],
+            lower_bound=34.8,
+            upper_bound=35.2,
+            source="ap242_pmi",
+            source_id="dimension:range",
+        )
+
+        src = emit_sheet_script(sheet.model(), "part", "range", title="P", number="N")
+        assert "lower_bound=34.8" in src and "upper_bound=35.2" in src
+        namespace = {"part": part}
+        body = src[: src.index("drawing = sheet.build()")]
+        exec(compile(body, "<range-emit>", "exec"), namespace)  # noqa: S102
+        feature = next(
+            feature
+            for feature in namespace["sheet"].model().features
+            if feature.source_id == "dimension:range"
+        )
+
+        assert (feature.lower_bound, feature.upper_bound) == (34.8, 35.2)
+        assert feature.label == "ø34.8 - ø35.2"
+
     def test_measured_dimension_rejects_unrenderable_kind(self):
         from draftwright import Sheet
 


### PR DESCRIPTION
Closes #675.

## What changed

- extract XCAF range bounds from `IsDimWithRange()` / `GetLowerBound()` / `GetUpperBound()`
- carry the bounds through `PmiRecord`, `AuthoredDimension`, the Sheet declaration surface, and generated-script round trips
- render a normalized limit label (`ø34.8 - ø35.2`) without pairing unrelated source requirements
- retain source identities and the existing PMI stage accounting

## Why

NIST CTC-01 contains two distinct diameter requirements encoded as ranges. Draftwright read only their nominal `GetValue()` and rendered both as bare `ø35`, silently losing the 34.8/35.2 limits. The source contains no semantic evidence that these should be grouped with the two separate one-sided diameter requirements.

## Validation so far

- mutation-first tests fail on the previous extraction, lowering, and script-emission paths
- focused extraction/lowering/declaration/emitter tests pass
- real CTC-01 annotate build renders both source IDs as `ø34.8 - ø35.2`
- CTC-01 accounting remains 38 source / 18 extracted / 8 lowered / 6 rendered / 2 dropped
- `ruff check`, `ruff format --check`, `mypy`, and `codespell` pass

The full local regression and adversarial review loop are still running; this PR remains draft until they are clean.