### PR TITLE
Accept ADR 0018 — requirement-driven view planning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,6 +500,25 @@ Current ADRs:
   breaks its claimed contract; a green suite alone is not evidence that the guard is
   load-bearing.
 
+- **0018** — **Accepted** (2026-08-16; #1130): **requirement-driven view planning
+  and editable sheet layout**. One view-planning model between drawing requirements and
+  projection: authored `ViewConstraints` and the automatic planner share one semantic
+  `ViewSpec`/layout vocabulary and produce one immutable `ResolvedViewPlan`. Page,
+  preferred scale, view set and arrangement are chosen **jointly** against complete view
+  blocks measured with fixed paper-space typography; a candidate is feasible only when
+  the real shared annotation solve preserves every supported requirement and all blocks
+  stay in bounds. Supersedes ADR 0004's **fixed four-view topology** (0004's
+  compose-then-pack of each selected block still stands). Users edit whole view blocks,
+  never feature-annotation coordinates (ADR 0012/0014 keep those). Infeasibility is a
+  first-class `plan_infeasible` result, never a silent relaxation of an authored
+  constraint.
+  **Nothing is implemented yet** — there is no `ViewSpec`/`ResolvedViewPlan` in the code
+  and the engine still builds fixed front/plan/side/iso. The ADR's "Required evidence
+  before acceptance" list is the per-slice delivery gate, not waived by acceptance.
+  Accepted on converging evidence from #1187 (leaders that cut the part have no clear
+  route because the SHEET is full — every remedy is compositional) and #1190 (the
+  section is placed into leftover space, so its presence tracks room rather than need).
+
 ## Dependencies
 
 - `build123d-drafting-helpers>=0.13.0` (Apache 2.0)

--- a/docs/adr/0004-compose-then-pack-view-blocks.md
+++ b/docs/adr/0004-compose-then-pack-view-blocks.md
@@ -1,7 +1,12 @@
 # ADR 0004 — Compose-then-pack: views as blocks carrying their annotation footprint
 
 - **Status:** Accepted (2026-06-19; amended 2026-06-20, 2026-07-09,
-  2026-07-18 and 2026-08-14 — see Amendments)
+  2026-07-18 and 2026-08-14 — see Amendments). **Its fixed four-view topology
+  assumption is superseded by [ADR 0018](0018-requirement-driven-view-planning-and-editable-sheet-layout.md)
+  (accepted 2026-08-16)**: which view blocks exist is now 0018's decision. Everything
+  else here stands and is what 0018 builds on — each selected view is still composed
+  with its annotation footprint before outer packing, and footprints are still page-mm
+  box layouts rather than bbox-measured geometry.
 - **Date:** 2026-06-19
 - **Deciders:** Paul Fremantle (pzfreo)
 

--- a/docs/adr/0018-requirement-driven-view-planning-and-editable-sheet-layout.md
+++ b/docs/adr/0018-requirement-driven-view-planning-and-editable-sheet-layout.md
@@ -1,8 +1,41 @@
 # ADR 0018 — Requirement-driven view planning and editable sheet layout
 
-- **Status:** Proposed; tracked by #1130
-- **Date:** 2026-08-11
+- **Status:** **Accepted** (2026-08-16). **Nothing here is implemented yet** — no
+  `ViewSpec`, `ViewConstraints` or `ResolvedViewPlan` exists in the code, and the engine
+  still builds the fixed front/plan/side/iso topology. Read this as the decided
+  direction, not as a description of current behaviour; delivery is phased through
+  #1130, first slice a no-behaviour-change `ViewSpec`/`ResolvedViewPlan` representation.
+  The "Required evidence before acceptance" list below is retained verbatim as the
+  **delivery gate** each slice is measured against — accepting the direction does not
+  waive it, and automatic semantic view selection lands only once those invariants are
+  guarded.
+- **Date:** 2026-08-11 (proposed), 2026-08-16 (accepted)
 - **Deciders:** Paul Fremantle (pzfreo)
+
+## Why now — the evidence that converged (2026-08-16)
+
+Proposed from one case (a thin planetary plate where the fixed four-view topology
+drove an A1 sheet at 1:1). Two independent investigations then landed on the same
+missing decision from opposite directions, neither looking for it:
+
+- **#1187 (leader routing).** After #798 and #1188, ten leaders still cut the part
+  across the corpus. Sweeping each one's elbow through 64 directions × 6 shaft lengths
+  — far more freedom than any producer offers — found **hundreds of routes clear of
+  the material and, for five of six distinct cases, zero clear of everything else**.
+  The part's shape is not what traps them: the sheet is full. Every remedy that
+  survives that finding is compositional — fewer things on the sheet, more room, or a
+  different view set — and none of them is a router's decision to make.
+- **#1190 (section A–A).** The section is not part of the scale/layout decision at
+  all. ADR 0004 picks a scale by packing view blocks; the section is then placed
+  opportunistically into whatever is left, which is why its presence tracked leftover
+  space rather than need. Making it a required scale outcome was tried and reverted —
+  it turned an optional view into a scale blocker that could raise
+  `ScaleIncompatibilityError`. The honest fix was to record the outcome, which leaves
+  the structural gap exactly where this ADR says it is.
+
+Both reduce to the same thing: **which views should exist is a decision nothing
+currently owns.** That is what tipped this from a good idea to a gap with measurements
+attached.
 
 ## Context
 


### PR DESCRIPTION
Docs only. Accepts the **direction** of ADR 0018 and records the consequences.

## What acceptance does and does not claim

**Nothing here is implemented.** There is no `ViewSpec`, `ViewConstraints` or `ResolvedViewPlan` in the code, and the engine still builds the fixed front/plan/side/iso topology. The status line says so plainly, because an ADR that reads as a description of current behaviour when it is a plan is worse than one left Proposed — these ADRs are the stated source of truth for why the engine is shaped as it is.

The ADR sets its own **"Required evidence before acceptance"** list, ~20 items, essentially all implementation-dependent. That list is retained verbatim and restated as the per-slice **delivery gate**: accepting the direction does not waive it, and automatic semantic view selection lands only after those invariants are guarded. Same shape as ADRs 0011, 0013 and 0017 — Accepted with phases outstanding, each saying which have landed.

## Why now

It was proposed from a single case: a thin planetary plate whose fixed four-view topology drove an A1 sheet at 1:1. Today two separate investigations reached the same missing decision from opposite directions, neither looking for it.

**#1187 — leader routing.** After #798 and #1188, ten leaders still cut the part across the corpus. Sweeping each one's elbow through 64 directions × 6 shaft lengths — far more freedom than any producer offers — found **hundreds of routes clear of the material and, for five of six distinct cases, zero clear of everything else.** The part's shape is not what traps them; the sheet is full. Every remedy that survives that measurement is compositional (fewer things on the sheet, more room, a different view set), and none of them is a router's decision to make.

**#1190 — section A–A.** The section is not part of the scale/layout decision at all. ADR 0004 picks a scale by packing view blocks; the section is then placed opportunistically into whatever is left, which is why its presence tracked leftover space rather than need. Making it a required scale outcome was tried and reverted — it turned an optional view into a scale blocker that could raise `ScaleIncompatibilityError`. The honest fix was to record the outcome, which leaves the structural gap exactly where this ADR says it is.

Both reduce to the same thing: **which views should exist is a decision nothing currently owns.**

## Consequences recorded, not just a status flip

- **ADR 0004's fixed four-view topology assumption is now superseded.** 0018 said "if accepted"; 0004's header now states it unconditionally. Everything else in 0004 stands and is what 0018 builds on — each selected view is still composed with its annotation footprint before outer packing, and footprints remain page-mm box layouts rather than bbox-measured geometry.
- **CLAUDE.md's ADR list did not mention 0018 at all.** Added, with the supersession and the not-implemented caveat, so the architecture summary and the ADRs agree.

Delivery stays tracked by #1130; first slice is the no-behaviour-change `ViewSpec`/`ResolvedViewPlan` representation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22