### PR TITLE
Make the projected solid an explicit input to assembly (#1137 slice 1)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -295,6 +295,7 @@ def _assemble(
     requested=None,
     authored=None,
     trace=None,
+    shape=None,
 ) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
@@ -433,7 +434,12 @@ def _assemble(
     dwg._build.trace = trace
     dwg._model_declared = model is not None  # ADR 0011 #448: gate model-driven hole render
 
-    part_s = a.part.scale(a.SCALE)
+    # The solid this assembly projects. ADR 0004 wants the real geometry built ONCE, but the
+    # measure-and-repack loop assembles up to three times, so today it is projected up to three
+    # times — the root cause of #1135's hour-long build. This parameter is the seam where the
+    # loop's intermediate assemblies will pass a cheap stand-in and only the final one the real
+    # solid (#1137). Every caller currently takes the default, so nothing has changed yet.
+    part_s = (a.part if shape is None else shape).scale(a.SCALE)
     dwg._add_view(
         "front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True
     )

--- a/tests/test_repack_geometry_seam.py
+++ b/tests/test_repack_geometry_seam.py
@@ -1,0 +1,63 @@
+"""The #1137 seam: which solid an assembly projects is an explicit input.
+
+ADR 0004 wants real geometry built once per build. The measure-and-repack loop assembles up
+to three times, so it is built up to three times — the root cause of #1135, where one part's
+plan view alone took over sixteen minutes of hidden-line removal.
+
+Slice 1 changes no behaviour: it makes the projected solid an argument that defaults to the
+analysed part, so a later slice can hand the loop's intermediate assemblies a cheap stand-in
+and keep the real solid for the final one. The guard below is therefore not "the parameter
+exists" — an ignored parameter would pass that — but "what is passed is what gets projected".
+"""
+
+from __future__ import annotations
+
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright.analysis import _analyse
+from draftwright.builder import _assemble
+
+
+def _stepped_shaft():
+    """A turned shaft: several distinct silhouette rungs, so a box stand-in is unmistakably
+    different from the real thing under projection."""
+    rungs = [(24, 6), (16, 8), (10, 6)]
+    z = 0.0
+    part = None
+    for diameter, height in rungs:
+        rung = Pos(0, 0, z) * Cylinder(
+            diameter / 2, height, align=(Align.CENTER, Align.CENTER, Align.MIN)
+        )
+        part = rung if part is None else part + rung
+        z += height
+    return part
+
+
+def _assembled_front_edges(part, shape=None):
+    a = _analyse(
+        part, title="", number="", tolerance="ISO 2768-m", drawn_by="", out="seam", pmi="off"
+    )
+    dwg = _assemble(a, "seam", None, None, auto_dims=False, shape=shape)
+    visible, _hidden = dwg.views["front"]
+    return len(visible.edges())
+
+
+def test_an_assembly_projects_the_shape_it_is_given():
+    part = _stepped_shaft()
+    bb = part.bounding_box()
+    stand_in = Pos(*bb.center()) * Box(bb.size.X, bb.size.Y, bb.size.Z)
+
+    real = _assembled_front_edges(part)
+    proxy = _assembled_front_edges(part, shape=stand_in)
+
+    assert real != proxy, (
+        "the shape argument reached no projector: a box stand-in and a stepped shaft "
+        f"cannot both project to {real} front-view edges"
+    )
+
+
+def test_the_default_is_still_the_analysed_part():
+    """The no-behaviour-change half: omitting the argument must project the real solid."""
+    part = _stepped_shaft()
+
+    assert _assembled_front_edges(part) == _assembled_front_edges(part, shape=part)


### PR DESCRIPTION
## What

Makes the solid an assembly projects a parameter, defaulting to the analysed part.
**No behaviour change** — every caller takes the default.

## Why

ADR 0004 says a build composes, sizes, packs, then builds geometry **once**. The
measure-and-repack loop assembles up to three times, because `_measure_blocks` reads each
view's real annotation footprint off a laid-out drawing — so the real solid is projected up
to three times, five HLR passes each.

On CADGenBench fixture 109 that is a part whose plan view alone exceeds sixteen minutes.
**That accounts for the whole of #1135's lost hour — there is no infinite loop in it.**

This is the seam a later slice needs: intermediate assemblies get a cheap stand-in, only
the final one the real solid.

## Guard

Deliberately not "the parameter exists", which an ignored parameter would satisfy. It
projects a box stand-in with the same bounding box as a stepped shaft and requires the
front views to differ. Mutation-checked: reverting the parameter to the analysed part
fails it.

## Verification

Full fast tier: 3253 passed. The one failure is the pre-existing DXF timeout flake
(#1140), unrelated. ruff / format / mypy / codespell clean.

Relates to #1135 (diagnosis, not yet the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)