### PR TITLE
Stop blocking the package on families Draftwright has not adopted

### DIFF
--- a/.github/workflows/bump-recogniser-dependency.yml
+++ b/.github/workflows/bump-recogniser-dependency.yml
@@ -49,6 +49,7 @@ jobs:
           scripts/check-recogniser-release
           uv run pytest -q \
             tests/test_external_recognition_boundary.py \
+            tests/test_recogniser_adoption.py \
             tests/test_recogniser_capabilities.py \
             tests/test_two_repository_workflow.py
       - name: Restrict generated diff

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -15,9 +15,16 @@ library.
 
 Validation fails closed and names the family and boundary whenever possible:
 
-- **family inventory mismatch** — the installed package added, removed, or renamed a family.
-  Update the package pin deliberately, add or remove the Draftwright declaration, and provide the
-  downstream behavior or an explicit non-supported state.
+- **family inventory mismatch (`stale=`)** — Draftwright declares a family the installed package
+  no longer ships, so a declared adapter would call a recogniser that is gone. Remove or repoint
+  the declaration.
+
+  The opposite direction does **not** fail this validation. A family the package ships and
+  Draftwright has not declared cannot reach any Draftwright code path, and blocking on it made the
+  package unreleasable until its consumer caught up. It is reported by
+  `pending_family_declarations` and fails `tests/test_recogniser_adoption.py` in Draftwright's own
+  CI instead — adoption is still required, and is enforced where the decision is made. Provide the
+  downstream behavior or an explicit non-supported state as before.
 - **record schema mismatch** — a consumed record schema changed. Review the record fields and
   compatibility notes, update the relevant adapter and tests, then pin the accepted schema version.
 - **stale implementation** — a declared adapter, `Sheet` method, emitter, renderer, or completeness

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -298,6 +298,26 @@ def _validate_stage(stage: object, family_id: str, boundary: str, root: Path | N
         raise RecogniserCapabilityError(f"{context} needs a non-empty rationale")
 
 
+def pending_family_declarations(*, package: object | None = None) -> list[str]:
+    """Package families this consumer has not declared yet, sorted.
+
+    Empty is the healthy state. A non-empty list means the installed package grew a
+    capability Draftwright has not yet decided what to do with -- which is a job for this
+    repository, not a reason to block the package's release. See
+    ``tests/test_recogniser_adoption.py``, which is what makes that job visible.
+    """
+    manifest = capability_manifest(format_version=1) if package is None else package
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("families"), list):
+        raise RecogniserCapabilityError("installed recogniser manifest format is unsupported")
+    package_ids = {
+        family["id"]
+        for family in manifest["families"]
+        if isinstance(family, dict) and isinstance(family.get("id"), str)
+    }
+    declared = {family["id"] for family in consumer_capability_declaration()["families"]}
+    return sorted(package_ids - declared)
+
+
 def validate_recogniser_capabilities(
     declaration: object | None = None,
     *,
@@ -372,13 +392,24 @@ def validate_recogniser_capabilities(
     ):
         raise RecogniserCapabilityError("consumer family declarations must be objects with IDs")
     ids = [family["id"] for family in families]
-    if ids != sorted(set(ids)) or set(ids) != set(package_by_id):
-        missing = sorted(set(package_by_id) - set(ids))
-        stale = sorted(set(ids) - set(package_by_id))
+    if ids != sorted(set(ids)):
+        raise RecogniserCapabilityError(
+            "consumer family declarations must be unique and sorted by id"
+        )
+    # Only the *stale* direction is a compatibility failure. A family we declare that the
+    # package no longer ships means this code would call a recogniser that is gone, so it
+    # stays fatal. A family the package ships that we have not declared cannot reach us at
+    # all -- nothing here constructs `RecognitionResult` or indexes the feature census, so a
+    # new field or key is inert -- and failing on it made the *provider* unreleasable until
+    # its consumer caught up, which inverts the dependency.
+    #
+    # Adoption is still required, and still enforced; it is enforced in Draftwright's own CI
+    # against `pending_family_declarations`, which is where the decision actually lives.
+    stale = sorted(set(ids) - set(package_by_id))
+    if stale:
         raise RecogniserCapabilityError(
             f"family inventory mismatch for installed {_PACKAGE_VERSION}; "
-            f"unknown={missing}, stale={stale}; "
-            "declare every package family explicitly"
+            f"stale={stale}; a declared family is no longer in the package"
         )
     checkout_root = Path(__file__).resolve().parents[2]
     root = source_root

--- a/tests/test_recogniser_adoption.py
+++ b/tests/test_recogniser_adoption.py
@@ -1,0 +1,43 @@
+"""Draftwright must decide what to do with every capability the installed package ships.
+
+This is the other half of splitting the recogniser inventory check. ``recogniser_contract``
+no longer fails when the package ships a family Draftwright has not declared, because that
+direction cannot break anything here and blocking on it made the *provider* unreleasable
+until its consumer caught up. The obligation to decide did not go away — it moved here,
+where the decision belongs.
+
+**This file is deliberately outside the downstream canary.** ``check_downstream.py`` in
+b123d-recognisers runs ``tests/test_recogniser_capabilities.py`` and
+``tests/test_import_boundaries.py`` against a candidate wheel; those two are the
+*compatibility* contract, and a candidate that adds a family has not broken compatibility.
+Adoption is a Draftwright schedule question, so it is checked in Draftwright's own CI and
+nowhere else. Adding this module to that list would restore exactly the coupling the split
+removed.
+"""
+
+from __future__ import annotations
+
+from draftwright.recogniser_contract import pending_family_declarations
+
+
+def test_every_installed_package_family_has_a_declaration() -> None:
+    """The installed package's families are all declared, so nothing is silently ignored.
+
+    When this fails, the installed ``b123d-recognisers`` has grown a recogniser family and
+    the choice of what Draftwright does with it is outstanding. Declare it in
+    ``recogniser_contract._FAMILIES`` — as ``supported`` with an IR adapter, DSL kind and
+    renderer, or as ``geometry-only`` if the evidence informs critique without becoming a
+    drafting feature.
+
+    Deciding "not yet" is legitimate, but it is still a decision and still gets written
+    down: raise or reference a tracking issue, then declare the family with the disposition
+    that says so. What this test refuses to allow is the family going unnoticed.
+    """
+
+    pending = pending_family_declarations()
+
+    assert pending == [], (
+        f"installed b123d-recognisers ships {len(pending)} undeclared "
+        f"recogniser {'family' if len(pending) == 1 else 'families'}: {pending}. "
+        "Declare each in recogniser_contract._FAMILIES; see this module's docstring."
+    )

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -281,7 +281,7 @@ def test_repeating_profile_is_explicit_geometry_only_critique_evidence() -> None
         ),
     ],
 )
-def test_consumer_declaration_fails_closed_on_stale_or_unknown_claims(
+def test_consumer_declaration_fails_closed_on_stale_or_malformed_claims(
     mutate, message: str
 ) -> None:
     declaration = consumer_capability_declaration()

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -263,11 +263,11 @@ def test_repeating_profile_is_explicit_geometry_only_critique_evidence() -> None
             "must pin",
         ),
         (
-            # An id the package does not ship: the direction that would have us calling a
-            # recogniser that is gone. Undeclaring a family it *does* ship is no longer a
-            # failure here -- see test_recogniser_adoption.py.
-            # The last family, so the rename cannot disturb the sorted-id ordering and
-            # trip that check first instead.
+            # The stale direction, and the one that really breaks: an id the package does not
+            # ship would have a declared adapter calling a recogniser that is gone. The
+            # opposite -- not declaring a family it *does* ship -- is deliberately no longer a
+            # failure here; see tests/test_recogniser_adoption.py. Renaming the *last* family
+            # so the change cannot disturb sorted-id ordering and trip that check first.
             lambda value: value["families"][-1].update({"id": "zz-retired-family"}),
             "stale=",
         ),
@@ -324,17 +324,26 @@ def test_a_package_family_we_have_not_declared_yet_does_not_fail_the_join() -> N
     assert "future-thread" in pending_family_declarations(package=package)
 
 
-def test_out_of_order_family_declarations_fail_closed() -> None:
-    """Ordering is checked separately from membership, so it cannot be masked by it.
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda families: families.reverse(), id="unsorted"),
+        pytest.param(
+            lambda families: families[0].update({"id": families[-1]["id"]}), id="duplicated"
+        ),
+    ],
+)
+def test_family_declarations_must_be_unique_and_sorted(mutate) -> None:
+    """Both halves of that condition, because one expression checks two different mistakes.
 
-    While the inventory check was one condition, unsorted ids and a stale family produced the
-    same error. They are different mistakes with different repairs, and splitting membership
-    into a stale-only test left ordering needing its own.
+    Ordering is now checked separately from membership, so it cannot be masked by it: while
+    the inventory check was a single condition, unsorted ids and a stale family raised the
+    same error. Reversing the list gives ordering without duplication; copying one id over
+    another gives duplication without any id the package does not ship. An earlier version of
+    this test did only the second while claiming to do the first.
     """
     declaration = consumer_capability_declaration()
-    # Rename the first family to sort last, without re-sorting: membership is untouched only
-    # in the sense that the id is still one the package ships -- it is the order that breaks.
-    declaration["families"][0]["id"] = declaration["families"][-1]["id"]
+    mutate(declaration["families"])
 
     with pytest.raises(RecogniserCapabilityError, match="unique and sorted"):
         validate_recogniser_capabilities(declaration)
@@ -352,15 +361,6 @@ def test_pending_declarations_reject_a_malformed_manifest() -> None:
     for broken in ("not-a-dict", {}, {"families": "not-an-array"}):
         with pytest.raises(RecogniserCapabilityError, match="manifest format is unsupported"):
             pending_family_declarations(package=broken)
-
-
-def test_a_declared_family_the_package_dropped_still_fails_closed() -> None:
-    """The stale direction stays fatal: this is the one that really breaks."""
-    declaration = consumer_capability_declaration()
-    declaration["families"][-1]["id"] = "zz-retired-family"
-
-    with pytest.raises(RecogniserCapabilityError, match="stale="):
-        validate_recogniser_capabilities(declaration)
 
 
 def test_schema_format_fails_closed() -> None:

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -137,7 +137,11 @@ def test_runtime_adapter_inventory_is_derived_independently_and_exhaustive() -> 
         for family in recognition.capability_manifest()["families"]
         for record in family["records"]
     }
-    assert declared_records == package_records
+    # Subset, not equality, and for the same reason the family inventory is: a record we
+    # declare that the package does not ship is a break, while one it ships and we have not
+    # declared yet is a Draftwright to-do. `tests/test_recogniser_adoption.py` owns the
+    # second direction; asserting equality here would put the coupling straight back.
+    assert declared_records <= package_records
 
 
 def test_dsl_and_generated_code_inventories_are_derived_from_live_code() -> None:
@@ -297,7 +301,9 @@ def test_a_package_family_we_have_not_declared_yet_does_not_fail_the_join() -> N
 
     validate_recogniser_capabilities(package=package)
 
-    assert pending_family_declarations(package=package) == ["future-thread"]
+    # `in`, not equality: any family the installed package has genuinely grown since the
+    # last declaration is legitimately pending too, and this test is not about those.
+    assert "future-thread" in pending_family_declarations(package=package)
 
 
 def test_a_declared_family_the_package_dropped_still_fails_closed() -> None:

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -25,6 +25,7 @@ from draftwright.model.detect import (
 from draftwright.recogniser_contract import (
     RecogniserCapabilityError,
     consumer_capability_declaration,
+    pending_family_declarations,
     validate_recogniser_capabilities,
 )
 from draftwright.sheet import Sheet
@@ -239,7 +240,15 @@ def test_repeating_profile_is_explicit_geometry_only_critique_evidence() -> None
             lambda value: value["package_compatibility"].update({"version": "==0.1.0"}),
             "must pin",
         ),
-        (lambda value: value["families"].pop(), "inventory mismatch"),
+        (
+            # An id the package does not ship: the direction that would have us calling a
+            # recogniser that is gone. Undeclaring a family it *does* ship is no longer a
+            # failure here -- see test_recogniser_adoption.py.
+            # The last family, so the rename cannot disturb the sorted-id ordering and
+            # trip that check first instead.
+            lambda value: value["families"][-1].update({"id": "zz-retired-family"}),
+            "stale=",
+        ),
         (
             lambda value: value["families"][0]["record_schemas"].update({"BossRecord": 99}),
             "record schema mismatch",
@@ -271,13 +280,36 @@ def test_consumer_declaration_fails_closed_on_stale_or_unknown_claims(
         validate_recogniser_capabilities(declaration)
 
 
-def test_unknown_package_family_and_schema_format_fail_closed() -> None:
+def test_a_package_family_we_have_not_declared_yet_does_not_fail_the_join() -> None:
+    """The additive direction is a Draftwright to-do, not a compatibility failure.
+
+    A family the package ships and this repository has not declared cannot reach any
+    Draftwright code path: nothing here constructs ``RecognitionResult`` or indexes the
+    feature census by key. Failing the join on it made every new recogniser a two-repo
+    lockstep release, with the provider blocked on its own consumer.
+
+    It is still tracked -- ``pending_family_declarations`` reports it and
+    ``tests/test_recogniser_adoption.py`` fails Draftwright's build until it is declared.
+    """
     package = recognition.capability_manifest()
     package["families"].append(copy.deepcopy(package["families"][0]))
     package["families"][-1]["id"] = "future-thread"
-    with pytest.raises(RecogniserCapabilityError, match="inventory mismatch"):
-        validate_recogniser_capabilities(package=package)
 
+    validate_recogniser_capabilities(package=package)
+
+    assert pending_family_declarations(package=package) == ["future-thread"]
+
+
+def test_a_declared_family_the_package_dropped_still_fails_closed() -> None:
+    """The stale direction stays fatal: this is the one that really breaks."""
+    declaration = consumer_capability_declaration()
+    declaration["families"][-1]["id"] = "zz-retired-family"
+
+    with pytest.raises(RecogniserCapabilityError, match="stale="):
+        validate_recogniser_capabilities(declaration)
+
+
+def test_schema_format_fails_closed() -> None:
     package = recognition.capability_manifest()
     package["format_version"] = 2
     with pytest.raises(RecogniserCapabilityError, match="manifest format"):

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -149,6 +149,18 @@ def test_runtime_adapter_inventory_is_derived_independently_and_exhaustive() -> 
     # second direction; asserting equality here would put the coupling straight back.
     assert declared_records <= package_records
 
+    # Restores the half the subset above gave up. `runtime == union(tiers)` used to assert two
+    # things at once: no converter for a record that does not exist, and no record without a
+    # converter. Relaxing it to a subset kept the first and dropped the second, which would let
+    # a family be declared `supported` while nothing converts what it emits.
+    #
+    # Scoped to records this repository has actually declared, so it cannot recouple: a record
+    # the package emits and we have not adopted is exactly the case that must stay free, and
+    # `tests/test_recogniser_adoption.py` owns it.
+    converted = {record.__name__ for record in set.union(*tiers)}
+    emitted = {record.__name__ for record in runtime}
+    assert emitted & declared_records <= converted
+
 
 def test_dsl_and_generated_code_inventories_are_derived_from_live_code() -> None:
     declaration = consumer_capability_declaration()
@@ -310,6 +322,36 @@ def test_a_package_family_we_have_not_declared_yet_does_not_fail_the_join() -> N
     # `in`, not equality: any family the installed package has genuinely grown since the
     # last declaration is legitimately pending too, and this test is not about those.
     assert "future-thread" in pending_family_declarations(package=package)
+
+
+def test_out_of_order_family_declarations_fail_closed() -> None:
+    """Ordering is checked separately from membership, so it cannot be masked by it.
+
+    While the inventory check was one condition, unsorted ids and a stale family produced the
+    same error. They are different mistakes with different repairs, and splitting membership
+    into a stale-only test left ordering needing its own.
+    """
+    declaration = consumer_capability_declaration()
+    # Rename the first family to sort last, without re-sorting: membership is untouched only
+    # in the sense that the id is still one the package ships -- it is the order that breaks.
+    declaration["families"][0]["id"] = declaration["families"][-1]["id"]
+
+    with pytest.raises(RecogniserCapabilityError, match="unique and sorted"):
+        validate_recogniser_capabilities(declaration)
+
+
+def test_pending_declarations_reject_a_malformed_manifest() -> None:
+    """The pending query fails closed too, rather than reporting an empty to-do list.
+
+    It is the control that replaced a hard failure, so a malformed manifest must not make it
+    quietly answer "nothing pending" -- that would read as adoption being complete.
+
+    ``None`` is deliberately absent from these: it is the "use the installed manifest"
+    sentinel, not a malformed value.
+    """
+    for broken in ("not-a-dict", {}, {"families": "not-an-array"}):
+        with pytest.raises(RecogniserCapabilityError, match="manifest format is unsupported"):
+            pending_family_declarations(package=broken)
 
 
 def test_a_declared_family_the_package_dropped_still_fails_closed() -> None:

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -122,7 +122,13 @@ def test_installed_released_package_contract_validates_without_a_sibling_checkou
 def test_runtime_adapter_inventory_is_derived_independently_and_exhaustive() -> None:
     runtime = _runtime_emitted_records()
     tiers = [set(_CONVERTERS), set(_DERIVED_CONVERTERS), set(_ORCHESTRATED_RECORDS)]
-    assert runtime == set.union(*tiers)
+    # Subset again, and the third place the same coupling was written. A converter for a
+    # record the installed package no longer emits is dead code pointing at a type that is
+    # gone, so that direction still fails. A record with no converter yet is the additive
+    # direction: the family carrying it is reported by `pending_family_declarations`, and
+    # declaring it `supported` forces an `ir_adapter` that `_resolve_implementation` must
+    # import -- so converter coverage is still compelled, at the point the decision is made.
+    assert set.union(*tiers) <= runtime
     assert all(
         not left & right for index, left in enumerate(tiers) for right in tiers[index + 1 :]
     )


### PR DESCRIPTION
Closes #1200. Unblocks [b123d-recognisers#85](https://github.com/pzfreo/b123d-recognisers/pull/85).

## The problem

`b123d-recognisers` could not release a new recogniser family until Draftwright declared it. That inverts the dependency — Draftwright depends on the package, not the reverse — and made every new recogniser a two-repo lockstep release.

The inventory check required exact set equality and treated both directions identically. They are not equivalent:

| direction | meaning | a real break? |
| --- | --- | --- |
| **`stale`** | we declare a family the package no longer ships | **yes** — a declared adapter would call a recogniser that is gone |
| **`unknown`** | the package ships a family we have not declared | **no** — unreachable from here |

The additive direction is provably inert: nothing in `src` constructs `RecognitionResult` (`git grep "RecognitionResult("` returns nothing — it is only ever read by attribute), and `score.py` re-exports `feature_census` wholesale rather than indexing keys. A new field or census key cannot reach Draftwright code.

## The change

The join now fails only on `stale`. The additive direction is reported by a new `pending_family_declarations()`.

**Adoption is still required — it moved to the repository that owns the decision.** `tests/test_recogniser_adoption.py` fails Draftwright's build while any installed family is undeclared, and its failure message says what to do. Deciding "not yet" stays legitimate and stays written down: declare the family with a disposition that says so.

That test is deliberately **outside** `test_recogniser_capabilities.py`. The package's `check_downstream.py` runs that module and `test_import_boundaries.py` against a candidate wheel; those two are the *compatibility* contract, and a candidate that adds a family has not broken compatibility. Adding the adoption test there would restore exactly the coupling this removes — the module docstring says so, so a future reader does not "fix" it.

## It was three couplings, not one

I expected a one-line change. Running the real canary rather than reading the code found the same equality written in two more places, both given the same split:

- `declared_records == package_records` — the record inventory.
- `set.union(*tiers) == runtime` — Draftwright's converters had to exactly cover the package's record types.

Record-level protection is **not** lost: the per-family `record_schemas != actual_schemas` check is still exact, so a record added to an already-declared family stays fatal. The subsets only ever admit records belonging to families that are themselves pending. Converter coverage is still compelled too — declaring a family `supported` requires an `ir_adapter` that `_resolve_implementation` imports.

## Verified end to end

Running the package's own `tools/check_downstream.py` against this branch with a 0.2.5 candidate wheel:

```
72 passed, 1 deselected
candidate package and Draftwright contract are compatible
```

And enforcement is intact, not merely relocated on paper:

```
installed today (0.2.4): []                 -> adoption test green
against 0.2.5          : ['angled-steps']   -> adoption test RED until declared
```

## Also in here

The adoption gate was missing from `bump-recogniser-dependency.yml`, which runs an explicit test list rather than `tests/` — and that workflow is the exact moment adoption matters, since it is where the pin moves to a version with new families. `ci.yml` runs `pytest tests/` so this was late notice rather than none, but late notice at the gate built to catch it is not good enough. Now in the list.

Worth knowing about that workflow: it restricts its generated diff to the pin, changelog, lockfile and `recogniser_contract.py`. A **`geometry-only`** declaration fits inside that and can be automated; a **`supported`** one needs converter and renderer code outside it, so it correctly stays a human PR.

Docs updated — the old text described the symmetric behaviour and told contributors to repair a failure that no longer occurs. One test name outlived its meaning (`..._on_stale_or_unknown_claims`; unknown claims are exactly what stopped failing) and is now `..._or_malformed_`.

## Test status

Focused sets pass locally: 63 for the contract + adoption modules, 89 for the bump workflow's exact list, 72 through the real canary; `ruff check src tests` clean. **The full `pytest tests/` sweep was still running when this was raised** — CI is the authoritative run, and I will follow up if the local sweep disagrees.

## Trade-off, stated plainly

Strict equality did guarantee no package capability sat unadopted and unnoticed. Loosening it means a family could languish if the adoption failure is ignored. That is the cost; the mitigation is that the pending list is loud *here* rather than quiet anywhere. If it turns out to be too quiet in practice, the narrower alternative from #1200 — an explicit one-line `pending` disposition — is still available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)