### PR TITLE
Preserve AP242 geometric tolerance relationships

### DIFF
--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -261,6 +261,7 @@ def build_pmi_features(pmi, bbox) -> list[AuthoredDimension | PmiFeature]:
                 ref_bbox=r.ref_bbox,
                 ref_pts=tuple(r.ref_pts),
                 source_id=r.source_id,
+                datum_refs=r.datum_refs,
             )
         )
     return out

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1171,6 +1171,7 @@ class PmiFeature:
     ref_bbox: tuple[float, float, float, float, float, float] | None = None
     ref_pts: tuple[Point, ...] = ()
     source_id: str = ""
+    datum_refs: tuple[str, ...] = ()
     kind: ClassVar[str] = "pmi"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -39,6 +39,7 @@ try:
     from OCP.TDF import TDF_LabelSequence, TDF_Tool
     from OCP.TDocStd import TDocStd_Document
     from OCP.XCAFDoc import (
+        XCAFDoc_Datum,
         XCAFDoc_Dimension,
         XCAFDoc_DimTolTool,
         XCAFDoc_DocumentTool,
@@ -93,20 +94,21 @@ _DIM_PREFIX: dict[str, str] = {
 
 # int → short tag for XCAFDimTolObjects_GeomToleranceType
 _GTOL_TYPE: dict[int, str] = {
-    1: "straightness",
-    2: "flatness",
+    1: "angularity",
+    2: "circular_runout",
     3: "circularity",
-    4: "cylindricity",
-    5: "profile_line",
-    6: "profile_surface",
-    7: "perpendicularity",
-    8: "angularity",
-    9: "parallelism",
+    4: "coaxiality",
+    5: "concentricity",
+    6: "cylindricity",
+    7: "flatness",
+    8: "parallelism",
+    9: "perpendicularity",
     10: "position",
-    11: "concentricity",
-    12: "symmetry",
-    13: "circular_runout",
-    14: "total_runout",
+    11: "profile_line",
+    12: "profile_surface",
+    13: "straightness",
+    14: "symmetry",
+    15: "total_runout",
 }
 
 
@@ -139,6 +141,7 @@ class PmiRecord:
                         in which the dimension primarily spans (based on the outer
                         bbox extent, not the centroid difference).
         label:          Ready-to-use annotation label (e.g. ``"ø35"``, ``"60"``).
+        datum_refs:     Ordered datum letters referenced by a geometric tolerance.
     """
 
     kind: str
@@ -156,6 +159,7 @@ class PmiRecord:
     # Appended to preserve the positional compatibility of the original record fields.
     lower_bound: float | None = None
     upper_bound: float | None = None
+    datum_refs: tuple[str, ...] = ()
 
 
 PmiSourceCategory = Literal["dimension", "geometric_tolerance", "datum"]
@@ -287,6 +291,67 @@ def _failure_reason(exc: Exception) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
+def _reference_geometry(label, shape_tool):
+    """Measure the geometry relationships shared by dimensions and tolerances."""
+    first_refs = TDF_LabelSequence()
+    second_refs = TDF_LabelSequence()
+    XCAFDoc_DimTolTool.GetRefShapeLabel_s(label, first_refs, second_refs)
+    points: list[tuple[float, float, float]] = []
+    boxes: list[tuple[float, float, float, float, float, float]] = []
+    partial_reasons: list[str] = []
+    reference_count = first_refs.Length() + second_refs.Length()
+    for refs in (first_refs, second_refs):
+        for index in range(1, refs.Length() + 1):
+            shape = shape_tool.GetShape_s(refs.Value(index))
+            if shape is None or shape.IsNull():
+                partial_reasons.append("one referenced shape is unavailable")
+                continue
+            try:
+                bbox = _shape_bbox(shape)
+                boxes.append(bbox)
+                points.append(_bbox_centroid(bbox))
+            except Exception as exc:
+                partial_reasons.append(
+                    f"one referenced shape could not be measured ({_failure_reason(exc)})"
+                )
+    if reference_count == 0:
+        partial_reasons.append("referenced geometry is unavailable")
+
+    ref_bbox = _merge_bboxes(boxes) if boxes else None
+    dominant_axis = _dominant_from_bbox(ref_bbox) if ref_bbox else "?"
+    return (
+        tuple(points),
+        ref_bbox,
+        dominant_axis,
+        tuple(dict.fromkeys(partial_reasons)),
+    )
+
+
+def _datum_references(label, dim_tol_tool) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return the ordered datum letters attached to one tolerance label."""
+    datum_labels = TDF_LabelSequence()
+    try:
+        dim_tol_tool.GetDatumOfTolerLabels_s(label, datum_labels)
+    except Exception as exc:
+        return (), (f"datum references are unavailable ({_failure_reason(exc)})",)
+
+    datum_refs: list[str] = []
+    partial_reasons: list[str] = []
+    for index in range(1, datum_labels.Length() + 1):
+        try:
+            datum = XCAFDoc_Datum.Set_s(datum_labels.Value(index)).GetObject()
+            name = datum.GetName()
+            datum_ref = str(name.ToCString()).strip() if name is not None else ""
+        except Exception as exc:
+            partial_reasons.append(f"one datum reference is unavailable ({_failure_reason(exc)})")
+            continue
+        if datum_ref:
+            datum_refs.append(datum_ref)
+        else:
+            partial_reasons.append("one datum reference has no letter")
+    return tuple(datum_refs), tuple(dict.fromkeys(partial_reasons))
+
+
 def _dimension_record(
     label, obj, type_code: int, shape_tool, source_id: str
 ) -> tuple[PmiRecord, tuple[str, ...]]:
@@ -334,33 +399,10 @@ def _dimension_record(
         except Exception as exc:
             partial_reasons.append(f"upper range bound is unavailable ({_failure_reason(exc)})")
 
-    first_refs = TDF_LabelSequence()
-    second_refs = TDF_LabelSequence()
-    XCAFDoc_DimTolTool.GetRefShapeLabel_s(label, first_refs, second_refs)
-    points: list[tuple[float, float, float]] = []
-    boxes: list[tuple[float, float, float, float, float, float]] = []
-    reference_count = first_refs.Length() + second_refs.Length()
-    for refs in (first_refs, second_refs):
-        for index in range(1, refs.Length() + 1):
-            shape = shape_tool.GetShape_s(refs.Value(index))
-            if shape is None or shape.IsNull():
-                partial_reasons.append("one referenced shape is unavailable")
-                continue
-            try:
-                bbox = _shape_bbox(shape)
-                boxes.append(bbox)
-                points.append(_bbox_centroid(bbox))
-            except Exception as exc:
-                partial_reasons.append(
-                    f"one referenced shape could not be measured ({_failure_reason(exc)})"
-                )
-    if reference_count == 0:
-        partial_reasons.append("referenced geometry is unavailable")
-
     # The outer edges of the referenced geometry give the correct measurement span (e.g.
     # the two far sides of a diameter) rather than the shorter centroid-to-centroid distance.
-    ref_bbox = _merge_bboxes(boxes) if boxes else None
-    dominant_axis = _dominant_from_bbox(ref_bbox) if ref_bbox else "?"
+    points, ref_bbox, dominant_axis, reference_reasons = _reference_geometry(label, shape_tool)
+    partial_reasons.extend(reference_reasons)
     kind = _DIM_TYPE.get(type_code, f"type{type_code}")
     return (
         PmiRecord(
@@ -388,16 +430,34 @@ def _dimension_record(
     )
 
 
-def _geometric_tolerance_record(obj, type_code: int, source_id: str) -> PmiRecord:
-    """Convert the currently preserved subset of one XCAF geometric tolerance."""
+def _geometric_tolerance_record(
+    label, obj, type_code: int, shape_tool, dim_tol_tool, source_id: str
+) -> tuple[PmiRecord, tuple[str, ...]]:
+    """Convert the XCAF-owned fields of one geometric tolerance."""
     value = float(obj.GetValue())
     kind = _GTOL_TYPE.get(type_code, f"gtol{type_code}")
-    return PmiRecord(
-        kind=kind,
-        type_code=type_code,
-        value=value,
-        label=f"{kind} {value:.3g}" if value else kind,
-        source_id=source_id,
+    partial_reasons: list[str] = []
+    if type_code not in _GTOL_TYPE:
+        partial_reasons.append(f"geometric-tolerance type {type_code} is unsupported")
+    if value <= 0:
+        partial_reasons.append("tolerance magnitude is unavailable")
+    points, ref_bbox, dominant_axis, reference_reasons = _reference_geometry(label, shape_tool)
+    partial_reasons.extend(reference_reasons)
+    datum_refs, datum_reasons = _datum_references(label, dim_tol_tool)
+    partial_reasons.extend(datum_reasons)
+    return (
+        PmiRecord(
+            kind=kind,
+            type_code=type_code,
+            value=value,
+            ref_pts=points,
+            ref_bbox=ref_bbox,
+            dominant_axis=dominant_axis,
+            label=f"{kind} {value:.3g}" if value > 0 else kind,
+            source_id=source_id,
+            datum_refs=datum_refs,
+        ),
+        tuple(dict.fromkeys(partial_reasons)),
     )
 
 
@@ -510,7 +570,9 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
         try:
             obj = XCAFDoc_GeomTolerance.Set_s(label).GetObject()
             tolerance_type_code = int(obj.GetType())
-            record = _geometric_tolerance_record(obj, tolerance_type_code, source_id)
+            record, partial_reasons = _geometric_tolerance_record(
+                label, obj, tolerance_type_code, shape_tool, dt, source_id
+            )
         except Exception as exc:
             sources.append(
                 PmiSourceEntity(
@@ -529,8 +591,8 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
                     source_id,
                     "geometric_tolerance",
                     tolerance_type_code,
-                    "partially_extracted",
-                    "only the characteristic type is preserved; value and references are incomplete",
+                    "partially_extracted" if partial_reasons else "extracted",
+                    "; ".join(partial_reasons),
                 )
             )
 
@@ -571,16 +633,21 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
         source.category == "geometric_tolerance" and source.outcome == "partially_extracted"
         for source in sources
     )
+    extracted_tolerances = sum(
+        source.category == "geometric_tolerance" and source.outcome == "extracted"
+        for source in sources
+    )
 
     _log.info(
         "PMI extracted from %s: %d/%d complete semantic dims (%d partial, "
         "%d presentation-only), "
-        "0/%d complete gtols (%d partial), 0/%d datums",
+        "%d/%d complete gtols (%d partial), 0/%d datums",
         Path(step_file).name,
         extracted_dimensions,
         semantic_dimensions,
         partial_dimensions,
         presentation_dimensions,
+        extracted_tolerances,
         tolerances.Length(),
         partial_tolerances,
         datums.Length(),

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -229,12 +229,13 @@ def _measured_dimension_line(f) -> str:
 
 def _raw_pmi_line(f) -> str:
     source_id = f", source_id={f.source_id!r}" if f.source_id else ""
+    datum_refs = f", datum_refs={f.datum_refs!r}" if f.datum_refs else ""
     return (
         "sheet.add(PmiFeature("
         f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
         f"pmi_kind={f.pmi_kind!r}, value={_n(f.value)}, label={f.label!r}, "
         f"dominant_axis={f.dominant_axis!r}, ref_bbox={_bbox_arg(f.ref_bbox)}, "
-        f"ref_pts=tuple({_pts_arg(f.ref_pts)}){source_id}"
+        f"ref_pts=tuple({_pts_arg(f.ref_pts)}){source_id}{datum_refs}"
         "))   # raw AP242 PMI fallback; not yet lowered to a drafting concept"
     )
 

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -325,6 +325,75 @@ class TestExtractPmi:
             "upper range bound is unavailable (RuntimeError: upper bound unavailable)" in reasons
         )
 
+    def test_gtol_field_failures_are_explicit_partial_outcomes(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        class FakeSequence:
+            def __init__(self):
+                self.items = []
+
+            def Length(self):
+                return len(self.items)
+
+            def Value(self, index):
+                return self.items[index - 1]
+
+        monkeypatch.setattr(pmi_module, "TDF_LabelSequence", FakeSequence)
+        broken_tool = SimpleNamespace(
+            GetDatumOfTolerLabels_s=lambda _label, _refs: (_ for _ in ()).throw(
+                RuntimeError("relationship failed")
+            )
+        )
+        assert pmi_module._datum_references(object(), broken_tool) == (
+            (),
+            ("datum references are unavailable (RuntimeError: relationship failed)",),
+        )
+
+        unreadable = object()
+        blank = object()
+
+        def get_datums(_label, refs):
+            refs.items.extend((unreadable, blank))
+
+        def set_datum(label):
+            if label is unreadable:
+                return SimpleNamespace(
+                    GetObject=lambda: (_ for _ in ()).throw(RuntimeError("datum failed"))
+                )
+            return SimpleNamespace(GetObject=lambda: SimpleNamespace(GetName=lambda: None))
+
+        monkeypatch.setattr(pmi_module, "XCAFDoc_Datum", SimpleNamespace(Set_s=set_datum))
+        assert pmi_module._datum_references(
+            object(), SimpleNamespace(GetDatumOfTolerLabels_s=get_datums)
+        ) == (
+            (),
+            (
+                "one datum reference is unavailable (RuntimeError: datum failed)",
+                "one datum reference has no letter",
+            ),
+        )
+
+        monkeypatch.setattr(
+            pmi_module,
+            "_reference_geometry",
+            lambda _label, _shape_tool: ((), None, "?", ()),
+        )
+        monkeypatch.setattr(
+            pmi_module,
+            "_datum_references",
+            lambda _label, _dim_tol_tool: ((), ()),
+        )
+        record, reasons = pmi_module._geometric_tolerance_record(
+            object(),
+            SimpleNamespace(GetValue=lambda: 0.1),
+            99,
+            object(),
+            object(),
+            "geometric_tolerance:unknown",
+        )
+        assert record.kind == "gtol99"
+        assert reasons == ("geometric-tolerance type 99 is unsupported",)
+
     def test_report_returns_structured_reader_failures(self, monkeypatch):
         import draftwright.pmi as pmi_module
 

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -62,6 +62,73 @@ class TestExtractPmi:
         ]
         assert len(gtols) >= 4
 
+    def test_occt_geometric_tolerance_enum_is_mapped_by_its_actual_values(self):
+        """Pin the installed OCCT enum, not a remembered ordering from another binding."""
+        from OCP.XCAFDimTolObjects import XCAFDimTolObjects_GeomToleranceType as GtolType
+
+        import draftwright.pmi as pmi_module
+
+        expected = {
+            "Angularity": "angularity",
+            "CircularRunout": "circular_runout",
+            "CircularityOrRoundness": "circularity",
+            "Coaxiality": "coaxiality",
+            "Concentricity": "concentricity",
+            "Cylindricity": "cylindricity",
+            "Flatness": "flatness",
+            "Parallelism": "parallelism",
+            "Perpendicularity": "perpendicularity",
+            "Position": "position",
+            "ProfileOfLine": "profile_line",
+            "ProfileOfSurface": "profile_surface",
+            "Straightness": "straightness",
+            "Symmetry": "symmetry",
+            "TotalRunout": "total_runout",
+        }
+        actual = {
+            int(getattr(GtolType, f"XCAFDimTolObjects_GeomToleranceType_{enum_name}")): kind
+            for enum_name, kind in expected.items()
+        }
+
+        assert pmi_module._GTOL_TYPE == actual
+
+    def test_nist_ctc01_gtols_keep_characteristic_geometry_and_datums(
+        self, ctc01_extraction_report
+    ):
+        """The NIST source identities are the oracle for all XCAF-owned GD&T fields."""
+        expected = {
+            "geometric_tolerance:0:1:4:1": ("position", 2, ("A", "B", "C")),
+            "geometric_tolerance:0:1:4:5": ("position", 2, ("A", "B", "C")),
+            "geometric_tolerance:0:1:4:11": ("profile_surface", 2, ("A", "B", "C")),
+            "geometric_tolerance:0:1:4:15": ("profile_surface", 6, ("A",)),
+            "geometric_tolerance:0:1:4:18": ("perpendicularity", 1, ("A",)),
+            "geometric_tolerance:0:1:4:20": ("flatness", 1, ()),
+        }
+        records = {
+            record.source_id: record
+            for record in ctc01_extraction_report.records
+            if record.source_id.startswith("geometric_tolerance:")
+        }
+
+        assert set(records) == set(expected)
+        for source_id, (kind, reference_count, datum_refs) in expected.items():
+            record = records[source_id]
+            assert record.kind == kind
+            assert len(record.ref_pts) == reference_count
+            assert record.ref_bbox is not None
+            assert record.dominant_axis in {"X", "Y", "Z"}
+            assert record.datum_refs == datum_refs
+
+        outcomes = {
+            source.source_id: source
+            for source in ctc01_extraction_report.sources
+            if source.category == "geometric_tolerance"
+        }
+        assert all(source.outcome == "partially_extracted" for source in outcomes.values())
+        assert {source.reason for source in outcomes.values()} == {
+            "tolerance magnitude is unavailable"
+        }
+
     def test_usable_dims_have_positive_value(self, ctc01_extraction_report):
         recs = ctc01_extraction_report.records
         usable = [r for r in recs if r.value > 0 and len(r.ref_pts) >= 2]
@@ -370,10 +437,10 @@ class TestExtractPmi:
         )
         original = pmi_module._geometric_tolerance_record
 
-        def fail_one(obj, type_code, source_id):
+        def fail_one(label, obj, type_code, shape_tool, dim_tol_tool, source_id):
             if source_id == target:
                 raise RuntimeError("mutation: gtol conversion failed")
-            return original(obj, type_code, source_id)
+            return original(label, obj, type_code, shape_tool, dim_tol_tool, source_id)
 
         monkeypatch.setattr(pmi_module, "_geometric_tolerance_record", fail_one)
         mutated = extract_pmi_report(CTC01)
@@ -542,10 +609,7 @@ class TestBuildDrawingPmi:
         assert (
             sum("datum extraction is not implemented" in issue.message for issue in issues) == 11
         )
-        assert (
-            sum("only the characteristic type is preserved" in issue.message for issue in issues)
-            == 6
-        )
+        assert sum("tolerance magnitude is unavailable" in issue.message for issue in issues) == 6
         summary = ctc01_annotated.lint_summary()
         assert summary["passed"] is False
         assert summary["by_code"]["pmi_not_extracted"] == 17
@@ -558,16 +622,28 @@ class TestBuildDrawingPmi:
     def test_pmi_annotate_reports_each_raw_ir_fallback(self, ctc01_annotated):
         from draftwright.model import PmiFeature
 
-        raw_source_ids = {
-            feature.source_id
+        raw_features = {
+            feature.source_id: feature
             for feature in ctc01_annotated.model().features
             if isinstance(feature, PmiFeature)
         }
         issues = [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_lowered"]
 
-        assert len(raw_source_ids) == 10
+        assert len(raw_features) == 10
         assert {issue.severity for issue in issues} == {"error"}
-        assert {issue.source_ids[0] for issue in issues} == raw_source_ids
+        assert {issue.source_ids[0] for issue in issues} == set(raw_features)
+        expected_gtol_datums = {
+            "geometric_tolerance:0:1:4:1": ("A", "B", "C"),
+            "geometric_tolerance:0:1:4:5": ("A", "B", "C"),
+            "geometric_tolerance:0:1:4:11": ("A", "B", "C"),
+            "geometric_tolerance:0:1:4:15": ("A",),
+            "geometric_tolerance:0:1:4:18": ("A",),
+            "geometric_tolerance:0:1:4:20": (),
+        }
+        assert {
+            source_id: raw_features[source_id].datum_refs for source_id in expected_gtol_datums
+        } == expected_gtol_datums
+        assert all(raw_features[source_id].ref_pts for source_id in expected_gtol_datums)
 
     def test_pmi_annotate_accounts_for_each_typed_dimension_at_the_render_seam(
         self, ctc01_annotated

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -3194,13 +3194,14 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
             model = detect_part_model(part)
             record = PmiFeature(
                 frame=Frame((1.0, 2.0, 3.0), "z"),
-                pmi_kind="linear",
-                value=60.0,
-                label="60",
+                pmi_kind="position",
+                value=0.1,
+                label="position 0.1",
                 dominant_axis="X",
                 ref_bbox=(-30.0, -20.0, -10.0, 30.0, 20.0, 10.0),
                 ref_pts=((-30.0, 0.0, 0.0), (30.0, 0.0, 0.0)),
-                source_id="dimension:0:1:4:raw-test",
+                source_id="geometric_tolerance:0:1:4:raw-test",
+                datum_refs=("A", "B"),
             )
             return part, dataclasses.replace(model, features=[*model.features, record])
 


### PR DESCRIPTION
## What changed

- correct the OCCT geometric-tolerance enum mapping, which was misclassifying four of six CTC-01 requirements
- extract referenced shape measurements and ordered datum letters from XCAF
- preserve datum references through the raw PMI IR and generated Sheet-script round trip
- replace the stale “type only” diagnostic with field-specific partial extraction reasons

## Why

Issue #62 assumed the existing characteristic vocabulary was correct and that both values and relationships were missing. CTC-01 proves otherwise: XCAF preserves the shape and datum relationships, but the installed OCCT enum ordering differs from the hand-written table and OCCT drops all six tolerance magnitudes during translation.

This slice fixes the report-mode correctness defect without pretending the records are ready to render. All six remain explicitly `partially_extracted` until their source magnitudes can be recovered.

Closes no issue; advances #62.

## Validation

- mutation-first CTC-01 gates pin all six source IDs, characteristics, reference counts, and datum chains
- generated raw-PMI script is executed and structurally compared after round trip
- `scripts/pr-check --static` (Ruff, format, codespell, mypy)
- `pytest -q tests/test_pmi.py tests/test_sheet_emit.py -x`: 406 passed, 2 xfailed
- strengthened focused gates rerun after review: 2 passed