### PR TITLE
Adopt the explicit recogniser step-ladder boundary

### DIFF
--- a/.github/recogniser-release.json
+++ b/.github/recogniser-release.json
@@ -1,10 +1,10 @@
 {
   "artifacts": {
-    "b123d_recognisers-0.2.0-py3-none-any.whl": "16f6e13160310069c2ab610233af3b8da3c6ffb03b481aa38e532e8743381eda",
-    "b123d_recognisers-0.2.0.tar.gz": "2ea7e0220bcfc590a2a36dd4eeb5c8ba30ab94141a1eac26094f7917e998f034"
+    "b123d_recognisers-0.2.1-py3-none-any.whl": "653d155d3a0862793da3a41fe6fe4565f3a1bdc70714b09ee7f59168ea9ad038",
+    "b123d_recognisers-0.2.1.tar.gz": "35607cf90a6122510067b365fdbc96fde3655e6a8583d6a54ff5546d3ec20b49"
   },
-  "capability_manifest_sha256": "ca54c870f54a77a605b3da10e112a98fc0eae74a0f2aa4435ff9c629552fe32e",
+  "capability_manifest_sha256": "383a196329ed6a3d1bf88f18ae4ff75613c032f35d40f2b53302b6744da4d19e",
   "distribution": "b123d-recognisers",
   "index": "https://pypi.org/simple",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
   unevidenced state transitions fail closed; intentionally geometry-only repeating-profile
   evidence remains usable without acquiring invented drafting semantics.
 
+### Changed
+
+- Updated the exact `b123d-recognisers` production lock from 0.2.0 to 0.2.1.
+  The immutable PyPI wheel/sdist hashes and capability-manifest digest
+  `383a196329ed6a3d1bf88f18ae4ff75613c032f35d40f2b53302b6744da4d19e` are
+  recorded in `.github/recogniser-release.json`; focused compatibility evidence and the
+  normal consumer gates run on the generated PR.
+
 ### Fixed
 
 - Post-release development-version bumps now update the consumer-contract identity on a branch,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.1",
-    "b123d-recognisers==0.2.0",
+    "b123d-recognisers==0.2.1",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/scripts/update-recogniser-dependency
+++ b/scripts/update-recogniser-dependency
@@ -96,16 +96,21 @@ def _add_changelog(root: Path, old: str, new: str, manifest_hash: str) -> None:
     if marker in text:
         return
     bullet = (
-        f"{marker}. The immutable PyPI wheel/sdist hashes and capability-manifest digest "
-        f"`{manifest_hash}` are recorded in `.github/recogniser-release.json`; focused "
-        "compatibility evidence and the normal consumer gates run on the generated PR.\n"
+        f"{marker}.\n"
+        "  The immutable PyPI wheel/sdist hashes and capability-manifest digest "
+        f"`{manifest_hash}` are\n"
+        "  recorded in `.github/recogniser-release.json`; focused compatibility evidence and "
+        "the\n"
+        "  normal consumer gates run on the generated PR.\n"
     )
-    unreleased_start = text.find("## [Unreleased]")
-    if unreleased_start < 0:
+    heading = re.search(r"^## (?:Unreleased|\[Unreleased\])$", text, re.MULTILINE)
+    if heading is None:
         raise RuntimeError("CHANGELOG.md has no Unreleased section")
-    unreleased_end = text.find("\n## [", unreleased_start + 1)
-    if unreleased_end < 0:
-        unreleased_end = len(text)
+    unreleased_start = heading.start()
+    next_heading = re.search(r"^## ", text[heading.end() :], re.MULTILINE)
+    unreleased_end = (
+        heading.end() + next_heading.start() if next_heading is not None else len(text)
+    )
     changed = text.find("### Changed\n", unreleased_start, unreleased_end)
     if changed >= 0:
         insert_at = changed + len("### Changed\n")

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -630,7 +630,7 @@ def _analyse(
         # by #1025). Both callers deriving this separately let lint project over a different
         # ladder than the model was sized from — which is exactly the divergence one waist is
         # supposed to prevent.
-        step_zs = recognition.step_ladder(bb)
+        step_zs = recognition.step_ladder_for_z_span(bb.min.Z, bb.max.Z)
     # The aggregate owns the shared substrate from here on.  Rebind the local projection so
     # model construction, Analysis and the finished BuildState all consume the same inventory
     # object rather than parallel list/tuple wrappers that merely happen to contain equal data.

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -1033,8 +1033,10 @@ def lint_prismatic_coverage(
             "caller-assembled inventory: an empty stand-in silences it."
         )
     _rec = build_recognition_result(part) if recognition is None else recognition
+    ladder_bounds = bbox if bbox is not None else part.bounding_box()
     source_shoulders = project_step_shoulders(
-        _rec.risers, levels=_rec.step_ladder(bbox if bbox is not None else part.bounding_box())
+        _rec.risers,
+        levels=_rec.step_ladder_for_z_span(ladder_bounds.min.Z, ladder_bounds.max.Z),
     )
     model_shoulders = {
         (axis, round(pos, 3))

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -19,7 +19,7 @@ from b123d_recognisers import capability_manifest
 
 CONSUMER_CAPABILITY_FORMAT = "draftwright-recogniser-capabilities"
 CONSUMER_CAPABILITY_FORMAT_VERSION = 1
-_PACKAGE_VERSION = "0.2.0"
+_PACKAGE_VERSION = "0.2.1"
 _BOUNDARIES = (
     "ir_adapter",
     "dsl_declaration",

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -497,8 +497,8 @@ def test_one_ladder_rule_serves_sizing_and_critique():
     face levels — that distinction exists because a blind bore's flat floor is a face level
     and is emphatically not an OD shoulder. `_analyse` had that rule; critique derived its own
     level set separately, so lint could project risers over a different ladder than the model
-    was sized from (Codex #1031 r3). `RecognitionResult.step_ladder` is now the one rule both
-    call.
+    was sized from (Codex #1031 r3). `RecognitionResult.step_ladder_for_z_span` is now the one
+    rule both call, with Draftwright adapting its bounding box to the two scalar Z limits.
 
     The fixture is chosen so the two candidate sets actually differ; on an ordinary prismatic
     part they coincide and this would assert nothing.
@@ -507,7 +507,7 @@ def test_one_ladder_rule_serves_sizing_and_critique():
     rec = build_recognition_result(part)
     bb = part.bounding_box()
 
-    ladder = rec.step_ladder(bb)
+    ladder = rec.step_ladder_for_z_span(bb.min.Z, bb.max.Z)
     raw_level_zs = [level.z for level in rec.step_levels]
     assert ladder != raw_level_zs, (
         "fixture stopped exercising the divergence — the turned ladder and the raw face "
@@ -520,7 +520,7 @@ def test_one_ladder_rule_serves_sizing_and_critique():
     # the call, because on a turned part `step_zs` feeds only the strip reservation — there is
     # no rendered rung to read the difference off, so a behavioural assertion here would be
     # vacuous and would pass with the consolidation removed (verified: it did).
-    with counting_calls({"ladder": RecognitionResult.step_ladder}) as calls:
+    with counting_calls({"ladder": RecognitionResult.step_ladder_for_z_span}) as calls:
         drawing = build_drawing(part)
         sizing = dict(calls)
         calls.clear()
@@ -528,15 +528,41 @@ def test_one_ladder_rule_serves_sizing_and_critique():
         critique = dict(calls)
 
     assert sizing.get("ladder"), (
-        "the build never called RecognitionResult.step_ladder — sizing is deriving its own "
-        "ladder again, which is the drift this consolidation removes"
+        "the build never called RecognitionResult.step_ladder_for_z_span — sizing is deriving "
+        "its own ladder again, which is the drift this consolidation removes"
     )
     # Both consumers, asserted separately. Counting across the whole build satisfied the
     # assertion from `_analyse`'s call alone, so critique could revert to the raw face levels
     # and this guard would stay green — the regression it names, undetected (Codex #1031 r2).
     assert critique.get("ladder"), (
-        "lint never called RecognitionResult.step_ladder — critique is projecting risers over "
-        "a different ladder than the model was sized from"
+        "lint never called RecognitionResult.step_ladder_for_z_span — critique is projecting "
+        "risers over a different ladder than the model was sized from"
     )
     lengths = sorted(n for n in drawing.annotations() if n.startswith("m_steplen"))
     assert len(lengths) == 2, f"expected one length per turned segment, got {lengths}"
+
+
+def test_sizing_and_critique_adapt_the_part_bounds_to_the_scalar_ladder_boundary(
+    monkeypatch,
+):
+    """Both production callers pass only the independently measured Z envelope."""
+    part = Pos(0, 0, 17) * _turned_shaft_with_blind_bore()
+    bb = part.bounding_box()
+    calls: list[tuple[float, float]] = []
+    original = RecognitionResult.step_ladder_for_z_span
+
+    def recording_projection(self, z_min, z_max, **kwargs):
+        calls.append((z_min, z_max))
+        return original(self, z_min, z_max, **kwargs)
+
+    monkeypatch.setattr(RecognitionResult, "step_ladder_for_z_span", recording_projection)
+
+    drawing = build_drawing(part)
+    sizing_calls = list(calls)
+    calls.clear()
+    drawing.lint()
+    critique_calls = list(calls)
+
+    expected = (bb.min.Z, bb.max.Z)
+    assert sizing_calls and all(call == expected for call in sizing_calls)
+    assert critique_calls and all(call == expected for call in critique_calls)

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -139,7 +139,7 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
         counted("repeating_radial_profiles", []),
     )
     monkeypatch.setattr(result_module, "recognise_turned_steps", cyl_consumer("turned_steps", []))
-    # The area-filtered records retain face support (#915); `step_ladder()` projects their Z
+    # The area-filtered records retain face support (#915); the scalar-span boundary projects Z
     # values for sizing/critique. It takes the part only — no substrate identity to assert.
     level_records = [FaceLevel(4.0, (0.0, 8.0), (0.0, 6.0)), FaceLevel(9.0)]
     monkeypatch.setattr(result_module, "step_level_records", counted("step_levels", level_records))
@@ -193,7 +193,7 @@ def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
     assert built.holes == tuple(holes)
     assert built.step_levels == tuple(level_records)
     bb = SimpleNamespace(min=SimpleNamespace(Z=0.0), max=SimpleNamespace(Z=10.0))
-    assert built.step_ladder(bb) == [4.0, 9.0]
+    assert built.step_ladder_for_z_span(bb.min.Z, bb.max.Z) == [4.0, 9.0]
 
 
 def _grooved_flatted_shaft():
@@ -260,6 +260,7 @@ def test_injecting_the_aggregate_builds_the_same_model_as_detecting(name, build)
     """
     part = build()
     rec = build_recognition_result(part)
+    bb = part.bounding_box()
 
     detected = build_part_model(part)
     injected = build_part_model(
@@ -275,7 +276,7 @@ def test_injecting_the_aggregate_builds_the_same_model_as_detecting(name, build)
         pockets=list(rec.pockets),
         pocket_patterns=list(rec.pocket_patterns),
         pads=list(rec.pads),
-        step_zs=rec.step_ladder(part.bounding_box()),
+        step_zs=rec.step_ladder_for_z_span(bb.min.Z, bb.max.Z),
         face_levels=list(rec.step_levels),
         risers=list(rec.risers),
         chamfers=list(rec.chamfers),

--- a/tests/test_two_repository_workflow.py
+++ b/tests/test_two_repository_workflow.py
@@ -107,7 +107,8 @@ def test_current_release_lock_has_machine_checked_registry_evidence() -> None:
     subprocess.run([str(ROOT / "scripts" / "check-recogniser-release")], cwd=ROOT, check=True)
 
 
-def test_dependency_updater_reuses_existing_unreleased_changed_heading() -> None:
+@pytest.mark.parametrize("heading", ("## Unreleased", "## [Unreleased]"))
+def test_dependency_updater_reuses_existing_unreleased_changed_heading(heading: str) -> None:
     loader = SourceFileLoader(
         "draftwright_recogniser_dependency_update",
         str(ROOT / "scripts/update-recogniser-dependency"),
@@ -120,7 +121,7 @@ def test_dependency_updater_reuses_existing_unreleased_changed_heading() -> None
         root = Path(directory)
         changelog = root / "CHANGELOG.md"
         changelog.write_text(
-            "# Changelog\n\n## [Unreleased]\n\n### Changed\n\n- Existing change.\n\n"
+            f"# Changelog\n\n{heading}\n\n### Changed\n\n- Existing change.\n\n"
             "### Fixed\n\n- Existing fix.\n\n## [0.1.0]\n",
             encoding="utf-8",
         )

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/4e/d039e3e90f985136ab2f72567bf7245527bab68b36ad7bf094c6457e976d/b123d_recognisers-0.2.0.tar.gz", hash = "sha256:2ea7e0220bcfc590a2a36dd4eeb5c8ba30ab94141a1eac26094f7917e998f034", size = 283187, upload-time = "2026-08-15T19:01:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/3c/7bdb79fc6b6e511e4a06daa3dd95419af83d6d76ae676c7b12ed95eaf89d/b123d_recognisers-0.2.1.tar.gz", hash = "sha256:35607cf90a6122510067b365fdbc96fde3655e6a8583d6a54ff5546d3ec20b49", size = 295553, upload-time = "2026-08-16T01:13:40.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/5b/c29a0c2618a5212e61596bd04a927561a58042d9e6e635b274d8088aff53/b123d_recognisers-0.2.0-py3-none-any.whl", hash = "sha256:16f6e13160310069c2ab610233af3b8da3c6ffb03b481aa38e532e8743381eda", size = 116896, upload-time = "2026-08-15T19:01:16.99Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a2/e0ae96fe0145d8604cf04f4c9a0c7a493168f6b383efe4054cb0a5fcb301/b123d_recognisers-0.2.1-py3-none-any.whl", hash = "sha256:653d155d3a0862793da3a41fe6fe4565f3a1bdc70714b09ee7f59168ea9ad038", size = 118082, upload-time = "2026-08-16T01:13:38.52Z" },
 ]
 
 [[package]]
@@ -745,7 +745,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.2.0" },
+    { name = "b123d-recognisers", specifier = "==0.2.1" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.1" },


### PR DESCRIPTION
Completes the Draftwright half of pzfreo/b123d-recognisers#19 against the released `b123d-recognisers==0.2.1` artifact.

## Changes

- updates the exact PyPI pin, lock, wheel/sdist hashes, installed capability digest, and consumer package declaration to 0.2.1;
- migrates both production callers—analysis/page sizing and independent prismatic coverage lint—from `step_ladder(BoundBox)` to `step_ladder_for_z_span(z_min, z_max)`;
- adds independent translated-geometry evidence that both callers adapt the actual part bounds to the scalar boundary, while retaining the existing divergence test proving sizing and critique share the package-owned ladder rule;
- fixes the dependency updater’s first real post-release defect by supporting both repository changelog heading conventions without creating duplicate `Changed` sections;
- leaves recognition semantics, canonical goldens, drawing policy, and the package-owned default margin unchanged.

## Evidence

- exact public PyPI 0.2.1 registry/hash/manifest checker passed;
- focused integration/contract/import/workflow suite: 116 passed before the final cheap-nit review; final changed-path regression: 4 passed;
- full regular suite after the production migration: 3,814 passed, 2 skipped, 2 expected xfails, 21 slow tests deselected in 68m33s;
- Ruff and diff checks passed; no remaining Draftwright source/test call uses the deprecated `step_ladder(BoundBox)` API;
- the slow CTC tier was not run locally.

Issue #19 should close only after this PR’s hosted supported-platform/Codecov gates pass and the exact released-artifact integration is merged.