### PR TITLE
Fix rendered hole-callout leader collision geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- Hole-callout obstacle checks now account for the rendered leader shaft width and
+  tip-local arrowhead flare instead of treating the leader as a zero-width centreline
+  (#367). The analytical check remains geometry-only and does not over-reserve the
+  arrowhead's clearance along the whole shaft.
+
 ## v0.4.5 — 2026-08-15
 
 **A focused technical-drawing correctness patch.** Cross-drilled hole locations now remain

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -264,7 +264,8 @@ down it knows only numbers.
   rest), not a custom-script rebuild.
 - Honest edges that remain: placement is per-view (cross-view contention rests
   on ADR 0004); AABB occupancy is deliberately conservative for diagonal
-  leaders (the precise `_geometry._segment_crosses_box` test covers leader
-  shafts); and a perpendicular-axis conflict — a witness line crossing a
-  fixed-height label — is outside the 1-D tier solve's reach, handled by the
-  post-drain `reconcile_witness_labels` shift (#690).
+  leaders (the geometry-only `_geometry._leader_ink_crosses_box` test covers
+  the rendered shaft width and tip-local arrowhead flare without claiming the
+  diagonal AABB's empty triangle, #367); and a perpendicular-axis conflict — a
+  witness line crossing a fixed-height label — is outside the 1-D tier solve's
+  reach, handled by the post-drain `reconcile_witness_labels` shift (#690).

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -369,11 +369,11 @@ def _leader_ink_crosses_box(
     """Whether a rendered leader's tip-to-elbow ink overlaps *box*.
 
     A leader is not a zero-width segment.  Its shaft is a swept rectangle of
-    ``line_width`` and its curved arrowhead is contained by the triangle from the tip to
-    a base ``arrow_length`` along the shaft, with the helper's ``arrow_length / 3``
-    lateral flare.  Testing those two local convex footprints keeps the arrow clearance
-    near the tip; inflating the entire shaft by the arrow size would reject genuinely
-    clear obstacles near the elbow (#367).
+    ``line_width`` and each supported arrowhead style is contained by the triangle from
+    the tip to a base ``arrow_length`` along the shaft, with the helper's
+    ``arrow_length / 3`` lateral flare.  Testing those two local convex footprints keeps
+    the arrow clearance near the tip; inflating the entire shaft by the arrow size would
+    reject genuinely clear obstacles near the elbow (#367).
 
     Touching boundaries are clear, matching :func:`_boxes_overlap` and the placement-side
     semantics of :func:`_segment_crosses_box`.

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -327,6 +327,94 @@ def _segment_clips_box(p, q, box, pad=0.0) -> bool:
     return _segment_clip_extent(p, q, box, pad=pad) is not None
 
 
+def _convex_polygon_overlaps_box(points, box) -> bool:
+    """Whether a convex page-plane polygon has positive-area overlap with an AABB.
+
+    This is the small separating-axis primitive used by
+    :func:`_leader_ink_crosses_box`.  Keeping it here makes the rendered-ink model pure
+    rectangle/vector maths: placement does not build temporary OCC geometry merely to ask
+    whether a candidate is clear (ADRs 0004/0014).
+    """
+    corners = (
+        (box[0], box[1]),
+        (box[2], box[1]),
+        (box[2], box[3]),
+        (box[0], box[3]),
+    )
+    axes = [(1.0, 0.0), (0.0, 1.0)]
+    axes.extend(
+        (-(second[1] - first[1]), second[0] - first[0])
+        for first, second in zip(points, (*points[1:], points[0]), strict=True)
+    )
+    for ax, ay in axes:
+        if abs(ax) + abs(ay) <= 1e-12:
+            continue
+        polygon_projection = [x * ax + y * ay for x, y in points]
+        box_projection = [x * ax + y * ay for x, y in corners]
+        if max(polygon_projection) <= min(box_projection) or max(box_projection) <= min(
+            polygon_projection
+        ):
+            return False
+    return True
+
+
+def _leader_ink_crosses_box(
+    tip,
+    elbow,
+    box,
+    *,
+    arrow_length: float,
+    line_width: float,
+) -> bool:
+    """Whether a rendered leader's tip-to-elbow ink overlaps *box*.
+
+    A leader is not a zero-width segment.  Its shaft is a swept rectangle of
+    ``line_width`` and its curved arrowhead is contained by the triangle from the tip to
+    a base ``arrow_length`` along the shaft, with the helper's ``arrow_length / 3``
+    lateral flare.  Testing those two local convex footprints keeps the arrow clearance
+    near the tip; inflating the entire shaft by the arrow size would reject genuinely
+    clear obstacles near the elbow (#367).
+
+    Touching boundaries are clear, matching :func:`_boxes_overlap` and the placement-side
+    semantics of :func:`_segment_crosses_box`.
+    """
+    dx, dy = float(elbow[0]) - float(tip[0]), float(elbow[1]) - float(tip[1])
+    length = math.hypot(dx, dy)
+    half_line = max(0.0, float(line_width)) / 2.0
+    head_length = max(0.0, float(arrow_length))
+
+    if length <= 1e-12:
+        half = max(half_line, head_length / 3.0)
+        point_box = (tip[0] - half, tip[1] - half, tip[0] + half, tip[1] + half)
+        return _boxes_overlap(point_box, box)
+
+    ux, uy = dx / length, dy / length
+    vx, vy = -uy, ux
+
+    if half_line > 0.0:
+        shaft = (
+            (tip[0] + vx * half_line, tip[1] + vy * half_line),
+            (elbow[0] + vx * half_line, elbow[1] + vy * half_line),
+            (elbow[0] - vx * half_line, elbow[1] - vy * half_line),
+            (tip[0] - vx * half_line, tip[1] - vy * half_line),
+        )
+        if _convex_polygon_overlaps_box(shaft, box):
+            return True
+
+    if head_length > 0.0:
+        half_head = head_length / 3.0
+        base_x, base_y = tip[0] + ux * head_length, tip[1] + uy * head_length
+        arrow = (
+            (tip[0], tip[1]),
+            (base_x + vx * half_head, base_y + vy * half_head),
+            (base_x - vx * half_head, base_y - vy * half_head),
+        )
+        if _convex_polygon_overlaps_box(arrow, box):
+            return True
+
+    return False
+
+
 def _segments_cross_or_overlap(a1, a2, b1, b2) -> bool:
     """Whether two page-plane segments cross or overlap beyond a shared endpoint.
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -33,7 +33,7 @@ from draftwright._core import (
     _iso_bbox,
     _log,
 )
-from draftwright._geometry import plane_axes
+from draftwright._geometry import _leader_ink_crosses_box, plane_axes
 from draftwright.annotations._common import (
     CROSSABLE_TYPES,
     CorridorCandidate,
@@ -42,7 +42,6 @@ from draftwright.annotations._common import (
     _geom_box,
     _hole_location_coverage_fact,
     _same_location_ordinate,
-    _segment_crosses_box,
     _with_hole_center_coverage,
     _with_hole_location_coverage,
     box_within_page_and_clear,
@@ -1885,15 +1884,25 @@ def _needs_section(feat: HoleFeature | PatternFeature):
     return bore.cbore is not None or bore.spotface is not None or not bore.through
 
 
-def _leader_hits(leader, tip, elbow, side, obstacles):
+def _leader_hits(leader, tip, elbow, side, obstacles, draft):
     """True when *leader*'s rendered footprint truly overlaps any *obstacles* box — split into
-    the diagonal tip→elbow SHAFT (checked precisely via `_segment_crosses_box`, since its AABB
-    over-claims the empty triangle it doesn't occupy — #305) and the elbow→label shelf+text
-    (axis-aligned, so the coarse AABB check there is already exact). Promoted (#638; pure)."""
+    the diagonal tip→elbow SHAFT + ARROWHEAD (checked against their analytical rendered ink,
+    since the composite AABB over-claims the empty triangle it doesn't occupy — #305/#367) and
+    the elbow→label shelf+text (axis-aligned, so the coarse AABB check there is already exact).
+    Promoted (#638; pure)."""
     full_box = _geom_box(leader)
     if full_box is None or not _box_hits(full_box, obstacles):
         return False  # fast reject: nowhere near any obstacle
-    if any(_segment_crosses_box(tip, elbow, o) for o in obstacles):
+    if any(
+        _leader_ink_crosses_box(
+            tip,
+            elbow,
+            obstacle,
+            arrow_length=draft.arrow_length,
+            line_width=draft.line_width,
+        )
+        for obstacle in obstacles
+    ):
         return True
     label_box = (
         (elbow[0], full_box[1], full_box[2], full_box[3])
@@ -2433,7 +2442,7 @@ def _place_queue(
             continue
         y = final_y[tid]
         leader, tip, elbow = _build_leader_at(s, edge, side, y, to_page, elbow_dx, draft, a.SCALE)
-        if _leader_hits(leader, tip, elbow, side, occupied):
+        if _leader_hits(leader, tip, elbow, side, occupied, draft):
             crossing.append((s, y, leader))
         else:
             placed.append((s, y, leader))

--- a/tests/test_issue_367_leader_ink.py
+++ b/tests/test_issue_367_leader_ink.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 from build123d import HeadType, Vector
-from build123d_drafting.helpers import Draft, Leader
+from build123d_drafting.helpers import ArrowHead, Draft, Leader
 
 from draftwright._geometry import (
     _convex_polygon_overlaps_box,
@@ -29,7 +29,7 @@ def test_arrowhead_flare_is_collision_evidence_beyond_the_idealised_segment(angl
     unit = (math.cos(radians), math.sin(radians))
     normal = (-unit[1], unit[0])
     elbow = (20.0 * unit[0], 20.0 * unit[1])
-    leader, tip, elbow, side = _leader(draft, elbow)
+    tip = (0.0, 0.0)
     sample = (
         unit[0] * draft.arrow_length * 0.83 + normal[0] * draft.arrow_length * 0.23,
         unit[1] * draft.arrow_length * 0.83 + normal[1] * draft.arrow_length * 0.23,
@@ -39,9 +39,29 @@ def test_arrowhead_flare_is_collision_evidence_beyond_the_idealised_segment(angl
     assert not _segment_crosses_box(tip, elbow, obstacle), (
         "fixture must miss the old zero-width centreline test"
     )
-    assert any(face.is_inside(Vector(sample[0], sample[1], 0.0)) for face in leader.faces()), (
-        "fixture must intersect the real rendered arrowhead"
+    arrow = ArrowHead(
+        size=draft.arrow_length,
+        head_type=head_type,
+        rotation=angle + 180.0,
     )
+    assert any(face.is_inside(Vector(sample[0], sample[1], 0.0)) for face in arrow.faces()), (
+        f"fixture must intersect the real rendered {head_type.name.lower()} arrowhead"
+    )
+    assert _leader_ink_crosses_box(
+        tip,
+        elbow,
+        obstacle,
+        arrow_length=draft.arrow_length,
+        line_width=draft.line_width,
+    )
+
+
+def test_annotation_side_leader_check_uses_the_rendered_arrow_ink():
+    draft = Draft()
+    leader, tip, elbow, side = _leader(draft)
+    obstacle = (2.44, 0.64, 2.54, 0.74)
+
+    assert not _segment_crosses_box(tip, elbow, obstacle)
     assert _leader_hits(leader, tip, elbow, side, (obstacle,), draft)
 
 

--- a/tests/test_issue_367_leader_ink.py
+++ b/tests/test_issue_367_leader_ink.py
@@ -105,6 +105,33 @@ def test_zero_length_leader_uses_its_local_ink_extent():
     )
 
 
+def test_arrow_and_shaft_components_can_be_disabled_independently():
+    # Keep the two footprint branches independently load-bearing.  A zero style value is
+    # a supported boundary for the pure geometry helper even though ordinary Draft values
+    # render both components.
+    assert _leader_ink_crosses_box(
+        (0.0, 0.0),
+        (20.0, 0.0),
+        (2.4, 0.6, 2.6, 0.8),
+        arrow_length=3.0,
+        line_width=0.0,
+    )
+    assert _leader_ink_crosses_box(
+        (0.0, 0.0),
+        (20.0, 0.0),
+        (9.9, 0.4, 10.1, 0.6),
+        arrow_length=0.0,
+        line_width=2.0,
+    )
+    assert not _leader_ink_crosses_box(
+        (0.0, 0.0),
+        (20.0, 0.0),
+        (9.9, -0.1, 10.1, 0.1),
+        arrow_length=0.0,
+        line_width=0.0,
+    )
+
+
 def test_convex_overlap_ignores_a_repeated_polygon_vertex():
     polygon = ((0.0, 0.0), (2.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0))
     assert _convex_polygon_overlaps_box(polygon, (1.0, 1.0, 3.0, 3.0))

--- a/tests/test_issue_367_leader_ink.py
+++ b/tests/test_issue_367_leader_ink.py
@@ -1,0 +1,90 @@
+"""Regression coverage for #367's rendered leader-ink collision model."""
+
+import math
+
+import pytest
+from build123d import HeadType, Vector
+from build123d_drafting.helpers import Draft, Leader
+
+from draftwright._geometry import (
+    _convex_polygon_overlaps_box,
+    _leader_ink_crosses_box,
+    _segment_crosses_box,
+)
+from draftwright.annotations.holes import _leader_hits
+
+
+def _leader(draft, elbow=(20.0, 0.0)):
+    tip = (0.0, 0.0)
+    side = "right" if elbow[0] > 0 else "left"
+    leader = Leader(tip=tip, elbow=elbow, label="X", draft=draft, text_side=side)
+    return leader, tip, elbow, side
+
+
+@pytest.mark.parametrize("head_type", tuple(HeadType))
+@pytest.mark.parametrize("angle", (0.0, 35.0, -35.0, 145.0))
+def test_arrowhead_flare_is_collision_evidence_beyond_the_idealised_segment(angle, head_type):
+    draft = Draft(head_type=head_type)
+    radians = math.radians(angle)
+    unit = (math.cos(radians), math.sin(radians))
+    normal = (-unit[1], unit[0])
+    elbow = (20.0 * unit[0], 20.0 * unit[1])
+    leader, tip, elbow, side = _leader(draft, elbow)
+    sample = (
+        unit[0] * draft.arrow_length * 0.83 + normal[0] * draft.arrow_length * 0.23,
+        unit[1] * draft.arrow_length * 0.83 + normal[1] * draft.arrow_length * 0.23,
+    )
+    obstacle = (sample[0] - 0.05, sample[1] - 0.05, sample[0] + 0.05, sample[1] + 0.05)
+
+    assert not _segment_crosses_box(tip, elbow, obstacle), (
+        "fixture must miss the old zero-width centreline test"
+    )
+    assert any(face.is_inside(Vector(sample[0], sample[1], 0.0)) for face in leader.faces()), (
+        "fixture must intersect the real rendered arrowhead"
+    )
+    assert _leader_hits(leader, tip, elbow, side, (obstacle,), draft)
+
+
+def test_arrowhead_clearance_is_local_to_the_tip_not_the_whole_shaft():
+    draft = Draft()
+    leader, tip, elbow, side = _leader(draft)
+    obstacle = (9.9, 0.6, 10.1, 0.8)
+
+    assert not any(face.is_inside(Vector(10.0, 0.7, 0.0)) for face in leader.faces())
+    assert not _leader_hits(leader, tip, elbow, side, (obstacle,), draft)
+
+
+def test_heavy_shaft_width_is_collision_evidence_beyond_the_centreline():
+    draft = Draft(line_width=4.0, arrow_length=1.0)
+    leader, tip, elbow, side = _leader(draft)
+    obstacle = (9.9, 1.4, 10.1, 1.6)
+
+    assert not _segment_crosses_box(tip, elbow, obstacle), (
+        "fixture must miss the old zero-width centreline test"
+    )
+    assert any(face.is_inside(Vector(10.0, 1.5, 0.0)) for face in leader.faces()), (
+        "fixture must intersect the real rendered shaft"
+    )
+    assert _leader_hits(leader, tip, elbow, side, (obstacle,), draft)
+
+
+def test_zero_length_leader_uses_its_local_ink_extent():
+    assert _leader_ink_crosses_box(
+        (5.0, 5.0),
+        (5.0, 5.0),
+        (5.5, 4.9, 5.6, 5.1),
+        arrow_length=3.0,
+        line_width=0.5,
+    )
+    assert not _leader_ink_crosses_box(
+        (5.0, 5.0),
+        (5.0, 5.0),
+        (6.1, 4.9, 6.2, 5.1),
+        arrow_length=3.0,
+        line_width=0.5,
+    )
+
+
+def test_convex_overlap_ignores_a_repeated_polygon_vertex():
+    polygon = ((0.0, 0.0), (2.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0))
+    assert _convex_polygon_overlaps_box(polygon, (1.0, 1.0, 3.0, 3.0))

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -56,6 +56,11 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         ("from_model", "_diameter_step_anchor"),
         ("from_model", "_renderable_pmi_records"),
         ("holes", "_legible_locations"),
+        # _leader_hits (#367) composes the pure rendered-ink primitive with the real
+        # Leader label footprint. Its sub-millimetre arrow/shaft counterexamples cannot
+        # be prescribed independently through the public strip solve, so direct coverage
+        # is warranted here and mutation-proves the annotation-side integration.
+        ("holes", "_leader_hits"),
         # Pass-level helpers exercised directly (candidates to retarget onto the ctx seam later).
         ("from_model", "_draw_step_chain"),
         # _reroute_crossing_diameters (#798): its pin-skip and restore-on-failure guards


### PR DESCRIPTION
Closes #367.

## What changed

- replace the idealised zero-width `tip -> elbow` obstacle check for hole-callout leaders with a deterministic analytical ink model;
- model the shaft as its rendered-width oriented rectangle and each supported arrow style by the common tip-local containing triangle (`arrow_length`, `arrow_length / 3` flare);
- keep the existing precise diagonal behavior: only the arrow region gets arrow clearance, so the empty triangle in a whole-leader AABB and the remote shaft are not over-reserved;
- keep the geometry primitive in `_geometry.py` and consume it from the existing hole-callout placement pass;
- update ADR 0014's current consequence note and the Unreleased changelog.

## Root cause

ADR 0009 Amendment 2 replaced a coarse diagonal-leader AABB with a precise segment/AABB check, but explicitly left #367 open: the segment represented the centreline only. The rendered helper draws a finite-width swept shaft and a flared arrowhead, so obstacles could occupy visible ink while the placement check still declared the candidate clear.

## Architecture / ADR corpus validation

I reviewed the complete current ADR corpus (0001–0018, including every amendment) against this change.

- **0001 / 0002 / 0003:** deterministic prevention in the placement decision; no repair-loop or stochastic fallback.
- **0004:** the search remains pure vector/rectangle math; it does not construct temporary OCC geometry while solving.
- **0005:** the new primitive lives in the `_geometry` leaf and `annotations/holes.py` depends downward only; no state bus or second placement path.
- **0006 / 0007 / 0008 / 0010 / 0011 / 0013 / 0015 / 0016 / 0017:** no font, recognition, IR, provenance, public-authoring, compiler, intent, or requirement-correspondence contract changes.
- **0009:** directly resolves the residual gap named in Amendment 2 while preserving Policy B and the precise diagonal/non-AABB decision.
- **0012:** live/deferred edit semantics and pin/priority behavior are unchanged.
- **0014:** uses the existing collect-then-solve hole-callout pass; the current consequence text is updated to name the rendered-ink primitive.
- **0018 (Proposed):** no view-plan or whole-block layout decision is affected.

No new architectural decision or ADR amendment is required: this implements an already accepted and explicitly tracked residual of ADR 0009/0014.

## Evidence

- Synthetic OCC-backed regressions prove the analytical footprint intersects the actual rendered shaft/head while the old centreline misses. Explicit `ArrowHead` geometry covers horizontal/diagonal orientations and all three supported styles; separate real-`Leader` canaries make the annotation-side integration load-bearing (the dependency currently renders `Leader` with its curved default regardless of `Draft.head_type`).
- A negative canary proves arrowhead clearance remains local to the tip instead of widening the entire shaft.
- Zero-length and repeated-vertex boundary cases are explicit.
- Mutation proof: replacing the annotation-side check with the old `_segment_crosses_box` makes the independent arrow/shaft integration regressions fail.
- `/Users/paul/steps/GRM-01_shank.step` renders A4 1:1 with no lint issues and all 14 audited hole requirements placed. The branch and `main` PNGs are byte-identical, confirming no collateral movement on this supplied part; the later #740/#1166/#798 PRs own its broader leader-layout improvements.

## Validation

- `uv run pytest -q tests/test_issue_367_leader_ink.py tests/test_leader_footprint.py tests/test_strip_layout.py tests/test_layout_cleanliness.py tests/test_issue_1142_hole_leader_labels.py tests/test_issue_1143_hole_completeness.py tests/test_import_boundaries.py` — 355 passed before the final boundary additions; final focused #367/private-ratchet selection 19 passed
- `scripts/pr-check --quick` — 91 passed
- `scripts/pr-check --full` — 3,661 passed, 5 skipped, 2 xfailed; total coverage 94.82%; changed-line coverage 100%
- `uv run pytest -q -m slow tests` — 21 passed
- `scripts/pr-check --static` — ruff, format, mypy, codespell, strict docs green
- `git diff --check` — green

## Compatibility

No public API or serialized model changes. Drawings change only when a hole-callout candidate's rendered shaft or arrowhead—not merely its idealised centreline—occupies an obstacle.
