### PR TITLE
Observe the drawing_consumer boundary instead of declaring it

### DIFF
--- a/docs/reference/step-analysis-evaluation.md
+++ b/docs/reference/step-analysis-evaluation.md
@@ -13,8 +13,13 @@ An observer may only normalize actual evidence; `ObservedFact` deliberately has 
 identifier. Expected and observed facts are matched by family plus authored physical identity fields.
 
 Format 1 currently proves the `holes` vertical slice. The observer reads released
-`b123d-recognisers` geometry records and the independently enforced Draftwright capability
-declaration. Adding another family requires its own independently authored fixtures, facts,
+`b123d-recognisers` geometry records, builds the drawing, and reads the `drawing_consumer`
+outcome off that build through the ADR 0010 provenance seam — `supported` when the hole's
+size reached the sheet as a callout or a hole-table row, `unsupported` when a feature
+accounts for it and carries neither, `unknown` when no feature accounts for it (#1202). The
+other three downstream boundaries still come from the independently enforced Draftwright
+capability declaration, which is a claim that a code path exists rather than an
+observation. Adding another family requires its own independently authored fixtures, facts,
 identity fields, observer, downstream evidence, and corpus version change; copying a manifest name
 alone cannot enlarge the denominator.
 

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -16,6 +16,8 @@ from math import isfinite
 from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
+from draftwright._geometry import _axis_letter_of
+
 Scalar: TypeAlias = int | float | str | bool
 Value: TypeAlias = Scalar | tuple[float, ...]
 Outcome: TypeAlias = Literal["supported", "unknown", "unsupported"]
@@ -615,65 +617,141 @@ def load_corpus(path: str | Path) -> BenchmarkCorpus:
     return BenchmarkCorpus(corpus_version, _METRIC_VERSION, scope, tuple(cases))
 
 
-#: How close a recognised hole's mouth must be to an IR feature's origin, in the plane
-#: normal to its axis, to be the same hole. Generous: the recogniser reports the mouth and
-#: the compiler may mint the origin at either end, so only the IN-PLANE position is
-#: compared, and the diameter must agree independently.
+#: Position agreement required to call a recognised hole and an IR feature the same hole.
+#: Tiny on purpose: the IR carries the recogniser's own ``hole.location`` verbatim
+#: (``model/detect.py`` builds ``Frame(origin=_xyz(rep.location))``), so agreement is
+#: EXACT on every corpus fixture — worst residual measured at 0.0, including the
+#: side-drilled case whose z is 6.66e-15. An earlier version compared only the in-plane
+#: coordinates, on a guess that the compiler might mint the origin at the far end of the
+#: bore. It does not, and dropping the axis component made two opposed coaxial holes of
+#: equal diameter alias onto one feature, hiding a dropped callout on the second.
 _CORRESPONDENCE_TOLERANCE = 1e-6
 
 
-def _hole_features(drawing) -> list:
-    """Every IR hole feature on *drawing*, in model order."""
-    return [f for f in drawing.model().features if type(f).__name__ == "HoleFeature"]
+@dataclass(frozen=True)
+class _Candidate:
+    """One IR feature and the hole positions it can account for."""
+
+    feature: object
+    axis: str
+    diameter: float
+    positions: tuple[tuple[float, ...], ...]
 
 
-def _in_plane(point, axis: str) -> tuple[float, ...]:
-    """*point* with the component along *axis* dropped — the coordinates that identify a
-    hole regardless of which end of the bore a producer chose to name."""
-    drop = {"x": 0, "y": 1, "z": 2}[axis]
-    return tuple(float(v) for i, v in enumerate(point) if i != drop)
+def _hole_candidates(drawing) -> list[_Candidate]:
+    """Every IR feature that can account for a recognised hole.
 
+    Patterned holes lower to a ``PatternFeature`` carrying a representative
+    ``HoleFeature`` and the member centres — they are NOT ``HoleFeature`` instances, so
+    matching on that type alone made recognising a pattern (a capability) *lower* the
+    score: four identical holes scored ``unknown`` where the same four at the same
+    positions with distinct diameters scored ``supported``, both fully drawn.
 
-def _axis_letter(vector) -> str:
-    return max(zip("xyz", vector, strict=True), key=lambda pair: abs(pair[1]))[0]
-
-
-def _drawing_consumer_outcome(hole, features, drawing) -> Outcome:
-    """Did the DRAWING call this recognised hole out? — observed, not declared.
-
-    ``supported`` the feature covering this hole carries a hole callout (``hc_*``);
-    ``unsupported`` a feature covers it and carries none, so the fact was recognised and
-    then lost before the sheet; ``unknown`` no feature corresponds, which is a gap in the
-    recognition-record-to-IR correspondence ADR 0017 explicitly does not yet provide — an
-    honest non-answer, never silently scored as either success or failure.
+    Dispatch is on the IR's own ``kind`` discriminator, which the engine itself uses,
+    rather than on ``type(f).__name__``.
     """
-    axis = _axis_letter(hole.axis)
-    target = _in_plane(hole.location, axis)
-    for feature in features:
-        if feature.frame.axis != axis or abs(feature.diameter - hole.diameter) > 1e-9:
-            continue
-        # A grouped `count×` callout covers several holes through one feature, so every
-        # member position counts, not just the frame origin.
-        positions = feature.members or (feature.frame.origin,)
-        if not any(
-            all(
-                abs(a - b) <= _CORRESPONDENCE_TOLERANCE
-                for a, b in zip(_in_plane(position, axis), target, strict=True)
+    candidates: list[_Candidate] = []
+    for feature in drawing.model().features:
+        kind = getattr(feature, "kind", None)
+        if kind == "hole":
+            # A grouped ``count×`` callout covers several holes through one feature.
+            positions = feature.members or (feature.frame.origin,)
+            candidates.append(
+                _Candidate(feature, feature.frame.axis, feature.diameter, tuple(positions))
             )
-            for position in positions
-        ):
-            continue
-        return (
-            "supported"
-            if any(n.startswith("hc_") for n in drawing.annotations_of(feature))
-            else "unsupported"
-        )
-    return "unknown"
+        elif kind == "pattern" and getattr(feature.member, "kind", None) == "hole":
+            candidates.append(
+                _Candidate(
+                    feature, feature.frame.axis, feature.member.diameter, tuple(feature.members)
+                )
+            )
+    return candidates
+
+
+def _table_represented(drawing) -> list:
+    """Features the engine recorded as carried by a hole TABLE rather than a callout.
+
+    Above ~16 scattered holes the engine escalates: it withdraws the individual ``hc_*``
+    callouts and places one table plus balloons, recording the substitution in
+    ``covers_hole_representations_by_feature``. Looking only for ``hc_`` therefore scored
+    every hole on a dense sheet as lost — on the very sheets #1176 and ADR 0018 are about,
+    the metric's first real encounter with a dense part would have been a false alarm.
+    Reading the engine's own ledger keeps this metric and the engine from disagreeing
+    about whether a fact reached the page.
+    """
+    covered = []
+    for _name, annotation in drawing.iter_annotations():
+        for entry in getattr(annotation, "covers_hole_representations_by_feature", ()):
+            covered.append(entry[0])
+    return covered
+
+
+def _consumed(feature, drawing, represented) -> bool:
+    """Did this feature's SIZE reach the sheet, by either sanctioned route?
+
+    Only the callout or the table counts. A hole whose callout was dropped still keeps
+    its centre mark and location dims (measured: ``m_cm0``, ``m_locx0``), so counting any
+    annotation would score a dropped callout as consumed.
+    """
+    if any(name.startswith("hc_") for name in drawing.annotations_of(feature)):
+        return True
+    return any(candidate == feature for candidate in represented)
+
+
+def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
+    """Per recognised hole: did the DRAWING carry it? — observed, not declared.
+
+    ``supported`` its size reached the sheet; ``unsupported`` a feature accounts for the
+    hole and carries neither callout nor table row; ``unknown`` no feature accounts for
+    it, which is a gap in the recognition-record-to-IR correspondence ADR 0017 explicitly
+    does not yet provide.
+
+    Be precise about ``unknown``: :func:`evaluate_case` credits a unit only when the state
+    is ``supported``, so downstream an ``unknown`` scores as a MISS, distinguishable from
+    a dropped callout only in the diagnostic text. It is an honest label, not an exemption
+    — an earlier version of this docstring claimed it was "never scored as either success
+    or failure", which was wrong about the pipeline it feeds.
+
+    Matching is injective per POSITION: a matched position is consumed, so two opposed
+    coaxial holes of equal diameter cannot both resolve to the first candidate. Grouped
+    features legitimately account for several holes, which is why the position is consumed
+    and not the whole candidate.
+    """
+    remaining = [(candidate, list(candidate.positions)) for candidate in _hole_candidates(drawing)]
+    represented = _table_represented(drawing)
+    outcomes: list[Outcome] = []
+    for hole in holes:
+        axis = _axis_letter_of(hole.axis)
+        target = tuple(float(value) for value in hole.location)
+        for candidate, positions in remaining:
+            if candidate.axis != axis or abs(candidate.diameter - hole.diameter) > 1e-9:
+                continue
+            hit = next(
+                (
+                    position
+                    for position in positions
+                    if all(
+                        abs(a - b) <= _CORRESPONDENCE_TOLERANCE
+                        for a, b in zip(tuple(float(v) for v in position), target, strict=True)
+                    )
+                ),
+                None,
+            )
+            if hit is None:
+                continue
+            positions.remove(hit)
+            outcomes.append(
+                "supported"
+                if _consumed(candidate.feature, drawing, represented)
+                else "unsupported"
+            )
+            break
+        else:
+            outcomes.append("unknown")
+    return outcomes
 
 
 def _default_observers() -> Mapping[str, Observer]:
-    from b123d_recognisers import build_recognition_result
-
     from draftwright.recogniser_contract import (
         consumer_capability_declaration,
         validate_recogniser_capabilities,
@@ -699,12 +777,27 @@ def _default_observers() -> Mapping[str, Observer]:
         # ``test_lazy_upward_imports_are_documented`` (ADR 0005 / #640).
         from draftwright.builder import build_drawing
 
-        recognition = build_recognition_result(part)  # type: ignore[arg-type]
-        # ONE drawing for the whole fixture, built here rather than per hole: the
-        # observation is "what did the sheet do with this fact", so it must come from a
-        # real build, and building per hole would multiply the cost by the hole count.
-        drawing = build_drawing(part)  # type: ignore[arg-type]
-        features = _hole_features(drawing)
+        # ONE drawing per fixture, and ONE recognition: the records scored here come from
+        # the build's own aggregate (ADR 0017's single owner per run), not a second
+        # `build_recognition_result` call, so the facts being scored and the features they
+        # are matched against cannot come from different recognition runs.
+        try:
+            drawing = build_drawing(part)  # type: ignore[arg-type]
+        except Exception:  # noqa: BLE001 — an unbuildable fixture is a non-answer, not a crash
+            drawing = None
+        if drawing is None:
+            from b123d_recognisers import build_recognition_result
+
+            holes = tuple(build_recognition_result(part).holes)  # type: ignore[arg-type]
+            outcomes: list[Outcome] = ["unknown"] * len(holes)
+        else:
+            recognition = drawing.recognition()
+            if recognition is None:  # pragma: no cover — the detected path always fills it
+                from b123d_recognisers import build_recognition_result
+
+                recognition = build_recognition_result(part)  # type: ignore[arg-type]
+            holes = tuple(recognition.holes)
+            outcomes = _drawing_consumer_outcomes(holes, drawing)
         return tuple(
             ObservedFact(
                 family="holes",
@@ -714,12 +807,9 @@ def _default_observers() -> Mapping[str, Observer]:
                     "depth": hole.depth,
                     "diameter": hole.diameter,
                 },
-                downstream={
-                    **declared,
-                    "drawing_consumer": _drawing_consumer_outcome(hole, features, drawing),
-                },
+                downstream={**declared, "drawing_consumer": outcome},
             )
-            for hole in recognition.holes
+            for hole, outcome in zip(holes, outcomes, strict=True)
         )
 
     return {"holes": observe_holes}

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -615,6 +615,62 @@ def load_corpus(path: str | Path) -> BenchmarkCorpus:
     return BenchmarkCorpus(corpus_version, _METRIC_VERSION, scope, tuple(cases))
 
 
+#: How close a recognised hole's mouth must be to an IR feature's origin, in the plane
+#: normal to its axis, to be the same hole. Generous: the recogniser reports the mouth and
+#: the compiler may mint the origin at either end, so only the IN-PLANE position is
+#: compared, and the diameter must agree independently.
+_CORRESPONDENCE_TOLERANCE = 1e-6
+
+
+def _hole_features(drawing) -> list:
+    """Every IR hole feature on *drawing*, in model order."""
+    return [f for f in drawing.model().features if type(f).__name__ == "HoleFeature"]
+
+
+def _in_plane(point, axis: str) -> tuple[float, ...]:
+    """*point* with the component along *axis* dropped — the coordinates that identify a
+    hole regardless of which end of the bore a producer chose to name."""
+    drop = {"x": 0, "y": 1, "z": 2}[axis]
+    return tuple(float(v) for i, v in enumerate(point) if i != drop)
+
+
+def _axis_letter(vector) -> str:
+    return max(zip("xyz", vector, strict=True), key=lambda pair: abs(pair[1]))[0]
+
+
+def _drawing_consumer_outcome(hole, features, drawing) -> Outcome:
+    """Did the DRAWING call this recognised hole out? — observed, not declared.
+
+    ``supported`` the feature covering this hole carries a hole callout (``hc_*``);
+    ``unsupported`` a feature covers it and carries none, so the fact was recognised and
+    then lost before the sheet; ``unknown`` no feature corresponds, which is a gap in the
+    recognition-record-to-IR correspondence ADR 0017 explicitly does not yet provide — an
+    honest non-answer, never silently scored as either success or failure.
+    """
+    axis = _axis_letter(hole.axis)
+    target = _in_plane(hole.location, axis)
+    for feature in features:
+        if feature.frame.axis != axis or abs(feature.diameter - hole.diameter) > 1e-9:
+            continue
+        # A grouped `count×` callout covers several holes through one feature, so every
+        # member position counts, not just the frame origin.
+        positions = feature.members or (feature.frame.origin,)
+        if not any(
+            all(
+                abs(a - b) <= _CORRESPONDENCE_TOLERANCE
+                for a, b in zip(_in_plane(position, axis), target, strict=True)
+            )
+            for position in positions
+        ):
+            continue
+        return (
+            "supported"
+            if any(n.startswith("hc_") for n in drawing.annotations_of(feature))
+            else "unsupported"
+        )
+    return "unknown"
+
+
 def _default_observers() -> Mapping[str, Observer]:
     from b123d_recognisers import build_recognition_result
 
@@ -626,10 +682,29 @@ def _default_observers() -> Mapping[str, Observer]:
     consumer = consumer_capability_declaration()
     validate_recogniser_capabilities(consumer)
     declaration = next(family for family in consumer["families"] if family["id"] == "holes")
-    downstream = {boundary: declaration[boundary]["state"] for boundary in _DOWNSTREAM_BOUNDARIES}
+    # The other three boundaries remain DECLARED states — "this code path exists" — which
+    # is the same self-validating shape, one layer along, and is tracked separately. Only
+    # `drawing_consumer` is observed here, because that is the boundary #1176 is about:
+    # a drawing scoring 1.0 while omitting the geometry it owes.
+    declared = {
+        boundary: declaration[boundary]["state"]
+        for boundary in _DOWNSTREAM_BOUNDARIES
+        if boundary != "drawing_consumer"
+    }
 
     def observe_holes(part: object) -> Sequence[ObservedFact]:
+        # The concrete module, not the package root: ``from draftwright import ...``
+        # pulls ``draftwright/__init__.py``, which the DAG guard treats as the TOP module,
+        # so it reads as an upward lazy import out of this top-layer package and fails
+        # ``test_lazy_upward_imports_are_documented`` (ADR 0005 / #640).
+        from draftwright.builder import build_drawing
+
         recognition = build_recognition_result(part)  # type: ignore[arg-type]
+        # ONE drawing for the whole fixture, built here rather than per hole: the
+        # observation is "what did the sheet do with this fact", so it must come from a
+        # real build, and building per hole would multiply the cost by the hole count.
+        drawing = build_drawing(part)  # type: ignore[arg-type]
+        features = _hole_features(drawing)
         return tuple(
             ObservedFact(
                 family="holes",
@@ -639,7 +714,10 @@ def _default_observers() -> Mapping[str, Observer]:
                     "depth": hole.depth,
                     "diameter": hole.diameter,
                 },
-                downstream=downstream,
+                downstream={
+                    **declared,
+                    "drawing_consumer": _drawing_consumer_outcome(hole, features, drawing),
+                },
             )
             for hole in recognition.holes
         )

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -7,14 +7,25 @@ benchmark case supplies the denominator and tolerances.
 The ``drawing_consumer`` boundary is OBSERVED from a real build (#1202) rather than read from
 a capability declaration. Known limit of that approach: it reads the ADR 0010 provenance seam,
 which ``Drawing.annotations_of`` documents as growing "as passes are migrated". An un-tagged
-render pass therefore reads as a genuine omission. The hole-table escalation was the first
-instance — it withdraws the individual callouts and records the substitution on the table — and
-a new representation route must be admitted here or it will register as a false loss.
+render pass therefore reads as a genuine omission, and this is a CLASS of limitation rather
+than a single case. Two instances are known:
+
+* the hole-table escalation, which withdraws the individual callouts and records the
+  substitution on the table — admitted here via that ledger;
+* a **turned** part, where the bore's diameter reaches the sheet as a ``Leader`` (``ldr_z0``)
+  whose ``registry.feature_of`` is ``None``, so it is neither a callout nor a table row. That
+  is inherited ADR 0015 / #754 debt (rotational OD/bore groups are not planner-routed) and
+  the engine's own ledger reports it as missing too, but this benchmark will report a loss
+  for a hole whose size is visibly printed. No corpus fixture is turned today; adding one
+  without addressing #754 would make the number wrong.
+
+A new representation route must be admitted here or it registers as a false loss.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -23,12 +34,12 @@ from math import isfinite
 from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
-from draftwright._geometry import _axis_letter_of
-
 Scalar: TypeAlias = int | float | str | bool
 Value: TypeAlias = Scalar | tuple[float, ...]
 Outcome: TypeAlias = Literal["supported", "unknown", "unsupported"]
 Observer: TypeAlias = Callable[[object], Sequence["ObservedFact"]]
+
+_log = logging.getLogger(__name__)
 
 _CORPUS_FORMAT = "draftwright-step-analysis-corpus"
 _CORPUS_FORMAT_VERSION = 1
@@ -745,6 +756,13 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
     features legitimately account for several holes, which is why the position is consumed
     and not the whole candidate.
     """
+    # Imported here, not at module level: `_geometry` imports build123d, so a top-level
+    # import would pull the CAD kernel into every consumer of this module — measured, it
+    # took import cost from 0.01 s to 1.27 s and made the lazy `builder` import below buy
+    # nothing at all. An earlier comment claimed that laziness saved the kernel import
+    # while this line was already paying it.
+    from draftwright._geometry import _axis_letter_of
+
     remaining = [(candidate, list(candidate.positions)) for candidate in _hole_candidates(drawing)]
     represented = _table_represented(drawing)
     outcomes: list[Outcome] = []
@@ -813,7 +831,13 @@ def _default_observers() -> Mapping[str, Observer]:
         # are matched against cannot come from different recognition runs.
         try:
             drawing = build_drawing(part)  # type: ignore[arg-type]
-        except Exception:  # noqa: BLE001 — an unbuildable fixture is a non-answer, not a crash
+        except Exception as exc:  # noqa: BLE001 — a non-answer, not an aborted corpus run
+            # The SCORE is the same `unknown` a correspondence gap produces — the oracle has
+            # three outcomes and no fourth — but the two must not be indistinguishable to a
+            # reader. A benchmark whose whole point is that a self-reported number cannot
+            # validate itself should not quietly equate "the compiler has no correspondence"
+            # with "the engine crashed", so the crash is announced.
+            _log.warning("evaluation: drawing build failed (%s); scoring holes as unknown", exc)
             drawing = None
         if drawing is None:
             # The recognition read is guarded too: a fixture that neither builds NOR

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -3,6 +3,13 @@
 This module scores recogniser observations against an independently authored oracle.  It does
 not inspect ``RecognitionResult`` or the feature census: adapters supply observations, while the
 benchmark case supplies the denominator and tolerances.
+
+The ``drawing_consumer`` boundary is OBSERVED from a real build (#1202) rather than read from
+a capability declaration. Known limit of that approach: it reads the ADR 0010 provenance seam,
+which ``Drawing.annotations_of`` documents as growing "as passes are migrated". An un-tagged
+render pass therefore reads as a genuine omission. The hole-table escalation was the first
+instance — it withdraws the individual callouts and records the substitution on the table — and
+a new representation route must be admitted here or it will register as a false loss.
 """
 
 from __future__ import annotations
@@ -668,34 +675,55 @@ def _hole_candidates(drawing) -> list[_Candidate]:
     return candidates
 
 
+#: The compiled requirement that carries a hole's SIZE. A table row documents several
+#: requirements per hole (location, through-ness, …); only this one is the fact
+#: ``drawing_consumer`` asks about.
+_SIZE_REQUIREMENT = "bore.diameter"
+
+
 def _table_represented(drawing) -> list:
     """Features the engine recorded as carried by a hole TABLE rather than a callout.
 
-    Above ~16 scattered holes the engine escalates: it withdraws the individual ``hc_*``
-    callouts and places one table plus balloons, recording the substitution in
-    ``covers_hole_representations_by_feature``. Looking only for ``hc_`` therefore scored
-    every hole on a dense sheet as lost — on the very sheets #1176 and ADR 0018 are about,
-    the metric's first real encounter with a dense part would have been a false alarm.
-    Reading the engine's own ledger keeps this metric and the engine from disagreeing
-    about whether a fact reached the page.
+    Above ~16 scattered holes the engine withdraws the individual ``hc_*`` callouts and
+    places one table plus balloons, recording the substitution on the table object. Reading
+    only ``hc_`` scored every hole on such a sheet as lost — measured 16 of 16 on a dense
+    plate with no lint issues at all — which inverted the metric: a correct sheet scored
+    worse than the same part with the table forced to fail.
+
+    Read ``covers_hole_representations_by_requirement`` and not the ``…_by_feature``
+    sibling. The sibling exists, and an earlier cut of this function read it, but **no
+    caller populates it**: `representation_features=` appears in the whole tree only at its
+    own definition and its own use in ``annotations/_common.py``. Both real callers pass
+    ``representation_requirements=`` instead. So that read returned nothing on every real
+    drawing while a hand-built stub in the tests made it look correct.
+
+    Filtered to the SIZE requirement: a table row also documents location and through-ness,
+    and crediting those would mean a hole with a located row but no diameter counted as
+    consumed.
+
+    Safe against a dropped table: the ledger is written only after the table is placed and
+    the balloon-completeness gate passes, and the annotation transaction rolls the table
+    back before that point, so a `table_dropped` sheet carries no entries (verified).
     """
     covered = []
     for _name, annotation in drawing.iter_annotations():
-        for entry in getattr(annotation, "covers_hole_representations_by_feature", ()):
-            covered.append(entry[0])
+        for entry in getattr(annotation, "covers_hole_representations_by_requirement", ()):
+            feature, parameter = entry[0], entry[1]
+            if parameter == _SIZE_REQUIREMENT:
+                covered.append(feature)
     return covered
 
 
 def _consumed(feature, drawing, represented) -> bool:
     """Did this feature's SIZE reach the sheet, by either sanctioned route?
 
-    Only the callout or the table counts. A hole whose callout was dropped still keeps
-    its centre mark and location dims (measured: ``m_cm0``, ``m_locx0``), so counting any
+    Only the callout or the table counts. A hole whose callout was dropped still keeps its
+    centre mark and location dims (measured: ``m_cm0``, ``m_locx0``), so counting any
     annotation would score a dropped callout as consumed.
     """
     if any(name.startswith("hc_") for name in drawing.annotations_of(feature)):
         return True
-    return any(candidate == feature for candidate in represented)
+    return any(represented_feature == feature for represented_feature in represented)
 
 
 def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
@@ -771,10 +799,12 @@ def _default_observers() -> Mapping[str, Observer]:
     }
 
     def observe_holes(part: object) -> Sequence[ObservedFact]:
-        # The concrete module, not the package root: ``from draftwright import ...``
-        # pulls ``draftwright/__init__.py``, which the DAG guard treats as the TOP module,
-        # so it reads as an upward lazy import out of this top-layer package and fails
-        # ``test_lazy_upward_imports_are_documented`` (ADR 0005 / #640).
+        # Lazy for COST, not for layering: `evaluation` is rank 7 and `builder` rank 6, so
+        # a module-level import here is a legal downward edge and passes the DAG guard —
+        # an earlier comment claimed otherwise. What it buys is not paying build123d's
+        # ~6 s import to load this module. Import the concrete module rather than the
+        # package root: `from draftwright import ...` pulls `__init__`, which the guard
+        # treats as the TOP module and would make this a genuine upward edge.
         from draftwright.builder import build_drawing
 
         # ONE drawing per fixture, and ONE recognition: the records scored here come from
@@ -786,9 +816,15 @@ def _default_observers() -> Mapping[str, Observer]:
         except Exception:  # noqa: BLE001 — an unbuildable fixture is a non-answer, not a crash
             drawing = None
         if drawing is None:
-            from b123d_recognisers import build_recognition_result
+            # The recognition read is guarded too: a fixture that neither builds NOR
+            # recognises must still yield a scored non-answer rather than a traceback out
+            # of the middle of a corpus run.
+            try:
+                from b123d_recognisers import build_recognition_result
 
-            holes = tuple(build_recognition_result(part).holes)  # type: ignore[arg-type]
+                holes = tuple(build_recognition_result(part).holes)  # type: ignore[arg-type]
+            except Exception:  # noqa: BLE001 — an unanalysable fixture observes nothing
+                return ()
             outcomes: list[Outcome] = ["unknown"] * len(holes)
         else:
             recognition = drawing.recognition()

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -150,17 +150,36 @@ class TestTheCorrespondenceIsNotFooledByGeometry:
     Adversarial review found three ways that answers wrongly."""
 
     def test_two_coaxial_holes_of_equal_diameter_do_not_alias(self):
-        # Dropping the axis component made two opposed bores at the same (x, y) resolve
-        # to the SAME feature, so a dropped callout on the second was invisible. Matching
-        # is now full-3D and consumes the matched position.
+        # Dropping the axis component made two opposed bores at the same (x, y) resolve to
+        # the SAME feature, so a dropped callout on the second was invisible.
+        #
+        # An earlier version of this test never called `_drawing_consumer_outcomes` at all
+        # — it counted candidate positions — so it passed with the function replaced by
+        # `raise NotImplementedError`, and the in-plane mutation it claimed to guard
+        # survived. It now blinds ONE of the two features and requires the outcome to move
+        # with it, which is the property "these do not alias" actually means.
         part = Box(60, 30, 20) - Pos(0, 0, 8) * Cylinder(3, 8) - Pos(0, 0, -5) * Cylinder(3, 14)
         drawing = build_drawing(part)
-        holes = _recognised(part)
-        if len({(h.diameter, tuple(h.location)) for h in holes}) < 2:
+        holes = list(drawing.recognition().holes)
+        if len({tuple(h.location) for h in holes}) < 2:
             pytest.skip("this build did not recognise two distinct coaxial holes")
         candidates = _hole_candidates(drawing)
-        matched = [c for c in candidates for _p in c.positions]
-        assert len(matched) >= 2, "the two bores collapsed to a single position"
+        assert len(candidates) >= 2, "the two bores collapsed to one candidate"
+
+        def blinded(index):
+            hidden = candidates[index].feature
+            view = _StrippedDrawing(drawing, None)
+            view.annotations_of = lambda f: {} if f == hidden else drawing.annotations_of(f)
+            return _drawing_consumer_outcomes(holes, view)
+
+        first, second = blinded(0), blinded(1)
+        assert first.count("unsupported") == 1 and second.count("unsupported") == 1, (
+            f"blinding one bore did not lose exactly one hole: {first} / {second}"
+        )
+        assert first != second, (
+            f"blinding either bore gave the same answer {first} — they alias onto one "
+            f"feature, so a dropped callout on the second is invisible"
+        )
 
     def test_a_patterned_hole_is_accounted_for(self):
         # Patterned holes lower to a PatternFeature, NOT a HoleFeature. Matching on that
@@ -234,26 +253,144 @@ class TestTheCorrespondenceIsNotFooledByGeometry:
 
 
 class TestAHoleTableIsAlsoTheFactReachingTheSheet:
-    def test_a_table_represented_feature_counts_as_consumed(self):
-        # Above ~16 scattered holes the engine WITHDRAWS the individual `hc_*` callouts
-        # and places one table plus balloons, recording the substitution in
-        # `covers_hole_representations_by_feature`. Looking only for `hc_` scored every
-        # hole on such a sheet as lost — a false alarm on exactly the dense sheets #1176
-        # and ADR 0018 are about. Mutation: drop the ledger read and this fails.
-        from draftwright.evaluation.step_analysis import _consumed
+    """Above ~16 scattered holes the engine WITHDRAWS the individual `hc_*` callouts and
+    places one table plus balloons. Reading only `hc_` scored every hole on such a sheet
+    as lost — 16 of 16 on a drawing with no lint issues at all — which inverted the
+    metric: a correct sheet scored worse than the same part with the table forced to fail.
 
-        feature = object()
-        table = SimpleNamespace(
-            covers_hole_representations_by_feature=((feature, "hole_table", "escalation"),)
+    Driven through a REAL build. The first version of this test hand-built a
+    `SimpleNamespace` carrying `covers_hole_representations_by_feature`, an attribute
+    **nothing in the engine ever populates** — `representation_features=` appears in the
+    whole tree only at its own definition and its own use. The stub was the entire reason
+    the fix looked correct, and adversarial review caught that the real path still scored
+    16/16 `unsupported`.
+    """
+
+    def _dense(self):
+        import sys
+
+        sys.path.insert(0, "tests")
+        from test_issue_1143_hole_completeness import _dense_scattered_plate
+
+        return _dense_scattered_plate()
+
+    def test_a_table_represented_hole_is_consumed_on_a_real_build(self):
+        part = self._dense()
+        drawing = build_drawing(part, page="A3")
+        annotations = {name for name, _o in drawing.iter_annotations()}
+        assert any(n.startswith("hole_table") for n in annotations), (
+            "fixture no longer escalates to a hole table; this tests nothing"
         )
-        drawing = SimpleNamespace(
-            annotations_of=lambda _f: {"m_cm0": object()},
-            iter_annotations=lambda: (("hole_table_plan", table),),
+        assert not any(n.startswith("hc_") for n in annotations), (
+            "the engine still placed individual callouts, so the table route is untested"
         )
+        outcomes = _drawing_consumer_outcomes(drawing.recognition().holes, drawing)
+        assert outcomes and set(outcomes) == {"supported"}, (
+            f"a correct table-escalated sheet scored {sorted(set(outcomes))}"
+        )
+
+    def test_the_metric_is_not_inverted_on_dense_parts(self):
+        # The sharpest statement of the defect: a correct sheet must not score WORSE than
+        # the same part whose table failed to fit. Before the fix the correct sheet scored
+        # 16/16 unsupported and the broken one only 12/16.
+        part = self._dense()
+        good = build_drawing(part, page="A3")
+        good_outcomes = _drawing_consumer_outcomes(good.recognition().holes, good)
+        good_lost = sum(1 for o in good_outcomes if o != "supported")
+
+        from draftwright import drawing as drawing_module
+
+        original = drawing_module.fit_box
+        drawing_module.fit_box = lambda *a, **k: None
+        try:
+            broken = build_drawing(part, page="A3")
+            broken_outcomes = _drawing_consumer_outcomes(broken.recognition().holes, broken)
+        finally:
+            drawing_module.fit_box = original
+        broken_lost = sum(1 for o in broken_outcomes if o != "supported")
+
+        assert broken_lost > 0, "the table did not actually fail to fit; nothing is compared"
+        assert good_lost < broken_lost, (
+            f"the correct sheet lost {good_lost} holes and the broken one {broken_lost} — "
+            f"the metric rewards a worse drawing"
+        )
+
+    def test_a_dropped_table_is_not_credited(self):
+        # The ledger is written only after the table is placed and the balloon gate
+        # passes, and the annotation transaction rolls it back before that — so a
+        # `table_dropped` sheet must carry no entries to credit.
+        from draftwright import drawing as drawing_module
         from draftwright.evaluation.step_analysis import _table_represented
 
-        assert _consumed(feature, drawing, _table_represented(drawing)) is True
-        assert _consumed(object(), drawing, _table_represented(drawing)) is False
+        original = drawing_module.fit_box
+        drawing_module.fit_box = lambda *a, **k: None
+        try:
+            broken = build_drawing(self._dense(), page="A3")
+        finally:
+            drawing_module.fit_box = original
+        assert _table_represented(broken) == [], (
+            "a table that never reached the sheet still credited its holes"
+        )
+
+    def test_a_row_without_the_size_requirement_is_not_credited(self):
+        # On a real dense plate every feature gets every requirement, so filtering or not
+        # gives the same answer there and the mutation survives. Driven directly. The
+        # attribute name and tuple shape are verified against a real build by the test
+        # below — this varies the PARAMETER, not the structure, so it is not the kind of
+        # invented stub that made the original defect look fixed.
+        from draftwright.evaluation.step_analysis import _table_represented
+
+        located_only = SimpleNamespace(
+            covers_hole_representations_by_requirement=(
+                ("feature-A", "location.location", "hole_table", "escalation"),
+            )
+        )
+        sized = SimpleNamespace(
+            covers_hole_representations_by_requirement=(
+                ("feature-B", "bore.diameter", "hole_table", "escalation"),
+            )
+        )
+        drawing = SimpleNamespace(iter_annotations=lambda: (("t1", located_only), ("t2", sized)))
+        assert _table_represented(drawing) == ["feature-B"], (
+            "a hole whose table row carries only its LOCATION was credited as having its "
+            "size on the sheet"
+        )
+
+    def test_only_the_size_requirement_counts(self):
+        # A table row documents location and through-ness as well. Crediting those would
+        # let a hole with a located row but no diameter score as consumed.
+        from draftwright.evaluation.step_analysis import _SIZE_REQUIREMENT, _table_represented
+
+        drawing = build_drawing(self._dense(), page="A3")
+        parameters = {
+            entry[1]
+            for _n, a in drawing.iter_annotations()
+            for entry in getattr(a, "covers_hole_representations_by_requirement", ())
+        }
+        assert parameters > {_SIZE_REQUIREMENT}, (
+            f"the table documents only {parameters}; the filter cannot be shown to matter"
+        )
+        assert _table_represented(drawing), "nothing was credited at all"
+
+
+class TestTheMatchIsFullyThreeDimensional:
+    def test_a_hole_is_matched_to_the_candidate_at_its_actual_depth(self):
+        # The in-plane defect is MASKED on real geometry by position consumption: two
+        # coaxial bores still resolve distinctly because the first hole consumes the
+        # first candidate's only position. It bites when a hole's true match is not the
+        # first candidate sharing its (x, y) — then the in-plane compare assigns it to
+        # the wrong feature, and the outcome is that feature's, not its own.
+        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 10.0), diameter=6.0)
+        drawing = _StubDrawing(
+            features=(
+                _stub_hole(6.0, (0.0, 0.0, 0.0)),  # same (x, y), different depth, DRAWN
+                _stub_hole(6.0, (0.0, 0.0, 10.0)),  # the real match, NOT drawn
+            ),
+            drawn={0},
+        )
+        assert _drawing_consumer_outcomes([hole], drawing) == ["unsupported"], (
+            "the hole was matched to the candidate at the wrong depth and inherited its outcome"
+        )
 
 
 class TestTheCorpusScoreMovesWithTheDrawing:

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -15,10 +15,15 @@ hole was dimensioned. A drawing that recognised a hole and then dropped its call
 identically to one that drew it — which is #1176's defect, inside the module meant to
 detect it.
 
-`drawing_consumer` is now derived from a real build: did a hole callout actually reach the
-sheet for this fact? The other three boundaries remain declared and are tracked separately
-— they are the same shape one layer along, and pretending otherwise here would be its own
-overclaim.
+`drawing_consumer` is now derived from a real build: did this hole's size reach the sheet,
+by either sanctioned route — an `hc_*` callout, or the hole TABLE the engine substitutes
+above ~16 scattered holes. The other three boundaries remain declared and are tracked
+separately; they are the same shape one layer along, and pretending otherwise here would be
+its own overclaim.
+
+`unknown` means no IR feature accounts for the hole. It is an honest label, not an
+exemption: `evaluate_case` credits a unit only when the state is `supported`, so downstream
+an `unknown` scores as a MISS.
 """
 
 from __future__ import annotations
@@ -30,8 +35,8 @@ from build123d import Box, Cylinder, Pos
 
 from draftwright import build_drawing
 from draftwright.evaluation.step_analysis import (
-    _drawing_consumer_outcome,
-    _hole_features,
+    _drawing_consumer_outcomes,
+    _hole_candidates,
     evaluate_step_corpus,
     load_corpus,
 )
@@ -51,54 +56,204 @@ def _recognised(part):
     return build_recognition_result(part).holes
 
 
+def _stub_hole(diameter, origin, members=()):
+    """A minimal IR hole feature: what `_hole_candidates` reads, and nothing else."""
+    return SimpleNamespace(
+        kind="hole",
+        frame=SimpleNamespace(origin=origin, axis="z"),
+        diameter=diameter,
+        members=members,
+    )
+
+
+class _StubDrawing:
+    """A drawing stand-in with hand-placed features. *drawn* is the set of feature indices
+    that carry a callout, so a test can say precisely which fact reached the sheet."""
+
+    def __init__(self, features, drawn=frozenset()):
+        self._features = tuple(features)
+        self._drawn = set(drawn)
+
+    def model(self):
+        return SimpleNamespace(features=self._features)
+
+    def iter_annotations(self):
+        return ()
+
+    def annotations_of(self, feature):
+        index = next(i for i, f in enumerate(self._features) if f is feature)
+        return {"hc_stub": object()} if index in self._drawn else {}
+
+
+class _StrippedDrawing:
+    """A real drawing with its provenance answers emptied — what a dropped callout looks
+    like to a consumer. Delegates everything else, so the IR and the table ledger are the
+    engine's own."""
+
+    def __init__(self, drawing, annotations):
+        self._drawing = drawing
+        self._annotations = annotations
+
+    def __getattr__(self, name):
+        return getattr(self._drawing, name)
+
+    def annotations_of(self, _feature):
+        return self._annotations
+
+
 class TestTheOutcomeIsReadOffTheDrawing:
     def test_a_hole_the_drawing_calls_out_is_supported(self):
         part = _part()
         drawing = build_drawing(part)
-        features = _hole_features(drawing)
-        assert features, "fixture produced no IR hole features, so this asserts nothing"
+        assert _hole_candidates(drawing), "no IR candidate accounts for any hole"
         holes = _recognised(part)
         assert holes, "fixture produced no recognised holes"
-        outcomes = {_drawing_consumer_outcome(h, features, drawing) for h in holes}
-        assert outcomes == {"supported"}, outcomes
+        assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}
 
     def test_a_hole_whose_callout_never_reached_the_sheet_is_unsupported(self):
-        # THE case the declared state could not express. The drawing is real; only the
-        # provenance answer is emptied, which is exactly what a dropped callout looks
-        # like to a consumer. Mutation: restore the declared constant and this passes
-        # while reporting `supported` for a hole that was never drawn.
+        # THE case the declared state could not express. Mutation: restore the declared
+        # constant and this reports `supported` for a hole that was never drawn.
         part = _part()
         drawing = build_drawing(part)
-        features = _hole_features(drawing)
-        hole = _recognised(part)[0]
-        assert _drawing_consumer_outcome(hole, features, drawing) == "supported"
-
-        stripped = SimpleNamespace(annotations_of=lambda _feature: {})
-        assert _drawing_consumer_outcome(hole, features, stripped) == "unsupported"
+        holes = _recognised(part)
+        assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}
+        stripped = _StrippedDrawing(drawing, {})
+        assert set(_drawing_consumer_outcomes(holes, stripped)) == {"unsupported"}
 
     def test_furniture_without_a_callout_does_not_count_as_consumed(self):
-        # A centre mark and location dims are placed for a hole whose SIZE callout was
-        # dropped. They are not the fact reaching the sheet — the callout states the
-        # diameter — so counting any annotation would let a dropped callout score as
-        # supported. Measured names on a real build: hc_plan0, m_cm0, m_locx0, m_locy0.
+        # A centre mark and location dims are still placed for a hole whose SIZE callout
+        # was dropped — measured on a real drop: the feature keeps `m_cm0`, sometimes
+        # `m_locy1`, and no `hc_`. Counting any annotation would score that as consumed.
         part = _part()
         drawing = build_drawing(part)
-        features = _hole_features(drawing)
-        hole = _recognised(part)[0]
-
-        furniture_only = SimpleNamespace(
-            annotations_of=lambda _f: {"m_cm0": object(), "m_locx0": object()}
-        )
-        assert _drawing_consumer_outcome(hole, features, furniture_only) == "unsupported"
+        holes = _recognised(part)
+        furniture = _StrippedDrawing(drawing, {"m_cm0": object(), "m_locx0": object()})
+        assert set(_drawing_consumer_outcomes(holes, furniture)) == {"unsupported"}
 
     def test_a_hole_with_no_corresponding_feature_is_unknown(self):
         # ADR 0017 states plainly that recognition-record -> IR-feature correspondence is
-        # NOT yet provided. Where it fails, the honest answer is `unknown` — the oracle's
-        # third outcome — never a silent success or a false failure.
+        # NOT yet provided. Where it fails, the label is `unknown`. It still scores as a
+        # MISS downstream — `evaluate_case` credits only `supported` — so this is an
+        # honest label, not an exemption.
         part = _part()
+        holes = _recognised(part)
+        no_features = SimpleNamespace(
+            model=lambda: SimpleNamespace(features=()),
+            iter_annotations=lambda: (),
+            annotations_of=lambda _f: {},
+        )
+        assert set(_drawing_consumer_outcomes(holes, no_features)) == {"unknown"}
+
+
+class TestTheCorrespondenceIsNotFooledByGeometry:
+    """The matcher was originally axis + diameter + IN-PLANE position, first match wins.
+    Adversarial review found three ways that answers wrongly."""
+
+    def test_two_coaxial_holes_of_equal_diameter_do_not_alias(self):
+        # Dropping the axis component made two opposed bores at the same (x, y) resolve
+        # to the SAME feature, so a dropped callout on the second was invisible. Matching
+        # is now full-3D and consumes the matched position.
+        part = Box(60, 30, 20) - Pos(0, 0, 8) * Cylinder(3, 8) - Pos(0, 0, -5) * Cylinder(3, 14)
         drawing = build_drawing(part)
-        hole = _recognised(part)[0]
-        assert _drawing_consumer_outcome(hole, [], drawing) == "unknown"
+        holes = _recognised(part)
+        if len({(h.diameter, tuple(h.location)) for h in holes}) < 2:
+            pytest.skip("this build did not recognise two distinct coaxial holes")
+        candidates = _hole_candidates(drawing)
+        matched = [c for c in candidates for _p in c.positions]
+        assert len(matched) >= 2, "the two bores collapsed to a single position"
+
+    def test_a_patterned_hole_is_accounted_for(self):
+        # Patterned holes lower to a PatternFeature, NOT a HoleFeature. Matching on that
+        # type alone made recognising a pattern — a capability — LOWER the score: four
+        # identical holes scored `unknown` where the same four with distinct diameters
+        # scored `supported`, both fully drawn.
+        part = Box(80, 80, 10)
+        for x, y in ((-20, -20), (20, -20), (-20, 20), (20, 20)):
+            part -= Pos(x, y, 0) * Cylinder(2.5, 40)
+        drawing = build_drawing(part)
+        holes = _recognised(part)
+        assert holes, "fixture recognised no holes"
+        outcomes = _drawing_consumer_outcomes(holes, drawing)
+        assert "unknown" not in outcomes, (
+            f"a patterned hole was not accounted for by any IR feature: {outcomes}"
+        )
+        assert set(outcomes) == {"supported"}, outcomes
+
+    def test_a_grouped_count_callout_accounts_for_every_member(self):
+        # One HoleFeature with `members` covers several holes. The corpus has no two
+        # holes of equal diameter, so this path was never exercised there.
+        part = Box(60, 30, 12) - Pos(-15, 0, 0) * Cylinder(3, 40) - Pos(15, 0, 0) * Cylinder(3, 40)
+        drawing = build_drawing(part)
+        grouped = [c for c in _hole_candidates(drawing) if len(c.positions) > 1]
+        assert grouped, "fixture no longer produces a grouped feature; the path is untested"
+        outcomes = _drawing_consumer_outcomes(_recognised(part), drawing)
+        assert set(outcomes) == {"supported"}, outcomes
+
+    def test_one_ir_position_cannot_account_for_two_recognised_holes(self):
+        # A matched position is CONSUMED. Without that, one feature answers for every hole
+        # that lands on it, so a duplicate or spurious recognition record silently
+        # inherits a real feature's "supported" instead of showing up as unaccounted.
+        # (With full-3D matching this is the residual case: distinct positions no longer
+        # alias, which is what the in-plane projection used to allow.)
+        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
+        drawing = _StubDrawing(features=(_stub_hole(6.0, (0.0, 0.0, 5.0)),), drawn={0})
+        assert _drawing_consumer_outcomes([hole, hole], drawing) == ["supported", "unknown"], (
+            "one IR position answered for two recognised holes"
+        )
+
+    def test_the_diameter_guard_refuses_a_positional_coincidence(self):
+        # With full-3D matching a position is very nearly unique on its own, so the
+        # axis+diameter test is a CROSS-CHECK, not the primary key — an earlier version of
+        # this test used distinct positions and therefore passed with the guard deleted.
+        # It bites exactly where two features share a position and differ in size, which
+        # is what a counterbore-like arrangement looks like to the matcher.
+        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
+        drawing = _StubDrawing(
+            features=(
+                _stub_hole(diameter=12.0, origin=(0.0, 0.0, 5.0)),  # same place, wrong size
+                _stub_hole(diameter=6.0, origin=(0.0, 0.0, 5.0)),  # the right one
+            ),
+            drawn={1},
+        )
+        assert _drawing_consumer_outcomes([hole], drawing) == ["supported"], (
+            "the hole matched the wrong-diameter feature sharing its position"
+        )
+
+    def test_the_position_tolerance_admits_analytic_noise_but_not_a_real_offset(self):
+        # The IR carries the recogniser's `hole.location` verbatim, so agreement is EXACT
+        # on every fixture (worst residual measured at 0.0, including a side-drilled case
+        # whose z is 6.66e-15). The tolerance is therefore never exercised by a build and
+        # survived being set to 0.0 — an untested constant. Driven directly instead.
+        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
+        near = _StubDrawing(features=(_stub_hole(6.0, (0.0, 5e-7, 5.0)),), drawn={0})
+        far = _StubDrawing(features=(_stub_hole(6.0, (0.0, 1e-3, 5.0)),), drawn={0})
+        assert _drawing_consumer_outcomes([hole], near) == ["supported"]
+        assert _drawing_consumer_outcomes([hole], far) == ["unknown"], (
+            "a millimetre-scale offset was accepted as the same hole"
+        )
+
+
+class TestAHoleTableIsAlsoTheFactReachingTheSheet:
+    def test_a_table_represented_feature_counts_as_consumed(self):
+        # Above ~16 scattered holes the engine WITHDRAWS the individual `hc_*` callouts
+        # and places one table plus balloons, recording the substitution in
+        # `covers_hole_representations_by_feature`. Looking only for `hc_` scored every
+        # hole on such a sheet as lost — a false alarm on exactly the dense sheets #1176
+        # and ADR 0018 are about. Mutation: drop the ledger read and this fails.
+        from draftwright.evaluation.step_analysis import _consumed
+
+        feature = object()
+        table = SimpleNamespace(
+            covers_hole_representations_by_feature=((feature, "hole_table", "escalation"),)
+        )
+        drawing = SimpleNamespace(
+            annotations_of=lambda _f: {"m_cm0": object()},
+            iter_annotations=lambda: (("hole_table_plan", table),),
+        )
+        from draftwright.evaluation.step_analysis import _table_represented
+
+        assert _consumed(feature, drawing, _table_represented(drawing)) is True
+        assert _consumed(object(), drawing, _table_represented(drawing)) is False
 
 
 class TestTheCorpusScoreMovesWithTheDrawing:

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -28,6 +28,8 @@ an `unknown` scores as a MISS.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -42,6 +44,14 @@ from draftwright.evaluation.step_analysis import (
 )
 
 _CORPUS = "tests/fixtures/evaluation/corpus-v1.json"
+
+# The engine's own dense fixture, imported once. An earlier version re-ran
+# `sys.path.insert(0, "tests")` on every call — unbounded duplication, and dependent on the
+# working directory.
+_TESTS = str(Path(__file__).parent)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+from test_issue_1143_hole_completeness import _dense_scattered_plate  # noqa: E402
 
 
 def _part():
@@ -267,11 +277,6 @@ class TestAHoleTableIsAlsoTheFactReachingTheSheet:
     """
 
     def _dense(self):
-        import sys
-
-        sys.path.insert(0, "tests")
-        from test_issue_1143_hole_completeness import _dense_scattered_plate
-
         return _dense_scattered_plate()
 
     def test_a_table_represented_hole_is_consumed_on_a_real_build(self):
@@ -371,6 +376,50 @@ class TestAHoleTableIsAlsoTheFactReachingTheSheet:
             f"the table documents only {parameters}; the filter cannot be shown to matter"
         )
         assert _table_represented(drawing), "nothing was credited at all"
+
+
+class TestTheCreditGoesToTheRightFeature:
+    def test_a_table_credits_only_the_features_it_carries(self):
+        # `_consumed` reduced to `bool(represented)` passed all 21 tests: the table route
+        # was only ever asserted where EVERY feature happened to be credited, so nothing
+        # pinned the credit to the right one. That is round 2's failure shape exactly —
+        # an assertion that holds for the wrong reason.
+        #
+        # Reachable in principle: a grouped pattern marker "has no defining table row and
+        # therefore remains deliberately non-certifying" (annotations/orchestrator.py), so
+        # a sheet can carry a table covering some features and a pattern covering others.
+        from draftwright.evaluation.step_analysis import _consumed
+
+        carried, not_carried = object(), object()
+        drawing = SimpleNamespace(annotations_of=lambda _f: {"m_cm0": object()})
+        assert _consumed(carried, drawing, [carried]) is True
+        assert _consumed(not_carried, drawing, [carried]) is False, (
+            "a feature the table does not carry was credited because some other feature was"
+        )
+
+
+class TestTheCandidateFilterIsLoadBearing:
+    def test_a_hole_is_not_matched_to_a_feature_on_another_axis(self):
+        # The axis half of the axis+diameter cross-check had no test, while the diameter
+        # half did — on the stated reasoning that a redundant cross-check needs one.
+        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
+        sideways = _stub_hole(6.0, (0.0, 0.0, 5.0))
+        sideways.frame = SimpleNamespace(origin=(0.0, 0.0, 5.0), axis="x")
+        drawing = _StubDrawing(features=(sideways,), drawn={0})
+        assert _drawing_consumer_outcomes([hole], drawing) == ["unknown"], (
+            "a z-axis hole was matched to an x-axis feature sharing its position"
+        )
+
+    def test_only_hole_and_pattern_features_are_candidates(self):
+        # Widening the `kind` filter to admit other feature kinds passed everything: no
+        # test established that a non-hole feature cannot account for a hole.
+        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
+        boss = _stub_hole(6.0, (0.0, 0.0, 5.0))
+        boss.kind = "boss"
+        assert _hole_candidates(_StubDrawing(features=(boss,))) == [], (
+            "a boss was admitted as a candidate for a hole"
+        )
+        assert _drawing_consumer_outcomes([hole], _StubDrawing(features=(boss,))) == ["unknown"]
 
 
 class TestTheMatchIsFullyThreeDimensional:

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -479,3 +479,42 @@ class TestTheRemainingBoundariesAreStillDeclared:
         assert observed, "no facts observed"
         assert {fact.downstream[boundary] for fact in observed} == {"supported"}
         assert {fact.downstream["drawing_consumer"] for fact in observed} == {"unsupported"}
+
+
+class TestAnUnbuildableFixtureIsScoredNotCrashed:
+    """The two fail-open paths. A corpus run must degrade to a scored non-answer rather
+    than a traceback out of its middle — and the crash must still be *visible*, because a
+    benchmark whose point is that a self-reported number cannot validate itself should not
+    quietly equate "the compiler has no correspondence" with "the engine crashed"."""
+
+    def _observe(self, part):
+        from draftwright.evaluation.step_analysis import _default_observers
+
+        return _default_observers()["holes"](part)
+
+    def test_a_build_failure_scores_every_hole_unknown_and_says_so(self, monkeypatch, caplog):
+        import draftwright.builder as builder_module
+
+        def explode(*_a, **_k):
+            raise RuntimeError("Standard_DomainError")
+
+        monkeypatch.setattr(builder_module, "build_drawing", explode)
+        with caplog.at_level("WARNING"):
+            observed = self._observe(_part())
+        assert observed, "recognition still works, so facts must still be observed"
+        assert {f.downstream["drawing_consumer"] for f in observed} == {"unknown"}
+        assert any("Standard_DomainError" in r.getMessage() for r in caplog.records), (
+            "the crash was scored but never announced, so it is indistinguishable from a "
+            "correspondence gap"
+        )
+
+    def test_a_fixture_that_neither_builds_nor_recognises_observes_nothing(self, monkeypatch):
+        # Not an empty score with invented facts — no observation at all, which the oracle
+        # scores as a detection miss against its independent denominator.
+        import draftwright.builder as builder_module
+
+        def explode(*_a, **_k):
+            raise RuntimeError("unanalysable")
+
+        monkeypatch.setattr(builder_module, "build_drawing", explode)
+        assert self._observe(object()) == ()

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -1,0 +1,140 @@
+"""S1 of #1202 — the `drawing_consumer` score must observe the drawing, not a declaration.
+
+#1169 closed on the principle that a completeness score derived only from what the system
+reports **can validate itself**: missed geometry never enters the denominator. The
+evaluation module was built on that principle and then broke it at its own last layer.
+
+`_default_observers` set every boundary — including `drawing_consumer` — from
+`consumer_capability_declaration()`, a static per-family claim that a module exists:
+
+    drawing_consumer -> {'state': 'supported',
+                         'implementation': 'draftwright.annotations.holes._annotate_holes'}
+
+So every hole in every fixture reported `drawing_consumer: supported`, whether or not any
+hole was dimensioned. A drawing that recognised a hole and then dropped its callout scored
+identically to one that drew it — which is #1176's defect, inside the module meant to
+detect it.
+
+`drawing_consumer` is now derived from a real build: did a hole callout actually reach the
+sheet for this fact? The other three boundaries remain declared and are tracked separately
+— they are the same shape one layer along, and pretending otherwise here would be its own
+overclaim.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.evaluation.step_analysis import (
+    _drawing_consumer_outcome,
+    _hole_features,
+    evaluate_step_corpus,
+    load_corpus,
+)
+
+_CORPUS = "tests/fixtures/evaluation/corpus-v1.json"
+
+
+def _part():
+    """Two through-holes of different diameter — the corpus's `topology-a` shape, built
+    in code so the unit tests do not depend on a fixture path."""
+    return Box(60, 30, 12) - Pos(-15, 0, 0) * Cylinder(3, 40) - Pos(15, 0, 0) * Cylinder(5, 40)
+
+
+def _recognised(part):
+    from b123d_recognisers import build_recognition_result
+
+    return build_recognition_result(part).holes
+
+
+class TestTheOutcomeIsReadOffTheDrawing:
+    def test_a_hole_the_drawing_calls_out_is_supported(self):
+        part = _part()
+        drawing = build_drawing(part)
+        features = _hole_features(drawing)
+        assert features, "fixture produced no IR hole features, so this asserts nothing"
+        holes = _recognised(part)
+        assert holes, "fixture produced no recognised holes"
+        outcomes = {_drawing_consumer_outcome(h, features, drawing) for h in holes}
+        assert outcomes == {"supported"}, outcomes
+
+    def test_a_hole_whose_callout_never_reached_the_sheet_is_unsupported(self):
+        # THE case the declared state could not express. The drawing is real; only the
+        # provenance answer is emptied, which is exactly what a dropped callout looks
+        # like to a consumer. Mutation: restore the declared constant and this passes
+        # while reporting `supported` for a hole that was never drawn.
+        part = _part()
+        drawing = build_drawing(part)
+        features = _hole_features(drawing)
+        hole = _recognised(part)[0]
+        assert _drawing_consumer_outcome(hole, features, drawing) == "supported"
+
+        stripped = SimpleNamespace(annotations_of=lambda _feature: {})
+        assert _drawing_consumer_outcome(hole, features, stripped) == "unsupported"
+
+    def test_furniture_without_a_callout_does_not_count_as_consumed(self):
+        # A centre mark and location dims are placed for a hole whose SIZE callout was
+        # dropped. They are not the fact reaching the sheet — the callout states the
+        # diameter — so counting any annotation would let a dropped callout score as
+        # supported. Measured names on a real build: hc_plan0, m_cm0, m_locx0, m_locy0.
+        part = _part()
+        drawing = build_drawing(part)
+        features = _hole_features(drawing)
+        hole = _recognised(part)[0]
+
+        furniture_only = SimpleNamespace(
+            annotations_of=lambda _f: {"m_cm0": object(), "m_locx0": object()}
+        )
+        assert _drawing_consumer_outcome(hole, features, furniture_only) == "unsupported"
+
+    def test_a_hole_with_no_corresponding_feature_is_unknown(self):
+        # ADR 0017 states plainly that recognition-record -> IR-feature correspondence is
+        # NOT yet provided. Where it fails, the honest answer is `unknown` — the oracle's
+        # third outcome — never a silent success or a false failure.
+        part = _part()
+        drawing = build_drawing(part)
+        hole = _recognised(part)[0]
+        assert _drawing_consumer_outcome(hole, [], drawing) == "unknown"
+
+
+class TestTheCorpusScoreMovesWithTheDrawing:
+    def test_the_corpus_downstream_layer_is_perfect_when_every_hole_is_drawn(self):
+        # Not a tautology now: on these fixtures every hole really is called out, so 1.0
+        # is EARNED by observation where it used to be asserted by declaration.
+        evaluation = evaluate_step_corpus(load_corpus(_CORPUS))
+        assert evaluation.downstream_usefulness.score == 1.0
+        assert evaluation.downstream_usefulness.total > 0, "nothing was scored at all"
+
+    def test_the_layer_drops_when_the_sheet_stops_drawing_holes(self, monkeypatch):
+        # The load-bearing claim: this score is a function of the DRAWING. Empty the
+        # provenance answer for every feature and the layer must fall. Under the old
+        # declared constant it stayed at 1.0 no matter what the sheet did.
+        from draftwright import drawing as drawing_module
+
+        monkeypatch.setattr(drawing_module.Drawing, "annotations_of", lambda _s, _f: {})
+        evaluation = evaluate_step_corpus(load_corpus(_CORPUS))
+        assert evaluation.downstream_usefulness.score is not None
+        assert evaluation.downstream_usefulness.score < 1.0, (
+            "the downstream layer stayed perfect while the sheet drew no callouts — it "
+            "is not reading the drawing"
+        )
+
+
+class TestTheRemainingBoundariesAreStillDeclared:
+    """Stated, not hidden. Three boundaries are still scored from a capability
+    declaration, and a reader must not infer from this PR that all four are observed."""
+
+    @pytest.mark.parametrize("boundary", ["ir_adapter", "dsl_declaration", "generated_code"])
+    def test_a_declared_boundary_does_not_move_with_the_drawing(self, boundary, monkeypatch):
+        from draftwright import drawing as drawing_module
+        from draftwright.evaluation.step_analysis import _default_observers
+
+        monkeypatch.setattr(drawing_module.Drawing, "annotations_of", lambda _s, _f: {})
+        observed = _default_observers()["holes"](_part())
+        assert observed, "no facts observed"
+        assert {fact.downstream[boundary] for fact in observed} == {"supported"}
+        assert {fact.downstream["drawing_consumer"] for fact in observed} == {"unsupported"}


### PR DESCRIPTION
**S1 of #1202.**

## The defect

#1169 closed on the principle that a completeness score derived only from what the system
reports **can validate itself** — missed geometry never enters the denominator. The
evaluation module was built on that principle and then broke it at its own last layer.

`_default_observers` set every boundary, `drawing_consumer` included, from
`consumer_capability_declaration()` — a static per-family claim that a module exists:

```
drawing_consumer -> {'state': 'supported',
                     'implementation': 'draftwright.annotations.holes._annotate_holes'}
```

So **every hole in every fixture reported `drawing_consumer: supported`**, whether or not a
single hole was dimensioned. A drawing that recognised a hole and then dropped its callout
scored exactly like one that drew it. That is #1176's defect, inside the module meant to
detect it.

## The fix

`drawing_consumer` now comes from a real build, through the ADR 0010 provenance seam:

| outcome | meaning |
|---|---|
| `supported` | a hole callout (`hc_*`) reached the sheet for the corresponding feature |
| `unsupported` | a feature covers the hole and carries no callout — recognised, then lost |
| `unknown` | no feature corresponds |

`unknown` is deliberate: ADR 0017 states plainly that recognition-record → IR-feature
correspondence is not yet provided, so where it fails the answer must be an honest
non-answer rather than a silent success or a false failure.

Three details that matter:

* **Only the callout counts.** A centre mark and location dims are still placed for a hole
  whose size callout was dropped (measured: `hc_plan0`, `m_cm0`, `m_locx0`, `m_locy0`), so
  counting any annotation would let a dropped callout score as consumed.
* **Grouped `count×` callouts** cover several holes through one feature, so every member
  position is matched, not just the frame origin.
* **The other three boundaries remain declared**, and a test asserts that, so no reader
  infers all four are observed. Same self-validating shape one layer along; tracked
  separately rather than quietly widened here.

## Evidence

The corpus still scores **1.0** — on these fixtures every hole really is drawn. The
difference is that 1.0 is now *earned by observation* rather than *asserted by
declaration*. Emptying the sheet's provenance drops the layer below 1.0; under the old
constant it stayed perfect no matter what the sheet did.

* Three mutations confirmed: the declared constant (kills 4), counting any annotation
  (kills 1), scoring a failed correspondence as success (kills 1).
* `scripts/pr-check --static` exit 0; **4091 passed**, 5 skipped, 2 xfailed.
* No new fixture needed — the five sha256-pinned corpus cases already exist.

## Note on scope

The epic's S1 proposed a new harness around PPP0101. Two things changed that: the PPP0101
STEP is not in this repo, `~/steps`, or build123d 0.11.1 — #1176's benchmark ran against a
fixture nobody else can reproduce, and #1190 already taught that a test gated on one
machine's path is the same as no test. And `evaluation/step_analysis.py` already implements
#1169's oracle, including a `drawing_consumer` boundary. Extending it beat standing up a
parallel mechanism.