### PR TITLE
Fix shank hole, pocket, and fillet annotation layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- Side-drilled hole heights that relocate around callout leaders now join the alternate
+  view's shared dimension ladder before placement, preserving every height and keeping
+  feature locations inside the overall dimension. Datum-starting open pockets no longer
+  print a redundant half-length centre offset, and equal-radius fillets across different
+  edge axes collapse into one counted ``n× R`` callout.
+
 ## v0.4.4 — 2026-08-15
 
 **A semantic-completeness and fail-closed layout patch release.** Hole requirements and drawing

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1759,16 +1759,16 @@ def _fillet_label(radius_text, count) -> str:
 
 def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
     """Fillet radius callouts (#561): a leader from an external edge fillet to its
-    ``R{radius}`` label — the arc analog of :func:`render_chamfers`. Equal-radius fillets on
-    the same edge axis share ONE ``n× R`` callout (#561 acceptance), placed in the view
-    normal to the rounded edge, led diagonally out of the corner into clear margin, and
+    ``R{radius}`` label — the arc analog of :func:`render_chamfers`. Equal-radius fillets
+    share ONE ``n× R`` callout (#561 acceptance), placed in the view normal to a
+    representative rounded edge, led diagonally out of the corner into clear margin, and
     dropped (lint, not silently) if it would overprint placed geometry. Returns the count.
 
     Planner-fed (#725 / #698): the radius VALUE + its tolerance come from the planner's
     ``DimParameter`` (as in ``render_chamfers``), bound explicitly by ``(role, kind)``,
     never positionally — formatting ``fl.radius`` directly dropped an authored tolerance
     (the #629 class). The equal-radius ``n× R`` COLLAPSE stays render-side (grouping by
-    ``(axis, value)`` here, as before) — planner-side grouping is a structural change,
+    radius here) — planner-side grouping is a structural change,
     explicitly out of scope for this migration (#698). Where grouped members' authored
     tolerances differ, the first (member-order) authored one wins — the documented
     ``render_diameters`` shared-ø precedent. ``g.view`` is safe: a FilletFeature's frame
@@ -1785,9 +1785,9 @@ def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
         )
         if pd is None:
             continue
-        collapse.setdefault((g.facts.axis, round(pd.value, 3)), []).append((g, pd))
+        collapse.setdefault(round(pd.value, 3), []).append((g, pd))
     jobs = []
-    for gi, ((axis, _radius), members) in enumerate(sorted(collapse.items())):
+    for gi, (_radius, members) in enumerate(sorted(collapse.items())):
         if only is not None:
             # #426 Ph2b subset (finalize): filter members AFTER the collapse is enumerated so
             # gi stays the full-drawing group index — a survivor keeps its m_fillet name even
@@ -1795,10 +1795,15 @@ def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
             members = [gp for gp in members if gp[0].ref in only]
             if not members:
                 continue
-        # One grouped ``n× R`` callout, but its leader may anchor at ANY of the equal fillets
-        # — _corner_candidates tries each corner (nearest-clear first) so the group is not
-        # dropped just because its first corner leads into an occupied region.
-        ordered = sorted(members, key=lambda gp: gp[0].facts.frame.origin)
+        # Point the leader at one coherent visible set. Members on other edge axes still
+        # contribute to the printed count and semantic measurements, but mixing their 3-D
+        # origins into this view could point at unrelated projected corners. Prefer the
+        # axis with the most members; ties are deterministic.
+        by_axis: dict[str, list] = {}
+        for gp in members:
+            by_axis.setdefault(gp[0].facts.axis, []).append(gp)
+        axis, visible = min(by_axis.items(), key=lambda item: (-len(item[1]), item[0]))
+        ordered = sorted(visible, key=lambda gp: gp[0].facts.frame.origin)
         view = ordered[0][0].view
         vb = dwg.view_bounds(view)
         if vb is None:
@@ -1812,7 +1817,7 @@ def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
                 f"m_fillet_{axis}{gi}",
                 view,
                 vb,
-                _fillet_label(members[0][1].value_text, len(ordered)) + _tol_suffix(tol, draft),
+                _fillet_label(members[0][1].value_text, len(members)) + _tol_suffix(tol, draft),
                 _corner_candidates(
                     dwg,
                     view,
@@ -1823,7 +1828,7 @@ def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
                 ),
                 # One `n× R` callout stands for EVERY collapsed member, so it draws all of
                 # their radii — the tuple storage exists for exactly this (#1002).
-                tuple(pd.id for _, pd in ordered),
+                tuple(pd.id for _, pd in members),
             )
         )
     return _leader_callout_pass(dwg, a, jobs, noun="fillet", drop_code="fillet_dropped", ctx=ctx)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -49,10 +49,12 @@ from draftwright.annotations._common import (
     carve_free_position,
     carve_free_segments,
     clear_label_of_centerlines,
+    corridor_blockers,
     dim_footprint,
     leader_footprint,
     place_strip_candidates,
     register_corridor,
+    strip_free_span,
     strip_obstacles,
 )
 from draftwright.annotations.from_model import (
@@ -967,6 +969,42 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
         strip, view, p_lo, p_hi, edge = primary
         primary_cand = _zc(view, p_lo, p_hi, edge)
 
+        # Choose the alternate BEFORE the shared corridor solve when the natural
+        # witness corridor is already known to cross a placed leader. A post-drain
+        # relocation cannot join the alternate view's existing ladder, so it used to
+        # land outside the overall height and cross its witness line. The inner-tier
+        # footprint is decisive: moving a right-side dimension farther out only grows
+        # the corridor back to the view and therefore cannot clear an existing blocker.
+        if strip is not None and alternates:
+            _lo, _hi, inner = strip_free_span(strip)
+            blocked = _box_hits(_geom_box(primary_cand[1](inner)), corridor_blockers(dwg, view))
+            if blocked:
+                alt_strip, alt_view, alt_p_lo, alt_p_hi, alt_edge = alternates[0]
+                alt_cand = _zc(alt_view, alt_p_lo, alt_p_hi, alt_edge)
+                alt_blocked = alt_strip is None
+                if alt_strip is not None:
+                    _alo, _ahi, alt_inner = strip_free_span(alt_strip)
+                    alt_blocked = _box_hits(
+                        _geom_box(alt_cand[1](alt_inner)),
+                        corridor_blockers(dwg, alt_view),
+                    )
+                    # Do not pre-route into a corridor that cannot hold its existing
+                    # shared ladder plus this candidate. In that case the historical
+                    # alternate/force path remains the honest policy-B fallback.
+                    existing = len(
+                        ctx.corridor_batch.get((alt_view, "right"), {}).get("cands", ())
+                    )
+                    pad = tier + alt_strip.spacing
+                    usable = max(0.0, _ahi - _alo - tier)
+                    capacity = int(usable / pad) + 1
+                    alt_blocked = alt_blocked or capacity < existing + 1
+                if not alt_blocked:
+                    original = primary
+                    primary = alternates[0]
+                    alternates = [original, *alternates[1:]]
+                    strip, view, p_lo, p_hi, edge = primary
+                    primary_cand = alt_cand
+
         def _fallback(
             _nm,
             _primary=primary,
@@ -974,10 +1012,14 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
             _cand=primary_cand,
             _feature_map=_zf,
             _measurement_map=_zm,
+            _candidate_factory=_zc,
             _zo=zo,
         ):
             for alt_strip, alt_view, alt_p_lo, alt_p_hi, alt_edge in _alts:
-                alt = _zc(alt_view, alt_p_lo, alt_p_hi, alt_edge)
+                # Capture this loop member's factory. Referring to `_zc` directly
+                # late-bound every callback to the final height, so two dropped hole
+                # heights retried the last one twice and silently lost the first.
+                alt = _candidate_factory(alt_view, alt_p_lo, alt_p_hi, alt_edge)
                 if not _off_axis_emit(
                     dwg,
                     tier,

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -963,17 +963,40 @@ def lint_prismatic_coverage(
                 unlocated += 1
             continue
         ps = pairs(view)
+        # A datum-starting pocket needs no redundant long-axis centre dimension: the
+        # coincident edge plus the length callout defines it. Ordinary inset pockets
+        # retain their established centre-location scheme. Keep critique on the same
+        # conditional target as the compiler.
+        target_world = {"x": x, "y": y, "z": z}
+        long_datum = float(getattr(bb.min, pocket.long_axis.upper()))
+        if abs(pocket.lo - long_datum) <= tol:
+            target_world[pocket.long_axis] = pocket.lo
         # Projection axes by principal view: plan=(x,y), front=(x,z), side=(y,z).
         coordinates = {
-            "plan": ((x, centre.X, bb.min.X), (y, centre.Y, bb.min.Y)),
-            "front": ((x, centre.X, bb.min.X), (z, centre.Z, bb.min.Z)),
-            "side": ((y, centre.Y, bb.min.Y), (z, centre.Z, bb.min.Z)),
+            "plan": (
+                (target_world["x"], centre.X, bb.min.X),
+                (target_world["y"], centre.Y, bb.min.Y),
+            ),
+            "front": (
+                (target_world["x"], centre.X, bb.min.X),
+                (target_world["z"], centre.Z, bb.min.Z),
+            ),
+            "side": (
+                (target_world["y"], centre.Y, bb.min.Y),
+                (target_world["z"], centre.Z, bb.min.Z),
+            ),
         }[view]
         datum_page = dwg.at(view, bb.min.X, bb.min.Y, bb.min.Z)
-        target_page = dwg.at(view, x, y, z)
+        target_page = dwg.at(
+            view,
+            target_world["x"],
+            target_world["y"],
+            target_world["z"],
+        )
         covered = []
-        for axis, (coord, mid, _datum) in enumerate(coordinates):
+        for axis, (coord, mid, datum) in enumerate(coordinates):
             symmetric = abs(coord - mid) <= 1.0
+            datum_coincident = abs(coord - datum) <= tol
             witnessed = _pair_covers(
                 ps,
                 axis,
@@ -981,7 +1004,7 @@ def lint_prismatic_coverage(
                 target_page[axis],
                 tol,
             )
-            covered.append(symmetric or witnessed)
+            covered.append(symmetric or datum_coincident or witnessed)
         if not all(covered):
             unlocated += 1
     if unlocated:

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -552,13 +552,17 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
                 # diagnostic to say why (Codex #996 r2).
                 dropped.append((f, role, "edge-anchored; the edge conveys the position"))
                 continue
-            # A recognised pocket frame may be anchored at an opening corner;
-            # location furniture defines the in-plane centre, which is expressed
-            # explicitly by lo/hi and w_center for every principal orientation.
-            centre = list(f.frame.origin)
-            centre["xyz".index(f.long_axis)] = (f.lo + f.hi) / 2
-            centre["xyz".index(f.width_axis)] = f.w_center
-            ref = (centre[0], centre[1], centre[2])
+            # An ordinary pocket keeps its established in-plane centre location. When
+            # its long end already starts on the lower datum, however, that edge plus
+            # the length callout fully defines the long position: printing half the
+            # length as a datum-to-centre offset is redundant and opaque (a datum-starting
+            # 62.1 mm pocket otherwise acquires a seemingly arbitrary 31.1 mm mark).
+            ref_point = list(f.frame.origin)
+            long_index = "xyz".index(f.long_axis)
+            datum_coord = (dx, dy, dz)[long_index]
+            ref_point[long_index] = f.lo if abs(f.lo - datum_coord) <= 1e-6 else (f.lo + f.hi) / 2
+            ref_point["xyz".index(f.width_axis)] = f.w_center
+            ref = (ref_point[0], ref_point[1], ref_point[2])
             refs.append((ref, role, f))
         else:
             refs.append((f.frame.origin, role, f))

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -518,6 +518,22 @@ class TestFillet:
         assert len(names) == 1  # ONE grouped callout, not four
         assert dwg.get_annotation(names[0]).label == "4× R3"
 
+    def test_equal_radii_across_edge_axes_share_one_callout(self):
+        # A rounded end can expose equal-R edges on X, Y and Z. Repeating the same R
+        # note once per projection over-specifies one manufacturing instruction.
+        features = [
+            fillet(axis="x", radius=1, at=(-20, -15, -10)),
+            fillet(axis="x", radius=1, at=(20, -15, -10)),
+            fillet(axis="y", radius=1, at=(-20, -15, -10)),
+            fillet(axis="z", radius=1, at=(-20, -15, -10)),
+            fillet(axis="z", radius=1, at=(20, 15, -10)),
+        ]
+        dwg = build_drawing(Box(40, 30, 20), model=features, number="X")
+        names = [name for name in dwg.annotations() if name.startswith("m_fillet")]
+        assert len(names) == 1
+        assert dwg.get_annotation(names[0]).label == "5× R1"
+        assert len(dwg.measurement_keys(names[0])) == 5
+
     def test_needs_axis_radius_at(self):
         with pytest.raises(ValueError):
             fillet(radius=3)  # no axis / at

--- a/tests/test_issue_885_prismatic_coverage.py
+++ b/tests/test_issue_885_prismatic_coverage.py
@@ -110,6 +110,26 @@ def test_side_opening_pocket_gets_two_in_plane_location_dimensions():
     assert "pocket_not_located" not in drawing.lint_summary()["by_code"]
 
 
+def test_datum_starting_side_pocket_does_not_print_half_its_length_as_a_position():
+    minimum = (Align.MIN, Align.CENTER, Align.MIN)
+    part = Box(13.55, 11, 80, align=minimum)
+    part -= Pos(12.61, -1, 0) * Box(
+        0.94,
+        2,
+        62.13,
+        align=(Align.MIN, Align.MIN, Align.MIN),
+    )
+    drawing = build_drawing(part)
+    labels = {
+        drawing.get_annotation(name).label
+        for name in drawing.annotations()
+        if name.startswith("m_pocket")
+    }
+    assert "31.1" not in labels
+    assert "2 × 62.1 × 0.9 DEEP" in labels
+    assert "pocket_not_located" not in drawing.lint_summary()["by_code"]
+
+
 def test_unrelated_dimension_endpoint_does_not_locate_side_pocket():
     part = Box(60, 50, 40) - Pos(20, 8, 5) * Box(20, 16, 18)
     drawing = build_drawing(part)

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1002,6 +1002,58 @@ def test_side_hole_z_dim_is_kept_not_dropped_under_policy_b():
     assert any(n.startswith("dim_loc_") and "_z" in n for n in names), "Z location dim was dropped"
 
 
+def test_two_cross_hole_heights_join_overall_ladder_without_crossing():
+    """The GRM-01 class: two X bores plus a long side pocket and equal-R end rounds.
+
+    Side-view callout leaders block the natural height corridor. Both heights must route
+    into the front corridor before its one shared solve, otherwise the first height can
+    vanish and a late retry lands outside/crosses the 80 mm overall witness line.
+    """
+    from dataclasses import replace
+
+    from build123d import Align, Rot
+
+    from draftwright.model import fillet
+
+    part = Box(13.55, 11, 80, align=(Align.MIN, Align.CENTER, Align.MIN))
+    part -= Pos(12.61, -1, 0) * Box(
+        0.94,
+        2,
+        62.13,
+        align=(Align.MIN, Align.MIN, Align.MIN),
+    )
+    for z, radius in ((66, 4), (75.5, 1.25)):
+        part -= (
+            Pos(0, 0, z)
+            * Rot(0, 90, 0)
+            * Cylinder(
+                radius,
+                13.55,
+                align=(Align.CENTER, Align.CENTER, Align.MIN),
+            )
+        )
+    detected = build_drawing(part, auto_dims=False).model()
+    rounded = [
+        fillet(axis="x", radius=1, at=(0, -5.5, 0)),
+        fillet(axis="x", radius=1, at=(13.55, -5.5, 0)),
+        fillet(axis="y", radius=1, at=(0, -5.5, 0)),
+        fillet(axis="z", radius=1, at=(0, -5.5, 0)),
+        fillet(axis="z", radius=1, at=(13.55, 5.5, 0)),
+    ]
+    drawing = build_drawing(
+        part,
+        model=replace(detected, features=[*detected.features, *rounded]),
+        page="A4",
+    )
+
+    names = ("dim_loc_front_z6600", "dim_loc_front_z7550", "dim_height")
+    assert [drawing.get_annotation(name).label for name in names] == ["66", "75.5", "80"]
+    # Inner-to-outer line order: both feature locations inside the overall dimension.
+    xmax = [drawing.get_annotation(name).bounding_box().max.X for name in names]
+    assert xmax[0] < xmax[1] < xmax[2]
+    assert drawing.lint() == []
+
+
 # --- unified above-corridor solve (ADR 0009 end state, #345/#346) -----------
 
 


### PR DESCRIPTION
## Summary

Fixes four drawing defects reproduced from `GRM-01_shank.step`:

- restores the missing 66 mm bottom location for the Ø8 cross-hole;
- routes both cross-hole heights into the front-right shared solve, producing the monotonic `66 → 75.5 → 80 overall` ladder without crossing witness lines;
- removes the opaque 31.1 mm half-length mark when a longitudinal pocket already starts on the lower datum (the `2 × 62.1 × 0.9 DEEP` callout and datum edge fully define it);
- collapses five equal R1 fillets across X/Y/Z edge axes into one `5× R1` callout.

The hole defect had two causes: the alternate-view retry late-bound both failed heights to the last loop member, and relocation happened after the alternate corridor had already solved. The fix captures each retry factory and pre-routes a known-blocked height only when the alternate shared corridor has capacity.

## Rendered evidence

Before: the Ø8 height was absent, 75.5 sat outside/crossed the 80 overall dimension, the pocket printed 31.1, and R1 appeared as three callout groups.

After (same source STEP, A4, 1:1): `66`, `75.5`, and `80` are ordered inner-to-outer; `31.1` is absent; fillets read `5× R1`; `Drawing.lint()` returns no findings.

Local rendered files used for review:

- `/tmp/grm01-shank-current.png`
- `/tmp/grm01-shank-fixed.png`

## Validation

- `scripts/pr-check --full`
  - 3,643 passed
  - 5 skipped
  - 2 expected failures
  - changed production lines: 100% coverage
- `scripts/pr-check --static`
- exact source STEP rebuilt/exported to SVG and PNG
- exact rebuilt drawing: zero lint findings
