### PR TITLE
ci: add a single aggregate gate so the test matrix can change shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,39 @@ jobs:
         # contract. Distribute individual cases: loadscope serialized the 18-case standards
         # module and left most workers idle (#1108).
         run: uv run pytest tests/ -m slow -n auto --dist load
+
+  ci-ok:
+    # The single status check branch protection should require.
+    #
+    # Protection currently names each matrix leg individually — `test (macos-latest, 3.12)`
+    # and nine others. A required context that names a job is only satisfied when a job of
+    # that exact name reports, so changing the matrix at all leaves those contexts stuck on
+    # "Expected" and makes every pull request permanently unmergeable. Requiring this job
+    # instead lets the matrix change shape without touching repository settings.
+    #
+    # `if: always()` is load-bearing, not decoration. Without it a failing dependency
+    # skips this job, and GitHub counts a skipped required check as satisfied — so a
+    # broken test suite would report a green gate.
+    if: always()
+    needs: [lint, test, coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every gating job to have succeeded or been legitimately skipped
+        env:
+          LINT: ${{ needs.lint.result }}
+          TEST: ${{ needs.test.result }}
+          COVERAGE: ${{ needs.coverage.result }}
+        run: |
+          echo "lint=$LINT test=$TEST coverage=$COVERAGE"
+          failed=0
+          for pair in "lint:$LINT" "test:$TEST" "coverage:$COVERAGE"; do
+            name=${pair%%:*}
+            result=${pair#*:}
+            # `skipped` is a pass: `test` does not run on push and `coverage` runs only on
+            # pull_request, by design. `failure` and `cancelled` are not passes.
+            case "$result" in
+              success|skipped) ;;
+              *) echo "::error::$name did not pass (result: $result)"; failed=1 ;;
+            esac
+          done
+          exit $failed


### PR DESCRIPTION
**Prerequisite for #1133.** Merge this first; #1133 is unmergeable until protection changes.

## The problem

Branch protection requires ten status checks **by name**, including
`test (macos-latest, 3.12)` and `test (windows-latest, 3.14)`.

A required context that names a job is satisfied only when a job of that exact name
reports. Remove or rename a matrix leg and its context sits at *Expected* forever — which
blocks **every** pull request, not just the one that changed the matrix.

This is demonstrated, not theorised. #1133 trims two legs and is `MERGEABLE / BLOCKED`
with both contexts unreported. Had it merged, every subsequent PR would have been stuck
until someone edited repository settings.

## The change

One job, `ci-ok`, which passes when `lint`, `test` and `coverage` have each either
succeeded or been legitimately skipped. Protection can then require a single stable name,
and the matrix becomes an implementation detail rather than repository configuration.

**Adds a job, removes none** — so it merges cleanly under the current settings.

## Two details worth reviewing closely

**`if: always()` is load-bearing.** Without it, a failing dependency causes this job to be
skipped, and GitHub counts a skipped required check as *satisfied*. A broken test suite
would report a green gate. This is the failure mode that makes naive aggregate gates worse
than none.

**`skipped` is accepted per dependency**, because `test` does not run on push and
`coverage` runs only on `pull_request`. `failure` and `cancelled` are not accepted.

## Follow-up required after merge

Switching protection to require `ci-ok` alone is a repository-settings change and cannot
be done in a PR:

1. Merge this.
2. Confirm `ci-ok` reports on a PR.
3. Settings -> Branches -> `main`: require **`ci-ok`** (plus `codecov/patch`,
   `codecov/project`), and drop the ten per-leg contexts.
4. Then #1133 becomes mergeable.

Doing step 3 before step 2 would leave nothing gating merges in the interim.
