### PR TITLE
Emit trustworthy named object references

### DIFF
--- a/docs/adr/0011-ir-as-public-input.md
+++ b/docs/adr/0011-ir-as-public-input.md
@@ -5,6 +5,10 @@
 - **Amendment 1** (2026-07-05): the three authoring modes + the **mode-3 generation surface**
   (a declarative `Sheet`-DSL emitter, #461/#462/#463) — sequenced *before* P2b. Decided: for
   detected input, emit a **part-seam** with detected numbers; reconstruction deferred.
+- **Amendment 4** (2026-08-09, #1041): a live-source features dataclass may designate a
+  Shape-valued `body` and expose named Shape fields. The emitter substitutes a source reference
+  only for independently polarity-checked, geometry-preserving, mutual one-to-one cylindrical
+  correspondence; every unavailable or ambiguous match retains the numeric declaration.
 - **Date:** 2026-07-05
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -329,3 +333,26 @@ bores are *sizing* bores come from the part classification (`analysis._classify_
 inference path for one fact (it silently dropped bores and mis-picked the axis when tried).
 #950 restores the object form once that classification is shared. (All bores share `role="bore"`, so a bore decoration folds onto every bore —
 distinguishing individual bores is out of scope.)
+
+## Amendment 4 — fail-closed named-source emission (2026-08-09, #1041)
+
+Mode 3b no longer requires the user to perform every mechanical numeric-to-object swap by hand.
+An object spec may resolve to the documented features dataclass form: one Shape-valued `body`
+plus public named Shape fields. The generated seam binds the result once as `features`, detects
+from `features.body`, and may emit `sheet.hole(features.bore)` or
+`sheet.step(features.journal)`.
+
+This does **not** weaken Amendment 1's rejection of reconstructed geometry. The candidates are
+the caller's real source objects; draftwright creates none. Nor does a plausible geometric
+resemblance earn a reference. A candidate is used only when all of these are established:
+
+1. Its Boolean relationship to `body` proves the required polarity: absent material for a hole
+   cutter, wholly present material for a boss or step. Partial overlap is unavailable evidence.
+2. Axis, diameter and in-plane position match the detected cylindrical feature, and the object
+   form reconstructs the same defining centre and axial length without numeric overrides.
+3. The feature has exactly one candidate and that candidate has exactly one feature. Duplicate
+   names, repeated geometry, or any other ambiguity fail closed to the pre-existing numeric line.
+
+The guard is deliberately per-line. Unsupported non-cylindrical features and unmatched
+cylindrical features remain complete numeric declarations in the same script. This preserves
+the honest 3a baseline and avoids turning partial source identity into an all-or-nothing mode.

--- a/docs/multi-feature-object-reference-workflow.md
+++ b/docs/multi-feature-object-reference-workflow.md
@@ -72,21 +72,20 @@ def build_thumbwheel() -> Part:
     return build_thumbwheel_features().body
 ```
 
-`--out ... --script` against a `module:attr` / `file.py:attr` spec needs a **zero-arg**
-callable returning a build123d `Shape` (or an already-built one) — so point it at
-`build_thumbwheel`, not `build_thumbwheel_features`: the latter returns a
-`ThumbwheelFeatures` dataclass and the resolver rejects it (`resolved to
-ThumbwheelFeatures, not a build123d Shape`);
-if your builder takes a `params` argument, point the spec at a small zero-arg factory
-instead of the parametrised function itself.
+`--out ... --script` against a `module:attr` / `file.py:attr` spec accepts either a zero-arg
+callable returning a build123d `Shape`, or the features-dataclass form above: a zero-arg callable
+returning a dataclass with a Shape-valued `body` and named Shape fields. Point it at
+`build_thumbwheel_features` to let the emitter preserve independently established references.
+If your builder takes a `params` argument, point the spec at a small zero-arg factory instead of
+the parametrised function itself.
 
 ## Generate the script first, then edit it
 
 You do not write the `Sheet` script below from scratch — you generate it and edit it. Point
-`--script` at the **Shape-returning** wrapper:
+`--script` at the **features-returning** factory:
 
 ```bash
-draftwright yourmodule:build_thumbwheel --script --out thumbwheel
+draftwright yourmodule:build_thumbwheel_features --script --out thumbwheel
 ```
 
 That writes `thumbwheel.py`. `--script` emits the declarative `Sheet` flavour by default (the
@@ -95,8 +94,9 @@ only one since 0.3 — `--style sheet` is the sole accepted value).
 What comes out — **verbatim, with feature and dimension lines elided where marked**:
 
 ```python
-from yourmodule import build_thumbwheel as _obj
-part = _obj()
+from yourmodule import build_thumbwheel_features as _obj
+features = _obj()
+part = features.body
 
 sheet = Sheet(part, title='DRAWING', number='DWG-001')
 hole1 = sheet.hole(diameter=1.6, at=(0.8, 0, 0), axis="x").depth(8)   # ⌀1.6 blind 8
@@ -114,16 +114,24 @@ drawing = sheet.build()
 drawing.export('thumbwheel', formats=('pdf',))
 ```
 
-`part` is rebound to your **live source**, not a frozen STEP. `authored_dimensions()` declares
-that this is the complete set, so commenting a `dimension(...)` line out drops exactly that
-dimension. `sheet.envelope()` reads the overall size off the part rather than restating it. The
-title defaults to `DRAWING` — pass `--title` to set it.
+`features` and `part` are rebound to your **live source**, not a frozen STEP. References are
+substituted only where polarity, defining geometry, and mutual one-to-one correspondence all
+agree. This particular fused body no longer has a one-to-one mapping: it detects more axial
+segments than the source names, the tap's construction span is offset from the finished bore,
+and the fused external objects partially overlap one another. Every line therefore stays a
+complete numeric declaration. That is intentional — a numeric fallback is safer than a
+plausible but wrong source name. A plate with an isolated named cutter whose centre agrees with
+the finished bore instead emits `sheet.hole(features.bore, depth=...)` automatically.
+`authored_dimensions()` declares that this is the complete set, so commenting a
+`dimension(...)` line out drops exactly that dimension. `sheet.envelope()` reads the overall
+size off the part rather than restating it. The title defaults to `DRAWING` — pass `--title` to
+set it.
 
-Honest, and a working starting point. But `diameter=4, length=3.7` are numbers *restated* from
-geometry you already have — change the journal in your source and the drawing quietly disagrees.
-Note too that the fused body detects as four `step`s: the silhouette is all detection can see
-once the objects are unioned. The rest of this doc is the edit that fixes both — swap each
-numbered line for the object it was measured from.
+Honest, and a working starting point. Note that the fused body detects as four `step`s: the
+silhouette is all detection can see once the objects are unioned. Source references cure
+restated numbers where identity survives; they do not recreate manufacturing identity that the
+finished solid no longer contains. The rest of this document shows how to declare that intent
+explicitly when the generated fail-closed mix cannot.
 
 ## Declaring the drawing by reference
 

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -174,15 +174,15 @@ def main(
     from draftwright.builder import build_drawing
 
     if script:
-        from draftwright.sheet_emit import generate_sheet_script, resolve_object_spec
+        from draftwright.sheet_emit import _resolve_object_source, generate_sheet_script
 
         # The Sheet script now carries the title-block / layout aspects (#474), so forward all
         # four flags — the generated script reproduces them on re-run (no more inert warning).
         if _looks_like_object_spec(step_file):
             # STEP_FILE is a `module:attr` / `file.py:attr` spec → reference a live object
-            obj, seam = resolve_object_spec(step_file)
+            source = _resolve_object_source(step_file)
             py_path = generate_sheet_script(
-                obj,
+                source.part,
                 out=out,
                 title=title,
                 number=number,
@@ -197,7 +197,8 @@ def main(
                 frame=frame,
                 zones=zones,
                 projection=projection or None,
-                part_expr=seam,
+                part_expr=source.seam,
+                object_candidates=source.candidates,
                 formats=tuple(formats),
             )
         else:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -4,13 +4,14 @@ Mode 3 of the three authoring modes: *generate an editable beautiful-Python scri
 **detected** :class:`PartModel` and print a :class:`~draftwright.Sheet` script — one commentable
 line per feature — that the user edits / comments-out / extends, then re-runs.
 
-**Detected input only writes numbers (the part-seam form, ADR 0011 Amdt 1 decision).** For a STEP
-file or a recovered solid the number *is* the ground truth, so a detected value is honest. We never
-fabricate a build123d part to chase a number-free layer — a synthesised solid silently drops what
-detection didn't model (a misread band, a thread's true form, an unrecognised relief) yet reads as
-authoritative. A caller who
-*has* the objects (mode 3b) wires their real part into the seam and swaps the number lines for
-``sheet.hole(obj)`` references — the emitter's numbers are a starting point, not a ceiling.
+**Detected STEP input only writes numbers (the part-seam form, ADR 0011 Amdt 1 decision).** For a
+STEP file or a recovered solid the number *is* the ground truth, so a detected value is honest. We
+never fabricate a build123d part to chase a number-free layer — a synthesised solid silently drops
+what detection didn't model (a misread band, a thread's true form, an unrecognised relief) yet reads
+as authoritative. A caller who *has* the objects (mode 3b) can expose a features dataclass with a
+Shape-valued ``body``; the emitter references a named object only where source polarity, geometry,
+and mutual one-to-one correspondence independently establish it (#1041). Every unavailable or
+ambiguous correspondence retains the complete detected numeric declaration.
 
 Kinds with no declarative verb are flagged inline — never silently dropped — and left to the
 auto-pass that runs over the declared model on re-run. Every *geometric* kind now has one
@@ -29,12 +30,132 @@ fixtures (#472).
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 
 from build123d import Shape
 
 from draftwright.builder import detect_part_model
+
+
+@dataclass(frozen=True)
+class _ObjectSource:
+    """A resolved live-source seam and the named geometry it can reference."""
+
+    part: Shape
+    seam: str
+    candidates: Mapping[str, Shape]
+
+
+_REFERENCE_EXTERNAL = {"hole": False, "boss": True, "step": True}
+_REFERENCE_DIA_TOL = 0.2
+_REFERENCE_POS_TOL = 0.5
+
+
+def _candidate_external(part: Shape, candidate: Shape) -> bool | None:
+    """Whether *candidate* is material in *part*, ``False`` for a removed tool.
+
+    A source object is independently useful only when the Boolean relationship is decisive:
+    wholly present means an external boss/step; wholly absent means an internal cutter.  A
+    partial overlap could be a construction solid, an unfinished Boolean, or a composite tool,
+    so it deliberately has no polarity and cannot acquire a reference.
+    """
+    volume = abs(float(candidate.volume))
+    if volume <= 1e-9:
+        return None
+    try:
+        intersection = part & candidate
+        if intersection is None:
+            return None
+        overlap = abs(float(intersection.volume))
+    except Exception:  # noqa: BLE001 — an unavailable Boolean means unavailable evidence
+        return None
+    fraction = overlap / volume
+    if fraction <= 1e-7:
+        return False
+    if fraction >= 1 - 1e-7:
+        return True
+    return None
+
+
+def _reference_geometry_matches(feature, candidate: Shape) -> bool:
+    """Whether a candidate can rebuild *feature* without restating its defining geometry."""
+    from draftwright.model.declare import _norm_axis, _read_cylinder
+
+    if getattr(feature, "kind", None) not in _REFERENCE_EXTERNAL:
+        return False
+    if feature.kind == "hole" and getattr(feature, "profile", None) not in (None, "circular"):
+        return False
+    if feature.kind == "hole" and getattr(feature, "count", 1) != 1:
+        return False
+    try:
+        axis, diameter, centre = _read_cylinder(candidate)
+        axis = _norm_axis(axis)
+    except Exception:  # noqa: BLE001 — an unreadable candidate is simply not evidence
+        return False
+    if axis != _norm_axis(feature.frame.axis):
+        return False
+    if abs(float(feature.diameter) - float(diameter)) > _REFERENCE_DIA_TOL:
+        return False
+    axis_index = "xyz".index(axis)
+    perpendicular = [index for index in range(3) if index != axis_index]
+    if any(
+        abs(float(feature.frame.origin[index]) - float(centre[index])) > _REFERENCE_POS_TOL
+        for index in perpendicular
+    ):
+        return False
+
+    # The broad correspondence deliberately ignores axial position, as Sheet._match_object
+    # does. Emission has a stronger obligation: the object form must reconstruct the same IR.
+    # If its centre/length differ, keep the complete numeric declaration rather than smuggling
+    # overrides beside a reference that appears authoritative.
+    if any(
+        abs(float(feature.frame.origin[index]) - float(centre[index])) > 5e-4 for index in range(3)
+    ):
+        return False
+    if abs(float(feature.diameter) - float(diameter)) > 5e-4:
+        return False
+    bb = candidate.bounding_box()
+    axial_length = (bb.size.X, bb.size.Y, bb.size.Z)[axis_index]
+    measured_length = getattr(feature, "length", None)
+    if measured_length is None and feature.kind == "boss":
+        measured_length = getattr(feature, "height", None)
+    return measured_length is None or abs(float(measured_length) - axial_length) <= 5e-4
+
+
+def _object_references(
+    features, part: Shape | None, candidates: Mapping[str, Shape] | None
+) -> dict[int, str]:
+    """Mutual one-to-one feature→source expressions, with ambiguity failing closed."""
+    if part is None or not candidates:
+        return {}
+
+    feature_edges: dict[int, list[str]] = {}
+    candidate_edges: dict[str, list[int]] = {name: [] for name in candidates}
+    polarities = {
+        name: _candidate_external(part, candidate) for name, candidate in candidates.items()
+    }
+    for feature in features:
+        kind = getattr(feature, "kind", None)
+        if not isinstance(kind, str):
+            continue
+        expected_external = _REFERENCE_EXTERNAL.get(kind)
+        if expected_external is None:
+            continue
+        for name, candidate in candidates.items():
+            if polarities[name] != expected_external:
+                continue
+            if not _reference_geometry_matches(feature, candidate):
+                continue
+            feature_edges.setdefault(id(feature), []).append(name)
+            candidate_edges[name].append(id(feature))
+
+    return {
+        feature_id: names[0]
+        for feature_id, names in feature_edges.items()
+        if len(names) == 1 and len(candidate_edges[names[0]]) == 1
+    }
 
 
 def _n(v) -> float | int:
@@ -68,7 +189,7 @@ def _tuple_arg(values) -> str:
     return "(" + ", ".join(vals) + ")"
 
 
-def _hole_line(f) -> str:
+def _hole_line(f, object_ref: str | None = None) -> str:
     if getattr(f, "profile", None) == "double_d":
         kw = [
             f"major_diameter={_n(f.diameter)}",
@@ -82,7 +203,15 @@ def _hole_line(f) -> str:
         if f.profile_direction is not None:
             kw.append(f"profile_direction={_direction(f.profile_direction)}")
         return f"sheet.double_d_bore({', '.join(kw)})"
-    kw = [f"diameter={_n(f.diameter)}", f"at={_pt(f.frame.origin)}", f'axis="{f.frame.axis}"']
+    kw = (
+        [object_ref]
+        if object_ref is not None
+        else [
+            f"diameter={_n(f.diameter)}",
+            f"at={_pt(f.frame.origin)}",
+            f'axis="{f.frame.axis}"',
+        ]
+    )
     if f.count and f.count > 1:
         kw.append(f"count={f.count}")
         # A count-group carries its member positions; without them the render collapses to a
@@ -324,7 +453,13 @@ def _datum_ref_line(f, origin_ref: str | None = None) -> str:
     )
 
 
-def _feature_line(f, part_envelope=None, *, origin_ref: str | None = None) -> str:
+def _feature_line(
+    f,
+    part_envelope=None,
+    *,
+    origin_ref: str | None = None,
+    object_ref: str | None = None,
+) -> str:
     """The declaration for one feature.
 
     *part_envelope* is the whole-part `EnvelopeFeature` when the caller knows it, so an
@@ -388,7 +523,7 @@ def _feature_line(f, part_envelope=None, *, origin_ref: str | None = None) -> st
             f'axis="{f.frame.axis}")'
         )
     if k == "hole":
-        return _hole_line(f)
+        return _hole_line(f, object_ref)
     if k == "boss":
         thr = (
             f", thread={f.thread!r}" if getattr(f, "thread", None) else ""
@@ -398,14 +533,22 @@ def _feature_line(f, part_envelope=None, *, origin_ref: str | None = None) -> st
         # regenerated model could not express a dimension its source had — silently before
         # the mirror named it, and as a raise afterwards. ADR 0011's round-trip rule is that
         # recognise, emit and declare agree about a feature's parameters.
-        height = f", height={_n(f.height)}" if getattr(f, "height", None) else ""
+        height = (
+            f", height={_n(f.height)}" if object_ref is None and getattr(f, "height", None) else ""
+        )
         # The SPAN too, not just the height. Detection reports `frame.origin` as the boss TOP
         # while `declare.boss` reads `at` as its CENTRE, so round-tripping the origin alone
         # shifted the height dimension by half the boss — same value, wrong witness lines
         # (#947 review, found by a boss fixture the corpus previously lacked). Emitting the
         # span states the geometry outright instead of relying on the two ends agreeing about
         # a coordinate convention.
-        span = f", span=({_pt(f.span[0])}, {_pt(f.span[1])})" if getattr(f, "span", None) else ""
+        span = (
+            f", span=({_pt(f.span[0])}, {_pt(f.span[1])})"
+            if object_ref is None and getattr(f, "span", None)
+            else ""
+        )
+        if object_ref is not None:
+            return f"sheet.diameter({object_ref}{thr})"
         return (
             f"sheet.diameter(diameter={_n(f.diameter)}{height}{span}, "
             f'at={_pt(f.frame.origin)}, axis="{f.frame.axis}"{thr})'
@@ -424,6 +567,8 @@ def _feature_line(f, part_envelope=None, *, origin_ref: str | None = None) -> st
         thr = (
             f", thread={f.thread!r}" if getattr(f, "thread", None) else ""
         )  # external thread (#859)
+        if object_ref is not None:
+            return f"sheet.step({object_ref}{thr})"
         return (
             f"sheet.step(diameter={_n(f.diameter)}, length={_n(f.length)}, "
             f'at={_pt(f.frame.origin)}, axis="{f.frame.axis}"{thr})'
@@ -1008,7 +1153,9 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
     return out
 
 
-def _feature_block(features, part_envelope=None) -> tuple[list[str], dict[int, str]]:
+def _feature_block(
+    features, part_envelope=None, object_refs: Mapping[int, str] | None = None
+) -> tuple[list[str], dict[int, str]]:
     """The emitted feature lines plus ``{id(feature): binding}`` for the names they bind.
 
     The map is RETURNED rather than recomputed by the dimension block, which needs the same
@@ -1046,11 +1193,13 @@ def _feature_block(features, part_envelope=None) -> tuple[list[str], dict[int, s
                     f"emit_sheet_script(): cannot preserve a {f.kind} whose origin has "
                     "no emitted binding"
                 )
-            line = (
-                _feature_line(f, part_envelope, origin_ref=origin_ref)
-                if gdt_with_origin
-                else _feature_line(f, part_envelope)
-            )
+            object_ref = (object_refs or {}).get(id(f))
+            if gdt_with_origin:
+                line = _feature_line(f, part_envelope, origin_ref=origin_ref)
+            elif object_ref is not None:
+                line = _feature_line(f, part_envelope, object_ref=object_ref)
+            else:
+                line = _feature_line(f, part_envelope)
             name = _binding(f, line, counts)
             if name is not None:
                 names[id(f)] = name
@@ -1075,9 +1224,9 @@ decorate one after the fact. They are bound rather than addressed by position on
 comment out a feature and any line naming it fails loudly, instead of silently retargeting
 onto its neighbour.
 
-The values are DETECTED off the geometry (honest for a STEP / recovered solid). If you
-built the part yourself, wire your object into the `part = …` seam and swap a numbered
-line for a reference — e.g.  sheet.hole(my_bore)  — to read the size off the object.
+The numeric values are DETECTED off the geometry (honest for a STEP / recovered solid).
+With a named features container, uniquely proven source objects are referenced directly;
+unavailable or ambiguous matches remain complete numeric declarations and fail closed.
 """'''
 
 
@@ -1100,6 +1249,8 @@ def emit_sheet_script(
     zones: bool = False,
     projection: str | None = None,
     object_ref: bool = False,
+    object_candidates: Mapping[str, Shape] | None = None,
+    source_part: Shape | None = None,
     formats: Sequence[str] = ("pdf",),
 ) -> str:
     """The generated declarative ``Sheet`` script text for a detected *model*.
@@ -1187,7 +1338,10 @@ def emit_sheet_script(
         ctor.append(f"projection={projection!r}")
     from draftwright.model.declare import _envelope_from_bbox
 
-    feature_lines, _names = _feature_block(model.features, _envelope_from_bbox(model.bbox))
+    object_refs = _object_references(model.features, source_part, object_candidates)
+    feature_lines, _names = _feature_block(
+        model.features, _envelope_from_bbox(model.bbox), object_refs
+    )
     # Narrowed to what the BODY actually names. The set above is derived from feature kinds,
     # which over-imports the moment a kind stops emitting a constructor: since #976 a
     # whole-part envelope emits `sheet.envelope()`, so `EnvelopeFeature` and `Frame` were
@@ -1226,6 +1380,13 @@ def emit_sheet_script(
         # script has no such objects, so this note is emitted only for object inputs).
         *(
             [
+                "# Named-source correspondence: unique cylindrical matches below reference",
+                "# `features.<name>` directly. Numeric lines are deliberate fail-closed fallbacks",
+                "# where source polarity, geometry, or one-to-one identity was not established.",
+                "",
+            ]
+            if object_candidates
+            else [
                 "# Object-reference tip: you built these objects, so swap a numbered arg for the",
                 "# object itself to read the size off it — e.g.  sheet.step(journal)  /",
                 "#  sheet.hole(m3_bore).thread('M3x0.5')  — no numbers restated (ADR 0011 declare).",
@@ -1270,12 +1431,13 @@ def emit_sheet_script(
     return "\n".join(lines) + "\n"
 
 
-def resolve_object_spec(spec: str) -> tuple[Shape, str]:
-    """Resolve a ``module:attr`` (or ``path/to/file.py:attr``) spec into ``(build123d object,
-    import seam)`` (ADR 0011, #469). The attribute is imported; a zero-argument callable (a
-    ``make_part()`` factory) is called. The returned seam is the Python that re-binds ``part``
-    in the generated script, so the drawing references your **live parametric source**, not a
-    frozen STEP.
+def _resolve_object_source(spec: str) -> _ObjectSource:
+    """Resolve a live Shape or a dataclass carrying ``body`` plus named Shape fields.
+
+    The features-container form is the source-identity seam from #1041: it binds the factory
+    result once as ``features``, detects from ``features.body``, and makes each other public
+    Shape field available to the correspondence guard. A plain Shape keeps the exact #469
+    behaviour and supplies no candidates.
 
     SECURITY: importing the target executes its module-level code — the same trust as running
     the file yourself."""
@@ -1365,10 +1527,39 @@ def resolve_object_spec(spec: str) -> tuple[Shape, str]:
             )
         obj, called = obj(), True
 
-    if not isinstance(obj, Shape):
-        raise ValueError(f"{spec!r}: resolved to {type(obj).__name__}, not a build123d Shape")
+    target = f"{ref}{'()' if called else ''}"
+    if isinstance(obj, Shape):
+        return _ObjectSource(obj, f"{seam}\npart = {target}", {})
 
-    return obj, f"{seam}\npart = {ref}{'()' if called else ''}"
+    body = getattr(obj, "body", None)
+    if is_dataclass(obj) and isinstance(body, Shape):
+        candidates = {
+            f"features.{field.name}": value
+            for field in fields(obj)
+            if field.name != "body"
+            and not field.name.startswith("_")
+            and isinstance((value := getattr(obj, field.name)), Shape)
+        }
+        return _ObjectSource(
+            body,
+            f"{seam}\nfeatures = {target}\npart = features.body",
+            candidates,
+        )
+
+    raise ValueError(
+        f"{spec!r}: resolved to {type(obj).__name__}, not a build123d Shape or a dataclass "
+        "with a Shape-valued body"
+    )
+
+
+def resolve_object_spec(spec: str) -> tuple[Shape, str]:
+    """Resolve a Shape-valued object spec into ``(object, import seam)`` (#469).
+
+    Kept as the compatibility surface for callers that only need the body. The CLI uses the
+    richer private resolver so a #1041 features container can also carry named candidates.
+    """
+    source = _resolve_object_source(spec)
+    return source.part, source.seam
 
 
 def generate_sheet_script(
@@ -1390,6 +1581,7 @@ def generate_sheet_script(
     projection: str | None = None,
     pmi: str = "off",
     part_expr: str | None = None,
+    object_candidates: Mapping[str, Shape] | None = None,
     formats: Sequence[str] = ("pdf",),
 ) -> str:
     """Write a declarative ``Sheet``-DSL script for *step_file* (a STEP path or a build123d
@@ -1440,6 +1632,8 @@ def generate_sheet_script(
         zones=zones,
         projection=projection,
         object_ref=is_shape,  # a live Shape / resolved object-spec has objects to reference (#771)
+        object_candidates=object_candidates,
+        source_part=step_file if isinstance(step_file, Shape) else None,
         formats=formats,
     )
     py_path = f"{stem}.py"

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -66,7 +66,7 @@ def _candidate_external(part: Shape, candidate: Shape) -> bool | None:
         return None
     try:
         intersection = part & candidate
-        if intersection is None:
+        if not isinstance(intersection, Shape):
             return None
         overlap = abs(float(intersection.volume))
     except Exception:  # noqa: BLE001 — an unavailable Boolean means unavailable evidence

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -39,6 +39,62 @@ _SOURCE_MODULE = (
     "def needs_args(x):\n    return x\n"
 )
 
+_SOURCE_FEATURES_MODULE = """
+from dataclasses import dataclass
+from build123d import Box, Cylinder, Part, Pos
+
+@dataclass
+class Features:
+    body: Part
+    bore: Part
+
+def make_features():
+    bore = Pos(20, 10, 4) * Cylinder(4, 20)
+    return Features(body=Box(80, 50, 8) - bore, bore=bore)
+
+@dataclass
+class AmbiguousFeatures:
+    body: Part
+    bore: Part
+    duplicate: Part
+
+def make_ambiguous_features():
+    bore = Pos(20, 10, 4) * Cylinder(4, 20)
+    return AmbiguousFeatures(body=Box(80, 50, 8) - bore, bore=bore, duplicate=bore)
+
+@dataclass
+class TwoBoreFeatures:
+    body: Part
+    small: Part
+    large: Part
+
+def make_two_bore_features():
+    small = Pos(-20, 10, 4) * Cylinder(3, 20)
+    large = Pos(20, -10, 4) * Cylinder(5, 20)
+    return TwoBoreFeatures(body=Box(80, 50, 8) - small - large, small=small, large=large)
+
+@dataclass
+class ShaftFeatures:
+    body: Part
+    large_step: Part
+    small_step: Part
+
+def make_shaft_features():
+    large_step = Pos(0, 0, 5) * Cylinder(10, 10)
+    small_step = Pos(0, 0, 15) * Cylinder(6, 10)
+    return ShaftFeatures(
+        body=large_step + small_step,
+        large_step=large_step,
+        small_step=small_step,
+    )
+
+def make_offset_tool_features():
+    bore = Pos(20, 10, -6) * Cylinder(4, 20)
+    return Features(body=Box(80, 50, 8) - bore, bore=bore)
+
+features = make_features()
+"""
+
 AP242_CTC01 = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap242.stp"
 
 
@@ -994,6 +1050,11 @@ class TestObjectSpec:
         p.write_text(_SOURCE_MODULE, encoding="utf-8")
         return p
 
+    def _features_mod(self, tmp_path, name="featuremod"):
+        p = tmp_path / f"{name}.py"
+        p.write_text(_SOURCE_FEATURES_MODULE, encoding="utf-8")
+        return p
+
     def test_file_attr_resolves_object_with_self_contained_seam(self, tmp_path):
         p = self._mod(tmp_path)
         obj, seam = resolve_object_spec(f"{p}:bracket")
@@ -1014,6 +1075,274 @@ class TestObjectSpec:
         export_step(Box(60, 40, 12), str(step))
         py2 = generate_sheet_script(str(step), out=str(tmp_path / "step"))
         assert "Object-reference tip" not in Path(py2).read_text(encoding="utf-8")
+
+    def test_features_container_emits_unique_bore_reference_and_rebuilds_same_feature(
+        self, tmp_path, monkeypatch
+    ):
+        import dataclasses
+
+        from typer.testing import CliRunner
+
+        from draftwright import Drawing
+        from draftwright.cli import app
+
+        self._features_mod(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app, ["featuremod:make_features", "--script", "--out", "referenced"]
+        )
+        assert result.exit_code == 0, result.output
+        source = (tmp_path / "referenced.py").read_text(encoding="utf-8")
+        assert "features = _obj()" in source
+        assert "part = features.body" in source
+        hole_line = _feature_line_for(source, "sheet.hole(")
+        assert "sheet.hole(features.bore, depth=8)" in hole_line
+        assert "diameter=" not in hole_line and "at=" not in hole_line and "axis=" not in hole_line
+
+        captured = {}
+        monkeypatch.setattr(
+            Drawing, "export", lambda self, *a, **k: captured.setdefault("drawing", self)
+        )
+        exec(compile(source, str(tmp_path / "referenced.py"), "exec"), {})  # noqa: S102
+        rebuilt = next(f for f in captured["drawing"].model().features if f.kind == "hole")
+        original = next(
+            f
+            for f in detect_part_model(__import__("featuremod").make_features().body).features
+            if f.kind == "hole"
+        )
+        # Same exemption as the repository-wide #964 oracle: a singleton detector records its
+        # own origin as the one member, while the declared singleton uses the empty default.
+        assert _structurally_equal(dataclasses.replace(original, members=()), rebuilt)
+
+    def test_two_names_for_one_cutter_fail_closed_to_the_numeric_declaration(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        self._features_mod(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app, ["featuremod:make_ambiguous_features", "--script", "--out", "ambiguous"]
+        )
+        assert result.exit_code == 0, result.output
+        source = (tmp_path / "ambiguous.py").read_text(encoding="utf-8")
+        hole_line = _feature_line_for(source, "sheet.hole(")
+        assert "sheet.hole(diameter=8" in hole_line
+        assert "features.bore" not in hole_line and "features.duplicate" not in hole_line
+
+    def test_distinct_bores_emit_their_own_names_not_a_geometric_neighbour(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        self._features_mod(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app, ["featuremod:make_two_bore_features", "--script", "--out", "two"]
+        )
+        assert result.exit_code == 0, result.output
+        source = (tmp_path / "two.py").read_text(encoding="utf-8")
+        lines = [
+            _feature_line_for(source, "sheet.hole(features.small"),
+            _feature_line_for(source, "sheet.hole(features.large"),
+        ]
+        assert "diameter=6" not in lines[0] and "at=" not in lines[0]
+        assert "diameter=10" not in lines[1] and "at=" not in lines[1]
+
+    def test_external_step_candidates_emit_only_the_corresponding_source_object(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        self._features_mod(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app, ["featuremod:make_shaft_features", "--script", "--out", "shaft"]
+        )
+        assert result.exit_code == 0, result.output
+        source = (tmp_path / "shaft.py").read_text(encoding="utf-8")
+        assert "sheet.step(features.large_step)" in source
+        assert "sheet.step(features.small_step)" in source
+        assert "sheet.step(diameter=" not in source
+
+    def test_axially_offset_construction_tool_fails_closed_to_numeric(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        self._features_mod(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app, ["featuremod:make_offset_tool_features", "--script", "--out", "offset"]
+        )
+        assert result.exit_code == 0, result.output
+        source = (tmp_path / "offset.py").read_text(encoding="utf-8")
+        hole_line = _feature_line_for(source, "sheet.hole(")
+        assert "sheet.hole(diameter=8" in hole_line
+        assert "features.bore" not in hole_line
+
+    def test_candidate_polarity_requires_wholly_present_or_wholly_absent_material(self):
+        from draftwright.sheet_emit import _candidate_external
+
+        candidate = Cylinder(4, 20)
+        containing = Box(40, 40, 40)
+        removed = containing - candidate
+        partial = Pos(0, 0, 15) * Box(40, 40, 40)
+        assert _candidate_external(containing, candidate) is True
+        assert _candidate_external(removed, candidate) is False
+        assert _candidate_external(partial, candidate) is None
+
+    def test_candidate_polarity_fails_closed_when_volume_or_boolean_evidence_is_unavailable(
+        self,
+    ):
+        from types import SimpleNamespace
+
+        from build123d import Edge
+
+        from draftwright.sheet_emit import _candidate_external
+
+        assert _candidate_external(Box(10, 10, 10), Edge.make_line((0, 0, 0), (1, 0, 0))) is None
+
+        candidate = SimpleNamespace(volume=1.0)
+
+        class NoIntersection:
+            def __and__(self, _other):
+                return None
+
+        assert _candidate_external(NoIntersection(), candidate) is None
+        assert _candidate_external(Box(10, 10, 10), candidate) is None
+
+    def test_reference_rejects_a_grouped_hole_and_a_nearby_wrong_diameter(self):
+        from types import SimpleNamespace
+
+        from draftwright.sheet_emit import _reference_geometry_matches
+
+        candidate = Cylinder(4, 20)
+        frame = SimpleNamespace(origin=(0.0, 0.0, 0.0), axis="z")
+        grouped = SimpleNamespace(kind="hole", profile=None, count=4, diameter=8.0, frame=frame)
+        wrong_diameter = SimpleNamespace(
+            kind="hole", profile=None, count=1, diameter=8.1, frame=frame
+        )
+        exact = SimpleNamespace(kind="hole", profile=None, count=1, diameter=8.0, frame=frame)
+        assert _reference_geometry_matches(grouped, candidate) is False
+        assert _reference_geometry_matches(wrong_diameter, candidate) is False
+        assert _reference_geometry_matches(exact, candidate) is True
+
+    def test_reference_geometry_mutations_reject_wrong_kind_profile_axis_position_and_length(
+        self,
+    ):
+        from dataclasses import replace
+        from types import SimpleNamespace
+
+        from draftwright.model import Frame, HoleFeature, StepFeature
+        from draftwright.sheet_emit import _reference_geometry_matches
+
+        candidate = Cylinder(4, 20)
+        exact_hole = HoleFeature(
+            frame=Frame((0.0, 0.0, 0.0), "z"), diameter=8.0, depth=None, through=True
+        )
+        mutations = [
+            SimpleNamespace(kind="slot"),
+            SimpleNamespace(
+                kind="hole",
+                profile="double_d",
+                count=1,
+                diameter=8.0,
+                frame=exact_hole.frame,
+            ),
+            replace(exact_hole, frame=Frame((0.0, 0.0, 0.0), "x")),
+            replace(exact_hole, frame=Frame((1.0, 0.0, 0.0), "z")),
+            replace(exact_hole, frame=Frame((0.0, 0.0, 1.0), "z")),
+            replace(exact_hole, diameter=8.5),
+            StepFeature(
+                frame=Frame((0.0, 0.0, 0.0), "z"),
+                diameter=8.0,
+                length=19.0,
+                span=((0.0, 0.0, -9.5), (0.0, 0.0, 9.5)),
+            ),
+        ]
+        assert _reference_geometry_matches(exact_hole, candidate) is True
+        assert all(
+            _reference_geometry_matches(mutation, candidate) is False for mutation in mutations
+        )
+
+    def test_unreadable_candidate_and_boss_height_guard_fail_closed(self, monkeypatch):
+        from draftwright.model import BossFeature, Frame
+        from draftwright.sheet_emit import _feature_line, _reference_geometry_matches
+
+        candidate = Cylinder(4, 20)
+        exact = BossFeature(
+            frame=Frame((0.0, 0.0, 0.0), "z"), diameter=8.0, height=20.0, thread="M8"
+        )
+        assert _reference_geometry_matches(exact, candidate) is True
+        assert (
+            _reference_geometry_matches(
+                BossFeature(frame=exact.frame, diameter=8.0, height=19.0), candidate
+            )
+            is False
+        )
+        assert _feature_line(exact, object_ref="features.boss") == (
+            "sheet.diameter(features.boss, thread='M8')"
+        )
+
+        monkeypatch.setattr(
+            "draftwright.model.declare._read_cylinder",
+            lambda _candidate: (_ for _ in ()).throw(ValueError("not cylindrical")),
+        )
+        assert _reference_geometry_matches(exact, candidate) is False
+
+    def test_reference_graph_skips_unknown_kinds_and_wrong_polarity(self):
+        from types import SimpleNamespace
+
+        from draftwright.model import Frame, HoleFeature
+        from draftwright.sheet_emit import _object_references
+
+        candidate = Cylinder(4, 20)
+        body = Box(40, 40, 20) + candidate
+        hole = HoleFeature(
+            frame=Frame((0.0, 0.0, 0.0), "z"), diameter=8.0, depth=None, through=True
+        )
+        assert (
+            _object_references(
+                [SimpleNamespace(kind=None), hole], body, {"features.bore": candidate}
+            )
+            == {}
+        )
+
+    def test_one_candidate_matching_two_features_is_not_assigned_to_either(self):
+        from dataclasses import replace
+
+        from draftwright.model import Frame, HoleFeature
+        from draftwright.sheet_emit import _object_references
+
+        candidate = Cylinder(4, 20)
+        body = Box(40, 40, 20) - candidate
+        first = HoleFeature(
+            frame=Frame((0.0, 0.0, 0.0), "z"), diameter=8.0, depth=None, through=True
+        )
+        second = replace(first)
+        assert _object_references([first, second], body, {"features.bore": candidate}) == {}
+
+    def test_already_built_features_container_binds_without_calling_it(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from draftwright.cli import app
+
+        self._features_mod(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(app, ["featuremod:features", "--script", "--out", "built"])
+        assert result.exit_code == 0, result.output
+        source = (tmp_path / "built.py").read_text(encoding="utf-8")
+        assert "features = _obj\npart = features.body" in source
+        assert "features = _obj()" not in source
 
     def test_zero_arg_factory_is_called(self, tmp_path):
         p = self._mod(tmp_path)


### PR DESCRIPTION
Fixes #1041

## What changed

- accept a live features dataclass with a Shape-valued `body` and public named Shape fields
- emit named references for cylindrical holes, bosses, and steps only when polarity, exact reconstruction, and mutual one-to-one correspondence are independently established
- retain complete numeric declarations for ambiguous, partial, offset, grouped, unsupported, or otherwise unavailable correspondence
- document the fail-closed contract in ADR 0011 and the object-reference workflow

## Why

Generated scripts previously restated detected dimensions even when the caller supplied the original named build123d objects. This preserves trustworthy source identity where it survives without inventing geometry or substituting a plausible-but-wrong name.

## Validation

- `scripts/pr-check --static`
- `scripts/pr-check --full`
- 3,144 passed, 4 skipped, 2 xfailed
- 100% diff coverage for changed executable lines
