### PR TITLE
Bump version to 0.4.4.dev0 after v0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.3.dev0"
+version = "0.4.4.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -693,7 +693,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.3.dev0"
+version = "0.4.4.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Summary

- restore development version metadata to `0.4.4.dev0` after the verified v0.4.3 release
- update only `pyproject.toml` and the root package entry in `uv.lock`
- recover through branch protection after the release workflow correctly rejected its direct push

## Release evidence

- GitHub release v0.4.3 published from audited main commit `8bc1286328ae79da292bee5d4582be9a48c7b8ff`
- trusted PyPI publication succeeded
- a fresh isolated Python 3.12 environment installed exactly `draftwright==0.4.3` from PyPI and completed a real drawing build

## Validation

- `scripts/pr-check --static`
- `uv build`: sdist and wheel built as `0.4.4.dev0`
- installed metadata reports `0.4.4.dev0`
- `uv lock --check`
- `git diff --check`
- exact diff reviewed: two version lines only

Closes #1119