### PR TITLE
Validate recogniser capabilities at the consumer boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Draftwright now validates the released `b123d-recognisers` 0.2.0 capability manifest against
+  an exhaustive consumer-owned declaration of IR, DSL, generated-code, drawing, completeness,
+  and documentation states. Unknown families, stale implementations, record-schema drift, and
+  unevidenced state transitions fail closed; intentionally geometry-only repeating-profile
+  evidence remains usable without acquiring invented drafting semantics.
+
 ### Fixed
 
 - Machined-feature leader callouts now collect all clear alternatives within each

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,11 @@ entry. Keep `_LAYERS` and this section in step.
 - **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
   external `build_recognition_result(part)` at most once for a build/lazy-critique run; the
   package owns recognition, while Draftwright owns when the result is computed and reused.
+- **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
+  only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,
+  `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
+  because validation dynamically resolves implementation references across every lower layer;
+  package geometry policy never imports or owns this consumer overlay.
 - **`model/`** — the ADR 0015 IR waist: `ir.py` (the `Feature`/`DimParameter`/
   `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
   `Feature` objects, adapting `b123d_recognisers` records), `planner.py`

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -1,0 +1,52 @@
+# Recogniser capability contract
+
+Draftwright consumes the public capability manifest installed with `b123d-recognisers`; it never
+reads a sibling checkout or a package-private file. The matching Draftwright-owned declaration is
+implemented in `draftwright.recogniser_contract` and validated in CI.
+
+The package manifest describes geometry evidence. Draftwright separately declares, for every
+package family, its IR adapter, fluent `Sheet` surface, generated-Sheet behavior, drawing consumer,
+completeness treatment, and documentation. A stage is either `supported`, `deferred`,
+`not-applicable`, or `unsupported`, with the evidence required by that state. This separation lets
+other CAD consumers apply different policy without making Draftwright policy part of the geometry
+library.
+
+## What failures mean
+
+Validation fails closed and names the family and boundary whenever possible:
+
+- **family inventory mismatch** — the installed package added, removed, or renamed a family.
+  Update the package pin deliberately, add or remove the Draftwright declaration, and provide the
+  downstream behavior or an explicit non-supported state.
+- **record schema mismatch** — a consumed record schema changed. Review the record fields and
+  compatibility notes, update the relevant adapter and tests, then pin the accepted schema version.
+- **stale implementation** — a declared adapter, `Sheet` method, emitter, renderer, or completeness
+  function no longer resolves. Repair the implementation reference and its independent behavior
+  evidence; do not merely rename the string.
+- **evidence is missing** — a supported claim points at a deleted test or document. Restore or
+  replace the behavior evidence before changing the path.
+- **unknown state or unsupported format** — the installed contract uses semantics this Draftwright
+  version does not understand. Upgrade the validator before accepting the package version.
+- **geometry-only family invents semantics** — geometry used for critique was incorrectly given an
+  inferred IR/DSL/code-generation/drawing path. Keep it geometry-only unless a separately reviewed
+  Draftwright feature introduces authored semantics and compatibility evidence.
+- **reserved family claims supported downstream semantics** — a family-level `deferred` or
+  `unsupported` disposition still advertises an implemented downstream stage. Either make the
+  family disposition supported with behavior evidence, or defer/disable every semantic stage and
+  retain its tracking issue.
+- **state transition lacks evidence** — a capability was strengthened or weakened without a named
+  Draftwright version, release notes, and compatibility tests. Supply all three as one reviewed
+  transition.
+
+## Adding or changing a recogniser
+
+Land the package record, independent geometry evidence, manifest update, and compatible package
+release first. Then update Draftwright against that immutable release. For each applicable stage,
+add the adapter, declaration, emitted-Sheet round trip, drawing behavior, and completeness evidence;
+for an inapplicable or deferred stage, state why and link its tracking issue. The contract test
+derives package record outputs, converter registries, live `Sheet` methods, and emitter branches
+independently, so copying a new name into the declaration alone cannot make CI pass.
+
+`bosses` is the fully consumed reference family. `repeating-radial-profiles` is the opposite
+reference: it remains geometry-only critique evidence for a separately authored gear declaration,
+with no inferred gear feature added to fill the table.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Sheet and fluent handles: reference/sheet.md
       - Drawing results: reference/drawing.md
       - Feature declarations: reference/declarations.md
+      - Recogniser capability contract: reference/recogniser-capabilities.md
       - External spur gear requirements: reference/external-spur-gears.md
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.1",
-    "b123d-recognisers==0.1.0",
+    "b123d-recognisers==0.2.0",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system
@@ -69,6 +69,9 @@ include = [
     "src/draftwright",
     "tests",
     "skills",
+    "docs/reference/recogniser-capabilities.md",
+    "docs/reference/sheet.md",
+    "docs/research/1062-repeating-radial-profile-evidence.md",
     "README.md",
     "LICENSE",
     "CHANGELOG.md",

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -166,7 +166,7 @@ def _pattern_feature(pat, members) -> PatternFeature:
             _member_hole(members[0], frame),
             members=locs,
             pitch=pat.pitch,
-            direction=tuple(pat.direction),
+            direction=pat.direction,
         )
     if isinstance(pat, RectGrid):
         frame = Frame(_xyz(pat.center), axis)

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -1,0 +1,512 @@
+"""Fail-closed Draftwright policy for the installed recogniser capability manifest.
+
+The geometry package says what it can prove.  This module is the separate consumer-owned
+declaration of what Draftwright does with that evidence.  Keeping the declarations here prevents
+recognition policy from leaking into ``b123d-recognisers`` and gives CI one exhaustive join point.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import re
+from dataclasses import dataclass
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+from typing import Any
+
+from b123d_recognisers import capability_manifest
+
+CONSUMER_CAPABILITY_FORMAT = "draftwright-recogniser-capabilities"
+CONSUMER_CAPABILITY_FORMAT_VERSION = 1
+_BOUNDARIES = (
+    "ir_adapter",
+    "dsl_declaration",
+    "generated_code",
+    "drawing_consumer",
+    "completeness",
+    "documentation",
+)
+_STATES = {"deferred", "not-applicable", "supported", "unsupported"}
+_IMPLEMENTATION = re.compile(r"^draftwright(?:\.[A-Za-z_]\w*)+$")
+_TRACKING = re.compile(
+    r"^https://github\.com/pzfreo/(?:draftwright|b123d-recognisers)/issues/\d+$"
+)
+
+
+class RecogniserCapabilityError(RuntimeError):
+    """The installed geometry contract and Draftwright policy cannot be safely joined."""
+
+
+@dataclass(frozen=True)
+class _FamilySpec:
+    records: tuple[str, ...]
+    ir: str
+    dsl: str
+    drawing: str
+
+
+_FAMILIES: dict[str, _FamilySpec] = {
+    "bosses": _FamilySpec(("BossRecord",), "_convert_boss", "boss", "render_boss_diameters"),
+    "chamfers": _FamilySpec(("Chamfer",), "_convert_chamfer", "chamfer", "render_chamfers"),
+    "channels": _FamilySpec(("Channel",), "_convert_channel", "channel", "render_slots"),
+    "countersinks": _FamilySpec(("CounterSink",), "build_part_model", "hole", "_annotate_holes"),
+    "double-d-bores": _FamilySpec(
+        ("DoubleDBore",), "_convert_double_d_bore", "double_d_bore", "_annotate_holes"
+    ),
+    "face-levels": _FamilySpec(
+        ("FaceLevel",), "build_part_model", "step_level", "render_height_ladder"
+    ),
+    "fillets": _FamilySpec(("Fillet",), "_convert_fillet", "fillet", "render_fillets"),
+    "flats": _FamilySpec(("Flat",), "_convert_flat", "flat", "render_flats"),
+    "grooves": _FamilySpec(("Groove",), "_convert_groove", "groove", "render_grooves"),
+    "hole-patterns": _FamilySpec(
+        ("BoltCircle", "LinearArray", "RectGrid"),
+        "_pattern_feature",
+        "pattern",
+        "_annotate_holes",
+    ),
+    "holes": _FamilySpec(
+        ("CounterBore", "HoleRecord", "HoleSpec"), "_member_hole", "hole", "_annotate_holes"
+    ),
+    "plates": _FamilySpec(("Plate",), "_convert_plate", "plate", "render_plates"),
+    "pocket-patterns": _FamilySpec(
+        ("PocketArray", "PocketGrid"),
+        "_pocket_pattern_feature",
+        "pocket_pattern",
+        "render_pocket_patterns",
+    ),
+    "pockets": _FamilySpec(("Pocket",), "_convert_pocket", "pocket", "render_pockets"),
+    "polygonal-bosses": _FamilySpec(
+        ("PolygonalBoss",), "_convert_polygonal_boss", "polygonal_boss", "render_polygonal_bosses"
+    ),
+    "polygonal-stock": _FamilySpec(
+        ("PolygonalStock",),
+        "_convert_polygonal_stock",
+        "polygonal_stock",
+        "render_polygonal_stock",
+    ),
+    "rectangular-pads": _FamilySpec(("RaisedPad",), "_convert_pad", "pad", "render_diameters"),
+    "risers": _FamilySpec(
+        ("RiserEvidence", "StepShoulder"),
+        "build_part_model",
+        "step_level",
+        "render_step_positions",
+    ),
+    "slot-patterns": _FamilySpec(
+        ("SlotArray", "SlotGrid"),
+        "_slot_pattern_feature",
+        "slot_pattern",
+        "render_slot_patterns",
+    ),
+    "slots": _FamilySpec(("Slot",), "_convert_slot", "slot", "render_slots"),
+    "turned-steps": _FamilySpec(
+        ("TurnedProfile", "TurnedStep"), "_convert_step", "step", "render_step_lengths"
+    ),
+}
+
+
+def _supported(implementation: str, evidence: str) -> dict[str, Any]:
+    return {"state": "supported", "implementation": implementation, "evidence": [evidence]}
+
+
+def _deferred_completeness() -> dict[str, Any]:
+    return {
+        "state": "deferred",
+        "rationale": (
+            "The feature is consumed for drafting, but evidence-based completeness scoring is "
+            "being specified separately rather than inferred from annotation presence."
+        ),
+        "tracking": "https://github.com/pzfreo/draftwright/issues/1169",
+    }
+
+
+def _family_declaration(family_id: str, spec: _FamilySpec) -> dict[str, Any]:
+    completeness = _deferred_completeness()
+    if family_id == "bosses":
+        completeness = _supported(
+            "draftwright.linting.coverage.lint_boss_height_coverage",
+            "tests/test_issue_885_prismatic_coverage.py",
+        )
+    return {
+        "id": family_id,
+        "record_schemas": {name: 1 for name in spec.records},
+        "disposition": "supported",
+        "ir_adapter": _supported(
+            f"draftwright.model.detect.{spec.ir}", "tests/test_detect_registry.py"
+        ),
+        "dsl_declaration": _supported(
+            f"draftwright.sheet.Sheet.{spec.dsl}", "tests/test_declare.py"
+        ),
+        "generated_code": _supported(
+            "draftwright.sheet_emit._feature_line", "tests/test_sheet_emit.py"
+        ),
+        "drawing_consumer": _supported(
+            (
+                f"draftwright.annotations.holes.{spec.drawing}"
+                if spec.drawing
+                in {"_annotate_holes", "render_pocket_patterns", "render_slot_patterns"}
+                else f"draftwright.annotations.from_model.{spec.drawing}"
+            ),
+            "tests/test_make_drawing.py",
+        ),
+        "completeness": completeness,
+        "documentation": {
+            "state": "supported",
+            "evidence": [
+                "docs/reference/recogniser-capabilities.md",
+                "docs/reference/sheet.md",
+            ],
+        },
+    }
+
+
+def _geometry_only_declaration() -> dict[str, Any]:
+    rationale = (
+        "Independent repeating-profile evidence critiques a separately authored gear; geometry "
+        "alone must not create inferred gear intent."
+    )
+    no_inferred = {
+        "state": "not-applicable",
+        "rationale": "No inferred drafting feature exists for geometry-only critique evidence.",
+    }
+    return {
+        "id": "repeating-radial-profiles",
+        "record_schemas": {"RepeatingRadialProfile": 1},
+        "disposition": "geometry-only",
+        "rationale": rationale,
+        "package_evidence": ["tests/golden/repeating_radial_profile/expected.json"],
+        "ir_adapter": copy.deepcopy(no_inferred),
+        "dsl_declaration": copy.deepcopy(no_inferred),
+        "generated_code": copy.deepcopy(no_inferred),
+        "drawing_consumer": copy.deepcopy(no_inferred),
+        "completeness": _supported(
+            "draftwright.linting.gear_coverage.lint_declared_gear_coverage",
+            "tests/test_issue_1086_declared_gears.py",
+        ),
+        "documentation": {
+            "state": "supported",
+            "evidence": [
+                "docs/reference/recogniser-capabilities.md",
+                "docs/research/1062-repeating-radial-profile-evidence.md",
+            ],
+        },
+    }
+
+
+def consumer_capability_declaration() -> dict[str, Any]:
+    """Return an isolated format-1 declaration for the released package contract."""
+    families = [_family_declaration(key, value) for key, value in sorted(_FAMILIES.items())]
+    families.append(_geometry_only_declaration())
+    families.sort(key=lambda family: family["id"])
+    return {
+        "format": CONSUMER_CAPABILITY_FORMAT,
+        "format_version": CONSUMER_CAPABILITY_FORMAT_VERSION,
+        "consumer": {"name": "draftwright", "version": "0.4.7.dev0"},
+        "package_compatibility": {
+            "distribution": "b123d-recognisers",
+            "version": "==0.2.0",
+            "manifest_format": 1,
+        },
+        "families": families,
+        "transitions": [],
+    }
+
+
+def _resolve_implementation(reference: str) -> object:
+    if not _IMPLEMENTATION.fullmatch(reference):
+        raise RecogniserCapabilityError(
+            f"invalid Draftwright implementation reference {reference!r}"
+        )
+    parts = reference.split(".")
+    for split in range(len(parts), 0, -1):
+        try:
+            value: object = importlib.import_module(".".join(parts[:split]))
+        except ModuleNotFoundError:
+            continue
+        for attribute in parts[split:]:
+            if not hasattr(value, attribute):
+                raise RecogniserCapabilityError(
+                    f"stale implementation {reference!r}; repair the declaration for this boundary"
+                )
+            value = getattr(value, attribute)
+        return value
+    raise RecogniserCapabilityError(f"stale implementation module in {reference!r}")
+
+
+def _validate_stage(stage: object, family_id: str, boundary: str, root: Path) -> None:
+    context = f"family {family_id!r} boundary {boundary!r}"
+    if not isinstance(stage, dict) or set(stage) - {
+        "evidence",
+        "implementation",
+        "rationale",
+        "state",
+        "tracking",
+    }:
+        raise RecogniserCapabilityError(f"{context} has unknown or invalid fields")
+    state = stage.get("state")
+    if state not in _STATES:
+        raise RecogniserCapabilityError(f"{context} has unknown state {state!r}")
+    if state == "supported":
+        expected = (
+            {"evidence", "state"}
+            if boundary == "documentation"
+            else {
+                "evidence",
+                "implementation",
+                "state",
+            }
+        )
+        if set(stage) != expected:
+            raise RecogniserCapabilityError(f"{context} supported claim lacks required evidence")
+        evidence = stage["evidence"]
+        if not isinstance(evidence, list) or not evidence or evidence != sorted(set(evidence)):
+            raise RecogniserCapabilityError(
+                f"{context} evidence must be non-empty, unique and sorted"
+            )
+        for path in evidence:
+            if not isinstance(path, str) or not (root / path).is_file():
+                raise RecogniserCapabilityError(
+                    f"{context} evidence {path!r} is missing; add an independent behavior test"
+                )
+        if boundary != "documentation":
+            implementation = stage["implementation"]
+            if not isinstance(implementation, str):
+                raise RecogniserCapabilityError(f"{context} implementation must be a reference")
+            _resolve_implementation(implementation)
+        return
+    if state == "deferred":
+        if set(stage) != {"rationale", "state", "tracking"} or not _TRACKING.fullmatch(
+            str(stage.get("tracking", ""))
+        ):
+            raise RecogniserCapabilityError(
+                f"{context} deferred state needs rationale and tracking"
+            )
+    elif set(stage) != {"rationale", "state"}:
+        raise RecogniserCapabilityError(f"{context} {state} state needs only a rationale")
+    if not isinstance(stage.get("rationale"), str) or not stage["rationale"].strip():
+        raise RecogniserCapabilityError(f"{context} needs a non-empty rationale")
+
+
+def validate_recogniser_capabilities(
+    declaration: object | None = None,
+    *,
+    package: object | None = None,
+    source_root: Path | None = None,
+) -> None:
+    """Fail closed when installed package truth and Draftwright policy do not exactly join."""
+    current = consumer_capability_declaration() if declaration is None else declaration
+    manifest = capability_manifest(format_version=1) if package is None else package
+    if not isinstance(current, dict) or set(current) != {
+        "consumer",
+        "families",
+        "format",
+        "format_version",
+        "package_compatibility",
+        "transitions",
+    }:
+        raise RecogniserCapabilityError(
+            "consumer declaration has unknown or missing top-level fields"
+        )
+    if (
+        current["format"] != CONSUMER_CAPABILITY_FORMAT
+        or type(current["format_version"]) is not int
+        or current["format_version"] != 1
+    ):
+        raise RecogniserCapabilityError("unsupported Draftwright recogniser declaration format")
+    consumer = current["consumer"]
+    if not isinstance(consumer, dict) or consumer != {
+        "name": "draftwright",
+        "version": distribution_version("draftwright"),
+    }:
+        raise RecogniserCapabilityError(
+            "consumer identity/version is stale; update it with the Draftwright release"
+        )
+    compatibility = current["package_compatibility"]
+    if not isinstance(compatibility, dict) or compatibility != {
+        "distribution": "b123d-recognisers",
+        "version": "==0.2.0",
+        "manifest_format": 1,
+    }:
+        raise RecogniserCapabilityError(
+            "package compatibility must pin b123d-recognisers 0.2.0 format 1"
+        )
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("format") != "b123d-recognisers-capabilities"
+        or type(manifest.get("format_version")) is not int
+        or manifest.get("format_version") != 1
+    ):
+        raise RecogniserCapabilityError("installed recogniser manifest format is unsupported")
+    package_info = manifest.get("package")
+    if not isinstance(package_info, dict) or package_info.get("version") != "0.2.0":
+        raise RecogniserCapabilityError(
+            f"installed package version {getattr(package_info, 'get', lambda _key: None)('version')!r} "
+            "does not satisfy ==0.2.0; update the pin and declaration together"
+        )
+    package_families = manifest.get("families")
+    families = current["families"]
+    if not isinstance(package_families, list) or not isinstance(families, list):
+        raise RecogniserCapabilityError("package and consumer families must be arrays")
+    package_by_id: dict[str, dict[str, Any]] = {}
+    for family in package_families:
+        if not isinstance(family, dict) or not isinstance(family.get("id"), str):
+            raise RecogniserCapabilityError(
+                "installed package has duplicate or malformed families"
+            )
+        package_by_id[family["id"]] = family
+    if len(package_by_id) != len(package_families):
+        raise RecogniserCapabilityError("installed package has duplicate or malformed families")
+    if not all(
+        isinstance(family, dict) and isinstance(family.get("id"), str) for family in families
+    ):
+        raise RecogniserCapabilityError("consumer family declarations must be objects with IDs")
+    ids = [family["id"] for family in families]
+    if ids != sorted(set(ids)) or set(ids) != set(package_by_id):
+        missing = sorted(set(package_by_id) - set(ids))
+        stale = sorted(set(ids) - set(package_by_id))
+        raise RecogniserCapabilityError(
+            f"family inventory mismatch for installed 0.2.0; unknown={missing}, stale={stale}; "
+            "declare every package family explicitly"
+        )
+    root = source_root or Path(__file__).resolve().parents[2]
+    for family in families:
+        family_id = family["id"]
+        allowed = {
+            "completeness",
+            "disposition",
+            "documentation",
+            "drawing_consumer",
+            "dsl_declaration",
+            "generated_code",
+            "id",
+            "ir_adapter",
+            "package_evidence",
+            "rationale",
+            "record_schemas",
+            "tracking",
+        }
+        if set(family) - allowed or not {
+            "id",
+            "record_schemas",
+            "disposition",
+            *_BOUNDARIES,
+        } <= set(family):
+            raise RecogniserCapabilityError(f"family {family_id!r} has unknown or missing fields")
+        records = package_by_id[family_id].get("records")
+        actual_schemas = (
+            {
+                record.get("name"): record.get("schema_version")
+                for record in records
+                if isinstance(record, dict)
+            }
+            if isinstance(records, list)
+            else {}
+        )
+        if family["record_schemas"] != actual_schemas:
+            raise RecogniserCapabilityError(
+                f"family {family_id!r} record schema mismatch; expected {actual_schemas!r}, "
+                f"declared {family['record_schemas']!r}; update the adapter and pin deliberately"
+            )
+        disposition = family["disposition"]
+        if disposition not in {"deferred", "geometry-only", "supported", "unsupported"}:
+            raise RecogniserCapabilityError(f"family {family_id!r} has invalid disposition")
+        if disposition == "geometry-only":
+            if not isinstance(family.get("rationale"), str) or not family["rationale"].strip():
+                raise RecogniserCapabilityError(
+                    f"geometry-only family {family_id!r} needs rationale"
+                )
+            package_evidence = family.get("package_evidence")
+            available = package_by_id[family_id].get("golden_evidence")
+            if not isinstance(package_evidence, list) or not set(package_evidence) <= set(
+                available or []
+            ):
+                raise RecogniserCapabilityError(
+                    f"geometry-only family {family_id!r} needs package-owned evidence"
+                )
+            for boundary in (
+                "ir_adapter",
+                "dsl_declaration",
+                "generated_code",
+                "drawing_consumer",
+            ):
+                stage = family[boundary]
+                if isinstance(stage, dict) and stage.get("state") == "supported":
+                    raise RecogniserCapabilityError(
+                        f"geometry-only family {family_id!r} invents {boundary} semantics"
+                    )
+        elif disposition == "supported":
+            if "rationale" in family or "package_evidence" in family or "tracking" in family:
+                raise RecogniserCapabilityError(
+                    f"supported family {family_id!r} has geometry-only/reserved fields"
+                )
+        else:
+            if (
+                not isinstance(family.get("rationale"), str)
+                or not family["rationale"].strip()
+                or not _TRACKING.fullmatch(str(family.get("tracking", "")))
+            ):
+                raise RecogniserCapabilityError(
+                    f"reserved family {family_id!r} needs rationale and tracking"
+                )
+            supported = [
+                boundary
+                for boundary in _BOUNDARIES[:-1]
+                if isinstance(family[boundary], dict)
+                and family[boundary].get("state") == "supported"
+            ]
+            if supported:
+                raise RecogniserCapabilityError(
+                    f"reserved family {family_id!r} claims supported downstream semantics: "
+                    f"{supported!r}"
+                )
+        for boundary in _BOUNDARIES:
+            _validate_stage(family[boundary], family_id, boundary, root)
+    transitions = current["transitions"]
+    if not isinstance(transitions, list):
+        raise RecogniserCapabilityError("transitions must be an array")
+    transition_keys: list[tuple[str, str]] = []
+    family_by_id = {family["id"]: family for family in families}
+    for transition in transitions:
+        if not isinstance(transition, dict) or set(transition) != {
+            "boundary",
+            "compatibility_evidence",
+            "family",
+            "from",
+            "release_notes",
+            "to",
+            "version",
+        }:
+            raise RecogniserCapabilityError(
+                "state transition lacks version and compatibility evidence"
+            )
+        transition_family = transition["family"]
+        transition_boundary = transition["boundary"]
+        if not isinstance(transition_family, str) or not isinstance(transition_boundary, str):
+            raise RecogniserCapabilityError(
+                "state transition lacks version and compatibility evidence"
+            )
+        evidence = transition["compatibility_evidence"]
+        notes = transition["release_notes"]
+        transition_keys.append((transition_family, transition_boundary))
+        target = family_by_id.get(transition_family, {}).get(transition_boundary, {}).get("state")
+        if (
+            transition["from"] == transition["to"]
+            or transition["from"] not in _STATES
+            or transition["to"] not in _STATES
+            or transition["to"] != target
+            or transition_family not in ids
+            or transition_boundary not in _BOUNDARIES
+            or not isinstance(evidence, list)
+            or not evidence
+            or evidence != sorted(set(evidence))
+            or any(not isinstance(path, str) or not (root / path).is_file() for path in evidence)
+            or not isinstance(notes, str)
+            or not (root / notes).is_file()
+            or not re.fullmatch(r"\d+\.\d+\.\d+(?:\.dev\d+)?", str(transition["version"]))
+        ):
+            raise RecogniserCapabilityError(
+                "state transition lacks version and compatibility evidence"
+            )
+    if transition_keys != sorted(set(transition_keys)):
+        raise RecogniserCapabilityError("state transitions must be unique and sorted")

--- a/tests/test_external_recognition_boundary.py
+++ b/tests/test_external_recognition_boundary.py
@@ -18,10 +18,10 @@ from draftwright.score import feature_census
 
 ROOT = Path(__file__).parents[1]
 RECOGNITION_DIR = ROOT / "src" / "draftwright" / "recognition"
-PINNED_VERSION = "0.1.0"
+PINNED_VERSION = "0.2.0"
 RELEASE_HASHES = {
-    "d6f59a9bc2e5bd3144452530cbc1a491e1fd9fbb5182fee9079f6c2f02060989",
-    "936b055a3e8feffe1b825242a6f87ffbc0ba565b6e68e8bae13f94a20bb982e0",
+    "16f6e13160310069c2ab610233af3b8da3c6ffb03b481aa38e532e8743381eda",
+    "2ea7e0220bcfc590a2a36dd4eeb5c8ba30ab94141a1eac26094f7917e998f034",
 }
 
 

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -30,9 +30,10 @@ Known limits (static analysis can't fully model these; none occurs in a way that
 DAG violation today, so they are accepted rather than chased):
 
 - **Dynamic imports.** ``importlib.import_module(x)`` / ``__import__(x)`` with a non-literal
-  argument can't be resolved statically. The two current uses (``__init__`` lazy public-API
-  loader, ``sheet_emit``'s emitter) both pass a variable and both live at the top layer
-  (L7/L8), where an upward edge is impossible anyway. A future dynamic import of an internal
+  argument can't be resolved statically. The current uses (``__init__`` lazy public-API
+  loader, ``sheet_emit``'s emitter, and ``recogniser_contract``'s declaration validator) pass a
+  variable and live at the top layer (L7/L8), where an upward edge is impossible anyway. A
+  future dynamic import of an internal
   module from a lower layer would not be seen — prefer a static import there.
 - **A function called during module init.** Imports inside a ``def`` are treated as lazy
   (cycle-breakers). If a module defined such a function *and called it at module scope*, the
@@ -98,6 +99,9 @@ _LAYERS: dict[str, int] = {
     "make_drawing": 7,
     "sheet": 7,
     "sheet_emit": 7,
+    # Cross-repository CI contract: dynamically resolves declared implementations at every
+    # lower layer, so it deliberately sits above the whole engine beside the user surfaces.
+    "recogniser_contract": 7,
     "cli": 7,
     # 8 — the package root: the public API surface, above everything
     "__init__": 8,

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -1,0 +1,512 @@
+"""Independent checks for the cross-repository recogniser capability join."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import dataclasses
+import importlib.metadata
+import inspect
+import typing
+from pathlib import Path
+
+import b123d_recognisers as recognition
+import pytest
+from build123d import Cylinder
+
+from draftwright.model.detect import (
+    _CONVERTERS,
+    _DERIVED_CONVERTERS,
+    _ORCHESTRATED_RECORDS,
+    build_part_model,
+)
+from draftwright.recogniser_contract import (
+    RecogniserCapabilityError,
+    consumer_capability_declaration,
+    validate_recogniser_capabilities,
+)
+from draftwright.sheet import Sheet
+from draftwright.sheet_emit import _feature_line, emit_sheet_script
+
+ROOT = Path(__file__).parents[1]
+
+
+def _families(declaration: dict) -> dict[str, dict]:
+    return {family["id"]: family for family in declaration["families"]}
+
+
+def _runtime_record_types(annotation: object) -> set[type[object]]:
+    args = typing.get_args(annotation)
+    if args:
+        found: set[type[object]] = set()
+        for argument in args:
+            found.update(_runtime_record_types(argument))
+        return found
+    if (
+        isinstance(annotation, type)
+        and dataclasses.is_dataclass(annotation)
+        and annotation.__module__.startswith("b123d_recognisers.")
+    ):
+        return {annotation}
+    return set()
+
+
+def _runtime_emitted_records() -> set[type[object]]:
+    found: set[type[object]] = set()
+    for name in dir(recognition):
+        if not name.startswith(("recognise_", "project_")):
+            continue
+        function = getattr(recognition, name)
+        hints = typing.get_type_hints(function)
+        records = _runtime_record_types(hints.get("return"))
+        assert records, f"{name} has no independently discoverable Record return"
+        found.update(records)
+    return found
+
+
+def _emitter_literal_kinds() -> set[str]:
+    """Derive the emitter inventory from executable branches, not the declaration."""
+    tree = ast.parse(inspect.getsource(_feature_line))
+    kinds: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare) or not isinstance(node.left, ast.Name):
+            continue
+        if node.left.id != "k" or len(node.ops) != 1 or len(node.comparators) != 1:
+            continue
+        right = node.comparators[0]
+        if isinstance(node.ops[0], ast.Eq) and isinstance(right, ast.Constant):
+            if isinstance(right.value, str):
+                kinds.add(right.value)
+        if isinstance(node.ops[0], ast.In) and isinstance(right, (ast.Tuple, ast.Set)):
+            kinds.update(
+                item.value
+                for item in right.elts
+                if isinstance(item, ast.Constant) and isinstance(item.value, str)
+            )
+    return kinds
+
+
+def test_installed_released_package_contract_validates_without_a_sibling_checkout() -> None:
+    distribution = importlib.metadata.distribution("b123d-recognisers")
+    assert distribution.version == "0.2.0"
+    assert distribution.read_text("direct_url.json") is None
+    package_path = Path(inspect.getfile(recognition)).resolve()
+    assert package_path.is_relative_to(ROOT / ".venv")
+
+    validate_recogniser_capabilities()
+    package = recognition.capability_manifest(format_version=1)
+    declaration = consumer_capability_declaration()
+    assert len(package["families"]) == len(declaration["families"]) == 22
+
+
+def test_runtime_adapter_inventory_is_derived_independently_and_exhaustive() -> None:
+    runtime = _runtime_emitted_records()
+    tiers = [set(_CONVERTERS), set(_DERIVED_CONVERTERS), set(_ORCHESTRATED_RECORDS)]
+    assert runtime == set.union(*tiers)
+    assert all(
+        not left & right for index, left in enumerate(tiers) for right in tiers[index + 1 :]
+    )
+
+    declared_records = {
+        name
+        for family in consumer_capability_declaration()["families"]
+        for name in family["record_schemas"]
+    }
+    package_records = {
+        record["name"]
+        for family in recognition.capability_manifest()["families"]
+        for record in family["records"]
+    }
+    assert declared_records == package_records
+
+
+def test_dsl_and_generated_code_inventories_are_derived_from_live_code() -> None:
+    declaration = consumer_capability_declaration()
+    supported = [
+        family
+        for family in declaration["families"]
+        if family["generated_code"]["state"] == "supported"
+    ]
+    sheet_methods = {
+        name
+        for name, value in inspect.getmembers(Sheet)
+        if callable(value) and not name.startswith("_")
+    }
+    declared_methods = {
+        family["dsl_declaration"]["implementation"].rsplit(".", 1)[-1] for family in supported
+    }
+    assert declared_methods <= sheet_methods
+
+    family_kinds = {
+        "bosses": "boss",
+        "chamfers": "chamfer",
+        "channels": "channel",
+        "countersinks": "hole",
+        "double-d-bores": "hole",
+        "face-levels": "step_level",
+        "fillets": "fillet",
+        "flats": "flat",
+        "grooves": "groove",
+        "hole-patterns": "pattern",
+        "holes": "hole",
+        "plates": "plate",
+        "pocket-patterns": "pocket_pattern",
+        "pockets": "pocket",
+        "polygonal-bosses": "polygonal_boss",
+        "polygonal-stock": "polygonal_stock",
+        "rectangular-pads": "pad",
+        "risers": "step_level",
+        "slot-patterns": "slot_pattern",
+        "slots": "slot",
+        "turned-steps": "step",
+    }
+    assert {family["id"] for family in supported} == set(family_kinds)
+    assert set(family_kinds.values()) <= _emitter_literal_kinds()
+
+
+def test_boss_is_fully_consumed_and_generated_sheet_round_trips() -> None:
+    boss = _families(consumer_capability_declaration())["bosses"]
+    assert boss["disposition"] == "supported"
+    assert all(
+        boss[boundary]["state"] == "supported"
+        for boundary in (
+            "ir_adapter",
+            "dsl_declaration",
+            "generated_code",
+            "drawing_consumer",
+            "completeness",
+            "documentation",
+        )
+    )
+
+    part = Cylinder(10, 20)
+    detected = build_part_model(part)
+    source = emit_sheet_script(
+        detected,
+        "part = Cylinder(10, 20)",
+        "contract-roundtrip",
+        title="CONTRACT",
+        number="BOSS-1",
+    )
+    source = "\n".join(
+        line for line in source.splitlines() if not line.startswith("drawing.export(")
+    )
+    namespace: dict[str, object] = {"Cylinder": Cylinder}
+    exec(compile(source, "<generated-sheet>", "exec"), namespace)
+    rebuilt = namespace["drawing"].model()
+    original_boss = next(feature for feature in detected.features if feature.kind == "boss")
+    rebuilt_boss = next(feature for feature in rebuilt.features if feature.kind == "boss")
+    assert rebuilt_boss.parameters() == original_boss.parameters()
+
+
+def test_repeating_profile_is_explicit_geometry_only_critique_evidence() -> None:
+    family = _families(consumer_capability_declaration())["repeating-radial-profiles"]
+    assert family["disposition"] == "geometry-only"
+    assert all(
+        family[boundary]["state"] == "not-applicable"
+        for boundary in ("ir_adapter", "dsl_declaration", "generated_code", "drawing_consumer")
+    )
+    assert family["completeness"]["state"] == "supported"
+    assert recognition.RepeatingRadialProfile in _ORCHESTRATED_RECORDS
+    assert recognition.RepeatingRadialProfile not in _CONVERTERS | _DERIVED_CONVERTERS
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda value: value.update({"format_version": 2}), "unsupported"),
+        (lambda value: value["consumer"].update({"version": "0.4.6"}), "identity/version"),
+        (
+            lambda value: value["package_compatibility"].update({"version": "==0.1.0"}),
+            "must pin",
+        ),
+        (lambda value: value["families"].pop(), "inventory mismatch"),
+        (
+            lambda value: value["families"][0]["record_schemas"].update({"BossRecord": 99}),
+            "record schema mismatch",
+        ),
+        (
+            lambda value: value["families"][0]["ir_adapter"].update(
+                {"implementation": "draftwright.model.detect.no_such_adapter"}
+            ),
+            "stale implementation",
+        ),
+        (
+            lambda value: value["families"][0]["documentation"].update(
+                {"evidence": ["docs/reference/missing.md"]}
+            ),
+            "evidence .* is missing",
+        ),
+        (
+            lambda value: value["families"][0]["completeness"].update({"state": "maybe"}),
+            "unknown state",
+        ),
+    ],
+)
+def test_consumer_declaration_fails_closed_on_stale_or_unknown_claims(
+    mutate, message: str
+) -> None:
+    declaration = consumer_capability_declaration()
+    mutate(declaration)
+    with pytest.raises(RecogniserCapabilityError, match=message):
+        validate_recogniser_capabilities(declaration)
+
+
+def test_unknown_package_family_and_schema_format_fail_closed() -> None:
+    package = recognition.capability_manifest()
+    package["families"].append(copy.deepcopy(package["families"][0]))
+    package["families"][-1]["id"] = "future-thread"
+    with pytest.raises(RecogniserCapabilityError, match="inventory mismatch"):
+        validate_recogniser_capabilities(package=package)
+
+    package = recognition.capability_manifest()
+    package["format_version"] = 2
+    with pytest.raises(RecogniserCapabilityError, match="manifest format"):
+        validate_recogniser_capabilities(package=package)
+
+
+def test_geometry_only_cannot_acquire_invented_drafting_semantics() -> None:
+    declaration = consumer_capability_declaration()
+    family = _families(declaration)["repeating-radial-profiles"]
+    family["ir_adapter"] = copy.deepcopy(_families(declaration)["bosses"]["ir_adapter"])
+    with pytest.raises(RecogniserCapabilityError, match="invents ir_adapter semantics"):
+        validate_recogniser_capabilities(declaration)
+
+
+def test_state_transition_requires_version_release_notes_and_compatibility_evidence() -> None:
+    declaration = consumer_capability_declaration()
+    declaration["transitions"] = [{"family": "bosses", "from": "deferred", "to": "supported"}]
+    with pytest.raises(RecogniserCapabilityError, match="transition lacks"):
+        validate_recogniser_capabilities(declaration)
+
+    declaration["transitions"] = [
+        {
+            "boundary": "completeness",
+            "compatibility_evidence": ["tests/test_recogniser_capabilities.py"],
+            "family": "chamfers",
+            "from": "supported",
+            "release_notes": "CHANGELOG.md",
+            "to": "deferred",
+            "version": "0.4.7",
+        }
+    ]
+    validate_recogniser_capabilities(declaration)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda declaration, _package: declaration["families"][0]["ir_adapter"].update(
+                {"implementation": "not-a-reference"}
+            ),
+            "invalid Draftwright implementation reference",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0].update({"ir_adapter": []}),
+            "unknown or invalid fields",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0]["ir_adapter"].pop(
+                "implementation"
+            ),
+            "supported claim lacks required evidence",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0]["ir_adapter"].update(
+                {"evidence": []}
+            ),
+            "evidence must be non-empty",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0]["ir_adapter"].update(
+                {"implementation": 7}
+            ),
+            "implementation must be a reference",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][1]["completeness"].pop(
+                "tracking"
+            ),
+            "deferred state needs rationale and tracking",
+        ),
+        (
+            lambda declaration, _package: _families(declaration)["repeating-radial-profiles"][
+                "ir_adapter"
+            ].update({"tracking": "https://github.com/pzfreo/draftwright/issues/1"}),
+            "state needs only a rationale",
+        ),
+        (
+            lambda declaration, _package: _families(declaration)["repeating-radial-profiles"][
+                "ir_adapter"
+            ].update({"rationale": ""}),
+            "needs a non-empty rationale",
+        ),
+        (
+            lambda declaration, _package: declaration.pop("transitions"),
+            "unknown or missing top-level fields",
+        ),
+        (
+            lambda _declaration, package: package["package"].update({"version": "0.2.1"}),
+            "does not satisfy ==0.2.0",
+        ),
+        (
+            lambda _declaration, package: package.update({"families": {}}),
+            "families must be arrays",
+        ),
+        (
+            lambda _declaration, package: package["families"].append(None),
+            "duplicate or malformed families",
+        ),
+        (
+            lambda _declaration, package: package["families"].append(
+                copy.deepcopy(package["families"][0])
+            ),
+            "duplicate or malformed families",
+        ),
+        (
+            lambda declaration, _package: declaration["families"].append(None),
+            "consumer family declarations",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0].update({"surprise": 1}),
+            "unknown or missing fields",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0].update(
+                {"disposition": "maybe"}
+            ),
+            "invalid disposition",
+        ),
+        (
+            lambda declaration, _package: _families(declaration)[
+                "repeating-radial-profiles"
+            ].update({"rationale": ""}),
+            "needs rationale",
+        ),
+        (
+            lambda declaration, _package: _families(declaration)[
+                "repeating-radial-profiles"
+            ].update({"package_evidence": ["not-package-evidence.json"]}),
+            "needs package-owned evidence",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0].update(
+                {"rationale": "not allowed on supported"}
+            ),
+            "has geometry-only/reserved fields",
+        ),
+        (
+            lambda declaration, _package: declaration["families"][0].update(
+                {"disposition": "deferred", "rationale": "later"}
+            ),
+            "reserved family .* needs rationale and tracking",
+        ),
+        (
+            lambda declaration, _package: declaration.update({"transitions": {}}),
+            "transitions must be an array",
+        ),
+    ],
+)
+def test_every_malformed_consumer_contract_fails_at_its_own_boundary(mutate, message: str) -> None:
+    declaration = consumer_capability_declaration()
+    package = recognition.capability_manifest()
+    mutate(declaration, package)
+    with pytest.raises(RecogniserCapabilityError, match=message):
+        validate_recogniser_capabilities(declaration, package=package)
+
+
+def _transition() -> dict[str, object]:
+    return {
+        "boundary": "completeness",
+        "compatibility_evidence": ["tests/test_recogniser_capabilities.py"],
+        "family": "chamfers",
+        "from": "supported",
+        "release_notes": "CHANGELOG.md",
+        "to": "deferred",
+        "version": "0.4.7",
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("family", 7),
+        ("boundary", 7),
+        ("from", "deferred"),
+        ("from", "future-state"),
+        ("to", "future-state"),
+        ("to", "supported"),
+        ("family", "future-family"),
+        ("boundary", "future-boundary"),
+        ("compatibility_evidence", "not-a-list"),
+        ("compatibility_evidence", []),
+        (
+            "compatibility_evidence",
+            ["tests/test_recogniser_capabilities.py", "tests/test_recogniser_capabilities.py"],
+        ),
+        ("compatibility_evidence", ["tests/missing-contract-evidence.py"]),
+        ("release_notes", 7),
+        ("release_notes", "docs/missing-release-notes.md"),
+        ("version", "next"),
+    ],
+)
+def test_each_unevidenced_transition_shape_fails_closed(field: str, value: object) -> None:
+    declaration = consumer_capability_declaration()
+    transition = _transition()
+    transition[field] = value
+    declaration["transitions"] = [transition]
+    with pytest.raises(RecogniserCapabilityError, match="transition lacks"):
+        validate_recogniser_capabilities(declaration)
+
+
+def test_transition_keys_must_be_unique() -> None:
+    declaration = consumer_capability_declaration()
+    declaration["transitions"] = [_transition(), _transition()]
+    with pytest.raises(RecogniserCapabilityError, match="unique and sorted"):
+        validate_recogniser_capabilities(declaration)
+
+
+def test_deferred_family_cannot_claim_supported_downstream_semantics() -> None:
+    declaration = consumer_capability_declaration()
+    family = declaration["families"][0]
+    family.update(
+        {
+            "disposition": "deferred",
+            "rationale": "Consumer support is deliberately scheduled later.",
+            "tracking": "https://github.com/pzfreo/draftwright/issues/1169",
+        }
+    )
+    with pytest.raises(RecogniserCapabilityError, match="claims supported downstream semantics"):
+        validate_recogniser_capabilities(declaration)
+
+    for boundary in (
+        "ir_adapter",
+        "dsl_declaration",
+        "generated_code",
+        "drawing_consumer",
+        "completeness",
+    ):
+        family[boundary] = {
+            "state": "deferred",
+            "rationale": "Consumer support is deliberately scheduled later.",
+            "tracking": "https://github.com/pzfreo/draftwright/issues/1169",
+        }
+    validate_recogniser_capabilities(declaration)
+
+
+def test_documentation_names_each_failure_and_contributor_repair_action() -> None:
+    documentation = (ROOT / "docs/reference/recogniser-capabilities.md").read_text(
+        encoding="utf-8"
+    )
+    for message in (
+        "family inventory mismatch",
+        "record schema mismatch",
+        "stale implementation",
+        "evidence is missing",
+        "geometry-only family invents semantics",
+        "reserved family claims supported downstream semantics",
+        "state transition lacks evidence",
+    ):
+        assert message in documentation
+    assert "Adding or changing a recogniser" in documentation

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/bb/88cf7d1cc6e9c5ae775954d75c30a26f3859860e50b86cdd24e40ce02177/b123d_recognisers-0.1.0.tar.gz", hash = "sha256:936b055a3e8feffe1b825242a6f87ffbc0ba565b6e68e8bae13f94a20bb982e0", size = 236315, upload-time = "2026-08-15T14:59:05.992Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/4e/d039e3e90f985136ab2f72567bf7245527bab68b36ad7bf094c6457e976d/b123d_recognisers-0.2.0.tar.gz", hash = "sha256:2ea7e0220bcfc590a2a36dd4eeb5c8ba30ab94141a1eac26094f7917e998f034", size = 283187, upload-time = "2026-08-15T19:01:18.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/e5/196c2507157049d10c9dd6d64f3d259d6d8e2b07ea41ad05608c25e1607f/b123d_recognisers-0.1.0-py3-none-any.whl", hash = "sha256:d6f59a9bc2e5bd3144452530cbc1a491e1fd9fbb5182fee9079f6c2f02060989", size = 106465, upload-time = "2026-08-15T14:59:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5b/c29a0c2618a5212e61596bd04a927561a58042d9e6e635b274d8088aff53/b123d_recognisers-0.2.0-py3-none-any.whl", hash = "sha256:16f6e13160310069c2ab610233af3b8da3c6ffb03b481aa38e532e8743381eda", size = 116896, upload-time = "2026-08-15T19:01:16.99Z" },
 ]
 
 [[package]]
@@ -745,7 +745,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.1.0" },
+    { name = "b123d-recognisers", specifier = "==0.2.0" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.1" },


### PR DESCRIPTION
Closes #1173.

## Summary

- pin the publicly released `b123d-recognisers==0.2.0` artifact and consume only its supported manifest API
- add an exhaustive Draftwright-owned format-1 declaration for all 22 families across IR, `Sheet`, generated code, drawing, completeness, and documentation
- fail closed on unknown/stale families, schema/version/format drift, dead implementation or evidence references, invented geometry-only semantics, reserved families claiming supported semantics, and unevidenced state transitions
- independently derive runtime record outputs/converter tiers, live `Sheet` methods, and executable emitter branches rather than validating the declaration against itself
- prove bosses end to end through generated-Sheet execution/IR round trip and preserve repeating radial profiles as geometry-only gear-critique evidence
- document each failure message and contributor repair action

Completeness is explicitly `deferred` to #1169 for families without an existing evidence-backed policy. Boss height coverage and repeating-profile gear critique are the two existing supported completeness treatments; this avoids turning annotation presence into an invented score.

## Validation

- public PyPI 0.2.0 wheel/sdist hashes independently verified and pinned in both lock and boundary test
- Ruff, formatting, mypy, strict docs, release-boundary, import-boundary and focused contract checks green
- focused validator suite: 69 passed; validator line/branch coverage 99.3% locally
- broad adapter/DSL/emitter/drawing/completeness suite: 1,407 passed, 1 deselected, 2 expected xfails before final hosted matrix
- exact-head hosted matrix green on Python 3.10-3.14; aggregate `ci-ok`, Codecov project, and 98.86% patch coverage green; slow tier legitimately skipped
- candidate-wheel two-checkout harness: 87 package checks plus 65 Draftwright contract/import checks green
- wheel contains the contract module and exact dependency; sdist contains declaration tests and referenced documentation; extracted-sdist validation passed
- adversarial review found and fixed a private-package test import, a stale 0.1.0 release assertion, insufficient mutation coverage, and a reserved-family false-claim gap
- no recognition behavior or canonical goldens changed; base fresh; no review threads
