### PR TITLE
Keep stable release identity in sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           base="${current%.dev*}"
-          uv version "${base}.dev${RUN_NUMBER}"
+          scripts/update-draftwright-version "${base}.dev${RUN_NUMBER}"
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
@@ -57,7 +57,7 @@ jobs:
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           base="${current%.dev*}"
-          uv version "$base"
+          scripts/update-draftwright-version "$base"
       - run: uv build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 
 ### Fixed
 
+- Stable release and TestPyPI snapshot builds now update package metadata and the independently
+  validated Draftwright consumer-contract identity atomically. This prevents stripped `.dev0`
+  and numbered development artifacts from failing their own capability-contract validation.
+- Installed wheels validate every portable recogniser-contract property without requiring the
+  repository-only behavior-test files whose existence remains a strict source/CI gate. This keeps
+  the packaged STEP-analysis evaluator usable without weakening evidence checks in development.
 - Post-release development-version bumps now update the consumer-contract identity on a branch,
   open a protected PR, and dispatch the narrow maintenance gate instead of attempting a rejected
   direct push to protected `main` (#1170).

--- a/scripts/update-draftwright-version
+++ b/scripts/update-draftwright-version
@@ -9,16 +9,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-_DEV_VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\.dev0$")
+_VERSION = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.dev(0|[1-9]\d*))?$"
+)
 
 
-def main() -> int:
-    root = Path(__file__).resolve().parents[1]
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("version")
-    args = parser.parse_args()
-    if not _DEV_VERSION.fullmatch(args.version):
-        parser.error("post-release version must be X.Y.Z.dev0")
+def update(root: Path, target: str) -> None:
+    """Update package metadata and the independently validated consumer identity together."""
+    if not _VERSION.fullmatch(target):
+        raise ValueError("version must be X.Y.Z or X.Y.Z.devN")
     project = root / "pyproject.toml"
     lock = root / "uv.lock"
     contract = root / "src/draftwright/recogniser_contract.py"
@@ -29,18 +28,29 @@ def main() -> int:
     current = current_match.group(1)
     contract_text = contract.read_text(encoding="utf-8")
     old_identity = f'"consumer": {{"name": "draftwright", "version": "{current}"}}'
-    new_identity = f'"consumer": {{"name": "draftwright", "version": "{args.version}"}}'
+    new_identity = f'"consumer": {{"name": "draftwright", "version": "{target}"}}'
     if contract_text.count(old_identity) != 1:
         raise RuntimeError("consumer declaration version is stale before the bump")
     snapshots = {path: path.read_bytes() for path in (project, lock, contract)}
     try:
-        subprocess.run(["uv", "version", args.version], cwd=root, check=True)
+        subprocess.run(["uv", "version", "--no-sync", target], cwd=root, check=True)
         contract.write_text(contract_text.replace(old_identity, new_identity), encoding="utf-8")
     except BaseException:
         for path, content in snapshots.items():
             path.write_bytes(content)
         raise
-    print(f"prepared Draftwright {current} -> {args.version}")
+    print(f"prepared Draftwright {current} -> {target}")
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version")
+    args = parser.parse_args()
+    try:
+        update(root, args.version)
+    except ValueError as error:
+        parser.error(str(error))
     return 0
 
 

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -235,7 +235,16 @@ def _resolve_implementation(reference: str) -> object:
     raise RecogniserCapabilityError(f"stale implementation module in {reference!r}")
 
 
-def _validate_stage(stage: object, family_id: str, boundary: str, root: Path) -> None:
+def _evidence_reference_is_valid(path: object, root: Path | None) -> bool:
+    if not isinstance(path, str) or not path:
+        return False
+    candidate = Path(path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return False
+    return root is None or (root / candidate).is_file()
+
+
+def _validate_stage(stage: object, family_id: str, boundary: str, root: Path | None) -> None:
     context = f"family {family_id!r} boundary {boundary!r}"
     if not isinstance(stage, dict) or set(stage) - {
         "evidence",
@@ -266,7 +275,7 @@ def _validate_stage(stage: object, family_id: str, boundary: str, root: Path) ->
                 f"{context} evidence must be non-empty, unique and sorted"
             )
         for path in evidence:
-            if not isinstance(path, str) or not (root / path).is_file():
+            if not _evidence_reference_is_valid(path, root):
                 raise RecogniserCapabilityError(
                     f"{context} evidence {path!r} is missing; add an independent behavior test"
                 )
@@ -371,7 +380,10 @@ def validate_recogniser_capabilities(
             f"unknown={missing}, stale={stale}; "
             "declare every package family explicitly"
         )
-    root = source_root or Path(__file__).resolve().parents[2]
+    checkout_root = Path(__file__).resolve().parents[2]
+    root = source_root
+    if root is None and (checkout_root / "pyproject.toml").is_file():
+        root = checkout_root
     for family in families:
         family_id = family["id"]
         allowed = {
@@ -502,9 +514,9 @@ def validate_recogniser_capabilities(
             or not isinstance(evidence, list)
             or not evidence
             or evidence != sorted(set(evidence))
-            or any(not isinstance(path, str) or not (root / path).is_file() for path in evidence)
+            or any(not _evidence_reference_is_valid(path, root) for path in evidence)
             or not isinstance(notes, str)
-            or not (root / notes).is_file()
+            or not _evidence_reference_is_valid(notes, root)
             or not re.fullmatch(r"\d+\.\d+\.\d+(?:\.dev\d+)?", str(transition["version"]))
         ):
             raise RecogniserCapabilityError(

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -15,6 +15,7 @@ import b123d_recognisers as recognition
 import pytest
 from build123d import Cylinder
 
+import draftwright.recogniser_contract as contract_module
 from draftwright.model.detect import (
     _CONVERTERS,
     _DERIVED_CONVERTERS,
@@ -33,6 +34,20 @@ ROOT = Path(__file__).parents[1]
 PINNED_VERSION = json.loads(
     (ROOT / ".github/recogniser-release.json").read_text(encoding="utf-8")
 )["version"]
+
+
+def test_installed_wheel_layout_validates_portable_contract_without_source_evidence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    installed_module = tmp_path / "lib/python/site-packages/draftwright/recogniser_contract.py"
+    monkeypatch.setattr(contract_module, "__file__", str(installed_module))
+
+    validate_recogniser_capabilities()
+
+
+@pytest.mark.parametrize("reference", [None, "", "/tmp/evidence.py", "../evidence.py"])
+def test_installed_wheel_rejects_nonportable_evidence_references(reference: object) -> None:
+    assert not contract_module._evidence_reference_is_valid(reference, None)
 
 
 def _families(declaration: dict) -> dict[str, dict]:

--- a/tests/test_two_repository_workflow.py
+++ b/tests/test_two_repository_workflow.py
@@ -99,6 +99,37 @@ def test_post_release_version_bump_is_a_pr_not_a_protected_main_push() -> None:
     assert "git push\n" not in bump
 
 
+@pytest.mark.parametrize("target", ("0.4.7", "0.4.8.dev0", "0.4.8.dev123"))
+def test_version_updater_keeps_release_and_development_identity_atomic(
+    tmp_path: Path, target: str
+) -> None:
+    for relative in (
+        "pyproject.toml",
+        "uv.lock",
+        "src/draftwright/recogniser_contract.py",
+    ):
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / relative, destination)
+
+    loader = SourceFileLoader(
+        "draftwright_version_update",
+        str(ROOT / "scripts/update-draftwright-version"),
+    )
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    module.update(tmp_path, target)
+
+    assert f'version = "{target}"' in (tmp_path / "pyproject.toml").read_text()
+    lock = (tmp_path / "uv.lock").read_text()
+    package = lock.split('[[package]]\nname = "draftwright"', 1)[1].split("[[package]]", 1)[0]
+    assert f'version = "{target}"' in package
+    contract = (tmp_path / "src/draftwright/recogniser_contract.py").read_text()
+    assert contract.count(f'"consumer": {{"name": "draftwright", "version": "{target}"}}') == 1
+
+
 def test_current_release_lock_has_machine_checked_registry_evidence() -> None:
     lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
     assert lock.count('name = "b123d-recognisers"') > 1, (

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -115,6 +115,7 @@ def test_testpypi_snapshot_build_and_publish_share_one_job():
     assert "if: github.event_name == 'push'" in snapshot
     assert "environment: testpypi" in snapshot
     assert "contents: read\n      id-token: write" in snapshot
+    assert 'scripts/update-draftwright-version "${base}.dev${RUN_NUMBER}"' in snapshot
     assert "- run: uv build" in snapshot
     assert (
         "- uses: pypa/gh-action-pypi-publish@"
@@ -122,4 +123,5 @@ def test_testpypi_snapshot_build_and_publish_share_one_job():
     )
     assert "repository-url: https://test.pypi.org/legacy/" in snapshot
     assert "if: github.event_name == 'release'" in _job(workflow, "build-release")
+    assert 'scripts/update-draftwright-version "$base"' in _job(workflow, "build-release")
     assert "needs: build-release" in _job(workflow, "publish-pypi")


### PR DESCRIPTION
## What changed

- makes the canonical Draftwright version updater accept both stable and `.dev0` patch identities
- uses that updater when stripping the development suffix for a real release
- keeps project metadata, lock identity, and the independently validated consumer capability identity atomic
- avoids an unnecessary environment sync during mechanical version updates
- adds stable/development regression coverage and a workflow-topology assertion
- keeps repository evidence-file existence strict in source/CI while allowing installed wheels to
  validate every portable contract property without files that are deliberately not packaged

## Why

The 0.4.7 release rehearsal exposed two release-only fail-closed defects. First, the publish workflow changed only project and lock metadata from `0.4.7.dev0` to `0.4.7`; the built artifact retained consumer identity `0.4.7.dev0`, causing 46 capability-contract tests to fail. Second, the clean wheel's STEP evaluator could not validate because repository-only behavior-test evidence paths are intentionally absent from the wheel. No 0.4.7 production artifact was published.

## Validation

- reproduced the defect on a locally stripped 0.4.7 wheel
- 95 focused workflow, two-repository, capability, and import tests pass
- stable `0.4.7` and development `0.4.8.dev0` update regressions pass
- release-tree rehearsal passes all 94 pre-wheel checks including installed-release identity
- Ruff and diff checks pass
- no slow test was run for this release-workflow/version-identity fix

Contributes to pzfreo/b123d-recognisers#25.
