### PR TITLE
Recover AP242 geometric tolerance magnitudes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,10 @@ entry. Keep `_LAYERS` and this section in step.
   detected as declared (#969); the DAG's bottom leaf (guarded
   by `test_geometry_is_a_leaf`) so the IR waist uses them without importing
   `_core`.
+- **`_pmi_part21.py`** — the rank-0 structured ISO 10303-21 adapter for AP242
+  geometric-tolerance facts that OCCT's XCAF transfer drops. It resolves explicit
+  Part21 references and SI length units, and requires unique semantic-name + kind
+  correspondence; it knows nothing about XCAF, drafting IR, or placement.
 - **`_warnings.py`** — the public warning categories (`SoftDeprecationWarning`), a
   dependency-free leaf. Separate from `_core` on purpose: `_core` imports build123d, so a
   category defined there costs the CAD kernel (~6 s) to reach, and the pytest
@@ -226,6 +230,8 @@ entry. Keep `_LAYERS` and this section in step.
   the drawing duck-typed as `dwg`; `Drawing.repair()` stays a thin wrapper.
   Depends only on `_core`.
 - **`pmi.py`** — PMI (product manufacturing information) extraction from STEP AP242.
+  Owns the XCAF source census and overlays `_pmi_part21` facts only after exact
+  correspondence, preserving both XCAF and Part21 source identities in the raw IR fallback.
 
 ## Architecture decisions — READ `docs/adr/` FIRST
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
     "pillow>=10",
     "pypdfium2>=4",
     "reportlab>=4.0",
+    # Structured ISO 10303-21 access for AP242 facts that OCCT's XCAF transfer drops (#62).
+    # STEPutils 0.1 is the only release; isolate it behind _pmi_part21 and pin its README's
+    # ANTLR compatibility constraint explicitly because the package metadata omits the cap.
+    "steputils==0.1",
+    "antlr4-python3-runtime<4.10",
     "svglib>=1.5",
     "typer>=0.12",
     # PEP 702 @deprecated: stdlib `warnings.deprecated` lands in 3.13; backport for 3.10–3.12.

--- a/src/draftwright/_pmi_part21.py
+++ b/src/draftwright/_pmi_part21.py
@@ -1,0 +1,210 @@
+"""Structured Part21 facts that OCCT's XCAF PMI transfer currently drops.
+
+This is deliberately a leaf adapter: it understands ISO 10303-21 entities and units, but
+knows nothing about XCAF labels, drafting IR, or placement.  ``pmi.py`` owns the overlay and
+may use a fact only after :func:`match_geometric_tolerance` proves exact correspondence.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+from steputils import p21
+
+_GTOL_ENTITY_KIND: dict[str, str] = {
+    "ANGULARITY_TOLERANCE": "angularity",
+    "CIRCULAR_RUNOUT_TOLERANCE": "circular_runout",
+    "ROUNDNESS_TOLERANCE": "circularity",
+    "COAXIALITY_TOLERANCE": "coaxiality",
+    "CONCENTRICITY_TOLERANCE": "concentricity",
+    "CYLINDRICITY_TOLERANCE": "cylindricity",
+    "FLATNESS_TOLERANCE": "flatness",
+    "PARALLELISM_TOLERANCE": "parallelism",
+    "PERPENDICULARITY_TOLERANCE": "perpendicularity",
+    "POSITION_TOLERANCE": "position",
+    "LINE_PROFILE_TOLERANCE": "profile_line",
+    "SURFACE_PROFILE_TOLERANCE": "profile_surface",
+    "STRAIGHTNESS_TOLERANCE": "straightness",
+    "SYMMETRY_TOLERANCE": "symmetry",
+    "TOTAL_RUNOUT_TOLERANCE": "total_runout",
+}
+
+# SI prefix → millimetres per prefixed metre.  The mapping is definition-level standard
+# data rather than a fixture inference; unsupported/non-SI units still fail closed.
+_SI_METRE_TO_MM: dict[str, float] = {
+    "$": 1e3,
+    ".EXA.": 1e21,
+    ".PETA.": 1e18,
+    ".TERA.": 1e15,
+    ".GIGA.": 1e12,
+    ".MEGA.": 1e9,
+    ".KILO.": 1e6,
+    ".HECTO.": 1e5,
+    ".DECA.": 1e4,
+    ".DECI.": 1e2,
+    ".CENTI.": 1e1,
+    ".MILLI.": 1.0,
+    ".MICRO.": 1e-3,
+    ".NANO.": 1e-6,
+    ".PICO.": 1e-9,
+    ".FEMTO.": 1e-12,
+    ".ATTO.": 1e-15,
+}
+
+
+@dataclass(frozen=True)
+class GeometricToleranceFact:
+    """One Part21 tolerance characteristic and its independently auditable magnitude."""
+
+    entity_id: str
+    semantic_name: str
+    kind: str
+    value_mm: float | None
+    reason: str = ""
+
+
+def _entities(instance) -> tuple:
+    entity = getattr(instance, "entity", None)
+    if entity is not None:
+        return (entity,)
+    return tuple(instance.entities)
+
+
+def _entity_named(instance, name: str):
+    return next((entity for entity in _entities(instance) if entity.name == name), None)
+
+
+def _unit_factor_mm(step, unit_ref: str) -> tuple[float | None, str]:
+    unit = step.get(unit_ref)
+    if unit is None:
+        return None, f"length unit {unit_ref} is missing"
+    si_unit = _entity_named(unit, "SI_UNIT")
+    if si_unit is None or len(si_unit.params) < 2:
+        return None, f"length unit {unit_ref} is not a supported SI metre unit"
+    prefix, unit_name = (str(param).upper() for param in si_unit.params[:2])
+    if unit_name != ".METRE." or prefix not in _SI_METRE_TO_MM:
+        return None, f"length unit {unit_ref} is not a supported SI metre unit"
+    return _SI_METRE_TO_MM[prefix], ""
+
+
+def _length_value_mm(step, measure_ref: str) -> tuple[float | None, str]:
+    measure = step.get(measure_ref)
+    if measure is None:
+        return None, f"tolerance magnitude {measure_ref} is missing"
+    measure_with_unit = _entity_named(measure, "MEASURE_WITH_UNIT")
+    if measure_with_unit is None:
+        entity = next(
+            (
+                candidate
+                for candidate in _entities(measure)
+                if candidate.name.endswith("MEASURE_WITH_UNIT") and len(candidate.params) >= 2
+            ),
+            None,
+        )
+        measure_with_unit = entity
+    if measure_with_unit is None or len(measure_with_unit.params) < 2:
+        return None, f"tolerance magnitude {measure_ref} is not a measure with unit"
+
+    typed_value, unit_ref = measure_with_unit.params[:2]
+    if (
+        not isinstance(typed_value, p21.TypedParameter)
+        or typed_value.type_name != "LENGTH_MEASURE"
+    ):
+        return None, f"tolerance magnitude {measure_ref} is not a length measure"
+    if not isinstance(unit_ref, p21.Reference):
+        return None, f"tolerance magnitude {measure_ref} has no referenced length unit"
+    try:
+        value = float(typed_value.param)
+    except (TypeError, ValueError):
+        return None, f"tolerance magnitude {measure_ref} is not numeric"
+    if not math.isfinite(value) or value <= 0:
+        return None, f"tolerance magnitude {measure_ref} must be finite and positive"
+
+    factor, reason = _unit_factor_mm(step, str(unit_ref))
+    if factor is None:
+        return None, reason
+    return value * factor, ""
+
+
+def read_geometric_tolerances(step_file: str | Path) -> tuple[GeometricToleranceFact, ...]:
+    """Read supported geometric-tolerance facts without inferring entity order.
+
+    Syntax/read failures propagate to the XCAF overlay, which records them as a partial
+    extraction reason rather than turning a broken Part21 pass into a report-level failure.
+    """
+
+    step = p21.readfile(step_file)
+    facts: list[GeometricToleranceFact] = []
+    for section in step.data:
+        for entity_id, instance in section.instances.items():
+            entities = _entities(instance)
+            characteristic_names = [
+                entity.name for entity in entities if entity.name in _GTOL_ENTITY_KIND
+            ]
+            if not characteristic_names:
+                continue
+            if len(characteristic_names) != 1:
+                facts.append(
+                    GeometricToleranceFact(
+                        entity_id,
+                        "",
+                        "",
+                        None,
+                        "geometric tolerance has multiple supported characteristics",
+                    )
+                )
+                continue
+
+            characteristic_name = characteristic_names[0]
+            kind = _GTOL_ENTITY_KIND[characteristic_name]
+            base = _entity_named(instance, "GEOMETRIC_TOLERANCE")
+            if base is None:
+                base = _entity_named(instance, characteristic_name)
+            if base is None or len(base.params) < 3:
+                facts.append(
+                    GeometricToleranceFact(
+                        entity_id,
+                        "",
+                        kind,
+                        None,
+                        "geometric tolerance has no name/magnitude tuple",
+                    )
+                )
+                continue
+
+            name_param, magnitude_param = base.params[0], base.params[2]
+            semantic_name = str(name_param).strip() if isinstance(name_param, str) else ""
+            if not isinstance(magnitude_param, p21.Reference):
+                facts.append(
+                    GeometricToleranceFact(
+                        entity_id,
+                        semantic_name,
+                        kind,
+                        None,
+                        "geometric tolerance has no referenced magnitude",
+                    )
+                )
+                continue
+            value_mm, reason = _length_value_mm(step, str(magnitude_param))
+            facts.append(GeometricToleranceFact(entity_id, semantic_name, kind, value_mm, reason))
+    return tuple(facts)
+
+
+def match_geometric_tolerance(
+    facts: tuple[GeometricToleranceFact, ...], semantic_name: str, kind: str
+) -> tuple[GeometricToleranceFact | None, str]:
+    """Require one exact, nonblank ``(semantic name, kind)`` correspondence."""
+
+    name = semantic_name.strip()
+    if not name:
+        return None, "XCAF geometric tolerance has no semantic name"
+    matches = [fact for fact in facts if fact.semantic_name == name and fact.kind == kind]
+    if not matches:
+        return None, f"Part21 has no {kind} geometric tolerance named {name!r}"
+    if len(matches) > 1:
+        entity_ids = ", ".join(fact.entity_id for fact in matches)
+        return None, f"Part21 correspondence is ambiguous for {kind} {name!r} ({entity_ids})"
+    fact = matches[0]
+    return fact, fact.reason

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -262,6 +262,7 @@ def build_pmi_features(pmi, bbox) -> list[AuthoredDimension | PmiFeature]:
                 ref_pts=tuple(r.ref_pts),
                 source_id=r.source_id,
                 datum_refs=r.datum_refs,
+                part21_id=r.part21_id,
             )
         )
     return out

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1172,6 +1172,7 @@ class PmiFeature:
     ref_pts: tuple[Point, ...] = ()
     source_id: str = ""
     datum_refs: tuple[str, ...] = ()
+    part21_id: str = ""
     kind: ClassVar[str] = "pmi"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -24,6 +24,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
 
+from draftwright._pmi_part21 import (
+    GeometricToleranceFact,
+    match_geometric_tolerance,
+    read_geometric_tolerances,
+)
+
 _log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -142,6 +148,7 @@ class PmiRecord:
                         bbox extent, not the centroid difference).
         label:          Ready-to-use annotation label (e.g. ``"ø35"``, ``"60"``).
         datum_refs:     Ordered datum letters referenced by a geometric tolerance.
+        part21_id:      Part21 entity id supplying an overlaid tolerance magnitude.
     """
 
     kind: str
@@ -160,6 +167,7 @@ class PmiRecord:
     lower_bound: float | None = None
     upper_bound: float | None = None
     datum_refs: tuple[str, ...] = ()
+    part21_id: str = ""
 
 
 PmiSourceCategory = Literal["dimension", "geometric_tolerance", "datum"]
@@ -352,6 +360,65 @@ def _datum_references(label, dim_tol_tool) -> tuple[tuple[str, ...], tuple[str, 
     return tuple(datum_refs), tuple(dict.fromkeys(partial_reasons))
 
 
+def _semantic_name(obj) -> tuple[str, str]:
+    """Return the XCAF name used solely for evidence-gated Part21 correspondence."""
+    try:
+        semantic_name = obj.GetSemanticName()
+        name = str(semantic_name.ToCString()).strip() if semantic_name is not None else ""
+    except Exception as exc:
+        return "", f"XCAF semantic name is unavailable ({_failure_reason(exc)})"
+    if not name:
+        return "", "XCAF geometric tolerance has no semantic name"
+    return name, ""
+
+
+def _unpreserved_geometric_tolerance_fields(obj) -> tuple[str, ...]:
+    """Keep a source partial when XCAF exposes requirement fields we do not yet carry."""
+    reasons: list[str] = []
+    enum_fields = (
+        ("GetTypeOfValue", "type-of-value"),
+        ("GetMaterialRequirementModifier", "material-requirement modifier"),
+        ("GetZoneModifier", "zone modifier"),
+    )
+    for accessor, description in enum_fields:
+        try:
+            enum_value = int(getattr(obj, accessor)())
+        except Exception as exc:
+            reasons.append(
+                f"geometric-tolerance {description} is unavailable ({_failure_reason(exc)})"
+            )
+        else:
+            if enum_value != 0:
+                reasons.append(f"geometric-tolerance {description} {enum_value} is not preserved")
+
+    float_fields = (
+        ("GetValueOfZoneModifier", "zone-modifier value"),
+        ("GetMaxValueModifier", "maximum-value modifier"),
+    )
+    for accessor, description in float_fields:
+        try:
+            numeric_value = float(getattr(obj, accessor)())
+        except Exception as exc:
+            reasons.append(
+                f"geometric-tolerance {description} is unavailable ({_failure_reason(exc)})"
+            )
+        else:
+            if abs(numeric_value) > 1e-9:
+                reasons.append(
+                    f"geometric-tolerance {description} {numeric_value:g} is not preserved"
+                )
+
+    try:
+        modifiers = tuple(int(modifier) for modifier in obj.GetModifiers())
+    except Exception as exc:
+        reasons.append(f"geometric-tolerance modifiers are unavailable ({_failure_reason(exc)})")
+    else:
+        if modifiers:
+            codes = ", ".join(str(modifier) for modifier in modifiers)
+            reasons.append(f"geometric-tolerance modifier(s) {codes} are not preserved")
+    return tuple(reasons)
+
+
 def _dimension_record(
     label, obj, type_code: int, shape_tool, source_id: str
 ) -> tuple[PmiRecord, tuple[str, ...]]:
@@ -431,16 +498,40 @@ def _dimension_record(
 
 
 def _geometric_tolerance_record(
-    label, obj, type_code: int, shape_tool, dim_tol_tool, source_id: str
+    label,
+    obj,
+    type_code: int,
+    shape_tool,
+    dim_tol_tool,
+    source_id: str,
+    part21_facts: tuple[GeometricToleranceFact, ...] = (),
+    part21_error: str = "",
 ) -> tuple[PmiRecord, tuple[str, ...]]:
     """Convert the XCAF-owned fields of one geometric tolerance."""
     value = float(obj.GetValue())
     kind = _GTOL_TYPE.get(type_code, f"gtol{type_code}")
     partial_reasons: list[str] = []
+    part21_id = ""
     if type_code not in _GTOL_TYPE:
         partial_reasons.append(f"geometric-tolerance type {type_code} is unsupported")
     if value <= 0:
-        partial_reasons.append("tolerance magnitude is unavailable")
+        if part21_error:
+            magnitude_reason = part21_error
+        else:
+            semantic_name, name_reason = _semantic_name(obj)
+            if name_reason:
+                magnitude_reason = name_reason
+            else:
+                fact, magnitude_reason = match_geometric_tolerance(
+                    part21_facts, semantic_name, kind
+                )
+                if fact is not None:
+                    part21_id = fact.entity_id
+                    if not magnitude_reason and fact.value_mm is not None:
+                        value = fact.value_mm
+        if value <= 0:
+            partial_reasons.append(f"tolerance magnitude is unavailable ({magnitude_reason})")
+    partial_reasons.extend(_unpreserved_geometric_tolerance_fields(obj))
     points, ref_bbox, dominant_axis, reference_reasons = _reference_geometry(label, shape_tool)
     partial_reasons.extend(reference_reasons)
     datum_refs, datum_reasons = _datum_references(label, dim_tol_tool)
@@ -456,6 +547,7 @@ def _geometric_tolerance_record(
             label=f"{kind} {value:.3g}" if value > 0 else kind,
             source_id=source_id,
             datum_refs=datum_refs,
+            part21_id=part21_id,
         ),
         tuple(dict.fromkeys(partial_reasons)),
     )
@@ -563,6 +655,14 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
     # ---- Geometric tolerances ----------------------------------------------
     tolerances = TDF_LabelSequence()
     dt.GetGeomToleranceLabels(tolerances)
+    part21_facts: tuple[GeometricToleranceFact, ...] = ()
+    part21_error = ""
+    if tolerances.Length() > 0:
+        try:
+            part21_facts = read_geometric_tolerances(step_file)
+        except Exception as exc:
+            part21_error = f"Part21 read failed: {_failure_reason(exc)}"
+            _log.debug("PMI Part21 overlay unavailable for %s: %s", Path(step_file).name, exc)
     for index in range(1, tolerances.Length() + 1):
         label = tolerances.Value(index)
         source_id = _source_id("geometric_tolerance", label)
@@ -571,7 +671,14 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
             obj = XCAFDoc_GeomTolerance.Set_s(label).GetObject()
             tolerance_type_code = int(obj.GetType())
             record, partial_reasons = _geometric_tolerance_record(
-                label, obj, tolerance_type_code, shape_tool, dt, source_id
+                label,
+                obj,
+                tolerance_type_code,
+                shape_tool,
+                dt,
+                source_id,
+                part21_facts,
+                part21_error,
             )
         except Exception as exc:
             sources.append(

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -230,12 +230,13 @@ def _measured_dimension_line(f) -> str:
 def _raw_pmi_line(f) -> str:
     source_id = f", source_id={f.source_id!r}" if f.source_id else ""
     datum_refs = f", datum_refs={f.datum_refs!r}" if f.datum_refs else ""
+    part21_id = f", part21_id={f.part21_id!r}" if f.part21_id else ""
     return (
         "sheet.add(PmiFeature("
         f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
         f"pmi_kind={f.pmi_kind!r}, value={_n(f.value)}, label={f.label!r}, "
         f"dominant_axis={f.dominant_axis!r}, ref_bbox={_bbox_arg(f.ref_bbox)}, "
-        f"ref_pts=tuple({_pts_arg(f.ref_pts)}){source_id}{datum_refs}"
+        f"ref_pts=tuple({_pts_arg(f.ref_pts)}){source_id}{datum_refs}{part21_id}"
         "))   # raw AP242 PMI fallback; not yet lowered to a drafting concept"
     )
 

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -56,6 +56,8 @@ _MODEL_DIR = _SRC / "model"
 _LAYERS: dict[str, int] = {
     # 0 — leaves: import nothing from draftwright (or only same-rank leaves / the IR waist)
     "_geometry": 0,
+    # Structured ISO 10303-21 facts only; XCAF correspondence remains in rank-2 pmi.py.
+    "_pmi_part21": 0,
     # Warning categories only. Imports nothing at all — deliberately, because a category
     # users are told to filter must not cost the CAD kernel to reach (#1043): defined beside
     # `_core` it dragged build123d, and the pytest filterwarnings entry naming it paid ~6 s on

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -8,6 +8,7 @@ import pytest
 from build123d import Box, export_step
 
 from draftwright import build_drawing, extract_pmi, extract_pmi_report
+from draftwright._pmi_part21 import GeometricToleranceFact
 from draftwright.pmi import _PMI_AVAILABLE, PmiExtractionReport, PmiRecord
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -489,6 +490,75 @@ class TestExtractPmi:
             "",
             "XCAF semantic name is unavailable (RuntimeError: unreadable)",
         )
+
+    @pytest.mark.parametrize(
+        ("semantic_name", "facts", "expected_part21_id", "expected_reason"),
+        (
+            (
+                None,
+                (),
+                "",
+                "XCAF geometric tolerance has no semantic name",
+            ),
+            (
+                "Wanted",
+                (),
+                "",
+                "Part21 has no flatness geometric tolerance named 'Wanted'",
+            ),
+            (
+                "Wanted",
+                (
+                    GeometricToleranceFact(
+                        "#9", "Wanted", "flatness", None, "unsupported length unit"
+                    ),
+                ),
+                "#9",
+                "unsupported length unit",
+            ),
+        ),
+    )
+    def test_gtol_magnitude_overlay_failures_remain_explicit(
+        self,
+        monkeypatch,
+        semantic_name,
+        facts,
+        expected_part21_id,
+        expected_reason,
+    ):
+        import draftwright.pmi as pmi_module
+
+        monkeypatch.setattr(
+            pmi_module,
+            "_reference_geometry",
+            lambda _label, _shape_tool: ((), None, "?", ()),
+        )
+        monkeypatch.setattr(
+            pmi_module,
+            "_datum_references",
+            lambda _label, _dim_tol_tool: ((), ()),
+        )
+        semantic = (
+            None if semantic_name is None else SimpleNamespace(ToCString=lambda: semantic_name)
+        )
+        obj = SimpleNamespace(
+            GetValue=lambda: 0.0,
+            GetSemanticName=lambda: semantic,
+            GetTypeOfValue=lambda: 0,
+            GetMaterialRequirementModifier=lambda: 0,
+            GetZoneModifier=lambda: 0,
+            GetValueOfZoneModifier=lambda: 0.0,
+            GetMaxValueModifier=lambda: 0.0,
+            GetModifiers=lambda: (),
+        )
+
+        record, reasons = pmi_module._geometric_tolerance_record(
+            object(), obj, 7, object(), object(), "geometric_tolerance:test", facts
+        )
+
+        assert record.value == 0.0
+        assert record.part21_id == expected_part21_id
+        assert reasons == (f"tolerance magnitude is unavailable ({expected_reason})",)
 
     def test_report_returns_structured_reader_failures(self, monkeypatch):
         import draftwright.pmi as pmi_module

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -97,12 +97,42 @@ class TestExtractPmi:
     ):
         """The NIST source identities are the oracle for all XCAF-owned GD&T fields."""
         expected = {
-            "geometric_tolerance:0:1:4:1": ("position", 2, ("A", "B", "C")),
-            "geometric_tolerance:0:1:4:5": ("position", 2, ("A", "B", "C")),
-            "geometric_tolerance:0:1:4:11": ("profile_surface", 2, ("A", "B", "C")),
-            "geometric_tolerance:0:1:4:15": ("profile_surface", 6, ("A",)),
-            "geometric_tolerance:0:1:4:18": ("perpendicularity", 1, ("A",)),
-            "geometric_tolerance:0:1:4:20": ("flatness", 1, ()),
+            "geometric_tolerance:0:1:4:1": (
+                "position",
+                2,
+                ("A", "B", "C"),
+                "#21",
+                0.75,
+            ),
+            "geometric_tolerance:0:1:4:5": (
+                "position",
+                2,
+                ("A", "B", "C"),
+                "#22",
+                0.75,
+            ),
+            "geometric_tolerance:0:1:4:11": (
+                "profile_surface",
+                2,
+                ("A", "B", "C"),
+                "#26",
+                1.25,
+            ),
+            "geometric_tolerance:0:1:4:15": (
+                "profile_surface",
+                6,
+                ("A",),
+                "#27",
+                0.5,
+            ),
+            "geometric_tolerance:0:1:4:18": (
+                "perpendicularity",
+                1,
+                ("A",),
+                "#56",
+                1.5,
+            ),
+            "geometric_tolerance:0:1:4:20": ("flatness", 1, (), "#57", 0.2),
         }
         records = {
             record.source_id: record
@@ -111,9 +141,11 @@ class TestExtractPmi:
         }
 
         assert set(records) == set(expected)
-        for source_id, (kind, reference_count, datum_refs) in expected.items():
+        for source_id, (kind, reference_count, datum_refs, part21_id, value) in expected.items():
             record = records[source_id]
             assert record.kind == kind
+            assert record.value == value
+            assert record.part21_id == part21_id
             assert len(record.ref_pts) == reference_count
             assert record.ref_bbox is not None
             assert record.dominant_axis in {"X", "Y", "Z"}
@@ -124,10 +156,14 @@ class TestExtractPmi:
             for source in ctc01_extraction_report.sources
             if source.category == "geometric_tolerance"
         }
-        assert all(source.outcome == "partially_extracted" for source in outcomes.values())
-        assert {source.reason for source in outcomes.values()} == {
-            "tolerance magnitude is unavailable"
-        }
+        modifier_source = outcomes["geometric_tolerance:0:1:4:15"]
+        assert modifier_source.outcome == "partially_extracted"
+        assert modifier_source.reason == "geometric-tolerance modifier(s) 15 are not preserved"
+        assert all(
+            source.outcome == "extracted" and source.reason == ""
+            for source_id, source in outcomes.items()
+            if source_id != modifier_source.source_id
+        )
 
     def test_usable_dims_have_positive_value(self, ctc01_extraction_report):
         recs = ctc01_extraction_report.records
@@ -200,7 +236,8 @@ class TestExtractPmi:
             {
                 ("dimension", "extracted"): 12,
                 ("dimension", "presentation_only"): 9,
-                ("geometric_tolerance", "partially_extracted"): 6,
+                ("geometric_tolerance", "extracted"): 5,
+                ("geometric_tolerance", "partially_extracted"): 1,
                 ("datum", "not_extracted"): 11,
             }
         )
@@ -385,7 +422,15 @@ class TestExtractPmi:
         )
         record, reasons = pmi_module._geometric_tolerance_record(
             object(),
-            SimpleNamespace(GetValue=lambda: 0.1),
+            SimpleNamespace(
+                GetValue=lambda: 0.1,
+                GetTypeOfValue=lambda: 0,
+                GetMaterialRequirementModifier=lambda: 0,
+                GetZoneModifier=lambda: 0,
+                GetValueOfZoneModifier=lambda: 0.0,
+                GetMaxValueModifier=lambda: 0.0,
+                GetModifiers=lambda: (),
+            ),
             99,
             object(),
             object(),
@@ -393,6 +438,57 @@ class TestExtractPmi:
         )
         assert record.kind == "gtol99"
         assert reasons == ("geometric-tolerance type 99 is unsupported",)
+
+    def test_unpreserved_geometric_tolerance_fields_fail_closed(self):
+        import draftwright.pmi as pmi_module
+
+        nondefault = SimpleNamespace(
+            GetTypeOfValue=lambda: 1,
+            GetMaterialRequirementModifier=lambda: 2,
+            GetZoneModifier=lambda: 3,
+            GetValueOfZoneModifier=lambda: 0.4,
+            GetMaxValueModifier=lambda: 0.5,
+            GetModifiers=lambda: (15, 16),
+        )
+        assert pmi_module._unpreserved_geometric_tolerance_fields(nondefault) == (
+            "geometric-tolerance type-of-value 1 is not preserved",
+            "geometric-tolerance material-requirement modifier 2 is not preserved",
+            "geometric-tolerance zone modifier 3 is not preserved",
+            "geometric-tolerance zone-modifier value 0.4 is not preserved",
+            "geometric-tolerance maximum-value modifier 0.5 is not preserved",
+            "geometric-tolerance modifier(s) 15, 16 are not preserved",
+        )
+
+        def unreadable():
+            raise RuntimeError("unreadable")
+
+        broken = SimpleNamespace(
+            GetTypeOfValue=unreadable,
+            GetMaterialRequirementModifier=unreadable,
+            GetZoneModifier=unreadable,
+            GetValueOfZoneModifier=unreadable,
+            GetMaxValueModifier=unreadable,
+            GetModifiers=unreadable,
+        )
+        reasons = pmi_module._unpreserved_geometric_tolerance_fields(broken)
+        assert len(reasons) == 6
+        assert all("RuntimeError: unreadable" in reason for reason in reasons)
+
+    def test_xcaf_semantic_name_failures_are_explicit(self):
+        import draftwright.pmi as pmi_module
+
+        assert pmi_module._semantic_name(SimpleNamespace(GetSemanticName=lambda: None)) == (
+            "",
+            "XCAF geometric tolerance has no semantic name",
+        )
+
+        def unreadable():
+            raise RuntimeError("unreadable")
+
+        assert pmi_module._semantic_name(SimpleNamespace(GetSemanticName=unreadable)) == (
+            "",
+            "XCAF semantic name is unavailable (RuntimeError: unreadable)",
+        )
 
     def test_report_returns_structured_reader_failures(self, monkeypatch):
         import draftwright.pmi as pmi_module
@@ -434,6 +530,30 @@ class TestExtractPmi:
         ):
             monkeypatch.setattr(pmi_module, "STEPCAFControl_Reader", lambda: reader)
             assert expected in pmi_module.extract_pmi_report("broken.step").error
+
+    def test_part21_failure_keeps_each_xcaf_tolerance_explicitly_partial(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        def fail(_step_file):
+            raise RuntimeError("mutation: Part21 parser failed")
+
+        monkeypatch.setattr(pmi_module, "read_geometric_tolerances", fail)
+        report = pmi_module.extract_pmi_report(CTC01)
+        sources = [source for source in report.sources if source.category == "geometric_tolerance"]
+        records = [
+            record
+            for record in report.records
+            if record.source_id.startswith("geometric_tolerance:")
+        ]
+
+        assert len(sources) == len(records) == 6
+        assert all(source.outcome == "partially_extracted" for source in sources)
+        assert all(
+            "tolerance magnitude is unavailable "
+            "(Part21 read failed: RuntimeError: mutation: Part21 parser failed)" in source.reason
+            for source in sources
+        )
+        assert all(record.value == 0.0 and record.part21_id == "" for record in records)
 
     def test_a_failed_conversion_does_not_disappear_from_the_source_denominator(
         self, monkeypatch, ctc01_extraction_report
@@ -506,10 +626,28 @@ class TestExtractPmi:
         )
         original = pmi_module._geometric_tolerance_record
 
-        def fail_one(label, obj, type_code, shape_tool, dim_tol_tool, source_id):
+        def fail_one(
+            label,
+            obj,
+            type_code,
+            shape_tool,
+            dim_tol_tool,
+            source_id,
+            part21_facts,
+            part21_error,
+        ):
             if source_id == target:
                 raise RuntimeError("mutation: gtol conversion failed")
-            return original(label, obj, type_code, shape_tool, dim_tol_tool, source_id)
+            return original(
+                label,
+                obj,
+                type_code,
+                shape_tool,
+                dim_tol_tool,
+                source_id,
+                part21_facts,
+                part21_error,
+            )
 
         monkeypatch.setattr(pmi_module, "_geometric_tolerance_record", fail_one)
         mutated = extract_pmi_report(CTC01)
@@ -628,9 +766,9 @@ class TestBuildDrawingPmi:
         pmi_names = [n for n in dwg.annotations() if n.startswith("pmi_")]
         assert pmi_names == [], "pmi='report' should not add drawing annotations"
         issues = [issue for issue in dwg.lint() if issue.code == "pmi_not_extracted"]
-        assert len(issues) == 17
+        assert len(issues) == 12
         assert {issue.severity for issue in issues} == {"info"}
-        assert len({issue.source_ids for issue in issues}) == 17
+        assert len({issue.source_ids for issue in issues}) == 12
         lowering = [issue for issue in dwg.lint() if issue.code == "pmi_not_lowered"]
         assert len(lowering) == 10
         assert {issue.severity for issue in lowering} == {"info"}
@@ -671,17 +809,17 @@ class TestBuildDrawingPmi:
 
     def test_pmi_annotate_reports_each_incomplete_source_record(self, ctc01_annotated):
         issues = [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_extracted"]
-        assert len(issues) == 17
+        assert len(issues) == 12
         assert {issue.severity for issue in issues} == {"error"}
-        assert len({issue.source_ids for issue in issues}) == 17
+        assert len({issue.source_ids for issue in issues}) == 12
         assert all(issue.source_ids[0] in issue.message for issue in issues)
         assert (
             sum("datum extraction is not implemented" in issue.message for issue in issues) == 11
         )
-        assert sum("tolerance magnitude is unavailable" in issue.message for issue in issues) == 6
+        assert sum("modifier(s) 15 are not preserved" in issue.message for issue in issues) == 1
         summary = ctc01_annotated.lint_summary()
         assert summary["passed"] is False
-        assert summary["by_code"]["pmi_not_extracted"] == 17
+        assert summary["by_code"]["pmi_not_extracted"] == 12
         assert all(
             "source_ids" in issue
             for issue in summary["issues"]
@@ -713,6 +851,16 @@ class TestBuildDrawingPmi:
             source_id: raw_features[source_id].datum_refs for source_id in expected_gtol_datums
         } == expected_gtol_datums
         assert all(raw_features[source_id].ref_pts for source_id in expected_gtol_datums)
+        assert {
+            source_id: raw_features[source_id].part21_id for source_id in expected_gtol_datums
+        } == {
+            "geometric_tolerance:0:1:4:1": "#21",
+            "geometric_tolerance:0:1:4:5": "#22",
+            "geometric_tolerance:0:1:4:11": "#26",
+            "geometric_tolerance:0:1:4:15": "#27",
+            "geometric_tolerance:0:1:4:18": "#56",
+            "geometric_tolerance:0:1:4:20": "#57",
+        }
 
     def test_pmi_annotate_accounts_for_each_typed_dimension_at_the_render_seam(
         self, ctc01_annotated
@@ -923,6 +1071,9 @@ def test_build_pmi_features_mirrors_detection(ctc01_extraction_report):
     assert all(f.kind == "authored_dimension" for f in authored)
     assert all(f.kind == "pmi" for f in raw)
     assert {feature.source_id for feature in feats} == {record.source_id for record in recs}
+    assert {feature.source_id: feature.part21_id for feature in raw if feature.part21_id} == {
+        record.source_id: record.part21_id for record in recs if record.part21_id
+    }
     # A dimensional PMI record's measured semantics ride onto its authored dimension verbatim.
     assert {f.label for f in authored} >= {r.label for r in dims}
     for r in dims:

--- a/tests/test_pmi_part21.py
+++ b/tests/test_pmi_part21.py
@@ -1,0 +1,248 @@
+"""Structured Part21 facts used to complete XCAF geometric tolerances."""
+
+from pathlib import Path
+
+import pytest
+
+from draftwright._pmi_part21 import (
+    GeometricToleranceFact,
+    match_geometric_tolerance,
+    read_geometric_tolerances,
+)
+
+CTC01 = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap242.stp"
+
+
+def _step(*instances: str) -> str:
+    return "\n".join(
+        (
+            "ISO-10303-21;",
+            "HEADER;",
+            "FILE_DESCRIPTION(('test'),'2;1');",
+            "FILE_NAME('test.step','',(''),(''),'','','');",
+            "FILE_SCHEMA(('AP242_MANAGED_MODEL_BASED_3D_ENGINEERING_MIM_LF'));",
+            "ENDSEC;",
+            "DATA;",
+            *instances,
+            "ENDSEC;",
+            "END-ISO-10303-21;",
+        )
+    )
+
+
+def _read(tmp_path, name: str, *instances: str):
+    step = tmp_path / f"{name}.step"
+    step.write_text(_step(*instances), encoding="utf-8")
+    return read_geometric_tolerances(step)
+
+
+def test_ctc01_geometric_tolerance_facts_are_exact():
+    facts = read_geometric_tolerances(CTC01)
+
+    assert [
+        (fact.entity_id, fact.semantic_name, fact.kind, fact.value_mm, fact.reason)
+        for fact in facts
+    ] == [
+        ("#21", "Position.1", "position", 0.75, ""),
+        ("#22", "Position.2", "position", 0.75, ""),
+        ("#26", "Position surfacic profile.3", "profile_surface", 1.25, ""),
+        ("#27", "Position surfacic profile.2", "profile_surface", 0.5, ""),
+        ("#56", "Perpendicularity.1", "perpendicularity", 1.5, ""),
+        ("#57", "Flatness.1", "flatness", 0.2, ""),
+    ]
+
+
+def test_si_length_unit_is_resolved_to_millimetres(tmp_path):
+    step = tmp_path / "centimetres.step"
+    step.write_text(
+        _step(
+            "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+            "#2=(LENGTH_MEASURE_WITH_UNIT() MEASURE_REPRESENTATION_ITEM() "
+            "MEASURE_WITH_UNIT(LENGTH_MEASURE(1.25),#3) REPRESENTATION_ITEM(''));",
+            "#3=(LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.CENTI.,.METRE.));",
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_geometric_tolerances(step) == (
+        GeometricToleranceFact("#1", "Probe", "position", 12.5),
+    )
+
+
+def test_unsupported_length_unit_stays_explicitly_unresolved(tmp_path):
+    step = tmp_path / "unsupported-unit.step"
+    step.write_text(
+        _step(
+            "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+            "#2=(LENGTH_MEASURE_WITH_UNIT() MEASURE_REPRESENTATION_ITEM() "
+            "MEASURE_WITH_UNIT(LENGTH_MEASURE(1.25),#3) REPRESENTATION_ITEM(''));",
+            "#3=CONVERSION_BASED_UNIT('INCH',#5);",
+        ),
+        encoding="utf-8",
+    )
+
+    (fact,) = read_geometric_tolerances(step)
+    assert fact.entity_id == "#1"
+    assert fact.value_mm is None
+    assert fact.reason == "length unit #3 is not a supported SI metre unit"
+
+
+def test_simple_length_measure_with_unit_is_supported(tmp_path):
+    facts = _read(
+        tmp_path,
+        "simple-measure",
+        "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+        "#2=LENGTH_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.5),#3);",
+        "#3=(LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT($,.METRE.));",
+    )
+
+    assert facts == (GeometricToleranceFact("#1", "Probe", "position", 1500.0),)
+
+
+@pytest.mark.parametrize(
+    ("name", "instances", "expected_reason"),
+    [
+        (
+            "missing-measure",
+            ("#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",),
+            "tolerance magnitude #2 is missing",
+        ),
+        (
+            "missing-unit",
+            (
+                "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+                "#2=MEASURE_WITH_UNIT(LENGTH_MEASURE(1.0),#3);",
+            ),
+            "length unit #3 is missing",
+        ),
+        (
+            "not-measure-with-unit",
+            (
+                "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+                "#2=REPRESENTATION_ITEM('not a measure');",
+            ),
+            "tolerance magnitude #2 is not a measure with unit",
+        ),
+        (
+            "not-length",
+            (
+                "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+                "#2=MEASURE_WITH_UNIT(PLANE_ANGLE_MEASURE(1.0),#3);",
+            ),
+            "tolerance magnitude #2 is not a length measure",
+        ),
+        (
+            "unit-not-reference",
+            (
+                "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+                "#2=MEASURE_WITH_UNIT(LENGTH_MEASURE(1.0),1.0);",
+            ),
+            "tolerance magnitude #2 has no referenced length unit",
+        ),
+        (
+            "not-numeric",
+            (
+                "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+                "#2=MEASURE_WITH_UNIT(LENGTH_MEASURE('bad'),#3);",
+            ),
+            "tolerance magnitude #2 is not numeric",
+        ),
+        (
+            "not-positive",
+            (
+                "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+                "#2=MEASURE_WITH_UNIT(LENGTH_MEASURE(0.0),#3);",
+            ),
+            "tolerance magnitude #2 must be finite and positive",
+        ),
+        (
+            "unsupported-prefix",
+            (
+                "#1=(GEOMETRIC_TOLERANCE('Probe','',#2,#4) POSITION_TOLERANCE());",
+                "#2=MEASURE_WITH_UNIT(LENGTH_MEASURE(1.0),#3);",
+                "#3=(LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.RADIAN.));",
+            ),
+            "length unit #3 is not a supported SI metre unit",
+        ),
+    ],
+)
+def test_malformed_or_unsupported_magnitudes_fail_closed(
+    tmp_path, name, instances, expected_reason
+):
+    (fact,) = _read(tmp_path, name, *instances)
+
+    assert fact.entity_id == "#1"
+    assert fact.value_mm is None
+    assert fact.reason == expected_reason
+
+
+@pytest.mark.parametrize(
+    ("name", "entity", "expected_semantic_name", "expected_kind", "expected_reason"),
+    [
+        (
+            "multiple-characteristics",
+            "#1=(FLATNESS_TOLERANCE() GEOMETRIC_TOLERANCE('Probe','',#2,#4) "
+            "POSITION_TOLERANCE());",
+            "",
+            "",
+            "geometric tolerance has multiple supported characteristics",
+        ),
+        (
+            "missing-tuple",
+            "#1=POSITION_TOLERANCE();",
+            "",
+            "position",
+            "geometric tolerance has no name/magnitude tuple",
+        ),
+        (
+            "magnitude-not-reference",
+            "#1=POSITION_TOLERANCE('Probe','',1.0,#4);",
+            "Probe",
+            "position",
+            "geometric tolerance has no referenced magnitude",
+        ),
+    ],
+)
+def test_malformed_characteristics_remain_inventory_facts(
+    tmp_path, name, entity, expected_semantic_name, expected_kind, expected_reason
+):
+    (fact,) = _read(tmp_path, name, entity)
+
+    assert fact == GeometricToleranceFact(
+        "#1", expected_semantic_name, expected_kind, None, expected_reason
+    )
+
+
+def test_correspondence_requires_one_nonblank_name_and_kind_pair():
+    facts = (
+        GeometricToleranceFact("#1", "Same", "position", 0.1),
+        GeometricToleranceFact("#2", "Same", "flatness", 0.2),
+    )
+
+    fact, reason = match_geometric_tolerance(facts, "Same", "flatness")
+    assert fact == facts[1]
+    assert reason == ""
+
+    fact, reason = match_geometric_tolerance(facts, "", "position")
+    assert fact is None
+    assert reason == "XCAF geometric tolerance has no semantic name"
+
+
+def test_correspondence_rejects_duplicates_instead_of_using_source_order():
+    facts = (
+        GeometricToleranceFact("#20", "Duplicate", "position", 0.2),
+        GeometricToleranceFact("#10", "Duplicate", "position", 0.1),
+    )
+
+    fact, reason = match_geometric_tolerance(facts, "Duplicate", "position")
+
+    assert fact is None
+    assert reason == ("Part21 correspondence is ambiguous for position 'Duplicate' (#20, #10)")
+
+
+@pytest.mark.parametrize("facts", [(), (GeometricToleranceFact("#1", "Other", "position", 0.1),)])
+def test_correspondence_reports_a_missing_pair(facts):
+    fact, reason = match_geometric_tolerance(facts, "Wanted", "position")
+
+    assert fact is None
+    assert reason == "Part21 has no position geometric tolerance named 'Wanted'"

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -291,6 +291,7 @@ class TestEmit:
         assert "# authored_dimension" not in src
         assert "source='ap242_pmi'" in src
         assert "sheet.add(PmiFeature(" in src
+        assert "part21_id='#21'" in src
         assert "sheet.step_level(" in src  # #578: fluent verb, no StepLevelFeature import
         import_line = next(
             ln for ln in src.splitlines() if ln.startswith("from draftwright.model")
@@ -352,6 +353,41 @@ class TestEmit:
 
         assert (feature.lower_bound, feature.upper_bound) == (34.8, 35.2)
         assert feature.label == "ø34.8 - ø35.2"
+
+    def test_raw_pmi_round_trips_part21_identity(self):
+        """Execute the generated declaration; emitted text alone is not the contract."""
+        import dataclasses
+
+        from draftwright.builder import detect_part_model
+        from draftwright.model import Frame, PmiFeature
+        from draftwright.sheet_emit import emit_sheet_script
+
+        part = Box(40, 20, 10)
+        model = detect_part_model(part)
+        source = PmiFeature(
+            frame=Frame((1.0, 2.0, 3.0), "z"),
+            pmi_kind="position",
+            value=0.1,
+            label="position 0.1",
+            dominant_axis="X",
+            source_id="geometric_tolerance:roundtrip",
+            datum_refs=("A", "B"),
+            part21_id="#123",
+        )
+        model = dataclasses.replace(model, features=[*model.features, source])
+
+        src = emit_sheet_script(model, "part", "pmi", title="P", number="N")
+        namespace = {"part": part}
+        body = src[: src.index("drawing = sheet.build()")]
+        exec(compile(body, "<pmi-emit>", "exec"), namespace)  # noqa: S102
+        restored = next(
+            feature
+            for feature in namespace["sheet"].model().features
+            if isinstance(feature, PmiFeature) and feature.source_id == source.source_id
+        )
+
+        assert restored.part21_id == "#123"
+        assert restored.datum_refs == ("A", "B")
 
     def test_measured_dimension_rejects_unrenderable_kind(self):
         from draftwright import Sheet
@@ -3202,6 +3238,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
                 ref_pts=((-30.0, 0.0, 0.0), (30.0, 0.0, 0.0)),
                 source_id="geometric_tolerance:0:1:4:raw-test",
                 datum_refs=("A", "B"),
+                part21_id="#123",
             )
             return part, dataclasses.replace(model, features=[*model.features, record])
 

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,12 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
 name = "anytree"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -86,23 +92,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "anytree" },
-    { name = "cadquery-ocp" },
-    { name = "ezdxf" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "anytree", marker = "python_full_version < '3.13'" },
+    { name = "cadquery-ocp", marker = "python_full_version < '3.13'" },
+    { name = "ezdxf", marker = "python_full_version < '3.13'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "lib3mf" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "lib3mf", marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "ocp-gordon" },
-    { name = "ocpsvg", version = "0.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "ocp-gordon", marker = "python_full_version < '3.13'" },
+    { name = "ocpsvg", version = "0.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "svgpathtools" },
-    { name = "sympy" },
-    { name = "trianglesolver" },
-    { name = "typing-extensions" },
-    { name = "webcolors" },
+    { name = "svgpathtools", marker = "python_full_version < '3.13'" },
+    { name = "sympy", marker = "python_full_version < '3.13'" },
+    { name = "trianglesolver", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "webcolors", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/00/b56ebe1d2a31611dbfcc315d22ebb5403eddc60027d5f82acd493ebb5ac1/build123d-0.10.0.tar.gz", hash = "sha256:73ded38ddca8ebb95e7dd078ac3d7aacc8ca42fce8f1d176f1040e35fba4f608", size = 20011921, upload-time = "2025-11-05T22:04:37.054Z" }
 wheels = [
@@ -117,23 +123,23 @@ resolution-markers = [
     "python_full_version >= '3.13'",
 ]
 dependencies = [
-    { name = "anytree" },
-    { name = "cadquery-ocp-novtk" },
-    { name = "ezdxf" },
-    { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "lib3mf", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "ocp-gordon" },
-    { name = "ocpsvg", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "py-lib3mf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "requests" },
-    { name = "scikit-learn" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "svgpathtools" },
-    { name = "sympy" },
-    { name = "trianglesolver" },
-    { name = "typing-extensions" },
-    { name = "webcolors" },
+    { name = "anytree", marker = "python_full_version >= '3.13'" },
+    { name = "cadquery-ocp-novtk", marker = "python_full_version >= '3.13'" },
+    { name = "ezdxf", marker = "python_full_version >= '3.13'" },
+    { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "lib3mf", marker = "(python_full_version >= '3.13' and platform_machine != 'aarch64') or (python_full_version >= '3.13' and sys_platform != 'linux')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "ocp-gordon", marker = "python_full_version >= '3.13'" },
+    { name = "ocpsvg", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "py-lib3mf", marker = "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "requests", marker = "python_full_version >= '3.13'" },
+    { name = "scikit-learn", marker = "python_full_version >= '3.13'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "svgpathtools", marker = "python_full_version >= '3.13'" },
+    { name = "sympy", marker = "python_full_version >= '3.13'" },
+    { name = "trianglesolver", marker = "python_full_version >= '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.13'" },
+    { name = "webcolors", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/27/b7487242de480cd349baad8d1a3eca6a5eb65ebfb331cf0c5b408a832f96/build123d-0.11.1.tar.gz", hash = "sha256:9647c3fc7e1ef11d9c335787a54cf26e9bbc2191186342fe9755ec24a480033b", size = 20911070, upload-time = "2026-07-02T18:33:10.783Z" }
 wheels = [
@@ -158,7 +164,7 @@ name = "cadquery-ocp"
 version = "7.8.1.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "vtk" },
+    { name = "vtk", marker = "python_full_version < '3.13'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/a6/760c6383f8e0cac562583feab0d4733876522ee265f2cfa3a26bdffef330/cadquery_ocp-7.8.1.1.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4413961e98a90686a56c2ac58b126773c7da4eb82b967ddcc1f394fe6a7b71ad", size = 68085209, upload-time = "2025-01-29T14:33:03.08Z" },
@@ -184,7 +190,7 @@ name = "cadquery-ocp-novtk"
 version = "7.9.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/33/6bbf47a7f5eab09b0e9bf26cd84c14353d66c7ebc72c36a65cd311f5d516/cadquery_ocp_novtk-7.9.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c750e8d8cf6b2c01c6a171ace4a9b66b8a855be0d7578cdba104b46e9c388e34", size = 61729426, upload-time = "2026-02-15T13:34:57.147Z" },
@@ -377,7 +383,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -447,7 +453,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -678,6 +684,7 @@ name = "draftwright"
 version = "0.4.2.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "antlr4-python3-runtime" },
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "build123d-drafting-helpers" },
@@ -686,6 +693,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pypdfium2" },
     { name = "reportlab" },
+    { name = "steputils" },
     { name = "svglib" },
     { name = "typer" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -705,6 +713,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "antlr4-python3-runtime", specifier = "<4.10" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.1" },
@@ -712,6 +721,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },
     { name = "reportlab", specifier = ">=4.0" },
+    { name = "steputils", specifier = "==0.1" },
     { name = "svglib", specifier = ">=1.5" },
     { name = "typer", specifier = ">=0.12" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.5" },
@@ -734,7 +744,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -959,17 +969,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -985,18 +995,18 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -1008,7 +1018,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1393,15 +1403,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version < '3.11'" },
+    { name = "fonttools", marker = "python_full_version < '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1469,15 +1479,15 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "cycler", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "fonttools", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "pillow", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -1809,8 +1819,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "cadquery-ocp" },
-    { name = "svgelements" },
+    { name = "cadquery-ocp", marker = "python_full_version < '3.13'" },
+    { name = "svgelements", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/e2/3ba2ad53395f91c72070cb3b8b033c5d9f9ba2ae6f61e869ef2a5f7f8ade/ocpsvg-0.5.0.tar.gz", hash = "sha256:5cd8dbec8bf590d373a82aaebeab241838185aab04ee2859f33b9d7956bbfba6", size = 54195, upload-time = "2025-02-21T15:54:12.333Z" }
 wheels = [
@@ -1825,8 +1835,8 @@ resolution-markers = [
     "python_full_version >= '3.13'",
 ]
 dependencies = [
-    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "svgelements" },
+    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "svgelements", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/48/f121f459dc6e184ca2ee99b8fba0a2f51b1ef710d829eafb43d9acd1100d/ocpsvg-0.6.0.tar.gz", hash = "sha256:f08da4347cc90ecd3565395e9bda5746d46ab8aafd6a2681bb03a9c321b54039", size = 54342, upload-time = "2026-01-08T12:31:35.206Z" }
 wheels = [
@@ -2158,7 +2168,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -2183,10 +2193,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version >= '3.13'" },
+    { name = "charset-normalizer", marker = "python_full_version >= '3.13'" },
+    { name = "idna", marker = "python_full_version >= '3.13'" },
+    { name = "urllib3", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -2236,11 +2246,11 @@ name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "joblib" },
-    { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.13'" },
+    { name = "narwhals", marker = "python_full_version >= '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -2284,7 +2294,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2344,7 +2354,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2449,6 +2459,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "steputils"
+version = "0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/2a/6c5dc314a3b2291bb3d404b5f57e8d6e01996ddb1b8141cf63ad88e1b502/steputils-0.1.zip", hash = "sha256:b77b99181d313c2535c6596ec55214a143f269ab06be26f8351c45cb3b69b63d", size = 712657, upload-time = "2022-03-29T03:56:49.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/88/3d64b2d7271b2ca6ac2ac3ff85a2356c9ee92bda2965c5d552bfd801daa6/steputils-0.1-py3-none-any.whl", hash = "sha256:8d3dd966b8778a6b5bcc6613414ba6adcd9948d313c67dec4feb328afcc2f582", size = 93330, upload-time = "2022-03-29T03:56:45.613Z" },
 ]
 
 [[package]]
@@ -2644,7 +2667,7 @@ name = "vtk"
 version = "9.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 wheels = [


### PR DESCRIPTION
## Summary

- add an isolated, structured Part21 adapter for AP242 geometric-tolerance facts that OCCT's XCAF transfer drops
- recover and normalize explicit SI length magnitudes only after unique semantic-name + tolerance-kind correspondence
- preserve both XCAF and Part21 provenance through raw PMI IR and executable sheet emission
- keep unsupported units, ambiguous correspondence, parser failures, and unpreserved requirement fields explicitly partial

## Evidence

On the CTC01 AP242 reference file, this recovers five geometric-tolerance magnitudes:

- two position tolerances at 0.75 mm
- surface profiles at 1.25 mm and 0.5 mm
- perpendicularity at 1.5 mm
- flatness at 0.2 mm

Five sources become complete. The 0.5 mm surface profile remains partial because XCAF reports an `All_Around` modifier that the IR does not yet preserve; that follow-up is tracked in #1095. This slice deliberately does not lower or render the recovered raw PMI records.

## Validation

- `tests/test_pmi.py`: 44 passed
- `tests/test_sheet_emit.py -x`: 367 passed, 2 expected failures
- parser and structural suite: 111 passed
- `scripts/pr-check --static`: green
- adversarial mutations proved duplicate matching, unit conversion, record-to-IR provenance, and executable emitter round-trip guards

Part of #62.
