### PR TITLE
Refuse to draw an angular dimension as a linear one

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4531,12 +4531,19 @@ def _record_pmi_unrenderable(dwg, label, rec, *, ctx):
     ``pmi_dropped`` (a *placement* failure): this is a *validation* failure, so a caller
     sees a specific reason instead of a misleading "no room" — an authored dim is only
     ``pmi_dropped`` after a real candidate reaches the corridor solver and cannot fit (#562)."""
+    source_id = getattr(rec, "source_id", "")
+    # `error` for a source-bearing record, for the same reason as
+    # `_record_unsupported_dimension_kind`: this SUPPRESSES the sibling `pmi_not_rendered`
+    # error, so leaving it a warning turned a lost AP242 requirement into `passed: True`.
+    # Adding the suppression without raising the severity was the very downgrade #1177's
+    # own commit message argued must not happen — committed one file away from where it
+    # said so.
     ctx.record_issue(
-        "warning",
+        "error" if source_id else "warning",
         "authored_dim_degenerate",
         f"authored dimension {label!r} has degenerate reference geometry (needs two "
         "distinct reference points spanning a legible distance)",
-        source=getattr(rec, "source_id", ""),
+        source=source_id,
     )
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4569,35 +4569,70 @@ _PMI_CORRIDOR_PRIORITY = PRIORITY.AUTHORED
 _PMI_SLOT = 10.0  # mm — slot size for PMI dim lines in the strip
 
 
-#: Dimension categories the IR admits but this renderer cannot draw. `Dimension` measures a
-#: straight projected path, so an ANGULAR record rendered through it produces a linear
-#: annotation whose label is in degrees and whose geometry is in millimetres — a drawing that
-#: asserts something false (#1177). The rendering library has no angular primitive at all
-#: (`Dimension`, `DimensionLine`, `SafeDimension`), so drawing one correctly is work in
-#: `build123d-drafting-helpers`, not a gate here.
+#: Dimension categories the IR admits but this renderer cannot draw TRUTHFULLY. `Dimension`
+#: measures a straight projected path, so a record whose value is measured on some other
+#: basis renders as an annotation whose geometry contradicts its own label — a drawing that
+#: asserts something false (#1177). Measured on a 1:1 sheet, value against drawn length:
 #:
-#: Refused at the RENDERER rather than at `Sheet.measured_dimension`, because `angular`
-#: reaches the IR from two sources — the authored façade and detected AP242 PMI
+#:   angular       60      ->  16.0   label states degrees, geometry states millimetres
+#:   curve_length  25.133  ->  16.0   arc length against its chord (57% out)
+#:   curved_dist   25.133  ->  16.0   same
+#:   oriented      20.0    ->  16.0   along a stated direction, not the projected axis (25% out)
+#:
+#: `linear`, `thickness` and `diameter` measure a straight span and are truthful, so they
+#: stay. `radius` is a THIRD defect — it renders a full-diameter-length line carrying an R
+#: label, because `_bore_half_span` returns the value rather than half of it — and is
+#: tracked separately rather than hidden behind a category refusal.
+#:
+#: NOT because the rendering library lacks the primitives. An earlier version of this
+#: comment claimed build123d has no angular dimension; it does — `DimensionLine` and
+#: `ExtensionLine` both take `label_angle`, and render "60.00°" from an arc. The missing
+#: work is on THIS side: deriving the arc and vertex from the record's reference points and
+#: routing the result through the corridor solve. Saying otherwise sends the follow-on to
+#: the wrong repository.
+#:
+#: Refused at the RENDERER rather than at `Sheet.measured_dimension`, because these kinds
+#: reach the IR from two sources — the authored façade and detected AP242 PMI
 #: (`model/detect.py`) — and refusing at the façade would leave the imported path drawing
-#: the false dimension while making a legitimate AP242 file unreadable.
-_UNRENDERABLE_DIMENSION_KINDS = frozenset({"angular"})
+#: the false dimension while making a legitimate AP242 file unreadable. NIST CTC-01 carries
+#: an angular record; CTC-04 carries one drawn 88% wrong.
+_UNRENDERABLE_DIMENSION_KINDS = frozenset({"angular", "curve_length", "curved_dist", "oriented"})
+
+#: What each refused category actually measures, for the diagnostic. Keyed by kind so the
+#: message stays true as the set grows: an earlier version hard-coded "the label states an
+#: angle", which would have been wrong the moment `curve_length` was added.
+_MEASUREMENT_BASIS = {
+    "angular": "an angle in degrees",
+    "curve_length": "a length along a curve",
+    "curved_dist": "a distance along a curve",
+    "oriented": "a distance along a stated direction",
+}
+
+
+def _authored_with_usable_references(record) -> bool:
+    """Whether *record* is an authored dimension with enough geometry to draw at all.
+
+    Shared by the renderable and refused filters so they cannot drift: a predicate added to
+    one only would make a record silently NEITHER drawn nor reported.
+    """
+    return record.kind == "authored_dimension" and record.value > 0 and len(record.ref_pts) >= 2
 
 
 def _record_unsupported_dimension_kind(ctx, rec):
-    """Record an authored dimension whose CATEGORY this renderer cannot draw.
+    """Record an authored dimension whose CATEGORY this renderer cannot draw truthfully.
 
     A validation outcome, not a placement one — the same distinction
-    :func:`_record_pmi_unrenderable` draws, and for the same reason as #1190: an optional
-    or unsupported outcome marked as a placement drop makes every scale infeasible, so an
+    :func:`_record_pmi_unrenderable` draws, and for the same reason as #1190: an optional or
+    unsupported outcome marked as a placement drop makes every scale infeasible, so an
     explicit ``scale=`` request burns the whole ladder and raises where it used to return a
     drawing.
     """
+    basis = _MEASUREMENT_BASIS.get(rec.pmi_kind, "a value this renderer cannot measure")
     ctx.record_issue(
         "warning",
         "dimension_kind_unsupported",
-        f"authored {rec.pmi_kind} dimension {getattr(rec, 'label', '')!r} is not drawn: "
-        f"this renderer measures straight projected paths, so drawing it would state a "
-        f"length where the label states an angle",
+        f"authored {rec.pmi_kind} dimension {getattr(rec, 'label', '')!r} is not drawn: it "
+        f"states {basis}, and this renderer measures only a straight projected path",
         source=getattr(rec, "source_id", ""),
         outcome_stage="validation",
     )
@@ -4614,11 +4649,9 @@ def _renderable_pmi_records(records):
     return [
         r
         for r in records
-        if r.kind == "authored_dimension"
+        if _authored_with_usable_references(r)
         and r.pmi_kind in AUTHORED_DIMENSION_KINDS
         and r.pmi_kind not in _UNRENDERABLE_DIMENSION_KINDS
-        and r.value > 0
-        and len(r.ref_pts) >= 2
     ]
 
 
@@ -4630,10 +4663,7 @@ def _unsupported_kind_records(records):
     return [
         r
         for r in records
-        if r.kind == "authored_dimension"
-        and r.pmi_kind in _UNRENDERABLE_DIMENSION_KINDS
-        and r.value > 0
-        and len(r.ref_pts) >= 2
+        if _authored_with_usable_references(r) and r.pmi_kind in _UNRENDERABLE_DIMENSION_KINDS
     ]
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4569,18 +4569,69 @@ _PMI_CORRIDOR_PRIORITY = PRIORITY.AUTHORED
 _PMI_SLOT = 10.0  # mm — slot size for PMI dim lines in the strip
 
 
+#: Dimension categories the IR admits but this renderer cannot draw. `Dimension` measures a
+#: straight projected path, so an ANGULAR record rendered through it produces a linear
+#: annotation whose label is in degrees and whose geometry is in millimetres — a drawing that
+#: asserts something false (#1177). The rendering library has no angular primitive at all
+#: (`Dimension`, `DimensionLine`, `SafeDimension`), so drawing one correctly is work in
+#: `build123d-drafting-helpers`, not a gate here.
+#:
+#: Refused at the RENDERER rather than at `Sheet.measured_dimension`, because `angular`
+#: reaches the IR from two sources — the authored façade and detected AP242 PMI
+#: (`model/detect.py`) — and refusing at the façade would leave the imported path drawing
+#: the false dimension while making a legitimate AP242 file unreadable.
+_UNRENDERABLE_DIMENSION_KINDS = frozenset({"angular"})
+
+
+def _record_unsupported_dimension_kind(ctx, rec):
+    """Record an authored dimension whose CATEGORY this renderer cannot draw.
+
+    A validation outcome, not a placement one — the same distinction
+    :func:`_record_pmi_unrenderable` draws, and for the same reason as #1190: an optional
+    or unsupported outcome marked as a placement drop makes every scale infeasible, so an
+    explicit ``scale=`` request burns the whole ladder and raises where it used to return a
+    drawing.
+    """
+    ctx.record_issue(
+        "warning",
+        "dimension_kind_unsupported",
+        f"authored {rec.pmi_kind} dimension {getattr(rec, 'label', '')!r} is not drawn: "
+        f"this renderer measures straight projected paths, so drawing it would state a "
+        f"length where the label states an angle",
+        source=getattr(rec, "source_id", ""),
+        outcome_stage="validation",
+    )
+
+
 def _renderable_pmi_records(records):
     """PMI records the dimension renderer may place.
 
     Raw ``PmiFeature`` fallbacks can preserve unsupported AP242 records. Do not render those
     just because they happen to carry a numeric value and references; only drafting dimension
-    categories belong in this placement path.
+    categories belong in this placement path — and only those this renderer can actually
+    draw (see :data:`_UNRENDERABLE_DIMENSION_KINDS`).
     """
     return [
         r
         for r in records
         if r.kind == "authored_dimension"
         and r.pmi_kind in AUTHORED_DIMENSION_KINDS
+        and r.pmi_kind not in _UNRENDERABLE_DIMENSION_KINDS
+        and r.value > 0
+        and len(r.ref_pts) >= 2
+    ]
+
+
+def _unsupported_kind_records(records):
+    """Authored records refused purely because of their category, so the omission can be
+    reported. Deliberately not folded into :func:`_renderable_pmi_records`: a record with a
+    zero value or one reference point is refused for a different reason and already has its
+    own diagnostic."""
+    return [
+        r
+        for r in records
+        if r.kind == "authored_dimension"
+        and r.pmi_kind in _UNRENDERABLE_DIMENSION_KINDS
         and r.value > 0
         and len(r.ref_pts) >= 2
     ]
@@ -5006,6 +5057,8 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
     draft = dwg.draft
     pmi = [f for f in model.features if f.kind in ("authored_dimension", "pmi")]
     usable = _renderable_pmi_records(pmi)
+    for refused in _unsupported_kind_records(pmi):
+        _record_unsupported_dimension_kind(ctx, refused)
     n_gtol = sum(1 for r in pmi if r.pmi_kind not in AUTHORED_DIMENSION_KINDS and r.value > 0)
     if n_gtol:
         _log.debug("PMI annotate: %d gtol/datum record(s) not yet annotatable (Phase 4)", n_gtol)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4579,10 +4579,18 @@ _PMI_SLOT = 10.0  # mm — slot size for PMI dim lines in the strip
 #:   curved_dist   25.133  ->  16.0   same
 #:   oriented      20.0    ->  16.0   along a stated direction, not the projected axis (25% out)
 #:
-#: `linear`, `thickness` and `diameter` measure a straight span and are truthful, so they
-#: stay. `radius` is a THIRD defect — it renders a full-diameter-length line carrying an R
-#: label, because `_bore_half_span` returns the value rather than half of it — and is
-#: tracked separately rather than hidden behind a category refusal.
+#: The criterion is whether the value is measured on a basis THIS RENDERER RECEIVES. It
+#: draws the projected span between reference points along the dominant axis, so:
+#: `linear`, `thickness` and `diameter` are that span by definition and stay. An arc length
+#: is not (`curve_length`, `curved_dist`), nor is an angle (`angular`). `oriented` is a
+#: straight span, but along a direction the record states and the renderer is never given —
+#: refused for a different reason from its neighbours, which an earlier version of this
+#: comment lumped together as "needs an arc".
+#:
+#: `radius` is a THIRD defect and is NOT refused: its value is a straight span, so it is
+#: fixable rather than unsupported. `_bore_half_span` returns the value where `diameter`
+#: halves it, so an R6 record renders a 12 mm line labelled R. Tracked as #1208, because
+#: refusing it would file a rendering bug under "unsupported category" and misdescribe it.
 #:
 #: NOT because the rendering library lacks the primitives. An earlier version of this
 #: comment claimed build123d has no angular dimension; it does — `DimensionLine` and
@@ -4627,13 +4635,19 @@ def _record_unsupported_dimension_kind(ctx, rec):
     explicit ``scale=`` request burns the whole ladder and raises where it used to return a
     drawing.
     """
-    basis = _MEASUREMENT_BASIS.get(rec.pmi_kind, "a value this renderer cannot measure")
+    basis = _MEASUREMENT_BASIS[rec.pmi_kind]
+    source_id = getattr(rec, "source_id", "")
+    # `error` for a source-bearing record, matching `_record_pmi_no_candidate` and the
+    # three `lint_pmi_*` checks: in annotate mode a requirement that came from the AP242
+    # file and is absent from the drawing is an error, and suppressing the sibling
+    # `pmi_not_rendered` must not quietly downgrade it. An authored declaration with no
+    # source is the author's own, and a warning.
     ctx.record_issue(
-        "warning",
+        "error" if source_id else "warning",
         "dimension_kind_unsupported",
         f"authored {rec.pmi_kind} dimension {getattr(rec, 'label', '')!r} is not drawn: it "
         f"states {basis}, and this renderer measures only a straight projected path",
-        source=getattr(rec, "source_id", ""),
+        source=source_id,
         outcome_stage="validation",
     )
 
@@ -4663,7 +4677,9 @@ def _unsupported_kind_records(records):
     return [
         r
         for r in records
-        if _authored_with_usable_references(r) and r.pmi_kind in _UNRENDERABLE_DIMENSION_KINDS
+        if _authored_with_usable_references(r)
+        and r.pmi_kind in AUTHORED_DIMENSION_KINDS
+        and r.pmi_kind in _UNRENDERABLE_DIMENSION_KINDS
     ]
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4551,14 +4551,28 @@ def _record_pmi_no_candidate(ctx, label, rec):
     )
 
 
-def _bore_half_span(pmi_kind: str, value: float) -> float:
-    """Half the perpendicular span of a bore-size dim from the bore centroid — the
-    distance to each witness base point. A ``"diameter"`` record stores the full
-    diameter (so half = radius = value/2); a ``"radius"`` record already stores the
-    radius (half = value). Keyed on the drafting dimension category, NOT ``.kind`` (the
-    IR feature kind) — the #360 bug used the latter, so the diameter branch was dead and
-    every diameter dim spanned ±diameter (2× wide)."""
-    return value / 2 if pmi_kind == "diameter" else value
+def _bore_span_offsets(pmi_kind: str, value: float) -> tuple[float, float]:
+    """Signed offsets from the bore centroid to each witness base point.
+
+    The invariant is that the DRAWN LENGTH equals the LABELLED VALUE, for both kinds:
+
+    * a ``"diameter"`` record stores the full diameter and its dimension spans the bore,
+      ``(-value/2, +value/2)`` — length ``value``;
+    * a ``"radius"`` record stores the radius and its dimension runs from the centre to
+      the surface, ``(0, +value)`` — length ``value``.
+
+    The predecessor returned a single half-span that the caller applied symmetrically, so
+    a radius record drew ``centre ± value``: an R6 record produced a **12 mm** line
+    labelled R6 (#1208). The diameter branch was correct, and the radius branch beside it
+    had the same shape of error #360 fixed one line along — that fix keyed on the drafting
+    category rather than the IR ``.kind``, and never questioned what radius should span.
+
+    Keyed on the drafting dimension category, NOT ``.kind``: the #360 bug used the latter,
+    so the diameter branch was dead and every diameter dim spanned ±diameter (2× wide).
+    """
+    if pmi_kind == "diameter":
+        return (-value / 2, value / 2)
+    return (0.0, value)
 
 
 # PMI is pre-authored manufacturing intent from the STEP file. When a strip is over
@@ -4954,7 +4968,10 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
         # Resolved axis (handles _bore_info's '?' degenerate-bbox fallback); the diameter
         # view table (Z→plan, X→side, Y→front) differs from the linear-dim one (#351 PR-4a).
         ax = bore_axis
-        half = _bore_half_span(rec.pmi_kind, rec.value)
+        lo, hi = _bore_span_offsets(rec.pmi_kind, rec.value)
+        # Half the DRAWN span, which is what the legibility gate is about: a radius dim is
+        # `value` long, not `2 * value`, so the two kinds no longer share a half-width.
+        half = (hi - lo) / 2
         # Narrow bores (page span < text width) lead out to a shelf; bracket dims only
         # when the span fits the label. An unresolved axis matches no cfg → bottom drop.
         half_pg = half * a.SCALE  # bore radius on page (mm)
@@ -4962,7 +4979,7 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
         if cfg is not None:
             u, v = cfg["centre"](cx_f, cy_f, cz_f)
             if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
-                p1, p2 = cfg["span"](cx_f, cy_f, cz_f, half)
+                p1, p2 = cfg["span"](cx_f, cy_f, cz_f, lo, hi)
                 placed = _pmi_queue_options(
                     dwg,
                     ctx,
@@ -5131,7 +5148,10 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
             "order": ("above", "below"),
             "leader_order": ("above", "below"),
             "centre": lambda cx, cy, cz: (PX(cx), PY(cy)),
-            "span": lambda cx, cy, cz, h: ((PX(cx - h), PY(cy), 0), (PX(cx + h), PY(cy), 0)),
+            "span": lambda cx, cy, cz, lo, hi: (
+                (PX(cx + lo), PY(cy), 0),
+                (PX(cx + hi), PY(cy), 0),
+            ),
         },
         "X": {
             "view": "side",
@@ -5139,7 +5159,10 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
             "order": ("above", "below"),
             "leader_order": ("above", "below"),
             "centre": lambda cx, cy, cz: (SX(cy), SZ(cz)),
-            "span": lambda cx, cy, cz, h: ((SX(cy - h), SZ(cz), 0), (SX(cy + h), SZ(cz), 0)),
+            "span": lambda cx, cy, cz, lo, hi: (
+                (SX(cy + lo), SZ(cz), 0),
+                (SX(cy + hi), SZ(cz), 0),
+            ),
         },
         "Y": {
             "view": "front",
@@ -5147,7 +5170,10 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
             "order": ("above", "below"),
             "leader_order": ("below", "above"),
             "centre": lambda cx, cy, cz: (FX(cx), FZ(cz)),
-            "span": lambda cx, cy, cz, h: ((FX(cx - h), FZ(cz), 0), (FX(cx + h), FZ(cz), 0)),
+            "span": lambda cx, cy, cz, lo, hi: (
+                (FX(cx + lo), FZ(cz), 0),
+                (FX(cx + hi), FZ(cz), 0),
+            ),
         },
     }
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -120,6 +120,9 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "unrecognised_defining_geometry",
         "pmi_not_lowered",
         "pmi_not_rendered",
+        # Replaces `pmi_not_rendered` for a record refused by category (#1177); the content
+        # is equally missing, so the count must not fall just because the reason improved.
+        "dimension_kind_unsupported",
         "axial_length_missing",
         "flat_requirement_suppressed",
         "flat_requirement_missing",

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -120,9 +120,13 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "unrecognised_defining_geometry",
         "pmi_not_lowered",
         "pmi_not_rendered",
-        # Replaces `pmi_not_rendered` for a record refused by category (#1177); the content
-        # is equally missing, so the count must not fall just because the reason improved.
+        # Both REPLACE `pmi_not_rendered` for a record that produced no annotation (#1177);
+        # the content is equally missing, so the count must not fall just because the
+        # reason improved. `authored_dim_degenerate` suppressed that error without
+        # carrying its weight, which is how a lost requirement came to report
+        # `geometry_issues: 0` alongside `passed: True`.
         "dimension_kind_unsupported",
+        "authored_dim_degenerate",
         "axial_length_missing",
         "flat_requirement_suppressed",
         "flat_requirement_missing",

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -167,6 +167,13 @@ def lint_pmi_lowering(report: PmiExtractionReport | None, features, mode: str) -
     return issues
 
 
+#: Codes that already explain why a typed record produced no annotation. This check exists
+#: to catch an UNEXPLAINED omission, so a record carrying one of these must not also be
+#: reported here — that is one omission with two reporters at different severities, which
+#: is the defect #1190 was opened for.
+_EXPLAINED_OMISSION_CODES = frozenset({"pmi_not_rendered", "dimension_kind_unsupported"})
+
+
 def lint_pmi_rendering(features, registry, mode: str) -> list[LintIssue]:
     """Report source-bearing typed PMI that produced no annotation or placement drop.
 
@@ -192,7 +199,7 @@ def lint_pmi_rendering(features, registry, mode: str) -> list[LintIssue]:
     already_reported = {
         source_id
         for issue in registry.issues
-        if getattr(issue, "code", None) == "pmi_not_rendered"
+        if getattr(issue, "code", None) in _EXPLAINED_OMISSION_CODES
         for source_id in getattr(issue, "source_ids", ())
     }
     return [

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -171,7 +171,17 @@ def lint_pmi_lowering(report: PmiExtractionReport | None, features, mode: str) -
 #: to catch an UNEXPLAINED omission, so a record carrying one of these must not also be
 #: reported here — that is one omission with two reporters at different severities, which
 #: is the defect #1190 was opened for.
-_EXPLAINED_OMISSION_CODES = frozenset({"pmi_not_rendered", "dimension_kind_unsupported"})
+_EXPLAINED_OMISSION_CODES = frozenset(
+    {
+        "pmi_not_rendered",
+        "dimension_kind_unsupported",
+        # `authored_dim_degenerate` exists so "a caller sees a specific reason instead of a
+        # misleading 'no room'" — and was then reported alongside a second, vaguer error for
+        # the same source. Fixing that only for the code #1177 introduced would have left
+        # the defect in place next door.
+        "authored_dim_degenerate",
+    }
+)
 
 
 def lint_pmi_rendering(features, registry, mode: str) -> list[LintIssue]:

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -850,9 +850,17 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     # An ANGULAR label is denominated in degrees; `measured_length` is a projected path in
     # millimetres. Comparing them is a category error, not a discrepancy — it reported a
     # 60 deg dovetail flank as "differs from measured path length 16.000 by 275.0%",
-    # blaming an axis swap for a units mismatch (#1177). The degree sign is the
-    # discriminator because it survives every path into lint: the rendered annotation
-    # carries no `dimension_kind`, so an item reaching here cannot be asked what it is.
+    # blaming an axis swap for a units mismatch (#1177). The label is the discriminator
+    # because a rendered annotation carries no `dimension_kind` and cannot be asked what
+    # it is.
+    #
+    # Be honest about the reach: this catches an AUTHORED label that spells the unit, and
+    # nothing else. Neither real angular record in the fixtures does — CTC-01's is
+    # '60 ±0.5' and CTC-04's is '90 ±1', and 0 of 194 PMI records carry a degree marker —
+    # so on the imported path this guard is inert and the renderer's category refusal is
+    # the whole protection. An earlier version of this comment claimed the marker "survives
+    # every path into lint", which is false. Tagging the annotation with its kind would fix
+    # that properly; it is not done here because nothing angular now reaches the renderer.
     if label_val is not None and measured is not None and not _is_angular_label(label):
         # When drawing_scale != 1.0 the geometry was scaled up before projecting
         # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -831,12 +831,29 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
     return overlap((cl_min_x, cl_min_y, cl_max_x, cl_max_y))
 
 
+#: Degree markers a dimension label may carry. ``°`` is what the engine and AP242 emit;
+#: ``deg`` is admitted because an authored label is free text.
+_DEGREE_MARKS = ("\u00b0", "deg")
+
+
+def _is_angular_label(label: str) -> bool:
+    """Whether *label* states an angle rather than a length."""
+    lowered = label.lower()
+    return any(mark in lowered for mark in _DEGREE_MARKS)
+
+
 def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:
     label = _item_label(item)
     measured = getattr(item, "measured_length", None)
 
     label_val = _label_value(label)
-    if label_val is not None and measured is not None:
+    # An ANGULAR label is denominated in degrees; `measured_length` is a projected path in
+    # millimetres. Comparing them is a category error, not a discrepancy — it reported a
+    # 60 deg dovetail flank as "differs from measured path length 16.000 by 275.0%",
+    # blaming an axis swap for a units mismatch (#1177). The degree sign is the
+    # discriminator because it survives every path into lint: the rendered annotation
+    # carries no `dimension_kind`, so an item reaching here cannot be asked what it is.
+    if label_val is not None and measured is not None and not _is_angular_label(label):
         # When drawing_scale != 1.0 the geometry was scaled up before projecting
         # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured
         # path length is the *scaled* length; the label carries the *real* value.

--- a/tests/test_issue_1177_angular_dimensions.py
+++ b/tests/test_issue_1177_angular_dimensions.py
@@ -1,0 +1,193 @@
+"""#1177 — an angular dimension must not be drawn as a linear one, or linted as one.
+
+An authored 60° dovetail flank rendered as a horizontal linear dimension, and lint then
+compared the degree label against the projected path length in millimetres:
+
+    Dim '60°': label value 60.000 differs from measured path length 16.000
+    by 275.0% — possible axis swap or wrong endpoint
+
+Two defects in one line. The drawing asserted a length where the author stated an angle,
+and the check that exists to catch a wrong value was itself comparing degrees to
+millimetres — so it reported a units mismatch as an axis swap.
+
+The issue's minimal contract allows either rendering a genuine angular dimension or
+failing loudly as unsupported *before* producing the misleading annotation. The rendering
+library has no angular primitive at all (`Dimension`, `DimensionLine`, `SafeDimension`),
+so drawing one correctly is work in `build123d-drafting-helpers`; this refuses instead,
+and says so.
+
+Refused at the RENDERER, not at `Sheet.measured_dimension`: `angular` reaches the IR from
+two sources — the authored façade and detected AP242 PMI — so a façade guard would leave
+the imported path drawing the false dimension, while refusing at import would make a
+legitimate AP242 file unreadable.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet
+from draftwright.annotations.from_model import (
+    _renderable_pmi_records,
+    _unsupported_kind_records,
+)
+from draftwright.linting.structural import _is_angular_label, _lint_dim
+
+_DOVETAIL = ((0, -25, 0), (0, -9, 0), (0, -13.619, 8))
+
+
+def _sheet_with_angular():
+    sheet = Sheet(Box(115, 50, 68), title="T", number="T-1")
+    sheet.measured_dimension(
+        kind="angular",
+        value=60,
+        label="60°",
+        dominant_axis="y",
+        ref_pts=_DOVETAIL,
+    )
+    sheet.authored_dimensions()
+    return sheet
+
+
+class TestTheDrawingNoLongerAssertsALengthForAnAngle:
+    def test_no_linear_dimension_is_drawn_for_an_angular_declaration(self):
+        # The reported reproduction. Before: `pmi_y_0`, a `Dimension` with
+        # `measured_length=16.0` carrying the label '60°'.
+        drawing = _sheet_with_angular().build()
+        drawn = [
+            name
+            for name, annotation in drawing.iter_annotations()
+            if getattr(annotation, "measured_length", None) is not None
+            and "60" in str(getattr(annotation, "label", ""))
+        ]
+        assert drawn == [], f"an angular declaration was drawn as a linear dimension: {drawn}"
+
+    def test_the_omission_is_reported_rather_than_silent(self):
+        # "Fail loudly as unsupported" — the alternative the issue permits. Refusing
+        # without saying so would trade a wrong drawing for a quietly incomplete one.
+        drawing = _sheet_with_angular().build()
+        reported = [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
+        assert reported, "the angular dimension vanished with no diagnostic"
+        assert "angular" in reported[0].message
+
+    def test_the_units_mismatch_is_no_longer_reported_as_an_axis_swap(self):
+        drawing = _sheet_with_angular().build()
+        assert not [i for i in drawing.lint() if i.code == "label_vs_measured"], (
+            "lint still compares the degree label against a millimetre path length"
+        )
+
+    def test_the_refusal_is_a_validation_outcome_not_a_placement_drop(self):
+        # #1190's lesson, reused: an optional or unsupported outcome marked as a PLACEMENT
+        # drop makes every scale infeasible, so an explicit `scale=` request burns the ISO
+        # ladder and raises where it used to return a drawing. An unsupported category is
+        # a fact about the renderer, not a reason to declare the page unusable.
+        from draftwright.linting.issues import is_placement_drop
+
+        drawing = _sheet_with_angular().build()
+        refusals = [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
+        assert refusals
+        assert not any(is_placement_drop(i) for i in refusals)
+
+    def test_an_explicit_scale_survives_an_angular_declaration(self):
+        # The consequence of the above, driven rather than asserted.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", scale=1)
+        sheet.measured_dimension(
+            kind="angular", value=60, label="60°", dominant_axis="y", ref_pts=_DOVETAIL
+        )
+        sheet.authored_dimensions()
+        assert sheet.build().scale == 1
+
+
+class TestALinearDeclarationIsUnaffected:
+    def test_a_linear_dimension_still_renders_and_still_lints(self):
+        # The refusal must be narrow. A linear authored dimension is the common case and
+        # must be untouched — including its `label_vs_measured` check, which is the whole
+        # reason that check exists.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1")
+        sheet.measured_dimension(
+            kind="linear",
+            value=16,
+            label="16",
+            dominant_axis="y",
+            ref_pts=((0, -25, 0), (0, -9, 0)),
+        )
+        sheet.authored_dimensions()
+        drawing = sheet.build()
+        assert not [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"], (
+            "a linear declaration was refused as an unsupported category"
+        )
+        drawn = [
+            name
+            for name, annotation in drawing.iter_annotations()
+            if getattr(annotation, "measured_length", None) is not None
+        ]
+        assert drawn, "the linear declaration was not drawn either"
+
+
+class TestTheRecordFiltersAgree:
+    """`_renderable_pmi_records` and `_unsupported_kind_records` must partition the
+    category refusal exactly — a record must not be both drawn and reported, nor silently
+    neither."""
+
+    def _record(self, kind, value=60.0, refs=2):
+        return SimpleNamespace(
+            kind="authored_dimension",
+            pmi_kind=kind,
+            value=value,
+            ref_pts=tuple(range(refs)),
+            label=f"{kind}-rec",
+            source_id="s",
+        )
+
+    def test_an_angular_record_is_refused_and_reported(self):
+        records = [self._record("angular")]
+        assert _renderable_pmi_records(records) == []
+        assert len(_unsupported_kind_records(records)) == 1
+
+    def test_a_linear_record_is_drawn_and_not_reported(self):
+        records = [self._record("linear")]
+        assert len(_renderable_pmi_records(records)) == 1
+        assert _unsupported_kind_records(records) == []
+
+    @pytest.mark.parametrize(("value", "refs"), [(0.0, 2), (60.0, 1)])
+    def test_a_record_refused_for_another_reason_is_not_reported_as_a_category(self, value, refs):
+        # A zero-value or single-reference record is refused for a different reason and
+        # has its own diagnostic. Reporting it as an unsupported CATEGORY would send a
+        # reader to the wrong constraint — the mistake #1190 made with `no_room` and the
+        # title block.
+        records = [self._record("angular", value=value, refs=refs)]
+        assert _renderable_pmi_records(records) == []
+        assert _unsupported_kind_records(records) == []
+
+
+class TestTheLintDiscriminatesByUnit:
+    """The lint half stands alone: it must never compare an angle to a length, whatever
+    produced the annotation. The rendered object carries no `dimension_kind`, so the label
+    is the only thing an item reaching lint can be asked about."""
+
+    @pytest.mark.parametrize("label", ["60°", "60 °", "60deg", "60 DEG", "1.5°"])
+    def test_a_degree_label_is_recognised(self, label):
+        assert _is_angular_label(label)
+
+    @pytest.mark.parametrize("label", ["60", "16.0", "ø12", "R6", "60 mm"])
+    def test_a_length_label_is_not(self, label):
+        assert not _is_angular_label(label)
+
+    def test_an_angle_is_never_compared_against_a_path_length(self):
+        issues: list = []
+        _lint_dim(SimpleNamespace(label="60°", measured_length=16.0), None, issues)
+        assert not [i for i in issues if i.code == "label_vs_measured"], (
+            "degrees were compared against millimetres"
+        )
+
+    def test_a_genuine_linear_discrepancy_is_still_caught(self):
+        # The check must stay load-bearing for the case it exists for: skipping too much
+        # would trade a false positive for a blind spot.
+        issues: list = []
+        _lint_dim(SimpleNamespace(label="60", measured_length=16.0), None, issues)
+        assert [i for i in issues if i.code == "label_vs_measured"], (
+            "a real 60-vs-16 linear mismatch is no longer reported"
+        )

--- a/tests/test_issue_1177_angular_dimensions.py
+++ b/tests/test_issue_1177_angular_dimensions.py
@@ -45,10 +45,11 @@ _DOVETAIL = ((0, -25, 0), (0, -9, 0), (0, -13.619, 8))
 
 #: Kinds whose value is CATEGORICALLY a straight projected span, so the linear renderer is
 #: the right renderer for them. That is a statement about the category, not a guarantee
-#: that today's renderer draws each correctly — two members are known not to:
-#: `radius` draws a full-diameter line (#1208), and on CTC-04 two `linear` PMI records
-#: draw 260 mm for values of 20 and 25 (#1209). Both are rendering bugs to fix, which is
-#: precisely why they are here and not in the refusal set.
+#: that today's renderer draws each correctly. `radius` did not — it drew a full-diameter
+#: line — and is fixed in this PR (#1208), which is what membership of this set earns
+#: rather than assumes. `linear` still does not on CTC-04, where two PMI records draw
+#: 260 mm for values of 20 and 25 (#1209): a rendering bug to fix, which is precisely why
+#: it is here and not in the refusal set.
 _RENDERABLE = frozenset({"linear", "thickness", "diameter", "radius"})
 
 
@@ -286,6 +287,49 @@ class TestTheOmissionIsReportedOnce:
             f"a source already explained by {explained} is reported again as unexplained"
         )
 
+    def test_suppressing_a_sibling_error_does_not_downgrade_the_outcome(self):
+        # THE regression this PR shipped and then fixed. Adding a code to the suppression
+        # set silences `pmi_not_rendered`, an ERROR that is also geometry-aware. A
+        # suppressor that is itself a plain warning outside `_GEOMETRY_AWARE_CODES`
+        # therefore turns a lost AP242 requirement into `passed: True` with
+        # `geometry_issues: 0` — measured exactly that, one file away from a commit
+        # message arguing it must not happen.
+        from build123d import Box
+
+        from draftwright import build_drawing
+        from draftwright.model.declare import measured_dimension
+
+        degenerate = measured_dimension(
+            kind="linear",
+            value=16,
+            label="16",
+            dominant_axis="Y",
+            ref_pts=((0, -9, 0), (0, -9, 0)),  # two identical points: no witness span
+            source_id="S-DEGEN",
+        )
+        drawing = build_drawing(
+            Box(60, 40, 20), title="T", number="N-1", model=[degenerate], pmi="annotate"
+        )
+        summary = drawing.lint_summary()
+        assert summary["passed"] is False, (
+            "a requirement that produced no annotation left the drawing reporting passed"
+        )
+        assert summary["geometry_issues"] >= 1, (
+            "the lost requirement stopped counting as missing content"
+        )
+
+    def test_every_code_that_suppresses_the_error_carries_its_weight(self):
+        # Stated as an invariant over the set rather than per member, so a fourth
+        # suppressor cannot be added and quietly downgrade its sources.
+        from draftwright.drawing import _GEOMETRY_AWARE_CODES
+        from draftwright.linting.pmi_coverage import _EXPLAINED_OMISSION_CODES
+
+        assert _EXPLAINED_OMISSION_CODES <= set(_GEOMETRY_AWARE_CODES), (
+            f"{sorted(set(_EXPLAINED_OMISSION_CODES) - set(_GEOMETRY_AWARE_CODES))} "
+            f"suppress a geometry-aware error without being geometry-aware, so the "
+            f"missing content stops being counted"
+        )
+
     def test_an_unexplained_omission_is_still_reported(self):
         # The suppression must stay narrow: a record that produced no annotation for a
         # reason nobody recorded is exactly what this check exists to surface.
@@ -356,6 +400,62 @@ class TestTheRefusalKeepsItsWeightInTheSummary:
             if i.code == "dimension_kind_unsupported"
         ]
         assert refusals and all(i.outcome_stage == "validation" for i in refusals)
+
+
+class TestTheRefusalSaysWhatTheKindMeasures:
+    @pytest.mark.parametrize(
+        ("kind", "phrase"),
+        [
+            ("angular", "an angle in degrees"),
+            ("curve_length", "a length along a curve"),
+            ("curved_dist", "a distance along a curve"),
+            ("oriented", "a distance along a stated direction"),
+        ],
+    )
+    def test_each_kind_states_its_own_basis(self, kind, phrase):
+        # `_MEASUREMENT_BASIS` is keyed per kind so "the message stays true as the set
+        # grows" — but nothing asserted any message TEXT, so replacing all four values
+        # with the angular phrase passed 162 tests. The keying was decorative.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", scale=1)
+        sheet.measured_dimension(
+            kind=kind,
+            value=25.0,
+            label="25",
+            dominant_axis="y",
+            ref_pts=((0, -25, 0), (0, -9, 0)),
+        )
+        sheet.authored_dimensions()
+        messages = [
+            i.message for i in sheet.build().lint() if i.code == "dimension_kind_unsupported"
+        ]
+        assert messages, f"{kind} produced no refusal"
+        assert phrase in messages[0], f"{kind} reported {messages[0]!r}"
+
+
+class TestAnEmittedScriptReportsTheLostRequirement:
+    def test_a_round_tripped_angular_record_is_an_error_not_a_warning(self):
+        # The most user-visible consequence of the severity rule, and it was neither
+        # stated nor tested. `sheet_emit` carries `source_id=` through, so a script
+        # emitted from CTC-01 declares the angular record with its AP242 identity — and
+        # the rule keys on `source_id`, not on pmi mode. The requirement really is lost,
+        # so the error is right; a user round-tripping a script sees `passed` flip.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", scale=1)
+        sheet.measured_dimension(
+            kind="angular",
+            value=60,
+            label="60°",
+            dominant_axis="y",
+            ref_pts=_DOVETAIL,
+            source_id="dimension:0:1:4:17",
+        )
+        sheet.authored_dimensions()
+        drawing = sheet.build()
+        refusals = [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
+        assert refusals and all(i.severity == "error" for i in refusals), (
+            "an emitted script carrying the AP242 source identity reported the loss as a "
+            "mere warning"
+        )
+        assert drawing.lint_summary()["passed"] is False
 
 
 class TestTheLintDiscriminatesByUnit:

--- a/tests/test_issue_1177_angular_dimensions.py
+++ b/tests/test_issue_1177_angular_dimensions.py
@@ -38,6 +38,10 @@ from draftwright.linting.structural import _is_angular_label, _lint_dim
 
 _DOVETAIL = ((0, -25, 0), (0, -9, 0), (0, -13.619, 8))
 
+#: Kinds whose value IS a straight span, so the linear renderer states them truthfully.
+#: Verified by measurement, not assumption: each draws a length equal to its value.
+_RENDERABLE = frozenset({"linear", "thickness", "diameter", "radius"})
+
 
 def _sheet_with_angular():
     sheet = Sheet(Box(115, 50, 68), title="T", number="T-1")
@@ -161,6 +165,124 @@ class TestTheRecordFiltersAgree:
         records = [self._record("angular", value=value, refs=refs)]
         assert _renderable_pmi_records(records) == []
         assert _unsupported_kind_records(records) == []
+
+
+class TestEveryDimensionKindIsClassified:
+    """Fail-closed, in the shape ADR 0017 phase 1 gave the recogniser manifest: a new kind
+    cannot be added to the IR and silently admitted to a renderer that cannot draw it.
+
+    Nothing iterated `AUTHORED_DIMENSION_KINDS` before, so a ninth kind would have gone
+    straight into the linear path — which is exactly how `curve_length`, `curved_dist` and
+    `oriented` came to be drawn 25-57% wrong without anyone noticing.
+    """
+
+    def test_every_kind_is_either_renderable_or_explicitly_refused(self):
+        from draftwright.annotations.from_model import _UNRENDERABLE_DIMENSION_KINDS
+        from draftwright.model.ir import AUTHORED_DIMENSION_KINDS
+
+        unclassified = set(AUTHORED_DIMENSION_KINDS) - _RENDERABLE - _UNRENDERABLE_DIMENSION_KINDS
+        assert not unclassified, (
+            f"dimension kind(s) {sorted(unclassified)} are neither known-truthful nor "
+            f"refused — they will be drawn through the LINEAR path, which measures a "
+            f"straight projected span. Verify what the kind measures and add it to one set."
+        )
+
+    def test_every_refused_kind_explains_what_it_measures(self):
+        from draftwright.annotations.from_model import (
+            _MEASUREMENT_BASIS,
+            _UNRENDERABLE_DIMENSION_KINDS,
+        )
+
+        assert _UNRENDERABLE_DIMENSION_KINDS <= set(_MEASUREMENT_BASIS), (
+            "a refused kind has no stated measurement basis, so its diagnostic falls back "
+            "to a generic phrase"
+        )
+
+    @pytest.mark.parametrize(
+        ("kind", "value"),
+        [("curve_length", 25.133), ("curved_dist", 25.133), ("oriented", 20.0)],
+    )
+    def test_a_kind_measured_on_another_basis_is_not_drawn(self, kind, value):
+        # Measured before the fix: each drew a 16.0 mm straight span for these values —
+        # 57%, 57% and 25% out. Same defect as angular; both sides happen to be
+        # millimetres, so lint reported an actionable-looking magnitude error instead of
+        # an axis swap.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", scale=1)
+        sheet.measured_dimension(
+            kind=kind,
+            value=value,
+            label=str(value),
+            dominant_axis="y",
+            ref_pts=((0, -25, 0), (0, -9, 0)),
+        )
+        sheet.authored_dimensions()
+        drawing = sheet.build()
+        drawn = [
+            getattr(o, "measured_length", None)
+            for _n, o in drawing.iter_annotations()
+            if getattr(o, "measured_length", None) is not None
+        ]
+        assert drawn == [], f"{kind} was drawn as a straight span of {drawn}"
+        assert [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
+
+    def test_a_truthful_kind_is_still_drawn(self):
+        # `thickness` measures a straight span and drew 16.0 for a value of 16.0. The
+        # refusal must not widen to kinds that are honest.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", scale=1)
+        sheet.measured_dimension(
+            kind="thickness",
+            value=16,
+            label="16",
+            dominant_axis="y",
+            ref_pts=((0, -25, 0), (0, -9, 0)),
+        )
+        sheet.authored_dimensions()
+        drawing = sheet.build()
+        assert not [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
+
+
+class TestTheOmissionIsReportedOnce:
+    """`lint_pmi_rendering` runs only in `pmi="annotate"` mode, so a Sheet-authored build
+    cannot exercise it — the first version of this class asserted the property on one and
+    passed with the suppression removed. Driven directly."""
+
+    def _reconcile(self, issue_code):
+        from draftwright.linting.pmi_coverage import lint_pmi_rendering
+
+        feature = SimpleNamespace(kind="authored_dimension", source_id="S1", source_ids=("S1",))
+        registry = SimpleNamespace(
+            issues=[SimpleNamespace(code=issue_code, source_ids=("S1",))],
+            names_for_feature=lambda _f: (),
+        )
+        return [i.code for i in lint_pmi_rendering([feature], registry, "annotate")]
+
+    @pytest.mark.parametrize(
+        "explained", ["dimension_kind_unsupported", "authored_dim_degenerate"]
+    )
+    def test_an_explained_omission_is_not_reported_a_second_time(self, explained):
+        # One omission, two reporters at different severities is the defect #1190 was
+        # opened for. `authored_dim_degenerate` had it too — its own docstring says it
+        # exists so "a caller sees a specific reason instead of a misleading 'no room'",
+        # and it was then accompanied by exactly that vaguer error.
+        assert "pmi_not_rendered" not in self._reconcile(explained), (
+            f"a source already explained by {explained} is reported again as unexplained"
+        )
+
+    def test_an_unexplained_omission_is_still_reported(self):
+        # The suppression must stay narrow: a record that produced no annotation for a
+        # reason nobody recorded is exactly what this check exists to surface.
+        assert "pmi_not_rendered" in self._reconcile("some_unrelated_code")
+
+    def test_an_explained_omission_is_not_also_reported_as_unexplained(self):
+        # `lint_pmi_rendering` reported the same source a SECOND time, as an error, having
+        # already been told about it as a warning — one omission, two reporters, different
+        # severities, which is the defect #1190 was opened for.
+        drawing = _sheet_with_angular().build()
+        codes = [i.code for i in drawing.lint()]
+        assert "dimension_kind_unsupported" in codes
+        assert "pmi_not_rendered" not in codes, (
+            "the refusal is reported twice, once with the real reason and once without"
+        )
 
 
 class TestTheLintDiscriminatesByUnit:

--- a/tests/test_issue_1177_angular_dimensions.py
+++ b/tests/test_issue_1177_angular_dimensions.py
@@ -11,10 +11,15 @@ and the check that exists to catch a wrong value was itself comparing degrees to
 millimetres — so it reported a units mismatch as an axis swap.
 
 The issue's minimal contract allows either rendering a genuine angular dimension or
-failing loudly as unsupported *before* producing the misleading annotation. The rendering
-library has no angular primitive at all (`Dimension`, `DimensionLine`, `SafeDimension`),
-so drawing one correctly is work in `build123d-drafting-helpers`; this refuses instead,
+failing loudly as unsupported *before* producing the misleading annotation. This refuses,
 and says so.
+
+NOT because the primitives are missing — an earlier version of this docstring claimed the
+rendering library "has no angular primitive at all", and that is false twice over:
+build123d's `DimensionLine` and `ExtensionLine` both take `label_angle` and render "60.00°"
+from an arc, and the helper `SafeDimension` builds one too. The missing work is here:
+deriving the arc and vertex from the record's reference points and routing the result
+through the corridor solve.
 
 Refused at the RENDERER, not at `Sheet.measured_dimension`: `angular` reaches the IR from
 two sources — the authored façade and detected AP242 PMI — so a façade guard would leave
@@ -38,8 +43,12 @@ from draftwright.linting.structural import _is_angular_label, _lint_dim
 
 _DOVETAIL = ((0, -25, 0), (0, -9, 0), (0, -13.619, 8))
 
-#: Kinds whose value IS a straight span, so the linear renderer states them truthfully.
-#: Verified by measurement, not assumption: each draws a length equal to its value.
+#: Kinds whose value is CATEGORICALLY a straight projected span, so the linear renderer is
+#: the right renderer for them. That is a statement about the category, not a guarantee
+#: that today's renderer draws each correctly — two members are known not to:
+#: `radius` draws a full-diameter line (#1208), and on CTC-04 two `linear` PMI records
+#: draw 260 mm for values of 20 and 25 (#1209). Both are rendering bugs to fix, which is
+#: precisely why they are here and not in the refusal set.
 _RENDERABLE = frozenset({"linear", "thickness", "diameter", "radius"})
 
 
@@ -187,6 +196,15 @@ class TestEveryDimensionKindIsClassified:
             f"straight projected span. Verify what the kind measures and add it to one set."
         )
 
+    def test_the_refusal_set_stays_inside_the_kinds_the_ir_admits(self):
+        from draftwright.annotations.from_model import _UNRENDERABLE_DIMENSION_KINDS
+        from draftwright.model.ir import AUTHORED_DIMENSION_KINDS
+
+        assert _UNRENDERABLE_DIMENSION_KINDS <= set(AUTHORED_DIMENSION_KINDS), (
+            "a refused kind is not one the IR admits, so it would be both reported here "
+            "and counted as an un-annotatable gtol record"
+        )
+
     def test_every_refused_kind_explains_what_it_measures(self):
         from draftwright.annotations.from_model import (
             _MEASUREMENT_BASIS,
@@ -283,6 +301,61 @@ class TestTheOmissionIsReportedOnce:
         assert "pmi_not_rendered" not in codes, (
             "the refusal is reported twice, once with the real reason and once without"
         )
+
+
+class TestTheRefusalKeepsItsWeightInTheSummary:
+    def test_the_refusal_counts_as_a_geometry_issue(self):
+        # `dimension_kind_unsupported` REPLACES `pmi_not_rendered` for these sources, and
+        # that code is geometry-aware. Without the new entry the count silently falls —
+        # measured 1 -> 0 here and 6 -> 5 on CTC-01 — so the drawing looks better because
+        # the diagnostic got more precise. Deleting the entry passed the entire 4,114-test
+        # suite before this test existed.
+        drawing = _sheet_with_angular().build()
+        assert drawing.lint_summary()["geometry_issues"] >= 1, (
+            "a refused dimension stopped counting as missing content"
+        )
+
+    def test_an_ap242_sourced_refusal_is_an_error(self):
+        # In annotate mode a requirement that came from the FILE and is absent from the
+        # drawing is an error — the convention `_record_pmi_no_candidate` and all three
+        # `lint_pmi_*` checks already follow. Suppressing the sibling `pmi_not_rendered`
+        # error must not quietly downgrade the outcome to a warning, which is what the
+        # first cut did.
+        from draftwright import build_drawing
+
+        drawing = build_drawing(
+            "tests/fixtures/nist_ctc_01_asme1_ap242.stp",
+            title="CTC-01",
+            number="N-1",
+            pmi="annotate",
+        )
+        refusals = [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
+        assert refusals, "CTC-01 no longer carries an angular record"
+        assert all(i.severity == "error" for i in refusals), (
+            f"an AP242-sourced omission is reported at {[i.severity for i in refusals]}"
+        )
+
+    def test_an_authored_refusal_with_no_source_is_a_warning(self):
+        # The other half of the same convention: an author's own declaration is theirs to
+        # fix, not a lost file requirement.
+        refusals = [
+            i
+            for i in _sheet_with_angular().build().lint()
+            if i.code == "dimension_kind_unsupported"
+        ]
+        assert refusals and all(i.severity == "warning" for i in refusals)
+
+    def test_the_refusal_carries_its_validation_stage_explicitly(self):
+        # `is_placement_drop` also falls back to a `_dropped` suffix, which this code does
+        # not have — so the stage kwarg is currently redundant and deleting it passed the
+        # whole suite. It is still the field `builder._is_required_scale_drop` reads, so
+        # pin it directly rather than relying on the name.
+        refusals = [
+            i
+            for i in _sheet_with_angular().build().lint()
+            if i.code == "dimension_kind_unsupported"
+        ]
+        assert refusals and all(i.outcome_stage == "validation" for i in refusals)
 
 
 class TestTheLintDiscriminatesByUnit:

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -1112,11 +1112,28 @@ class TestBuildDrawingPmi:
             for source_id in issue.source_ids
         }
 
+        # `dimension:0:1:4:17` is an ANGULAR dimension (label '60 ±0.5'). It used to render
+        # through the linear path, producing an annotation whose label states an angle and
+        # whose geometry states a length — the #1177 defect, present in a real NIST AP242
+        # fixture. It is now refused by category and reported instead, so the eight authored
+        # records partition into six rendered, one dropped for placement, and one refused.
+        refused = {
+            source_id
+            for issue in ctc01_annotated.registry.issues
+            if issue.code == "dimension_kind_unsupported"
+            for source_id in issue.source_ids
+        }
+        angular = {
+            feature.source_id for feature in authored if feature.dimension_kind == "angular"
+        }
         assert len(authored) == 8
-        assert len(rendered) == 7
+        assert len(rendered) == 6
         assert len(dropped) == 1
-        assert rendered.isdisjoint(dropped)
-        assert rendered | dropped == {feature.source_id for feature in authored}
+        assert refused == angular, (
+            f"category refusals {refused} do not match the angular records {angular}"
+        )
+        assert rendered.isdisjoint(dropped) and rendered.isdisjoint(refused)
+        assert rendered | dropped | refused == {feature.source_id for feature in authored}
         assert not [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_rendered"]
         assert ctc01_annotated.lint_summary()["pmi"] == {
             "mode": "annotate",
@@ -1124,7 +1141,9 @@ class TestBuildDrawingPmi:
             "by_category": {"datum": 11, "dimension": 21, "geometric_tolerance": 6},
             "extracted": 29,
             "lowered": 25,
-            "rendered": 24,
+            # 24 before #1177: the angular dimension was counted as rendered while what
+            # reached the sheet was a LINEAR annotation asserting a length for an angle.
+            "rendered": 23,
             "dropped": 1,
         }
 

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -72,11 +72,11 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         # exactly the wrong-reason mistake #1190 made with `no_room` and the title block.
         ("from_model", "_unsupported_kind_records"),
         # Pure geometry/selection helpers with unit-level coverage.
-        ("from_model", "_bore_half_span"),
+        ("from_model", "_bore_span_offsets"),
         ("from_model", "_diameter_column_left"),
         # _diameter_step_anchor: the shared-⌀ leader anchor (#794). The non-coaxial
         # same-⌀ case can't be reached through the public build seam, so its unit
-        # test reads the pure helper directly (like _bore_half_span above).
+        # test reads the pure helper directly (like _bore_span_offsets above).
         ("from_model", "_diameter_step_anchor"),
         ("from_model", "_renderable_pmi_records"),
         ("holes", "_legible_locations"),

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -55,6 +55,14 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         # under a mutation that deleted the filter entirely. A pure helper is testable
         # without hunting for such geometry, and its mutation demonstrably fails.
         ("sections", "_segments_clearing_title_block"),
+        # _unsupported_kind_records: the other half of the #1177 category partition. A
+        # record must be either DRAWN or REPORTED, never both and never silently neither,
+        # and the two filters that decide are private with no public surface between them.
+        # Asserting the partition through a built drawing could only ever observe one side
+        # at a time — and a record refused for a different reason (zero value, one
+        # reference point) must NOT be reported as an unsupported category, which is
+        # exactly the wrong-reason mistake #1190 made with `no_room` and the title block.
+        ("from_model", "_unsupported_kind_records"),
         # Pure geometry/selection helpers with unit-level coverage.
         ("from_model", "_bore_half_span"),
         ("from_model", "_diameter_column_left"),

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -55,6 +55,14 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         # under a mutation that deleted the filter entirely. A pure helper is testable
         # without hunting for such geometry, and its mutation demonstrably fails.
         ("sections", "_segments_clearing_title_block"),
+        # _UNRENDERABLE_DIMENSION_KINDS / _MEASUREMENT_BASIS: the #1177 fail-closed
+        # partition, in the shape ADR 0017 phase 1 gave the recogniser manifest. The guard
+        # asserts that EVERY member of `AUTHORED_DIMENSION_KINDS` is either known-truthful
+        # or explicitly refused, so it must read the refusal set itself — a built drawing
+        # can only ever show one kind at a time, which is precisely how `curve_length`,
+        # `curved_dist` and `oriented` came to be drawn 25-57% wrong unnoticed.
+        ("from_model", "_UNRENDERABLE_DIMENSION_KINDS"),
+        ("from_model", "_MEASUREMENT_BASIS"),
         # _unsupported_kind_records: the other half of the #1177 category partition. A
         # record must be either DRAWN or REPORTED, never both and never silently neither,
         # and the two filters that decide are private with no public surface between them.

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -101,26 +101,41 @@ class TestCalloutSpec:
 
 class TestBoreHalfSpan:
     """#360: an imported bore-size dim's half-span from the bore centroid. A diameter
-    record stores the diameter (half = radius); a radius record stores the radius
-    (half = value). The bug keyed on the IR feature `.kind` instead of the drafting
-    dimension category, so the diameter branch was dead and every diameter dim spanned
-    ±diameter — 2× too wide."""
+    record stores the diameter, so its dimension spans the bore; a radius record stores
+    the radius, so its dimension runs from the centre to the surface. Either way the drawn
+    length equals the labelled value. The #360 bug keyed on the IR feature `.kind` instead
+    of the drafting dimension category, so the diameter branch was dead and every diameter
+    dim spanned ±diameter — 2× too wide. #1208 was the same error left in the radius
+    branch, which that fix did not question."""
 
-    def test_diameter_halves_to_the_radius(self):
-        from draftwright.annotations.from_model import _bore_half_span
+    def test_a_diameter_spans_the_bore(self):
+        from draftwright.annotations.from_model import _bore_span_offsets
 
-        assert _bore_half_span("diameter", 35.0) == 17.5
+        assert _bore_span_offsets("diameter", 35.0) == (-17.5, 17.5)
 
-    def test_radius_is_used_as_is(self):
-        from draftwright.annotations.from_model import _bore_half_span
+    def test_a_radius_runs_from_the_centre_to_the_surface(self):
+        # Was `_bore_half_span("radius", 8.0) == 8.0`, which the caller applied
+        # SYMMETRICALLY — so an R8 record drew a 16 mm line labelled R8 (#1208). That
+        # assertion encoded the bug as intent: #360 fixed the diameter branch beside it
+        # and never asked what a radius should span.
+        from draftwright.annotations.from_model import _bore_span_offsets
 
-        assert _bore_half_span("radius", 8.0) == 8.0
+        assert _bore_span_offsets("radius", 8.0) == (0.0, 8.0)
+
+    def test_the_drawn_length_equals_the_labelled_value_for_both(self):
+        # The invariant the two cases share, stated once. A dimension whose drawn length
+        # contradicts its own label is the #1177/#1208/#1209 family.
+        from draftwright.annotations.from_model import _bore_span_offsets
+
+        for kind, value in (("diameter", 35.0), ("radius", 8.0)):
+            lo, hi = _bore_span_offsets(kind, value)
+            assert hi - lo == value, f"{kind} {value} draws {hi - lo}"
 
     def test_the_ir_kind_attr_never_triggers_the_diameter_branch(self):
         # The regression itself: an authored dimension's `.kind` identifies the IR concept,
         # so keying on it (as the old code did) never halves. Pin that pmi_kind is the
         # compatibility category and .kind is the wrong one.
-        from draftwright.annotations.from_model import _bore_half_span
+        from draftwright.annotations.from_model import _bore_span_offsets
         from draftwright.model import AuthoredDimension, Frame
 
         rec = AuthoredDimension(
@@ -131,8 +146,10 @@ class TestBoreHalfSpan:
             dominant_axis="Z",
         )
         assert rec.kind == "authored_dimension"  # IR concept, NOT the dimension category
-        assert _bore_half_span(rec.kind, rec.value) == 35.0  # the old bug: no halving
-        assert _bore_half_span(rec.pmi_kind, rec.value) == 17.5  # the fix: radius
+        # `.kind` is "authored_dimension", which is not "diameter", so the old code took
+        # the non-diameter branch and spanned the full value.
+        assert _bore_span_offsets(rec.kind, rec.value) == (0.0, 35.0)
+        assert _bore_span_offsets(rec.pmi_kind, rec.value) == (-17.5, 17.5)
 
     def test_raw_unsupported_pmi_is_not_renderable_as_a_dimension(self):
         from draftwright.annotations.from_model import _renderable_pmi_records


### PR DESCRIPTION
Closes #1177. **S2 of #1202.**

## The defect

An authored 60° dovetail flank rendered as a horizontal *linear* dimension, and lint then
compared the degree label against the projected path in millimetres:

```
Dim '60°': label value 60.000 differs from measured path length 16.000
by 275.0% — possible axis swap or wrong endpoint
```

Two defects in one line: the drawing asserts a length where the author stated an angle, and
the check meant to catch a wrong value is itself comparing degrees to millimetres — so it
reports a units mismatch as an axis swap.

## What is refused, and why

The renderer draws the **projected span between reference points along the dominant axis**.
A record whose value is measured on any other basis renders an annotation whose geometry
contradicts its own label. Measured on a 1:1 sheet, value → drawn length:

| kind | value | drawn | |
|---|---|---|---|
| `angular` | 60 | 16.0 | degrees vs millimetres |
| `curve_length` | 25.133 | 16.0 | arc length vs its chord — 57% out |
| `curved_dist` | 25.133 | 16.0 | same |
| `oriented` | 20.0 | 16.0 | along a direction the renderer never receives — 25% out |
| `linear` / `thickness` / `diameter` | | equal | the span itself — kept |

All four refused kinds are reachable from real AP242 (`pmi.py` maps XCAF enums 1, 12, 14).
They are invisible in this repo only because no checked-in fixture carries one — except
`angular`, which **two** do: NIST CTC-01 (`60 ±0.5`) and CTC-04 (`90 ±1`, drawn 88% wrong).

**Not because the primitives are missing.** build123d's `DimensionLine`/`ExtensionLine`
take `label_angle` and render `60.00°`; the helper `SafeDimension` builds one too. The
missing work is here — deriving the arc and vertex from the record's reference points and
routing it through the corridor solve.

**Refused at the renderer, not at `Sheet.measured_dimension`**, because these kinds reach
the IR from two sources — the authored façade and detected AP242 PMI — so a façade guard
leaves imports drawing the false dimension, while refusing at import would make a
legitimate AP242 file unreadable.

The refusal is a **validation** outcome, not a placement drop (#1190's lesson: an
unsupported outcome marked as placement makes every scale infeasible), and an **error** for
a source-bearing record, matching the convention of the three `lint_pmi_*` checks it
suppresses.

## Three follow-ons it exposed

* **`lint_pmi_rendering` reported the same omission twice**, as an error alongside the
  warning — the defect #1190 was opened for. `authored_dim_degenerate` had it too and is
  fixed with it.
* **CTC-01's PMI summary said `rendered: 24`** — counting a linear annotation that asserts a
  length for an angle as a rendered angular dimension.
* A **fail-closed partition** over `AUTHORED_DIMENSION_KINDS`, in the shape ADR 0017 gave
  the recogniser manifest. Nothing iterated that set before, which is how three kinds came
  to be drawn 25–57% wrong unnoticed.

## Not fixed here, filed instead

* **#1208** — `radius` draws a full-diameter-length line labelled R.
* **#1209** — CTC-04 `linear` records draw 260 mm for values of 20 and 25.

Both are the same shape: correct category, wrong span. They belong to the linear renderer
and should be fixed, not refused — filing them under "unsupported category" would
misdescribe them.

## Evidence

* Fixture impact quantified: CTC-01 55→54 annotations, CTC-04 144→143; CTC-02/03/05
  unchanged. Error/warning totals identical. CTC-01's `gdt_side_relaxed` also disappears —
  the freed strip let a GD&T frame reach its preferred side.
* Mutations confirmed across both rounds, including widening the lint skip to *every* label
  (which would trade the false positive for a blind spot), deleting the `_GEOMETRY_AWARE_CODES`
  entry, and flattening the severity.
* `scripts/pr-check --static` exit 0; **4119 passed**, 5 skipped, 2 xfailed.