### PR TITLE
Reduce hosted Actions compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,28 @@ jobs:
         run: scripts/pr-check --static
 
   test:
+    # The PR is the compatibility gate. A merge to protected main has already passed these
+    # exact checks, so main keeps lint + the slow post-merge safety net without repeating them.
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         # 3.10-3.12 resolve build123d 0.10 (cadquery-ocp + VTK); 3.13/3.14 resolve build123d
         # 0.11 (cadquery-ocp-novtk — VTK dropped, and the only kernel with 3.13/3.14 wheels).
-        # A few exact-position snapshots are skipped on 0.11 (see tests/_kernel.py).
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        # Ubuntu/Python 3.13 is the canonical coverage job below. Excluding it
-        # here keeps the OS/Python matrix complete without running it twice.
-        exclude:
-          - os: ubuntu-latest
-            python-version: "3.13"
+        # Linux covers every supported Python (3.13 is the coverage job below). macOS and
+        # Windows each cover the last VTK kernel and the current no-VTK kernel. This preserves
+        # every compatibility dimension without paying for the uninformative 3 x 5 product.
+        include:
+          - {os: ubuntu-latest, python-version: "3.10"}
+          - {os: ubuntu-latest, python-version: "3.11"}
+          - {os: ubuntu-latest, python-version: "3.12"}
+          - {os: ubuntu-latest, python-version: "3.14"}
+          - {os: macos-latest, python-version: "3.12"}
+          - {os: macos-latest, python-version: "3.14"}
+          - {os: windows-latest, python-version: "3.12"}
+          - {os: windows-latest, python-version: "3.14"}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -75,7 +82,8 @@ jobs:
           --durations=25
 
   coverage:
-    # The fifteenth OS/Python matrix entry, split out so only the one job that
+    if: github.event_name == 'pull_request'
+    # The ninth OS/Python compatibility entry, split out so only the one job that
     # uploads to Codecov receives an OIDC token and renders retained reports.
     name: test (ubuntu-latest, 3.13)
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,21 +7,39 @@ on:
     types: [published]
 
 jobs:
-  build:
+  # Main snapshots need no artifact hand-off: build and trusted publication share one runner.
+  publish-testpypi:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - name: Set TestPyPI dev version
-        if: github.event_name == 'push'
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           base="${current%.dev*}"
           uv version "${base}.dev${{ github.run_number }}"
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  # A real release retains the built artifact across the separately protected PyPI job.
+  build-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
       - name: Strip dev suffix for real release
-        if: github.event_name == 'release'
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           base="${current%.dev*}"
@@ -32,24 +50,8 @@ jobs:
           name: dist
           path: dist/
 
-  publish-testpypi:
-    needs: build
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   publish-pypi:
-    needs: build
+    needs: build-release
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: pypi

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,70 @@
+"""Executable guards for the hosted-runner budget and protected release topology."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def _workflow(name: str) -> str:
+    return (ROOT / ".github" / "workflows" / name).read_text()
+
+
+def _job(workflow: str, name: str) -> str:
+    lines = workflow.splitlines()
+    start = lines.index(f"  {name}:")
+    end = next(
+        (
+            index
+            for index in range(start + 1, len(lines))
+            if re.fullmatch(r"  [a-z][a-z0-9-]*:", lines[index])
+        ),
+        len(lines),
+    )
+    return "\n".join(lines[start:end])
+
+
+def test_pr_matrix_preserves_compatibility_dimensions_with_nine_test_jobs():
+    workflow = _workflow("ci.yml")
+    test_job = _job(workflow, "test")
+    entries = set(re.findall(r'- \{os: ([^,]+), python-version: "([^"]+)"\}', test_job))
+
+    assert "if: github.event_name == 'pull_request'" in test_job
+    assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
+    assert len(entries) + 1 == 9  # the separate Ubuntu 3.13 coverage job
+    assert {version for os_name, version in entries if os_name == "ubuntu-latest"} | {"3.13"} == {
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    }
+    for os_name in ("macos-latest", "windows-latest"):
+        assert {version for os_entry, version in entries if os_entry == os_name} == {
+            "3.12",
+            "3.14",
+        }
+
+
+def test_main_runs_static_and_slow_gates_without_repeating_fast_matrix():
+    workflow = _workflow("ci.yml")
+
+    assert "push:\n    branches: [main]" in workflow
+    assert "if:" not in _job(workflow, "lint")
+    assert "if: github.event_name == 'push'" in _job(workflow, "test-slow")
+    assert "if: github.event_name == 'pull_request'" in _job(workflow, "test")
+    assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
+
+
+def test_testpypi_snapshot_build_and_publish_share_one_job():
+    workflow = _workflow("publish.yml")
+    snapshot = _job(workflow, "publish-testpypi")
+
+    assert "if: github.event_name == 'push'" in snapshot
+    assert "environment: testpypi" in snapshot
+    assert "contents: read\n      id-token: write" in snapshot
+    assert "- run: uv build" in snapshot
+    assert "- uses: pypa/gh-action-pypi-publish@release/v1" in snapshot
+    assert "repository-url: https://test.pypi.org/legacy/" in snapshot
+    assert "if: github.event_name == 'release'" in _job(workflow, "build-release")
+    assert "needs: build-release" in _job(workflow, "publish-pypi")


### PR DESCRIPTION
## Summary

- replace the 3×5 compatibility cross-product with nine evidence-bearing PR test jobs
- keep every supported Python version on Ubuntu and both dependency/kernel generations on macOS and Windows
- skip the duplicate fast matrix on protected `main`, retaining static lint and the post-merge slow tier
- build and publish TestPyPI snapshots in one environment-scoped OIDC job while retaining the separate real-release artifact path
- add executable workflow-contract tests for matrix coverage, event gating, and publication topology

## Hosted-runner impact

- normal PR + merge: 35 jobs → 13 jobs (22 fewer, about 63%)
- PR compatibility suites: 15 → 9
- post-merge CI: 17 → 2 (lint + slow)
- main snapshot publication: 2 → 1

## Protection audit

`main` currently requires all 15 old matrix contexts, lint, and both Codecov contexts with strict/admin enforcement. Before merge, required contexts must be updated to the nine emitted compatibility checks plus lint and Codecov; doing that earlier would weaken the current branch gate.

The `testpypi` and `pypi` environments scope the trusted-publisher OIDC claims but currently have no reviewer or deployment-branch protection rules. This PR preserves that existing security posture; it does not claim to harden it.

## Validation

- `uv sync --group dev`
- `uv run pytest tests/test_workflows.py -q` (3 passed)
- `uv run pytest -m smoke -q` (73 passed)
- `scripts/pr-check --static`
- `uv lock --check`
- `git diff --check`

Closes #1103
