### PR TITLE
Link the recogniser delivery protocol

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,11 +15,15 @@
 
 - [ ] `scripts/pr-check --quick`
 - [ ] `scripts/pr-check` before final review
+- [ ] Cross-repository recogniser changes follow the [tests-first delivery protocol][recogniser-protocol]
+      and its two-checkout check
 - [ ] The named mutation was observed failing before the implementation passed it
 - [ ] Automatic, declared, and generated-script paths were checked where affected
 - [ ] Recognition and repeated-lint call counts were checked where affected
 
 Use `N/A` with a reason for items that do not apply, such as fixture evidence on a docs-only PR.
+
+[recogniser-protocol]: https://github.com/pzfreo/b123d-recognisers/blob/main/docs/delivery-protocol.md
 
 ## Stop check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,16 @@ Test helpers follow the same evidence rule. Extract a structural assertion only 
 two slices use the same contract. Physical grouping, applicability, and correspondence
 keys stay family-specific unless a failing fixture proves otherwise.
 
+### Cross-repository recognition changes
+
+Changes to a recogniser or its public record follow the package-owned
+[tests-first delivery protocol](https://github.com/pzfreo/b123d-recognisers/blob/main/docs/delivery-protocol.md).
+Draftwright owns the IR adapter, `Sheet` declaration, generated-code round trip, drawing
+regression, and completeness decision; it must not duplicate geometry recognition. Before either
+PR merges, run the documented two-checkout command from the package checkout against the committed
+Draftwright candidate branch. Production dependencies remain exact, hash-verified PyPI artifacts;
+never commit a path or Git override.
+
 ## Pull requests
 
 - Branch off `main` and open a PR with a clear description of **why**.

--- a/tests/test_cross_repository_delivery_protocol.py
+++ b/tests/test_cross_repository_delivery_protocol.py
@@ -1,0 +1,27 @@
+"""Contributor surfaces keep the package-owned delivery protocol discoverable."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+PROTOCOL = "https://github.com/pzfreo/b123d-recognisers/blob/main/docs/delivery-protocol.md"
+
+
+def test_contributor_guide_links_protocol_and_preserves_ownership_boundary() -> None:
+    guide = " ".join((ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8").split())
+    assert PROTOCOL in guide
+    for owned_stage in (
+        "IR adapter",
+        "Sheet` declaration",
+        "generated-code round trip",
+        "drawing regression",
+        "completeness decision",
+    ):
+        assert owned_stage in guide
+    assert "must not duplicate geometry recognition" in guide
+    assert "never commit a path or Git override" in guide
+
+
+def test_pull_request_template_requires_the_two_checkout_protocol() -> None:
+    template = (ROOT / ".github/pull_request_template.md").read_text(encoding="utf-8")
+    assert PROTOCOL in template
+    assert "two-checkout check" in template


### PR DESCRIPTION
Completes the Draftwright-owned cross-link portion of pzfreo/b123d-recognisers#24. Closes pzfreo/b123d-recognisers#24.

## What changed

- link Draftwright contributors to the now-merged canonical tests-first recogniser delivery protocol
- restate Draftwright ownership of IR, `Sheet`, generated code, drawing, and completeness while prohibiting duplicate geometry recognition and committed path/Git overrides
- add the two-checkout protocol gate to the Draftwright PR template
- add an independent regression test that keeps both contributor surfaces and ownership language discoverable

## Validation

- 68 focused contributor/capability/import tests passed
- Ruff, formatting, mypy, and strict documentation build passed after rebase onto Draftwright #1175
- exact two-checkout harness passed against this committed branch: 87 package contract/golden/protocol checks and 65 Draftwright contract/import checks
- canonical package protocol PR pzfreo/b123d-recognisers#35 merged with its full 3 OS × 3 Python matrix and Codecov green
- no runtime, dependency, recognition, drawing, manifest, or golden changes; no version bump
