### PR TITLE
Bump version to 0.4.3.dev0 after v0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.2.dev0"
+version = "0.4.3.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -693,7 +693,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.2.dev0"
+version = "0.4.3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Summary

- restore development version metadata to `0.4.3.dev0` after the verified v0.4.2 release
- update only `pyproject.toml` and the root package entry in `uv.lock`
- recover through branch protection after the release workflow's direct push was correctly rejected

## Validation

- `git diff --check`
- `uv lock --check`
- exact diff reviewed: two version lines only

Release and registry evidence are tracked in #1110.

Closes #1110
