### PR TITLE
Protect completeness for explicit drawing scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@
 
 ### Added
 
+- **Explicit drawing scales now protect required annotation completeness** (#1146).
+  `build_drawing(...)`, `make_drawing(...)`, `Sheet(...)`, and the CLI accept
+  `scale_policy="fallback"|"strict"|"permissive"`. The safe default retries preferred ISO
+  5455 reductions and returns the largest complete scale; strict mode raises with structured
+  requirement blockers, while permissive mode is an explicit warned opt-in to the historical
+  best-effort result. Every returned `Drawing.scale_decision` reports the requested and
+  effective scales, status, attempted scales, and any semantic placement blockers.
+
 - **Hole and hole-pattern requirements now participate in semantic completeness accounting**
   (#1143). `lint_summary()["quality"]["completeness"]` reconciles recognition-owned bore,
   depth/through, grouping, pattern, and location requirements to placed, suppressed, dropped,

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Choose formats, scale, and page; or emit an editable drawing script:
 ```
 draftwright my_part.step --format pdf,dxf     # also: svg, all
 draftwright my_part.step --scale 2 --page A3  # override the auto scale / page
+draftwright my_part.step --scale 1 --page A4 --scale-policy strict
 draftwright my_part.step --script             # write an editable declarative Sheet script
 ```
 
@@ -196,13 +197,18 @@ installed automatically as a dependency.
 ### Scale and page control
 
 ```python
-from draftwright import choose_scale
+from draftwright import build_drawing, choose_scale
 
 # Auto-select the best ISO/ASME standard scale for an A3 sheet
 scale, page_w, page_h, n_steps = choose_scale(80, 60, 20, page="A3")
 
-# Override
-make_drawing(part, out="drawing", scale=2.0, page="A2")
+# Override. Required annotations are protected by the default fallback policy.
+dwg = build_drawing(part, scale=1.0, page="A4")
+print(dwg.scale_decision)  # requested/effective scale, attempts, blockers
+
+# Refuse an incompatible request, or explicitly retain historical best-effort output.
+build_drawing(part, scale=1.0, page="A4", scale_policy="strict")
+build_drawing(part, scale=1.0, page="A4", scale_policy="permissive")
 ```
 
 ### Edit, critique, and self-repair

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -307,6 +307,12 @@ The explicit-scale contract is therefore amended as follows:
 4. Trial builds reuse imported, classified, recognised, and critique inventories. This keeps the
    policy search bounded and preserves the ADR's box-math performance rationale; discarded
    trials are not independent full recognition pipelines.
+5. Automatic page selection is deliberately more conservative than an explicitly forced page.
+   Required authored-table footprints are reserved before the flexible, orientation-only iso and
+   the candidate must retain the iso fitness budget. This may select a larger standard page even
+   when a caller-forced smaller page can place every requirement by fitting furniture around the
+   rendered iso. The forced-page build is complete and strict policy therefore honours it; the
+   automatic search is not a “smallest page on which lint happens to be clean” optimiser.
 
 The unconditional `_MIN_RENDER_MM` safety floor and the advisory `_MIN_VIEW_MM` warning retain
 their prior meanings. This amendment narrows only the old “honour explicit scale” statement:

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -104,17 +104,18 @@ scale↔footprint loop to iterate — `compose(scale)` fixes the legibility and
 escalation choices for that scale. The scattered estimators (`_est_*_depth`,
 table size, halo) collapse into one composer per view.
 
-**The legibility floor is advisory for an *explicit* scale (#489).** `_MIN_VIEW_MM`
-(10 mm) is purely the threshold below which an explicit scale earns a legibility
-*warning*. It does **not** bound the auto scale (`choose_scale` picks by a pure
-geometric page fit) and does **not** gate which annotations exist (step/location
-legibility use `_MIN_STEP_*`/`_MIN_LOC_SEP_MM`). A caller who sets an intentional
-1:1 (or `scale="1:10"`) has accepted the cramping, so an explicit scale below the
-floor is honoured, not vetoed — and the warning fires only when the auto scale
-would *itself* be legible, so its "omit the scale" advice is always real. The one
-hard rejection is `_MIN_RENDER_MM` (0.1 mm) — a conservative geometry floor well
-above where OCCT's annotation arcs actually degenerate (`Geom_TrimmedCurve U1==U2`,
-~1e-4 mm); there we raise a clean message rather than crash.
+**The geometry legibility floor remains advisory for an *explicit* scale (#489), but
+required annotation outcomes are not (#1146).** `_MIN_VIEW_MM` (10 mm) is purely the
+threshold below which an explicit scale earns a legibility *warning*. It does **not** bound
+the auto scale (`choose_scale` picks by a pure geometric page fit) and does **not** gate which
+annotations exist (step/location legibility use `_MIN_STEP_*`/`_MIN_LOC_SEP_MM`). Since #1146,
+the completed drawing is also checked for required placement drops: the default policy retries
+smaller preferred ISO 5455 scales, strict policy rejects the request, and only an explicit
+permissive policy returns the incomplete scale with a warning. Thus a caller may accept small
+geometry, but not silently lose manufacturing requirements. The one unconditional hard
+rejection is `_MIN_RENDER_MM` (0.1 mm) — a conservative geometry floor well above where OCCT's
+annotation arcs actually degenerate (`Geom_TrimmedCurve U1==U2`, ~1e-4 mm); there we raise a
+clean message rather than crash.
 
 ### Relationship to retired ADR 0003 and the rejected 2D solve
 

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -1,7 +1,7 @@
 # ADR 0004 — Compose-then-pack: views as blocks carrying their annotation footprint
 
-- **Status:** Accepted (2026-06-19; amended 2026-06-20, 2026-07-09 and
-  2026-07-18 — see Amendments)
+- **Status:** Accepted (2026-06-19; amended 2026-06-20, 2026-07-09,
+  2026-07-18 and 2026-08-14 — see Amendments)
 - **Date:** 2026-06-19
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -284,3 +284,30 @@ code is right, and the text is hereby reconciled rather than left to mislead:
    (`_annotations_out_of_bounds`) deliberately measure the *built* annotations'
    real bounding boxes — O(n) per bounded iteration, matching what lint tests.
    The rule constrains the fitness search, not the post-build verification.
+
+## Amendment (2026-08-14) — explicit scale cannot silently lose requirements (#1146)
+
+ADR 0004 originally said an explicit scale below the advisory geometry-legibility floor is
+honoured because the caller has accepted a cramped drawing. That remains true for geometry:
+an explicit scale may make a view small and earn a warning without being vetoed. It is not,
+however, authority to discard manufacturing requirements. A drawing that silently loses a
+required dimension, callout, GD&T frame, or authored table is incomplete rather than merely
+cramped.
+
+The explicit-scale contract is therefore amended as follows:
+
+1. A completed drawing is checked for required placement outcomes, including the measured
+   footprint of authored sheet tables. Pinning, priority, or informational diagnostic severity
+   cannot hide a displaced requirement.
+2. The default policy retries smaller preferred ISO 5455 scales and selects the largest complete
+   candidate at or below the requested scale. Strict policy rejects an incomplete requested
+   scale; permissive policy returns it only with an explicit warning.
+3. The decision remains inspectable through the drawing's structured scale-decision record,
+   including requested/effective scale, attempted candidates, and stable blocker identities.
+4. Trial builds reuse imported, classified, recognised, and critique inventories. This keeps the
+   policy search bounded and preserves the ADR's box-math performance rationale; discarded
+   trials are not independent full recognition pipelines.
+
+The unconditional `_MIN_RENDER_MM` safety floor and the advisory `_MIN_VIEW_MM` warning retain
+their prior meanings. This amendment narrows only the old “honour explicit scale” statement:
+caller-accepted geometric cramping is permitted, silent semantic incompleteness is not.

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 # on every TAB press (#313). Each name maps to the submodule that provides it.
 _LAZY = {
     "build_drawing": "draftwright.builder",
+    "ScaleIncompatibilityError": "draftwright.builder",
     "make_drawing": "draftwright.builder",
     "Drawing": "draftwright.drawing",
     "FeatureInfo": "draftwright.drawing",
@@ -40,6 +41,7 @@ _LAZY = {
     # dependency-free `_warnings` leaf for that second reason: defined in `_core` it cost ~6 s
     # to reach, and the pytest filterwarnings entry naming it paid that on every invocation.
     "SoftDeprecationWarning": "draftwright._warnings",
+    "ScaleCompletenessWarning": "draftwright._warnings",
 }
 
 
@@ -76,8 +78,8 @@ _sys.modules[__name__].__class__ = _DraftwrightModule
 
 
 if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel cost
-    from draftwright._warnings import SoftDeprecationWarning
-    from draftwright.builder import build_drawing, make_drawing
+    from draftwright._warnings import ScaleCompletenessWarning, SoftDeprecationWarning
+    from draftwright.builder import ScaleIncompatibilityError, build_drawing, make_drawing
     from draftwright.compose import choose_scale
     from draftwright.drawing import Drawing, FeatureInfo
     from draftwright.linting import lint_feature_coverage
@@ -106,6 +108,8 @@ __all__ = [
     "PmiRecord",
     "PmiSourceEntity",
     "Sheet",
+    "ScaleIncompatibilityError",
+    "ScaleCompletenessWarning",
     "build_drawing",
     "choose_scale",
     "extract_pmi",

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -997,6 +997,7 @@ class Analysis:
     layout_n_steps: int
     layout_section: bool
     layout_table_sizes: tuple[tuple[float, float], ...]
+    layout_required_tables: tuple[tuple[tuple[float, float], str], ...]
     sv_right: float
     iso_right_limit: float
     SCALE: float

--- a/src/draftwright/_warnings.py
+++ b/src/draftwright/_warnings.py
@@ -37,3 +37,11 @@ class SoftDeprecationWarning(UserWarning):
     in notebooks, several test runners, and library-internal call paths, whereas this shows
     unconditionally.
     """
+
+
+class ScaleCompletenessWarning(UserWarning):
+    """An explicit scale was changed or honored with required placement loss (#1146).
+
+    Callers can filter this policy decision independently of unrelated user warnings while
+    still inspecting the complete machine-readable record on ``Drawing.scale_decision``.
+    """

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -443,6 +443,7 @@ def _validate_explicit_scale(
     strips_i,
     layout_section,
     layout_table_sizes,
+    layout_required_tables=(),
     margin=_MARGIN,
     warn_advisory: bool = True,
 ) -> None:
@@ -479,6 +480,7 @@ def _validate_explicit_scale(
         strips=strips_i,
         section=layout_section,
         table_sizes=layout_table_sizes,
+        required_tables=layout_required_tables,
         margin=margin,
     )
     # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
@@ -517,6 +519,7 @@ def _analyse(
     projection: str | None = None,
     zones: bool = False,
     _reuse: Analysis | None = None,
+    _required_tables=(),
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -719,6 +722,7 @@ def _analyse(
     layout_table_sizes = _est_hole_table_sizes(
         sizing_model, bb, font_size=_FONT_SIZE, pad_around_text=_pad_around_text
     )
+    layout_required_tables = tuple(_required_tables)
 
     # Choose scale/page, iterating so the reserved step corridor matches the
     # number of steps the legibility gate will actually place (#1) — not the raw
@@ -747,6 +751,7 @@ def _analyse(
             strips=strips_i,
             section=layout_section,
             table_sizes=layout_table_sizes,
+            required_tables=layout_required_tables,
             margin=margin,
         )
 
@@ -767,6 +772,7 @@ def _analyse(
         strips_i,
         layout_section,
         layout_table_sizes,
+        layout_required_tables,
         margin=margin,
         warn_advisory=_reuse is None,
     )
@@ -797,6 +803,7 @@ def _analyse(
         n_steps,
         section=layout_section,
         table_sizes=layout_table_sizes,
+        required_tables=layout_required_tables,
         margin=margin,
     )
     fv_hw = _g.fv_hw
@@ -874,6 +881,7 @@ def _analyse(
         layout_n_steps=n_steps,
         layout_section=layout_section,
         layout_table_sizes=layout_table_sizes,
+        layout_required_tables=layout_required_tables,
         sv_right=sv_right,
         iso_right_limit=iso_right_limit,
         SCALE=SCALE,

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -15,6 +15,7 @@ import math
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, replace
+from typing import cast
 
 from build123d import Compound, Shape
 from build123d_drafting.helpers import draft_preset
@@ -443,6 +444,7 @@ def _validate_explicit_scale(
     layout_section,
     layout_table_sizes,
     margin=_MARGIN,
+    warn_advisory: bool = True,
 ) -> None:
     """Enforce the two scale floors when the caller pinned an explicit *scale* (#489, #590 split
     of :func:`_analyse`). An explicit scale is the user's call — honour it, subject to:
@@ -465,6 +467,8 @@ def _validate_explicit_scale(
             f"below {_MIN_RENDER_MM:g} mm (OCCT arc construction fails). "
             f"Use scale ≥ {safe:.3g} or omit the scale for automatic selection."
         )
+    if not warn_advisory:
+        return
     auto_scale, _, _, _ = choose_scale(
         x_size,
         y_size,
@@ -512,6 +516,7 @@ def _analyse(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
+    _reuse: Analysis | None = None,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -523,48 +528,68 @@ def _analyse(
     # placement both reserve room for the border. Computed up front so the choose_scale inside
     # step-count convergence sees it too.
     margin = _content_margin(frame)
-    if isinstance(step_file, Shape):
-        part = step_file
-        src = "build123d object"
+    if _reuse is not None:
+        # Explicit-scale fallback changes only page-space layout. Reuse the immutable geometry,
+        # STEP/PMI census, classification, and recognition waist from the requested trial rather
+        # than importing and recognising the same part up to fifteen more times (#1146).
+        part = _reuse.part
+        src = str(_reuse.step_file)
+        pmi_defaulted = _reuse.pmi_defaulted
+        pmi_mode = _reuse.pmi_mode
+        pmi_report = _reuse.pmi_report
+        pmi_records = list(getattr(pmi_report, "records", ())) if pmi_mode != "off" else []
+        bb = _reuse.bb
+        x_size, y_size, z_size = _reuse.x_size, _reuse.y_size, _reuse.z_size
+        cx, cy, cz = _reuse.cx, _reuse.cy, _reuse.cz
+        bbox_max = _reuse.bbox_max
+        z_cyls, cross_cyls = (list(items) for items in _reuse.cyls)
+        z_diams, cross_diams = _reuse.z_diams, _reuse.cross_diams
+        od_diam = _reuse.od_diam
+        od_axis = _reuse.od_axis
+        is_rotational = _reuse.is_rotational
     else:
-        part = _import_step(step_file)
-        src = str(step_file)
-    part = _solids_body(part, src)
+        if isinstance(step_file, Shape):
+            part = step_file
+            src = "build123d object"
+        else:
+            part = _import_step(step_file)
+            src = str(step_file)
+        part = _solids_body(part, src)
 
-    pmi_defaulted = pmi is None
-    pmi_mode = "off" if pmi_defaulted else pmi
+        pmi_defaulted = pmi is None
+        pmi_mode = "off" if pmi_defaulted else pmi
 
-    # Semantic PMI census (AP242 only; separate read-only pass). Even off mode inventories a
-    # STEP source so it can say authored PMI was ignored; it deliberately does not feed those
-    # records into the IR. In-memory Shapes have no AP242 document to inspect.
-    pmi_report = None
-    pmi_records: list = []
-    if not isinstance(step_file, Shape):
-        from draftwright.pmi import PmiExtractionReport, extract_pmi_report
+        # Semantic PMI census (AP242 only; separate read-only pass). Even off mode inventories a
+        # STEP source so it can say authored PMI was ignored; it deliberately does not feed those
+        # records into the IR. In-memory Shapes have no AP242 document to inspect.
+        pmi_report = None
+        pmi_records = []
+        if not isinstance(step_file, Shape):
+            from draftwright.pmi import PmiExtractionReport, extract_pmi_report
 
-        try:
-            pmi_report = extract_pmi_report(step_file)
-            if pmi_mode != "off":
-                pmi_records = list(pmi_report.records)
-        except Exception as exc:
-            _log.warning("PMI extraction failed: %s", exc)
-            pmi_report = PmiExtractionReport(error=f"{type(exc).__name__}: {exc}")
+            try:
+                pmi_report = extract_pmi_report(step_file)
+                if pmi_mode != "off":
+                    pmi_records = list(pmi_report.records)
+            except Exception as exc:
+                _log.warning("PMI extraction failed: %s", exc)
+                pmi_report = PmiExtractionReport(error=f"{type(exc).__name__}: {exc}")
 
-    bb = part.bounding_box()
-    x_size = bb.max.X - bb.min.X
-    y_size = bb.max.Y - bb.min.Y
-    z_size = bb.max.Z - bb.min.Z
-    cx = (bb.min.X + bb.max.X) / 2
-    cy = (bb.min.Y + bb.max.Y) / 2
-    cz = (bb.min.Z + bb.max.Z) / 2
-    bbox_max = max(x_size, y_size, z_size)
+        bb = part.bounding_box()
+        x_size = bb.max.X - bb.min.X
+        y_size = bb.max.Y - bb.min.Y
+        z_size = bb.max.Z - bb.min.Z
+        cx = (bb.min.X + bb.max.X) / 2
+        cy = (bb.min.Y + bb.max.Y) / 2
+        cz = (bb.min.Z + bb.max.Z) / 2
+        bbox_max = max(x_size, y_size, z_size)
 
-    _log.info("Loaded %s  bbox: %.2f × %.2f × %.2f mm", src, x_size, y_size, z_size)
+        _log.info("Loaded %s  bbox: %.2f × %.2f × %.2f mm", src, x_size, y_size, z_size)
 
-    _gc = _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz)
-    z_cyls, cross_cyls = _gc.z_cyls, _gc.cross_cyls
-    z_diams, cross_diams = _gc.z_diams, _gc.cross_diams
-    od_diam, od_axis, is_rotational = _gc.od_diam, _gc.od_axis, _gc.is_rotational
+        _gc = _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz)
+        z_cyls, cross_cyls = _gc.z_cyls, _gc.cross_cyls
+        z_diams, cross_diams = _gc.z_diams, _gc.cross_diams
+        od_diam, od_axis, is_rotational = _gc.od_diam, _gc.od_axis, _gc.is_rotational
 
     # Step Z-levels feed both the step-height ladder and the page-sizing step
     # count. For a vertical (Z-axis) turned part, take them from the unified
@@ -581,7 +606,11 @@ def _analyse(
     recognition: RecognitionResult | None
     _turned: TurnedProfile | None
     step_zs: list[float]
-    if layout_model is not None:
+    if _reuse is not None:
+        recognition = _reuse.recognition if layout_model is None else None
+        _turned = _reuse.prof
+        step_zs = list(_reuse.step_zs)
+    elif layout_model is not None:
         # Sizing must source `prof` and `step_zs` from the DECLARATION here. Taking them from
         # a recognition that has been gated away would silently change page/scale selection,
         # and leaving `prof=None` would silently disable axial critique for a declared turned
@@ -649,6 +678,8 @@ def _analyse(
     sizing_model = (
         layout_model
         if layout_model is not None
+        else cast(PartModel, _reuse.model)
+        if _reuse is not None and _reuse.model is not None
         else build_part_model(
             part,
             holes=holes,
@@ -737,6 +768,7 @@ def _analyse(
         layout_section,
         layout_table_sizes,
         margin=margin,
+        warn_advisory=_reuse is None,
     )
     DIM_PAD = _DIM_PAD
     # margin was computed up front (_content_margin(frame)) so scale selection already saw it.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -299,6 +299,7 @@ def _assemble(
     authored=None,
     trace=None,
     shape=None,
+    critique_recognition=None,
 ) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
@@ -425,7 +426,7 @@ def _assemble(
     # ADR 0005 §2 (#639): the ONE build-context attachment — analysis + finished model
     # in a single typed BuildState; the compat properties on Drawing read through it.
     dwg._build.analysis = a
-    dwg._build.recognition = a.recognition
+    dwg._build.recognition = a.recognition if a.recognition is not None else critique_recognition
     dwg._build.part_model = pm
     # Persist the caller's detail-view setting: on the auto_dims=False path the flag
     # reaches no pass here, but the finalize drain gates the prismatic detail
@@ -557,6 +558,7 @@ def _repack(
     requested=None,
     authored=None,
     trace=None,
+    critique_recognition=None,
 ):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
     when a view collides across views, pack the blocks disjoint — escalating the
@@ -589,6 +591,7 @@ def _repack(
             blocks=blocks,
             section=a.layout_section,
             table_sizes=a.layout_table_sizes,
+            required_tables=a.layout_required_tables,
             warn_no_iso=False,
             margin=a.margin,
         )
@@ -697,6 +700,7 @@ def _repack(
         requested=requested,
         authored=authored,
         trace=trace,
+        critique_recognition=critique_recognition,
     )
     return a2, dwg2
 
@@ -714,6 +718,7 @@ def _repack_to_fixed_point(
     requested=None,
     authored=None,
     trace=None,
+    critique_recognition=None,
 ):
     """Iterate measure→repack→assemble until stable or bounded (#302)."""
     cur_a, cur_dwg = a, dwg
@@ -731,6 +736,7 @@ def _repack_to_fixed_point(
             requested=requested,
             authored=authored,
             trace=trace,
+            critique_recognition=critique_recognition,
         )
         if repacked is None:
             if _needs_repack(cur_dwg, cur_a):
@@ -798,6 +804,8 @@ def _build_drawing_once(
     zones: bool = False,
     _analysis_base=None,
     _analysis_sink: Callable[[Analysis], None] | None = None,
+    _critique_recognition=None,
+    _required_tables=(),
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -898,6 +906,7 @@ def _build_drawing_once(
         projection=projection,
         zones=zones,
         _reuse=_analysis_base,
+        _required_tables=_required_tables,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real
@@ -915,6 +924,7 @@ def _build_drawing_once(
         requested=requested,
         authored=authored,
         trace=tracer,
+        critique_recognition=_critique_recognition,
     )
     if auto_dims:
         repacked = _repack_to_fixed_point(
@@ -930,6 +940,7 @@ def _build_drawing_once(
             requested=requested,
             authored=authored,
             trace=tracer,
+            critique_recognition=_critique_recognition,
         )
         if repacked is not None:
             a, dwg = repacked
@@ -1096,6 +1107,7 @@ def build_drawing(
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     _post_build: Callable[[Drawing], Drawing] | None = None,
+    _required_tables=(),
 ) -> Drawing:
     """Build a drawing, protecting required annotations under an explicit scale.
 
@@ -1138,8 +1150,10 @@ def build_drawing(
         frame=frame,
         projection=projection,
         zones=zones,
+        _required_tables=_required_tables,
     )
     analysis_base = None
+    critique_recognition = None
 
     def _build(candidate_scale: float | None) -> Drawing:
         nonlocal analysis_base
@@ -1153,8 +1167,16 @@ def build_drawing(
             scale=candidate_scale,
             _analysis_base=analysis_base,
             _analysis_sink=retain_analysis,
+            _critique_recognition=critique_recognition,
         )
         return _post_build(built) if _post_build is not None else built
+
+    def scale_blockers_for(built: Drawing) -> tuple[dict, ...]:
+        nonlocal critique_recognition
+        found = _scale_blockers(built)
+        if critique_recognition is None:
+            critique_recognition = built.recognition()
+        return found
 
     if scale is None:
         if scale_policy != "fallback":
@@ -1171,7 +1193,7 @@ def build_drawing(
     requested_scale = float(scale)
 
     drawing = _build(requested_scale)
-    blockers = _scale_blockers(drawing)
+    blockers = scale_blockers_for(drawing)
     if not blockers:
         drawing.scale_decision = _scale_decision(
             policy=scale_policy,
@@ -1245,7 +1267,7 @@ def build_drawing(
                 attempts.append(_scale_attempt(candidate, "render_floor", error=str(exc)))
                 break
             raise
-        candidate_blockers = _scale_blockers(fallback)
+        candidate_blockers = scale_blockers_for(fallback)
         if candidate_blockers:
             attempts.append(_scale_attempt(candidate, "incomplete", candidate_blockers))
             last_effective_scale = fallback.scale

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import os
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import replace
 from functools import partial
 from pathlib import Path
@@ -42,7 +42,7 @@ from draftwright._core import (
     _tb_width,
 )
 from draftwright._warnings import ScaleCompletenessWarning
-from draftwright.analysis import _analyse
+from draftwright.analysis import Analysis, _analyse
 from draftwright.annotations._common import SolveTrace
 from draftwright.annotations.gears import render_gear_tables
 from draftwright.annotations.orchestrator import (
@@ -796,6 +796,8 @@ def _build_drawing_once(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
+    _analysis_base=None,
+    _analysis_sink: Callable[[Analysis], None] | None = None,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -895,6 +897,7 @@ def _build_drawing_once(
         frame=frame,
         projection=projection,
         zones=zones,
+        _reuse=_analysis_base,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real
@@ -938,6 +941,8 @@ def _build_drawing_once(
         dwg.repair()
     if tracer is not None:  # one JSON per build; Drawing.finalize() re-writes it (#736)
         tracer.write()
+    if _analysis_sink is not None:
+        _analysis_sink(a)
     return dwg
 
 
@@ -1029,6 +1034,7 @@ def _scale_decision(
     status: str,
     blockers=(),
     attempted=(),
+    attempts=(),
 ) -> dict:
     return {
         "policy": policy,
@@ -1037,7 +1043,29 @@ def _scale_decision(
         "status": status,
         "blockers": tuple(blockers),
         "attempted_scales": tuple(attempted),
+        "attempts": tuple(attempts),
     }
+
+
+def _scale_attempt(scale: float, status: str, blockers=(), *, error: str | None = None) -> dict:
+    """One plain-data trial in an explicit-scale decision."""
+    attempt = {"scale": scale, "status": status, "blockers": tuple(blockers)}
+    if error is not None:
+        attempt["error"] = error
+    return attempt
+
+
+def _blocks_all_smaller_scales(blockers) -> bool:
+    """True when a blocker is mathematically monotone under scale reduction.
+
+    A step separation already below the fixed paper-space legibility threshold only shrinks
+    further at every smaller scale. Rebuilding the whole ISO ladder cannot remove it; stopping
+    here is both exact and keeps an impossible fallback bounded (#1146).
+    """
+    return any(
+        item["code"] == "step_dim_dropped" and "too closely spaced" in item["message"]
+        for item in blockers
+    )
 
 
 def build_drawing(
@@ -1067,6 +1095,7 @@ def build_drawing(
     projection: str | None = None,
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
+    _post_build: Callable[[Drawing], Drawing] | None = None,
 ) -> Drawing:
     """Build a drawing, protecting required annotations under an explicit scale.
 
@@ -1110,10 +1139,27 @@ def build_drawing(
         projection=projection,
         zones=zones,
     )
+    analysis_base = None
+
+    def _build(candidate_scale: float | None) -> Drawing:
+        nonlocal analysis_base
+
+        def retain_analysis(value: Analysis) -> None:
+            nonlocal analysis_base
+            if analysis_base is None:
+                analysis_base = value
+
+        built = one_pass(
+            scale=candidate_scale,
+            _analysis_base=analysis_base,
+            _analysis_sink=retain_analysis,
+        )
+        return _post_build(built) if _post_build is not None else built
+
     if scale is None:
         if scale_policy != "fallback":
             raise ValueError("scale_policy applies only when an explicit scale is supplied")
-        drawing = one_pass(scale=None)
+        drawing = _build(None)
         drawing.scale_decision = _scale_decision(
             policy="automatic",
             requested=None,
@@ -1124,9 +1170,6 @@ def build_drawing(
 
     requested_scale = float(scale)
 
-    def _build(candidate_scale: float) -> Drawing:
-        return one_pass(scale=candidate_scale)
-
     drawing = _build(requested_scale)
     blockers = _scale_blockers(drawing)
     if not blockers:
@@ -1136,6 +1179,7 @@ def build_drawing(
             effective=drawing.scale,
             status="honored",
             attempted=(requested_scale,),
+            attempts=(_scale_attempt(requested_scale, "complete"),),
         )
         return drawing
 
@@ -1147,6 +1191,7 @@ def build_drawing(
             status="degraded",
             blockers=blockers,
             attempted=(requested_scale,),
+            attempts=(_scale_attempt(requested_scale, "incomplete", blockers),),
         )
         codes = ", ".join(sorted({item["code"] for item in blockers}))
         warnings.warn(
@@ -1166,10 +1211,26 @@ def build_drawing(
                 status="rejected",
                 blockers=blockers,
                 attempted=(requested_scale,),
+                attempts=(_scale_attempt(requested_scale, "incomplete", blockers),),
             )
         )
 
     attempted = [requested_scale]
+    attempts = [_scale_attempt(requested_scale, "incomplete", blockers)]
+    last_effective_scale = drawing.scale
+    last_blockers = blockers
+    if _blocks_all_smaller_scales(blockers):
+        raise ScaleIncompatibilityError(
+            _scale_decision(
+                policy=scale_policy,
+                requested=requested_scale,
+                effective=drawing.scale,
+                status="no_complete_scale",
+                blockers=blockers,
+                attempted=attempted,
+                attempts=attempts,
+            )
+        )
     # ``_SCALES`` is descending and contains the preferred ISO 5455 reductions. The
     # requested non-standard scale is evaluated first above; fallback candidates must be
     # standard and no greater than it.
@@ -1181,11 +1242,16 @@ def build_drawing(
             # Once a smaller scale hits the hard rendering floor, every following candidate
             # is smaller still. Do not hide any unrelated build error.
             if "drawing geometry degenerates" in str(exc):
+                attempts.append(_scale_attempt(candidate, "render_floor", error=str(exc)))
                 break
             raise
         candidate_blockers = _scale_blockers(fallback)
         if candidate_blockers:
+            attempts.append(_scale_attempt(candidate, "incomplete", candidate_blockers))
+            last_effective_scale = fallback.scale
+            last_blockers = candidate_blockers
             continue
+        attempts.append(_scale_attempt(candidate, "complete"))
         fallback.scale_decision = _scale_decision(
             policy=scale_policy,
             requested=requested_scale,
@@ -1193,6 +1259,7 @@ def build_drawing(
             status="fallback",
             blockers=blockers,
             attempted=attempted,
+            attempts=attempts,
         )
         warnings.warn(
             f"requested scale {requested_scale:g} dropped required annotation outcomes; "
@@ -1206,10 +1273,11 @@ def build_drawing(
         _scale_decision(
             policy=scale_policy,
             requested=requested_scale,
-            effective=drawing.scale,
+            effective=last_effective_scale,
             status="no_complete_scale",
-            blockers=blockers,
+            blockers=last_blockers,
             attempted=attempted,
+            attempts=attempts,
         )
     )
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -11,8 +11,10 @@ stage modules -- never make_drawing -- so the graph stays a DAG.
 from __future__ import annotations
 
 import os
+import warnings
 from collections.abc import Sequence
 from dataclasses import replace
+from functools import partial
 from pathlib import Path
 from typing import Literal, cast
 
@@ -39,6 +41,7 @@ from draftwright._core import (
     _Projector,
     _tb_width,
 )
+from draftwright._warnings import ScaleCompletenessWarning
 from draftwright.analysis import _analyse
 from draftwright.annotations._common import SolveTrace
 from draftwright.annotations.gears import render_gear_tables
@@ -54,7 +57,7 @@ from draftwright.compose import (
     _layout_geometry,
     _view_geom,
 )
-from draftwright.drawing import Drawing
+from draftwright.drawing import Drawing, feature_key
 from draftwright.fonts import PLEX_MONO
 from draftwright.model import (
     Datum,
@@ -767,7 +770,7 @@ def _resolve_trace(trace, out) -> SolveTrace | None:
     return SolveTrace(path)
 
 
-def build_drawing(
+def _build_drawing_once(
     step_file: str | Path | Shape,
     out: str | None = None,
     title: str | None = None,
@@ -938,6 +941,293 @@ def build_drawing(
     return dwg
 
 
+class ScaleIncompatibilityError(ValueError):
+    """An explicit scale could not preserve required annotation outcomes.
+
+    ``decision`` is the same JSON-friendly record exposed on a successfully returned
+    :class:`Drawing` as :attr:`Drawing.scale_decision`.
+    """
+
+    def __init__(self, decision: dict):
+        self.decision = decision
+        codes = ", ".join(sorted({item["code"] for item in decision["blockers"]}))
+        attempted = decision.get("attempted_scales", ())
+        suffix = f"; tried {list(attempted)}" if attempted else ""
+        super().__init__(
+            f"requested scale {decision['requested_scale']:g} cannot preserve required "
+            f"annotations ({codes or 'no complete standard fallback'}){suffix}"
+        )
+
+
+def _scale_requirement(mid) -> dict:
+    """Plain-data identity for one compiler measurement in a scale decision."""
+    return {
+        "feature": feature_key(getattr(mid, "feature", None)),
+        "parameter": str(getattr(mid, "parameter", "")),
+    }
+
+
+def _hole_scale_requirement(requirement) -> dict:
+    """Plain-data identity for one recognition-owned hole requirement."""
+    feature, parameter = requirement
+    return {"feature": feature_key(feature), "parameter": str(parameter)}
+
+
+def _is_required_scale_drop(issue) -> bool:
+    """Whether *issue* is an unresolved required placement outcome.
+
+    Transactional table/balloon attempts may fail while restoring the original complete
+    representation; their unowned diagnostics are not evidence that a manufacturing
+    requirement was lost.  Semantic measurement/source provenance, an explicit placement
+    stage, and all other established ``*_dropped`` codes fail closed.
+    """
+    stage = getattr(issue, "outcome_stage", None)
+    if stage == "validation":
+        return False
+    if stage == "placement" or issue.code == "placement_unsatisfiable":
+        return True
+    if not issue.code.endswith("_dropped"):
+        return False
+    if issue.code in {"table_dropped", "balloon_dropped"}:
+        return bool(
+            getattr(issue, "measurement_ids", ())
+            or getattr(issue, "hole_requirement_ids", ())
+            or getattr(issue, "source_ids", ())
+        )
+    return True
+
+
+def _scale_blockers(drawing: Drawing) -> tuple[dict, ...]:
+    """Required placement failures on a finished drawing, as stable plain data."""
+    blockers = []
+    for issue in drawing.lint():
+        if not _is_required_scale_drop(issue):
+            continue
+        blockers.append(
+            {
+                "severity": issue.severity,
+                "code": issue.code,
+                "message": issue.message,
+                "measurements": tuple(
+                    _scale_requirement(mid) for mid in getattr(issue, "measurement_ids", ())
+                ),
+                "hole_requirements": tuple(
+                    _hole_scale_requirement(req)
+                    for req in getattr(issue, "hole_requirement_ids", ())
+                ),
+                "source_ids": tuple(getattr(issue, "source_ids", ())),
+            }
+        )
+    return tuple(blockers)
+
+
+def _scale_decision(
+    *,
+    policy: str,
+    requested: float | None,
+    effective: float,
+    status: str,
+    blockers=(),
+    attempted=(),
+) -> dict:
+    return {
+        "policy": policy,
+        "requested_scale": requested,
+        "effective_scale": effective,
+        "status": status,
+        "blockers": tuple(blockers),
+        "attempted_scales": tuple(attempted),
+    }
+
+
+def build_drawing(
+    step_file: str | Path | Shape,
+    out: str | None = None,
+    title: str | None = None,
+    number: str = "DWG-001",
+    tolerance: str = "ISO 2768-m",
+    drawn_by: str = "",
+    scale: float | None = None,
+    page: str | tuple | None = None,
+    auto_dims: bool = True,
+    detail_view: bool = True,
+    pmi: Literal["off", "report", "annotate"] | None = None,
+    repair: bool = True,
+    assembly: bool | None = None,
+    model: Sequence[Feature] | PartModel | None = None,
+    decorations: dict | None = None,
+    requested: tuple | None = None,
+    authored: tuple | None = None,
+    trace: str | Path | bool | None = None,
+    material: str = "",
+    date: str = "",
+    revision: str = "A",
+    company: str = "",
+    frame: bool = False,
+    projection: str | None = None,
+    zones: bool = False,
+    scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
+) -> Drawing:
+    """Build a drawing, protecting required annotations under an explicit scale.
+
+    ``scale_policy`` applies only when ``scale`` is supplied. ``"fallback"`` (the safe
+    default) retries smaller preferred ISO 5455 scales and returns the largest one with no
+    required placement drop. ``"strict"`` raises :class:`ScaleIncompatibilityError` instead.
+    ``"permissive"`` explicitly opts into the historical best-effort result and warns when
+    it is degraded. Every returned drawing exposes the JSON-friendly decision through
+    :attr:`Drawing.scale_decision`; :attr:`Drawing.scale` is the effective scale.
+
+    Other arguments and return semantics are unchanged from the one-pass builder.
+    """
+    if scale_policy not in {"strict", "fallback", "permissive"}:
+        raise ValueError(
+            f"scale_policy must be 'strict', 'fallback', or 'permissive', got {scale_policy!r}"
+        )
+    one_pass = partial(
+        _build_drawing_once,
+        step_file,
+        out=out,
+        title=title,
+        number=number,
+        tolerance=tolerance,
+        drawn_by=drawn_by,
+        page=page,
+        auto_dims=auto_dims,
+        detail_view=detail_view,
+        pmi=pmi,
+        repair=repair,
+        assembly=assembly,
+        model=model,
+        decorations=decorations,
+        requested=requested,
+        authored=authored,
+        trace=trace,
+        material=material,
+        date=date,
+        revision=revision,
+        company=company,
+        frame=frame,
+        projection=projection,
+        zones=zones,
+    )
+    if scale is None:
+        if scale_policy != "fallback":
+            raise ValueError("scale_policy applies only when an explicit scale is supplied")
+        drawing = one_pass(scale=None)
+        drawing.scale_decision = _scale_decision(
+            policy="automatic",
+            requested=None,
+            effective=drawing.scale,
+            status="automatic",
+        )
+        return drawing
+
+    requested_scale = float(scale)
+
+    def _build(candidate_scale: float) -> Drawing:
+        return one_pass(scale=candidate_scale)
+
+    drawing = _build(requested_scale)
+    blockers = _scale_blockers(drawing)
+    if not blockers:
+        drawing.scale_decision = _scale_decision(
+            policy=scale_policy,
+            requested=requested_scale,
+            effective=drawing.scale,
+            status="honored",
+            attempted=(requested_scale,),
+        )
+        return drawing
+
+    if scale_policy == "permissive":
+        drawing.scale_decision = _scale_decision(
+            policy=scale_policy,
+            requested=requested_scale,
+            effective=drawing.scale,
+            status="degraded",
+            blockers=blockers,
+            attempted=(requested_scale,),
+        )
+        codes = ", ".join(sorted({item["code"] for item in blockers}))
+        warnings.warn(
+            f"requested scale {requested_scale:g} dropped required annotation outcomes "
+            f"({codes}); returning the incomplete drawing because scale_policy='permissive'",
+            ScaleCompletenessWarning,
+            stacklevel=2,
+        )
+        return drawing
+
+    if scale_policy == "strict":
+        raise ScaleIncompatibilityError(
+            _scale_decision(
+                policy=scale_policy,
+                requested=requested_scale,
+                effective=drawing.scale,
+                status="rejected",
+                blockers=blockers,
+                attempted=(requested_scale,),
+            )
+        )
+
+    attempted = [requested_scale]
+    # ``_SCALES`` is descending and contains the preferred ISO 5455 reductions. The
+    # requested non-standard scale is evaluated first above; fallback candidates must be
+    # standard and no greater than it.
+    for candidate in (item for item in _SCALES if item < requested_scale):
+        attempted.append(candidate)
+        try:
+            fallback = _build(candidate)
+        except ValueError as exc:
+            # Once a smaller scale hits the hard rendering floor, every following candidate
+            # is smaller still. Do not hide any unrelated build error.
+            if "drawing geometry degenerates" in str(exc):
+                break
+            raise
+        candidate_blockers = _scale_blockers(fallback)
+        if candidate_blockers:
+            continue
+        fallback.scale_decision = _scale_decision(
+            policy=scale_policy,
+            requested=requested_scale,
+            effective=fallback.scale,
+            status="fallback",
+            blockers=blockers,
+            attempted=attempted,
+        )
+        warnings.warn(
+            f"requested scale {requested_scale:g} dropped required annotation outcomes; "
+            f"using complete fallback scale {fallback.scale:g}",
+            ScaleCompletenessWarning,
+            stacklevel=2,
+        )
+        return fallback
+
+    raise ScaleIncompatibilityError(
+        _scale_decision(
+            policy=scale_policy,
+            requested=requested_scale,
+            effective=drawing.scale,
+            status="no_complete_scale",
+            blockers=blockers,
+            attempted=attempted,
+        )
+    )
+
+
+# Preserve the established detailed public reference (model/trace/PMI/editing semantics) while
+# adding the new policy argument. The one-pass helper owns that long contract because it is the
+# pipeline implementation; mkdocstrings and ``help(build_drawing)`` see the augmented text here.
+build_drawing.__doc__ = (_build_drawing_once.__doc__ or "").replace(
+    "    Args:\n",
+    "    Args:\n"
+    "        scale_policy: required-annotation policy for an explicit scale. ``'fallback'`` "
+    "retries smaller preferred ISO 5455 scales; ``'strict'`` raises "
+    ":class:`ScaleIncompatibilityError`; ``'permissive'`` explicitly returns a warned "
+    "degraded result. Returned drawings expose ``scale_decision``.\n",
+    1,
+)
+
+
 # ---------------------------------------------------------------------------
 # Direct export (SVG + DXF)
 # ---------------------------------------------------------------------------
@@ -963,6 +1253,7 @@ def make_drawing(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
+    scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -977,6 +1268,9 @@ def make_drawing(
         drawn_by: Designer name for the title block.
         scale: Drawing-scale override (e.g. ``5`` for 5:1, ``0.5`` for 1:2).
             Default: chosen automatically by :func:`choose_scale`.
+        scale_policy: required-annotation policy for an explicit ``scale``. ``"fallback"``
+            retries smaller preferred scales, ``"strict"`` raises when the request loses a
+            required outcome, and ``"permissive"`` explicitly returns the degraded result.
         page: Page-size override — an ISO name (``"A3"``), ``"WIDTHxHEIGHT"``
             in mm, or a ``(width, height)`` tuple. Default: chosen
             automatically by :func:`choose_scale`.
@@ -1020,6 +1314,7 @@ def make_drawing(
         frame=frame,
         projection=projection,
         zones=zones,
+        scale_policy=scale_policy,
     ).export(formats=("svg", "dxf"))
     assert isinstance(_paths, dict)  # formats=... always returns the {format: path} dict
     return _paths["svg"], _paths["dxf"]

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -39,6 +39,14 @@ class PmiMode(str, Enum):
     annotate = "annotate"
 
 
+class ScalePolicy(str, Enum):
+    """Required-annotation policy for an explicit drawing scale (#1146)."""
+
+    strict = "strict"
+    fallback = "fallback"
+    permissive = "permissive"
+
+
 def _parse_formats(value: str) -> list[str]:
     """Parse a ``--format`` value (comma-list, with an ``all`` alias) into an
     ordered, de-duplicated list of formats. Raises on an unknown token."""
@@ -118,6 +126,11 @@ def main(
     scale: float | None = typer.Option(
         None, help="Drawing-scale override, e.g. 5 for 5:1 or 0.5 for 1:2 (default: auto)"
     ),
+    scale_policy: ScalePolicy = typer.Option(
+        ScalePolicy.fallback,
+        "--scale-policy",
+        help="Explicit-scale completeness policy: strict, fallback, or permissive",
+    ),
     page: str | None = typer.Option(
         None, help="Page-size override: A4..A0 or WIDTHxHEIGHT in mm, e.g. 420x297 (default: auto)"
     ),
@@ -189,6 +202,7 @@ def main(
                 tolerance=tolerance,
                 drawn_by=drawn_by,
                 scale=scale,
+                scale_policy=scale_policy.value,
                 page=page,
                 material=material,
                 date=date,
@@ -210,6 +224,7 @@ def main(
                 tolerance=tolerance,
                 drawn_by=drawn_by,
                 scale=scale,
+                scale_policy=scale_policy.value,
                 page=page,
                 material=material,
                 date=date,
@@ -232,6 +247,7 @@ def main(
         tolerance=tolerance,
         drawn_by=drawn_by,
         scale=scale,
+        scale_policy=scale_policy.value,
         page=page,
         pmi=pmi.value if pmi is not None else None,
         material=material,

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -179,6 +179,10 @@ def main(
     if script and style != "sheet":
         # validate before the ~5 s engine import so a typo fails fast
         raise typer.BadParameter("--style must be 'sheet'", param_hint="--style")
+    if scale is None and scale_policy is not ScalePolicy.fallback:
+        raise typer.BadParameter(
+            "--scale-policy requires an explicit --scale", param_hint="--scale-policy"
+        )
 
     # Import the engine lazily, only on the build path: it pulls in build123d/OCP
     # (~5 s of CAD-kernel import). Keeping it out of module scope means shell

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -445,6 +445,7 @@ def _fits(
     pack_iso_2d: bool = False,
     section: bool = False,
     table_sizes=(),
+    required_tables=(),
     margin: float = _MARGIN,
 ) -> bool:
     """True if the composed 4-view footprint fits the page at this scale.
@@ -466,6 +467,7 @@ def _fits(
         n_steps,
         section=section,
         table_sizes=table_sizes,
+        required_tables=required_tables,
         warn_no_iso=False,
         margin=margin,
     )
@@ -484,6 +486,7 @@ def _bisect_fit_scale(
     pack_iso_2d,
     section=False,
     table_sizes=(),
+    required_tables=(),
     margin=_MARGIN,
 ):
     """Largest scale at which the 4-view layout fits ``(pw, ph)``, found by bisection —
@@ -508,6 +511,7 @@ def _bisect_fit_scale(
             pack_iso_2d=pack_iso_2d,
             section=section,
             table_sizes=table_sizes,
+            required_tables=required_tables,
             margin=margin,
         ):
             lo = mid
@@ -526,6 +530,7 @@ def choose_scale(
     strips: StripDepths | None = None,
     section: bool = False,
     table_sizes=(),
+    required_tables=(),
     margin: float = _MARGIN,
 ) -> tuple:
     """Return (SCALE, PAGE_W, PAGE_H, TB_W) for a 4-view layout.
@@ -564,6 +569,7 @@ def choose_scale(
             pack_iso_2d=True,
             section=section,
             table_sizes=table_sizes,
+            required_tables=required_tables,
             margin=margin,
         ):
             _log.warning(
@@ -591,6 +597,7 @@ def choose_scale(
             pack_iso_2d=pack_iso_2d,
             section=section,
             table_sizes=table_sizes,
+            required_tables=required_tables,
             margin=margin,
         ):
             return cand
@@ -612,8 +619,9 @@ def choose_scale(
             strips,
             pack_iso_2d,
             section,
-            table_sizes,
-            margin,
+            table_sizes=table_sizes,
+            required_tables=required_tables,
+            margin=margin,
         )
         if s is not None:
             _log.warning(
@@ -785,6 +793,7 @@ def _layout_geometry(
     blocks=None,
     section: bool = False,
     table_sizes=(),
+    required_tables=(),
     warn_no_iso=True,
     margin: float = _MARGIN,
 ):
@@ -934,6 +943,21 @@ def _layout_geometry(
             left=DIM_PAD,
         )
         obstacles.append(section_block.footprint(SECTION_X, SECTION_Y))
+    # Authored Sheet tables are required fixed-size furniture, not alternative fallback shapes.
+    # Place their estimated footprints before allocating the iso so page selection can grow the
+    # sheet while preserving the requested scale (#1146). Each placement becomes an obstacle for
+    # the next table and for the iso, matching the runtime's declaration order.
+    required_tables_fit = True
+    required_table_boxes = []
+    for size, prefer in required_tables:
+        position = fit_box(size, drawable, obstacles, prefer, clearance=2.0)
+        if position is None:
+            required_tables_fit = False
+            break
+        x0, y0 = position
+        box = (x0, y0, x0 + size[0], y0 + size[1])
+        required_table_boxes.append(box)
+        obstacles.append(box)
     iso_left, iso_bottom, iso_right, iso_top = _largest_empty_rect(
         drawable, obstacles, warn=warn_no_iso
     )
@@ -986,12 +1010,14 @@ def _layout_geometry(
         table_obstacles.append(section_block.footprint(SECTION_X, SECTION_Y))
     if iso_valid:
         table_obstacles.append((iso_left, iso_bottom, iso_right, iso_top))
+    table_obstacles.extend(required_table_boxes)
     table_fits = not table_sizes or any(
         fit_box(size, drawable, table_obstacles, "tr") is not None for size in table_sizes
     )
     fits = (
         iso_fits
         and table_fits
+        and required_tables_fit
         and cy0 >= margin - _tol
         and cy1 <= page_h - margin + _tol
         and cx0 >= margin - _tol
@@ -1000,6 +1026,7 @@ def _layout_geometry(
     auto_fits = (
         auto_row_fits
         and table_fits
+        and required_tables_fit
         and cy0 >= margin - _tol
         and cy1 <= page_h - margin + _tol
         and cx0 >= margin - _tol

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -415,6 +415,7 @@ class Drawing:
             "status": "automatic",
             "blockers": (),
             "attempted_scales": (),
+            "attempts": (),
         }
         self.part = part
         self._cyl_cache = cyls
@@ -2532,7 +2533,9 @@ class Drawing:
         self._add(n, name, view=view)
         return name
 
-    def add_table(self, rows, *, prefer="tr", name="table", block_cols=None):
+    def add_table(
+        self, rows, *, prefer="tr", name="table", block_cols=None, _source_id: str | None = None
+    ):
         """Add a generic data table in the preferred available sheet region (#93/#1145).
 
         *rows* is a list of equal-length string tuples (``rows[0]`` is the
@@ -2633,11 +2636,16 @@ class Drawing:
                 )
             if detail is None:
                 detail = "solver returned no placement trace"
-            self._record_build_issue(
-                "warning",
-                "table_dropped",
-                f"table {name!r} did not fit the sheet; measured page-space footprint "
-                f"{measured}; {detail}",
+            self._registry.record_issue(
+                LintIssue(
+                    severity="warning",
+                    code="table_dropped",
+                    message=(
+                        f"table {name!r} did not fit the sheet; measured page-space footprint "
+                        f"{measured}; {detail}"
+                    ),
+                    source_ids=(_source_id,) if _source_id is not None else (),
+                )
             )
             return None
         return self._add(table.locate(Location((pos[0], pos[1], 0))), name)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -368,6 +368,8 @@ class Drawing:
 
     Attributes:
         scale: drawing scale factor (e.g. ``2.0`` for 2:1).
+        scale_decision: JSON-friendly resolution of an automatic or explicit scale request,
+            including the requested/effective scales and any required placement blockers.
         page_w, page_h: sheet size in mm.
         tb_w: title-block width in mm.
         draft: the shared ``Draft`` preset used by the automatic annotations.
@@ -404,6 +406,16 @@ class Drawing:
         assembly=None,
     ):
         self.scale = scale
+        # Public, JSON-friendly record of how the requested drawing scale was resolved
+        # (#1146). The build wrapper replaces this automatic default for explicit policies.
+        self.scale_decision = {
+            "policy": "automatic",
+            "requested_scale": None,
+            "effective_scale": scale,
+            "status": "automatic",
+            "blockers": (),
+            "attempted_scales": (),
+        }
         self.part = part
         self._cyl_cache = cyls
         # None → the coverage lint auto-detects a multi-solid part as an

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1858,35 +1858,41 @@ class Sheet:
         # order-independent: declaring the augment before the source must read the same
         # as declaring it after.
         self._check_dimension_source()
-        dwg = build_drawing(
+
+        def place_declared_tables(dwg):
+            """Place authored sheet furniture before explicit-scale completeness is decided."""
+            used = set(dwg.annotations())
+            for table in self._tables:
+                name = table["name"]
+                if name in used:
+                    base, k = name, 1
+                    while f"{base}_{k}" in used:
+                        k += 1
+                    name = f"{base}_{k}"
+                    warnings.warn(
+                        f"table name {table['name']!r} is already taken — placed as {name!r}",
+                        stacklevel=3,
+                    )
+                placed = dwg.add_table(
+                    table["rows"],
+                    prefer=table["prefer"],
+                    name=name,
+                    block_cols=table["block_cols"],
+                    _source_id=f"sheet.table:{name}",
+                )
+                if placed is not None:
+                    used.add(name)
+            return dwg
+
+        return build_drawing(
             self._part,
             model=self._features,
             decorations=self._decorations(),
             requested=self._requested_dimensions(),
             authored=self._authored_set(),
+            _post_build=place_declared_tables,
             **self._opts,
         )
-        # Add each declared table, uniquifying its name against everything already on the sheet
-        # (feature annotations + earlier tables) so a table NEVER silently overwrites another
-        # object via dwg.add (#493 review). A collision with an explicit name is warned; a table
-        # that doesn't fit still records `table_dropped` lint inside add_table.
-        used = set(dwg.annotations())  # the public read; the _named alias is gone (#720)
-        for t in self._tables:
-            name = t["name"]
-            if name in used:
-                base, k = name, 1
-                while f"{base}_{k}" in used:
-                    k += 1
-                name = f"{base}_{k}"
-                warnings.warn(
-                    f"table name {t['name']!r} is already taken — placed as {name!r}", stacklevel=2
-                )
-            placed = dwg.add_table(
-                t["rows"], prefer=t["prefer"], name=name, block_cols=t["block_cols"]
-            )
-            if placed is not None:  # a dropped table (didn't fit) frees its name (#493 review)
-                used.add(name)
-        return dwg
 
     def export(self, stem=None, *, formats=("pdf",), dpi=150):
         """Build the drawing and write the requested *formats* — a format name or an

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -714,6 +714,7 @@ class Sheet:
         drawn_by=None,
         tolerance=None,
         scale=None,
+        scale_policy="fallback",
         page=None,
         out=None,
         material=None,
@@ -772,7 +773,12 @@ class Sheet:
         # a literal Y, ``feature`` a declared-feature index, ``auto`` the part-centre Y.
         self._section: tuple | None = None
         self._opts = dict(
-            title=title, number=number, scale=_parse_scale(scale), page=page, out=out
+            title=title,
+            number=number,
+            scale=_parse_scale(scale),
+            scale_policy=scale_policy,
+            page=page,
+            out=out,
         )
         # drawn_by / tolerance (title block, #474) forward to build_drawing only when set, so an
         # unset value keeps build_drawing's own defaults ("" / "ISO 2768-m") rather than None.

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -59,6 +59,7 @@ from typing import TYPE_CHECKING
 from draftwright._geometry import _solids_body
 from draftwright._warnings import SoftDeprecationWarning
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
+from draftwright.compose import _est_table_size
 from draftwright.fits import fit_class
 from draftwright.model import DimensionParameterId, Feature
 from draftwright.model import boss as _boss
@@ -1858,11 +1859,22 @@ class Sheet:
         # order-independent: declaring the augment before the source must read the same
         # as declaring it after.
         self._check_dimension_source()
+        required_tables = tuple(
+            (size, table["prefer"])
+            for table in self._tables
+            if (
+                size := _est_table_size(
+                    table["rows"],
+                    block_cols=table["block_cols"],
+                )
+            )
+            is not None
+        )
 
         def place_declared_tables(dwg):
             """Place authored sheet furniture before explicit-scale completeness is decided."""
             used = set(dwg.annotations())
-            for table in self._tables:
+            for table_index, table in enumerate(self._tables):
                 name = table["name"]
                 if name in used:
                     base, k = name, 1
@@ -1878,7 +1890,7 @@ class Sheet:
                     prefer=table["prefer"],
                     name=name,
                     block_cols=table["block_cols"],
-                    _source_id=f"sheet.table:{name}",
+                    _source_id=f"sheet.table:{table_index}:{table['name']}",
                 )
                 if placed is not None:
                     used.add(name)
@@ -1891,6 +1903,7 @@ class Sheet:
             requested=self._requested_dimensions(),
             authored=self._authored_set(),
             _post_build=place_declared_tables,
+            _required_tables=required_tables,
             **self._opts,
         )
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1326,6 +1326,8 @@ def emit_sheet_script(
     comment a feature line out and re-run — which shifts every later index and silently
     retargets the declarations onto their neighbours. #931 and #932 removed positional
     addressing from the artefact, so the declarations can now be written honestly."""
+    if scale is None and scale_policy != "fallback":
+        raise ValueError("scale_policy applies only when an explicit scale is supplied")
     # The script declares this model — `model` plus an envelope when the overall height would
     # otherwise be unnameable under the mirrored (authored) set. BEFORE the import scan, since
     # a synthesised envelope needs `EnvelopeFeature` imported like a detected one.

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1289,6 +1289,7 @@ def emit_sheet_script(
     drawn_by: str = "",
     tolerance: str = "ISO 2768-m",
     scale=None,
+    scale_policy="fallback",
     page=None,
     material: str = "",
     date: str = "",
@@ -1369,6 +1370,8 @@ def emit_sheet_script(
         ctor.append(f"tolerance={tolerance!r}")
     if scale is not None:
         ctor.append(f"scale={scale!r}")
+    if scale_policy != "fallback":
+        ctor.append(f"scale_policy={scale_policy!r}")
     if page is not None:
         ctor.append(f"page={page!r}")
     if material:
@@ -1620,6 +1623,7 @@ def generate_sheet_script(
     tolerance: str = "ISO 2768-m",
     drawn_by: str = "",
     scale=None,
+    scale_policy="fallback",
     page=None,
     material: str = "",
     date: str = "",
@@ -1672,6 +1676,7 @@ def generate_sheet_script(
         drawn_by=drawn_by,
         tolerance=tolerance,
         scale=scale,
+        scale_policy=scale_policy,
         page=page,
         material=material,
         date=date,

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1279,6 +1279,14 @@ unavailable or ambiguous matches remain complete numeric declarations and fail c
 """'''
 
 
+def _validate_scale_policy(scale, scale_policy) -> None:
+    """Reject incoherent script options before detection or emission work begins."""
+    if scale_policy not in {"strict", "fallback", "permissive"}:
+        raise ValueError("scale_policy must be 'strict', 'fallback', or 'permissive'")
+    if scale is None and scale_policy != "fallback":
+        raise ValueError("scale_policy applies only when an explicit scale is supplied")
+
+
 def emit_sheet_script(
     model,
     part_expr: str,
@@ -1326,10 +1334,7 @@ def emit_sheet_script(
     comment a feature line out and re-run — which shifts every later index and silently
     retargets the declarations onto their neighbours. #931 and #932 removed positional
     addressing from the artefact, so the declarations can now be written honestly."""
-    if scale_policy not in {"strict", "fallback", "permissive"}:
-        raise ValueError("scale_policy must be 'strict', 'fallback', or 'permissive'")
-    if scale is None and scale_policy != "fallback":
-        raise ValueError("scale_policy applies only when an explicit scale is supplied")
+    _validate_scale_policy(scale, scale_policy)
     # The script declares this model — `model` plus an envelope when the overall height would
     # otherwise be unnameable under the mirrored (authored) set. BEFORE the import scan, since
     # a synthesised envelope needs `EnvelopeFeature` imported like a detected one.
@@ -1653,6 +1658,7 @@ def generate_sheet_script(
     surface (flagged inline).
     *part_expr*, when given, overrides the ``part = …`` seam — e.g. the import seam from
     :func:`resolve_object_spec` so the script references a live module (#469)."""
+    _validate_scale_policy(scale, scale_policy)
     is_shape = isinstance(step_file, Shape)
     stem = out or ("drawing" if is_shape else Path(step_file).stem)
     for _ext in (".py", ".svg", ".dxf"):

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1326,6 +1326,8 @@ def emit_sheet_script(
     comment a feature line out and re-run — which shifts every later index and silently
     retargets the declarations onto their neighbours. #931 and #932 removed positional
     addressing from the artefact, so the declarations can now be written honestly."""
+    if scale_policy not in {"strict", "fallback", "permissive"}:
+        raise ValueError("scale_policy must be 'strict', 'fallback', or 'permissive'")
     if scale is None and scale_policy != "fallback":
         raise ValueError("scale_policy applies only when an explicit scale is supplied")
     # The script declares this model — `model` plus an envelope when the overall height would

--- a/tests/test_flat_completeness.py
+++ b/tests/test_flat_completeness.py
@@ -268,7 +268,7 @@ def test_a_planner_omission_is_not_authored_suppression():
 
 
 def test_forced_placement_failure_is_dropped_not_missing():
-    dwg = build_drawing(_flatted_shaft(), page="A4", scale=3.0)
+    dwg = build_drawing(_flatted_shaft(), page="A4", scale=3.0, scale_policy="permissive")
     issues = dwg.lint()
     drop = next(issue for issue in issues if issue.code == "flat_dropped")
     assert len(drop.measurement_ids) == 2, (

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -327,6 +327,29 @@ def test_authored_table_footprint_can_select_a_larger_standard_page():
 
 
 @pytest.mark.timeout(120)
+def test_automatic_page_preserves_iso_budget_while_forced_page_honors_complete_layout():
+    """Auto page fitness is stronger than strict completeness on a caller-forced page."""
+    rows = [("H",), *(("X" * 60,) for _ in range(6))]
+
+    def sheet(page=None):
+        result = Sheet(
+            Box(40, 30, 10), page=page, scale=1.0, scale_policy="strict"
+        ).authored_dimensions()
+        for index, prefer in enumerate(("tr", "bl", "br")):
+            result.table(rows, name=f"required_{index}", prefer=prefer)
+        return result
+
+    automatic = sheet().build()
+    forced = sheet("A4").build()
+
+    assert (automatic.page_w, automatic.page_h) == (420.0, 297.0)
+    assert (forced.page_w, forced.page_h) == (297.0, 210.0)
+    assert forced.scale_decision["status"] == "honored"
+    assert {f"required_{index}" for index in range(3)} <= set(forced.annotations())
+    assert not [issue for issue in forced.lint() if issue.severity != "info"]
+
+
+@pytest.mark.timeout(120)
 def test_sheet_table_sources_are_stable_and_unique_when_display_names_are_reused():
     oversized = [("X" * 300,)]
 

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -447,15 +447,19 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
 
 
 def test_cli_rejects_nondefault_policy_without_scale_for_direct_and_script_modes():
+    from click import unstyle
     from typer.testing import CliRunner
 
     from draftwright.cli import app
 
     for extra in ([], ["--script"]):
-        result = CliRunner().invoke(app, ["part.step", "--scale-policy", "strict", *extra])
+        result = CliRunner().invoke(
+            app, ["part.step", "--scale-policy", "strict", *extra], color=True
+        )
         assert result.exit_code == 2
-        assert "--scale-policy requires an explicit" in result.output
-        assert "--scale" in result.output
+        output = unstyle(result.output)
+        assert "--scale-policy requires an explicit" in output
+        assert "--scale" in output
 
 
 def test_script_emitter_rejects_nondefault_policy_without_scale(tmp_path, monkeypatch):

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -435,8 +435,13 @@ def test_cli_rejects_nondefault_policy_without_scale_for_direct_and_script_modes
         assert "--scale" in result.output
 
 
-def test_script_emitter_rejects_nondefault_policy_without_scale(tmp_path):
+def test_script_emitter_rejects_nondefault_policy_without_scale(tmp_path, monkeypatch):
     from draftwright.sheet_emit import generate_sheet_script
+
+    def detection_must_not_run(*_args, **_kwargs):
+        raise AssertionError("invalid script options must fail before model detection")
+
+    monkeypatch.setattr("draftwright.sheet_emit.detect_part_model", detection_must_not_run)
 
     with pytest.raises(ValueError, match="only when an explicit scale"):
         generate_sheet_script(

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -13,6 +13,7 @@ from draftwright import (
     ScaleCompletenessWarning,
     ScaleIncompatibilityError,
     Sheet,
+    SoftDeprecationWarning,
     build_drawing,
 )
 from draftwright.builder import _is_required_scale_drop
@@ -69,11 +70,16 @@ def test_default_fallback_returns_largest_complete_standard_scale_and_reports_de
         "status": "fallback",
         "blockers": drawing.scale_decision["blockers"],
         "attempted_scales": (1.0, 0.5),
+        "attempts": drawing.scale_decision["attempts"],
     }
     (blocker,) = drawing.scale_decision["blockers"]
     assert blocker["code"] == "location_ref_dropped"
     assert blocker["measurements"][0]["parameter"] == "location.location"
     assert blocker["hole_requirements"][0]["parameter"] == "location.location.x"
+    assert [(item["scale"], item["status"]) for item in drawing.scale_decision["attempts"]] == [
+        (1.0, "incomplete"),
+        (0.5, "complete"),
+    ]
 
 
 @pytest.mark.timeout(120)
@@ -91,6 +97,7 @@ def test_strict_policy_fails_with_machine_readable_required_outcomes():
     assert decision["status"] == "rejected"
     assert decision["requested_scale"] == decision["effective_scale"] == 1.0
     assert decision["attempted_scales"] == (1.0,)
+    assert decision["attempts"][0]["status"] == "incomplete"
     assert {item["code"] for item in decision["blockers"]} == {"location_ref_dropped"}
 
 
@@ -122,6 +129,7 @@ def test_complete_requested_and_automatic_scales_report_honest_resolutions():
         "status": "honored",
         "blockers": (),
         "attempted_scales": (1.0,),
+        "attempts": ({"scale": 1.0, "status": "complete", "blockers": ()},),
     }
     assert automatic.scale_decision == {
         "policy": "automatic",
@@ -130,6 +138,7 @@ def test_complete_requested_and_automatic_scales_report_honest_resolutions():
         "status": "automatic",
         "blockers": (),
         "attempted_scales": (),
+        "attempts": (),
     }
 
 
@@ -185,7 +194,12 @@ def test_fallback_reports_exhaustion_at_the_hard_rendering_floor(monkeypatch):
     def fake_build(*args, scale, **kwargs):
         if scale == 0.2:
             raise ValueError("drawing geometry degenerates below the renderable floor")
-        return SimpleNamespace(scale=scale, lint=lambda: [drop])
+        candidate_drop = (
+            LintIssue(severity="warning", code="gdt_dropped", message="datum frame did not fit")
+            if scale == 0.5
+            else drop
+        )
+        return SimpleNamespace(scale=scale, lint=lambda: [candidate_drop], _analysis=None)
 
     monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5, 0.2, 0.1))
     monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
@@ -196,12 +210,18 @@ def test_fallback_reports_exhaustion_at_the_hard_rendering_floor(monkeypatch):
     assert caught.value.decision == {
         "policy": "fallback",
         "requested_scale": 1.0,
-        "effective_scale": 1.0,
+        "effective_scale": 0.5,
         "status": "no_complete_scale",
         "blockers": caught.value.decision["blockers"],
         "attempted_scales": (1.0, 0.5, 0.2),
+        "attempts": caught.value.decision["attempts"],
     }
-    assert caught.value.decision["blockers"][0]["code"] == "location_ref_dropped"
+    assert caught.value.decision["blockers"][0]["code"] == "gdt_dropped"
+    assert [(item["scale"], item["status"]) for item in caught.value.decision["attempts"]] == [
+        (1.0, "incomplete"),
+        (0.5, "incomplete"),
+        (0.2, "render_floor"),
+    ]
     assert "no complete standard fallback" not in str(caught.value)
 
 
@@ -217,7 +237,7 @@ def test_fallback_does_not_hide_an_unrelated_build_error(monkeypatch):
     def fake_build(*args, scale, **kwargs):
         if scale < 1.0:
             raise ValueError("invalid declared model")
-        return SimpleNamespace(scale=scale, lint=lambda: [drop])
+        return SimpleNamespace(scale=scale, lint=lambda: [drop], _analysis=None)
 
     monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5))
     monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
@@ -226,11 +246,125 @@ def test_fallback_does_not_hide_an_unrelated_build_error(monkeypatch):
         builder.build_drawing(Box(10, 10, 10), scale=1.0)
 
 
+def test_monotone_step_separation_failure_does_not_rebuild_smaller_scales(monkeypatch):
+    import draftwright.builder as builder
+
+    calls = []
+    drop = LintIssue(
+        severity="warning",
+        code="step_dim_dropped",
+        message="5 step height(s) too closely spaced to dimension at this scale",
+    )
+
+    def fake_build(*args, scale, **kwargs):
+        calls.append(scale)
+        return SimpleNamespace(scale=scale, lint=lambda: [drop], _analysis=None)
+
+    monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5, 0.2, 0.1))
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
+
+    with pytest.raises(ScaleIncompatibilityError) as caught:
+        builder.build_drawing(Box(10, 10, 10), scale=1.0)
+
+    assert calls == [1.0]
+    assert caught.value.decision["status"] == "no_complete_scale"
+    assert caught.value.decision["attempted_scales"] == (1.0,)
+
+
 def test_scale_warning_category_remains_a_dependency_free_user_warning():
     namespace = runpy.run_path(
         str(Path(__file__).parents[1] / "src" / "draftwright" / "_warnings.py")
     )
     assert issubclass(namespace["ScaleCompletenessWarning"], UserWarning)
+
+
+@pytest.mark.timeout(120)
+def test_sheet_authored_table_footprint_participates_in_fallback_and_strict_policy():
+    rows = [("NOTES",), *((f"{index}. " + "X" * 30,) for index in range(4))]
+
+    fallback_sheet = Sheet(Box(100, 100, 8), page="A4", scale=1.0).table(
+        rows, name="required_notes"
+    )
+    with pytest.warns(SoftDeprecationWarning):
+        fallback_sheet.auto_dimensions()
+    with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
+        drawing = fallback_sheet.build()
+
+    assert drawing.scale == 0.5
+    assert "required_notes" in drawing.annotations()
+    assert drawing.scale_decision["blockers"][0]["code"] == "table_dropped"
+    assert drawing.scale_decision["blockers"][0]["source_ids"] == ("sheet.table:required_notes",)
+
+    strict_sheet = Sheet(Box(100, 100, 8), page="A4", scale=1.0, scale_policy="strict").table(
+        rows, name="required_notes"
+    )
+    with pytest.warns(SoftDeprecationWarning):
+        strict_sheet.auto_dimensions()
+    with pytest.raises(ScaleIncompatibilityError) as caught:
+        strict_sheet.build()
+    assert caught.value.decision["blockers"][0]["code"] == "table_dropped"
+
+
+@pytest.mark.timeout(120)
+def test_priority_ranked_solver_drop_cannot_pass_strict_scale_policy():
+    part = Cylinder(70, 6)
+    for index, radius in enumerate((60, 52, 44, 36, 28, 20, 12)):
+        part -= Pos(0, 0, 3 - index * 0.7) * Cylinder(radius, 6)
+
+    with pytest.raises(ScaleIncompatibilityError) as caught:
+        build_drawing(part, page="A4", scale=1.0, scale_policy="strict")
+
+    (blocker,) = caught.value.decision["blockers"]
+    assert blocker["code"] == "callout_dropped"
+    assert "diameter(s)" in blocker["message"]
+
+
+@pytest.mark.timeout(120)
+def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
+    import draftwright.analysis as analysis
+
+    calls = {"classify": 0, "recognise": 0}
+    original_classify = analysis._classify_geometry
+    original_recognise = analysis.build_recognition_result
+
+    def counted_classify(*args, **kwargs):
+        calls["classify"] += 1
+        return original_classify(*args, **kwargs)
+
+    def counted_recognise(*args, **kwargs):
+        calls["recognise"] += 1
+        return original_recognise(*args, **kwargs)
+
+    monkeypatch.setattr(analysis, "_classify_geometry", counted_classify)
+    monkeypatch.setattr(analysis, "build_recognition_result", counted_recognise)
+    with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
+        drawing = build_drawing(_scale_sensitive_plate(), page="A4", scale=1.0, repair=False)
+
+    assert drawing.scale == 0.5
+    assert calls == {"classify": 1, "recognise": 1}
+
+
+def test_cli_rejects_nondefault_policy_without_scale_for_direct_and_script_modes():
+    from typer.testing import CliRunner
+
+    from draftwright.cli import app
+
+    for extra in ([], ["--script"]):
+        result = CliRunner().invoke(app, ["part.step", "--scale-policy", "strict", *extra])
+        assert result.exit_code == 2
+        assert "--scale-policy requires an explicit" in result.output
+        assert "--scale" in result.output
+
+
+def test_script_emitter_rejects_nondefault_policy_without_scale(tmp_path):
+    from draftwright.sheet_emit import generate_sheet_script
+
+    with pytest.raises(ValueError, match="only when an explicit scale"):
+        generate_sheet_script(
+            Box(10, 10, 10),
+            out=str(tmp_path / "invalid_policy"),
+            scale_policy="strict",
+        )
 
 
 def test_sheet_forwards_the_authored_scale_policy(monkeypatch):

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -1,0 +1,283 @@
+"""#1146 — explicit drawing scales may not silently reduce completeness."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import (
+    ScaleCompletenessWarning,
+    ScaleIncompatibilityError,
+    Sheet,
+    build_drawing,
+)
+from draftwright.builder import _is_required_scale_drop
+from draftwright.linting import LintIssue
+
+
+def _scale_sensitive_plate():
+    """A4 at 1:1 drops one X location; the same required set fits at 1:2."""
+    part = Box(100, 100, 8)
+    part -= Pos(-30, -20, 0) * Cylinder(2, 8)
+    part -= Pos(25, 25, 0) * Cylinder(2.7, 8)
+    return part
+
+
+def _placement_drops(drawing):
+    return [issue for issue in drawing.lint() if _is_required_scale_drop(issue)]
+
+
+@pytest.mark.timeout(120)
+def test_fixture_proves_requested_scale_loses_an_outcome_but_half_scale_is_complete():
+    with pytest.warns(ScaleCompletenessWarning, match="scale_policy='permissive'"):
+        requested = build_drawing(
+            _scale_sensitive_plate(),
+            page="A4",
+            scale=1.0,
+            scale_policy="permissive",
+            repair=False,
+        )
+    half = build_drawing(
+        _scale_sensitive_plate(),
+        page="A4",
+        scale=0.5,
+        scale_policy="permissive",
+        repair=False,
+    )
+
+    (drop,) = _placement_drops(requested)
+    assert drop.code == "location_ref_dropped"
+    assert drop.measurement_ids and drop.hole_requirement_ids
+    assert _placement_drops(half) == []
+
+
+@pytest.mark.timeout(120)
+def test_default_fallback_returns_largest_complete_standard_scale_and_reports_decision():
+    with pytest.warns(ScaleCompletenessWarning, match="complete fallback scale 0.5"):
+        drawing = build_drawing(_scale_sensitive_plate(), page="A4", scale=1.0, repair=False)
+
+    assert drawing.scale == 0.5
+    assert _placement_drops(drawing) == []
+    assert drawing.scale_decision == {
+        "policy": "fallback",
+        "requested_scale": 1.0,
+        "effective_scale": 0.5,
+        "status": "fallback",
+        "blockers": drawing.scale_decision["blockers"],
+        "attempted_scales": (1.0, 0.5),
+    }
+    (blocker,) = drawing.scale_decision["blockers"]
+    assert blocker["code"] == "location_ref_dropped"
+    assert blocker["measurements"][0]["parameter"] == "location.location"
+    assert blocker["hole_requirements"][0]["parameter"] == "location.location.x"
+
+
+@pytest.mark.timeout(120)
+def test_strict_policy_fails_with_machine_readable_required_outcomes():
+    with pytest.raises(ScaleIncompatibilityError) as caught:
+        build_drawing(
+            _scale_sensitive_plate(),
+            page="A4",
+            scale=1.0,
+            scale_policy="strict",
+            repair=False,
+        )
+
+    decision = caught.value.decision
+    assert decision["status"] == "rejected"
+    assert decision["requested_scale"] == decision["effective_scale"] == 1.0
+    assert decision["attempted_scales"] == (1.0,)
+    assert {item["code"] for item in decision["blockers"]} == {"location_ref_dropped"}
+
+
+@pytest.mark.timeout(120)
+def test_permissive_policy_is_explicit_warns_and_preserves_degraded_request():
+    with pytest.warns(ScaleCompletenessWarning, match="returning the incomplete drawing"):
+        drawing = build_drawing(
+            _scale_sensitive_plate(),
+            page="A4",
+            scale=1.0,
+            scale_policy="permissive",
+            repair=False,
+        )
+
+    assert drawing.scale == 1.0
+    assert drawing.scale_decision["status"] == "degraded"
+    assert drawing.scale_decision["policy"] == "permissive"
+    assert {item.code for item in _placement_drops(drawing)} == {"location_ref_dropped"}
+
+
+def test_complete_requested_and_automatic_scales_report_honest_resolutions():
+    explicit = build_drawing(Box(40, 30, 10), page="A4", scale=1.0)
+    automatic = build_drawing(Box(40, 30, 10))
+
+    assert explicit.scale_decision == {
+        "policy": "fallback",
+        "requested_scale": 1.0,
+        "effective_scale": 1.0,
+        "status": "honored",
+        "blockers": (),
+        "attempted_scales": (1.0,),
+    }
+    assert automatic.scale_decision == {
+        "policy": "automatic",
+        "requested_scale": None,
+        "effective_scale": automatic.scale,
+        "status": "automatic",
+        "blockers": (),
+        "attempted_scales": (),
+    }
+
+
+def test_policy_vocabulary_and_applicability_fail_before_build():
+    with pytest.raises(ValueError, match="scale_policy must be"):
+        build_drawing(Box(10, 10, 10), scale=1.0, scale_policy="quiet")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="only when an explicit scale"):
+        build_drawing(Box(10, 10, 10), scale_policy="strict")
+
+
+def test_info_severity_or_priority_cannot_hide_a_required_drop():
+    issue = LintIssue(
+        severity="info",
+        code="location_ref_dropped",
+        message="mandatory pinned candidate did not fit",
+    )
+    assert _is_required_scale_drop(issue)
+
+
+def test_validation_findings_are_not_scale_placement_failures():
+    issue = LintIssue(
+        severity="error",
+        code="declaration_mismatch",
+        message="the declared feature differs from the solid",
+        outcome_stage="validation",
+    )
+    assert not _is_required_scale_drop(issue)
+
+
+def test_unowned_transactional_table_failure_is_not_a_required_scale_drop():
+    assert not _is_required_scale_drop(
+        LintIssue(severity="warning", code="table_dropped", message="fallback restored")
+    )
+    assert _is_required_scale_drop(
+        LintIssue(
+            severity="warning",
+            code="table_dropped",
+            message="semantic table lost",
+            source_ids=("required-table",),
+        )
+    )
+
+
+def test_fallback_reports_exhaustion_at_the_hard_rendering_floor(monkeypatch):
+    import draftwright.builder as builder
+
+    drop = LintIssue(
+        severity="warning",
+        code="location_ref_dropped",
+        message="required location did not fit",
+    )
+
+    def fake_build(*args, scale, **kwargs):
+        if scale == 0.2:
+            raise ValueError("drawing geometry degenerates below the renderable floor")
+        return SimpleNamespace(scale=scale, lint=lambda: [drop])
+
+    monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5, 0.2, 0.1))
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
+
+    with pytest.raises(ScaleIncompatibilityError) as caught:
+        builder.build_drawing(Box(10, 10, 10), scale=1.0)
+
+    assert caught.value.decision == {
+        "policy": "fallback",
+        "requested_scale": 1.0,
+        "effective_scale": 1.0,
+        "status": "no_complete_scale",
+        "blockers": caught.value.decision["blockers"],
+        "attempted_scales": (1.0, 0.5, 0.2),
+    }
+    assert caught.value.decision["blockers"][0]["code"] == "location_ref_dropped"
+    assert "no complete standard fallback" not in str(caught.value)
+
+
+def test_fallback_does_not_hide_an_unrelated_build_error(monkeypatch):
+    import draftwright.builder as builder
+
+    drop = LintIssue(
+        severity="warning",
+        code="location_ref_dropped",
+        message="required location did not fit",
+    )
+
+    def fake_build(*args, scale, **kwargs):
+        if scale < 1.0:
+            raise ValueError("invalid declared model")
+        return SimpleNamespace(scale=scale, lint=lambda: [drop])
+
+    monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5))
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
+
+    with pytest.raises(ValueError, match="invalid declared model"):
+        builder.build_drawing(Box(10, 10, 10), scale=1.0)
+
+
+def test_scale_warning_category_remains_a_dependency_free_user_warning():
+    namespace = runpy.run_path(
+        str(Path(__file__).parents[1] / "src" / "draftwright" / "_warnings.py")
+    )
+    assert issubclass(namespace["ScaleCompletenessWarning"], UserWarning)
+
+
+def test_sheet_forwards_the_authored_scale_policy(monkeypatch):
+    captured = {}
+
+    def fake_build(*args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(annotations=lambda: ())
+
+    monkeypatch.setattr("draftwright.sheet.build_drawing", fake_build)
+    Sheet(Box(10, 10, 10), scale="1:1", scale_policy="strict").auto_dimensions().build()
+
+    assert captured["scale"] == 1.0
+    assert captured["scale_policy"] == "strict"
+
+
+def test_make_drawing_forwards_policy_to_the_live_build(monkeypatch):
+    import draftwright.builder as builder
+
+    captured = {}
+
+    class FakeDrawing:
+        def export(self, *, formats):
+            assert formats == ("svg", "dxf")
+            return {"svg": "drawing.svg", "dxf": "drawing.dxf"}
+
+    def fake_build(*args, **kwargs):
+        captured.update(kwargs)
+        return FakeDrawing()
+
+    monkeypatch.setattr(builder, "build_drawing", fake_build)
+    assert builder.make_drawing(Box(10, 10, 10), scale=1.0, scale_policy="strict") == (
+        "drawing.svg",
+        "drawing.dxf",
+    )
+    assert captured["scale_policy"] == "strict"
+
+
+def test_generated_sheet_script_round_trips_nondefault_policy(tmp_path):
+    from draftwright.sheet_emit import generate_sheet_script
+
+    path = generate_sheet_script(
+        Box(10, 10, 10),
+        out=str(tmp_path / "scale_policy"),
+        scale=1.0,
+        scale_policy="permissive",
+    )
+    text = Path(path).read_text(encoding="utf-8")
+    assert "scale=1.0" in text
+    assert "scale_policy='permissive'" in text

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import runpy
 from pathlib import Path
 from types import SimpleNamespace
@@ -447,7 +448,6 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
 
 
 def test_cli_rejects_nondefault_policy_without_scale_for_direct_and_script_modes():
-    from click import unstyle
     from typer.testing import CliRunner
 
     from draftwright.cli import app
@@ -457,7 +457,7 @@ def test_cli_rejects_nondefault_policy_without_scale_for_direct_and_script_modes
             app, ["part.step", "--scale-policy", "strict", *extra], color=True
         )
         assert result.exit_code == 2
-        output = unstyle(result.output)
+        output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         assert "--scale-policy requires an explicit" in output
         assert "--scale" in output
 

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -199,7 +199,9 @@ def test_fallback_reports_exhaustion_at_the_hard_rendering_floor(monkeypatch):
             if scale == 0.5
             else drop
         )
-        return SimpleNamespace(scale=scale, lint=lambda: [candidate_drop], _analysis=None)
+        return SimpleNamespace(
+            scale=scale, lint=lambda: [candidate_drop], recognition=lambda: None, _analysis=None
+        )
 
     monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5, 0.2, 0.1))
     monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
@@ -237,7 +239,9 @@ def test_fallback_does_not_hide_an_unrelated_build_error(monkeypatch):
     def fake_build(*args, scale, **kwargs):
         if scale < 1.0:
             raise ValueError("invalid declared model")
-        return SimpleNamespace(scale=scale, lint=lambda: [drop], _analysis=None)
+        return SimpleNamespace(
+            scale=scale, lint=lambda: [drop], recognition=lambda: None, _analysis=None
+        )
 
     monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5))
     monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
@@ -258,7 +262,9 @@ def test_monotone_step_separation_failure_does_not_rebuild_smaller_scales(monkey
 
     def fake_build(*args, scale, **kwargs):
         calls.append(scale)
-        return SimpleNamespace(scale=scale, lint=lambda: [drop], _analysis=None)
+        return SimpleNamespace(
+            scale=scale, lint=lambda: [drop], recognition=lambda: None, _analysis=None
+        )
 
     monkeypatch.setattr(builder, "_SCALES", (1.0, 0.5, 0.2, 0.1))
     monkeypatch.setattr(builder, "_build_drawing_once", fake_build)
@@ -280,7 +286,7 @@ def test_scale_warning_category_remains_a_dependency_free_user_warning():
 
 @pytest.mark.timeout(120)
 def test_sheet_authored_table_footprint_participates_in_fallback_and_strict_policy():
-    rows = [("NOTES",), *((f"{index}. " + "X" * 30,) for index in range(4))]
+    rows = [("NOTES",), *((f"{index}. " + "X" * 70,) for index in range(4))]
 
     fallback_sheet = Sheet(Box(100, 100, 8), page="A4", scale=1.0).table(
         rows, name="required_notes"
@@ -293,7 +299,7 @@ def test_sheet_authored_table_footprint_participates_in_fallback_and_strict_poli
     assert drawing.scale == 0.5
     assert "required_notes" in drawing.annotations()
     assert drawing.scale_decision["blockers"][0]["code"] == "table_dropped"
-    assert drawing.scale_decision["blockers"][0]["source_ids"] == ("sheet.table:required_notes",)
+    assert drawing.scale_decision["blockers"][0]["source_ids"] == ("sheet.table:0:required_notes",)
 
     strict_sheet = Sheet(Box(100, 100, 8), page="A4", scale=1.0, scale_policy="strict").table(
         rows, name="required_notes"
@@ -303,6 +309,74 @@ def test_sheet_authored_table_footprint_participates_in_fallback_and_strict_poli
     with pytest.raises(ScaleIncompatibilityError) as caught:
         strict_sheet.build()
     assert caught.value.decision["blockers"][0]["code"] == "table_dropped"
+
+
+@pytest.mark.timeout(120)
+def test_authored_table_footprint_can_select_a_larger_standard_page():
+    drawing = (
+        Sheet(Box(40, 30, 10), scale=1.0)
+        .authored_dimensions()
+        .table([("NOTES",), ("X" * 160,)], name="required_notes")
+        .build()
+    )
+
+    assert drawing.scale == 1.0
+    assert (drawing.page_w, drawing.page_h) == (420.0, 297.0)
+    assert drawing.scale_decision["status"] == "honored"
+    assert "required_notes" in drawing.annotations()
+
+
+@pytest.mark.timeout(120)
+def test_sheet_table_sources_are_stable_and_unique_when_display_names_are_reused():
+    oversized = [("X" * 300,)]
+
+    both_drop = (
+        Sheet(Box(100, 100, 8), page="A4", scale=1.0, scale_policy="strict")
+        .authored_dimensions()
+        .table(oversized, name="same")
+        .table(oversized, name="same")
+    )
+    with pytest.raises(ScaleIncompatibilityError) as caught:
+        both_drop.build()
+    assert [item["source_ids"] for item in caught.value.decision["blockers"]] == [
+        ("sheet.table:0:same",),
+        ("sheet.table:1:same",),
+    ]
+
+    drop_then_place = (
+        Sheet(Box(100, 100, 8), page="A4", scale=1.0, scale_policy="permissive")
+        .authored_dimensions()
+        .table(oversized, name="same")
+        .table([("OK",), ("visible",)], name="same")
+    )
+    with pytest.warns(ScaleCompletenessWarning, match="returning the incomplete drawing"):
+        drawing = drop_then_place.build()
+    assert "same" in drawing.annotations()
+    assert [item["source_ids"] for item in drawing.scale_decision["blockers"]] == [
+        ("sheet.table:0:same",)
+    ]
+
+
+@pytest.mark.timeout(120)
+def test_sheet_fallback_reuses_lazy_physical_recognition(monkeypatch):
+    import draftwright.drawing as drawing_module
+
+    sheet = Sheet.from_part(_scale_sensitive_plate(), page="A4", scale=1.0)
+    calls = []
+    original = drawing_module.build_recognition_result
+
+    def counted(part):
+        result = original(part)
+        calls.append(result)
+        return result
+
+    monkeypatch.setattr(drawing_module, "build_recognition_result", counted)
+    with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
+        drawing = sheet.build()
+
+    assert drawing.scale_decision["attempted_scales"] == (1.0, 0.5)
+    assert len(calls) == 1
+    assert drawing.recognition() is calls[0]
 
 
 @pytest.mark.timeout(120)
@@ -364,6 +438,13 @@ def test_script_emitter_rejects_nondefault_policy_without_scale(tmp_path):
             Box(10, 10, 10),
             out=str(tmp_path / "invalid_policy"),
             scale_policy="strict",
+        )
+    with pytest.raises(ValueError, match="scale_policy must be"):
+        generate_sheet_script(
+            Box(10, 10, 10),
+            out=str(tmp_path / "invalid_vocabulary"),
+            scale=1.0,
+            scale_policy="banana",
         )
 
 

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -391,6 +391,11 @@ def test_priority_ranked_solver_drop_cannot_pass_strict_scale_policy():
     (blocker,) = caught.value.decision["blockers"]
     assert blocker["code"] == "callout_dropped"
     assert "diameter(s)" in blocker["message"]
+    # The shared strip solve ranks bore candidates by diameter. The largest bore lands while
+    # the next-lower required bore drops; equalising priorities reverses this boundary and must
+    # fail this canary, while strict policy still rejects the surviving completeness loss.
+    assert "120.0" not in blocker["message"]
+    assert "104.0" in blocker["message"]
 
 
 @pytest.mark.timeout(120)

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -458,8 +458,12 @@ def test_cli_rejects_nondefault_policy_without_scale_for_direct_and_script_modes
         )
         assert result.exit_code == 2
         output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
-        assert "--scale-policy requires an explicit" in output
-        assert "--scale" in output
+        message = " ".join(
+            line.strip(" │") for line in output.splitlines() if line.startswith("│")
+        )
+        assert message == (
+            "Invalid value for --scale-policy: --scale-policy requires an explicit --scale"
+        )
 
 
 def test_script_emitter_rejects_nondefault_policy_without_scale(tmp_path, monkeypatch):

--- a/tests/test_issue_915_dense_case.py
+++ b/tests/test_issue_915_dense_case.py
@@ -12,7 +12,13 @@ _ISSUE_915 = Path(__file__).parent / "fixtures" / "issue_915_case_study_2.step"
 
 def test_issue_915_hole_callouts_share_one_spacing_solve():
     """Keep the real dense-plan failure distinct from its step-detail follow-up."""
-    dwg = build_drawing(_ISSUE_915, page="A2", scale=0.5, detail_view=False)
+    dwg = build_drawing(
+        _ISSUE_915,
+        page="A2",
+        scale=0.5,
+        scale_policy="permissive",
+        detail_view=False,
+    )
 
     assert Counter(feature.kind for feature in dwg.model().features) == Counter(
         {

--- a/tests/test_issue_955_height_contingency.py
+++ b/tests/test_issue_955_height_contingency.py
@@ -186,7 +186,13 @@ def test_an_authored_overall_height_does_not_claim_the_shoulders_are_located():
 
 @pytest.mark.timeout(120)
 def test_an_unplaceable_fallback_is_a_drop_not_a_stale_suppression():
-    drawing = build_drawing(_crowded_grooved_shaft(), page="90x70", scale=4.0, repair=False)
+    drawing = build_drawing(
+        _crowded_grooved_shaft(),
+        page="90x70",
+        scale=4.0,
+        scale_policy="permissive",
+        repair=False,
+    )
     codes = drawing.lint_summary()["by_code"]
 
     assert "dim_height" not in drawing.annotations()

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -1468,7 +1468,9 @@ class TestScaleMinimum:
         # floor. The user asked for it (#489): honour it with a legibility warning, don't raise.
         part = Box(680, 860, 80)
         with pytest.warns(UserWarning, match="legibility floor"):
-            result = make_drawing(part, out=str(tmp_path / "out"), scale=0.1)
+            result = make_drawing(
+                part, out=str(tmp_path / "out"), scale=0.1, scale_policy="permissive"
+            )
         assert result is not None
 
     def test_warning_suggests_safe_scale(self, tmp_path):
@@ -1476,7 +1478,7 @@ class TestScaleMinimum:
 
         part = Box(680, 860, 80)
         with pytest.warns(UserWarning) as record:
-            make_drawing(part, out=str(tmp_path / "out"), scale=0.1)
+            make_drawing(part, out=str(tmp_path / "out"), scale=0.1, scale_policy="permissive")
         msg = str(record[0].message)
         assert "scale" in msg.lower()
         # Names the minimum legible scale (≥ 10/80 = 0.125).
@@ -1526,7 +1528,9 @@ class TestScaleMinimum:
         from draftwright import Sheet
 
         with pytest.warns(UserWarning, match="legibility floor"):
-            sheet = Sheet(Box(680, 860, 80), scale="1:10").auto_dimensions()
+            sheet = Sheet(
+                Box(680, 860, 80), scale="1:10", scale_policy="permissive"
+            ).auto_dimensions()
             sheet.export(str(tmp_path / "s"))
         assert (tmp_path / "s.pdf").exists()  # #702: Sheet.export defaults to PDF
 
@@ -2857,7 +2861,7 @@ class TestComposeThenPackRepack:
         # bisects for a fitting scale ONLY when the scale is not pinned. A user-pinned
         # scale must be honoured (overflow accepted, as asked) — not silently reduced —
         # and the backstop must never crash on the degenerate no-positive-scale case.
-        dwg = build_drawing(Box(4200, 1600, 5400), scale=1)
+        dwg = build_drawing(Box(4200, 1600, 5400), scale=1, scale_policy="permissive")
         assert dwg.scale == 1.0  # pin honoured, not silently rescaled
 
     @pytest.mark.timeout(120)
@@ -9499,7 +9503,11 @@ class TestTurnedDiameters:
         # 1:1, but lifting the middle 5.5 onto a far tier makes it read like an
         # overall dimension. Keep only the 12 mm block on the side view and redraw
         # the three shoulder-to-shoulder links in a genuine enlarged side detail.
-        dwg = build_drawing(self._issue_892_y_chain(axis_z=axis_z, rotation=rotation), scale=1.0)
+        dwg = build_drawing(
+            self._issue_892_y_chain(axis_z=axis_z, rotation=rotation),
+            scale=1.0,
+            scale_policy="permissive",
+        )
 
         main = {n: o for n, o in dwg.iter_annotations() if n.startswith("m_steplen")}
         assert {o.label for o in main.values()} == {"12"}
@@ -9528,7 +9536,7 @@ class TestTurnedDiameters:
         from draftwright import Sheet
 
         part = self._issue_892_y_chain(axis_z=9.0)
-        sheet = Sheet(part, scale=1.0, page="A2").auto_dimensions()
+        sheet = Sheet(part, scale=1.0, page="A2", scale_policy="permissive").auto_dimensions()
         sheet.step(diameter=45, length=3, at=(0, -1.5, 9), axis="y").tolerance(0.2)
         sheet.step(diameter=34, length=5.5, at=(0, -5.75, 9), axis="y").tolerance(0.0, 0.3)
         sheet.step(diameter=28, length=3.5, at=(0, -10.25, 9), axis="y")
@@ -9551,7 +9559,7 @@ class TestTurnedDiameters:
         part = Cylinder(12, 3, align=(Align.CENTER, Align.CENTER, b))
         part += Pos(0, 0, 3) * Cylinder(10, 5, align=(Align.CENTER, Align.CENTER, b))
         part += Pos(0, 0, 8) * Cylinder(8, 4, align=(Align.CENTER, Align.CENTER, b))
-        dwg = build_drawing(part.rotate(Axis.X, 90), scale=1.0)
+        dwg = build_drawing(part.rotate(Axis.X, 90), scale=1.0, scale_policy="permissive")
 
         assert "detail_a" in dwg.views
         detail = {
@@ -9564,7 +9572,12 @@ class TestTurnedDiameters:
         # for the enlarged profile. Do not leave half a detail or reinstate the
         # ambiguous stagger; retain the overall block and let coverage lint expose
         # that the interior shoulders are not located.
-        dwg = build_drawing(self._issue_892_y_chain(), scale=1.0, page="140x100")
+        dwg = build_drawing(
+            self._issue_892_y_chain(),
+            scale=1.0,
+            page="140x100",
+            scale_policy="permissive",
+        )
         assert "detail_a" not in dwg.views
         main = [o for n, o in dwg.iter_annotations() if n.startswith("m_steplen")]
         assert [o.label for o in main] == ["12"]
@@ -10076,7 +10089,12 @@ class TestTurnedLengths:
             seg = Pos(0, 0, z + 1.0) * Cylinder((12 - 0.6 * i) / 2, 2.0)
             part = seg if part is None else part + seg
             z += 2.0
-        dwg = build_drawing(Rotation(0, 90, 0) * part, page="90x70", scale=4.0)
+        dwg = build_drawing(
+            Rotation(0, 90, 0) * part,
+            page="90x70",
+            scale=4.0,
+            scale_policy="permissive",
+        )
         assert not any(
             n.startswith("m_steplen") for n in dwg.annotations()
         )  # skipped, not off-page

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1589,6 +1589,8 @@ class TestCli:
                 "ISO 2768-f",
                 "--scale",
                 "2",
+                "--scale-policy",
+                "permissive",
                 "--page",
                 "A3",
                 "--out",
@@ -1602,6 +1604,7 @@ class TestCli:
         assert "drawn_by='Paul'" in ctor
         assert "tolerance='ISO 2768-f'" in ctor
         assert "scale=2.0" in ctor
+        assert "scale_policy='permissive'" in ctor
         assert "page='A3'" in ctor
 
     def test_sheet_style_omits_default_flags(self, tmp_path):

--- a/tests/test_slot_completeness.py
+++ b/tests/test_slot_completeness.py
@@ -397,7 +397,7 @@ def test_authored_pattern_omission_suppresses_both_location_directions():
 
 
 def test_a_real_placement_failure_retains_the_dropped_measurement():
-    dwg = build_drawing(_off_centre_slot(), page="A4", scale=1.5)
+    dwg = build_drawing(_off_centre_slot(), page="A4", scale=1.5, scale_policy="permissive")
     (drop,) = [issue for issue in dwg.lint() if issue.code == "slot_dim_dropped"]
     legibility = dwg.lint_summary()["quality"]["legibility"]
     assert legibility["by_code"]["slot_dim_dropped"] == 1
@@ -416,7 +416,7 @@ def test_a_real_placement_failure_retains_the_dropped_measurement():
 
 
 def test_pattern_placement_failures_retain_each_failed_measurement():
-    dwg = build_drawing(_slot_grid(), page="A4", scale=1.0)
+    dwg = build_drawing(_slot_grid(), page="A4", scale=1.0, scale_policy="permissive")
     outcomes = _outcomes(dwg)
     dropped = {outcome.parameter_id for outcome in outcomes if outcome.state == "dropped"}
     assert dropped == {


### PR DESCRIPTION
Closes #1146.

## What changed

Explicit scales can no longer silently discard required manufacturing annotations.

- Adds `strict`, `fallback`, and `permissive` scale-completeness policies.
- Makes the default fallback choose the largest complete preferred ISO 5455 scale at or below the requested scale.
- Records a structured `Drawing.scale_decision` with requested/effective scale, every attempted candidate, and stable blocker identities.
- Includes Sheet-authored table footprints in automatic page composition and final completeness checks.
- Reuses imported, classified, recognised, PMI, and critique inventories across discarded scale trials.
- Validates CLI and generated-script policy options before import/detection work.
- Amends ADR 0004 with the dated explicit-scale completeness decision and the automatic-page versus forced-page policy.

## User impact

A requested 1:1 drawing that loses a required location now either:

- fails immediately under `scale_policy="strict"`;
- falls back to the largest complete preferred scale under the default policy; or
- returns the incomplete drawing only under explicit `scale_policy="permissive"`, with a dedicated warning.

Pinning, priority, informational severity, or reused display names cannot hide a lost requirement.

## Render evidence

The reviewed implementation was rendered on A4 from the same two-hole plate (the final successors are test-only):

- [Requested 1:1 — one required X location is missing](https://gist.github.com/pzfreo/8370d7dc3d6ed0e5a940deaa5d6d6c2c#file-requested-1-to-1-svg)
- [Default 1:2 fallback — the X location is restored](https://gist.github.com/pzfreo/8370d7dc3d6ed0e5a940deaa5d6d6c2c#file-fallback-1-to-2-svg)

## Validation

Exact head `cb2e4f6eb40923432bcca33c7875a4fb55b34a5b`:

- local full gate: 3,640 passed, 5 skipped, 2 xfailed
- exact focused #1146 suite: 25 passed
- total coverage: 94.80%; changed-line coverage: 99% (217/218)
- Ruff, format, mypy (71 source files), codespell, strict MkDocs, and `git diff --check`: green
- independent final adversarial review: approved with zero substantive findings or nits
- hosted CI exposed terminal-rendering differences in one CLI test; the final canary forces colored output, strips ANSI with stdlib only, normalizes Rich panel wrapping, and asserts the exact complete message for both direct and `--script` modes

Earlier adversarial rounds rejected `bdde703`, `0b335da`, `4c8b3cd`, `1aa45e7`, and `286b40f`; each finding was fixed and reviewed again at a new immutable SHA.
