### PR TITLE
Support export-safe all-over GD&T leaders

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4587,6 +4587,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                 draft=draft,
                 callout=g,
                 all_around=getattr(_it, "all_around", False),
+                all_over=getattr(_it, "all_over", False),
             )
 
         def _drop(

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -287,6 +287,7 @@ def build_pmi_features(
                 replace(
                     item,
                     all_around="all_around" in r.gtol_modifiers,
+                    all_over="all_over" in r.gtol_modifiers,
                     source_id=r.source_id,
                     part21_id=r.part21_id,
                 )

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1217,6 +1217,8 @@ class ControlFrame:
     all_around: bool = False
     source_id: str = ""
     part21_id: str = ""
+    # Appended after the existing public fields to preserve positional ControlFrame construction.
+    all_over: bool = False
     kind: ClassVar[str] = "control_frame"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -127,8 +127,8 @@ _GTOL_TYPE: dict[int, str] = {
 }
 
 # int → stable semantic name for XCAFDimTolObjects_GeomToleranceModif.  The whole OCCT
-# vocabulary is inventoried even though only the all-around leader-scope symbol has a faithful,
-# export-safe drafting representation today; every other known value remains explicit and
+# vocabulary is inventoried even though only the leader-scope symbols have faithful,
+# export-safe drafting representations today; every other known value remains explicit and
 # fail-closed.
 _GTOL_MODIFIER: dict[int, str] = {
     0: "any_cross_section",
@@ -149,7 +149,7 @@ _GTOL_MODIFIER: dict[int, str] = {
     15: "all_around",
     16: "all_over",
 }
-_SUPPORTED_GTOL_SCOPE_MODIFIERS = frozenset(("all_around",))
+_SUPPORTED_GTOL_SCOPE_MODIFIERS = frozenset(("all_around", "all_over"))
 
 
 # ---------------------------------------------------------------------------
@@ -668,7 +668,7 @@ def _semantic_name(obj) -> tuple[str, str]:
 
 
 def _geometric_tolerance_modifiers(obj) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Inventory XCAF's modifier sequence and admit only one representable scope symbol."""
+    """Inventory XCAF's modifier sequence and admit representable scope symbols."""
     try:
         codes = tuple(int(modifier) for modifier in obj.GetModifiers())
     except Exception as exc:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -283,6 +283,8 @@ def _control_frame_line(f, origin_ref: str | None = None) -> str:
         kw.append(f"modifier={f.modifier!r}")
     if f.all_around:
         kw.append("all_around=True")
+    if f.all_over:
+        kw.append("all_over=True")
     if f.source_id:
         kw.append(f"source_id={f.source_id!r}")
     if f.part21_id:

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -8,8 +8,11 @@ never overlap, a full strip drops honestly (a warning, not a silent vanish), and
 placement stays lint-clean.
 """
 
+from collections import defaultdict
 from pathlib import Path
+from xml.etree import ElementTree
 
+import ezdxf
 import pytest
 from build123d import Box, Cylinder, Draft, Pos
 from build123d_drafting import FeatureControlFrame
@@ -82,6 +85,43 @@ def test_imported_scope_modifier_reaches_the_solver_owned_leader(monkeypatch, tm
     assert dwg.registry.names_for_feature(frame) == ["m_gdt0"]
     paths = dwg.export(str(tmp_path / "all-around"), formats=("svg", "dxf"))
     assert all(Path(path).exists() and Path(path).stat().st_size > 0 for path in paths.values())
+
+
+@pytest.mark.timeout(60)
+def test_all_over_control_frame_exports_two_rings_to_svg_and_dxf(tmp_path):
+    frame = ControlFrame(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        characteristic="profile_surface",
+        tolerance="0.5",
+        view="plan",
+        side="above",
+        all_over=True,
+        source_id="geometric_tolerance:fixture",
+        part21_id="#27",
+    )
+    dwg = _build(frame)
+
+    paths = dwg.export(str(tmp_path / "all-over"), formats=("svg", "dxf"))
+    assert all(Path(path).exists() and Path(path).stat().st_size > 0 for path in paths.values())
+
+    svg = ElementTree.parse(paths["svg"])
+    dims = next(element for element in svg.iter() if element.attrib.get("id") == "dims")
+    annular_paths = [
+        element.attrib["d"]
+        for element in dims
+        if element.tag.endswith("path")
+        and element.attrib.get("d", "").count(" A ") == 4
+        and element.attrib["d"].count("M ") == 2
+        and " L " not in element.attrib["d"]
+    ]
+    assert len(annular_paths) == 2
+
+    circles_by_center = defaultdict(set)
+    for entity in ezdxf.readfile(paths["dxf"]).modelspace():
+        if entity.dxf.layer == "dims" and entity.dxftype() == "CIRCLE":
+            center = tuple(round(value, 6) for value in entity.dxf.center)
+            circles_by_center[center].add(round(entity.dxf.radius, 6))
+    assert any(len(radii) == 4 for radii in circles_by_center.values())
 
 
 def test_automatically_imported_frame_stays_diagnostic_in_report_mode():

--- a/tests/test_pmi_gtol_lowering.py
+++ b/tests/test_pmi_gtol_lowering.py
@@ -42,7 +42,7 @@ def test_occt_geometric_tolerance_modifier_enum_is_fully_inventoried():
     assert pmi_module._GTOL_MODIFIER == actual
 
 
-def test_only_one_supported_scope_modifier_is_complete():
+def test_supported_scope_modifiers_are_complete():
     def modifiers(*codes):
         return SimpleNamespace(GetModifiers=lambda: codes)
 
@@ -52,7 +52,7 @@ def test_only_one_supported_scope_modifier_is_complete():
     )
     assert pmi_module._geometric_tolerance_modifiers(modifiers(16)) == (
         ("all_over",),
-        ("geometric-tolerance modifier 'all_over' is not supported",),
+        (),
     )
     assert pmi_module._geometric_tolerance_modifiers(modifiers(1)) == (
         ("common_zone",),
@@ -64,10 +64,7 @@ def test_only_one_supported_scope_modifier_is_complete():
     )
     assert pmi_module._geometric_tolerance_modifiers(modifiers(15, 16)) == (
         ("all_around", "all_over"),
-        (
-            "geometric-tolerance modifier 'all_over' is not supported",
-            "geometric-tolerance modifier combination ('all_around', 'all_over') is not supported",
-        ),
+        ("geometric-tolerance modifier combination ('all_around', 'all_over') is not supported",),
     )
 
     def unreadable():
@@ -114,6 +111,18 @@ def test_complete_geometric_tolerance_lowers_to_control_frame():
     assert feature.origin.gtol_modifiers == ("all_around",)
 
 
+def test_complete_all_over_tolerance_lowers_to_control_frame():
+    (feature,) = build_pmi_features(
+        (_record(modifiers=("all_over",)),), Box(20, 20, 20).bounding_box()
+    )
+
+    assert isinstance(feature, ControlFrame)
+    assert feature.all_around is False
+    assert feature.all_over is True
+    assert isinstance(feature.origin, PmiFeature)
+    assert feature.origin.gtol_modifiers == ("all_over",)
+
+
 def test_lowering_does_not_round_the_source_tolerance_magnitude():
     (feature,) = build_pmi_features((_record(value=0.12345),), Box(20, 20, 20).bounding_box())
 
@@ -121,7 +130,7 @@ def test_lowering_does_not_round_the_source_tolerance_magnitude():
     assert feature.tolerance == "0.12345"
 
 
-@pytest.mark.parametrize("modifier", ["common_zone", "all_over"])
+@pytest.mark.parametrize("modifier", ["common_zone"])
 def test_incomplete_geometric_tolerance_remains_a_provenance_rich_raw_fallback(modifier):
     blocker = f"geometric-tolerance modifier {modifier!r} is not supported"
     (feature,) = build_pmi_features(
@@ -166,6 +175,20 @@ def test_generated_sheet_line_round_trips_imported_control_frame():
     assert restored.origin.part21_id == restored.part21_id
 
 
+def test_generated_sheet_line_round_trips_imported_all_over_control_frame():
+    (feature,) = build_pmi_features(
+        (_record(modifiers=("all_over",)),), Box(20, 20, 20).bounding_box()
+    )
+
+    restored = _execute_feature_line(feature)
+
+    assert isinstance(restored, ControlFrame)
+    assert restored.all_around is False
+    assert restored.all_over is True
+    assert isinstance(restored.origin, PmiFeature)
+    assert restored.origin.gtol_modifiers == ("all_over",)
+
+
 def test_generated_sheet_line_round_trips_control_frame_zone_fields():
     feature = ControlFrame(
         frame=Frame((1.0, 2.0, 3.0), "z"),
@@ -183,6 +206,7 @@ def test_generated_sheet_line_round_trips_control_frame_zone_fields():
     assert restored.modifier == "M"
     assert restored.datums == ()
     assert restored.all_around is False
+    assert restored.all_over is False
     assert restored.source_id == ""
     assert restored.part21_id == ""
     assert restored.origin is None
@@ -202,7 +226,7 @@ def test_generated_sheet_refuses_a_control_frame_with_an_unbound_feature_origin(
         _feature_block([feature])
 
 
-@pytest.mark.parametrize("modifier", ["common_zone", "all_over"])
+@pytest.mark.parametrize("modifier", ["common_zone"])
 def test_generated_sheet_line_round_trips_raw_modifier_fallback(modifier):
     blocker = f"geometric-tolerance modifier {modifier!r} is not supported"
     (feature,) = build_pmi_features(


### PR DESCRIPTION
Closes #1097.

## What changed

- admit the AP242 `all_over` GD&T scope modifier while keeping incompatible scope combinations fail-closed
- preserve `all_over` through typed IR lowering, Sheet script emission, and the solver-owned leader path
- add an end-to-end SVG/DXF regression with structural double-ring assertions and a 60-second timeout

## Why

The original DXF hang no longer reproduces on the current supported CAD kernels, but the importer still discarded `all_over`. Preserving the source modifier and proving bounded export prevents a regression without introducing heuristic placement.

## Validation

- Python 3.12 relevant suite: 450 passed, 2 xfailed
- Python 3.14 focused suite: 28 passed
- full fast suite: 3,125 passed, 4 skipped, 2 xfailed
- Ruff, format, mypy, codespell, and changed-line coverage preflight passed
- `uv lock --check` passed

The slow tier has no all-over PMI fixture; the affected end-to-end export path is covered directly by the focused regression.