### PR TITLE
Follow the claim to the drawing instead of believing it (#1217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 - Lint now verifies that an annotation claiming to carry a measurement actually renders it
   (#1217). Coverage checks read provenance riders the annotations carry about themselves and
-  believed them; nothing checked the claim against what the annotation draws. Three new codes —
-  `claimed_value_absent`, `claimed_measurement_not_compiled` and two unverifiable states — and
-  `Drawing.add_table` now keeps the rows it draws so a table's claims are readable back.
-  Verified on every STEP in the corpus: 156 claims, 156 confirmed.
+  believed them; nothing checked the claim against what the annotation draws. Four new codes —
+  `claimed_value_absent`, `claimed_measurement_not_compiled`, and two that report an
+  unverifiable claim rather than passing it — and `Drawing.add_table` now keeps the rows it
+  draws so a table's claims are readable back. Measured over 20 of the 21 STEP fixtures (the
+  21st segfaults in OCC on import, unrelated to this change): 958 claims, 957 confirmed, and
+  one genuine provenance defect found — see #1219.
 
 - `lint_summary()["quality"]` gains a fourth component, `fidelity`: whether what the drawing
   says is TRUE. The existing three ask whether required content landed (completeness),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Lint now verifies that an annotation claiming to carry a measurement actually renders it
+  (#1217). Coverage checks read provenance riders the annotations carry about themselves and
+  believed them; nothing checked the claim against what the annotation draws. Three new codes —
+  `claimed_value_absent`, `claimed_measurement_not_compiled` and two unverifiable states — and
+  `Drawing.add_table` now keeps the rows it draws so a table's claims are readable back.
+  Verified on every STEP in the corpus: 156 claims, 156 confirmed.
+
 - `lint_summary()["quality"]` gains a fourth component, `fidelity`: whether what the drawing
   says is TRUE. The existing three ask whether required content landed (completeness),
   whether there is too much of it (restraint), and whether a reader can make it out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
   believed them; nothing checked the claim against what the annotation draws. Four new codes —
   `claimed_value_absent`, `claimed_measurement_not_compiled`, and two that report an
   unverifiable claim rather than passing it — and `Drawing.add_table` now keeps the rows it
-  draws so a table's claims are readable back. Measured over 20 of the 21 STEP fixtures (the
-  21st segfaults in OCC on import, unrelated to this change): 958 claims, 957 confirmed, and
-  one genuine provenance defect found — see #1219.
+  draws so a table's claims are readable back. Measured over all 21 STEP fixtures: 1,081
+  claims, 1,078 confirmed, and three findings — all instances of one genuine provenance
+  defect, see #1219.
 
 - `lint_summary()["quality"]` gains a fourth component, `fidelity`: whether what the drawing
   says is TRUE. The existing three ask whether required content landed (completeness),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,6 +572,87 @@ matrix, parallelised with `-n auto`) on every PR; the **slow tier runs post-merg
 on `main`**, not as a PR gate (#153) — a regression there is caught right after
 merge rather than blocking every PR for ~19 min.
 
+## Working practices — evidence, not confidence
+
+These are not style preferences. Each one is here because its absence produced a
+defect that shipped, or a claim that was believed and false. Epic #1202 alone
+produced roughly twenty-five confidently-written false statements in commit
+messages, comments, docstrings and PR bodies — several written *inside the fix
+for the previous one*, twice as a PR's own headline.
+
+### Reproduce every prose claim by execution before committing it
+
+If a sentence in a commit message, comment, docstring or PR body asserts a fact
+about this codebase — a count, a behaviour, "no caller does X", "this is the only
+Y" — run the thing that proves it. Not "I read the code and it looks true".
+
+Real examples, all of which passed review-by-reading and failed on execution:
+
+- *"`label_vs_measured` is currently the only such code"* — there were five.
+- *"any permutation fails"* — one passed all 4,092 tests.
+- *"the union of these registers is exactly the set of codes the engine emits"* —
+  41 against 55.
+- *"`representation_features` is populated by nothing"* — true of the field, but
+  the reason given was wrong, and the neighbouring live parameter was nearly
+  deleted with it.
+- *"156 claims, 156 confirmed across every STEP fixture"* — the script globbed
+  `*.step` and half the fixtures are `*.stp`. The corrected figure was **also**
+  wrong: it mixed repo fixtures with files from a local directory and used
+  `build123d.import_step` instead of the engine's `analysis._import_step`.
+
+**When measuring a corpus, say which files and through which entry point.**
+`build_drawing(path)` and `build123d.import_step(path)` are not the same code
+path — the first uses `STEPControl_Reader` specifically to avoid an XCAF segfault
+the second hits on CTC-02 AP242.
+
+### A green suite is not evidence that a guard is load-bearing
+
+Break the rule on purpose and confirm a named test fails. Assert the substitution
+applied — a run that collects no tests, or a `sed` that matched nothing, is a
+broken harness reporting success.
+
+Guards that survived the **entire** suite until mutated, each with a test sitting
+next to it: three of five `_FIDELITY_CODES` deleted outright; `_owner_drawn`
+replaced with `return True`; `_PLANE_TOL` widened from `1e-6` to **2.0**; both
+halves of an availability predicate *and* its fail-safe override.
+
+**Mutation results expire when the code changes.** Re-run them for anything a
+later commit touches. And beware tests that pass for the wrong reason: a
+determinism test comparing runs *within one process* passes on unsorted code,
+because string hashing is stable for a given `PYTHONHASHSEED`.
+
+### Every fixture asserts its own precondition
+
+A test that the defect is present, before asserting it is handled. Four tests in
+#1202 passed against completely unfixed code because their fixtures never
+contained the defect — a "this thickness is now printed once" test whose geometry
+produced no duplicate in the first place; an "everything else is unaffected"
+generator that was empty.
+
+A precondition is necessary and often not sufficient: a candidate can exist and be
+refused by a *different* mechanism than the one under test. Where that is possible,
+also assert that relaxing the named mechanism changes the outcome.
+
+### Fix it, or state a reason you could not have manufactured
+
+When work turns up a defect, the default is to fix it. Filing needs a reason that
+does not reduce to a choice you just made:
+
+- it needs a **decision that is the maintainer's**; or
+- you **attempted** it and found it larger than it looked.
+
+**"It is in a different file" and "it is a different subsystem" are not reasons.**
+You choose which files a change touches, so citing that boundary is circular — it
+lets any defect be deferred by declining to open the file. Look first; decide
+after. A reason produced before looking is a justification for what you already
+did.
+
+### Read a gate's exit code, never its output
+
+`scripts/pr-check --static` exits non-zero on failure. Grepping its text for
+`error` once hid ruff-format's "Would reformat" for several commits, so a real
+failure read as a pass.
+
 ## License
 
 AGPL-3.0. Anyone running draftwright as a network service must provide their

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -222,6 +222,31 @@ records cross is the sanctioned `build_part_model` boundary itself.
   real state of the adapter protocol, instead of 0008's aspirational
   "migration complete — one rule set".
 
+## Amendment — lint may read the compiled plan to check a claim (2026-08-18, #1217)
+
+The lint/coverage carve-out says lint reads recognition and the placed drawing, "never a
+build-time side channel, and **never the plan**", and points at
+`test_linting_does_not_import_model` as the structural guarantee that it cannot widen
+into IR coupling.
+
+`linting/evidence.py` is an exception, and it is narrow enough to state rather than
+smuggle. It verifies that an annotation claiming to carry a measurement actually renders
+the value **the compiler approved**, so the compiled plan is its expected side by
+construction. Comparing rendered output against rendered output would establish only that
+the renderer agrees with itself.
+
+The circularity the carve-out exists to prevent does not arise. That hazard is a
+completeness *denominator* derived from the plan — a feature the planner omitted would
+then never be flagged as missing. This check contributes no denominator: it takes the set
+of claims as given and asks whether each is borne out. A measurement the planner never
+approved is reported (`claimed_measurement_not_compiled`), not silently excused.
+
+The guard still holds — `linting/` imports no `draftwright.model`; `drawing._lint`
+compiles the plan and passes it in duck-typed — so this remains a fact about one function's
+arguments rather than a new package dependency. The carve-out's sentence is therefore
+qualified, not repealed: lint derives no *requirement* from the plan, and may compare
+against it when checking a claim the drawing itself makes.
+
 ## Amendment — cross-feature reconciliation by support-plane identity (2026-08-18, #1154)
 
 The planner's long-standing contract says features own their parameters and "do

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -92,7 +92,6 @@ def _register_hole_table_coverage(
     locations=(),
     requirements=(),
     representation_reason=None,
-    representation_features=(),
     representation_requirements=(),
 ):
     """Register the semantic facts visibly carried by a placed hole table.
@@ -103,11 +102,6 @@ def _register_hole_table_coverage(
     """
     table.covers_hole_locations = tuple(locations)
     table.covers_hole_requirements_by_feature = tuple(requirements)
-    table.covers_hole_representations_by_feature = tuple(
-        (feature, "hole_table", representation_reason)
-        for feature in representation_features
-        if representation_reason is not None
-    )
     table.covers_hole_representations_by_requirement = tuple(
         (feature, parameter, "hole_table", representation_reason)
         for feature, parameter in representation_requirements
@@ -140,11 +134,6 @@ def _annotation_hole_features(registry, name, annotation) -> frozenset:
             features.add(feature)
     for feature, _requirement, _count in getattr(
         annotation, "covers_hole_requirements_by_feature", ()
-    ):
-        if getattr(feature, "kind", None) in {"hole", "pattern"}:
-            features.add(feature)
-    for feature, _representation, _reason in getattr(
-        annotation, "covers_hole_representations_by_feature", ()
     ):
         if getattr(feature, "kind", None) in {"hole", "pattern"}:
             features.add(feature)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -79,6 +79,7 @@ from draftwright.linting import (
     lint_axial_coverage,
     lint_boss_height_coverage,
     lint_channel_coverage,
+    lint_claimed_representations,
     lint_declaration_reconciliation,
     lint_declared_gear_coverage,
     lint_drawing,
@@ -2714,6 +2715,12 @@ class Drawing:
         if not rows:
             return None
         table = _build_table(rows, self.draft, block_cols=block_cols)
+        # Keep the rows the table draws, so its content is readable back off the annotation
+        # (#1217). A table renders as compound geometry with no `label`, so without this a
+        # hole table's measurement claims can be neither confirmed nor refuted — and the
+        # claims it carries are exactly the ones coverage relies on when the engine withdraws
+        # the individual callouts. Mirrors `gear_requirement_rows`.
+        table.table_rows = tuple(tuple(str(cell) for cell in row) for row in rows)
         w, h = table.table_size
         a = self._analysis
         margin = a.margin if a is not None else 10.0
@@ -3131,6 +3138,16 @@ class Drawing:
                 **prof_kw,
             )
             model = self._part_model
+            if model is not None:
+                # Every annotation's measurement claims, resolved against what it renders
+                # (#1217). Coverage believes these claims; this is the only thing that
+                # checks them. Cheap — pure Python over the IR and the registry, no
+                # geometry — and it needs the compiled plan because the value an annotation
+                # SHOULD show is the compiler's, never a renderer's own formatting
+                # (ADR 0016 Amendment 1).
+                from draftwright.model.compiled import compile_dimensions
+
+                issues += lint_claimed_representations(self._registry, compile_dimensions(model))
             # Turned bosses/bands remain in the OD + axial-step policy; this check is
             # specifically for a prismatic boss's independent projection height.
             if model is not None and (a is None or (not a.is_rotational and a.prof is None)):

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -701,12 +701,12 @@ def _table_represented(drawing) -> list:
     plate with no lint issues at all — which inverted the metric: a correct sheet scored
     worse than the same part with the table forced to fail.
 
-    Read ``covers_hole_representations_by_requirement`` and not the ``…_by_feature``
-    sibling. The sibling exists, and an earlier cut of this function read it, but **no
-    caller populates it**: `representation_features=` appears in the whole tree only at its
-    own definition and its own use in ``annotations/_common.py``. Both real callers pass
-    ``representation_requirements=`` instead. So that read returned nothing on every real
-    drawing while a hand-built stub in the tests made it look correct.
+    Read ``covers_hole_representations_by_requirement``. An earlier cut read a
+    ``…_by_feature`` sibling that no caller ever populated — its ``representation_features``
+    argument appeared in the whole tree only at its own definition and its own use — so the
+    read returned nothing on every real drawing while a hand-built stub in the tests made it
+    look correct. The dead field was removed in #1217; this note stays because the lesson is
+    about the stub, not the field.
 
     Filtered to the SIZE requirement: a table row also documents location and through-ness,
     and crediting those would mean a hole with a located row but no diameter counted as

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -28,6 +28,11 @@ from draftwright.linting.coverage import (
     lint_principal_profile_coverage,
     lint_prismatic_coverage,
 )
+from draftwright.linting.evidence import (
+    ClaimOutcome,
+    lint_claimed_representations,
+    verify_measurement_claims,
+)
 from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.gear_coverage import lint_declared_gear_coverage
 from draftwright.linting.hole_coverage import lint_hole_coverage
@@ -46,10 +51,13 @@ from draftwright.linting.structural import is_dimension_like, lint_drawing
 from draftwright.linting.suggest import _suggest_fix
 
 __all__ = [
+    "ClaimOutcome",
     "CoverageState",
     "EXAMINABLE_DECLARED_KINDS",
     "LintIssue",
     "is_dimension_like",
+    "lint_claimed_representations",
+    "verify_measurement_claims",
     "lint_hole_coverage",
     "lint_polygonal_stock_coverage",
     "_suggest_fix",

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -5,10 +5,17 @@ reading **provenance riders** the annotations carry about themselves. That is a 
 observation: an annotation asserting it carries hole 3's diameter is believed, and nothing
 checks that it renders that diameter — or renders anything at all.
 
-The failure mode is not hypothetical. ``covers_hole_representations_by_feature`` was read in two
-places and populated by nothing, which inverted the benchmark's ``drawing_consumer`` metric
-(16/16 ``unsupported`` against a true 16/16 ``supported``) and went unnoticed, because the only
-thing that could have noticed was the metric itself.
+The failure mode is not hypothetical. The benchmark's ``drawing_consumer`` metric was inverted
+— 16/16 ``unsupported`` against a true 16/16 ``supported`` — because it read only ``hc_``
+callout names and so scored every hole on a table-escalated sheet as lost. The *fix* for that
+then read ``covers_hole_representations_by_feature``, a rider no caller populates, and looked
+correct only because a hand-built stub in the tests supplied it.
+
+(An earlier draft of this paragraph said the dead rider caused the inversion, and that it went
+unnoticed "for months". Neither is true: the rider made the attempted fix look correct, and it
+existed for four days — introduced 2026-08-14, caught by the next review cycle. Corrected here
+because a module explaining why claims must be checked is a poor place to leave an unchecked
+one.)
 
 So the ledger becomes a **pointer to the claimed representation, not final proof** (#1206). This
 module resolves each pointer against the built drawing and checks the rendered content carries
@@ -66,8 +73,15 @@ def _expected_numbers(approved) -> frozenset[float]:
     drawing: all four cases on the corpus are ordinary, correct location dimensions whose
     value the compiler did supply, in the field this function had not looked at.
 
-    Axis components only, never the 3-D distance between the span's ends — that is a number no
-    renderer draws, and admitting it would widen what counts as a match for nothing.
+    Narrowed to the approved ``axis`` where the compiler declares one. Accepting all three
+    components repeated the mistake this docstring already rejects for the 3-D distance ("a
+    number no renderer draws"): on a pocket located in a Z-normal plane the Z component is
+    drawn by nothing, and admitting it confirmed a deliberately relabelled X offset (#1218
+    review). Never the 3-D distance, for the original reason.
+
+    All three remain acceptable when no axis is declared, because then nothing says which the
+    renderer took. That residue is named in :func:`verify_measurement_claims`'s limits rather
+    than papered over.
     """
     text = getattr(approved, "value_text", "") or ""
     try:
@@ -78,14 +92,40 @@ def _expected_numbers(approved) -> frozenset[float]:
     if not span or len(span) != 2:
         return frozenset()
     start, end = span
-    return frozenset(float(_fmt(abs(float(end[axis]) - float(start[axis])))) for axis in range(3))
+    axis = getattr(approved, "axis", None)
+    # EXCLUDE the declared axis, do not restrict to it. For a location, `axis` is the
+    # FEATURE's axis (`compiled.py`: "`span` is (datum, located point) and `axis` is the
+    # feature's frame axis"), and the dimensions drawn are the offsets PERPENDICULAR to it —
+    # a pocket normal to Z is located by its X and Y. Restricting to the declared axis was
+    # the first cut of this fix and it excluded exactly the components that are drawn,
+    # turning three correct NIST location dimensions into mismatches.
+    excluded = "xyz".index(axis) if axis in ("x", "y", "z") else None
+    indices = [i for i in range(3) if i != excluded]
+    return frozenset(
+        float(_fmt(abs(float(end[index]) - float(start[index])))) for index in indices
+    )
 
 
 #: Every number a label renders. Deliberately ALL of them, not the leading one: a compound hole
 #: callout reads ``⌀8 THRU ⌴ ⌀14 ↧ 7`` and claims three separate measurements, so
 #: ``structural._label_value`` — which answers "what does this label assert about the path it is
 #: drawn on", a different question — sees only the 8.
-_NUMBER_RE = re.compile(r"\d+(?:\.\d+)?")
+_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+#: A leading ``4× ⌀`` repeat count, stripped before numbers are read. A count is not a
+#: measurement, and leaving it in let ``4× ⌀9 THRU`` confirm a claimed bore diameter of 4
+#: (#1218 review). Unlike the compound-label residue below, this was never within the stated
+#: limit — the number is not a measurement at all.
+#:
+#: The ⌀/R lookahead is load-bearing and is `structural._label_value`'s own discriminator:
+#: ``N× ⌀d`` counts d-diameter features, while ``N× v`` is a pitch span. Without it this
+#: pattern also matched a pocket's ``44 × 93.4 × 10 DEEP`` and deleted the width — turning
+#: two correct dimensions on `issue_915_case_study_2` into mismatches, which is how a
+#: safety fix becomes the defect it was guarding against.
+#:
+#: The ``N× v`` pitch form is deliberately left alone, so a claim whose value equals the
+#: count could still be confirmed by it. Named in the limits rather than guessed at.
+_REPEAT_RE = re.compile(r"^\s*\d+\s*[×x]\s*(?=[ø⌀Rr])")
 
 
 @dataclass(frozen=True)
@@ -134,12 +174,14 @@ def rendered_numbers(annotation) -> frozenset[float] | None:
     """
     try:
         label = getattr(annotation, "label", None) or getattr(annotation, "_annotate_label", None)
-        rows = getattr(annotation, "table_rows", None) or getattr(
-            annotation, "gear_requirement_rows", None
-        )
+        # `table_rows` only. A gear table carries `gear_requirement_rows` AND no measurement
+        # claim at all (measured: `claims: ()`), so this is never called on one — and it now
+        # carries `table_rows` regardless. Reading both was a second field read by nobody,
+        # added inside the fix for the first one (#1218 review).
+        rows = getattr(annotation, "table_rows", None)
     except Exception:  # noqa: BLE001 — a raising property on a caller's item must not kill lint
         return None
-    texts = [str(label)] if label else []
+    texts = [_REPEAT_RE.sub("", str(label))] if label else []
     texts += [str(cell) for row in (rows or ()) for cell in row]
     if not texts:
         return None
@@ -149,15 +191,41 @@ def rendered_numbers(annotation) -> frozenset[float] | None:
 def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
     """Resolve every annotation's measurement claims against what it renders.
 
-    This is a **presence** check, and that limit is worth stating: it proves the approved value
-    appears among the numbers the annotation draws, not that it appears in the right *position*
-    within a compound label. Attributing part of ``⌀8 THRU ⌴ ⌀14 ↧ 7`` to a specific measurement
-    would need the renderer to record spans as it formats. Presence is strictly stronger than
-    what preceded it, which was nothing.
+    **Four limits, all measured rather than reasoned about** (#1218 review found each of them
+    by relabelling a real drawing and watching this function stay silent):
+
+    1. **Presence, not attribution.** It proves the approved value appears among the numbers
+       the annotation draws, not that it appears in the right *position* within a compound
+       label. Relabelling ``⌀8 THRU ⌴ ⌀14 ↧ 7`` to ``⌀14 THRU ⌴ ⌀14 ↧ 8`` still confirms the
+       bore, from the counterbore's depth. Attribution needs the renderer to record spans as
+       it formats.
+    2. **Members of one `DimensionId` confirm each other.** A hole's location is one id holding
+       both the X and the Y offset, so swapping two location labels — two visibly wrong
+       dimensions — confirms both. On a four-hole pattern all eight offsets share the id. The
+       multimap is what stops false *mismatches*; this is its cost, and narrowing it needs
+       per-member identity, which #883 deliberately leaves open.
+    3. **Reach is bounded by ADR 0010 identity.** An annotation carrying no measurement claim
+       is skipped entirely, and roughly half do — measured, 81 of 170 annotations on
+       ``nist_ctc_02`` carry claims. "N claims, N confirmed" is a statement about the claimed
+       part of the sheet, never the whole sheet.
+    4. **Existence is assumed, not checked.** Claims are read by walking the registry, so an
+       approved measurement that NO annotation claims is invisible here. That direction is
+       coverage's job, and #1217's ``annotation_missing`` state is deliberately not
+       implemented — there is nothing to point at.
+
+    What the check compares is also worth being exact about: ``label`` is a rider the renderer
+    attaches, not glyphs recovered from the sheet, so this is the compiled plan against a
+    second self-report rather than against geometry. It is a real cross-source check — the
+    label is built from the formatted arguments the renderer was handed — and ``table_rows`` is
+    genuinely the drawn content. Verifying export-visible text is #1217's step 5.
     """
     approved = compiled_values(plan)
     outcomes: list[ClaimOutcome] = []
-    for name in registry.names():
+    # `sorted`, because `registry.names()` is a set: without it the emitted issue ORDER varies
+    # run to run on the same drawing (measured: five orderings in five processes), against
+    # ADR 0006's determinism posture — the defect #1196 fixed for lint text, reintroduced
+    # through iteration order.
+    for name in sorted(registry.names()):
         claims = registry.measurement_of(name)
         if not claims:
             continue

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -93,12 +93,18 @@ def _expected_numbers(approved) -> frozenset[float]:
         return frozenset()
     start, end = span
     axis = getattr(approved, "axis", None)
-    # EXCLUDE the declared axis, do not restrict to it. For a location, `axis` is the
-    # FEATURE's axis (`compiled.py`: "`span` is (datum, located point) and `axis` is the
-    # feature's frame axis"), and the dimensions drawn are the offsets PERPENDICULAR to it —
-    # a pocket normal to Z is located by its X and Y. Restricting to the declared axis was
-    # the first cut of this fix and it excluded exactly the components that are drawn,
-    # turning three correct NIST location dimensions into mismatches.
+    # EXCLUDE the declared axis, do not restrict to it — but only because of WHICH producer
+    # reaches here. `_compile_locations` sets `axis` to the FEATURE's axis, so a pocket normal
+    # to Z is located by its X and Y and the Z component is drawn by nothing. Restricting to
+    # the axis was this fix's first cut and it removed exactly the components that ARE drawn,
+    # turning three correct NIST dimensions into mismatches.
+    #
+    # It is NOT a general rule about `axis`. `_shoulder_span` and `_compile_slot_positions`
+    # set it to the MEASURED direction, where excluding it would remove the only drawn
+    # component — those are safe today solely because they set a numeric `value_text` and
+    # return above. A future producer that emits an empty `value_text` with a measured-axis
+    # `axis` would break silently here, so the discriminator wants to be the producer's
+    # intent rather than this inference (#1218 review round 2).
     excluded = "xyz".index(axis) if axis in ("x", "y", "z") else None
     indices = [i for i in range(3) if i != excluded]
     return frozenset(
@@ -110,7 +116,12 @@ def _expected_numbers(approved) -> frozenset[float]:
 #: callout reads ``⌀8 THRU ⌴ ⌀14 ↧ 7`` and claims three separate measurements, so
 #: ``structural._label_value`` — which answers "what does this label assert about the path it is
 #: drawn on", a different question — sees only the 8.
-_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+#: Unsigned, deliberately. A round-2 draft admitted a leading ``-`` for a hypothetical negative
+#: ``value_text``; measured, no producer emits one, and the sign turned ordinary hyphenated text
+#: into numbers — the gear table's ``ISO 21771-2:2025`` yielded ``-2.0`` where the drawn glyph is
+#: ``2``. Should a producer ever emit a negative value it reports `value_absent` rather than
+#: silently confirming, which is the safe direction to be wrong in (#1218 review round 2).
+_NUMBER_RE = re.compile(r"\d+(?:\.\d+)?")
 
 #: A leading ``4× ⌀`` repeat count, stripped before numbers are read. A count is not a
 #: measurement, and leaving it in let ``4× ⌀9 THRU`` confirm a claimed bore diameter of 4
@@ -161,6 +172,34 @@ def compiled_values(plan) -> dict:
     return {key: tuple(entries) for key, entries in values.items()}
 
 
+#: Table columns whose cells are counts or identifiers rather than measurements, matched on the
+#: header row a table carries as its first entry.
+#:
+#: ``QTY`` is the reason this exists. `add_hole_table` emits ``TAG | ⌀ | DEPTH | QTY``, and a
+#: table drawing ``ø99`` for a ⌀4 hole was confirmed by its own quantity cell — the same defect
+#: `_REPEAT_RE` fixes for ``4× ⌀9 THRU``, surviving in the path this module calls the one that
+#: matters most, because the strip was applied to the label and not to row cells (#1218 review
+#: round 2). ``TAG`` carries no digits today and is listed so a future numeric tag cannot
+#: quietly become a measurement.
+_NON_MEASURING_COLUMNS = frozenset({"QTY", "TAG", "ITEM", "REF"})
+
+
+def _table_texts(rows) -> list[str]:
+    """A table's cells, minus the columns that do not carry measurements.
+
+    The first row is the header — that is the shape both table producers emit — so the columns
+    to drop are named rather than guessed at by position. A table with no recognisable header
+    contributes every cell, which is the pre-existing behaviour and errs toward false
+    confirmation; that residue is named in :func:`verify_measurement_claims`'s limits.
+    """
+    rows = list(rows or ())
+    if not rows:
+        return []
+    header = [str(cell).strip().upper() for cell in rows[0]]
+    dropped = {i for i, name in enumerate(header) if name in _NON_MEASURING_COLUMNS}
+    return [str(cell) for row in rows[1:] for i, cell in enumerate(row) if i not in dropped]
+
+
 def rendered_numbers(annotation) -> frozenset[float] | None:
     """Every number *annotation* puts on the sheet, or ``None`` when nothing can read it.
 
@@ -182,7 +221,7 @@ def rendered_numbers(annotation) -> frozenset[float] | None:
     except Exception:  # noqa: BLE001 — a raising property on a caller's item must not kill lint
         return None
     texts = [_REPEAT_RE.sub("", str(label))] if label else []
-    texts += [str(cell) for row in (rows or ()) for cell in row]
+    texts += _table_texts(rows)
     if not texts:
         return None
     return frozenset(float(match.group()) for text in texts for match in _NUMBER_RE.finditer(text))
@@ -195,10 +234,16 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
     by relabelling a real drawing and watching this function stay silent):
 
     1. **Presence, not attribution.** It proves the approved value appears among the numbers
-       the annotation draws, not that it appears in the right *position* within a compound
-       label. Relabelling ``⌀8 THRU ⌴ ⌀14 ↧ 7`` to ``⌀14 THRU ⌴ ⌀14 ↧ 8`` still confirms the
-       bore, from the counterbore's depth. Attribution needs the renderer to record spans as
-       it formats.
+       the annotation draws, not that it appears in the right *position*. Relabelling
+       ``⌀8 THRU ⌴ ⌀14 ↧ 7`` to ``⌀14 THRU ⌴ ⌀14 ↧ 8`` still confirms the bore, from the
+       counterbore's depth. **A table is the severe case**, not a footnote to this one: its
+       cells are one flat pool, so a diameter claim can be satisfied by an X or Y coordinate
+       in another column — measured, replacing every diameter cell on a 17-row table left 17
+       of 32 claims confirmed. Matching a claim's parameter to a *column* would fix it and is
+       a real piece of design, not a tightening.
+    5. **One annotation may claim several different ids**, and one rendered number satisfies
+       all of them — measured up to ten distinct ids on a single annotation. Limit 2 is about
+       members *within* one id; this is across ids.
     2. **Members of one `DimensionId` confirm each other.** A hole's location is one id holding
        both the X and the Y offset, so swapping two location labels — two visibly wrong
        dimensions — confirms both. On a four-hole pattern all eight offsets share the id. The
@@ -275,7 +320,8 @@ def lint_claimed_representations(registry, plan) -> list[LintIssue]:
                     code="claimed_value_absent",
                     message=(
                         f"{outcome.annotation} claims {outcome.parameter_id} "
-                        f"({'/'.join(outcome.expected)}) but renders {outcome.rendered}"
+                        f"({'/'.join(outcome.expected)}) but renders "
+                        f"{outcome.rendered or 'no number'}"
                     ),
                 )
             )

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -1,0 +1,258 @@
+"""Verify that a claimed representation actually renders the value it claims (#1217).
+
+Coverage checks answer "did this requirement reach the sheet?" by walking the registry and
+reading **provenance riders** the annotations carry about themselves. That is a claim, not an
+observation: an annotation asserting it carries hole 3's diameter is believed, and nothing
+checks that it renders that diameter — or renders anything at all.
+
+The failure mode is not hypothetical. ``covers_hole_representations_by_feature`` was read in two
+places and populated by nothing, which inverted the benchmark's ``drawing_consumer`` metric
+(16/16 ``unsupported`` against a true 16/16 ``supported``) and went unnoticed, because the only
+thing that could have noticed was the metric itself.
+
+So the ledger becomes a **pointer to the claimed representation, not final proof** (#1206). This
+module resolves each pointer against the built drawing and checks the rendered content carries
+the value the compiler approved.
+
+**Shared, not hole-specific.** The claim is ``registry.measurement_of(name)``, which every
+feature family populates through the same seam (ADR 0010), so nothing here knows what a hole is.
+The expected value comes from the compiled plan (ADR 0016 Amendment 1), never from a renderer's
+own formatting — comparing rendered output against rendered output would prove only that the
+renderer is self-consistent.
+
+**Two consumers.** ``evaluation`` gets an observation it can score without trusting the engine's
+self-report; lint gets a self-consistency check it can act on. One implementation, because two
+would drift — which is the state #1206 was opened about.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Literal
+
+from draftwright._geometry import _fmt
+from draftwright.linting.issues import LintIssue
+
+#: What became of one claim.
+#:
+#: ``unresolved`` is the interesting one: an annotation claiming a measurement the compiled plan
+#: has no entry for means a renderer emitted content the compiler never approved, which ADR 0016
+#: Amendment 1 exists to prevent. It is reported rather than skipped.
+ClaimState = Literal["confirmed", "value_absent", "unresolved", "unreadable", "no_expected_value"]
+
+#: Values are compared as floats at this absolute tolerance, not as strings. A string compare
+#: would fail on ``"8"`` against ``"8.0"``; a substring compare would pass ``⌀8`` against a label
+#: reading ``⌀18``, which is the trap this module exists to avoid rather than introduce.
+_VALUE_TOL = 1e-6
+
+
+def _expected_numbers(approved) -> frozenset[float]:
+    """Every number the sheet may legitimately show for *approved*.
+
+    From ``value_text``, NOT ``value``. The compiler formats for display — a 13.649 mm extent
+    is approved as ``"13.6"`` and drawn as ``13.6`` — so comparing the raw float reports a
+    correctly drawn dimension as wrong. Measured: the first corpus run flagged 13 claims, and
+    ten were exactly this, including ``expected=('13.6',) rendered=13.6``.
+
+    Falling back to the **span** where there is no text. A location carries ``value=0.0`` and
+    ``value_text=""`` because its magnitude lives in ``span = (datum, located point)``; the
+    renderer takes one axis component of that span, so the acceptable numbers are the
+    per-axis components — formatted the same way, since a 29.35 mm offset is drawn as 29.4.
+
+    That fallback is the difference between verifying a location and declining to. The first
+    cut reported these as unverifiable, which was true of the implementation and not of the
+    drawing: all four cases on the corpus are ordinary, correct location dimensions whose
+    value the compiler did supply, in the field this function had not looked at.
+
+    Axis components only, never the 3-D distance between the span's ends — that is a number no
+    renderer draws, and admitting it would widen what counts as a match for nothing.
+    """
+    text = getattr(approved, "value_text", "") or ""
+    try:
+        return frozenset({float(text)})
+    except ValueError:
+        pass
+    span = getattr(approved, "span", None)
+    if not span or len(span) != 2:
+        return frozenset()
+    start, end = span
+    return frozenset(float(_fmt(abs(float(end[axis]) - float(start[axis])))) for axis in range(3))
+
+
+#: Every number a label renders. Deliberately ALL of them, not the leading one: a compound hole
+#: callout reads ``⌀8 THRU ⌴ ⌀14 ↧ 7`` and claims three separate measurements, so
+#: ``structural._label_value`` — which answers "what does this label assert about the path it is
+#: drawn on", a different question — sees only the 8.
+_NUMBER_RE = re.compile(r"\d+(?:\.\d+)?")
+
+
+@dataclass(frozen=True)
+class ClaimOutcome:
+    """One annotation's claim on one measurement, resolved against what it renders."""
+
+    annotation: str
+    parameter_id: str
+    state: ClaimState
+    expected: tuple[str, ...] = ()
+    rendered: str | None = None
+
+
+def compiled_values(plan) -> dict:
+    """``{measurement id: (ApprovedDimension, ...)}`` for everything the compiler approved.
+
+    A **multimap**, deliberately. A ``DimensionId`` is not unique per rendered dimension: one
+    hole's ``location.location`` yields both the X and the Y offset, and the overall height
+    appears in a group and in the ladder. Keyed as a single value it silently drops one of each
+    pair, and the verifier then reports a true dimension as a mismatch — measured while building
+    this, on a two-hole plate where the Y locations read 15 and 45 against a lookup insisting on
+    20 and 60.
+    """
+    values: dict = defaultdict(list)
+    for group in getattr(plan, "groups", ()):
+        for approved in group.dims:
+            values[approved.id].append(approved)
+    for ladder in getattr(plan, "ladders", ()):
+        for approved in ladder.rungs:
+            values[approved.id].append(approved)
+    for approved in getattr(plan, "locations", ()):
+        values[approved.id].append(approved)
+    return {key: tuple(entries) for key, entries in values.items()}
+
+
+def rendered_numbers(annotation) -> frozenset[float] | None:
+    """Every number *annotation* puts on the sheet, or ``None`` when nothing can read it.
+
+    Two sources: a ``label``, and the ROWS of a table. A table draws as compound geometry with
+    no label, so reading rows is what makes a hole table's claims checkable at all — and those
+    are precisely the claims that matter most, since the engine withdraws the individual
+    callouts when it escalates to a table.
+
+    ``None`` is a real answer and is reported as such. Silently counting an unreadable
+    annotation as confirmed would rebuild the trust this module exists to remove.
+    """
+    try:
+        label = getattr(annotation, "label", None) or getattr(annotation, "_annotate_label", None)
+        rows = getattr(annotation, "table_rows", None) or getattr(
+            annotation, "gear_requirement_rows", None
+        )
+    except Exception:  # noqa: BLE001 — a raising property on a caller's item must not kill lint
+        return None
+    texts = [str(label)] if label else []
+    texts += [str(cell) for row in (rows or ()) for cell in row]
+    if not texts:
+        return None
+    return frozenset(float(match.group()) for text in texts for match in _NUMBER_RE.finditer(text))
+
+
+def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
+    """Resolve every annotation's measurement claims against what it renders.
+
+    This is a **presence** check, and that limit is worth stating: it proves the approved value
+    appears among the numbers the annotation draws, not that it appears in the right *position*
+    within a compound label. Attributing part of ``⌀8 THRU ⌴ ⌀14 ↧ 7`` to a specific measurement
+    would need the renderer to record spans as it formats. Presence is strictly stronger than
+    what preceded it, which was nothing.
+    """
+    approved = compiled_values(plan)
+    outcomes: list[ClaimOutcome] = []
+    for name in registry.names():
+        claims = registry.measurement_of(name)
+        if not claims:
+            continue
+        numbers = rendered_numbers(registry.named(name))
+        for claim in claims:
+            entries = approved.get(claim, ())
+            parameter = str(getattr(claim, "parameter", claim))
+            expected = tuple(entry.value_text for entry in entries)
+            wanted = (
+                frozenset().union(*(_expected_numbers(entry) for entry in entries))
+                if entries
+                else frozenset()
+            )
+            if not entries:
+                outcomes.append(ClaimOutcome(name, parameter, "unresolved"))
+            elif not wanted:
+                outcomes.append(ClaimOutcome(name, parameter, "no_expected_value", expected))
+            elif numbers is None:
+                outcomes.append(ClaimOutcome(name, parameter, "unreadable", expected))
+            elif any(
+                any(abs(want - number) <= _VALUE_TOL for number in numbers) for want in wanted
+            ):
+                outcomes.append(ClaimOutcome(name, parameter, "confirmed", expected))
+            else:
+                outcomes.append(
+                    ClaimOutcome(
+                        name,
+                        parameter,
+                        "value_absent",
+                        expected,
+                        ", ".join(str(number) for number in sorted(numbers)) or None,
+                    )
+                )
+    return outcomes
+
+
+def lint_claimed_representations(registry, plan) -> list[LintIssue]:
+    """Report claims the drawing does not bear out."""
+    issues: list[LintIssue] = []
+    for outcome in verify_measurement_claims(registry, plan):
+        if outcome.state == "confirmed":
+            continue
+        if outcome.state == "value_absent":
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    code="claimed_value_absent",
+                    message=(
+                        f"{outcome.annotation} claims {outcome.parameter_id} "
+                        f"({'/'.join(outcome.expected)}) but renders {outcome.rendered}"
+                    ),
+                )
+            )
+        elif outcome.state == "unresolved":
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    code="claimed_measurement_not_compiled",
+                    message=(
+                        f"{outcome.annotation} claims {outcome.parameter_id}, which the "
+                        "compiler did not approve"
+                    ),
+                )
+            )
+        elif outcome.state == "no_expected_value":
+            issues.append(
+                LintIssue(
+                    severity="info",
+                    code="claimed_representation_no_expected_value",
+                    message=(
+                        f"{outcome.annotation} claims {outcome.parameter_id}, which the "
+                        "compiler approved with no displayable value, so the claim is "
+                        "neither confirmed nor refuted"
+                    ),
+                )
+            )
+        else:
+            issues.append(
+                LintIssue(
+                    severity="info",
+                    code="claimed_representation_unreadable",
+                    message=(
+                        f"{outcome.annotation} claims {outcome.parameter_id} and renders no "
+                        "readable text, so the claim is neither confirmed nor refuted"
+                    ),
+                )
+            )
+    return issues
+
+
+__all__ = [
+    "ClaimOutcome",
+    "ClaimState",
+    "compiled_values",
+    "lint_claimed_representations",
+    "rendered_numbers",
+    "verify_measurement_claims",
+]

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -488,11 +488,6 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         annotation = registry.named(name)
         representation = getattr(annotation, "hole_representation", None)
         representation_reason = getattr(annotation, "hole_representation_reason", None)
-        feature_representations: dict[object, set[tuple[str, str]]] = defaultdict(set)
-        for feature, feature_representation, reason in getattr(
-            annotation, "covers_hole_representations_by_feature", ()
-        ):
-            feature_representations[feature].add((str(feature_representation), str(reason)))
         requirement_representations: dict[tuple[object, str], set[tuple[str, str]]] = defaultdict(
             set
         )
@@ -508,8 +503,6 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
                 representations[(feature, parameter)].update(
                     requirement_representations[(feature, parameter)]
                 )
-            elif feature in feature_representations:
-                representations[(feature, parameter)].update(feature_representations[feature])
             elif representation is not None and representation_reason is not None:
                 representations[(feature, parameter)].add(
                     (str(representation), str(representation_reason))

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -183,6 +183,13 @@ _FIDELITY_CODES = frozenset(
         "gear_repeat_count_mismatch",
         "gear_axis_mismatch",
         "gear_requirement_mismatch",
+        # An annotation claiming a measurement it does not render, and one claiming a
+        # measurement the compiler never approved (#1217). Both are the sheet contradicting
+        # its own provenance: the drawing asserts, through the seam coverage reads, that it
+        # carries a value it demonstrably does not. Same shape as `label_vs_measured` — the
+        # source contradicted is the compiled plan rather than the projected path.
+        "claimed_value_absent",
+        "claimed_measurement_not_compiled",
     }
 )
 
@@ -226,6 +233,12 @@ _UNSCORED_CODES = frozenset(
         "pmi_not_rendered",
         "pmi_present_but_ignored",
         "pocket_not_located",
+        # Neither confirmed nor refuted: the annotation renders no readable text, or the
+        # compiler approved the measurement with no displayable value. Reported so an
+        # unverifiable claim is visible rather than counted as a pass — but it is evidence
+        # of nothing, so it scores nowhere (#1217).
+        "claimed_representation_unreadable",
+        "claimed_representation_no_expected_value",
         # A `_dropped` code that scores NOWHERE, which is why the suffix cannot be trusted
         # on its own. `is_placement_drop` consults `outcome_stage` FIRST and only falls back
         # to the suffix, and every `_skip_section` emission is `outcome_stage="validation"`

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -229,7 +229,6 @@ def test_annotation_hole_features_unions_every_semantic_owner_channel():
     direct_location_owner = feature()
     identified_location_owner = feature()
     requirement_owner = feature()
-    representation_owner = feature()
     scoped_representation_owner = feature()
     center_owner = feature()
     ignored_owner = feature("boss")
@@ -243,10 +242,9 @@ def test_annotation_hole_features_unions_every_semantic_owner_channel():
             (requirement_owner, "bore.through", 1),
             (ignored_owner, "bore.through", 1),
         ),
-        covers_hole_representations_by_feature=(
-            (representation_owner, "hole_table", "placed"),
-            (ignored_owner, "hole_table", "placed"),
-        ),
+        # `covers_hole_representations_by_feature` is deliberately absent: it was removed
+        # in #1217 once the verifier showed no caller had ever populated it, so a stub here
+        # would be exercising a reader that no longer exists.
         covers_hole_representations_by_requirement=(
             (
                 scoped_representation_owner,
@@ -277,7 +275,6 @@ def test_annotation_hole_features_unions_every_semantic_owner_channel():
             direct_location_owner,
             identified_location_owner,
             requirement_owner,
-            representation_owner,
             scoped_representation_owner,
             center_owner,
         }

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -270,10 +270,10 @@ class TestAHoleTableIsAlsoTheFactReachingTheSheet:
 
     Driven through a REAL build. The first version of this test hand-built a
     `SimpleNamespace` carrying `covers_hole_representations_by_feature`, an attribute
-    **nothing in the engine ever populates** — `representation_features=` appears in the
-    whole tree only at its own definition and its own use. The stub was the entire reason
-    the fix looked correct, and adversarial review caught that the real path still scored
-    16/16 `unsupported`.
+    nothing in the engine ever populated — its `representation_features` argument appeared
+    in the whole tree only at its own definition and its own use. The stub was the entire
+    reason the fix looked correct, and adversarial review caught that the real path still
+    scored 16/16 `unsupported`. The dead field itself was removed in #1217.
     """
 
     def _dense(self):

--- a/tests/test_issue_1217_claimed_representations.py
+++ b/tests/test_issue_1217_claimed_representations.py
@@ -1,0 +1,197 @@
+"""#1217 — a claimed representation must be borne out by the drawing.
+
+Coverage answers "did this requirement reach the sheet?" by reading provenance riders the
+annotations carry about *themselves*. That is a claim, not an observation. Before this, nothing
+checked that an annotation claiming to carry hole 3's diameter rendered that diameter, or
+rendered anything at all — and `covers_hole_representations_by_feature` was read in two places
+while no caller populated it, which inverted the benchmark's `drawing_consumer` metric (16/16
+`unsupported` against a true 16/16 `supported`) and went unnoticed for months.
+
+@pzfreo's decision on #1206: the ledger is a **pointer to the claimed representation, not final
+proof**. This is the verifier that follows the pointer.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright.builder import build_drawing
+from draftwright.linting.evidence import (
+    _expected_numbers,
+    lint_claimed_representations,
+    rendered_numbers,
+    verify_measurement_claims,
+)
+from draftwright.model.compiled import compile_dimensions
+
+_C = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+
+def _two_hole_plate():
+    return (
+        Box(80, 60, 20, align=_C)
+        - Pos(20, 15, 0) * Cylinder(4, 40, align=_C)
+        - Pos(-20, -15, 0) * Cylinder(3, 40, align=_C)
+    )
+
+
+def _verified(drawing):
+    return verify_measurement_claims(drawing.registry, compile_dimensions(drawing.model()))
+
+
+class TestTheDrawingBearsOutItsOwnClaims:
+    def test_every_claim_on_an_ordinary_drawing_is_confirmed(self):
+        # The baseline the rest depends on. If a correct drawing cannot pass its own
+        # verification, every finding below is noise.
+        outcomes = _verified(build_drawing(_two_hole_plate(), title="T", number="N-1"))
+        assert outcomes, "no claims were checked, so nothing here proves anything"
+        assert {o.state for o in outcomes} == {"confirmed"}, [
+            (o.annotation, o.parameter_id, o.state, o.expected, o.rendered)
+            for o in outcomes
+            if o.state != "confirmed"
+        ]
+
+    def test_a_claim_the_annotation_does_not_render_is_reported(self):
+        # THE case that distinguishes a pointer from proof. Without it the verifier only
+        # checks that the annotation exists, which the ledger already implied.
+        drawing = build_drawing(_two_hole_plate(), title="T", number="N-1")
+        name = next(n for n in drawing.registry.names() if n.startswith("hc_"))
+        annotation = drawing.registry.named(name)
+        before = _verified(drawing)
+        assert all(o.state == "confirmed" for o in before if o.annotation == name)
+
+        annotation.label = "⌀999 THRU"
+        after = [o for o in _verified(drawing) if o.annotation == name]
+        assert [o.state for o in after] == ["value_absent"], after
+        codes = [
+            i.code
+            for i in lint_claimed_representations(
+                drawing.registry, compile_dimensions(drawing.model())
+            )
+        ]
+        assert codes == ["claimed_value_absent"]
+
+    def test_a_near_miss_is_not_accepted_by_a_substring(self):
+        # `⌀8` reads as a substring of `⌀18`. Comparing text rather than numbers would call
+        # this confirmed, which is the trap this check exists to avoid rather than introduce.
+        drawing = build_drawing(_two_hole_plate(), title="T", number="N-1")
+        name = next(
+            n
+            for n in drawing.registry.names()
+            if n.startswith("hc_") and "8" in str(getattr(drawing.registry.named(n), "label", ""))
+        )
+        drawing.registry.named(name).label = "⌀18 THRU"
+        states = [o.state for o in _verified(drawing) if o.annotation == name]
+        assert states == ["value_absent"], "a digit-substring match was accepted as proof"
+
+    def test_a_claim_on_an_uncompiled_measurement_is_reported(self):
+        # A renderer emitting content the compiler never approved is an ADR 0016 Amdt 1
+        # violation. The verifier sees it because it resolves claims against the plan.
+        drawing = build_drawing(_two_hole_plate(), title="T", number="N-1")
+        plan = compile_dimensions(drawing.model())
+        empty = SimpleNamespace(groups=(), ladders=(), locations=())
+        states = {o.state for o in verify_measurement_claims(drawing.registry, empty)}
+        assert states == {"unresolved"}
+        assert {o.state for o in verify_measurement_claims(drawing.registry, plan)} == {
+            "confirmed"
+        }
+
+
+class TestWhatCountsAsTheExpectedValue:
+    def test_the_formatted_value_is_expected_not_the_raw_float(self):
+        # The compiler formats for display: a 13.649 mm extent is approved as "13.6" and drawn
+        # as 13.6. Comparing `value` reported ten correct dimensions as wrong on the first
+        # corpus run — including `expected=('13.6',) rendered=13.6`.
+        approved = SimpleNamespace(value=13.649, value_text="13.6", span=None)
+        assert _expected_numbers(approved) == frozenset({13.6})
+
+    def test_a_location_is_verified_from_its_span(self):
+        # A location carries `value=0.0` and `value_text=""`; its magnitude lives in
+        # `span = (datum, located point)` and the renderer draws one axis component. Declining
+        # to check these was true of the implementation and false of the drawing — all four
+        # corpus cases are ordinary, correct location dimensions.
+        approved = SimpleNamespace(
+            value=0.0, value_text="", span=((-26.5, -13.0, -13.0), (0.0, 16.35, 16.5))
+        )
+        # |dx| = 26.5, |dy| = 29.35 -> drawn as 29.4, |dz| = 29.5
+        assert _expected_numbers(approved) == frozenset({26.5, 29.4, 29.5})
+
+    def test_the_three_dimensional_distance_is_not_accepted(self):
+        # No renderer draws it, so admitting it would widen what counts as a match for nothing.
+        approved = SimpleNamespace(value=0.0, value_text="", span=((0, 0, 0), (3, 4, 0)))
+        assert 5.0 not in _expected_numbers(approved)
+
+    def test_a_compound_callout_renders_every_number_it_claims(self):
+        # `⌀8 THRU ⌴ ⌀14 ↧ 7` claims three measurements. Reading only the leading number —
+        # which is what `structural._label_value` answers, for a different question — would
+        # confirm the bore and report the counterbore as absent.
+        part = (
+            Box(80, 60, 20, align=_C)
+            - Cylinder(4, 40, align=_C)
+            - Pos(0, 0, 7) * Cylinder(7, 8, align=_C)
+        )
+        drawing = build_drawing(part, title="T", number="N-1")
+        name = next(n for n in drawing.registry.names() if n.startswith("hc_"))
+        claimed = {m.parameter for m in drawing.registry.measurement_of(name)}
+        assert len(claimed) >= 3, f"the fixture no longer makes a compound callout: {claimed}"
+        assert {o.state for o in _verified(drawing) if o.annotation == name} == {"confirmed"}
+
+
+class TestATableIsReadableToo:
+    def test_a_hole_table_carries_the_rows_it_draws(self):
+        # A table renders as compound geometry with no label. Without `table_rows` its claims
+        # are unverifiable — and those are exactly the claims that matter, because the engine
+        # WITHDRAWS the individual callouts when it escalates to a table.
+        from test_issue_1202_observed_drawing_consumer import _dense_scattered_plate
+
+        drawing = build_drawing(_dense_scattered_plate(), page="A3")
+        names = {n for n, _o in drawing.iter_annotations()}
+        table = next((n for n in names if n.startswith("hole_table")), None)
+        assert table is not None, "fixture no longer escalates to a table; this tests nothing"
+        assert not any(n.startswith("hc_") for n in names), (
+            "individual callouts survived, so the table route is not under test"
+        )
+        assert rendered_numbers(drawing.registry.named(table)), (
+            "the table renders no readable numbers, so its claims cannot be verified"
+        )
+        assert {o.state for o in _verified(drawing) if o.annotation == table} == {"confirmed"}
+
+
+class TestTheDeadFieldIsGone:
+    def test_no_caller_and_no_reader_remain(self):
+        # `covers_hole_representations_by_feature` was built from a `representation_features`
+        # argument no caller ever passed, so the tuple was always empty and the branch reading
+        # it was unreachable. Removed rather than populated: the live route is
+        # `covers_hole_representations_by_requirement`.
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1] / "src" / "draftwright"
+        offenders = [
+            f"{path.relative_to(root)}:{n}"
+            for path in root.rglob("*.py")
+            for n, line in enumerate(path.read_text().splitlines(), 1)
+            if "covers_hole_representations_by_feature" in line
+            and "#1217" not in line
+            and not line.lstrip().startswith(("#", "*", "The failure mode"))
+        ]
+        assert not offenders, f"the dead field is back: {offenders}"
+
+
+class TestLintSurfacesIt:
+    def test_an_ordinary_drawing_reports_nothing(self):
+        drawing = build_drawing(_two_hole_plate(), title="T", number="N-1")
+        assert not [i for i in drawing.lint() if i.code.startswith("claimed_")], (
+            "a correct drawing reported a claim defect"
+        )
+
+    def test_the_check_runs_inside_lint_not_only_as_a_helper(self):
+        # Guards the wiring, not the function: deleting the `_lint` call site leaves every
+        # test above passing.
+        drawing = build_drawing(_two_hole_plate(), title="T", number="N-1")
+        name = next(n for n in drawing.registry.names() if n.startswith("hc_"))
+        drawing.registry.named(name).label = "⌀999 THRU"
+        assert [i.code for i in drawing.lint() if i.code.startswith("claimed_")] == [
+            "claimed_value_absent"
+        ]

--- a/tests/test_issue_1217_claimed_representations.py
+++ b/tests/test_issue_1217_claimed_representations.py
@@ -3,9 +3,10 @@
 Coverage answers "did this requirement reach the sheet?" by reading provenance riders the
 annotations carry about *themselves*. That is a claim, not an observation. Before this, nothing
 checked that an annotation claiming to carry hole 3's diameter rendered that diameter, or
-rendered anything at all — and `covers_hole_representations_by_feature` was read in two places
-while no caller populated it, which inverted the benchmark's `drawing_consumer` metric (16/16
-`unsupported` against a true 16/16 `supported`) and went unnoticed for months.
+rendered anything at all. The benchmark's `drawing_consumer` metric was inverted — 16/16
+`unsupported` against a true 16/16 `supported` — by reading only `hc_` names; the *fix* for
+that then read `covers_hole_representations_by_feature`, a rider no caller populates, and
+passed only because a stub in the tests supplied it.
 
 @pzfreo's decision on #1206: the ledger is a **pointer to the claimed representation, not final
 proof**. This is the verifier that follows the pointer.
@@ -13,6 +14,8 @@ proof**. This is the verifier that follows the pointer.
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 from build123d import Align, Box, Cylinder, Pos
@@ -168,13 +171,19 @@ class TestTheDeadFieldIsGone:
         from pathlib import Path
 
         root = Path(__file__).resolve().parents[1] / "src" / "draftwright"
+        # Code, not prose. Matching any mention flagged this module's own docstring the
+        # moment it was reworded — a guard that fires on its own explanation is a guard
+        # people delete. An attribute is used by being assigned to or read off something,
+        # so both forms need a preceding dot or a `getattr` quote.
+        used = re.compile(
+            r"(\.covers_hole_representations_by_feature)"
+            r"|(getattr\([^)]*[\"']covers_hole_representations_by_feature)"
+        )
         offenders = [
             f"{path.relative_to(root)}:{n}"
             for path in root.rglob("*.py")
             for n, line in enumerate(path.read_text().splitlines(), 1)
-            if "covers_hole_representations_by_feature" in line
-            and "#1217" not in line
-            and not line.lstrip().startswith(("#", "*", "The failure mode"))
+            if used.search(line)
         ]
         assert not offenders, f"the dead field is back: {offenders}"
 
@@ -195,3 +204,140 @@ class TestLintSurfacesIt:
         assert [i.code for i in drawing.lint() if i.code.startswith("claimed_")] == [
             "claimed_value_absent"
         ]
+
+
+@dataclass(frozen=True)
+class _Claim:
+    """A hashable stand-in for `DimensionId` — the verifier only uses it as a dict key."""
+
+    parameter: str
+
+
+class _Registry:
+    """The two reads the verifier makes, over a hand-built annotation."""
+
+    def __init__(self, annotation, claims):
+        self._annotation = annotation
+        self._claims = claims
+
+    def names(self):
+        return {"probe"}
+
+    def named(self, _name):
+        return self._annotation
+
+    def measurement_of(self, _name):
+        return self._claims
+
+
+def _plan(*approved):
+    return SimpleNamespace(groups=(SimpleNamespace(dims=approved),), ladders=(), locations=())
+
+
+class TestEveryOutcomeReachesLint:
+    """Three of the four codes were emitted by no test: mutating their branch to `confirmed`,
+    and deleting the `unresolved` arm of the lint mapping outright, left the suite green
+    (#1218 review). A code nothing exercises is a code nothing has checked the wording,
+    severity or existence of."""
+
+    def test_a_claim_the_compiler_never_approved_reaches_lint(self):
+        claim = _Claim("bore.diameter")
+        registry = _Registry(SimpleNamespace(label="⌀8"), (claim,))
+        issues = lint_claimed_representations(registry, _plan())
+        assert [i.code for i in issues] == ["claimed_measurement_not_compiled"]
+        assert issues[0].severity == "warning"
+
+    def test_an_unreadable_annotation_reaches_lint(self):
+        claim = _Claim("bore.diameter")
+        approved = SimpleNamespace(id=claim, value_text="8", value=8.0, span=None, axis=None)
+        registry = _Registry(SimpleNamespace(), (claim,))
+        issues = lint_claimed_representations(registry, _plan(approved))
+        assert [i.code for i in issues] == ["claimed_representation_unreadable"]
+        assert issues[0].severity == "info"
+
+    def test_an_approval_with_no_displayable_value_reaches_lint(self):
+        claim = _Claim("location.location")
+        approved = SimpleNamespace(id=claim, value_text="", value=0.0, span=None, axis=None)
+        registry = _Registry(SimpleNamespace(label="20"), (claim,))
+        issues = lint_claimed_representations(registry, _plan(approved))
+        assert [i.code for i in issues] == ["claimed_representation_no_expected_value"]
+        assert issues[0].severity == "info"
+
+    def test_a_contradicted_claim_is_a_warning_not_an_info(self):
+        # Severity is not cosmetic: `claimed_value_absent` is classified as fidelity, and the
+        # fidelity score is computed from severity. Demoting it to info leaves the drawing
+        # scoring 1.0 on the axis that just caught it.
+        drawing = build_drawing(_two_hole_plate(), title="T", number="N-1")
+        name = next(n for n in drawing.registry.names() if n.startswith("hc_"))
+        drawing.registry.named(name).label = "⌀999 THRU"
+        issue = next(i for i in drawing.lint() if i.code == "claimed_value_absent")
+        assert issue.severity == "warning"
+        assert drawing.lint_summary()["quality"]["fidelity"]["score"] < 1.0
+
+    def test_ladder_rungs_are_part_of_the_expected_set(self):
+        # `compiled_values` reads groups, ladders and locations. Dropping ladders left the
+        # suite green because no test claimed a rung.
+        from draftwright.linting.evidence import compiled_values
+
+        rung = SimpleNamespace(id="rung", value_text="7", value=7.0, span=None, axis=None)
+        plan = SimpleNamespace(groups=(), ladders=(SimpleNamespace(rungs=(rung,)),), locations=())
+        assert compiled_values(plan) == {"rung": (rung,)}
+
+
+class TestTheAcceptanceSetIsNarrowedWhereItCanBe:
+    def test_a_repeat_count_cannot_confirm_a_diameter(self):
+        # `4× ⌀9 THRU` renders {4, 9}. Reading the count as a measurement confirmed a claimed
+        # bore diameter of 4 against a callout showing 9 (#1218 review). A count is not a
+        # measurement, so this was never inside the stated presence limit.
+        claim = _Claim("bore.diameter")
+        approved = SimpleNamespace(id=claim, value_text="4", value=4.0, span=None, axis=None)
+        registry = _Registry(SimpleNamespace(label="4× ⌀9 THRU"), (claim,))
+        states = [o.state for o in verify_measurement_claims(registry, _plan(approved))]
+        assert states == ["value_absent"]
+
+    def test_a_dimension_pair_is_not_mistaken_for_a_repeat_count(self):
+        # `44 × 93.4 × 10 DEEP` is width × length × depth. The first cut of the repeat strip
+        # matched any leading `N ×` and deleted the 44, turning two correct pocket dimensions
+        # on `issue_915_case_study_2` into mismatches — a safety fix becoming the defect it
+        # was guarding against. The ⌀ lookahead is `structural._label_value`'s own
+        # discriminator between a count and a size.
+        claim = _Claim("pocket_width.length")
+        approved = SimpleNamespace(id=claim, value_text="44", value=44.0, span=None, axis=None)
+        registry = _Registry(SimpleNamespace(label="44 × 93.4 × 10 DEEP"), (claim,))
+        states = [o.state for o in verify_measurement_claims(registry, _plan(approved))]
+        assert states == ["confirmed"]
+
+    def test_the_feature_axis_component_is_not_accepted(self):
+        # A pocket normal to Z is located by its X and Y offsets; the Z component of the span
+        # is drawn by nothing. Accepting all three confirmed a relabelled X offset.
+        approved = SimpleNamespace(
+            value=0.0, value_text="", span=((-60, -40, -10), (15, 10, 5.5)), axis="z"
+        )
+        assert _expected_numbers(approved) == frozenset({75.0, 50.0})
+
+    def test_all_components_stay_acceptable_when_no_axis_is_declared(self):
+        # Nothing then says which one the renderer took, and guessing would produce false
+        # mismatches on correct drawings. Named as a residual limit rather than hidden.
+        approved = SimpleNamespace(
+            value=0.0, value_text="", span=((-60, -40, -10), (15, 10, 5.5)), axis=None
+        )
+        assert _expected_numbers(approved) == frozenset({75.0, 50.0, 15.5})
+
+
+class TestTheOutputIsDeterministic:
+    def test_issue_order_does_not_depend_on_set_iteration(self):
+        # `registry.names()` is a set. Without `sorted` the emitted order varied run to run on
+        # one drawing — five orderings in five processes — which is against ADR 0006 and makes
+        # two lint runs undiffable, the defect #1196 fixed for lint TEXT.
+        drawing = build_drawing(_two_hole_plate(), title="T", number="N-1")
+        for name in [n for n in drawing.registry.names() if n.startswith(("hc_", "m_loc"))]:
+            drawing.registry.named(name).label = "⌀999"
+        plan = compile_dimensions(drawing.model())
+        issues = lint_claimed_representations(drawing.registry, plan)
+        assert len(issues) > 1, "the fixture produced too few issues to have an order"
+        # Assert the order IS sorted, not that it repeats. Repeating within one process is
+        # true of an unsorted set too — string hashing is stable for a given PYTHONHASHSEED —
+        # so a same-process comparison passes on the broken code, which is what the first cut
+        # of this test did (#1218 review round 2, found by mutation).
+        names = [i.message.split()[0] for i in issues]
+        assert names == sorted(names), names

--- a/tests/test_issue_1217_claimed_representations.py
+++ b/tests/test_issue_1217_claimed_representations.py
@@ -182,7 +182,7 @@ class TestTheDeadFieldIsGone:
         offenders = [
             f"{path.relative_to(root)}:{n}"
             for path in root.rglob("*.py")
-            for n, line in enumerate(path.read_text().splitlines(), 1)
+            for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
             if used.search(line)
         ]
         assert not offenders, f"the dead field is back: {offenders}"
@@ -341,3 +341,60 @@ class TestTheOutputIsDeterministic:
         # of this test did (#1218 review round 2, found by mutation).
         names = [i.message.split()[0] for i in issues]
         assert names == sorted(names), names
+
+
+class TestATableIsNotOneFlatNumberPool:
+    def test_a_quantity_column_cannot_confirm_a_diameter(self):
+        # `add_hole_table` emits TAG | ⌀ | DEPTH | QTY. A table drawing `ø99` for a ⌀4 hole was
+        # confirmed by its own quantity cell — the same defect `_REPEAT_RE` fixes for
+        # `4× ⌀9 THRU`, surviving in the table path because the strip was applied to the label
+        # and not to row cells (#1218 review round 2).
+        claim = _Claim("bore.diameter")
+        approved = SimpleNamespace(id=claim, value_text="4", value=4.0, span=None, axis=None)
+        rows = (("TAG", "⌀", "DEPTH", "QTY"), ("A", "ø99", "THRU", "4"))
+        registry = _Registry(SimpleNamespace(table_rows=rows), (claim,))
+        states = [o.state for o in verify_measurement_claims(registry, _plan(approved))]
+        assert states == ["value_absent"], "a QTY cell confirmed a wrong diameter"
+
+    def test_the_header_row_is_not_read_as_data(self):
+        # Defensive, and it survived its own mutation because no header in the tree carries a
+        # digit today. A column heading like `⌀ 2` is a caption, not a measurement, and a
+        # header that could satisfy a claim would confirm every row in the table at once.
+        claim = _Claim("bore.diameter")
+        approved = SimpleNamespace(id=claim, value_text="2", value=2.0, span=None, axis=None)
+        rows = (("TAG", "⌀ 2", "DEPTH"), ("A", "ø99", "THRU"))
+        registry = _Registry(SimpleNamespace(table_rows=rows), (claim,))
+        assert [o.state for o in verify_measurement_claims(registry, _plan(approved))] == [
+            "value_absent"
+        ]
+
+    def test_a_measuring_column_still_supplies_numbers(self):
+        # The automatic escalated table has no QTY: TAG | ⌀ | DEPTH | X | Y. Dropping too much
+        # would make every table claim unverifiable, which is the opposite failure.
+        claim = _Claim("bore.diameter")
+        approved = SimpleNamespace(id=claim, value_text="2", value=2.0, span=None, axis=None)
+        rows = (("TAG", "⌀", "DEPTH", "X", "Y"), ("A", "ø2", "THRU", "17.3", "12.6"))
+        registry = _Registry(SimpleNamespace(table_rows=rows), (claim,))
+        assert [o.state for o in verify_measurement_claims(registry, _plan(approved))] == [
+            "confirmed"
+        ]
+
+
+class TestTheRemainingSmallGuards:
+    def test_a_span_is_measured_as_a_magnitude(self):
+        # Both earlier span tests used increasing spans, so dropping `abs()` passed the whole
+        # fast tier. A datum above the located point is an ordinary drawing.
+        approved = SimpleNamespace(
+            value=0.0, value_text="", span=((15, 10, 5.5), (-60, -40, -10)), axis="z"
+        )
+        assert _expected_numbers(approved) == frozenset({75.0, 50.0})
+
+    def test_a_radius_repeat_count_is_stripped_too(self):
+        # `4× R25` and `10× R10` carry claims on four corpus fixtures, so the `R` half of the
+        # lookahead is live — and was unpinned, surviving its own mutation.
+        claim = _Claim("fillet.radius")
+        approved = SimpleNamespace(id=claim, value_text="4", value=4.0, span=None, axis=None)
+        registry = _Registry(SimpleNamespace(label="4× R25"), (claim,))
+        assert [o.state for o in verify_measurement_claims(registry, _plan(approved))] == [
+            "value_absent"
+        ]


### PR DESCRIPTION
PR 1 of 3 for #1217. Settles the mechanism half of #1206.

## The gap

Coverage checks answer *"did this requirement reach the sheet?"* by walking the registry and
reading provenance riders the annotations carry **about themselves**. That is a claim, not an
observation. An annotation asserting it carries hole 3's diameter was believed, and nothing
checked that it renders that diameter — or renders anything at all.

Not hypothetical: the benchmark's `drawing_consumer` metric was inverted — 16/16 `unsupported`
against a true 16/16 `supported` — because it read only `hc_` callout names. The *fix* for that
then read `covers_hole_representations_by_feature`, a rider no caller populates, and looked
correct only because a stub in the tests supplied it. (An earlier draft of this paragraph blamed
the dead rider for the inversion and said it survived "for months". Neither is true — it caused
the bad fix, not the bug, and `git log -S` puts it at four days.)

## What this adds

`linting/evidence.py` resolves each claim against the built drawing and checks the rendered
content carries the value the compiler approved.

**Shared, not hole-specific**, per the scope decision on #1206. The claim is
`registry.measurement_of(name)`, which every feature family populates through the same seam
(ADR 0010), so nothing in the verifier knows what a hole is. The expected value comes from the
compiled plan (ADR 0016 Amdt 1), never from a renderer's own formatting — comparing rendered
output against rendered output would prove only that the renderer agrees with itself.

Two consumers follow from one implementation: `evaluation` gets an observation it can score
without trusting the engine's self-report (PR 2), and lint gets a self-consistency check it can
act on (this PR).

## Four things the corpus taught

Each of these made the first run wrong, and each would have been tempting to fix by loosening the
check instead of understanding it:

- **Expected means `value_text`, not `value`.** The compiler formats for display — a 13.649 mm
  extent is approved as `"13.6"` and drawn as `13.6` — so comparing the raw float reported ten
  correct dimensions as wrong, including `expected=('13.6',) rendered=13.6`.
- **A `DimensionId` is not unique per rendered dimension.** One hole's `location.location` yields
  both the X and the Y offset, so a single-valued lookup drops one of each pair and then reports a
  true dimension as a mismatch. The expected side is a multimap.
- **A location's value lives in its span.** `value=0.0`, `value_text=""`, and the renderer draws
  one axis component of `span = (datum, located point)`. The first cut called these unverifiable —
  true of the implementation, false of the drawing. All four corpus cases are ordinary correct
  dimensions whose value the compiler did supply, in a field the verifier had not looked at.
- **A table draws as compound geometry with no label.** Its claims were unverifiable, and those
  are exactly the claims that matter, because the engine *withdraws* the individual callouts when
  it escalates to a table. `Drawing.add_table` now keeps the rows it draws, mirroring
  `gear_requirement_rows`.

## The limit, stated

Four, all measured by relabelling a real drawing and watching the check stay silent:

1. **Presence, not attribution** — the approved value must appear among the numbers the
   annotation draws, not in the right *position* within a compound label.
2. **Members of one `DimensionId` confirm each other** — swapping two location labels confirms
   both. Narrowing needs per-member identity, which #883 leaves open. Not fixed; stated.
   **A table is the severe case of limit 1**, not a footnote: its cells are one flat pool, so a
   diameter claim can be satisfied by a coordinate in another column — blanking every diameter
   cell on a 17-row table left 17 of 32 claims confirmed. The demonstrated exploit (a `QTY`
   column) is closed; matching a claim's parameter to a *column* is design, filed on #1217.
   **And one annotation may claim several different ids** — up to ten measured on one
   annotation — where a single number satisfies all of them.
3. **Reach is bounded by ADR 0010 identity** — roughly half the annotations on a sheet carry no
   claim and are never examined. "N claims, N confirmed" is about the claimed part of the sheet.
4. **Existence is assumed, not checked** — an approved measurement no annotation claims is
   invisible here, so #1217's `annotation_missing` state is deliberately not implemented.

And what is compared: `label` is a rider the renderer attaches, not glyphs recovered from the
sheet, so this is the compiled plan against a second self-report. A real cross-source check, and
`table_rows` is genuinely drawn content — but export-visible verification is #1217's step 5.

## The dead field

Deleted — and for a narrower reason than the epic first stated. `representation_reason` **is**
set, on the required-balloons path. `representation_features` is passed by **no caller**; the only
two mentions in the tree are comments documenting that fact. So the tuple was always empty and
`hole_coverage`'s branch reading it was unreachable. I nearly deleted `representation_reason`
alongside it on the strength of the sloppier claim.

## Verification

- **Corpus: 1,081 claims, 1,078 confirmed**, over all 21 STEP fixtures in the tree, measured
  through `build_drawing(path)` — the engine's own importer.
  Two earlier drafts of this line were wrong: the first globbed `*.step` when the NIST fixtures
  are `*.stp`; the second mixed the repo's fixtures with files from a local directory outside it
  and reached them through `build123d.import_step`, which is what produced the "one fixture
  segfaults" claim. It does not — `_import_step` uses `STEPControl_Reader` precisely to avoid
  that, and the slow tier already draws the file.
- **All three non-confirmed claims are one genuine defect** (#1219), and the reason this PR ships
  live warnings rather than none. On `nist_ctc_02`, `m_locy7` renders `430` and `m_locx8` renders
  `340`, while both claim `location_slot.length` — a 94.1 mm **Z** extent. Both axes of one
  slot's position bound to the wrong measurement, on the ADR 0010 seam that coverage reads.
  Excluding the AP242 file hid two of the three. Left as live warnings: suppressing a true
  finding to keep a corpus green is the behaviour this check exists to prevent.
- **Twenty mutations**, each with the substitution asserted applied, **all killed** — including
  the four lint codes, the severity (the fidelity score is computed from it), the ladder rungs,
  the axis narrowing, the repeat strip in both directions, the QTY-column filter, `abs()` in the
  span fallback, the header-row slice, `sorted(names)`, and removing the `_lint` call site, which
  otherwise leaves every test green on a facility nothing runs.
- Four new codes classified into the #1213 registers — two as fidelity, two as unscored — so the
  fail-closed audit passes.
- ADR 0015's lint carve-out ("never the plan") is **amended in this PR** rather than silently
  diverged from.
- Full fast tier **4,287 passed**, 5 skipped, 2 xfailed. `scripts/pr-check --static` exit 0.

## Not in this PR

PR 2 has the benchmark consume this and deletes its duplicate correspondence — **it must not land
first**, since consolidating while the ledger is still proof is the self-validation the decision
rejects. PR 3 adds a second feature family, whose gate is that it costs a producer and zero
changes to the facility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22

