### PR TITLE
Parallelize individual slow tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,4 +150,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
       - name: Run slow tests
-        run: uv run pytest tests/ -m slow -n auto --dist loadscope
+        # Slow cases isolate their outputs with tmp_path and carry no cross-test ordering
+        # contract. Distribute individual cases: loadscope serialized the 18-case standards
+        # module and left most workers idle (#1108).
+        run: uv run pytest tests/ -m slow -n auto --dist load

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -56,6 +56,14 @@ def test_main_runs_static_and_slow_gates_without_repeating_fast_matrix():
     assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
 
 
+def test_slow_gate_distributes_individual_cases_instead_of_serialising_modules():
+    slow_job = _job(_workflow("ci.yml"), "test-slow")
+
+    assert re.findall(r"run: (uv run pytest tests/ -m slow[^\n]*)", slow_job) == [
+        "uv run pytest tests/ -m slow -n auto --dist load"
+    ]
+
+
 def test_testpypi_snapshot_build_and_publish_share_one_job():
     workflow = _workflow("publish.yml")
     snapshot = _job(workflow, "publish-testpypi")


### PR DESCRIPTION
Closes #1108

## What changed

- distribute individual slow cases with xdist `load` instead of grouping the dominant module under `loadscope`
- document the isolation/ordering basis beside the workflow command
- add a focused executable guard that rejects a return to module serialization

## Evidence and impact

The slow inventory has 21 cases, 18 in one standards module. On the 18-worker benchmark machine, `loadscope` took 506.29s. Individual-case `load` took 138.81s and 133.32s in repeat runs—a roughly 73% reduction—with all 21 tests passing. Reported max RSS was 848MB for baseline versus 793–794MB for `load`.

`worksteal` also passed twice at 133.30s and 129.13s, but its roughly 4% advantage was not material enough to prefer a more dynamic scheduler. Slow outputs use per-test temporary paths, remaining fixture builds are read-only, and no cross-test ordering contract was found.

## Validation

- slow `loadscope`: 21 passed
- slow `load`: 21 passed twice
- slow `worksteal`: 21 passed twice
- `scripts/pr-check --full`: 3,151 passed, 4 skipped, 2 xfailed; 94.33% coverage
- focused workflow guard: 4 passed
- Ruff, formatting, mypy, codespell, strict docs, and `git diff --check` passed

The slow workflow remains post-merge-only; this changes neither PR triggers nor compatibility-matrix breadth.