### PR TITLE
One physical measurement, one owner (#1154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- A part whose feature-local extent runs between the same two faces as an overall extent
+  is no longer dimensioned twice (#1154). GRM-04's drive plate printed `4.5` twice — once
+  as the hub's height and once as the overall thickness — because two detected records
+  claim one physical fact. The overall extent keeps it; the feature-local one is withheld
+  and records, in `compile_dimensions(...).diagnostics`, which dimension the reader finds
+  it on. Reconciliation is by exact support-plane coincidence, never by value: a square
+  part's two equal extents run between different faces and remain two facts (#997).
+
 ### Added
 
 - `lint_summary()["quality"]` gains a fourth component, `fidelity`: whether what the drawing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
   claim one physical fact. The overall extent keeps it; the feature-local one is withheld
   and records, in `compile_dimensions(...).diagnostics`, which dimension the reader finds
   it on. Reconciliation is by exact support-plane coincidence, never by value: a square
-  part's two equal extents run between different faces and remain two facts (#997).
+  part's two equal extents run between different faces and remain two facts (#997). A
+  measurement is handed over only when the extent receiving it is actually drawn — by the
+  planner's rules, by the compiler's overall-height rules, and by an authored set — and
+  never when it carries a tolerance the extent does not, since a toleranced dimension and an
+  untoleranced one are not the same requirement.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,12 @@
 
 ## Unreleased
 
-### Fixed
+### Changed
 
-- A part whose feature-local extent runs between the same two faces as an overall extent
-  is no longer dimensioned twice (#1154). GRM-04's drive plate printed `4.5` twice — once
-  as the hub's height and once as the overall thickness — because two detected records
-  claim one physical fact. The overall extent keeps it; the feature-local one is withheld
-  and records, in `compile_dimensions(...).diagnostics`, which dimension the reader finds
-  it on. Reconciliation is by exact support-plane coincidence, never by value: a square
-  part's two equal extents run between different faces and remain two facts (#997). A
-  measurement is handed over only when the extent receiving it is actually drawn — by the
-  planner's rules, by the compiler's overall-height rules, and by an authored set — and
-  never when it carries a tolerance the extent does not, since a toleranced dimension and an
-  untoleranced one are not the same requirement.
+- `Drawing.suppressions()` rows gain a `conveyed_by` key: the dimension that states a
+  withheld measurement instead, or `None` when nothing takes the fact over (#1154). It is not
+  a synonym for the existing `authored` flag — that says whose decision it was, this says
+  where the measurement went.
 
 ### Added
 
@@ -67,6 +60,19 @@
   normal consumer gates run on the generated PR.
 
 ### Fixed
+
+- A part whose feature-local extent runs between the same two faces as an overall extent
+  is no longer dimensioned twice (#1154). GRM-04's drive plate printed `4.5` twice — once
+  as the hub's height and once as the overall thickness — because two detected records
+  claim one physical fact. The overall extent keeps it; the feature-local one is withheld
+  and records which dimension the reader finds it on. Reconciliation is by exact
+  support-plane coincidence, never by value: a square part's two equal extents run between
+  different faces and remain two facts (#997). A measurement is handed over only when the
+  extent receiving it is actually drawn — by the planner's rules, by the compiler's
+  overall-height rules, and by an authored set — and never when the yielding dimension
+  carries a tolerance the extent does not, since a toleranced dimension and an untoleranced
+  one are not the same requirement. (A tolerance on the *receiving* extent is the same
+  requirement on the same two faces, and does not prevent the consolidation.)
 
 - Stable release and TestPyPI snapshot builds now update package metadata and the independently
   validated Draftwright consumer-contract identity atomically. This prevents stripped `.dev0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 ## Unreleased
 
-### Changed
-
-- `Drawing.suppressions()` rows gain a `conveyed_by` key: the dimension that states a
-  withheld measurement instead, or `None` when nothing takes the fact over (#1154). It is not
-  a synonym for the existing `authored` flag — that says whose decision it was, this says
-  where the measurement went.
-
 ### Added
 
 - `lint_summary()["quality"]` gains a fourth component, `fidelity`: whether what the drawing
@@ -45,6 +38,11 @@
 
 ### Changed
 
+- `Drawing.suppressions()` rows gain a `conveyed_by` key: the dimension that states a
+  withheld measurement instead, or `None` when nothing takes the fact over (#1154). It is not
+  a synonym for the existing `authored` flag — that says whose decision it was, this says
+  where the measurement went.
+
 - Updated the exact `b123d-recognisers` production lock from 0.2.2 to 0.2.4.
   The immutable PyPI wheel/sdist hashes and capability-manifest digest `d0023d30e583c03abc55f09dfeaaa56fddf56334afa0417818480b2fa2ce3f0f` are
   recorded in `.github/recogniser-release.json`; focused compatibility evidence and the
@@ -70,9 +68,9 @@
   different faces and remain two facts (#997). A measurement is handed over only when the
   extent receiving it is actually drawn — by the planner's rules, by the compiler's
   overall-height rules, and by an authored set — and never when the yielding dimension
-  carries a tolerance the extent does not, since a toleranced dimension and an untoleranced
-  one are not the same requirement. (A tolerance on the *receiving* extent is the same
-  requirement on the same two faces, and does not prevent the consolidation.)
+  carries a tolerance, since a toleranced dimension and an untoleranced one are not the same
+  requirement. (A tolerance on the *receiving* extent is the same requirement on the same two
+  faces, and does not prevent the consolidation.)
 
 - Stable release and TestPyPI snapshot builds now update package metadata and the independently
   validated Draftwright consumer-contract identity atomically. This prevents stripped `.dev0`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,10 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
   `Feature` objects, adapting `b123d_recognisers` records), `planner.py`
   (`plan_dimensions` —
-  one rule set → a `DimensionGroup` per feature, + `plan_sections`), and
+  one rule set → a `DimensionGroup` per feature, + `plan_sections`; and, since #1154,
+  the one cross-feature reconciliation: two features measuring between the same two
+  support planes state one fact, so the overall extent keeps it and the feature-local
+  one records where it went), and
   `declare.py` (ADR 0011 object→feature constructors: `hole`/`boss`/`step`/… read
   a feature's size off the build123d object — a second, *declared* front-end into
   the same IR the detectors fill). The narrow middle of the compiler hourglass;

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -222,6 +222,41 @@ records cross is the sanctioned `build_part_model` boundary itself.
   real state of the adapter protocol, instead of 0008's aspirational
   "migration complete — one rule set".
 
+## Amendment — cross-feature reconciliation by support-plane identity (2026-08-18, #1154)
+
+The planner's long-standing contract says features own their parameters and "do
+not emit spurious duplicates", and that the planner does **not** de-duplicate by
+value. Both still hold. What #1154 showed is that they leave a case uncovered:
+two features can emit **one physical fact**. GRM-04's hub is flush with both
+faces of its plate, so `boss.boss_height.length` and `envelope.width.length`
+measure between the same two faces and the sheet prints `4.5` twice. Neither
+record is spurious, and no value comparison may collapse them — #997 deleted a
+rule that did exactly that and read a 100 x 95 part as square.
+
+So the planner now reconciles across features on **support-plane coincidence**:
+the two along-axis coordinates a length runs between, compared at the kernel's
+noise floor. The overall extent keeps the fact; the feature-local one is
+withheld and records, as an `Omission.conveyed_by`, the dimension that states it
+instead. This is a *third* kind of planner decision alongside per-parameter
+suppression and authored omission, and it is deliberately narrow: only an
+`envelope` extent may take ownership, because feature-to-feature consolidation
+would need an answer to which of two peers is canonical and there is none.
+
+Two consequences worth stating, both found by review rather than design:
+
+- **A handover requires a receiver.** The measurement moves only if the extent
+  taking it over is itself drawn — which three separate authorities decide (the
+  planner's envelope rules, an authored set, and the compiler's overall-height
+  rules). The model-derivable half of the third lives in `planner` as
+  `polygonal_stock_conveys_height` / `rotational_od_conveys_height` so that
+  `compiled._compile_overall_height` stays the single owner of *applying* them
+  while the planner can *ask* them.
+- **A tolerance is part of the requirement.** A toleranced dimension and an
+  untoleranced one are not the same fact, so a toleranced measurement is never
+  handed to an extent that cannot state it. The rule is asymmetric: a tolerance
+  on the *receiving* extent is the same requirement on the same two faces and
+  does not block the consolidation.
+
 ## Supersession
 
 ADR 0008 is **Superseded by this ADR**. Its status header, decision text, and

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -251,11 +251,15 @@ Two consequences worth stating, both found by review rather than design:
   `polygonal_stock_conveys_height` / `rotational_od_conveys_height` so that
   `compiled._compile_overall_height` stays the single owner of *applying* them
   while the planner can *ask* them.
-- **A tolerance is part of the requirement.** A toleranced dimension and an
-  untoleranced one are not the same fact, so a toleranced measurement is never
-  handed to an extent that cannot state it. The rule is asymmetric: a tolerance
-  on the *receiving* extent is the same requirement on the same two faces and
-  does not block the consolidation.
+- **A tolerance is part of the requirement.** A toleranced measurement is never
+  handed over, full stop. The rule is asymmetric — it is about the *yielding*
+  dimension alone, so a tolerance on the receiving extent is the same requirement
+  on the same two faces and does not block the consolidation. An earlier draft
+  read "never handed to an extent that cannot state it", which admitted equal
+  tolerances on both sides; measured, no envelope extent renders a decoration on
+  any axis, so that exception silently deleted the ± the yielder would have
+  printed. Whether the receiver happens to print a tolerance is not the rule's
+  business.
 
 ## Supersession
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -860,8 +860,11 @@ class Drawing:
         dimension it names. "This is not drawn" and "this is drawn over there" are different
         answers, and an audit that flattened them would read a de-duplication as a gap. It
         rides the same stable ``kind@(x,y,z)/axis`` key as ``feature``, so the two halves of
-        one consolidation can be matched up without importing IR types. ``None`` for every
-        other omission, authored ones included — nothing takes those over.
+        one consolidation can be matched up without importing IR types. ``None`` wherever
+        nothing takes the fact over — which is NOT the same question as ``authored``: an
+        authored omission carries a ``conveyed_by`` whenever the author's set keeps the
+        owner, since the author chooses which dimensions are drawn and not where the
+        geometry states a fact.
 
         The second is the one worth auditing. A rule that fires where it should not produces
         a drawing that is silently under-defined and lints clean, which is how #997's square

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -855,6 +855,14 @@ class Drawing:
           set means omission is suppression. Recoverable by adding a ``dimension(...)`` line.
         - otherwise — a **planner rule** decided it, and ``reason`` names which.
 
+        ``conveyed_by`` distinguishes a measurement that was WITHHELD from one that was
+        CONSOLIDATED (#1154): when it is set, the fact is still on the sheet, stated by the
+        dimension it names. "This is not drawn" and "this is drawn over there" are different
+        answers, and an audit that flattened them would read a de-duplication as a gap. It
+        rides the same stable ``kind@(x,y,z)/axis`` key as ``feature``, so the two halves of
+        one consolidation can be matched up without importing IR types. ``None`` for every
+        other omission, authored ones included — nothing takes those over.
+
         The second is the one worth auditing. A rule that fires where it should not produces
         a drawing that is silently under-defined and lints clean, which is how #997's square
         rule generated four separate issue reports without any of them naming the cause. An
@@ -876,6 +884,14 @@ class Drawing:
                 "value": o.value,
                 "reason": o.reason,
                 "authored": o.authored,
+                "conveyed_by": (
+                    None
+                    if o.conveyed_by is None
+                    else {
+                        "feature": feature_key(o.conveyed_by.feature),
+                        "parameter_id": o.conveyed_by.parameter,
+                    }
+                ),
             }
             for o in self._build.omissions
         ]
@@ -3120,6 +3136,7 @@ class Drawing:
                     self,
                     getattr(model, "features", ()),
                     assembly=self.assembly,
+                    omissions=self._build.omissions,
                 )
             issues += lint_location_coverage(
                 self.part,

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -1270,7 +1270,7 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     ]
 
 
-def lint_boss_height_coverage(part, dwg, features, assembly=None) -> list:
+def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) -> list:
     """Report modeled boss heights that have no rendered linear dimension (#632).
 
     Coverage is reconciled from the drawing registry's feature provenance, not a
@@ -1278,6 +1278,15 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None) -> list:
     is a ``Dimension``. Boss diameter annotations are leaders, so they cannot mask a
     missing axial height. Bosses without a modeled height retain the historical
     diameter-only contract and are outside this check.
+
+    A height the compiler **consolidated** onto an overall extent (#1154 — the boss spans
+    the full thickness, so its height and the envelope width measure the same two faces)
+    counts as covered, but only once that owner is verifiably on the sheet. The owner is
+    read from the omission's ``conveyed_by`` and looked up among the registry's placed
+    measurements: consolidating onto a dimension the placer then drops would otherwise turn
+    a measurement this check exists to demand into silence. Suppression that hands the fact
+    to nobody — an authored omission, a turned-part rule — carries no ``conveyed_by`` and is
+    deliberately not exempted here.
     """
     bosses = [
         feature
@@ -1285,10 +1294,22 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None) -> list:
         if getattr(feature, "kind", None) in ("boss", "polygonal_boss")
         and getattr(feature, "height", None) is not None
     ]
+    registry = getattr(dwg, "registry", None)
+    placed = (
+        {measurement for name in registry.names() for measurement in registry.measurement_of(name)}
+        if registry is not None
+        else set()
+    )
+    conveyed = {
+        omission.feature
+        for omission in omissions
+        if omission.conveyed_by is not None and omission.conveyed_by in placed
+    }
     missing = sum(
         1
         for boss in bosses
-        if not any(isinstance(ann, Dimension) for ann in dwg.annotations_of(boss).values())
+        if boss not in conveyed
+        and not any(isinstance(ann, Dimension) for ann in dwg.annotations_of(boss).values())
     )
     if not missing:
         return []

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -1284,9 +1284,13 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) 
     counts as covered, but only once that owner is verifiably on the sheet. The owner is
     read from the omission's ``conveyed_by`` and looked up among the registry's placed
     measurements: consolidating onto a dimension the placer then drops would otherwise turn
-    a measurement this check exists to demand into silence. Suppression that hands the fact
-    to nobody — an authored omission, a turned-part rule — carries no ``conveyed_by`` and is
-    deliberately not exempted here.
+    a measurement this check exists to demand into silence.
+
+    The exemption follows ``conveyed_by``, never ``authored``: an authored omission whose set
+    keeps the owner carries one, and takes the exemption, because the author chooses which
+    dimensions are drawn and not where the geometry states a fact (#964 parity). Only a
+    suppression that hands the fact to nobody — a turned-part rule, an authored set that
+    drops the owner too — is left to report.
     """
     bosses = [
         feature

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -421,6 +421,12 @@ class Omission:
     parameter_id: str
     value: float | None
     reason: str
+    #: The dimension that states this fact instead, when the omission was a
+    #: consolidation rather than a withholding (#1154). ``None`` for every other
+    #: omission — including the authored ones, where nothing takes the fact over.
+    #: Completeness lint requires this owner to have actually landed; a consolidation
+    #: onto a dimension the placer then drops is a missing measurement, not a covered one.
+    conveyed_by: DimensionId | None = None
 
     @property
     def authored(self) -> bool:
@@ -1159,6 +1165,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 pd.param.parameter_id,
                 float(pd.param.value),
                 pd.reason or "suppressed",
+                conveyed_by=pd.conveyed_by,
             )
             for pd in g.dims
             if pd.suppressed

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -71,9 +71,10 @@ from draftwright.model.planner import (
     DimensionId,
     authored_location_omitted,
     location_datum,
-    overall_height_withheld,
     plan_dimensions,
     plan_locations,
+    polygonal_stock_conveys_height,
+    rotational_od_conveys_height,
 )
 
 
@@ -820,7 +821,10 @@ def _compile_overall_height(
     """The part's overall height — the envelope's ``height`` parameter, drawn in the
     front-view right strip rather than below a view, which is why it rides the ladder.
 
-    Every reason it might not be drawn is settled here, in one place. They used to be split:
+    Every reason it might not be drawn is settled here — as conditions named in `planner`
+    (`polygonal_stock_conveys_height`, `rotational_od_conveys_height`) and applied here, so
+    that #1154's consolidation can ask the same questions without re-deriving them. They used
+    to be split in the way that actually hurts:
     the planner suppressed it for a Z-turned part while the renderer independently suppressed
     it for that AND an X/Y rotational OD AND `include_overall`, and neither knew about the
     other. ``include_overall`` is drawing state (the finalize drain's explicit-envelope-height
@@ -834,18 +838,16 @@ def _compile_overall_height(
     # Letting the bbox fallback add `dim_height` would state one physical requirement twice,
     # and would make authored suppression ineffective through an unrelated synthetic value.
     #
-    # Asked through `planner.overall_height_withheld` rather than re-tested here: the
-    # planner's consolidation needs the same answer (#1154), and the paragraph above about
-    # two owners of this decision applies to a second owner in either direction.
+    # Asked through the planner's predicates rather than re-tested here: its consolidation
+    # needs the same answers (#1154), and the paragraph above about two owners of this
+    # decision applies to a second owner in either direction. Each CONDITION is consulted
+    # where it belongs — collapsing both into one early return here deleted the rotational
+    # case's `Omission` for a part with no envelope feature (#1154 review r2).
+    if polygonal_stock_conveys_height(model):
+        return None, None, []
     env = next((f for f in model.features if isinstance(f, EnvelopeFeature)), None)
     bb: Any = model.bbox  # build123d BoundBox
     rot = next((f for f in model.features if isinstance(f, RotationalFeature)), None)
-    if overall_height_withheld(model) and (
-        rot is None or rot.frame.axis not in ("x", "y") or env is None
-    ):
-        # The X/Y-rotational half keeps its own richer return below (it reports an Omission
-        # naming the OD); only the polygonal-stock half returns bare.
-        return None, None, []
     if not include_overall:
         return None, None, []
     mark = marked.get((id(env), "height.length")) if env is not None else None
@@ -895,7 +897,9 @@ def _compile_overall_height(
             )
             return None, ApprovedContingency("step_length", ladder, inactive), [inactive]
         return ladder, None, []
-    if rot is not None and rot.frame.axis in ("x", "y"):
+    if rot is not None and rotational_od_conveys_height(model):
+        # `rot is not None` is implied by the predicate and stated anyway, so the message
+        # below can read the axis off it without a second narrowing.
         return (
             None,
             None,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -61,7 +61,6 @@ from draftwright.model.ir import (
     PatternFeature,
     PocketFeature,
     Point,
-    PolygonalStockFeature,
     RotationalFeature,
     SlotFeature,
     SlotPatternFeature,
@@ -72,6 +71,7 @@ from draftwright.model.planner import (
     DimensionId,
     authored_location_omitted,
     location_datum,
+    overall_height_withheld,
     plan_dimensions,
     plan_locations,
 )
@@ -422,8 +422,11 @@ class Omission:
     value: float | None
     reason: str
     #: The dimension that states this fact instead, when the omission was a
-    #: consolidation rather than a withholding (#1154). ``None`` for every other
-    #: omission — including the authored ones, where nothing takes the fact over.
+    #: consolidation rather than a withholding (#1154). ``None`` wherever nothing takes the
+    #: fact over — but NOT a synonym for "the rule set did it": an authored omission carries
+    #: it too whenever the author's set keeps the owner, because the author chooses which
+    #: dimensions are drawn and not where the geometry states a fact. Read ``authored`` for
+    #: whose decision it was and this for where the measurement went.
     #: Completeness lint requires this owner to have actually landed; a consolidation
     #: onto a dimension the placer then drops is a missing measurement, not a covered one.
     conveyed_by: DimensionId | None = None
@@ -830,11 +833,19 @@ def _compile_overall_height(
     # Whole polygonal stock already owns the same axial extent as `stock_length.length`.
     # Letting the bbox fallback add `dim_height` would state one physical requirement twice,
     # and would make authored suppression ineffective through an unrelated synthetic value.
-    if any(isinstance(feature, PolygonalStockFeature) for feature in model.features):
-        return None, None, []
+    #
+    # Asked through `planner.overall_height_withheld` rather than re-tested here: the
+    # planner's consolidation needs the same answer (#1154), and the paragraph above about
+    # two owners of this decision applies to a second owner in either direction.
     env = next((f for f in model.features if isinstance(f, EnvelopeFeature)), None)
     bb: Any = model.bbox  # build123d BoundBox
     rot = next((f for f in model.features if isinstance(f, RotationalFeature)), None)
+    if overall_height_withheld(model) and (
+        rot is None or rot.frame.axis not in ("x", "y") or env is None
+    ):
+        # The X/Y-rotational half keeps its own richer return below (it reports an Omission
+        # naming the OD); only the polygonal-stock half returns bare.
+        return None, None, []
     if not include_overall:
         return None, None, []
     mark = marked.get((id(env), "height.length")) if env is not None else None

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -113,13 +113,16 @@ class PlannedDimension:
     # The source IR feature this dim locates — carried so the renderer can record
     # provenance (ADR 0010). ``None`` for dims not tied to a single feature.
     feature: Feature | None = None
-    # When this dim is suppressed because ANOTHER dimension already states the same
-    # physical fact, the dimension that now owns it (#1154). Suppression alone says a
-    # measurement is not drawn; this says where the reader finds it instead, so
-    # completeness lint can require that the owner actually landed rather than assume
-    # a consolidated fact is on the sheet. ``None`` for every other suppression — those
-    # withhold a measurement that is genuinely absent or genuinely redundant with a
-    # chain no single id names.
+    # When this dim is not drawn because ANOTHER dimension already states the same physical
+    # fact, the dimension that now owns it (#1154). Suppression alone says a measurement is
+    # not drawn; this says where the reader finds it instead, so completeness lint can
+    # require that the owner actually landed rather than assume a consolidated fact is on
+    # the sheet.
+    #
+    # Set INDEPENDENTLY of `reason`: an authored omission carries it too, whenever the
+    # author's set keeps the owner. The author decides which dimensions are drawn, not where
+    # the geometry states a fact, and the two must critique alike (#964 parity). ``None``
+    # wherever nothing takes the fact over.
     conveyed_by: DimensionId | None = None
 
 
@@ -352,6 +355,27 @@ def _same_support_planes(
     return a[0] == b[0] and abs(a[1] - b[1]) <= _PLANE_TOL and abs(a[2] - b[2]) <= _PLANE_TOL
 
 
+def overall_height_withheld(model: PartModel) -> bool:
+    """Whether the overall HEIGHT is withheld for a reason the model alone settles.
+
+    Two conditions, both belonging to `compiled._compile_overall_height`, which is the single
+    owner of "is the overall height drawn" and says so in its own docstring — whole polygonal
+    stock already owning the same axial extent, and an X/Y rotational OD conveying it. They
+    live here, and that function calls this, because :func:`_owner_drawn` needs the same
+    answer and re-deriving half of it beside a docstring warning against exactly that split
+    is how the split happened the first time (#1154 review).
+
+    NOT settled here: ``include_overall``, which is drawing state. It is safe to ignore for
+    consolidation — it is False only when an explicit ``role="height"`` intent draws the same
+    height through the dimension path instead, so the fact is still on the sheet — and that
+    is why it stays an argument to the compiler rather than a model property.
+    """
+    if any(f.kind == "polygonal_stock" for f in model.features):
+        return True
+    rot = next((f for f in model.features if f.kind == "rotational"), None)
+    return rot is not None and rot.frame.axis in ("x", "y")
+
+
 def _envelope_suppression(model: PartModel, param: DimParameter):
     """The overall-extent suppression rules → ``(suppressed, reason)``.
 
@@ -373,6 +397,20 @@ def _envelope_suppression(model: PartModel, param: DimParameter):
     if param.role == "height" and model.orientation == "z":
         return True, "Z-turned (step-length chain conveys the height)"
     return False, None
+
+
+def _decorated(model: PartModel, feature: Feature, param: DimParameter) -> DimParameter:
+    """*param* with the caller's authored tolerance / fit folded on, if any (ADR 0011 §4).
+
+    One owner, because :func:`_consolidated_owner` has to compare a candidate against the
+    extent that would take its fact over, and comparing a decorated parameter with an
+    undecorated one made a toleranced boss height look interchangeable with a plain overall
+    thickness (#1154 review).
+    """
+    tol = model.decorations.get((feature, param.kind, param.role))
+    if tol is None:
+        tol = model.decorations.get((feature, param.kind))
+    return param if tol is None else replace(param, tolerance=tol)
 
 
 def _consolidated_owner(model: PartModel, feature: Feature, param: DimParameter):
@@ -406,6 +444,13 @@ def _consolidated_owner(model: PartModel, feature: Feature, param: DimParameter)
                 continue
             if not _owner_drawn(model, envelope, extent):
                 continue
+            if _decorated(model, envelope, extent).tolerance != param.tolerance:
+                # A toleranced dimension and an untoleranced one are not the same
+                # requirement, so the overall extent cannot state this fact on its behalf.
+                # Consolidating anyway DELETED a ±0.05 the author had written, silently and
+                # with nothing in lint (#1154 review) — which is the one case where the
+                # feature-local dimension is the one a machinist needs.
+                continue
             return DimensionId(envelope, extent.parameter_id)
     return None
 
@@ -417,6 +462,12 @@ def _owner_drawn(model: PartModel, envelope: Feature, extent: DimParameter) -> b
     out, would delete the measurement from the sheet — the consolidation must move a fact
     to another dimension, never to nowhere.
 
+    Three authorities decide that, not one: this module's envelope rules, the authored set,
+    and — for the overall HEIGHT specifically — `compiled._compile_overall_height`, whose
+    model-derivable half is :func:`overall_height_withheld`. The first cut consulted only the
+    first, so a declared X-rotational part consolidated its boss height onto an overall
+    height that same compiler was independently withholding (#1154 review).
+
     The authored half is why an authored omission can still carry a ``conveyed_by``: the
     author's list decides which dimensions are drawn, not where the geometry puts a fact.
     A script that lists the overall extent and not the boss height omits nothing a reader
@@ -424,6 +475,8 @@ def _owner_drawn(model: PartModel, envelope: Feature, extent: DimParameter) -> b
     (round-trip parity, epic #964).
     """
     if _envelope_suppression(model, extent)[0]:
+        return False
+    if extent.parameter_id == "height.length" and overall_height_withheld(model):
         return False
     if model.authored_dimensions is None:
         return True
@@ -902,11 +955,7 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
             # fallback that folds onto EVERY param of that kind. `kind` stays in the key —
             # a step's length and diameter share role="step", so role alone can't tell
             # them apart.
-            tol = model.decorations.get((feature, p.kind, p.role))
-            if tol is None:
-                tol = model.decorations.get((feature, p.kind))
-            if tol is not None:
-                p = replace(p, tolerance=tol)
+            p = _decorated(model, feature, p)
             suppressed, reason, conveyed_by = _suppression(model, feature, p)
             # A caller's `add_dimension(...)` overrides the rule set's suppression for
             # exactly the measurement it names (ADR 0016 / #872). It changes SELECTION

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -355,25 +355,37 @@ def _same_support_planes(
     return a[0] == b[0] and abs(a[1] - b[1]) <= _PLANE_TOL and abs(a[2] - b[2]) <= _PLANE_TOL
 
 
+def polygonal_stock_conveys_height(model: PartModel) -> bool:
+    """Whole polygonal stock already owns the same axial extent as ``stock_length.length``."""
+    return any(f.kind == "polygonal_stock" for f in model.features)
+
+
+def rotational_od_conveys_height(model: PartModel) -> bool:
+    """An X/Y rotational OD conveys the overall height, so it is not drawn separately."""
+    rot = next((f for f in model.features if f.kind == "rotational"), None)
+    return rot is not None and rot.frame.axis in ("x", "y")
+
+
 def overall_height_withheld(model: PartModel) -> bool:
     """Whether the overall HEIGHT is withheld for a reason the model alone settles.
 
-    Two conditions, both belonging to `compiled._compile_overall_height`, which is the single
-    owner of "is the overall height drawn" and says so in its own docstring — whole polygonal
-    stock already owning the same axial extent, and an X/Y rotational OD conveying it. They
-    live here, and that function calls this, because :func:`_owner_drawn` needs the same
-    answer and re-deriving half of it beside a docstring warning against exactly that split
-    is how the split happened the first time (#1154 review).
+    The two conditions above, which belong to `compiled._compile_overall_height` — the single
+    owner of "is the overall height drawn", as its own docstring insists. They live here, and
+    that function calls *them* rather than re-testing either, because :func:`_owner_drawn`
+    needs the same answer and re-deriving half of it beside a docstring warning against
+    exactly that split is how the split happened the first time (#1154 review).
+
+    Split into two named predicates rather than one, because the compiler needs them
+    separately: polygonal stock withholds the height outright, while the rotational case
+    returns a richer `Omission` naming the OD. Collapsing them into one early return deleted
+    that diagnostic for a rotational part with no envelope feature (#1154 review r2).
 
     NOT settled here: ``include_overall``, which is drawing state. It is safe to ignore for
     consolidation — it is False only when an explicit ``role="height"`` intent draws the same
     height through the dimension path instead, so the fact is still on the sheet — and that
     is why it stays an argument to the compiler rather than a model property.
     """
-    if any(f.kind == "polygonal_stock" for f in model.features):
-        return True
-    rot = next((f for f in model.features if f.kind == "rotational"), None)
-    return rot is not None and rot.frame.axis in ("x", "y")
+    return polygonal_stock_conveys_height(model) or rotational_od_conveys_height(model)
 
 
 def _envelope_suppression(model: PartModel, param: DimParameter):
@@ -444,12 +456,24 @@ def _consolidated_owner(model: PartModel, feature: Feature, param: DimParameter)
                 continue
             if not _owner_drawn(model, envelope, extent):
                 continue
-            if _decorated(model, envelope, extent).tolerance != param.tolerance:
+            if (
+                param.tolerance is not None
+                and _decorated(model, envelope, extent).tolerance != param.tolerance
+            ):
                 # A toleranced dimension and an untoleranced one are not the same
                 # requirement, so the overall extent cannot state this fact on its behalf.
                 # Consolidating anyway DELETED a ±0.05 the author had written, silently and
-                # with nothing in lint (#1154 review) — which is the one case where the
-                # feature-local dimension is the one a machinist needs.
+                # with nothing in lint (#1154 review) — the one case where the feature-local
+                # dimension is the one a machinist needs.
+                #
+                # ASYMMETRIC, deliberately. The first cut compared the two tolerances and
+                # refused whenever they differed, so tolerancing the OVERALL EXTENT brought
+                # the duplicate `8` straight back — this issue's own defect, re-opened by its
+                # fix (review r2). A tolerance on the OWNER is not a problem: it is the same
+                # two faces, so it is the same requirement and one dimension states it.
+                # (Measured: the height ladder renders `_fmt(value)` and does not print the
+                # envelope's decoration at all, so today nothing is even lost. That is a
+                # separate pre-existing gap, and this rule must not depend on it.)
                 continue
             return DimensionId(envelope, extent.parameter_id)
     return None

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -456,24 +456,26 @@ def _consolidated_owner(model: PartModel, feature: Feature, param: DimParameter)
                 continue
             if not _owner_drawn(model, envelope, extent):
                 continue
-            if (
-                param.tolerance is not None
-                and _decorated(model, envelope, extent).tolerance != param.tolerance
-            ):
+            if param.tolerance is not None:
                 # A toleranced dimension and an untoleranced one are not the same
                 # requirement, so the overall extent cannot state this fact on its behalf.
                 # Consolidating anyway DELETED a ±0.05 the author had written, silently and
                 # with nothing in lint (#1154 review) — the one case where the feature-local
                 # dimension is the one a machinist needs.
                 #
-                # ASYMMETRIC, deliberately. The first cut compared the two tolerances and
-                # refused whenever they differed, so tolerancing the OVERALL EXTENT brought
-                # the duplicate `8` straight back — this issue's own defect, re-opened by its
-                # fix (review r2). A tolerance on the OWNER is not a problem: it is the same
-                # two faces, so it is the same requirement and one dimension states it.
-                # (Measured: the height ladder renders `_fmt(value)` and does not print the
-                # envelope's decoration at all, so today nothing is even lost. That is a
-                # separate pre-existing gap, and this rule must not depend on it.)
+                # ASYMMETRIC, and about the YIELDER alone. A tolerance on the OWNER is not a
+                # problem — it is the same two faces, so it is the same requirement and one
+                # dimension states it. The first cut refused whenever the two DIFFERED, which
+                # brought the duplicate `8` back for anyone who toleranced the overall
+                # thickness: this issue's own defect, re-opened by its fix (review r2).
+                #
+                # The correction then went one step too far and admitted "equal tolerances on
+                # both sides", on the premise that the receiving extent states the same
+                # requirement. It does not, ever: measured, an envelope decoration is not
+                # rendered on any axis, while `render_boss_heights` appends `_tol_suffix`, so
+                # a boss height toleranced identically to its envelope lost its ± anyway
+                # (review r3). Whether the owner happens to print a tolerance is not this
+                # rule's business — a toleranced measurement is simply never handed over.
                 continue
             return DimensionId(envelope, extent.parameter_id)
     return None
@@ -491,6 +493,11 @@ def _owner_drawn(model: PartModel, envelope: Feature, extent: DimParameter) -> b
     model-derivable half is :func:`overall_height_withheld`. The first cut consulted only the
     first, so a declared X-rotational part consolidated its boss height onto an overall
     height that same compiler was independently withholding (#1154 review).
+
+    Not consulted: an `add_dimension(...)` request, which un-suppresses an owner in
+    `plan_dimensions` but not here, so a caller who explicitly asks for a withheld extent
+    gets a benign duplicate rather than a consolidation. It fails toward keeping content,
+    which is the safe direction for a rule whose whole risk is losing some.
 
     The authored half is why an authored omission can still carry a ``conveyed_by``: the
     author's list decides which dimensions are drawn, not where the geometry puts a fact.

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -12,6 +12,12 @@ contract was tightened twice under adversarial review of the counterbore work:
   two orthogonal 10 mm lengths are distinct. Features own their parameters; they
   do not emit spurious duplicates. Genuine redundancy/count of *repeated identical
   features* ("3× ø8") is upstream (pattern detection), not here.
+- **Collapse by support-plane identity, though** (#1154). Two features CAN emit one
+  physical fact: GRM-04's boss spans the full part thickness, so its height and the
+  envelope width measure between the same two faces and the sheet prints `4.5` twice.
+  That is not the value coincidence the rule above protects — it is one measurement with
+  two owners, and `_consolidated_owner` gives it to the overall extent. The test is exact
+  plane coincidence; see `_same_support_planes` for why nothing looser is admissible.
 
 Current scope: convention + group view selection. Richer render intents
 (suppression / datum / grouping) are the next planned increment (#250); the full
@@ -107,6 +113,14 @@ class PlannedDimension:
     # The source IR feature this dim locates — carried so the renderer can record
     # provenance (ADR 0010). ``None`` for dims not tied to a single feature.
     feature: Feature | None = None
+    # When this dim is suppressed because ANOTHER dimension already states the same
+    # physical fact, the dimension that now owns it (#1154). Suppression alone says a
+    # measurement is not drawn; this says where the reader finds it instead, so
+    # completeness lint can require that the owner actually landed rather than assume
+    # a consolidated fact is on the sheet. ``None`` for every other suppression — those
+    # withhold a measurement that is genuinely absent or genuinely redundant with a
+    # chain no single id names.
+    conveyed_by: DimensionId | None = None
 
 
 # Correlated sets (ADR 0016 identity, tier 3): exact ``(feature kind, role)`` pairs
@@ -288,8 +302,136 @@ def _group_view(feature: Feature) -> str:
     return _END_ON.get(feature.frame.axis, "plan")
 
 
+_PLANE_TOL = 1e-6
+
+#: The reason a feature-local extent carries when an overall extent already states the
+#: same two support planes (#1154).
+_CONSOLIDATED = "the overall extent already measures these two support planes"
+
+
+def _support_planes(param: DimParameter) -> tuple[str, float, float] | None:
+    """The two parallel support planes *param* measures between, as ``(axis, lo, hi)``.
+
+    ``None`` when the parameter does not measure a pair of planes at all: it has no span,
+    it is not a length, or its span is oblique (a diagonal segment crosses no single pair
+    of principal planes, so no other dimension can be *the same* pair).
+
+    Only the along-axis coordinates are kept. Two dimensions of one physical thickness are
+    normally drawn on different segments — GRM-04's boss height runs along the boss axis at
+    ``y=z=0`` while the envelope width runs along a bbox edge at ``y=z=-4`` — and they still
+    measure between the same two faces. The perpendicular offset is where the dimension is
+    *drawn*, not what it measures.
+    """
+    span = param.span
+    if span is None or param.kind != "length":
+        return None
+    a, b = span
+    moving = [i for i in range(3) if abs(b[i] - a[i]) > _PLANE_TOL]
+    if len(moving) != 1:
+        return None
+    i = moving[0]
+    lo, hi = sorted((a[i], b[i]))
+    return ("xyz"[i], lo, hi)
+
+
+def _same_support_planes(
+    a: tuple[str, float, float] | None, b: tuple[str, float, float] | None
+) -> bool:
+    """Whether two ``_support_planes`` results name the same pair of physical planes.
+
+    **Plane coincidence, never equal values.** The distinction is the whole rule and it is
+    the #997 lesson stated the other way round: a 100 x 100 part's width and depth are
+    equal and are two independent facts, because they run between different pairs of faces.
+    GRM-04's ``4.5`` pair run between the *same* two faces, so drawing both states one fact
+    twice. A value comparison cannot tell those apart, and a windowed one (#997 used 5%)
+    additionally reads 100 x 95 as square. So the test is exact plane coincidence at the
+    kernel's own noise floor.
+    """
+    if a is None or b is None:
+        return False
+    return a[0] == b[0] and abs(a[1] - b[1]) <= _PLANE_TOL and abs(a[2] - b[2]) <= _PLANE_TOL
+
+
+def _envelope_suppression(model: PartModel, param: DimParameter):
+    """The overall-extent suppression rules → ``(suppressed, reason)``.
+
+    Split out from :func:`_suppression` so :func:`_consolidated_owner` can ask whether the
+    envelope extent it wants to hand a fact to is *itself* drawn. Consolidating onto a
+    dimension the rule set already withholds would delete the measurement from the sheet.
+    """
+    # A rotational part's OD already conveys its cross-axis extent(s); the envelope
+    # dim(s) perpendicular to the turning axis would double-dimension it (#222). The
+    # axis-aligned envelope dim (the length) is kept. (The overall *height* dim is the
+    # height-ladder renderer's call — it skips it for an X/Y rotational part likewise.)
+    rot = next((f for f in model.features if f.kind == "rotational"), None)
+    if rot is not None:
+        od_perp = {"x": {"depth"}, "y": {"width"}, "z": {"width", "depth"}}[rot.frame.axis]
+        if param.role in od_perp:
+            return True, f"rotational OD ({rot.frame.axis}-axis) conveys this extent"
+    if param.role == "width" and model.orientation == "x":
+        return True, "X-turned (step-length chain conveys the length)"
+    if param.role == "height" and model.orientation == "z":
+        return True, "Z-turned (step-length chain conveys the height)"
+    return False, None
+
+
+def _consolidated_owner(model: PartModel, feature: Feature, param: DimParameter):
+    """The overall extent that already states *param*'s fact, or ``None`` (#1154).
+
+    GRM-04 draws ``4.5`` twice: a boss whose height spans the full part thickness, and the
+    envelope width across the same two faces. Two detected records, one physical fact — so
+    coordinate-key dedup (#650) cannot see it, and value dedup must not (see
+    :func:`_same_support_planes`).
+
+    The **overall extent wins**, always, and the feature-local one is withheld. A part has
+    one overall thickness and it is the dimension a machinist reads first; a boss height
+    that happens to equal it is the accident. The converse rule would delete a required
+    envelope dimension whenever some feature grew to full depth.
+
+    Scope is deliberately narrow: only an ``envelope`` extent can take ownership, and only
+    of a *different* feature's parameter. Feature-to-feature consolidation needs an answer
+    to which of two peers is canonical, and there is no principled one — a step height and
+    a pad thickness across the same two faces are equally entitled.
+    """
+    if feature.kind == "envelope":
+        return None
+    planes = _support_planes(param)
+    if planes is None:
+        return None
+    for envelope in model.features:
+        if envelope.kind != "envelope":
+            continue
+        for extent in envelope.parameters():
+            if not _same_support_planes(_support_planes(extent), planes):
+                continue
+            if not _owner_drawn(model, envelope, extent):
+                continue
+            return DimensionId(envelope, extent.parameter_id)
+    return None
+
+
+def _owner_drawn(model: PartModel, envelope: Feature, extent: DimParameter) -> bool:
+    """Whether the extent about to take ownership of a fact is itself drawn.
+
+    Consolidating onto a dimension the rule set withholds, or one an authored set leaves
+    out, would delete the measurement from the sheet — the consolidation must move a fact
+    to another dimension, never to nowhere.
+
+    The authored half is why an authored omission can still carry a ``conveyed_by``: the
+    author's list decides which dimensions are drawn, not where the geometry puts a fact.
+    A script that lists the overall extent and not the boss height omits nothing a reader
+    needs, and it must critique the same as the automatic drawing that consolidates them
+    (round-trip parity, epic #964).
+    """
+    if _envelope_suppression(model, extent)[0]:
+        return False
+    if model.authored_dimensions is None:
+        return True
+    return _authored_for(model, envelope, extent) is not None
+
+
 def _suppression(model: PartModel, feature: Feature, param: DimParameter):
-    """Model-level suppression intent → ``(suppressed, reason)``. Decisions the
+    """Model-level suppression intent → ``(suppressed, reason, conveyed_by)``. Decisions the
     planner can make from the model alone (ISO 129 no-double-dimensioning): a turned part's
     step-length chain already conveys the length (X) / height (Z), so the envelope dim along
     the turning axis is redundant, and its OD conveys the cross-axis extents.
@@ -340,26 +482,21 @@ def _suppression(model: PartModel, feature: Feature, param: DimParameter):
                     if abs(plate.lo - channel_hi) <= 1e-6 and abs(plate.hi - bbox_hi) <= 1e-6
                 ]
                 if len(lower) == len(upper) == 1 and feature == upper[0]:
-                    return True, (
-                        "opposite wall is derived from the overall extent, lower wall "
-                        "thickness, and channel width"
+                    return (
+                        True,
+                        (
+                            "opposite wall is derived from the overall extent, lower wall "
+                            "thickness, and channel width"
+                        ),
+                        None,
                     )
-    if feature.kind != "envelope":
-        return False, None
-    # A rotational part's OD already conveys its cross-axis extent(s); the envelope
-    # dim(s) perpendicular to the turning axis would double-dimension it (#222). The
-    # axis-aligned envelope dim (the length) is kept. (The overall *height* dim is the
-    # height-ladder renderer's call — it skips it for an X/Y rotational part likewise.)
-    rot = next((f for f in model.features if f.kind == "rotational"), None)
-    if rot is not None:
-        od_perp = {"x": {"depth"}, "y": {"width"}, "z": {"width", "depth"}}[rot.frame.axis]
-        if param.role in od_perp:
-            return True, f"rotational OD ({rot.frame.axis}-axis) conveys this extent"
-    if param.role == "width" and model.orientation == "x":
-        return True, "X-turned (step-length chain conveys the length)"
-    if param.role == "height" and model.orientation == "z":
-        return True, "Z-turned (step-length chain conveys the height)"
-    return False, None
+    if feature.kind == "envelope":
+        suppressed, reason = _envelope_suppression(model, param)
+        return suppressed, reason, None
+    owner = _consolidated_owner(model, feature, param)
+    if owner is not None:
+        return True, _CONSOLIDATED, owner
+    return False, None, None
 
 
 def _datum_for(model: PartModel, param: DimParameter) -> Datum | None:
@@ -770,7 +907,7 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
                 tol = model.decorations.get((feature, p.kind))
             if tol is not None:
                 p = replace(p, tolerance=tol)
-            suppressed, reason = _suppression(model, feature, p)
+            suppressed, reason, conveyed_by = _suppression(model, feature, p)
             # A caller's `add_dimension(...)` overrides the rule set's suppression for
             # exactly the measurement it names (ADR 0016 / #872). It changes SELECTION
             # only — the value still comes from the geometry, so a request can never
@@ -779,7 +916,7 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
             # must be able to ask without first knowing the rule set's mind.
             request = _request_for(model, feature, p)
             if request is not None:
-                suppressed, reason = False, None
+                suppressed, reason, conveyed_by = False, None, None
             if model.authored_dimensions is not None:
                 # An authored set REPLACES the rule set rather than adding to it: what the
                 # script lists is what the drawing carries, and everything else is omitted.
@@ -787,15 +924,21 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
                 # omission stays inspectable, and the compound-callout dependency rules
                 # still refuse to orphan half a term.
                 if _authored_for(model, feature, p) is None:
+                    # `conveyed_by` deliberately SURVIVES an authored omission: the author
+                    # chose which dimensions are drawn, but not where the geometry states
+                    # this fact. Nulling it made a script that lists the overall extent and
+                    # not the boss height critique differently from the automatic drawing
+                    # that consolidates exactly the same two into one (#964 parity).
                     suppressed, reason = True, _AUTHORED_OMISSION
                 else:
-                    suppressed, reason = False, None
+                    suppressed, reason, conveyed_by = False, None, None
             dims.append(
                 PlannedDimension(
                     param=p,
                     convention=_CONVENTION.get((p.role, p.kind), "linear"),
                     suppressed=suppressed,
                     reason=reason,
+                    conveyed_by=conveyed_by,
                     datum=_datum_for(model, p),
                 )
             )

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1036,6 +1036,20 @@ def unmirrored_dimensions(model) -> list[str]:
     #
     # `model`, not `declared`: the synthesised envelope adds width and depth parameters the
     # emitter deliberately omits, so compiling the mirror model would report them missing.
+    # A measurement the MIRROR consolidates onto another dimension is named by that
+    # dimension's line, so the script is complete without a line of its own (#1154). This
+    # only ever differs from the source model's answer because `mirror_model` synthesises an
+    # envelope for a part detected without one — a round body's boss height and its overall
+    # height run between the same two faces, so the mirror consolidates where the source had
+    # no overall extent to consolidate onto. Requiring a line for it would demand the script
+    # name a dimension re-running the script does not draw.
+    consolidated = {
+        (id(omission.feature), omission.parameter_id)
+        for omission in compile_dimensions(declared).diagnostics
+        if omission.conveyed_by is not None
+        and _asked(omission.conveyed_by.feature, omission.conveyed_by.parameter)
+    }
+
     missing: list[str] = []
     for intent in compile_dimensions(model).addressable():
         feature = resolve_feature(intent.ref)
@@ -1044,7 +1058,7 @@ def unmirrored_dimensions(model) -> list[str]:
             # synthesised envelope can name it, until #976 gives it a declarative target.
             if synthesised is None or (id(synthesised), "height.length") not in requested:
                 missing.append("(bounding box).overall_height")
-        elif not _asked(feature, intent.role):
+        elif not _asked(feature, intent.role) and (id(feature), intent.role) not in consolidated:
             missing.append(f"{feature.kind}.{intent.role}")
     return sorted(set(missing))
 

--- a/tests/test_issue_1154_one_owner_per_measurement.py
+++ b/tests/test_issue_1154_one_owner_per_measurement.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import pytest
 from build123d import Align, Box, Cylinder, Pos, Rot
 
+from draftwright import Sheet
 from draftwright.builder import build_drawing, detect_part_model
 from draftwright.drawing import feature_key
 from draftwright.model.compiled import compile_dimensions
@@ -31,7 +32,7 @@ _C = (Align.CENTER, Align.CENTER, Align.CENTER)
 
 
 def _x_hub_plate():
-    """GRM-04's shape: a 4.5 mm plate with a hub flush on both X faces.
+    """GRM-04's *shape*, not its dimensions: a 4.5 mm plate with a hub flush on both X faces.
 
     The hub's height and the overall X thickness are the same two faces, so this draws
     `4.5` twice before the reconciliation.
@@ -126,9 +127,16 @@ class TestTheSameTwoFacesAreDimensionedOnce:
         assert ("boss", "boss_height.length") not in placed
 
     def test_the_reconciliation_reaches_a_boss_on_the_other_axis(self):
-        # A Z boss height renders in a different strip of a different view, so this is the
-        # cross-view half of the acceptance criteria rather than a second copy of the case
-        # above.
+        # A Z boss height renders in the front view's RIGHT strip while an X one renders
+        # ABOVE it (`render_boss_heights`' `specs` table), so this is the cross-view half of
+        # the acceptance criteria rather than a second copy of the case above. It builds the
+        # drawing as well as the plan: asserting the omission alone left the "across
+        # different eligible views" claim resting on the specs table rather than on output
+        # (#1154 review).
+        labels = _labels(build_drawing(_z_hub_plate(), title="T", number="N-1"))
+        assert labels.count("8") == 1, (
+            f"the overall Z thickness is stated {labels.count('8')} times: {labels}"
+        )
         model = detect_part_model(_z_hub_plate())
         boss, param = _boss_height(model)
         assert param.value == 8.0 and param.span is not None
@@ -148,7 +156,10 @@ class TestTheSameTwoFacesAreDimensionedOnce:
             o for o in compile_dimensions(model).diagnostics if o.conveyed_by is not None
         ], "a boss standing proud of the plate lost its height"
         labels = _labels(build_drawing(_proud_boss_plate(), title="T", number="N-1"))
-        assert "4" in labels and "12" in labels, labels
+        # Counts, not membership: this fixture draws `4` twice (the boss height and the
+        # overall depth), so `"4" in labels` would still hold with one of them consolidated
+        # away — the exact loss this test exists to catch (#1154 review).
+        assert labels.count("4") == 2 and labels.count("12") == 1, labels
 
 
 def _envelope(model):
@@ -235,11 +246,10 @@ class TestTheConsolidationIsRecordedAndVerified:
             "feature": feature_key(_envelope(drawing.model())),
             "parameter_id": "width.length",
         }
-        assert all(
-            r["conveyed_by"] is None
-            for r in drawing.suppressions()
-            if r["parameter_id"] != "boss_height.length"
-        )
+        # `_x_hub_plate` produces exactly ONE suppression row, so an "everything else is
+        # None" generator over the rest is empty and trivially true — which is what the
+        # first cut asserted (#1154 review). Say the real thing instead.
+        assert [r["parameter_id"] for r in drawing.suppressions()] == ["boss_height.length"]
 
     def test_coverage_accepts_a_consolidated_height_only_while_its_owner_is_placed(self):
         # `boss_height_missing` exists to demand the axial extent. A consolidation satisfies
@@ -311,3 +321,116 @@ class TestTheConsolidationIsRecordedAndVerified:
             return sorted((i.code, i.severity) for i in dwg.lint())
 
         assert codes(captured["dwg"]) == codes(direct)
+
+
+class TestConsolidationMovesTheFactOrDoesNotHappen:
+    """`_owner_drawn`'s three authorities, none of which had a test (#1154 review).
+
+    Replacing the whole function with `return True` passed the full fast tier, so the guard
+    the commit message opens with — "the consolidation must move a fact to another dimension,
+    never to nowhere" — was asserted only in prose.
+    """
+
+    def test_a_toleranced_height_is_not_handed_to_an_untoleranced_extent(self):
+        # The one case where the feature-local dimension is the one a machinist needs. The
+        # overall extent carries no tolerance, so consolidating DELETED a ±0.05 the author
+        # wrote — silently, with nothing in lint, and recoverable only by knowing to add an
+        # `add_dimension` line. A toleranced dimension and an untoleranced one are not the
+        # same requirement.
+        part = Box(20, 8, 8, align=_C) + Cylinder(7, 8, align=_C)
+        sheet = Sheet(part, title="T", number="N-1", page="A2")
+        sheet.envelope()
+        sheet.diameter(
+            diameter=14, height=8, span=((0, 0, -4), (0, 0, 4)), at=(0, 0, 4), axis="z"
+        ).tolerance(0.05, on="length")
+        sheet.auto_dimensions()
+        drawing = sheet.build()
+        assert not [o for o in compile_dimensions(drawing.model()).diagnostics if o.conveyed_by], (
+            "a toleranced height was consolidated onto an extent that cannot carry it"
+        )
+        assert "8 ±0.1" in _labels(drawing), _labels(drawing)
+
+    def test_an_owner_the_rule_set_withholds_is_refused(self):
+        # A z-rotational part suppresses its envelope width and depth (the OD conveys them),
+        # so a boss spanning the full X extent has no drawn owner to hand its height to.
+        # Asserted on the compiled plan because `render_boss_heights` skips rotational parts
+        # anyway — the loss would be invisible in the drawing and permanent in the plan.
+        part = Cylinder(10, 30, align=_C)
+        sheet = Sheet(part, title="T", number="N-1", page="A2")
+        sheet.rotational(od=20, at=(0, 0, 0), axis="z")
+        sheet.envelope()
+        sheet.diameter(
+            diameter=8, height=20, span=((-10, 0, 0), (10, 0, 0)), at=(10, 0, 0), axis="x"
+        )
+        sheet.auto_dimensions()
+        plan = compile_dimensions(sheet.build().model())
+        assert {o.parameter_id for o in plan.diagnostics if o.conveyed_by} == set(), (
+            "the height was handed to an envelope extent the rotational rule withholds"
+        )
+        assert {o.reason for o in plan.diagnostics} == {
+            "rotational OD (z-axis) conveys this extent"
+        }, "the fixture no longer suppresses the envelope, so nothing is under test"
+
+    def test_an_owner_the_compiler_withholds_is_refused(self):
+        # The THIRD authority. `compiled._compile_overall_height` withholds the overall
+        # height for an X/Y rotational OD, and the first cut consulted only the planner's own
+        # rules — so a declared X-rotational part consolidated its boss height onto a
+        # dimension that same compiler was independently removing, and the drawing carried
+        # neither. `overall_height_withheld` is now the one owner both consult.
+        from draftwright.model.planner import overall_height_withheld
+
+        part = Rot(0, 90, 0) * Cylinder(10, 30, align=_C)
+        sheet = Sheet(part, title="T", number="N-1", page="A2")
+        sheet.rotational(od=20, at=(0, 0, 0), axis="x")
+        sheet.envelope()
+        sheet.diameter(
+            diameter=8, height=20, span=((0, 0, -10), (0, 0, 10)), at=(0, 0, 10), axis="z"
+        )
+        sheet.auto_dimensions()
+        model = sheet.build().model()
+        assert overall_height_withheld(model), (
+            "the fixture no longer withholds the overall height, so nothing is under test"
+        )
+        assert not [o for o in compile_dimensions(model).diagnostics if o.conveyed_by], (
+            "the height was handed to an overall height the compiler withholds"
+        )
+
+    def test_an_owner_the_authored_set_omits_is_refused(self):
+        # And the second authority, from the other side of the parity rule: `conveyed_by`
+        # survives an authored omission only when the author's set KEEPS the owner.
+        part = _z_hub_plate()
+        sheet = Sheet(part, title="T", number="N-1", page="A2")
+        boss = sheet.diameter(
+            diameter=14, height=8, span=((0, 0, -4), (0, 0, 4)), at=(0, 0, 4), axis="z"
+        )
+        envelope = sheet.envelope()
+        sheet.authored_dimensions()
+        sheet.dimension(envelope, "width.length")
+        sheet.dimension(boss, "boss.diameter")
+        model = sheet.build().model()
+        rows = [o for o in compile_dimensions(model).diagnostics if o.conveyed_by]
+        assert not rows, (
+            "the height was handed to an overall height the authored set leaves out: "
+            f"{[(o.parameter_id, o.conveyed_by) for o in rows]}"
+        )
+
+
+class TestThePlaneToleranceIsAToleranceNotAWindow:
+    def test_a_face_half_a_millimetre_short_is_a_different_plane(self):
+        # `_PLANE_TOL` is the kernel's noise floor, not a matching window. Widening it to 0.5
+        # or 2.0 passed the full fast tier (#1154 review), so nothing said which of those it
+        # was — and #997's deleted rule failed precisely by being a window.
+        part = Box(20, 8, 8, align=_C) + Pos(0, 0, 0.25) * Cylinder(7, 7.5, align=_C)
+        model = detect_part_model(part)
+        boss, height = _boss_height(model)
+        assert boss is not None and height.value == pytest.approx(7.5)
+        # The TOP face coincides exactly and the bottom is 0.5 mm short — the hardest case
+        # for a windowed comparison, and the one that decides whether this is a tolerance or
+        # a match radius.
+        assert _support_planes(height) == pytest.approx(("z", -3.5, 4.0), abs=1e-9)
+        assert _support_planes(
+            next(p for p in _envelope(model).parameters() if p.parameter_id == "height.length")
+        ) == pytest.approx(("z", -4.0, 4.0), abs=1e-9)
+        assert not [o for o in compile_dimensions(model).diagnostics if o.conveyed_by], (
+            "a boss 0.5 mm short of the lower face was consolidated onto the 8 mm extent"
+        )

--- a/tests/test_issue_1154_one_owner_per_measurement.py
+++ b/tests/test_issue_1154_one_owner_per_measurement.py
@@ -73,6 +73,31 @@ def _labels(drawing):
     )
 
 
+def _assert_a_candidate_exists(model, *, owner):
+    """A non-envelope length parameter really does share *owner*'s two support planes.
+
+    The positive anchor for the refusal tests. "Nothing was consolidated" is trivially true
+    when no consolidation candidate exists, and shrinking the declared boss in any of the
+    three so it no longer spans the extent left all three passing (#1154 review r2) — the
+    same vacuity `_assert_the_duplicate_exists` was written for, unapplied in the class added
+    to fix it.
+    """
+    extent = next(p for p in _envelope(model).parameters() if p.parameter_id == owner)
+    planes = _support_planes(extent)
+    assert planes is not None
+    candidates = [
+        (f.kind, p.parameter_id)
+        for f in model.features
+        if f.kind != "envelope"
+        for p in f.parameters()
+        if _support_planes(p) is not None and _support_planes(p) == pytest.approx(planes)
+    ]
+    assert candidates, (
+        f"no feature measures {owner}'s two support planes, so a refusal proves nothing"
+    )
+    return candidates
+
+
 def _assert_the_duplicate_exists(model):
     """The fixture must actually contain the defect, or every assertion below is vacuous.
 
@@ -363,7 +388,9 @@ class TestConsolidationMovesTheFactOrDoesNotHappen:
             diameter=8, height=20, span=((-10, 0, 0), (10, 0, 0)), at=(10, 0, 0), axis="x"
         )
         sheet.auto_dimensions()
-        plan = compile_dimensions(sheet.build().model())
+        model = sheet.build().model()
+        _assert_a_candidate_exists(model, owner="width.length")
+        plan = compile_dimensions(model)
         assert {o.parameter_id for o in plan.diagnostics if o.conveyed_by} == set(), (
             "the height was handed to an envelope extent the rotational rule withholds"
         )
@@ -388,6 +415,7 @@ class TestConsolidationMovesTheFactOrDoesNotHappen:
         )
         sheet.auto_dimensions()
         model = sheet.build().model()
+        _assert_a_candidate_exists(model, owner="height.length")
         assert overall_height_withheld(model), (
             "the fixture no longer withholds the overall height, so nothing is under test"
         )
@@ -408,6 +436,7 @@ class TestConsolidationMovesTheFactOrDoesNotHappen:
         sheet.dimension(envelope, "width.length")
         sheet.dimension(boss, "boss.diameter")
         model = sheet.build().model()
+        _assert_a_candidate_exists(model, owner="height.length")
         rows = [o for o in compile_dimensions(model).diagnostics if o.conveyed_by]
         assert not rows, (
             "the height was handed to an overall height the authored set leaves out: "
@@ -434,3 +463,50 @@ class TestThePlaneToleranceIsAToleranceNotAWindow:
         assert not [o for o in compile_dimensions(model).diagnostics if o.conveyed_by], (
             "a boss 0.5 mm short of the lower face was consolidated onto the 8 mm extent"
         )
+
+
+class TestTheConsolidationDoesNotDisturbTheHeightCompiler:
+    def test_a_rotational_part_without_an_envelope_keeps_its_suppression_record(self):
+        # Sharing the overall-height conditions with the planner collapsed two of them into
+        # one early return, which swallowed the richer `Omission` naming the OD whenever the
+        # part had no `.envelope()`. The audit row did not flatten — it vanished — from the
+        # surface whose own docstring says an audit that flattened them "would read a
+        # de-duplication as a gap" (#1154 review r2). The conditions are now two named
+        # predicates, each applied where it belongs.
+        sheet = Sheet(Rot(0, 90, 0) * Cylinder(10, 30), title="T", number="N-1", page="A2")
+        sheet.rotational(od=20, at=(0, 0, 0), axis="x")
+        sheet.auto_dimensions()
+        rows = [
+            row for row in sheet.build().suppressions() if row["parameter_id"] == "height.length"
+        ]
+        assert [row["reason"] for row in rows] == ["rotational OD (x-axis) conveys the height"]
+        assert rows[0]["conveyed_by"] is None, "nothing took this fact over; it is withheld"
+
+
+class TestTheToleranceRuleIsAsymmetric:
+    """Which side carries the tolerance decides the answer, and the two are not alike."""
+
+    def _z_hub_labels(self, *, on_boss=False, on_envelope=False):
+        part = Box(20, 8, 8, align=_C) + Cylinder(7, 8, align=_C)
+        sheet = Sheet(part, title="T", number="N-1", page="A2")
+        envelope = sheet.envelope()
+        boss = sheet.diameter(
+            diameter=14, height=8, span=((0, 0, -4), (0, 0, 4)), at=(0, 0, 4), axis="z"
+        )
+        if on_boss:
+            boss.tolerance(0.05, on="length")
+        if on_envelope:
+            envelope.tolerance(0.05, on="height")
+        sheet.auto_dimensions()
+        return [label for label in _labels(sheet.build()) if label.startswith("8")]
+
+    def test_tolerancing_the_yielding_dimension_keeps_both(self):
+        assert self._z_hub_labels(on_boss=True) == ["8", "8 ±0.1"]
+
+    def test_tolerancing_the_owner_still_consolidates(self):
+        # The first cut compared the two tolerances and refused whenever they differed, so an
+        # author who toleranced the OVERALL THICKNESS got the duplicate `8` back — #1154's own
+        # defect, re-opened by its fix (review r2). A tolerance on the owner is the same
+        # requirement on the same two faces; it does not make them two facts.
+        assert self._z_hub_labels(on_envelope=True) == ["8"]
+        assert self._z_hub_labels(on_boss=True, on_envelope=True) == ["8"]

--- a/tests/test_issue_1154_one_owner_per_measurement.py
+++ b/tests/test_issue_1154_one_owner_per_measurement.py
@@ -1,0 +1,313 @@
+"""#1154 — one physical measurement, one owner.
+
+GRM-04's drive plate prints `4.5` twice. A ø8 hub is flush with both faces of a 4.5 mm
+plate, so the detected `boss_height.length` and the detected `envelope.width.length` run
+between the SAME two faces, and the sheet states one fact through two feature owners:
+
+    boss.boss_height.length   4.5   span x −1.5 → 3   (drawn along the boss axis)
+    envelope.width.length     4.5   span x −1.5 → 3   (drawn along a bbox edge)
+
+This is not #650's coordinate-key dedup — the two records are semantically different
+features with different anchors and different witness lines — and it is emphatically not
+value dedup, which #997 deleted for good reasons this fixes rather than reopens (see
+`_same_support_planes`).
+
+The fixtures are synthetic because the source STEP is not in this repo. They are chosen for
+the geometry that produces the defect, not for the outline: a hub flush on both faces of a
+plate, which is the only way a feature-local height comes to equal an overall extent.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Align, Box, Cylinder, Pos, Rot
+
+from draftwright.builder import build_drawing, detect_part_model
+from draftwright.drawing import feature_key
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.planner import DimensionId, _support_planes
+
+_C = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+
+def _x_hub_plate():
+    """GRM-04's shape: a 4.5 mm plate with a hub flush on both X faces.
+
+    The hub's height and the overall X thickness are the same two faces, so this draws
+    `4.5` twice before the reconciliation.
+    """
+    # The hub must protrude beyond the plate outline in Y, not sit tangent to it: at
+    # `Box(4.5, 10, 25)` with r=5 the cylinder is exactly flush with the plate's Y faces and
+    # is not recognised as a boss at all — which made the first two tests below pass while
+    # asserting nothing, because a duplicate that never existed cannot be found twice.
+    return Box(4.5, 8, 24, align=_C) + Pos(0, 0, -8) * (Rot(0, 90, 0) * Cylinder(5, 4.5, align=_C))
+
+
+def _z_hub_plate():
+    """The same defect one axis over — a Z hub flush with both faces of an 8 mm plate.
+
+    A Z boss height renders in the front view's RIGHT strip while an X one renders ABOVE
+    it (`render_boss_heights`' `specs` table), so this and `_x_hub_plate` exercise the
+    reconciliation through two different eligible views.
+    """
+    return Box(20, 8, 8, align=_C) + Cylinder(7, 8, align=_C)
+
+
+def _proud_boss_plate():
+    """The discriminating control: a boss standing PROUD, whose height EQUALS an extent.
+
+    The 4 mm boss height (z 4 → 8) and the 4 mm overall depth (y −2 → 2) are the same
+    number between different pairs of faces. A rule keyed on the value collapses them; the
+    rule keyed on support planes must not. Chosen deliberately over a boss whose height
+    matches nothing, which cannot tell the two rules apart.
+    """
+    return Box(20, 4, 8, align=_C) + Pos(0, 0, 6) * Cylinder(1.5, 4, align=_C)
+
+
+def _labels(drawing):
+    return sorted(
+        str(label)
+        for _name, item in drawing.iter_annotations()
+        if (label := getattr(item, "label", None))
+    )
+
+
+def _assert_the_duplicate_exists(model):
+    """The fixture must actually contain the defect, or every assertion below is vacuous.
+
+    Written after the first cut used a hub tangent to the plate's Y faces: no boss was
+    recognised, so "the thickness appears once" and "the boss height is not placed" were
+    both trivially true and the tests passed against completely unfixed code.
+    """
+    boss, param = _boss_height(model)
+    extent = next(
+        p
+        for p in _envelope(model).parameters()
+        if p.span is not None and abs(p.value - param.value) < 1e-6
+    )
+    assert param.span is not None and extent.span is not None
+    # `approx`, not `==`: the two records reach 4.5 by different routes and differ in the
+    # last bit (4.5 vs 4.500000000000002). Worth knowing — a dedup keyed on the printed or
+    # stored VALUE would not even fire here, quite apart from being the wrong rule.
+    assert param.value == pytest.approx(extent.value), (
+        f"{param.value} and {extent.value} are no longer the same measurement"
+    )
+    return boss, param, extent
+
+
+def _boss_height(model):
+    boss = next(f for f in model.features if f.kind == "boss")
+    param = next(p for p in boss.parameters() if p.parameter_id == "boss_height.length")
+    return boss, param
+
+
+class TestTheSameTwoFacesAreDimensionedOnce:
+    def test_a_flush_hub_no_longer_states_the_thickness_twice(self):
+        drawing = build_drawing(_x_hub_plate(), title="T", number="N-1")
+        _assert_the_duplicate_exists(drawing.model())
+        labels = _labels(drawing)
+        assert labels.count("4.5") == 1, (
+            f"the overall X thickness is stated {labels.count('4.5')} times: {labels}"
+        )
+
+    def test_the_surviving_owner_is_the_overall_extent(self):
+        # Direction matters and is not arbitrary: a part has one overall thickness and it is
+        # what a machinist reads first, so the envelope keeps the fact and the feature-local
+        # height yields. The converse rule would delete a required envelope dimension
+        # whenever some feature happened to grow to full depth.
+        drawing = build_drawing(_x_hub_plate(), title="T", number="N-1")
+        _assert_the_duplicate_exists(drawing.model())
+        placed = {
+            (getattr(measurement.feature, "kind", None), measurement.parameter)
+            for name in drawing.registry.names()
+            for measurement in drawing.registry.measurement_of(name)
+        }
+        assert ("envelope", "width.length") in placed
+        assert ("boss", "boss_height.length") not in placed
+
+    def test_the_reconciliation_reaches_a_boss_on_the_other_axis(self):
+        # A Z boss height renders in a different strip of a different view, so this is the
+        # cross-view half of the acceptance criteria rather than a second copy of the case
+        # above.
+        model = detect_part_model(_z_hub_plate())
+        boss, param = _boss_height(model)
+        assert param.value == 8.0 and param.span is not None
+        omissions = [o for o in compile_dimensions(model).diagnostics if o.feature == boss]
+        assert [(o.parameter_id, o.conveyed_by) for o in omissions] == [
+            ("boss_height.length", DimensionId(_envelope(model), "height.length"))
+        ]
+
+    def test_a_proud_boss_keeps_both_dimensions(self):
+        # The rule must not collapse two genuinely different spans. This boss stands 4 mm
+        # above the plate, so its height and the 12 mm overall height are different pairs of
+        # faces and both are required.
+        model = detect_part_model(_proud_boss_plate())
+        _boss, param = _boss_height(model)
+        assert param.value == 4.0
+        assert not [
+            o for o in compile_dimensions(model).diagnostics if o.conveyed_by is not None
+        ], "a boss standing proud of the plate lost its height"
+        labels = _labels(build_drawing(_proud_boss_plate(), title="T", number="N-1"))
+        assert "4" in labels and "12" in labels, labels
+
+
+def _envelope(model):
+    return next(f for f in model.features if f.kind == "envelope")
+
+
+class TestTheCollapseIsPlaneIdentityNotValueEquality:
+    def test_a_height_equal_to_an_extent_between_other_faces_survives(self):
+        # The #997 lesson, stated the other way round, and the ONLY test here that
+        # distinguishes the two candidate rules. A boss 4 mm tall in Z on a part 4 mm deep
+        # in Y states two independent facts that happen to share a number; #997 deleted a
+        # rule that collapsed equal extents and so read a 100 x 95 part as square.
+        #
+        # Written after the first cut used a square 30 x 30 x 10 block here and a
+        # value-equality mutation SURVIVED it: `_consolidated_owner` never compares an
+        # envelope extent against another envelope extent, so a square part is protected by
+        # that exclusion and proves nothing about how the comparison is made.
+        model = detect_part_model(_proud_boss_plate())
+        _boss, height = _boss_height(model)
+        depth = next(p for p in _envelope(model).parameters() if p.parameter_id == "depth.length")
+        assert height.value == depth.value == 4.0, (
+            "the fixture no longer has two equal measurements, so a value rule and a plane "
+            "rule would agree on it"
+        )
+        assert _support_planes(height) == ("z", 4.0, 8.0)
+        assert _support_planes(depth) == ("y", -2.0, 2.0)
+        assert not [
+            o for o in compile_dimensions(model).diagnostics if o.conveyed_by is not None
+        ], "a measurement was consolidated onto an extent between different faces"
+
+    def test_a_square_footprint_keeps_both_of_its_equal_extents(self):
+        # Not a test of the comparison — see above — but the #997 regression itself, which
+        # this slice must not reopen from the other end.
+        model = detect_part_model(Box(30, 30, 10, align=_C))
+        assert not [o for o in compile_dimensions(model).diagnostics if o.conveyed_by is not None]
+        labels = _labels(build_drawing(Box(30, 30, 10, align=_C), title="T", number="N-1"))
+        assert labels.count("30") == 2, f"a square part lost one of its two extents: {labels}"
+
+    def test_an_oblique_span_measures_no_pair_of_planes(self):
+        from draftwright.model.ir import DimParameter
+
+        assert _support_planes(DimParameter("length", "boss_height", 5.0, span=None)) is None
+        assert (
+            _support_planes(
+                DimParameter("length", "boss_height", 5.0, span=((0, 0, 0), (3, 4, 0)))
+            )
+            is None
+        )
+        assert (
+            _support_planes(DimParameter("diameter", "boss", 5.0, span=((0, 0, 0), (5, 0, 0))))
+            is None
+        ), "a diameter is not a distance between two support planes"
+        assert _support_planes(
+            DimParameter("length", "boss_height", 5.0, span=((3, 9, 9), (-2, 9, 9)))
+        ) == ("x", -2.0, 3.0), "an axis-aligned span is normalised low-to-high"
+
+
+class TestTheConsolidationIsRecordedAndVerified:
+    def test_the_omission_names_the_dimension_that_now_carries_the_fact(self):
+        # Provenance: a reader of `plan.diagnostics` must be able to answer "where did this
+        # measurement go?", not merely "it is not drawn".
+        model = detect_part_model(_x_hub_plate())
+        boss, _param = _boss_height(model)
+        omission = next(
+            o
+            for o in compile_dimensions(model).diagnostics
+            if o.parameter_id == "boss_height.length"
+        )
+        assert omission.feature == boss
+        assert omission.value == 4.5
+        assert omission.conveyed_by == DimensionId(_envelope(model), "width.length")
+        assert not omission.authored, "a rule-set consolidation is not the author's doing"
+        assert "support planes" in omission.reason
+
+    def test_the_audit_read_distinguishes_withheld_from_consolidated(self):
+        # `Drawing.suppressions()` is the surface a harness or a script actually reads, and
+        # "this is not drawn" and "this is drawn over there" are different answers. Reporting
+        # a consolidation as a bare omission would read a de-duplication as a gap.
+        drawing = build_drawing(_x_hub_plate(), title="T", number="N-1")
+        _assert_the_duplicate_exists(drawing.model())
+        row = next(r for r in drawing.suppressions() if r["parameter_id"] == "boss_height.length")
+        assert row["authored"] is False
+        assert row["conveyed_by"] == {
+            "feature": feature_key(_envelope(drawing.model())),
+            "parameter_id": "width.length",
+        }
+        assert all(
+            r["conveyed_by"] is None
+            for r in drawing.suppressions()
+            if r["parameter_id"] != "boss_height.length"
+        )
+
+    def test_coverage_accepts_a_consolidated_height_only_while_its_owner_is_placed(self):
+        # `boss_height_missing` exists to demand the axial extent. A consolidation satisfies
+        # it because the fact is on the sheet — but ONLY on that condition, so the check
+        # verifies the owner landed rather than trusting the compiler's intent. Consolidating
+        # onto a dimension the placer then drops is a missing measurement.
+        from draftwright.linting.coverage import lint_boss_height_coverage
+
+        part = _x_hub_plate()
+        drawing = build_drawing(part, title="T", number="N-1")
+        model = drawing.model()
+        features = model.features
+        # Recompiled through the public model rather than read off `Drawing._build`: the
+        # compiler is deterministic over the model, so this is the same inventory the build
+        # used, and the encapsulation ratchet (#741) forbids the reach-through.
+        omissions = compile_dimensions(model).diagnostics
+        assert not lint_boss_height_coverage(part, drawing, features, omissions=omissions)
+
+        class _Registry:
+            """The same drawing with the owner absent from the placed inventory."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def names(self):
+                return [n for n in self._inner.names() if n != "m_env_width"]
+
+            def measurement_of(self, name):
+                return self._inner.measurement_of(name)
+
+        class _Dwg:
+            def __init__(self, inner):
+                self.registry = _Registry(inner.registry)
+                self._inner = inner
+
+            def annotations_of(self, feature):
+                return self._inner.annotations_of(feature)
+
+        assert "m_env_width" in drawing.registry.names(), (
+            "the owner annotation was renamed, so this stub proves nothing"
+        )
+        issues = lint_boss_height_coverage(part, _Dwg(drawing), features, omissions=omissions)
+        assert [i.code for i in issues] == ["boss_height_missing"]
+
+    def test_an_authored_set_that_keeps_the_owner_critiques_the_same_as_the_automatic_build(self):
+        # Round-trip parity (epic #964). The author's list decides which dimensions are
+        # drawn; it does not decide where the geometry states a fact. Nulling `conveyed_by`
+        # for an authored omission made an emitted script warn `boss_height_missing` where
+        # the drawing it was generated from did not.
+        from draftwright.sheet_emit import emit_sheet_script
+
+        part = _z_hub_plate()
+        direct = build_drawing(part, title="T", number="N-1")
+        source = emit_sheet_script(detect_part_model(part), "part", "s", title="T", number="N-1")
+        assert "boss_height" not in source, (
+            "the emitter now declares the consolidated height, so parity is not under test"
+        )
+        captured: dict = {"part": part}
+        from unittest.mock import patch
+
+        from draftwright import Drawing
+
+        with patch.object(
+            Drawing, "export", lambda self, *a, **k: captured.setdefault("dwg", self)
+        ):
+            exec(compile(source, "<emit>", "exec"), captured)  # noqa: S102
+
+        def codes(dwg):
+            return sorted((i.code, i.severity) for i in dwg.lint())
+
+        assert codes(captured["dwg"]) == codes(direct)

--- a/tests/test_issue_1154_one_owner_per_measurement.py
+++ b/tests/test_issue_1154_one_owner_per_measurement.py
@@ -19,6 +19,8 @@ plate, which is the only way a feature-local height comes to equal an overall ex
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 from build123d import Align, Box, Cylinder, Pos, Rot
 
@@ -26,7 +28,7 @@ from draftwright import Sheet
 from draftwright.builder import build_drawing, detect_part_model
 from draftwright.drawing import feature_key
 from draftwright.model.compiled import compile_dimensions
-from draftwright.model.planner import DimensionId, _support_planes
+from draftwright.model.planner import DimensionId, _same_support_planes, _support_planes
 
 _C = (Align.CENTER, Align.CENTER, Align.CENTER)
 
@@ -85,17 +87,29 @@ def _assert_a_candidate_exists(model, *, owner):
     extent = next(p for p in _envelope(model).parameters() if p.parameter_id == owner)
     planes = _support_planes(extent)
     assert planes is not None
+    # `_same_support_planes`, the production predicate — not `pytest.approx`, whose default
+    # relative tolerance is looser than `_PLANE_TOL` at these coordinates and could admit a
+    # candidate the rule itself would reject (#1154 review r3).
     candidates = [
         (f.kind, p.parameter_id)
         for f in model.features
         if f.kind != "envelope"
         for p in f.parameters()
-        if _support_planes(p) is not None and _support_planes(p) == pytest.approx(planes)
+        if _same_support_planes(_support_planes(p), planes)
     ]
     assert candidates, (
         f"no feature measures {owner}'s two support planes, so a refusal proves nothing"
     )
+    # Necessary but not sufficient: a candidate can exist and be refused by a DIFFERENT
+    # authority than the one under test — adding a tolerance to a fixture moved the refusal
+    # to the tolerance rule and left all three refusal tests passing (review r3). Each caller
+    # pairs this with a relaxation that shows the named authority is the one refusing.
     return candidates
+
+
+def _consolidates_when(model) -> bool:
+    """Whether *model* consolidates anything — the positive half of the refusal anchors."""
+    return bool([o for o in compile_dimensions(model).diagnostics if o.conveyed_by])
 
 
 def _assert_the_duplicate_exists(model):
@@ -390,6 +404,15 @@ class TestConsolidationMovesTheFactOrDoesNotHappen:
         sheet.auto_dimensions()
         model = sheet.build().model()
         _assert_a_candidate_exists(model, owner="width.length")
+        # Sufficiency: relaxing THIS authority — the rotational rule that withholds the
+        # envelope width — makes the same geometry consolidate. Without it, a fixture drifted
+        # in some other direction (a tolerance, say) would move the refusal elsewhere and the
+        # test would pass having proved nothing (#1154 review r3).
+        assert _consolidates_when(
+            dataclasses.replace(
+                model, features=tuple(f for f in model.features if f.kind != "rotational")
+            )
+        ), "the rotational rule is not what refuses this consolidation"
         plan = compile_dimensions(model)
         assert {o.parameter_id for o in plan.diagnostics if o.conveyed_by} == set(), (
             "the height was handed to an envelope extent the rotational rule withholds"
@@ -416,6 +439,13 @@ class TestConsolidationMovesTheFactOrDoesNotHappen:
         sheet.auto_dimensions()
         model = sheet.build().model()
         _assert_a_candidate_exists(model, owner="height.length")
+        # Sufficiency: with the rotational feature gone the compiler no longer withholds the
+        # overall height, and the same geometry consolidates.
+        assert _consolidates_when(
+            dataclasses.replace(
+                model, features=tuple(f for f in model.features if f.kind != "rotational")
+            )
+        ), "the compiler's overall-height rule is not what refuses this consolidation"
         assert overall_height_withheld(model), (
             "the fixture no longer withholds the overall height, so nothing is under test"
         )
@@ -437,6 +467,11 @@ class TestConsolidationMovesTheFactOrDoesNotHappen:
         sheet.dimension(boss, "boss.diameter")
         model = sheet.build().model()
         _assert_a_candidate_exists(model, owner="height.length")
+        # Sufficiency: drop the authored set and the same geometry consolidates, so it is
+        # the authored omission of the OWNER that refuses and not some other authority.
+        assert _consolidates_when(dataclasses.replace(model, authored_dimensions=None)), (
+            "the authored set is not what refuses this consolidation"
+        )
         rows = [o for o in compile_dimensions(model).diagnostics if o.conveyed_by]
         assert not rows, (
             "the height was handed to an overall height the authored set leaves out: "
@@ -509,4 +544,12 @@ class TestTheToleranceRuleIsAsymmetric:
         # defect, re-opened by its fix (review r2). A tolerance on the owner is the same
         # requirement on the same two faces; it does not make them two facts.
         assert self._z_hub_labels(on_envelope=True) == ["8"]
-        assert self._z_hub_labels(on_boss=True, on_envelope=True) == ["8"]
+
+    def test_equal_tolerances_on_both_sides_still_keep_both(self):
+        # The r2 correction then went one step too far and admitted "equal tolerances", on
+        # the premise that the receiving extent states the same requirement. Measured, an
+        # envelope decoration is not rendered on ANY axis while `render_boss_heights` appends
+        # `_tol_suffix`, so an identically toleranced boss height lost its ± anyway — the
+        # exact silent loss the tolerance rule was added to stop, re-created by the fix for
+        # its own over-correction (review r3). The rule is about the yielder alone.
+        assert self._z_hub_labels(on_boss=True, on_envelope=True) == ["8", "8 ±0.1"]

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -322,7 +322,17 @@ def test_the_ledger_is_plain_data():
     dwg = build_drawing(Rot(0, 90, 0) * Cylinder(10, 40), number="X")
     rows = dwg.suppressions()
     assert rows and all(isinstance(r, dict) for r in rows)
-    assert set(rows[0]) == {"feature", "parameter_id", "value", "reason", "authored"}
+    assert set(rows[0]) == {
+        "feature",
+        "parameter_id",
+        "value",
+        "reason",
+        "authored",
+        # #1154: whether the fact moved to another dimension, or simply went. `conveyed_by`
+        # is itself plain data (the same stable feature key plus a parameter id), so the
+        # audit surface stays diffable without importing `DimensionId`.
+        "conveyed_by",
+    }
     import json
 
     json.dumps(rows)  # must round-trip; a harness will serialise these


### PR DESCRIPTION
Closes #1154. Slice **S5** of epic #1202.

## The defect

GRM-04's drive plate prints `4.5` twice. Reproduced on the source STEP:

```
'4.5'   x2   ['m_bossheight_x0', 'm_env_width']
```

A ø8 hub is flush with both faces of a 4.5 mm plate, so `boss.boss_height.length`
(span x −1.5 → 3) and `envelope.width.length` (span x −1.5 → 3) run between the **same two
faces**. Two detected records, one physical fact — which is why #650's coordinate-key dedup
cannot see it.

## The rule

Reconciliation by **exact support-plane coincidence**, never by value.

That is #997's lesson stated the other way round: a 100 × 100 part's width and depth are
*equal* and are two independent facts, because they run between **different** pairs of faces.
#997 deleted a rule that collapsed them — in a 5% window, so it also read 100 × 95 as square.
A value comparison cannot tell the two cases apart, and it would not even fire here: the two
records reach 4.5 by different routes and differ in the last bit.

The **overall extent wins**; the feature-local measurement yields. A part has one overall
thickness and it is what a machinist reads first. The converse would delete a required
envelope dimension whenever some feature grew to full depth.

## A measurement is handed over only if the receiver actually carries it

Four ways the first cuts got this wrong, each found by running the code:

- **A tolerance was deleted, not moved.** A boss height written `.tolerance(0.05, on="length")`
  went to an overall extent that carries none, so the sheet printed `8` where it had printed
  `8 ±0.1` — silently, with nothing in lint. A toleranced dimension and an untoleranced one
  are not the same requirement, so consolidation now refuses.
- **Three authorities decide whether the owner is drawn, not one.** The planner's envelope
  rules, an authored set, and — for the overall height — `compiled._compile_overall_height`,
  whose docstring says every reason belongs there "in one place" because the planner and the
  renderer once each knew half. This PR recreated that split; the model-derivable half is now
  `planner.overall_height_withheld`, which both call.
- **`boss_height_missing` fired on the very drawings this fixes.** Coverage accepts a
  consolidation — but only while the owner is verifiably among the registry's *placed*
  measurements, so a consolidation onto a dimension the placer drops is still a missing
  measurement. That is why the omission carries a `DimensionId` and not a reason string.
- **`conveyed_by` must survive an authored omission.** The author's list decides which
  dimensions are drawn, not where the geometry states a fact; nulling it made an emitted
  script warn `boss_height_missing` where the drawing it was generated from did not (#964
  parity).

`unmirrored_dimensions` also needed the consolidation: `mirror_model` synthesises an envelope
for a part detected without one, so the completeness gate demanded a line for a dimension
re-running the script does not draw.

## Provenance

`Drawing.suppressions()` reports `conveyed_by` as plain data. "This is not drawn" and "this is
drawn over there" are different answers; an audit that flattened them would read a
de-duplication as a gap. It is **not** a synonym for "the rule set did it" — read `authored`
for whose decision it was and `conveyed_by` for where the measurement went.

## Acceptance (#1154)

- [x] GRM-04-derived synthetic fixture (`_x_hub_plate`) — the source STEP is not in this repo
- [x] Reconcile by semantic support-plane identity
- [x] One 4.5 mm thickness rendered when both candidates measure the same extent
- [x] Both preserved when the spans genuinely differ
- [x] Provenance records which candidate was consolidated and onto what
- [x] Cross-feature duplicates in two eligible *strips* — X boss → front/above, Z boss →
      front/right, each asserted on a **built drawing**. (Both are strips of the front view;
      only a Y-axis boss renders in the side view, so this is not yet the cross-*view* case
      the acceptance line asks for.)

## Defects the tests found in themselves

- The first fixture put the hub tangent to the plate's Y faces, so **no boss was recognised**
  and "the thickness appears once" passed while asserting nothing. Hence
  `_assert_the_duplicate_exists`.
- The plane-versus-value test used a square block, and a value-equality mutation **survived**
  it: an envelope extent is never compared against another envelope extent, so a square part
  is protected by that exclusion and proves nothing about the comparison. It now uses a 4 mm
  boss standing proud of a 4 mm-deep plate.
- An "everything else carries no `conveyed_by`" assertion whose generator was empty; a
  `"4" in labels` membership check on a fixture that draws `4` twice; and a cross-view claim
  resting on a lookup table rather than on output.
- `_PLANE_TOL` was unguarded — widening it to 0.5 **or 2.0** passed the whole tier, so nothing
  said whether it was the kernel's noise floor or a match radius, which is exactly how #997's
  rule failed. A boss flush at one face and 0.5 mm short at the other now says which.
- `_assert_a_candidate_exists` was necessary and not sufficient: a candidate can exist and be
  refused by a *different* authority than the one under test. Adding a tolerance to one
  fixture moved the refusal and left all three refusal tests green. Each now pairs the anchor
  with a relaxation showing the named authority is the one refusing.

## Verification

- 22 mutations of the new code, each with the substitution asserted applied: **all killed** —
  including `_owner_drawn → return True`, each of its three authorities separately, the
  tolerance rule reverted to its symmetric form, `_PLANE_TOL` widened, and a fixture drifted
  so a different authority does the refusing.
- An independent 176-case diff confirms the height-compiler rewire is exactly
  behaviour-preserving against base. An 18-part collateral scan shows **no lint change
  anywhere and no label change** outside the three intended consolidations; two rotational
  parts additionally gain a plan-level suppression row with a valid `conveyed_by`, drawn
  identically either way because rotational parts skip `render_boss_heights`.
- Full fast tier: **4216 passed**, 5 skipped, 2 xfailed. `scripts/pr-check --static`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22

