### PR TITLE
Establish the two-repository recogniser development workflow

### DIFF
--- a/.github/recogniser-release.json
+++ b/.github/recogniser-release.json
@@ -1,0 +1,10 @@
+{
+  "artifacts": {
+    "b123d_recognisers-0.2.0-py3-none-any.whl": "16f6e13160310069c2ab610233af3b8da3c6ffb03b481aa38e532e8743381eda",
+    "b123d_recognisers-0.2.0.tar.gz": "2ea7e0220bcfc590a2a36dd4eeb5c8ba30ab94141a1eac26094f7917e998f034"
+  },
+  "capability_manifest_sha256": "ca54c870f54a77a605b3da10e112a98fc0eae74a0f2aa4435ff9c629552fe32e",
+  "distribution": "b123d-recognisers",
+  "index": "https://pypi.org/simple",
+  "version": "0.2.0"
+}

--- a/.github/workflows/bump-recogniser-dependency.yml
+++ b/.github/workflows/bump-recogniser-dependency.yml
@@ -1,0 +1,89 @@
+name: Bump recogniser dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable b123d-recognisers version already published on PyPI
+        required: true
+        type: string
+      allow_line_change:
+        description: Explicitly permit a reviewed major/minor compatibility-window change
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: recogniser-dependency-bump
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  prepare-pr:
+    name: Prepare immutable recogniser dependency PR
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write # Dispatch the narrow, branch-SHA-bound CI run.
+      contents: write # Push only the generated automation branch.
+      pull-requests: write # Open the generated update PR.
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        # zizmor: ignore[artipacked] -- this job pushes; it uploads no artifacts.
+        with:
+          ref: main
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.13"
+      - name: Update exact release evidence
+        env:
+          ALLOW_LINE_CHANGE: ${{ inputs.allow_line_change }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          args=("$VERSION")
+          if [[ "$ALLOW_LINE_CHANGE" == "true" ]]; then args+=(--allow-line-change); fi
+          scripts/update-recogniser-dependency "${args[@]}"
+      - name: Run focused consumer compatibility checks
+        run: |
+          scripts/check-recogniser-release
+          uv run pytest -q \
+            tests/test_external_recognition_boundary.py \
+            tests/test_recogniser_capabilities.py \
+            tests/test_two_repository_workflow.py
+      - name: Restrict generated diff
+        shell: bash
+        run: |
+          while IFS= read -r path; do
+            case "$path" in
+              .github/recogniser-release.json|CHANGELOG.md|pyproject.toml|uv.lock|src/draftwright/recogniser_contract.py) ;;
+              *) echo "::error::unexpected generated path: $path"; exit 1 ;;
+            esac
+          done < <(git diff --name-only)
+          test -n "$(git diff --name-only)"
+      - name: Commit immutable dependency update
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          branch="automation/recognisers-${VERSION}-${GITHUB_RUN_ID}"
+          git switch -c "$branch"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/recogniser-release.json CHANGELOG.md pyproject.toml uv.lock \
+            src/draftwright/recogniser_contract.py
+          git commit -m "chore: bump b123d-recognisers to ${VERSION}"
+          git push origin HEAD:"$branch"
+          echo "BRANCH=$branch" >> "$GITHUB_ENV"
+      - name: Open evidence-bearing pull request and dispatch narrow CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          manifest=$(python -c \
+            "import json; print(json.load(open('.github/recogniser-release.json'))['capability_manifest_sha256'])")
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: bump b123d-recognisers to ${VERSION}" \
+            --body "Automated exact PyPI dependency update to \`${VERSION}\`. The generated diff records wheel/sdist SHA-256 values, capability-manifest digest \`${manifest}\`, changelog evidence, and the consumer compatibility pin. Focused contract tests passed; a single-runner canonical coverage gate is dispatched below. No slow tier is run."
+          pr_number=$(gh pr view "$BRANCH" --json number --jq .number)
+          gh workflow run ci.yml --ref "$BRANCH" \
+            -f maintenance_bump=true -f maintenance_pr_number="$pr_number"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,16 @@ on:
     # per-PR matrix is Linux-only.
     - cron: "17 4 * * 6"
   workflow_dispatch:
+    inputs:
+      maintenance_bump:
+        description: Run one canonical coverage suite for an automation-only version/dependency PR
+        required: false
+        default: false
+        type: boolean
+      maintenance_pr_number:
+        description: PR number receiving Codecov patch/project statuses for a maintenance bump
+        required: false
+        type: string
 
 # A PR needs results only for its latest head. Each main push gets a unique group because it
 # owns a post-merge slow-suite run that must survive later merges.
@@ -16,13 +26,18 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           python-version: "3.12"
@@ -36,7 +51,7 @@ jobs:
   test:
     # The PR is the compatibility gate. A merge to protected main has already passed these
     # exact checks, so main keeps lint + the slow post-merge safety net without repeating them.
-    if: github.event_name != 'push'
+    if: github.event_name != 'push' && !inputs.maintenance_bump
     permissions:
       contents: read
     strategy:
@@ -78,9 +93,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -106,18 +123,20 @@ jobs:
           --durations=25
 
   coverage:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || inputs.maintenance_bump
     # The ninth OS/Python compatibility entry, split out so only the one job that
     # uploads to Codecov receives an OIDC token and renders retained reports.
     name: test (ubuntu-latest, 3.13)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Authenticate the single canonical Codecov upload without a secret.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           python-version: "3.13"
@@ -135,17 +154,18 @@ jobs:
           --durations=25
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           files: coverage.xml
           # Branch protection requires Codecov's project and patch checks. Fail this
           # job too when the upload cannot produce those checks, rather than hanging.
           fail_ci_if_error: true
+          override_pr: ${{ inputs.maintenance_pr_number || github.event.pull_request.number }}
           use_oidc: true
 
       - name: Upload coverage report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-linux-py3.13
           path: |
@@ -166,8 +186,10 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,12 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
 jobs:
   # Main snapshots need no artifact hand-off: build and trusted publication share one runner.
   publish-testpypi:
@@ -14,19 +20,23 @@ jobs:
     environment: testpypi
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Authenticate trusted TestPyPI publication without a secret.
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          enable-cache: true
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
       - name: Set TestPyPI dev version
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           base="${current%.dev*}"
-          uv version "${base}.dev${{ github.run_number }}"
+          uv version "${base}.dev${RUN_NUMBER}"
       - run: uv build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -34,18 +44,22 @@ jobs:
   build-release:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          enable-cache: true
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
       - name: Strip dev suffix for real release
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           base="${current%.dev*}"
           uv version "$base"
       - run: uv build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -56,38 +70,52 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write
+      id-token: write # Authenticate trusted PyPI publication without a secret.
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   bump-version:
     needs: publish-pypi
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      actions: write # Dispatch the branch-SHA-bound maintenance CI run.
+      contents: write # Push only the generated post-release branch.
+      pull-requests: write # Open the protected-main bump PR.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        # zizmor: ignore[artipacked] -- this job pushes; it uploads no artifacts.
         with:
           ref: main
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Bump patch version with .dev0 suffix
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           base="${current%.dev*}"
           IFS='.' read -r major minor patch <<< "$base"
-          uv version "${major}.${minor}.$((patch + 1)).dev0"
-      - name: Commit and push
+          scripts/update-draftwright-version "${major}.${minor}.$((patch + 1)).dev0"
+      - name: Open the branch-protection-safe post-release bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           new_version=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          git add pyproject.toml uv.lock
+          branch="automation/post-release-${RELEASE_TAG}-${GITHUB_RUN_ID}"
+          git switch -c "$branch"
+          git add pyproject.toml uv.lock src/draftwright/recogniser_contract.py
           git commit -m "chore: bump version to ${new_version} after release"
-          git push
+          git push origin HEAD:"$branch"
+          gh pr create --base main --head "$branch" \
+            --title "chore: bump version to ${new_version} after ${RELEASE_TAG}" \
+            --body "Branch-protection-safe post-release development-version bump. Publication already succeeded for \`${RELEASE_TAG}\`; this PR changes only build/lock identity and the independently checked consumer-contract version. A single-runner regular coverage gate is dispatched; the slow tier is intentionally not run for a version-only bump."
+          pr_number=$(gh pr view "$branch" --json number --jq .number)
+          gh workflow run ci.yml --ref "$branch" \
+            -f maintenance_bump=true -f maintenance_pr_number="$pr_number"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Recogniser co-development now has a one-command, wheel-based two-checkout check; an exact
+  registry-release evidence record; automated dependency PR preparation; and documented landing,
+  compatibility, deprecation, rollback, ownership, and CI-budget rules. Dependency PRs retain the
+  canonical coverage/Codecov gate while avoiding four duplicate platform suites and the slow tier
+  (#1170).
 - A versioned, independently authored STEP-analysis corpus and evaluator now report detection
   recall/false positives, parameter fidelity, and downstream usefulness as separate evidence
   layers. Hash-pinned positive, negative, ambiguous, compound, and topology-order-variant fixtures,
@@ -17,6 +22,9 @@
 
 ### Fixed
 
+- Post-release development-version bumps now update the consumer-contract identity on a branch,
+  open a protected PR, and dispatch the narrow maintenance gate instead of attempting a rejected
+  direct push to protected `main` (#1170).
 - Machined-feature leader callouts now collect all clear alternatives within each
   post-drain pass and use a bounded maximum-cardinality, minimum-leader-length
   assignment instead of taking corners greedily in feature order (#740). If a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,10 @@ PR merges, run the documented two-checkout command from the package checkout aga
 Draftwright candidate branch. Production dependencies remain exact, hash-verified PyPI artifacts;
 never commit a path or Git override.
 
+The complete local command, compatibility windows, landing order, automation, rollback, CI budget,
+and failure-ownership rules are in the
+[recogniser development workflow](docs/recogniser-development-workflow.md).
+
 ## Pull requests
 
 - Branch off `main` and open a PR with a clear description of **why**.

--- a/docs/recogniser-development-workflow.md
+++ b/docs/recogniser-development-workflow.md
@@ -1,0 +1,119 @@
+# Recogniser development and release workflow
+
+Draftwright and `b123d-recognisers` land independently. Geometry algorithms and immutable records
+live in the package; Draftwright owns the IR adapter, declarations, generated code, drawing policy,
+and completeness. Neither repository needs a mutable production dependency to test a candidate.
+
+## Local candidate check
+
+Keep two committed checkouts beside each other and run this one command from Draftwright:
+
+```bash
+scripts/check-recogniser-candidate --package ../b123d-recognisers
+```
+
+The command delegates to the package-owned `tools/check_downstream.py` harness. That harness tests
+package contract/golden evidence, builds a wheel, exports the committed Draftwright checkout to a
+temporary directory, syncs Draftwright's released lock, replaces only the installed wheel, and runs
+the focused consumer contract/import tests. Neither checkout is edited. Use `--plan` to inspect the
+bounded command plan. Never commit a path or Git dependency; those sources are neither immutable nor
+representative of a release installation.
+
+The package's hosted downstream canary runs the same wheel harness against the resolved commit at
+Draftwright `main`. Its job summary records that SHA, so a failure is reproducible even if `main`
+moves later. This is deliberately a narrow contract canary, not another full Draftwright matrix.
+The package matrix proves geometry/platform behavior; Draftwright's own PR and release gates prove
+consumer/platform behavior.
+
+## Compatibility and landing order
+
+### Exact production window
+
+Draftwright supports exactly the stable version named by its `b123d-recognisers==X.Y.Z` dependency,
+consumer declaration, release record, and `uv.lock`. `.github/recogniser-release.json` records the
+PyPI wheel/sdist SHA-256 values and canonical capability-manifest digest. The executable
+`scripts/check-recogniser-release` gate rejects version drift, mutable origins, missing hashes,
+manifest drift, or a non-registry installation. An open version interval is not implied.
+
+### Additive package change
+
+1. Freeze independent package fixtures, negative cases, goldens, schema, and performance evidence.
+2. Land the package change while released Draftwright remains on its exact previous pin.
+3. Publish an `X.Y.ZrcN` only when consumer validation genuinely needs a prerelease; otherwise
+   publish the audited stable patch directly.
+4. Add Draftwright policy/support against the candidate wheel, then publish the stable package
+   patch and dispatch **Bump recogniser dependency** with that version.
+5. Merge the generated Draftwright PR only after its exact hashes, manifest, focused join tests,
+   canonical coverage run, Codecov checks, and `ci-ok` are green.
+
+### Breaking package change
+
+A record removal, identifier/schema break, or manifest-format break requires a major package
+release. Draftwright support for the replacement lands before removal, using a prerelease where an
+immutable candidate is needed. The old stable package and current Draftwright remain green until
+the replacement consumer is released. A breaking change is never hidden in cleanup or a patch.
+
+### Deprecation window
+
+On the current `0.2.x` line, a compatibility alias remains for the rest of that line and is removed
+no earlier than `1.0.0`; its warning names the replacement and removal version. A shorter window
+requires a separately approved compatibility decision and evidence from every supported consumer.
+
+### Release cadence
+
+Use patch releases on the current minor line for compatible, audited changes. Do not cut empty
+releases merely to exercise automation, and do not bump the minor line while the current contract
+can evolve compatibly. Batch no unrelated behavior into a release: each artifact must map to
+reviewed package evidence and release notes.
+
+## Automation, rollback, and triage
+
+The **Bump recogniser dependency** workflow accepts a stable PyPI version. Its generator updates the
+exact dependency, lock, consumer manifest version, changelog, artifact hashes, and capability digest
+as one bounded diff; installs from the registry; runs focused compatibility tests; opens a PR; and
+dispatches `ci.yml` with `maintenance_bump=true`. That mode runs static checks plus one canonical
+regular coverage suite. It skips the four duplicate compatibility copies and never runs the slow
+tier. Codecov project/patch and `ci-ok` still protect `main`.
+
+Draftwright's release workflow likewise opens a post-release `.dev0` bump PR and dispatches the
+same narrow gate. It never pushes directly to protected `main`. This repairs the failure observed
+after v0.4.6, where publication succeeded but a direct push was correctly rejected by branch
+protection.
+
+### Rollback
+
+- Revert a Draftwright bump PR to restore the previous exact PyPI version and hashes.
+- Correct package behavior by publishing a new patch; PyPI files and Git tags are immutable and are
+  never replaced.
+- Withdraw a bad candidate PR/release from the landing sequence, not by switching production to a
+  branch URL. PyPI does not support deleting a mistake into safety; yanking may discourage new
+  resolution but does not replace a consumer rollback.
+
+### Failure ownership
+
+- Package geometry, golden, public-record, manifest, or performance failure: package owner.
+- Draftwright IR, DSL, code generation, drawing, completeness, or release-lock failure: Draftwright
+  owner.
+- Package CI passes but the canary fails: keep the package PR/release candidate unpromoted, attach
+  the resolved Draftwright SHA and failing focused test, and triage at the join. Geometry truth stays
+  package-owned and downstream meaning stays Draftwright-owned; neither side copies the other's
+  implementation to make the check pass.
+- A transient infrastructure failure may be rerun only after its logs show no semantic/test failure.
+
+## Measured proof and CI budget
+
+The no-recognition-behavior 0.2.0 consumer update in
+[pzfreo/draftwright#1175](https://github.com/pzfreo/draftwright/pull/1175) proved the release join:
+Draftwright installed the public PyPI wheel with exact wheel/sdist hashes, independently validated
+all 22 manifest families, and round-tripped the fully consumed boss family while retaining an
+intentional geometry-only family. Its five Linux regular-suite jobs ran from 20:37:49 to 20:58:18,
+a 20m29s wall-time gate with four duplicate full-suite executions.
+
+Maintenance dispatch keeps the canonical coverage execution required by branch protection but
+eliminates those four copies; the package canary runs only the focused cross-repository contract.
+Record the hosted run URL, resolved Draftwright SHA, wall time, package version, artifact hashes, and
+manifest digest in every generated dependency PR. Expand to a full platform matrix only when the
+package changes kernel/platform resolution or the focused join exposes platform-specific behavior.
+
+The package-owned tests-first protocol remains the authoritative per-recogniser checklist:
+<https://github.com/pzfreo/b123d-recognisers/blob/main/docs/delivery-protocol.md>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Feature declarations: reference/declarations.md
       - Recogniser capability contract: reference/recogniser-capabilities.md
       - STEP analysis evaluation: reference/step-analysis-evaluation.md
+      - Recogniser development workflow: recogniser-development-workflow.md
       - External spur gear requirements: reference/external-spur-gears.md
 
 theme:

--- a/scripts/check-recogniser-candidate
+++ b/scripts/check-recogniser-candidate
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Delegate the local candidate check to the package-owned two-checkout harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", type=Path, default=root.parent / "b123d-recognisers")
+    parser.add_argument("--plan", action="store_true")
+    args = parser.parse_args()
+    package = args.package.resolve()
+    harness = package / "tools" / "check_downstream.py"
+    command = [
+        "uv",
+        "run",
+        str(harness),
+        "--package",
+        str(package),
+        "--draftwright",
+        str(root),
+    ]
+    if args.plan:
+        print(
+            json.dumps(
+                {
+                    "owner": "b123d-recognisers",
+                    "draftwright": str(root),
+                    "command": command + ["--plan"],
+                },
+                indent=2,
+            )
+        )
+        return 0
+    if not harness.is_file():
+        parser.error(f"{package} does not contain tools/check_downstream.py")
+    os.chdir(package)
+    os.execvp(command[0], command)
+    return 1  # pragma: no cover - os.execvp either replaces the process or raises
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-recogniser-release
+++ b/scripts/check-recogniser-release
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Fail closed unless Draftwright's recogniser pin is one immutable PyPI release."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"recogniser release evidence: {message}")
+
+
+def verify(root: Path, installed: object) -> str:
+    """Verify checked-in evidence against an independently probed installed distribution."""
+    evidence = json.loads((root / ".github/recogniser-release.json").read_text(encoding="utf-8"))
+    if set(evidence) != {
+        "artifacts",
+        "capability_manifest_sha256",
+        "distribution",
+        "index",
+        "version",
+    }:
+        fail("release record has unknown or missing fields")
+    version = evidence["version"]
+    if not isinstance(version, str) or not re.fullmatch(
+        r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", version
+    ):
+        fail("release record has an invalid version")
+    if evidence["distribution"] != "b123d-recognisers":
+        fail("release record has an invalid distribution")
+    if evidence["index"] != "https://pypi.org/simple":
+        fail("release record is not from the canonical PyPI index")
+    manifest_digest = evidence["capability_manifest_sha256"]
+    if not isinstance(manifest_digest, str) or not re.fullmatch(r"[0-9a-f]{64}", manifest_digest):
+        fail("release record has an invalid capability-manifest digest")
+    artifacts = evidence["artifacts"]
+    if (
+        not isinstance(artifacts, dict)
+        or not artifacts
+        or not all(
+            isinstance(name, str)
+            and isinstance(digest, str)
+            and re.fullmatch(r"[0-9a-f]{64}", digest)
+            for name, digest in artifacts.items()
+        )
+        or not any(name.endswith(".whl") for name in artifacts)
+        or not any(name.endswith(".tar.gz") for name in artifacts)
+    ):
+        fail("release record must contain hash-verified wheel and sdist artifacts")
+    dependency = f"b123d-recognisers=={version}"
+    project = (root / "pyproject.toml").read_text(encoding="utf-8")
+    if f'"{dependency}"' not in project:
+        fail("pyproject dependency and release record disagree")
+    contract = (root / "src/draftwright/recogniser_contract.py").read_text(encoding="utf-8")
+    if f'_PACKAGE_VERSION = "{version}"' not in contract:
+        fail("consumer capability declaration and release record disagree")
+
+    lock = (root / "uv.lock").read_text(encoding="utf-8")
+    blocks = re.findall(
+        r'\[\[package\]\]\nname = "b123d-recognisers"\n(.*?)(?=\n\[\[package\]\]|\Z)',
+        lock,
+        re.DOTALL,
+    )
+    if len(blocks) != 1:
+        fail("uv.lock must contain exactly one recogniser package block")
+    block = blocks[0]
+    version_match = re.match(r'version = "([^"]+)"\n', block)
+    if not version_match or version_match.group(1) != version:
+        fail("uv.lock version and release record disagree")
+    source_match = re.match(r'version = "[^"]+"\nsource = \{ registry = "([^"]+)" \}\n', block)
+    if not source_match or source_match.group(1) != evidence["index"]:
+        fail("uv.lock is not registry-backed by the recorded immutable index")
+    if "git+" in block or "path =" in block or "editable = true" in block:
+        fail("uv.lock contains a mutable Git/path source")
+    locked_artifacts = {
+        Path(url).name: digest
+        for url, digest in re.findall(r'url = "([^"]+)", hash = "sha256:([0-9a-f]{64})"', block)
+    }
+    if locked_artifacts != artifacts:
+        fail("uv.lock artifact names/hashes and release record disagree")
+
+    if installed != {
+        "version": version,
+        "direct_url": None,
+        "manifest_sha256": manifest_digest,
+    }:
+        fail(f"installed registry package does not match release evidence: {installed!r}")
+    return version
+
+
+def _installed_probe(root: Path) -> object:
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-c",
+            (
+                "import hashlib,importlib.metadata,json; "
+                "from b123d_recognisers import capability_manifest; "
+                "d=importlib.metadata.distribution('b123d-recognisers'); "
+                "m=json.dumps(capability_manifest(format_version=1),sort_keys=True,"
+                "separators=(',',':')).encode(); "
+                "print(json.dumps({'version':d.version,'direct_url':d.read_text('direct_url.json'),"
+                "'manifest_sha256':hashlib.sha256(m).hexdigest()}))"
+            ),
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    version = verify(root, _installed_probe(root))
+    print(f"b123d-recognisers {version}: exact PyPI pin, hashes and manifest verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update-draftwright-version
+++ b/scripts/update-draftwright-version
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Atomically update Draftwright's build version and consumer-contract identity."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_DEV_VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\.dev0$")
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version")
+    args = parser.parse_args()
+    if not _DEV_VERSION.fullmatch(args.version):
+        parser.error("post-release version must be X.Y.Z.dev0")
+    project = root / "pyproject.toml"
+    lock = root / "uv.lock"
+    contract = root / "src/draftwright/recogniser_contract.py"
+    project_text = project.read_text(encoding="utf-8")
+    current_match = re.search(r'^version = "([^"]+)"$', project_text, re.MULTILINE)
+    if not current_match:
+        raise RuntimeError("pyproject.toml has no single project version")
+    current = current_match.group(1)
+    contract_text = contract.read_text(encoding="utf-8")
+    old_identity = f'"consumer": {{"name": "draftwright", "version": "{current}"}}'
+    new_identity = f'"consumer": {{"name": "draftwright", "version": "{args.version}"}}'
+    if contract_text.count(old_identity) != 1:
+        raise RuntimeError("consumer declaration version is stale before the bump")
+    snapshots = {path: path.read_bytes() for path in (project, lock, contract)}
+    try:
+        subprocess.run(["uv", "version", args.version], cwd=root, check=True)
+        contract.write_text(contract_text.replace(old_identity, new_identity), encoding="utf-8")
+    except BaseException:
+        for path, content in snapshots.items():
+            path.write_bytes(content)
+        raise
+    print(f"prepared Draftwright {current} -> {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update-recogniser-dependency
+++ b/scripts/update-recogniser-dependency
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Prepare an exact, registry-backed b123d-recognisers dependency update."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def _replace_once(path: Path, before: str, after: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if text.count(before) != 1:
+        raise RuntimeError(f"expected exactly one {before!r} in {path}")
+    path.write_text(text.replace(before, after), encoding="utf-8")
+
+
+def _package_block(lock: str) -> str:
+    matches = re.findall(
+        r'\[\[package\]\]\nname = "b123d-recognisers"\n(.*?)(?=\n\[\[package\]\]|\Z)',
+        lock,
+        re.DOTALL,
+    )
+    if len(matches) != 1:
+        raise RuntimeError("uv.lock must contain exactly one b123d-recognisers package")
+    return matches[0]
+
+
+def _installed_manifest(root: Path) -> dict[str, object]:
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "-c",
+            (
+                "import hashlib,importlib.metadata,json; "
+                "from b123d_recognisers import capability_manifest; "
+                "d=importlib.metadata.distribution('b123d-recognisers'); "
+                "m=json.dumps(capability_manifest(format_version=1),sort_keys=True,"
+                "separators=(',',':')).encode(); "
+                "print(json.dumps({'version':d.version,'direct_url':d.read_text('direct_url.json'),"
+                "'manifest_sha256':hashlib.sha256(m).hexdigest()}))"
+            ),
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _record(root: Path, version: str) -> dict[str, object]:
+    block = _package_block((root / "uv.lock").read_text(encoding="utf-8"))
+    version_match = re.match(r'version = "([^"]+)"\n', block)
+    if not version_match or version_match.group(1) != version:
+        raise RuntimeError(f"uv.lock did not resolve requested version {version}")
+    source_match = re.match(r'version = "[^"]+"\nsource = \{ registry = "([^"]+)" \}\n', block)
+    if not source_match:
+        raise RuntimeError("candidate must resolve from a registry source")
+    index_match = source_match.group(1)
+    if index_match != "https://pypi.org/simple":
+        raise RuntimeError("candidate must resolve from the immutable PyPI index")
+    if "git+" in block or "path =" in block or "editable = true" in block:
+        raise RuntimeError("candidate resolved from a mutable Git/path source")
+    artifacts = {
+        Path(url).name: digest
+        for url, digest in re.findall(r'url = "([^"]+)", hash = "sha256:([0-9a-f]{64})"', block)
+    }
+    if not artifacts or not any(name.endswith(".whl") for name in artifacts):
+        raise RuntimeError("locked release has no hash-verified wheel")
+    if not any(name.endswith(".tar.gz") for name in artifacts):
+        raise RuntimeError("locked release has no hash-verified sdist")
+    installed = _installed_manifest(root)
+    if installed["version"] != version or installed["direct_url"] is not None:
+        raise RuntimeError(f"installed package is not the requested registry release: {installed}")
+    return {
+        "artifacts": dict(sorted(artifacts.items())),
+        "capability_manifest_sha256": installed["manifest_sha256"],
+        "distribution": "b123d-recognisers",
+        "index": index_match,
+        "version": version,
+    }
+
+
+def _add_changelog(root: Path, old: str, new: str, manifest_hash: str) -> None:
+    path = root / "CHANGELOG.md"
+    text = path.read_text(encoding="utf-8")
+    marker = f"- Updated the exact `b123d-recognisers` production lock from {old} to {new}"
+    if marker in text:
+        return
+    bullet = (
+        f"{marker}. The immutable PyPI wheel/sdist hashes and capability-manifest digest "
+        f"`{manifest_hash}` are recorded in `.github/recogniser-release.json`; focused "
+        "compatibility evidence and the normal consumer gates run on the generated PR.\n"
+    )
+    unreleased_start = text.find("## [Unreleased]")
+    if unreleased_start < 0:
+        raise RuntimeError("CHANGELOG.md has no Unreleased section")
+    unreleased_end = text.find("\n## [", unreleased_start + 1)
+    if unreleased_end < 0:
+        unreleased_end = len(text)
+    changed = text.find("### Changed\n", unreleased_start, unreleased_end)
+    if changed >= 0:
+        insert_at = changed + len("### Changed\n")
+        if text.startswith("\n", insert_at):
+            insert_at += 1
+        updated = text[:insert_at] + bullet + text[insert_at:]
+    else:
+        fixed = text.find("### Fixed\n", unreleased_start, unreleased_end)
+        if fixed < 0:
+            raise RuntimeError("CHANGELOG.md has no Unreleased Fixed section anchor")
+        updated = text[:fixed] + "### Changed\n\n" + bullet + "\n" + text[fixed:]
+    path.write_text(updated, encoding="utf-8")
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version")
+    parser.add_argument(
+        "--allow-line-change",
+        action="store_true",
+        help="allow an explicitly reviewed major/minor compatibility-window change",
+    )
+    args = parser.parse_args()
+    match = _VERSION.fullmatch(args.version)
+    if not match:
+        parser.error("version must be a stable X.Y.Z release")
+    contract = root / "src/draftwright/recogniser_contract.py"
+    contract_text = contract.read_text(encoding="utf-8")
+    current_match = re.search(r'^_PACKAGE_VERSION = "([^"]+)"$', contract_text, re.MULTILINE)
+    if not current_match:
+        raise RuntimeError("consumer contract has no single package version")
+    current = current_match.group(1)
+    current_parts = current.split(".")
+    target_parts = args.version.split(".")
+    if current_parts[:2] != target_parts[:2] and not args.allow_line_change:
+        parser.error(
+            f"{current} -> {args.version} changes the compatibility line; "
+            "use --allow-line-change only with breaking/additive policy evidence"
+        )
+
+    paths = [
+        root / "pyproject.toml",
+        root / "uv.lock",
+        contract,
+        root / ".github/recogniser-release.json",
+        root / "CHANGELOG.md",
+    ]
+    snapshots = {path: path.read_bytes() for path in paths}
+    try:
+        if current != args.version:
+            _replace_once(
+                root / "pyproject.toml",
+                f'"b123d-recognisers=={current}"',
+                f'"b123d-recognisers=={args.version}"',
+            )
+            _replace_once(
+                contract,
+                f'_PACKAGE_VERSION = "{current}"',
+                f'_PACKAGE_VERSION = "{args.version}"',
+            )
+        subprocess.run(
+            ["uv", "lock", "--upgrade-package", "b123d-recognisers"], cwd=root, check=True
+        )
+        subprocess.run(["uv", "sync", "--locked"], cwd=root, check=True)
+        record = _record(root, args.version)
+        (root / ".github/recogniser-release.json").write_text(
+            json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if current != args.version:
+            _add_changelog(root, current, args.version, str(record["capability_manifest_sha256"]))
+        subprocess.run([str(root / "scripts/check-recogniser-release")], cwd=root, check=True)
+    except BaseException:
+        for path, content in snapshots.items():
+            path.write_bytes(content)
+        raise
+    print(f"prepared b123d-recognisers {current} -> {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -19,6 +19,7 @@ from b123d_recognisers import capability_manifest
 
 CONSUMER_CAPABILITY_FORMAT = "draftwright-recogniser-capabilities"
 CONSUMER_CAPABILITY_FORMAT_VERSION = 1
+_PACKAGE_VERSION = "0.2.0"
 _BOUNDARIES = (
     "ir_adapter",
     "dsl_declaration",
@@ -205,7 +206,7 @@ def consumer_capability_declaration() -> dict[str, Any]:
         "consumer": {"name": "draftwright", "version": "0.4.7.dev0"},
         "package_compatibility": {
             "distribution": "b123d-recognisers",
-            "version": "==0.2.0",
+            "version": f"=={_PACKAGE_VERSION}",
             "manifest_format": 1,
         },
         "families": families,
@@ -325,11 +326,11 @@ def validate_recogniser_capabilities(
     compatibility = current["package_compatibility"]
     if not isinstance(compatibility, dict) or compatibility != {
         "distribution": "b123d-recognisers",
-        "version": "==0.2.0",
+        "version": f"=={_PACKAGE_VERSION}",
         "manifest_format": 1,
     }:
         raise RecogniserCapabilityError(
-            "package compatibility must pin b123d-recognisers 0.2.0 format 1"
+            f"package compatibility must pin b123d-recognisers {_PACKAGE_VERSION} format 1"
         )
     if (
         not isinstance(manifest, dict)
@@ -339,10 +340,10 @@ def validate_recogniser_capabilities(
     ):
         raise RecogniserCapabilityError("installed recogniser manifest format is unsupported")
     package_info = manifest.get("package")
-    if not isinstance(package_info, dict) or package_info.get("version") != "0.2.0":
+    if not isinstance(package_info, dict) or package_info.get("version") != _PACKAGE_VERSION:
         raise RecogniserCapabilityError(
             f"installed package version {getattr(package_info, 'get', lambda _key: None)('version')!r} "
-            "does not satisfy ==0.2.0; update the pin and declaration together"
+            f"does not satisfy =={_PACKAGE_VERSION}; update the pin and declaration together"
         )
     package_families = manifest.get("families")
     families = current["families"]
@@ -366,7 +367,8 @@ def validate_recogniser_capabilities(
         missing = sorted(set(package_by_id) - set(ids))
         stale = sorted(set(ids) - set(package_by_id))
         raise RecogniserCapabilityError(
-            f"family inventory mismatch for installed 0.2.0; unknown={missing}, stale={stale}; "
+            f"family inventory mismatch for installed {_PACKAGE_VERSION}; "
+            f"unknown={missing}, stale={stale}; "
             "declare every package family explicitly"
         )
     root = source_root or Path(__file__).resolve().parents[2]

--- a/tests/test_external_recognition_boundary.py
+++ b/tests/test_external_recognition_boundary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import b123d_recognisers as external
@@ -18,11 +19,9 @@ from draftwright.score import feature_census
 
 ROOT = Path(__file__).parents[1]
 RECOGNITION_DIR = ROOT / "src" / "draftwright" / "recognition"
-PINNED_VERSION = "0.2.0"
-RELEASE_HASHES = {
-    "16f6e13160310069c2ab610233af3b8da3c6ffb03b481aa38e532e8743381eda",
-    "2ea7e0220bcfc590a2a36dd4eeb5c8ba30ab94141a1eac26094f7917e998f034",
-}
+RELEASE = json.loads((ROOT / ".github/recogniser-release.json").read_text(encoding="utf-8"))
+PINNED_VERSION = RELEASE["version"]
+RELEASE_HASHES = set(RELEASE["artifacts"].values())
 
 
 def test_dependency_is_pinned_to_the_published_stable_release() -> None:

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -7,6 +7,7 @@ import copy
 import dataclasses
 import importlib.metadata
 import inspect
+import json
 import typing
 from pathlib import Path
 
@@ -29,6 +30,9 @@ from draftwright.sheet import Sheet
 from draftwright.sheet_emit import _feature_line, emit_sheet_script
 
 ROOT = Path(__file__).parents[1]
+PINNED_VERSION = json.loads(
+    (ROOT / ".github/recogniser-release.json").read_text(encoding="utf-8")
+)["version"]
 
 
 def _families(declaration: dict) -> dict[str, dict]:
@@ -88,7 +92,7 @@ def _emitter_literal_kinds() -> set[str]:
 
 def test_installed_released_package_contract_validates_without_a_sibling_checkout() -> None:
     distribution = importlib.metadata.distribution("b123d-recognisers")
-    assert distribution.version == "0.2.0"
+    assert distribution.version == PINNED_VERSION
     assert distribution.read_text("direct_url.json") is None
     package_path = Path(inspect.getfile(recognition)).resolve()
     assert package_path.is_relative_to(ROOT / ".venv")
@@ -347,8 +351,8 @@ def test_state_transition_requires_version_release_notes_and_compatibility_evide
             "unknown or missing top-level fields",
         ),
         (
-            lambda _declaration, package: package["package"].update({"version": "0.2.1"}),
-            "does not satisfy ==0.2.0",
+            lambda _declaration, package: package["package"].update({"version": "99.99.99"}),
+            f"does not satisfy =={PINNED_VERSION}",
         ),
         (
             lambda _declaration, package: package.update({"families": {}}),

--- a/tests/test_two_repository_workflow.py
+++ b/tests/test_two_repository_workflow.py
@@ -1,0 +1,238 @@
+"""The two-repository workflow is executable, reproducible, and branch-protection safe."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+GUIDE = ROOT / "docs" / "recogniser-development-workflow.md"
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+DEPENDENCY_BUMP = ROOT / ".github" / "workflows" / "bump-recogniser-dependency.yml"
+PUBLISH = ROOT / ".github" / "workflows" / "publish.yml"
+
+
+def test_policy_defines_compatibility_landing_rollback_and_failure_ownership() -> None:
+    guide = GUIDE.read_text(encoding="utf-8")
+    for required in (
+        "scripts/check-recogniser-candidate",
+        "Exact production window",
+        "Additive package change",
+        "Breaking package change",
+        "Deprecation window",
+        "Release cadence",
+        "Rollback",
+        "Failure ownership",
+        "Package CI passes but the canary fails",
+        "20m29s",
+        "pzfreo/draftwright#1175",
+    ):
+        assert required in guide
+    assert "path or Git dependency" in guide
+    assert "PyPI" in guide and "SHA-256" in guide
+
+
+def test_one_command_candidate_entry_point_delegates_to_package_owned_harness() -> None:
+    result = subprocess.run(
+        [
+            str(ROOT / "scripts" / "check-recogniser-candidate"),
+            "--package",
+            str(ROOT),
+            "--plan",
+        ],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    plan = json.loads(result.stdout)
+    assert plan["owner"] == "b123d-recognisers"
+    assert plan["draftwright"] == str(ROOT.resolve())
+    assert plan["command"][-3:] == ["--draftwright", str(ROOT.resolve()), "--plan"]
+    assert "tools/check_downstream.py" in plan["command"][2]
+
+
+def test_maintenance_dispatch_runs_one_coverage_suite_and_never_the_slow_tier() -> None:
+    workflow = CI.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in workflow
+    assert "maintenance_bump:" in workflow
+    assert "inputs.maintenance_bump" in workflow
+    assert "github.event_name == 'push'" in workflow, "slow remains post-merge only"
+    assert "github.event_name == 'pull_request' || inputs.maintenance_bump" in workflow
+    assert "github.event_name != 'push' && !inputs.maintenance_bump" in workflow
+    assert "maintenance_pr_number" in workflow
+    assert "override_pr:" in workflow
+
+
+def test_dependency_bump_automation_opens_a_pr_and_dispatches_narrow_ci() -> None:
+    workflow = DEPENDENCY_BUMP.read_text(encoding="utf-8")
+    for permission in ("actions: write", "contents: write", "pull-requests: write"):
+        assert permission in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "scripts/update-recogniser-dependency" in workflow
+    assert "scripts/check-recogniser-release" in workflow
+    assert "gh pr create" in workflow
+    assert "gh workflow run ci.yml" in workflow
+    assert "maintenance_bump=true" in workflow
+    assert 'maintenance_pr_number="$pr_number"' in workflow
+    assert "git push origin HEAD:" in workflow
+    assert "git push origin HEAD:main" not in workflow
+    assert "git+" not in workflow and "editable = true" not in workflow
+
+
+def test_post_release_version_bump_is_a_pr_not_a_protected_main_push() -> None:
+    workflow = PUBLISH.read_text(encoding="utf-8")
+    bump = workflow.split("  bump-version:", 1)[1]
+    assert "pull-requests: write" in bump and "actions: write" in bump
+    assert "gh pr create" in bump
+    assert "gh workflow run ci.yml" in bump
+    assert "maintenance_bump=true" in bump
+    assert 'maintenance_pr_number="$pr_number"' in bump
+    assert "git push origin HEAD:" in bump
+    assert "git push\n" not in bump
+
+
+def test_current_release_lock_has_machine_checked_registry_evidence() -> None:
+    lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
+    assert lock.count('name = "b123d-recognisers"') > 1, (
+        "the checker must distinguish the package block from dependency-table references"
+    )
+    subprocess.run([str(ROOT / "scripts" / "check-recogniser-release")], cwd=ROOT, check=True)
+
+
+def test_dependency_updater_reuses_existing_unreleased_changed_heading() -> None:
+    loader = SourceFileLoader(
+        "draftwright_recogniser_dependency_update",
+        str(ROOT / "scripts/update-recogniser-dependency"),
+    )
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        changelog = root / "CHANGELOG.md"
+        changelog.write_text(
+            "# Changelog\n\n## [Unreleased]\n\n### Changed\n\n- Existing change.\n\n"
+            "### Fixed\n\n- Existing fix.\n\n## [0.1.0]\n",
+            encoding="utf-8",
+        )
+        module._add_changelog(root, "0.2.0", "0.2.1", "a" * 64)
+        updated = changelog.read_text(encoding="utf-8")
+        assert updated.count("### Changed") == 1
+        assert "0.2.0 to 0.2.1" in updated
+        assert updated.index("0.2.0 to 0.2.1") < updated.index("### Fixed")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("bad-version", "invalid version"),
+        ("bad-distribution", "invalid distribution"),
+        ("bad-index", "canonical PyPI index"),
+        ("bad-manifest-digest", "invalid capability-manifest digest"),
+        ("missing-wheel", "wheel and sdist"),
+        ("dependency-drift", "pyproject dependency"),
+        ("contract-drift", "consumer capability"),
+        ("mutable-source", "registry-backed"),
+        ("hash-drift", "artifact names/hashes"),
+        ("duplicate-block", "exactly one recogniser package block"),
+        ("editable-install", "installed registry package"),
+        ("manifest-drift", "installed registry package"),
+    ],
+)
+def test_release_evidence_fails_closed_at_each_independent_boundary(
+    tmp_path: Path, mutation: str, message: str
+) -> None:
+    for relative in (
+        ".github/recogniser-release.json",
+        "pyproject.toml",
+        "src/draftwright/recogniser_contract.py",
+        "uv.lock",
+    ):
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / relative, destination)
+
+    evidence_path = tmp_path / ".github/recogniser-release.json"
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    current = evidence["version"]
+    installed = {
+        "version": evidence["version"],
+        "direct_url": None,
+        "manifest_sha256": evidence["capability_manifest_sha256"],
+    }
+    if mutation == "bad-version":
+        evidence["version"] = "v0.2"
+    elif mutation == "bad-distribution":
+        evidence["distribution"] = "lookalike"
+    elif mutation == "bad-index":
+        evidence["index"] = "https://example.invalid/simple"
+    elif mutation == "bad-manifest-digest":
+        evidence["capability_manifest_sha256"] = "not-a-digest"
+        installed["manifest_sha256"] = "not-a-digest"
+    elif mutation == "missing-wheel":
+        evidence["artifacts"] = {
+            name: digest
+            for name, digest in evidence["artifacts"].items()
+            if not name.endswith(".whl")
+        }
+    elif mutation == "dependency-drift":
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                f'"b123d-recognisers=={current}"',
+                '"b123d-recognisers @ git+https://invalid"',
+            ),
+            encoding="utf-8",
+        )
+    elif mutation == "contract-drift":
+        path = tmp_path / "src/draftwright/recogniser_contract.py"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                f'_PACKAGE_VERSION = "{current}"', '_PACKAGE_VERSION = "99.99.99"'
+            ),
+            encoding="utf-8",
+        )
+    elif mutation == "mutable-source":
+        path = tmp_path / "uv.lock"
+        lock = path.read_text(encoding="utf-8")
+        start = lock.index('[[package]]\nname = "b123d-recognisers"')
+        tail = lock[start:]
+        tail = tail.replace(
+            'source = { registry = "https://pypi.org/simple" }',
+            'source = { git = "https://invalid" }',
+            1,
+        )
+        path.write_text(lock[:start] + tail, encoding="utf-8")
+    elif mutation == "hash-drift":
+        evidence["artifacts"][next(iter(evidence["artifacts"]))] = "0" * 64
+    elif mutation == "duplicate-block":
+        path = tmp_path / "uv.lock"
+        lock = path.read_text(encoding="utf-8")
+        start = lock.index('[[package]]\nname = "b123d-recognisers"')
+        end = lock.index("\n[[package]]", start + 1)
+        path.write_text(lock + "\n" + lock[start:end] + "\n", encoding="utf-8")
+    elif mutation == "editable-install":
+        installed["direct_url"] = '{"dir_info":{"editable":true}}'
+    else:
+        installed["manifest_sha256"] = "f" * 64
+    evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+
+    loader = SourceFileLoader(
+        "draftwright_recogniser_release_check",
+        str(ROOT / "scripts/check-recogniser-release"),
+    )
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    with pytest.raises(SystemExit, match=message):
+        module.verify(tmp_path, installed)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -116,7 +116,10 @@ def test_testpypi_snapshot_build_and_publish_share_one_job():
     assert "environment: testpypi" in snapshot
     assert "contents: read\n      id-token: write" in snapshot
     assert "- run: uv build" in snapshot
-    assert "- uses: pypa/gh-action-pypi-publish@release/v1" in snapshot
+    assert (
+        "- uses: pypa/gh-action-pypi-publish@"
+        "dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1" in snapshot
+    )
     assert "repository-url: https://test.pypi.org/legacy/" in snapshot
     assert "if: github.event_name == 'release'" in _job(workflow, "build-release")
     assert "needs: build-release" in _job(workflow, "publish-pypi")


### PR DESCRIPTION
Closes #1170.

## What changed

- adds a one-command, package-owned candidate-wheel check for local two-checkout development
- records and verifies the exact PyPI version, wheel/sdist SHA-256 hashes, and capability-manifest digest
- adds a branch-protection-safe automated recogniser dependency-bump PR workflow
- narrows automation-only CI to static checks plus one canonical coverage run, while retaining Codecov project/patch and `ci-ok`
- repairs post-release `.dev0` bumps so they update consumer identity and open a PR instead of pushing to protected `main`
- documents compatibility windows, additive/breaking landing order, patch-only cadence, deprecation, rollback, ownership, and measured CI cost

## Why

A recogniser change should remain package-owned and independently releasable without forcing contributors through duplicate full matrices, mutable Git/path production dependencies, or an unsafe direct push. The workflow keeps both repositories green at each landing point and makes release evidence reproducible.

## Validation

- full regular suite: 3,812 passed, 2 skipped, 2 expected xfails in 19m33s (slow tier intentionally excluded)
- focused workflow/capability/release suite: 83 passed
- `scripts/pr-check --static`: Ruff, formatting, mypy, codespell, and strict MkDocs build passed
- `zizmor --pedantic` on all changed workflows: 0 low/medium/high findings (informational unnamed-job notices only; existing check names retained for branch protection)
- exact release verifier exercised against version, distribution, index, hash, manifest, lock-block, mutable-source, and editable-install mutations

The existing no-recognition-behavior package 0.2.0 update in #1175 supplies the acceptance proof for the release join and measured the prior duplicated Linux gate at 20m29s.