### PR TITLE
Document the v0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+## v0.4.3 — 2026-08-09
+
+**A trust and validation-throughput patch release.** Whole-part hexagonal stock now receives its
+manufacturing definition, assembly recognition no longer combines evidence across bodies, and
+performance validation is both more stable and faster to run.
+
+### Added
+
+- **Whole-part regular hexagonal stock is recognised independently of an attached boss and
+  dimensioned as `HEX … A/F` plus its axial length** (#1082). In-plane rotation preserves the
+  geometric across-flats size instead of substituting an orientation-dependent bounding-box
+  width. Automatic and declared paths share the same compiler and placement machinery, while
+  completeness lint distinguishes placed, authored-suppressed, dropped, missing, and ambiguous
+  outcomes.
+
+### Fixed
+
+- **Slot and pocket patterns cannot group members from separate assembly bodies** (#1073).
+  Recognition carries solid ownership through grouping and fails closed when ownership is
+  unavailable, preventing plausible-looking phantom patterns across disconnected parts.
+
+- **The annotation-obstacle performance guard uses deterministic work-count evidence instead of
+  a wall-clock threshold** (#1071). The regression test remains load-bearing under mutation but
+  no longer flakes because of machine load or suite ordering.
+
+### Changed
+
+- **The post-merge slow tier distributes individual tests across workers** (#1108), using
+  `pytest-xdist`'s load scheduling after local benchmark evidence showed a material speed-up
+  without weakening fixture coverage. Hosted slow validation remains the single post-merge gate.
+
 ## v0.4.2 — 2026-08-09
 
 **The trustworthy manufacturing drawings release.** AP242 PMI is now accounted for from its


### PR DESCRIPTION
## Summary

- reconcile every commit since v0.4.2 into a user-facing v0.4.3 changelog
- document whole-part polygonal-stock definition, cross-body pattern isolation, deterministic performance guarding, and finer-grained post-merge slow-test distribution
- keep release preparation changelog-only; the existing trusted-publish workflow normalises `0.4.3.dev0` when the GitHub release is published

## Commit audit

- assembly recognition correctness: #1073
- deterministic local performance guard: #1071
- slow-tier distribution and validation throughput: #1108
- whole-part polygonal-stock manufacturing definition and completeness: #1082
- post-v0.4.2 version metadata and merge bookkeeping require no separate user-facing entry

## Compatibility

This is patch-compatible: it adds an opt-in/public polygonal-stock feature contract, corrects false cross-body grouping, and changes validation behavior only. There are no removals or incompatible signature changes. Automatic drawing output changes only where prior output was incomplete or represented a false assembly-level pattern.

## Validation

- `scripts/pr-check --static`
- `scripts/pr-check --full`: 3,186 passed, 4 skipped, 2 xfailed; 94.34% coverage
- `uv run pytest tests/ -m slow -n auto --dist load`: 21 passed in 161.40s
- `git diff --check`

The GitHub release, trusted PyPI publication, fresh-registry smoke test, and protected-branch-compliant `0.4.4.dev0` recovery remain tracked by #1119 after this PR merges.

Refs #1119