### PR TITLE
Release Draftwright 0.4.6 with stable recognisers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## Unreleased
+## v0.4.6 — 2026-08-15
 
 ### Changed
 
 - **Geometry recognition is supplied by the standalone Apache-2.0
   [`b123d-recognisers`](https://github.com/pzfreo/b123d-recognisers) package.** The cutover
-  pins the published prerelease `v0.1.0a1` (built from commit
-  `4ba34fdcffac117dccc16c818485e779a92e2e29`), removes the
+  pins the published stable release `v0.1.0` (built from commit
+  `9e622716c14d491729b5191aa6e5d8351c982a51`), removes the
   duplicate embedded implementation, and keeps only identity-preserving
   `draftwright.recognition` / `draftwright.score` compatibility re-exports until 0.6.0.
   Draftwright continues to own the one-result build/lint cache, record→IR conversion, drafting

--- a/docs/adr/0007-own-recognition-and-linting.md
+++ b/docs/adr/0007-own-recognition-and-linting.md
@@ -198,10 +198,10 @@ remains draftwright-owned per this ADR.
 ## Amendment 2 — recognition is deployed from the shared package (2026-08-15)
 
 The gated extraction described above has landed as
-[`pzfreo/b123d-recognisers`](https://github.com/pzfreo/b123d-recognisers). Release
-`v0.1.0a1` is built from commit
-`4ba34fdcffac117dccc16c818485e779a92e2e29`; its reviewed semantic goldens are rooted in
-Draftwright baseline `3fe20b0f71a71deced06b310943dd44cc66e355e`.
+[`pzfreo/b123d-recognisers`](https://github.com/pzfreo/b123d-recognisers). Stable release
+`v0.1.0` is built from commit `9e622716c14d491729b5191aa6e5d8351c982a51`; its reviewed
+semantic goldens are rooted in Draftwright baseline
+`3fe20b0f71a71deced06b310943dd44cc66e355e`.
 
 Draftwright consumes that package directly. The former implementation modules under
 `src/draftwright/recognition/` are deleted; only `recognition/__init__.py` remains as an

--- a/docs/adr/0013-uniform-recognition-and-shared-package.md
+++ b/docs/adr/0013-uniform-recognition-and-shared-package.md
@@ -1,7 +1,7 @@
 # ADR 0013 — A uniform recogniser/feature contract and shared `b123d-recognisers` deployment
 
 - **Status:** Accepted; **Phase 1 and Phase 2 deployed**. The uniform contract and
-  typed record→Feature registry are live, and `b123d-recognisers` `v0.1.0a1` is the
+  typed record→Feature registry are live, and `b123d-recognisers` `v0.1.0` is the
   external implementation consumed by Draftwright (Amendment 4).
 - **Date:** 2026-07-12
 - **Deciders:** Paul Fremantle (pzfreo)
@@ -384,11 +384,12 @@ against a manifest-pinned Draftwright baseline and a reviewed semantic golden co
 implementation migration preserved the complete public recogniser inventory, aggregate result,
 shared substrates, and `feature_census`; no drafting or editing policy moved into the package.
 
-The first deployed artifact is `v0.1.0a1`, built from commit
+The first deployed artifact was `v0.1.0a1`, built from commit
 `4ba34fdcffac117dccc16c818485e779a92e2e29`. Publication promoted the reviewed GitHub release
-wheel and sdist through TestPyPI to PyPI with OIDC Trusted Publishing. Draftwright pins that
-exact index version during the cutover, without a mutable branch or version range; its lockfile
-also records the reviewed wheel and sdist hashes.
+wheel and sdist through TestPyPI to PyPI with OIDC Trusted Publishing. After the cutover passed,
+the same behavior was promoted as stable `v0.1.0` from commit
+`9e622716c14d491729b5191aa6e5d8351c982a51`. Draftwright pins that exact index version, without
+a mutable branch or version range; its lockfile also records the reviewed wheel and sdist hashes.
 
 The implementation boundary is enforced in Draftwright:
 

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -10,7 +10,7 @@
   the feature's `DimensionGroup`), moving out of the model-routed list. Only its
   axis centrelines and bore-stack layout remain model-routed furniture.
 - **Amendment 3** (2026-08-15): the recognition tier is deployed from external
-  `b123d-recognisers` `v0.1.0a1`. Draftwright owns the one per-build/lazy-critique
+  `b123d-recognisers` `v0.1.0`. Draftwright owns the one per-build/lazy-critique
   `RecognitionCache`, record→IR conversion, and all drafting policy. The former embedded
   implementation is deleted; compatibility re-exports expire in 0.6.0.
 - **Date:** 2026-07-18

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -78,7 +78,8 @@ accepted commitment or claim that phase 1 delivered semantic completeness.
 ## Amendment 2 — external orchestration, consumer-owned cache
 
 ADR 0013 Phase 2 moved `RecognitionResult` and `build_recognition_result` unchanged into
-`b123d-recognisers` `v0.1.0a1`. It did not move build lifecycle into the geometry package.
+`b123d-recognisers`; stable release `v0.1.0` now supplies them. It did not move build lifecycle
+into the geometry package.
 `BuildState.recognition_cache` owns a Draftwright `RecognitionCache`; `ensure(part)` calls the
 external orchestration at most once, and the compatibility `BuildState.recognition` property
 delegates to that state during the migration window. Automatic analysis fills it before

--- a/docs/plans/0013-shared-recognisers-roadmap.md
+++ b/docs/plans/0013-shared-recognisers-roadmap.md
@@ -2,9 +2,9 @@
 
 Execution record for [ADR 0013](../adr/0013-uniform-recognition-and-shared-package.md).
 **Phase 1 and the code portion of Draftwright-leading Phase 2 are complete.** The standalone
-Apache package is live at <https://github.com/pzfreo/b123d-recognisers>; `v0.1.0a1` is the
-golden-backed migration release and Draftwright consumes it with its duplicate implementation
-removed. mcp remains a slow follower until it chooses to adopt.
+Apache package is live at <https://github.com/pzfreo/b123d-recognisers>; `v0.1.0` is the
+golden-backed stable migration release and Draftwright consumes it with its duplicate
+implementation removed. mcp remains a slow follower until it chooses to adopt.
 
 ## Phase 1 — uniform, geometry-only, extraction-ready `recognition/` (now)
 
@@ -59,10 +59,10 @@ another tool appearing). Until then, do not spin the repo.
   OCP only). Licensing (the Phase 2 gate, ADR 0013 §7): relicense each migrated file to
   Apache in its header (pzfreo owns copyright). Countersink seeds from mcp's
   already-Apache code, so it needs no relicense.
-- **2b — publish + wire. ✅** `v0.1.0a1` was published from exact commit
-  `4ba34fdcffac117dccc16c818485e779a92e2e29`; the same reviewed wheel and sdist were promoted
-  TestPyPI-first through Trusted Publishing. Draftwright pins `b123d-recognisers==0.1.0a1`
-  from PyPI for the cutover, with both artifact hashes captured in `uv.lock`.
+- **2b — publish + wire. ✅** `v0.1.0a1` first proved the atomic cutover. Stable `v0.1.0`
+  was then published from exact commit `9e622716c14d491729b5191aa6e5d8351c982a51`; the same
+  reviewed wheel and sdist were promoted TestPyPI-first through Trusted Publishing. Draftwright
+  pins `b123d-recognisers==0.1.0` from PyPI, with both artifact hashes captured in `uv.lock`.
 - **2c — migrate draftwright imports. ✅** The internal→package swap is atomic; the
   uniform `detect.py` seam is unchanged.
 - **2d — governance. ✅** Geometry-only shareability is enforced by package contract,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.1",
-    "b123d-recognisers==0.1.0a1",
+    "b123d-recognisers==0.1.0",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/tests/test_external_recognition_boundary.py
+++ b/tests/test_external_recognition_boundary.py
@@ -18,14 +18,14 @@ from draftwright.score import feature_census
 
 ROOT = Path(__file__).parents[1]
 RECOGNITION_DIR = ROOT / "src" / "draftwright" / "recognition"
-PINNED_VERSION = "0.1.0a1"
+PINNED_VERSION = "0.1.0"
 RELEASE_HASHES = {
-    "5989187c1ee232778cd81ad4efdbe7d79a46101b40bdf6d0149ba107cc9e8b02",
-    "6e82bcd0d870d731e2de90e0e752716df9d2df4a13132b429755a207ea105d32",
+    "d6f59a9bc2e5bd3144452530cbc1a491e1fd9fbb5182fee9079f6c2f02060989",
+    "936b055a3e8feffe1b825242a6f87ffbc0ba565b6e68e8bae13f94a20bb982e0",
 }
 
 
-def test_dependency_is_pinned_to_the_published_prerelease() -> None:
+def test_dependency_is_pinned_to_the_published_stable_release() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
     dependency = next(d for d in project["dependencies"] if d.startswith("b123d-recognisers"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.1.0a1"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/ec/cc8480e436651a9f044341ddfbcd869c708c54f3c5239a32e9e24043fdd1/b123d_recognisers-0.1.0a1.tar.gz", hash = "sha256:6e82bcd0d870d731e2de90e0e752716df9d2df4a13132b429755a207ea105d32", size = 232423, upload-time = "2026-08-15T12:52:02.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/bb/88cf7d1cc6e9c5ae775954d75c30a26f3859860e50b86cdd24e40ce02177/b123d_recognisers-0.1.0.tar.gz", hash = "sha256:936b055a3e8feffe1b825242a6f87ffbc0ba565b6e68e8bae13f94a20bb982e0", size = 236315, upload-time = "2026-08-15T14:59:05.992Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/bc/2cf6c9faeab43bcad377f44a18d1a8cbc0f328cb4f169d5d10af3b5965cb/b123d_recognisers-0.1.0a1-py3-none-any.whl", hash = "sha256:5989187c1ee232778cd81ad4efdbe7d79a46101b40bdf6d0149ba107cc9e8b02", size = 106441, upload-time = "2026-08-15T12:52:01.179Z" },
+    { url = "https://files.pythonhosted.org/packages/11/e5/196c2507157049d10c9dd6d64f3d259d6d8e2b07ea41ad05608c25e1607f/b123d_recognisers-0.1.0-py3-none-any.whl", hash = "sha256:d6f59a9bc2e5bd3144452530cbc1a491e1fd9fbb5182fee9079f6c2f02060989", size = 106465, upload-time = "2026-08-15T14:59:04.733Z" },
 ]
 
 [[package]]
@@ -745,7 +745,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.1.0a1" },
+    { name = "b123d-recognisers", specifier = "==0.1.0" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.1" },


### PR DESCRIPTION
## Summary

- pin public `b123d-recognisers==0.1.0` and its exact PyPI artifact hashes
- record the stable extraction boundary in the accepted ADRs and execution roadmap
- cut the already-reviewed external-recognition changelog entry as Draftwright 0.4.6

No recognition, IR, drafting, layout, lint, or code-generation behavior changes.

## Release evidence

- package tag `v0.1.0` peels to reviewed merge `9e622716c14d491729b5191aa6e5d8351c982a51`
- TestPyPI, PyPI, GitHub assets, and direct downloads agree on wheel `d6f59a9b…60989` and sdist `936b055a…82e0`
- clean public-PyPI install/import/recognition smoke test passed

## Local validation

- focused stable boundary and recognition regressions: 50 passed
- static preflight: Ruff, format, mypy, codespell, strict docs all clean
- full fast suite: 3,669 passed, 2 skipped, 2 xfailed
- slow real-part/standards suite: 21 passed
- wheel/sdist audit: only `recognition/__init__.py` and `recognition_cache.py`; metadata requires exactly `b123d-recognisers==0.1.0`

This completes the first-compatible-Draftwright release gate in pzfreo/b123d-recognisers#1.