### PR TITLE
Deduplicate pairwise legibility score penalties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Changed
+
+- **Pairwise lint detail no longer multiplies the legibility score penalty** (#1147). Raw
+  severity and code counts retain their existing finding-level semantics, and every offending
+  pair remains in `issues`. The legibility component now also reports its primary issue counts
+  and scores one producer-identified annotation/failure mechanism once, with `affected_pairs`
+  exposing how many raw pair findings were aggregated. The legacy top-level `score` and
+  `diagnostic_score` remain unchanged.
+
 ### Added
 
 - **`lint_summary()` exposes drawing-quality evidence as separate completeness, restraint,

--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ assert completeness["scope"] == "audited_recognized_requirements"
 completeness["excludes"]                     # what the denominator cannot see
 completeness["unrecognised_geometry_reports"]  # a floor on that gap, never a measure
 legibility = crit["quality"]["legibility"]
+# Raw pair findings remain available and keep the original count semantics.
+legibility["warnings"], legibility["by_code"], crit["issues"]
+# The legibility scalar uses primary issues: one affected annotation/failure mechanism even
+# when several pairwise comparisons found it. These fields make that denominator explicit.
+legibility["primary_issues"], legibility["primary_by_code"], legibility["affected_pairs"]
+assert legibility["score_inventory"] == "primary_issues"
 restraint = crit["quality"]["restraint"]  # unavailable until provenance is complete
 dwg.repair()                # auto-fix mechanically-fixable lint; never worsens
 ```

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -91,6 +91,7 @@ from draftwright.linting import (
     lint_slot_coverage,
     pmi_stage_summary,
 )
+from draftwright.linting.issues import _IssueAggregation
 from draftwright.linting.quality import quality_components
 from draftwright.projection import (
     project_view_geometry,
@@ -2722,6 +2723,10 @@ class Drawing:
         (#1022). The default stays the full critique: a caller asking "is this drawing
         right?" means both halves.
         """
+        return self._lint(physical=physical)
+
+    def _lint(self, *, physical: bool = True, aggregation=None):
+        """Internal lint path with an optional summary-scoped pair ledger (#1147)."""
         # Drawable area (page minus the standard margin), passed explicitly to
         # lint_drawing for bounds checks — draftwright owns linting now and no
         # longer relies on the helpers set_page module-global (ADR 0007).
@@ -2748,6 +2753,7 @@ class Drawing:
                 view_shapes=view_shapes,
                 view_edge_cache=self._view_edge_cache,
                 ann_box_cache=self._ann_box_cache,
+                _aggregation=aggregation,
             )
         else:
             issues = []
@@ -2759,6 +2765,7 @@ class Drawing:
                     view_shapes=view_shapes,
                     view_edge_cache=self._view_edge_cache,
                     ann_box_cache=self._ann_box_cache,
+                    _aggregation=aggregation,
                 )
         if self.part is not None and physical:
             # Reuse the single feature inventory from the build (#244) when present,
@@ -2976,7 +2983,8 @@ class Drawing:
         - ``pmi`` — when source PMI exists, source-to-render stage counts derived from the
           extraction report, final IR, annotation registry, and structured placement drops.
         """
-        issues = self.lint()
+        aggregation = _IssueAggregation()
+        issues = self._lint(aggregation=aggregation)
         errors = sum(1 for i in issues if i.severity == "error")
         warnings = sum(1 for i in issues if i.severity == "warning")
         infos = sum(1 for i in issues if i.severity == "info")
@@ -3005,6 +3013,7 @@ class Drawing:
             issues=issues,
             error_penalty=_SCORE_ERROR_PENALTY,
             warning_penalty=_SCORE_WARNING_PENALTY,
+            _aggregation=aggregation,
         )
         return {
             "passed": errors == 0,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2965,7 +2965,9 @@ class Drawing:
         - ``score`` — legacy coarse 0–1 diagnostic heuristic (see ``_SCORE_*``);
         - ``diagnostic_score`` — the same value under its honest name;
         - ``quality`` — separable completeness, restraint, and legibility components. No
-          composite drawing-quality score is manufactured (#1127);
+          composite drawing-quality score is manufactured (#1127). Legibility's existing
+          severity/code counts are raw findings; its ``primary_*`` counts and scalar group
+          producer-identified pair findings by annotation and failure mechanism (#1147);
         - ``errors`` / ``warnings`` / ``infos`` — counts by severity;
         - ``by_code`` — per-check counts;
         - ``geometry_issues`` — count of standards/geometry-correctness issues

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -91,7 +91,7 @@ from draftwright.linting import (
     lint_slot_coverage,
     pmi_stage_summary,
 )
-from draftwright.linting.issues import _IssueAggregation
+from draftwright.linting.issues import _collect_issue_aggregation, _current_issue_aggregation
 from draftwright.linting.quality import quality_components
 from draftwright.projection import (
     project_view_geometry,
@@ -2723,7 +2723,7 @@ class Drawing:
         (#1022). The default stays the full critique: a caller asking "is this drawing
         right?" means both halves.
         """
-        return self._lint(physical=physical)
+        return self._lint(physical=physical, aggregation=_current_issue_aggregation())
 
     def _lint(self, *, physical: bool = True, aggregation=None):
         """Internal lint path with an optional summary-scoped pair ledger (#1147)."""
@@ -2983,8 +2983,11 @@ class Drawing:
         - ``pmi`` — when source PMI exists, source-to-render stage counts derived from the
           extraction report, final IR, annotation registry, and structured placement drops.
         """
-        aggregation = _IssueAggregation()
-        issues = self._lint(aggregation=aggregation)
+        # Keep dispatch through the documented public critique method: subclasses and callers
+        # may extend ``lint``. The context is task-local, and only the base implementation
+        # records pair evidence; custom issues remain independent (fail closed).
+        with _collect_issue_aggregation() as aggregation:
+            issues = self.lint()
         errors = sum(1 for i in issues if i.severity == "error")
         warnings = sum(1 for i in issues if i.severity == "warning")
         infos = sum(1 for i in issues if i.severity == "info")

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -6,7 +6,7 @@ standalone validators). draftwright owns linting; this is its ``LintIssue``.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 
@@ -32,3 +32,9 @@ class LintIssue:
     # (validation) and a valid candidate that did not fit (placement). Quality components must
     # not infer that distinction from the shared code or its message (#1127).
     outcome_stage: Literal["placement", "validation"] | None = None
+    # Opaque identity of the annotation that owns a pairwise diagnostic (#1147). Multiple
+    # raw pair findings with the same subject and code remain individually inspectable, but
+    # count as one primary issue in the legibility score. ``id(annotation)`` is intentional:
+    # the key lives for one lint aggregation only, is never serialised, and remains unique
+    # when Drawing has to lint separate scale groups. None means the finding is independent.
+    aggregation_subject: int | None = field(default=None, repr=False, compare=False)

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -49,14 +49,18 @@ class _IssueAggregation:
         # Retain the small plain-data issue value for this summary scope so its address cannot
         # be recycled onto an unrelated custom issue. This never retains the annotation/CAD
         # graph: public ``LintIssue`` values carry no aggregation subject (#1147 review).
-        self._issues_and_tokens: dict[int, tuple[LintIssue, object]] = {}
+        self._issues_and_tokens: dict[int, tuple[LintIssue, object, str]] = {}
 
     def record_pair(self, issue: LintIssue, token: object) -> None:
-        self._issues_and_tokens[id(issue)] = (issue, token)
+        self._issues_and_tokens[id(issue)] = (issue, token, issue.code)
 
     def token_for(self, issue: LintIssue):
         stored = self._issues_and_tokens.get(id(issue))
-        return stored[1] if stored is not None and stored[0] is issue else None
+        return (
+            stored[1]
+            if stored is not None and stored[0] is issue and stored[2] == issue.code
+            else None
+        )
 
 
 _CURRENT_AGGREGATION: ContextVar[_IssueAggregation | None] = ContextVar(

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -46,13 +46,17 @@ class _IssueAggregation:
     """
 
     def __init__(self) -> None:
-        self._tokens_by_issue_id: dict[int, object] = {}
+        # Retain the small plain-data issue value for this summary scope so its address cannot
+        # be recycled onto an unrelated custom issue. This never retains the annotation/CAD
+        # graph: public ``LintIssue`` values carry no aggregation subject (#1147 review).
+        self._issues_and_tokens: dict[int, tuple[LintIssue, object]] = {}
 
     def record_pair(self, issue: LintIssue, token: object) -> None:
-        self._tokens_by_issue_id[id(issue)] = token
+        self._issues_and_tokens[id(issue)] = (issue, token)
 
     def token_for(self, issue: LintIssue):
-        return self._tokens_by_issue_id.get(id(issue))
+        stored = self._issues_and_tokens.get(id(issue))
+        return stored[1] if stored is not None and stored[0] is issue else None
 
 
 _CURRENT_AGGREGATION: ContextVar[_IssueAggregation | None] = ContextVar(

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -46,12 +46,9 @@ class _IssueAggregation:
     """
 
     def __init__(self) -> None:
-        self._tokens_by_annotation_id: dict[int, object] = {}
         self._tokens_by_issue_id: dict[int, object] = {}
 
-    def record_pair(self, issue: LintIssue, annotation) -> None:
-        annotation_id = id(annotation)
-        token = self._tokens_by_annotation_id.setdefault(annotation_id, object())
+    def record_pair(self, issue: LintIssue, token: object) -> None:
         self._tokens_by_issue_id[id(issue)] = token
 
     def token_for(self, issue: LintIssue):

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -6,7 +6,7 @@ standalone validators). draftwright owns linting; this is its ``LintIssue``.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal
 
 
@@ -32,9 +32,23 @@ class LintIssue:
     # (validation) and a valid candidate that did not fit (placement). Quality components must
     # not infer that distinction from the shared code or its message (#1127).
     outcome_stage: Literal["placement", "validation"] | None = None
-    # Opaque identity of the annotation that owns a pairwise diagnostic (#1147). Multiple
-    # raw pair findings with the same subject and code remain individually inspectable, but
-    # count as one primary issue in the legibility score. ``id(annotation)`` is intentional:
-    # the key lives for one lint aggregation only, is never serialised, and remains unique
-    # when Drawing has to lint separate scale groups. None means the finding is independent.
-    aggregation_subject: int | None = field(default=None, repr=False, compare=False)
+
+
+class _PairLintIssue(LintIssue):
+    """Internal pair observation carrying its primary annotation by identity (#1147).
+
+    ``LintIssue`` is a public structured-diagnostic dataclass, so run-local aggregation state
+    must not become one of its fields. This private subclass stores the subject outside the
+    dataclass schema: :func:`dataclasses.asdict` sees only the stable public fields, while
+    quality aggregation can still recognise several raw comparisons of the same object.
+
+    Holding the object itself (not only ``id(subject)``) also owns the token's lifetime. Two
+    issue lists accumulated from separate lint runs cannot accidentally merge after CPython
+    reuses a released object's address.
+    """
+
+    __slots__ = ("_aggregation_subject",)
+
+    def __init__(self, *, aggregation_subject, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._aggregation_subject = aggregation_subject

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -34,21 +34,23 @@ class LintIssue:
     outcome_stage: Literal["placement", "validation"] | None = None
 
 
-class _PairLintIssue(LintIssue):
-    """Internal pair observation carrying its primary annotation by identity (#1147).
+class _IssueAggregation:
+    """Summary-scoped side ledger for pairwise score grouping (#1147).
 
-    ``LintIssue`` is a public structured-diagnostic dataclass, so run-local aggregation state
-    must not become one of its fields. This private subclass stores the subject outside the
-    dataclass schema: :func:`dataclasses.asdict` sees only the stable public fields, while
-    quality aggregation can still recognise several raw comparisons of the same object.
-
-    Holding the object itself (not only ``id(subject)``) also owns the token's lifetime. Two
-    issue lists accumulated from separate lint runs cannot accidentally merge after CPython
-    reuses a released object's address.
+    Public lint results remain ordinary ``LintIssue`` values. During one ``lint_summary`` call,
+    structural lint records an opaque token for each primary annotation beside the emitted issue.
+    The ledger retains neither annotations nor their process-local ids after aggregation and is
+    never serialised. A fresh instance per summary also makes separate lint runs independent.
     """
 
-    __slots__ = ("_aggregation_subject",)
+    def __init__(self) -> None:
+        self._tokens_by_annotation_id: dict[int, object] = {}
+        self._tokens_by_issue_id: dict[int, object] = {}
 
-    def __init__(self, *, aggregation_subject, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._aggregation_subject = aggregation_subject
+    def record_pair(self, issue: LintIssue, annotation) -> None:
+        annotation_id = id(annotation)
+        token = self._tokens_by_annotation_id.setdefault(annotation_id, object())
+        self._tokens_by_issue_id[id(issue)] = token
+
+    def token_for(self, issue: LintIssue):
+        return self._tokens_by_issue_id.get(id(issue))

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -6,6 +6,8 @@ standalone validators). draftwright owns linting; this is its ``LintIssue``.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Literal
 
@@ -54,3 +56,23 @@ class _IssueAggregation:
 
     def token_for(self, issue: LintIssue):
         return self._tokens_by_issue_id.get(id(issue))
+
+
+_CURRENT_AGGREGATION: ContextVar[_IssueAggregation | None] = ContextVar(
+    "draftwright_lint_aggregation", default=None
+)
+
+
+def _current_issue_aggregation() -> _IssueAggregation | None:
+    return _CURRENT_AGGREGATION.get()
+
+
+@contextmanager
+def _collect_issue_aggregation():
+    """Collect base-lint pair evidence while preserving public ``Drawing.lint`` dispatch."""
+    aggregation = _IssueAggregation()
+    token = _CURRENT_AGGREGATION.set(aggregation)
+    try:
+        yield aggregation
+    finally:
+        _CURRENT_AGGREGATION.reset(token)

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -136,15 +136,19 @@ _SEVERITY_RANK = {"info": 0, "warning": 1, "error": 2}
 def _primary_issues(issues) -> list[LintIssue]:
     """Collapse explicit pair observations to one issue per subject and mechanism.
 
-    Pair-producing lint checks opt in with ``aggregation_subject``. Everything else is
+    Pair-producing lint checks opt in through an internal pair-issue representation. Everything else is
     deliberately independent, even when code and message happen to match: blanket text/code
     deduplication would hide genuinely distinct collisions. If a malformed producer gives one
     group mixed severities, its strongest observation owns the score penalty.
     """
     primary: dict[tuple, LintIssue] = {}
     for ordinal, issue in enumerate(issues):
-        subject = getattr(issue, "aggregation_subject", None)
-        key = (issue.code, subject) if subject is not None else (None, ordinal)
+        subject = getattr(issue, "_aggregation_subject", None)
+        # The private pair issue retains the subject object for the issue list's lifetime;
+        # its address is therefore a collision-free identity within and across accumulated
+        # lint runs. Never invoke annotation equality or hashing: geometry objects may define
+        # either in domain-specific ways.
+        key = (issue.code, id(subject)) if subject is not None else (None, ordinal)
         previous = primary.get(key)
         if previous is None or _SEVERITY_RANK[issue.severity] > _SEVERITY_RANK[previous.severity]:
             primary[key] = issue
@@ -193,7 +197,7 @@ def _issue_component(issues, *, error_penalty: float, warning_penalty: float) ->
         "primary_infos": primary_infos,
         "primary_by_code": dict(sorted(primary_by_code.items())),
         "affected_pairs": sum(
-            getattr(issue, "aggregation_subject", None) is not None for issue in issues
+            getattr(issue, "_aggregation_subject", None) is not None for issue in issues
         ),
         # Keep the established basis value: severity and the info floor did not change.
         # This additive field names the inventory to which that basis is now applied.

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -5,7 +5,9 @@ quality verdict.  This module exposes the independently observable terms without
 them into another blessed scalar:
 
 - completeness follows recognition-owned physical requirements to compiler outcomes;
-- legibility contains only placement/layout diagnostics;
+- legibility contains only placement/layout diagnostics. Its compatibility counts remain raw
+  lint findings, while its score and ``primary_*`` counts collapse only producer-identified
+  pair observations from one annotation and failure mechanism;
 - restraint fails closed until measurement provenance can classify every annotation.
 
 Completeness is deliberately marked partial.  Only the feature families with a semantic
@@ -28,6 +30,7 @@ from collections import Counter
 
 from draftwright.linting.channel_coverage import channel_requirement_outcomes
 from draftwright.linting.flat_coverage import flat_requirement_outcomes
+from draftwright.linting.issues import LintIssue
 from draftwright.linting.polygonal_stock_coverage import polygonal_stock_outcomes
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
 
@@ -127,12 +130,40 @@ def _is_legibility_issue(issue) -> bool:
     return issue.code in _LEGIBILITY_CODES or _is_placement_drop(issue)
 
 
+_SEVERITY_RANK = {"info": 0, "warning": 1, "error": 2}
+
+
+def _primary_issues(issues) -> list[LintIssue]:
+    """Collapse explicit pair observations to one issue per subject and mechanism.
+
+    Pair-producing lint checks opt in with ``aggregation_subject``. Everything else is
+    deliberately independent, even when code and message happen to match: blanket text/code
+    deduplication would hide genuinely distinct collisions. If a malformed producer gives one
+    group mixed severities, its strongest observation owns the score penalty.
+    """
+    primary: dict[tuple, LintIssue] = {}
+    for ordinal, issue in enumerate(issues):
+        subject = getattr(issue, "aggregation_subject", None)
+        key = (issue.code, subject) if subject is not None else (None, ordinal)
+        previous = primary.get(key)
+        if previous is None or _SEVERITY_RANK[issue.severity] > _SEVERITY_RANK[previous.severity]:
+            primary[key] = issue
+    return list(primary.values())
+
+
 def _issue_component(issues, *, error_penalty: float, warning_penalty: float) -> dict:
+    # Compatibility fields remain raw lint-finding counts. Only the scalar penalty uses the
+    # explicitly grouped primary inventory; both inventories are exposed and documented.
     errors = sum(issue.severity == "error" for issue in issues)
     warnings = sum(issue.severity == "warning" for issue in issues)
     infos = sum(issue.severity == "info" for issue in issues)
     placement_drops = sum(_is_placement_drop(issue) for issue in issues)
     by_code = Counter(issue.code for issue in issues)
+    primary = _primary_issues(issues)
+    primary_errors = sum(issue.severity == "error" for issue in primary)
+    primary_warnings = sum(issue.severity == "warning" for issue in primary)
+    primary_infos = sum(issue.severity == "info" for issue in primary)
+    primary_by_code = Counter(issue.code for issue in primary)
     return {
         "available": True,
         # Every issue reaching here is a legibility defect by construction, so info severity
@@ -141,14 +172,33 @@ def _issue_component(issues, *, error_penalty: float, warning_penalty: float) ->
         # cannot report 1.0 while itemising output it has just called unreadable (#1127).
         "score": max(
             0.0,
-            1.0 - errors * error_penalty - (warnings + infos) * warning_penalty,
+            1.0
+            - primary_errors * error_penalty
+            - (primary_warnings + primary_infos) * warning_penalty,
         ),
+        # Raw compatibility inventory. These fields keep their #1127 semantics even when
+        # several pair observations contribute only one penalty.
         "errors": errors,
         "warnings": warnings,
         "infos": infos,
         "placement_drops": placement_drops,
         "by_code": dict(sorted(by_code.items())),
+        "raw_issues": len(issues),
+        # Score inventory: one entry per independent finding, or per explicitly identified
+        # annotation/failure-mechanism group. ``affected_pairs`` counts the raw opt-in pair
+        # observations; their complete messages stay in ``lint_summary()['issues']``.
+        "primary_issues": len(primary),
+        "primary_errors": primary_errors,
+        "primary_warnings": primary_warnings,
+        "primary_infos": primary_infos,
+        "primary_by_code": dict(sorted(primary_by_code.items())),
+        "affected_pairs": sum(
+            getattr(issue, "aggregation_subject", None) is not None for issue in issues
+        ),
+        # Keep the established basis value: severity and the info floor did not change.
+        # This additive field names the inventory to which that basis is now applied.
         "basis": "layout_issue_severity_with_info_floor",
+        "score_inventory": "primary_issues",
     }
 
 
@@ -251,6 +301,11 @@ def quality_components(
     ``audited_score`` over a stated denominator rather than a ``score``, and lists what that
     denominator ``excludes`` — a feature recognition never identified is absent from the
     ledger entirely, so a perfect audited score is not a complete drawing.
+
+    Legibility's ``errors``/``warnings``/``infos``/``by_code`` fields retain their original
+    raw-finding semantics. ``primary_*`` fields describe the inventory used by ``score``;
+    ``affected_pairs`` is the number of raw pair findings that opted into that aggregation.
+    Full pair messages remain in :meth:`Drawing.lint` and ``lint_summary()['issues']``.
     """
 
     legibility_issues = [issue for issue in issues if _is_legibility_issue(issue)]

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -133,29 +133,27 @@ def _is_legibility_issue(issue) -> bool:
 _SEVERITY_RANK = {"info": 0, "warning": 1, "error": 2}
 
 
-def _primary_issues(issues) -> list[LintIssue]:
+def _primary_issues(issues, aggregation=None) -> list[LintIssue]:
     """Collapse explicit pair observations to one issue per subject and mechanism.
 
-    Pair-producing lint checks opt in through an internal pair-issue representation. Everything else is
-    deliberately independent, even when code and message happen to match: blanket text/code
-    deduplication would hide genuinely distinct collisions. If a malformed producer gives one
-    group mixed severities, its strongest observation owns the score penalty.
+    Pair-producing lint checks opt in through a summary-scoped side ledger. Everything else
+    is deliberately independent, even when code and message happen to match: blanket
+    text/code deduplication would hide genuinely distinct collisions. If a malformed producer
+    gives one group mixed severities, its strongest observation owns the score penalty.
     """
     primary: dict[tuple, LintIssue] = {}
     for ordinal, issue in enumerate(issues):
-        subject = getattr(issue, "_aggregation_subject", None)
-        # The private pair issue retains the subject object for the issue list's lifetime;
-        # its address is therefore a collision-free identity within and across accumulated
-        # lint runs. Never invoke annotation equality or hashing: geometry objects may define
-        # either in domain-specific ways.
-        key = (issue.code, id(subject)) if subject is not None else (None, ordinal)
+        token = aggregation.token_for(issue) if aggregation is not None else None
+        key = (issue.code, token) if token is not None else (None, ordinal)
         previous = primary.get(key)
         if previous is None or _SEVERITY_RANK[issue.severity] > _SEVERITY_RANK[previous.severity]:
             primary[key] = issue
     return list(primary.values())
 
 
-def _issue_component(issues, *, error_penalty: float, warning_penalty: float) -> dict:
+def _issue_component(
+    issues, *, error_penalty: float, warning_penalty: float, aggregation=None
+) -> dict:
     # Compatibility fields remain raw lint-finding counts. Only the scalar penalty uses the
     # explicitly grouped primary inventory; both inventories are exposed and documented.
     errors = sum(issue.severity == "error" for issue in issues)
@@ -163,7 +161,7 @@ def _issue_component(issues, *, error_penalty: float, warning_penalty: float) ->
     infos = sum(issue.severity == "info" for issue in issues)
     placement_drops = sum(_is_placement_drop(issue) for issue in issues)
     by_code = Counter(issue.code for issue in issues)
-    primary = _primary_issues(issues)
+    primary = _primary_issues(issues, aggregation)
     primary_errors = sum(issue.severity == "error" for issue in primary)
     primary_warnings = sum(issue.severity == "warning" for issue in primary)
     primary_infos = sum(issue.severity == "info" for issue in primary)
@@ -197,7 +195,8 @@ def _issue_component(issues, *, error_penalty: float, warning_penalty: float) ->
         "primary_infos": primary_infos,
         "primary_by_code": dict(sorted(primary_by_code.items())),
         "affected_pairs": sum(
-            getattr(issue, "_aggregation_subject", None) is not None for issue in issues
+            aggregation is not None and aggregation.token_for(issue) is not None
+            for issue in issues
         ),
         # Keep the established basis value: severity and the info floor did not change.
         # This additive field names the inventory to which that basis is now applied.
@@ -296,6 +295,7 @@ def quality_components(
     issues,
     error_penalty: float,
     warning_penalty: float,
+    _aggregation=None,
 ) -> dict:
     """Return independently usable drawing-quality observations.
 
@@ -328,6 +328,7 @@ def quality_components(
             legibility_issues,
             error_penalty=error_penalty,
             warning_penalty=warning_penalty,
+            aggregation=_aggregation,
         ),
     }
 

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -253,6 +253,10 @@ def lint_drawing(
     # Per-run label_bbox warning memo (#711 review / Codex sweep): threaded to every
     # check so one bad item warns once per lint run, with no cross-run global state.
     warned_label_bbox: set[int] = set()
+    # Opaque primary-subject tokens exist only for this call. Every input object remains live
+    # in ``items`` while the map is used, so its id cannot be recycled; the summary ledger gets
+    # only the tokens, never annotation ids or CAD graphs (#1147 review).
+    pair_tokens = {id(item): object() for item in items} if _aggregation is not None else {}
 
     # Resolve page bounds: explicit arg beats module-level context.
     if page_bbox is None and _DRAWING_PAGE is not None:
@@ -312,6 +316,7 @@ def lint_drawing(
                     box_cache,
                     warned=warned_label_bbox,
                     aggregation=_aggregation,
+                    subject_token=pair_tokens.get(id(dim_item)),
                 )
                 continue
 
@@ -719,7 +724,13 @@ def _lint_view_shapes(
 
 
 def _lint_centerline_dim_overlap(
-    dim_item, cl_item, issues, box_cache=None, warned=None, aggregation=None
+    dim_item,
+    cl_item,
+    issues,
+    box_cache=None,
+    warned=None,
+    aggregation=None,
+    subject_token=None,
 ) -> None:
     """Flag label-vs-centerline overlap for a (dim, centerline) pair.
 
@@ -776,10 +787,10 @@ def _lint_centerline_dim_overlap(
             code="label_centerline_overlap",
         )
         issues.append(issue)
-        if aggregation is not None:
+        if aggregation is not None and subject_token is not None:
             # The side ledger sees which half of the pair owns the readability defect;
             # neither the annotation nor its run-local identity enters public diagnostics.
-            aggregation.record_pair(issue, dim_item)
+            aggregation.record_pair(issue, subject_token)
 
 
 def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -760,7 +760,17 @@ def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache=None, warn
                     f"{ox:.1f}×{oy:.1f} mm — use label_offset_x to shift "
                     f"or increase dim offset to clear the centerline"
                 ),
+                # Pair detail stays in the raw issue: this is the compared centre mark's
+                # extent centre, so equal-looking findings can still be traced spatially.
+                location=(
+                    (cl_min_x + cl_max_x) / 2.0,
+                    (cl_min_y + cl_max_y) / 2.0,
+                ),
                 code="label_centerline_overlap",
+                # The raw finding still represents this exact label/centreline pair. Quality
+                # aggregation uses the label identity to avoid multiplying one unreadable
+                # label into N score penalties merely because N centre marks cross it (#1147).
+                aggregation_subject=id(dim_item),
             )
         )
 

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -17,7 +17,7 @@ from build123d import GeomType
 
 from draftwright._core import _shape_box2d
 from draftwright._geometry import _boxes_overlap, _segment_clips_box
-from draftwright.linting.issues import LintIssue
+from draftwright.linting.issues import LintIssue, _PairLintIssue
 
 _log = logging.getLogger(__name__)
 
@@ -753,7 +753,7 @@ def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache=None, warn
     if ox > 0.5 and oy > 0.5:
         dim_label = getattr(dim_item, "label", "?")
         issues.append(
-            LintIssue(
+            _PairLintIssue(
                 severity="warning",
                 message=(
                     f"label '{dim_label}' overlaps centerline by "
@@ -770,7 +770,7 @@ def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache=None, warn
                 # The raw finding still represents this exact label/centreline pair. Quality
                 # aggregation uses the label identity to avoid multiplying one unreadable
                 # label into N score penalties merely because N centre marks cross it (#1147).
-                aggregation_subject=id(dim_item),
+                aggregation_subject=dim_item,
             )
         )
 

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -17,7 +17,7 @@ from build123d import GeomType
 
 from draftwright._core import _shape_box2d
 from draftwright._geometry import _boxes_overlap, _segment_clips_box
-from draftwright.linting.issues import LintIssue, _PairLintIssue
+from draftwright.linting.issues import LintIssue, _IssueAggregation
 
 _log = logging.getLogger(__name__)
 
@@ -174,6 +174,7 @@ def lint_drawing(
     view_shapes: list | None = None,
     view_edge_cache: dict | None = None,
     ann_box_cache: dict | None = None,
+    _aggregation: _IssueAggregation | None = None,
 ) -> list[LintIssue]:
     """Structural checks on a composed annotation list, duck-typed.
 
@@ -305,7 +306,12 @@ def lint_drawing(
                 dim_item = item_b if is_cl_a else item_a
                 cl_item = item_a if is_cl_a else item_b
                 _lint_centerline_dim_overlap(
-                    dim_item, cl_item, issues, box_cache, warned=warned_label_bbox
+                    dim_item,
+                    cl_item,
+                    issues,
+                    box_cache,
+                    warned=warned_label_bbox,
+                    aggregation=_aggregation,
                 )
                 continue
 
@@ -712,7 +718,9 @@ def _lint_view_shapes(
                 )
 
 
-def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache=None, warned=None) -> None:
+def _lint_centerline_dim_overlap(
+    dim_item, cl_item, issues, box_cache=None, warned=None, aggregation=None
+) -> None:
     """Flag label-vs-centerline overlap for a (dim, centerline) pair.
 
     #701: only the centreline measure is guarded (malformed ``segments`` /
@@ -752,27 +760,26 @@ def _lint_centerline_dim_overlap(dim_item, cl_item, issues, box_cache=None, warn
 
     if ox > 0.5 and oy > 0.5:
         dim_label = getattr(dim_item, "label", "?")
-        issues.append(
-            _PairLintIssue(
-                severity="warning",
-                message=(
-                    f"label '{dim_label}' overlaps centerline by "
-                    f"{ox:.1f}×{oy:.1f} mm — use label_offset_x to shift "
-                    f"or increase dim offset to clear the centerline"
-                ),
-                # Pair detail stays in the raw issue: this is the compared centre mark's
-                # extent centre, so equal-looking findings can still be traced spatially.
-                location=(
-                    (cl_min_x + cl_max_x) / 2.0,
-                    (cl_min_y + cl_max_y) / 2.0,
-                ),
-                code="label_centerline_overlap",
-                # The raw finding still represents this exact label/centreline pair. Quality
-                # aggregation uses the label identity to avoid multiplying one unreadable
-                # label into N score penalties merely because N centre marks cross it (#1147).
-                aggregation_subject=dim_item,
-            )
+        issue = LintIssue(
+            severity="warning",
+            message=(
+                f"label '{dim_label}' overlaps centerline by "
+                f"{ox:.1f}×{oy:.1f} mm — use label_offset_x to shift "
+                f"or increase dim offset to clear the centerline"
+            ),
+            # Pair detail stays in the raw issue: this is the compared centre mark's
+            # extent centre, so equal-looking findings can still be traced spatially.
+            location=(
+                (cl_min_x + cl_max_x) / 2.0,
+                (cl_min_y + cl_max_y) / 2.0,
+            ),
+            code="label_centerline_overlap",
         )
+        issues.append(issue)
+        if aggregation is not None:
+            # The side ledger sees which half of the pair owns the readability defect;
+            # neither the annotation nor its run-local identity enters public diagnostics.
+            aggregation.record_pair(issue, dim_item)
 
 
 def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pickle
+import weakref
 from dataclasses import asdict, replace
 from types import SimpleNamespace
 
@@ -175,6 +176,19 @@ def test_separate_structural_passes_in_one_summary_ledger_get_distinct_tokens():
     assert combined["raw_issues"] == 20
     assert combined["primary_issues"] == 4
     assert aggregation.token_for(first[0]) is not aggregation.token_for(second[0])
+
+
+def test_ledger_retains_plain_issue_values_so_custom_replacements_cannot_reuse_their_ids():
+    aggregation = _IssueAggregation()
+    issues, returned_aggregation = _two_labels_crossed_by_five_centre_marks(aggregation)
+    assert returned_aggregation is aggregation
+    recorded = weakref.ref(issues[0])
+    del issues
+
+    assert recorded() is not None, "the summary ledger must keep the address owner alive"
+
+    del returned_aggregation, aggregation
+    assert recorded() is None, "the summary ledger must not retain issues beyond its scope"
 
 
 def test_multi_scale_drawing_groups_each_annotation_inside_its_own_structural_pass():

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import asdict
 from types import SimpleNamespace
 
 import pytest
@@ -28,8 +28,7 @@ def _legibility(issues):
 
 def _two_labels_crossed_by_five_centre_marks():
     labels = [
-        SimpleNamespace(label=f"hole callout {index}", label_bbox=(0.0, 0.0, 10.0, 10.0))
-        for index in range(2)
+        SimpleNamespace(label="4× ⌀6 THRU", label_bbox=(0.0, 0.0, 10.0, 10.0)) for _ in range(2)
     ]
     centre_marks = [
         SimpleNamespace(
@@ -50,8 +49,7 @@ def test_two_affected_labels_keep_ten_pair_findings_but_take_two_score_penalties
     legibility = _legibility(issues)
 
     assert len(issues) == 10, "every offending label/centre-mark pair remains inspectable"
-    assert sum("hole callout 0" in issue.message for issue in issues) == 5
-    assert sum("hole callout 1" in issue.message for issue in issues) == 5
+    assert all("4× ⌀6 THRU" in issue.message for issue in issues)
     assert {issue.location for issue in issues} == {(float(x), 5.0) for x in range(1, 6)}
     assert legibility["warnings"] == 10, "the compatibility count remains raw lint findings"
     assert legibility["by_code"] == {"label_centerline_overlap": 10}
@@ -66,8 +64,25 @@ def test_two_affected_labels_keep_ten_pair_findings_but_take_two_score_penalties
 
     # Prove the producer identity is load-bearing: without it, the raw Cartesian findings
     # once again become ten independent penalties, reproducing the original 0.5 score.
-    ungrouped = [replace(issue, aggregation_subject=None) for issue in issues]
+    ungrouped = [
+        LintIssue(
+            severity=issue.severity,
+            message=issue.message,
+            location=issue.location,
+            code=issue.code,
+        )
+        for issue in issues
+    ]
     assert _legibility(ungrouped)["score"] == pytest.approx(0.5)
+
+
+def test_run_local_pair_subject_is_not_part_of_the_public_lint_issue_schema():
+    issue = _two_labels_crossed_by_five_centre_marks()[0]
+
+    assert isinstance(issue, LintIssue)
+    assert "aggregation" not in repr(issue)
+    assert not any("aggregation" in key for key in asdict(issue))
+    assert not any("aggregation" in key for key in vars(issue))
 
 
 def test_equal_codes_without_a_shared_subject_remain_independent_primary_issues():
@@ -84,20 +99,8 @@ def test_equal_codes_without_a_shared_subject_remain_independent_primary_issues(
 
 
 def test_one_subject_with_two_failure_mechanisms_remains_two_primary_issues():
-    issues = [
-        LintIssue(
-            severity="warning",
-            code="annotation_overlap",
-            message="collision",
-            aggregation_subject=17,
-        ),
-        LintIssue(
-            severity="warning",
-            code="label_centerline_overlap",
-            message="centreline crossing",
-            aggregation_subject=17,
-        ),
-    ]
+    issues = _two_labels_crossed_by_five_centre_marks()[:2]
+    issues[0].code = "annotation_overlap"
 
     legibility = _legibility(issues)
 
@@ -107,6 +110,23 @@ def test_one_subject_with_two_failure_mechanisms_remains_two_primary_issues():
         "label_centerline_overlap": 1,
     }
     assert legibility["score"] == pytest.approx(0.9)
+
+
+@pytest.mark.parametrize("severities", [("info", "error"), ("error", "info")])
+def test_one_group_uses_its_strongest_severity_in_either_observation_order(severities):
+    issues = _two_labels_crossed_by_five_centre_marks()[:2]
+    for issue, severity in zip(issues, severities, strict=True):
+        issue.severity = severity
+        issue.message = severity
+
+    legibility = _legibility(issues)
+
+    assert legibility["errors"] == 1
+    assert legibility["infos"] == 1
+    assert legibility["primary_issues"] == 1
+    assert legibility["primary_errors"] == 1
+    assert legibility["primary_infos"] == 0
+    assert legibility["score"] == pytest.approx(0.85)
 
 
 def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics(monkeypatch):
@@ -120,5 +140,5 @@ def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics(m
     assert summary["by_code"] == {"label_centerline_overlap": 10}
     assert summary["score"] == summary["diagnostic_score"] == pytest.approx(0.5)
     assert len(summary["issues"]) == 10
-    assert all("aggregation_subject" not in issue for issue in summary["issues"])
+    assert all(not any("aggregation" in key for key in issue) for issue in summary["issues"])
     assert summary["quality"]["legibility"]["score"] == pytest.approx(0.9)

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -124,9 +124,18 @@ def test_equal_codes_without_a_shared_subject_remain_independent_primary_issues(
 
 
 def test_one_subject_with_two_failure_mechanisms_remains_two_primary_issues():
-    all_issues, aggregation = _two_labels_crossed_by_five_centre_marks()
-    issues = all_issues[:2]
-    issues[0].code = "annotation_overlap"
+    aggregation = _IssueAggregation()
+    subject_token = object()
+    issues = [
+        LintIssue(severity="warning", code="annotation_overlap", message="collision"),
+        LintIssue(
+            severity="warning",
+            code="label_centerline_overlap",
+            message="centreline crossing",
+        ),
+    ]
+    for issue in issues:
+        aggregation.record_pair(issue, subject_token)
 
     legibility = _legibility(issues, aggregation)
 
@@ -276,6 +285,30 @@ def test_public_override_replacements_cannot_inherit_discarded_base_issue_tokens
     legibility = drawing.lint_summary()["quality"]["legibility"]
 
     assert legibility["raw_issues"] == 10
+    assert legibility["affected_pairs"] == 0
+    assert legibility["primary_issues"] == 10
+    assert legibility["score"] == pytest.approx(0.5)
+
+
+def test_public_override_code_mutations_cannot_inherit_the_old_failure_mechanism(monkeypatch):
+    drawing = build_drawing(Box(20, 15, 10))
+    drawing.items = _crossed_items()
+    drawing.views.clear()
+    drawing.part = None
+    base_lint = drawing.lint
+
+    def mutating_lint(*, physical=True):
+        issues = base_lint(physical=physical)
+        assert len(issues) == 10
+        for issue in issues:
+            issue.code = "annotation_overlap"
+        return issues
+
+    monkeypatch.setattr(drawing, "lint", mutating_lint)
+
+    legibility = drawing.lint_summary()["quality"]["legibility"]
+
+    assert legibility["by_code"] == {"annotation_overlap": 10}
     assert legibility["affected_pairs"] == 0
     assert legibility["primary_issues"] == 10
     assert legibility["score"] == pytest.approx(0.5)

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -10,7 +10,11 @@ import pytest
 from build123d import Box
 
 from draftwright import build_drawing
-from draftwright.linting.issues import LintIssue, _IssueAggregation
+from draftwright.linting.issues import (
+    LintIssue,
+    _current_issue_aggregation,
+    _IssueAggregation,
+)
 from draftwright.linting.quality import quality_components
 from draftwright.linting.structural import lint_drawing
 
@@ -30,14 +34,15 @@ def _legibility(issues, aggregation=None):
 
 def _crossed_items():
     labels = [
-        SimpleNamespace(label="4× ⌀6 THRU", label_bbox=(0.0, 0.0, 10.0, 10.0)) for _ in range(2)
+        SimpleNamespace(label="4× ⌀6 THRU", label_bbox=(x, 20.0, x + 10.0, 30.0))
+        for x in (20.0, 40.0)
     ]
     centre_marks = [
         SimpleNamespace(
             is_centerline=True,
-            segments=(((float(x), -2.0), (float(x), 12.0)),),
+            segments=(((18.0, float(y)), (52.0, float(y))),),
         )
-        for x in range(1, 6)
+        for y in range(21, 26)
     ]
     return [*labels, *centre_marks]
 
@@ -58,7 +63,7 @@ def test_two_affected_labels_keep_ten_pair_findings_but_take_two_score_penalties
 
     assert len(issues) == 10, "every offending label/centre-mark pair remains inspectable"
     assert all("4× ⌀6 THRU" in issue.message for issue in issues)
-    assert {issue.location for issue in issues} == {(float(x), 5.0) for x in range(1, 6)}
+    assert {issue.location for issue in issues} == {(35.0, float(y)) for y in range(21, 26)}
     assert legibility["warnings"] == 10, "the compatibility count remains raw lint findings"
     assert legibility["by_code"] == {"label_centerline_overlap": 10}
     assert legibility["raw_issues"] == 10
@@ -160,14 +165,11 @@ def test_separate_lint_runs_have_independent_summary_scoped_group_tokens():
     assert all(second_aggregation.token_for(issue) is None for issue in first)
 
 
-def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics(monkeypatch):
+def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics():
     drawing = build_drawing(Box(20, 15, 10))
-
-    def fake_lint(*, physical=True, aggregation=None):
-        issues, _ = _two_labels_crossed_by_five_centre_marks(aggregation)
-        return issues
-
-    monkeypatch.setattr(drawing, "_lint", fake_lint)
+    drawing.items = _crossed_items()
+    drawing.views.clear()
+    drawing.part = None
 
     summary = drawing.lint_summary()
 
@@ -177,3 +179,36 @@ def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics(m
     assert len(summary["issues"]) == 10
     assert all(not any("aggregation" in key for key in issue) for issue in summary["issues"])
     assert summary["quality"]["legibility"]["score"] == pytest.approx(0.9)
+
+
+def test_lint_summary_still_dispatches_through_a_public_lint_override(monkeypatch):
+    drawing = build_drawing(Box(20, 15, 10))
+    calls = []
+    external = LintIssue(severity="error", code="external_policy", message="custom critique")
+
+    def custom_lint(*, physical=True):
+        calls.append(physical)
+        return [external]
+
+    monkeypatch.setattr(drawing, "lint", custom_lint)
+
+    summary = drawing.lint_summary()
+
+    assert calls == [True]
+    assert summary["by_code"] == {"external_policy": 1}
+    assert summary["issues"][0]["message"] == "custom critique"
+
+
+def test_a_failing_public_lint_override_cannot_leak_summary_context(monkeypatch):
+    drawing = build_drawing(Box(20, 15, 10))
+
+    def failing_lint(*, physical=True):
+        assert _current_issue_aggregation() is not None
+        raise RuntimeError("custom critique failed")
+
+    monkeypatch.setattr(drawing, "lint", failing_lint)
+
+    with pytest.raises(RuntimeError, match="custom critique failed"):
+        drawing.lint_summary()
+
+    assert _current_issue_aggregation() is None

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import gc
 import pickle
 import weakref
 from dataclasses import asdict, replace
@@ -13,6 +15,7 @@ from build123d import Box
 from draftwright import build_drawing
 from draftwright.linting.issues import (
     LintIssue,
+    _collect_issue_aggregation,
     _current_issue_aggregation,
     _IssueAggregation,
 )
@@ -108,6 +111,41 @@ def test_run_local_pair_subject_does_not_change_public_lint_issue_value_behaviou
     assert not any("aggregation" in key for key in vars(issue))
     assert replace(issue) == issue
     assert pickle.loads(pickle.dumps(issue)) == issue
+
+
+def test_summary_evidence_does_not_retain_source_annotations_or_their_graphs():
+    class SourceGraph:
+        pass
+
+    class Annotation:
+        pass
+
+    source_graph = SourceGraph()
+    annotation = Annotation()
+    annotation.label = "4× ⌀6 THRU"
+    annotation.label_bbox = (20.0, 20.0, 30.0, 30.0)
+    annotation.source_graph = source_graph
+    annotation_ref = weakref.ref(annotation)
+    graph_ref = weakref.ref(source_graph)
+    aggregation = _IssueAggregation()
+    issues = lint_drawing(
+        [
+            annotation,
+            SimpleNamespace(
+                is_centerline=True,
+                segments=(((18.0, 25.0), (52.0, 25.0)),),
+            ),
+        ],
+        _aggregation=aggregation,
+    )
+    assert [issue.code for issue in issues] == ["label_centerline_overlap"]
+
+    del annotation, source_graph
+    gc.collect()
+
+    assert annotation_ref() is None
+    assert graph_ref() is None
+    assert aggregation.token_for(issues[0]) is not None
 
 
 def test_equal_codes_without_a_shared_subject_remain_independent_primary_issues():
@@ -326,4 +364,40 @@ def test_a_failing_public_lint_override_cannot_leak_summary_context(monkeypatch)
     with pytest.raises(RuntimeError, match="custom critique failed"):
         drawing.lint_summary()
 
+    assert _current_issue_aggregation() is None
+
+
+def test_nested_summary_context_restores_the_outer_ledger():
+    with _collect_issue_aggregation() as outer:
+        assert _current_issue_aggregation() is outer
+        with _collect_issue_aggregation() as inner:
+            assert inner is not outer
+            assert _current_issue_aggregation() is inner
+        assert _current_issue_aggregation() is outer
+
+    assert _current_issue_aggregation() is None
+
+
+def test_overlapping_async_summary_contexts_keep_distinct_task_local_ledgers():
+    async def exercise():
+        both_entered = asyncio.Event()
+        entered = 0
+
+        async def collect():
+            nonlocal entered
+            with _collect_issue_aggregation() as aggregation:
+                entered += 1
+                if entered == 2:
+                    both_entered.set()
+                await both_entered.wait()
+                # Force another scheduling boundary while both contexts remain active.
+                await asyncio.sleep(0)
+                return aggregation, _current_issue_aggregation()
+
+        return await asyncio.gather(collect(), collect())
+
+    results = asyncio.run(exercise())
+
+    assert results[0][0] is not results[1][0]
+    assert all(aggregation is observed for aggregation, observed in results)
     assert _current_issue_aggregation() is None

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -1,0 +1,124 @@
+"""Regression coverage for pairwise legibility score aggregation (#1147)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box
+
+from draftwright import build_drawing
+from draftwright.linting.issues import LintIssue
+from draftwright.linting.quality import quality_components
+from draftwright.linting.structural import lint_drawing
+
+
+def _legibility(issues):
+    return quality_components(
+        recognition=None,
+        features=(),
+        registry=None,
+        omissions=(),
+        issues=issues,
+        error_penalty=0.15,
+        warning_penalty=0.05,
+    )["legibility"]
+
+
+def _two_labels_crossed_by_five_centre_marks():
+    labels = [
+        SimpleNamespace(label=f"hole callout {index}", label_bbox=(0.0, 0.0, 10.0, 10.0))
+        for index in range(2)
+    ]
+    centre_marks = [
+        SimpleNamespace(
+            is_centerline=True,
+            segments=(((float(x), -2.0), (float(x), 12.0)),),
+        )
+        for x in range(1, 6)
+    ]
+    return [
+        issue
+        for issue in lint_drawing([*labels, *centre_marks])
+        if issue.code == "label_centerline_overlap"
+    ]
+
+
+def test_two_affected_labels_keep_ten_pair_findings_but_take_two_score_penalties():
+    issues = _two_labels_crossed_by_five_centre_marks()
+    legibility = _legibility(issues)
+
+    assert len(issues) == 10, "every offending label/centre-mark pair remains inspectable"
+    assert sum("hole callout 0" in issue.message for issue in issues) == 5
+    assert sum("hole callout 1" in issue.message for issue in issues) == 5
+    assert {issue.location for issue in issues} == {(float(x), 5.0) for x in range(1, 6)}
+    assert legibility["warnings"] == 10, "the compatibility count remains raw lint findings"
+    assert legibility["by_code"] == {"label_centerline_overlap": 10}
+    assert legibility["raw_issues"] == 10
+    assert legibility["affected_pairs"] == 10
+    assert legibility["primary_warnings"] == 2
+    assert legibility["primary_issues"] == 2
+    assert legibility["primary_by_code"] == {"label_centerline_overlap": 2}
+    assert legibility["basis"] == "layout_issue_severity_with_info_floor"
+    assert legibility["score_inventory"] == "primary_issues"
+    assert legibility["score"] == pytest.approx(0.9)
+
+    # Prove the producer identity is load-bearing: without it, the raw Cartesian findings
+    # once again become ten independent penalties, reproducing the original 0.5 score.
+    ungrouped = [replace(issue, aggregation_subject=None) for issue in issues]
+    assert _legibility(ungrouped)["score"] == pytest.approx(0.5)
+
+
+def test_equal_codes_without_a_shared_subject_remain_independent_primary_issues():
+    issues = [
+        LintIssue(severity="warning", code="annotation_overlap", message="first collision"),
+        LintIssue(severity="warning", code="annotation_overlap", message="second collision"),
+    ]
+
+    legibility = _legibility(issues)
+
+    assert legibility["primary_issues"] == 2
+    assert legibility["primary_by_code"] == {"annotation_overlap": 2}
+    assert legibility["score"] == pytest.approx(0.9)
+
+
+def test_one_subject_with_two_failure_mechanisms_remains_two_primary_issues():
+    issues = [
+        LintIssue(
+            severity="warning",
+            code="annotation_overlap",
+            message="collision",
+            aggregation_subject=17,
+        ),
+        LintIssue(
+            severity="warning",
+            code="label_centerline_overlap",
+            message="centreline crossing",
+            aggregation_subject=17,
+        ),
+    ]
+
+    legibility = _legibility(issues)
+
+    assert legibility["primary_issues"] == 2
+    assert legibility["primary_by_code"] == {
+        "annotation_overlap": 1,
+        "label_centerline_overlap": 1,
+    }
+    assert legibility["score"] == pytest.approx(0.9)
+
+
+def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics(monkeypatch):
+    issues = _two_labels_crossed_by_five_centre_marks()
+    drawing = build_drawing(Box(20, 15, 10))
+    monkeypatch.setattr(drawing, "lint", lambda: issues)
+
+    summary = drawing.lint_summary()
+
+    assert summary["warnings"] == 10
+    assert summary["by_code"] == {"label_centerline_overlap": 10}
+    assert summary["score"] == summary["diagnostic_score"] == pytest.approx(0.5)
+    assert len(summary["issues"]) == 10
+    assert all("aggregation_subject" not in issue for issue in summary["issues"])
+    assert summary["quality"]["legibility"]["score"] == pytest.approx(0.9)

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -252,6 +252,35 @@ def test_lint_summary_still_dispatches_through_a_public_lint_override(monkeypatc
     assert summary["issues"][0]["message"] == "custom critique"
 
 
+def test_public_override_replacements_cannot_inherit_discarded_base_issue_tokens(monkeypatch):
+    drawing = build_drawing(Box(20, 15, 10))
+    drawing.items = _crossed_items()
+    drawing.views.clear()
+    drawing.part = None
+    base_lint = drawing.lint
+
+    def replacing_lint(*, physical=True):
+        discarded = base_lint(physical=physical)
+        assert len(discarded) == 10
+        return [
+            LintIssue(
+                severity="warning",
+                code="label_centerline_overlap",
+                message=f"custom replacement {index}",
+            )
+            for index in range(10)
+        ]
+
+    monkeypatch.setattr(drawing, "lint", replacing_lint)
+
+    legibility = drawing.lint_summary()["quality"]["legibility"]
+
+    assert legibility["raw_issues"] == 10
+    assert legibility["affected_pairs"] == 0
+    assert legibility["primary_issues"] == 10
+    assert legibility["score"] == pytest.approx(0.5)
+
+
 def test_a_failing_public_lint_override_cannot_leak_summary_context(monkeypatch):
     drawing = build_drawing(Box(20, 15, 10))
 

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
+import pickle
+from dataclasses import asdict, replace
 from types import SimpleNamespace
 
 import pytest
 from build123d import Box
 
 from draftwright import build_drawing
-from draftwright.linting.issues import LintIssue
+from draftwright.linting.issues import LintIssue, _IssueAggregation
 from draftwright.linting.quality import quality_components
 from draftwright.linting.structural import lint_drawing
 
 
-def _legibility(issues):
+def _legibility(issues, aggregation=None):
     return quality_components(
         recognition=None,
         features=(),
@@ -23,10 +24,11 @@ def _legibility(issues):
         issues=issues,
         error_penalty=0.15,
         warning_penalty=0.05,
+        _aggregation=aggregation,
     )["legibility"]
 
 
-def _two_labels_crossed_by_five_centre_marks():
+def _crossed_items():
     labels = [
         SimpleNamespace(label="4× ⌀6 THRU", label_bbox=(0.0, 0.0, 10.0, 10.0)) for _ in range(2)
     ]
@@ -37,16 +39,22 @@ def _two_labels_crossed_by_five_centre_marks():
         )
         for x in range(1, 6)
     ]
-    return [
+    return [*labels, *centre_marks]
+
+
+def _two_labels_crossed_by_five_centre_marks(aggregation=None):
+    aggregation = aggregation or _IssueAggregation()
+    issues = [
         issue
-        for issue in lint_drawing([*labels, *centre_marks])
+        for issue in lint_drawing(_crossed_items(), _aggregation=aggregation)
         if issue.code == "label_centerline_overlap"
     ]
+    return issues, aggregation
 
 
 def test_two_affected_labels_keep_ten_pair_findings_but_take_two_score_penalties():
-    issues = _two_labels_crossed_by_five_centre_marks()
-    legibility = _legibility(issues)
+    issues, aggregation = _two_labels_crossed_by_five_centre_marks()
+    legibility = _legibility(issues, aggregation)
 
     assert len(issues) == 10, "every offending label/centre-mark pair remains inspectable"
     assert all("4× ⌀6 THRU" in issue.message for issue in issues)
@@ -76,13 +84,24 @@ def test_two_affected_labels_keep_ten_pair_findings_but_take_two_score_penalties
     assert _legibility(ungrouped)["score"] == pytest.approx(0.5)
 
 
-def test_run_local_pair_subject_is_not_part_of_the_public_lint_issue_schema():
-    issue = _two_labels_crossed_by_five_centre_marks()[0]
+def test_run_local_pair_subject_does_not_change_public_lint_issue_value_behaviour():
+    # The source annotation deliberately contains an unpickleable member. Only the public
+    # issue value may survive lint; the summary-scoped side ledger must not retain that graph.
+    items = _crossed_items()
+    items[0].unpickleable = lambda: None
+    aggregation = _IssueAggregation()
+    issue = next(
+        issue
+        for issue in lint_drawing(items, _aggregation=aggregation)
+        if issue.code == "label_centerline_overlap"
+    )
 
-    assert isinstance(issue, LintIssue)
+    assert type(issue) is LintIssue
     assert "aggregation" not in repr(issue)
     assert not any("aggregation" in key for key in asdict(issue))
     assert not any("aggregation" in key for key in vars(issue))
+    assert replace(issue) == issue
+    assert pickle.loads(pickle.dumps(issue)) == issue
 
 
 def test_equal_codes_without_a_shared_subject_remain_independent_primary_issues():
@@ -99,10 +118,11 @@ def test_equal_codes_without_a_shared_subject_remain_independent_primary_issues(
 
 
 def test_one_subject_with_two_failure_mechanisms_remains_two_primary_issues():
-    issues = _two_labels_crossed_by_five_centre_marks()[:2]
+    all_issues, aggregation = _two_labels_crossed_by_five_centre_marks()
+    issues = all_issues[:2]
     issues[0].code = "annotation_overlap"
 
-    legibility = _legibility(issues)
+    legibility = _legibility(issues, aggregation)
 
     assert legibility["primary_issues"] == 2
     assert legibility["primary_by_code"] == {
@@ -114,12 +134,13 @@ def test_one_subject_with_two_failure_mechanisms_remains_two_primary_issues():
 
 @pytest.mark.parametrize("severities", [("info", "error"), ("error", "info")])
 def test_one_group_uses_its_strongest_severity_in_either_observation_order(severities):
-    issues = _two_labels_crossed_by_five_centre_marks()[:2]
+    all_issues, aggregation = _two_labels_crossed_by_five_centre_marks()
+    issues = all_issues[:2]
     for issue, severity in zip(issues, severities, strict=True):
         issue.severity = severity
         issue.message = severity
 
-    legibility = _legibility(issues)
+    legibility = _legibility(issues, aggregation)
 
     assert legibility["errors"] == 1
     assert legibility["infos"] == 1
@@ -129,10 +150,24 @@ def test_one_group_uses_its_strongest_severity_in_either_observation_order(sever
     assert legibility["score"] == pytest.approx(0.85)
 
 
+def test_separate_lint_runs_have_independent_summary_scoped_group_tokens():
+    first, first_aggregation = _two_labels_crossed_by_five_centre_marks()
+    second, second_aggregation = _two_labels_crossed_by_five_centre_marks()
+
+    assert _legibility(first, first_aggregation)["primary_issues"] == 2
+    assert _legibility(second, second_aggregation)["primary_issues"] == 2
+    assert all(first_aggregation.token_for(issue) is None for issue in second)
+    assert all(second_aggregation.token_for(issue) is None for issue in first)
+
+
 def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics(monkeypatch):
-    issues = _two_labels_crossed_by_five_centre_marks()
     drawing = build_drawing(Box(20, 15, 10))
-    monkeypatch.setattr(drawing, "lint", lambda: issues)
+
+    def fake_lint(*, physical=True, aggregation=None):
+        issues, _ = _two_labels_crossed_by_five_centre_marks(aggregation)
+        return issues
+
+    monkeypatch.setattr(drawing, "_lint", fake_lint)
 
     summary = drawing.lint_summary()
 

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -165,6 +165,45 @@ def test_separate_lint_runs_have_independent_summary_scoped_group_tokens():
     assert all(second_aggregation.token_for(issue) is None for issue in first)
 
 
+def test_separate_structural_passes_in_one_summary_ledger_get_distinct_tokens():
+    aggregation = _IssueAggregation()
+    first, _ = _two_labels_crossed_by_five_centre_marks(aggregation)
+    second, _ = _two_labels_crossed_by_five_centre_marks(aggregation)
+
+    combined = _legibility([*first, *second], aggregation)
+
+    assert combined["raw_issues"] == 20
+    assert combined["primary_issues"] == 4
+    assert aggregation.token_for(first[0]) is not aggregation.token_for(second[0])
+
+
+def test_multi_scale_drawing_groups_each_annotation_inside_its_own_structural_pass():
+    drawing = build_drawing(Box(20, 15, 10))
+    items = _crossed_items()
+    for item in items[:1] + items[2:7]:
+        item._dw_scale = 1.0
+    for item in items[1:2]:
+        item._dw_scale = 2.0
+    # Give the second label its own five centre marks in the second scale group.
+    second_marks = [
+        SimpleNamespace(
+            is_centerline=True,
+            segments=mark.segments,
+            _dw_scale=2.0,
+        )
+        for mark in items[2:7]
+    ]
+    drawing.items = [items[0], *items[2:7], items[1], *second_marks]
+    drawing.views.clear()
+    drawing.part = None
+
+    legibility = drawing.lint_summary()["quality"]["legibility"]
+
+    assert legibility["raw_issues"] == 10
+    assert legibility["primary_issues"] == 2
+    assert legibility["score"] == pytest.approx(0.9)
+
+
 def test_legacy_summary_counts_and_diagnostic_score_keep_raw_finding_semantics():
     drawing = build_drawing(Box(20, 15, 10))
     drawing.items = _crossed_items()

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -380,24 +380,38 @@ def test_nested_summary_context_restores_the_outer_ledger():
 
 def test_overlapping_async_summary_contexts_keep_distinct_task_local_ledgers():
     async def exercise():
-        both_entered = asyncio.Event()
-        entered = 0
+        first_entered = asyncio.Event()
+        second_entered = asyncio.Event()
+        first_observed = asyncio.Event()
+        second_exited = asyncio.Event()
 
-        async def collect():
-            nonlocal entered
+        async def collect_first():
             with _collect_issue_aggregation() as aggregation:
-                entered += 1
-                if entered == 2:
-                    both_entered.set()
-                await both_entered.wait()
-                # Force another scheduling boundary while both contexts remain active.
-                await asyncio.sleep(0)
-                return aggregation, _current_issue_aggregation()
+                first_entered.set()
+                await second_entered.wait()
+                # Observe A while B's context is still active. A module-global stack would
+                # expose B here; task-local context must continue to expose A.
+                while_second_is_active = _current_issue_aggregation()
+                first_observed.set()
+                await second_exited.wait()
+                after_second_exits = _current_issue_aggregation()
+                return aggregation, while_second_is_active, after_second_exits
 
-        return await asyncio.gather(collect(), collect())
+        async def collect_second():
+            await first_entered.wait()
+            with _collect_issue_aggregation() as aggregation:
+                second_entered.set()
+                await first_observed.wait()
+                while_first_is_active = _current_issue_aggregation()
+            second_exited.set()
+            return aggregation, while_first_is_active
 
-    results = asyncio.run(exercise())
+        return await asyncio.gather(collect_first(), collect_second())
 
-    assert results[0][0] is not results[1][0]
-    assert all(aggregation is observed for aggregation, observed in results)
+    first, second = asyncio.run(exercise())
+
+    assert first[0] is not second[0]
+    assert first[1] is first[0]
+    assert first[2] is first[0]
+    assert second[1] is second[0]
     assert _current_issue_aggregation() is None

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5300,7 +5300,15 @@ class TestLintSummaryAndDrops:
             "infos": 1,
             "placement_drops": 2,
             "by_code": {"callout_dropped": 1, "slot_dim_dropped": 1},
+            "raw_issues": 2,
+            "primary_issues": 2,
+            "primary_errors": 0,
+            "primary_warnings": 1,
+            "primary_infos": 1,
+            "primary_by_code": {"callout_dropped": 1, "slot_dim_dropped": 1},
+            "affected_pairs": 0,
             "basis": "layout_issue_severity_with_info_floor",
+            "score_inventory": "primary_issues",
         }
         assert summary["quality"]["restraint"] == {
             "available": False,

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -78,6 +78,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_drop_view_coordinates",
         "_hole_spec_groups",
         "_is_scattered_hole_doc",
+        "_lint",
         "_lint_and_log",
         "_part_model",
         "_place_dim",


### PR DESCRIPTION
Closes #1147.

## Root cause

Structural lint deliberately emits one `label_centerline_overlap` issue for every label/centre-mark pair. Legibility scoring applied its severity penalty to that raw Cartesian inventory. In the #1142-shaped reproduction, two affected labels crossed by five centre marks therefore produced ten warnings and a 0.5 score, despite representing only two independent annotation defects.

## Solution

The pair-producing structural check records scoring evidence in a summary-scoped side ledger. Each `lint_drawing()` invocation mints opaque per-input tokens while its full input list is alive, then associates ordinary emitted `LintIssue` values with a token and their producer-recorded failure code. The ledger briefly retains only plain-data issue values—never annotations, annotation IDs, or CAD graphs. Retaining the issue prevents address reuse from transferring evidence to a replacement issue; recording the original code prevents in-place mutation into another mechanism from inheriting stale grouping evidence.

Legibility groups only issues whose identity and current failure code still match explicit producer evidence, using `(code, token)` as the primary key and the strongest severity within a group. Missing or invalid evidence fails closed: each issue remains independently chargeable. This belongs at the lint producer/quality boundary because the producer alone knows which member of a diagnostic pair is the affected annotation, while quality owns scoring.

The ledger exists only inside `lint_summary()`. A task-local context lets the unchanged public `Drawing.lint()` path contribute evidence while `lint_summary()` continues to call `self.lint()`, preserving subclass and instance critique extensions. The context is reset even when an override raises.

Every raw pair remains in `Drawing.lint()` and `lint_summary()["issues"]`; pair findings now also carry the compared centre mark's location. Existing legibility `errors`, `warnings`, `infos`, `placement_drops`, `by_code`, and `basis` retain raw-finding semantics. Additive `primary_*`, `raw_issues`, `affected_pairs`, and `score_inventory` fields expose the scoring inventory. The legacy top-level `score` and `diagnostic_score` remain raw and unchanged.

## ADR assessment

- ADR 0002 constrains the critique contract: raw gateable diagnostics, public lint dispatch, and the legacy diagnostic score remain unchanged; the component score declares its primary inventory.
- ADR 0005 requires a single annotation inventory. Opaque summary tokens are transient comparison state, not persistent identity, provenance, or a second registry.
- ADR 0007 keeps lint ownership inside Draftwright. Pair grouping remains within `draftwright.linting` and the `Drawing` critique path.
- ADR 0010 requires staged, machine-readable critique. Pair observations remain intact and primary-versus-raw counts are explicit.
- ADRs 0004 and 0014 remain unchanged: this is post-layout critique and neither places nor repairs annotations.
- ADRs 0015–0017 remain unchanged: recognition, PartModel, compilation, provenance, and coverage contracts are unaffected.

No accepted decision needs amendment.

## Tests and validation

The regression failed before the fix: ten raw pair findings produced ten penalties and score 0.5.

Coverage now proves:

- two distinct annotations with identical visible labels crossed by five centre marks retain ten spatial pair findings but yield two primaries and score 0.9;
- removing producer evidence is load-bearing and restores score 0.5;
- independent same-code issues remain independent, while two mechanisms on one subject remain distinct;
- mixed-severity groups use the strongest severity in either observation order;
- separate lint runs, separate structural passes, and a real multi-scale drawing use independent token namespaces;
- `lint_summary()` honors public `Drawing.lint()` overrides and always resets context;
- replacement issues and issues mutated in place to another code fail closed rather than inheriting stale evidence;
- address reuse cannot transfer annotation or issue identity;
- supported duck-typed annotations with unpickleable members never leak into results: values remain exact `LintIssue` instances preserving repr, `asdict`, `vars`, equality, `dataclasses.replace`, and pickle behavior;
- weak-reference/GC coverage proves annotations and their attached source graphs are collectible while the summary ledger and issues remain alive;
- nested and explicitly interleaved asynchronous summary contexts force one task to observe its ledger while another task's context is active, proving task-local isolation and enclosing-state restoration;
- legacy raw counts, complete issue inventory, top-level `score`, and `diagnostic_score` remain unchanged.

Local validation on exact head `591ee03`:

- focused lint/quality/#1142 compatibility suites: 110 passed;
- `uv run pytest -m smoke`: 73 passed;
- `scripts/pr-check --static`: green;
- `scripts/pr-check --full`: green, 3,438 passed, 5 skipped, 2 xfailed; 94.49% overall coverage and 100% changed-line coverage;
- `git diff --check`: green.

## Adversarial review fixes

- Review 1 removed a process-local identity field from the public dataclass and added identical-label and strongest-severity coverage.
- Review 2 replaced a private issue subclass that changed dataclass behavior and retained annotation graphs with the summary side ledger.
- Review 3 restored public `Drawing.lint()` dispatch and replaced persisted annotation IDs with per-call opaque tokens.
- Review 4 made the ledger retain its small plain-data issues during the summary scope, preventing discarded issue IDs from being reused by custom replacement findings.
- Review 5 bound aggregation evidence to the producer-recorded code, so in-place mutation into another failure mechanism fails closed.
- Review 6 added load-bearing lifetime, nested-context, and overlapping-task regressions for the ledger's isolation guarantees.

## Compatibility and failure behaviour

This is an additive legibility schema change and the intended component-score correction. Public `LintIssue`, `lint_drawing()` results, and `Drawing.lint()` remain ordinary data values. Raw compatibility fields and the full issue list keep their existing meaning. Public overrides remain authoritative. Producers or quality calls without valid summary evidence treat every finding as an independent primary penalty. Distinct codes never collapse, and each structural call intentionally mints a fresh token namespace.

No migration is required. Rendering and placement are unchanged, so screenshots are not applicable.

## Acceptance criteria

- [x] Equivalent warnings from one annotation and one failure mechanism are grouped for legibility scoring.
- [x] Pair-level findings and locations remain available.
- [x] Independent labels, including identical visible text, count independently.
- [x] The #1142-shaped regression reports two primary issues rather than ten score penalties.
- [x] README and schema distinguish raw findings, affected pairs, and primary score issues.
- [x] Raw compatibility fields, public issue values, public lint dispatch, and legacy diagnostic scoring retain their semantics.

Final gate: exact head `591ee03` received a fresh independent adversarial review with zero substantive findings or nits. All required GitHub checks, including `ci-ok`, are green on that exact commit.
