### PR TITLE
Bump version to 0.4.5.dev0 after v0.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.4.dev0"
+version = "0.4.5.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -693,7 +693,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.4.dev0"
+version = "0.4.5.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Summary

- advance the development version from `0.4.4.dev0` to `0.4.5.dev0`
- keep `pyproject.toml` and `uv.lock` in exact agreement

The `v0.4.4` GitHub release and trusted PyPI publication both succeeded. The release workflow then made this same two-file commit locally, but its direct push was rejected by `main` branch protection (`GH006`, three required checks expected). This focused PR routes the mechanical post-release bump through the protected workflow.

## Validation

- `uv lock --check`
- `scripts/pr-check --static`
- `uv build` — built `draftwright-0.4.5.dev0` wheel and sdist
- installed metadata assertion — `0.4.5.dev0`
- `git diff --check`

## Release verification

- GitHub release: https://github.com/pzfreo/draftwright/releases/tag/v0.4.4
- PyPI: https://pypi.org/project/draftwright/0.4.4/
- isolated PyPI install and real `build_drawing(Box(...))` smoke test passed
