### PR TITLE
Bound DXF spline conversion cost

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -32,7 +32,6 @@ else:
 
 from build123d import (
     Color,
-    ExportDXF,
     ExportSVG,
     LineType,
     Location,
@@ -55,6 +54,7 @@ from draftwright.annotations._common import (
 )
 from draftwright.annotations.balloons import render_balloons
 from draftwright.export import (
+    _DraftwrightDXF,
     _export_shape,
     _render_pdf,
     _render_png,
@@ -3011,7 +3011,7 @@ class Drawing:
 
     def _write_dxf(self, out: str) -> str:
         """Write the DXF (part/hidden/dims layers + metadata) and return its path."""
-        dxf_exp = ExportDXF()
+        dxf_exp = _DraftwrightDXF()
         dxf_exp.add_layer("part", line_weight=0.5)
         dxf_exp.add_layer("hidden", line_weight=0.25)
         dxf_exp.add_layer("dims", line_weight=0.05)
@@ -3200,6 +3200,7 @@ class Drawing:
             _export_shape(exporter, vis, "part", f"view {name!r}")
             if hid:
                 _export_shape(exporter, hid, "hidden", f"view {name!r}")
+        names = {id(annotation): name for name, annotation in self.iter_annotations()}
         for ann in self.items:
-            label = getattr(ann, "label", "") or type(ann).__name__
-            _export_shape(exporter, ann, "dims", f"annotation {label!r}")
+            identity = names.get(id(ann)) or getattr(ann, "label", "") or type(ann).__name__
+            _export_shape(exporter, ann, "dims", f"annotation {identity!r}")

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -164,9 +164,12 @@ class _DraftwrightDXF(ExportDXF):
     """
 
     def _convert_bspline(self, edge, attribs):
-        if not edge or edge.location is None:
+        if edge.is_null:
             raise ValueError(f"Edge is empty {edge}.")
         edge = edge.to_splines()
+        location = edge.location
+        if location is None:
+            raise ValueError(f"Edge has no location {edge}.")
         adaptor = edge.geom_adaptor()
         curve = adaptor.Curve().Curve()
         spline = GeomConvert.SplitBSplineCurve_s(
@@ -176,7 +179,7 @@ class _DraftwrightDXF(ExportDXF):
             self.PARAMETRIC_TOLERANCE,
         )
 
-        spline.Transform(edge.location.wrapped.Transformation())
+        spline.Transform(location.wrapped.Transformation())
 
         order = spline.Degree() + 1
         knots = [

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -15,7 +15,9 @@ import logging
 import re
 from pathlib import Path
 
-from build123d import ExportSVG
+import ezdxf
+from build123d import ExportDXF, ExportSVG
+from OCP.GeomConvert import GeomConvert
 
 from draftwright._core import _DRAFTWRIGHT_URL
 
@@ -148,6 +150,57 @@ def write_dxf(dxf, path: str, page_w: float, page_h: float) -> None:
         dxf.write(path)
         return
     doc.saveas(path, fmt="asc")
+
+
+class _DraftwrightDXF(ExportDXF):
+    """build123d's DXF exporter with bounded OCCT curve-array extraction.
+
+    ``Geom_BSplineCurve.Poles()`` and ``KnotSequence()`` expose OCCT arrays through
+    unusually expensive Python sequence wrappers.  A glyph-dense CTC-02 hole table has
+    4,504 Bezier edges; iterating just its 13,512 poles took 8.6 seconds while the
+    equivalent indexed ``Pole(i)`` calls took 0.014 seconds (#1070).  Keep build123d's
+    conversion and ezdxf construction unchanged, but read the same values through OCCT's
+    indexed API so output geometry is identical and cost is linear in the actual array size.
+    """
+
+    def _convert_bspline(self, edge, attribs):
+        if not edge or edge.location is None:
+            raise ValueError(f"Edge is empty {edge}.")
+        edge = edge.to_splines()
+        adaptor = edge.geom_adaptor()
+        curve = adaptor.Curve().Curve()
+        spline = GeomConvert.SplitBSplineCurve_s(
+            curve,
+            adaptor.FirstParameter(),
+            adaptor.LastParameter(),
+            self.PARAMETRIC_TOLERANCE,
+        )
+
+        spline.Transform(edge.location.wrapped.Transformation())
+
+        order = spline.Degree() + 1
+        knots = [
+            spline.Knot(index)
+            for index in range(1, spline.NbKnots() + 1)
+            for _ in range(spline.Multiplicity(index))
+        ]
+        poles = [
+            self._convert_point(spline.Pole(index)) for index in range(1, spline.NbPoles() + 1)
+        ]
+        weights = (
+            [spline.Weight(index) for index in range(1, spline.NbPoles() + 1)]
+            if spline.IsRational()
+            else None
+        )
+
+        # SplitBSplineCurve currently deperiodicizes every bounded edge.  Retain
+        # build123d's padding rule if a future OCCT version preserves periodicity.
+        if spline.IsPeriodic():  # pragma: no cover - defensive upstream parity
+            pad = spline.NbKnots() - spline.LastUKnotIndex()
+            poles += poles[:pad]
+
+        dxf_spline = ezdxf.math.BSpline(poles, order, knots, weights)
+        self._modelspace.add_spline(dxfattribs=attribs).apply_construction_tool(dxf_spline)
 
 
 def sanitize_svg_arcs(svg_path: str) -> int:

--- a/tests/test_export_dxf_curves.py
+++ b/tests/test_export_dxf_curves.py
@@ -1,0 +1,123 @@
+"""#1070: exact, bounded DXF conversion for glyph and projected curves."""
+
+from __future__ import annotations
+
+import ezdxf
+import pytest
+from build123d import Box, Edge
+from OCP.Geom import Geom_BSplineCurve
+from OCP.GeomConvert import GeomConvert
+
+from draftwright import build_drawing
+from draftwright._core import _build_table, draft_preset
+from draftwright.export import _DraftwrightDXF, _export_shape
+
+
+def _reject_bulk_curve_arrays(monkeypatch):
+    """Make OCCT's pathologically slow Python sequence wrappers load-bearing."""
+
+    def rejected(*_args, **_kwargs):
+        raise AssertionError("bulk OCCT curve arrays are forbidden on the DXF path")
+
+    monkeypatch.setattr(Geom_BSplineCurve, "Poles", rejected)
+    monkeypatch.setattr(Geom_BSplineCurve, "KnotSequence", rejected)
+
+
+def test_empty_curve_fails_before_occt_conversion():
+    with pytest.raises(ValueError, match="Edge is empty"):
+        _DraftwrightDXF()._convert_bspline(Edge(), {})
+
+
+def test_trimmed_rational_bezier_exports_exactly_without_bulk_curve_arrays(monkeypatch):
+    source = Edge.make_bezier(
+        (0, 0),
+        (2, 4),
+        (5, 3),
+        (7, 0),
+        weights=[1.0, 0.8, 1.2, 1.0],
+    ).trim(0.2, 0.75)
+    converted = source.to_splines()
+    adaptor = converted.geom_adaptor()
+    expected = GeomConvert.SplitBSplineCurve_s(
+        adaptor.Curve().Curve(),
+        adaptor.FirstParameter(),
+        adaptor.LastParameter(),
+        _DraftwrightDXF.PARAMETRIC_TOLERANCE,
+    )
+    expected.Transform(converted.location.wrapped.Transformation())
+    expected_points = [
+        (expected.Pole(i).X(), expected.Pole(i).Y(), expected.Pole(i).Z())
+        for i in range(1, expected.NbPoles() + 1)
+    ]
+    expected_weights = (
+        [expected.Weight(i) for i in range(1, expected.NbPoles() + 1)]
+        if expected.IsRational()
+        else []
+    )
+
+    _reject_bulk_curve_arrays(monkeypatch)
+    exporter = _DraftwrightDXF()
+    exporter.add_shape(source, layer="dims")
+
+    (spline,) = exporter._modelspace
+    assert spline.dxftype() == "SPLINE"
+    assert spline.dxf.degree == expected.Degree()
+    assert [tuple(point) for point in spline.control_points] == pytest.approx(expected_points)
+    assert list(spline.weights) == pytest.approx(expected_weights)
+    expected_knots = [
+        expected.Knot(index)
+        for index in range(1, expected.NbKnots() + 1)
+        for _ in range(expected.Multiplicity(index))
+    ]
+    expected_tool = ezdxf.math.BSpline(
+        expected_points,
+        expected.Degree() + 1,
+        expected_knots,
+        expected_weights or None,
+    )
+    assert list(spline.knots) == list(expected_tool.knots())
+
+
+@pytest.mark.timeout(5)
+def test_hole_table_dxf_conversion_avoids_bulk_curve_arrays(monkeypatch):
+    rows = [("TAG", "SIZE", "QTY")] + [(f"A{i}", f"⌀{i + 1}.5", str(i % 4 + 1)) for i in range(20)]
+    table = _build_table(rows, draft_preset(), block_cols=3)
+    edge_count = len(table.edges())
+    assert edge_count > 500, "fixture must retain enough glyph curves to expose #1070"
+
+    _reject_bulk_curve_arrays(monkeypatch)
+    exporter = _DraftwrightDXF()
+    _export_shape(exporter, table, "dims", "annotation 'hole_table_plan'")
+
+    entities = list(exporter._modelspace)
+    assert len(entities) == edge_count
+    assert {entity.dxftype() for entity in entities} == {"LINE", "SPLINE"}
+
+
+def test_dxf_export_failure_names_the_registered_annotation(tmp_path, monkeypatch):
+    drawing = build_drawing(Box(20, 10, 5))
+    drawing.add_table([("TAG", "SIZE"), ("A", "⌀5")], name="hole_table_plan")
+    table = drawing.get_annotation("hole_table_plan")
+    table_edges = set(table.edges())
+
+    real = _DraftwrightDXF.add_shape
+
+    def fail_table(self, shape, layer=""):
+        if shape is table or any(edge in table_edges for edge in shape.edges()):
+            raise AssertionError("synthetic curve failure")
+        return real(self, shape, layer=layer)
+
+    monkeypatch.setattr(_DraftwrightDXF, "add_shape", fail_table)
+    with pytest.raises(RuntimeError, match="annotation 'hole_table_plan'"):
+        drawing.export(str(tmp_path / "attributed"), formats="dxf")
+
+
+def test_exported_curve_file_remains_readable(tmp_path):
+    drawing = build_drawing(Box(20, 10, 5))
+    drawing.add_table([("TAG", "SIZE"), ("A", "⌀5")], name="hole_table_plan")
+
+    path = drawing.export(str(tmp_path / "curves"), formats="dxf")["dxf"]
+    entities = list(ezdxf.readfile(path).modelspace())
+
+    assert entities
+    assert any(entity.dxftype() == "SPLINE" for entity in entities)

--- a/tests/test_export_dxf_curves.py
+++ b/tests/test_export_dxf_curves.py
@@ -28,6 +28,18 @@ def test_empty_curve_fails_before_occt_conversion():
         _DraftwrightDXF()._convert_bspline(Edge(), {})
 
 
+def test_curve_without_location_fails_before_occt_conversion():
+    class MissingLocationEdge:
+        is_null = False
+        location = None
+
+        def to_splines(self):
+            return self
+
+    with pytest.raises(ValueError, match="Edge has no location"):
+        _DraftwrightDXF()._convert_bspline(MissingLocationEdge(), {})
+
+
 def test_trimmed_rational_bezier_exports_exactly_without_bulk_curve_arrays(monkeypatch):
     source = Edge.make_bezier(
         (0, 0),


### PR DESCRIPTION
Closes #1070.

## What changed

- use indexed OCCT knot/pole access in a narrow `ExportDXF` subclass while retaining build123d’s conversion and ezdxf construction semantics
- identify registered annotations by name during export failures, so a bad hole table reports `hole_table_plan` rather than `Compound`
- add exact trimmed/rational curve, hole-table complexity, readable-artifact, and failure-attribution regressions

## Root cause and impact

OCCT’s Python bulk array wrappers are pathologically slow for glyph-dense drawings. On CTC-02, `Poles()` took 8.59 s to iterate 13,512 points while indexed `Pole(i)` access took 0.014 s for the same values. The 4,504-Bezier hole table exposed this cost most strongly.

On the same Python 3.12/build123d 0.10 machine, DXF export fell from 70.8 s to 14.9 s (79% faster); total build+DXF fell from about 115 s to 59 s. No curve is approximated or skipped.

## Validation

- exact same-object entity semantics: types, degrees, poles, knots, weights, and lines
- focused regressions green on Python 3.12/build123d 0.10 and Python 3.14/build123d 0.11
- retained CTC-02 AP203 SVG/DXF standards node: green in 127 s under the 600 s cap
- full fast suite: 3,129 passed, 4 skipped, 2 xfailed
- Ruff, format, mypy, codespell, lock check, and diff check green
- changed-line coverage: 100%
