### PR TITLE
Resolve AP242 datum faces through OCCT transfer

### DIFF
--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -43,13 +43,16 @@ try:
     from OCP.Bnd import Bnd_Box
     from OCP.BRepAdaptor import BRepAdaptor_Surface
     from OCP.BRepBndLib import BRepBndLib
-    from OCP.GeomAbs import GeomAbs_Plane
+    from OCP.GeomAbs import GeomAbs_Cylinder, GeomAbs_Plane
     from OCP.IFSelect import IFSelect_RetDone
     from OCP.STEPCAFControl import STEPCAFControl_Reader
     from OCP.TCollection import TCollection_AsciiString, TCollection_ExtendedString
     from OCP.TDF import TDF_LabelSequence, TDF_Tool
     from OCP.TDocStd import TDocStd_Document
+    from OCP.TopAbs import TopAbs_FACE
+    from OCP.TopExp import TopExp
     from OCP.TopoDS import TopoDS
+    from OCP.TopTools import TopTools_IndexedMapOfShape
     from OCP.XCAFDoc import (
         XCAFDoc_Datum,
         XCAFDoc_Dimension,
@@ -383,51 +386,174 @@ def _reference_geometry(label, shape_tool):
     )
 
 
-def _datum_reference_geometry(label, shape_tool):
-    """Measure a datum feature and require an axis-aligned planar reference surface."""
-    points, ref_bbox, _dominant_axis, geometry_reasons = _reference_geometry(label, shape_tool)
-    first_refs = TDF_LabelSequence()
-    second_refs = TDF_LabelSequence()
-    XCAFDoc_DimTolTool.GetRefShapeLabel_s(label, first_refs, second_refs)
+def _datum_geometry_from_shapes(shapes):
+    """Measure exact datum faces and require one compatible axis-aligned surface."""
+    points: list[tuple[float, float, float]] = []
+    boxes: list[tuple[float, float, float, float, float, float]] = []
     axes: list[str] = []
-    axis_positions: list[float] = []
-    reasons = list(geometry_reasons)
-    for refs in (first_refs, second_refs):
-        for index in range(1, refs.Length() + 1):
-            shape = shape_tool.GetShape_s(refs.Value(index))
-            if shape is None or shape.IsNull():
+    surface_kinds: list[str] = []
+    supports: list[tuple[float, ...]] = []
+    reasons: list[str] = []
+    for shape in shapes:
+        if shape is None or shape.IsNull():
+            reasons.append("one referenced shape is unavailable")
+            continue
+        try:
+            bbox = _shape_bbox(shape)
+            boxes.append(bbox)
+            points.append(_bbox_centroid(bbox))
+            surface = BRepAdaptor_Surface(TopoDS.Face_s(shape))
+            surface_type = surface.GetType()
+            if surface_type == GeomAbs_Plane:
+                kind = "plane"
+                geometry = surface.Plane()
+            elif surface_type == GeomAbs_Cylinder:
+                kind = "cylinder"
+                geometry = surface.Cylinder()
+            else:
+                reasons.append("one datum reference is neither planar nor cylindrical")
                 continue
-            try:
-                surface = BRepAdaptor_Surface(TopoDS.Face_s(shape))
-                if surface.GetType() != GeomAbs_Plane:
-                    reasons.append("one datum reference is not planar")
-                    continue
-                plane = surface.Plane()
-                direction = plane.Axis().Direction()
-                components = (abs(direction.X()), abs(direction.Y()), abs(direction.Z()))
-                axis_index = max(range(3), key=components.__getitem__)
-                if (
-                    components[axis_index] < 1e-6
-                    or sum(components) - components[axis_index] > 0.1 * components[axis_index]
-                ):
-                    reasons.append("one datum reference plane is not axis-aligned")
-                    continue
-                axes.append("XYZ"[axis_index])
-                location = plane.Location()
-                axis_positions.append((location.X(), location.Y(), location.Z())[axis_index])
-            except Exception as exc:
-                reasons.append(
-                    f"one datum reference plane is unavailable ({_failure_reason(exc)})"
+            axis = geometry.Axis()
+            direction = axis.Direction()
+            components = (abs(direction.X()), abs(direction.Y()), abs(direction.Z()))
+            axis_index = max(range(3), key=components.__getitem__)
+            if (
+                components[axis_index] < 1e-6
+                or sum(components) - components[axis_index] > 0.1 * components[axis_index]
+            ):
+                reasons.append("one datum reference surface is not axis-aligned")
+                continue
+            location = axis.Location()
+            coordinates = (location.X(), location.Y(), location.Z())
+            if kind == "plane":
+                support = (coordinates[axis_index],)
+            else:
+                support = tuple(
+                    value for index, value in enumerate(coordinates) if index != axis_index
                 )
+            axes.append("XYZ"[axis_index])
+            surface_kinds.append(kind)
+            supports.append(support)
+        except Exception as exc:
+            reasons.append(f"one datum reference surface is unavailable ({_failure_reason(exc)})")
+    if not shapes:
+        reasons.append("referenced geometry is unavailable")
+
+    ref_bbox = _merge_bboxes(boxes) if boxes else None
     if not axes:
-        reasons.append("datum reference plane is unavailable")
+        reasons.append("datum reference surface is unavailable")
         reference_axis = ""
-    elif len(set(axes)) != 1 or max(axis_positions) - min(axis_positions) > 1e-4:
-        reasons.append("datum reference faces are not coplanar")
+    elif len(set(surface_kinds)) != 1:
+        reasons.append("datum reference faces mix planar and cylindrical surfaces")
+        reference_axis = ""
+    elif len(set(axes)) != 1 or any(
+        any(abs(value - supports[0][index]) > 1e-4 for index, value in enumerate(support))
+        for support in supports[1:]
+    ):
+        qualifier = "coplanar" if surface_kinds[0] == "plane" else "coaxial"
+        reasons.append(f"datum reference faces are not {qualifier}")
         reference_axis = ""
     else:
         reference_axis = axes[0]
-    return points, ref_bbox, reference_axis, tuple(dict.fromkeys(reasons))
+    return tuple(points), ref_bbox, reference_axis, tuple(dict.fromkeys(reasons))
+
+
+def _datum_reference_geometry(label, shape_tool):
+    """Measure datum faces reached through the direct XCAF relationship."""
+    first_refs = TDF_LabelSequence()
+    second_refs = TDF_LabelSequence()
+    XCAFDoc_DimTolTool.GetRefShapeLabel_s(label, first_refs, second_refs)
+    shapes = []
+    for refs in (first_refs, second_refs):
+        for index in range(1, refs.Length() + 1):
+            shapes.append(shape_tool.GetShape_s(refs.Value(index)))
+    return _datum_geometry_from_shapes(shapes)
+
+
+class _DatumTopologyResolver:
+    """Resolve Part21 face labels through OCCT's native transfer binders.
+
+    ``TransferOne(rank)`` stays inside C++, avoiding the OCP wrapper's loss of pointer
+    identity when a STEP entity is returned to Python.  It reuses the existing transfer
+    binder.  ``FindIndex`` then proves that result is ``IsSame`` to a face in the original
+    imported topology; no geometric comparison participates in correspondence.
+    """
+
+    def __init__(self, step_reader, imported_faces):
+        self._reader = step_reader
+        self._model = step_reader.StepModel()
+        self._imported_faces = imported_faces
+        self._items: dict[str, tuple[object, int]] = {}
+        self._definitions: dict[str, tuple[object, ...]] = {}
+        self._claims: dict[int, str] = {}
+
+    def _transfer_face(self, item_id: str):
+        cached = self._items.get(item_id)
+        if cached is not None:
+            return cached, ""
+        rank = self._model.NextNumberForLabel(item_id, 0, True)
+        if rank <= 0:
+            return None, f"Part21 representation item {item_id} is unavailable"
+        entity = self._model.Value(rank)
+        if entity.DynamicType().Name() != "StepShape_AdvancedFace":
+            return None, f"Part21 representation item {item_id} is not an advanced face"
+        before = self._reader.NbShapes()
+        try:
+            transferred = self._reader.TransferOne(rank)
+        except Exception as exc:
+            return None, (
+                f"Part21 representation item {item_id} could not be transferred "
+                f"({_failure_reason(exc)})"
+            )
+        after = self._reader.NbShapes()
+        if not transferred or after != before + 1:
+            return None, f"Part21 representation item {item_id} could not be transferred"
+        shape = self._reader.Shape(after)
+        if shape is None or shape.IsNull() or shape.ShapeType() != TopAbs_FACE:
+            return None, f"Part21 representation item {item_id} did not transfer to one face"
+        face_index = self._imported_faces.FindIndex(shape)
+        if face_index <= 0:
+            return None, (
+                f"Part21 representation item {item_id} is not a face in the imported topology"
+            )
+        result = (shape, face_index)
+        self._items[item_id] = result
+        return result, ""
+
+    def resolve(self, definition_id: str, item_ids: tuple[str, ...]):
+        """Return exact imported faces, or reasons that make the definition unsafe."""
+        cached = self._definitions.get(definition_id)
+        if cached is not None:
+            return cached, ()
+        if not item_ids:
+            return (), ("datum feature has no Part21 representation items",)
+
+        resolved = []
+        reasons: list[str] = []
+        for item_id in item_ids:
+            result, reason = self._transfer_face(item_id)
+            if reason:
+                reasons.append(reason)
+            elif result is not None:
+                resolved.append(result)
+        if reasons:
+            return (), tuple(dict.fromkeys(reasons))
+
+        indices = [face_index for _shape, face_index in resolved]
+        if len(set(indices)) != len(indices):
+            return (), ("datum feature representation items resolve to the same imported face",)
+        for face_index in indices:
+            owner = self._claims.get(face_index)
+            if owner is not None and owner != definition_id:
+                reasons.append(f"one imported face is already claimed by datum feature {owner}")
+        if reasons:
+            return (), tuple(dict.fromkeys(reasons))
+
+        shapes = tuple(shape for shape, _face_index in resolved)
+        for face_index in indices:
+            self._claims[face_index] = definition_id
+        self._definitions[definition_id] = shapes
+        return shapes, ()
 
 
 def _datum_letter(label) -> tuple[str, str]:
@@ -902,12 +1028,24 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
     dt.GetDatumLabels(datums)
     datum_facts: tuple[DatumOccurrenceFact, ...] = ()
     datum_part21_error = ""
+    datum_topology = None
+    datum_topology_error = ""
     if datums.Length() > 0:
         try:
             datum_facts = read_datum_occurrences(step_file)
         except Exception as exc:
             datum_part21_error = f"Part21 datum read failed: {_failure_reason(exc)}"
             _log.debug("PMI datum overlay unavailable for %s: %s", Path(step_file).name, exc)
+        if not datum_part21_error:
+            try:
+                step_reader = reader.Reader()
+                imported_faces = TopTools_IndexedMapOfShape()
+                TopExp.MapShapes_s(step_reader.OneShape(), TopAbs_FACE, imported_faces)
+                datum_topology = _DatumTopologyResolver(step_reader, imported_faces)
+            except Exception as exc:
+                datum_topology_error = (
+                    f"datum imported-topology map is unavailable ({_failure_reason(exc)})"
+                )
     datum_records: list[PmiRecord] = []
     for index in range(1, datums.Length() + 1):
         label = datums.Value(index)
@@ -922,6 +1060,20 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
             points, ref_bbox, reference_axis, geometry_reasons = _datum_reference_geometry(
                 label, shape_tool
             )
+            if fact is not None and fact.reference_item_ids:
+                if datum_topology is None:
+                    topology_shapes = ()
+                    topology_reasons = (datum_topology_error or datum_part21_error,)
+                else:
+                    topology_shapes, topology_reasons = datum_topology.resolve(
+                        fact.datum_feature_id, fact.reference_item_ids
+                    )
+                if topology_shapes:
+                    points, ref_bbox, reference_axis, geometry_reasons = (
+                        _datum_geometry_from_shapes(topology_shapes)
+                    )
+                else:
+                    geometry_reasons = tuple(dict.fromkeys((*geometry_reasons, *topology_reasons)))
             blockers = tuple(
                 dict.fromkeys(
                     reason

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -242,8 +242,7 @@ class TestExtractPmi:
                 ("dimension", "extracted"): 12,
                 ("dimension", "presentation_only"): 9,
                 ("geometric_tolerance", "extracted"): 6,
-                ("datum", "extracted"): 5,
-                ("datum", "partially_extracted"): 6,
+                ("datum", "extracted"): 11,
             }
         )
         assert {
@@ -302,7 +301,7 @@ class TestExtractPmi:
                 ("datum:0:1:4:3", "datum:0:1:4:7", "datum:0:1:4:13"),
                 ("Position.1", "Position.2", "Position surfacic profile.3"),
                 ("#854", "#853"),
-                "",
+                "Z",
             ),
             (
                 "C",
@@ -310,15 +309,11 @@ class TestExtractPmi:
                 ("datum:0:1:4:4", "datum:0:1:4:8", "datum:0:1:4:14"),
                 ("Position.1", "Position.2", "Position surfacic profile.3"),
                 ("#839", "#840"),
-                "",
+                "Z",
             ),
         ]
-        assert datums[0].lowering_blockers == ()
-        assert datums[0].ref_bbox is not None
-        assert all(
-            "referenced geometry is unavailable" in record.lowering_blockers
-            for record in datums[1:]
-        )
+        assert all(record.lowering_blockers == () for record in datums)
+        assert all(record.ref_bbox is not None for record in datums)
 
     def test_non_record_dimension_types_fail_closed(self):
         import draftwright.pmi as pmi_module
@@ -716,6 +711,45 @@ class TestExtractPmi:
         )
         assert all(record.part21_id == "" and len(record.source_ids) == 1 for record in records)
 
+    def test_a_failed_exact_topology_guard_keeps_all_datum_definitions_raw(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+        from draftwright.model import DatumRef, build_pmi_features
+
+        def reject(_self, _definition_id, _item_ids):
+            return (), ("mutation: exact imported-topology identity is unavailable",)
+
+        monkeypatch.setattr(pmi_module._DatumTopologyResolver, "resolve", reject)
+        report = pmi_module.extract_pmi_report(CTC01)
+        sources = [source for source in report.sources if source.category == "datum"]
+        records = [record for record in report.records if record.source_category == "datum"]
+
+        assert len(sources) == 11
+        assert all(source.outcome == "partially_extracted" for source in sources)
+        assert len(records) == 3
+        assert all(
+            any(
+                "exact imported-topology identity is unavailable" in reason
+                for reason in record.lowering_blockers
+            )
+            for record in records
+        )
+        features = build_pmi_features(records, Box(20, 20, 20).bounding_box())
+        assert not any(isinstance(feature, DatumRef) for feature in features)
+
+    def test_a_failed_topology_map_setup_is_a_per_datum_blocker(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        def fail():
+            raise RuntimeError("mutation: topology map setup failed")
+
+        monkeypatch.setattr(pmi_module, "TopTools_IndexedMapOfShape", fail)
+        report = pmi_module.extract_pmi_report(CTC01)
+        sources = [source for source in report.sources if source.category == "datum"]
+
+        assert len(sources) == 11
+        assert all(source.outcome == "partially_extracted" for source in sources)
+        assert all("topology map setup failed" in source.reason for source in sources)
+
     def test_a_failed_datum_conversion_keeps_every_source_identity(self, monkeypatch):
         import draftwright.pmi as pmi_module
 
@@ -946,20 +980,18 @@ class TestBuildDrawingPmi:
         pmi_names = [n for n in dwg.annotations() if n.startswith("pmi_")]
         assert pmi_names == [], "pmi='report' should not add drawing annotations"
         issues = [issue for issue in dwg.lint() if issue.code == "pmi_not_extracted"]
-        assert len(issues) == 6
-        assert {issue.severity for issue in issues} == {"info"}
-        assert len({issue.source_ids for issue in issues}) == 6
+        assert issues == []
         lowering = [issue for issue in dwg.lint() if issue.code == "pmi_not_lowered"]
-        assert len(lowering) == 10
+        assert len(lowering) == 4
         assert {issue.severity for issue in lowering} == {"info"}
-        assert len({issue.source_ids for issue in lowering}) == 10
+        assert len({issue.source_ids for issue in lowering}) == 4
         assert not [issue for issue in dwg.lint() if issue.code == "pmi_not_rendered"]
         assert dwg.lint_summary()["pmi"] == {
             "mode": "report",
             "sources": 38,
             "by_category": {"datum": 11, "dimension": 21, "geometric_tolerance": 6},
             "extracted": 29,
-            "lowered": 19,
+            "lowered": 25,
             "rendered": 0,
             "dropped": 0,
         }
@@ -989,19 +1021,10 @@ class TestBuildDrawingPmi:
 
     def test_pmi_annotate_reports_each_incomplete_source_record(self, ctc01_annotated):
         issues = [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_extracted"]
-        assert len(issues) == 6
-        assert {issue.severity for issue in issues} == {"error"}
-        assert len({issue.source_ids for issue in issues}) == 6
-        assert all(issue.source_ids[0] in issue.message for issue in issues)
-        assert all("referenced geometry is unavailable" in issue.message for issue in issues)
+        assert issues == []
         summary = ctc01_annotated.lint_summary()
         assert summary["passed"] is False
-        assert summary["by_code"]["pmi_not_extracted"] == 6
-        assert all(
-            "source_ids" in issue
-            for issue in summary["issues"]
-            if issue["code"] == "pmi_not_extracted"
-        )
+        assert "pmi_not_extracted" not in summary["by_code"]
 
     def test_pmi_annotate_reports_each_raw_ir_fallback(self, ctc01_annotated):
         from draftwright.model import ControlFrame, PmiFeature
@@ -1019,7 +1042,7 @@ class TestBuildDrawingPmi:
             if isinstance(feature, ControlFrame) and feature.source_id
         }
 
-        assert len(raw_features) == 6
+        assert len(raw_features) == 4
         assert {issue.severity for issue in issues} == {"error"}
         assert {issue.source_ids[0] for issue in issues} == {
             source_id
@@ -1048,7 +1071,7 @@ class TestBuildDrawingPmi:
         }
         assert frames["geometric_tolerance:0:1:4:15"].all_around is True
 
-    def test_pmi_annotate_renders_the_proven_datum_feature_once(self, ctc01_annotated):
+    def test_pmi_annotate_renders_each_proven_datum_feature_once(self, ctc01_annotated):
         from draftwright.model import DatumRef
 
         datums = [
@@ -1057,11 +1080,15 @@ class TestBuildDrawingPmi:
             if isinstance(feature, DatumRef)
         ]
 
-        assert len(datums) == 1
-        (datum,) = datums
-        assert (datum.letter, datum.part21_id) == ("A", "#34")
-        assert len(datum.source_ids) == 5
-        assert len(ctc01_annotated.registry.names_for_feature(datum.origin)) == 1
+        assert {(datum.letter, datum.part21_id) for datum in datums} == {
+            ("A", "#34"),
+            ("B", "#35"),
+            ("C", "#36"),
+        }
+        assert sum(len(datum.source_ids) for datum in datums) == 11
+        assert all(
+            len(ctc01_annotated.registry.names_for_feature(datum.origin)) == 1 for datum in datums
+        )
 
     def test_pmi_annotate_accounts_for_each_typed_dimension_at_the_render_seam(
         self, ctc01_annotated
@@ -1096,8 +1123,8 @@ class TestBuildDrawingPmi:
             "sources": 38,
             "by_category": {"datum": 11, "dimension": 21, "geometric_tolerance": 6},
             "extracted": 29,
-            "lowered": 19,
-            "rendered": 17,
+            "lowered": 25,
+            "rendered": 23,
             "dropped": 2,
         }
 
@@ -1277,9 +1304,9 @@ def test_build_pmi_features_mirrors_detection(ctc01_extraction_report):
     assert len(authored) == 8
     # Four location dimensions remain explicit raw fallbacks; all six supported geometric
     # tolerances lower to the existing control-frame drafting concept.
-    assert len(raw) == 6
+    assert len(raw) == 4
     assert len(frames) == 6
-    assert len(datum_refs) == 1
+    assert len(datum_refs) == 3
     assert all(f.kind == "authored_dimension" for f in authored)
     assert all(f.kind == "pmi" for f in raw)
     assert {
@@ -1287,11 +1314,14 @@ def test_build_pmi_features_mirrors_detection(ctc01_extraction_report):
         for feature in feats
         for source_id in (getattr(feature, "source_ids", ()) or (feature.source_id,))
     } == {source_id for record in recs for source_id in (record.source_ids or (record.source_id,))}
-    assert datum_refs[0].letter == "A"
-    assert datum_refs[0].part21_id == "#34"
-    assert datum_refs[0].source_ids == next(
-        record.source_ids for record in recs if record.part21_id == "#34"
-    )
+    assert {(datum.letter, datum.part21_id) for datum in datum_refs} == {
+        ("A", "#34"),
+        ("B", "#35"),
+        ("C", "#36"),
+    }
+    assert {datum.part21_id: datum.source_ids for datum in datum_refs} == {
+        record.part21_id: record.source_ids for record in recs if record.source_category == "datum"
+    }
     assert {feature.source_id: feature.part21_id for feature in frames if feature.part21_id} == {
         record.source_id: record.part21_id
         for record in recs

--- a/tests/test_pmi_datum_lowering.py
+++ b/tests/test_pmi_datum_lowering.py
@@ -30,6 +30,66 @@ class _Sequence:
         return self.items[index - 1]
 
 
+class _Face:
+    def __init__(self, identity):
+        self.identity = identity
+
+    def IsNull(self):
+        return False
+
+    def ShapeType(self):
+        return "face"
+
+    def IsSame(self, other):
+        return self.identity == other.identity
+
+
+class _ImportedFaces:
+    def __init__(self, *faces):
+        self.faces = faces
+
+    def FindIndex(self, shape):
+        return next((index for index, face in enumerate(self.faces, 1) if face.IsSame(shape)), 0)
+
+
+class _StepModel:
+    def __init__(self, ranks):
+        self.ranks = ranks
+
+    def NextNumberForLabel(self, label, lastnum=0, exact=True):
+        assert lastnum == 0
+        assert exact is True
+        return self.ranks.get(label, 0)
+
+    def Value(self, rank):
+        return SimpleNamespace(
+            DynamicType=lambda: SimpleNamespace(Name=lambda: "StepShape_AdvancedFace")
+        )
+
+
+class _StepReader:
+    def __init__(self, ranks, results):
+        self.model = _StepModel(ranks)
+        self.results = results
+        self.shapes = []
+
+    def StepModel(self):
+        return self.model
+
+    def TransferOne(self, rank):
+        shape = self.results.get(rank)
+        if shape is None:
+            return False
+        self.shapes.append(shape)
+        return True
+
+    def NbShapes(self):
+        return len(self.shapes)
+
+    def Shape(self, index):
+        return self.shapes[index - 1]
+
+
 def _record(*, blockers=(), axis="Z") -> PmiRecord:
     return PmiRecord(
         kind="datum",
@@ -63,6 +123,72 @@ def test_complete_datum_definition_lowers_once_for_all_source_occurrences():
     assert isinstance(feature.origin, PmiFeature)
     assert feature.origin.datum_contexts == ("Position.1", "Perpendicularity.1")
     assert feature.origin.reference_item_ids == ("#861",)
+
+
+def test_datum_topology_resolution_uses_part21_labels_and_exact_imported_identity(monkeypatch):
+    imported = (_Face("left"), _Face("right"))
+    reader = _StepReader({"#839": 7, "#840": 11}, {7: imported[0], 11: imported[1]})
+    monkeypatch.setattr(pmi_module, "TopAbs_FACE", "face")
+    resolver = pmi_module._DatumTopologyResolver(reader, _ImportedFaces(*imported))
+
+    shapes, reasons = resolver.resolve("#36", ("#839", "#840"))
+
+    assert reasons == ()
+    assert shapes == imported
+
+
+@pytest.mark.parametrize(
+    ("ranks", "results", "imported", "expected"),
+    (
+        ({"#839": 7}, {}, (_Face("left"),), "could not be transferred"),
+        (
+            {"#839": 7},
+            {7: _Face("other")},
+            (_Face("left"),),
+            "is not a face in the imported topology",
+        ),
+        (
+            {"#839": 7, "#840": 11},
+            {7: _Face("left"), 11: _Face("left")},
+            (_Face("left"),),
+            "resolve to the same imported face",
+        ),
+    ),
+)
+def test_datum_topology_resolution_fails_closed_for_missing_unimported_or_collapsed_faces(
+    monkeypatch, ranks, results, imported, expected
+):
+    monkeypatch.setattr(pmi_module, "TopAbs_FACE", "face")
+    resolver = pmi_module._DatumTopologyResolver(
+        _StepReader(ranks, results), _ImportedFaces(*imported)
+    )
+
+    shapes, reasons = resolver.resolve("#36", tuple(ranks))
+
+    assert shapes == ()
+    assert any(expected in reason for reason in reasons)
+
+
+def test_datum_topology_resolution_rejects_two_definitions_claiming_one_face(monkeypatch):
+    imported = (_Face("shared"), _Face("other"))
+    reader = _StepReader(
+        {"#839": 7, "#840": 11, "#853": 13},
+        {7: imported[0], 11: imported[1], 13: imported[0]},
+    )
+    monkeypatch.setattr(pmi_module, "TopAbs_FACE", "face")
+    resolver = pmi_module._DatumTopologyResolver(reader, _ImportedFaces(*imported))
+
+    assert resolver.resolve("#36", ("#839", "#840"))[1] == ()
+    shapes, reasons = resolver.resolve("#35", ("#853",))
+
+    assert shapes == ()
+    assert any("already claimed by datum feature #36" in reason for reason in reasons)
+
+    # The same source item reused by another definition takes the cache path and is rejected
+    # by the same imported-topology ownership guard.
+    shapes, reasons = resolver.resolve("#34", ("#839",))
+    assert shapes == ()
+    assert any("already claimed by datum feature #36" in reason for reason in reasons)
 
 
 def test_unresolved_datum_geometry_remains_one_provenance_rich_raw_definition():
@@ -134,9 +260,9 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
             dx, dy, dz = self.direction
             x, y, z = self.location
             direction = SimpleNamespace(X=lambda: dx, Y=lambda: dy, Z=lambda: dz)
-            axis = SimpleNamespace(Direction=lambda: direction)
             location = SimpleNamespace(X=lambda: x, Y=lambda: y, Z=lambda: z)
-            return SimpleNamespace(Axis=lambda: axis, Location=lambda: location)
+            axis = SimpleNamespace(Direction=lambda: direction, Location=lambda: location)
+            return SimpleNamespace(Axis=lambda: axis)
 
     def get_refs(label, first, second):
         for item in label[0]:
@@ -153,26 +279,25 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
     monkeypatch.setattr(
         pmi_module, "XCAFDoc_DimTolTool", SimpleNamespace(GetRefShapeLabel_s=get_refs)
     )
-    monkeypatch.setattr(
-        pmi_module,
-        "_reference_geometry",
-        lambda *_args: (((1.0, 2.0, 3.0),), (0.0, 0.0, 0.0, 1.0, 1.0, 1.0), "Z", ()),
-    )
+    monkeypatch.setattr(pmi_module, "_shape_bbox", lambda _shape: (0.0, 1.0, 2.0, 2.0, 3.0, 4.0))
     monkeypatch.setattr(pmi_module, "TopoDS", SimpleNamespace(Face_s=as_face))
     monkeypatch.setattr(pmi_module, "BRepAdaptor_Surface", lambda shape: shape.surface)
     monkeypatch.setattr(pmi_module, "GeomAbs_Plane", "plane")
     shape_tool = SimpleNamespace(GetShape_s=lambda ref: ref)
 
     cases = (
-        ((Shape(null=True),), "datum reference plane is unavailable"),
-        ((Shape(surface=Surface("cylinder")),), "one datum reference is not planar"),
+        ((Shape(null=True),), "datum reference surface is unavailable"),
+        (
+            (Shape(surface=Surface("unsupported")),),
+            "one datum reference is neither planar nor cylindrical",
+        ),
         (
             (Shape(surface=Surface("plane", direction=(1.0, 0.2, 0.0))),),
-            "one datum reference plane is not axis-aligned",
+            "one datum reference surface is not axis-aligned",
         ),
         (
             (Shape(broken=True),),
-            "one datum reference plane is unavailable (TypeError: not a face)",
+            "one datum reference surface is unavailable (TypeError: not a face)",
         ),
         (
             (
@@ -186,9 +311,10 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
         points, bbox, axis, reasons = pmi_module._datum_reference_geometry(
             (shapes, ()), shape_tool
         )
-        assert points == ((1.0, 2.0, 3.0),)
-        assert bbox == (0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
-        assert axis == ""
+        usable_shape_count = sum(not shape.null for shape in shapes)
+        assert points == ((1.0, 2.0, 3.0),) * usable_shape_count
+        assert bbox == ((0.0, 1.0, 2.0, 2.0, 3.0, 4.0) if usable_shape_count else None)
+        assert axis == "", expected_reason
         assert expected_reason in reasons
 
 

--- a/tests/test_pmi_datum_lowering.py
+++ b/tests/test_pmi_datum_lowering.py
@@ -53,8 +53,9 @@ class _ImportedFaces:
 
 
 class _StepModel:
-    def __init__(self, ranks):
+    def __init__(self, ranks, entity_type="StepShape_AdvancedFace"):
         self.ranks = ranks
+        self.entity_type = entity_type
 
     def NextNumberForLabel(self, label, lastnum=0, exact=True):
         assert lastnum == 0
@@ -62,14 +63,12 @@ class _StepModel:
         return self.ranks.get(label, 0)
 
     def Value(self, rank):
-        return SimpleNamespace(
-            DynamicType=lambda: SimpleNamespace(Name=lambda: "StepShape_AdvancedFace")
-        )
+        return SimpleNamespace(DynamicType=lambda: SimpleNamespace(Name=lambda: self.entity_type))
 
 
 class _StepReader:
-    def __init__(self, ranks, results):
-        self.model = _StepModel(ranks)
+    def __init__(self, ranks, results, *, entity_type="StepShape_AdvancedFace"):
+        self.model = _StepModel(ranks, entity_type)
         self.results = results
         self.shapes = []
 
@@ -169,6 +168,29 @@ def test_datum_topology_resolution_fails_closed_for_missing_unimported_or_collap
     assert any(expected in reason for reason in reasons)
 
 
+def test_datum_topology_resolution_rejects_empty_nonface_and_transfer_exception(monkeypatch):
+    monkeypatch.setattr(pmi_module, "TopAbs_FACE", "face")
+
+    resolver = pmi_module._DatumTopologyResolver(_StepReader({}, {}), _ImportedFaces())
+    assert resolver.resolve("#36", ())[1] == ("datum feature has no Part21 representation items",)
+    assert "is unavailable" in resolver.resolve("#36", ("#missing",))[1][0]
+
+    reader = _StepReader({"#839": 7}, {}, entity_type="StepRepr_RepresentationItem")
+    resolver = pmi_module._DatumTopologyResolver(reader, _ImportedFaces())
+    assert "is not an advanced face" in resolver.resolve("#36", ("#839",))[1][0]
+
+    reader = _StepReader({"#839": 7}, {})
+    reader.TransferOne = lambda _rank: (_ for _ in ()).throw(RuntimeError("binder failed"))
+    resolver = pmi_module._DatumTopologyResolver(reader, _ImportedFaces())
+    assert "RuntimeError: binder failed" in resolver.resolve("#36", ("#839",))[1][0]
+
+    bad_shape = _Face("bad")
+    bad_shape.ShapeType = lambda: "edge"
+    reader = _StepReader({"#839": 7}, {7: bad_shape})
+    resolver = pmi_module._DatumTopologyResolver(reader, _ImportedFaces(bad_shape))
+    assert "did not transfer to one face" in resolver.resolve("#36", ("#839",))[1][0]
+
+
 def test_datum_topology_resolution_rejects_two_definitions_claiming_one_face(monkeypatch):
     imported = (_Face("shared"), _Face("other"))
     reader = _StepReader(
@@ -264,6 +286,8 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
             axis = SimpleNamespace(Direction=lambda: direction, Location=lambda: location)
             return SimpleNamespace(Axis=lambda: axis)
 
+        Cylinder = Plane
+
     def get_refs(label, first, second):
         for item in label[0]:
             first.Append(item)
@@ -283,6 +307,7 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
     monkeypatch.setattr(pmi_module, "TopoDS", SimpleNamespace(Face_s=as_face))
     monkeypatch.setattr(pmi_module, "BRepAdaptor_Surface", lambda shape: shape.surface)
     monkeypatch.setattr(pmi_module, "GeomAbs_Plane", "plane")
+    monkeypatch.setattr(pmi_module, "GeomAbs_Cylinder", "cylinder")
     shape_tool = SimpleNamespace(GetShape_s=lambda ref: ref)
 
     cases = (
@@ -305,6 +330,13 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
                 Shape(surface=Surface("plane", location=(0.0, 0.0, 1.0))),
             ),
             "datum reference faces are not coplanar",
+        ),
+        (
+            (
+                Shape(surface=Surface("plane")),
+                Shape(surface=Surface("cylinder")),
+            ),
+            "datum reference faces mix planar and cylindrical surfaces",
         ),
     )
     for shapes, expected_reason in cases:

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -292,7 +292,14 @@ class TestEmit:
         assert "source='ap242_pmi'" in src
         assert "sheet.add(PmiFeature(" in src
         assert "sheet.add(ControlFrame(" in src
-        assert "sheet.add(DatumRef(" in src
+        assert src.count("sheet.add(DatumRef(") == 3
+        assert all(
+            f"letter={letter!r}" in src and f"part21_id={part21_id!r}" in src
+            for letter, part21_id in (("A", "#34"), ("B", "#35"), ("C", "#36"))
+        )
+        assert "reference_item_ids=('#861',)" in src
+        assert "reference_item_ids=('#854', '#853')" in src
+        assert "reference_item_ids=('#839', '#840')" in src
         assert "part21_id='#21'" in src
         assert "part21_id='#27'" in src and "all_around=True" in src
         assert "sheet.step_level(" in src  # #578: fluent verb, no StepLevelFeature import


### PR DESCRIPTION
Closes #1100.

## What changed

- Resolve each AP242 datum `ADVANCED_FACE` label through `StepModel.NextNumberForLabel(...)` and `STEPControl_Reader.TransferOne(...)`, reusing OCCT's native transfer binder.
- Admit a result only when it is exactly `IsSame` to a face in the original imported topology; reject unavailable, non-face, unimported, collapsed composite, and cross-definition alias mappings.
- Validate exact datum faces through one shared planar/coaxial-cylindrical surface path and fail closed for unsupported, mixed, non-axis-aligned, non-coplanar, or non-coaxial geometry.
- Lower CTC01 datum definitions A/B/C to three `DatumRef` features while retaining all 11 occurrence identities, Part21 definition IDs, and representation-item IDs through generated Sheet scripts.

## Why

CTC01 datum B/C have exact Part21 representation-item references but no direct XCAF datum-to-face labels. Directly translating those faces creates separate topology and cannot prove correspondence. `TransferOne(rank)` stays inside OCCT and reuses the import transfer binder; exact membership in the captured imported-face map supplies the independently auditable identity required by #1100 without geometry, occurrence-order, semantic-label, or page-placement heuristics.

## Validation

- `uv run pytest -m smoke` — 73 passed
- `uv run pytest tests/test_pmi.py tests/test_pmi_datum_lowering.py -q` — 67 passed
- `uv run pytest -n auto --dist loadscope` — 3,120 passed, 4 skipped, 2 xfailed
- `uv run pytest -m slow -n auto --dist loadscope` — 21 passed
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- `scripts/pr-check --static`

The rejection mutations cover missing/unimported faces, a composite collapsing onto one topology face, two definitions claiming one face, topology-map setup failure, and loss of exact identity forcing all datum definitions to remain raw.
