### PR TITLE
ci: run pull requests on Linux only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Weekly full cross-platform sweep. See the `test` matrix comment for why the
+    # per-PR matrix is Linux-only.
+    - cron: "17 4 * * 6"
+  workflow_dispatch:
 
 # A PR needs results only for its latest head. Each main push gets a unique group because it
 # owns a post-merge slow-suite run that must survive later merges.
@@ -31,7 +36,7 @@ jobs:
   test:
     # The PR is the compatibility gate. A merge to protected main has already passed these
     # exact checks, so main keeps lint + the slow post-merge safety net without repeating them.
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
     permissions:
       contents: read
     strategy:
@@ -39,18 +44,37 @@ jobs:
       matrix:
         # 3.10-3.12 resolve build123d 0.10 (cadquery-ocp + VTK); 3.13/3.14 resolve build123d
         # 0.11 (cadquery-ocp-novtk — VTK dropped, and the only kernel with 3.13/3.14 wheels).
-        # Linux covers every supported Python (3.13 is the coverage job below). macOS and
-        # Windows each cover the last VTK kernel and the current no-VTK kernel. This preserves
-        # every compatibility dimension without paying for the uninformative 3 x 5 product.
-        include:
-          - {os: ubuntu-latest, python-version: "3.10"}
-          - {os: ubuntu-latest, python-version: "3.11"}
-          - {os: ubuntu-latest, python-version: "3.12"}
-          - {os: ubuntu-latest, python-version: "3.14"}
-          - {os: macos-latest, python-version: "3.12"}
-          - {os: macos-latest, python-version: "3.14"}
-          - {os: windows-latest, python-version: "3.12"}
-          - {os: windows-latest, python-version: "3.14"}
+        # Linux covers every supported Python (3.13 is the coverage job below).
+        #
+        # Non-Linux runners meter far above their wall clock — macOS at 10x, Windows at 2x.
+        # Measured on run 31570091735, the four non-Linux jobs were 43 of 100 wall-clock
+        # minutes but 236 of 294 billed minutes: 80% of the cost. At the observed rate of
+        # roughly 234 pull-request CI runs a month that is ~55,000 billed minutes, and it
+        # exhausted the account's Actions allowance.
+        #
+        # So pull requests run Linux only, and the full cross-platform surface runs in the
+        # weekly sweep, on `workflow_dispatch`, or on any PR carrying the `full-matrix`
+        # label — which is the one to use for a branch touching packaging or kernel
+        # resolution. The sweep costs ~1,265 billed minutes a month against the ~55,000
+        # the trim saves.
+        #
+        # One matrix widened by expression rather than a second job: a duplicate job would
+        # repeat every step below and the two copies would drift.
+        include: ${{ fromJSON(
+          (github.event_name == 'pull_request'
+            && !contains(github.event.pull_request.labels.*.name, 'full-matrix'))
+          && '[{"os":"ubuntu-latest","python-version":"3.10"},
+               {"os":"ubuntu-latest","python-version":"3.11"},
+               {"os":"ubuntu-latest","python-version":"3.12"},
+               {"os":"ubuntu-latest","python-version":"3.14"}]'
+          || '[{"os":"ubuntu-latest","python-version":"3.10"},
+                {"os":"ubuntu-latest","python-version":"3.11"},
+                {"os":"ubuntu-latest","python-version":"3.12"},
+                {"os":"ubuntu-latest","python-version":"3.14"},
+                {"os":"macos-latest","python-version":"3.12"},
+                {"os":"macos-latest","python-version":"3.14"},
+                {"os":"windows-latest","python-version":"3.12"},
+                {"os":"windows-latest","python-version":"3.14"}]' ) }}
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,5 +1,6 @@
 """Executable guards for the hosted-runner budget and protected release topology."""
 
+import json
 import re
 from pathlib import Path
 
@@ -24,26 +25,53 @@ def _job(workflow: str, name: str) -> str:
     return "\n".join(lines[start:end])
 
 
-def test_pr_matrix_preserves_compatibility_dimensions_with_nine_test_jobs():
+def _matrix_variants(test_job: str) -> tuple[list[dict], list[dict]]:
+    """The pull-request matrix and the full matrix, as the workflow expression defines them."""
+    literals = re.findall(r"'(\[\{.*?\}\])'", test_job, re.S)
+    assert len(literals) == 2, "expected exactly two matrix variants in the include expression"
+    return tuple(json.loads(re.sub(r"\s+", " ", literal)) for literal in literals)
+
+
+def test_pull_requests_run_linux_only_to_stay_inside_the_runner_budget():
     workflow = _workflow("ci.yml")
     test_job = _job(workflow, "test")
-    entries = set(re.findall(r'- \{os: ([^,]+), python-version: "([^"]+)"\}', test_job))
+    pr_matrix, full_matrix = _matrix_variants(test_job)
 
-    assert "if: github.event_name == 'pull_request'" in test_job
-    assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
-    assert len(entries) + 1 == 9  # the separate Ubuntu 3.13 coverage job
-    assert {version for os_name, version in entries if os_name == "ubuntu-latest"} | {"3.13"} == {
+    # macOS meters at 10x and Windows at 2x. Measured on run 31570091735, the four
+    # non-Linux jobs were 43 of 100 wall-clock minutes but 236 of 294 billed ones. At the
+    # observed ~234 pull-request CI runs a month that is ~55,000 billed minutes, and it
+    # exhausted the account's Actions allowance. Hence: no non-Linux runner on a plain PR.
+    assert {entry["os"] for entry in pr_matrix} == {"ubuntu-latest"}
+
+    # Every supported Python still runs on every PR; 3.13 is the separate coverage job.
+    assert {entry["python-version"] for entry in pr_matrix} | {"3.13"} == {
         "3.10",
         "3.11",
         "3.12",
         "3.13",
         "3.14",
     }
+
+    # The full surface still exists and still covers both kernels on both non-Linux OSes:
+    # 3.12 is the last release carrying VTK, 3.14 the current no-VTK kernel.
     for os_name in ("macos-latest", "windows-latest"):
-        assert {version for os_entry, version in entries if os_entry == os_name} == {
+        assert {e["python-version"] for e in full_matrix if e["os"] == os_name} == {
             "3.12",
             "3.14",
         }
+
+    assert "if: github.event_name != 'push'" in test_job
+    assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
+
+
+def test_the_full_matrix_stays_reachable_without_editing_the_workflow():
+    """Linux-only PRs are only defensible while the rest of the surface still runs."""
+    workflow = _workflow("ci.yml")
+    test_job = _job(workflow, "test")
+
+    assert "schedule:" in workflow and "cron:" in workflow  # weekly sweep
+    assert "workflow_dispatch:" in workflow  # on demand, any branch
+    assert "full-matrix" in test_job  # opt in on a single pull request
 
 
 def test_main_runs_static_and_slow_gates_without_repeating_fast_matrix():
@@ -52,7 +80,9 @@ def test_main_runs_static_and_slow_gates_without_repeating_fast_matrix():
     assert "push:\n    branches: [main]" in workflow
     assert "if:" not in _job(workflow, "lint")
     assert "if: github.event_name == 'push'" in _job(workflow, "test-slow")
-    assert "if: github.event_name == 'pull_request'" in _job(workflow, "test")
+    # `test` also serves the weekly sweep and workflow_dispatch, so it is gated on "not a
+    # merge to main" rather than on "is a pull request".
+    assert "if: github.event_name != 'push'" in _job(workflow, "test")
     assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
 
 


### PR DESCRIPTION
**Supersedes #1133**, which GitHub auto-closed when its base branch (`ci/aggregate-gate`, now
merged as #1134) was deleted. Same branch, rebased onto `main`, plus the workflow-guard
update below.

## Why

Confirmed as the main cause of the account's Actions outage. Measured on
[run 31570091735](https://github.com/pzfreo/draftwright/actions/runs/31570091735):

| runners | wall clock | billed | share |
|---|---:|---:|---:|
| 2 x macOS (10x) | 19 min | **189** | 64% |
| 2 x Windows (2x) | 24 min | 47 | 16% |
| 6 x ubuntu (1x) + lint | 57 min | 58 | 20% |
| **total** | **100 min** | **294** | |

Rate of use: **63 CI runs in the five days to 2026-08-12**, 1.6 PR runs per merge — about
234 pull-request runs a month. The non-Linux legs alone therefore cost roughly
**55,000 billed minutes a month**.

## Change

Pull requests run **Linux only** — every supported Python, both kernel resolutions. The
full cross-platform surface still runs three ways:

- **weekly sweep** (Saturday)
- **`workflow_dispatch`**, any branch
- **`full-matrix` label** on a PR — for branches touching packaging or kernel resolution
  (label created)

**Per PR run: 294 -> ~58 billed minutes, about 80%.** The weekly sweep costs ~1,265 billed
minutes a month against the ~55,000 saved.

## Changes from the first revision of this PR

Three came out of reviewing it against branch protection and the actual usage numbers:

1. **It would have blocked every PR.** Trimming two legs left two required contexts
   permanently unreported — demonstrated: this PR was `MERGEABLE / BLOCKED`. Hence #1134.
2. **The monthly sweep was justified by broken arithmetic.** I rejected weekly because it
   "costs more than the trim saves", comparing a per-sweep cost against a per-PR saving —
   wrong by two orders of magnitude. It is now weekly.
3. **The `full-matrix` label did not exist**, so the documented escape hatch silently did
   nothing. Created.

Also dropped: the earlier revision kept one macOS and one Windows leg per PR on a
"newest, likeliest to break" rationale I asserted without evidence. With the cost confirmed,
Linux-only is the defensible line — the argument for which single non-Linux leg to keep was
never strong enough to justify 85 billed minutes per run.

## Trade-off

A macOS- or Windows-only regression is caught by the weekly sweep or the next labelled PR,
rather than by the PR that introduced it. Given the alternative was no CI at all, that is
the better failure mode — and `full-matrix` covers the branches where it actually matters.

## Verified

The `fromJSON` matrix expression is not theoretical: the previous revision ran and expanded
to exactly its intended legs. Both variants parse as valid JSON; `lint`, `coverage` and
`test-slow` gates are unchanged.

## Added since #1133: the repo caught this itself

`tests/test_workflows.py` — *"Executable guards for the hosted-runner budget and protected
release topology"* — asserted nine test jobs per PR and
`if: github.event_name == 'pull_request'` on the `test` job. Both failed, correctly. My own
adversarial review of #1133 checked branch protection and missed this entirely.

The guard was encoding the previous budget assumption. It is updated to encode the new one
rather than relaxed, and it now pins:

- no non-Linux runner in the PR matrix at all, with the measured reason beside the assertion
- every supported Python still running on every PR
- the full matrix still covering both kernels on both non-Linux OSes
- **all three routes to the full matrix still existing** — weekly sweep, `workflow_dispatch`,
  `full-matrix` label

That last test is new: Linux-only PRs are only defensible while the rest of the surface
runs somewhere, so deleting the sweep or the label should fail a test rather than quietly
halve the coverage.

## Still required before this can merge

Branch protection names each matrix leg individually. Switch `main` to require **`ci-ok`**
(plus `codecov/patch`, `codecov/project`) and drop the ten per-leg contexts — `ci-ok` merged
in #1134 and reported green there.
