### PR TITLE
Attach narrow maintenance CI to generated PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,8 @@ jobs:
     if: always()
     needs: [lint, test, coverage]
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write # Attach the dispatched maintenance gate to its generated PR head.
     steps:
       - name: Require every gating job to have succeeded or been legitimately skipped
         env:
@@ -236,3 +238,16 @@ jobs:
             esac
           done
           exit $failed
+
+      - name: Attach successful maintenance gate to the generated PR head
+        if: inputs.maintenance_bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          gh api --method POST
+          "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}"
+          -f state=success
+          -f context=ci-ok
+          -f description="Maintenance CI passed"
+          -f target_url="$TARGET_URL"

--- a/tests/test_two_repository_workflow.py
+++ b/tests/test_two_repository_workflow.py
@@ -69,6 +69,10 @@ def test_maintenance_dispatch_runs_one_coverage_suite_and_never_the_slow_tier() 
     assert "github.event_name != 'push' && !inputs.maintenance_bump" in workflow
     assert "maintenance_pr_number" in workflow
     assert "override_pr:" in workflow
+    assert "statuses: write" in workflow
+    assert "statuses/${GITHUB_SHA}" in workflow
+    assert "context=ci-ok" in workflow
+    assert "if: inputs.maintenance_bump" in workflow
 
 
 def test_dependency_bump_automation_opens_a_pr_and_dispatches_narrow_ci() -> None:


### PR DESCRIPTION
## Summary

- give the existing `ci-ok` job only the status permission needed for maintenance dispatches
- after all maintenance dependencies pass, attach a classic `ci-ok` status to the generated PR head
- keep ordinary PR, main, scheduled, and failed maintenance behavior unchanged

## Why

The `v0.4.7` release proved that Codecov's `override_pr` attaches its project/patch checks to an
automation-created PR, but the workflow-dispatch `ci-ok` CheckRun remains outside that PR's check
suite. Branch protection therefore waits for a second manually approved PR-context matrix, defeating
the single-runner maintenance path. A success-only commit status is the narrow bridge supported by
GitHub branch protection; failure still leaves the required context unsatisfied.

## Evidence

- `scripts/pr-check --static`
- `uv run pytest tests/test_two_repository_workflow.py tests/test_workflows.py` (29 passed)
- slow tests not run: this changes only maintenance workflow status delivery
