### PR TITLE
Use all viable sheet space for notes tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- **Generic notes/data tables use every viable free sheet region and explain failed placement**
+  (#1145). A drawn sheet frame or zone ruler now defines the usable inset instead of becoming a
+  page-sized solid obstacle, so a measured four-row notes block can use clear lower-left A4
+  space. Failed table diagnostics report the measured page-space footprint, attempted candidate
+  regions, and the named annotations that blocked the nearest candidates.
+
 - **Automatic hole-table escalation is transactional per semantic requirement** (#1144). The
   engine suppresses replaceable callouts and location dimensions only after the table fits and
   every visible row has its required feature-owned balloon. A failed or partial balloon attempt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - **Generic notes/data tables use every viable free sheet region and explain failed placement**
   (#1145). A drawn sheet frame or zone ruler now defines the usable inset instead of becoming a
   page-sized solid obstacle, so a measured four-row notes block can use clear lower-left A4
-  space. Failed table diagnostics report the measured page-space footprint, attempted candidate
-  regions, and the named annotations that blocked the nearest candidates.
+  space. Tables retain the drafting preset's external text clearance from named and anonymous
+  existing annotations. Failed placement diagnostics report the measured page-space footprint,
+  attempted candidate regions, and the named obstacles or clearance bands that blocked the
+  nearest candidates without materialising the candidate Cartesian product.
 
 - **Automatic hole-table escalation is transactional per semantic requirement** (#1144). The
   engine suppresses replaceable callouts and location dimensions only after the table fits and

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -67,7 +67,7 @@ from draftwright.export import (
     write_dxf,
 )
 from draftwright.intents import Intent
-from draftwright.layout import fit_box
+from draftwright.layout import FitBoxTrace, fit_box
 from draftwright.linting import (
     CoverageState,
     LintIssue,
@@ -2521,15 +2521,17 @@ class Drawing:
         return name
 
     def add_table(self, rows, *, prefer="tr", name="table", block_cols=None):
-        """Add a generic data table, placed in a free corner (#93).
+        """Add a generic data table in the preferred available sheet region (#93/#1145).
 
         *rows* is a list of equal-length string tuples (``rows[0]`` is the
-        header). The table is positioned by :func:`fit_box` clear of the views,
-        title block, and existing annotations; *prefer* is the page corner to sit
-        nearest. Returns the table annotation, or ``None`` if it has no rows or
-        will not fit (recorded as ``table_dropped`` lint). Gear-data, BOM, and
-        revision tables all go through here; :meth:`add_hole_table` is the
-        hole-specific convenience built on it.
+        header). The measured page-space footprint is positioned by :func:`fit_box`
+        clear of the views, title block, and existing annotations; *prefer* ranks
+        candidates by their distance from that page corner but does not restrict
+        placement to the corner. Returns the table annotation, or ``None`` if it
+        has no rows or will not fit. A failed solve records ``table_dropped`` with
+        the footprint, attempted candidate regions, and their named blockers.
+        Gear-data, BOM, and revision tables all go through here;
+        :meth:`add_hole_table` is the hole-specific convenience built on it.
         """
         if not rows:
             return None
@@ -2540,18 +2542,65 @@ class Drawing:
         pw = a.PAGE_W if a is not None else self.page_w
         ph = a.PAGE_H if a is not None else self.page_h
         region = (margin, margin, pw - margin, ph - margin)
-        obstacles = [b for v in self.views if (b := self.view_bounds(v)) is not None]
-        obstacles.extend(strip_obstacles(self))
-        for o in self.items:
-            try:
-                bb = o.bounding_box()
-            except Exception:  # noqa: BLE001 — not every annotation bbox-es cleanly
+        obstacles = [
+            (f"view:{view}", box)
+            for view in self.views
+            if (box := self.view_bounds(view)) is not None
+        ]
+        for annotation_name, box in strip_obstacles(self, named=True):
+            annotation = self.get_annotation(annotation_name)
+            # The border and zone ruler DEFINE the usable region above; treating
+            # either one's page-spanning Compound bbox as a solid obstacle makes
+            # every interior free rectangle disappear (#1145).  Their clearance
+            # is already encoded by ``a.margin``.
+            if any(
+                getattr(annotation, rider, False) for rider in ("is_sheet_frame", "is_zone_grid")
+            ):
                 continue
-            obstacles.append((bb.min.X, bb.min.Y, bb.max.X, bb.max.Y))
-        pos = fit_box((w, h), region, obstacles, prefer)
+            obstacles.append((f"annotation:{annotation_name}", box))
+
+        # A title block's decomposed grid lines bound text-filled cells; the whole
+        # block is furniture, not a collection of free pockets.  Keep its rendered
+        # hull as one named obstacle while other leaders/dimensions retain the more
+        # precise segment + label occupancy from ``strip_obstacles``.
+        title_block = self.get_annotation("title_block")
+        if title_block is not None:
+            try:
+                bb = title_block.bounding_box()
+            except Exception:  # noqa: BLE001 — the decomposed occupancy remains available
+                pass
+            else:
+                obstacles.append(
+                    ("annotation:title_block", (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y))
+                )
+
+        trace = FitBoxTrace()
+        pos = fit_box((w, h), region, obstacles, prefer, trace=trace)
         if pos is None:
+            measured = f"width={w:.1f} mm, height={h:.1f} mm"
+            detail = trace.violation
+            if detail is None and trace.rejected:
+                shown = trace.rejected[:4]
+                rejected = []
+                for attempt in shown:
+                    x0, y0, x1, y1 = attempt.region
+                    rejected.append(
+                        f"[{x0:.1f},{y0:.1f}–{x1:.1f},{y1:.1f}] blocked by "
+                        f"{', '.join(attempt.blockers)}"
+                    )
+                remaining = trace.rejected_candidates - len(shown)
+                suffix = f"; +{remaining} more" if remaining else ""
+                detail = (
+                    f"attempted {trace.attempted_candidates} candidate regions; rejected: "
+                    f"{'; '.join(rejected)}{suffix}"
+                )
+            if detail is None:
+                detail = "solver returned no placement trace"
             self._record_build_issue(
-                "warning", "table_dropped", f"table {name!r} did not fit the sheet"
+                "warning",
+                "table_dropped",
+                f"table {name!r} did not fit the sheet; measured page-space footprint "
+                f"{measured}; {detail}",
             )
             return None
         return self._add(table.locate(Location((pos[0], pos[1], 0))), name)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2525,11 +2525,12 @@ class Drawing:
 
         *rows* is a list of equal-length string tuples (``rows[0]`` is the
         header). The measured page-space footprint is positioned by :func:`fit_box`
-        clear of the views, title block, and existing annotations; *prefer* ranks
-        candidates by their distance from that page corner but does not restrict
-        placement to the corner. Returns the table annotation, or ``None`` if it
-        has no rows or will not fit. A failed solve records ``table_dropped`` with
-        the footprint, attempted candidate regions, and their named blockers.
+        clear of the views, title block, and existing annotations by the drafting
+        preset's external text clearance; *prefer* ranks candidates by their
+        distance from that page corner but does not restrict placement to the
+        corner. Returns the table annotation, or ``None`` if it has no rows or
+        will not fit. A failed solve records ``table_dropped`` with the footprint,
+        attempted candidate regions, and their named blockers/clearance bands.
         Gear-data, BOM, and revision tables all go through here;
         :meth:`add_hole_table` is the hole-specific convenience built on it.
         """
@@ -2559,6 +2560,23 @@ class Drawing:
                 continue
             obstacles.append((f"annotation:{annotation_name}", box))
 
+        # ``Drawing.add(obj, name=None)`` remains a supported compatibility
+        # surface until 0.5.0. Anonymous objects have no registry identity, so
+        # the named occupancy walk above cannot see them; retain the old full-bbox
+        # fallback for ONLY those objects (#1145 review), without reintroducing a
+        # coarse duplicate hull for every registered leader/dimension.
+        registered_ids = {id(annotation) for _name, annotation in self.iter_annotations()}
+        for index, annotation in enumerate(self.items):
+            if id(annotation) in registered_ids:
+                continue
+            try:
+                bb = annotation.bounding_box()
+            except Exception:  # noqa: BLE001 — not every compatibility object bbox-es cleanly
+                continue
+            obstacles.append(
+                (f"anonymous-annotation[{index}]", (bb.min.X, bb.min.Y, bb.max.X, bb.max.Y))
+            )
+
         # A title block's decomposed grid lines bound text-filled cells; the whole
         # block is furniture, not a collection of free pockets.  Keep its rendered
         # hull as one named obstacle while other leaders/dimensions retain the more
@@ -2575,7 +2593,14 @@ class Drawing:
                 )
 
         trace = FitBoxTrace()
-        pos = fit_box((w, h), region, obstacles, prefer, trace=trace)
+        pos = fit_box(
+            (w, h),
+            region,
+            obstacles,
+            prefer,
+            clearance=self.draft.pad_around_text,
+            trace=trace,
+        )
         if pos is None:
             measured = f"width={w:.1f} mm, height={h:.1f} mm"
             detail = trace.violation
@@ -2585,8 +2610,8 @@ class Drawing:
                 for attempt in shown:
                     x0, y0, x1, y1 = attempt.region
                     rejected.append(
-                        f"[{x0:.1f},{y0:.1f}–{x1:.1f},{y1:.1f}] blocked by "
-                        f"{', '.join(attempt.blockers)}"
+                        f"[{x0:.1f},{y0:.1f}–{x1:.1f},{y1:.1f}] blocked within "
+                        f"{trace.clearance:.1f} mm clearance by {', '.join(attempt.blockers)}"
                     )
                 remaining = trace.rejected_candidates - len(shown)
                 suffix = f"; +{remaining} more" if remaining else ""

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -45,7 +45,7 @@ non-linear) stays deferred (#94) and may never be needed — see that ADR's
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal, NamedTuple
 
 Axis = Literal["x", "y"]
@@ -651,15 +651,61 @@ def plan_strip(candidates, lo, hi, min_gap, *, axis: Axis = "y"):
 # ---------------------------------------------------------------------------
 
 
-def fit_box(size, region, obstacles, prefer="br"):
+@dataclass(frozen=True)
+class FitBoxRejection:
+    """One candidate rectangle rejected by :func:`fit_box` (#1145)."""
+
+    region: tuple[float, float, float, float]
+    blockers: tuple[str, ...]
+
+
+@dataclass
+class FitBoxTrace:
+    """Inspectable record of a :func:`fit_box` decision (#1145).
+
+    The placer stays a pure rectangle solver: callers may supply named obstacles
+    and opt into this side record when a failed furniture placement needs an
+    actionable diagnostic.  ``rejected_candidates`` retains the exact total;
+    ``rejected`` is a bounded, preference-ordered sample for messages.  The hot
+    paths that only need a position pay no trace construction cost.
+    """
+
+    attempted_candidates: int = 0
+    rejected_candidates: int = 0
+    rejected: list[FitBoxRejection] = field(default_factory=list)
+    violation: str | None = None
+    max_rejections: int = field(default=8, repr=False)
+
+
+def _fit_box_obstacle(item, index):
+    """Return ``(name, box)`` for a bare box or ``(name, box)`` input."""
+    if (
+        isinstance(item, tuple)
+        and len(item) == 2
+        and isinstance(item[0], str)
+        and isinstance(item[1], (tuple, list))
+        and len(item[1]) == 4
+    ):
+        return item[0], tuple(item[1])
+    return f"obstacle[{index}]", tuple(item)
+
+
+def fit_box(size, region, obstacles, prefer="br", *, trace=None):
     """Place a ``(w, h)`` box in *region* avoiding *obstacles*, sat as near the
     *prefer* corner as possible (ADR 0003, #93).
 
     *region* and each obstacle are ``(x0, y0, x1, y1)`` page-mm boxes. *prefer* is
-    one of ``"bl" "br" "tl" "tr"``. Returns the box ``(x0, y0)`` or ``None``.
+    one of ``"bl" "br" "tl" "tr"``. Obstacles may instead be supplied as
+    ``(name, box)`` pairs; names do not affect placement. Returns the box
+    ``(x0, y0)`` or ``None``.
+
+    Pass a :class:`FitBoxTrace` to *trace* to count every rejected candidate and
+    retain a bounded preference-ordered sample with the obstacle names that
+    blocked it.  This keeps diagnostics derived from the exact solve rather than
+    from a second explanatory model.
 
     An optimal placement always has each box edge flush against a region or
-    obstacle edge, so the candidate top-left positions are exactly
+    obstacle edge, so the candidate lower-left positions are exactly
     ``{edge, edge - boxsize}`` per axis — O(n) each, O(n²) positions, each
     checked against the obstacles in O(n). That is O(n³), tractable for the
     dozens-of-annotations obstacle sets the hole table feeds it (the old
@@ -668,12 +714,29 @@ def fit_box(size, region, obstacles, prefer="br"):
     """
     w, h = size
     rx0, ry0, rx1, ry1 = region
+    if trace is not None:
+        trace.attempted_candidates = 0
+        trace.rejected_candidates = 0
+        trace.rejected.clear()
+        trace.violation = None
     if w > rx1 - rx0 or h > ry1 - ry0:
+        if trace is not None:
+            violations = []
+            if w > rx1 - rx0:
+                violations.append(f"width exceeds usable region by {w - (rx1 - rx0):.1f} mm")
+            if h > ry1 - ry0:
+                violations.append(f"height exceeds usable region by {h - (ry1 - ry0):.1f} mm")
+            trace.violation = "; ".join(violations)
         return None
     # Only obstacles that can intersect the region constrain the placement.
-    obs = [o for o in obstacles if o[0] < rx1 and rx0 < o[2] and o[1] < ry1 and ry0 < o[3]]
-    x_edges = {rx0, rx1, *(o[0] for o in obs), *(o[2] for o in obs)}
-    y_edges = {ry0, ry1, *(o[1] for o in obs), *(o[3] for o in obs)}
+    named = [_fit_box_obstacle(item, index) for index, item in enumerate(obstacles)]
+    obs = [
+        (name, box)
+        for name, box in named
+        if box[0] < rx1 and rx0 < box[2] and box[1] < ry1 and ry0 < box[3]
+    ]
+    x_edges = {rx0, rx1, *(o[0] for _name, o in obs), *(o[2] for _name, o in obs)}
+    y_edges = {ry0, ry1, *(o[1] for _name, o in obs), *(o[3] for _name, o in obs)}
     xs = sorted({x for e in x_edges for x in (e, e - w) if rx0 <= x <= rx1 - w})
     ys = sorted({y for e in y_edges for y in (e, e - h) if ry0 <= y <= ry1 - h})
 
@@ -681,16 +744,37 @@ def fit_box(size, region, obstacles, prefer="br"):
     top = prefer in ("tl", "tr")
     cx = rx1 if right else rx0
     cy = ry1 if top else ry0
-    best = None
-    best_score = None
+    candidates = []
     for bx in xs:
         for by in ys:
-            if any(bx < o[2] and o[0] < bx + w and by < o[3] and o[1] < by + h for o in obs):
-                continue
             bcx = bx + w if right else bx
             bcy = by + h if top else by
             score = (bcx - cx) ** 2 + (bcy - cy) ** 2
-            if best_score is None or score < best_score:
-                best_score = score
-                best = (bx, by)
-    return best
+            candidates.append((score, bx, by))
+
+    # Sorting by score first is equivalent to the old full scan/minimum update;
+    # bx/by preserve its deterministic ascending tie-break.  It also lets the
+    # trace say which candidates the preference policy actually tried first.
+    for _score, bx, by in sorted(candidates):
+        if trace is None:
+            if any(
+                bx < o[2] and o[0] < bx + w and by < o[3] and o[1] < by + h for _name, o in obs
+            ):
+                continue
+            return (bx, by)
+        blockers = tuple(
+            sorted(
+                {
+                    name
+                    for name, o in obs
+                    if bx < o[2] and o[0] < bx + w and by < o[3] and o[1] < by + h
+                }
+            )
+        )
+        trace.attempted_candidates += 1
+        if not blockers:
+            return (bx, by)
+        trace.rejected_candidates += 1
+        if len(trace.rejected) < trace.max_rejections:
+            trace.rejected.append(FitBoxRejection((bx, by, bx + w, by + h), blockers))
+    return None

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -44,6 +44,7 @@ non-linear) stays deferred (#94) and may never be needed — see that ADR's
 
 from __future__ import annotations
 
+import heapq
 import math
 from dataclasses import dataclass, field
 from typing import Literal, NamedTuple
@@ -674,6 +675,7 @@ class FitBoxTrace:
     rejected_candidates: int = 0
     rejected: list[FitBoxRejection] = field(default_factory=list)
     violation: str | None = None
+    clearance: float = 0.0
     max_rejections: int = field(default=8, repr=False)
 
 
@@ -690,7 +692,7 @@ def _fit_box_obstacle(item, index):
     return f"obstacle[{index}]", tuple(item)
 
 
-def fit_box(size, region, obstacles, prefer="br", *, trace=None):
+def fit_box(size, region, obstacles, prefer="br", *, clearance=0.0, trace=None):
     """Place a ``(w, h)`` box in *region* avoiding *obstacles*, sat as near the
     *prefer* corner as possible (ADR 0003, #93).
 
@@ -699,26 +701,34 @@ def fit_box(size, region, obstacles, prefer="br", *, trace=None):
     ``(name, box)`` pairs; names do not affect placement. Returns the box
     ``(x0, y0)`` or ``None``.
 
+    *clearance* inflates each obstacle by that many page millimetres before
+    candidates are derived and tested.  The usable region itself is unchanged:
+    callers own its page/frame inset.
+
     Pass a :class:`FitBoxTrace` to *trace* to count every rejected candidate and
     retain a bounded preference-ordered sample with the obstacle names that
     blocked it.  This keeps diagnostics derived from the exact solve rather than
     from a second explanatory model.
 
     An optimal placement always has each box edge flush against a region or
-    obstacle edge, so the candidate lower-left positions are exactly
+    (clearance-inflated) obstacle edge, so the candidate lower-left positions are exactly
     ``{edge, edge - boxsize}`` per axis — O(n) each, O(n²) positions, each
     checked against the obstacles in O(n). That is O(n³), tractable for the
     dozens-of-annotations obstacle sets the hole table feeds it (the old
-    rectangle-enumeration form was O(n⁴) and blew up — #93 review). Deterministic
-    (sorted candidates, first minimum wins).
+    rectangle-enumeration form was O(n⁴) and blew up — #93 review). Candidate
+    pairs are streamed rather than materialised, keeping live memory O(n).
+    Deterministic (ascending candidates, first minimum wins).
     """
     w, h = size
     rx0, ry0, rx1, ry1 = region
+    if clearance < 0:
+        raise ValueError("fit_box clearance must be non-negative")
     if trace is not None:
         trace.attempted_candidates = 0
         trace.rejected_candidates = 0
         trace.rejected.clear()
         trace.violation = None
+        trace.clearance = clearance
     if w > rx1 - rx0 or h > ry1 - ry0:
         if trace is not None:
             violations = []
@@ -730,9 +740,21 @@ def fit_box(size, region, obstacles, prefer="br", *, trace=None):
         return None
     # Only obstacles that can intersect the region constrain the placement.
     named = [_fit_box_obstacle(item, index) for index, item in enumerate(obstacles)]
+    expanded = [
+        (
+            name,
+            (
+                box[0] - clearance,
+                box[1] - clearance,
+                box[2] + clearance,
+                box[3] + clearance,
+            ),
+        )
+        for name, box in named
+    ]
     obs = [
         (name, box)
-        for name, box in named
+        for name, box in expanded
         if box[0] < rx1 and rx0 < box[2] and box[1] < ry1 and ry0 < box[3]
     ]
     x_edges = {rx0, rx1, *(o[0] for _name, o in obs), *(o[2] for _name, o in obs)}
@@ -744,24 +766,21 @@ def fit_box(size, region, obstacles, prefer="br", *, trace=None):
     top = prefer in ("tl", "tr")
     cx = rx1 if right else rx0
     cy = ry1 if top else ry0
-    candidates = []
+    # Scores separate into X + Y terms.  Merge one sorted Y stream per X via a
+    # heap so candidates arrive in exact ``(score, bx, by)`` order without ever
+    # materialising the O(len(xs) * len(ys)) Cartesian product (#1145 review).
+    ranked_y = sorted(
+        ((((by + h if top else by) - cy) ** 2, by) for by in ys),
+        key=lambda candidate: (candidate[0], candidate[1]),
+    )
+    candidates: list[tuple[float, float, float, int, float]] = []
     for bx in xs:
-        for by in ys:
-            bcx = bx + w if right else bx
-            bcy = by + h if top else by
-            score = (bcx - cx) ** 2 + (bcy - cy) ** 2
-            candidates.append((score, bx, by))
+        x_score = ((bx + w if right else bx) - cx) ** 2
+        y_score, by = ranked_y[0]
+        heapq.heappush(candidates, (x_score + y_score, bx, by, 0, x_score))
 
-    # Sorting by score first is equivalent to the old full scan/minimum update;
-    # bx/by preserve its deterministic ascending tie-break.  It also lets the
-    # trace say which candidates the preference policy actually tried first.
-    for _score, bx, by in sorted(candidates):
-        if trace is None:
-            if any(
-                bx < o[2] and o[0] < bx + w and by < o[3] and o[1] < by + h for _name, o in obs
-            ):
-                continue
-            return (bx, by)
+    while candidates:
+        _score, bx, by, y_index, x_score = heapq.heappop(candidates)
         blockers = tuple(
             sorted(
                 {
@@ -771,10 +790,20 @@ def fit_box(size, region, obstacles, prefer="br", *, trace=None):
                 }
             )
         )
-        trace.attempted_candidates += 1
+        if trace is not None:
+            trace.attempted_candidates += 1
         if not blockers:
             return (bx, by)
-        trace.rejected_candidates += 1
-        if len(trace.rejected) < trace.max_rejections:
-            trace.rejected.append(FitBoxRejection((bx, by, bx + w, by + h), blockers))
+        if trace is not None:
+            trace.rejected_candidates += 1
+            if len(trace.rejected) < trace.max_rejections:
+                trace.rejected.append(FitBoxRejection((bx, by, bx + w, by + h), blockers))
+
+        next_index = y_index + 1
+        if next_index < len(ranked_y):
+            y_score, next_by = ranked_y[next_index]
+            heapq.heappush(
+                candidates,
+                (x_score + y_score, bx, next_by, next_index, x_score),
+            )
     return None

--- a/src/draftwright/layout.py
+++ b/src/draftwright/layout.py
@@ -692,6 +692,11 @@ def _fit_box_obstacle(item, index):
     return f"obstacle[{index}]", tuple(item)
 
 
+def _boxes_overlap(left, right):
+    """Return whether two page-space boxes overlap with positive area."""
+    return left[0] < right[2] and right[0] < left[2] and left[1] < right[3] and right[1] < left[3]
+
+
 def fit_box(size, region, obstacles, prefer="br", *, clearance=0.0, trace=None):
     """Place a ``(w, h)`` box in *region* avoiding *obstacles*, sat as near the
     *prefer* corner as possible (ADR 0003, #93).
@@ -752,11 +757,7 @@ def fit_box(size, region, obstacles, prefer="br", *, clearance=0.0, trace=None):
         )
         for name, box in named
     ]
-    obs = [
-        (name, box)
-        for name, box in expanded
-        if box[0] < rx1 and rx0 < box[2] and box[1] < ry1 and ry0 < box[3]
-    ]
+    obs = [(name, box) for name, box in expanded if _boxes_overlap(box, region)]
     x_edges = {rx0, rx1, *(o[0] for _name, o in obs), *(o[2] for _name, o in obs)}
     y_edges = {ry0, ry1, *(o[1] for _name, o in obs), *(o[3] for _name, o in obs)}
     xs = sorted({x for e in x_edges for x in (e, e - w) if rx0 <= x <= rx1 - w})
@@ -781,23 +782,25 @@ def fit_box(size, region, obstacles, prefer="br", *, clearance=0.0, trace=None):
 
     while candidates:
         _score, bx, by, y_index, x_score = heapq.heappop(candidates)
-        blockers = tuple(
-            sorted(
-                {
-                    name
-                    for name, o in obs
-                    if bx < o[2] and o[0] < bx + w and by < o[3] and o[1] < by + h
-                }
-            )
-        )
+        candidate_box = (bx, by, bx + w, by + h)
+        retain_rejection = trace is not None and len(trace.rejected) < trace.max_rejections
+        if retain_rejection:
+            blockers = tuple(sorted({name for name, o in obs if _boxes_overlap(candidate_box, o)}))
+            blocked = bool(blockers)
+        else:
+            # Once the bounded diagnostic sample is full, only collision truth is
+            # needed. Preserve the former solver's early exit instead of sorting
+            # every blocker name for every remaining O(n²) candidate (#1145 review).
+            blockers = ()
+            blocked = any(_boxes_overlap(candidate_box, o) for _name, o in obs)
         if trace is not None:
             trace.attempted_candidates += 1
-        if not blockers:
+        if not blocked:
             return (bx, by)
         if trace is not None:
             trace.rejected_candidates += 1
-            if len(trace.rejected) < trace.max_rejections:
-                trace.rejected.append(FitBoxRejection((bx, by, bx + w, by + h), blockers))
+            if retain_rejection:
+                trace.rejected.append(FitBoxRejection(candidate_box, blockers))
 
         next_index = y_index + 1
         if next_index < len(ranked_y):

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1406,8 +1406,9 @@ class Sheet:
         """Declare a corner-block data table — positioned at :meth:`build` by the engine's generic
         auto-placer, clear of the views, title block, and annotations (the same machinery as the
         hole table), and lint-checked. *rows* is a sequence of equal-length row sequences (row 0
-        the header); cells are stringified. *prefer* is the page corner to sit nearest
-        (``"tr"``/``"tl"``/``"br"``/``"bl"``). A table with no free corner records a
+        the header); cells are stringified. *prefer* ranks the free candidates by the page corner
+        to sit nearest (``"tr"``/``"tl"``/``"br"``/``"bl"``); it does not exclude viable interior
+        or opposite-corner space. A table with no fitting free region records an inspectable
         ``table_dropped`` lint — it never overlaps. Revision blocks, BOMs and schedules all use
         this; :meth:`notes` is the single-column convenience over it."""
         rows = list(rows)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -9,6 +9,7 @@ import pytest
 import draftwright.layout as L
 from draftwright.layout import (
     _ANCHOR_WEIGHT,
+    FitBoxTrace,
     _assign_balloon_bands,
     _greedy_strip_1d,
     _solve_guarded_strip_1d,
@@ -372,6 +373,47 @@ class TestFitBox:
         assert fit_box((10, 200), (0, 0, 100, 100), [], "br") is None  # too tall
         # A single obstacle leaving no 60-wide gap anywhere.
         assert fit_box((60, 60), (0, 0, 100, 100), [(20, 0, 80, 100)], "br") is None
+
+    def test_named_rejection_trace_comes_from_the_exact_candidate_solve(self):
+        trace = FitBoxTrace()
+        assert (
+            fit_box(
+                (60, 60),
+                (0, 0, 100, 100),
+                [("central keep-out", (20, 0, 80, 100))],
+                "br",
+                trace=trace,
+            )
+            is None
+        )
+        assert trace.violation is None
+        assert trace.attempted_candidates == trace.rejected_candidates >= len(trace.rejected) > 0
+        assert all(rejection.blockers == ("central keep-out",) for rejection in trace.rejected)
+        # The first record is the genuinely nearest preferred candidate, not a
+        # separately reconstructed explanation of the failure.
+        assert trace.rejected[0].region == (40, 0, 100, 60)
+
+    def test_rejection_trace_samples_are_bounded_while_total_remains_exact(self):
+        trace = FitBoxTrace(max_rejections=2)
+        assert (
+            fit_box(
+                (60, 60),
+                (0, 0, 100, 100),
+                [("central keep-out", (20, 0, 80, 100))],
+                trace=trace,
+            )
+            is None
+        )
+        assert len(trace.rejected) == 2
+        assert trace.rejected_candidates == trace.attempted_candidates == 6
+
+    def test_trace_explains_a_usable_region_size_violation(self):
+        trace = FitBoxTrace()
+        assert fit_box((110, 120), (0, 0, 100, 100), [], trace=trace) is None
+        assert trace.attempted_candidates == 0
+        assert trace.violation == (
+            "width exceeds usable region by 10.0 mm; height exceeds usable region by 20.0 mm"
+        )
 
     def test_deterministic(self):
         args = ((20, 10), (0, 0, 100, 100), [(30, 30, 60, 60)], "br")

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -421,6 +421,32 @@ class TestFitBox:
         assert len(trace.rejected) == 2
         assert trace.rejected_candidates == trace.attempted_candidates == 6
 
+    def test_blocker_scan_short_circuits_after_bounded_trace_sample(self, monkeypatch):
+        # The first obstacle rejects every candidate. Once the two retained
+        # diagnostic samples are full, each remaining candidate must stop there
+        # rather than sorting every colliding name (a 30x no-fit regression).
+        obstacles = [("cover", (0, 0, 100, 100))]
+        obstacles.extend(
+            (f"edge-{index}", (index + 0.1, index + 0.2, index + 0.3, index + 0.4))
+            for index in range(30)
+        )
+        overlap_calls = 0
+        original = L._boxes_overlap
+
+        def counted(left, right):
+            nonlocal overlap_calls
+            overlap_calls += 1
+            return original(left, right)
+
+        monkeypatch.setattr(L, "_boxes_overlap", counted)
+        trace = FitBoxTrace(max_rejections=2)
+        assert fit_box((20, 20), (0, 0, 100, 100), obstacles, "tr", trace=trace) is None
+
+        preprocessing = len(obstacles)
+        sampled_scans = len(trace.rejected) * len(obstacles)
+        short_circuited_scans = trace.rejected_candidates - len(trace.rejected)
+        assert overlap_calls == preprocessing + sampled_scans + short_circuited_scans
+
     def test_trace_explains_a_usable_region_size_violation(self):
         trace = FitBoxTrace()
         assert fit_box((110, 120), (0, 0, 100, 100), [], trace=trace) is None

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -4,6 +4,8 @@ These exercise the placement primitives in isolation, with no drawing build,
 which is the point of putting them in their own module.
 """
 
+import tracemalloc
+
 import pytest
 
 import draftwright.layout as L
@@ -393,6 +395,18 @@ class TestFitBox:
         # separately reconstructed explanation of the failure.
         assert trace.rejected[0].region == (40, 0, 100, 60)
 
+    def test_trace_attributes_the_nearest_candidate_to_its_distinct_blocker(self):
+        trace = FitBoxTrace()
+        quadrants = [
+            ("bottom-left", (0, 0, 50, 50)),
+            ("bottom-right", (50, 0, 100, 50)),
+            ("top-left", (0, 50, 50, 100)),
+            ("top-right", (50, 50, 100, 100)),
+        ]
+        assert fit_box((20, 20), (0, 0, 100, 100), quadrants, "tr", trace=trace) is None
+        assert trace.rejected[0].region == (80, 80, 100, 100)
+        assert trace.rejected[0].blockers == ("top-right",)
+
     def test_rejection_trace_samples_are_bounded_while_total_remains_exact(self):
         trace = FitBoxTrace(max_rejections=2)
         assert (
@@ -414,6 +428,13 @@ class TestFitBox:
         assert trace.violation == (
             "width exceeds usable region by 10.0 mm; height exceeds usable region by 20.0 mm"
         )
+
+    def test_clearance_inflates_obstacles_and_rejects_negative_values(self):
+        obstacle = [("wall", (20, 0, 40, 100))]
+        assert fit_box((20, 20), (0, 0, 100, 100), obstacle, "bl") == (0, 0)
+        assert fit_box((20, 20), (0, 0, 100, 100), obstacle, "bl", clearance=2) == (42, 0)
+        with pytest.raises(ValueError, match="non-negative"):
+            fit_box((20, 20), (0, 0, 100, 100), obstacle, clearance=-0.1)
 
     def test_deterministic(self):
         args = ((20, 10), (0, 0, 100, 100), [(30, 30, 60, 60)], "br")
@@ -443,6 +464,23 @@ class TestFitBox:
         # not blow up like the old O(n^4) form. Just assert it returns.
         obstacles = [(i, i, i + 2, i + 2) for i in range(0, 200, 5)]
         assert fit_box((20, 20), (0, 0, 300, 300), obstacles, "tr") is not None
+
+    def test_candidate_cartesian_product_is_streamed_with_bounded_live_memory(self):
+        # 400 sparse boxes produce >640k distinct X×Y candidate pairs, but the
+        # preferred A4 corner is immediately free. Materialising those triples
+        # consumed hundreds of MiB; the separable-score heap needs O(n) state.
+        obstacles = [
+            (16 + i * 0.2, 16 + i * 0.1, 16.05 + i * 0.2, 16.05 + i * 0.1) for i in range(400)
+        ]
+        tracemalloc.start()
+        try:
+            assert fit_box((7.51, 14.03), (16, 16, 281, 194), obstacles, "tr") == pytest.approx(
+                (273.49, 179.97)
+            )
+            _current, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert peak < 5_000_000
 
 
 def test_layout_engine_is_wired_into_the_drawing_path():

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -6,9 +6,9 @@ clear of the views + title block at build, and lint-checked.
 """
 
 import pytest
-from build123d import Box, Cylinder, Pos
+from build123d import Box, Cylinder, Location, Pos, Rectangle
 
-from draftwright import Sheet
+from draftwright import Sheet, build_drawing
 
 
 def _sheet():
@@ -40,6 +40,7 @@ def test_four_row_notes_block_uses_clear_lower_left_a4_space_inside_frame():
         number="DWG-A4-NOTES",
         page="A4",
         frame=True,
+        zones=True,
     ).authored_dimensions()
     s.envelope()
     s.hole(Pos(0, 0, 0) * Cylinder(4, 12))
@@ -57,13 +58,62 @@ def test_four_row_notes_block_uses_clear_lower_left_a4_space_inside_frame():
     assert not [issue for issue in drawing.lint() if issue.code == "table_dropped"]
 
 
+def test_default_preference_falls_back_to_the_only_clear_lower_left_region():
+    # A real public, zones-enabled A4 inventory whose free notes occupy every
+    # candidate above the bottom band and the bottom-right remainder.  ``prefer``
+    # is deliberately omitted: TR is rejected and the exact solver must reach
+    # the surviving lower-left region rather than restricting itself to corners.
+    drawing = build_drawing(Box(30, 20, 8), page="A4", auto_dims=False, frame=True, zones=True)
+    for index in range(19):
+        drawing.note("M" * 180, (148.5, 47.1 + 8 * index), name=f"top_band_{index}")
+    drawing.note("M" * 121, (170, 30), name="bottom_right_band")
+
+    table = drawing.add_table(
+        [("NOTES",), ("1  BREAK ALL EDGES 0.3",), ("2  DEBURR",), ("3  M3x0.5 TAP",)],
+        name="notes",
+    )
+
+    assert table is not None
+    box = table.bounding_box()
+    assert box.min.X < 20.0 and box.min.Y < 20.0
+    assert box.max.X < 62.0 and box.max.Y < 48.0
+
+
+def test_table_keeps_external_clearance_from_existing_annotation():
+    drawing = build_drawing(Box(30, 20, 8), page="A4", auto_dims=False, frame=True)
+    drawing.note("BLOCKER TEXT", (30, 22), name="blocker")
+
+    table = drawing.add_table([("HEAD",), ("row",)], prefer="bl", name="clearance_table")
+
+    assert table is not None
+    table_box = table.bounding_box()
+    blocker_box = drawing.get_annotation("blocker").bounding_box()
+    # X spans overlap, so the separating Y gap is the load-bearing external
+    # clearance (the old strict-overlap solve placed them exactly flush).
+    assert table_box.min.X < blocker_box.max.X and blocker_box.min.X < table_box.max.X
+    assert table_box.min.Y - blocker_box.max.Y >= drawing.draft.pad_around_text - 1e-6
+
+
+def test_table_still_avoids_anonymous_drawing_add_compatibility_object():
+    drawing = build_drawing(Box(40, 30, 10), page="A4", auto_dims=False, frame=True)
+    blocker = Rectangle(60, 40).locate(Location((46, 36, 0)))
+    with pytest.warns(DeprecationWarning, match="Drawing.add"):
+        drawing.add(blocker)
+
+    table = drawing.add_table([("H",), ("x",)], prefer="bl", name="compat_table")
+
+    assert table is not None
+    tb, bb = table.bounding_box(), blocker.bounding_box()
+    assert not (
+        tb.min.X < bb.max.X and bb.min.X < tb.max.X and tb.min.Y < bb.max.Y and bb.min.Y < tb.max.Y
+    )
+
+
 def test_failed_table_diagnostic_names_size_candidate_regions_and_blockers():
     # Free-form notes are the sanctioned user-positioned text surface.  These
     # intentionally fill the A4 usable region in horizontal bands so the real
     # generic table path has candidates, rejects them, and attributes the exact
     # blocking annotations in its public lint diagnostic.
-    from draftwright import build_drawing
-
     drawing = build_drawing(Box(40, 30, 10), page="A4", auto_dims=False, frame=True)
     for index, y in enumerate(range(20, 191, 8)):
         drawing.note("M" * 180, (148.5, y), name=f"block_{index}")
@@ -76,7 +126,7 @@ def test_failed_table_diagnostic_names_size_candidate_regions_and_blockers():
     )
     assert "measured page-space footprint width=7.5 mm, height=14.0 mm" in issue.message
     assert "attempted " in issue.message and "candidate regions; rejected:" in issue.message
-    assert "blocked by annotation:block_" in issue.message
+    assert "blocked within 2.0 mm clearance by annotation:block_" in issue.message
 
 
 def test_oversized_table_diagnostic_reports_both_measured_dimensions_and_violation():

--- a/tests/test_sheet_tables.py
+++ b/tests/test_sheet_tables.py
@@ -30,6 +30,68 @@ def test_notes_block_places_lint_clean():
     ]
 
 
+def test_four_row_notes_block_uses_clear_lower_left_a4_space_inside_frame():
+    # #1145 real failure seam: the sheet-frame Compound spans the page, but it is
+    # a boundary whose inset is already represented by analysis.margin—not a
+    # solid obstacle.  Three notes + title are the reported four-row inventory.
+    s = Sheet(
+        Box(80, 50, 12) - Pos(0, 0, 0) * Cylinder(4, 12),
+        title="Plate",
+        number="DWG-A4-NOTES",
+        page="A4",
+        frame=True,
+    ).authored_dimensions()
+    s.envelope()
+    s.hole(Pos(0, 0, 0) * Cylinder(4, 12))
+    s.notes(["BREAK ALL EDGES 0.3", "DEBURR", "M3x0.5 TAP"], prefer="bl")
+
+    drawing = s.build()
+    table = drawing.get_annotation("notes0")
+
+    assert table is not None
+    assert table.table_size == pytest.approx((43.1950001, 28.0))
+    box = table.bounding_box()
+    # The frame-enabled public A4 content inset is 16 mm; pin the rendered
+    # result without reaching through Drawing's private analysis state.
+    assert (box.min.X, box.min.Y) == pytest.approx((16.0, 16.0), abs=1e-6)
+    assert not [issue for issue in drawing.lint() if issue.code == "table_dropped"]
+
+
+def test_failed_table_diagnostic_names_size_candidate_regions_and_blockers():
+    # Free-form notes are the sanctioned user-positioned text surface.  These
+    # intentionally fill the A4 usable region in horizontal bands so the real
+    # generic table path has candidates, rejects them, and attributes the exact
+    # blocking annotations in its public lint diagnostic.
+    from draftwright import build_drawing
+
+    drawing = build_drawing(Box(40, 30, 10), page="A4", auto_dims=False, frame=True)
+    for index, y in enumerate(range(20, 191, 8)):
+        drawing.note("M" * 180, (148.5, y), name=f"block_{index}")
+
+    assert drawing.add_table([("H",), ("x",)], name="blocked") is None
+    issue = next(
+        issue
+        for issue in drawing.registry.issues
+        if issue.code == "table_dropped" and "'blocked'" in issue.message
+    )
+    assert "measured page-space footprint width=7.5 mm, height=14.0 mm" in issue.message
+    assert "attempted " in issue.message and "candidate regions; rejected:" in issue.message
+    assert "blocked by annotation:block_" in issue.message
+
+
+def test_oversized_table_diagnostic_reports_both_measured_dimensions_and_violation():
+    s = _sheet()
+    s.table([("H",)] + [(str(i),) for i in range(300)], name="oversized")
+    drawing = s.build()
+    issue = next(
+        issue
+        for issue in drawing.registry.issues
+        if issue.code == "table_dropped" and "'oversized'" in issue.message
+    )
+    assert "measured page-space footprint" in issue.message
+    assert "height exceeds usable region by" in issue.message
+
+
 def test_notes_autonumbers_under_a_title():
     s = _sheet()
     s.notes(["A", "B"], title="NOTES")


### PR DESCRIPTION
## Symptom and evidence

- **User-visible problem:** a measured four-row notes table was dropped on a framed A4 sheet even though the lower-left page region was clear.
- **Fixture/reproducer:** `Sheet(..., page="A4", frame=True, zones=True).notes([...])` with a title plus three note rows.
- **Before/after result:** the sheet-frame/zone compounds previously became page-sized solid obstacles; the same measured 43.195 × 28.0 mm table now lands at the public A4 content inset `(16, 16)`, clear of views, title block, annotations, and the drafting preset's 2 mm external text clearance.
- **Mutation that makes the guard fail:** treating the frame as a solid obstacle restores `table_dropped`; removing anonymous occupancy, clearance inflation, streamed candidate ordering, or post-sample blocker short-circuiting fails the corresponding regression.
- **Rendered A4 evidence (exact final implementation):** the measured four-row NOTES block occupies the clear lower-left region while the views, frame/zones, and title block remain unobstructed.

![Draftwright A4 drawing with four-row notes table placed in the lower-left free region](https://gist.githubusercontent.com/pzfreo/09f07c3d2da9536693ddfb344b1c2e32/raw/3cc421c797348a5ab89f3ca9dd75cfaa67d78a4e/notes-lower-left-a4.svg)

## What changed

- Treat the sheet frame and zone ruler as boundaries already represented by the usable-sheet inset, rather than solid page-spanning obstacles.
- Feed measured view/annotation/title-block occupancy into the shared `fit_box` leaf with stable obstacle names and 2 mm external clearance.
- Preserve deprecated anonymous `Drawing.add(..., name=None)` occupancy until that compatibility surface is removed.
- Stream preference-ordered X×Y candidates with O(n) live state instead of materialising the Cartesian product.
- Retain an exact, bounded sample of rejected candidate regions and blockers; after the sample fills, collision checks short-circuit while exact attempt/rejection totals remain.
- Report measured width/height, violated usable-region dimensions, attempted regions, named blockers, and clearance bands in `table_dropped`.

Closes #1145.

## Contract and scope

- **Smallest contract this change tests:** measured generic tables consider every solver-valid rectangle inside the usable sheet, ranked by `prefer`, while respecting existing occupancy and external clearance; failures are inspectable.
- **Relevant ADRs:** ADR 0004 (compose then pack), ADR 0010 (annotation/provenance compatibility), ADR 0011 (declared façade convergence), ADR 0014 (collect then solve).
- **Explicitly deferred:** no arbitrary-coordinate table API, no change to feature-annotation placement, and no new recognition/compiler behavior.

## Validation

Exact final head: `ed8663b934c25522d11a443d465b70fed5478e4f`

- [x] `scripts/pr-check --quick`
- [x] `scripts/pr-check --full` — 3,615 passed, 5 skipped, 2 xfailed; 94.74% total and 97% diff coverage
- [x] Focused layout/table suite — 70 passed
- [x] Standards/table slow path — 4 passed
- [x] #1144 table-regression selection — 111 passed
- [x] 20,000 randomized old/new solver comparisons — exact match across all preferences, clearances, and named/bare obstacles
- [x] 400-obstacle A4 memory regression — under 5 MB traced live allocation; reviewer stress run ~0.55 MB across 1.87 million rejected candidates
- [x] Named mutations were observed failing before the implementation passed them
- [x] Automatic/generated table paths and the public `Sheet.notes` / `Drawing.add_table` paths were checked
- [x] Recognition/repeated-lint call counts: N/A; this is a pure sheet-furniture placement slice

## Adversarial review

- Round 1 at `269a268`: found anonymous-object invisibility, eager Cartesian memory, missing clearance, and weak fallback/diagnostic fixtures. All fixed.
- Round 2 at `9ec322d`: found post-sample blocker-name collection caused a 30× no-fit regression. Fixed with short-circuit collision checks and a mutation-sensitive operation-count canary.
- Round 3 at exact final `ed8663b`: **approved with zero substantive findings** after full ADR/API/geometry/resource/test-quality review.

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] No new prerequisite or discovery split is required
