### PR TITLE
Productionise repeating radial profile evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,10 @@ entry. Keep `_LAYERS` and this section in step.
   (`_suggest_fix`, #29 snippets). Depends only on `_core`,
   `recognition/` (typed hole records in `coverage.py`) + build123d_drafting. `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
+- **`recognition/repeating_profiles.py`** — geometry-only complete-wire cyclic
+  correspondence for declared-gear critique (#1087). It proves closed, bijective sector
+  mappings and carries only axis/centre/span/count plus a serialisable sector signature;
+  it never infers gear semantics.
 - **`model/`** — the ADR 0015 IR waist: `ir.py` (the `Feature`/`DimParameter`/
   `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
   `Feature` objects, adapting `recognition/`), `planner.py` (`plan_dimensions` —

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -150,7 +150,7 @@ still computes a group that these passes do not consume):
   requirement record, not a collection of independently placeable dimensions. The
   post-ISO-fit renderer places its complete standards table through `Drawing.add_table()`'s
   solver-owned late-furniture path. Physical lint independently reconciles the placed table
-  snapshot and, when available, geometry-only repeating-profile evidence (#1086/#1087).
+  snapshot and geometry-only repeating-profile evidence (#1086/#1087).
 
 **Why the split matters:** the planner is where authored decorations fold onto
 dimension parameters and where dimension-level convention and suppression

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -340,6 +340,8 @@ completeness slice. The remaining abstractions are evaluated separately after Ga
 - [x] Classification-gated families are owned but skipped for inapplicable part classes.
 - [x] A counterexample/mutation fails when the cache, gate, manifest, or shared-evidence contract
   it protects is broken.
+- [x] Complete-wire repeating radial-profile evidence is scanned once by the orchestration;
+  declared-gear critique projects axis/count correspondence from it without rescanning (#1087).
 
 These guards accept the narrowed ADR. The former acceptance list for typed identities, shared
 requirements, general outcomes, reconciliation, and diagnostics belongs to the evidence-gated

--- a/docs/reference/external-spur-gears.md
+++ b/docs/reference/external-spur-gears.md
@@ -72,9 +72,13 @@ Completeness lint therefore distinguishes:
 - a tooth/repeat-count disagreement (`gear_repeat_count_mismatch`);
 - missing, ambiguous, or stale table output (`gear_requirement_*`).
 
-Issue #1087 supplies the production full-wire repeating-profile evidence. Until that producer is
-present, a declared gear stays explicitly unverifiable under physical lint, and cyclic-looking
-geometry retains `unrecognised_defining_geometry`.
+The recognition run proves repeating-profile evidence from every edge of two opposed closed
+outer wires. It requires a bijective sector mapping and carries a traversal/phase-neutral curve
+signature; common-circle arcs alone cannot certify the profile. Lint then corresponds a declared
+target by centre and axial span before checking axis and count. Missing, ambiguous, incomplete,
+or unequal evidence stays explicitly unverifiable. A proved cyclic profile still retains
+`unrecognised_defining_geometry`: geometry evidence does not manufacture gear semantics or a
+complete manufacturing definition.
 
 ## Out of scope
 

--- a/docs/research/1062-repeating-radial-profile-evidence.md
+++ b/docs/research/1062-repeating-radial-profile-evidence.md
@@ -1,8 +1,8 @@
 # Repeating Radial Profile Evidence (#1062)
 
-> **Status:** discovery decision, 2026-08-07. The executable evidence is in
-> `tests/test_issue_1058_wheel_profile.py`. No automatic gear semantics are approved by
-> this note.
+> **Status:** productionised by #1087, 2026-08-09. The executable mutations remain in
+> `tests/test_issue_1058_wheel_profile.py`; the reusable evidence is owned by
+> `recognition/repeating_profiles.py`. No automatic gear semantics are approved by this note.
 
 ## Decision
 
@@ -91,10 +91,9 @@ No ADR amendment is required. No placement decision is made, so ADR 0014 is unaf
 
 ## Follow-up Slices
 
-1. **Productionise repeating-profile evidence when a consumer is ready.** Extract the pure
-   full-wire correspondence into recognition, add it to the one orchestration, and use it for
-   physical critique and declared-profile correspondence. Do not clear completeness merely
-   because the repeat exists.
+1. **Productionised in #1087.** The pure full-wire correspondence is owned by the one
+   recognition orchestration and consumed by physical critique for declared-profile
+   correspondence. It does not clear completeness merely because the repeat exists.
 2. **Design declared gear requirements.** Start from the applicable drawing/gear standards
    and define the minimum honest declaration, validation, IR, and table/callout output. Include
    a mismatch diagnostic when declared count or axis disagrees with geometric evidence.

--- a/src/draftwright/linting/gear_coverage.py
+++ b/src/draftwright/linting/gear_coverage.py
@@ -65,9 +65,9 @@ def lint_declared_gear_coverage(
 ) -> list[LintIssue]:
     """Reconcile authored gear requirements with tables and independent profile facts.
 
-    ``profiles=None`` means that the production full-wire evidence source is not available
-    yet; an empty tuple means it ran and proved no repeating profile.  The distinction keeps
-    #1086 fail-closed while #1087 installs the geometry-only producer.
+    ``profiles=None`` means that the run did not supply the production evidence inventory;
+    an empty tuple means it ran and proved no repeating profile.  Both states remain
+    fail-closed rather than treating unavailable geometry as correspondence.
     """
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     gears = [f for f in features if getattr(f, "kind", None) == "external_spur_gear"]
@@ -113,8 +113,8 @@ def lint_declared_gear_coverage(
                     severity=severity,
                     code="gear_correspondence_unverifiable",
                     message=(
-                        "declared gear requirements cannot yet be reconciled to independently "
-                        "proved full-wire repeating-profile evidence"
+                        "declared gear requirements could not be reconciled because the run "
+                        "did not supply full-wire repeating-profile evidence"
                     ),
                 )
             )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -73,6 +73,7 @@ from draftwright.recognition import (
     PolygonalStock,
     RaisedPad,
     RectGrid,
+    RepeatingRadialProfile,
     RiserEvidence,
     Slot,
     SlotArray,
@@ -687,14 +688,18 @@ _DERIVED_CONVERTERS: dict[type, Callable[..., Feature]] = {
     SlotGrid: _slot_pattern_feature,
 }
 
-# Tier 3 — orchestrated records: no per-record converter, by design. Each is either a
-# nested sub-record or aggregated into a single furniture feature; the reason is the
-# residual scope ADR 0013 Phase 1 explicitly accepts.
+# Tier 3 — orchestrated/evidence records: no per-record converter, by design. Each is a
+# nested sub-record, aggregated into a correlated feature, or retained solely as independent
+# physical evidence; the reason is the residual scope ADR 0013 Phase 1 explicitly accepts.
 _ORCHESTRATED_RECORDS: dict[type, str] = {
     CounterSink: "a nested sub-record of HoleRecord — rides on the hole callout, never a top-level feature",
     FaceLevel: "aggregated into a single StepLevelFeature step ladder (one feature per part, not per level)",
     StepShoulder: "aggregated into StepLevelFeature.shoulders (in-plane step positions, not a standalone feature)",
     RiserEvidence: "pre-projection evidence (#1025) — projected to StepShoulder per consumer, never converted directly",
+    RepeatingRadialProfile: (
+        "geometry-only critique evidence (#1087) — validates a separately authored gear "
+        "declaration and must never become an inferred IR feature"
+    ),
 }
 
 

--- a/src/draftwright/recognition/__init__.py
+++ b/src/draftwright/recognition/__init__.py
@@ -108,6 +108,10 @@ from draftwright.recognition.polygonal_bosses import (
     recognise_polygonal_stock,
 )
 from draftwright.recognition.profiled_bores import DoubleDBore, recognise_double_d_bores
+from draftwright.recognition.repeating_profiles import (
+    RepeatingRadialProfile,
+    recognise_repeating_radial_profiles,
+)
 from draftwright.recognition.result import RecognitionResult, build_recognition_result
 from draftwright.recognition.slots import (
     Channel,
@@ -147,6 +151,7 @@ __all__ = [
     "PolygonalBoss",
     "PolygonalStock",
     "RaisedPad",
+    "RepeatingRadialProfile",
     "RectGrid",
     "Slot",
     "SlotArray",
@@ -185,6 +190,7 @@ __all__ = [
     "recognise_polygonal_bosses",
     "recognise_polygonal_stock",
     "recognise_rectangular_pads",
+    "recognise_repeating_radial_profiles",
     "recognise_slot_patterns",
     "recognise_slots",
     "recognise_turned_steps",

--- a/src/draftwright/recognition/repeating_profiles.py
+++ b/src/draftwright/recognition/repeating_profiles.py
@@ -1,0 +1,393 @@
+"""Geometry-only evidence for complete repeating radial boundary profiles (#1087).
+
+The recogniser proves cyclic correspondence over every edge of two opposed outer wires.  It
+does not attach gear semantics to the result: module, pressure angle, tooth form, quality and
+manufacturing intent remain authored requirements.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import atan2, cos, hypot, pi, sin
+
+from build123d import GeomType
+
+from draftwright.recognition._record import Record
+from draftwright.recognition.profiled_bores import principal_boundary_plane
+
+_SAMPLES_PER_CURVE = 9
+# The only production consumer supports declarations with z >= 5. Lower-order symmetry has
+# no correspondence consumer and would make ordinary prismatic stock enter this inventory.
+_MIN_REPEAT_COUNT = 5
+
+
+@dataclass(frozen=True, order=True)
+class RepeatingRadialProfile(Record):
+    """A complete physical profile proved invariant under one sector rotation.
+
+    ``sector_signature`` is a traversal- and phase-neutral inventory of the curves in one
+    sector.  Each entry carries the curve kind, length and sampled polar shape.  It is evidence
+    that the repeat count came from the complete wire rather than a tip-arc proxy; consumers
+    still correspond the physical occurrence by ``axis``, ``centre`` and ``span``.
+    """
+
+    axis: str
+    centre: tuple[float, float, float]
+    span: tuple[float, float]
+    repeat_count: int
+    edge_count: int
+    sector_signature: tuple[tuple[str, float, tuple[tuple[float, float], ...]], ...]
+
+
+@dataclass(frozen=True)
+class _CurveEvidence:
+    kind: str
+    length: float
+    points: tuple[tuple[float, float], ...]
+
+
+@dataclass(frozen=True)
+class _BoundaryEvidence:
+    axis: str
+    at: float
+    plane_axes: tuple[str, str]
+    centre: tuple[float, float]
+    repeat_count: int
+    edges: tuple[_CurveEvidence, ...]
+    orbits: tuple[tuple[int, ...], ...]
+
+
+def _distance(left: tuple[float, float], right: tuple[float, float]) -> float:
+    return hypot(left[0] - right[0], left[1] - right[1])
+
+
+def _one_closed_cycle(edges: tuple[_CurveEvidence, ...], *, tol: float) -> bool:
+    """Require one connected degree-two endpoint graph, independent of traversal order."""
+    if not edges:
+        return False
+    nodes: list[tuple[float, float]] = []
+    incident: list[list[int]] = []
+    edge_nodes: list[tuple[int, int]] = []
+    for edge_index, edge in enumerate(edges):
+        endpoints: list[int] = []
+        for point in (edge.points[0], edge.points[-1]):
+            matches = [index for index, node in enumerate(nodes) if _distance(point, node) <= tol]
+            if len(matches) > 1:
+                return False
+            if matches:
+                node_index = matches[0]
+            else:
+                node_index = len(nodes)
+                nodes.append(point)
+                incident.append([])
+            incident[node_index].append(edge_index)
+            endpoints.append(node_index)
+        if endpoints[0] == endpoints[1]:
+            return False
+        edge_nodes.append((endpoints[0], endpoints[1]))
+    if any(len(edge_ids) != 2 for edge_ids in incident):
+        return False
+
+    reached: set[int] = set()
+    frontier = [0]
+    while frontier:
+        edge_index = frontier.pop()
+        if edge_index in reached:
+            continue
+        reached.add(edge_index)
+        frontier.extend(
+            neighbour
+            for node_index in edge_nodes[edge_index]
+            for neighbour in incident[node_index]
+            if neighbour not in reached
+        )
+    return len(reached) == len(edges)
+
+
+def _rotate(
+    point: tuple[float, float], angle: float, centre: tuple[float, float]
+) -> tuple[float, float]:
+    x, y = point[0] - centre[0], point[1] - centre[1]
+    return (
+        centre[0] + x * cos(angle) - y * sin(angle),
+        centre[1] + x * sin(angle) + y * cos(angle),
+    )
+
+
+def _curves_match(
+    source: _CurveEvidence,
+    target: _CurveEvidence,
+    *,
+    angle: float,
+    centre: tuple[float, float],
+    tol: float,
+) -> bool:
+    if source.kind != target.kind or abs(source.length - target.length) > tol:
+        return False
+    rotated = tuple(_rotate(point, angle, centre) for point in source.points)
+    return any(
+        max(_distance(left, right) for left, right in zip(rotated, candidate, strict=True)) <= tol
+        for candidate in (target.points, tuple(reversed(target.points)))
+    )
+
+
+def _cyclic_edge_orbits(
+    edges: tuple[_CurveEvidence, ...],
+    *,
+    centre: tuple[float, float],
+    repeat_count: int,
+    tol: float,
+) -> tuple[tuple[int, ...], ...] | None:
+    """Prove a bijective complete-wire mapping under one sector rotation."""
+    if (
+        len(edges) <= repeat_count
+        or len(edges) % repeat_count
+        or not _one_closed_cycle(edges, tol=tol)
+    ):
+        return None
+    angle = 2 * pi / repeat_count
+    mapping: list[int] = []
+    for edge in edges:
+        matches = [
+            index
+            for index, candidate in enumerate(edges)
+            if _curves_match(edge, candidate, angle=angle, centre=centre, tol=tol)
+        ]
+        if len(matches) != 1:
+            return None
+        mapping.append(matches[0])
+    if len(set(mapping)) != len(edges):
+        return None
+
+    unseen = set(range(len(edges)))
+    orbits: list[tuple[int, ...]] = []
+    while unseen:
+        start = min(unseen)
+        orbit: list[int] = []
+        current = start
+        while current not in orbit:
+            orbit.append(current)
+            current = mapping[current]
+        if current != start or len(orbit) != repeat_count:
+            return None
+        unseen -= set(orbit)
+        orbits.append(tuple(orbit))
+    return tuple(orbits)
+
+
+def _sample_wire(wire, plane_axes: tuple[str, str]) -> tuple[_CurveEvidence, ...] | None:
+    sampled: list[_CurveEvidence] = []
+    try:
+        for edge in wire.edges():
+            points = tuple(
+                (
+                    float(getattr(point, plane_axes[0].upper())),
+                    float(getattr(point, plane_axes[1].upper())),
+                )
+                for index in range(_SAMPLES_PER_CURVE)
+                for point in (edge.position_at(index / (_SAMPLES_PER_CURVE - 1)),)
+            )
+            kind = getattr(edge.geom_type, "name", str(edge.geom_type))
+            sampled.append(_CurveEvidence(kind, float(edge.length), points))
+    except (AttributeError, RuntimeError, ValueError, ZeroDivisionError):
+        return None
+    return tuple(sampled)
+
+
+def _prove_boundary(face, bbox, *, tol: float) -> _BoundaryEvidence | None:
+    boundary = principal_boundary_plane(face, bbox)
+    if boundary is None:
+        return None
+    axis, plane_axes, at = boundary
+    wire = face.outer_wire()
+    edges = _sample_wire(wire, plane_axes)
+    # A collection of common-circle arcs is only a candidate-count proxy, never the full
+    # profile proof.  At least one intervening non-circular curve must participate.
+    if not edges or all(edge.kind == GeomType.CIRCLE.name for edge in edges):
+        return None
+    # Common-circle centres are legitimate geometric evidence for the rotation axis, but
+    # never sufficient evidence for the repeat itself.  The imported wheel's approximate
+    # spline extrema make its wire-bbox centre drift by 0.03 mm, while all 13 tip arcs carry
+    # the exact source centre.  Fall back to the bbox only when there is no unique common
+    # circle centre; the complete-wire bijection below remains the acceptance guard.
+    circle_centres: list[tuple[float, float]] = []
+    for edge in wire.edges():
+        if edge.geom_type != GeomType.CIRCLE:
+            continue
+        try:
+            circle_centres.append(
+                (
+                    float(getattr(edge.arc_center, plane_axes[0].upper())),
+                    float(getattr(edge.arc_center, plane_axes[1].upper())),
+                )
+            )
+        except (AttributeError, ValueError):
+            circle_centres = []
+            break
+    common_circle_centre: tuple[float, float] | None = None
+    if len(circle_centres) >= 2:
+        mean = (
+            sum(point[0] for point in circle_centres) / len(circle_centres),
+            sum(point[1] for point in circle_centres) / len(circle_centres),
+        )
+        if all(_distance(point, mean) <= tol for point in circle_centres):
+            common_circle_centre = mean
+    if common_circle_centre is None:
+        wbb = wire.bounding_box()
+        raw = tuple(float(getattr(wbb.center(), candidate.upper())) for candidate in plane_axes)
+        centre = (raw[0], raw[1])
+    else:
+        centre = common_circle_centre
+    candidates = (
+        count
+        for count in range(len(edges) - 1, _MIN_REPEAT_COUNT - 1, -1)
+        if len(edges) % count == 0
+    )
+    for repeat_count in candidates:
+        orbits = _cyclic_edge_orbits(
+            edges,
+            centre=centre,
+            repeat_count=repeat_count,
+            tol=tol,
+        )
+        if orbits is not None:
+            return _BoundaryEvidence(
+                axis,
+                at,
+                plane_axes,
+                centre,
+                repeat_count,
+                edges,
+                orbits,
+            )
+    return None
+
+
+def _profiles_correspond(
+    lower: _BoundaryEvidence, upper: _BoundaryEvidence, *, tol: float
+) -> bool:
+    return (
+        lower.axis == upper.axis
+        and lower.plane_axes == upper.plane_axes
+        and lower.repeat_count == upper.repeat_count
+        and len(lower.edges) == len(upper.edges)
+        and all(abs(a - b) <= tol for a, b in zip(lower.centre, upper.centre, strict=True))
+        # Each boundary has already proved its own bijective mapping.  Compare their
+        # traversal/phase-neutral sector inventories rather than absolute edge positions:
+        # opposed source faces may carry reversed parameterisation or a sector phase shift.
+        and _sector_signature(lower) == _sector_signature(upper)
+    )
+
+
+def _polar_signature(
+    points: tuple[tuple[float, float], ...], centre: tuple[float, float]
+) -> tuple[tuple[float, float], ...]:
+    """Canonical sampled curve shape modulo phase, reflection and traversal direction."""
+
+    def one_direction(candidate: tuple[tuple[float, float], ...]):
+        polar = [
+            (_distance(point, centre), atan2(point[1] - centre[1], point[0] - centre[0]))
+            for point in candidate
+        ]
+        unwrapped = [polar[0][1]]
+        for _radius, angle in polar[1:]:
+            previous = unwrapped[-1]
+            while angle - previous > pi:
+                angle -= 2 * pi
+            while angle - previous < -pi:
+                angle += 2 * pi
+            unwrapped.append(angle)
+        phase = unwrapped[0]
+        relative = tuple(
+            (round(radius, 6), round(angle - phase, 6))
+            for (radius, _raw), angle in zip(polar, unwrapped, strict=True)
+        )
+        reflected = tuple((radius, -angle) for radius, angle in relative)
+        return min(relative, reflected)
+
+    return min(one_direction(points), one_direction(tuple(reversed(points))))
+
+
+def _sector_signature(
+    boundary: _BoundaryEvidence,
+) -> tuple[tuple[str, float, tuple[tuple[float, float], ...]], ...]:
+    signature = []
+    for orbit in boundary.orbits:
+        edge = boundary.edges[orbit[0]]
+        signature.append(
+            (
+                edge.kind,
+                round(edge.length, 6),
+                _polar_signature(edge.points, boundary.centre),
+            )
+        )
+    return tuple(sorted(signature))
+
+
+def _recognise_solid(solid, *, tol: float) -> list[RepeatingRadialProfile]:
+    bbox = solid.bounding_box()
+    scale = max(float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z))
+    metric_tol = max(tol, scale * 1e-5)
+    boundaries = []
+    for face in solid.faces():
+        try:
+            evidence = _prove_boundary(face, bbox, tol=metric_tol)
+        except Exception:  # noqa: BLE001 - malformed B-rep evidence must fail closed
+            evidence = None
+        if evidence is not None:
+            boundaries.append(evidence)
+    found: list[RepeatingRadialProfile] = []
+    for axis in "xyz":
+        attr = axis.upper()
+        lo = float(getattr(bbox.min, attr))
+        hi = float(getattr(bbox.max, attr))
+        lowers = [b for b in boundaries if b.axis == axis and abs(b.at - lo) <= metric_tol]
+        uppers = [b for b in boundaries if b.axis == axis and abs(b.at - hi) <= metric_tol]
+        for lower in lowers:
+            matches = [
+                upper for upper in uppers if _profiles_correspond(lower, upper, tol=metric_tol)
+            ]
+            if len(matches) != 1:
+                continue
+            # Source-face correspondence is one-to-one in both directions. Two lower faces
+            # claiming the same upper face is ambiguous even if their serialised facts happen
+            # to be equal; collapsing that ambiguity would violate source/body identity.
+            if (
+                sum(
+                    _profiles_correspond(candidate, matches[0], tol=metric_tol)
+                    for candidate in lowers
+                )
+                != 1
+            ):
+                continue
+            coords = [0.0, 0.0, 0.0]
+            coords["xyz".index(lower.plane_axes[0])] = lower.centre[0]
+            coords["xyz".index(lower.plane_axes[1])] = lower.centre[1]
+            coords["xyz".index(axis)] = (lo + hi) / 2
+            found.append(
+                RepeatingRadialProfile(
+                    axis=axis,
+                    centre=(coords[0], coords[1], coords[2]),
+                    span=(lo, hi),
+                    repeat_count=lower.repeat_count,
+                    edge_count=len(lower.edges),
+                    sector_signature=_sector_signature(lower),
+                )
+            )
+    return found
+
+
+def recognise_repeating_radial_profiles(
+    part, *, tol: float = 1e-5
+) -> list[RepeatingRadialProfile]:
+    """Return complete repeating outer-profile evidence for each independently owned solid."""
+    solids = list(part.solids())
+    if not solids:
+        solids = [part]
+    found = [profile for solid in solids for profile in _recognise_solid(solid, tol=tol)]
+    # Preserve equal records from distinct solids. Lint must see two possible physical
+    # occurrences as ambiguous rather than deduplicating them into false uniqueness.
+    return sorted(found)
+
+
+__all__ = ["RepeatingRadialProfile", "recognise_repeating_radial_profiles"]

--- a/src/draftwright/recognition/result.py
+++ b/src/draftwright/recognition/result.py
@@ -30,6 +30,7 @@ from draftwright.recognition.polygonal_bosses import (
     recognise_polygonal_stock,
 )
 from draftwright.recognition.profiled_bores import recognise_double_d_bores
+from draftwright.recognition.repeating_profiles import recognise_repeating_radial_profiles
 from draftwright.recognition.slots import (
     recognise_channels,
     recognise_pocket_patterns,
@@ -65,6 +66,7 @@ MIGRATED: frozenset[str] = frozenset(
         "recognise_polygonal_bosses",
         "recognise_polygonal_stock",
         "recognise_rectangular_pads",
+        "recognise_repeating_radial_profiles",
         "recognise_risers",
         "recognise_slot_patterns",
         "recognise_slots",
@@ -170,6 +172,9 @@ class RecognitionResult:
     pockets: tuple
     pocket_patterns: tuple
     pads: tuple
+    #: Complete outer-wire cyclic correspondence.  Geometry-only: consumers may compare a
+    #: declared axis/count, but this inventory never manufactures gear semantics (#1087).
+    repeating_radial_profiles: tuple
     turned_steps: tuple
     #: Area-filtered interior prismatic levels. The support spans remain on each record so IR
     #: assembly can preserve level-to-face correspondence; sizing and critique project the Z
@@ -277,6 +282,7 @@ def build_recognition_result(
         pockets=tuple(pockets),
         pocket_patterns=tuple(recognise_pocket_patterns(pockets)),
         pads=tuple(recognise_rectangular_pads(part)),
+        repeating_radial_profiles=tuple(recognise_repeating_radial_profiles(part)),
         turned_steps=tuple(turned_steps),
         rotational=rotational,
         step_levels=tuple(step_level_records(part)),

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -59,6 +59,7 @@ from draftwright.recognition.repeating_profiles import (
     _cyclic_edge_orbits,
     _distance,
     _one_closed_cycle,
+    _polar_signature,
     _rotate,
     _sample_wire,
 )
@@ -377,6 +378,46 @@ def test_empty_or_unsampleable_wire_evidence_fails_closed():
     wire = SimpleNamespace(edges=lambda: [_BadEdge()])
     assert not _one_closed_cycle((), tol=_CORRESPONDENCE_TOL)
     assert _sample_wire(wire, ("x", "y")) is None
+
+
+def test_ambiguous_or_self_joined_endpoint_graph_fails_closed():
+    ambiguous = (
+        _CurveEvidence("line", 1.0, ((0.0, 0.0), (1.5e-5, 0.0))),
+        _CurveEvidence("line", 1.0, ((0.75e-5, 0.0), (1.0, 0.0))),
+    )
+    self_joined = (_CurveEvidence("line", 1.0, ((0.0, 0.0), (0.0, 0.0))),)
+
+    assert not _one_closed_cycle(ambiguous, tol=1e-5)
+    assert not _one_closed_cycle(self_joined, tol=1e-5)
+
+
+def test_polar_signature_is_stable_across_the_angle_branch_cut():
+    points = ((-1.0, 0.01), (-1.0, -0.01), (-0.9, -0.02))
+
+    assert _polar_signature(points, (0.0, 0.0)) == _polar_signature(
+        tuple(reversed(points)), (0.0, 0.0)
+    )
+
+
+def test_malformed_faces_and_a_shape_without_owned_solids_fail_closed(monkeypatch):
+    import draftwright.recognition.repeating_profiles as repeating_profiles
+
+    bbox = SimpleNamespace(
+        size=_point(1.0, 1.0, 1.0),
+        min=_point(0.0, 0.0, 0.0),
+        max=_point(1.0, 1.0, 1.0),
+    )
+    shape = SimpleNamespace(
+        bounding_box=lambda: bbox,
+        faces=lambda: [object()],
+        solids=lambda: [],
+    )
+
+    def malformed_boundary(*_args, **_kwargs):
+        raise RuntimeError("malformed face")
+
+    monkeypatch.setattr(repeating_profiles, "_prove_boundary", malformed_boundary)
+    assert repeating_profiles.recognise_repeating_radial_profiles(shape) == []
 
 
 def test_one_changed_intervening_curve_breaks_full_sector_correspondence(wheel_part):

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -1,10 +1,10 @@
 """Evidence-backed recognition and coverage for the double-D wheel profile (#1058)."""
 
 from collections import Counter
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from hashlib import sha256
 from inspect import signature
-from math import asin, cos, hypot, pi, sin, sqrt
+from math import asin, sqrt
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -43,12 +43,24 @@ from draftwright.model import (
     plan_dimensions,
 )
 from draftwright.model.callout import hole_callout_spec
-from draftwright.recognition import build_recognition_result, recognise_double_d_bores
+from draftwright.recognition import (
+    build_recognition_result,
+    recognise_double_d_bores,
+    recognise_repeating_radial_profiles,
+)
 from draftwright.recognition.profiled_bores import (
     DoubleDProfile,
     double_d_bores_from_openings,
     double_d_profile,
     principal_boundary_plane,
+)
+from draftwright.recognition.repeating_profiles import (
+    _CurveEvidence,
+    _cyclic_edge_orbits,
+    _distance,
+    _one_closed_cycle,
+    _rotate,
+    _sample_wire,
 )
 from draftwright.sheet_emit import _feature_line, _hole_line, emit_sheet_script
 
@@ -174,134 +186,11 @@ def _profile_evidence(case="valid"):
     return _ProfileWire([*lines, *arcs], size=size)
 
 
-@dataclass(frozen=True)
-class _CurveEvidence:
-    """A traversal-neutral sample of one real outer-wire edge for #1062 discovery."""
-
-    kind: GeomType
-    length: float
-    points: tuple[tuple[float, float], ...]
-
-
 def _sample_outer_wire(face, *, samples=9) -> tuple[_CurveEvidence, ...]:
-    evidence = []
-    for edge in face.outer_wire().edges():
-        points = []
-        for index in range(samples):
-            point = edge.position_at(index / (samples - 1))
-            points.append((float(point.X), float(point.Y)))
-        evidence.append(
-            _CurveEvidence(
-                kind=edge.geom_type,
-                length=float(edge.length),
-                points=tuple(points),
-            )
-        )
-    return tuple(evidence)
-
-
-def _distance(a, b) -> float:
-    return hypot(a[0] - b[0], a[1] - b[1])
-
-
-def _one_closed_cycle(edges: tuple[_CurveEvidence, ...], tol: float) -> bool:
-    """Every endpoint has degree two and every edge belongs to one connected component."""
-    if not edges:
-        return False
-    nodes: list[tuple[float, float]] = []
-    incident: list[list[int]] = []
-    edge_nodes = []
-    for edge_index, edge in enumerate(edges):
-        endpoints = []
-        for point in (edge.points[0], edge.points[-1]):
-            matches = [index for index, node in enumerate(nodes) if _distance(point, node) <= tol]
-            if len(matches) > 1:
-                return False
-            if matches:
-                node_index = matches[0]
-            else:
-                node_index = len(nodes)
-                nodes.append(point)
-                incident.append([])
-            incident[node_index].append(edge_index)
-            endpoints.append(node_index)
-        if endpoints[0] == endpoints[1]:
-            return False
-        edge_nodes.append(tuple(endpoints))
-    if any(len(edge_ids) != 2 for edge_ids in incident):
-        return False
-
-    reached_edges = set()
-    frontier = [0]
-    while frontier:
-        edge_index = frontier.pop()
-        if edge_index in reached_edges:
-            continue
-        reached_edges.add(edge_index)
-        frontier.extend(
-            neighbour
-            for node_index in edge_nodes[edge_index]
-            for neighbour in incident[node_index]
-            if neighbour not in reached_edges
-        )
-    return len(reached_edges) == len(edges)
-
-
-def _rotate(point, angle, centre):
-    x, y = point[0] - centre[0], point[1] - centre[1]
-    return (
-        centre[0] + x * cos(angle) - y * sin(angle),
-        centre[1] + x * sin(angle) + y * cos(angle),
-    )
-
-
-def _curves_match(source, target, *, angle, centre, tol) -> bool:
-    if source.kind != target.kind or abs(source.length - target.length) > tol:
-        return False
-    rotated = tuple(_rotate(point, angle, centre) for point in source.points)
-    return any(
-        max(_distance(a, b) for a, b in zip(rotated, candidate, strict=True)) <= tol
-        for candidate in (target.points, tuple(reversed(target.points)))
-    )
-
-
-def _cyclic_edge_orbits(edges, *, centre, repeat_count, tol):
-    """Prove the complete closed wire maps bijectively under one repeat rotation."""
-    edges = tuple(edges)
-    if (
-        len(edges) <= repeat_count
-        or len(edges) % repeat_count
-        or not _one_closed_cycle(edges, tol)
-    ):
-        return None
-    angle = 2 * pi / repeat_count
-    mapping = []
-    for edge in edges:
-        matches = [
-            index
-            for index, candidate in enumerate(edges)
-            if _curves_match(edge, candidate, angle=angle, centre=centre, tol=tol)
-        ]
-        if len(matches) != 1:
-            return None
-        mapping.append(matches[0])
-    if len(set(mapping)) != len(edges):
-        return None
-
-    unseen = set(range(len(edges)))
-    orbits = []
-    while unseen:
-        start = min(unseen)
-        orbit = []
-        current = start
-        while current not in orbit:
-            orbit.append(current)
-            current = mapping[current]
-        if current != start or len(orbit) != repeat_count:
-            return None
-        unseen -= set(orbit)
-        orbits.append(tuple(orbit))
-    return tuple(orbits)
+    assert samples == 9
+    evidence = _sample_wire(face.outer_wire(), ("x", "y"))
+    assert evidence is not None
+    return evidence
 
 
 @pytest.fixture(scope="module")
@@ -378,8 +267,69 @@ def test_real_wheel_proves_complete_thirteen_sector_correspondence(wheel_part):
         assert orbits is not None
         assert [len(orbit) for orbit in orbits] == [13, 13, 13, 13]
         assert Counter(evidence[orbit[0]].kind for orbit in orbits) == Counter(
-            {GeomType.BSPLINE: 3, GeomType.CIRCLE: 1}
+            {GeomType.BSPLINE.name: 3, GeomType.CIRCLE.name: 1}
         )
+
+
+def test_production_recogniser_carries_complete_serialisable_profile_evidence(wheel_part):
+    (profile,) = recognise_repeating_radial_profiles(wheel_part)
+
+    assert profile.axis == "z"
+    assert profile.centre == pytest.approx((0.0, 0.0, 0.0), abs=1e-6)
+    assert profile.span == pytest.approx((-3.8500001, 3.8500001))
+    assert profile.repeat_count == 13
+    assert profile.edge_count == 52
+    assert Counter(item[0] for item in profile.sector_signature) == Counter(
+        {GeomType.BSPLINE.name: 3, GeomType.CIRCLE.name: 1}
+    )
+    assert len(profile.to_dict()["sector_signature"]) == 4
+
+
+def test_equal_profiles_on_distinct_bodies_remain_ambiguous(wheel_part, monkeypatch):
+    import draftwright.recognition.repeating_profiles as repeating_profiles
+
+    (profile,) = recognise_repeating_radial_profiles(wheel_part)
+    bodies = (object(), object())
+    part = SimpleNamespace(solids=lambda: bodies)
+    monkeypatch.setattr(
+        repeating_profiles,
+        "_recognise_solid",
+        lambda solid, **_kwargs: [profile] if solid in bodies else [],
+    )
+
+    assert repeating_profiles.recognise_repeating_radial_profiles(part) == [profile, profile]
+
+
+def test_declared_gear_reconciles_to_the_recognition_owned_profile(wheel_part):
+    sheet = Sheet(wheel_part)
+    sheet.external_spur_gear(
+        at=(0, 0, 0),
+        axis="z",
+        tooth_count=13,
+        module=0.5,
+        pressure_angle=20,
+        profile_shift=0,
+        face_width=7.7000002,
+        tooth_thickness=0.78,
+        tooth_thickness_tolerance=(-0.03, 0.01),
+        flank_tolerance_class=7,
+    )
+    sheet.authored_dimensions()
+
+    drawing = sheet.build()
+    recognition = drawing.recognition()
+    assert recognition is None, "declared build/render must remain recognition-free"
+    codes = {issue.code for issue in drawing.lint()}
+    assert drawing.recognition() is not None
+    assert (
+        not {
+            "gear_correspondence_unverifiable",
+            "gear_axis_mismatch",
+            "gear_repeat_count_mismatch",
+        }
+        & codes
+    )
+    assert "unrecognised_defining_geometry" in codes
 
 
 def test_full_profile_correspondence_ignores_start_and_traversal(wheel_part):
@@ -403,7 +353,7 @@ def test_full_profile_correspondence_ignores_start_and_traversal(wheel_part):
 
 def test_common_circle_arcs_alone_do_not_prove_full_sector_correspondence(wheel_part):
     evidence = _sample_outer_wire(_wheel_end_faces(wheel_part)[0])
-    arcs = tuple(edge for edge in evidence if edge.kind == GeomType.CIRCLE)
+    arcs = tuple(edge for edge in evidence if edge.kind == GeomType.CIRCLE.name)
     assert len(arcs) == 13
     assert (
         _cyclic_edge_orbits(
@@ -416,10 +366,23 @@ def test_common_circle_arcs_alone_do_not_prove_full_sector_correspondence(wheel_
     )
 
 
+def test_empty_or_unsampleable_wire_evidence_fails_closed():
+    class _BadEdge:
+        geom_type = GeomType.BSPLINE
+        length = 1.0
+
+        def position_at(self, _fraction):
+            raise RuntimeError("malformed curve")
+
+    wire = SimpleNamespace(edges=lambda: [_BadEdge()])
+    assert not _one_closed_cycle((), tol=_CORRESPONDENCE_TOL)
+    assert _sample_wire(wire, ("x", "y")) is None
+
+
 def test_one_changed_intervening_curve_breaks_full_sector_correspondence(wheel_part):
     evidence = list(_sample_outer_wire(_wheel_end_faces(wheel_part)[0]))
     changed_index = next(
-        index for index, edge in enumerate(evidence) if edge.kind == GeomType.BSPLINE
+        index for index, edge in enumerate(evidence) if edge.kind == GeomType.BSPLINE.name
     )
     changed = evidence[changed_index]
     points = list(changed.points)
@@ -427,7 +390,7 @@ def test_one_changed_intervening_curve_breaks_full_sector_correspondence(wheel_p
     points[len(points) // 2] = (x + 0.01, y)
     evidence[changed_index] = replace(changed, points=tuple(points))
 
-    assert len([edge for edge in evidence if edge.kind == GeomType.CIRCLE]) == 13
+    assert len([edge for edge in evidence if edge.kind == GeomType.CIRCLE.name]) == 13
     assert (
         _cyclic_edge_orbits(
             evidence,
@@ -489,6 +452,30 @@ def test_one_unequal_sector_pitch_breaks_correspondence_even_when_closed(wheel_p
     )
 
 
+def test_non_bijective_sector_mapping_is_rejected_before_orbit_claim(wheel_part, monkeypatch):
+    import draftwright.recognition.repeating_profiles as repeating_profiles
+
+    evidence = _sample_outer_wire(_wheel_end_faces(wheel_part)[0])
+    assert _one_closed_cycle(evidence, tol=_CORRESPONDENCE_TOL)
+    targets = [(index + 4) % len(evidence) for index in range(len(evidence))]
+    targets[1] = targets[0]  # two source curves now claim the same physical target curve
+    target_for = {id(source): evidence[target] for source, target in zip(evidence, targets)}
+
+    def non_bijective(source, target, **_kwargs):
+        return target is target_for[id(source)]
+
+    monkeypatch.setattr(repeating_profiles, "_curves_match", non_bijective)
+    assert (
+        repeating_profiles._cyclic_edge_orbits(
+            evidence,
+            centre=(0.0, 0.0),
+            repeat_count=_RADIAL_REPEAT_COUNT,
+            tol=_CORRESPONDENCE_TOL,
+        )
+        is None
+    )
+
+
 def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawing):
     assert Counter(feature.kind for feature in wheel_drawing.model().features) == Counter(
         {"envelope": 1, "hole": 1}
@@ -525,7 +512,10 @@ def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawin
     assert tip[1] == pytest.approx(centre[1])
 
     summary = wheel_drawing.lint_summary()
-    assert summary["by_code"] == {"unrecognised_defining_geometry": 1}
+    assert summary["by_code"] == {
+        "gear_semantics_missing": 1,
+        "unrecognised_defining_geometry": 1,
+    }
     assert summary["score"] < 1.0
     assert "unsupported outer boundary" in summary["issues"][0]["message"]
     assert "13 evenly spaced common-circle arcs" in summary["issues"][0]["message"]

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import json
+from pathlib import Path
 
 import pytest
-from build123d import Align, Axis, Box, Cylinder, Pos, Rot, chamfer, fillet
+from build123d import Align, Axis, Box, Cylinder, Pos, Rot, chamfer, fillet, import_step
 
 from draftwright.recognition import (
     BoltCircle,
@@ -39,6 +40,7 @@ from draftwright.recognition import (
     PocketGrid,
     PolygonalBoss,
     RectGrid,
+    RepeatingRadialProfile,
     Slot,
     SlotArray,
     SlotGrid,
@@ -61,6 +63,7 @@ from draftwright.recognition import (
     recognise_pocket_patterns,
     recognise_pockets,
     recognise_polygonal_bosses,
+    recognise_repeating_radial_profiles,
     recognise_risers,
     recognise_slot_patterns,
     recognise_slots,
@@ -97,6 +100,7 @@ _EXPECTED_RECORD_TYPES = {
     FaceLevel,
     StepShoulder,
     TurnedStep,
+    RepeatingRadialProfile,
 }
 
 
@@ -253,6 +257,12 @@ def _records_from_recognisers():
         ("recognise_plates", recognise_plates(_l_bracket())),
         ("recognise_face_levels", recognise_face_levels(stepped)),
         ("recognise_risers", recognise_risers(stepped)),
+        (
+            "recognise_repeating_radial_profiles",
+            recognise_repeating_radial_profiles(
+                import_step(str(Path(__file__).parent / "fixtures" / "issue_1058_wheel_rh.step"))
+            ),
+        ),
         # `StepShoulder` stopped being a recogniser return in #1025 — it is now what
         # `project_step_shoulders` derives from riser evidence. It stays in this roster
         # because the record contract (frozen, JSON-serialisable, no leaked build123d object)
@@ -320,6 +330,7 @@ def test_part_based_recognisers_are_keyword_only_after_part():
         recognise_plates,
         recognise_face_levels,
         recognise_risers,
+        recognise_repeating_radial_profiles,
         recognise_turned_steps,
     ):
         params = list(inspect.signature(fn).parameters.values())

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -15,8 +15,9 @@ import pkgutil
 from contextlib import contextmanager
 from dataclasses import fields
 from math import cos, radians, sin
+from pathlib import Path
 
-from build123d import Align, Box, Cone, Cylinder, Pos, RegularPolygon, extrude
+from build123d import Align, Box, Cone, Cylinder, Pos, RegularPolygon, extrude, import_step
 from conftest import counting_calls
 
 import draftwright.model.detect as detect_module
@@ -45,6 +46,7 @@ from draftwright.recognition import (
     recognise_polygonal_bosses,
     recognise_polygonal_stock,
     recognise_rectangular_pads,
+    recognise_repeating_radial_profiles,
     recognise_risers,
     recognise_slot_patterns,
     recognise_slots,
@@ -143,6 +145,10 @@ def _u_channel():
     )
 
 
+def _repeating_wheel():
+    return import_step(str(Path(__file__).parent / "fixtures" / "issue_1058_wheel_rh.step"))
+
+
 #: Between them these cover every RecognitionResult field with a NON-EMPTY inventory, which
 #: is what makes the equality assertions in the oracle below discriminating rather than
 #: comparing () to ().
@@ -162,6 +168,7 @@ _ORACLE_FIXTURES = [
     ("U-channel", _u_channel),
     ("chamfered+filleted block", _chamfered_filleted_block),
     ("rotational shaft", _rotational_shaft),
+    ("repeating radial wheel", _repeating_wheel),
 ]
 
 
@@ -370,6 +377,7 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
         "pockets": tuple(pockets),
         "pocket_patterns": tuple(recognise_pocket_patterns(pockets)),
         "pads": tuple(recognise_rectangular_pads(part)),
+        "repeating_radial_profiles": tuple(recognise_repeating_radial_profiles(part)),
         "turned_steps": tuple(recognise_turned_steps(part, cyls=cyls)),
         "step_levels": tuple(step_level_records(part)),
         "risers": tuple(recognise_risers(part)),

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -132,6 +132,11 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
         result_module, "recognise_pocket_patterns", derived("pocket_patterns", pockets, [])
     )
     monkeypatch.setattr(result_module, "recognise_rectangular_pads", counted("pads", []))
+    monkeypatch.setattr(
+        result_module,
+        "recognise_repeating_radial_profiles",
+        counted("repeating_radial_profiles", []),
+    )
     monkeypatch.setattr(result_module, "recognise_turned_steps", cyl_consumer("turned_steps", []))
     # The area-filtered records retain face support (#915); `step_ladder()` projects their Z
     # values for sizing/critique. It takes the part only — no substrate identity to assert.
@@ -172,6 +177,7 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
         "pockets",
         "pocket_patterns",
         "pads",
+        "repeating_radial_profiles",
         "turned_steps",
         "step_levels",
         "slot_patterns",


### PR DESCRIPTION
Closes #1087.

## What changed

- productionise the complete-wire repeating radial profile proof as a frozen, serialisable recognition record
- run the recogniser exactly once through the ADR 0017 `RecognitionResult` orchestration
- reconcile declared external spur gears against independently proved centre/span, axis, and repeat-count evidence
- retain equal records from distinct bodies so coincident assembly occurrences stay ambiguous
- document the evidence boundary without inferring module, pressure angle, helix, gear standard, process, or quality

## Correctness boundary

The recogniser requires two opposed principal outer wires, one connected degree-two cycle, a unique bijective mapping for every edge under the sector rotation, and a matching traversal/phase-neutral sampled curve signature. It rejects arcs-only evidence, changed intervening curves, open cycles, unequal pitch, non-bijective mappings, ambiguous face pairing, and unavailable geometry. A proved repeat does not clear `unrecognised_defining_geometry` or create an automatic gear feature.

## Adversarial review

Repeated local review found and fixed substantive issues before publication:

- equal profile records were initially deduplicated, which could collapse two coincident assembly bodies into false uniqueness; equal records are now preserved and opposed faces require one-to-one pairing
- the first opposed-face signature retained only radial samples; it now retains sampled polar shape while remaining invariant to phase, reflection, and traversal
- Codecov exposed unexercised rejection boundaries; direct mutations now cover ambiguous and self-joined endpoint graphs, angle branch-cut traversal, malformed faces, and unowned single-shape topology

The architecture guard also required this critique-only record to be explicitly classified as evidence-only rather than IR-converted.

## Validation

- focused recognition/gear/manifest/contract suites: 126 passing tests
- `scripts/pr-check --full`: 3,233 passed, 5 skipped, 2 expected xfails
- total coverage 94.42%; changed-line coverage 97.1%
- Ruff, formatting, mypy, codespell, strict MkDocs build
- parallel local slow tier: 21 passed