### PR TITLE
Bound measured balloon work instead of predicting it (ADR 0014 Amdt 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,7 +407,13 @@ Current ADRs:
   filled projected-material lowering **shared with the
   `leader_crosses_silhouette` critique**, so router and lint cannot disagree; it
   is a cost, never an acceptance test, and the resource-cap floor — which is what
-  actually runs on dense parts — gained a bounded clear-route lookahead.
+  actually runs on dense parts — gained a bounded clear-route lookahead. Amendment 4
+  (2026-08-16) records that a work budget must bound **measured** work rather than
+  predict it: three guards were found silently disabling the feature they protect on
+  ordinary input (the joint assignment never running on any dense part; two balloon
+  bounds over by 1.5x and **497x**, the latter refusing a hole table at 0.4% of its
+  real cost). Prefer a live counter; an unavoidable pre-check must be exact rather
+  than conservative; and a budget that fires is a capability loss that should say so.
 - **0015** — **Accepted** (supersedes 0008, #697): **the part-drawing compiler
   as built** — detectors + declared features → the one PartModel waist (two
   tiers, ADR 0013) → planner → render-intents → shared infra; with the

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -207,6 +207,37 @@ richer candidates push dense parts back over the per-view budget and out of the 
 solve, which cost more than it bought. Candidate richness trades against solve reach,
 and #1188 records where that balance currently sits.
 
+**Amendment 4 (2026-08-16) — a work budget must bound measured work, not predict
+it.** Three guards were found in one session silently disabling the feature they
+protect, on ordinary input:
+
+| guard | predicted | actual | outcome |
+| --- | --- | --- | --- |
+| feature-leader candidate cap (#1188) | 20 jobs × ~72 candidates vs a 512 cap | — | the joint assignment never ran on ANY dense part, so Amendment 2's guarantees applied precisely nowhere they were needed |
+| balloon top-lane probe bound | 73,712 vs a 50,000 cap | — | 1.5× over; every hole-table balloon refused |
+| balloon carve probe bound | 10,546,848 vs a 5,000,000 cap | **21,228** | 497× over; a hole table refused at 0.4% of its real cost |
+
+Each was correct in intent and wrong in effect. The common fault is a **conservative
+pre-estimate**: a closed-form worst case computed before the work, sized by multiplying
+maxima that never co-occur. The carve bound assumed every retained box contributes its
+full complement of criticals and that every one survives to be probed; on the very input
+its own test called pathological it was wrong by three orders of magnitude.
+
+The rule this ADR now records:
+
+- **Prefer counting real work to predicting it.** A live counter that stops at the cap
+  bounds the work just as a pre-estimate does, and cannot refuse work that fits.
+- **Where a pre-check is genuinely needed, it must be EXACT, not conservative.** The
+  top-lane gate now multiplies the actual candidate-lane count (built in one linear
+  pass) by the obstacle count, because that product *is* the loop's cost.
+- **A budget that fires is a capability loss, and must be observable as one.** All three
+  degraded silently: the drawing simply came back missing a table, a joint solve or a
+  route, with a lint line at most. A guard firing should say which capability it cost.
+
+This is a placement-layer instance of the same discipline ADR 0001 applies to solvers:
+the bound has to be explainable, and "the estimate said it might be expensive" is not an
+explanation a user can act on.
+
 ## Context (short — the full story is 0009's)
 
 A recurring defect class (#133/#225/#305: the "invisible occupant" — one strip,

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -184,17 +184,6 @@ def render_balloons(
         # carve their horizontal free spans, and take the nearest lane that can
         # carry a balanced share of the ring.  This is measured render geometry;
         # ordered placement across the resulting segments remains in layout.py.
-        if (
-            avoid_annotation_labels
-            and _guarded_top_lane_probe_bound(len(obstacles))
-            > _GUARDED_TOP_LANE_MAX_OBSTACLE_PROBES
-        ):
-            ctx.record_issue(
-                "warning",
-                "balloon_dropped",
-                f"{len(specs)} balloon(s) exceeded the guarded perimeter work budget",
-            )
-            return
         top_lo, top_hi = band_defs["top"][2:]
         other_band_names = ["left", "right"]
         if has_bottom:
@@ -212,8 +201,32 @@ def render_balloons(
             if x1 > top_lo and x0 < top_hi and y1 >= pt:
                 candidates.add(y1 + _STRIP_SPACING + r)
 
+        # Gate on the EXACT quadratic cost, not a pre-estimate (#1190 follow-up). The
+        # loop below rescans every obstacle once per candidate lane, so the work is
+        # precisely `lanes x obstacles` — and the lane set is already built above, in
+        # one linear pass, because most obstacles produce no lane at all: a candidate
+        # comes only from an obstacle overlapping the top band's x-range and reaching
+        # its depth.
+        #
+        # The previous bound assumed one lane per obstacle, `n * (n + 1)`. On the parts
+        # the hole table exists for that overshot the truth by two orders of magnitude
+        # and refused every balloon — so the table's own transaction rolled back, the
+        # crowded callouts it would have replaced stayed, and the sheet stayed full.
+        # A budget for pathological input was disabling the feature on ordinary input.
+        lanes = [y for y in sorted(candidates) if first_line <= y <= last_line]
+        if avoid_annotation_labels and (
+            len(lanes) * len(obstacles) > _GUARDED_TOP_LANE_MAX_OBSTACLE_PROBES
+        ):
+            ctx.record_issue(
+                "warning",
+                "balloon_dropped",
+                f"{len(specs)} balloon(s) exceeded the guarded perimeter work budget "
+                f"({len(lanes)} lanes x {len(obstacles)} obstacles)",
+            )
+            return
+
         lane_options = []
-        for line in sorted(y for y in candidates if first_line <= y <= last_line):
+        for line in lanes:
             blocked = [
                 (x0, x1)
                 for x0, y0, x1, y1 in obstacles
@@ -416,8 +429,12 @@ def _guarded_free_segments(
     scale,
     label_boxes,
     text_box=None,
+    budget=None,
 ):
     """Continuous free coordinates for one member on one balloon band.
+
+    *budget* is a :class:`_CarveBudget` counting the box probes actually performed;
+    when it is exhausted this returns ``None`` and the caller abandons the attempt.
 
     Segment/box intersection can change only when the centre-to-centre ray passes
     a label-box corner; glyph intersection changes at the box edges expanded by
@@ -431,6 +448,8 @@ def _guarded_free_segments(
     )
 
     def hits(coordinate):
+        if budget is not None and not budget.spend():
+            raise _CarveBudgetExhausted
         bx, by = (line, coordinate) if axis == "y" else (coordinate, line)
         return balloon_geometry_hits_annotation_labels(
             tuple((bx + x0, by + y0, bx + x1, by + y1) for x0, y0, x1, y1 in local_glyph_boxes),
@@ -514,22 +533,36 @@ def _guarded_free_segments(
     return tuple(validated)
 
 
-def _guarded_carve_probe_bound(member_count, range_count, label_count, glyph_box_count):
-    """Conservative box-probe bound before continuous interval carving.
+class _CarveBudgetExhausted(Exception):
+    """Raised inside the carve when the live probe budget runs out."""
 
-    Each retained box contributes at most four corner rays, eight rim
-    intersections, and two glyph events per glyph component. Each resulting
-    interval can probe its midpoint, both ends, and the final merged ends, so
-    fewer than six probes are needed per critical coordinate. Every probe scans
-    the retained boxes. Keeping this arithmetic outside
-    :func:`_guarded_free_segments` makes the transaction fail closed before the
-    otherwise-quadratic critical-point expansion starts.
+
+class _CarveBudget:
+    """A live count of the box probes continuous carving actually performs.
+
+    Replaces a *conservative pre-estimate* that was wrong by orders of magnitude.
+    It multiplied worst-case criticals per label by every label and every member and
+    every band — assuming each retained box contributes its full complement of corner
+    rays, rim intersections and glyph events, and that every one survives to be probed.
+    Measured on NIST CTC-04 it predicted 10,546,848 probes for work that costs 21,228:
+    **497x** the truth, against a cap of 5,000,000. So a hole table was refused at 0.4%
+    of its real cost, which is not conservatism, it is a wrong answer — and the refusal
+    was silent, because the transaction simply rolled the table back and the crowded
+    callouts it would have replaced stayed on the sheet.
+
+    Counting real work keeps the guard's purpose (a pathological inventory must not
+    enter an unbounded scan) without it firing on ordinary ones. `spend` returns False
+    once exhausted; the carve then stops and the caller fails closed exactly as before.
     """
-    if member_count <= 0 or range_count <= 0 or label_count <= 0:
-        return 0
-    criticals_per_label = 12 + 2 * max(1, glyph_box_count)
-    probes_per_range = 6 * (2 + label_count * criticals_per_label)
-    return member_count * range_count * probes_per_range * label_count
+
+    __slots__ = ("remaining",)
+
+    def __init__(self, limit):
+        self.remaining = int(limit)
+
+    def spend(self, probes=1):
+        self.remaining -= probes
+        return self.remaining >= 0
 
 
 def _solve_guarded_band(member_indices, members, band_name, band_defs, free_segments):
@@ -841,37 +874,35 @@ def _place_guarded_inventory(
     if not retained_geometry_safe:
         return len(members)
     retained_boxes = (*label_boxes, *retained_component_boxes)
-    range_count = sum(
-        len(top_segments) if band == "top" and top_segments is not None else 1
-        for band, capacity in capacities.items()
-        if capacity > 0
-    )
-    glyph_box_count = max((len(boxes) for boxes in local_glyph_boxes.values()), default=1)
-    if (
-        _guarded_carve_probe_bound(len(members), range_count, len(retained_boxes), glyph_box_count)
-        > _GUARDED_CARVE_MAX_LABEL_PROBES
-    ):
-        return len(members)
     text_boxes = {
         tag: components[1] if len(components) > 1 else None
         for tag, components in local_glyph_boxes.items()
     }
     by_member_band = {}
-    for index, member in enumerate(members):
-        for band, (axis, line, lo, hi) in band_defs.items():
-            if capacities[band] <= 0:
-                continue
-            ranges = top_segments if band == "top" and top_segments is not None else ((lo, hi),)
-            by_member_band[index, band] = _guarded_free_segments(
-                member,
-                axis,
-                line,
-                ranges,
-                radius,
-                dwg.scale,
-                retained_boxes,
-                text_boxes[member[0]],
-            )
+    budget = _CarveBudget(_GUARDED_CARVE_MAX_LABEL_PROBES)
+    try:
+        for index, member in enumerate(members):
+            for band, (axis, line, lo, hi) in band_defs.items():
+                if capacities[band] <= 0:
+                    continue
+                ranges = (
+                    top_segments if band == "top" and top_segments is not None else ((lo, hi),)
+                )
+                by_member_band[index, band] = _guarded_free_segments(
+                    member,
+                    axis,
+                    line,
+                    ranges,
+                    radius,
+                    dwg.scale,
+                    retained_boxes,
+                    text_boxes[member[0]],
+                    budget=budget,
+                )
+    except _CarveBudgetExhausted:
+        # Fails closed exactly as the pre-estimate did — but only after the work has
+        # genuinely been done, not on a prediction that it might be.
+        return len(members)
     guarded = _GuardedSegments(by_member_band, gap, band_gaps)
     assignments, solutions, dropped = _guarded_assignment(
         members,

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -599,7 +599,22 @@ def test_guarded_solver_budget_rolls_the_automatic_table_transaction_back(monkey
     assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
 
 
-def test_guarded_carve_budget_fires_before_quadratic_label_expansion(monkeypatch):
+def test_guarded_carve_work_stays_within_its_budget(monkeypatch):
+    """The guard bounds the carve's work; it no longer predicts it.
+
+    This asserted that carving must never START on a large retained inventory — the
+    budget was a conservative pre-ESTIMATE checked up front. That estimate was wrong by
+    orders of magnitude in both directions that matter. On NIST CTC-04 it predicted
+    10,546,848 probes for work costing 21,228 (497x), refusing a hole table at 0.4% of
+    its real cost and silently leaving the crowded callouts it would have replaced. And
+    on the deliberately pathological input BELOW — 300 retained boxes, one member, the
+    very case it was written to catch — the real cost is about 4,500 probes, so it was
+    wrong by a further three orders of magnitude about its own worst case.
+
+    The protection's purpose survives: a pathological inventory must not enter an
+    unbounded scan. It is now enforced by counting probes as they happen and stopping
+    at the cap, which bounds the work without refusing work that fits inside it.
+    """
     import draftwright.annotations.balloons as balloons_module
 
     retained_boxes = tuple(
@@ -616,10 +631,14 @@ def test_guarded_carve_budget_fires_before_quadratic_label_expansion(monkeypatch
         lambda *_args: ((), (), True),
     )
 
-    def forbidden_carve(*_args, **_kwargs):
-        pytest.fail("critical-point carving ran before its deterministic work budget")
+    probes = []
+    real_hits = balloons_module.balloon_geometry_hits_annotation_labels
 
-    monkeypatch.setattr(balloons_module, "_guarded_free_segments", forbidden_carve)
+    def counted(*args, **kwargs):
+        probes.append(1)
+        return real_hits(*args, **kwargs)
+
+    monkeypatch.setattr(balloons_module, "balloon_geometry_hits_annotation_labels", counted)
     member = ("A", 0, SimpleNamespace(diameter=2.0), 0.0, 0.0)
 
     dropped = balloons_module._place_guarded_inventory(
@@ -642,7 +661,14 @@ def test_guarded_carve_budget_fires_before_quadratic_label_expansion(monkeypatch
         band_gaps={"left": 10.0},
     )
 
-    assert dropped == 1
+    assert dropped == 1  # still fails closed — for want of room, not want of budget
+    assert len(probes) <= balloons_module._GUARDED_CARVE_MAX_LABEL_PROBES, (
+        "the carve exceeded its budget without stopping"
+    )
+    assert len(probes) < 100_000, (
+        f"this input cost {len(probes)} probes; the retired pre-estimate claimed it "
+        f"exceeded 5,000,000, which is why it refused work that fits comfortably"
+    )
 
 
 def test_guarded_carve_budget_rolls_the_automatic_table_transaction_back(monkeypatch):


### PR DESCRIPTION
Follow-on from investigating why hole tables never form on the hole-dense parts they exist for. Found three blockers in a chain; the first two were **work budgets refusing valid work**.

## The measurements

| guard | predicted | actual | over by |
|---|---|---|---|
| top-lane probe bound (CTC-04) | 73,712 vs a 50,000 cap | — | **1.5×** |
| carve probe bound (CTC-04) | 10,546,848 vs a 5,000,000 cap | **21,228** | **497×** |

The carve guard refused a hole table at **0.4% of its real cost**, and did it silently: the transaction simply rolled the table back and the crowded callouts it would have replaced stayed on the sheet.

## The fixes

**Top-lane gate — exact instead of conservative.** It was `n × (n + 1)` on the obstacle count, assuming every obstacle yields a candidate lane. It does not: a lane comes only from an obstacle overlapping the top band's x-range and reaching its depth — and that set is already built in one linear pass. The gate now multiplies the *actual* lane count by the obstacle count, which **is** the loop's cost.

**Carve gate — count, don't predict.** A closed-form worst case multiplying maxima that never co-occur, replaced by a live `_CarveBudget` that counts probes as they happen and stops at the cap. Same protection (a pathological inventory must not enter an unbounded scan), without refusing work that fits inside it.

## A tested contract changed, deliberately

`test_guarded_carve_budget_fires_before_quadratic_label_expansion` asserted the carve must never *start* — it encoded the pre-estimate design. Rewritten to the honest contract: the work is bounded, and it still fails closed.

Worth stating why that is not a weakening: **the test's own deliberately-pathological input — 300 retained boxes, one member, the exact case the estimate was written to catch — costs about 4,500 probes.** The estimate was wrong by three orders of magnitude about its own worst case.

## No output changes, and that is the honest headline

Past both guards the balloons **still do not place**. The sheet is genuinely full; the table's own furniture competes with the callouts it would replace, so it cannot be the escape from a crowded sheet. That is #1187's finding one layer down, and it belongs to ADR 0018 — no guard tweak reaches it.

These are fixed because a guard refusing at 0.4% of cost is a latent bug that will bite a part we have not seen, not because a drawing improves today. Build time unchanged (CTC-04 24.2 s).

## ADR 0014 Amendment 4

This was the **third** instance in one session of a guard silently disabling the feature it protects — after #1188 (the joint assignment never running on any dense part) and #798. Three is a pattern, so it is recorded:

- prefer counting real work to predicting it;
- where a pre-check is genuinely needed it must be **exact**, not conservative;
- a budget that fires is a **capability loss** and should be observable as one — all three degraded silently, with a lint line at most.

## Testing

Full fast tier green (4039 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22