### PR TITLE
Release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.4.5 — 2026-08-15
+
+**A focused technical-drawing correctness patch.** Cross-drilled hole locations now remain
+complete and ordered, datum-starting pocket annotations avoid redundant dimensions, and repeated
+equal-radius fillets collapse into one manufacturing callout.
+
 ### Fixed
 
 - Side-drilled hole heights that relocate around callout leaders now join the alternate


### PR DESCRIPTION
## Summary

- document the focused v0.4.5 shank-drawing correctness patch
- retain an empty Unreleased section for subsequent changes

## Validation

- `git diff --check`
- `scripts/pr-check --static`
- fix PR #1163: full local suite and Python 3.10–3.14 CI green
