### PR TITLE
Point the radius leader at the surface, not at half the radius

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4608,23 +4608,11 @@ _PMI_SLOT = 10.0  # mm — slot size for PMI dim lines in the strip
 #: refused for a different reason from its neighbours, which an earlier version of this
 #: comment lumped together as "needs an arc".
 #:
-#: `radius` is a THIRD defect and is NOT refused: its value is a straight span, so it is
-#: fixable rather than unsupported. `_bore_half_span` returns the value where `diameter`
-#: halves it, so an R6 record renders a 12 mm line labelled R. Tracked as #1208, because
-#: refusing it would file a rendering bug under "unsupported category" and misdescribe it.
-#:
-#: NOT because the rendering library lacks the primitives. An earlier version of this
-#: comment claimed build123d has no angular dimension; it does — `DimensionLine` and
-#: `ExtensionLine` both take `label_angle`, and render "60.00°" from an arc. The missing
-#: work is on THIS side: deriving the arc and vertex from the record's reference points and
-#: routing the result through the corridor solve. Saying otherwise sends the follow-on to
-#: the wrong repository.
-#:
-#: Refused at the RENDERER rather than at `Sheet.measured_dimension`, because these kinds
-#: reach the IR from two sources — the authored façade and detected AP242 PMI
-#: (`model/detect.py`) — and refusing at the façade would leave the imported path drawing
-#: the false dimension while making a legitimate AP242 file unreadable. NIST CTC-01 carries
-#: an angular record; CTC-04 carries one drawn 88% wrong.
+#: `radius` is NOT refused: its value is a straight span, so it was fixable rather than
+#: unsupported, and #1208 fixed it in the same PR — a radius now runs centre-to-surface and
+#: draws its labelled length. Refusing it would have filed a rendering bug under
+#: "unsupported category" and misdescribed it. An earlier version of this comment still
+#: described the bug in the present tense, naming a function the same PR had deleted.
 _UNRENDERABLE_DIMENSION_KINDS = frozenset({"angular", "curve_length", "curved_dist", "oriented"})
 
 #: What each refused category actually measures, for the diagnostic. Keyed by kind so the
@@ -4965,7 +4953,8 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
     name_d = f"pmi_d_{idx}"
 
     if rec.pmi_kind in ("diameter", "radius"):
-        # Bore size: centroid ± value/2 perpendicular to bore axis.
+        # Bore size: a diameter spans centroid ± value/2; a radius runs centroid → +value
+        # (#1208). See `_bore_span_offsets`.
         info = _bore_info(rec)
         if info is None:
             _log.debug("PMI dim[%d] diam: no ref_bbox, skip", idx)
@@ -4976,16 +4965,27 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
         # view table (Z→plan, X→side, Y→front) differs from the linear-dim one (#351 PR-4a).
         ax = bore_axis
         lo, hi = _bore_span_offsets(rec.pmi_kind, rec.value)
-        # Half the DRAWN span, which is what the legibility gate is about: a radius dim is
-        # `value` long, not `2 * value`, so the two kinds no longer share a half-width.
-        half = (hi - lo) / 2
+        # TWO different quantities, which #1208 briefly conflated:
+        #
+        # * `half_span_pg` — half the DRAWN span, which is what the legibility gate asks
+        #   about ("does the label fit between the witness bases"). A radius dim is `value`
+        #   long, not `2 * value`, so the two kinds no longer share it.
+        # * `surface_pg` — the distance from the bore centre to its SURFACE, which is `hi`
+        #   for BOTH kinds and is where the leader's arrow must point.
+        #
+        # Redefining the single old `half` for the gate silently moved the arrow with it, so
+        # a radius leader pointed halfway between the centre and the arc — into the bore
+        # void — on a case that was previously right. And halving the gate value doubled the
+        # traffic onto that path. One variable, two consumers three lines apart, and the
+        # comment on the intervening line still asserting the old meaning.
+        half_span_pg = ((hi - lo) / 2) * a.SCALE
+        surface_pg = hi * a.SCALE  # centre-to-surface on the page (mm), both kinds
         # Narrow bores (page span < text width) lead out to a shelf; bracket dims only
         # when the span fits the label. An unresolved axis matches no cfg → bottom drop.
-        half_pg = half * a.SCALE  # bore radius on page (mm)
         cfg = bore_cfg.get(bore_axis)
         if cfg is not None:
             u, v = cfg["centre"](cx_f, cy_f, cz_f)
-            if half_pg >= _MIN_INPLACE_BORE_HALF_MM:
+            if half_span_pg >= _MIN_INPLACE_BORE_HALF_MM:
                 p1, p2 = cfg["span"](cx_f, cy_f, cz_f, lo, hi)
                 placed = _pmi_queue_options(
                     dwg,
@@ -5006,7 +5006,7 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
                     ctx,
                     [
                         _pmi_leader_spec(
-                            (u, v + (half_pg if s == "above" else -half_pg), 0),
+                            (u, v + (surface_pg if s == "above" else -surface_pg), 0),
                             cfg["zones"][s],
                             label,
                             name_d,
@@ -5147,7 +5147,8 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
     # circle in ONE view, dimensioned across it in-plane when the page span fits the label, else
     # led out to a shelf. This one table replaces three near-identical Z/X/Y blocks. `order` is
     # the in-place above/below fallback; `leader_order` the narrow-bore one (Y historically
-    # prefers below first). `centre`/`span` project the circle centre and its ±half endpoints.
+    # prefers below first). `centre`/`span` project the circle centre and its two span
+    # endpoints — symmetric for a diameter, centre-to-surface for a radius (#1208).
     _bore: dict[str, dict[str, Any]] = {
         "Z": {
             "view": "plan",

--- a/tests/test_issue_1177_angular_dimensions.py
+++ b/tests/test_issue_1177_angular_dimensions.py
@@ -318,6 +318,36 @@ class TestTheOmissionIsReportedOnce:
             "the lost requirement stopped counting as missing content"
         )
 
+    def test_every_suppressor_escalates_for_a_source_bearing_record(self):
+        # The regression had TWO symptoms — `geometry_issues: 0` (a COUNT) and
+        # `passed: True` (a SEVERITY; `passed` is literally `errors == 0`). The invariant
+        # below guards only the count, while its comment claimed a fourth suppressor
+        # "cannot quietly downgrade its sources". Downgrade is severity: a suppressor added
+        # at unconditional `warning` satisfies that invariant and still flips `passed`.
+        #
+        # Checked in the source, because there is no runtime registry of recorders — a new
+        # suppressor is a new `ctx.record_issue` call, and this is what makes adding one
+        # without the escalation visible.
+        import inspect
+        import re
+
+        from draftwright.annotations import from_model
+        from draftwright.linting.pmi_coverage import _EXPLAINED_OMISSION_CODES
+
+        source = inspect.getsource(from_model)
+        for code in _EXPLAINED_OMISSION_CODES:
+            if code == "pmi_not_rendered":
+                continue  # the suppressed error itself, not a suppressor
+            call = re.search(
+                r'ctx\.record_issue\(\s*([^\n]*?),\s*"' + re.escape(code) + r'"', source
+            )
+            assert call, f"{code} suppresses an error but is recorded nowhere in from_model"
+            assert "source_id" in call.group(1), (
+                f"{code} suppresses a source-bearing error at a fixed severity "
+                f"({call.group(1).strip()}) — a lost AP242 requirement would leave the "
+                f"drawing reporting passed"
+            )
+
     def test_every_code_that_suppresses_the_error_carries_its_weight(self):
         # Stated as an invariant over the set rather than per member, so a fourth
         # suppressor cannot be added and quietly downgrade its sources.

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -313,3 +313,73 @@ class TestDiameterColumnOccupancy:
             )
             == 0
         )
+
+
+class TestTheRadiusLeaderPointsAtTheSurface:
+    """#1208's fix redefined a variable the leader tip also read, three lines below.
+
+    `half` became "half the drawn span" for the legibility gate — correct for the gate,
+    and it silently moved the arrow with it: a radius leader pointed halfway between the
+    centre and the arc, into the bore void, on a case that was previously right. Halving
+    the gate value also doubled the traffic onto that path.
+
+    Two records describing the SAME circle must put the arrow in the same place.
+    """
+
+    def _tip_offset(self, kind, value):
+        from draftwright.annotations.from_model import _bore_span_offsets
+
+        _lo, hi = _bore_span_offsets(kind, value)
+        return hi
+
+    def test_the_same_circle_gives_the_same_tip_offset(self):
+        # r=3 and ø6 are one circle. The arrow lands on the surface either way.
+        assert self._tip_offset("radius", 3.0) == self._tip_offset("diameter", 6.0) == 3.0
+
+    def test_two_records_for_one_circle_draw_the_same_leader(self):
+        # The integration guard, because the unit test above does NOT catch the bug: it
+        # asserts `_bore_span_offsets` is right, and the defect was in the CONSUMER three
+        # lines below it, which stopped using `hi`. Reverting the tip to the gate value
+        # passes every offset assertion and moves this leader 1.5 mm.
+        #
+        # r=3 and ø6 describe the same circle. At scale 1 the drawn span is 3 mm, below the
+        # 4 mm in-place gate, so both take the LEADER path — which is exactly the path the
+        # regression doubled the traffic onto.
+        from build123d import Box
+
+        from draftwright import Sheet
+
+        def leader_extent(kind, value):
+            sheet = Sheet(Box(60, 60, 20), title="T", number="T-1", page="A3", scale=1)
+            sheet.measured_dimension(
+                kind=kind,
+                value=value,
+                label=f"X{value:g}",
+                dominant_axis="z",
+                ref_pts=((0, 0, 0), (0, 0, 10)),
+                ref_bbox=(-3, -3, 0, 3, 3, 10),
+            )
+            sheet.authored_dimensions()
+            drawing = sheet.build()
+            leaders = [
+                o
+                for n, o in drawing.iter_annotations()
+                if n.startswith("pmi_") and getattr(o, "elbow", None) is not None
+            ]
+            assert leaders, f"{kind} {value} produced no leader; the gate no longer routes here"
+            box = leaders[0].bounding_box()
+            return round(box.min.Y, 2)
+
+        assert leader_extent("radius", 3.0) == leader_extent("diameter", 6.0), (
+            "the radius leader points somewhere other than the bore surface"
+        )
+
+    def test_the_tip_offset_is_the_bore_radius_not_half_the_span(self):
+        # The regression, stated directly: for a radius the drawn span is `value` so half
+        # of it is `value / 2`, which is NOT where the surface is.
+        from draftwright.annotations.from_model import _bore_span_offsets
+
+        lo, hi = _bore_span_offsets("radius", 8.0)
+        assert (hi - lo) / 2 == 4.0, "the drawn span is still value long"
+        assert hi == 8.0, "the surface is at the full radius"
+        assert hi != (hi - lo) / 2, "gate and tip must not share one value for a radius"

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -374,6 +374,38 @@ class TestTheRadiusLeaderPointsAtTheSurface:
             "the radius leader points somewhere other than the bore surface"
         )
 
+    def test_a_bracketed_bore_draws_its_labelled_length(self):
+        # The OTHER branch. `half_span_pg >= 4` brackets the dimension in place instead of
+        # leading out, and that is the path #1208 actually fixed — yet the leader test
+        # above never reaches it, so the span the fix corrected was uncovered. A radius of
+        # 20 at 1:1 brackets; before #1208 it drew 40.
+        from build123d import Box
+
+        from draftwright import Sheet
+
+        def drawn(kind, value):
+            sheet = Sheet(Box(120, 120, 20), title="T", number="T-1", page="A2", scale=1)
+            sheet.measured_dimension(
+                kind=kind,
+                value=value,
+                label=f"X{value:g}",
+                dominant_axis="z",
+                ref_pts=((0, 0, 0), (0, 0, 10)),
+                ref_bbox=(-20, -20, 0, 20, 20, 10),
+            )
+            sheet.authored_dimensions()
+            drawing = sheet.build()
+            spans = [
+                o.measured_length
+                for n, o in drawing.iter_annotations()
+                if n.startswith("pmi_") and getattr(o, "measured_length", None) is not None
+            ]
+            assert spans, f"{kind} {value} did not bracket in place"
+            return round(spans[0], 3)
+
+        assert drawn("radius", 20.0) == 20.0, "a radius still draws twice its value"
+        assert drawn("diameter", 40.0) == 40.0, "a diameter no longer spans the bore"
+
     def test_the_tip_offset_is_the_bore_radius_not_half_the_span(self):
         # The regression, stated directly: for a radius the drawn span is `value` so half
         # of it is `value / 2`, which is NOT where the surface is.


### PR DESCRIPTION
Follow-up to #1207, which is already merged. Its fourth adversarial review found that the
`radius` fix folded into it (#1208) shipped a **silent geometry regression**.

## The defect

`half` was redefined from "the bore radius" to "half the drawn span" for the legibility
gate — correct for the gate. The leader's arrow tip read the same variable three lines
below:

| | radius 3 | diameter 6 |
|---|---|---|
| `main` (before #1207) | tip at centre **+3** | tip at centre +3 |
| #1207 as merged | tip at centre **+1.5** | tip at centre +3 |

Both records describe the same circle. The radius leader now points **halfway between the
centre and the arc**, into the bore void — on a case `main` got right.

Halving the gate value also moved the bracket threshold for radius from `value ≥ 4` to
`value ≥ 8`, **doubling the traffic onto the now-wrong path**. Nothing lints it.

Reachable from real AP242 — `pmi.py` maps XCAF enums 17/18 to `radius`. Invisible here only
because no CTC fixture carries a radius record, which is the same argument #1207 makes for
the four kinds it refuses.

## The fix

Two names, because they are two quantities: `half_span_pg` for the gate, `surface_pg` for
the tip. `surface_pg` is `hi` — the bore radius for **both** kinds.

## Why my own test missed it

The unit test I added with #1208 asserts `_bore_span_offsets` returns the right offsets.
The defect was in the **consumer**. Reverting the tip passes every offset assertion and the
whole 4,169-test suite. The guard is now an integration test: r=3 and ø6 must draw the same
leader — mutation-confirmed.

## Also fixed

* **A fourth stale claim in #1207.** The source comment still described #1208 in the present
  tense and named `_bore_half_span`, a function that PR deleted. Two further comments still
  described the pre-#1208 symmetric span.
* **The `_EXPLAINED_OMISSION_CODES` invariant guarded the wrong half.** The earlier
  regression had two symptoms — `geometry_issues: 0` (a count) and `passed: True` (a
  severity). The invariant checked membership of `_GEOMETRY_AWARE_CODES` — the count —
  while its comment claimed a fourth suppressor "cannot quietly downgrade its sources".
  A suppressor added at unconditional `warning` satisfied it and still flipped `passed`.
  Mutation-confirmed both ways.

`scripts/pr-check --static` exit 0; **4169 passed**, 5 skipped, 2 xfailed.