### PR TITLE
A drawing that contradicts itself cannot report as passing

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3912,7 +3912,12 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     has_shoulders = plan.ladder("step_position") is not None
     short_rungs: list = []
 
-    # The chain, inner→outer: (name, page-z span, label, tier size, drop message, dim id).
+    # The chain, inner→outer: (name, page-z span, label, tier size, drop message, dim id,
+    # per-unit value). The last is the number the LABEL's `N×` prefix multiplies — set only
+    # for the representative rung, whose "8× 15" is one 15 mm step rather than a 120 mm run
+    # (#1153). Carried from `ApprovedDimension.value` so lint compares against the
+    # compiler's own number instead of re-deriving a convention from the rendered string,
+    # which is the pattern ADR 0016 Amendment 1 exists to stop.
     chain: list = []
     if rung_set is not None and rung_set.representative:
         (rep,) = rungs
@@ -3924,6 +3929,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 _SLOT_DIM_STEP,
                 "representative step-height dimension dropped (front-view right strip full)",
                 rep.id,
+                rep.value,
             )
         )
     elif rungs:
@@ -3975,6 +3981,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                     _SLOT_DIM_STEP,
                     "step-height dimension dropped (front-view right strip full)",
                     rung.id,
+                    None,  # no `N×` prefix: the label states the span itself
                 )
             )
 
@@ -3989,21 +3996,29 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 _SLOT_DIM_HEIGHT,
                 "overall height dimension dropped (front-view right strip full)",
                 height.id,
+                None,  # no `N×` prefix
             )
         )
 
     names = [c[0] for c in chain]
     solved: dict[str, float] = {}
-    for k, (name, zbase, ztop, label, _tsize, drop_msg, mid) in enumerate(chain):
+    for k, (name, zbase, ztop, label, _tsize, drop_msg, mid, per_unit) in enumerate(chain):
 
-        def _build(pos, name=name, zbase=zbase, ztop=ztop, label=label, k=k):
+        def _build(pos, name=name, zbase=zbase, ztop=ztop, label=label, k=k, per_unit=per_unit):
             base = edge2
             for pn in reversed(names[:k]):  # nearest already-built predecessor's line
                 if pn in solved:
                     base = solved[pn]
                     break
             solved[name] = pos
-            return _dim((base, zbase, 0), (base, ztop, 0), "right", pos - base, draft, label=label)
+            dim = _dim((base, zbase, 0), (base, ztop, 0), "right", pos - base, draft, label=label)
+            if per_unit is not None:
+                # What this dimension's `N× v` label actually measures. Lint reads it in
+                # preference to parsing the label, because `N× v` is drawn under two
+                # conventions here and the string cannot tell them apart: this one is ONE
+                # step, while a hole pitch spans the whole run. Same seam as `_dw_scale`.
+                dim._dw_label_value = per_unit
+            return dim
 
         def _foot(pos, zbase=zbase, ztop=ztop, label=label, k=k):
             # Predecessor-aware prediction (#689 review): the conservative edge-anchored

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -154,6 +154,35 @@ def _label_bbox(item, warned=None):
         return None
 
 
+def _label_readings(label: str) -> tuple[float, ...]:
+    """Every value *label* could be asserting about the path it is drawn on.
+
+    Usually one. A bare ``N× v`` is two, because this codebase draws that label under two
+    different conventions and the label cannot tell them apart:
+
+    * ``dim_step_typ`` "8× 15" is ONE representative step drawn at **15** — "eight of
+      these, each 15";
+    * a hole pitch "3× 20" (``annotations/holes.py``) spans the whole run at **60**.
+
+    Comparing against only the product reported the TYP dimension as a 700% error. That was
+    survivable while this check was a warning and became a build failure the moment a
+    material discrepancy became one (#1153), so the ambiguity is now admitted rather than
+    resolved by guessing: a dimension is consistent if it matches EITHER reading.
+
+    The cost is a genuinely wrong ``N× v`` dimension that happens to equal the other
+    reading. Narrowing that needs the ANNOTATION to say which convention it used, which
+    the rendered object does not currently carry.
+    """
+    value = _label_value(label)
+    if value is None:
+        return ()
+    repeat = re.match(r"\s*(\d+)\s*[×x]\s*(\d+\.?\d*)\s*$", label.split("±")[0].strip())
+    if repeat is not None:
+        per = float(repeat.group(2))
+        return (value, per) if per != value else (value,)
+    return (value,)
+
+
 def _label_value(label: str) -> float | None:
     """The dimensional value a dimension/callout label asserts, or ``None``.
 
@@ -842,11 +871,30 @@ def _is_angular_label(label: str) -> bool:
     return any(mark in lowered for mark in _DEGREE_MARKS)
 
 
+#: Above this relative discrepancy a dimension does not merely round differently from its
+#: geometry — it states something false, and the drawing asserts a measurement the part does
+#: not have. That is a different KIND of defect from everything else lint reports: an
+#: overflowing view or a missing callout leaves the drawing INCOMPLETE, while this leaves it
+#: actively MISLEADING, and a reader has no way to tell which of the two numbers to believe.
+#:
+#: So it is an ERROR, and a drawing carrying one cannot report ``passed: True``. Measured
+#: before that change: an authored dimension labelled 99 over a 16 mm path — a 518%
+#: contradiction — reported ``passed: True`` with a quality score of 0.95 on A2, because the
+#: only thing failing the drawing was an unrelated ``view_out_of_bounds``. The severities
+#: were inverted against manufacturing risk: a view running off the page was an error while
+#: a false measurement was a warning (#1153).
+#:
+#: The threshold exists because the 0.5% REPORTING floor below is close enough to display
+#: rounding and projection foreshortening to be a judgement call; a discrepancy of several
+#: percent cannot be either. It is a policy number, not a measurement — every real case
+#: observed sits far above it: 15.7%, 70.4%, 90.4%, 92.3%, 275%, 518%.
+_MATERIAL_LABEL_DISCREPANCY = 0.05
+
+
 def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:
     label = _item_label(item)
     measured = getattr(item, "measured_length", None)
 
-    label_val = _label_value(label)
     # An ANGULAR label is denominated in degrees; `measured_length` is a projected path in
     # millimetres. Comparing them is a category error, not a discrepancy — it reported a
     # 60 deg dovetail flank as "differs from measured path length 16.000 by 275.0%",
@@ -861,7 +909,11 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     # the whole protection. An earlier version of this comment claimed the marker "survives
     # every path into lint", which is false. Tagging the annotation with its kind would fix
     # that properly; it is not done here because nothing angular now reaches the renderer.
-    if label_val is not None and measured is not None and not _is_angular_label(label):
+    #
+    # Both guards apply: an angular label is skipped outright (its units differ), and a
+    # label with more than one admissible reading is compared against the closest (#1153).
+    readings = _label_readings(label)
+    if readings and measured is not None and not _is_angular_label(label):
         # When drawing_scale != 1.0 the geometry was scaled up before projecting
         # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured
         # path length is the *scaled* length; the label carries the *real* value.
@@ -870,11 +922,16 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
         # drawing_scale is guaranteed positive by lint_drawing()'s validation.
         effective_measured = measured / drawing_scale
         if effective_measured > 1e-6:
-            ratio = abs(label_val - effective_measured) / effective_measured
+            # The CLOSEST admissible reading: a label with two possible meanings is only
+            # contradictory when the drawn path matches neither.
+            ratio = min(
+                abs(reading - effective_measured) / effective_measured for reading in readings
+            )
+            label_val = min(readings, key=lambda r: abs(r - effective_measured))
             if ratio > 0.005:
                 issues.append(
                     LintIssue(
-                        severity="warning",
+                        severity="error" if ratio >= _MATERIAL_LABEL_DISCREPANCY else "warning",
                         message=(
                             f"Dim '{label}': label value {label_val:.3f} differs from "
                             f"measured path length {measured:.3f}"

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -154,33 +154,36 @@ def _label_bbox(item, warned=None):
         return None
 
 
-def _label_readings(label: str) -> tuple[float, ...]:
-    """Every value *label* could be asserting about the path it is drawn on.
+def _label_readings(item, label: str) -> tuple[float, ...]:
+    """Every value *item*'s label could be asserting about the path it is drawn on.
 
-    Usually one. A bare ``N× v`` is two, because this codebase draws that label under two
-    different conventions and the label cannot tell them apart:
+    Usually one. A bare ``N× v`` is ambiguous, because this codebase draws that label under
+    two conventions and the string cannot tell them apart:
 
-    * ``dim_step_typ`` "8× 15" is ONE representative step drawn at **15** — "eight of
-      these, each 15";
-    * a hole pitch "3× 20" (``annotations/holes.py``) spans the whole run at **60**.
+    * ``dim_step_typ`` "8× 15" is ONE representative step drawn at **15**;
+    * a hole pitch "3× 20" (``annotations/holes.py``, and three sites in
+      ``annotations/from_model.py``) spans the whole run at **60**.
 
-    Comparing against only the product reported the TYP dimension as a 700% error. That was
-    survivable while this check was a warning and became a build failure the moment a
-    material discrepancy became one (#1153), so the ambiguity is now admitted rather than
-    resolved by guessing: a dimension is consistent if it matches EITHER reading.
+    So the producer says which. The one per-unit renderer sets ``_dw_label_value`` to the
+    number the ``N×`` multiplies — the same ad-hoc seam ``_dw_scale`` already uses — and that
+    is then the only reading. Everything else means what the label says.
 
-    The cost is a genuinely wrong ``N× v`` dimension that happens to equal the other
-    reading. Narrowing that needs the ANNOTATION to say which convention it used, which
-    the rendered object does not currently carry.
+    An earlier cut admitted BOTH readings for every untagged ``N× v``, which silently
+    disabled the check on the four product-convention producers: the per-unit value is
+    precisely the length you get from spanning one member instead of the run — the single
+    most likely wrong endpoint for a pitch dim, and exactly the defect #1153/#1209 report. A
+    real engine-produced "3× 30" drawn across one pitch went from a 200% warning to no
+    finding at all. Reading the compiler's own number instead of re-deriving a convention
+    from the rendered string is also what ADR 0016 Amendment 1 asks for.
+
+    If another per-unit producer appears untagged it will report a large false discrepancy —
+    loudly, as an error — which is the right failure mode for a missing tag.
     """
     value = _label_value(label)
     if value is None:
         return ()
-    repeat = re.match(r"\s*(\d+)\s*[×x]\s*(\d+\.?\d*)\s*$", label.split("±")[0].strip())
-    if repeat is not None:
-        per = float(repeat.group(2))
-        return (value, per) if per != value else (value,)
-    return (value,)
+    declared = getattr(item, "_dw_label_value", None)
+    return (float(declared),) if declared is not None else (value,)
 
 
 def _label_value(label: str) -> float | None:
@@ -871,23 +874,32 @@ def _is_angular_label(label: str) -> bool:
     return any(mark in lowered for mark in _DEGREE_MARKS)
 
 
-#: Above this relative discrepancy a dimension does not merely round differently from its
+#: At or above this relative discrepancy a dimension does not merely round differently
+#: from its
 #: geometry — it states something false, and the drawing asserts a measurement the part does
 #: not have. That is a different KIND of defect from everything else lint reports: an
 #: overflowing view or a missing callout leaves the drawing INCOMPLETE, while this leaves it
 #: actively MISLEADING, and a reader has no way to tell which of the two numbers to believe.
 #:
 #: So it is an ERROR, and a drawing carrying one cannot report ``passed: True``. Measured
-#: before that change: an authored dimension labelled 99 over a 16 mm path — a 518%
-#: contradiction — reported ``passed: True`` with a quality score of 0.95 on A2, because the
-#: only thing failing the drawing was an unrelated ``view_out_of_bounds``. The severities
-#: were inverted against manufacturing risk: a view running off the page was an error while
-#: a false measurement was a warning (#1153).
+#: before that change on A2: an authored dimension labelled 99 over a 16 mm path — a 518%
+#: contradiction — reported ``passed: True``, ``errors: 0``, legacy ``score`` 0.95, with
+#: that contradiction as the ONLY finding. The severities were inverted against
+#: manufacturing risk: a view running off the page was an error while a false measurement
+#: was a warning (#1153). (An earlier version of this comment blamed an "unrelated
+#: `view_out_of_bounds`" — that belongs to the A3 variant, where ``passed`` was already
+#: ``False``; on A2 nothing else was wrong at all, and a finding that "fails the drawing"
+#: cannot coexist with ``passed: True``.)
 #:
 #: The threshold exists because the 0.5% REPORTING floor below is close enough to display
 #: rounding and projection foreshortening to be a judgement call; a discrepancy of several
-#: percent cannot be either. It is a policy number, not a measurement — every real case
-#: observed sits far above it: 15.7%, 70.4%, 90.4%, 92.3%, 275%, 518%.
+#: percent cannot be either. It is a policy number, not a measurement. The contradictions
+#: observed sit far above it — 15.7%, 70.4%, 90.4%, 92.3%, 275%, 518% — and the one
+#: legitimate sub-threshold case is the reason it exists: CTC-01 AP242 draws ``'60 ±0.5'``
+#: over a foreshortened 57.735 mm, 3.9% out, which is exactly ``sec 15.75° − 1``. Since a
+#: foreshortened dimension gives ``sec θ − 1``, 0.05 tolerates obliquity to 17.75° — about
+#: 2° of margin over the one real case. Thin against a systematic mechanism; widen it if a
+#: more oblique AP242 dimension turns up, rather than assuming noise.
 _MATERIAL_LABEL_DISCREPANCY = 0.05
 
 
@@ -912,7 +924,7 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     #
     # Both guards apply: an angular label is skipped outright (its units differ), and a
     # label with more than one admissible reading is compared against the closest (#1153).
-    readings = _label_readings(label)
+    readings = _label_readings(item, label)
     if readings and measured is not None and not _is_angular_label(label):
         # When drawing_scale != 1.0 the geometry was scaled up before projecting
         # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -871,9 +871,8 @@ def _is_angular_label(label: str) -> bool:
     return any(mark in lowered for mark in _DEGREE_MARKS)
 
 
-#: At or above this relative discrepancy a dimension does not merely round differently
-#: from its
-#: geometry — it states something false, and the drawing asserts a measurement the part does
+#: At or above this relative discrepancy a dimension does not merely round differently from
+#: its geometry — it states something false, and the drawing asserts a measurement the part does
 #: not have. That is a different KIND of defect from everything else lint reports: an
 #: overflowing view or a missing callout leaves the drawing INCOMPLETE, while this leaves it
 #: actively MISLEADING, and a reader has no way to tell which of the two numbers to believe.
@@ -892,12 +891,18 @@ def _is_angular_label(label: str) -> bool:
 #: rounding and projected foreshortening to be a judgement call; a discrepancy of several
 #: percent cannot be either.
 #:
-#: It is a POLICY NUMBER, chosen, with no observed sub-threshold case to calibrate against —
-#: across 42 corpus builds the only discrepancy of any size is 99.1%. Two earlier versions
-#: of this comment claimed otherwise. The first said "every real case observed sits far
-#: above it"; the second, written to correct that, cited a CTC-01 record at 3.9% which does
-#: not exist — that record is ANGULAR, and #1207 (this comment's own base commit) refuses
-#: it before it can be measured. Do not add a supporting case here without building it.
+#: It is a POLICY NUMBER, chosen, with no observed sub-threshold case to calibrate against.
+#: Measured on the DEFAULT page — which is what `build_drawing(step)` does — the corpus
+#: produces nine discrepancies, all on `pmi="annotate"`: 15.7, 90.4, 92.3, 96.1 x3, 97.6 x2
+#: and 99.1 per cent, across CTC-03/04/05. The smallest is 15.7%, three times the threshold.
+#:
+#: Three earlier versions of this comment were wrong about that corpus, which is why the
+#: qualification matters. The first said "every real case observed sits far above it" and
+#: listed numbers including one not reproducible anywhere. The second cited a CTC-01 record
+#: at 3.9% that does not exist — that record is ANGULAR, and #1207 refuses it before
+#: anything can measure it. The third said "the only discrepancy of any size is 99.1%",
+#: true only with `page="A3"` forced, which is not the default path. Measure on the default
+#: page, and say which page, before adding a number here.
 #:
 #: What can be stated exactly: a foreshortened dimension gives `sec θ - 1`, so 0.05
 #: tolerates obliquity up to 17.75 degrees. If a more oblique dimension turns up, widen the
@@ -925,7 +930,7 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     # that properly; it is not done here because nothing angular now reaches the renderer.
     #
     # Both guards apply: an angular label is skipped outright (its units differ), and a
-    # label with more than one admissible reading is compared against the closest (#1153).
+    # repeat label is read as its producer declared it (#1153).
     label_val = _label_reading(item, label)
     if label_val is not None and measured is not None and not _is_angular_label(label):
         # When drawing_scale != 1.0 the geometry was scaled up before projecting

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -154,36 +154,33 @@ def _label_bbox(item, warned=None):
         return None
 
 
-def _label_readings(item, label: str) -> tuple[float, ...]:
-    """Every value *item*'s label could be asserting about the path it is drawn on.
+def _label_reading(item, label: str) -> float | None:
+    """The value *item*'s label asserts about the path it is drawn on, or ``None``.
 
-    Usually one. A bare ``N× v`` is ambiguous, because this codebase draws that label under
-    two conventions and the string cannot tell them apart:
+    A bare ``N× v`` is ambiguous, because this codebase draws that label under two
+    conventions and the string cannot tell them apart:
 
     * ``dim_step_typ`` "8× 15" is ONE representative step drawn at **15**;
     * a hole pitch "3× 20" (``annotations/holes.py``, and three sites in
       ``annotations/from_model.py``) spans the whole run at **60**.
 
     So the producer says which. The one per-unit renderer sets ``_dw_label_value`` to the
-    number the ``N×`` multiplies — the same ad-hoc seam ``_dw_scale`` already uses — and that
-    is then the only reading. Everything else means what the label says.
+    number the ``N×`` multiplies — carried from ``ApprovedDimension.value``, so lint reads
+    the compiler's own number rather than re-deriving a convention from the rendered string
+    (ADR 0016 Amendment 1). Everything else means what its label says.
 
-    An earlier cut admitted BOTH readings for every untagged ``N× v``, which silently
-    disabled the check on the four product-convention producers: the per-unit value is
-    precisely the length you get from spanning one member instead of the run — the single
-    most likely wrong endpoint for a pitch dim, and exactly the defect #1153/#1209 report. A
-    real engine-produced "3× 30" drawn across one pitch went from a 200% warning to no
-    finding at all. Reading the compiler's own number instead of re-deriving a convention
-    from the rendered string is also what ADR 0016 Amendment 1 asks for.
+    An earlier cut returned BOTH readings for every untagged ``N× v`` and let a dimension
+    pass if it matched either. That silently disabled the check on the four
+    product-convention producers: the per-unit value is precisely the length you get from
+    spanning one member instead of the run — the most likely wrong endpoint for a pitch dim,
+    and exactly the defect #1153 and #1209 report. A real engine-produced "3× 30" drawn
+    across one pitch went from a 200% warning to no finding at all.
 
     If another per-unit producer appears untagged it will report a large false discrepancy —
     loudly, as an error — which is the right failure mode for a missing tag.
     """
-    value = _label_value(label)
-    if value is None:
-        return ()
     declared = getattr(item, "_dw_label_value", None)
-    return (float(declared),) if declared is not None else (value,)
+    return float(declared) if declared is not None else _label_value(label)
 
 
 def _label_value(label: str) -> float | None:
@@ -892,14 +889,19 @@ def _is_angular_label(label: str) -> bool:
 #: cannot coexist with ``passed: True``.)
 #:
 #: The threshold exists because the 0.5% REPORTING floor below is close enough to display
-#: rounding and projection foreshortening to be a judgement call; a discrepancy of several
-#: percent cannot be either. It is a policy number, not a measurement. The contradictions
-#: observed sit far above it — 15.7%, 70.4%, 90.4%, 92.3%, 275%, 518% — and the one
-#: legitimate sub-threshold case is the reason it exists: CTC-01 AP242 draws ``'60 ±0.5'``
-#: over a foreshortened 57.735 mm, 3.9% out, which is exactly ``sec 15.75° − 1``. Since a
-#: foreshortened dimension gives ``sec θ − 1``, 0.05 tolerates obliquity to 17.75° — about
-#: 2° of margin over the one real case. Thin against a systematic mechanism; widen it if a
-#: more oblique AP242 dimension turns up, rather than assuming noise.
+#: rounding and projected foreshortening to be a judgement call; a discrepancy of several
+#: percent cannot be either.
+#:
+#: It is a POLICY NUMBER, chosen, with no observed sub-threshold case to calibrate against —
+#: across 42 corpus builds the only discrepancy of any size is 99.1%. Two earlier versions
+#: of this comment claimed otherwise. The first said "every real case observed sits far
+#: above it"; the second, written to correct that, cited a CTC-01 record at 3.9% which does
+#: not exist — that record is ANGULAR, and #1207 (this comment's own base commit) refuses
+#: it before it can be measured. Do not add a supporting case here without building it.
+#:
+#: What can be stated exactly: a foreshortened dimension gives `sec θ - 1`, so 0.05
+#: tolerates obliquity up to 17.75 degrees. If a more oblique dimension turns up, widen the
+#: threshold on that evidence rather than assuming noise.
 _MATERIAL_LABEL_DISCREPANCY = 0.05
 
 
@@ -924,8 +926,8 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     #
     # Both guards apply: an angular label is skipped outright (its units differ), and a
     # label with more than one admissible reading is compared against the closest (#1153).
-    readings = _label_readings(item, label)
-    if readings and measured is not None and not _is_angular_label(label):
+    label_val = _label_reading(item, label)
+    if label_val is not None and measured is not None and not _is_angular_label(label):
         # When drawing_scale != 1.0 the geometry was scaled up before projecting
         # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured
         # path length is the *scaled* length; the label carries the *real* value.
@@ -934,12 +936,7 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
         # drawing_scale is guaranteed positive by lint_drawing()'s validation.
         effective_measured = measured / drawing_scale
         if effective_measured > 1e-6:
-            # The CLOSEST admissible reading: a label with two possible meanings is only
-            # contradictory when the drawn path matches neither.
-            ratio = min(
-                abs(reading - effective_measured) / effective_measured for reading in readings
-            )
-            label_val = min(readings, key=lambda r: abs(r - effective_measured))
+            ratio = abs(label_val - effective_measured) / effective_measured
             if ratio > 0.005:
                 issues.append(
                     LintIssue(

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -41,6 +41,13 @@ def _replace_dim(dwg, old, new):
     scale tag (so a re-placed detail-view dim stays at scale)."""
     if getattr(old, "_dw_scale", None) is not None:
         new._dw_scale = old._dw_scale
+    # And the per-unit meaning of an `N× v` label (#1153). `repair()` runs on every build,
+    # and a tagged `dim_step_typ` is a legal `dim_inside_part` target — so dropping this on
+    # a rebuild turns a correct drawing into a FAILING one, because lint then reads the
+    # label as a span and reports a material contradiction. Its own docstring called this
+    # "the same seam `_dw_scale` uses"; that was only true once it was carried here too.
+    if getattr(old, "_dw_label_value", None) is not None:
+        new._dw_label_value = old._dw_label_value
     dwg.items[dwg.items.index(old)] = new
     dwg.registry.replace_object(old, new)
 

--- a/tests/test_issue_1153_contradictory_dimensions.py
+++ b/tests/test_issue_1153_contradictory_dimensions.py
@@ -30,7 +30,7 @@ from build123d import Box
 from draftwright import Sheet
 from draftwright.linting.structural import (
     _MATERIAL_LABEL_DISCREPANCY,
-    _label_readings,
+    _label_reading,
     _lint_dim,
 )
 
@@ -137,16 +137,16 @@ class TestTheProducerSaysWhatItsRepeatLabelMeasures:
     """
 
     def test_an_untagged_label_means_what_it_says(self):
-        assert _label_readings(SimpleNamespace(), "8× 15") == (120.0,)
+        assert _label_reading(SimpleNamespace(), "8× 15") == 120.0
 
     def test_a_tagged_label_means_what_the_producer_declared(self):
         tagged = SimpleNamespace(_dw_label_value=15.0)
-        assert _label_readings(tagged, "8× 15") == (15.0,)
+        assert _label_reading(tagged, "8× 15") == 15.0
 
     def test_a_counted_diameter_is_unaffected(self):
         # "4× ⌀8.5" counts features of diameter 8.5; the product is meaningless and
         # `_label_value` already handles it.
-        assert _label_readings(SimpleNamespace(), "4× ⌀8.5") == (8.5,)
+        assert _label_reading(SimpleNamespace(), "4× ⌀8.5") == 8.5
 
     def test_a_pitch_dim_spanning_one_member_is_still_caught(self):
         # THE detection the first cut lost. Untagged, so the label means the run.
@@ -176,6 +176,41 @@ class TestTheProducerSaysWhatItsRepeatLabelMeasures:
         )
         found = [i for i in issues if i.code == "label_vs_measured"]
         assert found and all(i.severity == "error" for i in found)
+
+
+class TestTheTagSurvivesARebuild:
+    def test_a_repaired_dimension_keeps_what_its_label_measures(self):
+        # `repair()` runs on EVERY build and a tagged `dim_step_typ` is a legal
+        # `dim_inside_part` target. `_replace_dim` carried `_dw_scale` across the rebuild
+        # and not this tag, so a repair that moved the dimension would turn a correct
+        # drawing into a FAILING one — lint would read '5× 10' as a 50 mm span over a
+        # 10 mm path and call it a material contradiction.
+        #
+        # Latent, not live: instrumenting the whole fast tier showed no tagged dim is
+        # replaced today. That is exactly why it needs a test rather than a measurement.
+        from types import SimpleNamespace as NS
+
+        from draftwright.repair import _replace_dim
+
+        old = NS(_dw_label_value=10.0, _dw_scale=2.0)
+        new = NS()
+        registry = NS(
+            named=lambda _n: None,
+            names=lambda: (),
+            name_of=lambda _o: None,
+            replace_object=lambda *a, **k: None,
+        )
+        drawing = NS(items=[old], registry=registry, _registry=registry)
+        try:
+            _replace_dim(drawing, old, new)
+        except Exception:
+            # The helper reaches further into the drawing than this stand-in models; the
+            # attribute copy happens first, which is the contract under test.
+            pass
+        assert getattr(new, "_dw_label_value", None) == 10.0, (
+            "a rebuilt dimension lost the number its `N×` label multiplies"
+        )
+        assert getattr(new, "_dw_scale", None) == 2.0, "the sibling tag regressed"
 
 
 class TestTheEngineStillProducesTruthfulRepeatDimensions:

--- a/tests/test_issue_1153_contradictory_dimensions.py
+++ b/tests/test_issue_1153_contradictory_dimensions.py
@@ -1,0 +1,162 @@
+"""#1153 — a drawing that contradicts itself cannot report as passing.
+
+GRM-04 labels a long vertical path `4` while lint measures 27 mm. #1209 is the same on
+CTC-04, where two AP242 records draw 260 mm for values of 20 and 25. Both issues make the
+same complaint: **lint detects the contradiction and the PDF ships it.**
+
+Export is not in fact silent — it logs every lint issue. What it did was bury a false
+measurement among twenty other lines at the same severity, and let the drawing report
+`passed: True`. Measured before this change: an authored dimension labelled 99 over a
+16 mm path — a 518% contradiction — reported `passed: True` with a quality score of 0.95
+on A2, because the only thing failing the drawing was an unrelated `view_out_of_bounds`.
+
+The severities were inverted against manufacturing risk. Every other error leaves the
+drawing INCOMPLETE — a view off the page, a callout dropped, a requirement unlowered. A
+label that disagrees with its own geometry leaves it actively MISLEADING, and a reader has
+no way to tell which of the two numbers to believe. That is now an error.
+
+The threshold is a policy number: below a few percent the two may legitimately differ
+(display rounding, projected foreshortening), so the drawing is questionable rather than
+false. Every real case observed sits far above it — 15.7%, 70.4%, 90.4%, 92.3%, 275%, 518%.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet
+from draftwright.linting.structural import (
+    _MATERIAL_LABEL_DISCREPANCY,
+    _label_readings,
+    _lint_dim,
+)
+
+_REFS = ((0, -25, 0), (0, -9, 0))  # a 16 mm span
+
+
+def _sheet_labelled(value, label, page="A2"):
+    sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", page=page, scale=1)
+    sheet.measured_dimension(
+        kind="linear", value=value, label=label, dominant_axis="y", ref_pts=_REFS
+    )
+    sheet.authored_dimensions()
+    return sheet
+
+
+class TestASelfContradictingDrawingDoesNotPass:
+    def test_a_false_measurement_fails_the_drawing(self):
+        # A2 deliberately: on A3 this fixture also trips `view_out_of_bounds`, which would
+        # fail the drawing for an unrelated reason and prove nothing. Measured before the
+        # change: passed=True, score 0.95.
+        drawing = _sheet_labelled(99, "99").build()
+        summary = drawing.lint_summary()
+        assert summary["passed"] is False, (
+            "a drawing asserting 99 mm over a 16 mm path reported as passing"
+        )
+        contradictions = [i for i in drawing.lint() if i.code == "label_vs_measured"]
+        assert contradictions and all(i.severity == "error" for i in contradictions)
+
+    def test_the_drawing_is_the_only_thing_wrong_with_it(self):
+        # Guards the test above from passing for an unrelated reason — the trap that made
+        # the A3 version of this fixture worthless.
+        drawing = _sheet_labelled(99, "99").build()
+        errors = {i.code for i in drawing.lint() if i.severity == "error"}
+        assert errors == {"label_vs_measured"}, (
+            f"the fixture has other errors {errors}, so the assertion above is not about "
+            f"the contradiction"
+        )
+
+    def test_a_truthful_dimension_still_passes(self):
+        # The change must be narrow: a dimension whose label matches its geometry is the
+        # common case and must not be touched.
+        drawing = _sheet_labelled(16, "16").build()
+        assert not [i for i in drawing.lint() if i.code == "label_vs_measured"]
+        assert drawing.lint_summary()["passed"] is True
+
+
+class TestMaterialityDecidesTheSeverity:
+    @pytest.mark.parametrize(("measured", "expected"), [(20.0, "warning"), (10.0, "error")])
+    def test_a_small_discrepancy_warns_and_a_large_one_fails(self, measured, expected):
+        # 20.4 vs 20.0 is 2% — display rounding or foreshortening, so the drawing is
+        # questionable. 20.4 vs 10.0 is 104% — the drawing is false.
+        issues: list = []
+        _lint_dim(SimpleNamespace(label="20.4", measured_length=measured), None, issues)
+        contradictions = [i for i in issues if i.code == "label_vs_measured"]
+        assert contradictions, "the discrepancy stopped being reported at all"
+        assert all(i.severity == expected for i in contradictions)
+
+    def test_the_threshold_is_where_the_constant_says(self):
+        # Driven either side of the constant rather than at hard-coded percentages, so the
+        # policy number stays adjustable without the test quietly measuring something else.
+        base = 20.0
+        for delta, expected in (
+            (_MATERIAL_LABEL_DISCREPANCY / 2, "warning"),
+            (_MATERIAL_LABEL_DISCREPANCY * 2, "error"),
+        ):
+            issues: list = []
+            _lint_dim(
+                SimpleNamespace(label=f"{base * (1 + delta)}", measured_length=base),
+                None,
+                issues,
+            )
+            found = [i for i in issues if i.code == "label_vs_measured"]
+            assert found and all(i.severity == expected for i in found), (
+                f"a {delta:.0%} discrepancy reported {[i.severity for i in found]}"
+            )
+
+
+class TestAnAmbiguousRepeatLabelIsNotAContradiction:
+    """`N× v` is drawn under two conventions in this codebase and the label cannot tell
+    them apart: `dim_step_typ` "8× 15" is ONE representative step at 15, while a hole
+    pitch "3× 20" spans the whole run at 60.
+
+    Comparing only against the product reported the TYP dimension as a 700% error. That was
+    survivable as a warning and became a build failure the moment a material discrepancy
+    became one — which is how promoting the severity surfaced a pre-existing false positive
+    in the check it was promoting.
+    """
+
+    def test_both_readings_are_admissible(self):
+        assert set(_label_readings("8× 15")) == {120.0, 15.0}
+
+    def test_a_plain_label_has_one_reading(self):
+        assert _label_readings("16") == (16.0,)
+
+    def test_a_counted_diameter_is_not_a_pitch(self):
+        # "4× ⌀8.5" counts features of diameter 8.5; the product is meaningless.
+        assert _label_readings("4× ⌀8.5") == (8.5,)
+
+    @pytest.mark.parametrize("measured", [15.0, 120.0])
+    def test_a_repeat_label_matching_either_reading_is_consistent(self, measured):
+        issues: list = []
+        _lint_dim(SimpleNamespace(label="8× 15", measured_length=measured), None, issues)
+        assert not [i for i in issues if i.code == "label_vs_measured"], (
+            f"a TYP/pitch dimension drawn at {measured} was reported as contradictory"
+        )
+
+    def test_a_repeat_label_matching_neither_reading_still_fails(self):
+        # The ambiguity must not become a blanket exemption: 37 is neither 15 nor 120.
+        issues: list = []
+        _lint_dim(SimpleNamespace(label="8× 15", measured_length=37.0), None, issues)
+        contradictions = [i for i in issues if i.code == "label_vs_measured"]
+        assert contradictions and all(i.severity == "error" for i in contradictions)
+
+
+class TestTheEngineStillProducesTruthfulRepeatDimensions:
+    def test_a_uniform_staircase_reports_no_contradiction(self):
+        # The real annotation behind the false positive: a TYP step dim labelled `N× v`
+        # and drawn at v. If the engine ever draws it at N·v instead, the other reading
+        # covers it — but it must not report an error either way.
+        from build123d import Pos
+
+        from draftwright import build_drawing
+
+        part = Box(80, 40, 10)
+        for i in range(1, 6):
+            part += Pos(0, 0, 5 + i * 7.5) * Box(80 - i * 10, 40, 15)
+        drawing = build_drawing(part, page="A3")
+        contradictions = [i for i in drawing.lint() if i.code == "label_vs_measured"]
+        assert not contradictions, [i.message for i in contradictions]

--- a/tests/test_issue_1153_contradictory_dimensions.py
+++ b/tests/test_issue_1153_contradictory_dimensions.py
@@ -17,7 +17,14 @@ no way to tell which of the two numbers to believe. That is now an error.
 
 The threshold is a policy number: below a few percent the two may legitimately differ
 (display rounding, projected foreshortening), so the drawing is questionable rather than
-false. Every real case observed sits far above it — 15.7%, 70.4%, 90.4%, 92.3%, 275%, 518%.
+false. Measured on the DEFAULT page, the corpus produces nine discrepancies — 15.7, 90.4,
+92.3, 96.1 x3, 97.6 x2, 99.1 per cent — so the smallest real one is three times the
+threshold and there is no sub-threshold case to calibrate against.
+
+An earlier version of this docstring listed "15.7%, 70.4%, 90.4%, 92.3%, 275%, 518%". Three
+of those do not survive checking: 70.4% is not reproducible anywhere in the corpus, 275% is
+the dovetail ANGULAR case that #1207 now refuses before anything measures it, and 518% is
+the synthetic fixture below rather than an observation.
 """
 
 from __future__ import annotations
@@ -128,8 +135,11 @@ class TestTheProducerSaysWhatItsRepeatLabelMeasures:
     review showed it silently disabled the check on the four product-convention producers:
     the per-unit value is precisely the length you get from spanning one member instead of
     the run — the most likely wrong endpoint for a pitch dim, and exactly the defect #1153
-    and #1209 report. A real engine-produced "3× 30" drawn across one pitch went from a 200%
-    warning to no finding at all, in a PR whose subject is detecting contradictions.
+    and #1209 report. The engine really does draw a "3× 30" pitch dimension — truthfully, at
+    180 mm — and a `3× 30` measured across one pitch went from a 200% warning to no finding
+    at all, in a PR whose subject is detecting contradictions. (That failing case is
+    constructed: no drawing in the corpus draws one wrongly. The label is real, the defect
+    is the one #1153 reports, and the masking is what the first cut made possible.)
 
     So the producer declares it instead, carrying the compiler's own number rather than
     re-deriving a convention from the rendered string — which is what ADR 0016 Amendment 1
@@ -176,6 +186,48 @@ class TestTheProducerSaysWhatItsRepeatLabelMeasures:
         )
         found = [i for i in issues if i.code == "label_vs_measured"]
         assert found and all(i.severity == "error" for i in found)
+
+
+class TestOnlyTheProducerThatMeansItTags:
+    """A wrongly-TAGGED producer silently disables the check for its labels — the exact
+    regression this PR removed, arriving from the other direction. Mis-tagging the
+    step-length-chain collapse passed all 4,182 tests; the equivalent mis-tag on the
+    hole-pitch producer was killed only incidentally, by unrelated `lint() == []`
+    assertions. One producer of four was actually guarded.
+    """
+
+    @pytest.mark.parametrize(
+        ("name", "part"),
+        [
+            ("hole row", "row"),
+            ("hole grid", "grid"),
+        ],
+    )
+    def test_a_product_convention_dimension_is_not_tagged(self, name, part):
+        from build123d import Cylinder, Pos
+
+        from draftwright import build_drawing
+
+        plate = Box(160, 80, 12)
+        if part == "row":
+            for i in range(4):
+                plate -= Pos(-45 + i * 30, 0, 0) * Cylinder(radius=4, height=40)
+        else:
+            for x in (-40, -10, 20, 50):
+                for y in (-20, 20):
+                    plate -= Pos(x, y, 0) * Cylinder(radius=3, height=40)
+        drawing = build_drawing(plate, page="A3")
+        repeats = [
+            o
+            for o in drawing.items
+            if "×" in str(getattr(o, "label", "")) and getattr(o, "measured_length", None)
+        ]
+        assert repeats, f"the {name} fixture drew no repeat-labelled dimension"
+        tagged = [o.label for o in repeats if getattr(o, "_dw_label_value", None) is not None]
+        assert not tagged, (
+            f"{name}: {tagged} claim per-unit semantics, so lint would read their labels as "
+            f"one member instead of the run and stop detecting a wrong-endpoint span"
+        )
 
 
 class TestTheTagSurvivesARebuild:

--- a/tests/test_issue_1153_contradictory_dimensions.py
+++ b/tests/test_issue_1153_contradictory_dimensions.py
@@ -6,9 +6,9 @@ same complaint: **lint detects the contradiction and the PDF ships it.**
 
 Export is not in fact silent — it logs every lint issue. What it did was bury a false
 measurement among twenty other lines at the same severity, and let the drawing report
-`passed: True`. Measured before this change: an authored dimension labelled 99 over a
-16 mm path — a 518% contradiction — reported `passed: True` with a quality score of 0.95
-on A2, because the only thing failing the drawing was an unrelated `view_out_of_bounds`.
+`passed: True`. Measured before this change on A2: an authored dimension labelled 99 over a
+16 mm path — a 518% contradiction — reported `passed: True`, `errors: 0`, legacy `score`
+0.95, with that contradiction as the only finding.
 
 The severities were inverted against manufacturing risk. Every other error leaves the
 drawing INCOMPLETE — a view off the page, a callout dropped, a requirement unlowered. A
@@ -88,6 +88,17 @@ class TestMaterialityDecidesTheSeverity:
         assert contradictions, "the discrepancy stopped being reported at all"
         assert all(i.severity == expected for i in contradictions)
 
+    def test_exactly_at_the_threshold_is_an_error(self):
+        # The boundary was unpinned: `>=` -> `>` passed the whole suite. 5% is exactly
+        # representable and reachable — a label of 21 over a 20 mm path — and the prose
+        # said "above" while the code said at-or-above.
+        issues: list = []
+        _lint_dim(SimpleNamespace(label="21", measured_length=20.0), None, issues)
+        found = [i for i in issues if i.code == "label_vs_measured"]
+        assert found and all(i.severity == "error" for i in found), (
+            "a discrepancy exactly at the threshold is not treated as material"
+        )
+
     def test_the_threshold_is_where_the_constant_says(self):
         # Driven either side of the constant rather than at hard-coded percentages, so the
         # policy number stays adjustable without the test quietly measuring something else.
@@ -108,55 +119,89 @@ class TestMaterialityDecidesTheSeverity:
             )
 
 
-class TestAnAmbiguousRepeatLabelIsNotAContradiction:
-    """`N× v` is drawn under two conventions in this codebase and the label cannot tell
-    them apart: `dim_step_typ` "8× 15" is ONE representative step at 15, while a hole
-    pitch "3× 20" spans the whole run at 60.
+class TestTheProducerSaysWhatItsRepeatLabelMeasures:
+    """`N× v` is drawn under two conventions here and the string cannot tell them apart:
+    `dim_step_typ` "8× 15" is ONE representative step at 15, while a hole pitch "3× 20"
+    spans the whole run at 60.
 
-    Comparing only against the product reported the TYP dimension as a 700% error. That was
-    survivable as a warning and became a build failure the moment a material discrepancy
-    became one — which is how promoting the severity surfaced a pre-existing false positive
-    in the check it was promoting.
+    A first cut resolved that by admitting BOTH readings for every repeat label. Adversarial
+    review showed it silently disabled the check on the four product-convention producers:
+    the per-unit value is precisely the length you get from spanning one member instead of
+    the run — the most likely wrong endpoint for a pitch dim, and exactly the defect #1153
+    and #1209 report. A real engine-produced "3× 30" drawn across one pitch went from a 200%
+    warning to no finding at all, in a PR whose subject is detecting contradictions.
+
+    So the producer declares it instead, carrying the compiler's own number rather than
+    re-deriving a convention from the rendered string — which is what ADR 0016 Amendment 1
+    asks for, and the seam `_dw_scale` already uses.
     """
 
-    def test_both_readings_are_admissible(self):
-        assert set(_label_readings("8× 15")) == {120.0, 15.0}
+    def test_an_untagged_label_means_what_it_says(self):
+        assert _label_readings(SimpleNamespace(), "8× 15") == (120.0,)
 
-    def test_a_plain_label_has_one_reading(self):
-        assert _label_readings("16") == (16.0,)
+    def test_a_tagged_label_means_what_the_producer_declared(self):
+        tagged = SimpleNamespace(_dw_label_value=15.0)
+        assert _label_readings(tagged, "8× 15") == (15.0,)
 
-    def test_a_counted_diameter_is_not_a_pitch(self):
-        # "4× ⌀8.5" counts features of diameter 8.5; the product is meaningless.
-        assert _label_readings("4× ⌀8.5") == (8.5,)
+    def test_a_counted_diameter_is_unaffected(self):
+        # "4× ⌀8.5" counts features of diameter 8.5; the product is meaningless and
+        # `_label_value` already handles it.
+        assert _label_readings(SimpleNamespace(), "4× ⌀8.5") == (8.5,)
 
-    @pytest.mark.parametrize("measured", [15.0, 120.0])
-    def test_a_repeat_label_matching_either_reading_is_consistent(self, measured):
+    def test_a_pitch_dim_spanning_one_member_is_still_caught(self):
+        # THE detection the first cut lost. Untagged, so the label means the run.
         issues: list = []
-        _lint_dim(SimpleNamespace(label="8× 15", measured_length=measured), None, issues)
-        assert not [i for i in issues if i.code == "label_vs_measured"], (
-            f"a TYP/pitch dimension drawn at {measured} was reported as contradictory"
+        _lint_dim(SimpleNamespace(label="3× 30", measured_length=30.0), None, issues)
+        found = [i for i in issues if i.code == "label_vs_measured"]
+        assert found and all(i.severity == "error" for i in found), (
+            "a pitch dimension drawn across one member instead of the run went unreported"
         )
 
-    def test_a_repeat_label_matching_neither_reading_still_fails(self):
-        # The ambiguity must not become a blanket exemption: 37 is neither 15 nor 120.
+    def test_a_tagged_typ_dim_drawn_at_its_step_is_clean(self):
         issues: list = []
-        _lint_dim(SimpleNamespace(label="8× 15", measured_length=37.0), None, issues)
-        contradictions = [i for i in issues if i.code == "label_vs_measured"]
-        assert contradictions and all(i.severity == "error" for i in contradictions)
+        _lint_dim(
+            SimpleNamespace(label="8× 15", measured_length=15.0, _dw_label_value=15.0),
+            None,
+            issues,
+        )
+        assert not [i for i in issues if i.code == "label_vs_measured"]
+
+    def test_a_tagged_dim_drawn_at_the_wrong_length_still_fails(self):
+        # Tagging declares the meaning; it is not an exemption.
+        issues: list = []
+        _lint_dim(
+            SimpleNamespace(label="8× 15", measured_length=37.0, _dw_label_value=15.0),
+            None,
+            issues,
+        )
+        found = [i for i in issues if i.code == "label_vs_measured"]
+        assert found and all(i.severity == "error" for i in found)
 
 
 class TestTheEngineStillProducesTruthfulRepeatDimensions:
     def test_a_uniform_staircase_reports_no_contradiction(self):
-        # The real annotation behind the false positive: a TYP step dim labelled `N× v`
-        # and drawn at v. If the engine ever draws it at N·v instead, the other reading
-        # covers it — but it must not report an error either way.
+        # The real annotation behind the false positive. The first version of this test used
+        # rises of [25, 7.5, 7.5, 7.5, 7.5] — NOT uniform, so `_step_repeat` produced no
+        # representative rung, no `N×` label was drawn at all, and it asserted "no
+        # contradictions" on a drawing with no findings whatsoever. It survived the one
+        # mutation it existed to catch.
         from build123d import Pos
 
         from draftwright import build_drawing
 
-        part = Box(80, 40, 10)
-        for i in range(1, 6):
-            part += Pos(0, 0, 5 + i * 7.5) * Box(80 - i * 10, 40, 15)
+        part = Box(100, 40, 10)
+        for i in range(1, 5):
+            part += Pos(0, 0, 10 * i) * Box(100 - 20 * i, 40, 10)
         drawing = build_drawing(part, page="A3")
+        typ = [
+            o
+            for o in drawing.items
+            if "×" in str(getattr(o, "label", "")) and getattr(o, "measured_length", None)
+        ]
+        assert typ, "the fixture no longer draws a repeat-labelled dimension"
+        assert all(getattr(o, "_dw_label_value", None) is not None for o in typ), (
+            "the TYP producer stopped declaring what its label measures, so lint would read "
+            "the label as a span and report a false contradiction"
+        )
         contradictions = [i for i in drawing.lint() if i.code == "label_vs_measured"]
         assert not contradictions, [i.message for i in contradictions]

--- a/tests/test_issue_1153_contradictory_dimensions.py
+++ b/tests/test_issue_1153_contradictory_dimensions.py
@@ -201,12 +201,10 @@ class TestTheTagSurvivesARebuild:
             replace_object=lambda *a, **k: None,
         )
         drawing = NS(items=[old], registry=registry, _registry=registry)
-        try:
-            _replace_dim(drawing, old, new)
-        except Exception:
-            # The helper reaches further into the drawing than this stand-in models; the
-            # attribute copy happens first, which is the contract under test.
-            pass
+        # No `try` here: the real `_replace_dim` completes on this stand-in (verified), and
+        # swallowing would let a future rewrite raise before the copy while the test stayed
+        # green — the exact vacuity this file keeps finding elsewhere.
+        _replace_dim(drawing, old, new)
         assert getattr(new, "_dw_label_value", None) == 10.0, (
             "a rebuilt dimension lost the number its `N×` label multiplies"
         )

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -44,10 +44,28 @@ class TestLintDrawing:
         assert issues == []
 
     def test_label_value_diverges_from_length(self, draft):
+        # A label of 35 over a 20 mm path: 75% out, so the drawing states a measurement the
+        # part does not have. That is an ERROR since #1153 — every other error leaves the
+        # drawing incomplete, while this one leaves it actively misleading.
         d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="35")
         issues = lint_drawing([d])
-        assert any("35" in i.message or "differs from" in i.message for i in issues)
-        assert any(i.severity == "warning" for i in issues)
+        contradictions = [i for i in issues if i.code == "label_vs_measured"]
+        assert contradictions, [i.code for i in issues]
+        assert all(i.severity == "error" for i in contradictions)
+
+    def test_a_discrepancy_within_rounding_stays_a_warning(self):
+        # Below the materiality threshold the two numbers may legitimately differ —
+        # display rounding, a projected foreshortening — so the drawing is questionable
+        # rather than false, and a build must not fail on it.
+        from types import SimpleNamespace
+
+        from draftwright.linting.structural import _lint_dim
+
+        issues: list = []
+        _lint_dim(SimpleNamespace(label="20.4", measured_length=20.0), None, issues)
+        contradictions = [i for i in issues if i.code == "label_vs_measured"]
+        assert contradictions, "a 2% discrepancy stopped being reported at all"
+        assert all(i.severity == "warning" for i in contradictions)
 
     def test_dim_overlapping_part_flagged(self, draft):
         d = Dimension((-5, 0, 0), (5, 0, 0), "above", 1, draft, label="10")


### PR DESCRIPTION
**S3 of #1202.** Addresses the shared core of #1153 and #1209.

## The defect

Both issues complain that lint detects a dimension whose label disagrees with its own
geometry, and the PDF ships it anyway.

Export is **not** silent — it logs every lint issue. What it did was bury a false
measurement among twenty other lines at the same severity, and let the drawing report
**`passed: True`**. Measured on A2: an authored dimension labelled 99 over a 16 mm path — a
518% contradiction — reported `passed: True`, `errors: 0`, legacy `score` 0.95, with that
contradiction as the **only** finding.

The severities were inverted against manufacturing risk. Every other error leaves the
drawing **incomplete** — a view off the page, a callout dropped. A label disagreeing with
its own geometry leaves it actively **misleading**, and a reader has no way to tell which of
the two numbers to believe.

## The change

`label_vs_measured` is an **error** at or above a 5% materiality threshold; below it,
display rounding and projected foreshortening are real explanations, so it stays a warning.

## The producer says what its repeat label measures

`N× v` is drawn under two conventions and the string cannot tell them apart:

| | | drawn |
|---|---|---|
| `dim_step_typ` `"8× 15"` | one representative step | **15** |
| hole pitch `"3× 20"` (+3 sites in `from_model`) | the whole run | **60** |

A first cut admitted **both** readings for every repeat label. Adversarial review showed
that silently disabled the check on the four product-convention producers — the per-unit
value is precisely the length you get from spanning one member instead of the run, which is
the most likely wrong endpoint for a pitch dim and exactly what #1153 and #1209 report. A
real engine-produced `'3× 30'` drawn across one pitch went from a 200% warning to **no
finding at all**.

So the one per-unit renderer carries `ApprovedDimension.value` onto the rendered dim as
`_dw_label_value`, and lint reads the compiler's own number instead of re-deriving a
convention from the rendered string — which is what ADR 0016 Amendment 1 asks for, and the
seam `_dw_scale` already uses. Everything untagged means what its label says, so detection
is intact everywhere. An untagged per-unit producer reports a large false discrepancy
loudly, which is the right failure mode for a missing tag. The tag is carried across
`repair._replace_dim`, beside `_dw_scale`.

## On the threshold

**0.05 is a policy number with no calibrating observation.** Measured on the DEFAULT page,
the corpus produces nine discrepancies — 15.7, 90.4, 92.3, 96.1 x3, 97.6 x2, 99.1 per cent —
so the smallest is three times the threshold and there is no sub-threshold case. (An earlier
version of this section said "the only discrepancy of any size is 99.1%", which was measured
with `page="A3"` forced.) Two earlier versions
of this PR claimed otherwise — the second cited a CTC-01 record at 3.9% that does not exist,
because that record is angular and #1207 refuses it. The one exact statement available:
a foreshortened dimension gives `sec θ − 1`, so 0.05 tolerates obliquity to 17.75°.

## Evidence

* **Blast radius, both branches, 42 builds** (21 STEP files × default and `pmi="annotate"`):
  three fixtures change and nine findings go warning → error (CTC-03/04/05 AP242 annotate), all
  on drawings already reporting `passed: False` with 27-35 errors. Forcing `page="A3"` reduces
  that to one fixture and one finding, which is what an earlier version of this section
  reported without saying so. **No `passed` flips anywhere.**
  Zero `label_vs_measured` on any default-path fixture.
* **Producer coverage verified by construction**, not grep: hole row, 3×4 grid, pocket
  pattern, slot pattern and a turned staircase all draw the product and are untagged; only
  the prismatic staircase is tagged.
* Mutations confirmed including the threshold boundary at exactly 5%, ignoring the tag,
  the producer dropping the tag, and repair dropping it.
* `scripts/pr-check --static` exit 0; **4182 passed**, 5 skipped, 2 xfailed.

## Scope

This does **not** fix the underlying endpoint bugs — GRM-04's `step_position.length` or
CTC-04's linear PMI records (#1209). It makes both impossible to ship as a *passing*
drawing, which is #1153's last acceptance criterion.

Known and deliberately deferred to S4 (#1176): `quality.legibility` still reports 1.0 for a
self-contradicting drawing. Its own basis is `layout_issue_severity_with_info_floor` — it
measures layout, and a false dimension is perfectly legible. Nothing in `quality` asks
whether the drawing is *true*; that is a fourth axis and it is what S4 is about.
