### PR TITLE
ci: run pull requests on Linux only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Weekly full cross-platform sweep. See the `test` matrix comment for why the
+    # per-PR matrix is Linux-only.
+    - cron: "17 4 * * 6"
+  workflow_dispatch:
 
 # A PR needs results only for its latest head. Each main push gets a unique group because it
 # owns a post-merge slow-suite run that must survive later merges.
@@ -31,7 +36,7 @@ jobs:
   test:
     # The PR is the compatibility gate. A merge to protected main has already passed these
     # exact checks, so main keeps lint + the slow post-merge safety net without repeating them.
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
     permissions:
       contents: read
     strategy:
@@ -39,18 +44,37 @@ jobs:
       matrix:
         # 3.10-3.12 resolve build123d 0.10 (cadquery-ocp + VTK); 3.13/3.14 resolve build123d
         # 0.11 (cadquery-ocp-novtk — VTK dropped, and the only kernel with 3.13/3.14 wheels).
-        # Linux covers every supported Python (3.13 is the coverage job below). macOS and
-        # Windows each cover the last VTK kernel and the current no-VTK kernel. This preserves
-        # every compatibility dimension without paying for the uninformative 3 x 5 product.
-        include:
-          - {os: ubuntu-latest, python-version: "3.10"}
-          - {os: ubuntu-latest, python-version: "3.11"}
-          - {os: ubuntu-latest, python-version: "3.12"}
-          - {os: ubuntu-latest, python-version: "3.14"}
-          - {os: macos-latest, python-version: "3.12"}
-          - {os: macos-latest, python-version: "3.14"}
-          - {os: windows-latest, python-version: "3.12"}
-          - {os: windows-latest, python-version: "3.14"}
+        # Linux covers every supported Python (3.13 is the coverage job below).
+        #
+        # Non-Linux runners meter far above their wall clock — macOS at 10x, Windows at 2x.
+        # Measured on run 31570091735, the four non-Linux jobs were 43 of 100 wall-clock
+        # minutes but 236 of 294 billed minutes: 80% of the cost. At the observed rate of
+        # roughly 234 pull-request CI runs a month that is ~55,000 billed minutes, and it
+        # exhausted the account's Actions allowance.
+        #
+        # So pull requests run Linux only, and the full cross-platform surface runs in the
+        # weekly sweep, on `workflow_dispatch`, or on any PR carrying the `full-matrix`
+        # label — which is the one to use for a branch touching packaging or kernel
+        # resolution. The sweep costs ~1,265 billed minutes a month against the ~55,000
+        # the trim saves.
+        #
+        # One matrix widened by expression rather than a second job: a duplicate job would
+        # repeat every step below and the two copies would drift.
+        include: ${{ fromJSON(
+          (github.event_name == 'pull_request'
+            && !contains(github.event.pull_request.labels.*.name, 'full-matrix'))
+          && '[{"os":"ubuntu-latest","python-version":"3.10"},
+               {"os":"ubuntu-latest","python-version":"3.11"},
+               {"os":"ubuntu-latest","python-version":"3.12"},
+               {"os":"ubuntu-latest","python-version":"3.14"}]'
+          || '[{"os":"ubuntu-latest","python-version":"3.10"},
+                {"os":"ubuntu-latest","python-version":"3.11"},
+                {"os":"ubuntu-latest","python-version":"3.12"},
+                {"os":"ubuntu-latest","python-version":"3.14"},
+                {"os":"macos-latest","python-version":"3.12"},
+                {"os":"macos-latest","python-version":"3.14"},
+                {"os":"windows-latest","python-version":"3.12"},
+                {"os":"windows-latest","python-version":"3.14"}]' ) }}
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
**Depends on #1134** (the `ci-ok` aggregate gate). Base is set to that branch; it must merge
first, and branch protection must switch to requiring `ci-ok`, or this leaves
`test (macos-latest, 3.12)` and `test (windows-latest, 3.14)` permanently unreported and
blocks every pull request.

## Why

Confirmed as the main cause of the account's Actions outage. Measured on
[run 31570091735](https://github.com/pzfreo/draftwright/actions/runs/31570091735):

| runners | wall clock | billed | share |
|---|---:|---:|---:|
| 2 x macOS (10x) | 19 min | **189** | 64% |
| 2 x Windows (2x) | 24 min | 47 | 16% |
| 6 x ubuntu (1x) + lint | 57 min | 58 | 20% |
| **total** | **100 min** | **294** | |

Rate of use: **63 CI runs in the five days to 2026-08-12**, 1.6 PR runs per merge — about
234 pull-request runs a month. The non-Linux legs alone therefore cost roughly
**55,000 billed minutes a month**.

## Change

Pull requests run **Linux only** — every supported Python, both kernel resolutions. The
full cross-platform surface still runs three ways:

- **weekly sweep** (Saturday)
- **`workflow_dispatch`**, any branch
- **`full-matrix` label** on a PR — for branches touching packaging or kernel resolution
  (label created)

**Per PR run: 294 -> ~58 billed minutes, about 80%.** The weekly sweep costs ~1,265 billed
minutes a month against the ~55,000 saved.

## Changes from the first revision of this PR

Three came out of reviewing it against branch protection and the actual usage numbers:

1. **It would have blocked every PR.** Trimming two legs left two required contexts
   permanently unreported — demonstrated: this PR was `MERGEABLE / BLOCKED`. Hence #1134.
2. **The monthly sweep was justified by broken arithmetic.** I rejected weekly because it
   "costs more than the trim saves", comparing a per-sweep cost against a per-PR saving —
   wrong by two orders of magnitude. It is now weekly.
3. **The `full-matrix` label did not exist**, so the documented escape hatch silently did
   nothing. Created.

Also dropped: the earlier revision kept one macOS and one Windows leg per PR on a
"newest, likeliest to break" rationale I asserted without evidence. With the cost confirmed,
Linux-only is the defensible line — the argument for which single non-Linux leg to keep was
never strong enough to justify 85 billed minutes per run.

## Trade-off

A macOS- or Windows-only regression is caught by the weekly sweep or the next labelled PR,
rather than by the PR that introduced it. Given the alternative was no CI at all, that is
the better failure mode — and `full-matrix` covers the branches where it actually matters.

## Verified

The `fromJSON` matrix expression is not theoretical: the previous revision ran and expanded
to exactly its intended legs. Both variants parse as valid JSON; `lint`, `coverage` and
`test-slow` gates are unchanged.
