### PR TITLE
Prevent cross-body slot and pocket patterns

### DIFF
--- a/src/draftwright/recognition/slots.py
+++ b/src/draftwright/recognition/slots.py
@@ -33,6 +33,7 @@ recess rather than some other facing-wall feature with three predicates a naive
 from __future__ import annotations
 
 import math
+from collections import Counter
 from dataclasses import dataclass, replace
 from types import SimpleNamespace
 from typing import TypeVar
@@ -92,6 +93,11 @@ class Slot(Record):
     hi: float
     d_lo: float
     d_hi: float
+    # Geometry-derived identity of the physical solid that supplied this record.  A compound
+    # must not turn equal features on separate bodies into one manufacturing pattern (#1073).
+    # The empty tuple preserves hand-built record compatibility. ``None`` is reserved for
+    # unavailable/ambiguous recognised provenance and is ineligible for pattern grouping.
+    body_key: tuple[float, ...] | None = ()
 
     @property
     def depth_axis(self) -> str:
@@ -177,6 +183,8 @@ class Pocket(Record):
     # A corner interruption touches two adjacent envelope edges, so its in-plane
     # location is implicit and no centre-location dimensions are required (#897).
     edge_anchored: bool = False
+    # See Slot.body_key.  Appended after the existing defaults to preserve positional callers.
+    body_key: tuple[float, ...] | None = ()
 
     @property
     def depth_axis(self) -> str:
@@ -803,6 +811,38 @@ def _recognise_slots_one(part) -> list[Slot]:
     return _extend_obround_ends(_collapse_collinear(_merge(candidates), part), part)
 
 
+def _body_signature(solid) -> tuple[float, ...]:
+    """Exact geometry-derived correspondence key for one physical solid.
+
+    Position, envelope, volume, and area are independent of compound traversal order.  The key
+    is deliberately not a traversal index or an OCP object/hash, so it remains serializable under
+    ADR 0013.  Callers treat duplicate signatures across separate solids as ambiguous and fail
+    closed rather than using the signature as proof of shared ownership.
+    """
+    bb = solid.bounding_box()
+    return (
+        float(bb.min.X),
+        float(bb.min.Y),
+        float(bb.min.Z),
+        float(bb.max.X),
+        float(bb.max.Y),
+        float(bb.max.Z),
+        float(solid.volume),
+        float(solid.area),
+    )
+
+
+def _body_scoped_records(sources, recognise_one):
+    """Recognise each source and attach unambiguous body correspondence."""
+    signatures = [_body_signature(solid) for solid in sources]
+    counts = Counter(signatures)
+    return [
+        replace(record, body_key=signature if counts[signature] == 1 else None)
+        for solid, signature in zip(sources, signatures, strict=True)
+        for record in recognise_one(solid)
+    ]
+
+
 def recognise_slots(part) -> list[Slot]:
     """Recognise enclosed through-slots independently within each solid in *part*.
 
@@ -817,7 +857,7 @@ def recognise_slots(part) -> list[Slot]:
     """
     solids = list(part.solids())
     sources = solids if len(solids) > 1 else [part]
-    slots = [slot for solid in sources for slot in _recognise_slots_one(solid)]
+    slots = _body_scoped_records(sources, _recognise_slots_one)
     return sorted(slots, key=lambda slot: (slot.width, _region_center(slot)))
 
 
@@ -1110,7 +1150,7 @@ def recognise_pockets(part) -> list[Pocket]:
     """
     solids = list(part.solids())
     sources = solids if len(solids) > 1 else [part]
-    pockets = [pocket for solid in sources for pocket in _recognise_pockets_one(solid)]
+    pockets = _body_scoped_records(sources, _recognise_pockets_one)
     return sorted(pockets, key=lambda pocket: (pocket.width, _region_center(pocket)))
 
 
@@ -1267,6 +1307,7 @@ def _pocket_spec_key(pk: Pocket) -> tuple:
         round(pk.d_hi, 3),
         pk.open_sign,  # opposite-facing pockets sharing a depth range are on different faces
         pk.edge_anchored,  # implicit-location corner recesses are a distinct feature class
+        pk.body_key,
     )
 
 
@@ -1307,6 +1348,8 @@ def recognise_pocket_patterns(pockets) -> list[PocketArray | PocketGrid]:
     axis_unit = {"x": (1.0, 0.0, 0.0), "y": (0.0, 1.0, 0.0), "z": (0.0, 0.0, 1.0)}
     groups: dict = {}
     for pk in pockets:
+        if pk.body_key is None:
+            continue  # ambiguous physical ownership cannot authorise a pattern
         groups.setdefault(_pocket_spec_key(pk), []).append(pk)
 
     patterns: list[PocketArray | PocketGrid] = []
@@ -1351,6 +1394,7 @@ def _slot_spec_key(sl: Slot) -> tuple:
         round(sl.length, 3),
         round(sl.d_lo, 3),
         round(sl.d_hi, 3),
+        sl.body_key,
     )
 
 
@@ -1390,6 +1434,8 @@ def recognise_slot_patterns(slots) -> list[SlotArray | SlotGrid]:
     axis_unit = {"x": (1.0, 0.0, 0.0), "y": (0.0, 1.0, 0.0), "z": (0.0, 0.0, 1.0)}
     groups: dict = {}
     for sl in slots:
+        if sl.body_key is None:
+            continue  # ambiguous physical ownership cannot authorise a pattern
         groups.setdefault(_slot_spec_key(sl), []).append(sl)
 
     patterns: list[SlotArray | SlotGrid] = []

--- a/tests/test_issue_1073_cross_body_patterns.py
+++ b/tests/test_issue_1073_cross_body_patterns.py
@@ -1,0 +1,95 @@
+"""#1073: derived patterns preserve physical-body ownership."""
+
+from dataclasses import replace
+
+from build123d import Box, Compound, Pos
+
+from draftwright.model.detect import build_part_model
+from draftwright.recognition import (
+    recognise_pocket_patterns,
+    recognise_pockets,
+    recognise_slot_patterns,
+    recognise_slots,
+)
+
+
+def _separate_bodies(feature):
+    return Compound(children=[Pos(0, y, 0) * feature for y in (0, 60, 120)])
+
+
+def _slotted_body():
+    return Box(60, 30, 10) - Box(30, 8, 20)
+
+
+def _pocketed_body():
+    return Box(60, 30, 20) - Pos(0, 0, 7) * Box(30, 8, 6)
+
+
+def test_separate_body_slots_do_not_form_one_pattern():
+    slots = recognise_slots(_separate_bodies(_slotted_body()))
+
+    assert len(slots) == 3
+    assert len({slot.body_key for slot in slots}) == 3
+    assert recognise_slot_patterns(slots) == []
+
+    # Targeted mutation: discarding the owning-body evidence recreates the false array.
+    assert len(recognise_slot_patterns([replace(slot, body_key=()) for slot in slots])) == 1
+
+
+def test_separate_body_pockets_do_not_form_one_pattern():
+    pockets = recognise_pockets(_separate_bodies(_pocketed_body()))
+
+    assert len(pockets) == 3
+    assert len({pocket.body_key for pocket in pockets}) == 3
+    assert recognise_pocket_patterns(pockets) == []
+
+    # Targeted mutation: discarding the owning-body evidence recreates the false array.
+    assert len(recognise_pocket_patterns([replace(pk, body_key=()) for pk in pockets])) == 1
+
+
+def test_real_patterns_within_one_body_still_group():
+    slotted = Box(60, 150, 10)
+    pocketed = Box(60, 150, 20)
+    for y in (-30, 0, 30):
+        slotted -= Pos(0, y, 0) * Box(30, 8, 20)
+        pocketed -= Pos(0, y, 7) * Box(30, 8, 6)
+
+    slots = recognise_slots(slotted)
+    pockets = recognise_pockets(pocketed)
+    assert len({slot.body_key for slot in slots}) == 1
+    assert len({pocket.body_key for pocket in pockets}) == 1
+    assert len(recognise_slot_patterns(slots)) == 1
+    assert len(recognise_pocket_patterns(pockets)) == 1
+
+
+def test_aggregate_model_keeps_cross_body_members_independent():
+    slotted = build_part_model(_separate_bodies(_slotted_body()))
+    pocketed = build_part_model(_separate_bodies(_pocketed_body()))
+
+    assert [feature.kind for feature in slotted.features].count("slot") == 3
+    assert [feature.kind for feature in slotted.features].count("slot_pattern") == 0
+    assert [feature.kind for feature in pocketed.features].count("pocket") == 3
+    assert [feature.kind for feature in pocketed.features].count("pocket_pattern") == 0
+
+
+def test_compound_traversal_order_does_not_change_body_correspondence():
+    body = _slotted_body()
+    forward = Compound(children=[Pos(0, y, 0) * body for y in (0, 60, 120)])
+    reverse = Compound(children=[Pos(0, y, 0) * body for y in (120, 60, 0)])
+
+    assert recognise_slots(forward) == recognise_slots(reverse)
+    assert recognise_slot_patterns(recognise_slots(forward)) == []
+    assert recognise_slot_patterns(recognise_slots(reverse)) == []
+
+
+def test_ambiguous_body_signature_fails_closed(monkeypatch):
+    from draftwright.recognition import slots as slots_module
+
+    monkeypatch.setattr(slots_module, "_body_signature", lambda _solid: (1.0,))
+    slots = recognise_slots(_separate_bodies(_slotted_body()))
+    pockets = recognise_pockets(_separate_bodies(_pocketed_body()))
+
+    assert len(slots) == 3 and all(slot.body_key is None for slot in slots)
+    assert len(pockets) == 3 and all(pocket.body_key is None for pocket in pockets)
+    assert recognise_slot_patterns(slots) == []
+    assert recognise_pocket_patterns(pockets) == []


### PR DESCRIPTION
Closes #1073

## What changed

- preserve physical-body ownership on recognised slot and pocket records using a serializable geometry-derived key
- include that ownership in derived-pattern grouping
- fail closed when body correspondence is ambiguous
- add adversarial regression tests for slots, pockets, mutations, traversal order, aggregate output, and signature collisions

## Root cause and impact

Pattern recognition grouped matching feature specifications across an entire compound without retaining which physical solid supplied each record. Independently manufactured bodies could therefore be reported as one slot or pocket pattern. The new correspondence guard prevents that false manufacturing claim while retaining real patterns within one body.

## Validation

- `scripts/pr-check --full`: 3,151 passed, 4 skipped, 2 xfailed
- total coverage 94.33%; diff coverage 100%
- focused recognition and aggregate tests: 39 passed
- Ruff, formatting, mypy, docs, and `git diff --check` passed

The slow tier was not run because this is confined to the fast pure-recognition path and the affected aggregate path is covered directly.