### PR TITLE
Ask whether the drawing is true, not only whether it is readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
   (legibility) — none asked whether it is correct, so a drawing labelled 99 over a 16 mm
   path reported a perfect score on every component available to it. Also covers a callout
   drawn for a feature the part does not have, and a gear data table stating a tooth count
-  the geometry contradicts (#1176).
+  the geometry contradicts — the last of which reports `passed: True` and clean severity
+  counts, so it is invisible to every other channel. Each `quality` component reports
+  `available: False` with a `reason` rather than a flattering number when it has no
+  evidence, and every lint code the engine emits is now classified onto exactly one
+  component or an explicit unscored register, audited fail-closed (#1176).
 
 - Recogniser co-development now has a one-command, wheel-based two-checkout check; an exact
   registry-release evidence record; automated dependency PR preparation; and documented landing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
   the geometry contradicts — the last of which reports `passed: True` and clean severity
   counts, so it is invisible to every other channel. Each `quality` component reports
   `available: False` with a `reason` rather than a flattering number when it has no
-  evidence, and every lint code the engine emits is now classified onto exactly one
-  component or an explicit unscored register, audited fail-closed (#1176).
+  evidence, and every lint code the engine emits is classified onto exactly one component or
+  an explicit unscored register. `quality["unscored"]` reports the findings that reached no
+  component at all, and flags any whose classification nobody made — a `section_dropped` was
+  found scoring on nothing while a comment beside its emission said the opposite (#1176).
 
 - Recogniser co-development now has a one-command, wheel-based two-checkout check; an exact
   registry-release evidence record; automated dependency PR preparation; and documented landing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@
   (legibility) — none asked whether it is correct, so a drawing labelled 99 over a 16 mm
   path reported a perfect score on every component available to it. Also covers a callout
   drawn for a feature the part does not have, and a gear data table stating a tooth count
-  the geometry contradicts — the last of which reports `passed: True` and clean severity
-  counts, so it is invisible to every other channel. Each `quality` component reports
-  `available: False` with a `reason` rather than a flattering number when it has no
-  evidence, and every lint code the engine emits is classified onto exactly one component or
-  an explicit unscored register. `quality["unscored"]` reports the findings that reached no
-  component at all, and flags any whose classification nobody made — a `section_dropped` was
-  found scoring on nothing while a comment beside its emission said the opposite (#1176).
+  the geometry contradicts — the last of which reports `passed: True` and zero errors, so
+  the only existing channel that names it is `by_code`. Completeness, restraint and fidelity
+  report `available: False` with a `reason` rather than a flattering number when they have no
+  evidence, and every lint code the engine emits is classified onto exactly one component,
+  an explicit unscored register, or a register of codes whose component depends on the
+  issue's `outcome_stage`. `quality["unscored"]` reports the findings that reached no
+  component at all and flags any whose classification nobody made — `section_dropped` was
+  found scoring on nothing while a comment beside its emission said the opposite, and eleven
+  more `*_dropped` codes reach the engine as `drop_code` data with the same shape (#1176).
 
 - Recogniser co-development now has a one-command, wheel-based two-checkout check; an exact
   registry-release evidence record; automated dependency PR preparation; and documented landing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- `lint_summary()["quality"]` gains a fourth component, `fidelity`: whether what the drawing
+  says is TRUE. The existing three ask whether required content landed (completeness),
+  whether there is too much of it (restraint), and whether a reader can make it out
+  (legibility) — none asked whether it is correct, so a drawing labelled 99 over a 16 mm
+  path reported a perfect score on every component available to it. Also covers a callout
+  drawn for a feature the part does not have, and a gear data table stating a tooth count
+  the geometry contradicts (#1176).
+
 - Recogniser co-development now has a one-command, wheel-based two-checkout check; an exact
   registry-release evidence record; automated dependency PR preparation; and documented landing,
   compatibility, deprecation, rollback, ownership, and CI-budget rules. Dependency PRs retain the

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ legibility = crit["quality"]["legibility"]
 # `quality` also carries `fidelity` (#1176): is what the drawing says TRUE? A drawing can
 # be complete, restrained and legible and still assert a measurement the part lacks.
 fidelity = crit["quality"]["fidelity"]
+# …and `unscored`, the findings no component priced, so four components reading "fine"
+# cannot conceal that some of the critique was scored by nothing.
+unscored = crit["quality"]["unscored"]
 # Raw pair findings remain available and keep the original count semantics.
 legibility["warnings"], legibility["by_code"], crit["issues"]
 # The legibility scalar uses primary issues: one affected annotation/failure mechanism even

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ assert completeness["scope"] == "audited_recognized_requirements"
 completeness["excludes"]                     # what the denominator cannot see
 completeness["unrecognised_geometry_reports"]  # a floor on that gap, never a measure
 legibility = crit["quality"]["legibility"]
+# `quality` also carries `fidelity` (#1176): is what the drawing says TRUE? A drawing can
+# be complete, restrained and legible and still assert a measurement the part lacks.
+fidelity = crit["quality"]["fidelity"]
 # Raw pair findings remain available and keep the original count semantics.
 legibility["warnings"], legibility["by_code"], crit["issues"]
 # The legibility scalar uses primary issues: one affected annotation/failure mechanism even

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -79,10 +79,11 @@ same iterate-and-fix laps — with no fluency in draftwright internals required.
   coverage gaps, not just drops. Blind spots become silent failures.
 - The legacy `score` is only a severity-weighted diagnostic heuristic. `diagnostic_score`
   exposes the same value under its honest name; callers should gate on severity/code counts
-  and inspect `quality.completeness`, `quality.restraint`, `quality.legibility` and `quality.fidelity`
-separately (#1176 added fidelity: whether what the drawing says is TRUE, which the other
-three do not ask — a drawing can be complete, restrained and legible and still assert a
-measurement the part does not have).
+  and inspect `quality.completeness`, `quality.restraint`, `quality.legibility` and
+  `quality.fidelity` separately. #1176 added fidelity: whether what the drawing says is
+  TRUE, which the other three do not ask — a drawing can be complete, restrained and
+  legible while a normative gear table prints twelve teeth on a thirteen-tooth part, and
+  `passed` stays True.
   Components state when their evidence is partial or unavailable, and no composite
   drawing-quality score is provided. Completeness is deliberately conditional on requirements
   Draftwright recognized and can audit; it reports that scope and any recognized-but-unscored

--- a/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
+++ b/docs/adr/0002-iterate-via-lint-critique-and-domain-repair.md
@@ -79,7 +79,10 @@ same iterate-and-fix laps — with no fluency in draftwright internals required.
   coverage gaps, not just drops. Blind spots become silent failures.
 - The legacy `score` is only a severity-weighted diagnostic heuristic. `diagnostic_score`
   exposes the same value under its honest name; callers should gate on severity/code counts
-  and inspect `quality.completeness`, `quality.restraint`, and `quality.legibility` separately.
+  and inspect `quality.completeness`, `quality.restraint`, `quality.legibility` and `quality.fidelity`
+separately (#1176 added fidelity: whether what the drawing says is TRUE, which the other
+three do not ask — a drawing can be complete, restrained and legible and still assert a
+measurement the part does not have).
   Components state when their evidence is partial or unavailable, and no composite
   drawing-quality score is provided. Completeness is deliberately conditional on requirements
   Draftwright recognized and can audit; it reports that scope and any recognized-but-unscored

--- a/docs/reference/step-analysis-evaluation.md
+++ b/docs/reference/step-analysis-evaluation.md
@@ -104,7 +104,8 @@ requirements the current recognition run already found, so it can diagnose downs
 cannot measure physical recall. The independent corpus can measure recall but cannot certify an
 arbitrary production part or a rendered sheet. Keep the feature census descriptive, use this
 evaluation for regression/coverage claims, and use lint codes plus separate drawing completeness,
-restraint, and legibility components for a drawing decision.
+restraint, legibility, and fidelity components for a drawing decision (#1176 added
+fidelity: whether what the drawing says is true, which the other three do not ask).
 
 ## API
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -286,7 +286,7 @@ crit = dwg.lint_summary()
 #    "issues": [{code, severity, message, suggestion?}, ...],
 #    "quality": {"completeness": …, "restraint": …, "legibility": …, "fidelity": …,
 #                "unscored": {"available": True, "score": None, "issues": n,
-#                             "by_code": {…}, "unclassified": [...]}}}
+#                             "by_code": {…}, "unclassified": [...], "reason": …}}}
 # Gate on the severity/code COUNTS, not the scalar score.
 #
 # The four `quality` components answer four different questions and none substitutes for

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -290,8 +290,10 @@ crit = dwg.lint_summary()
 #
 # The four `quality` components answer four different questions and none substitutes for
 # another: did required content land, is there too much of it, can a reader make it out,
-# and — `fidelity` — is what it says TRUE. Each reports `available: False` with a `reason`
-# rather than a flattering number when it has no evidence, so read `available` first.
+# and — `fidelity` — is what it says TRUE. Completeness, restraint and fidelity report
+# `available: False` with a `reason` rather than a flattering number when they have no
+# evidence, so read `available` first. (Legibility is always available: an empty sheet
+# genuinely IS legible, which is not the same kind of 1.0 as an empty sheet being truthful.)
 # `quality["unscored"]` lists the findings none of the four priced; a non-empty
 # `unclassified` there means a lint code reached no component and nobody decided it should.
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -285,7 +285,8 @@ crit = dwg.lint_summary()
 #    "errors": n, "warnings": n, "infos": n, "by_code": {code: n},
 #    "issues": [{code, severity, message, suggestion?}, ...],
 #    "quality": {"completeness": …, "restraint": …, "legibility": …, "fidelity": …,
-#                "unscored": {"issues": n, "by_code": {…}, "unclassified": [...]}}}
+#                "unscored": {"available": True, "score": None, "issues": n,
+#                             "by_code": {…}, "unclassified": [...]}}}
 # Gate on the severity/code COUNTS, not the scalar score.
 #
 # The four `quality` components answer four different questions and none substitutes for

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -284,13 +284,16 @@ crit = dwg.lint_summary()
 #   {"passed": bool, "score": 0..1, "diagnostic_score": 0..1,
 #    "errors": n, "warnings": n, "infos": n, "by_code": {code: n},
 #    "issues": [{code, severity, message, suggestion?}, ...],
-#    "quality": {"completeness": …, "restraint": …, "legibility": …, "fidelity": …}}
+#    "quality": {"completeness": …, "restraint": …, "legibility": …, "fidelity": …,
+#                "unscored": {"issues": n, "by_code": {…}, "unclassified": [...]}}}
 # Gate on the severity/code COUNTS, not the scalar score.
 #
 # The four `quality` components answer four different questions and none substitutes for
 # another: did required content land, is there too much of it, can a reader make it out,
 # and — `fidelity` — is what it says TRUE. Each reports `available: False` with a `reason`
 # rather than a flattering number when it has no evidence, so read `available` first.
+# `quality["unscored"]` lists the findings none of the four priced; a non-empty
+# `unclassified` there means a lint code reached no component and nobody decided it should.
 
 # 2. Each issue names the problem in DOMAIN terms and (when computable) carries a
 #    ready-to-apply suggestion — a domain-API call you paste in, not page maths.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -281,9 +281,16 @@ dwg = build_drawing(part)
 
 # 1. Critique — the machine channel. JSON-friendly aggregate of lint().
 crit = dwg.lint_summary()
-#   {"passed": bool, "score": 0..1, "errors": n, "warnings": n, "infos": n,
-#    "by_code": {code: n}, "issues": [{code, severity, message, suggestion?}, ...]}
+#   {"passed": bool, "score": 0..1, "diagnostic_score": 0..1,
+#    "errors": n, "warnings": n, "infos": n, "by_code": {code: n},
+#    "issues": [{code, severity, message, suggestion?}, ...],
+#    "quality": {"completeness": …, "restraint": …, "legibility": …, "fidelity": …}}
 # Gate on the severity/code COUNTS, not the scalar score.
+#
+# The four `quality` components answer four different questions and none substitutes for
+# another: did required content land, is there too much of it, can a reader make it out,
+# and — `fidelity` — is what it says TRUE. Each reports `available: False` with a `reason`
+# rather than a flattering number when it has no evidence, so read `available` first.
 
 # 2. Each issue names the problem in DOMAIN terms and (when computable) carries a
 #    ready-to-apply suggestion — a domain-API call you paste in, not page maths.

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -464,9 +464,16 @@ def _skip_section(dwg, ctx, reason: str, detail: str, *, severity: str = "warnin
     on its own — the title-block case at INFO, the no-room case at WARNING — so the
     same omission was visible on one part and invisible on another, and nothing
     reached `lint_summary` at all. A section is the only view showing internal
-    profile, so its loss is a `section_dropped` lint issue (the `*_dropped` suffix
-    puts it in the legibility inventory automatically) AND a structured record on the
-    drawing, which is what a caller can actually branch on.
+    profile, so its loss is a `section_dropped` lint issue AND a structured record on
+    the drawing, which is what a caller can actually branch on.
+
+    That issue is **not** in any quality component, and this comment claimed the
+    opposite until #1176 measured it: the `*_dropped` suffix routes to legibility only
+    where `outcome_stage` is unset, and the explicit `"validation"` below takes
+    precedence (`linting/issues.py::is_placement_drop`). The stage is the right choice
+    for the reason given next; the consequence is that a lost section shows up in
+    `lint()` and in `section_decision`, and in no score. `quality.py::_UNSCORED_CODES`
+    now records that rather than leaving it to be rediscovered.
 
     Deliberately NOT an ``outcome_stage="placement"`` drop. That stage marks a
     *required* outcome, so `builder._is_required_scale_drop` turns it into a scale

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3252,7 +3252,7 @@ class Drawing:
         - ``passed`` — no error-severity issues;
         - ``score`` — legacy coarse 0–1 diagnostic heuristic (see ``_SCORE_*``);
         - ``diagnostic_score`` — the same value under its honest name;
-        - ``quality`` — separable completeness, restraint, and legibility components. No
+        - ``quality`` — separable completeness, restraint, legibility and fidelity components. No
           composite drawing-quality score is manufactured (#1127). Legibility's existing
           severity/code counts are raw findings; its ``primary_*`` counts and scalar group
           producer-identified pair findings by annotation and failure mechanism (#1147);
@@ -3295,6 +3295,13 @@ class Drawing:
             registry=self._registry,
             omissions=self._build.omissions,
             issues=issues,
+            # Fidelity asks whether what the drawing SAYS is true, so a drawing that says
+            # nothing measurable has no answer rather than a perfect one.
+            has_asserted_content=any(
+                getattr(item, "measured_length", None) is not None
+                or getattr(item, "label_bbox", None) is not None
+                for item in self.items
+            ),
             error_penalty=_SCORE_ERROR_PENALTY,
             warning_penalty=_SCORE_WARNING_PENALTY,
             _aggregation=aggregation,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -74,6 +74,7 @@ from draftwright.linting import (
     CoverageState,
     LintIssue,
     _suggest_fix,
+    is_dimension_like,
     lint_axial_coverage,
     lint_boss_height_coverage,
     lint_channel_coverage,
@@ -3297,9 +3298,19 @@ class Drawing:
             issues=issues,
             # Fidelity asks whether what the drawing SAYS is true, so a drawing that says
             # nothing measurable has no answer rather than a perfect one.
+            #
+            # The predicate is exactly "a measured quantity is drawn", the domain of
+            # `label_vs_measured`; the four declaration-vs-geometry codes need no gate of
+            # their own because a component that HAS a finding overrides unavailability
+            # inside `_issue_component`. The first cut asked instead whether any item had a
+            # `label_bbox` — true of a title block — so it answered "this sheet has text on
+            # it" and was decided by whether an ISO-view caption happened to be emitted,
+            # which then discarded a real `declared_feature_absent` (#1176 review r3).
+            # The gear data table is the second checkable assertion: its rows ARE what
+            # `gear_repeat_count_mismatch` contradicts, so a sheet carrying one says
+            # something measurable even when it draws no dimension.
             has_asserted_content=any(
-                getattr(item, "measured_length", None) is not None
-                or getattr(item, "label_bbox", None) is not None
+                is_dimension_like(item) or getattr(item, "gear_requirement_rows", None)
                 for item in self.items
             ),
             error_penalty=_SCORE_ERROR_PENALTY,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -71,6 +71,7 @@ from draftwright.export import (
 from draftwright.intents import Intent
 from draftwright.layout import FitBoxTrace, fit_box
 from draftwright.linting import (
+    EXAMINABLE_DECLARED_KINDS,
     CoverageState,
     LintIssue,
     _suggest_fix,
@@ -3299,22 +3300,28 @@ class Drawing:
             # Fidelity asks whether what the drawing SAYS is true, so a drawing that says
             # nothing measurable has no answer rather than a perfect one.
             #
-            # The two terms are the domains of the five truth-class checks:
-            # `label_vs_measured` needs a drawn measured quantity, and the four
-            # declaration-vs-geometry codes need a DECLARED feature to check against the
-            # part. A drawing satisfying neither has nothing this axis could examine.
+            # The two terms are the domains of the five truth-class checks: a drawn measured
+            # quantity for `label_vs_measured`, and a declared feature of a kind some check
+            # actually EXAMINES for the other four — `EXAMINABLE_DECLARED_KINDS`, owned by
+            # `linting/coverage.py` beside the check that uses it.
             #
-            # Two earlier cuts got this wrong in opposite directions. The first asked
+            # Three earlier cuts got this wrong in three different ways. The first asked
             # whether any item had a `label_bbox` — true of a title block — so it meant
             # "this sheet has text on it", and it discarded a real `declared_feature_absent`
-            # (#1176 review r3). The second narrowed to drawn measurements alone, and then
-            # reported "the drawing asserts no measurable content" over a sheet carrying a
-            # ⌀6 THRU callout whose declaration `declared_feature_absent` had just checked
-            # and passed — a clean answer thrown away for the same reason the first threw
-            # away a false one (review r4).
+            # (#1176 review r3). The second narrowed to drawn measurements alone and then
+            # reported "asserts no measurable content" over a ⌀6 THRU callout whose
+            # declaration had just been checked and passed (r4). The third accepted ANY
+            # declared feature, so a declared slot — which no truth check looks at — was
+            # certified "nothing false said" by a drawing that said nothing (r5).
             has_asserted_content=(
                 any(is_dimension_like(item) for item in self.items)
-                or bool(self._model_declared and getattr(self._part_model, "features", ()))
+                or (
+                    self._model_declared
+                    and any(
+                        getattr(f, "kind", None) in EXAMINABLE_DECLARED_KINDS
+                        for f in getattr(self._part_model, "features", ())
+                    )
+                )
             ),
             error_penalty=_SCORE_ERROR_PENALTY,
             warning_penalty=_SCORE_WARNING_PENALTY,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3299,19 +3299,22 @@ class Drawing:
             # Fidelity asks whether what the drawing SAYS is true, so a drawing that says
             # nothing measurable has no answer rather than a perfect one.
             #
-            # The predicate is exactly "a measured quantity is drawn", the domain of
-            # `label_vs_measured`; the four declaration-vs-geometry codes need no gate of
-            # their own because a component that HAS a finding overrides unavailability
-            # inside `_issue_component`. The first cut asked instead whether any item had a
-            # `label_bbox` — true of a title block — so it answered "this sheet has text on
-            # it" and was decided by whether an ISO-view caption happened to be emitted,
-            # which then discarded a real `declared_feature_absent` (#1176 review r3).
-            # The gear data table is the second checkable assertion: its rows ARE what
-            # `gear_repeat_count_mismatch` contradicts, so a sheet carrying one says
-            # something measurable even when it draws no dimension.
-            has_asserted_content=any(
-                is_dimension_like(item) or getattr(item, "gear_requirement_rows", None)
-                for item in self.items
+            # The two terms are the domains of the five truth-class checks:
+            # `label_vs_measured` needs a drawn measured quantity, and the four
+            # declaration-vs-geometry codes need a DECLARED feature to check against the
+            # part. A drawing satisfying neither has nothing this axis could examine.
+            #
+            # Two earlier cuts got this wrong in opposite directions. The first asked
+            # whether any item had a `label_bbox` — true of a title block — so it meant
+            # "this sheet has text on it", and it discarded a real `declared_feature_absent`
+            # (#1176 review r3). The second narrowed to drawn measurements alone, and then
+            # reported "the drawing asserts no measurable content" over a sheet carrying a
+            # ⌀6 THRU callout whose declaration `declared_feature_absent` had just checked
+            # and passed — a clean answer thrown away for the same reason the first threw
+            # away a false one (review r4).
+            has_asserted_content=(
+                any(is_dimension_like(item) for item in self.items)
+                or bool(self._model_declared and getattr(self._part_model, "features", ()))
             ),
             error_penalty=_SCORE_ERROR_PENALTY,
             warning_penalty=_SCORE_WARNING_PENALTY,

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from draftwright.linting.channel_coverage import lint_channel_coverage
 from draftwright.linting.coverage import (
+    EXAMINABLE_DECLARED_KINDS,
     CoverageState,
     lint_axial_coverage,
     lint_boss_height_coverage,
@@ -46,6 +47,7 @@ from draftwright.linting.suggest import _suggest_fix
 
 __all__ = [
     "CoverageState",
+    "EXAMINABLE_DECLARED_KINDS",
     "LintIssue",
     "is_dimension_like",
     "lint_hole_coverage",

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -41,12 +41,13 @@ from draftwright.linting.pmi_coverage import (
 from draftwright.linting.polygonal_stock_coverage import lint_polygonal_stock_coverage
 from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
 from draftwright.linting.slot_coverage import lint_slot_coverage
-from draftwright.linting.structural import lint_drawing
+from draftwright.linting.structural import is_dimension_like, lint_drawing
 from draftwright.linting.suggest import _suggest_fix
 
 __all__ = [
     "CoverageState",
     "LintIssue",
+    "is_dimension_like",
     "lint_hole_coverage",
     "lint_polygonal_stock_coverage",
     "_suggest_fix",

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -74,11 +74,21 @@ _RECON_EXTERNAL = {"hole": False, "boss": True, "step": True}
 _RECON_KINDS = tuple(_RECON_EXTERNAL)  # derive to keep the kind list and polarity map in sync
 
 #: Declared feature kinds any TRUTH check can examine against the geometry — this module's
-#: `_RECON_KINDS` plus the profiled bores it also confirms, plus the gear the gear-coverage
-#: module reconciles. Exported because `lint_summary`'s fidelity component must know whether
-#: a declaration is examinable at all, and re-listing the kinds there let it report "checked,
-#: nothing false" over a declared slot no check looks at (#1176 review r5). One owner.
-EXAMINABLE_DECLARED_KINDS = (*_RECON_KINDS, "double_d_bore", "external_spur_gear")
+#: `_RECON_KINDS`, plus the gear that `gear_coverage` reconciles. Exported because
+#: `lint_summary`'s fidelity component must know whether a declaration is examinable at all,
+#: and re-listing the kinds there let it report "checked, nothing false" over a declared slot
+#: no check looks at (#1176 review r5).
+#:
+#: A first cut also listed ``"double_d_bore"``. There is no such `kind`: `declare.double_d_bore`
+#: returns a `HoleFeature`, and `lint_declaration_reconciliation` reaches it as
+#: ``kind == "hole" and profile == "double_d"``. Dead data, and the docstring's "plus the
+#: profiled bores" described a distinction the tuple did not make (#1176 review r6).
+#:
+#: `_RECON_KINDS` is derived; ``"external_spur_gear"`` is a literal that must match
+#: `gear_coverage`'s own filter. A new gear kind there would narrow this silently — in the
+#: fail-CLOSED direction, and the `bool(issues)` override in `quality.py` catches the
+#: consequence, so it is a real seam rather than a hazard.
+EXAMINABLE_DECLARED_KINDS = (*_RECON_KINDS, "external_spur_gear")
 
 
 def _dim_vertices(ann) -> list[tuple[float, float]]:

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -73,6 +73,13 @@ _RECON_POS_TOL = 0.5
 _RECON_EXTERNAL = {"hole": False, "boss": True, "step": True}
 _RECON_KINDS = tuple(_RECON_EXTERNAL)  # derive to keep the kind list and polarity map in sync
 
+#: Declared feature kinds any TRUTH check can examine against the geometry — this module's
+#: `_RECON_KINDS` plus the profiled bores it also confirms, plus the gear the gear-coverage
+#: module reconciles. Exported because `lint_summary`'s fidelity component must know whether
+#: a declaration is examinable at all, and re-listing the kinds there let it report "checked,
+#: nothing false" over a declared slot no check looks at (#1176 review r5). One owner.
+EXAMINABLE_DECLARED_KINDS = (*_RECON_KINDS, "double_d_bore", "external_spur_gear")
+
 
 def _dim_vertices(ann) -> list[tuple[float, float]]:
     """A ``Dimension``'s witness endpoints as ``(x, y)`` page points; ``[]`` if they

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -248,11 +248,14 @@ _UNSCORED_CODES = frozenset(
 #: can check rather than assume. It found `section_dropped` scoring nowhere while a comment
 #: beside its emission asserted the opposite.
 #:
-#: The eleven below `pmi_dropped` are every code handed to a leader job as ``drop_code``
-#: data: `leaders.py`'s one drop recorder stages them ``"validation"`` on a rendered-geometry
-#: failure and ``"placement"`` otherwise, so all eleven have the `section_dropped` shape.
-#: They were invisible to the first audit, which only read codes written as literals AT a
-#: producer call — passing the code in as an argument hid ten of them (#1176 review r5).
+#: Eleven of these — every entry except `gdt_dropped` and `pmi_dropped` — are codes handed
+#: to a leader job as ``drop_code`` data: `leaders.py`'s one drop recorder stages them
+#: ``"validation"`` on a rendered-geometry failure and ``"placement"`` otherwise, so all
+#: eleven have the `section_dropped` shape. They were invisible to the first audit, which
+#: read only codes written as literals AT a producer call; ten of the eleven were new to the
+#: registers, `callout_dropped` having already been here (#1176 review r5). The first version
+#: of this note said "the eleven below `pmi_dropped`", which is ten, and put `callout_dropped`
+#: in the wrong place to make the arithmetic work (review r6).
 _STAGE_ROUTED_CODES = frozenset(
     {
         "callout_dropped",

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -5,6 +5,9 @@ quality verdict.  This module exposes the independently observable terms without
 them into another blessed scalar:
 
 - completeness follows recognition-owned physical requirements to compiler outcomes;
+- fidelity asks whether the content the drawing DOES carry is contradicted by the geometry
+  it is drawn from — a drawing can be complete, restrained and legible and still assert a
+  measurement, a callout or a data-table value the part does not have (#1176);
 - legibility contains only placement/layout diagnostics. Its compatibility counts remain raw
   lint findings, while its score and ``primary_*`` counts collapse only producer-identified
   pair observations from one annotation and failure mechanism;
@@ -128,17 +131,42 @@ _UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
 #:
 #: This is a fourth axis, and its absence was a hole the other three could not cover. A
 #: drawing labelled 99 over a 16 mm path — a 518% contradiction — reported
-#: ``legibility: 1.0``, because legibility scores LAYOUT (its own basis field says
-#: ``layout_issue_severity_with_info_floor``) and a false dimension is perfectly legible.
-#: With completeness and restraint both unavailable on that drawing, 1.0 was the only
-#: number a caller saw (#1176).
+#: ``legibility: 1.0``, because legibility scores LAYOUT and a false dimension is perfectly
+#: legible. With completeness and restraint unavailable on that drawing, every component a
+#: caller could read said perfect (#1176).
 #:
-#: ``label_vs_measured`` is currently the only such code: it fires when a dimension's label
-#: disagrees with the geometry it is drawn on, which is the one finding that makes a
-#: drawing actively misleading rather than merely imperfect (#1153). Codes for content that
-#: was NOT drawn — ``dimension_kind_unsupported``, the ``*_dropped`` family — belong to
-#: completeness, not here: an omission is a gap, not a lie.
-_FIDELITY_CODES = frozenset({"label_vs_measured"})
+#: The first cut of this set held ``label_vs_measured`` alone and claimed it was "currently
+#: the only such code". That was false, and the two reproductions are worse than the case
+#: it was built for:
+#:
+#: * ``declared_feature_absent`` — a ``⌀6 THRU`` leader and a centre mark drawn pointing at
+#:   SOLID MATERIAL, because the declared hole is not in the part. The sheet tells a
+#:   machinist to drill something the model does not have.
+#: * ``gear_repeat_count_mismatch`` — a normative ISO data table stating 12 teeth on a part
+#:   the linter independently proves has 13. The wrong number is printed on the sheet.
+#:
+#: ``gear_axis_mismatch`` and ``gear_requirement_mismatch`` (a table preserving stale
+#: authored values) are the same shape: placed content contradicted by the geometry or by
+#: the declaration it claims to carry.
+#:
+#: What stays OUT is content that was not drawn — ``dimension_kind_unsupported``, the
+#: ``*_dropped`` family, the ``*_missing`` family. An omission is a gap, not a lie. Note
+#: this is a statement about what fidelity means, not about where those codes go instead:
+#: most of them score on NO component at all (see :func:`quality_components`).
+#:
+#: Hand-maintained, and that is a known weakness — nine lines below,
+#: :data:`_LEGIBILITY_CODES` argues for a suffix rule precisely because "a list has to be
+#: remembered". There is no suffix that means "false", so this list must be, and a new
+#: truth-class code will score as perfectly truthful until somebody adds it.
+_FIDELITY_CODES = frozenset(
+    {
+        "label_vs_measured",
+        "declared_feature_absent",
+        "gear_repeat_count_mismatch",
+        "gear_axis_mismatch",
+        "gear_requirement_mismatch",
+    }
+)
 
 
 def _is_fidelity_issue(issue) -> bool:
@@ -171,10 +199,24 @@ def _primary_issues(issues, aggregation=None) -> list[LintIssue]:
 
 
 def _issue_component(
-    issues, *, error_penalty: float, warning_penalty: float, aggregation=None
+    issues,
+    *,
+    error_penalty: float,
+    warning_penalty: float,
+    aggregation=None,
+    basis: str = "layout_issue_severity_with_info_floor",
+    available: bool = True,
+    unavailable_reason: str | None = None,
 ) -> dict:
     # Compatibility fields remain raw lint-finding counts. Only the scalar penalty uses the
     # explicitly grouped primary inventory; both inventories are exposed and documented.
+    if not available:
+        # Same contract as an unavailable completeness or restraint component: no evidence
+        # is DATA, not a perfect score. Fidelity affirming "nothing false was said" over a
+        # drawing that says nothing is the fail-open this module's own docstring argues
+        # against — and unlike legibility, where an empty sheet genuinely is legible,
+        # truthfulness of an empty utterance is not the same kind of 1.0.
+        return {"available": False, "score": None, "reason": unavailable_reason}
     errors = sum(issue.severity == "error" for issue in issues)
     warnings = sum(issue.severity == "warning" for issue in issues)
     infos = sum(issue.severity == "info" for issue in issues)
@@ -219,7 +261,7 @@ def _issue_component(
         ),
         # Keep the established basis value: severity and the info floor did not change.
         # This additive field names the inventory to which that basis is now applied.
-        "basis": "layout_issue_severity_with_info_floor",
+        "basis": basis,
         "score_inventory": "primary_issues",
     }
 
@@ -320,6 +362,7 @@ def quality_components(
     issues,
     error_penalty: float,
     warning_penalty: float,
+    has_asserted_content: bool = True,
     _aggregation=None,
 ) -> dict:
     """Return independently usable drawing-quality observations.
@@ -368,6 +411,11 @@ def quality_components(
             error_penalty=error_penalty,
             warning_penalty=warning_penalty,
             aggregation=_aggregation,
+            basis="asserted_content_contradicted_by_geometry",
+            available=has_asserted_content,
+            unavailable_reason=(
+                None if has_asserted_content else "the drawing asserts no measurable content"
+            ),
         ),
     }
 

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -149,9 +149,12 @@ _UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
 #: authored values) join them, and the membership rule has to be stated carefully because
 #: three of the five are *declaration*-vs-geometry checks that never inspect what was
 #: placed. What makes them belong is that the drawing does place something FOR the
-#: declaration: an absent hole gets its ``⌀6 THRU`` leader, and a gear feature gets a data
-#: table bound to it by provenance (``registry.names_for_feature`` — the reconciliation
-#: fails as ``gear_requirement_missing`` when there is not exactly one). A table whose
+#: declaration: an absent hole gets a centre mark, and on the automatic path a ``⌀6 THRU``
+#: leader as well (the authored path draws the mark alone — the check is
+#: declaration-vs-geometry and never inspects what landed, so it fires either way); and a
+#: gear feature gets a data table bound to it by provenance (``registry.names_for_feature``
+#: — the reconciliation fails as ``gear_requirement_missing`` when there is not exactly
+#: one). A table whose
 #: declared axis the geometry contradicts is describing a feature the part does not have
 #: there, exactly as the leader is. That the axis has no printed row does not make the table
 #: silent about it, any more than the leader prints the hole's coordinates.
@@ -215,6 +218,14 @@ _UNSCORED_CODES = frozenset(
         "pmi_not_rendered",
         "pmi_present_but_ignored",
         "pocket_not_located",
+        # A `_dropped` code that scores NOWHERE, which is why the suffix cannot be trusted
+        # on its own. `is_placement_drop` consults `outcome_stage` FIRST and only falls back
+        # to the suffix, and every `_skip_section` emission is `outcome_stage="validation"`
+        # — a deliberate choice, because a placement stage would make an optional section's
+        # absence a scale blocker. So the section-A–A loss reaches no component (#1176
+        # review r4). `sections.py` said the opposite four lines above the call that makes
+        # it false; that comment is corrected.
+        "section_dropped",
         "profiled_bore_not_dimensioned",
         "unrecognised_defining_geometry",
     }
@@ -228,6 +239,22 @@ _UNSCORED_CODES = frozenset(
 #: ``gear_requirement_mismatch`` is a fidelity code. The audit classifies every literal code
 #: individually, so the prefix register governs only the interpolating sites — it can never
 #: reclassify a code somebody spelled out.
+#: `_dropped` codes whose component depends on the ISSUE, not the code: emitted with
+#: ``outcome_stage="placement"`` at one site and ``"validation"`` at another, so the same code
+#: scores on legibility for one instance and on nothing for the next.
+#:
+#: Registered because the audit's "a `_dropped` suffix means legibility" shortcut is only
+#: true where no site sets a validation stage, and that is an assumption about code the audit
+#: can check rather than assume. It found `section_dropped` scoring nowhere while a comment
+#: beside its emission asserted the opposite.
+_STAGE_ROUTED_CODES = frozenset(
+    {
+        "callout_dropped",
+        "gdt_dropped",
+        "pmi_dropped",
+    }
+)
+
 _UNSCORED_CODE_PREFIXES = (
     "channel_requirement_",
     "flat_requirement_",
@@ -242,7 +269,54 @@ def _is_fidelity_issue(issue) -> bool:
     return issue.code in _FIDELITY_CODES
 
 
+def _is_unscored_issue(issue) -> bool:
+    return not _is_legibility_issue(issue) and not _is_fidelity_issue(issue)
+
+
+def _unscored_component(issues) -> dict:
+    """The findings NO quality component scored, as data (#1176 review r4).
+
+    Reported for the same reason completeness reports ``excludes``: a caller reading four
+    components all saying "fine" would otherwise have no way to see that a third of this
+    drawing's findings reached none of them. 25 of the engine's codes score nowhere, and
+    before this the only record of that was a comment.
+
+    ``unclassified`` is the fail-open signal made visible. A code here that is not in
+    :data:`_UNSCORED_CODES` reached no component AND nobody decided it should — which is
+    precisely how a new truth-class code would be silently reported as perfectly truthful.
+    The audit in ``tests/test_issue_1176_quality_fidelity.py`` catches that statically over
+    every code the engine can emit; this catches it at runtime, over the ones it just did.
+    """
+    unscored = [issue for issue in issues if _is_unscored_issue(issue)]
+    by_code = Counter(issue.code for issue in unscored)
+    return {
+        "issues": len(unscored),
+        "by_code": dict(sorted(by_code.items())),
+        "unclassified": sorted(
+            code
+            for code in by_code
+            if code not in _UNSCORED_CODES
+            and not code.startswith(_UNSCORED_CODE_PREFIXES)
+            and code not in _STAGE_ROUTED_CODES
+        ),
+        "reason": "reported by lint and deliberately scored on no quality component",
+    }
+
+
 def _is_legibility_issue(issue) -> bool:
+    """Whether *issue* is a layout defect this component should price.
+
+    Fidelity codes are excluded OUTRIGHT rather than merely being absent from
+    :data:`_LEGIBILITY_CODES`. `is_placement_drop` accepts any issue carrying
+    ``outcome_stage="placement"`` whatever its code, so a truth defect that also reported a
+    placement outcome would be penalised on both axes and make two independent observations
+    look correlated. Comparing the two SETS cannot prevent that, and the guard that claimed
+    to was inert because its probe left `outcome_stage` at its `None` default (#1176 review
+    r4). The precedence is stated here instead, where it is a fact about the code rather
+    than about the registers.
+    """
+    if _is_fidelity_issue(issue):
+        return False
     return issue.code in _LEGIBILITY_CODES or is_placement_drop(issue)
 
 
@@ -500,8 +574,12 @@ def quality_components(
             aggregation=_aggregation,
             basis="drawn_assertion_contradicted_by_its_source",
             available=has_asserted_content,
-            unavailable_reason="the drawing asserts no measurable content",
+            unavailable_reason=(
+                "the drawing states nothing this axis can check: no measured quantity is "
+                "drawn and no feature is declared"
+            ),
         ),
+        "unscored": _unscored_component(issues),
     }
 
 

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -123,6 +123,27 @@ _EXCLUDES = (
 # was noticed, not that nothing was missed.
 _UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
 
+#: Codes meaning the drawing ASSERTS SOMETHING FALSE — not that it is incomplete, hard to
+#: read, or over-dimensioned, but that a reader following it would be misled.
+#:
+#: This is a fourth axis, and its absence was a hole the other three could not cover. A
+#: drawing labelled 99 over a 16 mm path — a 518% contradiction — reported
+#: ``legibility: 1.0``, because legibility scores LAYOUT (its own basis field says
+#: ``layout_issue_severity_with_info_floor``) and a false dimension is perfectly legible.
+#: With completeness and restraint both unavailable on that drawing, 1.0 was the only
+#: number a caller saw (#1176).
+#:
+#: ``label_vs_measured`` is currently the only such code: it fires when a dimension's label
+#: disagrees with the geometry it is drawn on, which is the one finding that makes a
+#: drawing actively misleading rather than merely imperfect (#1153). Codes for content that
+#: was NOT drawn — ``dimension_kind_unsupported``, the ``*_dropped`` family — belong to
+#: completeness, not here: an omission is a gap, not a lie.
+_FIDELITY_CODES = frozenset({"label_vs_measured"})
+
+
+def _is_fidelity_issue(issue) -> bool:
+    return issue.code in _FIDELITY_CODES
+
 
 def _is_legibility_issue(issue) -> bool:
     return issue.code in _LEGIBILITY_CODES or is_placement_drop(issue)
@@ -310,6 +331,13 @@ def quality_components(
     denominator ``excludes`` — a feature recognition never identified is absent from the
     ledger entirely, so a perfect audited score is not a complete drawing.
 
+    The four axes answer different questions and none substitutes for another:
+    completeness asks whether required content landed, restraint whether there is too much
+    of it, legibility whether a reader can make it out, and **fidelity whether what it says
+    is true**. A drawing can be complete, restrained and legible while asserting a
+    measurement the part does not have, and before fidelity existed that combination scored
+    perfect on the only component available (#1176).
+
     Legibility's ``errors``/``warnings``/``infos``/``by_code`` fields retain their original
     raw-finding semantics. ``primary_*`` fields describe the inventory used by ``score``;
     ``affected_pairs`` is the number of raw pair findings that opted into that aggregation.
@@ -317,6 +345,7 @@ def quality_components(
     """
 
     legibility_issues = [issue for issue in issues if _is_legibility_issue(issue)]
+    fidelity_issues = [issue for issue in issues if _is_fidelity_issue(issue)]
     return {
         "completeness": _completeness_component(
             recognition, features, registry, omissions, issues
@@ -330,6 +359,12 @@ def quality_components(
         },
         "legibility": _issue_component(
             legibility_issues,
+            error_penalty=error_penalty,
+            warning_penalty=warning_penalty,
+            aggregation=_aggregation,
+        ),
+        "fidelity": _issue_component(
+            fidelity_issues,
             error_penalty=error_penalty,
             warning_penalty=warning_penalty,
             aggregation=_aggregation,

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -66,9 +66,12 @@ _LEGIBILITY_CODES = frozenset(
 # recognised by their ``*_dropped`` suffix rather than by a listed vocabulary. A list has to
 # be remembered; the suffix cannot be forgotten, so a drop code introduced tomorrow counts
 # against legibility on the day it is introduced instead of scoring as perfectly legible
-# until somebody notices (#1127 review). The two codes that cannot be read off their suffix
-# (``gdt_dropped``/``pmi_dropped``, which cover validation failures too) carry an explicit
-# ``outcome_stage`` from their producers instead; see ``is_placement_drop``.
+# until somebody notices (#1127 review). Codes that cannot be read off their suffix carry an
+# explicit ``outcome_stage`` from their producers instead (see ``is_placement_drop``); there
+# were two when this was written and there are fourteen now, enumerated in
+# :data:`_STAGE_ROUTED_CODES` and :data:`_UNSCORED_CODES` — and the suffix shortcut turned
+# out to be exactly as forgettable as the list it replaced, because nothing checked that the
+# suffix still meant what it says.
 
 # Recognition inventories that represent potentially dimension-bearing physical families.
 _RECOGNISED_REQUIREMENT_FAMILIES = {
@@ -190,10 +193,15 @@ _FIDELITY_CODES = frozenset(
 #: Nothing here is a bug by itself. Most are omissions — completeness's territory, and it
 #: builds its ledger from requirement outcomes rather than from lint codes, so it never
 #: reads this. What the register buys is the property the three sets could not have
-#: separately: the union of fidelity, legibility and this is exactly the set of codes the
-#: engine emits, audited by ``tests/test_issue_1176_quality_fidelity.py``. A new truth-class
-#: code would otherwise score as perfectly truthful and nothing would say so — the failure
-#: mode the ``_FIDELITY_CODES`` note above admits to and, before this, only admitted to.
+#: separately: every code the engine emits is in fidelity, legibility, this, or
+#: :data:`_STAGE_ROUTED_CODES`, or carries a ``*_dropped`` suffix that no producer overrides
+#: with a validation stage — audited over the source by
+#: ``tests/test_issue_1176_quality_fidelity.py``. A new truth-class code would otherwise
+#: score as perfectly truthful and nothing would say so — the failure mode the
+#: ``_FIDELITY_CODES`` note above admits to and, before this, only admitted to.
+#:
+#: Stated that carefully because the first version of this sentence claimed the union was
+#: "exactly the set of codes the engine emits", which was 41 against 55 (#1176 review r5).
 #:
 #: Membership is not an endorsement: several of these arguably SHOULD score somewhere, and
 #: this register is what makes that visible instead of implicit.
@@ -231,6 +239,38 @@ _UNSCORED_CODES = frozenset(
     }
 )
 
+#: `_dropped` codes whose component depends on the ISSUE, not the code — emitted with
+#: ``outcome_stage="placement"`` at one site and ``"validation"`` at another, so the same code
+#: scores on legibility for one instance and on nothing for the next.
+#:
+#: Registered because the audit's "a `_dropped` suffix means legibility" shortcut is only
+#: true where no site sets a validation stage, and that is an assumption about code the audit
+#: can check rather than assume. It found `section_dropped` scoring nowhere while a comment
+#: beside its emission asserted the opposite.
+#:
+#: The eleven below `pmi_dropped` are every code handed to a leader job as ``drop_code``
+#: data: `leaders.py`'s one drop recorder stages them ``"validation"`` on a rendered-geometry
+#: failure and ``"placement"`` otherwise, so all eleven have the `section_dropped` shape.
+#: They were invisible to the first audit, which only read codes written as literals AT a
+#: producer call — passing the code in as an argument hid ten of them (#1176 review r5).
+_STAGE_ROUTED_CODES = frozenset(
+    {
+        "callout_dropped",
+        "gdt_dropped",
+        "pmi_dropped",
+        "boss_dia_dropped",
+        "chamfer_dropped",
+        "diameter_dropped",
+        "fillet_dropped",
+        "flat_dropped",
+        "groove_dropped",
+        "pocket_dropped",
+        "polygonal_boss_dropped",
+        "polygonal_stock_dropped",
+        "slot_dropped",
+    }
+)
+
 #: Code FAMILIES built by interpolating a requirement state (``hole_requirement_missing``,
 #: ``…_suppressed``, ``…_unverifiable``). Registered by prefix because the state comes from a
 #: `Literal` alias rather than a literal at the call site.
@@ -239,22 +279,6 @@ _UNSCORED_CODES = frozenset(
 #: ``gear_requirement_mismatch`` is a fidelity code. The audit classifies every literal code
 #: individually, so the prefix register governs only the interpolating sites — it can never
 #: reclassify a code somebody spelled out.
-#: `_dropped` codes whose component depends on the ISSUE, not the code: emitted with
-#: ``outcome_stage="placement"`` at one site and ``"validation"`` at another, so the same code
-#: scores on legibility for one instance and on nothing for the next.
-#:
-#: Registered because the audit's "a `_dropped` suffix means legibility" shortcut is only
-#: true where no site sets a validation stage, and that is an assumption about code the audit
-#: can check rather than assume. It found `section_dropped` scoring nowhere while a comment
-#: beside its emission asserted the opposite.
-_STAGE_ROUTED_CODES = frozenset(
-    {
-        "callout_dropped",
-        "gdt_dropped",
-        "pmi_dropped",
-    }
-)
-
 _UNSCORED_CODE_PREFIXES = (
     "channel_requirement_",
     "flat_requirement_",
@@ -278,7 +302,8 @@ def _unscored_component(issues) -> dict:
 
     Reported for the same reason completeness reports ``excludes``: a caller reading four
     components all saying "fine" would otherwise have no way to see that a third of this
-    drawing's findings reached none of them. 25 of the engine's codes score nowhere, and
+    drawing's findings reached none of them. Twenty-two of the engine's codes score nowhere
+    unconditionally, and another thirteen do whenever their producer stages them, and
     before this the only record of that was a comment.
 
     ``unclassified`` is the fail-open signal made visible. A code here that is not in
@@ -290,6 +315,12 @@ def _unscored_component(issues) -> dict:
     unscored = [issue for issue in issues if _is_unscored_issue(issue)]
     by_code = Counter(issue.code for issue in unscored)
     return {
+        # `available`/`score` so a caller can walk `quality.values()` uniformly. This is an
+        # inventory, not a fifth axis: it is always computable, and it is deliberately not a
+        # number — pricing "how much went unscored" would be a fifth score nobody asked for
+        # (#1176 review r5, which found `for c in quality.values(): c["available"]` raising).
+        "available": True,
+        "score": None,
         "issues": len(unscored),
         "by_code": dict(sorted(by_code.items())),
         "unclassified": sorted(
@@ -359,8 +390,15 @@ def _issue_component(
     # predicate is an approximation of the checks' domains, while the finding is the check
     # having fired. The first cut let the argument win, and a `declared_feature_absent` on a
     # 20 mm box was reported as `{available: False, score: None}`: the gate fell closed over
-    # a detected falsehood, which is worse than the fail-open it was added to remove (#1176
-    # review r3).
+    # a detected falsehood (#1176 review r3).
+    #
+    # A FAIL-SAFE, not a live branch: once the predicate covers the checks' domains, an issue
+    # cannot arise while it is False, so no drawing reaches this line with work to do. Kept
+    # because the predicate has drifted from those domains three times in this issue's
+    # review history, and this is the difference between a drift that misreports and a drift
+    # that loses a finding. Guarded by a direct test of this function rather than through
+    # `lint_summary()` for exactly that reason — a consumer-level test of it would have to
+    # reproduce the drift it exists to survive (#1176 review r5).
     available = available or bool(issues)
     errors = sum(issue.severity == "error" for issue in issues)
     warnings = sum(issue.severity == "warning" for issue in issues)

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -251,11 +251,12 @@ _UNSCORED_CODES = frozenset(
 #: Eleven of these — every entry except `gdt_dropped` and `pmi_dropped` — are codes handed
 #: to a leader job as ``drop_code`` data: `leaders.py`'s one drop recorder stages them
 #: ``"validation"`` on a rendered-geometry failure and ``"placement"`` otherwise, so all
-#: eleven have the `section_dropped` shape. They were invisible to the first audit, which
-#: read only codes written as literals AT a producer call; ten of the eleven were new to the
-#: registers, `callout_dropped` having already been here (#1176 review r5). The first version
-#: of this note said "the eleven below `pmi_dropped`", which is ten, and put `callout_dropped`
-#: in the wrong place to make the arithmetic work (review r6).
+#: eleven have the `section_dropped` shape. TEN of them were invisible to the first audit,
+#: which read only codes written as literals AT a producer call, and were new to these
+#: registers; `callout_dropped` is the eleventh and was neither — it is also written as a
+#: literal at three producer calls, so the audit always saw it (#1176 review r5, corrected
+#: twice: the first note said "the eleven below `pmi_dropped`", which is ten, and the second
+#: still said all eleven had been invisible).
 _STAGE_ROUTED_CODES = frozenset(
     {
         "callout_dropped",

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -146,8 +146,19 @@ _UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
 #:   the linter independently proves has 13. The wrong number is printed on the sheet.
 #:
 #: ``gear_axis_mismatch`` and ``gear_requirement_mismatch`` (a table preserving stale
-#: authored values) are the same shape: placed content contradicted by the geometry or by
-#: the declaration it claims to carry.
+#: authored values) join them, and the membership rule has to be stated carefully because
+#: three of the five are *declaration*-vs-geometry checks that never inspect what was
+#: placed. What makes them belong is that the drawing does place something FOR the
+#: declaration: an absent hole gets its ``⌀6 THRU`` leader, and a gear feature gets a data
+#: table bound to it by provenance (``registry.names_for_feature`` — the reconciliation
+#: fails as ``gear_requirement_missing`` when there is not exactly one). A table whose
+#: declared axis the geometry contradicts is describing a feature the part does not have
+#: there, exactly as the leader is. That the axis has no printed row does not make the table
+#: silent about it, any more than the leader prints the hole's coordinates.
+#:
+#: Hence the basis is "contradicted by its SOURCE", not "by the geometry": the source is the
+#: part for four of the five, and the authored requirement for ``gear_requirement_mismatch``,
+#: where the sheet's table has drifted from the values it claims to carry.
 #:
 #: What stays OUT is content that was not drawn — ``dimension_kind_unsupported``, the
 #: ``*_dropped`` family, the ``*_missing`` family. An omission is a gap, not a lie. Note
@@ -156,8 +167,9 @@ _UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
 #:
 #: Hand-maintained, and that is a known weakness — nine lines below,
 #: :data:`_LEGIBILITY_CODES` argues for a suffix rule precisely because "a list has to be
-#: remembered". There is no suffix that means "false", so this list must be, and a new
-#: truth-class code will score as perfectly truthful until somebody adds it.
+#: remembered". There is no suffix that means "false", so this list must be. What keeps it
+#: from rotting silently is :data:`_UNSCORED_CODES`: every code the engine emits is in
+#: exactly one of the three, and a new one fails the audit until somebody classifies it.
 _FIDELITY_CODES = frozenset(
     {
         "label_vs_measured",
@@ -166,6 +178,63 @@ _FIDELITY_CODES = frozenset(
         "gear_axis_mismatch",
         "gear_requirement_mismatch",
     }
+)
+
+
+#: Every lint code that scores on NO quality component, named so that a new one cannot
+#: arrive unclassified (#1176 review r3).
+#:
+#: Nothing here is a bug by itself. Most are omissions — completeness's territory, and it
+#: builds its ledger from requirement outcomes rather than from lint codes, so it never
+#: reads this. What the register buys is the property the three sets could not have
+#: separately: the union of fidelity, legibility and this is exactly the set of codes the
+#: engine emits, audited by ``tests/test_issue_1176_quality_fidelity.py``. A new truth-class
+#: code would otherwise score as perfectly truthful and nothing would say so — the failure
+#: mode the ``_FIDELITY_CODES`` note above admits to and, before this, only admitted to.
+#:
+#: Membership is not an endorsement: several of these arguably SHOULD score somewhere, and
+#: this register is what makes that visible instead of implicit.
+_UNSCORED_CODES = frozenset(
+    {
+        "authored_dim_degenerate",
+        "authored_omission",
+        "axial_length_missing",
+        "boss_height_missing",
+        "dimension_kind_unsupported",
+        "feature_count_mismatch",
+        "feature_no_centermark",
+        "feature_not_dimensioned",
+        "feature_not_located",
+        "gdt_side_relaxed",
+        "gear_correspondence_unverifiable",
+        "gear_semantics_missing",
+        "missing_principal_dimension",
+        "pad_footprint_not_defined",
+        "pmi_not_extracted",
+        "pmi_not_lowered",
+        "pmi_not_rendered",
+        "pmi_present_but_ignored",
+        "pocket_not_located",
+        "profiled_bore_not_dimensioned",
+        "unrecognised_defining_geometry",
+    }
+)
+
+#: Code FAMILIES built by interpolating a requirement state (``hole_requirement_missing``,
+#: ``…_suppressed``, ``…_unverifiable``). Registered by prefix because the state comes from a
+#: `Literal` alias rather than a literal at the call site.
+#:
+#: Coarser than the sets above, deliberately: ``gear_requirement_`` appears here AND
+#: ``gear_requirement_mismatch`` is a fidelity code. The audit classifies every literal code
+#: individually, so the prefix register governs only the interpolating sites — it can never
+#: reclassify a code somebody spelled out.
+_UNSCORED_CODE_PREFIXES = (
+    "channel_requirement_",
+    "flat_requirement_",
+    "gear_requirement_",
+    "hole_requirement_",
+    "polygonal_stock_requirement_",
+    "slot_requirement_",
 )
 
 
@@ -210,13 +279,15 @@ def _issue_component(
 ) -> dict:
     # Compatibility fields remain raw lint-finding counts. Only the scalar penalty uses the
     # explicitly grouped primary inventory; both inventories are exposed and documented.
-    if not available:
-        # Same contract as an unavailable completeness or restraint component: no evidence
-        # is DATA, not a perfect score. Fidelity affirming "nothing false was said" over a
-        # drawing that says nothing is the fail-open this module's own docstring argues
-        # against — and unlike legibility, where an empty sheet genuinely is legible,
-        # truthfulness of an empty utterance is not the same kind of 1.0.
-        return {"available": False, "score": None, "reason": unavailable_reason}
+    #
+    # An issue OUTRANKS the availability argument. Unavailability means "no evidence either
+    # way", so a component that HAS a finding is by definition available — and the caller's
+    # predicate is an approximation of the checks' domains, while the finding is the check
+    # having fired. The first cut let the argument win, and a `declared_feature_absent` on a
+    # 20 mm box was reported as `{available: False, score: None}`: the gate fell closed over
+    # a detected falsehood, which is worse than the fail-open it was added to remove (#1176
+    # review r3).
+    available = available or bool(issues)
     errors = sum(issue.severity == "error" for issue in issues)
     warnings = sum(issue.severity == "warning" for issue in issues)
     infos = sum(issue.severity == "info" for issue in issues)
@@ -227,12 +298,14 @@ def _issue_component(
     primary_warnings = sum(issue.severity == "warning" for issue in primary)
     primary_infos = sum(issue.severity == "info" for issue in primary)
     primary_by_code = Counter(issue.code for issue in primary)
-    return {
+    component = {
         "available": True,
-        # Every issue reaching here is a legibility defect by construction, so info severity
-        # takes the warning floor too. Lint uses it for "place what fits" drops and for
-        # readability faults like a leader crossing a silhouette; either way the component
-        # cannot report 1.0 while itemising output it has just called unreadable (#1127).
+        # Info severity takes the WARNING floor: an issue reaching here is a defect in the
+        # axis being scored, and the component cannot report 1.0 while itemising a finding it
+        # has just made. Lint uses `info` for "place what fits" drops and readability faults
+        # like a leader crossing a silhouette (#1127), and — since #1176 — for every gear
+        # reconciliation in an ASSEMBLY context (`gear_coverage.py`), where a data table
+        # contradicting the geometry is no less false for the part having siblings.
         "score": max(
             0.0,
             1.0
@@ -264,6 +337,20 @@ def _issue_component(
         "basis": basis,
         "score_inventory": "primary_issues",
     }
+    if available:
+        return component
+    # Same contract as an unavailable completeness or restraint component: no evidence is
+    # DATA, not a perfect score. Fidelity affirming "nothing false was said" over a drawing
+    # that says nothing is the fail-open this module's own docstring argues against — and
+    # unlike legibility, where an empty sheet genuinely is legible, the truthfulness of an
+    # empty utterance is not the same kind of 1.0.
+    #
+    # The SHAPE is kept whole, unlike completeness's `_empty_completeness`, because this one
+    # is the second dict under a key whose first (`legibility`) is always available: a caller
+    # that reads `quality["fidelity"]["by_code"]` the way README reads legibility's must get
+    # an empty mapping, not a `KeyError`. Every count is genuinely zero here — an issue would
+    # have made the component available two lines above.
+    return {**component, "available": False, "score": None, "reason": unavailable_reason}
 
 
 def _empty_completeness(reason: str, unrecognised: int) -> dict:
@@ -362,7 +449,7 @@ def quality_components(
     issues,
     error_penalty: float,
     warning_penalty: float,
-    has_asserted_content: bool = True,
+    has_asserted_content: bool,
     _aggregation=None,
 ) -> dict:
     """Return independently usable drawing-quality observations.
@@ -411,11 +498,9 @@ def quality_components(
             error_penalty=error_penalty,
             warning_penalty=warning_penalty,
             aggregation=_aggregation,
-            basis="asserted_content_contradicted_by_geometry",
+            basis="drawn_assertion_contradicted_by_its_source",
             available=has_asserted_content,
-            unavailable_reason=(
-                None if has_asserted_content else "the drawing asserts no measurable content"
-            ),
+            unavailable_reason="the drawing asserts no measurable content",
         ),
     }
 

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -128,6 +128,21 @@ def _item_label(item) -> str:
     return getattr(item, "label", "") or getattr(item, "_annotate_label", "") or ""
 
 
+def is_dimension_like(item) -> bool:
+    """Whether *item* states a measured quantity — the ONE dimension-like predicate.
+
+    :func:`lint_structural` dispatches its label-vs-measured and dim-inside-part checks on
+    exactly this, so a caller asking "does this drawing assert anything measurable?" gets the
+    same answer the check that would contradict it uses. Spelling it a second time in
+    ``drawing.py`` is what let the quality gate read ``label_bbox`` — text presence on ANY
+    annotation, a title block included — and call it asserted content (#1176 review r3).
+
+    Deliberately narrow: ``measured_length`` is a plain attribute on the helper's dimension
+    types, so this needs none of :func:`_label_bbox`'s raising-property discipline.
+    """
+    return getattr(item, "measured_length", None) is not None
+
+
 def _label_bbox(item, warned=None):
     """``item.label_bbox`` or ``None`` — a raising property on a user-supplied
     duck-typed item cannot kill lint; it is logged (once per item), not swallowed

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -131,11 +131,17 @@ def _item_label(item) -> str:
 def is_dimension_like(item) -> bool:
     """Whether *item* states a measured quantity — the ONE dimension-like predicate.
 
-    :func:`lint_structural` dispatches its label-vs-measured and dim-inside-part checks on
-    exactly this, so a caller asking "does this drawing assert anything measurable?" gets the
-    same answer the check that would contradict it uses. Spelling it a second time in
-    ``drawing.py`` is what let the quality gate read ``label_bbox`` — text presence on ANY
-    annotation, a title block included — and call it asserted content (#1176 review r3).
+    :func:`lint_drawing` dispatches its label-vs-measured and dim-inside-part checks through
+    this, and so does the principal-dimension sweep below, so a caller asking "does this
+    drawing assert anything measurable?" gets the same answer as the check that would
+    contradict it. Spelling it a second time in ``drawing.py`` is what let the quality gate
+    read ``label_bbox`` — text presence on ANY annotation, a title block included — and call
+    it asserted content (#1176 review r3).
+
+    Both dispatch sites call it. Naming a shared predicate and leaving its callers spelling
+    the condition out is the same defect one step further back: it would make a change here
+    silently stop matching what lint actually does, which is exactly what the paragraph above
+    is about (#1176 review r4).
 
     Deliberately narrow: ``measured_length`` is a plain attribute on the helper's dimension
     types, so this needs none of :func:`_label_bbox`'s raising-property discipline.
@@ -353,7 +359,7 @@ def lint_drawing(
     for item in items:
         if getattr(item, "elbow", None) is not None:
             _lint_leader(item, issues, box_cache, warned=warned_label_bbox)
-        elif getattr(item, "measured_length", None) is not None:
+        elif is_dimension_like(item):
             _lint_dim(item, part_bbox, issues, drawing_scale, box_cache)
 
     # Pairwise label-overlap check. The compare-box for a label-less item is an
@@ -479,7 +485,7 @@ def lint_drawing(
     if part_bbox is not None:
         covered: set[float] = set()
         for item in items:
-            if getattr(item, "measured_length", None) is not None:
+            if is_dimension_like(item):
                 val = _label_value(_item_label(item))
                 if val is not None:
                     covered.add(val)

--- a/tests/test_issue_1147_legibility_pair_aggregation.py
+++ b/tests/test_issue_1147_legibility_pair_aggregation.py
@@ -32,6 +32,10 @@ def _legibility(issues, aggregation=None):
         issues=issues,
         error_penalty=0.15,
         warning_penalty=0.05,
+        # Irrelevant to the component under test; `quality_components` requires it rather
+        # than defaulting to True, because a fail-open default that only tests supply is a
+        # default that only tests are protected by (#1176 review r3).
+        has_asserted_content=True,
         _aggregation=aggregation,
     )["legibility"]
 

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -334,7 +334,8 @@ class TestPlacedContentContradictedByGeometryIsAlsoFalse:
         # earlier comment here claimed the authored path "draws NOTHING for the absent hole,
         # so nothing false reaches the sheet". Measured, that is wrong twice: the authored
         # path still draws a `CenterMark` at the phantom hole, and fidelity still drops to
-        # 0.95 there (`test_a_finding_outranks_the_availability_gate` uses exactly that).
+        # 0.95 there (`test_a_declared_falsehood_with_nothing_drawn_is_still_scored` uses
+        # exactly that).
         # `declared_feature_absent` is a declaration-vs-geometry check that never inspects
         # what was placed, so the difference between the paths is how loudly the sheet
         # states the lie, not whether the check fires.
@@ -531,13 +532,21 @@ def _producer_aliases(trees) -> dict[str, str]:
     (#1176 review r6). Simple assignment aliases (`_mk = LintIssue`) are followed too,
     iterated so a chain resolves.
 
-    **The limit, stated rather than implied**: a producer reached through anything this
-    cannot name — an attribute of an object, a `functools.partial`, a dict entry, a subclass
-    — is invisible, and unlike an unreadable `code` argument there is nothing to count,
-    because the walk cannot tell such a call from any other call in the package. So "every
-    code the engine emits is classified" holds for producers spelled as themselves or bound
-    to a name; it is not a proof against a determined author. What it is proof against is the
-    accident, which is what has actually happened five times.
+    **The limit, measured rather than asserted.** Attribute access is *not* a blind spot when
+    the attribute is named after a producer: `mod.LintIssue(...)` and `ctx.record_issue(...)`
+    are both matched on the attribute name, and the latter is the only way `record_issue` is
+    ever reached. What IS invisible: a `functools.partial`, a dict entry, a subclass, and —
+    measured while writing this — an annotated binding (`_mk: object = LintIssue`) or a
+    tuple-unpack binding, neither of which this function follows. There is nothing to count
+    for any of them, because the walk cannot tell such a call from any other call in the
+    package.
+
+    So "every code the engine emits is classified" holds for producers spelled as themselves,
+    reached as an attribute of that name, or bound by a plain assignment. It is not a proof
+    against a determined author. What it is proof against is the accident, which is what has
+    actually happened six times. The first version of this paragraph claimed one gap that is
+    not one and missed two that are (#1176 re-check) — which is the failure mode this whole
+    slice is about, in the paragraph written to be honest about limits.
     """
     aliases: dict[str, str] = {}
     for tree in trees.values():
@@ -662,6 +671,26 @@ def _emitted_codes(sources=None):
     for path, tree in trees.items():
         rel = path.relative_to(root)
         for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                # A `drop_code` DEFAULT is a lint code too. The walk read call keywords only,
+                # so introducing a code as a forwarding helper's default hid it in exactly the
+                # way a module constant did one round earlier — and the shape already exists
+                # (`holes.py` carries `drop_code=None` defaults on two staged forwarders), so
+                # changing one to a string is the accident this guards (#1176 re-check).
+                args = node.args
+                positional = [*args.posonlyargs, *args.args]
+                pairs = [
+                    *zip(positional[len(positional) - len(args.defaults) :], args.defaults),
+                    *zip(args.kwonlyargs, args.kw_defaults),
+                ]
+                for arg, default in pairs:
+                    if arg.arg != "drop_code" or default is None:
+                        continue
+                    if isinstance(default, ast.Constant) and isinstance(default.value, str):
+                        record(default, rel, "<staged>" if node.name in recorders else None)
+                    elif not isinstance(default, ast.Constant):
+                        indirect.append(f"{rel}:{default.lineno}")
+                continue
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
@@ -672,6 +701,9 @@ def _emitted_codes(sources=None):
                 # "no code here".
                 indirect.append(f"{rel}:{node.lineno}")
                 continue
+            if name in recorders and any(k.arg is None for k in node.keywords):
+                # `_leader_callout_pass(..., **{"drop_code": …})` — unreadable, so counted.
+                indirect.append(f"{rel}:{node.lineno}")
             drop = next((k for k in node.keywords if k.arg == "drop_code"), None)
             if drop is not None:
                 if isinstance(drop.value, ast.Constant):
@@ -873,6 +905,26 @@ class TestTheAuditCannotBeSmuggledPast:
         )
         assert "smuggled_drop" in literals
         assert stages["smuggled_drop"] == {"<staged>"}
+
+    def test_a_drop_code_in_a_parameter_default_is_seen(self):
+        # The same class as the module constant one round earlier: the walk read call
+        # KEYWORDS only, so a code introduced as a forwarding helper's default was in neither
+        # register. The shape already exists — `holes.py` carries `drop_code=None` defaults on
+        # two staged forwarders, so changing one to a string is the accident (#1176 re-check).
+        literals, _indirect, stages = self._codes(
+            "def _probe(dwg, a, jobs, ctx, drop_code='x_dropped'):\n"
+            "    return _leader_callout_pass(dwg, a, jobs, drop_code=drop_code, ctx=ctx)\n"
+        )
+        assert "x_dropped" in literals
+        assert stages["x_dropped"] == {"<staged>"}
+
+    def test_a_splatted_drop_code_is_counted(self):
+        # `_leader_callout_pass(..., **{"drop_code": …})`. The `**kwargs` guard covered the
+        # three producers and not the recorders.
+        _literals, indirect, _stages = self._codes(
+            '_leader_callout_pass(dwg, a, jobs, **{"drop_code": "y_dropped"}, ctx=ctx)\n'
+        )
+        assert indirect, "a splatted recorder call passed as 'no code here'"
 
     def test_a_drop_code_held_in_a_constant_is_counted(self):
         # `drop_code` was recorded only when it was a literal; a `Name` was used to grow the

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -49,11 +49,12 @@ from draftwright.linting.structural import is_dimension_like as _is_dimension_li
 
 _REFS = ((0, -25, 0), (0, -9, 0))  # a 16 mm span
 
-#: Producer call sites that forward a code held in a variable, so the AST walk cannot read
-#: the string. Shrink-only. Seven, down from the first cut's ten once conditional
-#: expressions were walked to their leaves; six are the pass-through parameters of the drop
-#: recorders in `annotations/`, and the seventh is `Drawing._record_build_issue` forwarding
-#: its own argument.
+#: Producer call sites where the code is held in a variable the AST walk cannot resolve.
+#: Shrink-only — a new one has to be argued rather than silently widening the blind spot.
+#:
+#: The count is measured, not described: earlier comments here miscounted what the sites
+#: were, which is its own small instance of this issue's failure mode. Assert on the number;
+#: run the test to see the list.
 _INDIRECT_PRODUCER_SITES = 7
 
 
@@ -140,6 +141,66 @@ class TestFidelityIsReportedSeparately:
         assert component["basis"] == available["basis"], (
             "an unavailable component must still say WHAT it would have measured"
         )
+
+    def test_a_detected_drawing_that_dimensions_the_part_is_answerable(self):
+        # The `is_dimension_like` half of the predicate, which nothing exercised: deleting it
+        # passed the entire 4,214-test tier, because every other fixture here reaches
+        # availability through the DECLARED half (#1176 review r5). A detected build declares
+        # nothing, so only the drawn dimensions can make this answerable.
+        from draftwright.builder import build_drawing
+
+        drawing = build_drawing(Box(60, 40, 20), title="T", number="N-1")
+        assert not drawing.model_declared, "the fixture must reach availability the other way"
+        assert any(_is_dimension_like(item) for _n, item in drawing.iter_annotations())
+        component = drawing.lint_summary()["quality"]["fidelity"]
+        assert component["available"] is True and component["score"] == 1.0
+
+    def test_a_declaration_no_truth_check_examines_is_not_certified(self):
+        # The predicate accepted ANY declared feature, so a declared slot — which
+        # `declared_feature_absent` does not look at (`_RECON_KINDS`) and no gear check
+        # touches — was reported as "checked, nothing false" by a drawing that drew nothing
+        # (#1176 review r5). That is the fail-open this module's docstring forbids, reached
+        # from the opposite side to round 3's fail-closed.
+        sheet = Sheet(Box(80, 60, 20), title="T", number="N-1", page="A2")
+        sheet.slot(
+            width=6,
+            length=20,
+            long_axis="x",
+            width_axis="y",
+            depth_axis="z",
+            w_center=0,
+            lo=-10,
+            hi=10,
+            at=(0, 0, 10),
+        )
+        sheet.authored_dimensions()
+        drawing = sheet.build()
+        assert drawing.model_declared and drawing.model().features, (
+            "the fixture must declare something, or it proves nothing about the second term"
+        )
+        component = drawing.lint_summary()["quality"]["fidelity"]
+        assert component["available"] is False and component["score"] is None
+
+    def test_a_finding_always_outranks_the_availability_gate(self):
+        # A direct test of `_issue_component`, deliberately. The override is a FAIL-SAFE
+        # against the predicate drifting from the checks' domains — which has happened three
+        # times in this issue's review history — so a consumer-level test would have to
+        # reproduce the drift it exists to survive. Round 4's consumer-level attempt did not:
+        # widening the predicate made its fixture available by the other term, and deleting
+        # the override then passed the whole tier while the test's comment said otherwise.
+        from draftwright.linting.issues import LintIssue
+        from draftwright.linting.quality import _issue_component
+
+        component = _issue_component(
+            [LintIssue(severity="error", code="label_vs_measured", message="m")],
+            error_penalty=0.2,
+            warning_penalty=0.05,
+            available=False,
+            unavailable_reason="the caller said there was nothing to check",
+        )
+        assert component["available"] is True, "a detected falsehood was discarded unscored"
+        assert component["score"] < 1.0
+        assert component["by_code"] == {"label_vs_measured": 1}
 
     def test_a_finding_outranks_the_availability_gate(self):
         # The gate must never DISCARD a falsehood. This drawing draws no measured quantity,
@@ -295,7 +356,10 @@ class TestFidelityIsAboutFalsehoodNotAbsence:
         assert component["by_code"] == {}, (
             "refusing to draw something was scored as drawing something false"
         )
-        assert component["score"] == 1.0
+        # And the refusal leaves nothing this axis can examine: no measured quantity is
+        # drawn, and a `measured_dimension` declaration is not a feature any truth check
+        # looks at. "No answer" rather than a perfect one.
+        assert component["available"] is False and component["score"] is None
         # And the refusal is itself scored by nothing — an omission is not a legibility
         # fault either. That is reported rather than left implicit.
         assert summary["quality"]["unscored"]["by_code"]["dimension_kind_unsupported"] == 1
@@ -394,28 +458,65 @@ class TestAGearTableCanBeFalseWhileTheDrawingPasses:
         assert summary["quality"]["fidelity"]["score"] < 1.0
 
 
-def _emitted_codes():
-    """Every lint code the engine can produce, by AST over its THREE producer forms.
+#: Producer callables whose ``code`` argument is a lint code. `LintIssue`'s is the FOURTH
+#: positional field (`severity, message, location, code`), which is why the positional form
+#: has to be read by index rather than assumed absent (#1176 review r5).
+_PRODUCERS = {"LintIssue": 3, "record_issue": 1, "_record_build_issue": 1}
 
-    `LintIssue(code=…)`, `ctx.record_issue(severity, code, …)` and
-    `Drawing._record_build_issue(severity, code, …)`, each accepting the code positionally or
-    by keyword. Read from the source rather than by running the engine, because a code
-    emitted only on a path no test reaches is exactly the one that would slip through
-    unclassified.
+#: Callables that take a lint code as ``drop_code`` DATA and record it later. Ten codes
+#: reached the engine only this way and were invisible to an audit that read literals at
+#: producer calls alone; `_render_polygonal_prisms` is here because it forwards its own
+#: ``drop_code`` parameter into a job, and is discovered rather than listed.
+_STAGED_RECORDERS = {"_leader_callout_pass", "FeatureLeaderJob"}
 
-    The first cut of this walk had three demonstrated escapes, each of which let a brand-new
-    code pass all four audits (#1176 review r4): it required `len(args) >= 2` and so skipped
-    the keyword form of the very producer it modelled; it did not know about
-    `_record_build_issue` at all; and it treated a conditional expression as opaque, so
-    widening `"pmi_dropped" if source_ids else "gdt_dropped"` to a third branch hid a new
-    code inside a call site already counted. Conditional branches are now walked to their
-    constant leaves.
+
+def _enclosing_function(tree, node):
+    best = None
+    for func in ast.walk(tree):
+        if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)) and func.lineno <= (
+            node.lineno
+        ) <= (func.end_lineno or func.lineno):
+            if best is None or func.lineno > best.lineno:
+                best = func
+    return best
+
+
+def _emitted_codes(sources=None):
+    """Every lint code the engine can produce, by AST over its producer forms.
+
+    *sources* is a ``{name: text}`` mapping for the smuggling tests below, which feed the
+    walk a snippet instead of the package. Default: every module under ``src/draftwright``.
+
+    Three direct producers — `LintIssue`, `ctx.record_issue` and
+    `Drawing._record_build_issue`, each taking the code positionally or by keyword — plus
+    every ``drop_code=`` argument, which is a lint code handed to a recorder as data.
+
+    Read from the source rather than by running the engine, because a code emitted only on a
+    path no test reaches is exactly the one that would slip through unclassified.
+
+    Successive rounds of #1176 review found five escapes from earlier versions of this walk,
+    each of which let a brand-new code pass every audit below: it required two positional
+    args and so skipped the keyword form of the producer it modelled; it did not know
+    `_record_build_issue` existed; it treated a conditional expression as opaque, so a third
+    branch hid a new code inside a site already counted; it read `LintIssue`'s code only as a
+    keyword, though its positional slot is reachable; and it did not follow ``drop_code``,
+    which is how eleven `*_dropped` codes reach `record_issue`. Each of the five is a
+    regression test in `TestTheAuditCannotBeSmuggledPast`.
+
+    Returns ``(literals, prefixes, indirect, stages)`` where ``stages`` maps a code to the
+    set of ``outcome_stage`` values its producers can give it — ``"<staged>"`` for a code
+    handed to a leader job, whose one recorder stages it ``"validation"`` on a
+    rendered-geometry failure.
     """
     literals: set[str] = set()
     prefixes: set[str] = set()
     indirect: list[str] = []
     stages: dict[str, set[str | None]] = {}
     root = Path(__file__).resolve().parents[1] / "src" / "draftwright"
+    if sources is None:
+        trees = {path: ast.parse(path.read_text()) for path in sorted(root.rglob("*.py"))}
+    else:
+        trees = {root / name: ast.parse(text) for name, text in sources.items()}
 
     def leaves(expr, path, out):
         if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
@@ -429,17 +530,58 @@ def _emitted_codes():
             out.append(None)
             indirect.append(f"{path}:{expr.lineno}")
 
-    for path in sorted(root.rglob("*.py")):
-        for node in ast.walk(ast.parse(path.read_text())):
+    def record(expr, path, staged):
+        found: list = []
+        leaves(expr, path, found)
+        for code in found:
+            if code is None:
+                continue
+            if code.endswith("{}"):
+                prefixes.add(code[:-2])
+            else:
+                literals.add(code)
+                stages.setdefault(code, set()).add(staged)
+
+    # Which functions forward a `drop_code` parameter into a staged recorder. Resolved to a
+    # fixed point rather than listed, so a new forwarding layer is followed instead of
+    # hiding its codes.
+    recorders = set(_STAGED_RECORDERS)
+    for _ in range(4):
+        for path, tree in trees.items():
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+                if name not in recorders:
+                    continue
+                arg = next((k for k in node.keywords if k.arg == "drop_code"), None)
+                if arg is not None and isinstance(arg.value, ast.Name):
+                    enclosing = _enclosing_function(tree, node)
+                    if enclosing is not None:
+                        recorders.add(enclosing.name)
+
+    for path, tree in trees.items():
+        rel = path.relative_to(root)
+        for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
             name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
-            if name not in ("LintIssue", "record_issue", "_record_build_issue"):
+            if any(k.arg is None for k in node.keywords) and name in _PRODUCERS:
+                # `LintIssue(**kwargs)` — the code is not readable and must not pass as
+                # "no code here".
+                indirect.append(f"{rel}:{node.lineno}")
+                continue
+            drop = next((k for k in node.keywords if k.arg == "drop_code"), None)
+            if drop is not None and isinstance(drop.value, ast.Constant):
+                record(drop.value, rel, "<staged>" if name in recorders else None)
+            if name not in _PRODUCERS:
                 continue
             expr = next((k.value for k in node.keywords if k.arg == "code"), None)
-            if expr is None and name != "LintIssue" and len(node.args) >= 2:
-                expr = node.args[1]
+            if expr is None:
+                index = _PRODUCERS[name]
+                expr = node.args[index] if len(node.args) > index else None
             if expr is None:
                 continue
             stage = next((k.value for k in node.keywords if k.arg == "outcome_stage"), None)
@@ -449,16 +591,7 @@ def _emitted_codes():
                 staged = stage.value
             else:
                 staged = "<conditional>"
-            found: list = []
-            leaves(expr, path.relative_to(root), found)
-            for code in found:
-                if code is None:
-                    continue
-                if code.endswith("{}"):
-                    prefixes.add(code[:-2])
-                else:
-                    literals.add(code)
-                    stages.setdefault(code, set()).add(staged)
+            record(expr, rel, staged)
     return literals, prefixes, indirect, stages
 
 
@@ -495,7 +628,7 @@ class TestEveryLintCodeIsClassified:
             code
             for code, seen in stages.items()
             if code.endswith("_dropped")
-            and ("validation" in seen or "<conditional>" in seen)
+            and not seen.isdisjoint({"validation", "<conditional>", "<staged>"})
             and code not in (_UNSCORED_CODES | _STAGE_ROUTED_CODES)
         )
         assert not unexamined, (
@@ -508,7 +641,8 @@ class TestEveryLintCodeIsClassified:
         # The other direction: a renamed code must not leave a dead entry behind, which
         # would make the audit above pass while the real code went unclassified.
         literals, _prefixes, _indirect, _stages = _emitted_codes()
-        stale = sorted((_FIDELITY_CODES | _UNSCORED_CODES | _STAGE_ROUTED_CODES) - literals)
+        registered = _FIDELITY_CODES | _UNSCORED_CODES | _STAGE_ROUTED_CODES | _LEGIBILITY_CODES
+        stale = sorted(registered - literals)
         assert not stale, f"{stale} are registered but no longer emitted anywhere"
 
     def test_every_interpolated_code_family_is_registered(self):
@@ -527,6 +661,39 @@ class TestEveryLintCodeIsClassified:
             f"cannot see it: {indirect}"
         )
 
+    def test_a_stage_routed_code_is_not_reported_as_unclassified(self):
+        # A stage-routed code scores on legibility for its placement instances and on nothing
+        # for its validation ones, so a validation instance reaching `unscored` is EXPECTED,
+        # not an unclassified code. Dropping `_STAGE_ROUTED_CODES` from the filter passed
+        # both quality test files (#1176 review r5).
+        from draftwright.linting.issues import LintIssue
+        from draftwright.linting.quality import _unscored_component
+
+        report = _unscored_component(
+            [
+                LintIssue(
+                    severity="warning",
+                    code="chamfer_dropped",
+                    message="m",
+                    outcome_stage="validation",
+                ),
+                LintIssue(severity="warning", code="not_a_registered_code", message="m"),
+            ]
+        )
+        assert report["by_code"] == {"chamfer_dropped": 1, "not_a_registered_code": 1}
+        assert report["unclassified"] == ["not_a_registered_code"], (
+            "a registered stage-routed code was reported as nobody's decision"
+        )
+
+    def test_the_unscored_inventory_reads_like_the_components_beside_it(self):
+        # It sits under `quality` next to four components, so `for c in quality.values():
+        # c["available"]` must not raise on it — the same ergonomic contract this file
+        # dedicates a test to for the unavailable fidelity shape (#1176 review r5).
+        quality = _quality(99, "99")
+        assert all("available" in component for component in quality.values())
+        assert quality["unscored"]["available"] is True
+        assert quality["unscored"]["score"] is None, "the inventory must not become a score"
+
     def test_the_runtime_report_agrees_with_the_static_register(self):
         # `quality["unscored"]["unclassified"]` is the same question asked of one drawing's
         # own findings, which is what gives `_UNSCORED_CODES` a production consumer rather
@@ -539,3 +706,75 @@ class TestEveryLintCodeIsClassified:
         quality = sheet.build().lint_summary()["quality"]
         assert quality["unscored"]["unclassified"] == []
         assert quality["unscored"]["issues"] == sum(quality["unscored"]["by_code"].values())
+
+
+class TestTheAuditCannotBeSmuggledPast:
+    """One regression test per escape found in a previous version of `_emitted_codes`.
+
+    Each ran green against the walk of its day. They feed the walk a snippet rather than
+    mutating `src/`, so they are fast and deterministic; the source-wide audits above are
+    what tie the walk to the real package.
+    """
+
+    def _codes(self, body):
+        literals, _prefixes, indirect, stages = _emitted_codes({"snippet.py": body})
+        return literals, indirect, stages
+
+    def test_a_keyword_code_on_record_issue_is_seen(self):
+        # The walk read `record_issue`'s code positionally and required two positional args,
+        # so the keyword form of the very producer it modelled was skipped (review r4).
+        literals, _indirect, _stages = self._codes(
+            'ctx.record_issue(severity="warning", code="smuggled_kw", message="m")'
+        )
+        assert "smuggled_kw" in literals
+
+    def test_the_build_issue_producer_is_seen(self):
+        # A third live producer the walk did not know about (review r4).
+        literals, _indirect, _stages = self._codes(
+            'self._record_build_issue("warning", "smuggled_build", "m")'
+        )
+        assert "smuggled_build" in literals
+
+    def test_every_branch_of_a_conditional_code_is_seen(self):
+        # Widening `"a" if p else "b"` to a third branch hid a new code inside a call site
+        # already counted by the indirect ratchet (review r4).
+        literals, _indirect, _stages = self._codes(
+            'ctx.record_issue("warning", "smuggled_if" if p else ("a" if q else "b"), "m")'
+        )
+        assert {"smuggled_if", "a", "b"} <= literals
+
+    def test_a_positional_code_on_lintissue_is_seen(self):
+        # `LintIssue`'s code is its FOURTH field, and the walk read it only as a keyword
+        # (review r5).
+        literals, _indirect, _stages = self._codes(
+            'LintIssue("error", "m", None, "smuggled_positional")'
+        )
+        assert "smuggled_positional" in literals
+
+    def test_a_splatted_producer_call_is_counted_not_ignored(self):
+        # `LintIssue(**kwargs)` matched no `code=` keyword, so it was skipped AND not
+        # counted as indirect — invisible twice over (review r5).
+        literals, indirect, _stages = self._codes("LintIssue(**kwargs)")
+        assert not literals
+        assert indirect, "a splatted producer call passed as 'no code here'"
+
+    def test_a_code_handed_over_as_drop_code_data_is_seen(self):
+        # Eleven `*_dropped` codes reach `record_issue` only as a `drop_code` argument, and
+        # the leader recorder can stage them "validation" — the `section_dropped` defect,
+        # times eleven, invisible to a walk that read literals at producer calls (review r5).
+        literals, _indirect, stages = self._codes(
+            '_leader_callout_pass(dwg, a, jobs, drop_code="smuggled_drop", ctx=ctx)'
+        )
+        assert "smuggled_drop" in literals
+        assert stages["smuggled_drop"] == {"<staged>"}
+
+    def test_a_forwarded_drop_code_makes_its_caller_a_recorder(self):
+        # The forwarding layer is resolved to a fixed point, not listed: a helper that passes
+        # its own `drop_code` parameter into a job makes ITS callers' codes staged too.
+        literals, _indirect, stages = self._codes(
+            "def _wrapper(drop_code):\n"
+            "    return _leader_callout_pass(dwg, a, jobs, drop_code=drop_code, ctx=ctx)\n"
+            '_wrapper(drop_code="smuggled_forwarded")\n'
+        )
+        assert stages["smuggled_forwarded"] == {"<staged>"}
+        assert "smuggled_forwarded" in literals

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -14,7 +14,14 @@ contradiction:
 
 `legibility` is 1.0 correctly — its own basis field says
 `layout_issue_severity_with_info_floor`, it scores LAYOUT, and a false dimension is
-perfectly legible. With the other two unavailable, 1.0 was the only number a caller saw.
+perfectly legible.
+
+An earlier draft of this docstring said "1.0 was the only number a caller saw". Measured, it
+is not: that drawing already reported `passed: False`, `errors: 1` and `score: 0.8`, so a
+caller following ADR 0002's own advice (gate on severity and code counts, not the scalar)
+caught it. The signal fidelity actually adds is the case where those gates say nothing —
+`TestAGearTableCanBeFalseWhileTheDrawingPasses` below, where a normative ISO data table
+prints twelve teeth on a thirteen-tooth part and `passed` is True.
 
 So the four axes now answer four different questions: did required content land
 (completeness), is there too much of it (restraint), can a reader make it out (legibility),
@@ -23,13 +30,28 @@ and is what it says true (fidelity). A drawing can pass the first three and stil
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 import pytest
-from build123d import Box
+from build123d import Box, import_step
 
 from draftwright import Sheet
-from draftwright.linting.quality import _FIDELITY_CODES, _LEGIBILITY_CODES
+from draftwright.linting.quality import (
+    _FIDELITY_CODES,
+    _LEGIBILITY_CODES,
+    _UNSCORED_CODE_PREFIXES,
+    _UNSCORED_CODES,
+    _is_legibility_issue,
+)
+from draftwright.linting.structural import is_dimension_like as _is_dimension_like
 
 _REFS = ((0, -25, 0), (0, -9, 0))  # a 16 mm span
+
+
+def _quality_of(sheet):
+    sheet.authored_dimensions()
+    return sheet.build().lint_summary()["quality"]
 
 
 def _quality(value, label, page="A2"):
@@ -62,28 +84,57 @@ class TestFidelityIsReportedSeparately:
         # — the PR contradicting its own evidence.
         quality = _quality(99, "99")
         assert quality["legibility"]["basis"] == "layout_issue_severity_with_info_floor"
-        assert quality["fidelity"]["basis"] == "asserted_content_contradicted_by_geometry"
+        assert quality["fidelity"]["basis"] == "drawn_assertion_contradicted_by_its_source"
 
     def test_fidelity_has_no_answer_when_the_drawing_asserts_nothing(self):
         # No evidence is DATA, not a perfect score — the same contract completeness and
         # restraint already follow, and the fail-open this module's docstring argues
         # against. Unlike legibility, where an empty sheet genuinely IS legible,
         # truthfulness of an empty utterance is not the same kind of 1.0.
-        from draftwright.linting.quality import quality_components
-
-        component = quality_components(
-            recognition=None,
-            features=(),
-            registry=None,
-            omissions=(),
-            issues=[],
-            error_penalty=0.05,
-            warning_penalty=0.05,
-            has_asserted_content=False,
-        )["fidelity"]
+        #
+        # Through `lint_summary()`, not `quality_components(...)`. The first cut called the
+        # helper directly with `has_asserted_content=False` and so tested the helper's `if`
+        # rather than the predicate: replacing the whole predicate in `drawing.py` with the
+        # constant `True` — deleting the fix outright — passed every test in this file
+        # (#1176 review r3). It also reported 1.0 for exactly this drawing, because the
+        # predicate asked whether any item had a `label_bbox`, which a title block has.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", page="A2", scale=1)
+        sheet.authored_dimensions()
+        drawing = sheet.build()
+        assert not [item for _n, item in drawing.iter_annotations() if _is_dimension_like(item)], (
+            "the fixture now draws a measured quantity, so it does assert something"
+        )
+        component = drawing.lint_summary()["quality"]["fidelity"]
         assert component["available"] is False
         assert component["score"] is None
         assert component["reason"]
+
+    def test_an_unavailable_fidelity_still_publishes_the_whole_shape(self):
+        # README reads `quality["legibility"]["by_code"]`; a caller reading fidelity's the
+        # same way must get an empty mapping, not a KeyError, on the drawing above. Every
+        # count is genuinely zero — a finding would have made the component available.
+        component = _quality_of(Sheet(Box(115, 50, 68), page="A2", scale=1))["fidelity"]
+        assert component["available"] is False
+        assert component["by_code"] == {} and component["raw_issues"] == 0
+
+    def test_a_finding_outranks_the_availability_gate(self):
+        # The gate must never DISCARD a falsehood. This drawing draws no measured quantity,
+        # so the predicate says "asserts nothing" — and it carries a `declared_feature_absent`
+        # for a hole the part lacks. Reported as `{available: False, score: None}`, the round-2
+        # fix would have failed closed over a detected lie, which is worse than the fail-open
+        # it replaced (#1176 review r3). Mutation: drop `available = available or bool(issues)`.
+        sheet = Sheet(Box(20, 20, 20), title="T", number="N-1", page="A2")
+        sheet.hole(at=(5, 5, 0), axis="z", diameter=3, through=True)
+        sheet.authored_dimensions()
+        drawing = sheet.build()
+        summary = drawing.lint_summary()
+        assert not [item for _n, item in drawing.iter_annotations() if _is_dimension_like(item)], (
+            "the fixture now asserts a measured quantity, so the gate is not under test"
+        )
+        assert [i for i in summary["issues"] if i["code"] == "declared_feature_absent"]
+        component = summary["quality"]["fidelity"]
+        assert component["available"] is True, "a detected falsehood was discarded unscored"
+        assert component["score"] < 1.0
 
     def test_the_full_fidelity_shape_is_pinned(self):
         # Legibility's complete dict is pinned in `test_make_drawing.py`; fidelity's was
@@ -129,6 +180,25 @@ class TestFidelityIsReportedSeparately:
         assert not (_FIDELITY_CODES & _LEGIBILITY_CODES), (
             f"{sorted(_FIDELITY_CODES & _LEGIBILITY_CODES)} is scored on two axes"
         )
+        # And nothing may be both scored and registered as unscored — the audit below
+        # would still pass, while the register would be describing the opposite of the truth.
+        both = (_FIDELITY_CODES | _LEGIBILITY_CODES) & _UNSCORED_CODES
+        assert not both, f"{sorted(both)} are registered as unscored and also scored"
+
+    def test_a_placement_drop_cannot_also_be_a_fidelity_code(self):
+        # `_is_legibility_issue` accepts a code the set does not name when the issue carries
+        # `outcome_stage="placement"` or a `_dropped` suffix. `test_the_axes_do_not_share_codes`
+        # compares the two SETS and so cannot see that branch: a fidelity code arriving with
+        # a placement stage would be scored twice.
+        from draftwright.linting.issues import LintIssue
+
+        doubled = [
+            code
+            for code in sorted(_FIDELITY_CODES)
+            if _is_legibility_issue(LintIssue(severity="error", code=code, message=""))
+            or code.endswith("_dropped")
+        ]
+        assert not doubled, f"{doubled} would be scored on legibility as well as fidelity"
 
 
 class TestPlacedContentContradictedByGeometryIsAlsoFalse:
@@ -140,10 +210,14 @@ class TestPlacedContentContradictedByGeometryIsAlsoFalse:
         # not have, and it scored 1.0.
         sheet = Sheet(Box(80, 60, 20), title="T", number="N-1")
         sheet.hole(at=(10, 10, 0), axis="z", diameter=6, through=True)
-        # `auto_dimensions`, not `authored_dimensions`: measured, the authored path draws
-        # NOTHING for the absent hole, so nothing false reaches the sheet and there is no
-        # falsehood to score. The lie is specific to the automatic path, which renders the
-        # callout from the declaration without checking the geometry carries it.
+        # `auto_dimensions`, because it is the path that draws the LABELLED callout. An
+        # earlier comment here claimed the authored path "draws NOTHING for the absent hole,
+        # so nothing false reaches the sheet". Measured, that is wrong twice: the authored
+        # path still draws a `CenterMark` at the phantom hole, and fidelity still drops to
+        # 0.95 there (`test_a_finding_outranks_the_availability_gate` uses exactly that).
+        # `declared_feature_absent` is a declaration-vs-geometry check that never inspects
+        # what was placed, so the difference between the paths is how loudly the sheet
+        # states the lie, not whether the check fires.
         sheet.auto_dimensions()
         drawing = sheet.build()
         summary = drawing.lint_summary()
@@ -188,6 +262,155 @@ class TestFidelityIsAboutFalsehoodNotAbsence:
         assert [i for i in summary["issues"] if i["code"] == "dimension_kind_unsupported"], (
             "the fixture no longer produces a refused dimension"
         )
-        assert summary["quality"]["fidelity"]["score"] == 1.0, (
+        component = summary["quality"]["fidelity"]
+        assert component["by_code"] == {}, (
             "refusing to draw something was scored as drawing something false"
+        )
+        # And the refusal leaves the sheet asserting nothing measurable at all, so the
+        # honest report is "no answer" rather than a perfect one.
+        assert component["available"] is False and component["score"] is None
+
+
+_WHEEL = Path(__file__).parent / "fixtures" / "issue_1058_wheel_rh.step"
+_WHEEL_TEETH = 13  # independently proved by `recognise_repeating_radial_profiles`
+
+
+def _wheel_gear_sheet(tooth_count, axis="z"):
+    """The 13-tooth wheel with a declared metric external spur gear over it.
+
+    `at` and `face_width` must reproduce the proved profile's centre and axial span exactly
+    or `lint_declared_gear_coverage` reports `gear_correspondence_unverifiable` and never
+    reaches the reconciliation this exercises — which is what a first attempt using the bbox
+    CENTRE (x = -0.013) did.
+    """
+    part = import_step(str(_WHEEL))
+    sheet = Sheet(part, title="T", number="N-1", page="A2", scale=1)
+    sheet.external_spur_gear(
+        at=(0, 0, 0),
+        axis=axis,
+        tooth_count=tooth_count,
+        module=1.0,
+        pressure_angle=20.0,
+        profile_shift=0.0,
+        face_width=float(part.bounding_box().size.Z),
+        tooth_thickness=1.5,
+        tooth_thickness_tolerance=(-0.05, 0.0),
+        flank_tolerance_class=8,
+    )
+    sheet.authored_dimensions()
+    return sheet
+
+
+class TestAGearTableCanBeFalseWhileTheDrawingPasses:
+    """The case that justifies the axis, and the one three of its five codes had no test for.
+
+    Deleting `gear_repeat_count_mismatch`, `gear_axis_mismatch` and `gear_requirement_mismatch`
+    from `_FIDELITY_CODES` passed the entire 4,201-test fast tier (#1176 review r3). The
+    existing gear tests call `lint_declared_gear_coverage` with synthetic profile objects and
+    never reach `lint_summary()`.
+    """
+
+    def test_a_data_table_stating_the_wrong_tooth_count_lowers_fidelity(self):
+        drawing = _wheel_gear_sheet(_WHEEL_TEETH - 1).build()
+        summary = drawing.lint_summary()
+        rows = [
+            row
+            for _n, item in drawing.iter_annotations()
+            for row in getattr(item, "gear_requirement_rows", None) or ()
+        ]
+        assert ("TEETH z", "12", "ISO 21771-1:2024") in rows, (
+            f"the sheet no longer PRINTS the false tooth count, so nothing asserts it: {rows}"
+        )
+        assert summary["passed"] is True, (
+            "the severity gates now catch this, so it no longer shows what fidelity adds"
+        )
+        assert summary["quality"]["fidelity"]["by_code"] == {"gear_repeat_count_mismatch": 1}
+        assert summary["quality"]["fidelity"]["score"] < 1.0
+
+    def test_the_true_tooth_count_keeps_fidelity_perfect(self):
+        summary = _wheel_gear_sheet(_WHEEL_TEETH).build().lint_summary()
+        assert not [i for i in summary["issues"] if i["code"].startswith("gear_")], (
+            "the correspondence broke, so the mismatch test above proves nothing"
+        )
+        assert summary["quality"]["fidelity"]["score"] == 1.0
+
+    def test_a_data_table_bound_to_the_wrong_axis_lowers_fidelity(self):
+        summary = _wheel_gear_sheet(_WHEEL_TEETH, axis="x").build().lint_summary()
+        assert summary["quality"]["fidelity"]["by_code"] == {"gear_axis_mismatch": 1}
+        assert summary["quality"]["fidelity"]["score"] < 1.0
+
+
+def _emitted_codes():
+    """Every lint code the engine can produce, by AST over its two producer forms.
+
+    `LintIssue(code=...)` and `ctx.record_issue(severity, code, ...)`. Read from the source
+    rather than from a runtime sweep because a code emitted only on a path no test reaches is
+    exactly the one that would slip through unclassified.
+    """
+    literals: set[str] = set()
+    prefixes: set[str] = set()
+    indirect: list[str] = []
+    root = Path(__file__).resolve().parents[1] / "src" / "draftwright"
+    for path in sorted(root.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if name == "LintIssue":
+                expr = next((k.value for k in node.keywords if k.arg == "code"), None)
+            elif name == "record_issue" and len(node.args) >= 2:
+                expr = node.args[1]
+            else:
+                continue
+            if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+                literals.add(expr.value)
+            elif isinstance(expr, ast.JoinedStr) and isinstance(expr.values[0], ast.Constant):
+                prefixes.add(expr.values[0].value)
+            elif expr is not None:
+                indirect.append(f"{path.relative_to(root)}:{expr.lineno}")
+    return literals, prefixes, indirect
+
+
+class TestEveryLintCodeIsClassified:
+    """The fail-closed half of the classification, which the first cut only apologised for.
+
+    `_FIDELITY_CODES`' own note says a new truth-class code "will score as perfectly
+    truthful until somebody adds it". Admitting a hole is not closing one — the precedent is
+    `test_quality_components.py`'s recognition-inventory audit, and ADR 0017's manifest,
+    which is fail-closed for exactly this reason.
+    """
+
+    def test_no_lint_code_scores_on_an_unstated_axis(self):
+        literals, _prefixes, _indirect = _emitted_codes()
+        classified = _FIDELITY_CODES | _LEGIBILITY_CODES | _UNSCORED_CODES
+        unclassified = sorted(
+            code for code in literals if code not in classified and not code.endswith("_dropped")
+        )
+        assert not unclassified, (
+            f"{unclassified} score on no quality component and are not registered as "
+            "unscored — a new truth-class code would be reported as perfectly truthful. Add "
+            "each to _FIDELITY_CODES, _LEGIBILITY_CODES or _UNSCORED_CODES."
+        )
+
+    def test_the_registers_describe_codes_that_exist(self):
+        # The other direction: a renamed code must not leave a dead entry behind, which
+        # would make the audit above pass while the real code went unclassified.
+        literals, _prefixes, _indirect = _emitted_codes()
+        stale = sorted((_FIDELITY_CODES | _UNSCORED_CODES) - literals)
+        assert not stale, f"{stale} are registered but no longer emitted anywhere"
+
+    def test_every_interpolated_code_family_is_registered(self):
+        _literals, prefixes, _indirect = _emitted_codes()
+        assert sorted(prefixes) == sorted(_UNSCORED_CODE_PREFIXES)
+
+    def test_the_indirect_producer_sites_do_not_grow(self):
+        # Ten call sites forward a code held in a variable, so the audit cannot see the
+        # string. A shrink-only ratchet (the `_ALLOW` pattern from
+        # `test_private_test_imports.py`): a new indirection has to be argued rather than
+        # silently widening the blind spot.
+        _literals, _prefixes, indirect = _emitted_codes()
+        assert len(indirect) <= 10, (
+            f"a new lint code is passed through a variable, so the classification audit "
+            f"cannot see it: {indirect}"
         )

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -34,9 +34,10 @@ import ast
 from pathlib import Path
 
 import pytest
-from build123d import Box, import_step
+from build123d import Box, Cylinder, Pos, import_step
 
 from draftwright import Sheet
+from draftwright.linting.coverage import EXAMINABLE_DECLARED_KINDS
 from draftwright.linting.quality import (
     _FIDELITY_CODES,
     _LEGIBILITY_CODES,
@@ -110,7 +111,9 @@ class TestFidelityIsReportedSeparately:
         sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", page="A2", scale=1)
         sheet.authored_dimensions()
         drawing = sheet.build()
-        assert not [item for _n, item in drawing.iter_annotations() if _is_dimension_like(item)], (
+        # `drawing.items`, which is what production reads — `iter_annotations()` yields only
+        # the NAMED ones, so a precondition over it can hold while the predicate is false.
+        assert not [item for item in drawing.items if _is_dimension_like(item)], (
             "the fixture now draws a measured quantity, so it does assert something"
         )
         component = drawing.lint_summary()["quality"]["fidelity"]
@@ -140,6 +143,30 @@ class TestFidelityIsReportedSeparately:
         )
         assert component["basis"] == available["basis"], (
             "an unavailable component must still say WHAT it would have measured"
+        )
+
+    def test_a_detected_model_is_not_treated_as_a_declaration(self):
+        # The predicate's THIRD term. `lint_declaration_reconciliation` is gated on
+        # `model_declared`, so a DETECTED `kind="hole"` feature is examined by nothing —
+        # dropping `self._model_declared` re-creates the declared-slot fail-open for every
+        # detected drawing. It survived the whole tier because `is_dimension_like` is true for
+        # essentially every detected build, so this fixture removes that cover: a detected
+        # part whose dimensions have all been stripped from the drawing.
+        from draftwright.builder import build_drawing
+
+        part = Box(60, 40, 20) - Pos(15, 10, 0) * Cylinder(3, 40)
+        drawing = build_drawing(part, title="T", number="N-1")
+        assert not drawing.model_declared
+        assert any(f.kind in EXAMINABLE_DECLARED_KINDS for f in drawing.model().features), (
+            "the fixture detects nothing examinable, so the term is not under test"
+        )
+        for name in [
+            name for name, item in drawing.iter_annotations() if _is_dimension_like(item)
+        ]:
+            drawing.remove(name)
+        component = drawing.lint_summary()["quality"]["fidelity"]
+        assert component["available"] is False, (
+            "a detected model was treated as a declaration this axis can examine"
         )
 
     def test_a_detected_drawing_that_dimensions_the_part_is_answerable(self):
@@ -202,18 +229,21 @@ class TestFidelityIsReportedSeparately:
         assert component["score"] < 1.0
         assert component["by_code"] == {"label_vs_measured": 1}
 
-    def test_a_finding_outranks_the_availability_gate(self):
-        # The gate must never DISCARD a falsehood. This drawing draws no measured quantity,
-        # so the predicate says "asserts nothing" — and it carries a `declared_feature_absent`
-        # for a hole the part lacks. Reported as `{available: False, score: None}`, the round-2
-        # fix would have failed closed over a detected lie, which is worse than the fail-open
-        # it replaced (#1176 review r3). Mutation: drop `available = available or bool(issues)`.
+    def test_a_declared_falsehood_with_nothing_drawn_is_still_scored(self):
+        # The r3 case, kept because it is the user-facing shape: a `⌀6 THRU` declared over
+        # solid material, no measured quantity drawn, and fidelity must still say 0.95.
+        #
+        # It reaches availability through the DECLARED term — `sheet.hole(...)` is a
+        # `kind == "hole"` feature, which is examinable — NOT through the `bool(issues)`
+        # override. Round 5's commit message identified that this comment claimed otherwise
+        # and rewrote a different test, leaving this one saying the untrue thing (review r6).
+        # The override's own guard is `test_a_finding_always_outranks_the_availability_gate`.
         sheet = Sheet(Box(20, 20, 20), title="T", number="N-1", page="A2")
         sheet.hole(at=(5, 5, 0), axis="z", diameter=3, through=True)
         sheet.authored_dimensions()
         drawing = sheet.build()
         summary = drawing.lint_summary()
-        assert not [item for _n, item in drawing.iter_annotations() if _is_dimension_like(item)], (
+        assert not [item for item in drawing.items if _is_dimension_like(item)], (
             "the fixture now asserts a measured quantity, so the gate is not under test"
         )
         assert [i for i in summary["issues"] if i["code"] == "declared_feature_absent"]
@@ -463,11 +493,74 @@ class TestAGearTableCanBeFalseWhileTheDrawingPasses:
 #: has to be read by index rather than assumed absent (#1176 review r5).
 _PRODUCERS = {"LintIssue": 3, "record_issue": 1, "_record_build_issue": 1}
 
-#: Callables that take a lint code as ``drop_code`` DATA and record it later. Ten codes
-#: reached the engine only this way and were invisible to an audit that read literals at
-#: producer calls alone; `_render_polygonal_prisms` is here because it forwards its own
-#: ``drop_code`` parameter into a job, and is discovered rather than listed.
+#: Callables that take a lint code as ``drop_code`` DATA and record it later. Eleven codes
+#: reach the engine only this way and were invisible to an audit that read literals at
+#: producer calls alone. Only the two entry points are listed: the forwarding layers
+#: (`_render_polygonal_prisms` among them) are DISCOVERED by resolving to a fixed point, so a
+#: new one is followed rather than needing to be remembered here.
 _STAGED_RECORDERS = {"_leader_callout_pass", "FeatureLeaderJob"}
+
+
+def _is_forwarded_parameter(expr, tree, node) -> bool:
+    """Whether *expr* is a parameter of some function enclosing *node*.
+
+    Those are the forwarding layers the fixed point already follows to their callers, so
+    counting them again would ratchet on plumbing rather than on a hidden code. ANY enclosing
+    scope, not just the innermost: `holes.py`'s pitch helper forwards its outer function's
+    `drop_code` from inside a nested closure, where the name is a free variable rather than a
+    parameter of the `def` it sits in.
+    """
+    if not isinstance(expr, ast.Name):
+        return False
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not func.lineno <= node.lineno <= (func.end_lineno or func.lineno):
+            continue
+        args = func.args
+        if expr.id in {a.arg for a in (*args.args, *args.posonlyargs, *args.kwonlyargs)}:
+            return True
+    return False
+
+
+def _producer_aliases(trees) -> dict[str, str]:
+    """``{local name: producer name}`` for aliased imports of a producer.
+
+    The walk matches producers by NAME, so `from ...issues import LintIssue as _LI` made
+    every `_LI(...)` call invisible — not counted as a producer and not counted as indirect
+    (#1176 review r6). Simple assignment aliases (`_mk = LintIssue`) are followed too,
+    iterated so a chain resolves.
+
+    **The limit, stated rather than implied**: a producer reached through anything this
+    cannot name — an attribute of an object, a `functools.partial`, a dict entry, a subclass
+    — is invisible, and unlike an unreadable `code` argument there is nothing to count,
+    because the walk cannot tell such a call from any other call in the package. So "every
+    code the engine emits is classified" holds for producers spelled as themselves or bound
+    to a name; it is not a proof against a determined author. What it is proof against is the
+    accident, which is what has actually happened five times.
+    """
+    aliases: dict[str, str] = {}
+    for tree in trees.values():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.asname and alias.name in _PRODUCERS:
+                        aliases[alias.asname] = alias.name
+    while True:
+        before = len(aliases)
+        for tree in trees.values():
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Name):
+                    continue
+                source = aliases.get(node.value.id, node.value.id)
+                if source not in _PRODUCERS:
+                    continue
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        aliases[target.id] = source
+        if len(aliases) == before:
+            break
+    return aliases
 
 
 def _enclosing_function(tree, node):
@@ -542,11 +635,14 @@ def _emitted_codes(sources=None):
                 literals.add(code)
                 stages.setdefault(code, set()).add(staged)
 
+    aliases = _producer_aliases(trees)
+
     # Which functions forward a `drop_code` parameter into a staged recorder. Resolved to a
     # fixed point rather than listed, so a new forwarding layer is followed instead of
     # hiding its codes.
     recorders = set(_STAGED_RECORDERS)
-    for _ in range(4):
+    while True:
+        before = len(recorders)
         for path, tree in trees.items():
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):
@@ -560,6 +656,8 @@ def _emitted_codes(sources=None):
                     enclosing = _enclosing_function(tree, node)
                     if enclosing is not None:
                         recorders.add(enclosing.name)
+        if len(recorders) == before:
+            break
 
     for path, tree in trees.items():
         rel = path.relative_to(root)
@@ -568,14 +666,22 @@ def _emitted_codes(sources=None):
                 continue
             func = node.func
             name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            name = aliases.get(name, name)
             if any(k.arg is None for k in node.keywords) and name in _PRODUCERS:
                 # `LintIssue(**kwargs)` — the code is not readable and must not pass as
                 # "no code here".
                 indirect.append(f"{rel}:{node.lineno}")
                 continue
             drop = next((k for k in node.keywords if k.arg == "drop_code"), None)
-            if drop is not None and isinstance(drop.value, ast.Constant):
-                record(drop.value, rel, "<staged>" if name in recorders else None)
+            if drop is not None:
+                if isinstance(drop.value, ast.Constant):
+                    record(drop.value, rel, "<staged>" if name in recorders else None)
+                elif not _is_forwarded_parameter(drop.value, tree, node):
+                    # A `drop_code` that is neither a literal nor the enclosing function's own
+                    # parameter hides a code the walk cannot read — a module constant, say,
+                    # which is ordinary refactoring rather than an adversarial act. Counting
+                    # it as indirect is what makes the ratchet bite (#1176 review r6).
+                    indirect.append(f"{rel}:{drop.value.lineno}")
             if name not in _PRODUCERS:
                 continue
             expr = next((k.value for k in node.keywords if k.arg == "code"), None)
@@ -767,6 +873,56 @@ class TestTheAuditCannotBeSmuggledPast:
         )
         assert "smuggled_drop" in literals
         assert stages["smuggled_drop"] == {"<staged>"}
+
+    def test_a_drop_code_held_in_a_constant_is_counted(self):
+        # `drop_code` was recorded only when it was a literal; a `Name` was used to grow the
+        # recorder set and then silently dropped — neither in `literals` nor in `indirect`.
+        # Factoring a repeated code into a module constant is ordinary refactoring, so this
+        # was accident-plausible, and at runtime the leader recorder stages it "validation"
+        # on a geometry failure: `section_dropped`'s defect, invisible (#1176 review r6).
+        literals, indirect, _stages = self._codes(
+            '_MUT = "x_dropped"\n_leader_callout_pass(dwg, a, jobs, drop_code=_MUT, ctx=ctx)\n'
+        )
+        assert not literals
+        assert indirect, "a code held in a module constant passed as 'no code here'"
+
+    def test_an_aliased_producer_import_is_still_a_producer(self):
+        # The walk matched producers by NAME, so `LintIssue as _LI` made every call
+        # invisible — not a producer, and not counted as indirect either (#1176 review r6).
+        literals, _indirect, _stages = self._codes(
+            "from draftwright.linting.issues import LintIssue as _LI\n"
+            '_LI("error", "m", None, "smuggled_alias")\n'
+        )
+        assert "smuggled_alias" in literals
+
+    def test_a_producer_bound_to_another_name_is_still_a_producer(self):
+        # `_mk = LintIssue` then `_mk(...)`, resolved by iterating the assignments so a chain
+        # resolves too. A producer reached through an attribute, a `partial` or a dict entry
+        # stays invisible — `_producer_aliases` says so plainly rather than implying the walk
+        # is proof against a determined author (#1176 review r6).
+        literals, _indirect, _stages = self._codes(
+            '_mk = LintIssue\n_mk2 = _mk\n_mk2("error", "m", None, "smuggled_var")\n'
+        )
+        assert "smuggled_var" in literals
+
+    def test_the_recorder_resolution_converges_rather_than_giving_up(self):
+        # `for _ in range(4)` silently exempted a code behind five forwarding layers: staged
+        # `None` instead of `<staged>`, with `indirect` still zero (#1176 review r6).
+        # REVERSE dependency order, deliberately: defined innermost-first, one pass over the
+        # source resolves the whole chain and a bounded loop looks fine. Written outermost
+        # first, each pass advances the frontier by one layer, which is the shape that
+        # exposed `range(4)`.
+        layers = "".join(
+            f"def _w{i}(drop_code):\n    return _w{i - 1}(drop_code=drop_code)\n"
+            for i in range(6, 0, -1)
+        )
+        body = (
+            layers + "def _w0(drop_code):\n"
+            "    return _leader_callout_pass(dwg, a, jobs, drop_code=drop_code, ctx=ctx)\n"
+            + '_w6(drop_code="smuggled_deep")\n'
+        )
+        _literals, _indirect, stages = self._codes(body)
+        assert stages["smuggled_deep"] == {"<staged>"}
 
     def test_a_forwarded_drop_code_makes_its_caller_a_recorder(self):
         # The forwarding layer is resolved to a fixed point, not listed: a helper that passes

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -1,0 +1,105 @@
+"""#1176 — a drawing that says something false must not score perfect.
+
+The reported case is a PPP0101 bracket scoring lint 1.0 while omitting its defining
+radii and the whole dovetail. Its STEP is not in this repo, so this slice takes the half
+that is reproducible here and is the same defect one axis over: `quality` had no component
+asking whether the drawing is TRUE.
+
+Measured before this change, on a drawing labelled 99 over a 16 mm path — a 518%
+contradiction:
+
+    completeness  available=False   (no auditable recognised requirements)
+    restraint     available=False   (provenance incomplete)
+    legibility    1.0
+
+`legibility` is 1.0 correctly — its own basis field says
+`layout_issue_severity_with_info_floor`, it scores LAYOUT, and a false dimension is
+perfectly legible. With the other two unavailable, 1.0 was the only number a caller saw.
+
+So the four axes now answer four different questions: did required content land
+(completeness), is there too much of it (restraint), can a reader make it out (legibility),
+and is what it says true (fidelity). A drawing can pass the first three and still lie.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet
+from draftwright.linting.quality import _FIDELITY_CODES, _LEGIBILITY_CODES
+
+_REFS = ((0, -25, 0), (0, -9, 0))  # a 16 mm span
+
+
+def _quality(value, label, page="A2"):
+    sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", page=page, scale=1)
+    sheet.measured_dimension(
+        kind="linear", value=value, label=label, dominant_axis="y", ref_pts=_REFS
+    )
+    sheet.authored_dimensions()
+    return sheet.build().lint_summary()["quality"]
+
+
+class TestFidelityIsReportedSeparately:
+    def test_a_false_dimension_lowers_fidelity(self):
+        # Mutation: drop `label_vs_measured` from `_FIDELITY_CODES` and this returns 1.0.
+        quality = _quality(99, "99")
+        assert quality["fidelity"]["available"] is True
+        assert quality["fidelity"]["score"] < 1.0, (
+            "a drawing asserting 99 mm over a 16 mm path scored perfect on fidelity"
+        )
+
+    def test_a_truthful_dimension_keeps_fidelity_perfect(self):
+        # The axis must be narrow: an ordinary correct drawing is unaffected.
+        quality = _quality(16, "16")
+        assert quality["fidelity"]["score"] == 1.0
+
+    def test_legibility_is_unchanged_and_still_says_the_drawing_is_readable(self):
+        # The point of a separate axis. A false dimension IS legible, so legibility is
+        # right to report 1.0 — folding fidelity into it would have made a layout score
+        # answer a truthfulness question, which is the category error that produced the
+        # hole in the first place.
+        quality = _quality(99, "99")
+        assert quality["legibility"]["score"] == 1.0
+        assert quality["legibility"]["basis"] == "layout_issue_severity_with_info_floor"
+
+    def test_the_axes_do_not_share_codes(self):
+        # A code counted twice would penalise one defect on two axes and make them look
+        # correlated when they are independent observations.
+        assert not (_FIDELITY_CODES & _LEGIBILITY_CODES), (
+            f"{sorted(_FIDELITY_CODES & _LEGIBILITY_CODES)} is scored on two axes"
+        )
+
+
+class TestFidelityIsAboutFalsehoodNotAbsence:
+    @pytest.mark.parametrize(
+        "code",
+        ["dimension_kind_unsupported", "callout_dropped", "feature_not_located"],
+    )
+    def test_a_missing_thing_is_not_a_false_thing(self, code):
+        # An omission is a gap, not a lie: it belongs to completeness. Admitting the
+        # `*_dropped` family here would make fidelity a second completeness score and
+        # leave nothing measuring truthfulness — which is the state this slice fixes.
+        assert code not in _FIDELITY_CODES
+
+    def test_an_unsupported_dimension_does_not_lower_fidelity(self):
+        # #1207 refuses to draw an angular dimension rather than drawing it as a linear
+        # one. Nothing false reaches the sheet, so fidelity is intact; the content is
+        # missing, which is a different axis.
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", page="A2", scale=1)
+        sheet.measured_dimension(
+            kind="angular",
+            value=60,
+            label="60°",
+            dominant_axis="y",
+            ref_pts=((0, -25, 0), (0, -9, 0), (0, -13.619, 8)),
+        )
+        sheet.authored_dimensions()
+        summary = sheet.build().lint_summary()
+        assert [i for i in summary["issues"] if i["code"] == "dimension_kind_unsupported"], (
+            "the fixture no longer produces a refused dimension"
+        )
+        assert summary["quality"]["fidelity"]["score"] == 1.0, (
+            "refusing to draw something was scored as drawing something false"
+        )

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -55,6 +55,65 @@ class TestFidelityIsReportedSeparately:
         quality = _quality(16, "16")
         assert quality["fidelity"]["score"] == 1.0
 
+    def test_each_axis_publishes_its_own_basis(self):
+        # `basis` is what tells a caller WHAT a component measured, and the argument for a
+        # separate fidelity axis rests on legibility's basis naming layout. Shipping
+        # fidelity with the same string would have made the field stop distinguishing them
+        # — the PR contradicting its own evidence.
+        quality = _quality(99, "99")
+        assert quality["legibility"]["basis"] == "layout_issue_severity_with_info_floor"
+        assert quality["fidelity"]["basis"] == "asserted_content_contradicted_by_geometry"
+
+    def test_fidelity_has_no_answer_when_the_drawing_asserts_nothing(self):
+        # No evidence is DATA, not a perfect score — the same contract completeness and
+        # restraint already follow, and the fail-open this module's docstring argues
+        # against. Unlike legibility, where an empty sheet genuinely IS legible,
+        # truthfulness of an empty utterance is not the same kind of 1.0.
+        from draftwright.linting.quality import quality_components
+
+        component = quality_components(
+            recognition=None,
+            features=(),
+            registry=None,
+            omissions=(),
+            issues=[],
+            error_penalty=0.05,
+            warning_penalty=0.05,
+            has_asserted_content=False,
+        )["fidelity"]
+        assert component["available"] is False
+        assert component["score"] is None
+        assert component["reason"]
+
+    def test_the_full_fidelity_shape_is_pinned(self):
+        # Legibility's complete dict is pinned in `test_make_drawing.py`; fidelity's was
+        # not, so mutating its error penalty to the warning penalty, or its `available` to
+        # `bool(issues)`, passed the entire 4,197-test suite.
+        component = _quality(99, "99")["fidelity"]
+        assert set(component) == {
+            "available",
+            "score",
+            "errors",
+            "warnings",
+            "infos",
+            "placement_drops",
+            "by_code",
+            "raw_issues",
+            "primary_issues",
+            "primary_errors",
+            "primary_warnings",
+            "primary_infos",
+            "primary_by_code",
+            "affected_pairs",
+            "basis",
+            "score_inventory",
+        }
+        assert component["errors"] == 1 and component["warnings"] == 0
+        assert component["score"] == pytest.approx(0.8), (
+            "the error penalty changed; a material contradiction must not be priced as a warning"
+        )
+        assert component["by_code"] == {"label_vs_measured": 1}
+
     def test_legibility_is_unchanged_and_still_says_the_drawing_is_readable(self):
         # The point of a separate axis. A false dimension IS legible, so legibility is
         # right to report 1.0 — folding fidelity into it would have made a layout score
@@ -72,15 +131,44 @@ class TestFidelityIsReportedSeparately:
         )
 
 
+class TestPlacedContentContradictedByGeometryIsAlsoFalse:
+    def test_a_callout_for_a_feature_the_part_lacks_lowers_fidelity(self):
+        # The PR's first cut claimed `label_vs_measured` was "currently the only such
+        # code". This is worse than the case it was built for: a `⌀6 THRU` leader and a
+        # centre mark are DRAWN, pointing at solid material, because the declared hole is
+        # not in the part. The sheet tells a machinist to drill something the model does
+        # not have, and it scored 1.0.
+        sheet = Sheet(Box(80, 60, 20), title="T", number="N-1")
+        sheet.hole(at=(10, 10, 0), axis="z", diameter=6, through=True)
+        # `auto_dimensions`, not `authored_dimensions`: measured, the authored path draws
+        # NOTHING for the absent hole, so nothing false reaches the sheet and there is no
+        # falsehood to score. The lie is specific to the automatic path, which renders the
+        # callout from the declaration without checking the geometry carries it.
+        sheet.auto_dimensions()
+        drawing = sheet.build()
+        summary = drawing.lint_summary()
+        assert [i for i in summary["issues"] if i["code"] == "declared_feature_absent"], (
+            "the fixture no longer declares a hole the part lacks"
+        )
+        drawn = [str(getattr(o, "label", "")) for _n, o in drawing.iter_annotations()]
+        assert any("⌀6" in d for d in drawn), (
+            f"nothing was drawn for the absent hole, so nothing false reached the sheet: {drawn}"
+        )
+        assert summary["quality"]["fidelity"]["score"] < 1.0
+
+
 class TestFidelityIsAboutFalsehoodNotAbsence:
     @pytest.mark.parametrize(
         "code",
         ["dimension_kind_unsupported", "callout_dropped", "feature_not_located"],
     )
     def test_a_missing_thing_is_not_a_false_thing(self, code):
-        # An omission is a gap, not a lie: it belongs to completeness. Admitting the
-        # `*_dropped` family here would make fidelity a second completeness score and
-        # leave nothing measuring truthfulness — which is the state this slice fixes.
+        # An omission is a gap, not a lie. Note this says where those codes do NOT belong,
+        # not where they go: measured, `callout_dropped` scores on legibility (via the
+        # placement-drop suffix) and `dimension_kind_unsupported` and `feature_not_located`
+        # score on NOTHING. No lint code routes to completeness at all — it builds its
+        # ledger from requirement outcomes. An earlier comment here claimed they "belong to
+        # completeness", which was an invented mechanism.
         assert code not in _FIDELITY_CODES
 
     def test_an_unsupported_dimension_does_not_lower_fidelity(self):

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -40,6 +40,7 @@ from draftwright import Sheet
 from draftwright.linting.quality import (
     _FIDELITY_CODES,
     _LEGIBILITY_CODES,
+    _STAGE_ROUTED_CODES,
     _UNSCORED_CODE_PREFIXES,
     _UNSCORED_CODES,
     _is_legibility_issue,
@@ -47,6 +48,13 @@ from draftwright.linting.quality import (
 from draftwright.linting.structural import is_dimension_like as _is_dimension_like
 
 _REFS = ((0, -25, 0), (0, -9, 0))  # a 16 mm span
+
+#: Producer call sites that forward a code held in a variable, so the AST walk cannot read
+#: the string. Shrink-only. Seven, down from the first cut's ten once conditional
+#: expressions were walked to their leaves; six are the pass-through parameters of the drop
+#: recorders in `annotations/`, and the seventh is `Drawing._record_build_issue` forwarding
+#: its own argument.
+_INDIRECT_PRODUCER_SITES = 7
 
 
 def _quality_of(sheet):
@@ -113,9 +121,25 @@ class TestFidelityIsReportedSeparately:
         # README reads `quality["legibility"]["by_code"]`; a caller reading fidelity's the
         # same way must get an empty mapping, not a KeyError, on the drawing above. Every
         # count is genuinely zero — a finding would have made the component available.
+        #
+        # The whole dict is pinned, not two keys of it: the AVAILABLE shape was pinned and
+        # the unavailable one was not, which is the asymmetry that let the KeyError exist in
+        # the first place.
         component = _quality_of(Sheet(Box(115, 50, 68), page="A2", scale=1))["fidelity"]
-        assert component["available"] is False
-        assert component["by_code"] == {} and component["raw_issues"] == 0
+        available = _quality(99, "99")["fidelity"]
+        assert set(component) == set(available) | {"reason"}, (
+            "the unavailable component no longer publishes the available component's keys"
+        )
+        assert component["available"] is False and component["score"] is None
+        assert component["reason"]
+        assert all(
+            component[key] in (0, {})
+            for key in component
+            if key not in ("available", "score", "reason", "basis", "score_inventory")
+        )
+        assert component["basis"] == available["basis"], (
+            "an unavailable component must still say WHAT it would have measured"
+        )
 
     def test_a_finding_outranks_the_availability_gate(self):
         # The gate must never DISCARD a falsehood. This drawing draws no measured quantity,
@@ -192,11 +216,16 @@ class TestFidelityIsReportedSeparately:
         # a placement stage would be scored twice.
         from draftwright.linting.issues import LintIssue
 
+        # `outcome_stage="placement"` must be SET on the probe. Without it the field
+        # defaults to None, `is_placement_drop` falls back to the suffix, and the branch this
+        # test exists for is never executed — the test reduced to the set comparison above
+        # while its comment claimed otherwise (#1176 review r4).
         doubled = [
             code
             for code in sorted(_FIDELITY_CODES)
-            if _is_legibility_issue(LintIssue(severity="error", code=code, message=""))
-            or code.endswith("_dropped")
+            if _is_legibility_issue(
+                LintIssue(severity="error", code=code, message="", outcome_stage="placement")
+            )
         ]
         assert not doubled, f"{doubled} would be scored on legibility as well as fidelity"
 
@@ -266,9 +295,11 @@ class TestFidelityIsAboutFalsehoodNotAbsence:
         assert component["by_code"] == {}, (
             "refusing to draw something was scored as drawing something false"
         )
-        # And the refusal leaves the sheet asserting nothing measurable at all, so the
-        # honest report is "no answer" rather than a perfect one.
-        assert component["available"] is False and component["score"] is None
+        assert component["score"] == 1.0
+        # And the refusal is itself scored by nothing — an omission is not a legibility
+        # fault either. That is reported rather than left implicit.
+        assert summary["quality"]["unscored"]["by_code"]["dimension_kind_unsupported"] == 1
+        assert not summary["quality"]["unscored"]["unclassified"]
 
 
 _WHEEL = Path(__file__).parent / "fixtures" / "issue_1058_wheel_rh.step"
@@ -334,6 +365,29 @@ class TestAGearTableCanBeFalseWhileTheDrawingPasses:
         )
         assert summary["quality"]["fidelity"]["score"] == 1.0
 
+    def test_a_table_that_no_longer_carries_the_authored_values_lowers_fidelity(self):
+        # `gear_requirement_mismatch` was the last member with no behavioural guard: moving
+        # it into `_UNSCORED_CODES` — declaring a stale normative table not to be a falsehood
+        # — passed the entire fast tier (#1176 review r4).
+        #
+        # It fires when the PLACED table stops matching the requirement it claims to carry,
+        # which no ordinary build produces, so the table is edited after placement. That is
+        # the defect exactly: a sheet whose data table and its source have diverged. This is
+        # also the member whose source of truth is the authored requirement rather than the
+        # geometry, which is why the published basis says "its source".
+        drawing = _wheel_gear_sheet(_WHEEL_TEETH).build()
+        table = next(
+            item
+            for _n, item in drawing.iter_annotations()
+            if getattr(item, "gear_requirement_values", None) is not None
+        )
+        stale = list(table.gear_requirement_values)
+        stale[0] = _WHEEL_TEETH - 1
+        table.gear_requirement_values = tuple(stale)
+        summary = drawing.lint_summary()
+        assert summary["quality"]["fidelity"]["by_code"] == {"gear_requirement_mismatch": 1}
+        assert summary["quality"]["fidelity"]["score"] < 1.0
+
     def test_a_data_table_bound_to_the_wrong_axis_lowers_fidelity(self):
         summary = _wheel_gear_sheet(_WHEEL_TEETH, axis="x").build().lint_summary()
         assert summary["quality"]["fidelity"]["by_code"] == {"gear_axis_mismatch": 1}
@@ -341,35 +395,71 @@ class TestAGearTableCanBeFalseWhileTheDrawingPasses:
 
 
 def _emitted_codes():
-    """Every lint code the engine can produce, by AST over its two producer forms.
+    """Every lint code the engine can produce, by AST over its THREE producer forms.
 
-    `LintIssue(code=...)` and `ctx.record_issue(severity, code, ...)`. Read from the source
-    rather than from a runtime sweep because a code emitted only on a path no test reaches is
-    exactly the one that would slip through unclassified.
+    `LintIssue(code=…)`, `ctx.record_issue(severity, code, …)` and
+    `Drawing._record_build_issue(severity, code, …)`, each accepting the code positionally or
+    by keyword. Read from the source rather than by running the engine, because a code
+    emitted only on a path no test reaches is exactly the one that would slip through
+    unclassified.
+
+    The first cut of this walk had three demonstrated escapes, each of which let a brand-new
+    code pass all four audits (#1176 review r4): it required `len(args) >= 2` and so skipped
+    the keyword form of the very producer it modelled; it did not know about
+    `_record_build_issue` at all; and it treated a conditional expression as opaque, so
+    widening `"pmi_dropped" if source_ids else "gdt_dropped"` to a third branch hid a new
+    code inside a call site already counted. Conditional branches are now walked to their
+    constant leaves.
     """
     literals: set[str] = set()
     prefixes: set[str] = set()
     indirect: list[str] = []
+    stages: dict[str, set[str | None]] = {}
     root = Path(__file__).resolve().parents[1] / "src" / "draftwright"
+
+    def leaves(expr, path, out):
+        if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+            out.append(expr.value)
+        elif isinstance(expr, ast.IfExp):
+            leaves(expr.body, path, out)
+            leaves(expr.orelse, path, out)
+        elif isinstance(expr, ast.JoinedStr) and isinstance(expr.values[0], ast.Constant):
+            out.append(expr.values[0].value + "{}")
+        else:
+            out.append(None)
+            indirect.append(f"{path}:{expr.lineno}")
+
     for path in sorted(root.rglob("*.py")):
         for node in ast.walk(ast.parse(path.read_text())):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
             name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
-            if name == "LintIssue":
-                expr = next((k.value for k in node.keywords if k.arg == "code"), None)
-            elif name == "record_issue" and len(node.args) >= 2:
-                expr = node.args[1]
-            else:
+            if name not in ("LintIssue", "record_issue", "_record_build_issue"):
                 continue
-            if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
-                literals.add(expr.value)
-            elif isinstance(expr, ast.JoinedStr) and isinstance(expr.values[0], ast.Constant):
-                prefixes.add(expr.values[0].value)
-            elif expr is not None:
-                indirect.append(f"{path.relative_to(root)}:{expr.lineno}")
-    return literals, prefixes, indirect
+            expr = next((k.value for k in node.keywords if k.arg == "code"), None)
+            if expr is None and name != "LintIssue" and len(node.args) >= 2:
+                expr = node.args[1]
+            if expr is None:
+                continue
+            stage = next((k.value for k in node.keywords if k.arg == "outcome_stage"), None)
+            if stage is None:
+                staged: str | None = None
+            elif isinstance(stage, ast.Constant):
+                staged = stage.value
+            else:
+                staged = "<conditional>"
+            found: list = []
+            leaves(expr, path.relative_to(root), found)
+            for code in found:
+                if code is None:
+                    continue
+                if code.endswith("{}"):
+                    prefixes.add(code[:-2])
+                else:
+                    literals.add(code)
+                    stages.setdefault(code, set()).add(staged)
+    return literals, prefixes, indirect, stages
 
 
 class TestEveryLintCodeIsClassified:
@@ -382,8 +472,8 @@ class TestEveryLintCodeIsClassified:
     """
 
     def test_no_lint_code_scores_on_an_unstated_axis(self):
-        literals, _prefixes, _indirect = _emitted_codes()
-        classified = _FIDELITY_CODES | _LEGIBILITY_CODES | _UNSCORED_CODES
+        literals, _prefixes, _indirect, _stages = _emitted_codes()
+        classified = _FIDELITY_CODES | _LEGIBILITY_CODES | _UNSCORED_CODES | _STAGE_ROUTED_CODES
         unclassified = sorted(
             code for code in literals if code not in classified and not code.endswith("_dropped")
         )
@@ -393,24 +483,59 @@ class TestEveryLintCodeIsClassified:
             "each to _FIDELITY_CODES, _LEGIBILITY_CODES or _UNSCORED_CODES."
         )
 
+    def test_a_dropped_suffix_is_only_trusted_where_it_is_true(self):
+        # The audit above exempts `*_dropped` because the suffix routes to legibility. That
+        # is true only where no emission site sets `outcome_stage`, which takes precedence
+        # (`issues.py::is_placement_drop`) — and `section_dropped` is emitted ONLY as
+        # `"validation"`, so it reaches no component at all while a comment beside it
+        # asserted the opposite (#1176 review r4). The exemption is now conditional on the
+        # thing it assumes.
+        _literals, _prefixes, _indirect, stages = _emitted_codes()
+        unexamined = sorted(
+            code
+            for code, seen in stages.items()
+            if code.endswith("_dropped")
+            and ("validation" in seen or "<conditional>" in seen)
+            and code not in (_UNSCORED_CODES | _STAGE_ROUTED_CODES)
+        )
+        assert not unexamined, (
+            f"{unexamined} are emitted with a validation outcome_stage, so the `_dropped` "
+            "suffix does NOT put them in the legibility inventory. Register each in "
+            "_UNSCORED_CODES (always unscored) or _STAGE_ROUTED_CODES (scored per issue)."
+        )
+
     def test_the_registers_describe_codes_that_exist(self):
         # The other direction: a renamed code must not leave a dead entry behind, which
         # would make the audit above pass while the real code went unclassified.
-        literals, _prefixes, _indirect = _emitted_codes()
-        stale = sorted((_FIDELITY_CODES | _UNSCORED_CODES) - literals)
+        literals, _prefixes, _indirect, _stages = _emitted_codes()
+        stale = sorted((_FIDELITY_CODES | _UNSCORED_CODES | _STAGE_ROUTED_CODES) - literals)
         assert not stale, f"{stale} are registered but no longer emitted anywhere"
 
     def test_every_interpolated_code_family_is_registered(self):
-        _literals, prefixes, _indirect = _emitted_codes()
+        _literals, prefixes, _indirect, _stages = _emitted_codes()
         assert sorted(prefixes) == sorted(_UNSCORED_CODE_PREFIXES)
 
     def test_the_indirect_producer_sites_do_not_grow(self):
-        # Ten call sites forward a code held in a variable, so the audit cannot see the
+        # Call sites that forward a code held in a variable, so the audit cannot see the
         # string. A shrink-only ratchet (the `_ALLOW` pattern from
         # `test_private_test_imports.py`): a new indirection has to be argued rather than
-        # silently widening the blind spot.
-        _literals, _prefixes, indirect = _emitted_codes()
-        assert len(indirect) <= 10, (
+        # silently widening the blind spot. Walking conditional expressions to their leaves
+        # took this from ten sites to the genuinely opaque ones.
+        _literals, _prefixes, indirect, _stages = _emitted_codes()
+        assert len(indirect) <= _INDIRECT_PRODUCER_SITES, (
             f"a new lint code is passed through a variable, so the classification audit "
             f"cannot see it: {indirect}"
         )
+
+    def test_the_runtime_report_agrees_with_the_static_register(self):
+        # `quality["unscored"]["unclassified"]` is the same question asked of one drawing's
+        # own findings, which is what gives `_UNSCORED_CODES` a production consumer rather
+        # than making it test data shipped in `src/` (#1176 review r4).
+        sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", page="A2", scale=1)
+        sheet.measured_dimension(
+            kind="linear", value=99, label="99", dominant_axis="y", ref_pts=_REFS
+        )
+        sheet.authored_dimensions()
+        quality = sheet.build().lint_summary()["quality"]
+        assert quality["unscored"]["unclassified"] == []
+        assert quality["unscored"]["issues"] == sum(quality["unscored"]["by_code"].values())

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5265,7 +5265,11 @@ class TestLintSummaryAndDrops:
         assert s["passed"] is (s["errors"] == 0)
         assert 0.0 <= s["score"] <= 1.0
         assert s["diagnostic_score"] == s["score"]
-        assert set(s["quality"]) == {"completeness", "restraint", "legibility"}
+        # `fidelity` joined in #1176: completeness asks whether required content landed,
+        # restraint whether there is too much of it, legibility whether a reader can make
+        # it out, and fidelity whether what it says is TRUE. A drawing can pass the first
+        # three and still assert a measurement the part does not have.
+        assert set(s["quality"]) == {"completeness", "restraint", "legibility", "fidelity"}
         completeness = s["quality"]["completeness"]
         assert completeness["available"] is True
         assert completeness["audited_score"] == 1.0

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5269,7 +5269,17 @@ class TestLintSummaryAndDrops:
         # restraint whether there is too much of it, legibility whether a reader can make
         # it out, and fidelity whether what it says is TRUE. A drawing can pass the first
         # three and still assert a measurement the part does not have.
-        assert set(s["quality"]) == {"completeness", "restraint", "legibility", "fidelity"}
+        # `unscored` is not a fifth axis — it is the inventory of findings that reached
+        # NONE of the four, reported for the same reason completeness reports `excludes`
+        # (#1176 review r4): four components all saying "fine" would otherwise conceal that
+        # some of this drawing's findings were scored by nothing at all.
+        assert set(s["quality"]) == {
+            "completeness",
+            "restraint",
+            "legibility",
+            "fidelity",
+            "unscored",
+        }
         completeness = s["quality"]["completeness"]
         assert completeness["available"] is True
         assert completeness["audited_score"] == 1.0

--- a/tests/test_quality_components.py
+++ b/tests/test_quality_components.py
@@ -29,6 +29,10 @@ def _legibility(*issues):
         issues=issues,
         error_penalty=0.15,
         warning_penalty=0.05,
+        # Irrelevant to the component under test; `quality_components` requires it rather
+        # than defaulting to True, because a fail-open default that only tests supply is a
+        # default that only tests are protected by (#1176 review r3).
+        has_asserted_content=True,
     )["legibility"]
 
 
@@ -41,6 +45,10 @@ def _completeness(*issues):
         issues=issues,
         error_penalty=0.15,
         warning_penalty=0.05,
+        # Irrelevant to the component under test; `quality_components` requires it rather
+        # than defaulting to True, because a fail-open default that only tests supply is a
+        # default that only tests are protected by (#1176 review r3).
+        has_asserted_content=True,
     )["completeness"]
 
 
@@ -159,6 +167,10 @@ def test_an_unavailable_completeness_component_is_data_not_a_zero_score():
         issues=(),
         error_penalty=0.15,
         warning_penalty=0.05,
+        # Irrelevant to the component under test; `quality_components` requires it rather
+        # than defaulting to True, because a fail-open default that only tests supply is a
+        # default that only tests are protected by (#1176 review r3).
+        has_asserted_content=True,
     )
     completeness = components["completeness"]
 


### PR DESCRIPTION
Closes #1176. Slice **S4** of epic #1202.

## The hole

`lint_summary()["quality"]` asked three questions — did required content land
(completeness), is there too much of it (restraint), can a reader make it out
(legibility) — and none asked whether the drawing is **true**.

The case that justifies the axis, reproduced end to end on a fixture already in the repo
(`tests/fixtures/issue_1058_wheel_rh.step`, 13 teeth):

```
rows:      ('TEETH z', '12', 'ISO 21771-1:2024')
top-level: passed=True, errors=0, warnings=4, score=0.8
```

A normative ISO data table printing **twelve teeth on a thirteen-tooth part**, with
`passed: True` and zero errors. `by_code` names it, so a caller following ADR 0002's advice
can see it — but nothing *scores* it, and the drawing is otherwise perfect.

(An earlier version of this PR claimed "1.0 was the only number a caller saw" on a
518%-wrong dimension. That was false and the branch says so: that drawing already reported
`passed: False, errors: 1, score: 0.8`.)

## What is added

- **`quality["fidelity"]`** — basis `drawn_assertion_contradicted_by_its_source`, over five
  codes: `label_vs_measured`, `declared_feature_absent`, `gear_repeat_count_mismatch`,
  `gear_axis_mismatch`, `gear_requirement_mismatch`. Four are contradicted by the part; the
  fifth by the authored requirement the table claims to carry.
- **`quality["unscored"]`** — the findings that reached *no* component (22 codes never do,
  and 13 more depend on the issue's `outcome_stage`), with `unclassified` flagging any whose
  classification nobody made.
- **A classification audit** over every code the engine emits: three producer forms,
  positional and keyword, conditional expressions walked to their leaves, `drop_code` data
  followed through its forwarding layers to a fixed point, aliased imports resolved. Plus a
  shrink-only ratchet on the call sites whose code the walk cannot read, and a check that
  the `*_dropped` suffix shortcut is only trusted where `outcome_stage` does not override it.

## Defects this found in the engine

- **`section_dropped` scores on nothing.** `is_placement_drop` reads `outcome_stage` first
  and `_skip_section` sets `"validation"` deliberately — so a lost section reaches no
  component, while the comment four lines above that call said the suffix "puts it in the
  legibility inventory automatically". Eleven more `*_dropped` codes reach the engine as
  `drop_code` data with the same shape.
- **Every fidelity code was double-scored if it carried a placement stage.** Fixed in
  production: `_is_legibility_issue` excludes fidelity codes outright.

## Six rounds of adversarial review

Each round found the previous round's fix defective, and each is recorded in the commit that
fixed it:

1. `label_vs_measured` was claimed to be "the only such code". Four more, two reproduced end
   to end and both worse than the case the axis was built for.
2. The component published legibility's `basis` string — the very string this PR's own test
   cites as proof legibility measures layout.
3. The availability gate **failed closed over a detected falsehood**, discarding a real
   `declared_feature_absent`, decided by whether an ISO-view note happened to be emitted.
   Its only test called the helper directly, so replacing the whole predicate with `True`
   passed every test in the file.
4. The audit added in round 3 had three escapes; the double-scoring guard was inert; and the
   gate could report a falsehood but never a clean pass.
5. The predicate then failed **open** — a declared slot, which no truth check examines, was
   certified "checked, nothing false". Both halves of the predicate and the override were
   untested. Two more audit escapes (`LintIssue`'s positional code; `**kwargs`), and eleven
   `*_dropped` codes invisible because they arrive as `drop_code` data.
6. The `drop_code` fix recorded only literals, so a module constant — ordinary refactoring —
   was invisible again; aliased producer imports likewise; the "fixed point" was a bounded
   four-pass loop; and the third term of the predicate was still untested. Four more
   measured-false claims corrected, including a `kind` that does not exist.

## Verification

- Every member of `_FIDELITY_CODES` individually mutated out → each fails its own test.
- All escapes from every round reproduced as mutations → all killed, including three injected
  into `src/`.
- Full fast tier: **4240 passed**, 5 skipped, 2 xfailed. `scripts/pr-check --static`: exit 0.

Docs: `lint_summary()`'s contract, `quality.py`, ADR 0002, README, `skills/SKILL.md`,
CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22