### PR TITLE
Bump development version after v0.4.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.6.dev0"
+version = "0.4.7.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -706,7 +706,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.6.dev0"
+version = "0.4.7.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## Summary

- advance Draftwright development metadata to `0.4.7.dev0`
- keep the lockfile root package version in sync

The v0.4.6 trusted publish succeeded, but its follow-up direct push was correctly rejected by `main` branch protection. This PR applies the exact two-file bump through the protected review/CI path.

## Verification

- `uv lock --check`
- `git diff --check`
- exact two-file diff reviewed