### PR TITLE
Bump version to 0.4.6.dev0 after v0.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.5.dev0"
+version = "0.4.6.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -693,7 +693,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.5.dev0"
+version = "0.4.6.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Summary

- advance the development version to `0.4.6.dev0` after publishing v0.4.5
- keep `pyproject.toml` and `uv.lock` aligned

## Validation

- `git diff --check`
- `uv lock --check`
- `scripts/pr-check --static`
