### PR TITLE
Make automatic hole-table replacement transactional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@
   Callouts carrying compound, thread, profile, pattern, tolerance, or fit facts the table cannot
   state remain active, and unresolved dropped callouts stay diagnostic. Hole outcome records
   identify per feature whether a committed table or a restored feature annotation supplied the
-  placed requirement, together with the fallback reason. Transactional public replacement is
-  plan-view-only until the balloon halo is view-generic; additive tables remain available in all
-  orthographic views.
+  placed requirement, together with the fallback reason; mixed table/feature evidence deliberately
+  claims no single winner. Exceptions also restore those semantic markers, and automatic
+  escalation fails closed rather than overwrite an existing annotation that owns a reserved table
+  or balloon name. Transactional public replacement is plan-view-only until the balloon halo is
+  view-generic; additive tables remain available in all orthographic views.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
   escalation and the opt-in public `add_hole_table(..., replace_callouts=True)` surface now
   suppress original callouts only after the table fits and every required feature balloon lands.
   A failed table restores the exact annotations and registry identities; a partial balloon set
-  restores the unresolved feature callouts and re-solves the table around them before committing.
+  restores the unresolved feature callouts, re-solves the table, and re-runs the shared balloon
+  placement against the final callout inventory before committing. Balloons that would cross a
+  retained or restored callout label fail closed instead of creating a misleading clean lint.
   Callouts carrying compound, thread, profile, pattern, tolerance, or fit facts the table cannot
   state remain active, and unresolved dropped callouts stay diagnostic. Hole outcome records
   identify per feature whether a committed table or a restored feature annotation supplied the
-  placed requirement, together with the fallback reason.
+  placed requirement, together with the fallback reason. Transactional public replacement is
+  plan-view-only until the balloon halo is view-generic; additive tables remain available in all
+  orthographic views.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@
   identities, coverage, and issues. Precise ring, glyph, and leader-segment tests keep placement
   clear of retained callout labels, leader shafts, and existing public-balloon components without
   changing the existing additive `add_hole_table()`/`add_balloons()` behavior; malformed component
-  metadata falls back conservatively or fails the optional replacement closed. Compound, thread,
+  metadata—including ambiguous Boolean cardinalities—falls back conservatively or fails the
+  optional replacement closed. New balloon shafts must also remain mutually crossing-free.
+  Compound, thread,
   profile, pattern, tolerance, and fit facts the table cannot state remain active, while
   independently replaceable X/Y locations may still move to the table. Guarded interval solving
-  has deterministic pre-carve and work/state budgets; an adversarially fragmented label inventory
-  or band fails the replacement closed before excessive work or allocation. Required row-key
+  has deterministic pre-lane, pre-carve, and work/state budgets; an adversarially fragmented label
+  inventory or band fails the replacement closed before excessive work or allocation. Required row-key
   balloons take priority over optional non-certifying pattern markers, so an independently complete
   table cannot be displaced by an auxiliary marker.
   Hole outcomes identify the winning representation per requirement;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   identities, coverage, and issues. Precise ring, glyph, and leader-segment tests keep placement
   clear of retained callout labels, leader shafts, and existing public-balloon components without
   changing the existing additive `add_hole_table()`/`add_balloons()` behavior; malformed component
-  metadata—including ambiguous Boolean cardinalities—falls back conservatively or fails the
+  metadata—including Boolean cardinalities or coordinate payloads—falls back conservatively or fails the
   optional replacement closed. New balloon shafts must also remain mutually crossing-free.
   Compound, thread,
   profile, pattern, tolerance, and fit facts the table cannot state remain active, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 ### Fixed
 
 - **Automatic hole-table escalation is transactional per semantic requirement** (#1144). The
-  engine suppresses a replaceable callout or location dimension only after the table fits and its
-  required feature balloon lands. A failed table restores the exact annotations, ordering,
-  registry identities, coverage, and issues; a partial balloon set restores unresolved fallbacks
-  and re-solves the final table/balloon inventory. Precise ring, glyph, and leader-segment tests
-  keep retry placement clear of retained callout labels without changing the existing additive
+  engine suppresses replaceable callouts and location dimensions only after the table fits and
+  every visible row has its required feature-owned balloon. A failed or partial balloon attempt
+  rolls the shared table back as a unit and restores the exact annotations, ordering, registry
+  identities, coverage, and issues. Precise ring, glyph, and leader-segment tests keep placement
+  clear of retained callout labels without changing the existing additive
   `add_hole_table()`/`add_balloons()` behavior. Compound, thread, profile, pattern, tolerance, and
   fit facts the table cannot state remain active, while independently replaceable X/Y locations
   may still move to the table. Hole outcomes identify the winning representation per requirement;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
   clear of retained callout labels without changing the existing additive
   `add_hole_table()`/`add_balloons()` behavior. Compound, thread, profile, pattern, tolerance, and
   fit facts the table cannot state remain active, while independently replaceable X/Y locations
-  may still move to the table. Hole outcomes identify the winning representation per requirement;
+  may still move to the table. Guarded interval solving has a deterministic work/state budget;
+  an adversarially fragmented band fails the replacement closed before excessive allocation.
+  Hole outcomes identify the winning representation per requirement;
   mixed table/feature evidence deliberately claims no single winner. Exceptions restore those
   semantic markers, and automatic escalation fails closed rather than overwrite an existing
   annotation that owns a reserved table or balloon name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   every visible row has its required feature-owned balloon. A failed or partial balloon attempt
   rolls the shared table back as a unit and restores the exact annotations, ordering, registry
   identities, coverage, and issues. Precise ring, glyph, and leader-segment tests keep placement
-  clear of retained callout labels without changing the existing additive
+  clear of retained callout labels and leader shafts without changing the existing additive
   `add_hole_table()`/`add_balloons()` behavior. Compound, thread, profile, pattern, tolerance, and
   fit facts the table cannot state remain active, while independently replaceable X/Y locations
   may still move to the table. Guarded interval solving has a deterministic work/state budget;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
   escalation and the opt-in public `add_hole_table(..., replace_callouts=True)` surface now
   suppress original callouts only after the table fits and every required feature balloon lands.
   A failed table restores the exact annotations and registry identities; a partial balloon set
-  restores the unresolved feature callouts and cannot claim their requirements. Hole outcome
-  records identify whether a committed table or a restored feature annotation supplied the
-  placed requirement, together with the fallback reason.
+  restores the unresolved feature callouts and re-solves the table around them before committing.
+  Callouts carrying compound, thread, profile, or pattern facts the table cannot state remain
+  active. Hole outcome records identify whether a committed table or a restored feature
+  annotation supplied the placed requirement, together with the fallback reason.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   rolls the shared table back as a unit and restores the exact annotations, ordering, registry
   identities, coverage, and issues. Precise ring, glyph, and leader-segment tests keep placement
   clear of retained callout labels, leader shafts, and existing public-balloon components without
-  changing the existing additive `add_hole_table()`/`add_balloons()` behavior. Compound, thread,
+  changing the existing additive `add_hole_table()`/`add_balloons()` behavior; malformed component
+  metadata falls back conservatively or fails the optional replacement closed. Compound, thread,
   profile, pattern, tolerance, and fit facts the table cannot state remain active, while
   independently replaceable X/Y locations may still move to the table. Guarded interval solving
   has a deterministic work/state budget; an adversarially fragmented band fails the replacement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@
   metadata falls back conservatively or fails the optional replacement closed. Compound, thread,
   profile, pattern, tolerance, and fit facts the table cannot state remain active, while
   independently replaceable X/Y locations may still move to the table. Guarded interval solving
-  has a deterministic work/state budget; an adversarially fragmented band fails the replacement
-  closed before excessive allocation.
+  has deterministic pre-carve and work/state budgets; an adversarially fragmented label inventory
+  or band fails the replacement closed before excessive work or allocation. Required row-key
+  balloons take priority over optional non-certifying pattern markers, so an independently complete
+  table cannot be displaced by an auxiliary marker.
   Hole outcomes identify the winning representation per requirement;
   mixed table/feature evidence deliberately claims no single winner. Exceptions restore those
   semantic markers, and automatic escalation fails closed rather than overwrite an existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,18 @@
 
 ### Fixed
 
-- **Hole-table replacement is transactional per semantic feature** (#1144). Automatic
-  escalation and the opt-in public `add_hole_table(..., replace_callouts=True)` surface now
-  suppress original callouts only after the table fits and every required feature balloon lands.
-  A failed table restores the exact annotations and registry identities; a partial balloon set
-  restores the unresolved feature callouts, re-solves the table, and re-runs the shared balloon
-  placement against the final callout inventory before committing. Balloons that would cross a
-  retained or restored callout label fail closed instead of creating a misleading clean lint.
-  Callouts carrying compound, thread, profile, pattern, tolerance, or fit facts the table cannot
-  state remain active, and unresolved dropped callouts stay diagnostic. Hole outcome records
-  identify per feature whether a committed table or a restored feature annotation supplied the
-  placed requirement, together with the fallback reason; mixed table/feature evidence deliberately
-  claims no single winner. Exceptions also restore those semantic markers, and automatic
-  escalation fails closed rather than overwrite an existing annotation that owns a reserved table
-  or balloon name. Transactional public replacement is plan-view-only until the balloon halo is
-  view-generic; additive tables remain available in all orthographic views.
+- **Automatic hole-table escalation is transactional per semantic requirement** (#1144). The
+  engine suppresses a replaceable callout or location dimension only after the table fits and its
+  required feature balloon lands. A failed table restores the exact annotations, ordering,
+  registry identities, coverage, and issues; a partial balloon set restores unresolved fallbacks
+  and re-solves the final table/balloon inventory. Precise ring, glyph, and leader-segment tests
+  keep retry placement clear of retained callout labels without changing the existing additive
+  `add_hole_table()`/`add_balloons()` behavior. Compound, thread, profile, pattern, tolerance, and
+  fit facts the table cannot state remain active, while independently replaceable X/Y locations
+  may still move to the table. Hole outcomes identify the winning representation per requirement;
+  mixed table/feature evidence deliberately claims no single winner. Exceptions restore those
+  semantic markers, and automatic escalation fails closed rather than overwrite an existing
+  annotation that owns a reserved table or balloon name.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@
   every visible row has its required feature-owned balloon. A failed or partial balloon attempt
   rolls the shared table back as a unit and restores the exact annotations, ordering, registry
   identities, coverage, and issues. Precise ring, glyph, and leader-segment tests keep placement
-  clear of retained callout labels and leader shafts without changing the existing additive
-  `add_hole_table()`/`add_balloons()` behavior. Compound, thread, profile, pattern, tolerance, and
-  fit facts the table cannot state remain active, while independently replaceable X/Y locations
-  may still move to the table. Guarded interval solving has a deterministic work/state budget;
-  an adversarially fragmented band fails the replacement closed before excessive allocation.
+  clear of retained callout labels, leader shafts, and existing public-balloon components without
+  changing the existing additive `add_hole_table()`/`add_balloons()` behavior. Compound, thread,
+  profile, pattern, tolerance, and fit facts the table cannot state remain active, while
+  independently replaceable X/Y locations may still move to the table. Guarded interval solving
+  has a deterministic work/state budget; an adversarially fragmented band fails the replacement
+  closed before excessive allocation.
   Hole outcomes identify the winning representation per requirement;
   mixed table/feature evidence deliberately claims no single winner. Exceptions restore those
   semantic markers, and automatic escalation fails closed rather than overwrite an existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
   suppress original callouts only after the table fits and every required feature balloon lands.
   A failed table restores the exact annotations and registry identities; a partial balloon set
   restores the unresolved feature callouts and re-solves the table around them before committing.
-  Callouts carrying compound, thread, profile, or pattern facts the table cannot state remain
-  active. Hole outcome records identify whether a committed table or a restored feature
-  annotation supplied the placed requirement, together with the fallback reason.
+  Callouts carrying compound, thread, profile, pattern, tolerance, or fit facts the table cannot
+  state remain active, and unresolved dropped callouts stay diagnostic. Hole outcome records
+  identify per feature whether a committed table or a restored feature annotation supplied the
+  placed requirement, together with the fallback reason.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Hole-table replacement is transactional per semantic feature** (#1144). Automatic
+  escalation and the opt-in public `add_hole_table(..., replace_callouts=True)` surface now
+  suppress original callouts only after the table fits and every required feature balloon lands.
+  A failed table restores the exact annotations and registry identities; a partial balloon set
+  restores the unresolved feature callouts and cannot claim their requirements. Hole outcome
+  records identify whether a committed table or a restored feature annotation supplied the
+  placed requirement, together with the fallback reason.
+
 ### Changed
 
 - **Pairwise lint detail no longer multiplies the legibility score penalty** (#1147). Raw

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -325,3 +325,61 @@ def _segment_clips_box(p, q, box, pad=0.0) -> bool:
     lint checks use; :func:`_segment_crosses_box` is the strict placement-side
     sibling (#700)."""
     return _segment_clip_extent(p, q, box, pad=pad) is not None
+
+
+def _segments_cross_or_overlap(a1, a2, b1, b2) -> bool:
+    """Whether two page-plane segments cross or overlap beyond a shared endpoint.
+
+    Proper interior crossings, a T-junction into the other segment's interior,
+    and collinear overlap are conflicts. Merely sharing one endpoint is not: two
+    leaders may legitimately terminate at the same feature/ring boundary.
+    """
+    epsilon = 1e-9
+
+    def cross(origin, first, second):
+        return (first[0] - origin[0]) * (second[1] - origin[1]) - (first[1] - origin[1]) * (
+            second[0] - origin[0]
+        )
+
+    def same(first, second):
+        return abs(first[0] - second[0]) <= epsilon and abs(first[1] - second[1]) <= epsilon
+
+    def on_segment(point, first, second):
+        return (
+            abs(cross(first, second, point)) <= epsilon
+            and min(first[0], second[0]) - epsilon
+            <= point[0]
+            <= max(first[0], second[0]) + epsilon
+            and min(first[1], second[1]) - epsilon
+            <= point[1]
+            <= max(first[1], second[1]) + epsilon
+        )
+
+    oa1 = cross(b1, b2, a1)
+    oa2 = cross(b1, b2, a2)
+    ob1 = cross(a1, a2, b1)
+    ob2 = cross(a1, a2, b2)
+    if oa1 * oa2 < -(epsilon**2) and ob1 * ob2 < -(epsilon**2):
+        return True
+
+    if all(abs(value) <= epsilon for value in (oa1, oa2, ob1, ob2)):
+        axis = (
+            0
+            if max(abs(a2[0] - a1[0]), abs(b2[0] - b1[0]))
+            >= max(abs(a2[1] - a1[1]), abs(b2[1] - b1[1]))
+            else 1
+        )
+        overlap = min(max(a1[axis], a2[axis]), max(b1[axis], b2[axis])) - max(
+            min(a1[axis], a2[axis]), min(b1[axis], b2[axis])
+        )
+        return bool(overlap > epsilon)
+
+    for point, first, second in (
+        (a1, b1, b2),
+        (a2, b1, b2),
+        (b1, a1, a2),
+        (b2, a1, a2),
+    ):
+        if on_segment(point, first, second) and not (same(point, first) or same(point, second)):
+            return True
+    return False

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -281,11 +281,14 @@ def _segment_crosses_box(p1, p2, box) -> bool:
     return any(_seg_seg(p1, p2, corners[i], corners[(i + 1) % 4]) for i in range(4))
 
 
-def _segment_clips_box(p, q, box, pad=0.0) -> bool:
-    """Liang–Barsky: does segment *p*→*q* intersect the *pad*-inflated AABB
-    *box*? Inclusive at the boundary (a touch is a hit) — the tolerant form the
-    lint checks use; :func:`_segment_crosses_box` is the strict placement-side
-    sibling (#700)."""
+def _segment_clip_extent(p, q, box, pad=0.0):
+    """AABB of the part of *p*→*q* inside the *pad*-inflated *box*.
+
+    Return ``None`` when the segment is disjoint.  The Liang–Barsky clip is
+    inclusive at the boundary: lint uses the returned extent both as its
+    tolerant hit gate and to measure only the rendered part that actually
+    reaches a label (#1144).
+    """
     minx, miny, maxx, maxy = box[0] - pad, box[1] - pad, box[2] + pad, box[3] + pad
     x0, y0 = p
     dx, dy = q[0] - x0, q[1] - y0
@@ -293,15 +296,32 @@ def _segment_clips_box(p, q, box, pad=0.0) -> bool:
     for pp, qq in ((-dx, x0 - minx), (dx, maxx - x0), (-dy, y0 - miny), (dy, maxy - y0)):
         if abs(pp) < 1e-12:
             if qq < 0:
-                return False
+                return None
         else:
             r = qq / pp
             if pp < 0:
                 if r > t1:
-                    return False
+                    return None
                 t0 = max(t0, r)
             else:
                 if r < t0:
-                    return False
+                    return None
                 t1 = min(t1, r)
-    return t0 <= t1
+    if t0 > t1:
+        return None
+    first = (x0 + t0 * dx, y0 + t0 * dy)
+    second = (x0 + t1 * dx, y0 + t1 * dy)
+    return (
+        min(first[0], second[0]),
+        min(first[1], second[1]),
+        max(first[0], second[0]),
+        max(first[1], second[1]),
+    )
+
+
+def _segment_clips_box(p, q, box, pad=0.0) -> bool:
+    """Liang–Barsky: does segment *p*→*q* intersect the *pad*-inflated AABB
+    *box*? Inclusive at the boundary (a touch is a hit) — the tolerant form the
+    lint checks use; :func:`_segment_crosses_box` is the strict placement-side
+    sibling (#700)."""
+    return _segment_clip_extent(p, q, box, pad=pad) is not None

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -85,17 +85,21 @@ def _register_hole_table_coverage(
     locations=(),
     requirements=(),
     representation_reason=None,
+    representation_features=(),
 ):
     """Register the semantic facts visibly carried by a placed hole table.
 
     Automatic escalation and the public table verb share this seam so the table object,
-    registry measurement inventory, and physical hole ledger cannot drift apart.
+    registry measurement inventory, per-feature replacement evidence, and physical hole
+    ledger cannot drift apart.
     """
     table.covers_hole_locations = tuple(locations)
     table.covers_hole_requirements_by_feature = tuple(requirements)
-    if representation_reason is not None:
-        table.hole_representation = "hole_table"
-        table.hole_representation_reason = representation_reason
+    table.covers_hole_representations_by_feature = tuple(
+        (feature, "hole_table", representation_reason)
+        for feature in representation_features
+        if representation_reason is not None
+    )
     identity = registry.identity_of(name)
     identity["measurement"] = tuple(measurements)
     registry.reapply(name, identity)
@@ -123,6 +127,11 @@ def _annotation_hole_features(registry, name, annotation) -> frozenset:
             features.add(feature)
     for feature, _requirement, _count in getattr(
         annotation, "covers_hole_requirements_by_feature", ()
+    ):
+        if getattr(feature, "kind", None) in {"hole", "pattern"}:
+            features.add(feature)
+    for feature, _representation, _reason in getattr(
+        annotation, "covers_hole_representations_by_feature", ()
     ):
         if getattr(feature, "kind", None) in {"hole", "pattern"}:
             features.add(feature)
@@ -161,6 +170,24 @@ def _hole_table_replaceable_annotation(registry, name, annotation) -> bool:
         getattr(measurement, "parameter", None) in table_parameters
         for measurement in registry.measurement_of(name)
     )
+
+
+def _hole_table_replaceable_feature(feature, dimensions=()) -> bool:
+    """Whether the current table schema can replace *feature*'s compiled callout facts.
+
+    Annotation metadata alone is insufficient: an authored tolerance or fit lives on the
+    compiler-approved dimension, and an automatic callout may have dropped before any
+    annotation object existed.  Keep this predicate feature/plan based so both public and
+    automatic transactions make the same decision without parsing rendered text.
+    """
+    if getattr(feature, "kind", None) != "hole":
+        return False
+    if any(
+        getattr(feature, attribute, None) is not None
+        for attribute in ("cbore", "spotface", "csink", "thread", "profile")
+    ):
+        return False
+    return all(getattr(dimension, "tolerance", None) is None for dimension in dimensions)
 
 
 @dataclass(frozen=True)

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1181,27 +1181,21 @@ def _box_hits(bb, boxes):
     return bb is not None and any(_boxes_overlap(bb, c) for c in boxes)
 
 
-def balloon_hits_annotation_label(dwg, glyph, segments, view) -> bool:
-    """Whether precise balloon geometry crosses a surviving callout label.
+def balloon_annotation_label_boxes(dwg, view):
+    """Return the surviving annotation label boxes in *view*.
 
-    The glyph (ring + text) is compact enough for an AABB test.  The leader is not:
-    ADR 0009 forbids treating a diagonal shaft's empty AABB triangle as occupied, so each
-    real segment is tested against the text box independently.  This guard is enabled only
-    by transactional automatic escalation; ordinary public/additive balloons retain their
-    established placement contract.
+    Public label metadata keeps dimensions compact (witness lines are not
+    obstacles); objects without it, such as notes/tables/section arrows, fall
+    back to their rendered box. Collecting once keeps guarded balloon solving
+    free of temporary OCC glyph construction and shared-box-cache churn.
     """
     cache = getattr(dwg, "box_cache", None)
-    glyph_box = _geom_box(glyph, cache)
+    boxes = []
     for name, annotation in dwg.iter_annotations():
         owner = dwg.view_of(name)
         if owner is not None and owner != view:
             continue
         if getattr(annotation, "is_centerline", False):
-            continue
-        # The transaction changes only feature-backed callout presence. Other
-        # dimension/furniture conflicts belong to their owning placement passes; treating
-        # every witness-line bbox as a balloon obstacle would discard most of a dense ring.
-        if getattr(annotation, "elbow", None) is None:
             continue
         try:
             label_box = getattr(annotation, "label_bbox", None)
@@ -1211,11 +1205,17 @@ def balloon_hits_annotation_label(dwg, glyph, segments, view) -> bool:
             label_box = _geom_box(annotation, cache)
         if label_box is None:
             continue
-        if (glyph_box is not None and _boxes_overlap(glyph_box, label_box)) or any(
-            _segment_clips_box(start, end, label_box, pad=0.0) for start, end in segments
-        ):
-            return True
-    return False
+        boxes.append(label_box)
+    return tuple(boxes)
+
+
+def balloon_geometry_hits_annotation_labels(glyph_box, segments, label_boxes) -> bool:
+    """Whether a compact glyph or any real shaft crosses a retained label."""
+    return any(
+        _boxes_overlap(glyph_box, label_box)
+        or any(_segment_clips_box(start, end, label_box, pad=0.0) for start, end in segments)
+        for label_box in label_boxes
+    )
 
 
 def box_within_page_and_clear(bb, page_box, obstacles) -> bool:

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -216,6 +216,7 @@ class _AnnotationTransactionSnapshot:
     issues: tuple
     items: tuple
     coverage: Any
+    representations: tuple[tuple[Any, Any, Any], ...]
 
 
 def _snapshot_annotation_transaction(dwg, coverage) -> _AnnotationTransactionSnapshot:
@@ -225,12 +226,34 @@ def _snapshot_annotation_transaction(dwg, coverage) -> _AnnotationTransactionSna
         issues=dwg.registry.issues,
         items=tuple(dwg.items),
         coverage=coverage.snapshot(),
+        representations=tuple(
+            (
+                annotation,
+                getattr(annotation, "hole_representation", _MISSING_REPRESENTATION),
+                getattr(
+                    annotation,
+                    "hole_representation_reason",
+                    _MISSING_REPRESENTATION,
+                ),
+            )
+            for _name, annotation in dwg.iter_annotations()
+        ),
     )
 
 
 def _restore_annotation_transaction(dwg, coverage, snapshot, stashed, *, reason=None) -> None:
     """Restore *snapshot* exactly, optionally marking visible fallback semantics."""
     _reset_stashed_representation(stashed)
+    for annotation, representation, representation_reason in snapshot.representations:
+        for attribute, value in (
+            ("hole_representation", representation),
+            ("hole_representation_reason", representation_reason),
+        ):
+            if value is _MISSING_REPRESENTATION:
+                if hasattr(annotation, attribute):
+                    delattr(annotation, attribute)
+            else:
+                setattr(annotation, attribute, value)
     dwg.registry.restore(snapshot.registry)
     dwg.registry.restore_issues(snapshot.issues)
     dwg.items[:] = snapshot.items

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -26,7 +26,11 @@ from draftwright._core import (  # noqa: F401 — _anno_box re-exported (#700)
 from draftwright._geometry import _boxes_overlap, _segment_crosses_box  # noqa: F401
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.linting.issues import LintIssue
-from draftwright.linting.structural import _ann_box, _centerline_extent
+from draftwright.linting.structural import (
+    _ann_box,
+    _centerline_extent,
+    _label_centerline_overlap,
+)
 from draftwright.model.compiled import resolve_feature
 
 _log = logging.getLogger(__name__)
@@ -202,6 +206,39 @@ class _StashedAnnotation:
 
 
 _MISSING_REPRESENTATION = object()
+
+
+@dataclass(frozen=True)
+class _AnnotationTransactionSnapshot:
+    """Complete mutable drawing state needed by an annotation rollback."""
+
+    registry: dict
+    issues: tuple
+    items: tuple
+    coverage: Any
+
+
+def _snapshot_annotation_transaction(dwg, coverage) -> _AnnotationTransactionSnapshot:
+    """Capture identity/order, issues, render order, and semantic coverage."""
+    return _AnnotationTransactionSnapshot(
+        registry=dwg.registry.snapshot(),
+        issues=dwg.registry.issues,
+        items=tuple(dwg.items),
+        coverage=coverage.snapshot(),
+    )
+
+
+def _restore_annotation_transaction(dwg, coverage, snapshot, stashed, *, reason=None) -> None:
+    """Restore *snapshot* exactly, optionally marking visible fallback semantics."""
+    _reset_stashed_representation(stashed)
+    dwg.registry.restore(snapshot.registry)
+    dwg.registry.restore_issues(snapshot.issues)
+    dwg.items[:] = snapshot.items
+    coverage.restore(snapshot.coverage)
+    if reason is not None:
+        for record in stashed.values():
+            record.annotation.hole_representation = "feature_annotation"
+            record.annotation.hole_representation_reason = reason
 
 
 def _stash_annotations(dwg, names) -> dict[str, _StashedAnnotation]:
@@ -1089,6 +1126,32 @@ def _box_hits(bb, boxes):
     does not count as an overlap, so a candidate never overprints — at worst it
     is dropped a hair early."""
     return bb is not None and any(_boxes_overlap(bb, c) for c in boxes)
+
+
+def balloon_hits_annotation_label(dwg, balloon, view) -> bool:
+    """Whether *balloon* would create a lint-significant visible-text collision.
+
+    Balloon compounds are centreline-like furniture, so their leader/ring footprint is
+    compared with every surviving annotation label through the exact structural-lint
+    predicate.  This is a final-inventory guard inside the shared balloon placement pass:
+    retained or transactionally restored callouts remain real obstacles rather than being
+    re-added after the solve (#1144 / ADR 0014).
+    """
+    cache = getattr(dwg, "box_cache", None)
+    for name, annotation in dwg.iter_annotations():
+        owner = dwg.view_of(name)
+        if owner is not None and owner != view:
+            continue
+        if getattr(annotation, "is_centerline", False):
+            continue
+        # The transaction changes only feature-backed callout presence. Other
+        # dimension/furniture conflicts belong to their owning placement passes; treating
+        # every witness-line bbox as a balloon obstacle would discard most of a dense ring.
+        if getattr(annotation, "elbow", None) is None:
+            continue
+        if _label_centerline_overlap(annotation, balloon, cache) is not None:
+            return True
+    return False
 
 
 def box_within_page_and_clear(bb, page_box, obstacles) -> bool:

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1209,10 +1209,10 @@ def balloon_annotation_label_boxes(dwg, view):
     return tuple(boxes)
 
 
-def balloon_geometry_hits_annotation_labels(glyph_box, segments, label_boxes) -> bool:
-    """Whether a compact glyph or any real shaft crosses a retained label."""
+def balloon_geometry_hits_annotation_labels(glyph_boxes, segments, label_boxes) -> bool:
+    """Whether any rendered glyph component or real shaft crosses a retained label."""
     return any(
-        _boxes_overlap(glyph_box, label_box)
+        any(_boxes_overlap(glyph_box, label_box) for glyph_box in glyph_boxes)
         or any(_segment_clips_box(start, end, label_box, pad=0.0) for start, end in segments)
         for label_box in label_boxes
     )

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -132,6 +132,37 @@ def _annotation_hole_features(registry, name, annotation) -> frozenset:
     return frozenset(features)
 
 
+def _hole_table_replaceable_annotation(registry, name, annotation) -> bool:
+    """Whether a table can replace *all* semantic facts carried by an annotation.
+
+    The current hole-table schema states only a plain circular bore's diameter/depth,
+    through state, quantity, and (on the automatic table) X/Y positions. A compound
+    callout is indivisible: counterbores, spotfaces, countersinks, profiles, threads, and
+    pattern geometry must keep their leader even when a useful table row is also added.
+    """
+    features = _annotation_hole_features(registry, name, annotation)
+    if not features:
+        return False
+    for feature in features:
+        if getattr(feature, "kind", None) != "hole":
+            return False
+        if any(
+            getattr(feature, attribute, None) is not None
+            for attribute in ("cbore", "spotface", "csink", "thread", "profile")
+        ):
+            return False
+    table_parameters = {
+        "bore.diameter",
+        "bore.depth",
+        "location.location",
+        "location_pattern.location",
+    }
+    return all(
+        getattr(measurement, "parameter", None) in table_parameters
+        for measurement in registry.measurement_of(name)
+    )
+
+
 @dataclass(frozen=True)
 class _StashedAnnotation:
     """One reversible annotation removal with its complete registry identity."""
@@ -139,6 +170,11 @@ class _StashedAnnotation:
     annotation: Any
     identity: dict
     features: frozenset
+    representation: Any
+    representation_reason: Any
+
+
+_MISSING_REPRESENTATION = object()
 
 
 def _stash_annotations(dwg, names) -> dict[str, _StashedAnnotation]:
@@ -150,8 +186,28 @@ def _stash_annotations(dwg, names) -> dict[str, _StashedAnnotation]:
             continue
         identity = dwg.registry.identity_of(name)
         features = _annotation_hole_features(dwg.registry, name, annotation)
-        stashed[name] = _StashedAnnotation(dwg.remove(name), identity, features)
+        stashed[name] = _StashedAnnotation(
+            dwg.remove(name),
+            identity,
+            features,
+            getattr(annotation, "hole_representation", _MISSING_REPRESENTATION),
+            getattr(annotation, "hole_representation_reason", _MISSING_REPRESENTATION),
+        )
     return stashed
+
+
+def _reset_stashed_representation(stashed) -> None:
+    """Restore annotation-object markers after an exceptional transaction rollback."""
+    for record in stashed.values():
+        for attribute, value in (
+            ("hole_representation", record.representation),
+            ("hole_representation_reason", record.representation_reason),
+        ):
+            if value is _MISSING_REPRESENTATION:
+                if hasattr(record.annotation, attribute):
+                    delattr(record.annotation, attribute)
+            else:
+                setattr(record.annotation, attribute, value)
 
 
 def _restore_stashed_annotations(dwg, ctx, stashed, *, features=None, reason=None) -> set[str]:
@@ -169,6 +225,9 @@ def _restore_stashed_annotations(dwg, ctx, stashed, *, features=None, reason=Non
         if reason is not None:
             record.annotation.hole_representation = "feature_annotation"
             record.annotation.hole_representation_reason = reason
+        if dwg.registry.named(name) is record.annotation:
+            restored.add(name)
+            continue
         ctx.place(
             record.annotation,
             name,
@@ -181,30 +240,32 @@ def _restore_stashed_annotations(dwg, ctx, stashed, *, features=None, reason=Non
     return restored
 
 
-def _fully_ballooned_features(view, tagged_holes, placed_names) -> set:
-    """Features for which every required ``(tag, member-index)`` balloon landed."""
-    names_by_feature: dict[object, list[str]] = {}
+def _fully_ballooned_features(view, tagged_holes, placed_names, registry, expected_counts) -> set:
+    """Features whose exact-cardinality balloons landed in this render attempt.
+
+    A name that happened to exist before the attempt is not evidence. Nor is a landed
+    balloon owned by another semantic feature. Both checks are deliberately made here,
+    beside the declared-QTY cardinality check, so automatic and public tables share one
+    commit predicate.
+    """
+    attempted = set(placed_names)
+    names_by_feature: dict[object, set[str]] = {}
     for tag, member_index, _hole, feature in tagged_holes:
-        names_by_feature.setdefault(feature, []).append(f"balloon_{view}_{tag}_{member_index}")
+        names_by_feature.setdefault(feature, set()).add(f"balloon_{view}_{tag}_{member_index}")
     return {
         feature
         for feature, required_names in names_by_feature.items()
-        if all(name in placed_names for name in required_names)
+        if len(required_names) == expected_counts.get(feature, 0)
+        and all(
+            name in attempted and registry.feature_of(name) == feature for name in required_names
+        )
     }
 
 
-def _discard_incomplete_feature_balloons(dwg, view, tagged_holes, successful_features) -> set[str]:
-    """Remove landed balloons whose feature did not complete its required set.
-
-    A partial group has not established a usable table-to-geometry mapping. Keeping its
-    surviving balloons would both imply a committed replacement and obstruct the restored
-    feature callout. Complete groups remain untouched.
-    """
+def _discard_attempt_annotations(dwg, names) -> set[str]:
+    """Remove annotations created by an uncommitted placement attempt."""
     removed = set()
-    for tag, member_index, _hole, feature in tagged_holes:
-        if feature in successful_features:
-            continue
-        name = f"balloon_{view}_{tag}_{member_index}"
+    for name in names:
         if dwg.registry.named(name) is not None:
             dwg.remove(name)
             removed.add(name)

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -328,36 +328,6 @@ def _reset_stashed_representation(stashed) -> None:
                 setattr(record.annotation, attribute, value)
 
 
-def _restore_stashed_annotations(dwg, ctx, stashed, *, features=None, reason=None) -> set[str]:
-    """Restore stashed annotations intersecting *features* through the placement seam.
-
-    ``features=None`` restores the complete transaction. Shared annotations are restored as
-    a unit when any unresolved semantic owner needs them; duplicating a fact is safer than
-    discarding another owner's only visible evidence.
-    """
-    selected = None if features is None else set(features)
-    restored = set()
-    for name, record in stashed.items():
-        if selected is not None and record.features and record.features.isdisjoint(selected):
-            continue
-        if reason is not None:
-            record.annotation.hole_representation = "feature_annotation"
-            record.annotation.hole_representation_reason = reason
-        if dwg.registry.named(name) is record.annotation:
-            restored.add(name)
-            continue
-        ctx.place(
-            record.annotation,
-            name,
-            view=record.identity.get("view"),
-            feature=record.identity.get("feature"),
-            measurement=record.identity.get("measurement", ()),
-        )
-        dwg.registry.reapply(name, record.identity)
-        restored.add(name)
-    return restored
-
-
 def _fully_ballooned_features(view, tagged_holes, placed_names, registry, expected_counts) -> set:
     """Features whose exact-cardinality balloons landed in this render attempt.
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -84,6 +84,7 @@ def _register_hole_table_coverage(
     measurements=(),
     locations=(),
     requirements=(),
+    representation_reason=None,
 ):
     """Register the semantic facts visibly carried by a placed hole table.
 
@@ -92,10 +93,122 @@ def _register_hole_table_coverage(
     """
     table.covers_hole_locations = tuple(locations)
     table.covers_hole_requirements_by_feature = tuple(requirements)
+    if representation_reason is not None:
+        table.hole_representation = "hole_table"
+        table.hole_representation_reason = representation_reason
     identity = registry.identity_of(name)
     identity["measurement"] = tuple(measurements)
     registry.reapply(name, identity)
     return table
+
+
+def _annotation_hole_features(registry, name, annotation) -> frozenset:
+    """Semantic hole/pattern owners carried by one placed annotation.
+
+    Registry ownership is intentionally singular and may be empty for a visible mark shared
+    by several features. Measurement and structured-coverage provenance are therefore the
+    authoritative union used by replacement transactions.
+    """
+    features = set()
+    owner = registry.feature_of(name)
+    if getattr(owner, "kind", None) in {"hole", "pattern"}:
+        features.add(owner)
+    for measurement in registry.measurement_of(name):
+        feature = getattr(measurement, "feature", None)
+        if getattr(feature, "kind", None) in {"hole", "pattern"}:
+            features.add(feature)
+    for fact in getattr(annotation, "covers_hole_locations", ()):
+        feature = fact[0] if len(fact) == 3 else getattr(fact[0], "feature", None)
+        if getattr(feature, "kind", None) in {"hole", "pattern"}:
+            features.add(feature)
+    for feature, _requirement, _count in getattr(
+        annotation, "covers_hole_requirements_by_feature", ()
+    ):
+        if getattr(feature, "kind", None) in {"hole", "pattern"}:
+            features.add(feature)
+    for feature, _point, _view in getattr(annotation, "covers_hole_centers", ()):
+        if getattr(feature, "kind", None) in {"hole", "pattern"}:
+            features.add(feature)
+    return frozenset(features)
+
+
+@dataclass(frozen=True)
+class _StashedAnnotation:
+    """One reversible annotation removal with its complete registry identity."""
+
+    annotation: Any
+    identity: dict
+    features: frozenset
+
+
+def _stash_annotations(dwg, names) -> dict[str, _StashedAnnotation]:
+    """Remove *names* while retaining enough state for an exact semantic rollback."""
+    stashed = {}
+    for name in names:
+        annotation = dwg.registry.named(name)
+        if annotation is None:
+            continue
+        identity = dwg.registry.identity_of(name)
+        features = _annotation_hole_features(dwg.registry, name, annotation)
+        stashed[name] = _StashedAnnotation(dwg.remove(name), identity, features)
+    return stashed
+
+
+def _restore_stashed_annotations(dwg, ctx, stashed, *, features=None, reason=None) -> set[str]:
+    """Restore stashed annotations intersecting *features* through the placement seam.
+
+    ``features=None`` restores the complete transaction. Shared annotations are restored as
+    a unit when any unresolved semantic owner needs them; duplicating a fact is safer than
+    discarding another owner's only visible evidence.
+    """
+    selected = None if features is None else set(features)
+    restored = set()
+    for name, record in stashed.items():
+        if selected is not None and record.features and record.features.isdisjoint(selected):
+            continue
+        if reason is not None:
+            record.annotation.hole_representation = "feature_annotation"
+            record.annotation.hole_representation_reason = reason
+        ctx.place(
+            record.annotation,
+            name,
+            view=record.identity.get("view"),
+            feature=record.identity.get("feature"),
+            measurement=record.identity.get("measurement", ()),
+        )
+        dwg.registry.reapply(name, record.identity)
+        restored.add(name)
+    return restored
+
+
+def _fully_ballooned_features(view, tagged_holes, placed_names) -> set:
+    """Features for which every required ``(tag, member-index)`` balloon landed."""
+    names_by_feature: dict[object, list[str]] = {}
+    for tag, member_index, _hole, feature in tagged_holes:
+        names_by_feature.setdefault(feature, []).append(f"balloon_{view}_{tag}_{member_index}")
+    return {
+        feature
+        for feature, required_names in names_by_feature.items()
+        if all(name in placed_names for name in required_names)
+    }
+
+
+def _discard_incomplete_feature_balloons(dwg, view, tagged_holes, successful_features) -> set[str]:
+    """Remove landed balloons whose feature did not complete its required set.
+
+    A partial group has not established a usable table-to-geometry mapping. Keeping its
+    surviving balloons would both imply a committed replacement and obstruct the restored
+    feature callout. Complete groups remain untouched.
+    """
+    removed = set()
+    for tag, member_index, _hole, feature in tagged_holes:
+        if feature in successful_features:
+            continue
+        name = f"balloon_{view}_{tag}_{member_index}"
+        if dwg.registry.named(name) is not None:
+            dwg.remove(name)
+            removed.add(name)
+    return removed
 
 
 @dataclass(frozen=True)

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -232,8 +232,6 @@ class _StashedAnnotation:
     annotation: Any
     identity: dict
     features: frozenset
-    representation: Any
-    representation_reason: Any
 
 
 _MISSING_REPRESENTATION = object()
@@ -274,7 +272,6 @@ def _snapshot_annotation_transaction(dwg, coverage) -> _AnnotationTransactionSna
 
 def _restore_annotation_transaction(dwg, coverage, snapshot, stashed, *, reason=None) -> None:
     """Restore *snapshot* exactly, optionally marking visible fallback semantics."""
-    _reset_stashed_representation(stashed)
     for annotation, representation, representation_reason in snapshot.representations:
         for attribute, value in (
             ("hole_representation", representation),
@@ -308,24 +305,8 @@ def _stash_annotations(dwg, names) -> dict[str, _StashedAnnotation]:
             dwg.remove(name),
             identity,
             features,
-            getattr(annotation, "hole_representation", _MISSING_REPRESENTATION),
-            getattr(annotation, "hole_representation_reason", _MISSING_REPRESENTATION),
         )
     return stashed
-
-
-def _reset_stashed_representation(stashed) -> None:
-    """Restore annotation-object markers after an exceptional transaction rollback."""
-    for record in stashed.values():
-        for attribute, value in (
-            ("hole_representation", record.representation),
-            ("hole_representation_reason", record.representation_reason),
-        ):
-            if value is _MISSING_REPRESENTATION:
-                if hasattr(record.annotation, attribute):
-                    delattr(record.annotation, attribute)
-            else:
-                setattr(record.annotation, attribute, value)
 
 
 def _fully_ballooned_features(view, tagged_holes, placed_names, registry, expected_counts) -> set:

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -23,13 +23,16 @@ from draftwright._core import (  # noqa: F401 — _anno_box re-exported (#700)
     _text_size,
     place_annotation,
 )
-from draftwright._geometry import _boxes_overlap, _segment_crosses_box  # noqa: F401
+from draftwright._geometry import (  # noqa: F401
+    _boxes_overlap,
+    _segment_clips_box,
+    _segment_crosses_box,
+)
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import (
     _ann_box,
     _centerline_extent,
-    _label_centerline_overlap,
 )
 from draftwright.model.compiled import resolve_feature
 
@@ -90,11 +93,12 @@ def _register_hole_table_coverage(
     requirements=(),
     representation_reason=None,
     representation_features=(),
+    representation_requirements=(),
 ):
     """Register the semantic facts visibly carried by a placed hole table.
 
     Automatic escalation and the public table verb share this seam so the table object,
-    registry measurement inventory, per-feature replacement evidence, and physical hole
+    registry measurement inventory, requirement-scoped replacement evidence, and physical hole
     ledger cannot drift apart.
     """
     table.covers_hole_locations = tuple(locations)
@@ -102,6 +106,11 @@ def _register_hole_table_coverage(
     table.covers_hole_representations_by_feature = tuple(
         (feature, "hole_table", representation_reason)
         for feature in representation_features
+        if representation_reason is not None
+    )
+    table.covers_hole_representations_by_requirement = tuple(
+        (feature, parameter, "hole_table", representation_reason)
+        for feature, parameter in representation_requirements
         if representation_reason is not None
     )
     identity = registry.identity_of(name)
@@ -136,6 +145,11 @@ def _annotation_hole_features(registry, name, annotation) -> frozenset:
             features.add(feature)
     for feature, _representation, _reason in getattr(
         annotation, "covers_hole_representations_by_feature", ()
+    ):
+        if getattr(feature, "kind", None) in {"hole", "pattern"}:
+            features.add(feature)
+    for feature, _parameter, _representation, _reason in getattr(
+        annotation, "covers_hole_representations_by_requirement", ()
     ):
         if getattr(feature, "kind", None) in {"hole", "pattern"}:
             features.add(feature)
@@ -176,13 +190,30 @@ def _hole_table_replaceable_annotation(registry, name, annotation) -> bool:
     )
 
 
+def _hole_table_replaceable_location_annotation(registry, name, annotation) -> bool:
+    """Whether *annotation* carries only table-rendered X/Y location facts.
+
+    Location eligibility is intentionally independent of bore-callout eligibility: a
+    fitted, toleranced, threaded, or compound hole keeps its manufacturing callout while
+    the table may still replace a separately dropped ordinate for the same feature.
+    """
+    features = _annotation_hole_features(registry, name, annotation)
+    if not features or any(getattr(feature, "kind", None) != "hole" for feature in features):
+        return False
+    measurements = tuple(registry.measurement_of(name))
+    return bool(measurements) and all(
+        getattr(measurement, "parameter", None) == "location.location"
+        for measurement in measurements
+    )
+
+
 def _hole_table_replaceable_feature(feature, dimensions=()) -> bool:
     """Whether the current table schema can replace *feature*'s compiled callout facts.
 
     Annotation metadata alone is insufficient: an authored tolerance or fit lives on the
     compiler-approved dimension, and an automatic callout may have dropped before any
-    annotation object existed.  Keep this predicate feature/plan based so both public and
-    automatic transactions make the same decision without parsing rendered text.
+    annotation object existed. Keep this predicate feature/plan based so the automatic
+    transaction does not parse rendered text.
     """
     if getattr(feature, "kind", None) != "hole":
         return False
@@ -332,8 +363,7 @@ def _fully_ballooned_features(view, tagged_holes, placed_names, registry, expect
 
     A name that happened to exist before the attempt is not evidence. Nor is a landed
     balloon owned by another semantic feature. Both checks are deliberately made here,
-    beside the declared-QTY cardinality check, so automatic and public tables share one
-    commit predicate.
+    beside the declared-QTY cardinality check, so every automatic commit uses one predicate.
     """
     attempted = set(placed_names)
     names_by_feature: dict[object, set[str]] = {}
@@ -1151,16 +1181,17 @@ def _box_hits(bb, boxes):
     return bb is not None and any(_boxes_overlap(bb, c) for c in boxes)
 
 
-def balloon_hits_annotation_label(dwg, balloon, view) -> bool:
-    """Whether *balloon* would create a lint-significant visible-text collision.
+def balloon_hits_annotation_label(dwg, glyph, segments, view) -> bool:
+    """Whether precise balloon geometry crosses a surviving callout label.
 
-    Balloon compounds are centreline-like furniture, so their leader/ring footprint is
-    compared with every surviving annotation label through the exact structural-lint
-    predicate.  This is a final-inventory guard inside the shared balloon placement pass:
-    retained or transactionally restored callouts remain real obstacles rather than being
-    re-added after the solve (#1144 / ADR 0014).
+    The glyph (ring + text) is compact enough for an AABB test.  The leader is not:
+    ADR 0009 forbids treating a diagonal shaft's empty AABB triangle as occupied, so each
+    real segment is tested against the text box independently.  This guard is enabled only
+    by transactional automatic escalation; ordinary public/additive balloons retain their
+    established placement contract.
     """
     cache = getattr(dwg, "box_cache", None)
+    glyph_box = _geom_box(glyph, cache)
     for name, annotation in dwg.iter_annotations():
         owner = dwg.view_of(name)
         if owner is not None and owner != view:
@@ -1172,7 +1203,17 @@ def balloon_hits_annotation_label(dwg, balloon, view) -> bool:
         # every witness-line bbox as a balloon obstacle would discard most of a dense ring.
         if getattr(annotation, "elbow", None) is None:
             continue
-        if _label_centerline_overlap(annotation, balloon, cache) is not None:
+        try:
+            label_box = getattr(annotation, "label_bbox", None)
+        except Exception:  # noqa: BLE001 — external leader metadata may be unreadable
+            label_box = None
+        if label_box is None:
+            label_box = _geom_box(annotation, cache)
+        if label_box is None:
+            continue
+        if (glyph_box is not None and _boxes_overlap(glyph_box, label_box)) or any(
+            _segment_clips_box(start, end, label_box, pad=0.0) for start, end in segments
+        ):
             return True
     return False
 

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -22,7 +22,8 @@ from draftwright._core import (
     _balloon_radius,
 )
 from draftwright.annotations._common import (
-    balloon_hits_annotation_label,
+    balloon_annotation_label_boxes,
+    balloon_geometry_hits_annotation_labels,
     carve_free_segments,
     strip_obstacles,
 )
@@ -30,6 +31,7 @@ from draftwright.fonts import PLEX_MONO
 from draftwright.layout import (
     _assign_balloon_bands,
     _greedy_strip_1d,
+    _solve_guarded_strip_1d,
     _solve_segmented_strip_1d,
     _solve_strip_1d,
     _strip_capacity,
@@ -223,6 +225,30 @@ def render_balloons(
         for name, (_axis, _line, lo, hi) in band_defs.items()
     }
     preferred_bands = tuple(name for name, capacity in capacities.items() if capacity > 0)
+    if avoid_annotation_labels:
+        dropped = _place_guarded_inventory(
+            dwg,
+            view,
+            members,
+            choices_by_member,
+            band_defs,
+            capacities,
+            gap,
+            fs,
+            r,
+            ctx,
+            top_segments=top_segments,
+            prefer_bands=preferred_bands if perimeter else (),
+            preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
+        )
+        if dropped:
+            ctx.record_issue(
+                "warning",
+                "balloon_dropped",
+                f"{dropped} balloon(s) could not fit their reserved band and were dropped",
+            )
+        return
+
     bands, dropped = _assign_balloon_bands(
         members,
         choices_by_member,
@@ -230,7 +256,6 @@ def render_balloons(
         prefer_bands=preferred_bands if perimeter else (),
         preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
     )
-    collision_kwargs = {"avoid_annotation_labels": True} if avoid_annotation_labels else {}
     dropped += _place_band(
         dwg,
         view,
@@ -240,7 +265,6 @@ def render_balloons(
         fs,
         r,
         ctx,
-        **collision_kwargs,
     )
     dropped += _place_band(
         dwg,
@@ -251,7 +275,6 @@ def render_balloons(
         fs,
         r,
         ctx,
-        **collision_kwargs,
     )
     top_args = (
         dwg,
@@ -264,12 +287,11 @@ def render_balloons(
         ctx,
     )
     dropped += (
-        _place_band(*top_args, **collision_kwargs)
+        _place_band(*top_args)
         if top_segments is None
         else _place_band(
             *top_args,
             segments=top_segments,
-            **collision_kwargs,
         )
     )
     dropped += _place_band(
@@ -281,7 +303,6 @@ def render_balloons(
         fs,
         r,
         ctx,
-        **collision_kwargs,
     )
     # A band too crowded to hold every balloon drops its tail (the strip solver's
     # prefix fallback) — record it instead of letting the balloons vanish silently
@@ -293,6 +314,343 @@ def render_balloons(
             "balloon_dropped",
             f"{dropped} balloon(s) could not fit their reserved band and were dropped",
         )
+
+
+def _balloon_shaft_segments(cx, cy, bx, by, hole_r, balloon_r):
+    """Analytic 2D shaft geometry shared by guarded solve and rendering."""
+    dx, dy = bx - cx, by - cy
+    distance = math.hypot(dx, dy)
+    if distance <= hole_r + balloon_r:
+        return ()
+    ux, uy = dx / distance, dy / distance
+    return (
+        (
+            (cx + ux * hole_r, cy + uy * hole_r),
+            (bx - ux * balloon_r, by - uy * balloon_r),
+        ),
+    )
+
+
+def _balloon_glyph_box(bx, by, radius):
+    return (bx - radius, by - radius, bx + radius, by + radius)
+
+
+def _guarded_free_segments(member, axis, line, ranges, radius, scale, label_boxes):
+    """Continuous free coordinates for one member on one balloon band.
+
+    Segment/box intersection can change only when the centre-to-centre ray passes
+    a label-box corner; glyph intersection changes at the box edges expanded by
+    the ring radius.  Partitioning at those geometry events and testing the real
+    shortened shaft yields exact free intervals without a sampling grid.
+    """
+    _tag, _member_index, hole, cx, cy = member
+    hole_r = hole.diameter * scale / 2
+
+    def hits(coordinate):
+        bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
+        return balloon_geometry_hits_annotation_labels(
+            _balloon_glyph_box(bx, by, radius),
+            _balloon_shaft_segments(cx, cy, bx, by, hole_r, radius),
+            label_boxes,
+        )
+
+    result = []
+    for range_lo, range_hi in ranges:
+        critical = {float(range_lo), float(range_hi)}
+        for x0, y0, x1, y1 in label_boxes:
+            rim_points: list[tuple[float, float]] = []
+            for qx in (x0, x1):
+                remainder = hole_r * hole_r - (qx - cx) ** 2
+                if remainder >= 0:
+                    delta = math.sqrt(remainder)
+                    rim_points.extend(
+                        (qx, qy) for qy in (cy - delta, cy + delta) if y0 <= qy <= y1
+                    )
+            for qy in (y0, y1):
+                remainder = hole_r * hole_r - (qy - cy) ** 2
+                if remainder >= 0:
+                    delta = math.sqrt(remainder)
+                    rim_points.extend(
+                        (qx, qy) for qx in (cx - delta, cx + delta) if x0 <= qx <= x1
+                    )
+            if axis == "y":
+                if x0 - radius < line < x1 + radius:
+                    critical.update((y0 - radius, y1 + radius))
+                if not math.isclose(line, cx):
+                    for qx in (x0, x1):
+                        if not math.isclose(qx, cx):
+                            for qy in (y0, y1):
+                                critical.add(cy + (qy - cy) * (line - cx) / (qx - cx))
+                    for qx, qy in rim_points:
+                        if not math.isclose(qx, cx):
+                            critical.add(cy + (qy - cy) * (line - cx) / (qx - cx))
+            else:
+                if y0 - radius < line < y1 + radius:
+                    critical.update((x0 - radius, x1 + radius))
+                if not math.isclose(line, cy):
+                    for qy in (y0, y1):
+                        if not math.isclose(qy, cy):
+                            for qx in (x0, x1):
+                                critical.add(cx + (qx - cx) * (line - cy) / (qy - cy))
+                    for qx, qy in rim_points:
+                        if not math.isclose(qy, cy):
+                            critical.add(cx + (qx - cx) * (line - cy) / (qy - cy))
+        points = sorted({min(max(value, range_lo), range_hi) for value in critical})
+        for point in points:
+            if not hits(point):
+                result.append((point, point))
+        for lo, hi in zip(points, points[1:]):
+            if hi <= lo:
+                continue
+            midpoint = (lo + hi) / 2
+            if hits(midpoint):
+                continue
+            free_lo = lo if not hits(lo) else math.nextafter(lo, hi)
+            free_hi = hi if not hits(hi) else math.nextafter(hi, lo)
+            if free_lo <= free_hi:
+                result.append((free_lo, free_hi))
+
+    merged: list[tuple[float, float]] = []
+    for lo, hi in sorted(result):
+        if merged and lo <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], hi))
+        else:
+            merged.append((lo, hi))
+    validated = []
+    for lo, hi in merged:
+        clearance = max(1e-6, max(abs(lo), abs(hi)) * 1e-12)
+        if hits(lo):
+            lo += clearance
+        if hits(hi):
+            hi -= clearance
+        if lo <= hi:
+            validated.append((lo, hi))
+    return tuple(validated)
+
+
+def _solve_guarded_band(member_indices, members, band_name, band_defs, free_segments):
+    """Return ``{member_index: coordinate}`` for one complete guarded band."""
+    axis = band_defs[band_name][0]
+    natural_index = 4 if axis == "y" else 3
+    ordered = sorted(member_indices, key=lambda index: members[index][natural_index])
+    coordinates = _solve_guarded_strip_1d(
+        [members[index][natural_index] for index in ordered],
+        free_segments.min_gap,
+        [free_segments.by_member_band[index, band_name] for index in ordered],
+    )
+    if coordinates is None:
+        return None
+    return dict(zip(ordered, coordinates, strict=True))
+
+
+class _GuardedSegments:
+    """Small internal carrier for one guarded inventory solve."""
+
+    def __init__(self, by_member_band, min_gap):
+        self.by_member_band = by_member_band
+        self.min_gap = min_gap
+
+
+def _guarded_assignment(
+    members,
+    choices_by_member,
+    band_defs,
+    capacities,
+    free_segments,
+    *,
+    prefer_bands=(),
+    preference_limit=0.0,
+):
+    """Globally assign members to bands while all band coordinates remain feasible.
+
+    The ordinary min-cost flow gives a cardinality upper bound using each band's
+    geometric capacity.  If that assignment is jointly feasible under the
+    retained-label intervals it is preserved exactly.  Otherwise a deterministic
+    branch-and-bound search finds the same highest attainable cardinality across
+    all bands; label feasibility therefore participates in band assignment rather
+    than causing a greedy post-solve drop.
+    """
+    filtered_choices = [
+        {
+            band: distance
+            for band, distance in choices.items()
+            if free_segments.by_member_band.get((index, band))
+        }
+        for index, choices in enumerate(choices_by_member)
+    ]
+    effective_capacities = {}
+    for band, capacity in capacities.items():
+        union = sorted(
+            segment
+            for index in range(len(members))
+            for segment in free_segments.by_member_band.get((index, band), ())
+        )
+        merged_union: list[tuple[float, float]] = []
+        for lo, hi in union:
+            if merged_union and lo <= merged_union[-1][1]:
+                merged_union[-1] = (
+                    merged_union[-1][0],
+                    max(merged_union[-1][1], hi),
+                )
+            else:
+                merged_union.append((lo, hi))
+        effective_capacities[band] = min(
+            capacity,
+            sum(_strip_capacity(lo, hi, free_segments.min_gap) for lo, hi in merged_union),
+        )
+    seed, _flow_dropped = _assign_balloon_bands(
+        members,
+        filtered_choices,
+        effective_capacities,
+        prefer_bands=prefer_bands,
+        preference_limit=preference_limit,
+    )
+    member_index = {id(member): index for index, member in enumerate(members)}
+    seed_indices = {
+        band: [member_index[id(member)] for member in assigned]
+        for band, assigned in seed.items()
+        if band in band_defs
+    }
+    seed_solutions = {
+        band: _solve_guarded_band(indices, members, band, band_defs, free_segments)
+        for band, indices in seed_indices.items()
+    }
+    target = sum(len(indices) for indices in seed_indices.values())
+    if all(solution is not None for solution in seed_solutions.values()):
+        return seed_indices, seed_solutions, len(members) - target
+
+    available = [index for index, choices in enumerate(filtered_choices) if choices]
+    unavailable = len(members) - len(available)
+    ordered = sorted(
+        available,
+        key=lambda index: (
+            len(filtered_choices[index]),
+            min(filtered_choices[index].values()),
+            index,
+        ),
+    )
+    band_names = tuple(band_defs)
+    groups: dict[str, list[int]] = {band: [] for band in band_names}
+    solve_cache: dict[tuple[str, tuple[int, ...]], dict[int, float] | None] = {}
+
+    def solve_band(band):
+        key = (band, tuple(sorted(groups[band])))
+        if key not in solve_cache:
+            solve_cache[key] = _solve_guarded_band(
+                groups[band], members, band, band_defs, free_segments
+            )
+        return solve_cache[key]
+
+    for required in range(target, -1, -1):
+        answer = None
+
+        def visit(position, placed):
+            nonlocal answer
+            if answer is not None:
+                return
+            if placed + len(ordered) - position < required:
+                return
+            if position == len(ordered):
+                if placed == required:
+                    answer = (
+                        {band: list(indices) for band, indices in groups.items()},
+                        {band: solve_band(band) for band in band_names},
+                    )
+                return
+            index = ordered[position]
+            choices = sorted(
+                filtered_choices[index],
+                key=lambda band: (
+                    filtered_choices[index][band]
+                    - (preference_limit if band in prefer_bands and not groups[band] else 0.0),
+                    filtered_choices[index][band],
+                    band,
+                ),
+            )
+            for band in choices:
+                if len(groups[band]) >= effective_capacities[band]:
+                    continue
+                groups[band].append(index)
+                if solve_band(band) is not None:
+                    visit(position + 1, placed + 1)
+                groups[band].pop()
+                if answer is not None:
+                    return
+            if placed + len(ordered) - position - 1 >= required:
+                visit(position + 1, placed)
+
+        visit(0, 0)
+        if answer is not None:
+            assignments, solutions = answer
+            return assignments, solutions, unavailable + len(available) - required
+    return {band: [] for band in band_names}, {band: {} for band in band_names}, len(members)
+
+
+def _place_guarded_inventory(
+    dwg,
+    view,
+    members,
+    choices_by_member,
+    band_defs,
+    capacities,
+    gap,
+    fs,
+    radius,
+    ctx,
+    *,
+    top_segments,
+    prefer_bands,
+    preference_limit,
+):
+    """Solve and render the final collision-safe automatic balloon inventory."""
+    label_boxes = balloon_annotation_label_boxes(dwg, view)
+    by_member_band = {}
+    for index, member in enumerate(members):
+        for band, (axis, line, lo, hi) in band_defs.items():
+            if capacities[band] <= 0:
+                continue
+            ranges = top_segments if band == "top" and top_segments is not None else ((lo, hi),)
+            by_member_band[index, band] = _guarded_free_segments(
+                member,
+                axis,
+                line,
+                ranges,
+                radius,
+                dwg.scale,
+                label_boxes,
+            )
+    guarded = _GuardedSegments(by_member_band, gap)
+    assignments, solutions, dropped = _guarded_assignment(
+        members,
+        choices_by_member,
+        band_defs,
+        capacities,
+        guarded,
+        prefer_bands=prefer_bands,
+        preference_limit=preference_limit,
+    )
+    for band, indices in assignments.items():
+        axis, line, _lo, _hi = band_defs[band]
+        solution = solutions[band]
+        for index in sorted(indices, key=lambda item: solution[item]):
+            tag, member_index, hole, cx, cy = members[index]
+            coordinate = solution[index]
+            bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
+            _render_balloon(
+                dwg,
+                view,
+                tag,
+                member_index,
+                hole,
+                cx,
+                cy,
+                bx,
+                by,
+                fs,
+                radius,
+                ctx,
+            )
+    return dropped
 
 
 def _place_band(
@@ -326,6 +684,28 @@ def _place_band(
     k = 4 if axis == "y" else 3  # index of cy / cx in the member tuple
     members.sort(key=lambda m: m[k])
     naturals = [m[k] for m in members]
+    if avoid_annotation_labels:
+        ranges = segments if segments is not None else ((lo, hi),)
+        label_boxes = balloon_annotation_label_boxes(dwg, view)
+        allowed = [
+            _guarded_free_segments(
+                member,
+                axis,
+                line,
+                ranges,
+                r,
+                dwg.scale,
+                label_boxes,
+            )
+            for member in members
+        ]
+        coords = _solve_guarded_strip_1d(naturals, gap, allowed)
+        if coords is None:
+            return len(members)
+        for (tag, j, hole, cx, cy), coordinate in zip(members, coords, strict=True):
+            bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
+            _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx)
+        return 0
     if segments is not None:
         coords = _solve_segmented_strip_1d(naturals, gap, segments, prefix=True) or []
     else:
@@ -334,12 +714,9 @@ def _place_band(
             or _greedy_strip_1d(naturals, gap, lo, hi)
             or _greedy_strip_1d(naturals, gap, lo, hi, prefix=True)
         )
-    placed_coords = list(coords)
-    collision_kwargs = {"avoid_annotation_labels": True} if avoid_annotation_labels else {}
-    rejected = 0
-    for member_index, ((tag, j, hole, cx, cy), c) in enumerate(zip(members, coords)):
+    for (tag, j, hole, cx, cy), c in zip(members, coords):
         bx, by = (line, c) if axis == "y" else (c, line)
-        rendered = _render_balloon(
+        _render_balloon(
             dwg,
             view,
             tag,
@@ -352,52 +729,8 @@ def _place_band(
             fs,
             r,
             ctx,
-            **collision_kwargs,
         )
-        if rendered is not False:
-            continue
-
-        # The max-cardinality strip solve does not know the final retained callout
-        # labels. If its natural coordinate creates a real glyph/segment crossing,
-        # search the same sanctioned strip for the nearest collision-free coordinate
-        # before dropping the row key. Other solved balloon coordinates stay reserved,
-        # so this retry cannot trade one collision for a balloon overlap.
-        ranges = segments if segments is not None else [(lo, hi)]
-        alternatives = {
-            round(start + step * 0.5, 6)
-            for start, end in ranges
-            for step in range(max(0, int(math.floor((end - start) / 0.5))) + 1)
-        }
-        occupied = [
-            coordinate for index, coordinate in enumerate(placed_coords) if index != member_index
-        ]
-        for alternative in sorted(alternatives, key=lambda value: (abs(value - c), value)):
-            if any(abs(alternative - coordinate) < gap - 1e-6 for coordinate in occupied):
-                continue
-            bx, by = (line, alternative) if axis == "y" else (alternative, line)
-            if (
-                _render_balloon(
-                    dwg,
-                    view,
-                    tag,
-                    j,
-                    hole,
-                    cx,
-                    cy,
-                    bx,
-                    by,
-                    fs,
-                    r,
-                    ctx,
-                    avoid_annotation_labels=True,
-                )
-                is not False
-            ):
-                placed_coords[member_index] = alternative
-                break
-        else:
-            rejected += 1
-    return len(members) - len(coords) + rejected
+    return len(members) - len(coords)
 
 
 def _render_balloon(
@@ -413,8 +746,6 @@ def _render_balloon(
     fs,
     r,
     ctx,
-    *,
-    avoid_annotation_labels=False,
 ):
     """Build and add one balloon glyph + leader at solved centre ``(bx, by)``
     for hole ``(cx, cy)`` (#111)."""
@@ -431,7 +762,14 @@ def _render_balloon(
     ).locate(loc)
     glyph_parts = [*ring_faces, *text.faces()]
     parts = list(glyph_parts)
-    segments = ()
+    shaft_segments = _balloon_shaft_segments(
+        cx,
+        cy,
+        bx,
+        by,
+        hole.diameter * dwg.scale / 2,
+        r,
+    )
     # Leader from the hole rim to the balloon's near edge — the glyph is the
     # label, so label="".  Skipped when the balloon could not clear the hole
     # (degenerate fallback), where a leader would be a stub through the ring.
@@ -444,22 +782,16 @@ def _render_balloon(
         elbow = (bx - ux * r, by - uy * r, 0)
         leader = Leader(tip, elbow, "", dwg.draft)
         parts.append(leader)
-        segments = tuple(getattr(leader, "segments", ()))
     balloon = Compound(children=parts)
-    # Structural lint must inspect the real leader shaft, not the compound AABB's
-    # empty diagonal triangle (ADR 0009).  Placement has already checked the compact
-    # glyph separately above.
-    balloon.segments = segments
+    # Structural lint treats the shaft and compact glyph as two precise pieces:
+    # the shaft avoids the compound AABB's empty diagonal triangle (ADR 0009),
+    # while the glyph remains visible to critique instead of disappearing behind
+    # the centreline exemption.
+    balloon.centerline_segments = shaft_segments
+    balloon.centerline_boxes = (_balloon_glyph_box(bx, by, r),)
     # Furniture that legitimately sits on the view geometry — exempt from the
     # annotation-overlap / centreline lint, as the section arrows do.
     balloon.is_centerline = True
-    if avoid_annotation_labels and balloon_hits_annotation_label(
-        dwg,
-        Compound(children=glyph_parts),
-        segments,
-        view,
-    ):
-        return False
     ctx.place(
         balloon,
         f"balloon_{view}_{tag}_{j}",

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -214,33 +214,60 @@ def render_balloons(
         members.append((tag, j, hole, cx, cy))
         choices_by_member.append(choices)
 
+    local_glyph_boxes = {
+        tag: _balloon_local_glyph_boxes(tag, fs, r)
+        for tag, _member_index, _hole, _cx, _cy in members
+    }
+    band_gaps = {
+        name: _balloon_component_gap(
+            (
+                local_glyph_boxes[members[index][0]]
+                for index, choices in enumerate(choices_by_member)
+                if name in choices
+            ),
+            axis,
+            r,
+            gap,
+        )
+        for name, (axis, _line, _lo, _hi) in band_defs.items()
+    }
     capacities = {
         name: (
-            sum(_strip_capacity(seg_lo, seg_hi, gap) for seg_lo, seg_hi in top_segments)
+            sum(
+                _strip_capacity(seg_lo, seg_hi, band_gaps[name]) for seg_lo, seg_hi in top_segments
+            )
             if name == "top" and top_segments is not None
-            else _strip_capacity(lo, hi, gap)
+            else _strip_capacity(lo, hi, band_gaps[name])
             if name != "bottom" or has_bottom
             else 0
         )
         for name, (_axis, _line, lo, hi) in band_defs.items()
     }
     preferred_bands = tuple(name for name, capacity in capacities.items() if capacity > 0)
-    if avoid_annotation_labels:
-        dropped = _place_guarded_inventory(
-            dwg,
-            view,
+    if not avoid_annotation_labels:
+        bands, dropped = _assign_balloon_bands(
             members,
             choices_by_member,
-            band_defs,
             capacities,
-            gap,
-            fs,
-            r,
-            ctx,
-            top_segments=top_segments,
             prefer_bands=preferred_bands if perimeter else (),
             preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
         )
+        for name in ("left", "right", "top", "bottom"):
+            args = (
+                dwg,
+                view,
+                bands[name],
+                *band_defs[name],
+                band_gaps[name],
+                fs,
+                r,
+                ctx,
+            )
+            dropped += (
+                _place_band(*args, segments=top_segments)
+                if name == "top" and top_segments is not None
+                else _place_band(*args)
+            )
         if dropped:
             ctx.record_issue(
                 "warning",
@@ -249,60 +276,24 @@ def render_balloons(
             )
         return
 
-    bands, dropped = _assign_balloon_bands(
+    dropped = _place_guarded_inventory(
+        dwg,
+        view,
         members,
         choices_by_member,
+        band_defs,
         capacities,
+        gap,
+        fs,
+        r,
+        ctx,
+        top_segments=top_segments,
         prefer_bands=preferred_bands if perimeter else (),
         preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
-    )
-    dropped += _place_band(
-        dwg,
-        view,
-        bands["left"],
-        *band_defs["left"],
-        gap,
-        fs,
-        r,
-        ctx,
-    )
-    dropped += _place_band(
-        dwg,
-        view,
-        bands["right"],
-        *band_defs["right"],
-        gap,
-        fs,
-        r,
-        ctx,
-    )
-    top_args = (
-        dwg,
-        view,
-        bands["top"],
-        *band_defs["top"],
-        gap,
-        fs,
-        r,
-        ctx,
-    )
-    dropped += (
-        _place_band(*top_args)
-        if top_segments is None
-        else _place_band(
-            *top_args,
-            segments=top_segments,
-        )
-    )
-    dropped += _place_band(
-        dwg,
-        view,
-        bands["bottom"],
-        *band_defs["bottom"],
-        gap,
-        fs,
-        r,
-        ctx,
+        page_box=(margin, margin, pw - margin, ph - margin),
+        avoid_existing_labels=avoid_annotation_labels,
+        local_glyph_boxes=local_glyph_boxes,
+        band_gaps=band_gaps,
     )
     # A band too crowded to hold every balloon drops its tail (the strip solver's
     # prefix fallback) — record it instead of letting the balloons vanish silently
@@ -353,6 +344,23 @@ def _balloon_text_box(tag, font_size):
         float(bounds.max.X),
         float(bounds.max.Y),
     )
+
+
+def _balloon_local_glyph_boxes(tag, font_size, radius):
+    """Ring and optional text boxes relative to the balloon centre."""
+    text_box = _balloon_text_box(tag, font_size)
+    return ((-radius, -radius, radius, radius),) + ((text_box,) if text_box is not None else ())
+
+
+def _balloon_component_gap(glyph_boxes, axis, radius, base_gap):
+    """Conservative centre gap that separates every rendered tag in a band."""
+    boxes = [box for components in glyph_boxes for box in components]
+    if not boxes:
+        return base_gap
+    lo_index, hi_index = (1, 3) if axis == "y" else (0, 2)
+    component_span = max(box[hi_index] for box in boxes) - min(box[lo_index] for box in boxes)
+    padding = max(0.0, base_gap - 2 * radius)
+    return max(base_gap, component_span + padding)
 
 
 def _guarded_free_segments(
@@ -469,7 +477,7 @@ def _solve_guarded_band(member_indices, members, band_name, band_defs, free_segm
     ordered = sorted(member_indices, key=lambda index: members[index][natural_index])
     coordinates = _solve_guarded_strip_1d(
         [members[index][natural_index] for index in ordered],
-        free_segments.min_gap,
+        free_segments.gap_for(band_name),
         [free_segments.by_member_band[index, band_name] for index in ordered],
     )
     if coordinates is None:
@@ -480,9 +488,13 @@ def _solve_guarded_band(member_indices, members, band_name, band_defs, free_segm
 class _GuardedSegments:
     """Small internal carrier for one guarded inventory solve."""
 
-    def __init__(self, by_member_band, min_gap):
+    def __init__(self, by_member_band, min_gap, min_gap_by_band=None):
         self.by_member_band = by_member_band
         self.min_gap = min_gap
+        self.min_gap_by_band = min_gap_by_band or {}
+
+    def gap_for(self, band):
+        return self.min_gap_by_band.get(band, self.min_gap)
 
 
 def _guarded_assignment(
@@ -532,7 +544,7 @@ def _guarded_assignment(
                 merged_union.append((lo, hi))
         effective_capacities[band] = min(
             capacity,
-            sum(_strip_capacity(lo, hi, free_segments.min_gap) for lo, hi in merged_union),
+            sum(_strip_capacity(lo, hi, free_segments.gap_for(band)) for lo, hi in merged_union),
         )
     seed, _flow_dropped = _assign_balloon_bands(
         members,
@@ -561,6 +573,30 @@ def _guarded_assignment(
     )
 
 
+def _guarded_inventory_geometry_is_clear(geometry, page_box):
+    """Final bounded validation of cross-band glyphs and page bounds.
+
+    Shaft-vs-retained-label geometry is already part of each member's continuous
+    interval carve. The established band assignment deliberately permits shafts
+    from different bands to pass one another; this final gate prevents the newly
+    relevant variable-width ring/text glyphs from colliding across those bands.
+    """
+    for boxes, _segments in geometry:
+        if any(
+            box[0] < page_box[0]
+            or box[1] < page_box[1]
+            or box[2] > page_box[2]
+            or box[3] > page_box[3]
+            for box in boxes
+        ):
+            return False
+    for index, (boxes, _segments) in enumerate(geometry):
+        for other_boxes, _other_segments in geometry[index + 1 :]:
+            if balloon_geometry_hits_annotation_labels(boxes, (), other_boxes):
+                return False
+    return True
+
+
 def _place_guarded_inventory(
     dwg,
     view,
@@ -576,11 +612,16 @@ def _place_guarded_inventory(
     top_segments,
     prefer_bands,
     preference_limit,
+    page_box,
+    avoid_existing_labels,
+    local_glyph_boxes,
+    band_gaps,
 ):
-    """Solve and render the final collision-safe automatic balloon inventory."""
-    label_boxes = balloon_annotation_label_boxes(dwg, view)
+    """Solve and render one text-aware, cross-band-safe balloon inventory."""
+    label_boxes = balloon_annotation_label_boxes(dwg, view) if avoid_existing_labels else ()
     text_boxes = {
-        tag: _balloon_text_box(tag, fs) for tag, _member_index, _hole, _cx, _cy in members
+        tag: components[1] if len(components) > 1 else None
+        for tag, components in local_glyph_boxes.items()
     }
     by_member_band = {}
     for index, member in enumerate(members):
@@ -598,7 +639,7 @@ def _place_guarded_inventory(
                 label_boxes,
                 text_boxes[member[0]],
             )
-    guarded = _GuardedSegments(by_member_band, gap)
+    guarded = _GuardedSegments(by_member_band, gap, band_gaps)
     assignments, solutions, dropped = _guarded_assignment(
         members,
         choices_by_member,
@@ -608,6 +649,29 @@ def _place_guarded_inventory(
         prefer_bands=prefer_bands,
         preference_limit=preference_limit,
     )
+    geometry = []
+    for band, indices in assignments.items():
+        axis, line, _lo, _hi = band_defs[band]
+        solution = solutions[band]
+        for index in indices:
+            _tag, _member_index, hole, cx, cy = members[index]
+            coordinate = solution[index]
+            bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
+            boxes = tuple(
+                (bx + x0, by + y0, bx + x1, by + y1)
+                for x0, y0, x1, y1 in local_glyph_boxes[members[index][0]]
+            )
+            segments = _balloon_shaft_segments(
+                cx,
+                cy,
+                bx,
+                by,
+                hole.diameter * dwg.scale / 2,
+                radius,
+            )
+            geometry.append((boxes, segments))
+    if not _guarded_inventory_geometry_is_clear(geometry, page_box):
+        return len(members)
     for band, indices in assignments.items():
         axis, line, _lo, _hi = band_defs[band]
         solution = solutions[band]
@@ -679,7 +743,13 @@ def _place_band(
             )
             for member in members
         ]
-        coords = _solve_guarded_strip_1d(naturals, gap, allowed)
+        guarded_gap = _balloon_component_gap(
+            (_balloon_local_glyph_boxes(member[0], fs, r) for member in members),
+            axis,
+            r,
+            gap,
+        )
+        coords = _solve_guarded_strip_1d(naturals, guarded_gap, allowed)
         if coords is None:
             return len(members)
         for (tag, j, hole, cx, cy), coordinate in zip(members, coords, strict=True):

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -733,7 +733,10 @@ def _retained_annotation_geometry(dwg, view):
         for box in entries:
             try:
                 x0, y0, x1, y1 = box
-                values = tuple(float(value) for value in (x0, y0, x1, y1))
+                raw_values = (x0, y0, x1, y1)
+                if any(type(value) is bool for value in raw_values):
+                    return None
+                values = tuple(float(value) for value in raw_values)
             except (TypeError, ValueError):
                 return None
             if (
@@ -754,7 +757,10 @@ def _retained_annotation_geometry(dwg, view):
         for segment in entries:
             try:
                 (x0, y0), (x1, y1) = segment
-                values = tuple(float(value) for value in (x0, y0, x1, y1))
+                raw_values = (x0, y0, x1, y1)
+                if any(type(value) is bool for value in raw_values):
+                    return None
+                values = tuple(float(value) for value in raw_values)
             except (TypeError, ValueError):
                 return None
             if not all(math.isfinite(value) for value in values) or values[:2] == values[2:]:

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -575,7 +575,7 @@ def _guarded_assignment(
 
 
 def _guarded_inventory_geometry_is_clear(
-    geometry, page_box, retained_label_boxes=(), retained_leader_segments=()
+    geometry, page_box, retained_boxes=(), retained_segments=()
 ):
     """Final bounded validation of rendered balloon geometry and page bounds.
 
@@ -601,14 +601,14 @@ def _guarded_inventory_geometry_is_clear(
         # clear even for a single, unusually long pattern tag.
         if balloon_geometry_hits_annotation_labels((), segments, boxes[1:]):
             return False
-        if balloon_geometry_hits_annotation_labels(boxes, segments, retained_label_boxes):
+        if balloon_geometry_hits_annotation_labels(boxes, segments, retained_boxes):
             return False
-        if balloon_geometry_hits_annotation_labels((), retained_leader_segments, boxes):
+        if balloon_geometry_hits_annotation_labels((), retained_segments, boxes):
             return False
         if any(
             _segments_cross_or_overlap(start, end, retained_start, retained_end)
             for start, end in segments
-            for retained_start, retained_end in retained_leader_segments
+            for retained_start, retained_end in retained_segments
         ):
             return False
     for index, (boxes, segments) in enumerate(geometry):
@@ -624,17 +624,48 @@ def _guarded_inventory_geometry_is_clear(
     return True
 
 
-def _retained_leader_segments(dwg, view):
-    """Real segments of feature leaders that survive an automatic table attempt."""
+def _retained_annotation_geometry(dwg, view):
+    """Precise boxes/segments that survive an automatic table attempt.
+
+    Public balloons are centerline ``Compound`` objects rather than top-level
+    ``Leader`` instances. Their explicit component metadata is the only honest
+    collision geometry: the compound AABB would recreate ADR 0009's forbidden
+    empty diagonal triangle. Feature leaders additionally expose real segments.
+    """
+    boxes: list[tuple[float, float, float, float]] = []
     segments: list[tuple[tuple[float, float], tuple[float, float]]] = []
+
+    def append_segments(raw_segments):
+        for segment in raw_segments:
+            try:
+                (x0, y0), (x1, y1) = segment
+                segments.append(((float(x0), float(y0)), (float(x1), float(y1))))
+            except (TypeError, ValueError):
+                continue
+
     for name, annotation in dwg.iter_annotations():
         owner = dwg.view_of(name)
         if owner is not None and owner != view:
             continue
+        try:
+            raw_boxes = getattr(annotation, "centerline_boxes", ()) or ()
+            raw_segments = getattr(annotation, "centerline_segments", ()) or ()
+        except Exception:  # noqa: BLE001 — external optional metadata may be unreadable
+            # External annotations may expose malformed optional metadata. It
+            # cannot become placement evidence; their ordinary rendered/label
+            # box remains available through the existing obstacle collectors.
+            raw_boxes = raw_segments = ()
+        for box in raw_boxes:
+            try:
+                x0, y0, x1, y1 = box
+                boxes.append((float(x0), float(y0), float(x1), float(y1)))
+            except (TypeError, ValueError):
+                continue
+        append_segments(raw_segments)
         if not isinstance(annotation, Leader):
             continue
-        segments.extend(getattr(annotation, "segments", ()) or ())
-    return tuple(segments)
+        append_segments(getattr(annotation, "segments", ()) or ())
+    return tuple(dict.fromkeys(boxes)), tuple(dict.fromkeys(segments))
 
 
 def _place_guarded_inventory(
@@ -659,7 +690,10 @@ def _place_guarded_inventory(
 ):
     """Solve and render one text-aware, cross-band-safe balloon inventory."""
     label_boxes = balloon_annotation_label_boxes(dwg, view) if avoid_existing_labels else ()
-    retained_segments = _retained_leader_segments(dwg, view) if avoid_existing_labels else ()
+    retained_component_boxes, retained_segments = (
+        _retained_annotation_geometry(dwg, view) if avoid_existing_labels else ((), ())
+    )
+    retained_boxes = (*label_boxes, *retained_component_boxes)
     text_boxes = {
         tag: components[1] if len(components) > 1 else None
         for tag, components in local_glyph_boxes.items()
@@ -677,7 +711,7 @@ def _place_guarded_inventory(
                 ranges,
                 radius,
                 dwg.scale,
-                label_boxes,
+                retained_boxes,
                 text_boxes[member[0]],
             )
     guarded = _GuardedSegments(by_member_band, gap, band_gaps)
@@ -714,8 +748,8 @@ def _place_guarded_inventory(
     if not _guarded_inventory_geometry_is_clear(
         geometry,
         page_box,
-        retained_label_boxes=label_boxes,
-        retained_leader_segments=retained_segments,
+        retained_boxes=retained_boxes,
+        retained_segments=retained_segments,
     ):
         return len(members)
     for band, indices in assignments.items():
@@ -756,7 +790,6 @@ def _place_band(
     ctx,
     *,
     segments=None,
-    avoid_annotation_labels=False,
 ) -> int:
     """Spread *members* (``(tag, j, hole, cx, cy)``) along one reserved band
     with the strip solver, then render a leadered balloon for each (#111).
@@ -773,35 +806,6 @@ def _place_band(
     k = 4 if axis == "y" else 3  # index of cy / cx in the member tuple
     members.sort(key=lambda m: m[k])
     naturals = [m[k] for m in members]
-    if avoid_annotation_labels:
-        ranges = segments if segments is not None else ((lo, hi),)
-        label_boxes = balloon_annotation_label_boxes(dwg, view)
-        allowed = [
-            _guarded_free_segments(
-                member,
-                axis,
-                line,
-                ranges,
-                r,
-                dwg.scale,
-                label_boxes,
-                _balloon_text_box(member[0], fs),
-            )
-            for member in members
-        ]
-        guarded_gap = _balloon_component_gap(
-            (_balloon_local_glyph_boxes(member[0], fs, r) for member in members),
-            axis,
-            r,
-            gap,
-        )
-        coords = _solve_guarded_strip_1d(naturals, guarded_gap, allowed)
-        if coords is None:
-            return len(members)
-        for (tag, j, hole, cx, cy), coordinate in zip(members, coords, strict=True):
-            bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
-            _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx)
-        return 0
     if segments is not None:
         coords = _solve_segmented_strip_1d(naturals, gap, segments, prefix=True) or []
     else:

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -335,7 +335,36 @@ def _balloon_glyph_box(bx, by, radius):
     return (bx - radius, by - radius, bx + radius, by + radius)
 
 
-def _guarded_free_segments(member, axis, line, ranges, radius, scale, label_boxes):
+def _balloon_text_box(tag, font_size):
+    """Rendered text extent relative to a balloon centre, or ``None`` if empty."""
+    text = Text(
+        txt=tag,
+        font_size=font_size,
+        font_path=PLEX_MONO,
+        align=(Align.CENTER, Align.CENTER),
+        mode=Mode.PRIVATE,
+    )
+    if not text.faces():
+        return None
+    bounds = text.bounding_box()
+    return (
+        float(bounds.min.X),
+        float(bounds.min.Y),
+        float(bounds.max.X),
+        float(bounds.max.Y),
+    )
+
+
+def _guarded_free_segments(
+    member,
+    axis,
+    line,
+    ranges,
+    radius,
+    scale,
+    label_boxes,
+    text_box=None,
+):
     """Continuous free coordinates for one member on one balloon band.
 
     Segment/box intersection can change only when the centre-to-centre ray passes
@@ -345,11 +374,14 @@ def _guarded_free_segments(member, axis, line, ranges, radius, scale, label_boxe
     """
     _tag, _member_index, hole, cx, cy = member
     hole_r = hole.diameter * scale / 2
+    local_glyph_boxes = ((-radius, -radius, radius, radius),) + (
+        (text_box,) if text_box is not None else ()
+    )
 
     def hits(coordinate):
         bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
         return balloon_geometry_hits_annotation_labels(
-            _balloon_glyph_box(bx, by, radius),
+            tuple((bx + x0, by + y0, bx + x1, by + y1) for x0, y0, x1, y1 in local_glyph_boxes),
             _balloon_shaft_segments(cx, cy, bx, by, hole_r, radius),
             label_boxes,
         )
@@ -374,8 +406,9 @@ def _guarded_free_segments(member, axis, line, ranges, radius, scale, label_boxe
                         (qx, qy) for qx in (cx - delta, cx + delta) if x0 <= qx <= x1
                     )
             if axis == "y":
-                if x0 - radius < line < x1 + radius:
-                    critical.update((y0 - radius, y1 + radius))
+                for gx0, gy0, gx1, gy1 in local_glyph_boxes:
+                    if x0 - gx1 < line < x1 - gx0:
+                        critical.update((y0 - gy1, y1 - gy0))
                 if not math.isclose(line, cx):
                     for qx in (x0, x1):
                         if not math.isclose(qx, cx):
@@ -385,8 +418,9 @@ def _guarded_free_segments(member, axis, line, ranges, radius, scale, label_boxe
                         if not math.isclose(qx, cx):
                             critical.add(cy + (qy - cy) * (line - cx) / (qx - cx))
             else:
-                if y0 - radius < line < y1 + radius:
-                    critical.update((x0 - radius, x1 + radius))
+                for gx0, gy0, gx1, gy1 in local_glyph_boxes:
+                    if y0 - gy1 < line < y1 - gy0:
+                        critical.update((x0 - gx1, x1 - gx0))
                 if not math.isclose(line, cy):
                     for qy in (y0, y1):
                         if not math.isclose(qy, cy):
@@ -545,6 +579,9 @@ def _place_guarded_inventory(
 ):
     """Solve and render the final collision-safe automatic balloon inventory."""
     label_boxes = balloon_annotation_label_boxes(dwg, view)
+    text_boxes = {
+        tag: _balloon_text_box(tag, fs) for tag, _member_index, _hole, _cx, _cy in members
+    }
     by_member_band = {}
     for index, member in enumerate(members):
         for band, (axis, line, lo, hi) in band_defs.items():
@@ -559,6 +596,7 @@ def _place_guarded_inventory(
                 radius,
                 dwg.scale,
                 label_boxes,
+                text_boxes[member[0]],
             )
     guarded = _GuardedSegments(by_member_band, gap)
     assignments, solutions, dropped = _guarded_assignment(
@@ -637,6 +675,7 @@ def _place_band(
                 r,
                 dwg.scale,
                 label_boxes,
+                _balloon_text_box(member[0], fs),
             )
             for member in members
         ]
@@ -701,14 +740,19 @@ def _render_balloon(
         align=(Align.CENTER, Align.CENTER),
         mode=Mode.PRIVATE,
     ).locate(loc)
-    text_bounds = text.bounding_box()
-    text_box = (
-        float(text_bounds.min.X),
-        float(text_bounds.min.Y),
-        float(text_bounds.max.X),
-        float(text_bounds.max.Y),
-    )
-    glyph_parts = [*ring_faces, *text.faces()]
+    text_faces = text.faces()
+    text_boxes: tuple[tuple[float, float, float, float], ...] = ()
+    if text_faces:
+        text_bounds = text.bounding_box()
+        text_boxes = (
+            (
+                float(text_bounds.min.X),
+                float(text_bounds.min.Y),
+                float(text_bounds.max.X),
+                float(text_bounds.max.Y),
+            ),
+        )
+    glyph_parts = [*ring_faces, *text_faces]
     parts = list(glyph_parts)
     shaft_segments = _balloon_shaft_segments(
         cx,
@@ -736,7 +780,7 @@ def _render_balloon(
     # while the glyph remains visible to critique instead of disappearing behind
     # the centreline exemption.
     balloon.centerline_segments = shaft_segments
-    balloon.centerline_boxes = (_balloon_glyph_box(bx, by, r), text_box)
+    balloon.centerline_boxes = (_balloon_glyph_box(bx, by, r), *text_boxes)
     # Furniture that legitimately sits on the view geometry — exempt from the
     # annotation-overlap / centreline lint, as the section arrows do.
     balloon.is_centerline = True

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -40,6 +40,7 @@ from draftwright.layout import (
 )
 
 _BALLOON_RING_STROKE = 0.35
+_GUARDED_TOP_LANE_MAX_OBSTACLE_PROBES = 50_000
 _GUARDED_CARVE_MAX_LABEL_PROBES = 5_000_000
 
 
@@ -66,6 +67,17 @@ def _select_top_lane(lane_options, target, fallback_line):
     if lane_options:
         return lane_options[0]
     return fallback_line, [], 0
+
+
+def _guarded_top_lane_probe_bound(obstacle_count):
+    """Conservative work bound for perimeter lane candidates.
+
+    At most one candidate is derived from each obstacle plus the initial lane;
+    each candidate filters the complete obstacle inventory before carving. The
+    optional automatic replacement must reject an oversized inventory before
+    entering that quadratic scan.
+    """
+    return obstacle_count * (obstacle_count + 1)
 
 
 def render_balloons(
@@ -172,6 +184,17 @@ def render_balloons(
         # carve their horizontal free spans, and take the nearest lane that can
         # carry a balanced share of the ring.  This is measured render geometry;
         # ordered placement across the resulting segments remains in layout.py.
+        if (
+            avoid_annotation_labels
+            and _guarded_top_lane_probe_bound(len(obstacles))
+            > _GUARDED_TOP_LANE_MAX_OBSTACLE_PROBES
+        ):
+            ctx.record_issue(
+                "warning",
+                "balloon_dropped",
+                f"{len(specs)} balloon(s) exceeded the guarded perimeter work budget",
+            )
+            return
         top_lo, top_hi = band_defs["top"][2:]
         other_band_names = ["left", "right"]
         if has_bottom:
@@ -638,10 +661,9 @@ def _guarded_inventory_geometry_is_clear(
     Shaft-vs-retained-label geometry is already part of each member's continuous
     interval carve and is rechecked here. A balloon shaft deliberately terminates
     at its own ring, but must not cross its own rendered tag text. Across balloons,
-    neither glyphs nor shafts may cross another glyph. The established band
-    assignment deliberately permits new shafts from different bands to pass one
-    another, but optional replacement must fail closed when any new glyph/shaft
-    crosses a retained feature leader.
+    neither glyphs nor shafts may cross another glyph or shaft. Optional
+    replacement fails closed when the canonical selected inventory is not
+    crossing-free; it does not start a second placement search.
     """
     for boxes, segments in geometry:
         if any(
@@ -675,6 +697,12 @@ def _guarded_inventory_geometry_is_clear(
                 other_boxes,
                 other_segments,
                 boxes,
+            ):
+                return False
+            if any(
+                _segments_cross_or_overlap(start, end, other_start, other_end)
+                for start, end in segments
+                for other_start, other_end in other_segments
             ):
                 return False
     return True
@@ -744,9 +772,9 @@ def _retained_annotation_geometry(dwg, view):
                 component_segments = normalised_segments(annotation.centerline_segments)
                 expected_box_count, expected_segment_count = annotation.balloon_component_counts
                 component_inventory_complete = (
-                    isinstance(expected_box_count, int)
+                    type(expected_box_count) is int
                     and expected_box_count > 0
-                    and isinstance(expected_segment_count, int)
+                    and type(expected_segment_count) is int
                     and expected_segment_count >= 0
                     and component_boxes is not None
                     and len(component_boxes) == expected_box_count

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -574,14 +574,15 @@ def _guarded_assignment(
 
 
 def _guarded_inventory_geometry_is_clear(geometry, page_box):
-    """Final bounded validation of cross-band glyphs and page bounds.
+    """Final bounded validation of rendered balloon geometry and page bounds.
 
     Shaft-vs-retained-label geometry is already part of each member's continuous
-    interval carve. The established band assignment deliberately permits shafts
-    from different bands to pass one another; this final gate prevents the newly
-    relevant variable-width ring/text glyphs from colliding across those bands.
+    interval carve. A balloon shaft deliberately terminates at its own ring, but
+    must not cross its own rendered tag text. Across balloons, neither glyphs nor
+    shafts may cross another glyph. The established band assignment deliberately
+    permits shafts from different bands to pass one another.
     """
-    for boxes, _segments in geometry:
+    for boxes, segments in geometry:
         if any(
             box[0] < page_box[0]
             or box[1] < page_box[1]
@@ -589,6 +590,11 @@ def _guarded_inventory_geometry_is_clear(geometry, page_box):
             or box[3] > page_box[3]
             for box in boxes
         ):
+            return False
+        # ``boxes[0]`` is the ring that the shaft intentionally touches. Any
+        # remaining boxes are the actual rendered text extents and must remain
+        # clear even for a single, unusually long pattern tag.
+        if balloon_geometry_hits_annotation_labels((), segments, boxes[1:]):
             return False
     for index, (boxes, segments) in enumerate(geometry):
         for other_boxes, other_segments in geometry[index + 1 :]:

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -23,6 +23,7 @@ from draftwright._core import (
 )
 from draftwright._geometry import _segments_cross_or_overlap
 from draftwright.annotations._common import (
+    _geom_box,
     balloon_annotation_label_boxes,
     balloon_geometry_hits_annotation_labels,
     carve_free_segments,
@@ -630,42 +631,82 @@ def _retained_annotation_geometry(dwg, view):
     Public balloons are centerline ``Compound`` objects rather than top-level
     ``Leader`` instances. Their explicit component metadata is the only honest
     collision geometry: the compound AABB would recreate ADR 0009's forbidden
-    empty diagonal triangle. Feature leaders additionally expose real segments.
+    empty diagonal triangle. If that metadata has been removed or corrupted by
+    a caller, use the conservative rendered box instead; if even that cannot be
+    measured, report unsafe so the optional table transaction fails closed.
+    Feature leaders additionally expose real segments.
     """
     boxes: list[tuple[float, float, float, float]] = []
     segments: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    safe = True
+    cache = getattr(dwg, "box_cache", None)
 
-    def append_segments(raw_segments):
-        for segment in raw_segments:
+    def normalised_boxes(raw_boxes):
+        normalised = []
+        try:
+            entries = tuple(raw_boxes)
+        except Exception:  # noqa: BLE001 — optional external metadata
+            return None
+        for box in entries:
+            try:
+                x0, y0, x1, y1 = box
+                values = tuple(float(value) for value in (x0, y0, x1, y1))
+            except (TypeError, ValueError):
+                return None
+            if (
+                not all(math.isfinite(value) for value in values)
+                or values[0] >= values[2]
+                or values[1] >= values[3]
+            ):
+                return None
+            normalised.append(values)
+        return tuple(normalised)
+
+    def normalised_segments(raw_segments):
+        normalised = []
+        try:
+            entries = tuple(raw_segments)
+        except Exception:  # noqa: BLE001 — optional external metadata
+            return None
+        for segment in entries:
             try:
                 (x0, y0), (x1, y1) = segment
-                segments.append(((float(x0), float(y0)), (float(x1), float(y1))))
+                values = tuple(float(value) for value in (x0, y0, x1, y1))
             except (TypeError, ValueError):
-                continue
+                return None
+            if not all(math.isfinite(value) for value in values) or values[:2] == values[2:]:
+                return None
+            normalised.append(((values[0], values[1]), (values[2], values[3])))
+        return tuple(normalised)
 
     for name, annotation in dwg.iter_annotations():
         owner = dwg.view_of(name)
         if owner is not None and owner != view:
             continue
-        try:
-            raw_boxes = getattr(annotation, "centerline_boxes", ()) or ()
-            raw_segments = getattr(annotation, "centerline_segments", ()) or ()
-        except Exception:  # noqa: BLE001 — external optional metadata may be unreadable
-            # External annotations may expose malformed optional metadata. It
-            # cannot become placement evidence; their ordinary rendered/label
-            # box remains available through the existing obstacle collectors.
-            raw_boxes = raw_segments = ()
-        for box in raw_boxes:
+        if getattr(annotation, "is_balloon", False):
             try:
-                x0, y0, x1, y1 = box
-                boxes.append((float(x0), float(y0), float(x1), float(y1)))
-            except (TypeError, ValueError):
-                continue
-        append_segments(raw_segments)
-        if not isinstance(annotation, Leader):
-            continue
-        append_segments(getattr(annotation, "segments", ()) or ())
-    return tuple(dict.fromkeys(boxes)), tuple(dict.fromkeys(segments))
+                component_boxes = normalised_boxes(annotation.centerline_boxes)
+                component_segments = normalised_segments(annotation.centerline_segments)
+            except Exception:  # noqa: BLE001 — optional external metadata
+                component_boxes = component_segments = None
+            # Every rendered balloon has at least its ring box. Empty boxes,
+            # absent attributes, or any malformed entry make the complete
+            # component inventory untrustworthy; do not use a partial subset.
+            if component_boxes and component_segments is not None:
+                boxes.extend(component_boxes)
+                segments.extend(component_segments)
+            else:
+                rendered_box = _geom_box(annotation, cache)
+                if rendered_box is None:
+                    safe = False
+                else:
+                    x0, y0, x1, y1 = rendered_box
+                    boxes.append((float(x0), float(y0), float(x1), float(y1)))
+        if isinstance(annotation, Leader):
+            leader_segments = normalised_segments(getattr(annotation, "segments", ()) or ())
+            if leader_segments is not None:
+                segments.extend(leader_segments)
+    return tuple(dict.fromkeys(boxes)), tuple(dict.fromkeys(segments)), safe
 
 
 def _place_guarded_inventory(
@@ -690,9 +731,11 @@ def _place_guarded_inventory(
 ):
     """Solve and render one text-aware, cross-band-safe balloon inventory."""
     label_boxes = balloon_annotation_label_boxes(dwg, view) if avoid_existing_labels else ()
-    retained_component_boxes, retained_segments = (
-        _retained_annotation_geometry(dwg, view) if avoid_existing_labels else ((), ())
+    retained_component_boxes, retained_segments, retained_geometry_safe = (
+        _retained_annotation_geometry(dwg, view) if avoid_existing_labels else ((), (), True)
     )
+    if not retained_geometry_safe:
+        return len(members)
     retained_boxes = (*label_boxes, *retained_component_boxes)
     text_boxes = {
         tag: components[1] if len(components) > 1 else None
@@ -901,6 +944,7 @@ def _render_balloon(
     # the centreline exemption.
     balloon.centerline_segments = shaft_segments
     balloon.centerline_boxes = (_balloon_glyph_box(bx, by, r), *text_boxes)
+    balloon.is_balloon = True
     # Furniture that legitimately sits on the view geometry — exempt from the
     # annotation-overlap / centreline lint, as the section arrows do.
     balloon.is_centerline = True

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -21,6 +21,7 @@ from draftwright._core import (
     _balloon_halo,
     _balloon_radius,
 )
+from draftwright._geometry import _segments_cross_or_overlap
 from draftwright.annotations._common import (
     balloon_annotation_label_boxes,
     balloon_geometry_hits_annotation_labels,
@@ -573,14 +574,18 @@ def _guarded_assignment(
     )
 
 
-def _guarded_inventory_geometry_is_clear(geometry, page_box):
+def _guarded_inventory_geometry_is_clear(
+    geometry, page_box, retained_label_boxes=(), retained_leader_segments=()
+):
     """Final bounded validation of rendered balloon geometry and page bounds.
 
     Shaft-vs-retained-label geometry is already part of each member's continuous
-    interval carve. A balloon shaft deliberately terminates at its own ring, but
-    must not cross its own rendered tag text. Across balloons, neither glyphs nor
-    shafts may cross another glyph. The established band assignment deliberately
-    permits shafts from different bands to pass one another.
+    interval carve and is rechecked here. A balloon shaft deliberately terminates
+    at its own ring, but must not cross its own rendered tag text. Across balloons,
+    neither glyphs nor shafts may cross another glyph. The established band
+    assignment deliberately permits new shafts from different bands to pass one
+    another, but optional replacement must fail closed when any new glyph/shaft
+    crosses a retained feature leader.
     """
     for boxes, segments in geometry:
         if any(
@@ -596,6 +601,16 @@ def _guarded_inventory_geometry_is_clear(geometry, page_box):
         # clear even for a single, unusually long pattern tag.
         if balloon_geometry_hits_annotation_labels((), segments, boxes[1:]):
             return False
+        if balloon_geometry_hits_annotation_labels(boxes, segments, retained_label_boxes):
+            return False
+        if balloon_geometry_hits_annotation_labels((), retained_leader_segments, boxes):
+            return False
+        if any(
+            _segments_cross_or_overlap(start, end, retained_start, retained_end)
+            for start, end in segments
+            for retained_start, retained_end in retained_leader_segments
+        ):
+            return False
     for index, (boxes, segments) in enumerate(geometry):
         for other_boxes, other_segments in geometry[index + 1 :]:
             if balloon_geometry_hits_annotation_labels(
@@ -607,6 +622,19 @@ def _guarded_inventory_geometry_is_clear(geometry, page_box):
             ):
                 return False
     return True
+
+
+def _retained_leader_segments(dwg, view):
+    """Real segments of feature leaders that survive an automatic table attempt."""
+    segments: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    for name, annotation in dwg.iter_annotations():
+        owner = dwg.view_of(name)
+        if owner is not None and owner != view:
+            continue
+        if not isinstance(annotation, Leader):
+            continue
+        segments.extend(getattr(annotation, "segments", ()) or ())
+    return tuple(segments)
 
 
 def _place_guarded_inventory(
@@ -631,6 +659,7 @@ def _place_guarded_inventory(
 ):
     """Solve and render one text-aware, cross-band-safe balloon inventory."""
     label_boxes = balloon_annotation_label_boxes(dwg, view) if avoid_existing_labels else ()
+    retained_segments = _retained_leader_segments(dwg, view) if avoid_existing_labels else ()
     text_boxes = {
         tag: components[1] if len(components) > 1 else None
         for tag, components in local_glyph_boxes.items()
@@ -682,7 +711,12 @@ def _place_guarded_inventory(
                 radius,
             )
             geometry.append((boxes, segments))
-    if not _guarded_inventory_geometry_is_clear(geometry, page_box):
+    if not _guarded_inventory_geometry_is_clear(
+        geometry,
+        page_box,
+        retained_label_boxes=label_boxes,
+        retained_leader_segments=retained_segments,
+    ):
         return len(members)
     for band, indices in assignments.items():
         axis, line, _lo, _hi = band_defs[band]

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -21,7 +21,11 @@ from draftwright._core import (
     _balloon_halo,
     _balloon_radius,
 )
-from draftwright.annotations._common import carve_free_segments, strip_obstacles
+from draftwright.annotations._common import (
+    balloon_hits_annotation_label,
+    carve_free_segments,
+    strip_obstacles,
+)
 from draftwright.fonts import PLEX_MONO
 from draftwright.layout import (
     _assign_balloon_bands,
@@ -298,10 +302,12 @@ def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx, *, segm
             or _greedy_strip_1d(naturals, gap, lo, hi)
             or _greedy_strip_1d(naturals, gap, lo, hi, prefix=True)
         )
+    rejected = 0
     for (tag, j, hole, cx, cy), c in zip(members, coords):
         bx, by = (line, c) if axis == "y" else (c, line)
-        _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx)
-    return len(members) - len(coords)
+        if _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx) is False:
+            rejected += 1
+    return len(members) - len(coords) + rejected
 
 
 def _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx):
@@ -334,9 +340,12 @@ def _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx):
     # Furniture that legitimately sits on the view geometry — exempt from the
     # annotation-overlap / centreline lint, as the section arrows do.
     balloon.is_centerline = True
+    if balloon_hits_annotation_label(dwg, balloon, view):
+        return False
     ctx.place(
         balloon,
         f"balloon_{view}_{tag}_{j}",
         view=view,
         feature=ctx.feature_of_hole_at(hole.location),
     )
+    return True

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -461,14 +461,16 @@ def _guarded_assignment(
     prefer_bands=(),
     preference_limit=0.0,
 ):
-    """Globally assign members to bands while all band coordinates remain feasible.
+    """Run the canonical band flow, then validate its complete guarded inventory.
 
-    The ordinary min-cost flow gives a cardinality upper bound using each band's
-    geometric capacity.  If that assignment is jointly feasible under the
-    retained-label intervals it is preserved exactly.  Otherwise a deterministic
-    branch-and-bound search finds the same highest attainable cardinality across
-    all bands; label feasibility therefore participates in band assignment rather
-    than causing a greedy post-solve drop.
+    ADR 0014 owns band selection in :func:`layout._assign_balloon_bands`: that
+    bounded flow maximises cardinality and then minimises leader length.  The
+    member-specific intervals here are render-layer geometry, so they may only
+    validate the flow result.  If its complete selected inventory is infeasible,
+    fail the attempt closed; the automatic table transaction restores the original
+    feature annotations.  Do not search a second assignment space here: doing so
+    would duplicate the shared solver, lose its cost objective, and risk unbounded
+    work on dense tables.
     """
     filtered_choices = [
         {
@@ -518,72 +520,11 @@ def _guarded_assignment(
     target = sum(len(indices) for indices in seed_indices.values())
     if all(solution is not None for solution in seed_solutions.values()):
         return seed_indices, seed_solutions, len(members) - target
-
-    available = [index for index, choices in enumerate(filtered_choices) if choices]
-    unavailable = len(members) - len(available)
-    ordered = sorted(
-        available,
-        key=lambda index: (
-            len(filtered_choices[index]),
-            min(filtered_choices[index].values()),
-            index,
-        ),
+    return (
+        {band: [] for band in band_defs},
+        {band: {} for band in band_defs},
+        len(members),
     )
-    band_names = tuple(band_defs)
-    groups: dict[str, list[int]] = {band: [] for band in band_names}
-    solve_cache: dict[tuple[str, tuple[int, ...]], dict[int, float] | None] = {}
-
-    def solve_band(band):
-        key = (band, tuple(sorted(groups[band])))
-        if key not in solve_cache:
-            solve_cache[key] = _solve_guarded_band(
-                groups[band], members, band, band_defs, free_segments
-            )
-        return solve_cache[key]
-
-    for required in range(target, -1, -1):
-        answer = None
-
-        def visit(position, placed):
-            nonlocal answer
-            if answer is not None:
-                return
-            if placed + len(ordered) - position < required:
-                return
-            if position == len(ordered):
-                if placed == required:
-                    answer = (
-                        {band: list(indices) for band, indices in groups.items()},
-                        {band: solve_band(band) for band in band_names},
-                    )
-                return
-            index = ordered[position]
-            choices = sorted(
-                filtered_choices[index],
-                key=lambda band: (
-                    filtered_choices[index][band]
-                    - (preference_limit if band in prefer_bands and not groups[band] else 0.0),
-                    filtered_choices[index][band],
-                    band,
-                ),
-            )
-            for band in choices:
-                if len(groups[band]) >= effective_capacities[band]:
-                    continue
-                groups[band].append(index)
-                if solve_band(band) is not None:
-                    visit(position + 1, placed + 1)
-                groups[band].pop()
-                if answer is not None:
-                    return
-            if placed + len(ordered) - position - 1 >= required:
-                visit(position + 1, placed)
-
-        visit(0, 0)
-        if answer is not None:
-            assignments, solutions = answer
-            return assignments, solutions, unavailable + len(available) - required
-    return {band: [] for band in band_names}, {band: {} for band in band_names}, len(members)
 
 
 def _place_guarded_inventory(
@@ -760,6 +701,13 @@ def _render_balloon(
         align=(Align.CENTER, Align.CENTER),
         mode=Mode.PRIVATE,
     ).locate(loc)
+    text_bounds = text.bounding_box()
+    text_box = (
+        float(text_bounds.min.X),
+        float(text_bounds.min.Y),
+        float(text_bounds.max.X),
+        float(text_bounds.max.Y),
+    )
     glyph_parts = [*ring_faces, *text.faces()]
     parts = list(glyph_parts)
     shaft_segments = _balloon_shaft_segments(
@@ -788,7 +736,7 @@ def _render_balloon(
     # while the glyph remains visible to critique instead of disappearing behind
     # the centreline exemption.
     balloon.centerline_segments = shaft_segments
-    balloon.centerline_boxes = (_balloon_glyph_box(bx, by, r),)
+    balloon.centerline_boxes = (_balloon_glyph_box(bx, by, r), text_box)
     # Furniture that legitimately sits on the view geometry — exempt from the
     # annotation-overlap / centreline lint, as the section arrows do.
     balloon.is_centerline = True

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -590,9 +590,15 @@ def _guarded_inventory_geometry_is_clear(geometry, page_box):
             for box in boxes
         ):
             return False
-    for index, (boxes, _segments) in enumerate(geometry):
-        for other_boxes, _other_segments in geometry[index + 1 :]:
-            if balloon_geometry_hits_annotation_labels(boxes, (), other_boxes):
+    for index, (boxes, segments) in enumerate(geometry):
+        for other_boxes, other_segments in geometry[index + 1 :]:
+            if balloon_geometry_hits_annotation_labels(
+                boxes, segments, other_boxes
+            ) or balloon_geometry_hits_annotation_labels(
+                other_boxes,
+                other_segments,
+                boxes,
+            ):
                 return False
     return True
 

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -63,7 +63,16 @@ def _select_top_lane(lane_options, target, fallback_line):
     return fallback_line, [], 0
 
 
-def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
+def render_balloons(
+    dwg,
+    a,
+    view,
+    specs,
+    ctx,
+    *,
+    perimeter=False,
+    avoid_annotation_labels=False,
+):
     """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
     fitted into the halo the layout reserved around the view (#111).
 
@@ -221,6 +230,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         prefer_bands=preferred_bands if perimeter else (),
         preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
     )
+    collision_kwargs = {"avoid_annotation_labels": True} if avoid_annotation_labels else {}
     dropped += _place_band(
         dwg,
         view,
@@ -230,6 +240,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         fs,
         r,
         ctx,
+        **collision_kwargs,
     )
     dropped += _place_band(
         dwg,
@@ -240,6 +251,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         fs,
         r,
         ctx,
+        **collision_kwargs,
     )
     top_args = (
         dwg,
@@ -252,9 +264,13 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         ctx,
     )
     dropped += (
-        _place_band(*top_args)
+        _place_band(*top_args, **collision_kwargs)
         if top_segments is None
-        else _place_band(*top_args, segments=top_segments)
+        else _place_band(
+            *top_args,
+            segments=top_segments,
+            **collision_kwargs,
+        )
     )
     dropped += _place_band(
         dwg,
@@ -265,6 +281,7 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         fs,
         r,
         ctx,
+        **collision_kwargs,
     )
     # A band too crowded to hold every balloon drops its tail (the strip solver's
     # prefix fallback) — record it instead of letting the balloons vanish silently
@@ -278,7 +295,22 @@ def render_balloons(dwg, a, view, specs, ctx, *, perimeter=False):
         )
 
 
-def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx, *, segments=None) -> int:
+def _place_band(
+    dwg,
+    view,
+    members,
+    axis,
+    line,
+    lo,
+    hi,
+    gap,
+    fs,
+    r,
+    ctx,
+    *,
+    segments=None,
+    avoid_annotation_labels=False,
+) -> int:
     """Spread *members* (``(tag, j, hole, cx, cy)``) along one reserved band
     with the strip solver, then render a leadered balloon for each (#111).
 
@@ -302,15 +334,88 @@ def _place_band(dwg, view, members, axis, line, lo, hi, gap, fs, r, ctx, *, segm
             or _greedy_strip_1d(naturals, gap, lo, hi)
             or _greedy_strip_1d(naturals, gap, lo, hi, prefix=True)
         )
+    placed_coords = list(coords)
+    collision_kwargs = {"avoid_annotation_labels": True} if avoid_annotation_labels else {}
     rejected = 0
-    for (tag, j, hole, cx, cy), c in zip(members, coords):
+    for member_index, ((tag, j, hole, cx, cy), c) in enumerate(zip(members, coords)):
         bx, by = (line, c) if axis == "y" else (c, line)
-        if _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx) is False:
+        rendered = _render_balloon(
+            dwg,
+            view,
+            tag,
+            j,
+            hole,
+            cx,
+            cy,
+            bx,
+            by,
+            fs,
+            r,
+            ctx,
+            **collision_kwargs,
+        )
+        if rendered is not False:
+            continue
+
+        # The max-cardinality strip solve does not know the final retained callout
+        # labels. If its natural coordinate creates a real glyph/segment crossing,
+        # search the same sanctioned strip for the nearest collision-free coordinate
+        # before dropping the row key. Other solved balloon coordinates stay reserved,
+        # so this retry cannot trade one collision for a balloon overlap.
+        ranges = segments if segments is not None else [(lo, hi)]
+        alternatives = {
+            round(start + step * 0.5, 6)
+            for start, end in ranges
+            for step in range(max(0, int(math.floor((end - start) / 0.5))) + 1)
+        }
+        occupied = [
+            coordinate for index, coordinate in enumerate(placed_coords) if index != member_index
+        ]
+        for alternative in sorted(alternatives, key=lambda value: (abs(value - c), value)):
+            if any(abs(alternative - coordinate) < gap - 1e-6 for coordinate in occupied):
+                continue
+            bx, by = (line, alternative) if axis == "y" else (alternative, line)
+            if (
+                _render_balloon(
+                    dwg,
+                    view,
+                    tag,
+                    j,
+                    hole,
+                    cx,
+                    cy,
+                    bx,
+                    by,
+                    fs,
+                    r,
+                    ctx,
+                    avoid_annotation_labels=True,
+                )
+                is not False
+            ):
+                placed_coords[member_index] = alternative
+                break
+        else:
             rejected += 1
     return len(members) - len(coords) + rejected
 
 
-def _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx):
+def _render_balloon(
+    dwg,
+    view,
+    tag,
+    j,
+    hole,
+    cx,
+    cy,
+    bx,
+    by,
+    fs,
+    r,
+    ctx,
+    *,
+    avoid_annotation_labels=False,
+):
     """Build and add one balloon glyph + leader at solved centre ``(bx, by)``
     for hole ``(cx, cy)`` (#111)."""
     loc = Location((bx, by, 0))
@@ -324,7 +429,9 @@ def _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx):
         align=(Align.CENTER, Align.CENTER),
         mode=Mode.PRIVATE,
     ).locate(loc)
-    parts = [*ring_faces, *text.faces()]
+    glyph_parts = [*ring_faces, *text.faces()]
+    parts = list(glyph_parts)
+    segments = ()
     # Leader from the hole rim to the balloon's near edge — the glyph is the
     # label, so label="".  Skipped when the balloon could not clear the hole
     # (degenerate fallback), where a leader would be a stub through the ring.
@@ -335,12 +442,23 @@ def _render_balloon(dwg, view, tag, j, hole, cx, cy, bx, by, fs, r, ctx):
         ux, uy = dx / dist, dy / dist
         tip = (cx + ux * hole_r, cy + uy * hole_r, 0)
         elbow = (bx - ux * r, by - uy * r, 0)
-        parts.append(Leader(tip, elbow, "", dwg.draft))
+        leader = Leader(tip, elbow, "", dwg.draft)
+        parts.append(leader)
+        segments = tuple(getattr(leader, "segments", ()))
     balloon = Compound(children=parts)
+    # Structural lint must inspect the real leader shaft, not the compound AABB's
+    # empty diagonal triangle (ADR 0009).  Placement has already checked the compact
+    # glyph separately above.
+    balloon.segments = segments
     # Furniture that legitimately sits on the view geometry — exempt from the
     # annotation-overlap / centreline lint, as the section arrows do.
     balloon.is_centerline = True
-    if balloon_hits_annotation_label(dwg, balloon, view):
+    if avoid_annotation_labels and balloon_hits_annotation_label(
+        dwg,
+        Compound(children=glyph_parts),
+        segments,
+        view,
+    ):
         return False
     ctx.place(
         balloon,

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -40,6 +40,7 @@ from draftwright.layout import (
 )
 
 _BALLOON_RING_STROKE = 0.35
+_GUARDED_CARVE_MAX_LABEL_PROBES = 5_000_000
 
 
 def _top_lane_target(member_count, other_capacities, usable_band_count):
@@ -76,6 +77,7 @@ def render_balloons(
     *,
     perimeter=False,
     avoid_annotation_labels=False,
+    required_count=0,
 ):
     """Place a leadered balloon for each ``(tag, j, hole)`` in *specs*,
     fitted into the halo the layout reserved around the view (#111).
@@ -92,6 +94,11 @@ def render_balloons(
     usable band receives a balloon when the member count permits; this is the
     dense-hole table escalation's deliberate ring treatment (#901).  Ordinary
     and manually requested balloons retain nearest-band assignment.
+
+    The first *required_count* specs are row keys for a transactional automatic
+    table.  They win equal-cardinality contention over any following optional,
+    non-certifying pattern markers; the shared flow still chooses all bands and
+    positions, and callers that leave the default retain the ordinary policy.
 
     The drawing is duck-typed as *dwg* and touched only through its public
     surface; build state rides *a* and *ctx* (ADR 0005 §2 / #639, #699).
@@ -173,7 +180,8 @@ def render_balloons(
             _strip_capacity(*band_defs[name][2:], gap) for name in other_band_names
         ]
         usable_band_count = len(other_band_names) + 1  # plus top
-        top_target = _top_lane_target(len(specs), other_capacities, usable_band_count)
+        layout_member_count = required_count or len(specs)
+        top_target = _top_lane_target(layout_member_count, other_capacities, usable_band_count)
         first_line = pt + centre_offset
         last_line = ph - margin - r
         candidates = {first_line}
@@ -247,13 +255,23 @@ def render_balloons(
     }
     preferred_bands = tuple(name for name, capacity in capacities.items() if capacity > 0)
     if not avoid_annotation_labels:
-        bands, dropped = _assign_balloon_bands(
-            members,
-            choices_by_member,
-            capacities,
-            prefer_bands=preferred_bands if perimeter else (),
-            preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
-        )
+        if required_count:
+            bands, dropped = _assign_balloon_bands(
+                members,
+                choices_by_member,
+                capacities,
+                prefer_bands=preferred_bands if perimeter else (),
+                preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
+                required_count=required_count,
+            )
+        else:
+            bands, dropped = _assign_balloon_bands(
+                members,
+                choices_by_member,
+                capacities,
+                prefer_bands=preferred_bands if perimeter else (),
+                preference_limit=_band_preference_limit(fs) if perimeter else 0.0,
+            )
         for name in ("left", "right", "top", "bottom"):
             args = (
                 dwg,
@@ -296,6 +314,7 @@ def render_balloons(
         avoid_existing_labels=avoid_annotation_labels,
         local_glyph_boxes=local_glyph_boxes,
         band_gaps=band_gaps,
+        required_count=required_count,
     )
     # A band too crowded to hold every balloon drops its tail (the strip solver's
     # prefix fallback) — record it instead of letting the balloons vanish silently
@@ -472,6 +491,24 @@ def _guarded_free_segments(
     return tuple(validated)
 
 
+def _guarded_carve_probe_bound(member_count, range_count, label_count, glyph_box_count):
+    """Conservative box-probe bound before continuous interval carving.
+
+    Each retained box contributes at most four corner rays, eight rim
+    intersections, and two glyph events per glyph component. Each resulting
+    interval can probe its midpoint, both ends, and the final merged ends, so
+    fewer than six probes are needed per critical coordinate. Every probe scans
+    the retained boxes. Keeping this arithmetic outside
+    :func:`_guarded_free_segments` makes the transaction fail closed before the
+    otherwise-quadratic critical-point expansion starts.
+    """
+    if member_count <= 0 or range_count <= 0 or label_count <= 0:
+        return 0
+    criticals_per_label = 12 + 2 * max(1, glyph_box_count)
+    probes_per_range = 6 * (2 + label_count * criticals_per_label)
+    return member_count * range_count * probes_per_range * label_count
+
+
 def _solve_guarded_band(member_indices, members, band_name, band_defs, free_segments):
     """Return ``{member_index: coordinate}`` for one complete guarded band."""
     axis = band_defs[band_name][0]
@@ -508,66 +545,84 @@ def _guarded_assignment(
     *,
     prefer_bands=(),
     preference_limit=0.0,
+    required_count=0,
 ):
-    """Run the canonical band flow, then validate its complete guarded inventory.
+    """Run the canonical band flow, then validate its guarded inventory.
 
     ADR 0014 owns band selection in :func:`layout._assign_balloon_bands`: that
-    bounded flow maximises cardinality and then minimises leader length.  The
-    member-specific intervals here are render-layer geometry, so they may only
-    validate the flow result.  If its complete selected inventory is infeasible,
-    fail the attempt closed; the automatic table transaction restores the original
-    feature annotations.  Do not search a second assignment space here: doing so
-    would duplicate the shared solver, lose its cost objective, and risk unbounded
-    work on dense tables.
+    bounded flow maximises cardinality, preserves the required prefix, and then
+    minimises leader length. The member-specific intervals here are render-layer
+    geometry, so they may only validate the flow result. If optional members make
+    the complete selected inventory infeasible, validate the required prefix once
+    through the same canonical flow and keep that solution. This is the bounded
+    second phase of one lexicographic solve—not an alternate search or placement
+    engine—and prevents a non-certifying pattern marker from rolling back an
+    independently complete table (#1144). If the required inventory itself is
+    infeasible, the automatic transaction restores the feature annotations.
     """
-    filtered_choices = [
-        {
-            band: distance
-            for band, distance in choices.items()
-            if free_segments.by_member_band.get((index, band))
+
+    def solve_prefix(limit, required):
+        selected_members = members[:limit]
+        filtered_choices = [
+            {
+                band: distance
+                for band, distance in choices_by_member[index].items()
+                if free_segments.by_member_band.get((index, band))
+            }
+            for index in range(limit)
+        ]
+        effective_capacities = {}
+        for band, capacity in capacities.items():
+            union = sorted(
+                segment
+                for index in range(limit)
+                for segment in free_segments.by_member_band.get((index, band), ())
+            )
+            merged_union: list[tuple[float, float]] = []
+            for lo, hi in union:
+                if merged_union and lo <= merged_union[-1][1]:
+                    merged_union[-1] = (
+                        merged_union[-1][0],
+                        max(merged_union[-1][1], hi),
+                    )
+                else:
+                    merged_union.append((lo, hi))
+            effective_capacities[band] = min(
+                capacity,
+                sum(
+                    _strip_capacity(lo, hi, free_segments.gap_for(band)) for lo, hi in merged_union
+                ),
+            )
+        seed, _flow_dropped = _assign_balloon_bands(
+            selected_members,
+            filtered_choices,
+            effective_capacities,
+            prefer_bands=prefer_bands,
+            preference_limit=preference_limit,
+            required_count=required,
+        )
+        member_index = {id(member): index for index, member in enumerate(selected_members)}
+        seed_indices = {
+            band: [member_index[id(member)] for member in assigned]
+            for band, assigned in seed.items()
+            if band in band_defs
         }
-        for index, choices in enumerate(choices_by_member)
-    ]
-    effective_capacities = {}
-    for band, capacity in capacities.items():
-        union = sorted(
-            segment
-            for index in range(len(members))
-            for segment in free_segments.by_member_band.get((index, band), ())
-        )
-        merged_union: list[tuple[float, float]] = []
-        for lo, hi in union:
-            if merged_union and lo <= merged_union[-1][1]:
-                merged_union[-1] = (
-                    merged_union[-1][0],
-                    max(merged_union[-1][1], hi),
-                )
-            else:
-                merged_union.append((lo, hi))
-        effective_capacities[band] = min(
-            capacity,
-            sum(_strip_capacity(lo, hi, free_segments.gap_for(band)) for lo, hi in merged_union),
-        )
-    seed, _flow_dropped = _assign_balloon_bands(
-        members,
-        filtered_choices,
-        effective_capacities,
-        prefer_bands=prefer_bands,
-        preference_limit=preference_limit,
-    )
-    member_index = {id(member): index for index, member in enumerate(members)}
-    seed_indices = {
-        band: [member_index[id(member)] for member in assigned]
-        for band, assigned in seed.items()
-        if band in band_defs
-    }
-    seed_solutions = {
-        band: _solve_guarded_band(indices, members, band, band_defs, free_segments)
-        for band, indices in seed_indices.items()
-    }
-    target = sum(len(indices) for indices in seed_indices.values())
-    if all(solution is not None for solution in seed_solutions.values()):
-        return seed_indices, seed_solutions, len(members) - target
+        seed_solutions = {
+            band: _solve_guarded_band(indices, members, band, band_defs, free_segments)
+            for band, indices in seed_indices.items()
+        }
+        target = sum(len(indices) for indices in seed_indices.values())
+        if all(solution is not None for solution in seed_solutions.values()):
+            return seed_indices, seed_solutions, len(members) - target
+        return None
+
+    complete = solve_prefix(len(members), required_count)
+    if complete is not None:
+        return complete
+    if required_count:
+        required = solve_prefix(required_count, required_count)
+        if required is not None:
+            return required
     return (
         {band: [] for band in band_defs},
         {band: {} for band in band_defs},
@@ -687,12 +742,26 @@ def _retained_annotation_geometry(dwg, view):
             try:
                 component_boxes = normalised_boxes(annotation.centerline_boxes)
                 component_segments = normalised_segments(annotation.centerline_segments)
+                expected_box_count, expected_segment_count = annotation.balloon_component_counts
+                component_inventory_complete = (
+                    isinstance(expected_box_count, int)
+                    and expected_box_count > 0
+                    and isinstance(expected_segment_count, int)
+                    and expected_segment_count >= 0
+                    and component_boxes is not None
+                    and len(component_boxes) == expected_box_count
+                    and component_segments is not None
+                    and len(component_segments) == expected_segment_count
+                )
             except Exception:  # noqa: BLE001 — optional external metadata
                 component_boxes = component_segments = None
+                component_inventory_complete = False
             # Every rendered balloon has at least its ring box. Empty boxes,
-            # absent attributes, or any malformed entry make the complete
-            # component inventory untrustworthy; do not use a partial subset.
-            if component_boxes and component_segments is not None:
+            # absent attributes, a cardinality mismatch, or any malformed entry
+            # make the complete inventory untrustworthy; do not use a partial
+            # subset that could silently omit a shaft or long-tag text box.
+            if component_inventory_complete:
+                assert component_boxes is not None and component_segments is not None
                 boxes.extend(component_boxes)
                 segments.extend(component_segments)
             else:
@@ -728,6 +797,7 @@ def _place_guarded_inventory(
     avoid_existing_labels,
     local_glyph_boxes,
     band_gaps,
+    required_count=0,
 ):
     """Solve and render one text-aware, cross-band-safe balloon inventory."""
     label_boxes = balloon_annotation_label_boxes(dwg, view) if avoid_existing_labels else ()
@@ -737,6 +807,17 @@ def _place_guarded_inventory(
     if not retained_geometry_safe:
         return len(members)
     retained_boxes = (*label_boxes, *retained_component_boxes)
+    range_count = sum(
+        len(top_segments) if band == "top" and top_segments is not None else 1
+        for band, capacity in capacities.items()
+        if capacity > 0
+    )
+    glyph_box_count = max((len(boxes) for boxes in local_glyph_boxes.values()), default=1)
+    if (
+        _guarded_carve_probe_bound(len(members), range_count, len(retained_boxes), glyph_box_count)
+        > _GUARDED_CARVE_MAX_LABEL_PROBES
+    ):
+        return len(members)
     text_boxes = {
         tag: components[1] if len(components) > 1 else None
         for tag, components in local_glyph_boxes.items()
@@ -766,35 +847,87 @@ def _place_guarded_inventory(
         guarded,
         prefer_bands=prefer_bands,
         preference_limit=preference_limit,
+        required_count=required_count,
     )
-    geometry = []
-    for band, indices in assignments.items():
-        axis, line, _lo, _hi = band_defs[band]
-        solution = solutions[band]
-        for index in indices:
-            _tag, _member_index, hole, cx, cy = members[index]
-            coordinate = solution[index]
-            bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
-            boxes = tuple(
-                (bx + x0, by + y0, bx + x1, by + y1)
-                for x0, y0, x1, y1 in local_glyph_boxes[members[index][0]]
-            )
-            segments = _balloon_shaft_segments(
-                cx,
-                cy,
-                bx,
-                by,
-                hole.diameter * dwg.scale / 2,
+
+    def rendered_geometry(current_assignments, current_solutions):
+        geometry = []
+        for band, indices in current_assignments.items():
+            axis, line, _lo, _hi = band_defs[band]
+            solution = current_solutions[band]
+            for index in indices:
+                _tag, _member_index, hole, cx, cy = members[index]
+                coordinate = solution[index]
+                bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
+                boxes = tuple(
+                    (bx + x0, by + y0, bx + x1, by + y1)
+                    for x0, y0, x1, y1 in local_glyph_boxes[members[index][0]]
+                )
+                segments = _balloon_shaft_segments(
+                    cx,
+                    cy,
+                    bx,
+                    by,
+                    hole.diameter * dwg.scale / 2,
+                    radius,
+                )
+                geometry.append((boxes, segments))
+        return geometry
+
+    def geometry_is_clear(current_assignments, current_solutions):
+        return _guarded_inventory_geometry_is_clear(
+            rendered_geometry(current_assignments, current_solutions),
+            page_box,
+            retained_boxes=retained_boxes,
+            retained_segments=retained_segments,
+        )
+
+    required_placed = sum(
+        index < required_count for indices in assignments.values() for index in indices
+    )
+    if not geometry_is_clear(assignments, solutions) or required_placed < required_count:
+        if not 0 < required_count < len(members):
+            return len(members)
+        required_band_gaps = {
+            name: _balloon_component_gap(
+                (
+                    local_glyph_boxes[members[index][0]]
+                    for index in range(required_count)
+                    if name in choices_by_member[index]
+                ),
+                axis,
                 radius,
+                gap,
             )
-            geometry.append((boxes, segments))
-    if not _guarded_inventory_geometry_is_clear(
-        geometry,
-        page_box,
-        retained_boxes=retained_boxes,
-        retained_segments=retained_segments,
-    ):
-        return len(members)
+            for name, (axis, _line, _lo, _hi) in band_defs.items()
+        }
+        required_capacities = {
+            name: (
+                0
+                if capacities.get(name, 0) <= 0
+                else sum(
+                    _strip_capacity(seg_lo, seg_hi, required_band_gaps[name])
+                    for seg_lo, seg_hi in top_segments
+                )
+                if name == "top" and top_segments is not None
+                else _strip_capacity(lo, hi, required_band_gaps[name])
+            )
+            for name, (_axis, _line, lo, hi) in band_defs.items()
+        }
+        required_guarded = _GuardedSegments(by_member_band, gap, required_band_gaps)
+        assignments, solutions, dropped = _guarded_assignment(
+            members[:required_count],
+            choices_by_member[:required_count],
+            band_defs,
+            required_capacities,
+            required_guarded,
+            prefer_bands=prefer_bands,
+            preference_limit=preference_limit,
+            required_count=required_count,
+        )
+        dropped += len(members) - required_count
+        if not geometry_is_clear(assignments, solutions):
+            return len(members)
     for band, indices in assignments.items():
         axis, line, _lo, _hi = band_defs[band]
         solution = solutions[band]
@@ -944,6 +1077,10 @@ def _render_balloon(
     # the centreline exemption.
     balloon.centerline_segments = shaft_segments
     balloon.centerline_boxes = (_balloon_glyph_box(bx, by, r), *text_boxes)
+    balloon.balloon_component_counts = (
+        len(balloon.centerline_boxes),
+        len(balloon.centerline_segments),
+    )
     balloon.is_balloon = True
     # Furniture that legitimately sits on the view geometry — exempt from the
     # annotation-overlap / centreline lint, as the section arrows do.

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -589,11 +589,19 @@ def _record_callout_drop(ctx, dwg, view, diam, reason, feat=None, callout=None):
         for _ in range(count):
             ctx.coverage.drop_profile(profile)
     measurements = tuple(getattr(callout, "measurements", ()))
+    hole_requirements = (
+        tuple(
+            (feat, requirement) for requirement in getattr(callout, "covers_hole_requirements", ())
+        )
+        if feat is not None
+        else ()
+    )
     ctx.record_issue(
         "warning",
         "callout_dropped",
         f"hole callout ø{_fmt(diam)} dropped from the {view} view ({reason})",
         measurement=measurements,
+        hole_requirements=hole_requirements,
     )
     # First-class escalation object alongside the lint code (ADR 0009 Amdt 1, #351 PR-2).
     # The resolver (`_maybe_tabulate_holes`) triggers on these; the lint code stays for

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -588,16 +588,25 @@ def _record_callout_drop(ctx, dwg, view, diam, reason, feat=None, callout=None):
     for profile in getattr(callout, "covers_profiles", ()):
         for _ in range(count):
             ctx.coverage.drop_profile(profile)
+    measurements = tuple(getattr(callout, "measurements", ()))
     ctx.record_issue(
         "warning",
         "callout_dropped",
         f"hole callout ø{_fmt(diam)} dropped from the {view} view ({reason})",
-        measurement=getattr(callout, "measurements", ()),
+        measurement=measurements,
     )
     # First-class escalation object alongside the lint code (ADR 0009 Amdt 1, #351 PR-2).
     # The resolver (`_maybe_tabulate_holes`) triggers on these; the lint code stays for
     # coverage. 1:1 with the code emit, so the object trigger is byte-identical.
-    ctx.escalations.append(Escalation(kind="callout", view=view, feature=feat, reason=reason))
+    ctx.escalations.append(
+        Escalation(
+            kind="callout",
+            view=view,
+            feature=feat,
+            reason=reason,
+            targets=measurements,
+        )
+    )
 
 
 class _OffHole(NamedTuple):

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -789,8 +789,9 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
     tags = _tag_sequence(n_scattered + len(pattern_feats))
     scattered_tags, pattern_tags = tags[:n_scattered], tags[n_scattered:]
     # One balloon per pattern, tagged with its member count so the ring reads
-    # "6×A" rather than one glyph per member (#348) — no table row needed, the
-    # count + diameter travel with the balloon itself.
+    # "6×A" rather than one glyph per member (#348).  Without a table/legend the
+    # marker does not state the pattern's diameter, depth or arrangement; it is
+    # deliberately non-certifying and cannot clear the original callout drop.
     pattern_specs = [
         (
             f"{feat.count}×{tag}",
@@ -925,6 +926,7 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
         )
 
         # Widen the chart into more column-blocks until it fits the page.
+        table_issue_base = dwg.registry.issues
         for ncols in (1, 2, 3, 4):
             table = dwg.add_table(
                 _wrap_rows(header, data, ncols), name="hole_table_plan", block_cols=len(header)
@@ -932,7 +934,10 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             if table is not None:
                 table_ncols = ncols
                 break
-        ctx.drop_issues("table_dropped")
+        # ``add_table`` records one diagnostic for every rejected wrapping attempt.
+        # Restore the exact pre-attempt issue inventory instead of clearing every
+        # table_dropped finding: an unrelated failed public table remains actionable.
+        dwg.registry.restore_issues(table_issue_base)
         if table is None:
             # Even wrapped it will not fit — restore the callouts/dims and keep the
             # drop lint, so the sheet is never left with neither. The pattern
@@ -1262,23 +1267,13 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             ),
         )
 
-    # Clear `callout_dropped` only when EVERY dropped plan-view callout is now
-    # documented — one unified check across both remedies (the scattered table and the
-    # pattern balloons), so neither hides the other. A plan-view callout escalation is
-    # resolved iff:
-    #   - it is a pattern whose balloon actually LANDED on the sheet (a crowded band
-    #     can drop the tail — _place_band's strip-solver prefix fallback — leaving the
-    #     pattern undocumented), or
-    #   - it is a scattered hole whose row is fully keyed by landed balloons.
+    # Clear `callout_dropped` only when the complete dropped callout is now documented
+    # by a successfully keyed scattered-hole table row.  A grouped pattern marker such
+    # as ``6×A`` has no defining table row and therefore remains deliberately
+    # non-certifying: it may provide the ADR-0009 visual grouping cue, but the original
+    # callout drop and its physical-requirement outcomes must remain actionable.
     # A drop this resolver does not cover — a table that didn't fit, a balloon that
     # didn't land, or any callout dropped in a non-plan view — leaves the lint standing.
-    resolved_feats = {
-        feat
-        for (full_tag, _, _), feat in zip(pattern_specs, pattern_feats, strict=True)
-        if (name := f"balloon_plan_{full_tag}_0") in placed_names
-        and dwg.registry.feature_of(name) == feat
-    }
-
     callout_escalations = [e for e in escalations if e.kind == "callout"]
     available_issues = [issue for issue in ctx.registry.issues if issue.code == "callout_dropped"]
     resolved_issue_ids = set()
@@ -1295,8 +1290,6 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
         if escalation.view != "plan":
             continue
         if isinstance(escalation.feature, PatternFeature):
-            if escalation.feature in resolved_feats:
-                resolved_issue_ids.add(id(issue))
             continue
         issue_features = {
             getattr(measurement, "feature", None) for measurement in issue.measurement_ids

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -703,9 +703,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     """Run hole-table escalation as one exception-atomic annotation transaction.
 
-    Ordinary fit/balloon failures are handled by the implementation's selective
-    fallback policy. An exception is different: none of the attempted table state,
-    including semantic markers applied to restored leader objects, may survive it.
+    Ordinary fit/balloon failures roll the shared table transaction back as a unit.
+    An exception additionally restores the outer snapshot before re-raising, so none
+    of the attempted table state or temporary semantic markers may survive it.
     """
     if not any(escalation.kind in {"callout", "location"} for escalation in ctx.escalations):
         return

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -956,7 +956,7 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
     placed_names: set = set()
     balloon_issue_base = dwg.registry.issues
 
-    def _place_balloon_attempt(specs, *, perimeter):
+    def _place_balloon_attempt(specs, *, perimeter, required_count=0):
         nonlocal placed_names
         attempted = {f"balloon_plan_{tag}_{member_index}" for tag, member_index, _ in specs}
         dwg.registry.restore_issues(balloon_issue_base)
@@ -973,6 +973,7 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             # attempts have no table, but must still fail closed against retained labels
             # before their landed name/owner may clear a callout drop.
             avoid_annotation_labels=True,
+            required_count=required_count,
         )
         placed_names = {
             name
@@ -989,7 +990,11 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
         # balloon request: spread its tags around the usable perimeter so a
         # deep occupied strip cannot collapse the ring onto two near sides
         # (#901). Pattern-only and public-verb balloons keep nearest-band cost.
-        _place_balloon_attempt(balloon_specs, perimeter=table_placed)
+        _place_balloon_attempt(
+            balloon_specs,
+            perimeter=table_placed,
+            required_count=len(scattered_specs),
+        )
 
     # Commit the shared table replacement only after every balloon that maps its
     # visible rows back to physical holes has landed (#1144).

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -42,6 +42,7 @@ from draftwright.annotations._common import (
     _hole_location_coverage_fact,
     _hole_table_replaceable_annotation,
     _hole_table_replaceable_feature,
+    _hole_table_replaceable_location_annotation,
     _register_hole_table_coverage,
     _restore_annotation_transaction,
     _restore_stashed_annotations,
@@ -813,8 +814,9 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
     table_ncols = None
     table_features: tuple = ()
     replacement_features: set = set()
-    replaceable_table_features: set = set()
-    table_replacement_features: set = set()
+    replaceable_callout_features: set = set()
+    table_callout_replacement_features: set = set()
+    table_location_replacement_features: set = set()
     replaced = {}
     table_transaction_snap = None
 
@@ -861,7 +863,7 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             feature = resolve_feature(location.ref)
             if getattr(feature, "kind", None) == "hole":
                 compiled_dimensions_by_feature.setdefault(feature, []).append(location)
-        replaceable_table_features = {
+        replaceable_callout_features = {
             hole.feature
             for hole in holes
             if _hole_table_replaceable_feature(
@@ -911,9 +913,14 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
                 n
                 for n, annotation in list(dwg.iter_annotations())
                 if ctx.coverage.is_scattered_hole_doc(n)
-                and _hole_table_replaceable_annotation(dwg.registry, n, annotation)
-                and _annotation_hole_features(dwg.registry, n, annotation)
-                <= replaceable_table_features
+                and (
+                    _hole_table_replaceable_location_annotation(dwg.registry, n, annotation)
+                    or (
+                        _hole_table_replaceable_annotation(dwg.registry, n, annotation)
+                        and _annotation_hole_features(dwg.registry, n, annotation)
+                        <= replaceable_callout_features
+                    )
+                )
             ],
         )
 
@@ -954,7 +961,15 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
         dwg.registry.restore_issues(balloon_issue_base)
         _discard_attempt_annotations(dwg, attempted)
         previous_objects = {name: dwg.registry.named(name) for name in attempted}
-        render_balloons(dwg, a, "plan", specs, ctx, perimeter=perimeter)
+        render_balloons(
+            dwg,
+            a,
+            "plan",
+            specs,
+            ctx,
+            perimeter=perimeter,
+            avoid_annotation_labels=table_placed,
+        )
         placed_names = {
             name
             for name, previous in previous_objects.items()
@@ -1118,31 +1133,95 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             if int(feature.count or len(feature.members) or 1) > 1
             and "bore.diameter" in approved_hole_dimensions.get(feature, {})
         )
-        escalated_replacement_features = {
+        stashed_callout_features = {
+            feature
+            for record in replaced.values()
+            if any(
+                isinstance(parameter := getattr(measurement, "parameter", None), str)
+                and parameter.startswith("bore.")
+                for measurement in record.identity.get("measurement", ())
+            )
+            for feature in record.features
+        }
+        stashed_location_features = {
+            feature
+            for record in replaced.values()
+            if any(
+                isinstance(parameter := getattr(measurement, "parameter", None), str)
+                and parameter.startswith("location")
+                for measurement in record.identity.get("measurement", ())
+            )
+            for feature in record.features
+        }
+        escalated_callout_features = {
             escalation.feature
             for escalation in escalations
-            if escalation.kind in {"callout", "location"}
+            if escalation.kind == "callout"
             and escalation.view == "plan"
-            and escalation.feature in replaceable_table_features
+            and escalation.feature in replaceable_callout_features
         }
-        dropped_replacement_features = {
+        escalated_location_features = {
+            escalation.feature
+            for escalation in escalations
+            if escalation.kind == "location"
+            and escalation.view == "plan"
+            and escalation.feature in table_features
+        }
+        dropped_callout_features = {
             feature
             for issue in ctx.registry.issues
-            if issue.code in {"callout_dropped", "location_ref_dropped"}
+            if issue.code == "callout_dropped"
             for feature in (
                 *(getattr(measurement, "feature", None) for measurement in issue.measurement_ids),
                 *(requirement[0] for requirement in issue.hole_requirement_ids),
             )
-            if feature in replaceable_table_features
+            if feature in replaceable_callout_features
         }
-        table_replacement_features = (
-            table_success_features
-            & (
-                replacement_features
-                | escalated_replacement_features
-                | dropped_replacement_features
+        dropped_location_features = {
+            feature
+            for issue in ctx.registry.issues
+            if issue.code == "location_ref_dropped"
+            for feature in (
+                *(getattr(measurement, "feature", None) for measurement in issue.measurement_ids),
+                *(requirement[0] for requirement in issue.hole_requirement_ids),
             )
+            if feature in table_features
+        }
+        table_callout_replacement_features = (
+            table_success_features
+            & (stashed_callout_features | escalated_callout_features | dropped_callout_features)
             - restored_features
+        )
+        table_location_replacement_features = (
+            table_success_features
+            & (stashed_location_features | escalated_location_features | dropped_location_features)
+            - restored_features
+        )
+        representation_requirements = tuple(
+            dict.fromkeys(
+                [
+                    (measurement.feature, measurement.parameter)
+                    for measurement in table_measurements
+                    if (
+                        measurement.parameter.startswith("location")
+                        and measurement.feature in table_location_replacement_features
+                    )
+                    or (
+                        not measurement.parameter.startswith("location")
+                        and measurement.feature in table_callout_replacement_features
+                    )
+                ]
+                + [
+                    (feature, parameter)
+                    for feature, parameter, _point in table_locations
+                    if feature in table_location_replacement_features
+                ]
+                + [
+                    (feature, parameter)
+                    for feature, parameter, _count in table_requirements
+                    if feature in table_callout_replacement_features
+                ]
+            )
         )
         _register_hole_table_coverage(
             table,
@@ -1152,7 +1231,7 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             locations=table_locations,
             requirements=table_requirements,
             representation_reason="required_balloons_placed",
-            representation_features=table_replacement_features,
+            representation_requirements=representation_requirements,
         )
 
         # Resolve only drops whose complete semantic requirement set belongs to the
@@ -1162,7 +1241,7 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             lambda issue: (
                 bool(issue.hole_requirement_ids)
                 and all(
-                    requirement[0] in table_replacement_features
+                    requirement[0] in table_location_replacement_features
                     for requirement in issue.hole_requirement_ids
                 )
             ),
@@ -1208,6 +1287,6 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             getattr(measurement, "feature", None) for measurement in issue.measurement_ids
         }
         issue_features.discard(None)
-        if issue_features and issue_features <= table_replacement_features:
+        if issue_features and issue_features <= table_callout_replacement_features:
             resolved_issue_ids.add(id(issue))
     ctx.drop_issues_where("callout_dropped", lambda issue: id(issue) in resolved_issue_ids)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -36,10 +36,12 @@ from draftwright._core import (
 from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import (
     PlacementContext,
+    _annotation_hole_features,
     _discard_attempt_annotations,
     _fully_ballooned_features,
     _hole_location_coverage_fact,
     _hole_table_replaceable_annotation,
+    _hole_table_replaceable_feature,
     _register_hole_table_coverage,
     _restore_stashed_annotations,
     _stash_annotations,
@@ -791,6 +793,9 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     table = None
     table_ncols = None
     table_features: tuple = ()
+    replacement_features: set = set()
+    replaceable_table_features: set = set()
+    table_replacement_features: set = set()
     replaced = {}
     if tabulate_scattered:
         compiled = plan if plan is not None else compile_dimensions(_model)
@@ -799,6 +804,20 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
                 dimension.parameter_id: dimension for dimension in group.dims
             }
             for group in compiled.of_kind("hole")
+        }
+        compiled_dimensions_by_feature: dict[object, list] = {
+            resolve_feature(group.ref): list(group.dims) for group in compiled.of_kind("hole")
+        }
+        for location in compiled.locations:
+            feature = resolve_feature(location.ref)
+            if getattr(feature, "kind", None) == "hole":
+                compiled_dimensions_by_feature.setdefault(feature, []).append(location)
+        replaceable_table_features = {
+            hole.feature
+            for hole in holes
+            if _hole_table_replaceable_feature(
+                hole.feature, compiled_dimensions_by_feature.get(hole.feature, ())
+            )
         }
         approved_locations = {
             (resolve_feature(location.ref), tuple(location.span[1]), location.discriminator): (
@@ -843,6 +862,8 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
                 for n, annotation in list(dwg.iter_annotations())
                 if ctx.coverage.is_scattered_hole_doc(n)
                 and _hole_table_replaceable_annotation(dwg.registry, n, annotation)
+                and _annotation_hole_features(dwg.registry, n, annotation)
+                <= replaceable_table_features
             ],
         )
 
@@ -1000,6 +1021,26 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             if int(feature.count or len(feature.members) or 1) > 1
             and "bore.diameter" in approved_hole_dimensions.get(feature, {})
         )
+        escalated_replacement_features = {
+            escalation.feature
+            for escalation in escalations
+            if escalation.kind in {"callout", "location"}
+            and escalation.view == "plan"
+            and escalation.feature in replaceable_table_features
+        }
+        dropped_replacement_features = {
+            feature
+            for issue in ctx.registry.issues
+            if issue.code in {"callout_dropped", "location_ref_dropped"}
+            for feature in (
+                *(getattr(measurement, "feature", None) for measurement in issue.measurement_ids),
+                *(requirement[0] for requirement in issue.hole_requirement_ids),
+            )
+            if feature in replaceable_table_features
+        }
+        table_replacement_features = table_success_features & (
+            replacement_features | escalated_replacement_features | dropped_replacement_features
+        )
         _register_hole_table_coverage(
             table,
             dwg.registry,
@@ -1008,6 +1049,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             locations=table_locations,
             requirements=table_requirements,
             representation_reason="required_balloons_placed",
+            representation_features=table_replacement_features,
         )
 
         # Resolve only drops whose complete semantic requirement set belongs to the
@@ -1017,7 +1059,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             lambda issue: (
                 bool(issue.hole_requirement_ids)
                 and all(
-                    requirement[0] in table_success_features
+                    requirement[0] in table_replacement_features
                     for requirement in issue.hole_requirement_ids
                 )
             ),
@@ -1036,7 +1078,8 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     resolved_feats = {
         feat
         for (full_tag, _, _), feat in zip(pattern_specs, pattern_feats, strict=True)
-        if f"balloon_plan_{full_tag}_0" in placed_names
+        if (name := f"balloon_plan_{full_tag}_0") in placed_names
+        and dwg.registry.feature_of(name) == feat
     }
 
     callout_escalations = [e for e in escalations if e.kind == "callout"]
@@ -1062,6 +1105,6 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             getattr(measurement, "feature", None) for measurement in issue.measurement_ids
         }
         issue_features.discard(None)
-        if issue_features and issue_features <= table_success_features:
+        if issue_features and issue_features <= table_replacement_features:
             resolved_issue_ids.add(id(issue))
     ctx.drop_issues_where("callout_dropped", lambda issue: id(issue) in resolved_issue_ids)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -701,6 +701,23 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 
 
 def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
+    """Run hole-table escalation as one exception-atomic annotation transaction.
+
+    Ordinary fit/balloon failures are handled by the implementation's selective
+    fallback policy. An exception is different: none of the attempted table state,
+    including semantic markers applied to restored leader objects, may survive it.
+    """
+    if not any(escalation.kind in {"callout", "location"} for escalation in ctx.escalations):
+        return
+    snapshot = _snapshot_annotation_transaction(dwg, ctx.coverage)
+    try:
+        return _maybe_tabulate_holes_impl(dwg, a, ctx=ctx, plan=plan)
+    except BaseException:
+        _restore_annotation_transaction(dwg, ctx.coverage, snapshot, {})
+        raise
+
+
+def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
     """Escalate to a per-instance hole table + balloons when the plan view is too
     dense to dimension every hole individually (#93); a dropped ISO pattern
     callout gets one grouped balloon of its own (#351 PR-3, ADR 0009 Amdt 1
@@ -800,6 +817,35 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     table_replacement_features: set = set()
     replaced = {}
     table_transaction_snap = None
+
+    # Automatic/finalize escalation uses deterministic internal names. A sanctioned
+    # public edit may already own one of them; replacing that object would destroy user
+    # state and a pre-existing name is not evidence from this placement attempt. Fail
+    # closed before stashing anything. A later naming-policy change can allocate a fresh
+    # namespace here without weakening the attempt-local ownership contract.
+    reserved_attempt_names = {f"balloon_plan_{tag}_0" for tag in scattered_tags} | {
+        f"balloon_plan_{feature.count}×{tag}_0"
+        for tag, feature in zip(pattern_tags, pattern_feats, strict=True)
+    }
+    if tabulate_scattered:
+        reserved_attempt_names.add("hole_table_plan")
+    colliding_names = reserved_attempt_names.intersection(dwg.registry.names())
+    if colliding_names:
+        names = ", ".join(sorted(colliding_names))
+        if tabulate_scattered:
+            ctx.record_issue(
+                "warning",
+                "table_dropped",
+                f"hole table reserved annotation name(s) already exist: {names}",
+            )
+        else:
+            ctx.record_issue(
+                "warning",
+                "balloon_dropped",
+                f"hole balloon reserved annotation name(s) already exist: {names}",
+            )
+        return
+
     if tabulate_scattered:
         compiled = plan if plan is not None else compile_dimensions(_model)
         approved_hole_dimensions = {

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -1082,6 +1082,18 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             } & placed_names
             placed_names -= _discard_attempt_annotations(dwg, incomplete_names)
 
+            unkeyed_features = set(table_features) - table_success_features
+            if unkeyed_features and not any(
+                issue.code == "balloon_dropped"
+                for issue in dwg.registry.issues[len(balloon_issue_base) :]
+            ):
+                ctx.record_issue(
+                    "warning",
+                    "balloon_dropped",
+                    f"{len(unkeyed_features)} hole-table row(s) lack required "
+                    "feature-owned balloons",
+                )
+
     if table_placed and table is not None:
         ordered_table_success_features = tuple(
             feature for feature in table_features if feature in table_success_features

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -45,7 +45,6 @@ from draftwright.annotations._common import (
     _hole_table_replaceable_location_annotation,
     _register_hole_table_coverage,
     _restore_annotation_transaction,
-    _restore_stashed_annotations,
     _snapshot_annotation_transaction,
     _stash_annotations,
 )
@@ -812,9 +811,7 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
     scattered_specs: list = []
     table_placed = False
     table = None
-    table_ncols = None
     table_features: tuple = ()
-    replacement_features: set = set()
     replaceable_callout_features: set = set()
     table_callout_replacement_features: set = set()
     table_location_replacement_features: set = set()
@@ -932,7 +929,6 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
                 _wrap_rows(header, data, ncols), name="hole_table_plan", block_cols=len(header)
             )
             if table is not None:
-                table_ncols = ncols
                 break
         # ``add_table`` records one diagnostic for every rejected wrapping attempt.
         # Restore the exact pre-attempt issue inventory instead of clearing every
@@ -995,10 +991,8 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
         # (#901). Pattern-only and public-verb balloons keep nearest-band cost.
         _place_balloon_attempt(balloon_specs, perimeter=table_placed)
 
-    # Commit table replacement per semantic feature only after every balloon that maps
-    # its visible row(s) back to physical holes has landed. A partially placed ring leaves
-    # the table itself as useful evidence for successful rows, while unresolved features
-    # get their original annotations back as the transactional fallback (#1144).
+    # Commit the shared table replacement only after every balloon that maps its
+    # visible rows back to physical holes has landed (#1144).
     table_success_features: set = set()
     if table_placed and table is not None:
         table_tagged_holes = [
@@ -1014,93 +1008,41 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             dwg.registry,
             expected_counts,
         )
-        replacement_features = {
-            feature for record in replaced.values() for feature in record.features
-        }
-        restored_features: set = set()
-        unresolved_replacements = replacement_features - table_success_features
-        while unresolved_replacements:
-            restored_features |= unresolved_replacements
-            # The first fit legitimately used the fallbacks' freed footprints. Restore
-            # the unresolved subset, then solve the table again against those real
-            # obstacles. Then solve the complete balloon inventory again: retaining
-            # balloons from the first, fallback-free solve could cross a restored label.
-            _discard_attempt_annotations(dwg, {"hole_table_plan"})
-            _restore_stashed_annotations(
+        # A hole table is one shared visual/index artifact. If even one visible
+        # row lacks its required feature-owned balloon, keeping a partial table
+        # creates a drawing-level object that cannot participate honestly in
+        # per-feature fallback placement—and outer compose-then-pack may later
+        # move a view into that orphan footprint. Fail the shared transaction
+        # closed: restore every feature-backed fallback and discard every table
+        # balloon. This still satisfies partial-result semantics because no
+        # uncovered requirement is suppressed; the complete original inventory
+        # wins as a unit.
+        if table_success_features != set(table_features):
+            assert table_transaction_snap is not None
+            _restore_annotation_transaction(
                 dwg,
-                ctx,
+                ctx.coverage,
+                table_transaction_snap,
                 replaced,
-                features=unresolved_replacements,
                 reason="required_balloon_not_placed",
             )
-            assert table_ncols is not None
-            table = dwg.add_table(
-                _wrap_rows(header, data, table_ncols),
-                name="hole_table_plan",
-                block_cols=len(header),
+            ctx.record_issue(
+                "warning",
+                "table_dropped",
+                "hole table lacked complete feature-owned balloon evidence",
             )
-            if table is None:
-                assert table_transaction_snap is not None
-                had_balloon_drop = any(
-                    issue.code == "balloon_dropped"
-                    for issue in dwg.registry.issues[len(balloon_issue_base) :]
-                )
-                _restore_annotation_transaction(
-                    dwg,
-                    ctx.coverage,
-                    table_transaction_snap,
-                    replaced,
-                    reason="required_balloon_not_placed",
-                )
-                ctx.record_issue(
-                    "warning",
-                    "table_dropped",
-                    "hole table could not fit with its fallback callouts",
-                )
-                if had_balloon_drop:
-                    ctx.record_issue(
-                        "warning",
-                        "balloon_dropped",
-                        "one or more required hole-table balloons could not be placed",
-                    )
-                table_placed = False
-                table_success_features = set()
-                if pattern_specs:
-                    balloon_issue_base = dwg.registry.issues
-                    _place_balloon_attempt(pattern_specs, perimeter=False)
-                break
-
-            _place_balloon_attempt(balloon_specs, perimeter=True)
-            table_success_features = _fully_ballooned_features(
-                "plan",
-                table_tagged_holes,
-                placed_names,
-                dwg.registry,
-                expected_counts,
+            ctx.record_issue(
+                "warning",
+                "balloon_dropped",
+                "one or more required hole-table balloons could not be placed",
             )
-            unresolved_replacements = (
-                replacement_features - restored_features - table_success_features
-            )
-
-        if table_placed and table is not None:
-            incomplete_names = {
-                f"balloon_plan_{tag}_0"
-                for tag, hole in zip(scattered_tags, holes, strict=True)
-                if hole.feature not in table_success_features
-            } & placed_names
-            placed_names -= _discard_attempt_annotations(dwg, incomplete_names)
-
-            unkeyed_features = set(table_features) - table_success_features
-            if unkeyed_features and not any(
-                issue.code == "balloon_dropped"
-                for issue in dwg.registry.issues[len(balloon_issue_base) :]
-            ):
-                ctx.record_issue(
-                    "warning",
-                    "balloon_dropped",
-                    f"{len(unkeyed_features)} hole-table row(s) lack required "
-                    "feature-owned balloons",
-                )
+            table_placed = False
+            table = None
+            table_success_features = set()
+            placed_names = set()
+            if pattern_specs:
+                balloon_issue_base = dwg.registry.issues
+                _place_balloon_attempt(pattern_specs, perimeter=False)
 
     if table_placed and table is not None:
         ordered_table_success_features = tuple(
@@ -1207,15 +1149,11 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             )
             if feature in table_features
         }
-        table_callout_replacement_features = (
-            table_success_features
-            & (stashed_callout_features | escalated_callout_features | dropped_callout_features)
-            - restored_features
+        table_callout_replacement_features = table_success_features & (
+            stashed_callout_features | escalated_callout_features | dropped_callout_features
         )
-        table_location_replacement_features = (
-            table_success_features
-            & (stashed_location_features | escalated_location_features | dropped_location_features)
-            - restored_features
+        table_location_replacement_features = table_success_features & (
+            stashed_location_features | escalated_location_features | dropped_location_features
         )
         representation_requirements = tuple(
             dict.fromkeys(

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -968,7 +968,10 @@ def _maybe_tabulate_holes_impl(dwg, a: Analysis, *, ctx, plan=None):
             specs,
             ctx,
             perimeter=perimeter,
-            avoid_annotation_labels=table_placed,
+            # Every automatic escalation balloon is replacement evidence. Pattern-only
+            # attempts have no table, but must still fail closed against retained labels
+            # before their landed name/owner may clear a callout drop.
+            avoid_annotation_labels=True,
         )
         placed_names = {
             name

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -36,8 +36,12 @@ from draftwright._core import (
 from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import (
     PlacementContext,
+    _discard_incomplete_feature_balloons,
+    _fully_ballooned_features,
     _hole_location_coverage_fact,
     _register_hole_table_coverage,
+    _restore_stashed_annotations,
+    _stash_annotations,
 )
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.from_model import (
@@ -783,6 +787,9 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
 
     scattered_specs: list = []
     table_placed = False
+    table = None
+    table_features: tuple = ()
+    replaced = {}
     if tabulate_scattered:
         compiled = plan if plan is not None else compile_dimensions(_model)
         approved_hole_dimensions = {
@@ -827,18 +834,16 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
         # Structured coverage state (registered at placement time, #351 PR-4c), not
         # an annotation-name-prefix grep — the last stringly-typed inference this
         # resolver relied on (ADR 0009 Amdt 1).
-        replaced = {
-            n: o for n, o in list(dwg.iter_annotations()) if ctx.coverage.is_scattered_hole_doc(n)
-        }
-        # Identity as a UNIT (#1002). This captured the view alone, so a restored dim came
-        # back stripped of the feature provenance added in #398 and of the measurement id
-        # added here — the audit would then read it as "nothing claims it" (Codex r2).
-        replaced_identity = {n: dwg.registry.identity_of(n) for n in replaced}
-        for n in replaced:
-            dwg.remove(n)
+        replaced = _stash_annotations(
+            dwg,
+            [
+                n
+                for n, _annotation in list(dwg.iter_annotations())
+                if ctx.coverage.is_scattered_hole_doc(n)
+            ],
+        )
 
         # Widen the chart into more column-blocks until it fits the page.
-        table = None
         for ncols in (1, 2, 3, 4):
             table = dwg.add_table(
                 _wrap_rows(header, data, ncols), name="hole_table_plan", block_cols=len(header)
@@ -850,89 +855,12 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             # Even wrapped it will not fit — restore the callouts/dims and keep the
             # drop lint, so the sheet is never left with neither. The pattern
             # balloons below are unaffected — nothing of theirs was removed.
-            for n, obj in replaced.items():
-                ctx.place(obj, n)
-                dwg.registry.reapply(n, replaced_identity[n])
+            _restore_stashed_annotations(dwg, ctx, replaced, reason="table_not_placed")
             ctx.record_issue("warning", "table_dropped", "hole table did not fit the sheet")
         else:
-            # One entry per hole (with repeats) so the coverage *count* check sees
-            # that the table documents every instance, not just each distinct
-            # diameter.
-            table.covers_diameters = tuple(
-                h.diameter
-                for h in holes
-                if "bore.diameter" in approved_hole_dimensions.get(h.feature, {})
-            )
             table_features = tuple(dict.fromkeys(h.feature for h in holes))
-            table_measurements = tuple(
-                dict.fromkeys(
-                    [
-                        dim.id
-                        for group in compiled.of_kind("hole")
-                        if resolve_feature(group.ref) in table_features
-                        for dim in group.dims
-                        if dim.id is not None
-                        and dim.parameter_id in {"bore.diameter", "bore.depth"}
-                    ]
-                    + [
-                        location.id
-                        for location in compiled.locations
-                        if location.id is not None
-                        and resolve_feature(location.ref) in table_features
-                    ]
-                )
-            )
-            table_locations = tuple(
-                _hole_location_coverage_fact(location)
-                for location in compiled.locations
-                if location.id is not None
-                and location.span is not None
-                and resolve_feature(location.ref) in table_features
-            )
-            table_requirements = tuple(
-                (feature, "bore.through", 1)
-                for feature in table_features
-                if feature.through and "bore.diameter" in approved_hole_dimensions.get(feature, {})
-            ) + tuple(
-                (
-                    feature,
-                    "grouping.count",
-                    int(feature.count or len(feature.members) or 1),
-                )
-                for feature in table_features
-                if int(feature.count or len(feature.members) or 1) > 1
-                and "bore.diameter" in approved_hole_dimensions.get(feature, {})
-            )
-            _register_hole_table_coverage(
-                table,
-                dwg.registry,
-                "hole_table_plan",
-                measurements=table_measurements,
-                locations=table_locations,
-                requirements=table_requirements,
-            )
             scattered_specs = [(tag, 0, h) for tag, h in zip(scattered_tags, holes, strict=True)]
             table_placed = True
-            # The table's X/Y columns document every scattered hole's location, so only
-            # drop findings whose complete semantic requirement set belongs to those
-            # table features are resolved here. A pattern or other non-table requirement
-            # may share the same layout pass and must keep its observed drop provenance.
-            # `callout_dropped`, however, is cleared
-            # below — only after the balloons are placed and per feature — because a
-            # pattern balloon sharing this resolver's combined band can still drop
-            # (review follow-up: this used to clear callout_dropped wholesale here,
-            # masking a dropped pattern balloon).
-            table_feature_set = set(table_features)
-            ctx.drop_issues_where(
-                "location_ref_dropped",
-                lambda issue: (
-                    bool(issue.hole_requirement_ids)
-                    and all(
-                        requirement[0] in table_feature_set
-                        for requirement in issue.hole_requirement_ids
-                    )
-                ),
-            )
 
     balloon_specs = scattered_specs + pattern_specs
     placed_names: set = set()
@@ -948,6 +876,112 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
         render_balloons(dwg, a, "plan", balloon_specs, ctx, perimeter=table_placed)
         placed_names = {n for n, _ in dwg.iter_annotations()}
 
+    # Commit table replacement per semantic feature only after every balloon that maps
+    # its visible row(s) back to physical holes has landed. A partially placed ring leaves
+    # the table itself as useful evidence for successful rows, while unresolved features
+    # get their original annotations back as the transactional fallback (#1144).
+    table_success_features: set = set()
+    if table_placed and table is not None:
+        table_success_features = _fully_ballooned_features(
+            "plan",
+            [
+                (tag, 0, hole, hole.feature)
+                for tag, hole in zip(scattered_tags, holes, strict=True)
+            ],
+            placed_names,
+        )
+        removed_partial_balloons = _discard_incomplete_feature_balloons(
+            dwg,
+            "plan",
+            [
+                (tag, 0, hole, hole.feature)
+                for tag, hole in zip(scattered_tags, holes, strict=True)
+            ],
+            table_success_features,
+        )
+        placed_names -= removed_partial_balloons
+        ordered_table_success_features = tuple(
+            feature for feature in table_features if feature in table_success_features
+        )
+        unresolved_table_features = set(table_features) - table_success_features
+        if unresolved_table_features:
+            _restore_stashed_annotations(
+                dwg,
+                ctx,
+                replaced,
+                features=unresolved_table_features,
+                reason="required_balloon_not_placed",
+            )
+
+        # One entry per successfully keyed hole (with repeats) so the legacy count check
+        # and the semantic ledger agree about the exact committed subset.
+        table.covers_diameters = tuple(
+            h.diameter
+            for h in holes
+            if h.feature in table_success_features
+            and "bore.diameter" in approved_hole_dimensions.get(h.feature, {})
+        )
+        table_measurements = tuple(
+            dict.fromkeys(
+                [
+                    dim.id
+                    for group in compiled.of_kind("hole")
+                    if resolve_feature(group.ref) in table_success_features
+                    for dim in group.dims
+                    if dim.id is not None and dim.parameter_id in {"bore.diameter", "bore.depth"}
+                ]
+                + [
+                    location.id
+                    for location in compiled.locations
+                    if location.id is not None
+                    and resolve_feature(location.ref) in table_success_features
+                ]
+            )
+        )
+        table_locations = tuple(
+            _hole_location_coverage_fact(location)
+            for location in compiled.locations
+            if location.id is not None
+            and location.span is not None
+            and resolve_feature(location.ref) in table_success_features
+        )
+        table_requirements = tuple(
+            (feature, "bore.through", 1)
+            for feature in ordered_table_success_features
+            if feature.through and "bore.diameter" in approved_hole_dimensions.get(feature, {})
+        ) + tuple(
+            (
+                feature,
+                "grouping.count",
+                int(feature.count or len(feature.members) or 1),
+            )
+            for feature in ordered_table_success_features
+            if int(feature.count or len(feature.members) or 1) > 1
+            and "bore.diameter" in approved_hole_dimensions.get(feature, {})
+        )
+        _register_hole_table_coverage(
+            table,
+            dwg.registry,
+            "hole_table_plan",
+            measurements=table_measurements,
+            locations=table_locations,
+            requirements=table_requirements,
+            representation_reason="required_balloons_placed",
+        )
+
+        # Resolve only drops whose complete semantic requirement set belongs to the
+        # successfully keyed subset. Unrelated or partially covered failures remain honest.
+        ctx.drop_issues_where(
+            "location_ref_dropped",
+            lambda issue: (
+                bool(issue.hole_requirement_ids)
+                and all(
+                    requirement[0] in table_success_features
+                    for requirement in issue.hole_requirement_ids
+                )
+            ),
+        )
+
     # Clear `callout_dropped` only when EVERY dropped plan-view callout is now
     # documented — one unified check across both remedies (the scattered table and the
     # pattern balloons), so neither hides the other. A plan-view callout escalation is
@@ -955,7 +989,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     #   - it is a pattern whose balloon actually LANDED on the sheet (a crowded band
     #     can drop the tail — _place_band's strip-solver prefix fallback — leaving the
     #     pattern undocumented), or
-    #   - it is a scattered hole and the table was placed (its X/Y row documents it).
+    #   - it is a scattered hole whose row is fully keyed by landed balloons.
     # A drop this resolver does not cover — a table that didn't fit, a balloon that
     # didn't land, or any callout dropped in a non-plan view — leaves the lint standing.
     resolved_feats = {
@@ -964,13 +998,29 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
         if f"balloon_plan_{full_tag}_0" in placed_names
     }
 
-    def _resolved(e) -> bool:
-        if e.view != "plan":
-            return False
-        if isinstance(e.feature, PatternFeature):
-            return e.feature in resolved_feats
-        return table_placed  # a scattered plan-hole callout is documented by the table
-
-    unresolved = [e for e in escalations if e.kind == "callout" and not _resolved(e)]
-    if not unresolved:
-        ctx.drop_issues("callout_dropped")
+    callout_escalations = [e for e in escalations if e.kind == "callout"]
+    available_issues = [issue for issue in ctx.registry.issues if issue.code == "callout_dropped"]
+    resolved_issue_ids = set()
+    for escalation in callout_escalations:
+        candidates = [
+            issue
+            for issue in available_issues
+            if tuple(issue.measurement_ids) == tuple(escalation.targets)
+        ]
+        if len(candidates) != 1:
+            continue  # ambiguous producer correspondence fails closed
+        issue = candidates[0]
+        available_issues = [candidate for candidate in available_issues if candidate is not issue]
+        if escalation.view != "plan":
+            continue
+        if isinstance(escalation.feature, PatternFeature):
+            if escalation.feature in resolved_feats:
+                resolved_issue_ids.add(id(issue))
+            continue
+        issue_features = {
+            getattr(measurement, "feature", None) for measurement in issue.measurement_ids
+        }
+        issue_features.discard(None)
+        if issue_features and issue_features <= table_success_features:
+            resolved_issue_ids.add(id(issue))
+    ctx.drop_issues_where("callout_dropped", lambda issue: id(issue) in resolved_issue_ids)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -36,9 +36,10 @@ from draftwright._core import (
 from draftwright.analysis import _sizing_bores
 from draftwright.annotations._common import (
     PlacementContext,
-    _discard_incomplete_feature_balloons,
+    _discard_attempt_annotations,
     _fully_ballooned_features,
     _hole_location_coverage_fact,
+    _hole_table_replaceable_annotation,
     _register_hole_table_coverage,
     _restore_stashed_annotations,
     _stash_annotations,
@@ -788,6 +789,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     scattered_specs: list = []
     table_placed = False
     table = None
+    table_ncols = None
     table_features: tuple = ()
     replaced = {}
     if tabulate_scattered:
@@ -838,8 +840,9 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             dwg,
             [
                 n
-                for n, _annotation in list(dwg.iter_annotations())
+                for n, annotation in list(dwg.iter_annotations())
                 if ctx.coverage.is_scattered_hole_doc(n)
+                and _hole_table_replaceable_annotation(dwg.registry, n, annotation)
             ],
         )
 
@@ -849,6 +852,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
                 _wrap_rows(header, data, ncols), name="hole_table_plan", block_cols=len(header)
             )
             if table is not None:
+                table_ncols = ncols
                 break
         ctx.drop_issues("table_dropped")
         if table is None:
@@ -873,8 +877,16 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
         # balloon request: spread its tags around the usable perimeter so a
         # deep occupied strip cannot collapse the ring onto two near sides
         # (#901). Pattern-only and public-verb balloons keep nearest-band cost.
+        attempted_names = {
+            f"balloon_plan_{tag}_{member_index}" for tag, member_index, _hole in balloon_specs
+        }
+        previous_objects = {name: dwg.registry.named(name) for name in attempted_names}
         render_balloons(dwg, a, "plan", balloon_specs, ctx, perimeter=table_placed)
-        placed_names = {n for n, _ in dwg.iter_annotations()}
+        placed_names = {
+            name
+            for name, previous in previous_objects.items()
+            if dwg.registry.named(name) is not None and dwg.registry.named(name) is not previous
+        }
 
     # Commit table replacement per semantic feature only after every balloon that maps
     # its visible row(s) back to physical holes has landed. A partially placed ring leaves
@@ -882,36 +894,65 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     # get their original annotations back as the transactional fallback (#1144).
     table_success_features: set = set()
     if table_placed and table is not None:
+        table_tagged_holes = [
+            (tag, 0, hole, hole.feature) for tag, hole in zip(scattered_tags, holes, strict=True)
+        ]
+        expected_counts = {
+            feature: int(feature.count or len(feature.members) or 1) for feature in table_features
+        }
         table_success_features = _fully_ballooned_features(
             "plan",
-            [
-                (tag, 0, hole, hole.feature)
-                for tag, hole in zip(scattered_tags, holes, strict=True)
-            ],
+            table_tagged_holes,
             placed_names,
+            dwg.registry,
+            expected_counts,
         )
-        removed_partial_balloons = _discard_incomplete_feature_balloons(
-            dwg,
-            "plan",
-            [
-                (tag, 0, hole, hole.feature)
-                for tag, hole in zip(scattered_tags, holes, strict=True)
-            ],
-            table_success_features,
-        )
-        placed_names -= removed_partial_balloons
-        ordered_table_success_features = tuple(
-            feature for feature in table_features if feature in table_success_features
-        )
-        unresolved_table_features = set(table_features) - table_success_features
-        if unresolved_table_features:
+        replacement_features = {
+            feature for record in replaced.values() for feature in record.features
+        }
+        unresolved_replacements = replacement_features - table_success_features
+        scattered_attempt_names = {
+            f"balloon_plan_{tag}_0" for tag in scattered_tags
+        } & placed_names
+        if unresolved_replacements:
+            # The first fit legitimately used the fallbacks' freed footprints. Restore
+            # the unresolved subset, then solve the table again against those real
+            # obstacles; blindly reusing the first box could create a collision.
+            _discard_attempt_annotations(dwg, {"hole_table_plan"})
             _restore_stashed_annotations(
                 dwg,
                 ctx,
                 replaced,
-                features=unresolved_table_features,
+                features=unresolved_replacements,
                 reason="required_balloon_not_placed",
             )
+            assert table_ncols is not None
+            table = dwg.add_table(
+                _wrap_rows(header, data, table_ncols),
+                name="hole_table_plan",
+                block_cols=len(header),
+            )
+            if table is None:
+                _discard_attempt_annotations(dwg, scattered_attempt_names)
+                placed_names -= scattered_attempt_names
+                _restore_stashed_annotations(
+                    dwg, ctx, replaced, reason="required_balloon_not_placed"
+                )
+                table_placed = False
+                table_success_features = set()
+
+        if table_placed and table is not None:
+            incomplete_names = {
+                f"balloon_plan_{tag}_0"
+                for tag, hole in zip(scattered_tags, holes, strict=True)
+                if hole.feature not in table_success_features
+            } & placed_names
+            placed_names -= _discard_attempt_annotations(dwg, incomplete_names)
+
+    if table_placed and table is not None:
+        ordered_table_success_features = tuple(
+            feature for feature in table_features if feature in table_success_features
+        )
 
         # One entry per successfully keyed hole (with repeats) so the legacy count check
         # and the semantic ledger agree about the exact committed subset.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -43,7 +43,9 @@ from draftwright.annotations._common import (
     _hole_table_replaceable_annotation,
     _hole_table_replaceable_feature,
     _register_hole_table_coverage,
+    _restore_annotation_transaction,
     _restore_stashed_annotations,
+    _snapshot_annotation_transaction,
     _stash_annotations,
 )
 from draftwright.annotations.balloons import render_balloons
@@ -797,6 +799,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
     replaceable_table_features: set = set()
     table_replacement_features: set = set()
     replaced = {}
+    table_transaction_snap = None
     if tabulate_scattered:
         compiled = plan if plan is not None else compile_dimensions(_model)
         approved_hole_dimensions = {
@@ -855,6 +858,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
         # Structured coverage state (registered at placement time, #351 PR-4c), not
         # an annotation-name-prefix grep — the last stringly-typed inference this
         # resolver relied on (ADR 0009 Amdt 1).
+        table_transaction_snap = _snapshot_annotation_transaction(dwg, ctx.coverage)
         replaced = _stash_annotations(
             dwg,
             [
@@ -880,7 +884,14 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             # Even wrapped it will not fit — restore the callouts/dims and keep the
             # drop lint, so the sheet is never left with neither. The pattern
             # balloons below are unaffected — nothing of theirs was removed.
-            _restore_stashed_annotations(dwg, ctx, replaced, reason="table_not_placed")
+            assert table_transaction_snap is not None
+            _restore_annotation_transaction(
+                dwg,
+                ctx.coverage,
+                table_transaction_snap,
+                replaced,
+                reason="table_not_placed",
+            )
             ctx.record_issue("warning", "table_dropped", "hole table did not fit the sheet")
         else:
             table_features = tuple(dict.fromkeys(h.feature for h in holes))
@@ -889,6 +900,21 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
 
     balloon_specs = scattered_specs + pattern_specs
     placed_names: set = set()
+    balloon_issue_base = dwg.registry.issues
+
+    def _place_balloon_attempt(specs, *, perimeter):
+        nonlocal placed_names
+        attempted = {f"balloon_plan_{tag}_{member_index}" for tag, member_index, _ in specs}
+        dwg.registry.restore_issues(balloon_issue_base)
+        _discard_attempt_annotations(dwg, attempted)
+        previous_objects = {name: dwg.registry.named(name) for name in attempted}
+        render_balloons(dwg, a, "plan", specs, ctx, perimeter=perimeter)
+        placed_names = {
+            name
+            for name, previous in previous_objects.items()
+            if dwg.registry.named(name) is not None and dwg.registry.named(name) is not previous
+        }
+
     if balloon_specs:
         # One call: the strip solver must see every band member together, or two
         # independent render_balloons calls could stack a pattern balloon on a
@@ -898,16 +924,7 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
         # balloon request: spread its tags around the usable perimeter so a
         # deep occupied strip cannot collapse the ring onto two near sides
         # (#901). Pattern-only and public-verb balloons keep nearest-band cost.
-        attempted_names = {
-            f"balloon_plan_{tag}_{member_index}" for tag, member_index, _hole in balloon_specs
-        }
-        previous_objects = {name: dwg.registry.named(name) for name in attempted_names}
-        render_balloons(dwg, a, "plan", balloon_specs, ctx, perimeter=table_placed)
-        placed_names = {
-            name
-            for name, previous in previous_objects.items()
-            if dwg.registry.named(name) is not None and dwg.registry.named(name) is not previous
-        }
+        _place_balloon_attempt(balloon_specs, perimeter=table_placed)
 
     # Commit table replacement per semantic feature only after every balloon that maps
     # its visible row(s) back to physical holes has landed. A partially placed ring leaves
@@ -931,14 +948,14 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
         replacement_features = {
             feature for record in replaced.values() for feature in record.features
         }
+        restored_features: set = set()
         unresolved_replacements = replacement_features - table_success_features
-        scattered_attempt_names = {
-            f"balloon_plan_{tag}_0" for tag in scattered_tags
-        } & placed_names
-        if unresolved_replacements:
+        while unresolved_replacements:
+            restored_features |= unresolved_replacements
             # The first fit legitimately used the fallbacks' freed footprints. Restore
             # the unresolved subset, then solve the table again against those real
-            # obstacles; blindly reusing the first box could create a collision.
+            # obstacles. Then solve the complete balloon inventory again: retaining
+            # balloons from the first, fallback-free solve could cross a restored label.
             _discard_attempt_annotations(dwg, {"hole_table_plan"})
             _restore_stashed_annotations(
                 dwg,
@@ -954,13 +971,47 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
                 block_cols=len(header),
             )
             if table is None:
-                _discard_attempt_annotations(dwg, scattered_attempt_names)
-                placed_names -= scattered_attempt_names
-                _restore_stashed_annotations(
-                    dwg, ctx, replaced, reason="required_balloon_not_placed"
+                assert table_transaction_snap is not None
+                had_balloon_drop = any(
+                    issue.code == "balloon_dropped"
+                    for issue in dwg.registry.issues[len(balloon_issue_base) :]
                 )
+                _restore_annotation_transaction(
+                    dwg,
+                    ctx.coverage,
+                    table_transaction_snap,
+                    replaced,
+                    reason="required_balloon_not_placed",
+                )
+                ctx.record_issue(
+                    "warning",
+                    "table_dropped",
+                    "hole table could not fit with its fallback callouts",
+                )
+                if had_balloon_drop:
+                    ctx.record_issue(
+                        "warning",
+                        "balloon_dropped",
+                        "one or more required hole-table balloons could not be placed",
+                    )
                 table_placed = False
                 table_success_features = set()
+                if pattern_specs:
+                    balloon_issue_base = dwg.registry.issues
+                    _place_balloon_attempt(pattern_specs, perimeter=False)
+                break
+
+            _place_balloon_attempt(balloon_specs, perimeter=True)
+            table_success_features = _fully_ballooned_features(
+                "plan",
+                table_tagged_holes,
+                placed_names,
+                dwg.registry,
+                expected_counts,
+            )
+            unresolved_replacements = (
+                replacement_features - restored_features - table_success_features
+            )
 
         if table_placed and table is not None:
             incomplete_names = {
@@ -1038,8 +1089,14 @@ def _maybe_tabulate_holes(dwg, a: Analysis, *, ctx, plan=None):
             )
             if feature in replaceable_table_features
         }
-        table_replacement_features = table_success_features & (
-            replacement_features | escalated_replacement_features | dropped_replacement_features
+        table_replacement_features = (
+            table_success_features
+            & (
+                replacement_features
+                | escalated_replacement_features
+                | dropped_replacement_features
+            )
+            - restored_features
         )
         _register_hole_table_coverage(
             table,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -53,6 +53,7 @@ from draftwright.annotations._common import (
     _discard_attempt_annotations,
     _fully_ballooned_features,
     _hole_table_replaceable_annotation,
+    _hole_table_replaceable_feature,
     _register_hole_table_coverage,
     _reset_stashed_representation,
     _restore_stashed_annotations,
@@ -2639,12 +2640,12 @@ class Drawing:
         restores every callout. After a partial balloon result, unresolved fallbacks are
         restored and the table is solved again against their real footprints; if that fit
         fails, the whole attempted table/balloon representation is discarded. Compound,
-        threaded, profiled, and pattern callouts remain because this table schema cannot
-        replace all of their visible facts. This is the transactional replacement surface —
-        callers must not remove leaders themselves first. Replacement requires
-        ``balloons=True`` and unused table/balloon names. The default remains additive for
-        compatibility. Returns the committed table, or ``None`` when *view* has no holes or
-        the final representation will not fit.
+        threaded, profiled, patterned, toleranced, and fitted callouts remain because this
+        table schema cannot replace all of their visible facts. This is the transactional
+        replacement surface — callers must not remove leaders themselves first. Replacement
+        requires ``balloons=True`` and distinct, unused table/balloon names. The default
+        remains additive for compatibility. Returns the committed table, or ``None`` when
+        *view* has no holes or the final representation will not fit.
         """
         groups = self._hole_spec_groups(view)
         if not groups:
@@ -2666,15 +2667,21 @@ class Drawing:
             for j, hole in enumerate(holes)
         ]
         table_name = name or f"hole_table_{view}"
+        attempted_names = {
+            f"balloon_{view}_{tag}_{member_index}"
+            for tag, member_index, _hole, _owner in tagged_holes
+        }
+        if balloons and table_name in attempted_names:
+            raise ValueError(
+                "the hole-table name must differ from every generated balloon name; "
+                f"{table_name!r} is reserved by this attempt"
+            )
         stashed = {}
         reg_snap = issues_snap = items_snap = coverage_snap = None
         if replace_callouts:
             from build123d_drafting import Leader
 
-            reserved_names = {table_name} | {
-                f"balloon_{view}_{tag}_{member_index}"
-                for tag, member_index, _hole, _owner in tagged_holes
-            }
+            reserved_names = {table_name} | attempted_names
             collisions = sorted(reserved_names & set(self._registry.names()))
             if collisions:
                 raise ValueError(
@@ -2702,6 +2709,18 @@ class Drawing:
                     "replace_callouts=True requires an existing bore callout for every "
                     f"{view!r}-view table feature"
                 )
+            from draftwright.model.compiled import compile_dimensions, resolve_feature
+
+            compiled = compile_dimensions(self._part_model)
+            compiled_dimensions = {
+                resolve_feature(group.ref): tuple(group.dims)
+                for group in compiled.of_kind("hole", "pattern")
+            }
+            replaceable_features = {
+                feature
+                for feature in group_features
+                if _hole_table_replaceable_feature(feature, compiled_dimensions.get(feature, ()))
+            }
             replaceable_names = [
                 annotation_name
                 for annotation_name in callout_names
@@ -2710,6 +2729,12 @@ class Drawing:
                     annotation_name,
                     self._registry.named(annotation_name),
                 )
+                and _annotation_hole_features(
+                    self._registry,
+                    annotation_name,
+                    self._registry.named(annotation_name),
+                )
+                <= replaceable_features
                 and all(
                     len(holes) == count
                     for _tag, owner, holes, count in groups
@@ -2747,10 +2772,6 @@ class Drawing:
                 return None
 
             if balloons:
-                attempted_names = {
-                    f"balloon_{view}_{tag}_{member_index}"
-                    for tag, member_index, _hole, _owner in tagged_holes
-                }
                 if self._analysis is None:
                     placed_names = set()
                 else:
@@ -2847,6 +2868,9 @@ class Drawing:
                 measurements=measurements,
                 requirements=requirements,
                 representation_reason=("required_balloons_placed" if replace_callouts else None),
+                representation_features=(
+                    replacement_features & successful_features if replace_callouts else ()
+                ),
             )
             return table
         except BaseException:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -55,8 +55,9 @@ from draftwright.annotations._common import (
     _hole_table_replaceable_annotation,
     _hole_table_replaceable_feature,
     _register_hole_table_coverage,
-    _reset_stashed_representation,
+    _restore_annotation_transaction,
     _restore_stashed_annotations,
+    _snapshot_annotation_transaction,
     _stash_annotations,
     carve_free_position,
     strip_obstacles,
@@ -2644,14 +2645,21 @@ class Drawing:
         table schema cannot replace all of their visible facts. This is the transactional
         replacement surface — callers must not remove leaders themselves first. Replacement
         requires ``balloons=True`` and distinct, unused table/balloon names. The default
-        remains additive for compatibility. Returns the committed table, or ``None`` when
-        *view* has no holes or the final representation will not fit.
+        remains additive for compatibility. Transactional replacement is currently limited
+        to the plan view because the shared balloon halo is a plan-layout contract; additive
+        tables remain available for every orthographic view. Returns the committed table, or
+        ``None`` when *view* has no holes or the final representation will not fit.
         """
         groups = self._hole_spec_groups(view)
         if not groups:
             return None
         if replace_callouts and not balloons:
             raise ValueError("replace_callouts=True requires balloons=True")
+        if replace_callouts and view != "plan":
+            raise ValueError(
+                "replace_callouts=True currently requires view='plan'; front/side balloon "
+                "halos are not yet part of the shared layout contract"
+            )
 
         ctx = PlacementContext(
             registry=self._registry,
@@ -2677,7 +2685,7 @@ class Drawing:
                 f"{table_name!r} is reserved by this attempt"
             )
         stashed = {}
-        reg_snap = issues_snap = items_snap = coverage_snap = None
+        transaction_snap = None
         if replace_callouts:
             from build123d_drafting import Leader
 
@@ -2746,55 +2754,70 @@ class Drawing:
                     )
                 )
             ]
-            reg_snap = self._registry.snapshot()
-            issues_snap = self._registry.issues
-            items_snap = list(self.items)
-            coverage_snap = self._coverage.snapshot()
+            transaction_snap = _snapshot_annotation_transaction(self, self._coverage)
             try:
                 stashed = _stash_annotations(self, replaceable_names)
             except BaseException:
-                self._registry.restore(reg_snap)
-                self._registry.restore_issues(issues_snap)
-                self.items[:] = items_snap
-                self._coverage.restore(coverage_snap)
+                _restore_annotation_transaction(self, self._coverage, transaction_snap, stashed)
                 raise
 
-        rows = [("TAG", "⌀", "DEPTH", "QTY")]
-        for tag, _owner, holes, count in groups:
-            h = holes[0]
-            depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
-            rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(count)))
         try:
+            rows = [("TAG", "⌀", "DEPTH", "QTY")]
+            for tag, _owner, holes, count in groups:
+                h = holes[0]
+                depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
+                rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(count)))
             table = self.add_table(rows, prefer=prefer, name=table_name)
             if table is None:
-                if stashed:
-                    _restore_stashed_annotations(self, ctx, stashed, reason="table_not_placed")
+                if replace_callouts:
+                    assert transaction_snap is not None
+                    _restore_annotation_transaction(
+                        self,
+                        self._coverage,
+                        transaction_snap,
+                        stashed,
+                        reason="table_not_placed",
+                    )
+                    self._record_build_issue(
+                        "warning",
+                        "table_dropped",
+                        f"table {table_name!r} did not fit the sheet",
+                    )
                 return None
 
             if balloons:
-                if self._analysis is None:
-                    placed_names = set()
-                else:
-                    render_balloons(
-                        self,
-                        self._analysis,
+                balloon_issue_base = self._registry.issues
+
+                def place_attempt_balloons():
+                    self._registry.restore_issues(balloon_issue_base)
+                    _discard_attempt_annotations(self, attempted_names)
+                    if self._analysis is None:
+                        landed = set()
+                    else:
+                        render_balloons(
+                            self,
+                            self._analysis,
+                            view,
+                            [
+                                (tag, member_index, hole)
+                                for tag, member_index, hole, _owner in tagged_holes
+                            ],
+                            ctx,
+                        )
+                        landed = {
+                            name
+                            for name in attempted_names
+                            if self._registry.named(name) is not None
+                        }
+                    return landed, _fully_ballooned_features(
                         view,
-                        [
-                            (tag, member_index, hole)
-                            for tag, member_index, hole, _owner in tagged_holes
-                        ],
-                        ctx,
+                        tagged_holes,
+                        landed,
+                        self._registry,
+                        expected_counts,
                     )
-                    placed_names = {
-                        name for name in attempted_names if self._registry.named(name) is not None
-                    }
-                successful_features = _fully_ballooned_features(
-                    view,
-                    tagged_holes,
-                    placed_names,
-                    self._registry,
-                    expected_counts,
-                )
+
+                placed_names, successful_features = place_attempt_balloons()
             else:
                 placed_names = set()
                 successful_features = set(group_features)
@@ -2802,8 +2825,10 @@ class Drawing:
             replacement_features = {
                 feature for record in stashed.values() for feature in record.features
             }
+            restored_features = set()
             unresolved_replacements = replacement_features - successful_features
-            if unresolved_replacements:
+            while unresolved_replacements:
+                restored_features |= unresolved_replacements
                 # Refit through the same free-box solve after restoring the unresolved
                 # leaders. The original box may occupy their temporarily freed footprint.
                 _discard_attempt_annotations(self, {table_name})
@@ -2816,11 +2841,34 @@ class Drawing:
                 )
                 table = self.add_table(rows, prefer=prefer, name=table_name)
                 if table is None:
-                    _discard_attempt_annotations(self, placed_names)
-                    _restore_stashed_annotations(
-                        self, ctx, stashed, reason="required_balloon_not_placed"
+                    assert transaction_snap is not None
+                    had_balloon_drop = any(
+                        issue.code == "balloon_dropped"
+                        for issue in self._registry.issues[len(balloon_issue_base) :]
+                    )
+                    _restore_annotation_transaction(
+                        self,
+                        self._coverage,
+                        transaction_snap,
+                        stashed,
+                        reason="required_balloon_not_placed",
+                    )
+                    if had_balloon_drop:
+                        self._record_build_issue(
+                            "warning",
+                            "balloon_dropped",
+                            "one or more required hole-table balloons could not be placed",
+                        )
+                    self._record_build_issue(
+                        "warning",
+                        "table_dropped",
+                        "hole table could not fit with its fallback callouts",
                     )
                     return None
+                placed_names, successful_features = place_attempt_balloons()
+                unresolved_replacements = (
+                    replacement_features - restored_features - successful_features
+                )
 
             incomplete_names = {
                 f"balloon_{view}_{tag}_{member_index}"
@@ -2869,23 +2917,16 @@ class Drawing:
                 requirements=requirements,
                 representation_reason=("required_balloons_placed" if replace_callouts else None),
                 representation_features=(
-                    replacement_features & successful_features if replace_callouts else ()
+                    (replacement_features - restored_features) & successful_features
+                    if replace_callouts
+                    else ()
                 ),
             )
             return table
         except BaseException:
             if replace_callouts:
-                assert (
-                    reg_snap is not None
-                    and issues_snap is not None
-                    and items_snap is not None
-                    and coverage_snap is not None
-                )
-                _reset_stashed_representation(stashed)
-                self._registry.restore(reg_snap)
-                self._registry.restore_issues(issues_snap)
-                self.items[:] = items_snap
-                self._coverage.restore(coverage_snap)
+                assert transaction_snap is not None
+                _restore_annotation_transaction(self, self._coverage, transaction_snap, stashed)
             raise
 
     def pin(self, name):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -49,9 +49,12 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import (
     PlacementContext,
-    _discard_incomplete_feature_balloons,
+    _annotation_hole_features,
+    _discard_attempt_annotations,
     _fully_ballooned_features,
+    _hole_table_replaceable_annotation,
     _register_hole_table_coverage,
+    _reset_stashed_representation,
     _restore_stashed_annotations,
     _stash_annotations,
     carve_free_position,
@@ -2633,12 +2636,15 @@ class Drawing:
 
         With ``replace_callouts=True``, feature-backed bore callouts are stashed while the
         table and required balloons use the sanctioned placement solvers. A failed table
-        restores every callout; a partial balloon result restores callouts for the
-        unresolved feature subset. This is the transactional replacement surface — callers
-        must not remove leaders themselves first. Replacement requires ``balloons=True`` so
-        every committed row remains visibly keyed to its physical hole. The default remains
-        additive for compatibility. Returns the table, or ``None`` when *view* has no holes
-        or it will not fit.
+        restores every callout. After a partial balloon result, unresolved fallbacks are
+        restored and the table is solved again against their real footprints; if that fit
+        fails, the whole attempted table/balloon representation is discarded. Compound,
+        threaded, profiled, and pattern callouts remain because this table schema cannot
+        replace all of their visible facts. This is the transactional replacement surface —
+        callers must not remove leaders themselves first. Replacement requires
+        ``balloons=True`` and unused table/balloon names. The default remains additive for
+        compatibility. Returns the committed table, or ``None`` when *view* has no holes or
+        the final representation will not fit.
         """
         groups = self._hole_spec_groups(view)
         if not groups:
@@ -2653,12 +2659,34 @@ class Drawing:
             part_model=self._part_model,
         )
         group_features = {owner for _tag, owner, _holes, _count in groups}
+        expected_counts = {owner: count for _tag, owner, _holes, count in groups}
+        tagged_holes = [
+            (tag, j, hole, owner)
+            for tag, owner, holes, _count in groups
+            for j, hole in enumerate(holes)
+        ]
+        table_name = name or f"hole_table_{view}"
         stashed = {}
+        reg_snap = issues_snap = items_snap = coverage_snap = None
         if replace_callouts:
+            from build123d_drafting import Leader
+
+            reserved_names = {table_name} | {
+                f"balloon_{view}_{tag}_{member_index}"
+                for tag, member_index, _hole, _owner in tagged_holes
+            }
+            collisions = sorted(reserved_names & set(self._registry.names()))
+            if collisions:
+                raise ValueError(
+                    "replace_callouts=True requires unused table/balloon names; "
+                    f"already present: {', '.join(collisions)}"
+                )
             callout_names = []
             callout_features = set()
             for annotation_name in self._registry.names():
                 if self._registry.view_of(annotation_name) != view:
+                    continue
+                if not isinstance(self._registry.named(annotation_name), Leader):
                     continue
                 features = {
                     getattr(measurement, "feature", None)
@@ -2674,89 +2702,167 @@ class Drawing:
                     "replace_callouts=True requires an existing bore callout for every "
                     f"{view!r}-view table feature"
                 )
-            stashed = _stash_annotations(self, callout_names)
+            replaceable_names = [
+                annotation_name
+                for annotation_name in callout_names
+                if _hole_table_replaceable_annotation(
+                    self._registry,
+                    annotation_name,
+                    self._registry.named(annotation_name),
+                )
+                and all(
+                    len(holes) == count
+                    for _tag, owner, holes, count in groups
+                    if owner
+                    in _annotation_hole_features(
+                        self._registry,
+                        annotation_name,
+                        self._registry.named(annotation_name),
+                    )
+                )
+            ]
+            reg_snap = self._registry.snapshot()
+            issues_snap = self._registry.issues
+            items_snap = list(self.items)
+            coverage_snap = self._coverage.snapshot()
+            try:
+                stashed = _stash_annotations(self, replaceable_names)
+            except BaseException:
+                self._registry.restore(reg_snap)
+                self._registry.restore_issues(issues_snap)
+                self.items[:] = items_snap
+                self._coverage.restore(coverage_snap)
+                raise
 
         rows = [("TAG", "⌀", "DEPTH", "QTY")]
         for tag, _owner, holes, count in groups:
             h = holes[0]
             depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
             rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(count)))
-        table_name = name or f"hole_table_{view}"
-        table = self.add_table(rows, prefer=prefer, name=table_name)
-        if table is None:
-            if stashed:
-                _restore_stashed_annotations(self, ctx, stashed, reason="table_not_placed")
-            return None
+        try:
+            table = self.add_table(rows, prefer=prefer, name=table_name)
+            if table is None:
+                if stashed:
+                    _restore_stashed_annotations(self, ctx, stashed, reason="table_not_placed")
+                return None
 
-        tagged_holes = [
-            (tag, j, hole, owner)
-            for tag, owner, holes, _count in groups
-            for j, hole in enumerate(holes)
-        ]
-        if balloons:
-            self.add_balloons(
-                view,
-                [(tag, member_index, hole) for tag, member_index, hole, _owner in tagged_holes],
-            )
-            successful_features = _fully_ballooned_features(
-                view, tagged_holes, self._registry.names()
-            )
-            _discard_incomplete_feature_balloons(self, view, tagged_holes, successful_features)
-        else:
-            successful_features = set(group_features)
+            if balloons:
+                attempted_names = {
+                    f"balloon_{view}_{tag}_{member_index}"
+                    for tag, member_index, _hole, _owner in tagged_holes
+                }
+                if self._analysis is None:
+                    placed_names = set()
+                else:
+                    render_balloons(
+                        self,
+                        self._analysis,
+                        view,
+                        [
+                            (tag, member_index, hole)
+                            for tag, member_index, hole, _owner in tagged_holes
+                        ],
+                        ctx,
+                    )
+                    placed_names = {
+                        name for name in attempted_names if self._registry.named(name) is not None
+                    }
+                successful_features = _fully_ballooned_features(
+                    view,
+                    tagged_holes,
+                    placed_names,
+                    self._registry,
+                    expected_counts,
+                )
+            else:
+                placed_names = set()
+                successful_features = set(group_features)
 
-        if replace_callouts:
-            unresolved_features = group_features - successful_features
-            if unresolved_features:
+            replacement_features = {
+                feature for record in stashed.values() for feature in record.features
+            }
+            unresolved_replacements = replacement_features - successful_features
+            if unresolved_replacements:
+                # Refit through the same free-box solve after restoring the unresolved
+                # leaders. The original box may occupy their temporarily freed footprint.
+                _discard_attempt_annotations(self, {table_name})
                 _restore_stashed_annotations(
                     self,
                     ctx,
                     stashed,
-                    features=unresolved_features,
+                    features=unresolved_replacements,
                     reason="required_balloon_not_placed",
                 )
+                table = self.add_table(rows, prefer=prefer, name=table_name)
+                if table is None:
+                    _discard_attempt_annotations(self, placed_names)
+                    _restore_stashed_annotations(
+                        self, ctx, stashed, reason="required_balloon_not_placed"
+                    )
+                    return None
 
-        successful_groups = [group for group in groups if group[1] in successful_features]
-        # Legacy physical-diameter lint counts one structured entry per bore. Repeat the
-        # value exactly as many times as the visibly keyed QTY asserts.
-        table.covers_diameters = tuple(
-            holes[0].diameter
-            for _tag, _owner, holes, count in successful_groups
-            for _member in range(count)
-        )
-        from draftwright.model.compiled import DimensionId
+            incomplete_names = {
+                f"balloon_{view}_{tag}_{member_index}"
+                for tag, member_index, _hole, owner in tagged_holes
+                if owner not in successful_features
+            } & placed_names
+            _discard_attempt_annotations(self, incomplete_names)
 
-        # Calling the public verb is an explicit edit: the table itself authors every
-        # measurement it visibly prints, even when the original dimension set omitted a
-        # generated callout.  Construct the same stable identities the compiler uses so
-        # holes and patterns join the physical outcome ledger through one seam.
-        measurements = tuple(
-            DimensionId(owner, parameter)
-            for _tag, owner, holes, _count in successful_groups
-            for parameter in (
-                ("bore.diameter",)
-                if holes[0].through or holes[0].depth is None
-                else ("bore.diameter", "bore.depth")
+            successful_groups = [group for group in groups if group[1] in successful_features]
+            # Legacy physical-diameter lint counts one structured entry per bore. Repeat the
+            # value exactly as many times as the visibly keyed QTY asserts.
+            table.covers_diameters = tuple(
+                holes[0].diameter
+                for _tag, _owner, holes, count in successful_groups
+                for _member in range(count)
             )
-        )
-        requirements = tuple(
-            (owner, "bore.through", 1)
-            for _tag, owner, holes, _count in successful_groups
-            if holes[0].through
-        ) + tuple(
-            (owner, "grouping.count", count)
-            for _tag, owner, _holes, count in successful_groups
-            if count > 1
-        )
-        _register_hole_table_coverage(
-            table,
-            self._registry,
-            table_name,
-            measurements=measurements,
-            requirements=requirements,
-            representation_reason=("required_balloons_placed" if replace_callouts else None),
-        )
-        return table
+            from draftwright.model.compiled import DimensionId
+
+            # Calling the public verb is an explicit edit: the table itself authors every
+            # measurement it visibly prints, even when the original dimension set omitted a
+            # generated callout. Construct the same stable identities the compiler uses so
+            # holes and patterns join the physical outcome ledger through one seam.
+            measurements = tuple(
+                DimensionId(owner, parameter)
+                for _tag, owner, holes, _count in successful_groups
+                for parameter in (
+                    ("bore.diameter",)
+                    if holes[0].through or holes[0].depth is None
+                    else ("bore.diameter", "bore.depth")
+                )
+            )
+            requirements = tuple(
+                (owner, "bore.through", 1)
+                for _tag, owner, holes, _count in successful_groups
+                if holes[0].through
+            ) + tuple(
+                (owner, "grouping.count", count)
+                for _tag, owner, _holes, count in successful_groups
+                if count > 1
+            )
+            _register_hole_table_coverage(
+                table,
+                self._registry,
+                table_name,
+                measurements=measurements,
+                requirements=requirements,
+                representation_reason=("required_balloons_placed" if replace_callouts else None),
+            )
+            return table
+        except BaseException:
+            if replace_callouts:
+                assert (
+                    reg_snap is not None
+                    and issues_snap is not None
+                    and items_snap is not None
+                    and coverage_snap is not None
+                )
+                _reset_stashed_representation(stashed)
+                self._registry.restore(reg_snap)
+                self._registry.restore_issues(issues_snap)
+                self.items[:] = items_snap
+                self._coverage.restore(coverage_snap)
+            raise
 
     def pin(self, name):
         """Pin a named annotation so the engine never moves it (#89).

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -49,7 +49,11 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import (
     PlacementContext,
+    _discard_incomplete_feature_balloons,
+    _fully_ballooned_features,
     _register_hole_table_coverage,
+    _restore_stashed_annotations,
+    _stash_annotations,
     carve_free_position,
     strip_obstacles,
 )
@@ -2609,7 +2613,15 @@ class Drawing:
         """Single-balloon convenience over :meth:`add_balloons` (#111)."""
         self.add_balloons(view, [(tag, j, hole)])
 
-    def add_hole_table(self, view="plan", *, prefer="tr", name=None, balloons=True):
+    def add_hole_table(
+        self,
+        view="plan",
+        *,
+        prefer="tr",
+        name=None,
+        balloons=True,
+        replace_callouts=False,
+    ):
         """Add a hole table for *view*'s holes, placed in a free corner (#93).
 
         One row per hole spec-group — ``TAG | ⌀ | DEPTH | QTY`` with tags
@@ -2617,29 +2629,101 @@ class Drawing:
         default) a circled tag is added at each hole keyed to its row. The table
         carries the same semantic measurement and structured requirement provenance as
         automatic table escalation, so physical hole outcomes count only the facts the
-        table visibly states. Returns the table, or ``None`` when *view* has no holes or it
-        will not fit.
+        table visibly states.
+
+        With ``replace_callouts=True``, feature-backed bore callouts are stashed while the
+        table and required balloons use the sanctioned placement solvers. A failed table
+        restores every callout; a partial balloon result restores callouts for the
+        unresolved feature subset. This is the transactional replacement surface — callers
+        must not remove leaders themselves first. Replacement requires ``balloons=True`` so
+        every committed row remains visibly keyed to its physical hole. The default remains
+        additive for compatibility. Returns the table, or ``None`` when *view* has no holes
+        or it will not fit.
         """
         groups = self._hole_spec_groups(view)
         if not groups:
             return None
+        if replace_callouts and not balloons:
+            raise ValueError("replace_callouts=True requires balloons=True")
+
+        ctx = PlacementContext(
+            registry=self._registry,
+            coverage=self._coverage,
+            items=self.items,
+            part_model=self._part_model,
+        )
+        group_features = {owner for _tag, owner, _holes, _count in groups}
+        stashed = {}
+        if replace_callouts:
+            callout_names = []
+            callout_features = set()
+            for annotation_name in self._registry.names():
+                if self._registry.view_of(annotation_name) != view:
+                    continue
+                features = {
+                    getattr(measurement, "feature", None)
+                    for measurement in self._registry.measurement_of(annotation_name)
+                    if getattr(measurement, "parameter", None) == "bore.diameter"
+                    and getattr(measurement, "feature", None) in group_features
+                }
+                if features:
+                    callout_names.append(annotation_name)
+                    callout_features.update(features)
+            if callout_features != group_features:
+                raise ValueError(
+                    "replace_callouts=True requires an existing bore callout for every "
+                    f"{view!r}-view table feature"
+                )
+            stashed = _stash_annotations(self, callout_names)
+
         rows = [("TAG", "⌀", "DEPTH", "QTY")]
-        diams = []
         for tag, _owner, holes, count in groups:
             h = holes[0]
             depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
             rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(count)))
-            # Legacy physical-diameter lint counts one structured entry per bore.
-            # Repeat the value exactly as many times as the visible QTY asserts, just as
-            # automatic escalation does, while the semantic ledger below retains the
-            # feature-scoped grouping identity.
-            diams.extend([h.diameter] * count)
         table_name = name or f"hole_table_{view}"
         table = self.add_table(rows, prefer=prefer, name=table_name)
         if table is None:
+            if stashed:
+                _restore_stashed_annotations(self, ctx, stashed, reason="table_not_placed")
             return None
-        # The table documents these diameters — let lint see that (#93).
-        table.covers_diameters = tuple(diams)
+
+        tagged_holes = [
+            (tag, j, hole, owner)
+            for tag, owner, holes, _count in groups
+            for j, hole in enumerate(holes)
+        ]
+        if balloons:
+            self.add_balloons(
+                view,
+                [(tag, member_index, hole) for tag, member_index, hole, _owner in tagged_holes],
+            )
+            successful_features = _fully_ballooned_features(
+                view, tagged_holes, self._registry.names()
+            )
+            _discard_incomplete_feature_balloons(self, view, tagged_holes, successful_features)
+        else:
+            successful_features = set(group_features)
+
+        if replace_callouts:
+            unresolved_features = group_features - successful_features
+            if unresolved_features:
+                _restore_stashed_annotations(
+                    self,
+                    ctx,
+                    stashed,
+                    features=unresolved_features,
+                    reason="required_balloon_not_placed",
+                )
+
+        successful_groups = [group for group in groups if group[1] in successful_features]
+        # Legacy physical-diameter lint counts one structured entry per bore. Repeat the
+        # value exactly as many times as the visibly keyed QTY asserts.
+        table.covers_diameters = tuple(
+            holes[0].diameter
+            for _tag, _owner, holes, count in successful_groups
+            for _member in range(count)
+        )
         from draftwright.model.compiled import DimensionId
 
         # Calling the public verb is an explicit edit: the table itself authors every
@@ -2648,7 +2732,7 @@ class Drawing:
         # holes and patterns join the physical outcome ledger through one seam.
         measurements = tuple(
             DimensionId(owner, parameter)
-            for _tag, owner, holes, _count in groups
+            for _tag, owner, holes, _count in successful_groups
             for parameter in (
                 ("bore.diameter",)
                 if holes[0].through or holes[0].depth is None
@@ -2656,9 +2740,13 @@ class Drawing:
             )
         )
         requirements = tuple(
-            (owner, "bore.through", 1) for _tag, owner, holes, _count in groups if holes[0].through
+            (owner, "bore.through", 1)
+            for _tag, owner, holes, _count in successful_groups
+            if holes[0].through
         ) + tuple(
-            (owner, "grouping.count", count) for _tag, owner, _holes, count in groups if count > 1
+            (owner, "grouping.count", count)
+            for _tag, owner, _holes, count in successful_groups
+            if count > 1
         )
         _register_hole_table_coverage(
             table,
@@ -2666,16 +2754,8 @@ class Drawing:
             table_name,
             measurements=measurements,
             requirements=requirements,
+            representation_reason=("required_balloons_placed" if replace_callouts else None),
         )
-        if balloons:
-            self.add_balloons(
-                view,
-                [
-                    (tag, j, h)
-                    for tag, _owner, holes, _count in groups
-                    for j, h in enumerate(holes)
-                ],
-            )
         return table
 
     def pin(self, name):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -49,16 +49,7 @@ from draftwright._core import (
 )
 from draftwright.annotations._common import (
     PlacementContext,
-    _annotation_hole_features,
-    _discard_attempt_annotations,
-    _fully_ballooned_features,
-    _hole_table_replaceable_annotation,
-    _hole_table_replaceable_feature,
     _register_hole_table_coverage,
-    _restore_annotation_transaction,
-    _restore_stashed_annotations,
-    _snapshot_annotation_transaction,
-    _stash_annotations,
     carve_free_position,
     strip_obstacles,
 )
@@ -2618,15 +2609,7 @@ class Drawing:
         """Single-balloon convenience over :meth:`add_balloons` (#111)."""
         self.add_balloons(view, [(tag, j, hole)])
 
-    def add_hole_table(
-        self,
-        view="plan",
-        *,
-        prefer="tr",
-        name=None,
-        balloons=True,
-        replace_callouts=False,
-    ):
+    def add_hole_table(self, view="plan", *, prefer="tr", name=None, balloons=True):
         """Add a hole table for *view*'s holes, placed in a free corner (#93).
 
         One row per hole spec-group — ``TAG | ⌀ | DEPTH | QTY`` with tags
@@ -2634,300 +2617,66 @@ class Drawing:
         default) a circled tag is added at each hole keyed to its row. The table
         carries the same semantic measurement and structured requirement provenance as
         automatic table escalation, so physical hole outcomes count only the facts the
-        table visibly states.
-
-        With ``replace_callouts=True``, feature-backed bore callouts are stashed while the
-        table and required balloons use the sanctioned placement solvers. A failed table
-        restores every callout. After a partial balloon result, unresolved fallbacks are
-        restored and the table is solved again against their real footprints; if that fit
-        fails, the whole attempted table/balloon representation is discarded. Compound,
-        threaded, profiled, patterned, toleranced, and fitted callouts remain because this
-        table schema cannot replace all of their visible facts. This is the transactional
-        replacement surface — callers must not remove leaders themselves first. Replacement
-        requires ``balloons=True`` and distinct, unused table/balloon names. The default
-        remains additive for compatibility. Transactional replacement is currently limited
-        to the plan view because the shared balloon halo is a plan-layout contract; additive
-        tables remain available for every orthographic view. Returns the committed table, or
-        ``None`` when *view* has no holes or the final representation will not fit.
+        table visibly states. Returns the table, or ``None`` when *view* has no holes or it
+        will not fit.
         """
         groups = self._hole_spec_groups(view)
         if not groups:
             return None
-        if replace_callouts and not balloons:
-            raise ValueError("replace_callouts=True requires balloons=True")
-        if replace_callouts and view != "plan":
-            raise ValueError(
-                "replace_callouts=True currently requires view='plan'; front/side balloon "
-                "halos are not yet part of the shared layout contract"
-            )
-
-        ctx = PlacementContext(
-            registry=self._registry,
-            coverage=self._coverage,
-            items=self.items,
-            part_model=self._part_model,
-        )
-        group_features = {owner for _tag, owner, _holes, _count in groups}
-        expected_counts = {owner: count for _tag, owner, _holes, count in groups}
-        tagged_holes = [
-            (tag, j, hole, owner)
-            for tag, owner, holes, _count in groups
-            for j, hole in enumerate(holes)
-        ]
+        rows = [("TAG", "⌀", "DEPTH", "QTY")]
+        diams = []
+        for tag, _owner, holes, count in groups:
+            h = holes[0]
+            depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
+            rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(count)))
+            # Legacy physical-diameter lint counts one structured entry per bore.
+            # Repeat the value exactly as many times as the visible QTY asserts, just as
+            # automatic escalation does, while the semantic ledger below retains the
+            # feature-scoped grouping identity.
+            diams.extend([h.diameter] * count)
         table_name = name or f"hole_table_{view}"
-        attempted_names = {
-            f"balloon_{view}_{tag}_{member_index}"
-            for tag, member_index, _hole, _owner in tagged_holes
-        }
-        if balloons and table_name in attempted_names:
-            raise ValueError(
-                "the hole-table name must differ from every generated balloon name; "
-                f"{table_name!r} is reserved by this attempt"
+        table = self.add_table(rows, prefer=prefer, name=table_name)
+        if table is None:
+            return None
+        # The table documents these diameters — let lint see that (#93).
+        table.covers_diameters = tuple(diams)
+        from draftwright.model.compiled import DimensionId
+
+        # Calling the public verb is an explicit edit: the table itself authors every
+        # measurement it visibly prints, even when the original dimension set omitted a
+        # generated callout. Construct the same stable identities the compiler uses so
+        # holes and patterns join the physical outcome ledger through one seam.
+        measurements = tuple(
+            DimensionId(owner, parameter)
+            for _tag, owner, holes, _count in groups
+            for parameter in (
+                ("bore.diameter",)
+                if holes[0].through or holes[0].depth is None
+                else ("bore.diameter", "bore.depth")
             )
-        stashed = {}
-        transaction_snap = None
-        if replace_callouts:
-            from build123d_drafting import Leader
-
-            reserved_names = {table_name} | attempted_names
-            collisions = sorted(reserved_names & set(self._registry.names()))
-            if collisions:
-                raise ValueError(
-                    "replace_callouts=True requires unused table/balloon names; "
-                    f"already present: {', '.join(collisions)}"
-                )
-            callout_names = []
-            callout_features = set()
-            for annotation_name in self._registry.names():
-                if self._registry.view_of(annotation_name) != view:
-                    continue
-                if not isinstance(self._registry.named(annotation_name), Leader):
-                    continue
-                features = {
-                    getattr(measurement, "feature", None)
-                    for measurement in self._registry.measurement_of(annotation_name)
-                    if getattr(measurement, "parameter", None) == "bore.diameter"
-                    and getattr(measurement, "feature", None) in group_features
-                }
-                if features:
-                    callout_names.append(annotation_name)
-                    callout_features.update(features)
-            if callout_features != group_features:
-                raise ValueError(
-                    "replace_callouts=True requires an existing bore callout for every "
-                    f"{view!r}-view table feature"
-                )
-            from draftwright.model.compiled import compile_dimensions, resolve_feature
-
-            compiled = compile_dimensions(self._part_model)
-            compiled_dimensions = {
-                resolve_feature(group.ref): tuple(group.dims)
-                for group in compiled.of_kind("hole", "pattern")
-            }
-            replaceable_features = {
-                feature
-                for feature in group_features
-                if _hole_table_replaceable_feature(feature, compiled_dimensions.get(feature, ()))
-            }
-            replaceable_names = [
-                annotation_name
-                for annotation_name in callout_names
-                if _hole_table_replaceable_annotation(
-                    self._registry,
-                    annotation_name,
-                    self._registry.named(annotation_name),
-                )
-                and _annotation_hole_features(
-                    self._registry,
-                    annotation_name,
-                    self._registry.named(annotation_name),
-                )
-                <= replaceable_features
-                and all(
-                    len(holes) == count
-                    for _tag, owner, holes, count in groups
-                    if owner
-                    in _annotation_hole_features(
-                        self._registry,
-                        annotation_name,
-                        self._registry.named(annotation_name),
-                    )
-                )
-            ]
-            transaction_snap = _snapshot_annotation_transaction(self, self._coverage)
-            try:
-                stashed = _stash_annotations(self, replaceable_names)
-            except BaseException:
-                _restore_annotation_transaction(self, self._coverage, transaction_snap, stashed)
-                raise
-
-        try:
-            rows = [("TAG", "⌀", "DEPTH", "QTY")]
-            for tag, _owner, holes, count in groups:
-                h = holes[0]
-                depth = "THRU" if h.through else (_fmt(h.depth) if h.depth else "")
-                rows.append((tag, f"ø{_fmt(h.diameter)}", depth, str(count)))
-            table = self.add_table(rows, prefer=prefer, name=table_name)
-            if table is None:
-                if replace_callouts:
-                    assert transaction_snap is not None
-                    _restore_annotation_transaction(
-                        self,
-                        self._coverage,
-                        transaction_snap,
-                        stashed,
-                        reason="table_not_placed",
-                    )
-                    self._record_build_issue(
-                        "warning",
-                        "table_dropped",
-                        f"table {table_name!r} did not fit the sheet",
-                    )
-                return None
-
-            if balloons:
-                balloon_issue_base = self._registry.issues
-
-                def place_attempt_balloons():
-                    self._registry.restore_issues(balloon_issue_base)
-                    _discard_attempt_annotations(self, attempted_names)
-                    if self._analysis is None:
-                        landed = set()
-                    else:
-                        render_balloons(
-                            self,
-                            self._analysis,
-                            view,
-                            [
-                                (tag, member_index, hole)
-                                for tag, member_index, hole, _owner in tagged_holes
-                            ],
-                            ctx,
-                        )
-                        landed = {
-                            name
-                            for name in attempted_names
-                            if self._registry.named(name) is not None
-                        }
-                    return landed, _fully_ballooned_features(
-                        view,
-                        tagged_holes,
-                        landed,
-                        self._registry,
-                        expected_counts,
-                    )
-
-                placed_names, successful_features = place_attempt_balloons()
-            else:
-                placed_names = set()
-                successful_features = set(group_features)
-
-            replacement_features = {
-                feature for record in stashed.values() for feature in record.features
-            }
-            restored_features = set()
-            unresolved_replacements = replacement_features - successful_features
-            while unresolved_replacements:
-                restored_features |= unresolved_replacements
-                # Refit through the same free-box solve after restoring the unresolved
-                # leaders. The original box may occupy their temporarily freed footprint.
-                _discard_attempt_annotations(self, {table_name})
-                _restore_stashed_annotations(
-                    self,
-                    ctx,
-                    stashed,
-                    features=unresolved_replacements,
-                    reason="required_balloon_not_placed",
-                )
-                table = self.add_table(rows, prefer=prefer, name=table_name)
-                if table is None:
-                    assert transaction_snap is not None
-                    had_balloon_drop = any(
-                        issue.code == "balloon_dropped"
-                        for issue in self._registry.issues[len(balloon_issue_base) :]
-                    )
-                    _restore_annotation_transaction(
-                        self,
-                        self._coverage,
-                        transaction_snap,
-                        stashed,
-                        reason="required_balloon_not_placed",
-                    )
-                    if had_balloon_drop:
-                        self._record_build_issue(
-                            "warning",
-                            "balloon_dropped",
-                            "one or more required hole-table balloons could not be placed",
-                        )
-                    self._record_build_issue(
-                        "warning",
-                        "table_dropped",
-                        "hole table could not fit with its fallback callouts",
-                    )
-                    return None
-                placed_names, successful_features = place_attempt_balloons()
-                unresolved_replacements = (
-                    replacement_features - restored_features - successful_features
-                )
-
-            incomplete_names = {
-                f"balloon_{view}_{tag}_{member_index}"
-                for tag, member_index, _hole, owner in tagged_holes
-                if owner not in successful_features
-            } & placed_names
-            _discard_attempt_annotations(self, incomplete_names)
-
-            successful_groups = [group for group in groups if group[1] in successful_features]
-            # Legacy physical-diameter lint counts one structured entry per bore. Repeat the
-            # value exactly as many times as the visibly keyed QTY asserts.
-            table.covers_diameters = tuple(
-                holes[0].diameter
-                for _tag, _owner, holes, count in successful_groups
-                for _member in range(count)
+        )
+        requirements = tuple(
+            (owner, "bore.through", 1) for _tag, owner, holes, _count in groups if holes[0].through
+        ) + tuple(
+            (owner, "grouping.count", count) for _tag, owner, _holes, count in groups if count > 1
+        )
+        _register_hole_table_coverage(
+            table,
+            self._registry,
+            table_name,
+            measurements=measurements,
+            requirements=requirements,
+        )
+        if balloons:
+            self.add_balloons(
+                view,
+                [
+                    (tag, j, h)
+                    for tag, _owner, holes, _count in groups
+                    for j, h in enumerate(holes)
+                ],
             )
-            from draftwright.model.compiled import DimensionId
-
-            # Calling the public verb is an explicit edit: the table itself authors every
-            # measurement it visibly prints, even when the original dimension set omitted a
-            # generated callout. Construct the same stable identities the compiler uses so
-            # holes and patterns join the physical outcome ledger through one seam.
-            measurements = tuple(
-                DimensionId(owner, parameter)
-                for _tag, owner, holes, _count in successful_groups
-                for parameter in (
-                    ("bore.diameter",)
-                    if holes[0].through or holes[0].depth is None
-                    else ("bore.diameter", "bore.depth")
-                )
-            )
-            requirements = tuple(
-                (owner, "bore.through", 1)
-                for _tag, owner, holes, _count in successful_groups
-                if holes[0].through
-            ) + tuple(
-                (owner, "grouping.count", count)
-                for _tag, owner, _holes, count in successful_groups
-                if count > 1
-            )
-            _register_hole_table_coverage(
-                table,
-                self._registry,
-                table_name,
-                measurements=measurements,
-                requirements=requirements,
-                representation_reason=("required_balloons_placed" if replace_callouts else None),
-                representation_features=(
-                    (replacement_features - restored_features) & successful_features
-                    if replace_callouts
-                    else ()
-                ),
-            )
-            return table
-        except BaseException:
-            if replace_callouts:
-                assert transaction_snap is not None
-                _restore_annotation_transaction(self, self._coverage, transaction_snap, stashed)
-            raise
+        return table
 
     def pin(self, name):
         """Pin a named annotation so the engine never moves it (#89).

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -96,6 +96,92 @@ def _solve_strip_1d(naturals, min_gap, lo, hi):
     return _solve_strip_1d_pava(naturals, [min_gap] * (len(naturals) - 1), lo, hi)
 
 
+def _solve_guarded_strip_1d(naturals, min_gap, allowed_segments):
+    """Place an ordered strip when each member has its own allowed intervals.
+
+    Returns one coordinate per member, or ``None`` when the complete set cannot
+    fit.  The solve is joint: moving an earlier member may make room for a later
+    one.  Candidate coordinates are derived from interval boundaries, natural
+    positions, and the exact separation constraint; there is no sampling grid.
+
+    The finite candidate set is complete for this interval-constrained L1
+    problem: a feasible placement can be translated until a coordinate reaches
+    an interval boundary, its natural position, or another coordinate's
+    ``min_gap`` boundary.  Adding every such source shifted by up to ``n`` gaps
+    therefore contains a feasible representative whenever one exists.
+    """
+    if not naturals:
+        return []
+    if len(naturals) != len(allowed_segments):
+        raise ValueError("naturals and allowed_segments must have equal length")
+    if any(not segments for segments in allowed_segments):
+        return None
+
+    count = len(naturals)
+    sources = set()
+    for natural, segments in zip(naturals, allowed_segments, strict=True):
+        sources.add(float(natural))
+        for lo, hi in segments:
+            if hi < lo:
+                raise ValueError("allowed segment has descending bounds")
+            sources.update((float(lo), float(hi), min(max(float(natural), lo), hi)))
+    coordinates = sorted(
+        {source + offset * min_gap for source in sources for offset in range(-count, count + 1)}
+    )
+
+    allowed = [
+        [any(lo <= value <= hi for lo, hi in segments) for value in coordinates]
+        for segments in allowed_segments
+    ]
+    previous = []
+    left = 0
+    for index, value in enumerate(coordinates):
+        while left < index and coordinates[left] <= value - min_gap + _LAYOUT_EPSILON:
+            left += 1
+        previous.append(left - 1)
+
+    # DP over ordered members and ordered coordinates.  Each state carries the
+    # minimum L1 displacement for a complete prefix; ``None`` means infeasible.
+    infinity = float("inf")
+    costs = [[infinity] * len(coordinates) for _ in range(count)]
+    parents: list[list[int | None]] = [[None] * len(coordinates) for _ in range(count)]
+    for coordinate_index, value in enumerate(coordinates):
+        if allowed[0][coordinate_index]:
+            costs[0][coordinate_index] = abs(value - naturals[0])
+    for member_index in range(1, count):
+        best_cost = infinity
+        best_index = None
+        scan = 0
+        for coordinate_index, value in enumerate(coordinates):
+            limit = previous[coordinate_index]
+            while scan <= limit:
+                candidate = costs[member_index - 1][scan]
+                if candidate < best_cost - _LAYOUT_EPSILON:
+                    best_cost = candidate
+                    best_index = scan
+                scan += 1
+            if allowed[member_index][coordinate_index] and best_index is not None:
+                costs[member_index][coordinate_index] = best_cost + abs(
+                    value - naturals[member_index]
+                )
+                parents[member_index][coordinate_index] = best_index
+
+    final_index = min(
+        range(len(coordinates)),
+        key=lambda index: (costs[-1][index], coordinates[index]),
+    )
+    if math.isinf(costs[-1][final_index]):
+        return None
+    result = [0.0] * count
+    for member_index in range(count - 1, -1, -1):
+        result[member_index] = coordinates[final_index]
+        parent = parents[member_index][final_index]
+        if member_index:
+            assert parent is not None
+            final_index = parent
+    return result
+
+
 _ANCHOR_WEIGHT = 1.0e6
 """Weight that pins an anchored candidate at its natural position in the weighted
 median (:func:`_solve_strip_1d_pava`). Any value that dwarfs the sum of a strip's

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -132,25 +132,44 @@ def _solve_guarded_strip_1d(naturals, min_gap, allowed_segments):
         return None
 
     count = len(naturals)
-    sources = set()
-    for natural, segments in zip(naturals, allowed_segments, strict=True):
-        sources.add(float(natural))
+    total_segments = sum(len(segments) for segments in allowed_segments)
+    for segments in allowed_segments:
         for lo, hi in segments:
             if hi < lo:
                 raise ValueError("allowed segment has descending bounds")
-            sources.update((float(lo), float(hi), min(max(float(natural), lo), hi)))
-    total_segments = sum(len(segments) for segments in allowed_segments)
     coordinate_budget = min(
         _GUARDED_STRIP_MAX_STATES // count,
         _GUARDED_STRIP_MAX_INTERVAL_PROBES // total_segments,
     )
     if coordinate_budget <= 0:
         return None
+
     coordinate_set: set[float] = set()
-    for source in sources:
+    sources: set[float] = set()
+
+    def add_source(source) -> bool:
+        source = float(source)
+        if source in sources:
+            return True
+        sources.add(source)
         for offset in range(-count, count + 1):
             coordinate_set.add(source + offset * min_gap)
             if len(coordinate_set) > coordinate_budget:
+                return False
+        return True
+
+    for natural, segments in zip(naturals, allowed_segments, strict=True):
+        natural = float(natural)
+        if not add_source(natural):
+            return None
+        for lo, hi in segments:
+            lo = float(lo)
+            hi = float(hi)
+            if (
+                not add_source(lo)
+                or not add_source(hi)
+                or not add_source(min(max(natural, lo), hi))
+            ):
                 return None
     coordinates = sorted(coordinate_set)
 

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -114,6 +114,8 @@ def _solve_guarded_strip_1d(naturals, min_gap, allowed_segments):
         return []
     if len(naturals) != len(allowed_segments):
         raise ValueError("naturals and allowed_segments must have equal length")
+    if min_gap <= 0:
+        raise ValueError("min_gap must be positive")
     if any(not segments for segments in allowed_segments):
         return None
 

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -403,14 +403,22 @@ def _assign_balloon_bands(
     *,
     prefer_bands=(),
     preference_limit=0.0,
+    required_count=0,
 ):
     """Globally assign balloons to side bands (#516/#901).
 
-    The primary objective is maximum cardinality. Within that maximum flow, the
-    first member assigned to a band named by *prefer_bands* receives a bounded
-    *preference_limit* distance credit before leader length is minimised. This is
-    a preference, not a lexicographic override: a remote band stays unused.
+    The primary objective is maximum cardinality, followed by maximum placement
+    of the first *required_count* members. Within those lexicographic objectives,
+    the first member assigned to a band named by *prefer_bands* receives a
+    bounded *preference_limit* distance credit before leader length is minimised.
+    This is a preference, not a lexicographic override: a remote band stays
+    unused. Required-member priority lets a shared automatic table inventory
+    include optional non-certifying pattern markers without allowing one to
+    displace a row-key balloon (#1144).
     """
+
+    if not 0 <= required_count <= len(members):
+        raise ValueError("required_count must be between zero and len(members)")
 
     band_order = ("left", "right", "top", "bottom")
     bands = [b for b in band_order if capacities.get(b, 0) > 0]
@@ -431,6 +439,19 @@ def _assign_balloon_bands(
         graph[to].append(rev)
         return fwd
 
+    preference_bonus = int(round(max(0.0, preference_limit) * _FLOW_COST_SCALE))
+    base_costs = [
+        int(round(max(0.0, distance) * _FLOW_COST_SCALE)) + band_order.index(band)
+        for choices in choices_by_member
+        for band, distance in choices.items()
+        if band in bands
+    ]
+    max_flow = min(len(members), sum(capacities.get(b, 0) for b in bands))
+    # One optional-member penalty dominates the complete possible spread of
+    # leader/preference cost across an equal-cardinality flow. It does not alter
+    # the primary max-flow objective; it only decides which members survive.
+    optional_penalty = max_flow * (max(base_costs, default=0) + preference_bonus + 1) + 1
+
     used_edges: dict[tuple[int, str], _FlowEdge] = {}
     for i, choices in enumerate(choices_by_member):
         add_edge(source, member0 + i, 1, 0)
@@ -440,13 +461,14 @@ def _assign_balloon_bands(
             # Costs are integerised for deterministic shortest paths; the tiny band
             # ordinal keeps exact ties stable without changing real distance order.
             cost = int(round(max(0.0, choices[band]) * _FLOW_COST_SCALE)) + band_order.index(band)
+            if i >= required_count:
+                cost += optional_penalty
             used_edges[(i, band)] = add_edge(member0 + i, band0 + j, 1, cost)
 
     # Give the first balloon in each preferred band a bounded distance credit.
     # Unlike the old lexicographically dominant activation bonus (#901 review),
     # this cannot justify a leader more than `preference_limit` longer merely to
     # occupy another side. SPFA supports the negative residual edges.
-    preference_bonus = int(round(max(0.0, preference_limit) * _FLOW_COST_SCALE))
     preferred = set(prefer_bands)
     for j, band in enumerate(bands):
         capacity = capacities[band]
@@ -479,7 +501,6 @@ def _assign_balloon_bands(
                     in_queue[edge.to] = True
         return prev if prev[sink] is not None else None
 
-    max_flow = min(len(members), sum(capacities.get(b, 0) for b in bands))
     flow = 0
     while flow < max_flow and (prev := shortest_path()) is not None:
         v = sink

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -51,6 +51,11 @@ from typing import Literal, NamedTuple
 Axis = Literal["x", "y"]
 _LAYOUT_EPSILON = 1e-9
 _FLOW_COST_SCALE = 1000
+# The guarded DP allocates three count×coordinate matrices; these caps keep that
+# inventory to tens—not thousands—of MiB and bound the preceding interval scan.
+# They are safety limits, not layout heuristics: hitting either returns infeasible.
+_GUARDED_STRIP_MAX_STATES = 500_000
+_GUARDED_STRIP_MAX_INTERVAL_PROBES = 2_000_000
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +114,13 @@ def _solve_guarded_strip_1d(naturals, min_gap, allowed_segments):
     an interval boundary, its natural position, or another coordinate's
     ``min_gap`` boundary.  Adding every such source shifted by up to ``n`` gaps
     therefore contains a feasible representative whenever one exists.
+
+    Candidate expansion is deliberately resource-bounded.  A dense inventory
+    crossed with many disjoint label keep-outs can otherwise create millions of
+    Python DP cells before the caller gets a chance to restore its fallbacks.
+    Returning ``None`` at the budget is the conservative result: guarded balloon
+    placement treats it exactly like any other infeasible inventory and fails the
+    replacement transaction closed (ADR 0014 Policy B).
     """
     if not naturals:
         return []
@@ -127,9 +139,20 @@ def _solve_guarded_strip_1d(naturals, min_gap, allowed_segments):
             if hi < lo:
                 raise ValueError("allowed segment has descending bounds")
             sources.update((float(lo), float(hi), min(max(float(natural), lo), hi)))
-    coordinates = sorted(
-        {source + offset * min_gap for source in sources for offset in range(-count, count + 1)}
+    total_segments = sum(len(segments) for segments in allowed_segments)
+    coordinate_budget = min(
+        _GUARDED_STRIP_MAX_STATES // count,
+        _GUARDED_STRIP_MAX_INTERVAL_PROBES // total_segments,
     )
+    if coordinate_budget <= 0:
+        return None
+    coordinate_set: set[float] = set()
+    for source in sources:
+        for offset in range(-count, count + 1):
+            coordinate_set.add(source + offset * min_gap)
+            if len(coordinate_set) > coordinate_budget:
+                return None
+    coordinates = sorted(coordinate_set)
 
     allowed = [
         [any(lo <= value <= hi for lo, hi in segments) for value in coordinates]

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -23,7 +23,12 @@ _DIRECTION_PROJECTION_REL_TOL = 1e-6
 
 @dataclass(frozen=True)
 class HoleRequirementOutcome:
-    """The observable engine outcome of one recognised hole requirement."""
+    """The observable engine outcome of one recognised hole requirement.
+
+    ``representation`` and ``representation_reason`` identify a transactional table win or
+    feature-annotation rollback. They remain ``None`` for ordinary/additive evidence and when
+    more than one marked representation contributes, so critique never guesses a winner.
+    """
 
     source_kind: HoleSourceKind
     source_at: tuple[float, float, float]
@@ -31,6 +36,8 @@ class HoleRequirementOutcome:
     parameter_id: str
     state: HoleRequirementState
     requirement_count: int = 1
+    representation: str | None = None
+    representation_reason: str | None = None
 
 
 def _rounded(value) -> float:
@@ -457,6 +464,7 @@ class _HoleEvidence:
     requirement_counts: dict[tuple[object, str], set[int]]
     locations: dict[tuple[object, str], set[tuple[float, float, float]]]
     centers: dict[object, set[tuple[tuple[float, float, float], str]]]
+    representations: dict[tuple[object, str], set[tuple[str, str]]]
 
 
 def _normalised_location(feature, point) -> tuple[float, float, float]:
@@ -472,8 +480,18 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
     requirement_counts: dict[tuple[object, str], set[int]] = defaultdict(set)
     locations: dict[tuple[object, str], set[tuple[float, float, float]]] = defaultdict(set)
     centers: dict[object, set[tuple[tuple[float, float, float], str]]] = defaultdict(set)
+    representations: dict[tuple[object, str], set[tuple[str, str]]] = defaultdict(set)
     for name in registry.names():
         annotation = registry.named(name)
+        representation = getattr(annotation, "hole_representation", None)
+        representation_reason = getattr(annotation, "hole_representation_reason", None)
+
+        def record_representation(feature, parameter):
+            if representation is not None and representation_reason is not None:
+                representations[(feature, parameter)].add(
+                    (str(representation), str(representation_reason))
+                )
+
         measurements = tuple(registry.measurement_of(name))
         diameter_features = set()
         for measurement in measurements:
@@ -482,18 +500,22 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
             if feature is None or parameter is None:
                 continue
             placed.add((feature, parameter))
+            record_representation(feature, parameter)
             if parameter == "bore.diameter":
                 diameter_features.add(feature)
         for feature, requirement, count in getattr(
             annotation, "covers_hole_requirements_by_feature", ()
         ):
             requirement_counts[(feature, requirement)].add(int(count))
+            record_representation(feature, requirement)
         for feature in diameter_features:
             for requirement in getattr(annotation, "covers_hole_requirements", ()):
                 requirement_counts[(feature, requirement)].add(1)
+                record_representation(feature, requirement)
             requirement_counts[(feature, "grouping.count")].add(
                 int(getattr(annotation, "covers_count", 1) or 1)
             )
+            record_representation(feature, "grouping.count")
         for fact in getattr(annotation, "covers_hole_locations", ()):
             if len(fact) == 3:
                 feature, parameter, point = fact
@@ -503,6 +525,7 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
                 parameter = getattr(measurement, "parameter", None)
             if getattr(feature, "kind", None) in {"hole", "pattern"} and parameter is not None:
                 locations[(feature, parameter)].add(_normalised_location(feature, point))
+                record_representation(feature, parameter)
         for feature, point, view in getattr(annotation, "covers_hole_centers", ()):
             if getattr(feature, "kind", None) in {"hole", "pattern"}:
                 centers[feature].add((_normalised_location(feature, point), view))
@@ -526,7 +549,22 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         requirement_counts,
         locations,
         centers,
+        representations,
     )
+
+
+def _placed_representation(evidence, features, parameter, state):
+    """The transactional representation that supplied a placed requirement, if any."""
+    if state != "placed":
+        return (None, None)
+    markers = {
+        marker
+        for feature in features
+        for marker in evidence.representations.get((feature, parameter), ())
+    }
+    if len(markers) != 1:
+        return (None, None)
+    return next(iter(markers))
 
 
 def _structured_locations_placed(evidence, features, parameter: str, turned_axis_centers) -> bool:
@@ -866,23 +904,29 @@ def hole_requirement_outcomes(
                 )
             )
             continue
-        outcomes.extend(
-            HoleRequirementOutcome(
-                kind,
-                at,
-                member_count,
+        for parameter in parameters:
+            state = _state(
+                matched,
                 parameter,
-                _state(
-                    matched,
-                    parameter,
-                    member_count=member_count,
-                    evidence_index=evidence_index,
-                    suppressed=suppressed,
-                    turned_axis_centers=turned_axis_centers,
-                ),
+                member_count=member_count,
+                evidence_index=evidence_index,
+                suppressed=suppressed,
+                turned_axis_centers=turned_axis_centers,
             )
-            for parameter in parameters
-        )
+            representation, representation_reason = _placed_representation(
+                evidence_index, matched, parameter, state
+            )
+            outcomes.append(
+                HoleRequirementOutcome(
+                    kind,
+                    at,
+                    member_count,
+                    parameter,
+                    state,
+                    representation=representation,
+                    representation_reason=representation_reason,
+                )
+            )
     # The current HoleRecord waist has one countersink slot.  A second seat on the
     # opposite face is still a recognised physical requirement, but cannot be joined to
     # IR/compiler provenance without guessing which face the single slot represents.

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -465,6 +465,7 @@ class _HoleEvidence:
     locations: dict[tuple[object, str], set[tuple[float, float, float]]]
     centers: dict[object, set[tuple[tuple[float, float, float], str]]]
     representations: dict[tuple[object, str], set[tuple[str, str]]]
+    unmarked_representations: set[tuple[object, str]]
 
 
 def _normalised_location(feature, point) -> tuple[float, float, float]:
@@ -481,6 +482,7 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
     locations: dict[tuple[object, str], set[tuple[float, float, float]]] = defaultdict(set)
     centers: dict[object, set[tuple[tuple[float, float, float], str]]] = defaultdict(set)
     representations: dict[tuple[object, str], set[tuple[str, str]]] = defaultdict(set)
+    unmarked_representations: set[tuple[object, str]] = set()
     for name in registry.names():
         annotation = registry.named(name)
         representation = getattr(annotation, "hole_representation", None)
@@ -498,6 +500,12 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
                 representations[(feature, parameter)].add(
                     (str(representation), str(representation_reason))
                 )
+            else:
+                # An ordinary feature annotation is still contributing semantic
+                # evidence. Keep that absence explicit: if another owner in the same
+                # recognised physical source was replaced by a table, the outcome is a
+                # mixed representation and no scalar transaction winner is truthful.
+                unmarked_representations.add((feature, parameter))
 
         measurements = tuple(registry.measurement_of(name))
         diameter_features = set()
@@ -557,12 +565,15 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         locations,
         centers,
         representations,
+        unmarked_representations,
     )
 
 
 def _placed_representation(evidence, features, parameter, state):
     """The transactional representation that supplied a placed requirement, if any."""
     if state != "placed":
+        return (None, None)
+    if any((feature, parameter) in evidence.unmarked_representations for feature in features):
         return (None, None)
     markers = {
         marker

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -492,9 +492,22 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
             annotation, "covers_hole_representations_by_feature", ()
         ):
             feature_representations[feature].add((str(feature_representation), str(reason)))
+        requirement_representations: dict[tuple[object, str], set[tuple[str, str]]] = defaultdict(
+            set
+        )
+        for feature, parameter, feature_representation, reason in getattr(
+            annotation, "covers_hole_representations_by_requirement", ()
+        ):
+            requirement_representations[(feature, parameter)].add(
+                (str(feature_representation), str(reason))
+            )
 
         def record_representation(feature, parameter):
-            if feature in feature_representations:
+            if (feature, parameter) in requirement_representations:
+                representations[(feature, parameter)].update(
+                    requirement_representations[(feature, parameter)]
+                )
+            elif feature in feature_representations:
                 representations[(feature, parameter)].update(feature_representations[feature])
             elif representation is not None and representation_reason is not None:
                 representations[(feature, parameter)].add(

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -485,9 +485,16 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         annotation = registry.named(name)
         representation = getattr(annotation, "hole_representation", None)
         representation_reason = getattr(annotation, "hole_representation_reason", None)
+        feature_representations: dict[object, set[tuple[str, str]]] = defaultdict(set)
+        for feature, feature_representation, reason in getattr(
+            annotation, "covers_hole_representations_by_feature", ()
+        ):
+            feature_representations[feature].add((str(feature_representation), str(reason)))
 
         def record_representation(feature, parameter):
-            if representation is not None and representation_reason is not None:
+            if feature in feature_representations:
+                representations[(feature, parameter)].update(feature_representations[feature])
+            elif representation is not None and representation_reason is not None:
                 representations[(feature, parameter)].add(
                     (str(representation), str(representation_reason))
                 )

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -784,6 +784,16 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
         return None
     lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
 
+    # A diagonal or elbowed centreline's aggregate AABB contains a large empty
+    # triangle.  ADR 0009 makes its real segments authoritative: the AABB remains
+    # useful for overlap magnitude/reporting, but cannot create a warning unless at
+    # least one rendered shaft actually reaches the label box.
+    segments = getattr(cl_item, "segments", None)
+    if segments and not any(
+        _segment_clips_box(start, end, label_bbox, pad=0.0) for start, end in segments
+    ):
+        return None
+
     cl_w = cl_max_x - cl_min_x
     cl_h = cl_max_y - cl_min_y
     if cl_w < 0.1:

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -16,7 +16,7 @@ import re
 from build123d import GeomType
 
 from draftwright._core import _shape_box2d
-from draftwright._geometry import _boxes_overlap, _segment_clips_box
+from draftwright._geometry import _boxes_overlap, _segment_clip_extent, _segment_clips_box
 from draftwright.linting.issues import LintIssue, _IssueAggregation
 
 _log = logging.getLogger(__name__)
@@ -789,41 +789,51 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
     lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
 
     # A diagonal or elbowed centreline's aggregate AABB contains a large empty
-    # triangle.  ADR 0009 makes its real segments authoritative: the AABB remains
-    # useful for overlap magnitude/reporting, but cannot create a warning unless at
-    # least one rendered shaft actually reaches the label box.
+    # triangle. ADR 0009 makes its real components authoritative for BOTH the hit
+    # gate and the reported magnitude: a remote shaft must not inflate a 0.1 mm
+    # ring-edge touch into a legibility warning.
     segments = getattr(
         cl_item,
         "centerline_segments",
         getattr(cl_item, "segments", None),
     )
     component_boxes = getattr(cl_item, "centerline_boxes", ())
-    if (segments or component_boxes) and not (
-        any(_segment_clips_box(start, end, label_bbox, pad=0.0) for start, end in (segments or ()))
-        or any(_boxes_overlap(box, label_bbox) for box in component_boxes)
-    ):
-        return None
 
-    cl_w = cl_max_x - cl_min_x
-    cl_h = cl_max_y - cl_min_y
-    if cl_w < 0.1:
-        cl_x = (cl_min_x + cl_max_x) / 2.0
-        ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
-    else:
-        ox = max(0.0, min(lmax_x, cl_max_x) - max(lmin_x, cl_min_x))
-    if cl_h < 0.1:
-        cl_y = (cl_min_y + cl_max_y) / 2.0
-        oy = min(cl_y - lmin_y, lmax_y - cl_y) if lmin_y < cl_y < lmax_y else 0.0
-    else:
-        oy = max(0.0, min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y))
+    aggregate_location = ((cl_min_x + cl_max_x) / 2.0, (cl_min_y + cl_max_y) / 2.0)
 
-    if ox <= 0.5 or oy <= 0.5:
-        return None
-    return (
-        ox,
-        oy,
-        ((cl_min_x + cl_max_x) / 2.0, (cl_min_y + cl_max_y) / 2.0),
-    )
+    def overlap(extent):
+        min_x, min_y, max_x, max_y = extent
+        width = max_x - min_x
+        height = max_y - min_y
+        if width < 0.1:
+            centre_x = (min_x + max_x) / 2.0
+            ox = min(centre_x - lmin_x, lmax_x - centre_x) if lmin_x < centre_x < lmax_x else 0.0
+        else:
+            ox = max(0.0, min(lmax_x, max_x) - max(lmin_x, min_x))
+        if height < 0.1:
+            centre_y = (min_y + max_y) / 2.0
+            oy = min(centre_y - lmin_y, lmax_y - centre_y) if lmin_y < centre_y < lmax_y else 0.0
+        else:
+            oy = max(0.0, min(lmax_y, max_y) - max(lmin_y, min_y))
+        if ox <= 0.5 or oy <= 0.5:
+            return None
+        return ox, oy, aggregate_location
+
+    if segments or component_boxes:
+        hit_extents = [
+            extent
+            for start, end in (segments or ())
+            if (extent := _segment_clip_extent(start, end, label_bbox)) is not None
+        ]
+        hit_extents.extend(box for box in component_boxes if _boxes_overlap(box, label_bbox))
+        significant = [result for extent in hit_extents if (result := overlap(extent))]
+        return (
+            max(significant, key=lambda result: (result[0] * result[1], result))
+            if significant
+            else None
+        )
+
+    return overlap((cl_min_x, cl_min_y, cl_max_x, cl_max_y))
 
 
 def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -739,37 +739,9 @@ def _lint_centerline_dim_overlap(
     arithmetic runs unguarded so a bug fails loudly instead of silently
     disabling the check.
     """
-    if box_cache is None:
-        box_cache = {}
-    try:
-        cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl_item, box_cache)
-    except Exception as exc:  # noqa: BLE001 — duck-typed centreline may not measure
-        _log.debug("lint: centreline did not measure (%s); overlap check skips it", exc)
-        return
-
-    label_bbox = _label_bbox(dim_item, warned)
-    if label_bbox is None:
-        label_bbox = _ann_box(dim_item, box_cache)
-    if label_bbox is None:
-        return
-    lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
-
-    cl_w = cl_max_x - cl_min_x
-    cl_h = cl_max_y - cl_min_y
-
-    if cl_w < 0.1:
-        cl_x = (cl_min_x + cl_max_x) / 2.0
-        ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
-    else:
-        ox = max(0.0, min(lmax_x, cl_max_x) - max(lmin_x, cl_min_x))
-
-    if cl_h < 0.1:
-        cl_y = (cl_min_y + cl_max_y) / 2.0
-        oy = min(cl_y - lmin_y, lmax_y - cl_y) if lmin_y < cl_y < lmax_y else 0.0
-    else:
-        oy = max(0.0, min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y))
-
-    if ox > 0.5 and oy > 0.5:
+    overlap = _label_centerline_overlap(dim_item, cl_item, box_cache, warned)
+    if overlap is not None:
+        ox, oy, location = overlap
         dim_label = getattr(dim_item, "label", "?")
         issue = LintIssue(
             severity="warning",
@@ -780,10 +752,7 @@ def _lint_centerline_dim_overlap(
             ),
             # Pair detail stays in the raw issue: this is the compared centre mark's
             # extent centre, so equal-looking findings can still be traced spatially.
-            location=(
-                (cl_min_x + cl_max_x) / 2.0,
-                (cl_min_y + cl_max_y) / 2.0,
-            ),
+            location=location,
             code="label_centerline_overlap",
         )
         issues.append(issue)
@@ -791,6 +760,50 @@ def _lint_centerline_dim_overlap(
             # The side ledger sees which half of the pair owns the readability defect;
             # neither the annotation nor its run-local identity enters public diagnostics.
             aggregation.record_pair(issue, subject_token)
+
+
+def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
+    """Return the lint-significant label/centreline overlap, or ``None``.
+
+    Balloon placement uses the same predicate before committing a leadered glyph. Keeping
+    the tolerance and thin-line handling here prevents placement and critique from making
+    contradictory decisions about the final annotation inventory (#1144).
+    """
+    if box_cache is None:
+        box_cache = {}
+    try:
+        cl_min_x, cl_min_y, cl_max_x, cl_max_y = _centerline_extent(cl_item, box_cache)
+    except Exception as exc:  # noqa: BLE001 — duck-typed centreline may not measure
+        _log.debug("lint: centreline did not measure (%s); overlap check skips it", exc)
+        return None
+
+    label_bbox = _label_bbox(dim_item, warned)
+    if label_bbox is None:
+        label_bbox = _ann_box(dim_item, box_cache)
+    if label_bbox is None:
+        return None
+    lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
+
+    cl_w = cl_max_x - cl_min_x
+    cl_h = cl_max_y - cl_min_y
+    if cl_w < 0.1:
+        cl_x = (cl_min_x + cl_max_x) / 2.0
+        ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
+    else:
+        ox = max(0.0, min(lmax_x, cl_max_x) - max(lmin_x, cl_min_x))
+    if cl_h < 0.1:
+        cl_y = (cl_min_y + cl_max_y) / 2.0
+        oy = min(cl_y - lmin_y, lmax_y - cl_y) if lmin_y < cl_y < lmax_y else 0.0
+    else:
+        oy = max(0.0, min(lmax_y, cl_max_y) - max(lmin_y, cl_min_y))
+
+    if ox <= 0.5 or oy <= 0.5:
+        return None
+    return (
+        ox,
+        oy,
+        ((cl_min_x + cl_max_x) / 2.0, (cl_min_y + cl_max_y) / 2.0),
+    )
 
 
 def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -801,16 +801,22 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
 
     aggregate_location = ((cl_min_x + cl_max_x) / 2.0, (cl_min_y + cl_max_y) / 2.0)
 
-    def overlap(extent):
+    def overlap(extent, *, segment=False):
         min_x, min_y, max_x, max_y = extent
         width = max_x - min_x
         height = max_y - min_y
-        if width < 0.1:
+        # A segment is a zero-width stroke, not a filled version of its clipped
+        # AABB.  Measure penetration on the stroke's minor axis and travelled
+        # distance on its major axis.  This keeps a deep near-vertical crossing
+        # significant without reviving the empty diagonal-triangle false positive.
+        line_x = segment and width < height
+        line_y = segment and height < width
+        if line_x or (not segment and width < 0.1):
             centre_x = (min_x + max_x) / 2.0
             ox = min(centre_x - lmin_x, lmax_x - centre_x) if lmin_x < centre_x < lmax_x else 0.0
         else:
             ox = max(0.0, min(lmax_x, max_x) - max(lmin_x, min_x))
-        if height < 0.1:
+        if line_y or (not segment and height < 0.1):
             centre_y = (min_y + max_y) / 2.0
             oy = min(centre_y - lmin_y, lmax_y - centre_y) if lmin_y < centre_y < lmax_y else 0.0
         else:
@@ -820,13 +826,16 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
         return ox, oy, aggregate_location
 
     if segments or component_boxes:
-        hit_extents = [
+        segment_extents = [
             extent
             for start, end in (segments or ())
             if (extent := _segment_clip_extent(start, end, label_bbox)) is not None
         ]
-        hit_extents.extend(box for box in component_boxes if _boxes_overlap(box, label_bbox))
-        significant = [result for extent in hit_extents if (result := overlap(extent))]
+        box_extents = [box for box in component_boxes if _boxes_overlap(box, label_bbox)]
+        significant = [
+            result for extent in segment_extents if (result := overlap(extent, segment=True))
+        ]
+        significant.extend(result for extent in box_extents if (result := overlap(extent)))
         return (
             max(significant, key=lambda result: (result[0] * result[1], result))
             if significant

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -90,14 +90,18 @@ def _ann_box(item, cache):
 def _centerline_extent(cl_item, box_cache=None):
     """Return (min_x, min_y, max_x, max_y) for a centreline.
 
-    Prefers the zero-width ``.segments`` (the true centreline) so a thin-faced
-    centreline still reads as a zero-width vertical/horizontal line; falls back
-    to the rendered ``.bounding_box()`` (which is line_width wide).
+    Prefers precise component metadata (``centerline_segments`` plus optional
+    ``centerline_boxes``), then the conventional zero-width ``.segments``, so a
+    thin-faced centreline still reads as a line while a compound balloon retains
+    its compact ring/text glyph. Falls back to rendered ``.bounding_box()``.
     """
-    segs = getattr(cl_item, "segments", None)
-    if segs:
-        xs = [p[0] for s in segs for p in s]
-        ys = [p[1] for s in segs for p in s]
+    segs = getattr(cl_item, "centerline_segments", getattr(cl_item, "segments", None))
+    component_boxes = getattr(cl_item, "centerline_boxes", ())
+    if segs or component_boxes:
+        xs = [p[0] for s in (segs or ()) for p in s]
+        ys = [p[1] for s in (segs or ()) for p in s]
+        xs.extend(value for box in component_boxes for value in (box[0], box[2]))
+        ys.extend(value for box in component_boxes for value in (box[1], box[3]))
         return (min(xs), min(ys), max(xs), max(ys))
     box = _ann_box(cl_item, box_cache if box_cache is not None else {})
     if box is None:
@@ -788,9 +792,15 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
     # triangle.  ADR 0009 makes its real segments authoritative: the AABB remains
     # useful for overlap magnitude/reporting, but cannot create a warning unless at
     # least one rendered shaft actually reaches the label box.
-    segments = getattr(cl_item, "segments", None)
-    if segments and not any(
-        _segment_clips_box(start, end, label_bbox, pad=0.0) for start, end in segments
+    segments = getattr(
+        cl_item,
+        "centerline_segments",
+        getattr(cl_item, "segments", None),
+    )
+    component_boxes = getattr(cl_item, "centerline_boxes", ())
+    if (segments or component_boxes) and not (
+        any(_segment_clips_box(start, end, label_bbox, pad=0.0) for start, end in (segments or ()))
+        or any(_boxes_overlap(box, label_bbox) for box in component_boxes)
     ):
         return None
 

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -725,7 +725,6 @@ def test_every_direct_placement_records_identity_or_says_why_not():
         ("from_model.py", "_diameter_column_left"): "direct-placing rotational group (#754)",
         # -- identity arrives by another route --------------------------------------
         ("from_model.py", "_reroute_crossing_diameters"): "reapplies the saved identity",
-        ("orchestrator.py", "_maybe_tabulate_holes"): "reapplies the saved identity",
         ("sections.py", "_resolve_details"): "reapplies the saved identity",
         # -- not a measurement (ADR 0011) -------------------------------------------
         ("from_model.py", "_drop._retry"): "GD&T relaxed-side retry places a control frame",

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -2102,7 +2102,7 @@ def test_successful_hole_table_escalation_carries_every_replaced_requirement():
 
 
 def test_scattered_hole_table_preserves_placed_pattern_location_evidence():
-    drawing = build_drawing(_dense_scattered_plate_with_bolt_circle((20.4, 10.4)), page="A3")
+    drawing = build_drawing(_dense_scattered_plate_with_bolt_circle((20.4, 10.4)), page="A2")
     pattern = next(feature for feature in drawing.model().features if feature.kind == "pattern")
 
     assert "hole_table_plan" in drawing.annotations()
@@ -2129,7 +2129,7 @@ def test_scattered_hole_table_preserves_placed_pattern_location_evidence():
 
 
 def test_scattered_hole_table_preserves_unresolved_pattern_location_drops():
-    drawing = build_drawing(_dense_scattered_plate_with_bolt_circle((19.6, 9.6)), page="A3")
+    drawing = build_drawing(_dense_scattered_plate_with_bolt_circle((19.6, 9.6)), page="A2")
 
     assert "hole_table_plan" in drawing.annotations()
     assert {

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -1,6 +1,5 @@
 """Regression coverage for hole-family semantic outcomes (#1143)."""
 
-import itertools
 from collections import Counter
 from dataclasses import replace
 from types import SimpleNamespace
@@ -26,6 +25,25 @@ from draftwright.recognition import (
 from draftwright.registry import AnnotationRegistry
 
 _XYZ_MIN = (Align.CENTER, Align.CENTER, Align.MIN)
+
+_TABLE_SAFE_POSITIONS = (
+    (-42.7, -27.4),
+    (-15.1, -31.9),
+    (11.0, -28.7),
+    (44.8, -27.9),
+    (-46.0, 32.2),
+    (-16.8, 32.4),
+    (16.8, 29.3),
+    (45.3, 31.5),
+    (-56.5, -17.6),
+    (-51.6, -7.9),
+    (-51.6, 7.5),
+    (-51.2, 16.7),
+    (50.7, -15.6),
+    (56.4, -6.4),
+    (50.8, 3.6),
+    (55.1, 16.3),
+)
 
 
 def _pattern_and_central_bore():
@@ -131,39 +149,26 @@ def _countersunk_pattern():
 
 
 def _dense_scattered_plate():
-    positions = (
-        [(x, -30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
-        + [(x, 30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
-        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
-        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
-    )
     part = Box(120, 80, 12)
-    for i, (x, y) in enumerate(positions):
+    for i, (x, y) in enumerate(_TABLE_SAFE_POSITIONS):
         part -= Pos(x, y, 0) * Cylinder(1.0 + i * 0.15, 20)
     return part
 
 
 def _dense_scattered_blind_plate():
-    positions = (
-        [(x, -30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
-        + [(x, 30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
-        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
-        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
-    )
     part = Box(120, 80, 12, align=_XYZ_MIN)
-    for i, (x, y) in enumerate(positions):
+    for i, (x, y) in enumerate(_TABLE_SAFE_POSITIONS):
         part -= Pos(x, y, 6) * Cylinder(1.0 + i * 0.15, 6, align=_XYZ_MIN)
     return part
 
 
 def _dense_scattered_plate_with_bolt_circle(near_scattered):
-    part = Box(180, 120, 10, align=_XYZ_MIN)
-    scattered = list(itertools.product((-75, -55, -35, -15, 55), (-40, -20, 0, 20)))[:15]
-    scattered.append(near_scattered)
+    part = Box(120, 80, 10, align=_XYZ_MIN)
+    scattered = [*_TABLE_SAFE_POSITIONS[:15], near_scattered]
     for i, (x, y) in enumerate(scattered):
         part -= Pos(x, y, 0) * Cylinder(1.0 + i * 0.1, 10, align=_XYZ_MIN)
-    for x, y in ((35, 10), (20, 25), (5, 10), (20, -5)):
-        part -= Pos(x, y, 0) * Cylinder(3, 10, align=_XYZ_MIN)
+    for x, y in ((25, 10), (20, 15), (15, 10), (20, 5)):
+        part -= Pos(x, y, 0) * Cylinder(0.8, 10, align=_XYZ_MIN)
     return part
 
 
@@ -2102,8 +2107,18 @@ def test_successful_hole_table_escalation_carries_every_replaced_requirement():
 
 
 def test_scattered_hole_table_preserves_placed_pattern_location_evidence():
-    drawing = build_drawing(_dense_scattered_plate_with_bolt_circle((20.4, 10.4)), page="A2")
+    drawing = build_drawing(
+        _dense_scattered_plate_with_bolt_circle((20.4, 10.4)),
+        page="A3",
+        auto_dims=False,
+    )
     pattern = next(feature for feature in drawing.model().features if feature.kind == "pattern")
+    assert len(drawing.locate(pattern)) == 2
+    with drawing.deferred():
+        for feature in drawing.model().features:
+            if feature.kind == "hole":
+                drawing.callout(feature)
+                drawing.locate(feature)
 
     assert "hole_table_plan" in drawing.annotations()
     pattern_location_facts = [
@@ -2129,7 +2144,7 @@ def test_scattered_hole_table_preserves_placed_pattern_location_evidence():
 
 
 def test_scattered_hole_table_preserves_unresolved_pattern_location_drops():
-    drawing = build_drawing(_dense_scattered_plate_with_bolt_circle((19.6, 9.6)), page="A2")
+    drawing = build_drawing(_dense_scattered_plate_with_bolt_circle((19.6, 9.6)), page="A3")
 
     assert "hole_table_plan" in drawing.annotations()
     assert {
@@ -2267,7 +2282,7 @@ def test_blind_hole_table_prints_every_depth_it_claims(monkeypatch):
         return original(self, rows, **kwargs)
 
     monkeypatch.setattr(Drawing, "add_table", capture_rows)
-    drawing = build_drawing(_dense_scattered_blind_plate(), page="A3")
+    drawing = build_drawing(_dense_scattered_blind_plate(), page="A2")
 
     assert "hole_table_plan" in drawing.annotations()
     rows = captured_rows[-1]

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -131,18 +131,28 @@ def _countersunk_pattern():
 
 
 def _dense_scattered_plate():
-    part = Box(90, 60, 12)
-    columns = [-40 + i * 20 for i in range(5)]
-    for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
-        part -= Pos(columns[column], y, 0) * Cylinder(1.0 + i * 0.2, 20)
+    positions = (
+        [(x, -30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(x, 30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+    )
+    part = Box(120, 80, 12)
+    for i, (x, y) in enumerate(positions):
+        part -= Pos(x, y, 0) * Cylinder(1.0 + i * 0.15, 20)
     return part
 
 
 def _dense_scattered_blind_plate():
-    part = Box(90, 60, 12, align=_XYZ_MIN)
-    columns = [-40 + i * 20 for i in range(5)]
-    for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
-        part -= Pos(columns[column], y, 6) * Cylinder(1.0 + i * 0.2, 6, align=_XYZ_MIN)
+    positions = (
+        [(x, -30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(x, 30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+    )
+    part = Box(120, 80, 12, align=_XYZ_MIN)
+    for i, (x, y) in enumerate(positions):
+        part -= Pos(x, y, 6) * Cylinder(1.0 + i * 0.15, 6, align=_XYZ_MIN)
     return part
 
 
@@ -2076,14 +2086,16 @@ def test_grouped_loose_holes_require_every_member_location_mark():
 
 
 def test_successful_hole_table_escalation_carries_every_replaced_requirement():
-    drawing = build_drawing(_dense_scattered_plate())
+    drawing = build_drawing(_dense_scattered_plate(), page="A3")
 
     assert "hole_table_plan" in drawing.annotations()
+    hole_count = len([feature for feature in drawing.model().features if feature.kind == "hole"])
+    assert hole_count == 16
     keys = drawing.measurement_keys("hole_table_plan")
-    assert len(keys) == 40
+    assert len(keys) == hole_count * 2
     assert len({(key["feature"], key["parameter_id"]) for key in keys}) == len(keys)
     outcomes = _outcomes(drawing)
-    assert len(outcomes) == 80
+    assert len(outcomes) == hole_count * 4
     assert all(item.state == "placed" for item in outcomes)
     assert not [issue for issue in drawing.lint() if issue.code.startswith("hole_requirement_")]
     assert _completeness(drawing)["audited_score"] == 1.0
@@ -2268,7 +2280,7 @@ def test_blind_hole_table_prints_every_depth_it_claims(monkeypatch):
         if row[offset]
     } == {"6"}
     outcomes = _outcomes(drawing)
-    assert len(outcomes) == 80
+    assert len(outcomes) == 16 * 4
     assert all(item.state == "placed" for item in outcomes)
 
 
@@ -2307,7 +2319,7 @@ def test_failed_hole_table_escalation_restores_semantic_fallback_evidence(monkey
     import draftwright.drawing as drawing_module
 
     monkeypatch.setattr(drawing_module, "fit_box", lambda *_args, **_kwargs: None)
-    drawing = build_drawing(_dense_scattered_plate())
+    drawing = build_drawing(_dense_scattered_plate(), page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert "table_dropped" in {issue.code for issue in drawing.lint()}

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -26,6 +26,21 @@ def _multi_hole_plate():
     )
 
 
+def _bolt_circle_plate():
+    xyz_min = (Align.CENTER, Align.CENTER, Align.MIN)
+    part = Box(80, 80, 10, align=xyz_min)
+    for x, y in (
+        (25.0, 0.0),
+        (12.5, 21.650635),
+        (-12.5, 21.650635),
+        (-25.0, 0.0),
+        (-12.5, -21.650635),
+        (12.5, -21.650635),
+    ):
+        part -= Pos(x, y, 0) * Cylinder(3, 10, align=xyz_min)
+    return part
+
+
 def _dense_scattered_plate():
     """Twenty distinct-spec bores, forcing automatic table escalation."""
     part = Box(90, 60, 12)
@@ -37,26 +52,46 @@ def _dense_scattered_plate():
 
 def _dense_plate_with_close_x_ordinates():
     """Dense inventory with two separately placed X ordinates only 0.4 mm apart."""
-    positions = list(itertools.product((-36, -18, 0, 18, 36), (-20, -7, 7, 20)))
-    # Give the close pair the two largest bores so their callouts survive the
-    # strip's diameter-priority solve while one of their X ordinates is rejected.
-    positions[-2] = (0.0, -25.0)
-    positions[-1] = (0.4, 25.0)
-    part = Box(90, 60, 12)
+    positions = (
+        [(x, -30.0) for x in (-45.0, 0.4, 15.0, 45.0)]
+        + [(x, 30.0) for x in (-45.0, 0.0, 15.0, 45.0)]
+        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+    )
+    part = Box(120, 80, 12)
     for index, (x, y) in enumerate(positions):
-        part -= Pos(x, y, 0) * Cylinder(1.0 + index * 0.18, 20)
+        part -= Pos(x, y, 0) * Cylinder(1.0 + index * 0.15, 20)
+    return part
+
+
+def _dense_perimeter_plate():
+    """Sixteen scattered bores whose short outward balloons are collision-free."""
+    positions = (
+        [(x, -30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(x, 30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+    )
+    part = Box(120, 80, 12)
+    for index, (x, y) in enumerate(positions):
+        part -= Pos(x, y, 0) * Cylinder(1.0 + index * 0.15, 20)
     return part
 
 
 def _dense_plate_with_counterbore():
     """Reviewer fixture whose diagonal balloon AABB used to reject a clear leader."""
-    part = Box(90, 60, 12)
-    columns = [-40 + i * 20 for i in range(5)]
-    for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
+    positions = (
+        [(x, -30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(x, 30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
+        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
+    )
+    part = Box(120, 80, 12)
+    for i, (x, y) in enumerate(positions):
         diameter = 2.0 + i * 0.4
-        part -= Pos(columns[column], y, 0) * Cylinder(diameter / 2, 20)
-        if i == 2:
-            part -= Pos(columns[column], y, 4.5) * Cylinder(2.5, 3)
+        part -= Pos(x, y, 0) * Cylinder(diameter / 2, 20)
+        if i == len(positions) - 1:
+            part -= Pos(x, y, 4.5) * Cylinder((diameter + 3.0) / 2, 3)
     return part
 
 
@@ -304,6 +339,17 @@ def test_centerline_warning_tolerance_uses_the_actual_colliding_component():
 
     assert _label_centerline_overlap(edge_touch, balloon) is None
     assert _label_centerline_overlap(significant, balloon) is not None
+
+
+def test_near_axis_segment_keeps_deep_label_penetration_visible():
+    from draftwright.linting.structural import _label_centerline_overlap
+
+    label = SimpleNamespace(label="CALL", label_bbox=(0.0, 0.0, 10.0, 10.0))
+    vertical = SimpleNamespace(centerline_segments=(((5.0, -1.0), (5.0, 11.0)),))
+    near_vertical = SimpleNamespace(centerline_segments=(((4.9, -1.0), (5.1, 11.0)),))
+
+    assert _label_centerline_overlap(label, vertical) is not None
+    assert _label_centerline_overlap(label, near_vertical) is not None
 
 
 def test_long_public_balloon_text_remains_visible_to_structural_lint():
@@ -596,10 +642,15 @@ def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry(
     first = ((((10.0, 10.0, 20.0, 20.0),), ()),)
     clear_second = (((30.0, 30.0, 40.0, 40.0),), ())
     overlapping_second = (((19.0, 15.0, 29.0, 25.0),), ())
+    shaft_crossing_second = (((24.0, 12.0, 28.0, 18.0),), ())
+    shaft_crossing_first = ((((10.0, 10.0, 20.0, 20.0),), (((0.0, 15.0), (30.0, 15.0)),)),)
     off_page = (((95.0, 95.0, 105.0, 105.0),), ())
 
     assert _guarded_inventory_geometry_is_clear((*first, clear_second), page)
     assert not _guarded_inventory_geometry_is_clear((*first, overlapping_second), page)
+    assert not _guarded_inventory_geometry_is_clear(
+        (*shaft_crossing_first, shaft_crossing_second), page
+    )
     assert not _guarded_inventory_geometry_is_clear((*first, off_page), page)
 
 
@@ -785,15 +836,19 @@ def test_automatic_partial_balloon_result_restores_only_the_unresolved_feature(m
 
 
 def test_scattered_table_reports_a_balloon_landed_on_the_wrong_semantic_owner():
-    detected = build_drawing(_dense_scattered_plate(), auto_dims=False).model()
-    victim = next(feature for feature in detected.features if feature.kind == "hole")
+    part = _dense_perimeter_plate()
+    detected = build_drawing(part, auto_dims=False).model()
+    victim = max(
+        (feature for feature in detected.features if feature.kind == "hole"),
+        key=lambda feature: feature.diameter,
+    )
     # The sanctioned position bridge resolves the last feature at a coincident
     # centre.  A distinct appended declaration therefore owns both rendered
     # balloons even though the original feature still has its own visible row.
     wrong_owner = replace(victim, diameter=victim.diameter + 0.123)
     declared = replace(detected, features=[*detected.features, wrong_owner])
 
-    drawing = build_drawing(_dense_scattered_plate(), model=declared)
+    drawing = build_drawing(part, model=declared, page="A3")
 
     assert "hole_table_plan" in drawing.annotations()
     assert victim in _plan_bore_callouts(drawing)
@@ -806,6 +861,100 @@ def test_scattered_table_reports_a_balloon_landed_on_the_wrong_semantic_owner():
         if outcome.source_at[:2] == tuple(victim.frame.origin[:2])
         and outcome.parameter_id == "bore.diameter"
     } != {"hole_table"}
+
+
+def test_successful_auto_table_preserves_an_unrelated_public_table_drop():
+    drawing = build_drawing(_dense_perimeter_plate(), auto_dims=False, page="A3")
+    assert (
+        drawing.add_table(
+            [("X" * 50,) for _ in range(100)],
+            name="user_oversize_table",
+        )
+        is None
+    )
+    user_issue = next(
+        issue
+        for issue in drawing.registry.issues
+        if issue.code == "table_dropped" and "user_oversize_table" in issue.message
+    )
+
+    with drawing.deferred():
+        for feature in drawing.model().features:
+            if feature.kind == "hole":
+                drawing.callout(feature)
+                drawing.locate(feature)
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 16
+    assert user_issue in drawing.registry.issues
+
+
+def test_grouped_pattern_marker_cannot_certify_an_undefined_hole_tag():
+    from draftwright.analysis import _analyse
+    from draftwright.annotations._common import Escalation, PlacementContext
+    from draftwright.annotations.orchestrator import _maybe_tabulate_holes
+    from draftwright.linting.issues import LintIssue
+
+    part = _bolt_circle_plate()
+    drawing = build_drawing(part, page="A4")
+    analysis = _analyse(
+        part,
+        title="",
+        number="",
+        tolerance="ISO 2768-m",
+        drawn_by="",
+        out="",
+        page="A4",
+        model=drawing.model(),
+    )
+    pattern = next(feature for feature in drawing.model().features if feature.kind == "pattern")
+    callout_name = next(name for name in drawing.annotations() if name.startswith("hc_plan"))
+    measurements = drawing.registry.measurement_of(callout_name)
+    drawing.remove(callout_name)
+    issue = LintIssue(
+        severity="warning",
+        code="callout_dropped",
+        message="synthetic grouped pattern callout drop",
+        measurement_ids=measurements,
+        hole_requirement_ids=(
+            (pattern, "bore.through"),
+            (pattern, "grouping.count"),
+        ),
+    )
+    drawing.registry.record_issue(issue)
+    ctx = PlacementContext(
+        registry=drawing.registry,
+        coverage=drawing.coverage,
+        items=drawing.items,
+        part_model=drawing.model(),
+        escalations=(
+            Escalation(
+                kind="callout",
+                view="plan",
+                feature=pattern,
+                reason="strip_full",
+                targets=measurements,
+            ),
+        ),
+    )
+
+    _maybe_tabulate_holes(drawing, analysis, ctx=ctx)
+
+    balloon_name = "balloon_plan_6×A_0"
+    assert balloon_name in drawing.annotations()
+    assert drawing.measurement_keys(balloon_name) == []
+    assert issue in drawing.registry.issues
+    dropped = {
+        outcome.parameter_id
+        for outcome in _outcomes(drawing)
+        if outcome.source_kind == "hole_pattern" and outcome.state == "dropped"
+    }
+    assert dropped == {
+        "bore.diameter",
+        "bore.through",
+        "bolt_circle.diameter",
+        "grouping.count",
+    }
 
 
 def test_automatic_partial_result_rolls_back_when_fallback_aware_refit_fails(monkeypatch):
@@ -850,7 +999,11 @@ def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkey
         if issue.code == "location_ref_dropped"
         and _features_from_issue(issue) & placed_callout_features
     )
-    feature = next(iter(_features_from_issue(location_issue)))
+    feature = next(iter(_features_from_issue(location_issue) & placed_callout_features))
+    dropped_parameters = {
+        parameter for owner, parameter in location_issue.hole_requirement_ids if owner is feature
+    }
+    assert dropped_parameters
     declared = replace(
         baseline.model(),
         decorations={(feature, "diameter"): fit_class("H7", feature.diameter)},
@@ -876,7 +1029,7 @@ def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkey
     assert {
         outcome.representation
         for outcome in outcomes
-        if outcome.parameter_id.startswith("location")
+        if outcome.parameter_id in dropped_parameters
     } == {"hole_table"}
     assert {
         outcome.representation for outcome in outcomes if outcome.parameter_id == "bore.diameter"
@@ -957,8 +1110,8 @@ def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
     } == {None}
 
 
-def test_automatic_table_keeps_compound_callout_and_all_feasible_balloons():
-    drawing = build_drawing(_dense_plate_with_counterbore())
+def test_automatic_compound_inventory_fails_closed_on_cross_balloon_geometry():
+    drawing = build_drawing(_dense_plate_with_counterbore(), page="A3")
     feature = next(
         feature
         for feature in drawing.model().features
@@ -967,8 +1120,8 @@ def test_automatic_table_keeps_compound_callout_and_all_feasible_balloons():
 
     assert "hole_table_plan" in drawing.annotations()
     assert feature in _plan_bore_callouts(drawing)
-    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 20
-    assert not [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
     states = {outcome.parameter_id: outcome.state for outcome in _outcomes(drawing)}
     assert states["counterbore.diameter"] == "placed"
     assert states["counterbore.depth"] == "placed"
@@ -981,7 +1134,8 @@ def test_automatic_table_keeps_compound_callout_and_all_feasible_balloons():
         (outcome.representation, outcome.representation_reason) for outcome in compound_outcomes
     } == {(None, None)}
     assert any(
-        outcome.representation == "hole_table"
+        outcome.representation == "feature_annotation"
+        and outcome.representation_reason == "required_balloon_not_placed"
         for outcome in _outcomes(drawing)
         if outcome.source_at[:2] != tuple(feature.frame.origin[:2])
     )
@@ -993,8 +1147,11 @@ def test_automatic_table_keeps_compound_callout_and_all_feasible_balloons():
     assert not [
         issue
         for issue in drawing.lint()
-        if issue.code == "label_centerline_overlap"
-        and any(f"label '{label}'" in issue.message for label in visible_labels)
+        if issue.code in {"label_centerline_overlap", "hole_requirement_missing"}
+        and (
+            issue.code == "hole_requirement_missing"
+            or any(f"label '{label}'" in issue.message for label in visible_labels)
+        )
     ]
 
 

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -194,6 +194,75 @@ def test_requirement_scoped_representation_is_a_semantic_owner_seam():
     ) == frozenset({feature})
 
 
+def test_table_commit_requires_exact_balloon_cardinality_and_owner():
+    from draftwright.annotations._common import _fully_ballooned_features
+    from draftwright.registry import AnnotationRegistry
+
+    feature = type("Feature", (), {"kind": "hole"})()
+    wrong_owner = type("Feature", (), {"kind": "hole"})()
+    tagged = [
+        ("A", 0, object(), feature),
+        ("A", 1, object(), feature),
+    ]
+    registry = AnnotationRegistry()
+    first, second = object(), object()
+    registry.add(first, "balloon_plan_A_0", "plan", feature=feature)
+
+    # A declared QTY=2 row is not committed from one landed member.
+    assert not _fully_ballooned_features(
+        "plan",
+        tagged,
+        {"balloon_plan_A_0"},
+        registry,
+        {feature: 2},
+    )
+
+    # The right attempt-local name is still not evidence when another feature
+    # owns that physical balloon position.
+    registry.add(second, "balloon_plan_A_1", "plan", feature=wrong_owner)
+    assert not _fully_ballooned_features(
+        "plan",
+        tagged,
+        {"balloon_plan_A_0", "balloon_plan_A_1"},
+        registry,
+        {feature: 2},
+    )
+
+    registry.add(second, "balloon_plan_A_1", "plan", feature=feature)
+    assert _fully_ballooned_features(
+        "plan",
+        tagged,
+        {"balloon_plan_A_0", "balloon_plan_A_1"},
+        registry,
+        {feature: 2},
+    ) == {feature}
+
+
+def test_guarded_balloon_obstacles_use_compact_labels_and_note_boxes():
+    from draftwright.annotations._common import balloon_annotation_label_boxes
+
+    class BoxedNote:
+        def bounding_box(self):
+            return SimpleNamespace(
+                min=SimpleNamespace(X=3.0, Y=4.0),
+                max=SimpleNamespace(X=8.0, Y=9.0),
+            )
+
+    label = SimpleNamespace(label_bbox=(1.0, 1.0, 2.0, 2.0))
+    note = BoxedNote()
+    other_view = SimpleNamespace(label_bbox=(20.0, 20.0, 21.0, 21.0))
+    drawing = SimpleNamespace(
+        box_cache={},
+        iter_annotations=lambda: iter((("label", label), ("note", note), ("other", other_view))),
+        view_of=lambda name: "side" if name == "other" else "plan",
+    )
+
+    assert balloon_annotation_label_boxes(drawing, "plan") == (
+        (1.0, 1.0, 2.0, 2.0),
+        (3.0, 4.0, 8.0, 9.0),
+    )
+
+
 def test_segmented_centerline_diagnostic_ignores_only_the_empty_aabb_triangle():
     from draftwright.linting.structural import _label_centerline_overlap
 
@@ -205,6 +274,178 @@ def test_segmented_centerline_diagnostic_ignores_only_the_empty_aabb_triangle():
 
     assert _label_centerline_overlap(label, clear_elbow) is None
     assert _label_centerline_overlap(label, crossing) is not None
+
+    # A balloon's ring/text glyph is a real occupied component even when its
+    # leader shaft stays clear.  The precise component box keeps that collision
+    # visible without restoring the compound's empty diagonal AABB triangle.
+    balloon_glyph = SimpleNamespace(
+        centerline_segments=(((-1.0, -1.0), (3.0, -1.0)),),
+        centerline_boxes=((0.5, 0.5, 1.5, 1.5),),
+    )
+    assert _label_centerline_overlap(label, balloon_glyph) is not None
+    assert (
+        _label_centerline_overlap(
+            SimpleNamespace(label="", label_bbox=None),
+            balloon_glyph,
+        )
+        is None
+    )
+
+
+def test_guarded_assignment_can_reassign_a_balloon_to_a_spare_band():
+    from draftwright.annotations.balloons import (
+        _guarded_assignment,
+        _GuardedSegments,
+    )
+
+    members = [
+        ("A", 0, object(), 0.0, 0.0),
+        ("B", 0, object(), 0.0, 0.0),
+        ("C", 0, object(), 0.0, 10.0),
+    ]
+    # Capacity-only min-cost flow chooses A+B on the left and C on the right;
+    # A and B share the same sole left coordinate, so the guarded global solve
+    # must move B to the remote right band and keep C at left=10.
+    choices = [
+        {"left": 0.0},
+        {"left": 0.0, "right": 100.0},
+        {"left": 0.0, "right": 0.0},
+    ]
+    bands = {
+        "left": ("y", 0.0, 0.0, 10.0),
+        "right": ("y", 20.0, 0.0, 10.0),
+    }
+    guarded = _GuardedSegments(
+        {
+            (0, "left"): ((5.0, 5.0),),
+            (1, "left"): ((5.0, 5.0),),
+            (1, "right"): ((5.0, 5.0),),
+            (2, "left"): ((10.0, 10.0),),
+            (2, "right"): ((10.0, 10.0),),
+        },
+        5.0,
+    )
+
+    assignments, solutions, dropped = _guarded_assignment(
+        members,
+        choices,
+        bands,
+        {"left": 2, "right": 1},
+        guarded,
+    )
+
+    assert dropped == 0
+    assert assignments == {"left": [0, 2], "right": [1]}
+    assert solutions == {"left": {0: 5.0, 2: 10.0}, "right": {1: 5.0}}
+
+
+def test_real_shaft_crossing_carves_the_guarded_band_without_aabb_sampling():
+    from draftwright.annotations.balloons import (
+        _balloon_shaft_segments,
+        _guarded_free_segments,
+    )
+
+    assert _balloon_shaft_segments(0.0, 0.0, 1.0, 0.0, 1.0, 1.0) == ()
+
+    member = ("A", 0, SimpleNamespace(diameter=2.0), 0.0, 0.0)
+    free = _guarded_free_segments(
+        member,
+        "y",
+        10.0,
+        ((0.0, 10.0),),
+        1.0,
+        1.0,
+        ((4.0, 4.0, 6.0, 6.0),),
+    )
+
+    assert any(lo <= 0.0 <= hi for lo, hi in free)
+    assert not any(lo <= 10.0 <= hi for lo, hi in free)
+
+
+def test_guarded_private_band_places_joint_solution_and_fails_closed(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+
+    members = [
+        ("A", 0, SimpleNamespace(diameter=2.0), 0.0, 0.0),
+        ("B", 0, SimpleNamespace(diameter=2.0), 0.0, 5.0),
+    ]
+    rendered = []
+    monkeypatch.setattr(
+        balloons_module,
+        "balloon_annotation_label_boxes",
+        lambda *_args: (),
+    )
+    monkeypatch.setattr(
+        balloons_module,
+        "_render_balloon",
+        lambda *args: rendered.append(args),
+    )
+
+    dropped = balloons_module._place_band(
+        SimpleNamespace(scale=1.0),
+        "plan",
+        members,
+        "y",
+        20.0,
+        0.0,
+        10.0,
+        5.0,
+        3.0,
+        1.0,
+        object(),
+        avoid_annotation_labels=True,
+    )
+
+    assert dropped == 0
+    assert len(rendered) == 2
+
+    monkeypatch.setattr(
+        balloons_module,
+        "_guarded_free_segments",
+        lambda *_args: (),
+    )
+    assert (
+        balloons_module._place_band(
+            SimpleNamespace(scale=1.0),
+            "plan",
+            members,
+            "y",
+            20.0,
+            0.0,
+            10.0,
+            5.0,
+            3.0,
+            1.0,
+            object(),
+            avoid_annotation_labels=True,
+        )
+        == 2
+    )
+
+
+def test_automatic_actual_label_guard_restores_features_with_no_safe_balloon(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+
+    # A real retained-label box occupying every reserved band makes every
+    # attempted ring/shaft infeasible. The automatic transaction must retain
+    # the feature-backed leaders instead of silently accepting table coverage.
+    monkeypatch.setattr(
+        balloons_module,
+        "balloon_annotation_label_boxes",
+        lambda *_args: ((-1000.0, -1000.0, 1000.0, 1000.0),),
+    )
+
+    drawing = build_drawing(_dense_scattered_plate())
+
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert len(_plan_bore_callouts(drawing)) == 17
+    assert "balloon_dropped" in {issue.code for issue in drawing.registry.issues}
+    assert ("feature_annotation", "required_balloon_not_placed") in {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _outcomes(drawing)
+        if outcome.state == "placed"
+    }
+    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
 def test_public_hole_table_remains_additive_and_keeps_every_balloon():
@@ -275,6 +516,11 @@ def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
     codes = [issue.code for issue in drawing.lint()]
     assert codes.count("table_dropped") == 1
     assert "hole_requirement_missing" not in codes
+    assert ("feature_annotation", "table_not_placed") in {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _outcomes(drawing)
+        if outcome.state == "placed"
+    }
 
 
 def test_automatic_partial_balloon_result_restores_only_the_unresolved_feature(monkeypatch):
@@ -297,6 +543,19 @@ def test_automatic_partial_balloon_result_restores_only_the_unresolved_feature(m
     ) == len(table.covers_diameters)
     assert "balloon_dropped" in {issue.code for issue in drawing.lint()}
     assert {outcome.state for outcome in _outcomes(drawing)} <= {"placed", "dropped"}
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _outcomes(drawing)
+        if outcome.source_at[:2] == tuple(unresolved.frame.origin[:2])
+        and outcome.parameter_id in {"bore.diameter", "bore.through"}
+    } == {("feature_annotation", "required_balloon_not_placed")}
+    unresolved_label = _plan_bore_callouts(drawing)[unresolved][1].label
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code == "label_centerline_overlap"
+        and f"label '{unresolved_label}'" in issue.message
+    ]
 
 
 def test_automatic_partial_result_rolls_back_when_fallback_aware_refit_fails(monkeypatch):

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -162,7 +162,9 @@ def _transaction_state(drawing):
         "coverage": drawing.coverage.snapshot(),
         "markers": {
             name: (
+                hasattr(drawing.get_annotation(name), "hole_representation"),
                 getattr(drawing.get_annotation(name), "hole_representation", None),
+                hasattr(drawing.get_annotation(name), "hole_representation_reason"),
                 getattr(drawing.get_annotation(name), "hole_representation_reason", None),
             )
             for name in drawing.annotations()
@@ -1386,6 +1388,10 @@ def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
     marked_annotation.hole_representation = "preexisting_representation"
     marked_annotation.hole_representation_reason = "preexisting_reason"
     before = _transaction_state(drawing)
+    unmarked_name, _unmarked_annotation = next(
+        value for value in original_callouts.values() if value[0] != marked_name
+    )
+    assert before["markers"][unmarked_name] == (False, None, False, None)
     original_reapply = drawing.registry.reapply
 
     def fail_after_coverage(name, identity):

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -575,6 +575,26 @@ def test_guarded_assignment_is_bounded_and_fails_an_infeasible_flow_closed(monke
     assert dropped == member_count
 
 
+def test_guarded_solver_budget_rolls_the_automatic_table_transaction_back(monkeypatch):
+    import draftwright.layout as layout_module
+
+    # Make the production resource guard load-bearing without constructing a
+    # pathological state matrix in the test process.  Exceeding the budget is
+    # an ordinary infeasible guarded inventory: the shared table and all of its
+    # balloons must lose to the complete feature-backed fallback inventory.
+    monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_STATES", 1)
+
+    drawing = build_drawing(_dense_scattered_plate(), page="A3")
+
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert len([name for name in drawing.annotations() if name.startswith("hc_plan")]) == 17
+    codes = [issue.code for issue in drawing.registry.issues]
+    assert "table_dropped" in codes
+    assert "balloon_dropped" in codes
+    assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
+
+
 def test_real_shaft_crossing_carves_the_guarded_band_without_aabb_sampling():
     from draftwright.annotations.balloons import (
         _balloon_shaft_segments,

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -292,6 +292,20 @@ def test_segmented_centerline_diagnostic_ignores_only_the_empty_aabb_triangle():
     )
 
 
+def test_centerline_warning_tolerance_uses_the_actual_colliding_component():
+    from draftwright.linting.structural import _label_centerline_overlap
+
+    balloon = SimpleNamespace(
+        centerline_segments=(((-10.0, 0.5), (0.0, 0.5)),),
+        centerline_boxes=((0.0, 0.0, 1.0, 1.0),),
+    )
+    edge_touch = SimpleNamespace(label="EDGE", label_bbox=(0.9, 0.0, 2.0, 1.0))
+    significant = SimpleNamespace(label="HIT", label_bbox=(0.4, 0.0, 2.0, 1.0))
+
+    assert _label_centerline_overlap(edge_touch, balloon) is None
+    assert _label_centerline_overlap(significant, balloon) is not None
+
+
 def test_long_public_balloon_text_remains_visible_to_structural_lint():
     from draftwright.linting.structural import _label_centerline_overlap
 
@@ -533,6 +547,83 @@ def test_guarded_private_band_places_joint_solution_and_fails_closed(monkeypatch
     )
 
 
+def test_guarded_private_band_separates_sibling_long_tag_text(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+    from draftwright._geometry import _boxes_overlap
+
+    tags = ("LONG_BALLOON_TAG_0", "LONG_BALLOON_TAG_1")
+    members = [
+        (tag, 0, SimpleNamespace(diameter=2.0), natural, 0.0)
+        for tag, natural in zip(tags, (0.0, 13.0), strict=True)
+    ]
+    placed = []
+    monkeypatch.setattr(balloons_module, "balloon_annotation_label_boxes", lambda *_args: ())
+    monkeypatch.setattr(
+        balloons_module,
+        "_render_balloon",
+        lambda _dwg, _view, tag, _j, _hole, _cx, _cy, bx, by, *_rest: placed.append((tag, bx, by)),
+    )
+
+    dropped = balloons_module._place_band(
+        SimpleNamespace(scale=1.0),
+        "plan",
+        members,
+        "x",
+        20.0,
+        -50.0,
+        50.0,
+        13.0,
+        3.0,
+        4.5,
+        object(),
+        avoid_annotation_labels=True,
+    )
+
+    assert dropped == 0
+    assert len(placed) == 2
+    boxes = []
+    for tag, bx, by in placed:
+        text_box = balloons_module._balloon_text_box(tag, 3.0)
+        assert text_box is not None
+        boxes.append(tuple(value + offset for value, offset in zip(text_box, (bx, by, bx, by))))
+    assert not _boxes_overlap(*boxes)
+
+
+def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry():
+    from draftwright.annotations.balloons import _guarded_inventory_geometry_is_clear
+
+    page = (0.0, 0.0, 100.0, 100.0)
+    first = ((((10.0, 10.0, 20.0, 20.0),), ()),)
+    clear_second = (((30.0, 30.0, 40.0, 40.0),), ())
+    overlapping_second = (((19.0, 15.0, 29.0, 25.0),), ())
+    off_page = (((95.0, 95.0, 105.0, 105.0),), ())
+
+    assert _guarded_inventory_geometry_is_clear((*first, clear_second), page)
+    assert not _guarded_inventory_geometry_is_clear((*first, overlapping_second), page)
+    assert not _guarded_inventory_geometry_is_clear((*first, off_page), page)
+
+
+def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+
+    monkeypatch.setattr(
+        balloons_module,
+        "_guarded_inventory_geometry_is_clear",
+        lambda *_args: False,
+    )
+
+    drawing = build_drawing(_dense_scattered_plate())
+
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert len(_plan_bore_callouts(drawing)) == 17
+    assert "balloon_dropped" in {issue.code for issue in drawing.registry.issues}
+    assert ("feature_annotation", "required_balloon_not_placed") in {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _outcomes(drawing)
+        if outcome.state == "placed"
+    }
+
+
 def test_automatic_actual_label_guard_restores_features_with_no_safe_balloon(monkeypatch):
     import draftwright.annotations.balloons as balloons_module
 
@@ -590,6 +681,31 @@ def test_public_add_balloons_retains_its_existing_cardinality_contract():
         f"balloon_plan_T{index}_0" for index in range(3)
     }
     assert not [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
+
+
+def test_public_add_balloons_separates_long_sibling_text_components():
+    from draftwright._geometry import _boxes_overlap
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4", auto_dims=False)
+    holes = drawing.recognition().holes
+    drawing.add_balloons(
+        "plan",
+        [(f"LONG_BALLOON_TAG_{index}", 0, holes[index % len(holes)]) for index in range(4)],
+    )
+    balloons = [
+        drawing.get_annotation(name)
+        for name in drawing.annotations()
+        if name.startswith("balloon_plan_LONG_BALLOON_TAG_")
+    ]
+
+    assert len(balloons) == 4
+    assert not any(
+        _boxes_overlap(first_box, second_box)
+        for index, first in enumerate(balloons)
+        for second in balloons[index + 1 :]
+        for first_box in first.centerline_boxes
+        for second_box in second.centerline_boxes
+    )
 
 
 def test_public_hole_table_does_not_expose_an_uncomposable_replacement_option():

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -817,13 +817,43 @@ def test_public_add_balloons_separates_long_sibling_text_components():
     )
 
 
-def test_automatic_table_fails_closed_against_a_retained_public_balloon():
+@pytest.mark.parametrize(
+    "component_metadata",
+    ["valid", "empty", "malformed", "nonfinite", "descending", "absent", "unmeasurable"],
+)
+def test_automatic_table_fails_closed_against_a_retained_public_balloon(
+    component_metadata, monkeypatch
+):
     drawing = build_drawing(_dense_perimeter_plate(), page="A3", auto_dims=False)
     tag = "RETAINED_PUBLIC_BALLOON_WITH_A_VERY_LONG_TAG"
     retained_name = f"balloon_plan_{tag}_0"
     drawing.add_balloons("plan", [(tag, 0, drawing.recognition().holes[0])])
     retained = drawing.get_annotation(retained_name)
     assert retained is not None
+    assert retained.is_balloon
+    if component_metadata in {"empty", "unmeasurable"}:
+        retained.centerline_boxes = ()
+        retained.centerline_segments = ()
+    elif component_metadata == "malformed":
+        retained.centerline_boxes = (("not", "a", "box"),)
+    elif component_metadata == "nonfinite":
+        retained.centerline_boxes = ((float("nan"), 0.0, 1.0, 1.0),)
+    elif component_metadata == "descending":
+        retained.centerline_boxes = ((1.0, 1.0, 0.0, 0.0),)
+    elif component_metadata == "absent":
+        del retained.centerline_boxes
+        del retained.centerline_segments
+    if component_metadata == "unmeasurable":
+        import draftwright.annotations.balloons as balloons_module
+
+        original_geom_box = balloons_module._geom_box
+        monkeypatch.setattr(
+            balloons_module,
+            "_geom_box",
+            lambda annotation, cache: (
+                None if annotation is retained else original_geom_box(annotation, cache)
+            ),
+        )
 
     with drawing.deferred():
         for feature in drawing.model().features:

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -930,6 +930,8 @@ def test_public_add_balloons_separates_long_sibling_text_components():
         "absent_counts",
         "wrong_counts",
         "boolean_counts",
+        "boolean_box_coordinates",
+        "boolean_segment_coordinates",
         "malformed",
         "nonfinite",
         "descending",
@@ -967,6 +969,13 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
         retained.centerline_boxes = retained.centerline_boxes[:1]
         retained.centerline_segments = ()
         retained.balloon_component_counts = (True, False)
+    elif component_metadata == "boolean_box_coordinates":
+        retained.centerline_boxes = (
+            (False, False, True, True),
+            (False, False, True, True),
+        )
+    elif component_metadata == "boolean_segment_coordinates":
+        retained.centerline_segments = (((False, False), (True, True)),)
     elif component_metadata == "malformed":
         retained.centerline_boxes = (("not", "a", "box"),)
     elif component_metadata == "nonfinite":

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -1,18 +1,18 @@
-"""Regression coverage for transactional hole-table replacement (#1144)."""
+"""Regression coverage for transactional automatic hole-table escalation (#1144)."""
 
 from __future__ import annotations
 
+import inspect
 import itertools
 from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from build123d import Align, Box, Cylinder, Pos, Rot
+from build123d import Align, Box, Cylinder, Pos
 
 from draftwright import build_drawing
 from draftwright.fits import fit_class
 from draftwright.linting.hole_coverage import hole_requirement_outcomes
-from draftwright.linting.issues import LintIssue
 from draftwright.model.compiled import compile_dimensions
 
 
@@ -35,20 +35,32 @@ def _dense_scattered_plate():
     return part
 
 
+def _dense_plate_with_close_x_ordinates():
+    """Dense inventory with two separately placed X ordinates only 0.4 mm apart."""
+    positions = list(itertools.product((-36, -18, 0, 18, 36), (-20, -7, 7, 20)))
+    # Give the close pair the two largest bores so their callouts survive the
+    # strip's diameter-priority solve while one of their X ordinates is rejected.
+    positions[-2] = (0.0, -25.0)
+    positions[-1] = (0.4, 25.0)
+    part = Box(90, 60, 12)
+    for index, (x, y) in enumerate(positions):
+        part -= Pos(x, y, 0) * Cylinder(1.0 + index * 0.18, 20)
+    return part
+
+
 def _dense_plate_with_counterbore():
-    """Dense escalation with one recognised compound hole callout."""
+    """Reviewer fixture whose diagonal balloon AABB used to reject a clear leader."""
     part = Box(90, 60, 12)
     columns = [-40 + i * 20 for i in range(5)]
     for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
         diameter = 2.0 + i * 0.4
         part -= Pos(columns[column], y, 0) * Cylinder(diameter / 2, 20)
-        if i == 0:
+        if i == 2:
             part -= Pos(columns[column], y, 4.5) * Cylinder(2.5, 3)
     return part
 
 
 def _dense_plate_with_double_d():
-    """Dense escalation with one recognised DOUBLE-D through bore."""
     part = Box(90, 60, 12)
     columns = [-40 + i * 20 for i in range(5)]
     centered = (Align.CENTER, Align.CENTER, Align.CENTER)
@@ -61,16 +73,35 @@ def _dense_plate_with_double_d():
     return part
 
 
-def _double_d_plate():
-    centered = (Align.CENTER, Align.CENTER, Align.CENTER)
-    cutter = Cylinder(5, 20, align=centered) & Box(7.2, 20, 30, align=centered)
-    return Box(30, 30, 10, align=centered) - cutter
-
-
-def _build_multi_hole_drawing(*, declared):
-    part = _multi_hole_plate()
-    model = build_drawing(part, auto_dims=False).model() if declared else None
-    return build_drawing(part, page="A4", model=model)
+def _dense_plate_with_one_group():
+    """Twenty bores, including one physical two-member machining-spec group."""
+    positions = [
+        (-39, -19),
+        (-27, -14),
+        (-14, -21),
+        (1, -16),
+        (17, -22),
+        (35, -17),
+        (-36, -4),
+        (-21, 2),
+        (-7, -6),
+        (9, 1),
+        (24, -5),
+        (39, 4),
+        (-34, 14),
+        (-18, 21),
+        (-2, 12),
+        (13, 20),
+        (29, 13),
+        (38, 23),
+        (-28, 26),
+        (4, 27),
+    ]
+    part = Box(100, 70, 12)
+    for index, (x, y) in enumerate(positions):
+        radius = 2.0 if index < 2 else 1.0 + index * 0.17
+        part -= Pos(x, y, 0) * Cylinder(radius, 20)
+    return part
 
 
 def _outcomes(drawing):
@@ -84,7 +115,6 @@ def _outcomes(drawing):
 
 
 def _transaction_state(drawing):
-    """Every mutable surface the public table transaction promises to restore."""
     registry = drawing.registry.snapshot()
     return {
         "items": tuple(id(item) for item in drawing.items),
@@ -105,43 +135,22 @@ def _transaction_state(drawing):
     }
 
 
-def _source_outcomes(drawing, feature):
-    point = list(feature.frame.origin)
-    if feature.through:
-        point["xyz".index(feature.frame.axis)] = 0.0
-    expected = tuple(round(float(value), 3) for value in point)
-    return [outcome for outcome in _outcomes(drawing) if outcome.source_at == expected]
-
-
 def _plan_bore_callouts(drawing):
-    """Map semantic bore owner to its placed plan-view callout."""
     callouts = {}
     for name in drawing.annotations():
         if drawing.registry.view_of(name) != "plan":
             continue
-        measurements = tuple(drawing.registry.measurement_of(name))
-        diameter_ids = [item for item in measurements if item.parameter == "bore.diameter"]
+        diameter_ids = [
+            item
+            for item in drawing.registry.measurement_of(name)
+            if item.parameter == "bore.diameter"
+        ]
         if len(diameter_ids) == 1:
             callouts[diameter_ids[0].feature] = (name, drawing.get_annotation(name))
     return callouts
 
 
-def _callout_label_overlap_issues(drawing):
-    labels = {
-        annotation.label
-        for _feature, (_name, annotation) in _plan_bore_callouts(drawing).items()
-        if annotation.label
-    }
-    return [
-        issue
-        for issue in drawing.lint()
-        if issue.code == "label_centerline_overlap"
-        and any(f"label '{label}'" in issue.message for label in labels)
-    ]
-
-
 def _drop_one_diameter_balloon(monkeypatch, diameter):
-    """Force one otherwise feasible balloon assignment to become partial."""
     import draftwright.annotations.balloons as balloons_module
 
     original = balloons_module._assign_balloon_bands
@@ -158,72 +167,56 @@ def _drop_one_diameter_balloon(monkeypatch, diameter):
     monkeypatch.setattr(balloons_module, "_assign_balloon_bands", partial_assignment)
 
 
-def test_transaction_collects_every_structured_feature_seam():
-    from draftwright.annotations._common import (
-        _annotation_hole_features,
-        _hole_table_replaceable_annotation,
-        _stash_annotations,
-    )
+def _features_from_issue(issue):
+    return {
+        feature
+        for feature in (
+            *(getattr(measurement, "feature", None) for measurement in issue.measurement_ids),
+            *(requirement[0] for requirement in issue.hole_requirement_ids),
+        )
+        if feature is not None
+    }
+
+
+def test_requirement_scoped_representation_is_a_semantic_owner_seam():
+    from draftwright.annotations._common import _annotation_hole_features
     from draftwright.registry import AnnotationRegistry
 
     feature = type("Feature", (), {"kind": "hole"})()
-    representation_feature = type("Feature", (), {"kind": "hole"})()
     annotation = SimpleNamespace(
-        covers_hole_locations=(),
-        covers_hole_requirements_by_feature=((feature, "bore.through", 1),),
-        covers_hole_centers=((feature, (0.0, 0.0, 0.0), "plan"),),
-        covers_hole_representations_by_feature=(
-            (representation_feature, "hole_table", "required_balloons_placed"),
-        ),
+        covers_hole_representations_by_requirement=(
+            (feature, "location.location.x", "hole_table", "required_balloons_placed"),
+        )
     )
-    registry = AnnotationRegistry()
 
-    assert _annotation_hole_features(registry, "missing", annotation) == frozenset(
-        {feature, representation_feature}
+    assert _annotation_hole_features(
+        AnnotationRegistry(), "unregistered", annotation
+    ) == frozenset({feature})
+
+
+def test_segmented_centerline_diagnostic_ignores_only_the_empty_aabb_triangle():
+    from draftwright.linting.structural import _label_centerline_overlap
+
+    label = SimpleNamespace(label="CALL", label_bbox=(0.0, 0.0, 2.0, 2.0))
+    clear_elbow = SimpleNamespace(
+        segments=(((-1.0, -1.0), (3.0, -1.0)), ((3.0, -1.0), (3.0, 3.0)))
     )
-    assert not _hole_table_replaceable_annotation(
-        registry, "missing", SimpleNamespace(covers_hole_locations=())
-    )
-    assert _stash_annotations(SimpleNamespace(registry=registry), ["missing"]) == {}
+    crossing = SimpleNamespace(segments=(((-1.0, 1.0), (3.0, 1.0)),))
+
+    assert _label_centerline_overlap(label, clear_elbow) is None
+    assert _label_centerline_overlap(label, crossing) is not None
 
 
-@pytest.mark.parametrize("declared", [False, True], ids=["automatic", "declared-ir"])
-def test_successful_public_replacement_commits_only_after_every_balloon_lands(declared):
-    drawing = _build_multi_hole_drawing(declared=declared)
-    original = _plan_bore_callouts(drawing)
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert all(name not in drawing.annotations() for name, _annotation in original.values())
-    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 3
-    assert set(table.covers_diameters) == {10.0, 16.0}
-    table_features = {
-        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
-    }
-    assert table_features == set(original)
-    represented = [
-        outcome
-        for outcome in _outcomes(drawing)
-        if outcome.parameter_id in {"bore.diameter", "bore.through", "grouping.count"}
-    ]
-    assert represented
-    assert {
-        (outcome.state, outcome.representation, outcome.representation_reason)
-        for outcome in represented
-    } == {("placed", "hole_table", "required_balloons_placed")}
-    assert not {"hole_requirement_missing", "feature_not_dimensioned"} & {
-        issue.code for issue in drawing.lint()
-    }
-
-
-def test_public_table_remains_additive_by_default_for_compatibility():
+def test_public_hole_table_remains_additive_and_keeps_every_balloon():
     drawing = build_drawing(_multi_hole_plate(), page="A4")
     original = _plan_bore_callouts(drawing)
 
-    assert drawing.add_hole_table("plan") is not None
+    table = drawing.add_hole_table("plan")
 
-    assert all(name in drawing.annotations() for name, _annotation in original.values())
+    assert table is not None
+    assert all(drawing.get_annotation(name) is item for name, item in original.values())
+    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 3
+    assert not [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
     assert {
         (outcome.representation, outcome.representation_reason)
         for outcome in _outcomes(drawing)
@@ -231,220 +224,27 @@ def test_public_table_remains_additive_by_default_for_compatibility():
     } == {(None, None)}
 
 
-def test_constrained_a4_table_failure_restores_exact_callouts_and_identity(monkeypatch):
-    import draftwright.drawing as drawing_module
-
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    before_order = tuple(id(item) for item in drawing.items)
-    before_names = tuple(drawing.annotations())
-    original = _plan_bore_callouts(drawing)
-    identities = {
-        name: drawing.registry.identity_of(name) for name, _annotation in original.values()
-    }
-    pinned_name = next(iter(identities))
-    drawing.pin(pinned_name)
-    identities[pinned_name] = drawing.registry.identity_of(pinned_name)
-    monkeypatch.setattr(drawing_module, "fit_box", lambda *_args, **_kwargs: None)
-
-    assert drawing.add_hole_table("plan", replace_callouts=True) is None
-
-    for name, annotation in original.values():
-        assert drawing.get_annotation(name) is annotation
-        assert drawing.registry.identity_of(name) == identities[name]
-    assert drawing.registry.is_pinned(pinned_name)
-    assert tuple(id(item) for item in drawing.items) == before_order
-    assert tuple(drawing.annotations()) == before_names
-    codes = [issue.code for issue in drawing.lint()]
-    assert codes.count("table_dropped") == 1
-    assert "hole_requirement_missing" not in codes
-    represented = [
-        outcome
-        for outcome in _outcomes(drawing)
-        if outcome.parameter_id in {"bore.diameter", "bore.through", "grouping.count"}
+def test_public_add_balloons_retains_its_existing_cardinality_contract():
+    drawing = build_drawing(_multi_hole_plate(), page="A4", auto_dims=False)
+    holes = [
+        SimpleNamespace(location=point, diameter=feature.diameter)
+        for feature in drawing.model().features
+        if feature.kind == "hole"
+        for point in (feature.members or (feature.frame.origin,))
     ]
-    assert {
-        (outcome.state, outcome.representation, outcome.representation_reason)
-        for outcome in represented
-    } == {("placed", "feature_annotation", "table_not_placed")}
 
+    drawing.add_balloons("plan", [(f"T{index}", 0, hole) for index, hole in enumerate(holes)])
 
-def test_partial_public_balloon_commit_restores_only_the_unresolved_group(monkeypatch):
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    original = _plan_bore_callouts(drawing)
-    grouped_feature = next(feature for feature in original if feature.count == 2)
-    single_feature = next(feature for feature in original if feature.count == 1)
-    _drop_one_diameter_balloon(monkeypatch, 10.0)
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    grouped_name, grouped_callout = original[grouped_feature]
-    assert drawing.get_annotation(grouped_name) is grouped_callout
-    assert original[single_feature][0] not in drawing.annotations()
-    assert table.covers_diameters == (16.0,)
-    assert {
-        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
-    } == {single_feature}
-    assert not [
-        name
-        for name in drawing.annotations()
-        if name.startswith("balloon_plan_")
-        and drawing.registry.feature_of(name) == grouped_feature
-    ]
-    warning_codes = {
-        issue.code for issue in drawing.lint() if issue.severity in {"warning", "error"}
+    assert {name for name in drawing.annotations() if name.startswith("balloon_plan_T")} == {
+        f"balloon_plan_T{index}_0" for index in range(3)
     }
-    assert warning_codes == {"balloon_dropped"}
-    outcomes = _outcomes(drawing)
-    assert all(outcome.state == "placed" for outcome in outcomes)
-    represented = {
-        (
-            outcome.representation,
-            outcome.representation_reason,
-        )
-        for outcome in outcomes
-        if outcome.parameter_id == "bore.diameter"
-    }
-    assert represented == {
-        ("hole_table", "required_balloons_placed"),
-        ("feature_annotation", "required_balloon_not_placed"),
-    }
+    assert not [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
 
 
-def test_public_replacement_rejects_non_plan_views_before_mutation():
-    part = Box(12, 40, 30) - Pos(0, 8, 6) * Rot(0, 90, 0) * Cylinder(3, 12)
-    drawing = build_drawing(part, page="A4")
-    before = _transaction_state(drawing)
+def test_public_hole_table_does_not_expose_an_uncomposable_replacement_option():
+    from draftwright.drawing import Drawing
 
-    with pytest.raises(ValueError, match="currently requires view='plan'"):
-        drawing.add_hole_table("side", replace_callouts=True)
-
-    assert _transaction_state(drawing) == before
-
-
-def test_public_replacement_rolls_back_when_row_formatting_raises(monkeypatch):
-    import draftwright.drawing as drawing_module
-
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    before = _transaction_state(drawing)
-
-    def fail_format(_value):
-        raise RuntimeError("forced row formatting failure")
-
-    monkeypatch.setattr(drawing_module, "_fmt", fail_format)
-
-    with pytest.raises(RuntimeError, match="forced row formatting failure"):
-        drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert _transaction_state(drawing) == before
-
-
-def test_partial_public_commit_refits_clear_of_the_restored_fallback(monkeypatch):
-    import draftwright.drawing as drawing_module
-
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    original = _plan_bore_callouts(drawing)
-    grouped_feature = next(feature for feature in original if feature.count == 2)
-    grouped_callout = original[grouped_feature][1]
-    bbox = grouped_callout.bounding_box()
-    original_fit_box = drawing_module.fit_box
-    fit_calls = 0
-
-    def occupy_freed_fallback(size, region, obstacles, prefer):
-        nonlocal fit_calls
-        fit_calls += 1
-        if fit_calls == 1:
-            return (bbox.min.X, bbox.min.Y)
-        return original_fit_box(size, region, obstacles, prefer)
-
-    monkeypatch.setattr(drawing_module, "fit_box", occupy_freed_fallback)
-    _drop_one_diameter_balloon(monkeypatch, 10.0)
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert fit_calls == 2
-    assert drawing.get_annotation(original[grouped_feature][0]) is grouped_callout
-    assert not {
-        "annotation_overlap",
-        "view_annotation_overlap",
-    } & {issue.code for issue in drawing.lint()}
-
-
-def test_partial_public_commit_rolls_back_when_the_fallback_aware_refit_fails(monkeypatch):
-    import draftwright.drawing as drawing_module
-
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    original = _plan_bore_callouts(drawing)
-    original_fit_box = drawing_module.fit_box
-    fit_calls = 0
-
-    def fail_second_fit(size, region, obstacles, prefer):
-        nonlocal fit_calls
-        fit_calls += 1
-        if fit_calls == 2:
-            return None
-        return original_fit_box(size, region, obstacles, prefer)
-
-    monkeypatch.setattr(drawing_module, "fit_box", fail_second_fit)
-    _drop_one_diameter_balloon(monkeypatch, 10.0)
-
-    assert drawing.add_hole_table("plan", replace_callouts=True) is None
-
-    assert fit_calls == 2
-    assert all(
-        drawing.get_annotation(name) is annotation for name, annotation in original.values()
-    )
-    assert "hole_table_plan" not in drawing.annotations()
-    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    codes = {issue.code for issue in drawing.lint()}
-    assert {"balloon_dropped", "table_dropped"} <= codes
-    assert "hole_requirement_missing" not in codes
-
-
-def test_automatic_partial_balloon_result_never_claims_the_unkeyed_feature(monkeypatch):
-    _drop_one_diameter_balloon(monkeypatch, 2.0)
-
-    drawing = build_drawing(_dense_scattered_plate())
-
-    table = drawing.get_annotation("hole_table_plan")
-    assert table is not None
-    assert 0 < len(table.covers_diameters) < 20
-    table_features = {
-        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
-    }
-    assert len(table_features) == len(table.covers_diameters)
-    assert {feature.diameter for feature in table_features} == set(table.covers_diameters)
-    assert 2.0 not in table.covers_diameters
-    assert len(
-        [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    ) == len(table.covers_diameters)
-    assert "balloon_dropped" in {issue.code for issue in drawing.lint()}
-    outcomes = _outcomes(drawing)
-    assert {outcome.state for outcome in outcomes} <= {"placed", "dropped"}
-    assert all(
-        any(
-            issue.code == "callout_dropped"
-            and any(
-                tuple(measurement.feature.frame.origin[:2]) == tuple(outcome.source_at[:2])
-                for measurement in issue.measurement_ids
-            )
-            for issue in drawing.registry.issues
-        )
-        for outcome in outcomes
-        if outcome.state == "dropped" and outcome.parameter_id == "bore.diameter"
-    )
-    diameter_representations = {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in outcomes
-        if outcome.parameter_id == "bore.diameter"
-    }
-    assert diameter_representations == {
-        ("hole_table", "required_balloons_placed"),
-        ("feature_annotation", "required_balloon_not_placed"),
-        (None, None),
-    }
-    assert not _callout_label_overlap_issues(drawing)
+    assert "replace_callouts" not in inspect.signature(Drawing.add_hole_table).parameters
 
 
 def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
@@ -455,9 +255,9 @@ def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
         baseline = build_drawing(part)
-    baseline_callout_measurements = {
-        tuple(baseline.registry.measurement_of(name))
-        for name in baseline.annotations()
+    baseline_callouts = {
+        name: (item, baseline.registry.identity_of(name))
+        for name, item in baseline.iter_annotations()
         if name.startswith("hc_plan")
     }
     monkeypatch.setattr(drawing_module, "fit_box", lambda *_args, **_kwargs: None)
@@ -468,18 +268,38 @@ def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
     assert tuple(drawing.annotations()) == tuple(baseline.annotations())
     assert drawing.coverage.snapshot() == baseline.coverage.snapshot()
     assert {
-        tuple(drawing.registry.measurement_of(name))
+        name: drawing.registry.identity_of(name)
         for name in drawing.annotations()
         if name.startswith("hc_plan")
-    } == baseline_callout_measurements
+    } == {name: identity for name, (_item, identity) in baseline_callouts.items()}
     codes = [issue.code for issue in drawing.lint()]
     assert codes.count("table_dropped") == 1
     assert "hole_requirement_missing" not in codes
 
 
-def test_automatic_partial_result_rolls_back_when_the_fallback_aware_refit_fails(
-    monkeypatch,
-):
+def test_automatic_partial_balloon_result_restores_only_the_unresolved_feature(monkeypatch):
+    _drop_one_diameter_balloon(monkeypatch, 2.0)
+
+    drawing = build_drawing(_dense_scattered_plate())
+
+    table = drawing.get_annotation("hole_table_plan")
+    assert table is not None
+    assert 0 < len(table.covers_diameters) < 20
+    assert 2.0 not in table.covers_diameters
+    unresolved = next(
+        feature
+        for feature in drawing.model().features
+        if feature.kind == "hole" and feature.diameter == pytest.approx(2.0)
+    )
+    assert unresolved in _plan_bore_callouts(drawing)
+    assert len(
+        [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    ) == len(table.covers_diameters)
+    assert "balloon_dropped" in {issue.code for issue in drawing.lint()}
+    assert {outcome.state for outcome in _outcomes(drawing)} <= {"placed", "dropped"}
+
+
+def test_automatic_partial_result_rolls_back_when_fallback_aware_refit_fails(monkeypatch):
     import draftwright.drawing as drawing_module
 
     original_fit_box = drawing_module.fit_box
@@ -503,270 +323,55 @@ def test_automatic_partial_result_rolls_back_when_the_fallback_aware_refit_fails
     assert first_success_seen
     assert "hole_table_plan" not in drawing.annotations()
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    codes = {issue.code for issue in drawing.lint()}
-    assert {"balloon_dropped", "table_dropped"} <= codes
-    represented = {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _outcomes(drawing)
-        if outcome.state == "placed" and outcome.parameter_id == "bore.diameter"
-    }
-    assert represented == {("feature_annotation", "required_balloon_not_placed")}
+    assert {"balloon_dropped", "table_dropped"} <= {issue.code for issue in drawing.lint()}
+    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
-def test_replacement_without_balloons_fails_before_mutating_the_drawing():
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    before = tuple(drawing.annotations())
+def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkeypatch):
+    import draftwright.annotations.orchestrator as orchestrator
 
-    with pytest.raises(ValueError, match="requires balloons=True"):
-        drawing.add_hole_table("plan", balloons=False, replace_callouts=True)
-
-    assert tuple(drawing.annotations()) == before
-    assert "hole_table_plan" not in drawing.annotations()
-
-
-def test_replacement_without_a_complete_callout_fallback_fails_before_mutation():
-    drawing = build_drawing(_multi_hole_plate(), page="A4", auto_dims=False)
-    before = tuple(drawing.annotations())
-
-    with pytest.raises(ValueError, match="existing bore callout for every"):
-        drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert tuple(drawing.annotations()) == before
-    assert "hole_table_plan" not in drawing.annotations()
-
-
-def test_an_existing_table_cannot_substitute_for_a_missing_leader_fallback():
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    callout_name = next(iter(_plan_bore_callouts(drawing).values()))[0]
-    assert drawing.add_hole_table("plan") is not None
-    drawing.remove(callout_name)
-    for name in tuple(drawing.annotations()):
-        if name.startswith("balloon_plan_"):
-            drawing.remove(name)
-    before = tuple(drawing.annotations())
-
-    with pytest.raises(ValueError, match="existing bore callout for every"):
-        drawing.add_hole_table("plan", name="replacement_table", replace_callouts=True)
-
-    assert tuple(drawing.annotations()) == before
-    assert "replacement_table" not in drawing.annotations()
-
-
-def test_declared_qty_without_member_positions_cannot_commit_one_balloon_as_two():
-    part = _multi_hole_plate()
-    detected = build_drawing(part, auto_dims=False).model()
-    grouped = next(
-        feature for feature in detected.features if feature.kind == "hole" and feature.count == 2
+    part = _dense_plate_with_close_x_ordinates()
+    with monkeypatch.context() as disabled:
+        disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
+        baseline = build_drawing(part, page="A3")
+    placed_callout_features = set(_plan_bore_callouts(baseline))
+    location_issue = next(
+        issue
+        for issue in baseline.registry.issues
+        if issue.code == "location_ref_dropped"
+        and _features_from_issue(issue) & placed_callout_features
     )
-    declared_group = replace(grouped, members=())
+    feature = next(iter(_features_from_issue(location_issue)))
     declared = replace(
-        detected,
-        features=[
-            declared_group if feature is grouped else feature for feature in detected.features
-        ],
+        baseline.model(),
+        decorations={(feature, "diameter"): fit_class("H7", feature.diameter)},
     )
-    drawing = build_drawing(part, page="A4", model=declared)
-    original = _plan_bore_callouts(drawing)
-    before_codes = {issue.code for issue in drawing.lint()}
 
-    table = drawing.add_hole_table("plan", replace_callouts=True)
+    drawing = build_drawing(part, page="A3", model=declared)
 
+    table = drawing.get_annotation("hole_table_plan")
     assert table is not None
-    grouped_name, grouped_callout = original[declared_group]
-    assert drawing.get_annotation(grouped_name) is grouped_callout
-    assert not [
-        name
-        for name in drawing.annotations()
-        if name.startswith("balloon_plan_") and drawing.registry.feature_of(name) == declared_group
-    ]
-    assert declared_group not in {
-        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
-    }
-    assert table.covers_diameters == (16.0,)
-    after_codes = {issue.code for issue in drawing.lint()}
-    assert after_codes == before_codes | {"balloon_dropped"}
-    assert "hole_requirement_missing" not in after_codes
-
-
-@pytest.mark.parametrize("failing_stage", ["table", "balloons"])
-def test_public_replacement_rolls_back_exactly_when_placement_raises(monkeypatch, failing_stage):
-    import draftwright.drawing as drawing_module
-
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    before = _transaction_state(drawing)
-
-    def mutate_then_fail():
-        drawing.registry.record_issue(
-            LintIssue(
-                severity="warning",
-                code="temporary_transaction_issue",
-                message="must be rolled back",
-            )
-        )
-        drawing.coverage.cover_scattered_hole_doc("temporary_transaction_coverage")
-        raise RuntimeError(f"forced {failing_stage} failure")
-
-    if failing_stage == "table":
-        original = drawing.add_table
-
-        def fail_after_table(*args, **kwargs):
-            assert original(*args, **kwargs) is not None
-            mutate_then_fail()
-
-        monkeypatch.setattr(drawing, "add_table", fail_after_table)
-    else:
-        original = drawing_module.render_balloons
-
-        def fail_after_balloons(*args, **kwargs):
-            original(*args, **kwargs)
-            assert any(name.startswith("balloon_plan_") for name in drawing.annotations())
-            mutate_then_fail()
-
-        monkeypatch.setattr(drawing_module, "render_balloons", fail_after_balloons)
-
-    with pytest.raises(RuntimeError, match=f"forced {failing_stage} failure"):
-        drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert _transaction_state(drawing) == before
-
-
-def test_public_replacement_rolls_back_if_stashing_itself_raises(monkeypatch):
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    before = _transaction_state(drawing)
-    original_remove = drawing.remove
-    removals = 0
-
-    def fail_during_second_stash(name):
-        nonlocal removals
-        removals += 1
-        if removals == 2:
-            drawing.registry.record_issue(
-                LintIssue(
-                    severity="warning",
-                    code="partial_stash_issue",
-                    message="must be rolled back",
-                )
-            )
-            drawing.coverage.cover_scattered_hole_doc("partial_stash_coverage")
-            raise RuntimeError("forced partial stash failure")
-        return original_remove(name)
-
-    monkeypatch.setattr(drawing, "remove", fail_during_second_stash)
-
-    with pytest.raises(RuntimeError, match="forced partial stash failure"):
-        drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert removals == 2
-    assert _transaction_state(drawing) == before
-
-
-def test_exception_after_partial_restore_clears_temporary_representation_markers(monkeypatch):
-    import draftwright.drawing as drawing_module
-
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    original = _plan_bore_callouts(drawing)
-    for _name, annotation in original.values():
-        annotation.hole_representation = "existing_representation"
-        annotation.hole_representation_reason = "existing_reason"
-    before_markers = {
-        name: (
-            getattr(annotation, "hole_representation", None),
-            getattr(annotation, "hole_representation_reason", None),
-        )
-        for name, annotation in original.values()
-    }
-    before = _transaction_state(drawing)
-    _drop_one_diameter_balloon(monkeypatch, 10.0)
-    original_coverage = drawing_module._register_hole_table_coverage
-
-    def fail_coverage(*args, **kwargs):
-        original_coverage(*args, **kwargs)
-        drawing.registry.record_issue(
-            LintIssue(
-                severity="warning",
-                code="temporary_coverage_issue",
-                message="must be rolled back",
-            )
-        )
-        drawing.coverage.cover_scattered_hole_doc("temporary_coverage_state")
-        raise RuntimeError("forced coverage failure")
-
-    monkeypatch.setattr(drawing_module, "_register_hole_table_coverage", fail_coverage)
-
-    with pytest.raises(RuntimeError, match="forced coverage failure"):
-        drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert {
-        name: (
-            getattr(drawing.get_annotation(name), "hole_representation", None),
-            getattr(drawing.get_annotation(name), "hole_representation_reason", None),
-        )
-        for name, _annotation in original.values()
-    } == before_markers
-    assert _transaction_state(drawing) == before
-
-
-def test_replacement_rejects_a_table_name_reserved_by_a_fallback_before_mutation():
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    fallback_name = next(iter(_plan_bore_callouts(drawing).values()))[0]
-    before = tuple(drawing.annotations())
-
-    with pytest.raises(ValueError, match="unused table/balloon names"):
-        drawing.add_hole_table("plan", name=fallback_name, replace_callouts=True)
-
-    assert tuple(drawing.annotations()) == before
-    assert drawing.get_annotation(fallback_name) is not None
-
-
-def test_preexisting_balloon_name_cannot_spoof_semantic_commit():
-    drawing = build_drawing(Box(60, 40, 10) - Cylinder(4, 20), page="A4")
-    original = _plan_bore_callouts(drawing)
-    note_name = drawing.note("EXISTING", (20, 20), view="plan", name="balloon_plan_A_0")
-    note = drawing.get_annotation(note_name)
-
-    with pytest.raises(ValueError, match="balloon_plan_A_0"):
-        drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert drawing.get_annotation(note_name) is note
-    assert all(
-        drawing.get_annotation(name) is annotation for name, annotation in original.values()
-    )
-    assert "hole_table_plan" not in drawing.annotations()
-
-
-def test_table_name_cannot_collide_with_a_balloon_from_the_same_attempt():
-    drawing = build_drawing(Box(60, 40, 10) - Cylinder(4, 20), page="A4")
-    before = _transaction_state(drawing)
-
-    with pytest.raises(ValueError, match="must differ.*balloon_plan_A_0"):
-        drawing.add_hole_table("plan", name="balloon_plan_A_0", replace_callouts=True)
-
-    assert _transaction_state(drawing) == before
-
-
-@pytest.mark.parametrize(
-    ("decoration", "visible_token"),
-    [(0.1, "±0.1"), (fit_class("H7", 8), "H7")],
-    ids=["tolerance", "fit"],
-)
-def test_public_replacement_retains_toleranced_and_fitted_callouts(decoration, visible_token):
-    part = Box(60, 40, 8) - Pos(0, 0, 4) * Cylinder(4, 8)
-    detected = build_drawing(part, auto_dims=False).model()
-    hole = next(feature for feature in detected.features if feature.kind == "hole")
-    declared = replace(detected, decorations={(hole, "diameter"): decoration})
-    drawing = build_drawing(part, page="A4", model=declared)
-    callout_name, callout = _plan_bore_callouts(drawing)[hole]
-    assert visible_token in callout.label
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
+    callout_name, callout = _plan_bore_callouts(drawing)[feature]
+    assert "H7" in callout.label
     assert drawing.get_annotation(callout_name) is callout
-    assert visible_token in drawing.get_annotation(callout_name).label
+    assert any(fact[0] == feature for fact in getattr(table, "covers_hole_locations", ()))
+    assert not any(
+        issue.code == "location_ref_dropped" and feature in _features_from_issue(issue)
+        for issue in drawing.registry.issues
+    )
+    outcomes = [
+        outcome
+        for outcome in _outcomes(drawing)
+        if outcome.source_at[:2] == tuple(feature.frame.origin[:2])
+    ]
     assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, hole)
-    } == {(None, None)}
+        outcome.representation
+        for outcome in outcomes
+        if outcome.parameter_id.startswith("location")
+    } == {"hole_table"}
+    assert {
+        outcome.representation for outcome in outcomes if outcome.parameter_id == "bore.diameter"
+    } == {None}
 
 
 @pytest.mark.parametrize(
@@ -786,21 +391,25 @@ def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(monkeypatch,
         for issue in baseline.registry.issues
         if issue.code == "callout_dropped" and issue.measurement_ids
     )
-    dropped_feature = dropped_issue.measurement_ids[0].feature
-    declared = replace(baseline.model(), decorations={(dropped_feature, "diameter"): decoration})
+    feature = dropped_issue.measurement_ids[0].feature
+    declared = replace(
+        baseline.model(),
+        decorations={(feature, "diameter"): decoration},
+    )
 
     drawing = build_drawing(part, model=declared)
 
     assert "hole_table_plan" in drawing.annotations()
     assert any(
-        issue.code == "callout_dropped"
-        and any(measurement.feature == dropped_feature for measurement in issue.measurement_ids)
+        issue.code == "callout_dropped" and feature in _features_from_issue(issue)
         for issue in drawing.registry.issues
     )
     assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, dropped_feature)
-    } == {(None, None)}
+        outcome.representation
+        for outcome in _outcomes(drawing)
+        if outcome.source_at[:2] == tuple(feature.frame.origin[:2])
+        and outcome.parameter_id == "bore.diameter"
+    } == {None}
 
 
 def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
@@ -815,13 +424,12 @@ def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
         for issue in baseline.registry.issues
         if issue.code == "callout_dropped" and issue.measurement_ids
     )
-    dropped_feature = dropped_issue.measurement_ids[0].feature
-    threaded = replace(dropped_feature, thread="M5x0.8")
+    original = dropped_issue.measurement_ids[0].feature
+    threaded = replace(original, thread="M5x0.8")
     declared = replace(
         baseline.model(),
         features=[
-            threaded if feature is dropped_feature else feature
-            for feature in baseline.model().features
+            threaded if feature is original else feature for feature in baseline.model().features
         ],
     )
 
@@ -829,216 +437,59 @@ def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
 
     assert "hole_table_plan" in drawing.annotations()
     assert any(
-        issue.code == "callout_dropped"
-        and any(measurement.feature == threaded for measurement in issue.measurement_ids)
+        issue.code == "callout_dropped" and threaded in _features_from_issue(issue)
         for issue in drawing.registry.issues
     )
     assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, threaded)
-    } == {(None, None)}
-
-
-def test_public_replacement_retains_a_compound_callout_the_table_cannot_cover():
-    part = Box(60, 40, 20) - Cylinder(4, 30) - Pos(0, 0, 2) * Cylinder(7, 20)
-    drawing = build_drawing(part, page="A4")
-    feature = next(feature for feature in drawing.model().features if feature.kind == "hole")
-    assert feature.cbore is not None
-    callout_name, callout = _plan_bore_callouts(drawing)[feature]
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert drawing.get_annotation(callout_name) is callout
-    assert {
-        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
-    } == {
-        "bore.diameter",
-        "counterbore.diameter",
-        "counterbore.depth",
-    }
-    assert {
-        measurement.parameter for measurement in drawing.registry.measurement_of("hole_table_plan")
-    } == {"bore.diameter"}
-    assert all(outcome.state == "placed" for outcome in _outcomes(drawing))
-    assert feature not in {
-        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
-    }
-    assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, feature)
-    } == {(None, None)}
-    assert not {"feature_not_dimensioned", "hole_requirement_missing"} & {
-        issue.code for issue in drawing.lint()
-    }
-
-
-def test_mixed_public_table_marks_only_the_plain_replacement_winner():
-    part = Box(80, 40, 20)
-    part -= Pos(-20, 0, 0) * Cylinder(4, 30)
-    part -= Pos(-20, 0, 2) * Cylinder(7, 20)
-    part -= Pos(20, 0, 0) * Cylinder(5, 30)
-    drawing = build_drawing(part, page="A4")
-    features = [feature for feature in drawing.model().features if feature.kind == "hole"]
-    compound = next(feature for feature in features if feature.cbore is not None)
-    plain = next(feature for feature in features if feature.cbore is None)
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, plain)
-        if outcome.parameter_id in {"bore.diameter", "bore.through"}
-    } == {("hole_table", "required_balloons_placed")}
-    assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, compound)
-    } == {(None, None)}
-
-
-def test_one_recognised_group_with_mixed_declared_owners_has_no_scalar_winner():
-    part = _multi_hole_plate()
-    detected = build_drawing(part, auto_dims=False).model()
-    grouped = next(
-        feature for feature in detected.features if feature.kind == "hole" and feature.count == 2
-    )
-    split = tuple(
-        replace(grouped, frame=replace(grouped.frame, origin=point), count=1, members=(point,))
-        for point in grouped.members
-    )
-    fitted, plain = split
-    declared = replace(
-        detected,
-        features=[
-            *split,
-            *(feature for feature in detected.features if feature is not grouped),
-        ],
-        decorations={(fitted, "diameter"): fit_class("H7", fitted.diameter)},
-    )
-    drawing = build_drawing(part, page="A4", model=declared)
-    original = _plan_bore_callouts(drawing)
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert drawing.get_annotation(original[fitted][0]) is original[fitted][1]
-    assert original[plain][0] not in drawing.annotations()
-    grouped_outcomes = [
-        outcome
+        outcome.representation
         for outcome in _outcomes(drawing)
-        if outcome.member_count == 2
-        and outcome.parameter_id in {"bore.diameter", "bore.through", "grouping.count"}
-    ]
-    assert grouped_outcomes
-    assert {outcome.state for outcome in grouped_outcomes} == {"placed"}
-    assert {
-        (outcome.representation, outcome.representation_reason) for outcome in grouped_outcomes
-    } == {(None, None)}
+        if outcome.source_at[:2] == tuple(threaded.frame.origin[:2])
+        and outcome.parameter_id == "bore.diameter"
+    } == {None}
 
 
-def test_public_replacement_retains_a_declared_thread_callout():
-    part = Box(60, 40, 10) - Cylinder(4, 20)
-    detected = build_drawing(part, auto_dims=False).model()
-    hole = next(feature for feature in detected.features if feature.kind == "hole")
-    threaded = replace(hole, thread="M8x1")
-    declared = replace(
-        detected,
-        features=[threaded if feature is hole else feature for feature in detected.features],
-    )
-    drawing = build_drawing(part, page="A4", model=declared)
-    callout_name, callout = _plan_bore_callouts(drawing)[threaded]
-    assert "M8x1" in callout.label
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert drawing.get_annotation(callout_name) is callout
-    assert all(outcome.state == "placed" for outcome in _outcomes(drawing))
-
-
-def test_public_replacement_retains_a_double_d_profile_callout():
-    drawing = build_drawing(_double_d_plate(), page="A4")
-    feature = next(
-        feature for feature in drawing.model().features if feature.profile == "double_d"
-    )
-    callout_name, callout = _plan_bore_callouts(drawing)[feature]
-    assert "DOUBLE-D 7.2 A/F" in callout.label
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert drawing.get_annotation(callout_name) is callout
-    assert {
-        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
-    } == {"bore.diameter", "profile_across_flats.length"}
-    assert feature not in {
-        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
-    }
-
-
-def test_public_replacement_retains_a_pattern_callout_with_geometry_the_table_omits():
-    part = Box(80, 40, 10)
-    for x in (-20, 0, 20):
-        part -= Pos(x, 0, 0) * Cylinder(3, 20)
-    drawing = build_drawing(part, page="A4")
-    pattern = next(feature for feature in drawing.model().features if feature.kind == "pattern")
-    callout_name, callout = _plan_bore_callouts(drawing)[pattern]
-
-    table = drawing.add_hole_table("plan", replace_callouts=True)
-
-    assert table is not None
-    assert drawing.get_annotation(callout_name) is callout
-    assert any(
-        outcome.parameter_id == "pitch.length" and outcome.state == "placed"
-        for outcome in _outcomes(drawing)
-    )
-
-
-def test_automatic_table_never_removes_a_recognised_compound_callout():
+def test_automatic_table_keeps_compound_callout_and_all_feasible_balloons():
     drawing = build_drawing(_dense_plate_with_counterbore())
     feature = next(
         feature
         for feature in drawing.model().features
         if feature.kind == "hole" and feature.cbore is not None
     )
-    callouts = _plan_bore_callouts(drawing)
 
     assert "hole_table_plan" in drawing.annotations()
-    table = drawing.get_annotation("hole_table_plan")
-    assert feature in callouts
-    callout_name, callout = callouts[feature]
-    assert drawing.get_annotation(callout_name) is callout
+    assert feature in _plan_bore_callouts(drawing)
+    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 20
+    assert not [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
+    states = {outcome.parameter_id: outcome.state for outcome in _outcomes(drawing)}
+    assert states["counterbore.diameter"] == "placed"
+    assert states["counterbore.depth"] == "placed"
+    compound_outcomes = [
+        outcome
+        for outcome in _outcomes(drawing)
+        if outcome.source_at[:2] == tuple(feature.frame.origin[:2])
+    ]
     assert {
-        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
-    } >= {
-        "counterbore.diameter",
-        "counterbore.depth",
-    }
-    outcome_states = {outcome.parameter_id: outcome.state for outcome in _outcomes(drawing)}
-    assert outcome_states["counterbore.diameter"] == "placed"
-    assert outcome_states["counterbore.depth"] == "placed"
-    assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, feature)
+        (outcome.representation, outcome.representation_reason) for outcome in compound_outcomes
     } == {(None, None)}
-    represented_features = {
-        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
+    assert any(
+        outcome.representation == "hole_table"
+        for outcome in _outcomes(drawing)
+        if outcome.source_at[:2] != tuple(feature.frame.origin[:2])
+    )
+    visible_labels = {
+        annotation.label
+        for _owner, (_name, annotation) in _plan_bore_callouts(drawing).items()
+        if annotation.label
     }
-    plain = next(candidate for candidate in represented_features if candidate.cbore is None)
-    assert plain is not feature
-    assert {
-        (outcome.representation, outcome.representation_reason)
-        for outcome in _source_outcomes(drawing, plain)
-        if outcome.parameter_id == "bore.diameter"
-    } == {("hole_table", "required_balloons_placed")}
-    assert not {"feature_not_dimensioned", "hole_requirement_missing"} & {
-        issue.code for issue in drawing.lint()
-    }
-    assert not _callout_label_overlap_issues(drawing)
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code == "label_centerline_overlap"
+        and any(f"label '{label}'" in issue.message for label in visible_labels)
+    ]
 
 
-def test_automatic_table_never_removes_a_recognised_double_d_callout():
+def test_automatic_table_keeps_profiled_callout():
     drawing = build_drawing(_dense_plate_with_double_d())
     feature = next(
         feature for feature in drawing.model().features if feature.profile == "double_d"
@@ -1048,12 +499,12 @@ def test_automatic_table_never_removes_a_recognised_double_d_callout():
     assert "hole_table_plan" in drawing.annotations()
     assert drawing.get_annotation(callout_name) is callout
     assert "DOUBLE-D 3.6 A/F" in callout.label
-    assert {
-        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
-    } == {"bore.diameter", "profile_across_flats.length"}
     table = drawing.get_annotation("hole_table_plan")
     assert feature not in {
-        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
+        owner
+        for owner, _parameter, _representation, _reason in getattr(
+            table, "covers_hole_representations_by_requirement", ()
+        )
     }
 
 
@@ -1065,10 +516,9 @@ def test_automatic_escalation_preserves_preexisting_reserved_names(reserved_name
 
     with drawing.deferred():
         for feature in drawing.model().features:
-            if feature.kind != "hole":
-                continue
-            drawing.callout(feature)
-            drawing.locate(feature)
+            if feature.kind == "hole":
+                drawing.callout(feature)
+                drawing.locate(feature)
 
     assert drawing.get_annotation(reserved_name) is user_annotation
     if reserved_name != "hole_table_plan":
@@ -1098,13 +548,50 @@ def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
     with pytest.raises(RuntimeError, match="forced automatic coverage failure"):
         with drawing.deferred():
             for feature in drawing.model().features:
-                if feature.kind != "hole":
-                    continue
-                drawing.callout(feature)
-                drawing.locate(feature)
+                if feature.kind == "hole":
+                    drawing.callout(feature)
+                    drawing.locate(feature)
 
     assert _transaction_state(drawing) == before
     assert all(
         drawing.get_annotation(name) is annotation
         for name, annotation in original_callouts.values()
     )
+
+
+def test_one_physical_group_with_mixed_table_and_fit_evidence_has_no_scalar_winner():
+    part = _dense_plate_with_one_group()
+    detected = build_drawing(part, auto_dims=False).model()
+    grouped = next(
+        feature for feature in detected.features if feature.kind == "hole" and feature.count == 2
+    )
+    split = tuple(
+        replace(grouped, frame=replace(grouped.frame, origin=point), count=1, members=(point,))
+        for point in grouped.members
+    )
+    fitted, plain = split
+    declared = replace(
+        detected,
+        features=[
+            *split,
+            *(feature for feature in detected.features if feature is not grouped),
+        ],
+        decorations={(fitted, "diameter"): fit_class("H7", fitted.diameter)},
+    )
+
+    drawing = build_drawing(part, model=declared)
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert fitted in _plan_bore_callouts(drawing)
+    assert plain not in _plan_bore_callouts(drawing)
+    grouped_outcomes = [
+        outcome
+        for outcome in _outcomes(drawing)
+        if outcome.member_count == 2
+        and outcome.parameter_id in {"bore.diameter", "bore.through", "grouping.count"}
+    ]
+    assert grouped_outcomes
+    assert {outcome.state for outcome in grouped_outcomes} == {"placed"}
+    assert {
+        (outcome.representation, outcome.representation_reason) for outcome in grouped_outcomes
+    } == {(None, None)}

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -15,6 +15,25 @@ from draftwright.fits import fit_class
 from draftwright.linting.hole_coverage import hole_requirement_outcomes
 from draftwright.model.compiled import compile_dimensions
 
+_CROSSING_FREE_PERIMETER_POSITIONS = (
+    (-42.7, -27.4),
+    (-15.1, -31.9),
+    (11.0, -28.7),
+    (44.8, -27.9),
+    (-46.0, 32.2),
+    (-16.8, 32.4),
+    (16.8, 29.3),
+    (45.3, 31.5),
+    (-56.5, -17.6),
+    (-51.6, -7.9),
+    (-51.6, 7.5),
+    (-51.2, 16.7),
+    (50.7, -15.6),
+    (56.4, -6.4),
+    (50.8, 3.6),
+    (55.1, 16.3),
+)
+
 
 def _multi_hole_plate():
     """Two semantic groups: one Ø16 bore and a two-member Ø10 group."""
@@ -52,12 +71,9 @@ def _dense_scattered_plate():
 
 def _dense_plate_with_close_x_ordinates():
     """Dense inventory with two separately placed X ordinates only 0.4 mm apart."""
-    positions = (
-        [(x, -30.0) for x in (-45.0, 0.4, 15.0, 45.0)]
-        + [(x, 30.0) for x in (-45.0, 0.0, 15.0, 45.0)]
-        + [(-54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
-        + [(54.0, y) for y in (-18.0, -6.0, 6.0, 18.0)]
-    )
+    positions = list(_CROSSING_FREE_PERIMETER_POSITIONS)
+    positions[1] = (0.4, positions[1][1])
+    positions[5] = (0.0, positions[5][1])
     part = Box(120, 80, 12)
     for index, (x, y) in enumerate(positions):
         part -= Pos(x, y, 0) * Cylinder(1.0 + index * 0.15, 20)
@@ -65,7 +81,15 @@ def _dense_plate_with_close_x_ordinates():
 
 
 def _dense_perimeter_plate():
-    """Sixteen scattered bores whose short outward balloons are collision-free."""
+    """Sixteen irregular perimeter bores with a crossing-free A3 table inventory."""
+    part = Box(120, 80, 12)
+    for index, (x, y) in enumerate(_CROSSING_FREE_PERIMETER_POSITIONS):
+        part -= Pos(x, y, 0) * Cylinder(1.0 + index * 0.15, 20)
+    return part
+
+
+def _crossing_perimeter_plate():
+    """Regular rows whose A3 table inventory contains two crossing shafts."""
     positions = (
         [(x, -30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
         + [(x, 30.0) for x in (-45.0, -15.0, 15.0, 45.0)]
@@ -109,31 +133,9 @@ def _dense_plate_with_double_d():
 
 
 def _dense_plate_with_one_group():
-    """Twenty bores, including one physical two-member machining-spec group."""
-    positions = [
-        (-39, -19),
-        (-27, -14),
-        (-14, -21),
-        (1, -16),
-        (17, -22),
-        (35, -17),
-        (-36, -4),
-        (-21, 2),
-        (-7, -6),
-        (9, 1),
-        (24, -5),
-        (39, 4),
-        (-34, 14),
-        (-18, 21),
-        (-2, 12),
-        (13, 20),
-        (29, 13),
-        (38, 23),
-        (-28, 26),
-        (4, 27),
-    ]
-    part = Box(100, 70, 12)
-    for index, (x, y) in enumerate(positions):
+    """Sixteen bores, including one physical two-member machining-spec group."""
+    part = Box(120, 80, 12)
+    for index, (x, y) in enumerate(_CROSSING_FREE_PERIMETER_POSITIONS):
         radius = 2.0 if index < 2 else 1.0 + index * 0.17
         part -= Pos(x, y, 0) * Cylinder(radius, 20)
     return part
@@ -659,6 +661,27 @@ def test_guarded_carve_budget_rolls_the_automatic_table_transaction_back(monkeyp
     assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
 
 
+def test_guarded_top_lane_budget_fires_before_quadratic_obstacle_scan(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+
+    monkeypatch.setattr(balloons_module, "_GUARDED_TOP_LANE_MAX_OBSTACLE_PROBES", 1)
+
+    def forbidden_carve(*_args, **_kwargs):
+        pytest.fail("perimeter lane carving ran before its deterministic work budget")
+
+    monkeypatch.setattr(balloons_module, "carve_free_segments", forbidden_carve)
+
+    drawing = build_drawing(_dense_scattered_plate(), page="A3")
+
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert len([name for name in drawing.annotations() if name.startswith("hc_plan")]) == 17
+    codes = [issue.code for issue in drawing.registry.issues]
+    assert "table_dropped" in codes
+    assert "balloon_dropped" in codes
+    assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
+
+
 def test_real_shaft_crossing_carves_the_guarded_band_without_aabb_sampling():
     from draftwright.annotations.balloons import (
         _balloon_shaft_segments,
@@ -726,6 +749,8 @@ def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry(
     overlapping_second = (((19.0, 15.0, 29.0, 25.0),), ())
     shaft_crossing_second = (((24.0, 12.0, 28.0, 18.0),), ())
     shaft_crossing_first = ((((10.0, 10.0, 20.0, 20.0),), (((0.0, 15.0), (30.0, 15.0)),)),)
+    crossing_shaft_first = ((((9.5, 9.5, 10.5, 10.5),), (((0.0, 0.0), (9.0, 9.0)),)),)
+    crossing_shaft_second = (((9.5, -0.5, 10.5, 0.5),), (((0.0, 10.0), (9.0, 1.0)),))
     self_text_crossing = (
         (
             (10.0, 10.0, 20.0, 20.0),
@@ -739,6 +764,9 @@ def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry(
     assert not _guarded_inventory_geometry_is_clear((*first, overlapping_second), page)
     assert not _guarded_inventory_geometry_is_clear(
         (*shaft_crossing_first, shaft_crossing_second), page
+    )
+    assert not _guarded_inventory_geometry_is_clear(
+        (*crossing_shaft_first, crossing_shaft_second), page
     )
     assert not _guarded_inventory_geometry_is_clear((self_text_crossing,), page)
     assert not _guarded_inventory_geometry_is_clear((*first, off_page), page)
@@ -793,6 +821,19 @@ def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(mo
         if outcome.state == "placed"
     }
     assert "view_annotation_overlap" not in {issue.code for issue in drawing.lint()}
+
+
+def test_automatic_transaction_rejects_a_real_required_shaft_crossing():
+    part = _crossing_perimeter_plate()
+    drawing = build_drawing(part, page="A3")
+
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert {"table_dropped", "balloon_dropped"} <= {
+        issue.code for issue in drawing.registry.issues
+    }
+    assert [name for name in drawing.annotations() if name.startswith("hc_plan")]
+    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
 def test_automatic_actual_label_guard_restores_features_with_no_safe_balloon(monkeypatch):
@@ -888,6 +929,7 @@ def test_public_add_balloons_separates_long_sibling_text_components():
         "partial_segments",
         "absent_counts",
         "wrong_counts",
+        "boolean_counts",
         "malformed",
         "nonfinite",
         "descending",
@@ -921,6 +963,10 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
         del retained.balloon_component_counts
     elif component_metadata == "wrong_counts":
         retained.balloon_component_counts = (1, 0)
+    elif component_metadata == "boolean_counts":
+        retained.centerline_boxes = retained.centerline_boxes[:1]
+        retained.centerline_segments = ()
+        retained.balloon_component_counts = (True, False)
     elif component_metadata == "malformed":
         retained.centerline_boxes = (("not", "a", "box"),)
     elif component_metadata == "nonfinite":
@@ -1050,6 +1096,40 @@ def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
         for outcome in _outcomes(drawing)
         if outcome.state == "placed"
     }
+
+
+def test_real_constrained_a4_failure_keeps_valid_fallback_coverage():
+    from draftwright.model.ir import RequestedDimension
+
+    part = _dense_perimeter_plate()
+    detected = build_drawing(part, auto_dims=False).model()
+    holes = [feature for feature in detected.features if feature.kind == "hole"]
+    # Keep the A4 assertion about the transaction rather than asking an already
+    # crowded sheet to render 32 location ordinates. Authored omission remains
+    # explicit suppression in the #1143 physical ledger.
+    model = replace(
+        detected,
+        authored_dimensions=tuple(
+            RequestedDimension(feature, "bore.diameter") for feature in holes
+        ),
+    )
+
+    drawing = build_drawing(part, model=model, page="A4")
+
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    fallback_names = [name for name in drawing.annotations() if name.startswith("hc_plan")]
+    assert len(fallback_names) == 2
+    assert all(drawing.measurement_keys(name) for name in fallback_names)
+    assert {"table_dropped", "balloon_dropped"} <= {
+        issue.code for issue in drawing.registry.issues
+    }
+    placed = [outcome for outcome in _outcomes(drawing) if outcome.state == "placed"]
+    assert len(placed) == 4  # diameter + THRU for both leaders that had fitted
+    assert {(outcome.representation, outcome.representation_reason) for outcome in placed} == {
+        ("feature_annotation", "required_balloon_not_placed")
+    }
+    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
 def test_automatic_partial_balloon_result_rolls_back_the_shared_table(monkeypatch):
@@ -1219,21 +1299,29 @@ def test_optional_pattern_marker_cannot_displace_required_table_rows(monkeypatch
     assert captured_analysis
 
     features = list(drawing.model().features)
-    origin = (-50.0, -18.0, 6.0)
-    member = HoleFeature(
-        frame=Frame(origin=origin, axis="z"),
-        diameter=5.0,
-        depth=None,
-        through=True,
-    )
-    pattern = PatternFeature(
-        frame=Frame(origin=origin, axis="z"),
-        pattern="bolt_circle",
-        count=6,
-        member=member,
-        members=tuple((origin[0] + index, origin[1], origin[2]) for index in range(6)),
-    )
-    model = replace(drawing.model(), features=[*features, pattern])
+    patterns = []
+    for optional_index in range(8):
+        origin = (
+            -50.0 + (optional_index % 5) * 0.01,
+            -18.0 + (optional_index % 7) * 0.01,
+            6.0,
+        )
+        member = HoleFeature(
+            frame=Frame(origin=origin, axis="z"),
+            diameter=5.0,
+            depth=None,
+            through=True,
+        )
+        patterns.append(
+            PatternFeature(
+                frame=Frame(origin=origin, axis="z"),
+                pattern="bolt_circle",
+                count=6,
+                member=member,
+                members=tuple((origin[0] + index, origin[1], origin[2]) for index in range(6)),
+            )
+        )
+    model = replace(drawing.model(), features=[*features, *patterns])
     ctx = PlacementContext(
         registry=drawing.registry,
         coverage=drawing.coverage,
@@ -1241,7 +1329,7 @@ def test_optional_pattern_marker_cannot_displace_required_table_rows(monkeypatch
         part_model=model,
         escalations=(
             Escalation("location", "plan", features[0], "illegible"),
-            Escalation("callout", "plan", pattern, "strip_full"),
+            *(Escalation("callout", "plan", pattern, "strip_full") for pattern in patterns),
         ),
     )
 
@@ -1251,7 +1339,9 @@ def test_optional_pattern_marker_cannot_displace_required_table_rows(monkeypatch
     assert {name for name in drawing.annotations() if name.startswith("balloon_plan_")} == {
         f"balloon_plan_{tag}_0" for tag in "ABCDEFGHIJKLMNOP"
     }
-    assert "balloon_plan_6×Q_0" not in drawing.annotations()
+    assert not {f"balloon_plan_6×{tag}_0" for tag in "QRSTUVWX"}.intersection(
+        drawing.annotations()
+    )
     assert "table_dropped" not in {issue.code for issue in drawing.registry.issues}
     assert "balloon_dropped" in {issue.code for issue in drawing.registry.issues}
     assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
@@ -1333,7 +1423,10 @@ def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkey
         if issue.code == "location_ref_dropped"
         and _features_from_issue(issue) & placed_callout_features
     )
-    feature = next(iter(_features_from_issue(location_issue) & placed_callout_features))
+    feature = min(
+        _features_from_issue(location_issue) & placed_callout_features,
+        key=lambda candidate: candidate.diameter,
+    )
     dropped_parameters = {
         parameter for owner, parameter in location_issue.hole_requirement_ids if owner is feature
     }
@@ -1490,23 +1583,29 @@ def test_automatic_compound_inventory_fails_closed_on_cross_balloon_geometry():
     ]
 
 
-def test_automatic_table_keeps_profiled_callout():
+def test_automatic_transaction_keeps_profiled_callout_when_table_is_unsafe():
     drawing = build_drawing(_dense_plate_with_double_d())
     feature = next(
         feature for feature in drawing.model().features if feature.profile == "double_d"
     )
     callout_name, callout = _plan_bore_callouts(drawing)[feature]
 
-    assert "hole_table_plan" in drawing.annotations()
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
     assert drawing.get_annotation(callout_name) is callout
     assert "DOUBLE-D 3.6 A/F" in callout.label
-    table = drawing.get_annotation("hole_table_plan")
-    assert feature not in {
-        owner
-        for owner, _parameter, _representation, _reason in getattr(
-            table, "covers_hole_representations_by_requirement", ()
-        )
+    assert {item["parameter_id"] for item in drawing.measurement_keys(callout_name)} == {
+        "bore.diameter",
+        "profile_across_flats.length",
     }
+    assert {"table_dropped", "balloon_dropped"} <= {
+        issue.code for issue in drawing.registry.issues
+    }
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code in {"feature_not_dimensioned", "hole_requirement_missing"}
+    ]
 
 
 @pytest.mark.parametrize("reserved_name", ["hole_table_plan", "balloon_plan_A_0"])
@@ -1619,18 +1718,24 @@ def test_one_physical_group_with_mixed_table_and_fit_evidence_has_no_scalar_winn
 
 
 def test_retained_fit_leader_crossing_rolls_the_automatic_table_back():
+    from draftwright.model.ir import RequestedDimension
+
     part = _dense_plate_with_close_x_ordinates()
     detected = build_drawing(part, page="A3", auto_dims=False).model()
     fitted = next(
         feature
         for feature in detected.features
         if feature.kind == "hole"
-        and feature.frame.origin == (-54.0, -18.0, 6.0)
-        and feature.diameter == pytest.approx(4.4)
+        and feature.frame.origin == (-42.7, -27.4, 6.0)
+        and feature.diameter == pytest.approx(2.0)
     )
+    holes = [feature for feature in detected.features if feature.kind == "hole"]
     declared = replace(
         detected,
         decorations={(fitted, "diameter"): fit_class("H7", fitted.diameter)},
+        authored_dimensions=tuple(
+            RequestedDimension(feature, "bore.diameter") for feature in holes
+        ),
     )
 
     drawing = build_drawing(part, model=declared, page="A3")

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -959,40 +959,6 @@ def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
     }
 
 
-def test_stash_ignores_absent_names_and_restore_is_idempotent():
-    from draftwright.annotations._common import (
-        PlacementContext,
-        _restore_stashed_annotations,
-        _stash_annotations,
-    )
-
-    drawing = build_drawing(_multi_hole_plate(), page="A4")
-    name = next(iter(_plan_bore_callouts(drawing).values()))[0]
-    annotation = drawing.get_annotation(name)
-    identity = drawing.registry.identity_of(name)
-    stashed = _stash_annotations(drawing, ("not_present", name))
-    ctx = PlacementContext(
-        registry=drawing.registry,
-        coverage=drawing.coverage,
-        items=drawing.items,
-        part_model=drawing.model(),
-    )
-
-    assert set(stashed) == {name}
-    assert drawing.get_annotation(name) is None
-    assert _restore_stashed_annotations(drawing, ctx, stashed) == {name}
-    assert drawing.get_annotation(name) is annotation
-    assert drawing.registry.identity_of(name) == identity
-
-    # Retrying rollback must recognise the exact already-restored object rather
-    # than duplicating it or perturbing its semantic identity.
-    items = tuple(drawing.items)
-    assert _restore_stashed_annotations(drawing, ctx, stashed) == {name}
-    assert tuple(drawing.items) == items
-    assert drawing.get_annotation(name) is annotation
-    assert drawing.registry.identity_of(name) == identity
-
-
 def test_automatic_partial_balloon_result_rolls_back_the_shared_table(monkeypatch):
     _drop_one_diameter_balloon(monkeypatch, 2.0)
 

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from build123d import Align, Box, Cylinder, Pos
+from build123d import Align, Box, Cylinder, Pos, Rot
 
 from draftwright import build_drawing
 from draftwright.fits import fit_class
@@ -126,6 +126,20 @@ def _plan_bore_callouts(drawing):
     return callouts
 
 
+def _callout_label_overlap_issues(drawing):
+    labels = {
+        annotation.label
+        for _feature, (_name, annotation) in _plan_bore_callouts(drawing).items()
+        if annotation.label
+    }
+    return [
+        issue
+        for issue in drawing.lint()
+        if issue.code == "label_centerline_overlap"
+        and any(f"label '{label}'" in issue.message for label in labels)
+    ]
+
+
 def _drop_one_diameter_balloon(monkeypatch, diameter):
     """Force one otherwise feasible balloon assignment to become partial."""
     import draftwright.annotations.balloons as balloons_module
@@ -221,6 +235,8 @@ def test_constrained_a4_table_failure_restores_exact_callouts_and_identity(monke
     import draftwright.drawing as drawing_module
 
     drawing = build_drawing(_multi_hole_plate(), page="A4")
+    before_order = tuple(id(item) for item in drawing.items)
+    before_names = tuple(drawing.annotations())
     original = _plan_bore_callouts(drawing)
     identities = {
         name: drawing.registry.identity_of(name) for name, _annotation in original.values()
@@ -236,6 +252,8 @@ def test_constrained_a4_table_failure_restores_exact_callouts_and_identity(monke
         assert drawing.get_annotation(name) is annotation
         assert drawing.registry.identity_of(name) == identities[name]
     assert drawing.registry.is_pinned(pinned_name)
+    assert tuple(id(item) for item in drawing.items) == before_order
+    assert tuple(drawing.annotations()) == before_names
     codes = [issue.code for issue in drawing.lint()]
     assert codes.count("table_dropped") == 1
     assert "hole_requirement_missing" not in codes
@@ -291,6 +309,34 @@ def test_partial_public_balloon_commit_restores_only_the_unresolved_group(monkey
         ("hole_table", "required_balloons_placed"),
         ("feature_annotation", "required_balloon_not_placed"),
     }
+
+
+def test_public_replacement_rejects_non_plan_views_before_mutation():
+    part = Box(12, 40, 30) - Pos(0, 8, 6) * Rot(0, 90, 0) * Cylinder(3, 12)
+    drawing = build_drawing(part, page="A4")
+    before = _transaction_state(drawing)
+
+    with pytest.raises(ValueError, match="currently requires view='plan'"):
+        drawing.add_hole_table("side", replace_callouts=True)
+
+    assert _transaction_state(drawing) == before
+
+
+def test_public_replacement_rolls_back_when_row_formatting_raises(monkeypatch):
+    import draftwright.drawing as drawing_module
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    before = _transaction_state(drawing)
+
+    def fail_format(_value):
+        raise RuntimeError("forced row formatting failure")
+
+    monkeypatch.setattr(drawing_module, "_fmt", fail_format)
+
+    with pytest.raises(RuntimeError, match="forced row formatting failure"):
+        drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert _transaction_state(drawing) == before
 
 
 def test_partial_public_commit_refits_clear_of_the_restored_fallback(monkeypatch):
@@ -363,17 +409,31 @@ def test_automatic_partial_balloon_result_never_claims_the_unkeyed_feature(monke
 
     table = drawing.get_annotation("hole_table_plan")
     assert table is not None
-    assert len(table.covers_diameters) == 19
+    assert 0 < len(table.covers_diameters) < 20
     table_features = {
         measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
     }
-    assert len(table_features) == 19
+    assert len(table_features) == len(table.covers_diameters)
     assert {feature.diameter for feature in table_features} == set(table.covers_diameters)
     assert 2.0 not in table.covers_diameters
-    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 19
+    assert len(
+        [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    ) == len(table.covers_diameters)
     assert "balloon_dropped" in {issue.code for issue in drawing.lint()}
     outcomes = _outcomes(drawing)
-    assert all(outcome.state == "placed" for outcome in outcomes)
+    assert {outcome.state for outcome in outcomes} <= {"placed", "dropped"}
+    assert all(
+        any(
+            issue.code == "callout_dropped"
+            and any(
+                tuple(measurement.feature.frame.origin[:2]) == tuple(outcome.source_at[:2])
+                for measurement in issue.measurement_ids
+            )
+            for issue in drawing.registry.issues
+        )
+        for outcome in outcomes
+        if outcome.state == "dropped" and outcome.parameter_id == "bore.diameter"
+    )
     diameter_representations = {
         (outcome.representation, outcome.representation_reason)
         for outcome in outcomes
@@ -382,7 +442,39 @@ def test_automatic_partial_balloon_result_never_claims_the_unkeyed_feature(monke
     assert diameter_representations == {
         ("hole_table", "required_balloons_placed"),
         ("feature_annotation", "required_balloon_not_placed"),
+        (None, None),
     }
+    assert not _callout_label_overlap_issues(drawing)
+
+
+def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
+    import draftwright.annotations.orchestrator as orchestrator
+    import draftwright.drawing as drawing_module
+
+    part = _dense_scattered_plate()
+    with monkeypatch.context() as disabled:
+        disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
+        baseline = build_drawing(part)
+    baseline_callout_measurements = {
+        tuple(baseline.registry.measurement_of(name))
+        for name in baseline.annotations()
+        if name.startswith("hc_plan")
+    }
+    monkeypatch.setattr(drawing_module, "fit_box", lambda *_args, **_kwargs: None)
+
+    drawing = build_drawing(part)
+
+    assert "hole_table_plan" not in drawing.annotations()
+    assert tuple(drawing.annotations()) == tuple(baseline.annotations())
+    assert drawing.coverage.snapshot() == baseline.coverage.snapshot()
+    assert {
+        tuple(drawing.registry.measurement_of(name))
+        for name in drawing.annotations()
+        if name.startswith("hc_plan")
+    } == baseline_callout_measurements
+    codes = [issue.code for issue in drawing.lint()]
+    assert codes.count("table_dropped") == 1
+    assert "hole_requirement_missing" not in codes
 
 
 def test_automatic_partial_result_rolls_back_when_the_fallback_aware_refit_fails(
@@ -492,7 +584,7 @@ def test_declared_qty_without_member_positions_cannot_commit_one_balloon_as_two(
     }
     assert table.covers_diameters == (16.0,)
     after_codes = {issue.code for issue in drawing.lint()}
-    assert after_codes == before_codes
+    assert after_codes == before_codes | {"balloon_dropped"}
     assert "hole_requirement_missing" not in after_codes
 
 
@@ -781,6 +873,30 @@ def test_public_replacement_retains_a_compound_callout_the_table_cannot_cover():
     }
 
 
+def test_mixed_public_table_marks_only_the_plain_replacement_winner():
+    part = Box(80, 40, 20)
+    part -= Pos(-20, 0, 0) * Cylinder(4, 30)
+    part -= Pos(-20, 0, 2) * Cylinder(7, 20)
+    part -= Pos(20, 0, 0) * Cylinder(5, 30)
+    drawing = build_drawing(part, page="A4")
+    features = [feature for feature in drawing.model().features if feature.kind == "hole"]
+    compound = next(feature for feature in features if feature.cbore is not None)
+    plain = next(feature for feature in features if feature.cbore is None)
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, plain)
+        if outcome.parameter_id in {"bore.diameter", "bore.through"}
+    } == {("hole_table", "required_balloons_placed")}
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, compound)
+    } == {(None, None)}
+
+
 def test_public_replacement_retains_a_declared_thread_callout():
     part = Box(60, 40, 10) - Cylinder(4, 20)
     detected = build_drawing(part, auto_dims=False).model()
@@ -849,6 +965,7 @@ def test_automatic_table_never_removes_a_recognised_compound_callout():
     callouts = _plan_bore_callouts(drawing)
 
     assert "hole_table_plan" in drawing.annotations()
+    table = drawing.get_annotation("hole_table_plan")
     assert feature in callouts
     callout_name, callout = callouts[feature]
     assert drawing.get_annotation(callout_name) is callout
@@ -865,9 +982,20 @@ def test_automatic_table_never_removes_a_recognised_compound_callout():
         (outcome.representation, outcome.representation_reason)
         for outcome in _source_outcomes(drawing, feature)
     } == {(None, None)}
+    represented_features = {
+        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
+    }
+    plain = next(candidate for candidate in represented_features if candidate.cbore is None)
+    assert plain is not feature
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, plain)
+        if outcome.parameter_id == "bore.diameter"
+    } == {("hole_table", "required_balloons_placed")}
     assert not {"feature_not_dimensioned", "hole_requirement_missing"} & {
         issue.code for issue in drawing.lint()
     }
+    assert not _callout_label_overlap_issues(drawing)
 
 
 def test_automatic_table_never_removes_a_recognised_double_d_callout():

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -774,14 +774,18 @@ def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(mo
 
     drawing = build_drawing(_dense_scattered_plate())
 
+    assert "hole_table_plan" not in drawing.annotations()
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
     assert len(_plan_bore_callouts(drawing)) == 17
-    assert "balloon_dropped" in {issue.code for issue in drawing.registry.issues}
+    assert {"balloon_dropped", "table_dropped"} <= {
+        issue.code for issue in drawing.registry.issues
+    }
     assert ("feature_annotation", "required_balloon_not_placed") in {
         (outcome.representation, outcome.representation_reason)
         for outcome in _outcomes(drawing)
         if outcome.state == "placed"
     }
+    assert "view_annotation_overlap" not in {issue.code for issue in drawing.lint()}
 
 
 def test_automatic_actual_label_guard_restores_features_with_no_safe_balloon(monkeypatch):
@@ -943,39 +947,24 @@ def test_stash_ignores_absent_names_and_restore_is_idempotent():
     assert drawing.registry.identity_of(name) == identity
 
 
-def test_automatic_partial_balloon_result_restores_only_the_unresolved_feature(monkeypatch):
+def test_automatic_partial_balloon_result_rolls_back_the_shared_table(monkeypatch):
     _drop_one_diameter_balloon(monkeypatch, 2.0)
 
     drawing = build_drawing(_dense_scattered_plate())
 
-    table = drawing.get_annotation("hole_table_plan")
-    assert table is not None
-    assert 0 < len(table.covers_diameters) < 20
-    assert 2.0 not in table.covers_diameters
-    unresolved = next(
-        feature
-        for feature in drawing.model().features
-        if feature.kind == "hole" and feature.diameter == pytest.approx(2.0)
-    )
-    assert unresolved in _plan_bore_callouts(drawing)
-    assert len(
-        [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    ) == len(table.covers_diameters)
-    assert "balloon_dropped" in {issue.code for issue in drawing.lint()}
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert len(_plan_bore_callouts(drawing)) == 17
+    codes = {issue.code for issue in drawing.lint()}
+    assert {"balloon_dropped", "table_dropped"} <= codes
+    assert "view_annotation_overlap" not in codes
+    assert "hole_requirement_missing" not in codes
     assert {outcome.state for outcome in _outcomes(drawing)} <= {"placed", "dropped"}
-    assert {
+    assert ("feature_annotation", "required_balloon_not_placed") in {
         (outcome.representation, outcome.representation_reason)
         for outcome in _outcomes(drawing)
-        if outcome.source_at[:2] == tuple(unresolved.frame.origin[:2])
-        and outcome.parameter_id in {"bore.diameter", "bore.through"}
-    } == {("feature_annotation", "required_balloon_not_placed")}
-    unresolved_label = _plan_bore_callouts(drawing)[unresolved][1].label
-    assert not [
-        issue
-        for issue in drawing.lint()
-        if issue.code == "label_centerline_overlap"
-        and f"label '{unresolved_label}'" in issue.message
-    ]
+        if outcome.state == "placed"
+    }
 
 
 def test_scattered_table_reports_a_balloon_landed_on_the_wrong_semantic_owner():
@@ -993,11 +982,14 @@ def test_scattered_table_reports_a_balloon_landed_on_the_wrong_semantic_owner():
 
     drawing = build_drawing(part, model=declared, page="A3")
 
-    assert "hole_table_plan" in drawing.annotations()
+    assert "hole_table_plan" not in drawing.annotations()
     assert victim in _plan_bore_callouts(drawing)
     failures = [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
     assert len(failures) == 1
-    assert "feature-owned balloons" in failures[0].message
+    assert any(
+        issue.code == "table_dropped" and "feature-owned balloon" in issue.message
+        for issue in drawing.registry.issues
+    )
     assert {
         outcome.representation
         for outcome in _outcomes(drawing)
@@ -1162,34 +1154,6 @@ def test_long_grouped_pattern_marker_fails_closed_when_its_shaft_crosses_its_tex
     assert "balloon_dropped" in {record.code for record in drawing.registry.issues}
 
 
-def test_automatic_partial_result_rolls_back_when_fallback_aware_refit_fails(monkeypatch):
-    import draftwright.drawing as drawing_module
-
-    original_fit_box = drawing_module.fit_box
-    first_success_seen = False
-
-    def fail_after_first_success(size, region, obstacles, prefer):
-        nonlocal first_success_seen
-        result = original_fit_box(size, region, obstacles, prefer)
-        if result is None:
-            return None
-        if first_success_seen:
-            return None
-        first_success_seen = True
-        return result
-
-    monkeypatch.setattr(drawing_module, "fit_box", fail_after_first_success)
-    _drop_one_diameter_balloon(monkeypatch, 2.0)
-
-    drawing = build_drawing(_dense_scattered_plate())
-
-    assert first_success_seen
-    assert "hole_table_plan" not in drawing.annotations()
-    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    assert {"balloon_dropped", "table_dropped"} <= {issue.code for issue in drawing.lint()}
-    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
-
-
 def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkeypatch):
     import draftwright.annotations.orchestrator as orchestrator
 
@@ -1266,7 +1230,8 @@ def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(monkeypatch,
 
     drawing = build_drawing(part, model=declared)
 
-    assert "hole_table_plan" in drawing.annotations()
+    assert "hole_table_plan" not in drawing.annotations()
+    assert any(issue.code == "table_dropped" for issue in drawing.registry.issues)
     assert any(
         issue.code == "callout_dropped" and feature in _features_from_issue(issue)
         for issue in drawing.registry.issues
@@ -1302,7 +1267,8 @@ def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
 
     drawing = build_drawing(part, model=declared)
 
-    assert "hole_table_plan" in drawing.annotations()
+    assert "hole_table_plan" not in drawing.annotations()
+    assert any(issue.code == "table_dropped" for issue in drawing.registry.issues)
     assert any(
         issue.code == "callout_dropped" and threaded in _features_from_issue(issue)
         for issue in drawing.registry.issues
@@ -1323,7 +1289,7 @@ def test_automatic_compound_inventory_fails_closed_on_cross_balloon_geometry():
         if feature.kind == "hole" and feature.cbore is not None
     )
 
-    assert "hole_table_plan" in drawing.annotations()
+    assert "hole_table_plan" not in drawing.annotations()
     assert feature in _plan_bore_callouts(drawing)
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
     assert [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
@@ -1338,12 +1304,11 @@ def test_automatic_compound_inventory_fails_closed_on_cross_balloon_geometry():
     assert {
         (outcome.representation, outcome.representation_reason) for outcome in compound_outcomes
     } == {(None, None)}
-    assert any(
-        outcome.representation == "feature_annotation"
-        and outcome.representation_reason == "required_balloon_not_placed"
+    assert ("feature_annotation", "required_balloon_not_placed") in {
+        (outcome.representation, outcome.representation_reason)
         for outcome in _outcomes(drawing)
-        if outcome.source_at[:2] != tuple(feature.frame.origin[:2])
-    )
+        if outcome.state == "placed"
+    }
     visible_labels = {
         annotation.label
         for _owner, (_name, annotation) in _plan_bore_callouts(drawing).items()
@@ -1400,7 +1365,7 @@ def test_automatic_escalation_preserves_preexisting_reserved_names(reserved_name
 def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
     import draftwright.annotations.orchestrator as orchestrator
 
-    part = _dense_scattered_plate()
+    part = _dense_perimeter_plate()
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
         drawing = build_drawing(part)
@@ -1409,7 +1374,6 @@ def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
     marked_annotation.hole_representation = "preexisting_representation"
     marked_annotation.hole_representation_reason = "preexisting_reason"
     before = _transaction_state(drawing)
-    _drop_one_diameter_balloon(monkeypatch, 2.0)
     original_reapply = drawing.registry.reapply
 
     def fail_after_coverage(name, identity):

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -655,109 +655,6 @@ def test_guarded_band_rejects_a_retained_label_in_long_balloon_text():
     )
 
 
-def test_guarded_private_band_places_joint_solution_and_fails_closed(monkeypatch):
-    import draftwright.annotations.balloons as balloons_module
-
-    members = [
-        ("A", 0, SimpleNamespace(diameter=2.0), 0.0, 0.0),
-        ("B", 0, SimpleNamespace(diameter=2.0), 0.0, 5.0),
-    ]
-    rendered = []
-    monkeypatch.setattr(
-        balloons_module,
-        "balloon_annotation_label_boxes",
-        lambda *_args: (),
-    )
-    monkeypatch.setattr(
-        balloons_module,
-        "_render_balloon",
-        lambda *args: rendered.append(args),
-    )
-
-    dropped = balloons_module._place_band(
-        SimpleNamespace(scale=1.0),
-        "plan",
-        members,
-        "y",
-        20.0,
-        0.0,
-        10.0,
-        5.0,
-        3.0,
-        1.0,
-        object(),
-        avoid_annotation_labels=True,
-    )
-
-    assert dropped == 0
-    assert len(rendered) == 2
-
-    monkeypatch.setattr(
-        balloons_module,
-        "_guarded_free_segments",
-        lambda *_args: (),
-    )
-    assert (
-        balloons_module._place_band(
-            SimpleNamespace(scale=1.0),
-            "plan",
-            members,
-            "y",
-            20.0,
-            0.0,
-            10.0,
-            5.0,
-            3.0,
-            1.0,
-            object(),
-            avoid_annotation_labels=True,
-        )
-        == 2
-    )
-
-
-def test_guarded_private_band_separates_sibling_long_tag_text(monkeypatch):
-    import draftwright.annotations.balloons as balloons_module
-    from draftwright._geometry import _boxes_overlap
-
-    tags = ("LONG_BALLOON_TAG_0", "LONG_BALLOON_TAG_1")
-    members = [
-        (tag, 0, SimpleNamespace(diameter=2.0), natural, 0.0)
-        for tag, natural in zip(tags, (0.0, 13.0), strict=True)
-    ]
-    placed = []
-    monkeypatch.setattr(balloons_module, "balloon_annotation_label_boxes", lambda *_args: ())
-    monkeypatch.setattr(
-        balloons_module,
-        "_render_balloon",
-        lambda _dwg, _view, tag, _j, _hole, _cx, _cy, bx, by, *_rest: placed.append((tag, bx, by)),
-    )
-
-    dropped = balloons_module._place_band(
-        SimpleNamespace(scale=1.0),
-        "plan",
-        members,
-        "x",
-        20.0,
-        -50.0,
-        50.0,
-        13.0,
-        3.0,
-        4.5,
-        object(),
-        avoid_annotation_labels=True,
-    )
-
-    assert dropped == 0
-    assert len(placed) == 2
-    boxes = []
-    for tag, bx, by in placed:
-        text_box = balloons_module._balloon_text_box(tag, 3.0)
-        assert text_box is not None
-        boxes.append(tuple(value + offset for value, offset in zip(text_box, (bx, by, bx, by))))
-    assert not _boxes_overlap(*boxes)
-
-
 def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry():
     from draftwright.annotations.balloons import _guarded_inventory_geometry_is_clear
 
@@ -786,18 +683,18 @@ def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry(
     assert not _guarded_inventory_geometry_is_clear(
         first,
         page,
-        retained_label_boxes=((15.0, 15.0, 25.0, 25.0),),
+        retained_boxes=((15.0, 15.0, 25.0, 25.0),),
     )
     assert not _guarded_inventory_geometry_is_clear(
         first,
         page,
-        retained_leader_segments=(((0.0, 15.0), (30.0, 15.0)),),
+        retained_segments=(((0.0, 15.0), (30.0, 15.0)),),
     )
     shaft_only = ((((40.0, 40.0, 50.0, 50.0),), (((0.0, 15.0), (30.0, 15.0)),)),)
     assert not _guarded_inventory_geometry_is_clear(
         shaft_only,
         page,
-        retained_leader_segments=(((15.0, 0.0), (15.0, 30.0)),),
+        retained_segments=(((15.0, 0.0), (15.0, 30.0)),),
     )
 
 
@@ -918,6 +815,31 @@ def test_public_add_balloons_separates_long_sibling_text_components():
         for first_box in first.centerline_boxes
         for second_box in second.centerline_boxes
     )
+
+
+def test_automatic_table_fails_closed_against_a_retained_public_balloon():
+    drawing = build_drawing(_dense_perimeter_plate(), page="A3", auto_dims=False)
+    tag = "RETAINED_PUBLIC_BALLOON_WITH_A_VERY_LONG_TAG"
+    retained_name = f"balloon_plan_{tag}_0"
+    drawing.add_balloons("plan", [(tag, 0, drawing.recognition().holes[0])])
+    retained = drawing.get_annotation(retained_name)
+    assert retained is not None
+
+    with drawing.deferred():
+        for feature in drawing.model().features:
+            if feature.kind == "hole":
+                drawing.callout(feature)
+                drawing.locate(feature)
+
+    assert drawing.get_annotation(retained_name) is retained
+    assert "hole_table_plan" not in drawing.annotations()
+    assert {name for name in drawing.annotations() if name.startswith("balloon_plan_")} == {
+        retained_name
+    }
+    assert {"table_dropped", "balloon_dropped"} <= {
+        issue.code for issue in drawing.registry.issues
+    }
+    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
 def test_public_hole_table_does_not_expose_an_uncomposable_replacement_option():

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -1378,8 +1378,9 @@ def test_automatic_escalation_preserves_preexisting_reserved_names(reserved_name
 
 def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
     import draftwright.annotations.orchestrator as orchestrator
+    from draftwright.annotations._common import PlacementContext
 
-    part = _dense_perimeter_plate()
+    part = _dense_scattered_plate()
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
         drawing = build_drawing(part)
@@ -1392,16 +1393,24 @@ def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
         value for value in original_callouts.values() if value[0] != marked_name
     )
     assert before["markers"][unmarked_name] == (False, None, False, None)
-    original_reapply = drawing.registry.reapply
+    _drop_one_diameter_balloon(monkeypatch, 2.0)
+    original_record_issue = PlacementContext.record_issue
 
-    def fail_after_coverage(name, identity):
-        original_reapply(name, identity)
-        if name == "hole_table_plan":
-            raise RuntimeError("forced automatic coverage failure")
+    def fail_after_inner_rollback(self, severity, code, message, **kwargs):
+        original_record_issue(self, severity, code, message, **kwargs)
+        if code == "table_dropped" and message == (
+            "hole table lacked complete feature-owned balloon evidence"
+        ):
+            annotation = drawing.get_annotation(unmarked_name)
+            assert (
+                annotation.hole_representation,
+                annotation.hole_representation_reason,
+            ) == ("feature_annotation", "required_balloon_not_placed")
+            raise RuntimeError("forced failure after marked inner rollback")
 
-    monkeypatch.setattr(drawing.registry, "reapply", fail_after_coverage)
+    monkeypatch.setattr(PlacementContext, "record_issue", fail_after_inner_rollback)
 
-    with pytest.raises(RuntimeError, match="forced automatic coverage failure"):
+    with pytest.raises(RuntimeError, match="forced failure after marked inner rollback"):
         with drawing.deferred():
             for feature in drawing.model().features:
                 if feature.kind == "hole":

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -213,20 +213,94 @@ def _features_from_issue(issue):
     }
 
 
-def test_requirement_scoped_representation_is_a_semantic_owner_seam():
+def test_annotation_hole_features_unions_every_semantic_owner_channel():
     from draftwright.annotations._common import _annotation_hole_features
     from draftwright.registry import AnnotationRegistry
 
-    feature = type("Feature", (), {"kind": "hole"})()
+    def feature(kind="hole"):
+        return type("Feature", (), {"kind": kind})()
+
+    owner = feature()
+    measurement_owner = feature()
+    direct_location_owner = feature()
+    identified_location_owner = feature()
+    requirement_owner = feature()
+    representation_owner = feature()
+    scoped_representation_owner = feature()
+    center_owner = feature()
+    ignored_owner = feature("boss")
     annotation = SimpleNamespace(
+        covers_hole_locations=(
+            (direct_location_owner, (1.0, 2.0, 3.0), "plan"),
+            (SimpleNamespace(feature=identified_location_owner), (1.0, 2.0, 3.0)),
+            (ignored_owner, (1.0, 2.0, 3.0), "plan"),
+        ),
+        covers_hole_requirements_by_feature=(
+            (requirement_owner, "bore.through", 1),
+            (ignored_owner, "bore.through", 1),
+        ),
+        covers_hole_representations_by_feature=(
+            (representation_owner, "hole_table", "placed"),
+            (ignored_owner, "hole_table", "placed"),
+        ),
         covers_hole_representations_by_requirement=(
-            (feature, "location.location.x", "hole_table", "required_balloons_placed"),
-        )
+            (
+                scoped_representation_owner,
+                "location.location.x",
+                "hole_table",
+                "required_balloons_placed",
+            ),
+            (ignored_owner, "location.location.x", "hole_table", "placed"),
+        ),
+        covers_hole_centers=(
+            (center_owner, (0.0, 0.0, 0.0), "plan"),
+            (ignored_owner, (0.0, 0.0, 0.0), "plan"),
+        ),
+    )
+    registry = AnnotationRegistry()
+    registry.add(
+        annotation,
+        "semantic_union",
+        "plan",
+        feature=owner,
+        measurement=SimpleNamespace(feature=measurement_owner),
     )
 
-    assert _annotation_hole_features(
-        AnnotationRegistry(), "unregistered", annotation
-    ) == frozenset({feature})
+    assert _annotation_hole_features(registry, "semantic_union", annotation) == frozenset(
+        {
+            owner,
+            measurement_owner,
+            direct_location_owner,
+            identified_location_owner,
+            requirement_owner,
+            representation_owner,
+            scoped_representation_owner,
+            center_owner,
+        }
+    )
+
+
+def test_hole_table_eligibility_fails_closed_without_a_plain_hole_owner():
+    from draftwright.annotations._common import (
+        _hole_table_replaceable_annotation,
+        _hole_table_replaceable_feature,
+        _hole_table_replaceable_location_annotation,
+    )
+    from draftwright.registry import AnnotationRegistry
+
+    registry = AnnotationRegistry()
+    annotation = SimpleNamespace()
+    pattern = type("Feature", (), {"kind": "pattern"})()
+
+    assert not _hole_table_replaceable_annotation(registry, "missing", annotation)
+    assert not _hole_table_replaceable_location_annotation(registry, "missing", annotation)
+    assert not _hole_table_replaceable_feature(pattern)
+
+    registry.add(annotation, "pattern_annotation", "plan", feature=pattern)
+    assert not _hole_table_replaceable_annotation(registry, "pattern_annotation", annotation)
+    assert not _hole_table_replaceable_location_annotation(
+        registry, "pattern_annotation", annotation
+    )
 
 
 def test_table_commit_requires_exact_balloon_cardinality_and_owner():
@@ -283,17 +357,44 @@ def test_guarded_balloon_obstacles_use_compact_labels_and_note_boxes():
                 max=SimpleNamespace(X=8.0, Y=9.0),
             )
 
+    class UnreadableLabel(BoxedNote):
+        @property
+        def label_bbox(self):
+            raise RuntimeError("external label metadata unavailable")
+
+    class Unmeasurable:
+        label_bbox = None
+
+        def bounding_box(self):
+            raise RuntimeError("external annotation does not measure")
+
     label = SimpleNamespace(label_bbox=(1.0, 1.0, 2.0, 2.0))
     note = BoxedNote()
+    unreadable = UnreadableLabel()
+    unmeasurable = Unmeasurable()
+    centerline = SimpleNamespace(
+        is_centerline=True,
+        label_bbox=(30.0, 30.0, 31.0, 31.0),
+    )
     other_view = SimpleNamespace(label_bbox=(20.0, 20.0, 21.0, 21.0))
     drawing = SimpleNamespace(
         box_cache={},
-        iter_annotations=lambda: iter((("label", label), ("note", note), ("other", other_view))),
+        iter_annotations=lambda: iter(
+            (
+                ("label", label),
+                ("note", note),
+                ("unreadable", unreadable),
+                ("unmeasurable", unmeasurable),
+                ("centerline", centerline),
+                ("other", other_view),
+            )
+        ),
         view_of=lambda name: "side" if name == "other" else "plan",
     )
 
     assert balloon_annotation_label_boxes(drawing, "plan") == (
         (1.0, 1.0, 2.0, 2.0),
+        (3.0, 4.0, 8.0, 9.0),
         (3.0, 4.0, 8.0, 9.0),
     )
 
@@ -644,6 +745,13 @@ def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry(
     overlapping_second = (((19.0, 15.0, 29.0, 25.0),), ())
     shaft_crossing_second = (((24.0, 12.0, 28.0, 18.0),), ())
     shaft_crossing_first = ((((10.0, 10.0, 20.0, 20.0),), (((0.0, 15.0), (30.0, 15.0)),)),)
+    self_text_crossing = (
+        (
+            (10.0, 10.0, 20.0, 20.0),
+            (20.5, 13.0, 30.0, 17.0),
+        ),
+        (((15.0, 15.0), (25.0, 15.0)),),
+    )
     off_page = (((95.0, 95.0, 105.0, 105.0),), ())
 
     assert _guarded_inventory_geometry_is_clear((*first, clear_second), page)
@@ -651,6 +759,7 @@ def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry(
     assert not _guarded_inventory_geometry_is_clear(
         (*shaft_crossing_first, shaft_crossing_second), page
     )
+    assert not _guarded_inventory_geometry_is_clear((self_text_crossing,), page)
     assert not _guarded_inventory_geometry_is_clear((*first, off_page), page)
 
 
@@ -798,6 +907,40 @@ def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
         for outcome in _outcomes(drawing)
         if outcome.state == "placed"
     }
+
+
+def test_stash_ignores_absent_names_and_restore_is_idempotent():
+    from draftwright.annotations._common import (
+        PlacementContext,
+        _restore_stashed_annotations,
+        _stash_annotations,
+    )
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    name = next(iter(_plan_bore_callouts(drawing).values()))[0]
+    annotation = drawing.get_annotation(name)
+    identity = drawing.registry.identity_of(name)
+    stashed = _stash_annotations(drawing, ("not_present", name))
+    ctx = PlacementContext(
+        registry=drawing.registry,
+        coverage=drawing.coverage,
+        items=drawing.items,
+        part_model=drawing.model(),
+    )
+
+    assert set(stashed) == {name}
+    assert drawing.get_annotation(name) is None
+    assert _restore_stashed_annotations(drawing, ctx, stashed) == {name}
+    assert drawing.get_annotation(name) is annotation
+    assert drawing.registry.identity_of(name) == identity
+
+    # Retrying rollback must recognise the exact already-restored object rather
+    # than duplicating it or perturbing its semantic identity.
+    items = tuple(drawing.items)
+    assert _restore_stashed_annotations(drawing, ctx, stashed) == {name}
+    assert tuple(drawing.items) == items
+    assert drawing.get_annotation(name) is annotation
+    assert drawing.registry.identity_of(name) == identity
 
 
 def test_automatic_partial_balloon_result_restores_only_the_unresolved_feature(monkeypatch):
@@ -955,6 +1098,68 @@ def test_grouped_pattern_marker_cannot_certify_an_undefined_hole_tag():
         "bolt_circle.diameter",
         "grouping.count",
     }
+
+
+def test_long_grouped_pattern_marker_fails_closed_when_its_shaft_crosses_its_text():
+    from draftwright.analysis import _analyse
+    from draftwright.annotations._common import Escalation, PlacementContext
+    from draftwright.annotations.orchestrator import _maybe_tabulate_holes
+    from draftwright.linting.issues import LintIssue
+
+    part = _bolt_circle_plate()
+    detected = build_drawing(part, page="A4")
+    pattern = next(feature for feature in detected.model().features if feature.kind == "pattern")
+    long_pattern = replace(pattern, count=1000)
+    model = replace(
+        detected.model(),
+        features=[
+            long_pattern if feature is pattern else feature
+            for feature in detected.model().features
+        ],
+    )
+    drawing = build_drawing(part, model=model, page="A4")
+    analysis = _analyse(
+        part,
+        title="",
+        number="",
+        tolerance="ISO 2768-m",
+        drawn_by="",
+        out="",
+        page="A4",
+        model=model,
+    )
+    callout_name = next(name for name in drawing.annotations() if name.startswith("hc_plan"))
+    measurements = drawing.registry.measurement_of(callout_name)
+    drawing.remove(callout_name)
+    issue = LintIssue(
+        severity="warning",
+        code="callout_dropped",
+        message="synthetic long grouped pattern callout drop",
+        measurement_ids=measurements,
+        hole_requirement_ids=((long_pattern, "grouping.count"),),
+    )
+    drawing.registry.record_issue(issue)
+    ctx = PlacementContext(
+        registry=drawing.registry,
+        coverage=drawing.coverage,
+        items=drawing.items,
+        part_model=model,
+        escalations=(
+            Escalation(
+                kind="callout",
+                view="plan",
+                feature=long_pattern,
+                reason="strip_full",
+                targets=measurements,
+            ),
+        ),
+    )
+
+    _maybe_tabulate_holes(drawing, analysis, ctx=ctx)
+
+    assert "balloon_plan_1000×A_0" not in drawing.annotations()
+    assert issue in drawing.registry.issues
+    assert "balloon_dropped" in {record.code for record in drawing.registry.issues}
 
 
 def test_automatic_partial_result_rolls_back_when_fallback_aware_refit_fails(monkeypatch):
@@ -1199,8 +1404,11 @@ def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
         drawing = build_drawing(part)
-    before = _transaction_state(drawing)
     original_callouts = _plan_bore_callouts(drawing)
+    marked_name, marked_annotation = next(iter(original_callouts.values()))
+    marked_annotation.hole_representation = "preexisting_representation"
+    marked_annotation.hole_representation_reason = "preexisting_reason"
+    before = _transaction_state(drawing)
     _drop_one_diameter_balloon(monkeypatch, 2.0)
     original_reapply = drawing.registry.reapply
 
@@ -1223,6 +1431,11 @@ def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
         drawing.get_annotation(name) is annotation
         for name, annotation in original_callouts.values()
     )
+    assert drawing.get_annotation(marked_name) is marked_annotation
+    assert (
+        marked_annotation.hole_representation,
+        marked_annotation.hole_representation_reason,
+    ) == ("preexisting_representation", "preexisting_reason")
 
 
 def test_one_physical_group_with_mixed_table_and_fit_evidence_has_no_scalar_winner():

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -974,6 +974,9 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
             (False, False, True, True),
             (False, False, True, True),
         )
+        # Keep the separately valid shaft harmless so rollback depends on the
+        # Boolean box payload selecting conservative rendered geometry.
+        retained.centerline_segments = (((10_000.0, 10_000.0), (10_001.0, 10_001.0)),)
     elif component_metadata == "boolean_segment_coordinates":
         retained.centerline_segments = (((False, False), (True, True)),)
     elif component_metadata == "malformed":
@@ -996,6 +999,19 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
     elif component_metadata == "absent":
         del retained.centerline_boxes
         del retained.centerline_segments
+    if component_metadata in {"boolean_box_coordinates", "boolean_segment_coordinates"}:
+        from draftwright.annotations.balloons import (
+            _geom_box,
+            _retained_annotation_geometry,
+        )
+
+        rendered_box = _geom_box(retained, drawing.box_cache)
+        assert rendered_box is not None
+        retained_boxes, _retained_segments, retained_safe = _retained_annotation_geometry(
+            drawing, "plan"
+        )
+        assert retained_safe
+        assert tuple(float(value) for value in rendered_box) in retained_boxes
     if component_metadata == "unmeasurable":
         import draftwright.annotations.balloons as balloons_module
 

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -312,6 +312,19 @@ def test_long_public_balloon_text_remains_visible_to_structural_lint():
     assert _label_centerline_overlap(label, balloon) is not None
 
 
+def test_empty_public_balloon_tag_does_not_create_a_page_origin_lint_box():
+    from draftwright.linting.structural import _label_centerline_overlap
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4", auto_dims=False)
+    hole = drawing.recognition().holes[0]
+    drawing.add_balloons("plan", [("", 0, hole)])
+    balloon = drawing.get_annotation("balloon_plan__0")
+
+    assert len(balloon.centerline_boxes) == 1
+    origin_label = SimpleNamespace(label="ORIGIN", label_bbox=(-1.0, -1.0, 1.0, 1.0))
+    assert _label_centerline_overlap(origin_label, balloon) is None
+
+
 def test_guarded_assignment_preserves_the_canonical_flow_cost_objective():
     from draftwright.annotations.balloons import (
         _guarded_assignment,
@@ -422,6 +435,41 @@ def test_real_shaft_crossing_carves_the_guarded_band_without_aabb_sampling():
 
     assert any(lo <= 0.0 <= hi for lo, hi in free)
     assert not any(lo <= 10.0 <= hi for lo, hi in free)
+
+
+def test_guarded_band_rejects_a_retained_label_in_long_balloon_text():
+    from draftwright.annotations.balloons import (
+        _balloon_text_box,
+        _guarded_free_segments,
+    )
+
+    tag = "LONG_BALLOON_TAG"
+    font_size = 3.0
+    text_box = _balloon_text_box(tag, font_size)
+    assert text_box is not None
+    radius = 4.5
+    line = 20.0
+    label_box = (
+        line + radius + 0.2,
+        text_box[1] + 0.2,
+        line + text_box[2] - 0.2,
+        text_box[3] - 0.2,
+    )
+    member = (tag, 0, SimpleNamespace(diameter=2.0), 0.0, 0.0)
+
+    assert (
+        _guarded_free_segments(
+            member,
+            "y",
+            line,
+            ((0.0, 0.0),),
+            radius,
+            1.0,
+            (label_box,),
+            text_box,
+        )
+        == ()
+    )
 
 
 def test_guarded_private_band_places_joint_solution_and_fails_closed(monkeypatch):

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import itertools
+from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 from build123d import Box, Cylinder, Pos
@@ -28,6 +30,18 @@ def _dense_scattered_plate():
     columns = [-40 + i * 20 for i in range(5)]
     for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
         part -= Pos(columns[column], y, 0) * Cylinder(1.0 + i * 0.2, 20)
+    return part
+
+
+def _dense_plate_with_counterbore():
+    """Dense escalation with one recognised compound hole callout."""
+    part = Box(90, 60, 12)
+    columns = [-40 + i * 20 for i in range(5)]
+    for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
+        diameter = 2.0 + i * 0.4
+        part -= Pos(columns[column], y, 0) * Cylinder(diameter / 2, 20)
+        if i == 0:
+            part -= Pos(columns[column], y, 4.5) * Cylinder(2.5, 3)
     return part
 
 
@@ -76,6 +90,29 @@ def _drop_one_diameter_balloon(monkeypatch, diameter):
         raise AssertionError(f"no assigned Ø{diameter:g} balloon to remove")
 
     monkeypatch.setattr(balloons_module, "_assign_balloon_bands", partial_assignment)
+
+
+def test_transaction_collects_every_structured_feature_seam():
+    from draftwright.annotations._common import (
+        _annotation_hole_features,
+        _hole_table_replaceable_annotation,
+        _stash_annotations,
+    )
+    from draftwright.registry import AnnotationRegistry
+
+    feature = type("Feature", (), {"kind": "hole"})()
+    annotation = SimpleNamespace(
+        covers_hole_locations=(),
+        covers_hole_requirements_by_feature=((feature, "bore.through", 1),),
+        covers_hole_centers=((feature, (0.0, 0.0, 0.0), "plan"),),
+    )
+    registry = AnnotationRegistry()
+
+    assert _annotation_hole_features(registry, "missing", annotation) == frozenset({feature})
+    assert not _hole_table_replaceable_annotation(
+        registry, "missing", SimpleNamespace(covers_hole_locations=())
+    )
+    assert _stash_annotations(SimpleNamespace(registry=registry), ["missing"]) == {}
 
 
 @pytest.mark.parametrize("declared", [False, True], ids=["automatic", "declared-ir"])
@@ -198,6 +235,69 @@ def test_partial_public_balloon_commit_restores_only_the_unresolved_group(monkey
     }
 
 
+def test_partial_public_commit_refits_clear_of_the_restored_fallback(monkeypatch):
+    import draftwright.drawing as drawing_module
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    original = _plan_bore_callouts(drawing)
+    grouped_feature = next(feature for feature in original if feature.count == 2)
+    grouped_callout = original[grouped_feature][1]
+    bbox = grouped_callout.bounding_box()
+    original_fit_box = drawing_module.fit_box
+    fit_calls = 0
+
+    def occupy_freed_fallback(size, region, obstacles, prefer):
+        nonlocal fit_calls
+        fit_calls += 1
+        if fit_calls == 1:
+            return (bbox.min.X, bbox.min.Y)
+        return original_fit_box(size, region, obstacles, prefer)
+
+    monkeypatch.setattr(drawing_module, "fit_box", occupy_freed_fallback)
+    _drop_one_diameter_balloon(monkeypatch, 10.0)
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert fit_calls == 2
+    assert drawing.get_annotation(original[grouped_feature][0]) is grouped_callout
+    assert not {
+        "annotation_overlap",
+        "view_annotation_overlap",
+    } & {issue.code for issue in drawing.lint()}
+
+
+def test_partial_public_commit_rolls_back_when_the_fallback_aware_refit_fails(monkeypatch):
+    import draftwright.drawing as drawing_module
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    original = _plan_bore_callouts(drawing)
+    original_fit_box = drawing_module.fit_box
+    fit_calls = 0
+
+    def fail_second_fit(size, region, obstacles, prefer):
+        nonlocal fit_calls
+        fit_calls += 1
+        if fit_calls == 2:
+            return None
+        return original_fit_box(size, region, obstacles, prefer)
+
+    monkeypatch.setattr(drawing_module, "fit_box", fail_second_fit)
+    _drop_one_diameter_balloon(monkeypatch, 10.0)
+
+    assert drawing.add_hole_table("plan", replace_callouts=True) is None
+
+    assert fit_calls == 2
+    assert all(
+        drawing.get_annotation(name) is annotation for name, annotation in original.values()
+    )
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    codes = {issue.code for issue in drawing.lint()}
+    assert {"balloon_dropped", "table_dropped"} <= codes
+    assert "hole_requirement_missing" not in codes
+
+
 def test_automatic_partial_balloon_result_never_claims_the_unkeyed_feature(monkeypatch):
     _drop_one_diameter_balloon(monkeypatch, 2.0)
 
@@ -227,6 +327,42 @@ def test_automatic_partial_balloon_result_never_claims_the_unkeyed_feature(monke
     }
 
 
+def test_automatic_partial_result_rolls_back_when_the_fallback_aware_refit_fails(
+    monkeypatch,
+):
+    import draftwright.drawing as drawing_module
+
+    original_fit_box = drawing_module.fit_box
+    first_success_seen = False
+
+    def fail_after_first_success(size, region, obstacles, prefer):
+        nonlocal first_success_seen
+        result = original_fit_box(size, region, obstacles, prefer)
+        if result is None:
+            return None
+        if first_success_seen:
+            return None
+        first_success_seen = True
+        return result
+
+    monkeypatch.setattr(drawing_module, "fit_box", fail_after_first_success)
+    _drop_one_diameter_balloon(monkeypatch, 2.0)
+
+    drawing = build_drawing(_dense_scattered_plate())
+
+    assert first_success_seen
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    codes = {issue.code for issue in drawing.lint()}
+    assert {"balloon_dropped", "table_dropped"} <= codes
+    represented = {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _outcomes(drawing)
+        if outcome.state == "placed" and outcome.parameter_id == "bore.diameter"
+    }
+    assert represented == {("feature_annotation", "required_balloon_not_placed")}
+
+
 def test_replacement_without_balloons_fails_before_mutating_the_drawing():
     drawing = build_drawing(_multi_hole_plate(), page="A4")
     before = tuple(drawing.annotations())
@@ -247,3 +383,258 @@ def test_replacement_without_a_complete_callout_fallback_fails_before_mutation()
 
     assert tuple(drawing.annotations()) == before
     assert "hole_table_plan" not in drawing.annotations()
+
+
+def test_an_existing_table_cannot_substitute_for_a_missing_leader_fallback():
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    callout_name = next(iter(_plan_bore_callouts(drawing).values()))[0]
+    assert drawing.add_hole_table("plan") is not None
+    drawing.remove(callout_name)
+    for name in tuple(drawing.annotations()):
+        if name.startswith("balloon_plan_"):
+            drawing.remove(name)
+    before = tuple(drawing.annotations())
+
+    with pytest.raises(ValueError, match="existing bore callout for every"):
+        drawing.add_hole_table("plan", name="replacement_table", replace_callouts=True)
+
+    assert tuple(drawing.annotations()) == before
+    assert "replacement_table" not in drawing.annotations()
+
+
+def test_declared_qty_without_member_positions_cannot_commit_one_balloon_as_two():
+    part = _multi_hole_plate()
+    detected = build_drawing(part, auto_dims=False).model()
+    grouped = next(
+        feature for feature in detected.features if feature.kind == "hole" and feature.count == 2
+    )
+    declared_group = replace(grouped, members=())
+    declared = replace(
+        detected,
+        features=[
+            declared_group if feature is grouped else feature for feature in detected.features
+        ],
+    )
+    drawing = build_drawing(part, page="A4", model=declared)
+    original = _plan_bore_callouts(drawing)
+    before_codes = {issue.code for issue in drawing.lint()}
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    grouped_name, grouped_callout = original[declared_group]
+    assert drawing.get_annotation(grouped_name) is grouped_callout
+    assert not [
+        name
+        for name in drawing.annotations()
+        if name.startswith("balloon_plan_") and drawing.registry.feature_of(name) == declared_group
+    ]
+    assert declared_group not in {
+        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
+    }
+    assert table.covers_diameters == (16.0,)
+    after_codes = {issue.code for issue in drawing.lint()}
+    assert after_codes == before_codes
+    assert "hole_requirement_missing" not in after_codes
+
+
+@pytest.mark.parametrize("failing_stage", ["table", "balloons"])
+def test_public_replacement_rolls_back_exactly_when_placement_raises(monkeypatch, failing_stage):
+    import draftwright.drawing as drawing_module
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    before_names = tuple(drawing.annotations())
+    before_objects = {name: drawing.get_annotation(name) for name in before_names}
+    before_identities = {name: drawing.registry.identity_of(name) for name in before_names}
+    before_codes = [issue.code for issue in drawing.lint()]
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError(f"forced {failing_stage} failure")
+
+    if failing_stage == "table":
+        monkeypatch.setattr(drawing, "add_table", fail)
+    else:
+        monkeypatch.setattr(drawing_module, "render_balloons", fail)
+
+    with pytest.raises(RuntimeError, match=f"forced {failing_stage} failure"):
+        drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert tuple(drawing.annotations()) == before_names
+    assert {name: drawing.get_annotation(name) for name in before_names} == before_objects
+    assert {name: drawing.registry.identity_of(name) for name in before_names} == before_identities
+    assert [issue.code for issue in drawing.lint()] == before_codes
+
+
+def test_public_replacement_rolls_back_if_stashing_itself_raises(monkeypatch):
+    import draftwright.drawing as drawing_module
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    before_names = tuple(drawing.annotations())
+    before_objects = {name: drawing.get_annotation(name) for name in before_names}
+    before_identities = {name: drawing.registry.identity_of(name) for name in before_names}
+
+    def fail_stash(*_args, **_kwargs):
+        raise RuntimeError("forced stash failure")
+
+    monkeypatch.setattr(drawing_module, "_stash_annotations", fail_stash)
+
+    with pytest.raises(RuntimeError, match="forced stash failure"):
+        drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert tuple(drawing.annotations()) == before_names
+    assert {name: drawing.get_annotation(name) for name in before_names} == before_objects
+    assert {name: drawing.registry.identity_of(name) for name in before_names} == before_identities
+
+
+def test_exception_after_partial_restore_clears_temporary_representation_markers(monkeypatch):
+    import draftwright.drawing as drawing_module
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    original = _plan_bore_callouts(drawing)
+    for _name, annotation in original.values():
+        annotation.hole_representation = "existing_representation"
+        annotation.hole_representation_reason = "existing_reason"
+    before_markers = {
+        name: (
+            getattr(annotation, "hole_representation", None),
+            getattr(annotation, "hole_representation_reason", None),
+        )
+        for name, annotation in original.values()
+    }
+    _drop_one_diameter_balloon(monkeypatch, 10.0)
+
+    def fail_coverage(*_args, **_kwargs):
+        raise RuntimeError("forced coverage failure")
+
+    monkeypatch.setattr(drawing_module, "_register_hole_table_coverage", fail_coverage)
+
+    with pytest.raises(RuntimeError, match="forced coverage failure"):
+        drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert {
+        name: (
+            getattr(drawing.get_annotation(name), "hole_representation", None),
+            getattr(drawing.get_annotation(name), "hole_representation_reason", None),
+        )
+        for name, _annotation in original.values()
+    } == before_markers
+
+
+def test_replacement_rejects_a_table_name_reserved_by_a_fallback_before_mutation():
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    fallback_name = next(iter(_plan_bore_callouts(drawing).values()))[0]
+    before = tuple(drawing.annotations())
+
+    with pytest.raises(ValueError, match="unused table/balloon names"):
+        drawing.add_hole_table("plan", name=fallback_name, replace_callouts=True)
+
+    assert tuple(drawing.annotations()) == before
+    assert drawing.get_annotation(fallback_name) is not None
+
+
+def test_preexisting_balloon_name_cannot_spoof_semantic_commit():
+    drawing = build_drawing(Box(60, 40, 10) - Cylinder(4, 20), page="A4")
+    original = _plan_bore_callouts(drawing)
+    note_name = drawing.note("EXISTING", (20, 20), view="plan", name="balloon_plan_A_0")
+    note = drawing.get_annotation(note_name)
+
+    with pytest.raises(ValueError, match="balloon_plan_A_0"):
+        drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert drawing.get_annotation(note_name) is note
+    assert all(
+        drawing.get_annotation(name) is annotation for name, annotation in original.values()
+    )
+    assert "hole_table_plan" not in drawing.annotations()
+
+
+def test_public_replacement_retains_a_compound_callout_the_table_cannot_cover():
+    part = Box(60, 40, 20) - Cylinder(4, 30) - Pos(0, 0, 2) * Cylinder(7, 20)
+    drawing = build_drawing(part, page="A4")
+    feature = next(feature for feature in drawing.model().features if feature.kind == "hole")
+    assert feature.cbore is not None
+    callout_name, callout = _plan_bore_callouts(drawing)[feature]
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert drawing.get_annotation(callout_name) is callout
+    assert {
+        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
+    } == {
+        "bore.diameter",
+        "counterbore.diameter",
+        "counterbore.depth",
+    }
+    assert {
+        measurement.parameter for measurement in drawing.registry.measurement_of("hole_table_plan")
+    } == {"bore.diameter"}
+    assert all(outcome.state == "placed" for outcome in _outcomes(drawing))
+    assert not {"feature_not_dimensioned", "hole_requirement_missing"} & {
+        issue.code for issue in drawing.lint()
+    }
+
+
+def test_public_replacement_retains_a_declared_thread_callout():
+    part = Box(60, 40, 10) - Cylinder(4, 20)
+    detected = build_drawing(part, auto_dims=False).model()
+    hole = next(feature for feature in detected.features if feature.kind == "hole")
+    threaded = replace(hole, thread="M8x1")
+    declared = replace(
+        detected,
+        features=[threaded if feature is hole else feature for feature in detected.features],
+    )
+    drawing = build_drawing(part, page="A4", model=declared)
+    callout_name, callout = _plan_bore_callouts(drawing)[threaded]
+    assert "M8x1" in callout.label
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert drawing.get_annotation(callout_name) is callout
+    assert all(outcome.state == "placed" for outcome in _outcomes(drawing))
+
+
+def test_public_replacement_retains_a_pattern_callout_with_geometry_the_table_omits():
+    part = Box(80, 40, 10)
+    for x in (-20, 0, 20):
+        part -= Pos(x, 0, 0) * Cylinder(3, 20)
+    drawing = build_drawing(part, page="A4")
+    pattern = next(feature for feature in drawing.model().features if feature.kind == "pattern")
+    callout_name, callout = _plan_bore_callouts(drawing)[pattern]
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert drawing.get_annotation(callout_name) is callout
+    assert any(
+        outcome.parameter_id == "pitch.length" and outcome.state == "placed"
+        for outcome in _outcomes(drawing)
+    )
+
+
+def test_automatic_table_never_removes_a_recognised_compound_callout():
+    drawing = build_drawing(_dense_plate_with_counterbore())
+    feature = next(
+        feature
+        for feature in drawing.model().features
+        if feature.kind == "hole" and feature.cbore is not None
+    )
+    callouts = _plan_bore_callouts(drawing)
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert feature in callouts
+    callout_name, callout = callouts[feature]
+    assert drawing.get_annotation(callout_name) is callout
+    assert {
+        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
+    } >= {
+        "counterbore.diameter",
+        "counterbore.depth",
+    }
+    outcome_states = {outcome.parameter_id: outcome.state for outcome in _outcomes(drawing)}
+    assert outcome_states["counterbore.diameter"] == "placed"
+    assert outcome_states["counterbore.depth"] == "placed"
+    assert not {"feature_not_dimensioned", "hole_requirement_missing"} & {
+        issue.code for issue in drawing.lint()
+    }

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -7,10 +7,12 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from build123d import Box, Cylinder, Pos
+from build123d import Align, Box, Cylinder, Pos
 
 from draftwright import build_drawing
+from draftwright.fits import fit_class
 from draftwright.linting.hole_coverage import hole_requirement_outcomes
+from draftwright.linting.issues import LintIssue
 from draftwright.model.compiled import compile_dimensions
 
 
@@ -45,6 +47,26 @@ def _dense_plate_with_counterbore():
     return part
 
 
+def _dense_plate_with_double_d():
+    """Dense escalation with one recognised DOUBLE-D through bore."""
+    part = Box(90, 60, 12)
+    columns = [-40 + i * 20 for i in range(5)]
+    centered = (Align.CENTER, Align.CENTER, Align.CENTER)
+    for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
+        if i == 0:
+            cutter = Cylinder(2.5, 20, align=centered) & Box(3.6, 20, 30, align=centered)
+        else:
+            cutter = Cylinder(1.0 + i * 0.2, 20)
+        part -= Pos(columns[column], y, 0) * cutter
+    return part
+
+
+def _double_d_plate():
+    centered = (Align.CENTER, Align.CENTER, Align.CENTER)
+    cutter = Cylinder(5, 20, align=centered) & Box(7.2, 20, 30, align=centered)
+    return Box(30, 30, 10, align=centered) - cutter
+
+
 def _build_multi_hole_drawing(*, declared):
     part = _multi_hole_plate()
     model = build_drawing(part, auto_dims=False).model() if declared else None
@@ -59,6 +81,36 @@ def _outcomes(drawing):
         drawing.registry,
         compile_dimensions(drawing.model()).diagnostics,
     )
+
+
+def _transaction_state(drawing):
+    """Every mutable surface the public table transaction promises to restore."""
+    registry = drawing.registry.snapshot()
+    return {
+        "items": tuple(id(item) for item in drawing.items),
+        "named": {name: id(item) for name, item in registry["named"].items()},
+        "views": registry["anno_view"],
+        "features": registry["anno_feature"],
+        "measurements": registry["anno_measurement"],
+        "pins": registry["pinned"],
+        "issues": drawing.registry.issues,
+        "coverage": drawing.coverage.snapshot(),
+        "markers": {
+            name: (
+                getattr(drawing.get_annotation(name), "hole_representation", None),
+                getattr(drawing.get_annotation(name), "hole_representation_reason", None),
+            )
+            for name in drawing.annotations()
+        },
+    }
+
+
+def _source_outcomes(drawing, feature):
+    point = list(feature.frame.origin)
+    if feature.through:
+        point["xyz".index(feature.frame.axis)] = 0.0
+    expected = tuple(round(float(value), 3) for value in point)
+    return [outcome for outcome in _outcomes(drawing) if outcome.source_at == expected]
 
 
 def _plan_bore_callouts(drawing):
@@ -101,14 +153,20 @@ def test_transaction_collects_every_structured_feature_seam():
     from draftwright.registry import AnnotationRegistry
 
     feature = type("Feature", (), {"kind": "hole"})()
+    representation_feature = type("Feature", (), {"kind": "hole"})()
     annotation = SimpleNamespace(
         covers_hole_locations=(),
         covers_hole_requirements_by_feature=((feature, "bore.through", 1),),
         covers_hole_centers=((feature, (0.0, 0.0, 0.0), "plan"),),
+        covers_hole_representations_by_feature=(
+            (representation_feature, "hole_table", "required_balloons_placed"),
+        ),
     )
     registry = AnnotationRegistry()
 
-    assert _annotation_hole_features(registry, "missing", annotation) == frozenset({feature})
+    assert _annotation_hole_features(registry, "missing", annotation) == frozenset(
+        {feature, representation_feature}
+    )
     assert not _hole_table_replaceable_annotation(
         registry, "missing", SimpleNamespace(covers_hole_locations=())
     )
@@ -443,47 +501,71 @@ def test_public_replacement_rolls_back_exactly_when_placement_raises(monkeypatch
     import draftwright.drawing as drawing_module
 
     drawing = build_drawing(_multi_hole_plate(), page="A4")
-    before_names = tuple(drawing.annotations())
-    before_objects = {name: drawing.get_annotation(name) for name in before_names}
-    before_identities = {name: drawing.registry.identity_of(name) for name in before_names}
-    before_codes = [issue.code for issue in drawing.lint()]
+    before = _transaction_state(drawing)
 
-    def fail(*_args, **_kwargs):
+    def mutate_then_fail():
+        drawing.registry.record_issue(
+            LintIssue(
+                severity="warning",
+                code="temporary_transaction_issue",
+                message="must be rolled back",
+            )
+        )
+        drawing.coverage.cover_scattered_hole_doc("temporary_transaction_coverage")
         raise RuntimeError(f"forced {failing_stage} failure")
 
     if failing_stage == "table":
-        monkeypatch.setattr(drawing, "add_table", fail)
+        original = drawing.add_table
+
+        def fail_after_table(*args, **kwargs):
+            assert original(*args, **kwargs) is not None
+            mutate_then_fail()
+
+        monkeypatch.setattr(drawing, "add_table", fail_after_table)
     else:
-        monkeypatch.setattr(drawing_module, "render_balloons", fail)
+        original = drawing_module.render_balloons
+
+        def fail_after_balloons(*args, **kwargs):
+            original(*args, **kwargs)
+            assert any(name.startswith("balloon_plan_") for name in drawing.annotations())
+            mutate_then_fail()
+
+        monkeypatch.setattr(drawing_module, "render_balloons", fail_after_balloons)
 
     with pytest.raises(RuntimeError, match=f"forced {failing_stage} failure"):
         drawing.add_hole_table("plan", replace_callouts=True)
 
-    assert tuple(drawing.annotations()) == before_names
-    assert {name: drawing.get_annotation(name) for name in before_names} == before_objects
-    assert {name: drawing.registry.identity_of(name) for name in before_names} == before_identities
-    assert [issue.code for issue in drawing.lint()] == before_codes
+    assert _transaction_state(drawing) == before
 
 
 def test_public_replacement_rolls_back_if_stashing_itself_raises(monkeypatch):
-    import draftwright.drawing as drawing_module
-
     drawing = build_drawing(_multi_hole_plate(), page="A4")
-    before_names = tuple(drawing.annotations())
-    before_objects = {name: drawing.get_annotation(name) for name in before_names}
-    before_identities = {name: drawing.registry.identity_of(name) for name in before_names}
+    before = _transaction_state(drawing)
+    original_remove = drawing.remove
+    removals = 0
 
-    def fail_stash(*_args, **_kwargs):
-        raise RuntimeError("forced stash failure")
+    def fail_during_second_stash(name):
+        nonlocal removals
+        removals += 1
+        if removals == 2:
+            drawing.registry.record_issue(
+                LintIssue(
+                    severity="warning",
+                    code="partial_stash_issue",
+                    message="must be rolled back",
+                )
+            )
+            drawing.coverage.cover_scattered_hole_doc("partial_stash_coverage")
+            raise RuntimeError("forced partial stash failure")
+        return original_remove(name)
 
-    monkeypatch.setattr(drawing_module, "_stash_annotations", fail_stash)
+    monkeypatch.setattr(drawing, "remove", fail_during_second_stash)
 
-    with pytest.raises(RuntimeError, match="forced stash failure"):
+    with pytest.raises(RuntimeError, match="forced partial stash failure"):
         drawing.add_hole_table("plan", replace_callouts=True)
 
-    assert tuple(drawing.annotations()) == before_names
-    assert {name: drawing.get_annotation(name) for name in before_names} == before_objects
-    assert {name: drawing.registry.identity_of(name) for name in before_names} == before_identities
+    assert removals == 2
+    assert _transaction_state(drawing) == before
 
 
 def test_exception_after_partial_restore_clears_temporary_representation_markers(monkeypatch):
@@ -501,9 +583,20 @@ def test_exception_after_partial_restore_clears_temporary_representation_markers
         )
         for name, annotation in original.values()
     }
+    before = _transaction_state(drawing)
     _drop_one_diameter_balloon(monkeypatch, 10.0)
+    original_coverage = drawing_module._register_hole_table_coverage
 
-    def fail_coverage(*_args, **_kwargs):
+    def fail_coverage(*args, **kwargs):
+        original_coverage(*args, **kwargs)
+        drawing.registry.record_issue(
+            LintIssue(
+                severity="warning",
+                code="temporary_coverage_issue",
+                message="must be rolled back",
+            )
+        )
+        drawing.coverage.cover_scattered_hole_doc("temporary_coverage_state")
         raise RuntimeError("forced coverage failure")
 
     monkeypatch.setattr(drawing_module, "_register_hole_table_coverage", fail_coverage)
@@ -518,6 +611,7 @@ def test_exception_after_partial_restore_clears_temporary_representation_markers
         )
         for name, _annotation in original.values()
     } == before_markers
+    assert _transaction_state(drawing) == before
 
 
 def test_replacement_rejects_a_table_name_reserved_by_a_fallback_before_mutation():
@@ -548,6 +642,111 @@ def test_preexisting_balloon_name_cannot_spoof_semantic_commit():
     assert "hole_table_plan" not in drawing.annotations()
 
 
+def test_table_name_cannot_collide_with_a_balloon_from_the_same_attempt():
+    drawing = build_drawing(Box(60, 40, 10) - Cylinder(4, 20), page="A4")
+    before = _transaction_state(drawing)
+
+    with pytest.raises(ValueError, match="must differ.*balloon_plan_A_0"):
+        drawing.add_hole_table("plan", name="balloon_plan_A_0", replace_callouts=True)
+
+    assert _transaction_state(drawing) == before
+
+
+@pytest.mark.parametrize(
+    ("decoration", "visible_token"),
+    [(0.1, "±0.1"), (fit_class("H7", 8), "H7")],
+    ids=["tolerance", "fit"],
+)
+def test_public_replacement_retains_toleranced_and_fitted_callouts(decoration, visible_token):
+    part = Box(60, 40, 8) - Pos(0, 0, 4) * Cylinder(4, 8)
+    detected = build_drawing(part, auto_dims=False).model()
+    hole = next(feature for feature in detected.features if feature.kind == "hole")
+    declared = replace(detected, decorations={(hole, "diameter"): decoration})
+    drawing = build_drawing(part, page="A4", model=declared)
+    callout_name, callout = _plan_bore_callouts(drawing)[hole]
+    assert visible_token in callout.label
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert drawing.get_annotation(callout_name) is callout
+    assert visible_token in drawing.get_annotation(callout_name).label
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, hole)
+    } == {(None, None)}
+
+
+@pytest.mark.parametrize(
+    "decoration",
+    [0.1, fit_class("H7", 5.2)],
+    ids=["tolerance", "fit"],
+)
+def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(monkeypatch, decoration):
+    import draftwright.annotations.orchestrator as orchestrator
+
+    part = _dense_scattered_plate()
+    with monkeypatch.context() as disabled:
+        disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
+        baseline = build_drawing(part)
+    dropped_issue = next(
+        issue
+        for issue in baseline.registry.issues
+        if issue.code == "callout_dropped" and issue.measurement_ids
+    )
+    dropped_feature = dropped_issue.measurement_ids[0].feature
+    declared = replace(baseline.model(), decorations={(dropped_feature, "diameter"): decoration})
+
+    drawing = build_drawing(part, model=declared)
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert any(
+        issue.code == "callout_dropped"
+        and any(measurement.feature == dropped_feature for measurement in issue.measurement_ids)
+        for issue in drawing.registry.issues
+    )
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, dropped_feature)
+    } == {(None, None)}
+
+
+def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
+    import draftwright.annotations.orchestrator as orchestrator
+
+    part = _dense_scattered_plate()
+    with monkeypatch.context() as disabled:
+        disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
+        baseline = build_drawing(part)
+    dropped_issue = next(
+        issue
+        for issue in baseline.registry.issues
+        if issue.code == "callout_dropped" and issue.measurement_ids
+    )
+    dropped_feature = dropped_issue.measurement_ids[0].feature
+    threaded = replace(dropped_feature, thread="M5x0.8")
+    declared = replace(
+        baseline.model(),
+        features=[
+            threaded if feature is dropped_feature else feature
+            for feature in baseline.model().features
+        ],
+    )
+
+    drawing = build_drawing(part, model=declared)
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert any(
+        issue.code == "callout_dropped"
+        and any(measurement.feature == threaded for measurement in issue.measurement_ids)
+        for issue in drawing.registry.issues
+    )
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, threaded)
+    } == {(None, None)}
+
+
 def test_public_replacement_retains_a_compound_callout_the_table_cannot_cover():
     part = Box(60, 40, 20) - Cylinder(4, 30) - Pos(0, 0, 2) * Cylinder(7, 20)
     drawing = build_drawing(part, page="A4")
@@ -570,6 +769,13 @@ def test_public_replacement_retains_a_compound_callout_the_table_cannot_cover():
         measurement.parameter for measurement in drawing.registry.measurement_of("hole_table_plan")
     } == {"bore.diameter"}
     assert all(outcome.state == "placed" for outcome in _outcomes(drawing))
+    assert feature not in {
+        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
+    }
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, feature)
+    } == {(None, None)}
     assert not {"feature_not_dimensioned", "hole_requirement_missing"} & {
         issue.code for issue in drawing.lint()
     }
@@ -593,6 +799,26 @@ def test_public_replacement_retains_a_declared_thread_callout():
     assert table is not None
     assert drawing.get_annotation(callout_name) is callout
     assert all(outcome.state == "placed" for outcome in _outcomes(drawing))
+
+
+def test_public_replacement_retains_a_double_d_profile_callout():
+    drawing = build_drawing(_double_d_plate(), page="A4")
+    feature = next(
+        feature for feature in drawing.model().features if feature.profile == "double_d"
+    )
+    callout_name, callout = _plan_bore_callouts(drawing)[feature]
+    assert "DOUBLE-D 7.2 A/F" in callout.label
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert drawing.get_annotation(callout_name) is callout
+    assert {
+        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
+    } == {"bore.diameter", "profile_across_flats.length"}
+    assert feature not in {
+        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
+    }
 
 
 def test_public_replacement_retains_a_pattern_callout_with_geometry_the_table_omits():
@@ -635,6 +861,29 @@ def test_automatic_table_never_removes_a_recognised_compound_callout():
     outcome_states = {outcome.parameter_id: outcome.state for outcome in _outcomes(drawing)}
     assert outcome_states["counterbore.diameter"] == "placed"
     assert outcome_states["counterbore.depth"] == "placed"
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _source_outcomes(drawing, feature)
+    } == {(None, None)}
     assert not {"feature_not_dimensioned", "hole_requirement_missing"} & {
         issue.code for issue in drawing.lint()
+    }
+
+
+def test_automatic_table_never_removes_a_recognised_double_d_callout():
+    drawing = build_drawing(_dense_plate_with_double_d())
+    feature = next(
+        feature for feature in drawing.model().features if feature.profile == "double_d"
+    )
+    callout_name, callout = _plan_bore_callouts(drawing)[feature]
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert drawing.get_annotation(callout_name) is callout
+    assert "DOUBLE-D 3.6 A/F" in callout.label
+    assert {
+        measurement.parameter for measurement in drawing.registry.measurement_of(callout_name)
+    } == {"bore.diameter", "profile_across_flats.length"}
+    table = drawing.get_annotation("hole_table_plan")
+    assert feature not in {
+        owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
     }

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -1,0 +1,249 @@
+"""Regression coverage for transactional hole-table replacement (#1144)."""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.linting.hole_coverage import hole_requirement_outcomes
+from draftwright.model.compiled import compile_dimensions
+
+
+def _multi_hole_plate():
+    """Two semantic groups: one Ø16 bore and a two-member Ø10 group."""
+    return (
+        Box(120, 80, 20)
+        - Pos(40, 25, 0) * Cylinder(5, 30)
+        - Pos(-40, 25, 0) * Cylinder(5, 30)
+        - Pos(0, -25, 0) * Cylinder(8, 30)
+    )
+
+
+def _dense_scattered_plate():
+    """Twenty distinct-spec bores, forcing automatic table escalation."""
+    part = Box(90, 60, 12)
+    columns = [-40 + i * 20 for i in range(5)]
+    for i, (column, y) in enumerate(itertools.product(range(5), (-18, -6, 6, 18))):
+        part -= Pos(columns[column], y, 0) * Cylinder(1.0 + i * 0.2, 20)
+    return part
+
+
+def _build_multi_hole_drawing(*, declared):
+    part = _multi_hole_plate()
+    model = build_drawing(part, auto_dims=False).model() if declared else None
+    return build_drawing(part, page="A4", model=model)
+
+
+def _outcomes(drawing):
+    drawing.lint()
+    return hole_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        compile_dimensions(drawing.model()).diagnostics,
+    )
+
+
+def _plan_bore_callouts(drawing):
+    """Map semantic bore owner to its placed plan-view callout."""
+    callouts = {}
+    for name in drawing.annotations():
+        if drawing.registry.view_of(name) != "plan":
+            continue
+        measurements = tuple(drawing.registry.measurement_of(name))
+        diameter_ids = [item for item in measurements if item.parameter == "bore.diameter"]
+        if len(diameter_ids) == 1:
+            callouts[diameter_ids[0].feature] = (name, drawing.get_annotation(name))
+    return callouts
+
+
+def _drop_one_diameter_balloon(monkeypatch, diameter):
+    """Force one otherwise feasible balloon assignment to become partial."""
+    import draftwright.annotations.balloons as balloons_module
+
+    original = balloons_module._assign_balloon_bands
+
+    def partial_assignment(*args, **kwargs):
+        bands, dropped = original(*args, **kwargs)
+        for members in bands.values():
+            for index, member in enumerate(members):
+                if member[2].diameter == pytest.approx(diameter):
+                    members.pop(index)
+                    return bands, dropped + 1
+        raise AssertionError(f"no assigned Ø{diameter:g} balloon to remove")
+
+    monkeypatch.setattr(balloons_module, "_assign_balloon_bands", partial_assignment)
+
+
+@pytest.mark.parametrize("declared", [False, True], ids=["automatic", "declared-ir"])
+def test_successful_public_replacement_commits_only_after_every_balloon_lands(declared):
+    drawing = _build_multi_hole_drawing(declared=declared)
+    original = _plan_bore_callouts(drawing)
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert all(name not in drawing.annotations() for name, _annotation in original.values())
+    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 3
+    assert set(table.covers_diameters) == {10.0, 16.0}
+    table_features = {
+        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
+    }
+    assert table_features == set(original)
+    represented = [
+        outcome
+        for outcome in _outcomes(drawing)
+        if outcome.parameter_id in {"bore.diameter", "bore.through", "grouping.count"}
+    ]
+    assert represented
+    assert {
+        (outcome.state, outcome.representation, outcome.representation_reason)
+        for outcome in represented
+    } == {("placed", "hole_table", "required_balloons_placed")}
+    assert not {"hole_requirement_missing", "feature_not_dimensioned"} & {
+        issue.code for issue in drawing.lint()
+    }
+
+
+def test_public_table_remains_additive_by_default_for_compatibility():
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    original = _plan_bore_callouts(drawing)
+
+    assert drawing.add_hole_table("plan") is not None
+
+    assert all(name in drawing.annotations() for name, _annotation in original.values())
+    assert {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in _outcomes(drawing)
+        if outcome.parameter_id == "bore.diameter"
+    } == {(None, None)}
+
+
+def test_constrained_a4_table_failure_restores_exact_callouts_and_identity(monkeypatch):
+    import draftwright.drawing as drawing_module
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    original = _plan_bore_callouts(drawing)
+    identities = {
+        name: drawing.registry.identity_of(name) for name, _annotation in original.values()
+    }
+    pinned_name = next(iter(identities))
+    drawing.pin(pinned_name)
+    identities[pinned_name] = drawing.registry.identity_of(pinned_name)
+    monkeypatch.setattr(drawing_module, "fit_box", lambda *_args, **_kwargs: None)
+
+    assert drawing.add_hole_table("plan", replace_callouts=True) is None
+
+    for name, annotation in original.values():
+        assert drawing.get_annotation(name) is annotation
+        assert drawing.registry.identity_of(name) == identities[name]
+    assert drawing.registry.is_pinned(pinned_name)
+    codes = [issue.code for issue in drawing.lint()]
+    assert codes.count("table_dropped") == 1
+    assert "hole_requirement_missing" not in codes
+    represented = [
+        outcome
+        for outcome in _outcomes(drawing)
+        if outcome.parameter_id in {"bore.diameter", "bore.through", "grouping.count"}
+    ]
+    assert {
+        (outcome.state, outcome.representation, outcome.representation_reason)
+        for outcome in represented
+    } == {("placed", "feature_annotation", "table_not_placed")}
+
+
+def test_partial_public_balloon_commit_restores_only_the_unresolved_group(monkeypatch):
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    original = _plan_bore_callouts(drawing)
+    grouped_feature = next(feature for feature in original if feature.count == 2)
+    single_feature = next(feature for feature in original if feature.count == 1)
+    _drop_one_diameter_balloon(monkeypatch, 10.0)
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    grouped_name, grouped_callout = original[grouped_feature]
+    assert drawing.get_annotation(grouped_name) is grouped_callout
+    assert original[single_feature][0] not in drawing.annotations()
+    assert table.covers_diameters == (16.0,)
+    assert {
+        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
+    } == {single_feature}
+    assert not [
+        name
+        for name in drawing.annotations()
+        if name.startswith("balloon_plan_")
+        and drawing.registry.feature_of(name) == grouped_feature
+    ]
+    warning_codes = {
+        issue.code for issue in drawing.lint() if issue.severity in {"warning", "error"}
+    }
+    assert warning_codes == {"balloon_dropped"}
+    outcomes = _outcomes(drawing)
+    assert all(outcome.state == "placed" for outcome in outcomes)
+    represented = {
+        (
+            outcome.representation,
+            outcome.representation_reason,
+        )
+        for outcome in outcomes
+        if outcome.parameter_id == "bore.diameter"
+    }
+    assert represented == {
+        ("hole_table", "required_balloons_placed"),
+        ("feature_annotation", "required_balloon_not_placed"),
+    }
+
+
+def test_automatic_partial_balloon_result_never_claims_the_unkeyed_feature(monkeypatch):
+    _drop_one_diameter_balloon(monkeypatch, 2.0)
+
+    drawing = build_drawing(_dense_scattered_plate())
+
+    table = drawing.get_annotation("hole_table_plan")
+    assert table is not None
+    assert len(table.covers_diameters) == 19
+    table_features = {
+        measurement.feature for measurement in drawing.registry.measurement_of("hole_table_plan")
+    }
+    assert len(table_features) == 19
+    assert {feature.diameter for feature in table_features} == set(table.covers_diameters)
+    assert 2.0 not in table.covers_diameters
+    assert len([name for name in drawing.annotations() if name.startswith("balloon_plan_")]) == 19
+    assert "balloon_dropped" in {issue.code for issue in drawing.lint()}
+    outcomes = _outcomes(drawing)
+    assert all(outcome.state == "placed" for outcome in outcomes)
+    diameter_representations = {
+        (outcome.representation, outcome.representation_reason)
+        for outcome in outcomes
+        if outcome.parameter_id == "bore.diameter"
+    }
+    assert diameter_representations == {
+        ("hole_table", "required_balloons_placed"),
+        ("feature_annotation", "required_balloon_not_placed"),
+    }
+
+
+def test_replacement_without_balloons_fails_before_mutating_the_drawing():
+    drawing = build_drawing(_multi_hole_plate(), page="A4")
+    before = tuple(drawing.annotations())
+
+    with pytest.raises(ValueError, match="requires balloons=True"):
+        drawing.add_hole_table("plan", balloons=False, replace_callouts=True)
+
+    assert tuple(drawing.annotations()) == before
+    assert "hole_table_plan" not in drawing.annotations()
+
+
+def test_replacement_without_a_complete_callout_fallback_fails_before_mutation():
+    drawing = build_drawing(_multi_hole_plate(), page="A4", auto_dims=False)
+    before = tuple(drawing.annotations())
+
+    with pytest.raises(ValueError, match="existing bore callout for every"):
+        drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert tuple(drawing.annotations()) == before
+    assert "hole_table_plan" not in drawing.annotations()

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -897,6 +897,46 @@ def test_mixed_public_table_marks_only_the_plain_replacement_winner():
     } == {(None, None)}
 
 
+def test_one_recognised_group_with_mixed_declared_owners_has_no_scalar_winner():
+    part = _multi_hole_plate()
+    detected = build_drawing(part, auto_dims=False).model()
+    grouped = next(
+        feature for feature in detected.features if feature.kind == "hole" and feature.count == 2
+    )
+    split = tuple(
+        replace(grouped, frame=replace(grouped.frame, origin=point), count=1, members=(point,))
+        for point in grouped.members
+    )
+    fitted, plain = split
+    declared = replace(
+        detected,
+        features=[
+            *split,
+            *(feature for feature in detected.features if feature is not grouped),
+        ],
+        decorations={(fitted, "diameter"): fit_class("H7", fitted.diameter)},
+    )
+    drawing = build_drawing(part, page="A4", model=declared)
+    original = _plan_bore_callouts(drawing)
+
+    table = drawing.add_hole_table("plan", replace_callouts=True)
+
+    assert table is not None
+    assert drawing.get_annotation(original[fitted][0]) is original[fitted][1]
+    assert original[plain][0] not in drawing.annotations()
+    grouped_outcomes = [
+        outcome
+        for outcome in _outcomes(drawing)
+        if outcome.member_count == 2
+        and outcome.parameter_id in {"bore.diameter", "bore.through", "grouping.count"}
+    ]
+    assert grouped_outcomes
+    assert {outcome.state for outcome in grouped_outcomes} == {"placed"}
+    assert {
+        (outcome.representation, outcome.representation_reason) for outcome in grouped_outcomes
+    } == {(None, None)}
+
+
 def test_public_replacement_retains_a_declared_thread_callout():
     part = Box(60, 40, 10) - Cylinder(4, 20)
     detected = build_drawing(part, auto_dims=False).model()
@@ -1015,3 +1055,56 @@ def test_automatic_table_never_removes_a_recognised_double_d_callout():
     assert feature not in {
         owner for owner, _representation, _reason in table.covers_hole_representations_by_feature
     }
+
+
+@pytest.mark.parametrize("reserved_name", ["hole_table_plan", "balloon_plan_A_0"])
+def test_automatic_escalation_preserves_preexisting_reserved_names(reserved_name):
+    drawing = build_drawing(_dense_scattered_plate(), auto_dims=False)
+    drawing.note("USER KEEP", (15, 15), view="plan", name=reserved_name)
+    user_annotation = drawing.get_annotation(reserved_name)
+
+    with drawing.deferred():
+        for feature in drawing.model().features:
+            if feature.kind != "hole":
+                continue
+            drawing.callout(feature)
+            drawing.locate(feature)
+
+    assert drawing.get_annotation(reserved_name) is user_annotation
+    if reserved_name != "hole_table_plan":
+        assert "hole_table_plan" not in drawing.annotations()
+    assert any(issue.code == "table_dropped" for issue in drawing.registry.issues)
+
+
+def test_finalize_exception_restores_automatic_transaction_markers(monkeypatch):
+    import draftwright.annotations.orchestrator as orchestrator
+
+    part = _dense_scattered_plate()
+    with monkeypatch.context() as disabled:
+        disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
+        drawing = build_drawing(part)
+    before = _transaction_state(drawing)
+    original_callouts = _plan_bore_callouts(drawing)
+    _drop_one_diameter_balloon(monkeypatch, 2.0)
+    original_reapply = drawing.registry.reapply
+
+    def fail_after_coverage(name, identity):
+        original_reapply(name, identity)
+        if name == "hole_table_plan":
+            raise RuntimeError("forced automatic coverage failure")
+
+    monkeypatch.setattr(drawing.registry, "reapply", fail_after_coverage)
+
+    with pytest.raises(RuntimeError, match="forced automatic coverage failure"):
+        with drawing.deferred():
+            for feature in drawing.model().features:
+                if feature.kind != "hole":
+                    continue
+                drawing.callout(feature)
+                drawing.locate(feature)
+
+    assert _transaction_state(drawing) == before
+    assert all(
+        drawing.get_annotation(name) is annotation
+        for name, annotation in original_callouts.values()
+    )

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -292,7 +292,27 @@ def test_segmented_centerline_diagnostic_ignores_only_the_empty_aabb_triangle():
     )
 
 
-def test_guarded_assignment_can_reassign_a_balloon_to_a_spare_band():
+def test_long_public_balloon_text_remains_visible_to_structural_lint():
+    from draftwright.linting.structural import _label_centerline_overlap
+
+    drawing = build_drawing(_multi_hole_plate(), page="A4", auto_dims=False)
+    hole = drawing.recognition().holes[0]
+    drawing.add_balloons("plan", [("LONG_BALLOON_TAG", 0, hole)])
+    balloon = drawing.get_annotation("balloon_plan_LONG_BALLOON_TAG_0")
+    ring_box, text_box = balloon.centerline_boxes
+
+    assert text_box[0] < ring_box[0]
+    overlap_box = (
+        text_box[0] + 0.1,
+        (text_box[1] + text_box[3]) / 2 - 0.6,
+        ring_box[0] - 0.1,
+        (text_box[1] + text_box[3]) / 2 + 0.6,
+    )
+    label = SimpleNamespace(label="OTHER", label_bbox=overlap_box)
+    assert _label_centerline_overlap(label, balloon) is not None
+
+
+def test_guarded_assignment_preserves_the_canonical_flow_cost_objective():
     from draftwright.annotations.balloons import (
         _guarded_assignment,
         _GuardedSegments,
@@ -301,42 +321,84 @@ def test_guarded_assignment_can_reassign_a_balloon_to_a_spare_band():
     members = [
         ("A", 0, object(), 0.0, 0.0),
         ("B", 0, object(), 0.0, 0.0),
-        ("C", 0, object(), 0.0, 10.0),
+        ("C", 0, object(), 0.0, 0.0),
     ]
-    # Capacity-only min-cost flow chooses A+B on the left and C on the right;
-    # A and B share the same sole left coordinate, so the guarded global solve
-    # must move B to the remote right band and keep C at left=10.
     choices = [
-        {"left": 0.0},
-        {"left": 0.0, "right": 100.0},
-        {"left": 0.0, "right": 0.0},
+        {"left": 2.0, "right": 13.0},
+        {"left": 16.0, "right": 1.0},
+        {"left": 8.0},
     ]
     bands = {
         "left": ("y", 0.0, 0.0, 10.0),
-        "right": ("y", 20.0, 0.0, 10.0),
+        "right": ("y", 1.0, 0.0, 10.0),
     }
     guarded = _GuardedSegments(
         {
-            (0, "left"): ((5.0, 5.0),),
+            (0, "left"): ((2.0, 2.0),),
+            (0, "right"): ((2.0, 2.0),),
             (1, "left"): ((5.0, 5.0),),
-            (1, "right"): ((5.0, 5.0),),
-            (2, "left"): ((10.0, 10.0),),
-            (2, "right"): ((10.0, 10.0),),
+            (1, "right"): ((2.0, 2.0),),
+            (2, "left"): ((0.0, 0.0),),
         },
-        5.0,
+        1.0,
     )
 
     assignments, solutions, dropped = _guarded_assignment(
         members,
         choices,
         bands,
-        {"left": 2, "right": 1},
+        {"left": 1, "right": 1},
         guarded,
     )
 
-    assert dropped == 0
-    assert assignments == {"left": [0, 2], "right": [1]}
-    assert solutions == {"left": {0: 5.0, 2: 10.0}, "right": {1: 5.0}}
+    assert dropped == 1
+    assert assignments == {"left": [0], "right": [1]}
+    assert solutions == {"left": {0: 2.0}, "right": {1: 2.0}}
+
+
+def test_guarded_assignment_is_bounded_and_fails_an_infeasible_flow_closed(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+
+    band_names = ("left", "right", "top", "bottom")
+    member_count = 28
+    members = [
+        (str(index), 0, object(), float(index), float(index)) for index in range(member_count)
+    ]
+    bands = {
+        band: ("y", float(index), 0.0, float(member_count))
+        for index, band in enumerate(band_names)
+    }
+    choices = [{band: 0.0 for band in band_names} for _member in members]
+    guarded = balloons_module._GuardedSegments(
+        {
+            (index, band): ((float(member_count - index),) * 2,)
+            for index in range(member_count)
+            for band in band_names
+        },
+        1.0,
+    )
+    calls = 0
+    original = balloons_module._solve_guarded_band
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(balloons_module, "_solve_guarded_band", counted)
+
+    assignments, solutions, dropped = balloons_module._guarded_assignment(
+        members,
+        choices,
+        bands,
+        {band: member_count for band in band_names},
+        guarded,
+    )
+
+    assert calls == len(band_names)
+    assert assignments == {band: [] for band in band_names}
+    assert solutions == {band: {} for band in band_names}
+    assert dropped == member_count
 
 
 def test_real_shaft_crossing_carves_the_guarded_band_without_aabb_sampling():
@@ -556,6 +618,30 @@ def test_automatic_partial_balloon_result_restores_only_the_unresolved_feature(m
         if issue.code == "label_centerline_overlap"
         and f"label '{unresolved_label}'" in issue.message
     ]
+
+
+def test_scattered_table_reports_a_balloon_landed_on_the_wrong_semantic_owner():
+    detected = build_drawing(_dense_scattered_plate(), auto_dims=False).model()
+    victim = next(feature for feature in detected.features if feature.kind == "hole")
+    # The sanctioned position bridge resolves the last feature at a coincident
+    # centre.  A distinct appended declaration therefore owns both rendered
+    # balloons even though the original feature still has its own visible row.
+    wrong_owner = replace(victim, diameter=victim.diameter + 0.123)
+    declared = replace(detected, features=[*detected.features, wrong_owner])
+
+    drawing = build_drawing(_dense_scattered_plate(), model=declared)
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert victim in _plan_bore_callouts(drawing)
+    failures = [issue for issue in drawing.registry.issues if issue.code == "balloon_dropped"]
+    assert len(failures) == 1
+    assert "feature-owned balloons" in failures[0].message
+    assert {
+        outcome.representation
+        for outcome in _outcomes(drawing)
+        if outcome.source_at[:2] == tuple(victim.frame.origin[:2])
+        and outcome.parameter_id == "bore.diameter"
+    } != {"hole_table"}
 
 
 def test_automatic_partial_result_rolls_back_when_fallback_aware_refit_fails(monkeypatch):

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -597,6 +597,68 @@ def test_guarded_solver_budget_rolls_the_automatic_table_transaction_back(monkey
     assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
 
 
+def test_guarded_carve_budget_fires_before_quadratic_label_expansion(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+
+    retained_boxes = tuple(
+        (float(index), 200.0, float(index) + 0.25, 201.0) for index in range(300)
+    )
+    monkeypatch.setattr(
+        balloons_module,
+        "balloon_annotation_label_boxes",
+        lambda *_args: retained_boxes,
+    )
+    monkeypatch.setattr(
+        balloons_module,
+        "_retained_annotation_geometry",
+        lambda *_args: ((), (), True),
+    )
+
+    def forbidden_carve(*_args, **_kwargs):
+        pytest.fail("critical-point carving ran before its deterministic work budget")
+
+    monkeypatch.setattr(balloons_module, "_guarded_free_segments", forbidden_carve)
+    member = ("A", 0, SimpleNamespace(diameter=2.0), 0.0, 0.0)
+
+    dropped = balloons_module._place_guarded_inventory(
+        SimpleNamespace(scale=1.0),
+        "plan",
+        [member],
+        [{"left": 1.0}],
+        {"left": ("y", 10.0, 0.0, 100.0)},
+        {"left": 1},
+        5.0,
+        3.0,
+        4.5,
+        object(),
+        top_segments=None,
+        prefer_bands=(),
+        preference_limit=0.0,
+        page_box=(0.0, 0.0, 100.0, 100.0),
+        avoid_existing_labels=True,
+        local_glyph_boxes={"A": ((-4.5, -4.5, 4.5, 4.5),)},
+        band_gaps={"left": 10.0},
+    )
+
+    assert dropped == 1
+
+
+def test_guarded_carve_budget_rolls_the_automatic_table_transaction_back(monkeypatch):
+    import draftwright.annotations.balloons as balloons_module
+
+    monkeypatch.setattr(balloons_module, "_GUARDED_CARVE_MAX_LABEL_PROBES", 1)
+
+    drawing = build_drawing(_dense_scattered_plate(), page="A3")
+
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert len([name for name in drawing.annotations() if name.startswith("hc_plan")]) == 17
+    codes = [issue.code for issue in drawing.registry.issues]
+    assert "table_dropped" in codes
+    assert "balloon_dropped" in codes
+    assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
+
+
 def test_real_shaft_crossing_carves_the_guarded_band_without_aabb_sampling():
     from draftwright.annotations.balloons import (
         _balloon_shaft_segments,
@@ -819,7 +881,20 @@ def test_public_add_balloons_separates_long_sibling_text_components():
 
 @pytest.mark.parametrize(
     "component_metadata",
-    ["valid", "empty", "malformed", "nonfinite", "descending", "absent", "unmeasurable"],
+    [
+        "valid",
+        "empty",
+        "partial_boxes",
+        "partial_segments",
+        "absent_counts",
+        "wrong_counts",
+        "malformed",
+        "nonfinite",
+        "descending",
+        "getter_error",
+        "absent",
+        "unmeasurable",
+    ],
 )
 def test_automatic_table_fails_closed_against_a_retained_public_balloon(
     component_metadata, monkeypatch
@@ -831,15 +906,38 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
     retained = drawing.get_annotation(retained_name)
     assert retained is not None
     assert retained.is_balloon
+    assert retained.balloon_component_counts == (
+        len(retained.centerline_boxes),
+        len(retained.centerline_segments),
+    )
     if component_metadata in {"empty", "unmeasurable"}:
         retained.centerline_boxes = ()
         retained.centerline_segments = ()
+    elif component_metadata == "partial_boxes":
+        retained.centerline_boxes = retained.centerline_boxes[:1]
+    elif component_metadata == "partial_segments":
+        retained.centerline_segments = ()
+    elif component_metadata == "absent_counts":
+        del retained.balloon_component_counts
+    elif component_metadata == "wrong_counts":
+        retained.balloon_component_counts = (1, 0)
     elif component_metadata == "malformed":
         retained.centerline_boxes = (("not", "a", "box"),)
     elif component_metadata == "nonfinite":
         retained.centerline_boxes = ((float("nan"), 0.0, 1.0, 1.0),)
     elif component_metadata == "descending":
         retained.centerline_boxes = ((1.0, 1.0, 0.0, 0.0),)
+    elif component_metadata == "getter_error":
+
+        def unreadable_components(_annotation):
+            raise RuntimeError("external component metadata unavailable")
+
+        monkeypatch.setattr(
+            type(retained),
+            "centerline_boxes",
+            property(unreadable_components),
+            raising=False,
+        )
     elif component_metadata == "absent":
         del retained.centerline_boxes
         del retained.centerline_segments
@@ -870,6 +968,47 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
         issue.code for issue in drawing.registry.issues
     }
     assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
+
+
+@pytest.mark.parametrize(("retained_view", "table_commits"), [(None, False), ("side", True)])
+def test_retained_public_balloon_component_geometry_respects_view_scope(
+    retained_view, table_commits
+):
+    drawing = build_drawing(_dense_perimeter_plate(), page="A3", auto_dims=False)
+    tag = "DRAWING_OR_OTHER_VIEW_BALLOON_WITH_A_VERY_LONG_TAG"
+    retained_name = f"balloon_plan_{tag}_0"
+    drawing.add_balloons("plan", [(tag, 0, drawing.recognition().holes[0])])
+    retained = drawing.get_annotation(retained_name)
+    identity = drawing.registry.identity_of(retained_name)
+    drawing.registry.reapply(retained_name, {**identity, "view": retained_view})
+    assert drawing.view_of(retained_name) == retained_view
+
+    with drawing.deferred():
+        for feature in drawing.model().features:
+            if feature.kind == "hole":
+                drawing.callout(feature)
+                drawing.locate(feature)
+
+    assert drawing.get_annotation(retained_name) is retained
+    assert ("hole_table_plan" in drawing.annotations()) is table_commits
+    if table_commits:
+        assert (
+            len(
+                [
+                    name
+                    for name in drawing.annotations()
+                    if name.startswith("balloon_plan_") and name != retained_name
+                ]
+            )
+            == 16
+        )
+    else:
+        assert {name for name in drawing.annotations() if name.startswith("balloon_plan_")} == {
+            retained_name
+        }
+        assert {"table_dropped", "balloon_dropped"} <= {
+            issue.code for issue in drawing.registry.issues
+        }
 
 
 def test_public_hole_table_does_not_expose_an_uncomposable_replacement_option():
@@ -1056,6 +1195,66 @@ def test_grouped_pattern_marker_cannot_certify_an_undefined_hole_tag():
         "bolt_circle.diameter",
         "grouping.count",
     }
+
+
+def test_optional_pattern_marker_cannot_displace_required_table_rows(monkeypatch):
+    import draftwright.annotations.orchestrator as orchestrator
+    from draftwright.annotations._common import Escalation, PlacementContext
+    from draftwright.model import Frame, HoleFeature, PatternFeature
+
+    part = _dense_perimeter_plate()
+    captured_analysis = []
+
+    def capture_analysis(_drawing, analysis, **_kwargs):
+        captured_analysis.append(analysis)
+
+    with monkeypatch.context() as disabled:
+        disabled.setattr(orchestrator, "_maybe_tabulate_holes", capture_analysis)
+        drawing = build_drawing(part, page="A3", auto_dims=False)
+        with drawing.deferred():
+            for feature in drawing.model().features:
+                if feature.kind == "hole":
+                    drawing.callout(feature)
+                    drawing.locate(feature)
+    assert captured_analysis
+
+    features = list(drawing.model().features)
+    origin = (-50.0, -18.0, 6.0)
+    member = HoleFeature(
+        frame=Frame(origin=origin, axis="z"),
+        diameter=5.0,
+        depth=None,
+        through=True,
+    )
+    pattern = PatternFeature(
+        frame=Frame(origin=origin, axis="z"),
+        pattern="bolt_circle",
+        count=6,
+        member=member,
+        members=tuple((origin[0] + index, origin[1], origin[2]) for index in range(6)),
+    )
+    model = replace(drawing.model(), features=[*features, pattern])
+    ctx = PlacementContext(
+        registry=drawing.registry,
+        coverage=drawing.coverage,
+        items=drawing.items,
+        part_model=model,
+        escalations=(
+            Escalation("location", "plan", features[0], "illegible"),
+            Escalation("callout", "plan", pattern, "strip_full"),
+        ),
+    )
+
+    orchestrator._maybe_tabulate_holes(drawing, captured_analysis[-1], ctx=ctx)
+
+    assert "hole_table_plan" in drawing.annotations()
+    assert {name for name in drawing.annotations() if name.startswith("balloon_plan_")} == {
+        f"balloon_plan_{tag}_0" for tag in "ABCDEFGHIJKLMNOP"
+    }
+    assert "balloon_plan_6×Q_0" not in drawing.annotations()
+    assert "table_dropped" not in {issue.code for issue in drawing.registry.issues}
+    assert "balloon_dropped" in {issue.code for issue in drawing.registry.issues}
+    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
 def test_long_grouped_pattern_marker_fails_closed_when_its_shaft_crosses_its_text():

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -781,6 +781,32 @@ def test_final_guarded_inventory_validation_covers_cross_band_and_page_geometry(
     )
     assert not _guarded_inventory_geometry_is_clear((self_text_crossing,), page)
     assert not _guarded_inventory_geometry_is_clear((*first, off_page), page)
+    assert not _guarded_inventory_geometry_is_clear(
+        first,
+        page,
+        retained_label_boxes=((15.0, 15.0, 25.0, 25.0),),
+    )
+    assert not _guarded_inventory_geometry_is_clear(
+        first,
+        page,
+        retained_leader_segments=(((0.0, 15.0), (30.0, 15.0)),),
+    )
+    shaft_only = ((((40.0, 40.0, 50.0, 50.0),), (((0.0, 15.0), (30.0, 15.0)),)),)
+    assert not _guarded_inventory_geometry_is_clear(
+        shaft_only,
+        page,
+        retained_leader_segments=(((15.0, 0.0), (15.0, 30.0)),),
+    )
+
+
+def test_retained_leader_segment_intersection_ignores_only_a_shared_endpoint():
+    from draftwright._geometry import _segments_cross_or_overlap
+
+    assert _segments_cross_or_overlap((0.0, 0.0), (2.0, 2.0), (0.0, 2.0), (2.0, 0.0))
+    assert _segments_cross_or_overlap((0.0, 0.0), (3.0, 0.0), (1.0, 0.0), (4.0, 0.0))
+    assert _segments_cross_or_overlap((0.0, 0.0), (3.0, 0.0), (1.0, -1.0), (1.0, 0.0))
+    assert not _segments_cross_or_overlap((0.0, 0.0), (1.0, 0.0), (1.0, 0.0), (2.0, 1.0))
+    assert not _segments_cross_or_overlap((0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0))
 
 
 def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(monkeypatch):
@@ -789,7 +815,7 @@ def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(mo
     monkeypatch.setattr(
         balloons_module,
         "_guarded_inventory_geometry_is_clear",
-        lambda *_args: False,
+        lambda *_args, **_kwargs: False,
     )
 
     drawing = build_drawing(_dense_scattered_plate())
@@ -1180,7 +1206,7 @@ def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkey
     part = _dense_plate_with_close_x_ordinates()
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
-        baseline = build_drawing(part, page="A3")
+        baseline = build_drawing(part, page="A2")
     placed_callout_features = set(_plan_bore_callouts(baseline))
     location_issue = next(
         issue
@@ -1198,7 +1224,7 @@ def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkey
         decorations={(feature, "diameter"): fit_class("H7", feature.diameter)},
     )
 
-    drawing = build_drawing(part, page="A3", model=declared)
+    drawing = build_drawing(part, page="A2", model=declared)
 
     table = drawing.get_annotation("hole_table_plan")
     assert table is not None
@@ -1458,3 +1484,29 @@ def test_one_physical_group_with_mixed_table_and_fit_evidence_has_no_scalar_winn
     assert {
         (outcome.representation, outcome.representation_reason) for outcome in grouped_outcomes
     } == {(None, None)}
+
+
+def test_retained_fit_leader_crossing_rolls_the_automatic_table_back():
+    part = _dense_plate_with_close_x_ordinates()
+    detected = build_drawing(part, page="A3", auto_dims=False).model()
+    fitted = next(
+        feature
+        for feature in detected.features
+        if feature.kind == "hole"
+        and feature.frame.origin == (-54.0, -18.0, 6.0)
+        and feature.diameter == pytest.approx(4.4)
+    )
+    declared = replace(
+        detected,
+        decorations={(fitted, "diameter"): fit_class("H7", fitted.diameter)},
+    )
+
+    drawing = build_drawing(part, model=declared, page="A3")
+
+    assert "hole_table_plan" not in drawing.annotations()
+    assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert fitted in _plan_bore_callouts(drawing)
+    assert {"table_dropped", "balloon_dropped"} <= {
+        issue.code for issue in drawing.registry.issues
+    }
+    assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -66,6 +66,26 @@ class TestAssignBalloonBands:
         assert bands["top"] == []
         assert dropped == 0
 
+    def test_required_members_win_before_optional_leader_cost(self):
+        members = ["required-row", "optional-marker"]
+        choices = [{"left": 100.0}, {"left": 1.0}]
+
+        ordinary, ordinary_dropped = _assign_balloon_bands(members, choices, {"left": 1})
+        prioritised, prioritised_dropped = _assign_balloon_bands(
+            members,
+            choices,
+            {"left": 1},
+            required_count=1,
+        )
+
+        assert ordinary["left"] == ["optional-marker"]
+        assert prioritised["left"] == ["required-row"]
+        assert ordinary_dropped == prioritised_dropped == 1
+
+    def test_required_count_must_address_the_member_prefix(self):
+        with pytest.raises(ValueError, match="required_count"):
+            _assign_balloon_bands(["row"], [{"left": 1.0}], {"left": 1}, required_count=2)
+
 
 class TestSolveSegmentedStrip1d:
     def test_empty_members_need_no_segments(self):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -141,6 +141,8 @@ class TestSolveStrip1d:
         with pytest.raises(ValueError, match="equal length"):
             _solve_guarded_strip_1d([0.0], 5.0, [])
         assert _solve_guarded_strip_1d([0.0], 5.0, [[]]) is None
+        with pytest.raises(ValueError, match="positive"):
+            _solve_guarded_strip_1d([0.0], 0.0, [[(0.0, 1.0)]])
         with pytest.raises(ValueError, match="descending"):
             _solve_guarded_strip_1d([0.0], 5.0, [[(2.0, 1.0)]])
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -146,6 +146,41 @@ class TestSolveStrip1d:
         with pytest.raises(ValueError, match="descending"):
             _solve_guarded_strip_1d([0.0], 5.0, [[(2.0, 1.0)]])
 
+    def test_guarded_solve_fails_closed_before_dense_interval_state_explodes(self):
+        # A valid dense sheet may leave dozens of disjoint free intervals per
+        # balloon after retained-label keep-outs are carved.  Expanding every
+        # boundary by every possible gap used to allocate more than a gigabyte
+        # for a 61-member band before transactional fallback could run.
+        count = 61
+        allowed = [
+            [
+                (float(interval * 30 + member), float(interval * 30 + member + 20))
+                for interval in range(40)
+            ]
+            for member in range(count)
+        ]
+
+        assert (
+            _solve_guarded_strip_1d(
+                [float(member * 11) for member in range(count)],
+                11.0,
+                allowed,
+            )
+            is None
+        )
+
+    def test_guarded_solve_keeps_a_dense_unfragmented_band_within_budget(self):
+        naturals = [float(member * 11) for member in range(61)]
+
+        assert (
+            _solve_guarded_strip_1d(
+                naturals,
+                11.0,
+                [[(0.0, 1000.0)] for _member in naturals],
+            )
+            == naturals
+        )
+
     def test_deterministic_across_runs(self):
         args = ([1.0, 1.0, 1.0, 1.0], 3.0, 0.0, 100.0)
         assert _solve_strip_1d(*args) == _solve_strip_1d(*args)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -146,11 +146,10 @@ class TestSolveStrip1d:
         with pytest.raises(ValueError, match="descending"):
             _solve_guarded_strip_1d([0.0], 5.0, [[(2.0, 1.0)]])
 
-    def test_guarded_solve_fails_closed_before_dense_interval_state_explodes(self):
+    def test_guarded_solve_fails_closed_before_fragmented_interval_scan_explodes(self):
         # A valid dense sheet may leave dozens of disjoint free intervals per
-        # balloon after retained-label keep-outs are carved.  Expanding every
-        # boundary by every possible gap used to allocate more than a gigabyte
-        # for a 61-member band before transactional fallback could run.
+        # balloon after retained-label keep-outs are carved.  This inventory
+        # exceeds the deterministic interval-membership work budget.
         count = 61
         allowed = [
             [
@@ -165,6 +164,62 @@ class TestSolveStrip1d:
                 [float(member * 11) for member in range(count)],
                 11.0,
                 allowed,
+            )
+            is None
+        )
+
+    def test_guarded_solve_applies_budget_before_materialising_endpoint_sources(self, monkeypatch):
+        import draftwright.layout as layout_module
+
+        class Endpoint(float):
+            def __float__(self):
+                raise AssertionError("budgeted endpoint was materialised")
+
+        monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_INTERVAL_PROBES", 1)
+
+        assert (
+            _solve_guarded_strip_1d(
+                [0.0],
+                1.0,
+                [[(Endpoint(0.0), Endpoint(1.0)), (Endpoint(2.0), Endpoint(3.0))]],
+            )
+            is None
+        )
+
+    def test_guarded_solve_state_budget_is_independently_load_bearing(self, monkeypatch):
+        import draftwright.layout as layout_module
+
+        count = 20
+        naturals = [member * 11.037 for member in range(count)]
+        allowed = [
+            [
+                (
+                    block * 400.123 + member * 0.137,
+                    block * 400.123 + member * 0.137 + 300.0,
+                )
+                for block in range(3)
+            ]
+            for member in range(count)
+        ]
+        monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_INTERVAL_PROBES", 10_000_000)
+        monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_STATES", 20_000)
+        assert _solve_guarded_strip_1d(naturals, 11.0, allowed) is None
+
+        # The inventory is feasible; only the explicit state budget rejects it.
+        monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_STATES", 10_000_000)
+        assert _solve_guarded_strip_1d(naturals, 11.0, allowed) == naturals
+
+    def test_guarded_solve_caps_the_first_source_expansion(self, monkeypatch):
+        import draftwright.layout as layout_module
+
+        monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_STATES", 4)
+        monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_INTERVAL_PROBES", 1_000)
+
+        assert (
+            _solve_guarded_strip_1d(
+                [0.0, 5.0],
+                5.0,
+                [[(0.0, 10.0)], [(0.0, 10.0)]],
             )
             is None
         )

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -11,6 +11,7 @@ from draftwright.layout import (
     _ANCHOR_WEIGHT,
     _assign_balloon_bands,
     _greedy_strip_1d,
+    _solve_guarded_strip_1d,
     _solve_segmented_strip_1d,
     _solve_strip_1d,
     _solve_strip_1d_pava,
@@ -119,6 +120,29 @@ class TestSolveStrip1d:
 
     def test_empty_returns_empty(self):
         assert _solve_strip_1d([], min_gap=5, lo=0, hi=10) == []
+
+    def test_guarded_solve_reassigns_earlier_coordinate_jointly(self):
+        # A greedy retry holds B's original 5 mm coordinate, drops A, then moves
+        # B to 10.  The joint solve sees the complete inventory and places both.
+        assert _solve_guarded_strip_1d(
+            [0.0, 5.0],
+            5.0,
+            [[(5.0, 5.0)], [(0.0, 0.0), (10.0, 10.0)]],
+        ) == [5.0, 10.0]
+
+    def test_guarded_solve_uses_geometry_endpoints_not_a_sampling_grid(self):
+        assert _solve_guarded_strip_1d(
+            [0.0, 5.0],
+            5.0,
+            [[(0.3, 0.3)], [(5.3, 5.3)]],
+        ) == [0.3, 5.3]
+
+    def test_guarded_solve_rejects_invalid_or_empty_constraints(self):
+        with pytest.raises(ValueError, match="equal length"):
+            _solve_guarded_strip_1d([0.0], 5.0, [])
+        assert _solve_guarded_strip_1d([0.0], 5.0, [[]]) is None
+        with pytest.raises(ValueError, match="descending"):
+            _solve_guarded_strip_1d([0.0], 5.0, [[(2.0, 1.0)]])
 
     def test_deterministic_across_runs(self):
         args = ([1.0, 1.0, 1.0, 1.0], 3.0, 0.0, 100.0)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -11043,7 +11043,7 @@ class TestPatternGroupBalloon:
             members=members,
         )
 
-    def test_dropped_pattern_gets_one_grouped_balloon(self):
+    def test_dropped_pattern_gets_one_grouped_balloon(self, monkeypatch):
         from dataclasses import replace
 
         from draftwright.annotations._common import Escalation, PlacementContext
@@ -11102,6 +11102,27 @@ class TestPatternGroupBalloon:
         assert new_balloons[0].split("_")[2] == "6×A"
         assert dwg.registry.feature_of(new_balloons[0]) == feat
         assert "callout_dropped" not in {i.code for i in dwg.lint()}  # resolved, not just hidden
+
+        # A pattern-only escalation has no scattered-hole table. It must still use
+        # the automatic retained-label guard before a landed name may clear the
+        # original callout drop (#1144).
+        import draftwright.annotations.balloons as balloons
+
+        dwg.remove(new_balloons[0])
+        guarded_issue = LintIssue(
+            severity="warning", code="callout_dropped", message="guarded pattern drop"
+        )
+        dwg.registry.record_issue(guarded_issue)
+        monkeypatch.setattr(
+            balloons,
+            "balloon_annotation_label_boxes",
+            lambda *_args: ((-1000.0, -1000.0, 1000.0, 1000.0),),
+        )
+        _maybe_tabulate_holes(dwg, analysis, ctx=ctx)
+
+        assert not [name for name in dwg.annotations() if name.startswith("balloon_plan_6×A")]
+        assert guarded_issue in dwg.registry.issues
+        assert "balloon_dropped" in {finding.code for finding in dwg.registry.issues}
 
     def test_multiple_dropped_patterns_get_distinct_non_overlapping_balloons(self):
         from draftwright.annotations._common import Escalation, PlacementContext

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -11101,7 +11101,11 @@ class TestPatternGroupBalloon:
         assert len(new_balloons) == 1
         assert new_balloons[0].split("_")[2] == "6×A"
         assert dwg.registry.feature_of(new_balloons[0]) == feat
-        assert "callout_dropped" not in {i.code for i in dwg.lint()}  # resolved, not just hidden
+        # ADR 0009 retains one grouped visual marker, but ``6×A`` has no
+        # defining table/legend and therefore cannot certify the dropped
+        # diameter/depth/pattern requirements.
+        assert issue in dwg.registry.issues
+        assert dwg.measurement_keys(new_balloons[0]) == []
 
         # A pattern-only escalation has no scattered-hole table. It must still use
         # the automatic retained-label guard before a landed name may clear the

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -11044,29 +11044,55 @@ class TestPatternGroupBalloon:
         )
 
     def test_dropped_pattern_gets_one_grouped_balloon(self):
+        from dataclasses import replace
+
         from draftwright.annotations._common import Escalation, PlacementContext
         from draftwright.annotations.orchestrator import _maybe_tabulate_holes
 
         dwg = build_drawing(_multi_hole_plate())  # sparse — density gate stays shut
         before = set(dwg.annotations())
         feat = self._fake_pattern(count=6, diameter=5.0)
+        overlapping_hole = replace(
+            feat.member, frame=replace(feat.member.frame, origin=feat.members[0])
+        )
+        correct_model = replace(dwg.model(), features=[*dwg.model().features, feat])
         ctx = PlacementContext(
             registry=dwg.registry,
             coverage=dwg.coverage,
             items=dwg.items,
-            part_model=dwg.model(),  # (#639) the tabulation resolver reads the model off ctx now
+            part_model=replace(
+                correct_model, features=[*correct_model.features, overlapping_hole]
+            ),
             escalations=[
                 Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
             ],
         )
         # Mirror what _record_callout_drop does in production, so clearing it below
         # actually exercises the resolve path rather than trivially passing.
-        dwg.registry.record_issue(
-            LintIssue(
-                severity="warning", code="callout_dropped", message="synthetic plan-view drop"
-            )
+        issue = LintIssue(
+            severity="warning", code="callout_dropped", message="synthetic plan-view drop"
         )
-        _maybe_tabulate_holes(dwg, dwg._analysis, ctx=ctx)
+        dwg.registry.record_issue(issue)
+        analysis = dwg._analysis
+
+        # The last IR owner at the shared member position wins balloon attribution. A name
+        # landing is not enough: the wrong feature must leave the pattern drop unresolved.
+        _maybe_tabulate_holes(dwg, analysis, ctx=ctx)
+        balloon_name = "balloon_plan_6×A_0"
+        assert dwg.registry.feature_of(balloon_name) == overlapping_hole
+        assert issue in dwg.registry.issues
+
+        dwg.remove(balloon_name)
+        ctx = PlacementContext(
+            registry=dwg.registry,
+            coverage=dwg.coverage,
+            items=dwg.items,
+            part_model=correct_model,
+            escalations=[
+                Escalation(kind="callout", view="plan", feature=feat, reason="strip_full")
+            ],
+        )
+        _maybe_tabulate_holes(dwg, analysis, ctx=ctx)
 
         assert "hole_table_plan" not in dwg.annotations()  # density gate untouched
         new_balloons = [
@@ -11074,6 +11100,7 @@ class TestPatternGroupBalloon:
         ]
         assert len(new_balloons) == 1
         assert new_balloons[0].split("_")[2] == "6×A"
+        assert dwg.registry.feature_of(new_balloons[0]) == feat
         assert "callout_dropped" not in {i.code for i in dwg.lint()}  # resolved, not just hidden
 
     def test_multiple_dropped_patterns_get_distinct_non_overlapping_balloons(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -216,8 +216,8 @@ def test_every_remove_and_restore_site_goes_through_the_identity_pair():
     # function name -> why it may remove without restoring identity
     EXEMPT = {
         "_clear_section_reservation": "deletes the reserved section marks outright; no restore",
-        "_discard_incomplete_feature_balloons": (
-            "permanently deletes balloons for a table group that did not commit"
+        "_discard_attempt_annotations": (
+            "permanently deletes table/balloon geometry from an uncommitted attempt"
         ),
         "_stash_annotations": (
             "captures the identity half of the shared stash/restore transaction; paired below"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -215,7 +215,13 @@ def test_every_remove_and_restore_site_goes_through_the_identity_pair():
 
     # function name -> why it may remove without restoring identity
     EXEMPT = {
-        "_clear_section_reservation": "deletes the reserved section marks outright; no restore"
+        "_clear_section_reservation": "deletes the reserved section marks outright; no restore",
+        "_discard_incomplete_feature_balloons": (
+            "permanently deletes balloons for a table group that did not commit"
+        ),
+        "_stash_annotations": (
+            "captures the identity half of the shared stash/restore transaction; paired below"
+        ),
     }
 
     root = pathlib.Path("src/draftwright/annotations")
@@ -238,3 +244,23 @@ def test_every_remove_and_restore_site_goes_through_the_identity_pair():
         "these remove a named annotation without round-tripping its identity: "
         + ", ".join(offenders)
     )
+
+    # #1144: a replacement transaction must span table/balloon placement before it knows
+    # which feature subset to restore. Keep the two shared halves load-bearing so moving the
+    # old hand-rolled bug into a helper cannot satisfy the site ratchet by exemption alone.
+    common_tree = ast.parse((root / "_common.py").read_text(encoding="utf-8"))
+    functions = {
+        fn.name: fn
+        for fn in ast.walk(common_tree)
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    def calls(function_name):
+        return {
+            node.func.attr
+            for node in ast.walk(functions[function_name])
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+
+    assert {"identity_of", "remove"} <= calls("_stash_annotations")
+    assert {"place", "reapply"} <= calls("_restore_stashed_annotations")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -245,9 +245,10 @@ def test_every_remove_and_restore_site_goes_through_the_identity_pair():
         + ", ".join(offenders)
     )
 
-    # #1144: a replacement transaction must span table/balloon placement before it knows
-    # which feature subset to restore. Keep the two shared halves load-bearing so moving the
-    # old hand-rolled bug into a helper cannot satisfy the site ratchet by exemption alone.
+    # #1144: a replacement transaction spans table/balloon placement before it knows
+    # whether the shared result can commit. Keep its one stash/snapshot seam load-bearing so
+    # moving the old hand-rolled identity bug into a helper cannot satisfy this ratchet by
+    # exemption alone.
     common_tree = ast.parse((root / "_common.py").read_text(encoding="utf-8"))
     functions = {
         fn.name: fn
@@ -263,4 +264,4 @@ def test_every_remove_and_restore_site_goes_through_the_identity_pair():
         }
 
     assert {"identity_of", "remove"} <= calls("_stash_annotations")
-    assert {"place", "reapply"} <= calls("_restore_stashed_annotations")
+    assert {"restore", "restore_issues"} <= calls("_restore_annotation_transaction")

--- a/tests/test_shared_box_memo.py
+++ b/tests/test_shared_box_memo.py
@@ -68,7 +68,8 @@ def test_placement_seeds_the_memo(built):
 
 def test_lint_does_not_re_measure_what_placement_measured(built):
     """The consequence that makes the shared memo worth having."""
-    seeded = {k for k in built.box_cache}
+    live_annotations = {id(item) for item in built.items}
+    seeded = {key for key in built.box_cache if key in live_annotations}
     assert seeded, "nothing was seeded, so this test cannot prove anything"
 
     boxed_during_lint: list[int] = []


### PR DESCRIPTION
Closes #1144.

## Root cause

Automatic scattered-hole escalation removed feature-backed callouts and location dimensions before it knew whether the replacement table would fit and whether every row could be keyed back to physical holes by a landed, correctly owned balloon. Failure and partial-success paths could therefore leave the sheet less complete, erase unresolved drop diagnostics, or attribute table coverage to requirements that still depended on retained feature annotations.

The old resolver also inferred success from annotation names, treated eligibility as all-or-nothing per feature, restored fallbacks after solving the table/balloon inventory without them, and had no exception-atomic boundary spanning registry identity, item order, coverage, issues, and annotation-object metadata.

## Solution

- Add one automatic annotation-transaction seam that snapshots and restores exact objects, registry identity/order, issues, coverage, item order, pins, and representation markers. The obsolete selective restore helper was removed so snapshot restoration is the only rollback mechanism.
- Stash only annotations whose complete visible facts the current table schema can replace. Compound, thread, profile, pattern, tolerance, and fit callouts remain active.
- Evaluate callout and X/Y-location eligibility independently. A fitted or compound callout can remain while a separately dropped location requirement is truthfully replaced by the table.
- Require attempt-local, feature-owned, exact-cardinality balloons for every visible row before committing the shared table. Pre-existing or wrong-owner names are never evidence.
- Treat the shared table as one transaction: any missing or wrongly owned row balloon rolls back the table and all table balloons, restores every feature-backed fallback, and preserves the failed-escalation diagnostics.
- Record the winning representation per semantic requirement. Mixed table/ordinary-feature evidence deliberately reports no scalar winner.
- Preserve unresolved `callout_dropped` / `location_ref_dropped` findings unless exact requirement correspondence proves that a successfully keyed table row replaced them.
- Keep ADR 0009's single grouped pattern marker, but treat an undefined tag such as `6×A` as explicitly non-certifying: it cannot clear the dropped diameter/depth/pattern callout or create semantic coverage.
- Fail closed before mutation when a user annotation already owns a reserved automatic table/balloon name.
- Keep the established public `add_hole_table()` and `add_balloons()` surfaces additive; the proposed public replacement option was removed after ADR 0010 review.
- Scope retained-annotation avoidance to automatic escalation. Placement derives continuous free intervals from compact label boxes, retains exact feature-leader segments and complete public-balloon component boxes/segments for final validation, makes the shared strip capacity/spacing account for actual rendered tag extents, keeps the established bounded max-cardinality/min-cost band flow authoritative, and validates its selected complete inventory for retained-annotation, cross-band glyph, shaft-to-sibling-glyph, shaft-to-shaft, and page collisions. Missing, partial, cardinality-inconsistent (including Boolean pseudo-counts), Boolean-coordinate, malformed, non-finite, or degenerate public-balloon component metadata uses a conservative rendered box; an unmeasurable or otherwise infeasible guarded inventory fails the table attempt closed instead of launching a second or unbounded assignment search.
- Apply deterministic budgets before both perimeter-lane obstacle scans and continuous free-interval carving, so optional escalation fails closed before entering quadratic retained-obstacle work or allocating an oversized solver state.
- Give required table row-key balloons lexicographic priority over optional non-certifying pattern markers inside that same bounded flow. Optional markers cannot displace an independently complete table, and no second placement engine is introduced.
- Use the same ring, actual rendered-text, and shaft components in guarded placement and lint. Empty diagonal triangles cannot create warnings, long tags cannot bypass transaction validation, and empty tags contribute no phantom page-origin box.

No feature annotation is hand-positioned. Table placement still uses `fit_box`; balloon membership uses the max-cardinality/min-cost band assignment; positions remain inside the shared strip solve and its reserved bands.

## ADR assessment

- **ADR 0004:** outer layout remains compose-then-pack; an incomplete table is removed before outer packing rather than leaving an orphan drawing-level footprint beside restored fallbacks.
- **ADR 0005:** the registry remains the single identity/build-issue owner; rollback round-trips its complete identity unit.
- **ADR 0009:** exact structured placement evidence resolves escalation, and real leader/glyph components—not diagonal AABBs—decide crossings.
- **ADR 0010:** the unmerged public replacement expansion was removed. Automatic shared-table row editing remains a pre-existing limitation and is tracked separately in #1156 rather than redefined here.
- **ADR 0014:** table and balloon candidates stay collect-then-solve; the existing bounded max-cardinality/min-cost flow remains the only band-assignment engine. Its objective first preserves required row keys before optional markers, render-layer intervals validate the selected inventory, and an infeasible required result restores feature fallbacks rather than starting an unbounded search.
- **ADR 0016:** authored/planned requirements remain distinct from placement outcomes; the table receives only facts it visibly states, and replacement provenance is requirement-scoped.
- **ADR 0017:** correspondence is attempt-local, feature-scoped, exact-cardinality evidence and fails closed on ambiguity.

No accepted ADR change is required.

## Compatibility and failure behaviour

- No public API is added or changed. `add_hole_table()` and `add_balloons()` retain their additive behavior and orthographic-view support.
- A successfully keyed plain requirement may move to the table. Unsupported manufacturing facts keep their callout, while independently supported X/Y location facts may still move to the same table.
- Initial table-fit failure restores the exact fallback inventory and records `table_dropped`.
- Partial balloon placement rolls the shared table and every table balloon back, restores all feature fallbacks, and preserves both `table_dropped` and `balloon_dropped`; no row receives a replacement claim.
- A balloon that lands under the expected attempt name but belongs to the wrong semantic feature does not key the row and emits an explicit failed-escalation diagnostic.
- Exceptions restore registry state, issues, coverage, render order, pins, exact annotation identities, and temporary representation markers before re-raising.
- Reserved-name collisions fail closed without overwriting user annotations.
- Shared automatic-table edit semantics through `annotations_of()` / `drop(feature)` predate this change and are tracked in #1156.

## Acceptance criteria

- [x] Successful escalation suppresses only requirements whose complete, exact-cardinality, feature-owned balloon mapping landed.
- [x] Failed table placement restores original feature-backed leaders/dimensions with exact semantic state and deterministic ordering.
- [x] Partial placement rolls back the shared table, restores all fallbacks, and cannot claim or clear any requirement.
- [x] Retained/restored callout labels, exact leader segments, and complete existing public-balloon component geometry participate in guarded validation; false diagonal-AABB rejection is impossible, and actual leader/shaft/glyph crossings fail closed without an unbounded alternate-assignment search.
- [x] Required row-key balloons win capacity before optional non-certifying pattern markers, so an independently complete table is not rolled back by an auxiliary cue.
- [x] Compound/thread/profile/tolerance/fit facts remain visible or retain their exact dropped diagnostic.
- [x] Hole outcomes record the winning representation per requirement and claim no winner for mixed table/feature evidence.
- [x] Automatic initial-fit, partial/zero-success, exception, reserved-name, wrong-owner, cardinality, per-requirement eligibility, and collision paths are load-bearing.
- [x] A real constrained A4 automatic attempt preserves valid feature-backed fallback coverage and produces no missing-hole outcome when the table cannot commit.
- [x] Existing public additive table/balloon cardinality is unchanged.

## Validation on `0c640149db7df41c81249d97fec122a6b17b46be`

- Exact #1144 regression file — 62 passed
- Broad #1143/#1144/layout/registry/private-boundary selection — 215 passed
- `scripts/pr-check --static` — green
- `scripts/pr-check --full` — 3,602 passed, 5 skipped, 2 xfailed; 94.71% total coverage; 97% changed-line coverage
- Exact Boolean component-cardinality mutation, pre-perimeter-lane work cap, required new-shaft crossing rollback, and real constrained-A4 fallback branches are load-bearing
- The former regular-grid “success” fixture is now the negative real-crossing canary; successful table fixtures use an independently inspected irregular inventory whose 16 selected shafts/glyphs are actually crossing-free
- A 61-member unfragmented guarded band still solves exactly; fragmented probe work and nonaligned state growth are independently capped, and a load-bearing endpoint canary proves the budget exits before source materialisation
- Mutation check: disabling exact retained-segment intersection makes the A3 fitted-callout transaction regression fail by incorrectly committing `hole_table_plan`
- Mutation check: excluding retained public-balloon component metadata makes the public-additive-to-automatic regression fail by incorrectly committing `hole_table_plan`
- Boundary check: valid, empty, partial-box, partial-segment, absent-count, inconsistent-count, absent, getter-error, malformed, non-finite, descending, and unmeasurable public-balloon component inventories all preserve exact fallback completeness and fail unsafe replacement closed; drawing-level geometry participates while other-view geometry does not block plan replacement
- Capacity-boundary check: the same A3 inventory commits all 16 required row balloons both with and without an added optional grouped-pattern marker; only the optional marker is dropped and its diagnostic is retained
- 7,000 exhaustive random small-flow inventories agree with the lexicographic objective: maximum cardinality, then maximum required-row count, then minimum deterministic leader cost
- 2,000 randomized shaft/glyph/label geometries (over 800,000 sampled coordinates) agreed with the derived continuous free intervals
- The reviewer's 28-member adversarial guarded inventory performs exactly four per-band validations and fails closed; the removed alternative search took about 17 seconds on that fixture
- The canonical-flow cost counterexample selects the minimum-leader-cost equal-cardinality assignment
- `git diff --check` — clean

## Rendered evidence

- [16-row automatic success](https://gist.github.com/pzfreo/3f1add96178156b87281478b1607df67#file-success-current-svg) — all 16 feature-owned balloons landed in a genuinely crossing-free selected inventory with no `balloon_dropped`, table drop, or hole-requirement loss.
- [automatic shaft-crossing rejection with complete fallback](https://gist.github.com/pzfreo/3f1add96178156b87281478b1607df67#file-partial-current-svg) — the regular perimeter inventory would make two required balloon shafts cross, so the shared table and every balloon roll back; feature-backed callouts remain and no hole requirement becomes missing.

Both SVGs were regenerated from exact `0c64014` and inspected at original resolution. The irregular perimeter fixture isolates successful transaction semantics; the former regular-grid success fixture now proves that a selected inventory containing a real required shaft crossing fails closed without leaving an orphan table footprint. Separate compound, fitted-callout, retained-public-balloon, constrained-A4, malformed-metadata, and resource-budget fixtures prove the remaining rollback boundaries. Tests assert semantic registry/outcome state, not pixels alone.

## Adversarial review

- Round 1 on `8a6eb3c7`: six substantive findings fixed (declared cardinality, exception atomicity, name corruption, spoofable balloon evidence, compound-fact loss, fallback/table overlap).
- Round 2 on `3d0cd576`: seven substantive findings fixed (tolerance/fit/thread loss including dropped callouts, intra-attempt collision, wrong-owner pattern evidence, annotation-global provenance, profile guard coverage, partial-stash atomicity, exact rollback surfaces).
- Round 3 on `9c0ad7c`: seven substantive findings fixed (row formatting rollback gap, order drift, unsupported non-plan public replacement, final-inventory collisions, automatic initial-fit coverage, mixed evidence, stale-ID CI nondeterminism).
- Round 4 on `8df3716`: three substantive findings fixed (mixed-owner provenance, finalize marker leakage, automatic reserved-name overwrite).
- Round 5 on `f0056fc`: four substantive findings fixed (feature-wide location eligibility, ADR 0010 public replacement incompatibility, additive public balloon regression, diagonal-AABB false rejection/max-cardinality loss). The public replacement proposal was removed and #1156 records the distinct historical shared-table edit problem.
- Round 6 on `a0efa45`: six substantive findings fixed (greedy/phantom strip retry, arbitrary 0.5 mm probing, missing cross-band reassignment, invisible balloon glyphs in lint, non-load-bearing collision/cardinality/owner/reason tests, and failed diff coverage).
- Round 7 on `833ebc5`: four substantive findings fixed (unbounded exponential alternate assignment, lost minimum-leader-cost objective, truncated long-tag lint metadata, and silent wrong-owner scattered rows). The canonical bounded flow is again the sole band assignment engine; guarded infeasibility now fails the table attempt closed.
- Round 8 on `74b46b9`: two substantive findings fixed (long rendered text was visible to lint but absent from guarded placement, and empty text contributed a false page-origin component). Placement and critique now share the exact rendered text extent and empty tags add no text geometry.
- Round 9 on `98c739c`: three substantive findings fixed (pattern-only escalation bypassed the retained-label guard, sibling long-tag balloons used ring-only spacing with no cross-band/page validation, and lint measured severity from the aggregate balloon extent rather than the component that collided). Automatic escalation now guards every balloon inventory, rendered text drives strip capacity/spacing, the final bounded gate fails unsafe replacement closed, and structural lint evaluates the actual clipped segment/component while preserving diagnostic compatibility.
- Round 10 on `b777199`: four substantive findings fixed (shaft-to-sibling-glyph collisions escaped final validation, successful escalation erased unrelated public `table_dropped` diagnostics, an undefined grouped pattern marker falsely cleared the manufacturing callout drop, and near-axis shafts could disappear from structural lint at an arbitrary slope threshold). Final inventory validation is now bidirectional for each balloon pair, table-attempt issue cleanup is exact and attempt-local, grouped markers remain visibly useful but explicitly non-certifying, and line penetration is slope-continuous.
- Round 11 on `303181a`: one substantive finding fixed (a balloon shaft could cross its own long rendered tag while the final gate checked only sibling balloons). The final gate now excludes only the intentionally touched ring, rejects self-shaft/text crossings, and has both a direct geometry canary and an automatic `1000×A` fail-closed regression. No other substantive finding or nit survived the reviewer's reattack.
- Round 12 on `c9e57a9`: one substantive transaction/layout finding fixed (zero-success and partial balloon attempts retained an empty or incomplete table that later overlapped a repacked view). The shared table now commits only when every visible row is keyed; otherwise the complete attempt rolls back before outer packing. The obsolete partial-refit branch was removed, and successful mixed pattern evidence remains covered on a roomy A2 fixture.
- Round 13 on `c6f5a06`: one substantive resource-bound finding fixed (a 61-member band fragmented by many retained labels could allocate more than 1 GB in the guarded interval DP). Candidate expansion now has deterministic state/work caps; exceeding either returns infeasible and exercises the same complete transactional rollback. A dense unfragmented 61-member band remains inside the budget.
- Round 14 on `9c82494`: one substantive guard-order/test-truth finding fixed (endpoint sources were materialised before the budget decision, and the original aligned fixture exercised probe work rather than its claimed state explosion). Validation now precedes the cap without allocating endpoint floats; source expansion is incremental and bounded; separate load-bearing tests isolate probe, state, first-source, and transaction-rollback limits while proving a feasible inventory succeeds when its state budget is raised.
- Round 15 on `5624cf8`: one substantive retained-geometry finding fixed (a new balloon shaft could cross a retained fitted-callout leader while the guarded solve considered only its text box). Automatic replacement now retains exact surviving `Leader` segments and rejects proper crossings, T-junctions, and collinear overlaps while allowing a legitimate shared endpoint. The reviewer's exact A3 fixture rolls the whole table back; its collision-free A2 counterpart still proves requirement-scoped table replacement.
- Round 16 on `cd7ff72`: one substantive single-seam finding fixed (an unused selective annotation-restoration helper and its dedicated test survived after round 12 made shared-table rollback all-or-nothing). The dead alternate path is removed, and the registry ratchet now enforces the production snapshot restore seam.
- Round 17 on `a686648`: one substantive duplicate-state finding and one related test-quality gap fixed (the snapshot rollback still restored representation markers first from redundant per-stash fields and then from the authoritative snapshot; the exception test could not distinguish absent marker attributes from explicit `None`). The duplicate fields/helper are removed, stale selective-fallback wording now describes the all-or-nothing transaction, and exact marker attribute presence is load-bearing.
- Round 18 on `3b4e755`: one substantive load-bearing gap fixed (the exception canary failed before an inner rollback had actually marked restored fallbacks, so deleting marker restoration still passed). The test now forces a partial table attempt, verifies the inner rollback wrote its temporary representation, raises through the sanctioned `PlacementContext` seam, and proves the outer snapshot restores exact attribute presence and values. A runtime mutation that omits marker restoration now fails.
- Round 19 on `89de6bf`: two substantive findings fixed (automatic guarded escalation omitted the precise component geometry of an existing public balloon, and a production-dead private `_place_band` guarded branch duplicated the authoritative whole-inventory solver). Retained public balloons now contribute their explicit component boxes and segments without falling back to a diagonal compound AABB, and the stale alternate branch/tests are removed. The public-additive-to-automatic regression is load-bearing against removing the new retained-geometry inventory.
- Round 20 on `f3660b2`: one substantive fail-closed finding fixed (empty, missing, malformed, or non-finite component metadata on a retained public balloon was silently discarded while the ordinary label collector deliberately skipped centerline objects). Rendered balloons now carry explicit semantic identity; valid metadata keeps precise components, invalid metadata falls back to the conservative rendered box, and an unmeasurable fallback aborts only the optional table transaction. Public same-view regressions cover valid, empty, absent, malformed, non-finite, descending, and unmeasurable inventories. No additional independent finding or nit survived the reviewer’s full reattack.
- Round 21 on `6f172a8`: four substantive findings fixed (partial but superficially valid component metadata could omit a retained shaft; free-interval carving performed quadratic retained-label work before the later solver budgets; getter-error and drawing/other-view component paths were not load-bearing; and an optional non-certifying pattern marker could consume capacity from a required row balloon and roll back an otherwise complete table). Rendered balloons now declare exact component cardinality, invalid or incomplete inventories fail closed through the conservative fallback, a deterministic pre-carve work bound fires before critical-point expansion, every metadata/scope branch has an integration canary, and required row keys win before optional markers inside the same bounded canonical flow. No nit was reported.
- Round 22 on `1346d6a`: four substantive findings fixed (Boolean values passed integer component-count validation; the perimeter top-lane obstacle scan ran before the later work cap; new balloon shafts could cross each other and silently commit; and the required real constrained-A4 fallback scenario was absent). Exact plain-integer cardinality is now enforced, the perimeter-lane budget fires before candidate/obstacle scans, the final inventory rejects new shaft crossings, and a real A4 regression proves valid fallback coverage remains non-missing. Tightening the crossing gate exposed four stale positive fixtures; each now uses visibly and geometrically crossing-free evidence, while the old regular geometry is the load-bearing rollback canary. No nit was reported.
- Round 23 on `52f5e9f`: one substantive malformed-metadata finding fixed (Boolean box or segment coordinate payloads were still accepted through `float(value)` even though Boolean cardinalities were rejected). Both coordinate normalizers now reject Boolean values before coercion, and independent end-to-end box and segment mutations prove each branch falls back conservatively. No independent nit was reported; every other round-22 fix survived reattack.
- Round 24 on `3fcdc08`: one substantive load-bearing test gap fixed (the Boolean-box fixture's retained shaft independently forced rollback, so it did not prove the Boolean-box rejection). The box case now carries valid harmless shaft metadata and directly asserts conservative rendered-box fallback; deleting only the Boolean-box guard is caught. No production defect or independent nit was reported.
- Round 25 on `0c64014`: final fresh adversarial review found zero substantive findings and zero nits. The reviewer independently confirmed that deleting only the Boolean-box rejection fails the direct conservative-fallback oracle, that the Boolean-segment guard is independently mutation-caught, and that transaction rollback, identity/order/coverage/issues restoration, provenance, ownership/cardinality, malformed/scoped metadata, solver budgets, required-row priority, shaft crossings, constrained A4 fallback, DAG, and applicable ADR contracts remain clean. The review selection passed 132 tests and the retained-balloon metadata matrix passed 15 tests.

The fresh adversarial review of exact `0c640149db7df41c81249d97fec122a6b17b46be` found no substantive issue, and exact-head lint, Python 3.10–3.14, `ci-ok`, and both Codecov checks are green. The PR is ready to merge.
