### PR TITLE
Stop building leader geometry just to measure it (#1138)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -493,11 +493,11 @@ def leader_footprint(tip, elbow, draft, *, text_side="auto", callout_box=None):
     Mirrors ``helpers.Leader.__init__``: the shelf runs ``pad_around_text`` from
     the elbow in ``shelf_dir`` (``text_side``, or tip→elbow's horizontal sense when
     ``"auto"``), and the callout hangs at the shelf end — its near edge on the
-    shelf end, centred vertically on the elbow. The shaft is inflated by half the
-    arrow length rather than half the line width: the arrowhead at *tip* is the
-    widest thing on it, and over-claiming is the safe direction (this box selects
-    which obstacles a carve considers, so a box that is too big keeps an
-    irrelevant obstacle, while one that is too small drops a real one).
+    shelf end, centred vertically on the elbow. The shaft is inflated by half of
+    whichever of *arrow_length* / *line_width* dominates, and over-claiming is the
+    safe direction (this box selects which obstacles a carve considers, so a box
+    that is too big keeps an irrelevant obstacle, while one that is too small drops
+    a real one).
 
     Returns ``None`` where ``Leader`` itself would raise — a forced *text_side*
     that runs the shaft through the label — so callers omit the candidate exactly
@@ -510,7 +510,10 @@ def leader_footprint(tip, elbow, draft, *, text_side="auto", callout_box=None):
         shelf_dir = 1.0 if text_side == "right" else -1.0
     shelf_end_x = elbow[0] + shelf_dir * gap
 
-    half_shaft = draft.arrow_length / 2.0  # head half-width bounds the shaft's
+    # The arrowhead bounds the shaft only while it is the wider of the two; a style with a
+    # heavy line and a small arrow inverts that, and a diagonal shaft then pushes its stroke
+    # past an arrow-only box. Pad by whichever dominates.
+    half_shaft = max(draft.arrow_length, draft.line_width) / 2.0
     xs = [tip[0] - half_shaft, tip[0] + half_shaft, elbow[0] - half_shaft, elbow[0] + half_shaft]
     ys = [tip[1] - half_shaft, tip[1] + half_shaft, elbow[1] - half_shaft, elbow[1] + half_shaft]
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -616,7 +616,7 @@ def clear_label_of_centerlines(label_bbox, centerlines, gap):
     return target_x - lmin_x
 
 
-def occupancy_boxes(o, stroke_pad=None, cache=None):
+def occupancy_boxes(o, stroke_pad=None):
     """*o*'s occupancy as a list of AABBs — decomposed, not one hull (#685).
 
     An annotation's rendered hull includes large EMPTY corner regions (a dimension's
@@ -635,7 +635,7 @@ def occupancy_boxes(o, stroke_pad=None, cache=None):
     """
     segs = getattr(o, "segments", None)
     if not segs:
-        b = _geom_box(o, cache)
+        b = _geom_box(o)
         return [b] if b is not None else []
     pad = _STROKE_PAD if stroke_pad is None else stroke_pad
     out = []
@@ -700,10 +700,6 @@ def strip_obstacles(dwg, view=None, *, crossable=(), named=False):
     # Preset-aware stroke pad (#688 review): arrowheads scale with font_size.
     al = getattr(getattr(dwg, "draft", None), "arrow_length", None)
     pad = max(_STROKE_PAD, al / 2) if al else _STROKE_PAD
-    # Share the drawing's one box memo (#1138) — this runs once per strip solve over
-    # every placed annotation, so it is where the double-measuring concentrated.
-    # getattr: `dwg` is duck-typed throughout annotations/, and stand-ins need not carry it.
-    cache = getattr(dwg, "box_cache", None)
     boxes: list = []
     for name, o in dwg.iter_annotations():
         if view is not None:
@@ -712,7 +708,7 @@ def strip_obstacles(dwg, view=None, *, crossable=(), named=False):
                 continue  # owned by a different ortho view → its own (disjoint) block
         if type(o).__name__ in crossable:
             continue  # this consumer may cross it (centre lines/marks for a dim)
-        occ = occupancy_boxes(o, stroke_pad=pad, cache=cache)  # decomposed, not one hull (#685)
+        occ = occupancy_boxes(o, stroke_pad=pad)  # decomposed, not one hull (#685)
         boxes.extend(((name, b) for b in occ) if named else occ)
     return boxes
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -26,7 +26,7 @@ from draftwright._core import (  # noqa: F401 — _anno_box re-exported (#700)
 from draftwright._geometry import _boxes_overlap, _segment_crosses_box  # noqa: F401
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.linting.issues import LintIssue
-from draftwright.linting.structural import _centerline_extent
+from draftwright.linting.structural import _ann_box, _centerline_extent
 from draftwright.model.compiled import resolve_feature
 
 _log = logging.getLogger(__name__)
@@ -376,12 +376,22 @@ class SolveTrace:
             _log.warning("trace: could not write %s: %s", self.path, exc)
 
 
-def _geom_box(o):
+def _geom_box(o, cache=None):
     """Full rendered-geometry bbox ``(x0, y0, x1, y1)`` of an annotation — leader
     shafts and arrow tips, dimension witness/extension lines, centrelines, hatch —
     *not* just its label box. ``None`` if it does not bbox cleanly (logged at
     debug: a silently dropped occupant is the wrong failure mode for an occupancy
-    model, so the omission is at least observable)."""
+    model, so the omission is at least observable).
+
+    With *cache* (a drawing's :attr:`~draftwright.drawing.Drawing.box_cache`) the
+    measurement goes through lint's ``_ann_box`` memo instead of straight to OCC, so
+    an annotation is boxed once per build rather than once here and again in lint
+    (#1138). Same memo, not a parallel one — its identity+location-token entries are
+    what make sharing safe, and lint's prune is what keeps it from leaking. Without a
+    cache the behaviour is unchanged, which keeps the duck-typed callers and the
+    tests that call this bare working."""
+    if cache is not None:
+        return _ann_box(o, cache)
     try:
         b = o.bounding_box()
         return (b.min.X, b.min.Y, b.max.X, b.max.Y)
@@ -468,6 +478,66 @@ def dim_footprint(p1, p2, side, distance, draft, label):
     return (min(xs) - pad, min(ys) - pad, max(xs) + pad, max(ys) + pad)
 
 
+def leader_footprint(tip, elbow, draft, *, text_side="auto", callout_box=None):
+    """Analytical page-mm AABB ``(x0, y0, x1, y1)`` of the :class:`Leader` that
+    ``Leader(tip, elbow, label="", draft, text_side=…, callout=…)`` would build —
+    WITHOUT constructing any OCC geometry (#1138, the #602 pattern applied to
+    leaders).
+
+    Probing one callout leader's footprint by *building* it costs 0.12–0.21 s —
+    6–10 % of a whole drawing — because a ``Leader`` fuses an ``Arrow``, a swept
+    shelf rectangle and the callout sketch before anything can be measured. The
+    footprint is arithmetic given the callout's own box, which is measured once
+    and memoised rather than re-measured per candidate position.
+
+    Mirrors ``helpers.Leader.__init__``: the shelf runs ``pad_around_text`` from
+    the elbow in ``shelf_dir`` (``text_side``, or tip→elbow's horizontal sense when
+    ``"auto"``), and the callout hangs at the shelf end — its near edge on the
+    shelf end, centred vertically on the elbow. The shaft is inflated by half the
+    arrow length rather than half the line width: the arrowhead at *tip* is the
+    widest thing on it, and over-claiming is the safe direction (this box selects
+    which obstacles a carve considers, so a box that is too big keeps an
+    irrelevant obstacle, while one that is too small drops a real one).
+
+    Returns ``None`` where ``Leader`` itself would raise — a forced *text_side*
+    that runs the shaft through the label — so callers omit the candidate exactly
+    as the built-geometry probe's except-handler did.
+    """
+    gap = draft.pad_around_text
+    if text_side == "auto":
+        shelf_dir = 1.0 if elbow[0] >= tip[0] else -1.0
+    else:
+        shelf_dir = 1.0 if text_side == "right" else -1.0
+    shelf_end_x = elbow[0] + shelf_dir * gap
+
+    half_shaft = draft.arrow_length / 2.0  # head half-width bounds the shaft's
+    xs = [tip[0] - half_shaft, tip[0] + half_shaft, elbow[0] - half_shaft, elbow[0] + half_shaft]
+    ys = [tip[1] - half_shaft, tip[1] + half_shaft, elbow[1] - half_shaft, elbow[1] + half_shaft]
+
+    half_line = draft.line_width / 2.0
+    xs += [min(elbow[0], shelf_end_x) - half_line, max(elbow[0], shelf_end_x) + half_line]
+    ys += [elbow[1] - half_line, elbow[1] + half_line]
+
+    if callout_box is not None:
+        cw = callout_box[2] - callout_box[0]
+        ch = callout_box[3] - callout_box[1]
+        if shelf_dir > 0:
+            cx0, cx1 = shelf_end_x, shelf_end_x + cw
+        else:
+            cx0, cx1 = shelf_end_x - cw, shelf_end_x
+        cy0, cy1 = elbow[1] - ch / 2.0, elbow[1] + ch / 2.0
+        # Leader raises rather than draw a shaft through its own label; a forced side
+        # is the only way to get there, matching helpers' own guard condition.
+        if text_side != "auto" and _segment_crosses_box(
+            (tip[0], tip[1]), (elbow[0], elbow[1]), (cx0, cy0, cx1, cy1)
+        ):
+            return None
+        xs += [cx0, cx1]
+        ys += [cy0, cy1]
+
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
 CROSSABLE_TYPES = frozenset({"Centerline", "CenterlineCircle", "CenterMark"})
 """Annotation types a *dimension* may legitimately cross (ISO 128): centre lines
 and centre marks. A **leader**, by contrast, must avoid them (#305) — so this is a
@@ -543,7 +613,7 @@ def clear_label_of_centerlines(label_bbox, centerlines, gap):
     return target_x - lmin_x
 
 
-def occupancy_boxes(o, stroke_pad=None):
+def occupancy_boxes(o, stroke_pad=None, cache=None):
     """*o*'s occupancy as a list of AABBs — decomposed, not one hull (#685).
 
     An annotation's rendered hull includes large EMPTY corner regions (a dimension's
@@ -562,7 +632,7 @@ def occupancy_boxes(o, stroke_pad=None):
     """
     segs = getattr(o, "segments", None)
     if not segs:
-        b = _geom_box(o)
+        b = _geom_box(o, cache)
         return [b] if b is not None else []
     pad = _STROKE_PAD if stroke_pad is None else stroke_pad
     out = []
@@ -627,6 +697,10 @@ def strip_obstacles(dwg, view=None, *, crossable=(), named=False):
     # Preset-aware stroke pad (#688 review): arrowheads scale with font_size.
     al = getattr(getattr(dwg, "draft", None), "arrow_length", None)
     pad = max(_STROKE_PAD, al / 2) if al else _STROKE_PAD
+    # Share the drawing's one box memo (#1138) — this runs once per strip solve over
+    # every placed annotation, so it is where the double-measuring concentrated.
+    # getattr: `dwg` is duck-typed throughout annotations/, and stand-ins need not carry it.
+    cache = getattr(dwg, "box_cache", None)
     boxes: list = []
     for name, o in dwg.iter_annotations():
         if view is not None:
@@ -635,7 +709,7 @@ def strip_obstacles(dwg, view=None, *, crossable=(), named=False):
                 continue  # owned by a different ortho view → its own (disjoint) block
         if type(o).__name__ in crossable:
             continue  # this consumer may cross it (centre lines/marks for a dim)
-        occ = occupancy_boxes(o, stroke_pad=pad)  # decomposed, not one hull (#685)
+        occ = occupancy_boxes(o, stroke_pad=pad, cache=cache)  # decomposed, not one hull (#685)
         boxes.extend(((name, b) for b in occ) if named else occ)
     return boxes
 
@@ -727,6 +801,7 @@ def corridor_blockers(dwg, view):
     128). Sibling location/envelope dims are excluded: they chain off the shared datum
     and legitimately share the corridor. View scoping mirrors :func:`strip_obstacles`
     (this view's own annotations + drawing-level occupants that no ortho view owns)."""
+    cache = getattr(dwg, "box_cache", None)  # the drawing's one box memo (#1138)
     boxes = []
     for name, o in dwg.iter_annotations():
         if view is not None:
@@ -735,7 +810,7 @@ def corridor_blockers(dwg, view):
                 continue
         if isinstance(o, (Dimension, SafeDimension)) or type(o).__name__ in CROSSABLE_TYPES:
             continue  # datum-chained dims share the corridor; centre lines are crossable
-        bb = _geom_box(o)
+        bb = _geom_box(o, cache)
         if bb is not None:
             boxes.append(bb)
     return boxes

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -46,6 +46,7 @@ from draftwright.annotations._common import (
     carve_free_segments,
     clear_label_of_centerlines,
     dim_footprint,
+    leader_footprint,
     place_strip_candidates,
     register_corridor,
     strip_obstacles,
@@ -1768,36 +1769,30 @@ def _rim_tip(centre, elbow, dia, scale, *, callout=None, location=None, to_page=
     return (centre[0] + dx / norm * r, centre[1] + dy / norm * r)
 
 
-def _build_leader_at(s, edge, side, y, to_page, elbow_dx, draft, scale):
-    """The Leader a callout would draw for queue entry *s* at elbow-Y *y* — built but not
-    placed, so its footprint can be checked before committing (ADR 0009 P5 strand 3). Returns
-    ``(leader, tip, elbow)``. Promoted (#638; pure)."""
+def _leader_anchors(s, edge, side, y, to_page, elbow_dx, draft, scale):
+    """The ``(tip, elbow)`` page points a callout leader for queue entry *s* would span at
+    elbow-Y *y* — pure arithmetic, no OCC. Shared by :func:`_build_leader_at` (which then
+    builds the geometry) and :func:`_probe_box` (which only needs the footprint), so the
+    two cannot describe different leaders (#1138)."""
     _locs, dia, callout, _feat, _ny, rep = s
     centre = to_page(rep)
     if side == "right":
         elbow = (edge + elbow_dx, y)
-        tip = _rim_tip(
-            centre,
-            elbow,
-            dia,
-            scale,
-            callout=callout,
-            location=rep,
-            to_page=to_page,
-        )
+        tip = _rim_tip(centre, elbow, dia, scale, callout=callout, location=rep, to_page=to_page)
         tip = (min(tip[0], edge - draft.arrow_length), tip[1])
     else:
         elbow = (edge - elbow_dx, y)
-        tip = _rim_tip(
-            centre,
-            elbow,
-            dia,
-            scale,
-            callout=callout,
-            location=rep,
-            to_page=to_page,
-        )
+        tip = _rim_tip(centre, elbow, dia, scale, callout=callout, location=rep, to_page=to_page)
         tip = (max(tip[0], edge + draft.arrow_length), tip[1])
+    return tip, elbow
+
+
+def _build_leader_at(s, edge, side, y, to_page, elbow_dx, draft, scale):
+    """The Leader a callout would draw for queue entry *s* at elbow-Y *y* — built but not
+    placed, so its footprint can be checked before committing (ADR 0009 P5 strand 3). Returns
+    ``(leader, tip, elbow)``. Promoted (#638; pure)."""
+    callout = s[2]
+    tip, elbow = _leader_anchors(s, edge, side, y, to_page, elbow_dx, draft, scale)
     leader = _profiled_callout_leader(
         tip=(tip[0], tip[1], 0),
         elbow=(elbow[0], elbow[1], 0),
@@ -1824,17 +1819,26 @@ def _is_central(s, a, to_page, view_cx, view_cy, draft):
     return abs(cx - view_cx) < tol and abs(cy - view_cy) < tol
 
 
-def _probe_box(s, edge, side, to_page, elbow_dx, draft, scale):
+def _probe_box(s, edge, side, to_page, elbow_dx, draft, scale, cache=None):
     """Probe a queued candidate's leader footprint up front (before it's chosen for placement),
     so a degenerate geometry (a hole essentially coincident with the strip edge) gets a
     defensive catch, matching _geom_box's "not every annotation bbox-es cleanly" idiom. Returns
-    the box or ``None``. Promoted (#638; side-effect-free bar a debug log on failure)."""
+    the box or ``None``. Promoted (#638; side-effect-free bar a debug log on failure).
+
+    Computed analytically (#1138). Building the Leader to measure it cost 0.12–0.21 s per
+    probe — 6–10 % of a whole drawing — to fuse an Arrow, a swept shelf and the callout
+    sketch, all of which was then discarded: the caller reads only the horizontal extent,
+    to decide which obstacles the carve should consider. The one measurement that is not
+    arithmetic, the callout's own box, goes through the drawing's shared memo, so a callout
+    probed at several candidate rows is measured once rather than once per row."""
+    callout = s[2]
     try:
-        leader, _, _ = _build_leader_at(s, edge, side, s[4], to_page, elbow_dx, draft, scale)
-    except Exception as exc:  # noqa: BLE001 — geometry construction raises broadly
+        tip, elbow = _leader_anchors(s, edge, side, s[4], to_page, elbow_dx, draft, scale)
+        callout_box = None if callout is None else _geom_box(callout, cache)
+        return leader_footprint(tip, elbow, draft, text_side=side, callout_box=callout_box)
+    except Exception as exc:  # noqa: BLE001 — degenerate placements raise broadly
         _log.debug("plan/side %s strip: probe leader failed (%s); omitted", side, exc)
         return None
-    return _geom_box(leader)
 
 
 class _StripCtx(NamedTuple):
@@ -2201,10 +2205,11 @@ def _place_queue(
     # position-dependent geometry (it runs from the fixed hole location
     # to the elbow), so probing everyone at one far-away Y badly
     # misjudges it.
+    cache = getattr(dwg, "box_cache", None)  # measure each callout once (#1138)
     probe_boxes = [
         b
         for s in queue
-        if (b := _probe_box(s, edge, side, to_page, elbow_dx, draft, a.SCALE)) is not None
+        if (b := _probe_box(s, edge, side, to_page, elbow_dx, draft, a.SCALE, cache)) is not None
     ]
     occupied = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
     if probe_boxes:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -661,6 +661,27 @@ class Drawing:
     def _ann_box_cache(self) -> dict:
         return self._build.ann_box_cache
 
+    @property
+    def box_cache(self) -> dict:
+        """The ONE annotation bounding-box memo for this build (#1138).
+
+        Placement and lint measure the same annotations. Until now they measured them
+        twice: ``_common._geom_box`` boxed each occupant while solving a strip, then
+        ``linting.structural._ann_box`` boxed it again from a cold cache — 46% of lint's
+        bounding-box time on a plate build was re-measuring geometry placement had
+        already measured. An *optimal* ``bounding_box()`` tessellates, so a Dimension
+        costs ~10 ms and a Leader ~16 ms; doing it twice is the whole of that waste.
+
+        Exposed publicly (not as ``_ann_box_cache``) because the annotations layer is
+        duck-typed against ``dwg`` and, per ADR 0005, reads no private Drawing state.
+        Sharing the dict rather than adding a second memo also means ``lint()``'s
+        existing liveness prune — which drops entries for objects no longer on the
+        sheet — covers placement-seeded entries for free; a separate placement cache
+        would have to re-implement that pruning, and a missed prune keeps OCC geometry
+        alive for the drawing's lifetime.
+        """
+        return self._build.ann_box_cache
+
     @deprecated(
         "Drawing.attach_part_model() is deprecated (#817): build-state attach is engine "
         "plumbing; the mutator is now private (_attach_part_model). Removed in 0.5.0."

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -665,12 +665,17 @@ class Drawing:
     def box_cache(self) -> dict:
         """The ONE annotation bounding-box memo for this build (#1138).
 
-        Placement and lint measure the same annotations. Until now they measured them
-        twice: ``_common._geom_box`` boxed each occupant while solving a strip, then
-        ``linting.structural._ann_box`` boxed it again from a cold cache — 46% of lint's
-        bounding-box time on a plate build was re-measuring geometry placement had
-        already measured. An *optimal* ``bounding_box()`` tessellates, so a Dimension
-        costs ~10 ms and a Leader ~16 ms; doing it twice is the whole of that waste.
+        Placement and lint both measure annotations, and an *optimal* ``bounding_box()``
+        tessellates (~16 ms for a Leader), so anything measured on both paths is worth
+        measuring once. Sharing one memo makes that hold by construction.
+
+        Keep its measured scope in mind before attributing a build's cost to it: on a
+        plate build it holds **two** entries, on a flange **three**, all leaders and
+        their callouts. Dimensions are *not* among them and cannot be — ``strip_obstacles``
+        decomposes anything exposing ``.segments`` instead of boxing it whole, and
+        ``corridor_blockers`` skips ``Dimension``/``SafeDimension`` outright. The memo is
+        worth tens of milliseconds, not a phase; the leader work in #1138 is what moved
+        the number.
 
         Exposed publicly (not as ``_ann_box_cache``) because the annotations layer is
         duck-typed against ``dwg`` and, per ADR 0005, reads no private Drawing state.

--- a/tests/test_leader_footprint.py
+++ b/tests/test_leader_footprint.py
@@ -1,0 +1,137 @@
+"""The analytic leader footprint must CONTAIN the geometry it stands in for (#1138).
+
+`_probe_box` used to build a real ``Leader`` -- fusing an Arrow, a swept shelf rectangle
+and the callout sketch -- purely to read its bounding box, at 0.12-0.21 s per probe. It is
+now arithmetic, mirroring ``helpers.Leader.__init__`` the way ``dim_footprint`` mirrors
+``Dimension``.
+
+The safety contract differs from ``dim_footprint``'s, and that difference is the whole
+point of this file. A dimension candidate accepted off its footprint is REBUILT and
+re-validated, so a mismatch there costs a wasted probe. A leader probe box is not
+re-validated: it sets the x-band deciding which obstacles the carve considers. An analytic
+box that is too SMALL therefore drops a real obstacle silently -- the invisible-occupant
+defect (#133/#225/#305) the probe exists to prevent. Too big is harmless.
+
+So the assertion is containment, not equality, and it is checked against real built
+geometry rather than against a golden number, which would only restate the arithmetic.
+The reference geometry is helpers' ``Leader`` itself rather than draftwright's thin
+construction wrapper, because helpers' rendering IS the thing the footprint must mirror.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box, Cylinder, Pos
+from build123d_drafting.helpers import Draft, HoleCallout, Leader
+
+from draftwright.analysis import _analyse
+from draftwright.annotations._common import _geom_box, leader_footprint
+from draftwright.builder import _assemble
+
+
+@pytest.fixture(scope="module")
+def draft():
+    return Draft()
+
+
+@pytest.fixture(scope="module")
+def callout(draft):
+    return HoleCallout(diameter=8.0, draft=draft)
+
+
+@pytest.fixture(scope="module")
+def callout_box(callout):
+    return _geom_box(callout)
+
+
+def _build(tip, elbow, side, draft, callout):
+    return Leader(
+        tip=(tip[0], tip[1], 0),
+        elbow=(elbow[0], elbow[1], 0),
+        label="",
+        draft=draft,
+        text_side=side,
+        callout=callout,
+    )
+
+
+# Both shelf directions, tips above/below/level with the elbow, short and long shafts:
+# the shaft's diagonal is what makes a leader's box position-dependent.
+CASES = [
+    (side, dx, dy)
+    for side in ("right", "left")
+    for dy in (-30.0, -8.0, 0.0, 8.0, 30.0)
+    for dx in (5.0, 20.0, 60.0)
+]
+
+
+@pytest.mark.parametrize("side,dx,dy", CASES)
+def test_analytic_footprint_contains_the_built_leader(side, dx, dy, draft, callout, callout_box):
+    sign = 1.0 if side == "right" else -1.0
+    tip, elbow = (0.0, 0.0), (sign * dx, dy)
+
+    leader = _build(tip, elbow, side, draft, callout)
+    real = _geom_box(leader)
+    analytic = leader_footprint(tip, elbow, draft, text_side=side, callout_box=callout_box)
+
+    assert analytic is not None, "helpers built this leader, so the footprint must describe it"
+    assert real is not None
+
+    # Containment, with a hair of float tolerance: the callout half is measured rather than
+    # estimated, so the two boxes coincide exactly on whichever side the callout dominates.
+    tol = 1e-6
+    assert analytic[0] <= real[0] + tol, f"under-claims left by {analytic[0] - real[0]:.4f} mm"
+    assert analytic[1] <= real[1] + tol, f"under-claims bottom by {analytic[1] - real[1]:.4f} mm"
+    assert analytic[2] >= real[2] - tol, f"under-claims right by {real[2] - analytic[2]:.4f} mm"
+    assert analytic[3] >= real[3] - tol, f"under-claims top by {real[3] - analytic[3]:.4f} mm"
+
+
+def test_it_declines_exactly_where_helpers_refuses_to_build(draft, callout, callout_box):
+    """A forced side that runs the shaft through the label makes ``Leader`` raise. The
+    analytic path must decline it too, or a candidate helpers cannot draw would be probed
+    as though it were placeable."""
+    # side forced "right" while the elbow sits LEFT of the tip: the shelf and label run back
+    # across the shaft.
+    tip, elbow = (0.0, 0.0), (-25.0, 0.0)
+
+    with pytest.raises(ValueError):
+        _build(tip, elbow, "right", draft, callout)
+
+    assert leader_footprint(tip, elbow, draft, text_side="right", callout_box=callout_box) is None
+
+
+def _plate():
+    part = Box(120, 80, 12)
+    for x in (-40, 0, 40):
+        part -= Pos(x, 20, 0) * Cylinder(4, 40)
+    part -= Pos(-30, -20, 0) * Box(40, 12, 40)
+    return part
+
+
+def test_a_build_constructs_no_leader_it_throws_away(monkeypatch):
+    """The reason the change exists, stated behaviourally.
+
+    A probe that builds its subject shows up as a Leader constructed and never placed. This
+    counts constructions across a whole build rather than reaching into the probe helper, so
+    it holds through renames and needs no white-box import (the #641 gap-2 ratchet).
+    """
+    constructed = []
+    original = Leader.__init__
+
+    def counting(self, *args, **kwargs):
+        constructed.append(self)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Leader, "__init__", counting)
+
+    a = _analyse(
+        _plate(), title="", number="", tolerance="ISO 2768-m", drawn_by="", out="lf", pmi="off"
+    )
+    dwg = _assemble(a, "lf", None, None, auto_dims=True)
+
+    placed = [o for _n, o in dwg.iter_annotations() if isinstance(o, Leader)]
+    assert placed, "the fixture must place at least one callout leader for this to mean anything"
+    assert len(constructed) == len(placed), (
+        f"{len(constructed)} Leaders built but only {len(placed)} placed — "
+        f"{len(constructed) - len(placed)} were constructed just to be measured"
+    )

--- a/tests/test_leader_footprint.py
+++ b/tests/test_leader_footprint.py
@@ -112,6 +112,27 @@ def test_it_declines_exactly_where_helpers_refuses_to_build(draft, callout, call
     assert leader_footprint(tip, elbow, draft, text_side="right", callout_box=callout_box) is None
 
 
+@pytest.mark.parametrize("dx", (25.0, -25.0))
+@pytest.mark.parametrize("dy", (-12.0, 0.0, 12.0))
+def test_auto_side_picks_the_shelf_direction_helpers_picks(dx, dy, draft, callout, callout_box):
+    """``text_side="auto"`` is the footprint's default and the case a forced side cannot
+    stand in for: the shelf direction is *derived* from where the elbow sits rather than
+    given. Deriving it the other way would put the label on the wrong side of the elbow and
+    silently mis-state the footprint by the label's whole width.
+    """
+    tip, elbow = (0.0, 0.0), (dx, dy)
+
+    real = _geom_box(_build(tip, elbow, "auto", draft, callout))
+    analytic = leader_footprint(tip, elbow, draft, callout_box=callout_box)
+
+    assert analytic is not None
+    tol = 1e-6
+    assert analytic[0] <= real[0] + tol, f"under-claims left by {analytic[0] - real[0]:.4f} mm"
+    assert analytic[1] <= real[1] + tol, f"under-claims bottom by {analytic[1] - real[1]:.4f} mm"
+    assert analytic[2] >= real[2] - tol, f"under-claims right by {real[2] - analytic[2]:.4f} mm"
+    assert analytic[3] >= real[3] - tol, f"under-claims top by {real[3] - analytic[3]:.4f} mm"
+
+
 def _plate():
     part = Box(120, 80, 12)
     for x in (-40, 0, 40):

--- a/tests/test_leader_footprint.py
+++ b/tests/test_leader_footprint.py
@@ -28,10 +28,22 @@ from draftwright.analysis import _analyse
 from draftwright.annotations._common import _geom_box, leader_footprint
 from draftwright.builder import _assemble
 
+# The footprint reads its padding off ``Draft``, and ``Drawing.draft`` is public, live state
+# — so the styles are an axis of the contract, not a constant. ``inverted`` is the one that
+# matters: while the arrowhead is the widest thing on the shaft, padding by the arrow alone
+# happens to contain the stroke, but a heavy line with a small arrow inverts that and a
+# diagonal shaft escapes an arrow-only box by ~1.4 mm.
+DRAFT_STYLES = {
+    "default": Draft(),
+    "inverted": Draft(line_width=4, arrow_length=1),
+    "equal": Draft(line_width=2, arrow_length=2),
+    "hairline": Draft(line_width=0.1, arrow_length=6),
+}
 
-@pytest.fixture(scope="module")
-def draft():
-    return Draft()
+
+@pytest.fixture(scope="module", params=sorted(DRAFT_STYLES), ids=sorted(DRAFT_STYLES))
+def draft(request):
+    return DRAFT_STYLES[request.param]
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_shared_box_memo.py
+++ b/tests/test_shared_box_memo.py
@@ -1,15 +1,22 @@
 """Placement and lint share ONE annotation bounding-box memo (#1138).
 
-An *optimal* ``bounding_box()`` tessellates, so boxing a placed annotation costs ~10 ms
-for a Dimension and ~16 ms for a Leader. Placement boxes every occupant while solving a
-strip; lint then boxes the same objects for its overlap checks. Measuring twice was ~1/3
-of every labelling pass's bounding-box time.
+An *optimal* ``bounding_box()`` tessellates (~16 ms for a Leader), so an annotation both
+paths measure is worth measuring once: placement boxes occupants while solving a strip,
+and lint boxes them again for its overlap checks.
 
-The guard below is deliberately NOT "the cache attribute exists" — an unused dict passes
-that. It asserts the observable consequence: an annotation placement already measured is
-never handed to OCC again by lint. Reverting either seeding call site (``strip_obstacles``
-or ``corridor_blockers`` back to a bare ``_geom_box(o)``) empties the memo and fails the
-first assertion; keeping the memo but giving lint a *separate* one fails the second.
+Be precise about the scope, because the obvious reading of "placement and lint share a
+memo" is too generous. Measured on the fixture below, the memo holds **two** entries: the
+placed leader (via ``corridor_blockers``) and the callout ``_probe_box`` measured to size
+it. It holds no *dimension* and structurally cannot — ``strip_obstacles`` decomposes
+anything exposing ``.segments`` rather than boxing it whole, and ``corridor_blockers``
+skips ``Dimension``/``SafeDimension``. So this guards a real but small win, and asserting
+on the leader specifically is what keeps it from passing on an unrelated entry.
+
+The guard is deliberately NOT "the cache attribute exists" — an unused dict passes that.
+It asserts the observable consequence: an annotation placement already measured is never
+handed to OCC again by lint. Reverting ``corridor_blockers`` to a bare ``_geom_box(o)``
+fails the first assertion; keeping the memo but giving lint a *separate* one fails the
+second.
 """
 
 from __future__ import annotations
@@ -17,14 +24,15 @@ from __future__ import annotations
 import pytest
 from build123d import Box, Cylinder, Pos
 from build123d.topology import Shape
+from build123d_drafting.helpers import Leader
 
 from draftwright.analysis import _analyse
 from draftwright.builder import _assemble
 
 
 def _plate():
-    """Enough distinct annotations — hole callouts, envelope dims, a notch — that the
-    memo has real occupants rather than a single dimension's worth."""
+    """Holes on one face and a notch: enough to place a callout leader, which is the
+    annotation kind the memo actually holds."""
     part = Box(120, 80, 12)
     for x in (-40, 0, 40):
         part -= Pos(x, 20, 0) * Cylinder(4, 40)
@@ -42,13 +50,19 @@ def built():
 
 
 def test_placement_seeds_the_memo(built):
-    """Placement must leave measured boxes behind, not throw them away."""
-    placed = {name: o for name, o in built.iter_annotations()}
-    cached = {k for k in built.box_cache if any(id(o) == k for o in placed.values())}
+    """Placement must leave measured boxes behind, not throw them away.
 
+    Asserted on the placed *leader* rather than on "some entry": the probe's callout box
+    is also in the memo, so a laxer assertion would still pass with the placement-side
+    seeding removed entirely.
+    """
+    leaders = {id(o): n for n, o in built.iter_annotations() if isinstance(o, Leader)}
+    assert leaders, "the fixture must place a callout leader for this test to mean anything"
+
+    cached = [n for k, n in leaders.items() if k in built.box_cache]
     assert cached, (
-        "placement measured every strip occupant and cached none of them: "
-        f"{len(placed)} annotations placed, box_cache holds {len(built.box_cache)} entries"
+        "placement boxed every strip occupant and cached none of the leaders it placed: "
+        f"{len(leaders)} leaders placed, box_cache holds {len(built.box_cache)} entries"
     )
 
 

--- a/tests/test_shared_box_memo.py
+++ b/tests/test_shared_box_memo.py
@@ -1,0 +1,86 @@
+"""Placement and lint share ONE annotation bounding-box memo (#1138).
+
+An *optimal* ``bounding_box()`` tessellates, so boxing a placed annotation costs ~10 ms
+for a Dimension and ~16 ms for a Leader. Placement boxes every occupant while solving a
+strip; lint then boxes the same objects for its overlap checks. Measuring twice was ~1/3
+of every labelling pass's bounding-box time.
+
+The guard below is deliberately NOT "the cache attribute exists" — an unused dict passes
+that. It asserts the observable consequence: an annotation placement already measured is
+never handed to OCC again by lint. Reverting either seeding call site (``strip_obstacles``
+or ``corridor_blockers`` back to a bare ``_geom_box(o)``) empties the memo and fails the
+first assertion; keeping the memo but giving lint a *separate* one fails the second.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box, Cylinder, Pos
+from build123d.topology import Shape
+
+from draftwright.analysis import _analyse
+from draftwright.builder import _assemble
+
+
+def _plate():
+    """Enough distinct annotations — hole callouts, envelope dims, a notch — that the
+    memo has real occupants rather than a single dimension's worth."""
+    part = Box(120, 80, 12)
+    for x in (-40, 0, 40):
+        part -= Pos(x, 20, 0) * Cylinder(4, 40)
+    part -= Pos(-30, -20, 0) * Box(40, 12, 40)
+    return part
+
+
+@pytest.fixture(scope="module")
+def built():
+    part = _plate()
+    a = _analyse(
+        part, title="", number="", tolerance="ISO 2768-m", drawn_by="", out="memo", pmi="off"
+    )
+    return _assemble(a, "memo", None, None, auto_dims=True)
+
+
+def test_placement_seeds_the_memo(built):
+    """Placement must leave measured boxes behind, not throw them away."""
+    placed = {name: o for name, o in built.iter_annotations()}
+    cached = {k for k in built.box_cache if any(id(o) == k for o in placed.values())}
+
+    assert cached, (
+        "placement measured every strip occupant and cached none of them: "
+        f"{len(placed)} annotations placed, box_cache holds {len(built.box_cache)} entries"
+    )
+
+
+def test_lint_does_not_re_measure_what_placement_measured(built):
+    """The consequence that makes the shared memo worth having."""
+    seeded = {k for k in built.box_cache}
+    assert seeded, "nothing was seeded, so this test cannot prove anything"
+
+    boxed_during_lint: list[int] = []
+    original = Shape.bounding_box
+
+    def recording(self, *args, **kwargs):
+        boxed_during_lint.append(id(self))
+        return original(self, *args, **kwargs)
+
+    Shape.bounding_box = recording
+    try:
+        built.lint()
+    finally:
+        Shape.bounding_box = original
+
+    re_measured = seeded & set(boxed_during_lint)
+    assert not re_measured, (
+        f"lint re-measured {len(re_measured)} of the {len(seeded)} annotations placement had "
+        "already boxed — the two paths are not sharing one memo"
+    )
+
+
+def test_the_memo_is_optional(built):
+    """The annotations layer duck-types ``dwg``; a stand-in without ``box_cache`` must
+    still measure rather than crash, or every test double becomes a Drawing."""
+    from draftwright.annotations._common import _geom_box
+
+    _name, obj = next(iter(built.iter_annotations()))
+    assert _geom_box(obj, None) == _geom_box(obj)


### PR DESCRIPTION
## What

Deciding where to hang a hole callout meant **constructing a complete `Leader`** — Arrow,
swept shelf rectangle and callout sketch, fused in OCC — reading its bounding box, and
throwing the whole thing away. `_probe_box` is now arithmetic, mirroring
`helpers.Leader.__init__` the way `dim_footprint` (#602) mirrors `Dimension`.

Also extends the existing `_ann_box` memo so placement and lint share one box cache.

## Numbers

| | probe cost | |
|---|---|---|
| plate | 0.119s → 0.016s | −87% |
| flange | 0.209s → 0.045s | −78% |

Leaders constructed per callout column: **2 → 1**.

End-to-end the win is smaller — ~5.1% on the flange, ~1.7% on the plate (within noise).
Some of what the probe was paying for is OCC warm-up the build pays anyway. Measured by
alternating both arms in one process and taking the median of 5; single-pair timings
swung enough to invent a 40% effect that wasn't there.

## Why containment, not equality

`dim_footprint`'s contract does not carry over. A dimension candidate accepted off its
footprint is **rebuilt and re-validated**, so a mismatch costs a wasted probe. A leader
probe box is **not** re-validated — it sets the x-band deciding which obstacles the carve
considers. Too small silently drops a real obstacle (the invisible-occupant class,
#133/#225/#305). Too big is harmless.

So `tests/test_leader_footprint.py` asserts the analytic box **contains** real built
geometry, across 4 draft styles × 30 geometries, plus the case helpers refuses to build.

## Review fixes (second commit)

An adversarial Codex review found two real defects, both fixed here:

1. **The footprint under-claimed for custom draft styles.** `half_shaft` used
   `arrow_length / 2`, which holds only while the arrow dominates the line — with
   `Draft(line_width=4, arrow_length=1)` a diagonal shaft escapes by **1.39 mm**. Now pads
   by whichever dominates. **No-op for the built-in preset** (arrow 3.0 vs line 0.5), so no
   existing drawing's layout moves. The guard missed it because it only exercised
   `Draft()`; `Draft` is public live state, so style is now an axis of the test.

2. **The shared memo's claims were overstated.** The docstrings implied dimensions
   benefited and cited "46% of lint's bounding-box time". Dimensions are structurally
   excluded — `strip_obstacles` decomposes anything exposing `.segments`, and
   `corridor_blockers` skips `Dimension`/`SafeDimension`. Measured, the memo holds **2
   entries on a plate, 3 on a flange**, all leaders and callouts: tens of milliseconds, not
   a phase. Claims corrected to what was measured, and the guard — which passed on the
   probe's callout entry even with placement-side seeding removed — now asserts on the
   placed leader.

**The memo is worth reviewing on its merits.** At ~2 cache entries it may not be paying
rent; the leader work is what moved the number. Happy to drop it if you'd rather.

## Verification

- Full fast tier green on this branch: **3380 passed**, 0 failed
- ruff check / ruff format / mypy / codespell all clean
- Both new guards **canary-verified**: reverting either fix makes its guard fail
  (arrow-only padding → "under-claims left by 1.3906 mm"; unseeding `corridor_blockers` →
  "cached none of the leaders it placed")

## Architecture

Follows the #602 analytic-footprint pattern and ADR 0004's rule that footprints are page-mm
box layouts rather than bbox-measured geometry. `box_cache` is public because `annotations/`
is duck-typed against `dwg` and per ADR 0005 reads no private `Drawing` state; sharing the
dict means `lint()`'s existing liveness prune covers placement-seeded entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)