### PR TITLE
Separate drawing quality scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Added
+
+- **`lint_summary()` exposes drawing-quality evidence as separate completeness, restraint,
+  and legibility components** (#1127). The legacy `score` remains byte-compatible and is also
+  returned as the honestly named `diagnostic_score`; no composite quality verdict is invented.
+  Completeness scores recognition-owned requirements in the families with semantic outcome
+  ledgers and states that conditional scope explicitly; recognized families not yet scored are
+  listed separately. Legibility includes only layout and placement diagnostics, including
+  information-level placement drops, and restraint fails closed as unavailable until measurement
+  provenance can classify every annotation.
+
 ## v0.4.3 — 2026-08-09
 
 **A trust and validation-throughput patch release.** Whole-part hexagonal stock now receives its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
   returned as the honestly named `diagnostic_score`; no composite quality verdict is invented.
   Completeness scores recognition-owned requirements in the families with semantic outcome
   ledgers and states that conditional scope explicitly; recognized families not yet scored are
-  listed separately. Legibility includes only layout and placement diagnostics, and scores
+  listed separately. Its scalar is `audited_score`, not `score`, because a feature recognition
+  missed never became a requirement — so a part with a recogniser gap can reach 1.0, and the
+  qualifier belongs where it survives being quoted. The block also lists what its denominator
+  `excludes` and counts `unrecognised_geometry_reports` (a floor on that gap, not a measure).
+  It is not a completion gate. Legibility includes only layout and placement diagnostics, and scores
   information-severity ones — "place what fits" drops, a leader crossing a silhouette — against
   the warning floor, so it cannot read 1.0 while itemising output it calls unreadable. A drop is
   identified by its `*_dropped` code suffix unless its producer records an explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@
   returned as the honestly named `diagnostic_score`; no composite quality verdict is invented.
   Completeness scores recognition-owned requirements in the families with semantic outcome
   ledgers and states that conditional scope explicitly; recognized families not yet scored are
-  listed separately. Legibility includes only layout and placement diagnostics, including
-  information-level placement drops, and restraint fails closed as unavailable until measurement
-  provenance can classify every annotation.
+  listed separately. Legibility includes only layout and placement diagnostics, and scores
+  information-severity ones — "place what fits" drops, a leader crossing a silhouette — against
+  the warning floor, so it cannot read 1.0 while itemising output it calls unreadable. A drop is
+  identified by its `*_dropped` code suffix unless its producer records an explicit
+  `outcome_stage`, so a drop code added later counts without being registered anywhere.
+  Restraint fails closed as unavailable until measurement provenance can classify every
+  annotation.
 
 ## v0.4.3 — 2026-08-09
 

--- a/README.md
+++ b/README.md
@@ -217,9 +217,23 @@ dwg = build_drawing(part)
 env = next(f for f in dwg.model().features if f.kind == "envelope")
 dwg.dimension(env, "length", role="width", side="below", pin=True)
 
-crit = dwg.lint_summary()   # {"passed", "score", "by_code", "issues":[…suggestion]}
+crit = dwg.lint_summary()
+# Legacy diagnostic severity heuristic (not overall drawing quality):
+assert crit["diagnostic_score"] == crit["score"]
+# Independently observable components; no composite quality score is invented:
+completeness = crit["quality"]["completeness"]
+# Conditional on the requirements Draftwright recognized and can currently audit:
+recognized_completeness = completeness["score"]
+assert completeness["scope"] == "audited_recognized_requirements"
+legibility = crit["quality"]["legibility"]
+restraint = crit["quality"]["restraint"]  # unavailable until provenance is complete
 dwg.repair()                # auto-fix mechanically-fixable lint; never worsens
 ```
+
+Completeness is strict about authored omissions: removing a dimension from a complete authored
+set records a `suppressed` requirement and lowers the score. The evidence distinguishes that
+choice from a placement failure, but cannot certify that the omission is engineering-correct;
+plain deletion is not an accepted-waiver mechanism.
 
 Each `LintIssue` carries a domain-meaningful `code` and, when computable, a
 ready-to-apply `suggestion`. See `docs/adr/` for the design (deterministic

--- a/README.md
+++ b/README.md
@@ -222,18 +222,27 @@ crit = dwg.lint_summary()
 assert crit["diagnostic_score"] == crit["score"]
 # Independently observable components; no composite quality score is invented:
 completeness = crit["quality"]["completeness"]
-# Conditional on the requirements Draftwright recognized and can currently audit:
-recognized_completeness = completeness["score"]
+# Named for its denominator: the requirements Draftwright recognized AND can audit.
+# 1.0 does NOT mean the drawing is complete — a feature recognition missed never became
+# a requirement, so it is absent from the ledger rather than counted against it.
+audited = completeness["audited_score"]
 assert completeness["scope"] == "audited_recognized_requirements"
+completeness["excludes"]                     # what the denominator cannot see
+completeness["unrecognised_geometry_reports"]  # a floor on that gap, never a measure
 legibility = crit["quality"]["legibility"]
 restraint = crit["quality"]["restraint"]  # unavailable until provenance is complete
 dwg.repair()                # auto-fix mechanically-fixable lint; never worsens
 ```
 
 Completeness is strict about authored omissions: removing a dimension from a complete authored
-set records a `suppressed` requirement and lowers the score. The evidence distinguishes that
-choice from a placement failure, but cannot certify that the omission is engineering-correct;
-plain deletion is not an accepted-waiver mechanism.
+set records a `suppressed` requirement and lowers the audited score. The evidence distinguishes
+that choice from a placement failure, but cannot certify that the omission is
+engineering-correct; plain deletion is not an accepted-waiver mechanism.
+
+**`audited_score` is not a completion gate.** It answers "of the requirements we recognised and
+can audit, how many were placed?" — so a part whose geometry recognition missed entirely still
+scores 1.0. Gate on issue codes and severities, and read `excludes` and
+`unrecognised_geometry_reports` for what the denominator cannot account for.
 
 Each `LintIssue` carries a domain-meaningful `code` and, when computable, a
 ready-to-apply `suggestion`. See `docs/adr/` for the design (deterministic

--- a/README.md
+++ b/README.md
@@ -223,8 +223,9 @@ assert crit["diagnostic_score"] == crit["score"]
 # Independently observable components; no composite quality score is invented:
 completeness = crit["quality"]["completeness"]
 # Named for its denominator: the requirements Draftwright recognized AND can audit.
-# 1.0 does NOT mean the drawing is complete — a feature recognition missed never became
-# a requirement, so it is absent from the ledger rather than counted against it.
+# 1.0 does NOT mean the drawing is complete — it means every requirement recognition did
+# identify was placed, however much of the part it missed. What was never recognized never
+# became a requirement. (Recognized nothing auditable at all? available is False, not 1.0.)
 audited = completeness["audited_score"]
 assert completeness["scope"] == "audited_recognized_requirements"
 completeness["excludes"]                     # what the denominator cannot see
@@ -240,9 +241,9 @@ that choice from a placement failure, but cannot certify that the omission is
 engineering-correct; plain deletion is not an accepted-waiver mechanism.
 
 **`audited_score` is not a completion gate.** It answers "of the requirements we recognised and
-can audit, how many were placed?" — so a part whose geometry recognition missed entirely still
-scores 1.0. Gate on issue codes and severities, and read `excludes` and
-`unrecognised_geometry_reports` for what the denominator cannot account for.
+can audit, how many were placed?" — so a part can score 1.0 with whole features missing from the
+drawing, if recognition never identified them. Gate on issue codes and severities, and read
+`excludes` and `unrecognised_geometry_reports` for what the denominator cannot account for.
 
 Each `LintIssue` carries a domain-meaningful `code` and, when computable, a
 ready-to-apply `suggestion`. See `docs/adr/` for the design (deterministic

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -29,8 +29,8 @@ refinement model, with the lint system as the machine-readable critic.
 
 1. **`build` — automatic first pass.** `build_drawing(...)` applies all
    deterministic intelligence and returns both the drawing *and* a critique
-   (`lint_summary()`): `passed`, a coarse `score`, severity counts, and per-issue
-   records with domain-meaningful codes (`feature_not_dimensioned`,
+   (`lint_summary()`): `passed`, a coarse diagnostic score, separate quality components,
+   severity counts, and per-issue records with domain-meaningful codes (`feature_not_dimensioned`,
    `callout_dropped`, `location_ref_dropped`, …). Because of ADR 0001's
    deterministic investment, the common case ends here — no iteration needed.
 
@@ -45,7 +45,9 @@ refinement model, with the lint system as the machine-readable critic.
 3. **`domain-fix` — repair in domain vocabulary, never the layout DSL.** Each fix
    is expressed as domain intent — `dimension(feature=…)`, `section("A",
    through=…)` — not strip/zone/`dwg.at` mechanics. Then re-build and re-critique;
-   loop until `passed` (or the score plateaus).
+   loop until the relevant issue codes are resolved. The legacy scalar must not be an
+   optimisation target: #1126 demonstrated that sparse authored input can improve it while
+   making a geometry-only drawing less complete.
 
 4. **Make the loop cheap to close.** Two mechanisms reduce the fix step to near
    review-only:
@@ -75,8 +77,18 @@ same iterate-and-fix laps — with no fluency in draftwright internals required.
 - The loop is only as good as the critic: lint must keep growing toward
   "flags everything a competent reviewer would," including *never-attempted*
   coverage gaps, not just drops. Blind spots become silent failures.
-- The `score` is a heuristic; callers should gate on severity/code **counts**,
-  treating the scalar as secondary.
+- The legacy `score` is only a severity-weighted diagnostic heuristic. `diagnostic_score`
+  exposes the same value under its honest name; callers should gate on severity/code counts
+  and inspect `quality.completeness`, `quality.restraint`, and `quality.legibility` separately.
+  Components state when their evidence is partial or unavailable, and no composite
+  drawing-quality score is provided. Completeness is deliberately conditional on requirements
+  Draftwright recognized and can audit; it reports that scope and any recognized-but-unscored
+  families instead of treating unknown physical features as a reason to suppress the useful
+  score (#1127).
+- Completeness cannot infer that deleting an authored dimension was an engineering-correct
+  redundancy decision. Such an omission remains a visible `suppressed` requirement and scores
+  as unplaced. Counting every authored omission as complete would make the metric trivially
+  gameable; an accepted waiver would need a distinct, explicit, reviewable provenance state.
 - Requires building the domain-semantic API, suggestions, and repair loop
   (roadmap Cluster B / #25–#30) — the loop is aspirational until they exist.
 

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -89,6 +89,16 @@ same iterate-and-fix laps — with no fluency in draftwright internals required.
   redundancy decision. Such an omission remains a visible `suppressed` requirement and scores
   as unplaced. Counting every authored omission as complete would make the metric trivially
   gameable; an accepted waiver would need a distinct, explicit, reviewable provenance state.
+- **Completeness is bounded by recognition, and its scalar says so in its own name.** The
+  component reports `audited_score` — placed over *recognised and auditable* requirements — not
+  `score`. A feature recognition never identified never became a requirement, so it is absent
+  from the ledger rather than counted as missing, and a part with a recogniser gap can reach
+  1.0. The qualifier lives in the field name because a caveat kept in a sibling key is lost the
+  moment the number is quoted, and the primary consumer of this API is an agent summarising it.
+  The block also emits `excludes` and an `unrecognised_geometry_reports` count (a floor on the
+  gap, from the `unrecognised_defining_geometry` check — zero means nothing was *noticed*).
+  **Neither is a completion gate**: closing the loop still means driving issue codes to zero,
+  and closing a recogniser gap is recognition work, not a metric change.
 - Requires building the domain-semantic API, suggestions, and repair loop
   (roadmap Cluster B / #25–#30) — the loop is aspirational until they exist.
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1120,7 +1120,9 @@ class PlacementContext:
             self._hole_feature_index = idx
         return self._hole_feature_index.get(tuple(round(c, 3) for c in location))
 
-    def record_issue(self, severity, code, message, *, measurement=None, source=None) -> None:
+    def record_issue(
+        self, severity, code, message, *, measurement=None, source=None, outcome_stage=None
+    ) -> None:
         """Record a build-time lint issue on the run's registry (#639). Replaces the passes'
         old `dwg._record_build_issue`."""
         ids: tuple
@@ -1141,6 +1143,7 @@ class PlacementContext:
                 message=message,
                 measurement_ids=ids,
                 source_ids=source_ids,
+                outcome_stage=outcome_stage,
             )
         )
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3945,6 +3945,7 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
         "pmi_dropped",
         f"PMI {label!r} not placed (no room beside the {view})",
         source=getattr(rec, "source_id", ""),
+        outcome_stage="placement",
     )
     ctx.escalations.append(
         Escalation(kind="pmi", view=view, feature=rec, reason="no room beside the view")
@@ -4575,6 +4576,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                 "pmi_dropped" if source_ids else "gdt_dropped",
                 f"{name}: bad target {item.view!r}/{item.side!r}",
                 source=source_ids,
+                outcome_stage="validation",
             )
             continue
         zones, hproj, vproj, hi, vi = vk
@@ -4597,6 +4599,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                 "pmi_dropped" if source_ids else "gdt_dropped",
                 f"{name}: cannot render ({type(e).__name__}: {e})",
                 source=source_ids,
+                outcome_stage="validation",
             )
             continue
         size = (gb.X, gb.Y)
@@ -4705,6 +4708,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                     "pmi_dropped" if _source else "gdt_dropped",
                     f"{nm} not placed (no room in any {_v} strip)",
                     source=_source,
+                    outcome_stage="placement",
                 )
 
             ctx.post_drain.append(_retry)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -91,6 +91,7 @@ from draftwright.linting import (
     lint_slot_coverage,
     pmi_stage_summary,
 )
+from draftwright.linting.quality import quality_components
 from draftwright.projection import (
     project_view_geometry,
 )
@@ -2929,13 +2930,16 @@ class Drawing:
         return issues
 
     def lint_summary(self) -> dict:
-        """Aggregate :meth:`lint` into a JSON-friendly quality summary.
+        """Aggregate :meth:`lint` into a JSON-friendly diagnostic summary.
 
-        Gives a non-interactive caller (a script, or an LLM via the API) a
-        single signal to gate and optimise on without rendering the SVG:
+        Gives a non-interactive caller (a script, or an LLM via the API) structured
+        diagnostics and independently inspectable components without rendering the SVG:
 
         - ``passed`` — no error-severity issues;
-        - ``score`` — coarse 0–1 quality heuristic (see ``_SCORE_*``);
+        - ``score`` — legacy coarse 0–1 diagnostic heuristic (see ``_SCORE_*``);
+        - ``diagnostic_score`` — the same value under its honest name;
+        - ``quality`` — separable completeness, restraint, and legibility components. No
+          composite drawing-quality score is manufactured (#1127);
         - ``errors`` / ``warnings`` / ``infos`` — counts by severity;
         - ``by_code`` — per-check counts;
         - ``geometry_issues`` — count of standards/geometry-correctness issues
@@ -2965,9 +2969,20 @@ class Drawing:
             if self._analysis is not None
             else None
         )
+        quality = quality_components(
+            recognition=self._build.recognition,
+            features=getattr(self._part_model, "features", ()),
+            registry=self._registry,
+            omissions=self._build.omissions,
+            issues=issues,
+            error_penalty=_SCORE_ERROR_PENALTY,
+            warning_penalty=_SCORE_WARNING_PENALTY,
+        )
         return {
             "passed": errors == 0,
             "score": score,
+            "diagnostic_score": score,
+            "quality": quality,
             "errors": errors,
             "warnings": warnings,
             "infos": infos,
@@ -2986,6 +3001,11 @@ class Drawing:
                         else {}
                     ),
                     **({"source_ids": i.source_ids} if i.source_ids else {}),
+                    **(
+                        {"outcome_stage": i.outcome_stage}
+                        if getattr(i, "outcome_stage", None) is not None
+                        else {}
+                    ),
                 }
                 for i in issues
             ],

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -27,3 +27,8 @@ class LintIssue:
     # populated narrowly by source reconciliation such as AP242 PMI (#623); this does not
     # introduce a second feature/measurement identity system.
     source_ids: tuple[str, ...] = ()
+    # Build-time outcome stage where one issue code can represent more than one failure class.
+    # In particular ``gdt_dropped``/``pmi_dropped`` historically cover both malformed input
+    # (validation) and a valid candidate that did not fit (placement). Quality components must
+    # not infer that distinction from the shared code or its message (#1127).
+    outcome_stage: Literal["placement", "validation"] | None = None

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -12,12 +12,14 @@ Completeness is deliberately marked partial.  Only the feature families with a s
 ``*_outcomes`` ledger participate today; warning counts and declared IR are never substituted
 for the missing physical denominator.
 
-Its scalar is therefore named ``audited_score``, not ``score``.  A drawing of a part whose
-geometry recognition missed entirely still scores 1.0, because the missed feature never
-became a requirement — so the qualifier belongs in the field name, where it survives being
-quoted, and not only in the metadata beside it.  **It is not a completion gate**: gate on
-issue codes and severities (ADR 0002), and read ``excludes`` for what the denominator
-cannot see.
+Its scalar is therefore named ``audited_score``, not ``score``.  A part reaches 1.0 whenever
+every requirement recognition *did* identify was placed, however much of the part it missed:
+what was never recognised never became a requirement, so it is absent from the ledger rather
+than counted against it.  (Where nothing auditable was recognised at all, the component
+reports ``available: False`` and a ``None`` score — not a perfect one.)  The qualifier
+belongs in the field name, where it survives being quoted, and not only in the metadata
+beside it.  **It is not a completion gate**: gate on issue codes and severities (ADR 0002),
+and read ``excludes`` for what the denominator cannot see.
 """
 
 from __future__ import annotations

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -11,6 +11,13 @@ them into another blessed scalar:
 Completeness is deliberately marked partial.  Only the feature families with a semantic
 ``*_outcomes`` ledger participate today; warning counts and declared IR are never substituted
 for the missing physical denominator.
+
+Its scalar is therefore named ``audited_score``, not ``score``.  A drawing of a part whose
+geometry recognition missed entirely still scores 1.0, because the missed feature never
+became a requirement — so the qualifier belongs in the field name, where it survives being
+quoted, and not only in the metadata beside it.  **It is not a completion gate**: gate on
+issue codes and severities (ADR 0002), and read ``excludes`` for what the denominator
+cannot see.
 """
 
 from __future__ import annotations
@@ -86,6 +93,19 @@ _NON_REQUIREMENT_INVENTORIES = frozenset(
 
 _AUDITED_FAMILIES = ("channels", "flats", "polygonal_stock", "slot_patterns", "slots")
 
+# What the audited score does not cover, emitted as data rather than left to prose. The
+# first entry is the dangerous one: a requirement recognition never produced cannot appear
+# in any state, so it is absent rather than "missing".
+_EXCLUDES = (
+    "physical geometry that recognition did not identify",
+    "recognized families without a semantic outcome ledger",
+)
+
+# The lint check that reports geometry recognition could not account for. Its count is a
+# FLOOR on the unrecognised-geometry blind spot, never a measure of it: zero means nothing
+# was noticed, not that nothing was missed.
+_UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
+
 
 def _is_placement_drop(issue) -> bool:
     """Whether this issue reports a valid annotation candidate that did not land.
@@ -130,13 +150,15 @@ def _issue_component(issues, *, error_penalty: float, warning_penalty: float) ->
     }
 
 
-def _empty_completeness(reason: str) -> dict:
+def _empty_completeness(reason: str, unrecognised: int) -> dict:
     return {
         "available": False,
-        "score": None,
+        "audited_score": None,
         "scope": "audited_recognized_requirements",
         "coverage": "unavailable",
         "reason": reason,
+        "excludes": list(_EXCLUDES),
+        "unrecognised_geometry_reports": unrecognised,
         "denominator": "recognition",
         "audited_families": list(_AUDITED_FAMILIES),
         "unscored_recognized_families": [],
@@ -146,9 +168,10 @@ def _empty_completeness(reason: str) -> dict:
     }
 
 
-def _completeness_component(recognition, features, registry, omissions) -> dict:
+def _completeness_component(recognition, features, registry, omissions, issues) -> dict:
+    unrecognised = sum(issue.code == _UNRECOGNISED_GEOMETRY_CODE for issue in issues)
     if recognition is None:
-        return _empty_completeness("physical recognition inventory unavailable")
+        return _empty_completeness("physical recognition inventory unavailable", unrecognised)
 
     outcomes = {
         "channels": channel_requirement_outcomes(recognition, features, registry, omissions),
@@ -180,7 +203,10 @@ def _completeness_component(recognition, features, registry, omissions) -> dict:
     unaudited = sorted(recognised - set(_AUDITED_FAMILIES))
     audited_score = counts["placed"] / requirements if requirements else None
     if requirements:
-        reason = "score covers recognized requirements in audited families"
+        reason = (
+            "audited_score covers recognized requirements in audited families only; it is "
+            "not evidence that the drawing is complete"
+        )
     elif unaudited:
         reason = "recognized requirements exist only in families without outcome ledgers"
     else:
@@ -190,10 +216,12 @@ def _completeness_component(recognition, features, registry, omissions) -> dict:
         # recognised AND for which Draftwright has a semantic outcome ledger. Missing
         # recognisers are outside the scope; recognised-but-unscored families remain explicit.
         "available": requirements > 0,
-        "score": audited_score,
+        "audited_score": audited_score,
         "scope": "audited_recognized_requirements",
         "coverage": "partial",
         "reason": reason,
+        "excludes": list(_EXCLUDES),
+        "unrecognised_geometry_reports": unrecognised,
         "denominator": "recognition",
         "audited_families": list(_AUDITED_FAMILIES),
         "unscored_recognized_families": unaudited,
@@ -217,12 +245,17 @@ def quality_components(
 
     No composite score is returned.  In particular, an unavailable restraint component is
     data, not zero: treating unclassified annotations as redundant would recreate the false
-    confidence this API is intended to remove.
+    confidence this API is intended to remove.  For the same reason completeness reports an
+    ``audited_score`` over a stated denominator rather than a ``score``, and lists what that
+    denominator ``excludes`` — a feature recognition never identified is absent from the
+    ledger entirely, so a perfect audited score is not a complete drawing.
     """
 
     legibility_issues = [issue for issue in issues if _is_legibility_issue(issue)]
     return {
-        "completeness": _completeness_component(recognition, features, registry, omissions),
+        "completeness": _completeness_component(
+            recognition, features, registry, omissions, issues
+        ),
         "restraint": {
             "available": False,
             "score": None,

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -1,0 +1,250 @@
+"""Separable, honest drawing-quality components (#1127).
+
+The legacy lint ``score`` is a severity-weighted diagnostic convenience, not a drawing-
+quality verdict.  This module exposes the independently observable terms without composing
+them into another blessed scalar:
+
+- completeness follows recognition-owned physical requirements to compiler outcomes;
+- legibility contains only placement/layout diagnostics;
+- restraint fails closed until measurement provenance can classify every annotation.
+
+Completeness is deliberately marked partial.  Only the feature families with a semantic
+``*_outcomes`` ledger participate today; warning counts and declared IR are never substituted
+for the missing physical denominator.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from draftwright.linting.channel_coverage import channel_requirement_outcomes
+from draftwright.linting.flat_coverage import flat_requirement_outcomes
+from draftwright.linting.polygonal_stock_coverage import polygonal_stock_outcomes
+from draftwright.linting.slot_coverage import slot_requirement_outcomes
+
+_OUTCOME_STATES = ("placed", "suppressed", "dropped", "missing", "unverifiable")
+
+# Structural diagnostics that describe whether the composed sheet remains readable. Placement
+# drops have their own explicit inventory below because a ``*_dropped`` suffix alone cannot
+# distinguish validation from layout.
+_LEGIBILITY_CODES = frozenset(
+    {
+        "annotation_out_of_bounds",
+        "annotation_overlap",
+        "detail_unplaceable",
+        "dim_inside_part",
+        "label_centerline_overlap",
+        "leader_crosses_silhouette",
+        "leader_line_through_text",
+        "placement_unsatisfiable",
+        "view_annotation_inside_extents",
+        "view_annotation_overlap",
+        "view_out_of_bounds",
+        "view_overlap",
+    }
+)
+
+# Codes whose meaning is unambiguously "a valid annotation candidate did not land". The two
+# historically ambiguous codes (``gdt_dropped`` and ``pmi_dropped``) are deliberately absent;
+# their producers attach ``outcome_stage`` so validation and placement are separable.
+_PLACEMENT_DROP_CODES = frozenset(
+    {
+        "balloon_dropped",
+        "boss_dia_dropped",
+        "callout_dropped",
+        "chamfer_dropped",
+        "channel_width_dropped",
+        "diameter_dropped",
+        "dimension_dropped",
+        "fillet_dropped",
+        "flat_dropped",
+        "groove_dropped",
+        "location_ref_dropped",
+        "off_axis_location_dropped",
+        "pad_dim_dropped",
+        "plate_thickness_dropped",
+        "pocket_dim_dropped",
+        "pocket_dropped",
+        "polygonal_boss_dropped",
+        "polygonal_stock_dropped",
+        "polygonal_stock_length_dropped",
+        "slot_dim_dropped",
+        "slot_dropped",
+        "step_dim_dropped",
+        "step_position_dropped",
+        "table_dropped",
+    }
+)
+
+# Recognition inventories that represent potentially dimension-bearing physical families.
+# Substrates (cylinders, face levels, risers, plates) are intentionally omitted: listing the
+# same physical requirement twice would make the coverage admission less honest, not more.
+_RECOGNISED_REQUIREMENT_FAMILIES = {
+    "holes": "holes",
+    "double_d_bores": "profiled_bores",
+    "hole_patterns": "hole_patterns",
+    "bosses": "bosses",
+    "polygonal_bosses": "polygonal_bosses",
+    "polygonal_stock": "polygonal_stock",
+    "channels": "channels",
+    "slots": "slots",
+    "slot_patterns": "slot_patterns",
+    "grooves": "grooves",
+    "flats": "flats",
+    "pockets": "pockets",
+    "pocket_patterns": "pocket_patterns",
+    "pads": "pads",
+    "repeating_radial_profiles": "repeating_radial_profiles",
+    "turned_steps": "turned_steps",
+    "chamfers": "chamfers",
+    "fillets": "fillets",
+}
+
+_AUDITED_FAMILIES = ("channels", "flats", "polygonal_stock", "slot_patterns", "slots")
+
+
+def _is_placement_drop(issue) -> bool:
+    stage = getattr(issue, "outcome_stage", None)
+    if stage is not None:
+        return bool(stage == "placement")
+    return issue.code in _PLACEMENT_DROP_CODES
+
+
+def _is_legibility_issue(issue) -> bool:
+    return issue.code in _LEGIBILITY_CODES or _is_placement_drop(issue)
+
+
+def _issue_component(issues, *, error_penalty: float, warning_penalty: float) -> dict:
+    errors = sum(issue.severity == "error" for issue in issues)
+    warnings = sum(issue.severity == "warning" for issue in issues)
+    infos = sum(issue.severity == "info" for issue in issues)
+    placement_drops = sum(_is_placement_drop(issue) for issue in issues)
+    # "Place what fits" feature drops are intentionally info severity in lint, but they are
+    # still lost annotations. Give each info-level drop the warning floor so legibility cannot
+    # remain 1.0 after arbitrarily many dimensions disappear (#1127 adversarial review).
+    info_drops = sum(issue.severity == "info" and _is_placement_drop(issue) for issue in issues)
+    by_code = Counter(issue.code for issue in issues)
+    return {
+        "available": True,
+        "score": max(
+            0.0,
+            1.0 - errors * error_penalty - (warnings + info_drops) * warning_penalty,
+        ),
+        "errors": errors,
+        "warnings": warnings,
+        "infos": infos,
+        "placement_drops": placement_drops,
+        "by_code": dict(sorted(by_code.items())),
+        "basis": "layout_issue_severity_with_drop_floor",
+    }
+
+
+def _empty_completeness(reason: str) -> dict:
+    return {
+        "available": False,
+        "score": None,
+        "scope": "audited_recognized_requirements",
+        "coverage": "unavailable",
+        "reason": reason,
+        "denominator": "recognition",
+        "audited_families": list(_AUDITED_FAMILIES),
+        "unscored_recognized_families": [],
+        "requirements": 0,
+        **{state: 0 for state in _OUTCOME_STATES},
+        "by_family": {},
+    }
+
+
+def _completeness_component(recognition, features, registry, omissions) -> dict:
+    if recognition is None:
+        return _empty_completeness("physical recognition inventory unavailable")
+
+    outcomes = {
+        "channels": channel_requirement_outcomes(recognition, features, registry, omissions),
+        "flats": flat_requirement_outcomes(recognition, features, registry, omissions),
+        "polygonal_stock": polygonal_stock_outcomes(recognition, features, registry, omissions),
+        "slots": [],
+        "slot_patterns": [],
+    }
+    for outcome in slot_requirement_outcomes(recognition, features, registry, omissions):
+        outcomes["slot_patterns" if outcome.source_kind == "slot_pattern" else "slots"].append(
+            outcome
+        )
+
+    counts: Counter = Counter()
+    by_family: dict[str, int] = {}
+    for family, family_outcomes in outcomes.items():
+        family_count = 0
+        for outcome in family_outcomes:
+            requirement_count = int(getattr(outcome, "requirement_count", 1))
+            counts[outcome.state] += requirement_count
+            family_count += requirement_count
+        by_family[family] = family_count
+    requirements = sum(counts.values())
+    recognised = {
+        family
+        for attribute, family in _RECOGNISED_REQUIREMENT_FAMILIES.items()
+        if getattr(recognition, attribute, ())
+    }
+    unaudited = sorted(recognised - set(_AUDITED_FAMILIES))
+    audited_score = counts["placed"] / requirements if requirements else None
+    if requirements:
+        reason = "score covers recognized requirements in audited families"
+    elif unaudited:
+        reason = "recognized requirements exist only in families without outcome ledgers"
+    else:
+        reason = "no auditable recognized requirements"
+    return {
+        # Conditional completeness, not physical recall: score the requirements this run
+        # recognised AND for which Draftwright has a semantic outcome ledger. Missing
+        # recognisers are outside the scope; recognised-but-unscored families remain explicit.
+        "available": requirements > 0,
+        "score": audited_score,
+        "scope": "audited_recognized_requirements",
+        "coverage": "partial",
+        "reason": reason,
+        "denominator": "recognition",
+        "audited_families": list(_AUDITED_FAMILIES),
+        "unscored_recognized_families": unaudited,
+        "requirements": requirements,
+        **{state: counts[state] for state in _OUTCOME_STATES},
+        "by_family": by_family,
+    }
+
+
+def quality_components(
+    *,
+    recognition,
+    features,
+    registry,
+    omissions,
+    issues,
+    error_penalty: float,
+    warning_penalty: float,
+) -> dict:
+    """Return independently usable drawing-quality observations.
+
+    No composite score is returned.  In particular, an unavailable restraint component is
+    data, not zero: treating unclassified annotations as redundant would recreate the false
+    confidence this API is intended to remove.
+    """
+
+    legibility_issues = [issue for issue in issues if _is_legibility_issue(issue)]
+    return {
+        "completeness": _completeness_component(recognition, features, registry, omissions),
+        "restraint": {
+            "available": False,
+            "score": None,
+            "reason": (
+                "measurement provenance and physical requirement equivalence are incomplete"
+            ),
+        },
+        "legibility": _issue_component(
+            legibility_issues,
+            error_penalty=error_penalty,
+            warning_penalty=warning_penalty,
+        ),
+    }
+
+
+__all__ = ["quality_components"]

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -76,11 +76,14 @@ _PLACEMENT_DROP_CODES = frozenset(
     }
 )
 
+# The two ambiguous codes, named rather than merely absent so the vocabulary ratchet can tell
+# "deliberately classified as stage-carrying" from "nobody classified this at all".
+_STAGE_CLASSIFIED_DROP_CODES = frozenset({"gdt_dropped", "pmi_dropped"})
+
 # Recognition inventories that represent potentially dimension-bearing physical families.
-# Substrates (cylinders, face levels, risers, plates) are intentionally omitted: listing the
-# same physical requirement twice would make the coverage admission less honest, not more.
 _RECOGNISED_REQUIREMENT_FAMILIES = {
     "holes": "holes",
+    "countersinks": "countersinks",
     "double_d_bores": "profiled_bores",
     "hole_patterns": "hole_patterns",
     "bosses": "bosses",
@@ -99,6 +102,15 @@ _RECOGNISED_REQUIREMENT_FAMILIES = {
     "chamfers": "chamfers",
     "fillets": "fillets",
 }
+
+# Inventories that are deliberately NOT requirement families: the substrates would list the
+# same physical requirement a second time, and ``rotational`` is a classification flag rather
+# than an inventory. Kept explicit rather than implied by absence so that a new
+# ``RecognitionResult`` inventory cannot silently join the blind spot the completeness
+# component exists to report (``tests/test_quality_components.py``).
+_NON_REQUIREMENT_INVENTORIES = frozenset(
+    {"cylinders", "plates", "risers", "rotational", "step_levels"}
+)
 
 _AUDITED_FAMILIES = ("channels", "flats", "polygonal_stock", "slot_patterns", "slots")
 

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -44,41 +44,13 @@ _LEGIBILITY_CODES = frozenset(
     }
 )
 
-# Codes whose meaning is unambiguously "a valid annotation candidate did not land". The two
-# historically ambiguous codes (``gdt_dropped`` and ``pmi_dropped``) are deliberately absent;
-# their producers attach ``outcome_stage`` so validation and placement are separable.
-_PLACEMENT_DROP_CODES = frozenset(
-    {
-        "balloon_dropped",
-        "boss_dia_dropped",
-        "callout_dropped",
-        "chamfer_dropped",
-        "channel_width_dropped",
-        "diameter_dropped",
-        "dimension_dropped",
-        "fillet_dropped",
-        "flat_dropped",
-        "groove_dropped",
-        "location_ref_dropped",
-        "off_axis_location_dropped",
-        "pad_dim_dropped",
-        "plate_thickness_dropped",
-        "pocket_dim_dropped",
-        "pocket_dropped",
-        "polygonal_boss_dropped",
-        "polygonal_stock_dropped",
-        "polygonal_stock_length_dropped",
-        "slot_dim_dropped",
-        "slot_dropped",
-        "step_dim_dropped",
-        "step_position_dropped",
-        "table_dropped",
-    }
-)
-
-# The two ambiguous codes, named rather than merely absent so the vocabulary ratchet can tell
-# "deliberately classified as stage-carrying" from "nobody classified this at all".
-_STAGE_CLASSIFIED_DROP_CODES = frozenset({"gdt_dropped", "pmi_dropped"})
+# Codes whose meaning is unambiguously "a valid annotation candidate did not land" are
+# recognised by their ``*_dropped`` suffix rather than by a listed vocabulary. A list has to
+# be remembered; the suffix cannot be forgotten, so a drop code introduced tomorrow counts
+# against legibility on the day it is introduced instead of scoring as perfectly legible
+# until somebody notices (#1127 review). The two codes that cannot be read off their suffix
+# (``gdt_dropped``/``pmi_dropped``, which cover validation failures too) carry an explicit
+# ``outcome_stage`` from their producers instead; see ``_is_placement_drop``.
 
 # Recognition inventories that represent potentially dimension-bearing physical families.
 _RECOGNISED_REQUIREMENT_FAMILIES = {
@@ -116,10 +88,17 @@ _AUDITED_FAMILIES = ("channels", "flats", "polygonal_stock", "slot_patterns", "s
 
 
 def _is_placement_drop(issue) -> bool:
+    """Whether this issue reports a valid annotation candidate that did not land.
+
+    ``gdt_dropped`` and ``pmi_dropped`` each cover both malformed input and a candidate that
+    simply did not fit, so their producers attach an explicit ``outcome_stage``; that always
+    decides. Every other drop is read off the code suffix, which fails closed — an
+    unclassified new drop code is counted as a lost annotation rather than ignored.
+    """
     stage = getattr(issue, "outcome_stage", None)
     if stage is not None:
         return bool(stage == "placement")
-    return issue.code in _PLACEMENT_DROP_CODES
+    return bool(issue.code.endswith("_dropped"))
 
 
 def _is_legibility_issue(issue) -> bool:
@@ -131,23 +110,23 @@ def _issue_component(issues, *, error_penalty: float, warning_penalty: float) ->
     warnings = sum(issue.severity == "warning" for issue in issues)
     infos = sum(issue.severity == "info" for issue in issues)
     placement_drops = sum(_is_placement_drop(issue) for issue in issues)
-    # "Place what fits" feature drops are intentionally info severity in lint, but they are
-    # still lost annotations. Give each info-level drop the warning floor so legibility cannot
-    # remain 1.0 after arbitrarily many dimensions disappear (#1127 adversarial review).
-    info_drops = sum(issue.severity == "info" and _is_placement_drop(issue) for issue in issues)
     by_code = Counter(issue.code for issue in issues)
     return {
         "available": True,
+        # Every issue reaching here is a legibility defect by construction, so info severity
+        # takes the warning floor too. Lint uses it for "place what fits" drops and for
+        # readability faults like a leader crossing a silhouette; either way the component
+        # cannot report 1.0 while itemising output it has just called unreadable (#1127).
         "score": max(
             0.0,
-            1.0 - errors * error_penalty - (warnings + info_drops) * warning_penalty,
+            1.0 - errors * error_penalty - (warnings + infos) * warning_penalty,
         ),
         "errors": errors,
         "warnings": warnings,
         "infos": infos,
         "placement_drops": placement_drops,
         "by_code": dict(sorted(by_code.items())),
-        "basis": "layout_issue_severity_with_drop_floor",
+        "basis": "layout_issue_severity_with_info_floor",
     }
 
 

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -28,6 +28,11 @@ class SlotRequirementOutcome:
     member_count: int
     parameter_id: str
     state: SlotRequirementState
+    # Normally one outcome row is one measurement. When exact IR correspondence is
+    # unavailable, the row is a fail-closed placeholder for the physical source's whole
+    # recognition-derived requirement vocabulary. Preserve that cardinality so deleting a
+    # declaration cannot shrink a completeness denominator (#1127).
+    requirement_count: int = 1
 
 
 def _rounded(value) -> float:
@@ -175,6 +180,20 @@ def _matches(measurement, feature, parameter: str) -> bool:
     )
 
 
+def _physical_requirement_count(kind: SlotSourceKind, source) -> int:
+    """Requirement cardinality derived from recognition, never declared IR.
+
+    A lone slot requires width, length, and location. A pattern adds its independent pitch
+    vocabulary and two datum locations: linear = width/length/pitch/X/Y; grid =
+    width/length/row-pitch/column-pitch/X/Y. This mirrors the semantic roles enforced by
+    ``_parameter_ids`` while remaining available when the declaration is absent.
+    """
+
+    if kind == "slot":
+        return 3
+    return 5 if _pattern_key(source)[0] == "linear" else 6
+
+
 def _state(feature, parameter, *, placed, suppressed, dropped, registry):
     if any(_matches(measurement, feature, parameter) for measurement in placed):
         return "placed"
@@ -257,7 +276,16 @@ def slot_requirement_outcomes(
         if parameter_ids is None:
             # The association or required compiler vocabulary is not provable. Keep the
             # physical item visible as one unchecked outcome rather than inventing ids.
-            outcomes.append(SlotRequirementOutcome(kind, at, member_count, "?", "unverifiable"))
+            outcomes.append(
+                SlotRequirementOutcome(
+                    kind,
+                    at,
+                    member_count,
+                    "?",
+                    "unverifiable",
+                    requirement_count=_physical_requirement_count(kind, _source),
+                )
+            )
             continue
         outcomes.extend(
             SlotRequirementOutcome(

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -111,7 +111,7 @@ def test_a_placed_engine_callout_satisfies_the_recognised_requirement():
     assert completeness["coverage"] == "partial"
     assert completeness["scope"] == "audited_recognized_requirements"
     assert completeness["requirements"] == completeness["placed"] == 1
-    assert completeness["available"] is True and completeness["score"] == 1.0
+    assert completeness["available"] is True and completeness["audited_score"] == 1.0
 
 
 def test_issue_914_case_study_keeps_its_only_flat_definition():
@@ -244,7 +244,7 @@ def test_authored_omission_is_suppressed_not_missing():
     completeness = dwg.lint_summary()["quality"]["completeness"]
     assert completeness["requirements"] == completeness["suppressed"] == 1
     assert completeness["placed"] == 0
-    assert completeness["score"] == 0.0
+    assert completeness["audited_score"] == 0.0
 
 
 def test_a_planner_omission_is_not_authored_suppression():
@@ -300,7 +300,7 @@ def test_a_recognised_requirement_missing_from_the_declared_ir_is_unverifiable()
     completeness = dwg.lint_summary()["quality"]["completeness"]
     assert completeness["requirements"] == completeness["unverifiable"] == 1
     assert completeness["placed"] == 0
-    assert completeness["score"] == 0.0
+    assert completeness["audited_score"] == 0.0
 
 
 def test_requirement_identity_without_source_record_correspondence_is_unverifiable():

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -106,6 +106,12 @@ def test_a_placed_engine_callout_satisfies_the_recognised_requirement():
         "coverage result would have no semantic evidence"
     )
     assert _flat_codes(dwg) == []
+    completeness = dwg.lint_summary()["quality"]["completeness"]
+    assert completeness["denominator"] == "recognition"
+    assert completeness["coverage"] == "partial"
+    assert completeness["scope"] == "audited_recognized_requirements"
+    assert completeness["requirements"] == completeness["placed"] == 1
+    assert completeness["available"] is True and completeness["score"] == 1.0
 
 
 def test_issue_914_case_study_keeps_its_only_flat_definition():
@@ -235,6 +241,10 @@ def test_authored_omission_is_suppressed_not_missing():
         "precondition: the authored set omitted the A/F measurement"
     )
     assert _flat_codes(dwg) == ["flat_requirement_suppressed"]
+    completeness = dwg.lint_summary()["quality"]["completeness"]
+    assert completeness["requirements"] == completeness["suppressed"] == 1
+    assert completeness["placed"] == 0
+    assert completeness["score"] == 0.0
 
 
 def test_a_planner_omission_is_not_authored_suppression():
@@ -287,6 +297,10 @@ def test_a_recognised_requirement_missing_from_the_declared_ir_is_unverifiable()
     dwg = sheet.build()
 
     assert _flat_codes(dwg) == ["flat_requirement_unverifiable"]
+    completeness = dwg.lint_summary()["quality"]["completeness"]
+    assert completeness["requirements"] == completeness["unverifiable"] == 1
+    assert completeness["placed"] == 0
+    assert completeness["score"] == 0.0
 
 
 def test_requirement_identity_without_source_record_correspondence_is_unverifiable():

--- a/tests/test_gdt_placement.py
+++ b/tests/test_gdt_placement.py
@@ -236,7 +236,12 @@ def test_bad_target_drops_without_crashing():
         side="above",
     )
     dwg = _build(frame)
-    assert [i for i in dwg.registry.issues if i.code == "gdt_dropped"]
+    dropped = [i for i in dwg.registry.issues if i.code == "gdt_dropped"]
+    assert dropped and dropped[0].outcome_stage == "validation"
+    summary = dwg.lint_summary()
+    assert "gdt_dropped" not in summary["quality"]["legibility"]["by_code"]
+    serialized = next(issue for issue in summary["issues"] if issue["code"] == "gdt_dropped")
+    assert serialized["outcome_stage"] == "validation"
     assert "m_gdt0" not in dwg.annotations()
 
 
@@ -253,6 +258,7 @@ def test_invalid_glyph_spec_drops_not_crashes():
     dwg = _build(frame)  # must not raise
     dropped = [i for i in dwg.registry.issues if i.code == "gdt_dropped"]
     assert dropped and "m_gdt0" in dropped[0].message
+    assert dropped[0].outcome_stage == "validation"
     assert "m_gdt0" not in dwg.annotations()
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5300,7 +5300,7 @@ class TestLintSummaryAndDrops:
             "infos": 1,
             "placement_drops": 2,
             "by_code": {"callout_dropped": 1, "slot_dim_dropped": 1},
-            "basis": "layout_issue_severity_with_drop_floor",
+            "basis": "layout_issue_severity_with_info_floor",
         }
         assert summary["quality"]["restraint"] == {
             "available": False,

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5237,6 +5237,8 @@ class TestLintSummaryAndDrops:
         assert set(s) == {
             "passed",
             "score",
+            "diagnostic_score",
+            "quality",
             "errors",
             "warnings",
             "infos",
@@ -5247,10 +5249,66 @@ class TestLintSummaryAndDrops:
         assert s["errors"] + s["warnings"] + s["infos"] == len(issues)
         assert s["passed"] is (s["errors"] == 0)
         assert 0.0 <= s["score"] <= 1.0
+        assert s["diagnostic_score"] == s["score"]
+        assert set(s["quality"]) == {"completeness", "restraint", "legibility"}
+        completeness = s["quality"]["completeness"]
+        assert completeness["available"] is False
+        assert completeness["score"] is None
+        assert completeness["coverage"] == "partial"
+        assert completeness["scope"] == "audited_recognized_requirements"
+        assert completeness["unscored_recognized_families"] == ["holes"]
+        assert completeness["reason"] == (
+            "recognized requirements exist only in families without outcome ledgers"
+        )
         assert sum(s["by_code"].values()) == len(issues)
         assert len(s["issues"]) == len(issues)
         # A single-hole plate doesn't overflow the per-view callout cap.
         assert "callout_dropped" not in s["by_code"]
+
+    def test_quality_components_do_not_mix_semantic_and_layout_diagnostics(self):
+        from build123d import Box
+
+        from draftwright import build_drawing
+
+        dwg = build_drawing(Box(60, 40, 30))
+        dwg.registry.record_issue(
+            LintIssue(severity="warning", code="callout_dropped", message="layout")
+        )
+        dwg.registry.record_issue(
+            LintIssue(severity="warning", code="feature_not_dimensioned", message="completeness")
+        )
+        dwg.registry.record_issue(
+            LintIssue(severity="info", code="slot_dim_dropped", message="info placement drop")
+        )
+        dwg.registry.record_issue(
+            LintIssue(
+                severity="warning",
+                code="gdt_dropped",
+                message="invalid characteristic",
+                outcome_stage="validation",
+            )
+        )
+
+        summary = dwg.lint_summary()
+        legibility = summary["quality"]["legibility"]
+        assert summary["score"] == summary["diagnostic_score"] == 0.85
+        assert legibility == {
+            "available": True,
+            "score": 0.9,
+            "errors": 0,
+            "warnings": 1,
+            "infos": 1,
+            "placement_drops": 2,
+            "by_code": {"callout_dropped": 1, "slot_dim_dropped": 1},
+            "basis": "layout_issue_severity_with_drop_floor",
+        }
+        assert summary["quality"]["restraint"] == {
+            "available": False,
+            "score": None,
+            "reason": (
+                "measurement provenance and physical requirement equivalence are incomplete"
+            ),
+        }
 
     def test_recorded_build_issue_surfaces_and_counts(self):
         from build123d import Box

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5253,7 +5253,7 @@ class TestLintSummaryAndDrops:
         assert set(s["quality"]) == {"completeness", "restraint", "legibility"}
         completeness = s["quality"]["completeness"]
         assert completeness["available"] is False
-        assert completeness["score"] is None
+        assert completeness["audited_score"] is None
         assert completeness["coverage"] == "partial"
         assert completeness["scope"] == "audited_recognized_requirements"
         assert completeness["unscored_recognized_families"] == ["holes"]

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -1185,6 +1185,7 @@ class TestBuildDrawingPmi:
         assert [(issue.severity, issue.source_ids) for issue in drops] == [
             ("warning", ("dimension:mutation",))
         ]
+        assert [issue.outcome_stage for issue in drops] == ["placement"]
         assert lint_pmi_rendering(drawing.model().features, drawing.registry, "annotate") == []
 
     def test_pmi_annotate_exports_svg_dxf(self, ctc01_annotated):

--- a/tests/test_quality_components.py
+++ b/tests/test_quality_components.py
@@ -1,0 +1,110 @@
+"""Fail-closed guards over the quality components' hand-maintained vocabularies (#1127).
+
+The completeness and legibility components each classify a vocabulary the rest of the engine
+owns: the lint drop codes, and the recognition inventories. Both are literal collections, so
+a code or an inventory added elsewhere would join them by omission — legibility would stop
+counting a lost annotation, and completeness would stop reporting a blind spot it advertises
+as explicit. These tests turn "somebody remembered" into "CI refuses".
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from draftwright.linting.quality import (
+    _NON_REQUIREMENT_INVENTORIES,
+    _PLACEMENT_DROP_CODES,
+    _RECOGNISED_REQUIREMENT_FAMILIES,
+    _STAGE_CLASSIFIED_DROP_CODES,
+    quality_components,
+)
+from draftwright.recognition import RecognitionResult
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "draftwright"
+
+# The one site that builds a drop code at runtime rather than writing it out
+# (``annotations/from_model.py``'s slot/pad/pocket dim drop). Its expansion is listed here
+# because a literal scrape cannot see it; the scrape's blind spot is itself guarded below.
+_DYNAMIC_DROP_CODES = frozenset({"pad_dim_dropped", "pocket_dim_dropped", "slot_dim_dropped"})
+
+
+def _producer_files():
+    """Every engine module except the classifier itself.
+
+    Scanning ``quality.py`` would make both directions of the ratchet vacuous: its own
+    frozensets would supply every code the scrape then finds.
+    """
+
+    return sorted(path for path in _SRC.rglob("*.py") if path.name != "quality.py")
+
+
+def _recorded_drop_codes() -> set[str]:
+    pattern = re.compile(r"""["']([a-z_]+_dropped)["']""")
+    return {
+        code for path in _producer_files() for code in pattern.findall(path.read_text("utf-8"))
+    } | set(_DYNAMIC_DROP_CODES)
+
+
+def test_every_drop_code_the_engine_can_record_is_classified():
+    classified = _PLACEMENT_DROP_CODES | _STAGE_CLASSIFIED_DROP_CODES
+    unclassified = sorted(_recorded_drop_codes() - classified)
+
+    assert unclassified == [], (
+        "these lint drop codes are neither placement drops nor stage-carrying, so an "
+        f"annotation they report as lost would still score as perfectly legible: {unclassified}"
+    )
+
+
+def test_no_classified_drop_code_has_left_the_engine():
+    """The other direction: a stale entry means the classification is no longer exercised."""
+    stale = sorted((_PLACEMENT_DROP_CODES | _STAGE_CLASSIFIED_DROP_CODES) - _recorded_drop_codes())
+
+    assert stale == [], f"classified drop codes that no producer records any more: {stale}"
+
+
+def test_a_runtime_built_drop_code_cannot_evade_the_literal_scrape():
+    f_string_drop = re.compile(r"""f["'][^"']*\{[^}]+\}[a-z_]*_dropped["']""")
+    sites = sorted(
+        (str(path.relative_to(_SRC)), match)
+        for path in _producer_files()
+        for match in f_string_drop.findall(path.read_text("utf-8"))
+    )
+
+    assert sites == [("annotations/from_model.py", 'f"{noun}_dim_dropped"')], (
+        "a drop code assembled at runtime is invisible to the literal scrape; add its "
+        f"expansion to _DYNAMIC_DROP_CODES and record the new site here: {sites}"
+    )
+
+
+def test_every_recognition_inventory_is_either_a_requirement_family_or_excluded():
+    inventories = set(RecognitionResult.__dataclass_fields__)
+    classified = set(_RECOGNISED_REQUIREMENT_FAMILIES) | _NON_REQUIREMENT_INVENTORIES
+    unclassified = sorted(inventories - classified)
+
+    assert unclassified == [], (
+        "completeness reports recognised-but-unscored families from a literal map, so these "
+        f"inventories would be a blind spot it never admits to: {unclassified}"
+    )
+    assert not _NON_REQUIREMENT_INVENTORIES - inventories, (
+        "excluded inventories that no longer exist make the exclusion rationale unreadable"
+    )
+
+
+def test_an_unavailable_completeness_component_is_data_not_a_zero_score():
+    components = quality_components(
+        recognition=None,
+        features=(),
+        registry=None,
+        omissions=(),
+        issues=(),
+        error_penalty=0.15,
+        warning_penalty=0.05,
+    )
+    completeness = components["completeness"]
+
+    assert completeness["available"] is False
+    assert completeness["score"] is None, "a missing inventory must not read as zero coverage"
+    assert completeness["coverage"] == "unavailable"
+    assert completeness["reason"] == "physical recognition inventory unavailable"
+    assert completeness["requirements"] == 0

--- a/tests/test_quality_components.py
+++ b/tests/test_quality_components.py
@@ -31,6 +31,51 @@ def _legibility(*issues):
     )["legibility"]
 
 
+def _completeness(*issues):
+    return quality_components(
+        recognition=None,
+        features=(),
+        registry=None,
+        omissions=(),
+        issues=issues,
+        error_penalty=0.15,
+        warning_penalty=0.05,
+    )["completeness"]
+
+
+def test_the_audited_score_carries_its_qualifier_in_its_own_name():
+    """A recogniser gap makes a perfect score reachable, so the caveat cannot live in a
+    sibling key: metadata is dropped when a number is quoted, a field name is not."""
+    completeness = _completeness()
+
+    assert "score" not in completeness
+    assert "audited_score" in completeness
+
+
+def test_the_denominator_states_what_it_cannot_see():
+    completeness = _completeness()
+
+    assert completeness["excludes"] == [
+        "physical geometry that recognition did not identify",
+        "recognized families without a semantic outcome ledger",
+    ]
+
+
+def test_a_recognition_gap_the_linter_did_notice_is_reported_beside_the_score():
+    """A floor on the blind spot, not a measure of it — but absent geometry gets a number
+    whenever lint could name it, instead of leaving the score to imply there is none."""
+    completeness = _completeness(
+        LintIssue(
+            severity="warning",
+            code="unrecognised_defining_geometry",
+            message="dimension-relevant source geometry is absent from recognised IR",
+        )
+    )
+
+    assert completeness["unrecognised_geometry_reports"] == 1
+    assert _completeness()["unrecognised_geometry_reports"] == 0
+
+
 def test_a_drop_code_nobody_registered_still_counts_against_legibility():
     """The fail-closed half: no list to update, so a new drop cannot score as legible."""
     legibility = _legibility(
@@ -111,7 +156,9 @@ def test_an_unavailable_completeness_component_is_data_not_a_zero_score():
     completeness = components["completeness"]
 
     assert completeness["available"] is False
-    assert completeness["score"] is None, "a missing inventory must not read as zero coverage"
+    assert completeness["audited_score"] is None, (
+        "a missing inventory must not read as zero coverage"
+    )
     assert completeness["coverage"] == "unavailable"
     assert completeness["reason"] == "physical recognition inventory unavailable"
     assert completeness["requirements"] == 0

--- a/tests/test_quality_components.py
+++ b/tests/test_quality_components.py
@@ -1,80 +1,87 @@
-"""Fail-closed guards over the quality components' hand-maintained vocabularies (#1127).
+"""Fail-closed guards over the quality components' classifications (#1127).
 
-The completeness and legibility components each classify a vocabulary the rest of the engine
-owns: the lint drop codes, and the recognition inventories. Both are literal collections, so
-a code or an inventory added elsewhere would join them by omission — legibility would stop
-counting a lost annotation, and completeness would stop reporting a blind spot it advertises
-as explicit. These tests turn "somebody remembered" into "CI refuses".
+Legibility decides what counts as a lost annotation, and completeness decides which
+recognition inventories it can admit to not scoring. Both decisions used to depend on a
+literal collection being kept up to date, which fails open: a code or an inventory added
+elsewhere joins by omission, and the component keeps reporting a clean sheet. These tests
+pin the behaviour that replaced the drop-code list, and ratchet the one classification that
+is still a literal map.
 """
 
 from __future__ import annotations
 
-import re
-from pathlib import Path
-
+from draftwright.linting.issues import LintIssue
 from draftwright.linting.quality import (
     _NON_REQUIREMENT_INVENTORIES,
-    _PLACEMENT_DROP_CODES,
     _RECOGNISED_REQUIREMENT_FAMILIES,
-    _STAGE_CLASSIFIED_DROP_CODES,
     quality_components,
 )
 from draftwright.recognition import RecognitionResult
 
-_SRC = Path(__file__).resolve().parents[1] / "src" / "draftwright"
 
-# The one site that builds a drop code at runtime rather than writing it out
-# (``annotations/from_model.py``'s slot/pad/pocket dim drop). Its expansion is listed here
-# because a literal scrape cannot see it; the scrape's blind spot is itself guarded below.
-_DYNAMIC_DROP_CODES = frozenset({"pad_dim_dropped", "pocket_dim_dropped", "slot_dim_dropped"})
-
-
-def _producer_files():
-    """Every engine module except the classifier itself.
-
-    Scanning ``quality.py`` would make both directions of the ratchet vacuous: its own
-    frozensets would supply every code the scrape then finds.
-    """
-
-    return sorted(path for path in _SRC.rglob("*.py") if path.name != "quality.py")
+def _legibility(*issues):
+    return quality_components(
+        recognition=None,
+        features=(),
+        registry=None,
+        omissions=(),
+        issues=issues,
+        error_penalty=0.15,
+        warning_penalty=0.05,
+    )["legibility"]
 
 
-def _recorded_drop_codes() -> set[str]:
-    pattern = re.compile(r"""["']([a-z_]+_dropped)["']""")
-    return {
-        code for path in _producer_files() for code in pattern.findall(path.read_text("utf-8"))
-    } | set(_DYNAMIC_DROP_CODES)
+def test_a_drop_code_nobody_registered_still_counts_against_legibility():
+    """The fail-closed half: no list to update, so a new drop cannot score as legible."""
+    legibility = _legibility(
+        LintIssue(severity="info", code="teleporter_dropped", message="a brand new drop")
+    )
+
+    assert legibility["placement_drops"] == 1
+    assert legibility["score"] < 1.0
+    assert legibility["by_code"] == {"teleporter_dropped": 1}
 
 
-def test_every_drop_code_the_engine_can_record_is_classified():
-    classified = _PLACEMENT_DROP_CODES | _STAGE_CLASSIFIED_DROP_CODES
-    unclassified = sorted(_recorded_drop_codes() - classified)
+def test_an_explicit_validation_stage_keeps_a_drop_out_of_legibility():
+    """The other half: a producer can still say "this was malformed input, not a layout loss"."""
+    legibility = _legibility(
+        LintIssue(
+            severity="warning",
+            code="gdt_dropped",
+            message="bad target",
+            outcome_stage="validation",
+        )
+    )
 
-    assert unclassified == [], (
-        "these lint drop codes are neither placement drops nor stage-carrying, so an "
-        f"annotation they report as lost would still score as perfectly legible: {unclassified}"
+    assert legibility["placement_drops"] == 0
+    assert legibility["by_code"] == {}
+    assert legibility["score"] == 1.0
+
+
+def test_an_info_severity_readability_fault_lowers_the_score():
+    """A leader through the outline is a legibility defect at info severity, not a free pass."""
+    legibility = _legibility(
+        LintIssue(
+            severity="info",
+            code="leader_crosses_silhouette",
+            message="leader shaft crosses the view silhouette",
+        )
+    )
+
+    assert legibility["infos"] == 1
+    assert legibility["placement_drops"] == 0, "precondition: this is not a drop"
+    assert legibility["score"] < 1.0, (
+        "legibility cannot read 1.0 while itemising output it calls unreadable"
     )
 
 
-def test_no_classified_drop_code_has_left_the_engine():
-    """The other direction: a stale entry means the classification is no longer exercised."""
-    stale = sorted((_PLACEMENT_DROP_CODES | _STAGE_CLASSIFIED_DROP_CODES) - _recorded_drop_codes())
-
-    assert stale == [], f"classified drop codes that no producer records any more: {stale}"
-
-
-def test_a_runtime_built_drop_code_cannot_evade_the_literal_scrape():
-    f_string_drop = re.compile(r"""f["'][^"']*\{[^}]+\}[a-z_]*_dropped["']""")
-    sites = sorted(
-        (str(path.relative_to(_SRC)), match)
-        for path in _producer_files()
-        for match in f_string_drop.findall(path.read_text("utf-8"))
+def test_semantic_issues_stay_out_of_the_legibility_component():
+    legibility = _legibility(
+        LintIssue(severity="warning", code="feature_not_dimensioned", message="completeness")
     )
 
-    assert sites == [("annotations/from_model.py", 'f"{noun}_dim_dropped"')], (
-        "a drop code assembled at runtime is invisible to the literal scrape; add its "
-        f"expansion to _DYNAMIC_DROP_CODES and record the new site here: {sites}"
-    )
+    assert legibility["by_code"] == {}
+    assert legibility["score"] == 1.0
 
 
 def test_every_recognition_inventory_is_either_a_requirement_family_or_excluded():

--- a/tests/test_quality_components.py
+++ b/tests/test_quality_components.py
@@ -44,8 +44,14 @@ def _completeness(*issues):
 
 
 def test_the_audited_score_carries_its_qualifier_in_its_own_name():
-    """A recogniser gap makes a perfect score reachable, so the caveat cannot live in a
-    sibling key: metadata is dropped when a number is quoted, a field name is not."""
+    """Only the key naming is checked here — sibling metadata is dropped when a number is
+    quoted, a field name is not.
+
+    That a perfect score really is reachable beside an admitted blind spot is a claim about
+    a built drawing, not about this dict, and is established on a real part by
+    ``test_audited_recognized_requirements_remain_scorable_beside_unscored_families`` in
+    ``tests/test_slot_completeness.py``.
+    """
     completeness = _completeness()
 
     assert "score" not in completeness

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -290,6 +290,8 @@ def test_removing_a_slot_declaration_cannot_shrink_the_quality_denominator():
 
 
 def test_audited_recognized_requirements_remain_scorable_beside_unscored_families():
+    """A perfect audited score is reachable while the component is itself reporting a blind
+    spot — which is why the scalar is named for its denominator (#1127)."""
     part = _off_centre_slot() - Pos(-25, 15, -5) * Cylinder(4, 20)
     completeness = build_drawing(part).lint_summary()["quality"]["completeness"]
 

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -285,8 +285,8 @@ def test_removing_a_slot_declaration_cannot_shrink_the_quality_denominator():
     assert complete_quality["requirements"] == sparse_quality["requirements"] == 3
     assert complete_quality["placed"] == 3
     assert sparse_quality["unverifiable"] == 3
-    assert complete_quality["score"] == 1.0
-    assert sparse_quality["score"] == 0.0
+    assert complete_quality["audited_score"] == 1.0
+    assert sparse_quality["audited_score"] == 0.0
 
 
 def test_audited_recognized_requirements_remain_scorable_beside_unscored_families():
@@ -294,7 +294,7 @@ def test_audited_recognized_requirements_remain_scorable_beside_unscored_familie
     completeness = build_drawing(part).lint_summary()["quality"]["completeness"]
 
     assert completeness["available"] is True
-    assert completeness["score"] == 1.0
+    assert completeness["audited_score"] == 1.0
     assert completeness["scope"] == "audited_recognized_requirements"
     assert completeness["requirements"] == completeness["placed"] == 3
     assert completeness["unscored_recognized_families"] == ["holes"]
@@ -333,9 +333,9 @@ def test_deleting_declared_features_cannot_improve_a_damaged_quality_score():
     empty_quality = empty.lint_summary()["quality"]["completeness"]
     assert damaged_quality["requirements"] == sparse_quality["requirements"] == 6
     assert damaged_quality["placed"] == sparse_quality["placed"] == 3
-    assert damaged_quality["score"] == sparse_quality["score"] == 0.5
+    assert damaged_quality["audited_score"] == sparse_quality["audited_score"] == 0.5
     assert empty_quality["requirements"] == empty_quality["unverifiable"] == 6
-    assert empty_quality["score"] == 0.0
+    assert empty_quality["audited_score"] == 0.0
 
 
 @pytest.mark.parametrize(("part_factory", "requirement_count"), [(_slot_row, 5), (_slot_grid, 6)])

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from build123d import Box, Pos
+from build123d import Box, Cylinder, Pos
 
 from draftwright import Drawing, Sheet, build_drawing
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
@@ -15,6 +15,10 @@ from draftwright.recognition import recognise_slots
 
 def _off_centre_slot():
     return Box(100, 70, 10) - Pos(22, -11, 0) * Box(30, 8, 20)
+
+
+def _two_distinct_slots():
+    return Box(140, 90, 10) - Pos(-35, -15, 0) * Box(30, 8, 20) - Pos(30, 18, 0) * Box(24, 12, 20)
 
 
 def _slot_grid():
@@ -269,6 +273,86 @@ def test_authored_omission_is_suppressed_not_missing():
     assert _slot_requirement_codes(dwg) == ["slot_requirement_suppressed"] * 3
 
 
+def test_removing_a_slot_declaration_cannot_shrink_the_quality_denominator():
+    complete, _handle = _declared_slot_drawing()
+    sparse = Sheet(_off_centre_slot())
+    envelope = sparse.envelope()
+    sparse.dimension(envelope, "width.length")
+
+    complete_quality = complete.lint_summary()["quality"]["completeness"]
+    sparse_quality = sparse.build().lint_summary()["quality"]["completeness"]
+    assert complete_quality["available"] is sparse_quality["available"] is True
+    assert complete_quality["requirements"] == sparse_quality["requirements"] == 3
+    assert complete_quality["placed"] == 3
+    assert sparse_quality["unverifiable"] == 3
+    assert complete_quality["score"] == 1.0
+    assert sparse_quality["score"] == 0.0
+
+
+def test_audited_recognized_requirements_remain_scorable_beside_unscored_families():
+    part = _off_centre_slot() - Pos(-25, 15, -5) * Cylinder(4, 20)
+    completeness = build_drawing(part).lint_summary()["quality"]["completeness"]
+
+    assert completeness["available"] is True
+    assert completeness["score"] == 1.0
+    assert completeness["scope"] == "audited_recognized_requirements"
+    assert completeness["requirements"] == completeness["placed"] == 3
+    assert completeness["unscored_recognized_families"] == ["holes"]
+
+
+def test_deleting_declared_features_cannot_improve_a_damaged_quality_score():
+    part = _two_distinct_slots()
+    full = build_drawing(part)
+    declared_slots = [feature for feature in full.model().features if feature.kind == "slot"]
+    for name in list(full.registry.names_for_feature(declared_slots[0])):
+        full.remove(name)
+
+    source = recognise_slots(part)[0]
+    sparse_sheet = Sheet(part)
+    sparse_sheet.slot(
+        width=source.width,
+        length=source.length,
+        long_axis=source.long_axis,
+        width_axis=source.width_axis,
+        depth_axis=source.depth_axis,
+        w_center=source.w_center,
+        lo=source.lo,
+        hi=source.hi,
+        at=source.location,
+    )
+    sparse_sheet.auto_dimensions()
+    sparse = sparse_sheet.build()
+
+    empty_sheet = Sheet(part)
+    envelope = empty_sheet.envelope()
+    empty_sheet.dimension(envelope, "width.length")
+    empty = empty_sheet.build()
+
+    damaged_quality = full.lint_summary()["quality"]["completeness"]
+    sparse_quality = sparse.lint_summary()["quality"]["completeness"]
+    empty_quality = empty.lint_summary()["quality"]["completeness"]
+    assert damaged_quality["requirements"] == sparse_quality["requirements"] == 6
+    assert damaged_quality["placed"] == sparse_quality["placed"] == 3
+    assert damaged_quality["score"] == sparse_quality["score"] == 0.5
+    assert empty_quality["requirements"] == empty_quality["unverifiable"] == 6
+    assert empty_quality["score"] == 0.0
+
+
+@pytest.mark.parametrize(("part_factory", "requirement_count"), [(_slot_row, 5), (_slot_grid, 6)])
+def test_removing_a_pattern_declaration_preserves_recognised_cardinality(
+    part_factory, requirement_count
+):
+    part = part_factory()
+    complete = build_drawing(part).lint_summary()["quality"]["completeness"]
+    sparse = Sheet(part)
+    envelope = sparse.envelope()
+    sparse.dimension(envelope, "width.length")
+    omitted = sparse.build().lint_summary()["quality"]["completeness"]
+
+    assert complete["requirements"] == omitted["requirements"] == requirement_count
+    assert omitted["unverifiable"] == requirement_count
+
+
 def test_authored_pattern_omission_suppresses_both_location_directions():
     part = _slot_grid()
     detected = build_drawing(part)
@@ -313,6 +397,10 @@ def test_authored_pattern_omission_suppresses_both_location_directions():
 def test_a_real_placement_failure_retains_the_dropped_measurement():
     dwg = build_drawing(_off_centre_slot(), page="A4", scale=1.5)
     (drop,) = [issue for issue in dwg.lint() if issue.code == "slot_dim_dropped"]
+    legibility = dwg.lint_summary()["quality"]["legibility"]
+    assert legibility["by_code"]["slot_dim_dropped"] == 1
+    assert legibility["placement_drops"] >= 1
+    assert legibility["score"] < 1.0
     assert len(drop.measurement_ids) == 1
     dropped_parameter = drop.measurement_ids[0].parameter
     outcome = next(item for item in _outcomes(dwg) if item.parameter_id == dropped_parameter)


### PR DESCRIPTION
Closes #1127.

## What changed

`Drawing.lint_summary()` gains a `quality` block with three independently observable
components, and the legacy severity-weighted `score` is preserved byte-for-byte alongside a
new `diagnostic_score` carrying the same value under an honest name. No composite quality
verdict is invented.

- **completeness** — follows recognition-owned physical requirements to compiler outcomes.
  Its scalar is `audited_score`, never a bare `score`: a part reaches 1.0 whenever every
  requirement recognition *did* identify was placed, however much of the part it missed.
  The block states its `scope`, what its denominator `excludes`, any
  `unscored_recognized_families`, and an `unrecognised_geometry_reports` count (a floor on
  the recognition blind spot, never a measure of it).
- **legibility** — layout and placement diagnostics only. Info severity takes the warning
  floor, so it cannot read 1.0 while itemising output it has just called unreadable. A drop
  is identified by its `*_dropped` code suffix unless its producer recorded an explicit
  `outcome_stage`, so a drop code added later counts without being registered anywhere.
- **restraint** — fails closed as unavailable until measurement provenance can classify
  every annotation. Unavailable is data, not zero.

Authored omission stays conservative: a removed line is recorded as `suppressed`, remains in
the completeness denominator, and scores as unplaced. Deletion alone is not an
accepted-waiver mechanism. Slot and pattern denominators keep their recognition-derived
cardinality when a declaration disappears, so a sparser declaration cannot raise the score.

## Why

The legacy severity-weighted score can *improve* when authored input becomes sparser (#1126),
which makes it a useful diagnostic convenience and an unsafe optimisation target. The new
components keep their evidence separate and make their scope and unavailable states
machine-readable.

`audited_score` is named for its denominator because the primary consumer of this API is an
agent summarising it, and a caveat kept in a sibling key is lost the moment the number is
quoted. **Neither number is a completion gate** — gate on issue codes and severities
(ADR 0002). Closing a recogniser gap is recognition work, not a metric change.

## Validation

Four adversarial review rounds — one self-review, three independent (Codex, each in an
isolated worktree at the PR head, the later ones instructed to treat earlier fixes as
suspect). Six substantive findings, all fixed: an unratcheted drop-code vocabulary, an
unreported `countersinks` blind spot, an unguarded "unavailable is not zero" contract, a
legibility score that could read 1.0 while reporting a leader through the part outline, a
drop classification that was the wrong shape rather than merely incomplete, and finally
documentation plus a test docstring that claimed behaviour the code did not have.

Every new guard was mutation-checked — reinstating a fixed drop list, removing the info
floor, ignoring `outcome_stage`, restoring the bare `score` key, zeroing the unrecognised
count and emptying `excludes` each fail exactly one test and nothing else.

Round two deleted more than it added: a 24-entry drop vocabulary and three source-scraping
tests gave way to a rule that fails closed in behaviour rather than in CI.