### PR TITLE
Ignore drawing-export artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,15 @@ coverage*.json
 htmlcov/
 site/
 .DS_Store
+
+# Drawing exports. `Drawing.export()` writes wherever the calling script runs from, so
+# ad-hoc scripts drop artefacts in the repo root — `bracket.pdf` and `grm01.pdf` were
+# swept into a commit that way. These are build products, never sources.
+#
+# PDF and DXF have no tracked instances, so they are ignored anywhere. SVG and PNG DO
+# (docs/images/), so only the repo root is ignored — the one place throwaway scripts
+# write to — rather than hiding a legitimate new docs image.
+*.pdf
+*.dxf
+/*.svg
+/*.png


### PR DESCRIPTION
`Drawing.export()` writes relative to the calling script, so ad-hoc scripts drop artefacts in the repo root. Two of them (`bracket.pdf`, `grm01.pdf`) were swept into a commit during #1190 and had to be removed afterwards.

**Scoped rather than blanket,** because the formats differ:

| pattern | why |
|---|---|
| `*.pdf`, `*.dxf` | no tracked instances — safe to ignore anywhere |
| `/*.svg`, `/*.png` | `docs/images/` **has** tracked instances — repo root only |

A blanket `*.svg` / `*.png` would leave the existing docs images alone (they're already tracked) but silently hide the *next* one someone adds — trading one papercut for a worse one. The repo root is the only place throwaway scripts write.

Verified both directions: `docs/images/draftwright-icon.{svg,png}` remain unignored, and a root-level `pdf`/`dxf`/`svg`/`png` is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22